### PR TITLE
replacing zod's default email validation with a custom refine function

### DIFF
--- a/app/routes/_auth+/forgot-password.tsx
+++ b/app/routes/_auth+/forgot-password.tsx
@@ -8,7 +8,7 @@ import { Button } from "~/components/shared/button";
 import { db } from "~/database";
 
 import { getAuthSession, sendResetPasswordLink } from "~/modules/auth";
-import { assertIsPost, isFormProcessing, tw } from "~/utils";
+import { assertIsPost, isFormProcessing, tw, validEmail } from "~/utils";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 
 export async function loader({ request }: LoaderArgs) {
@@ -24,8 +24,10 @@ export async function loader({ request }: LoaderArgs) {
 const ForgotPasswordSchema = z.object({
   email: z
     .string()
-    .email("Please enter a valid Email address")
-    .transform((email) => email.toLowerCase()),
+    .transform((email) => email.toLowerCase())
+    .refine(validEmail, () => ({
+      message: "Please enter a valid email",
+    })),
 });
 
 export async function action({ request }: ActionArgs) {

--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -20,7 +20,7 @@ import {
   signInWithEmail,
   ContinueWithEmailForm,
 } from "~/modules/auth";
-import { assertIsPost, isFormProcessing } from "~/utils";
+import { assertIsPost, isFormProcessing, validEmail } from "~/utils";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 
 export async function loader({ request }: LoaderArgs) {
@@ -34,8 +34,10 @@ export async function loader({ request }: LoaderArgs) {
 const LoginFormSchema = z.object({
   email: z
     .string()
-    .email("Please enter a valid email.")
-    .transform((email) => email.toLowerCase()),
+    .transform((email) => email.toLowerCase())
+    .refine(validEmail, () => ({
+      message: "Please enter a valid email",
+    })),
   password: z.string().min(8, "Password is too short. Minimum 8 characters."),
   redirectTo: z.string().optional(),
 });

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -18,3 +18,4 @@ export * from "./gif-to-png";
 export * from "./slugify";
 export * from "./geolocate.server";
 export * from "./user-friendly-asset-status";
+export * from "./misc";

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -5,6 +5,4 @@
  * So we use the custom validation
  *  */
 export const validEmail = (val: string) =>
-  /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i.test(
-    val
-  );
+  /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i.test(val);

--- a/app/utils/misc.ts
+++ b/app/utils/misc.ts
@@ -1,0 +1,10 @@
+/**
+ * .email() has an issue with validating email
+ * addresses where the there is a subdomain and a dash included:
+ * https://github.com/colinhacks/zod/pull/2157
+ * So we use the custom validation
+ *  */
+export const validEmail = (val: string) =>
+  /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i.test(
+    val
+  );


### PR DESCRIPTION
Zod's `.email()` has an issue with validating email addresses where the there is a subdomain and a dash included: https://github.com/colinhacks/zod/pull/2157

So we made custom validation using `.refine()` and regex.