### PR TITLE
Solved the mentioned bug

### DIFF
--- a/app/components/assets/actions-dropdown.tsx
+++ b/app/components/assets/actions-dropdown.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const ActionsDopdown = ({ asset }: Props) => (
-  <DropdownMenu>
+  <DropdownMenu modal={false}>
     <DropdownMenuTrigger className="asset-actions">
       <Button variant="secondary" to="#" data-test-id="assetActionsButton">
         <span className="flex items-center gap-2">
@@ -42,7 +42,6 @@ export const ActionsDopdown = ({ asset }: Props) => (
           Edit
         </Button>
       </DropdownMenuItem>
-
       <DeleteAsset asset={asset} />
     </DropdownMenuContent>
   </DropdownMenu>

--- a/app/components/location/actions-dropdown.tsx
+++ b/app/components/location/actions-dropdown.tsx
@@ -19,7 +19,7 @@ interface Props {
 }
 
 export const ActionsDopdown = ({ location, fullWidth }: Props) => (
-  <DropdownMenu>
+  <DropdownMenu modal={false}>
     <DropdownMenuTrigger
       className={tw("asset-actions", fullWidth ? "w-full" : "")}
     >


### PR DESCRIPTION
## Cause
Basically when the Radix-UI dropdown is opened it adds css property "pointer-events: none" to body tag and which disables all interactions of child elements of Body tag, and the property "pointer-events: none" is removed when the user selects/clicks on the DropdownMenuItem component as it closes the dropdown menu.

previously :
![image](https://github.com/Shelf-nu/shelf.nu/assets/129367263/d15c416a-1480-4787-a838-c7397d7bc865)

Here is the previously written code , which shows that DeleteAsset component is a part of dropdown menu but is not wrapper in  DropdownMenuItem component, when Delete asset is selected it didn't removed the  "pointer-events: none"  from body as it did not closed the dropdown and we couldn't wrap the delete asset component in the DropdownMenuItem component because of conflicting events which resulted in not rendering the delete asset popup

## Solution

As from the API reference of dropdown component from the docs of Radix-UI
![image](https://github.com/Shelf-nu/shelf.nu/assets/129367263/11c34862-7746-4e97-8235-1eb3880a41f3)

there is a property named `modal` which is by default true, and it serves a purpose of disabling interactions when dropdown menu is displayed, setting it to false on actions dropdown as we don't want to disable other interactions and this resulted in enabling other interactions even when the dropdown menu is open.

