### PR TITLE
Fixing time ago on notes

### DIFF
--- a/app/components/assets/notes/note.tsx
+++ b/app/components/assets/notes/note.tsx
@@ -56,7 +56,7 @@ const Comment = ({
         <span className="commentator font-medium text-gray-900">
           {user?.firstName} {user?.lastName}
         </span>{" "}
-        <span className="text-gray-600">{timeAgo(note.dateDisplay)}</span>
+        <span className="text-gray-600">{timeAgo(note.createdAt)}</span>
       </div>
       <ActionsDopdown note={note} />
     </header>


### PR DESCRIPTION
It was using the display date instead of `createdAt` so it was showing the wrong time.