### PR TITLE
Bugfix(401): Force to re-fetch location image, if its been updated recently

### DIFF
--- a/app/components/shared/image.tsx
+++ b/app/components/shared/image.tsx
@@ -1,17 +1,32 @@
 import { tw } from "~/utils";
+import { getDifferenceInSeconds } from "~/utils/date-fns";
 
+const FORCE_RELOAD_WITHIN_SECONDS = 30;
 export const Image = ({
   imageId,
   alt,
   className,
+  updatedAt = "",
 }: {
   imageId?: string | null;
   alt: string;
   className?: string;
-}) => (
-  <img
-    src={imageId ? `/api/image/${imageId}` : `/images/asset-placeholder.jpg`}
-    alt={alt}
-    className={tw(className)}
-  />
-);
+  updatedAt?: Date | string | number;
+}) => {
+  const imageUpdatedAt = new Date(updatedAt);
+  const imageUpdatedAtDiff = getDifferenceInSeconds(imageUpdatedAt, new Date());
+  // @NOTE: force reload the image, if image is updated with last 30 seconds.
+  const forceReload = imageUpdatedAtDiff < FORCE_RELOAD_WITHIN_SECONDS;
+  return (
+    <img
+      src={
+        imageId
+          ? `/api/image/${imageId}${forceReload ? `?t=${Date.now()}` : ""}`
+          : `/images/asset-placeholder.jpg`
+      }
+      alt={alt}
+      className={tw(className)}
+      loading="lazy"
+    />
+  );
+};

--- a/app/modules/location/service.server.ts
+++ b/app/modules/location/service.server.ts
@@ -35,6 +35,7 @@ export async function getLocation({
     db.location.findFirst({
       where: { id, userId },
       include: {
+        image: true,
         assets: {
           include: {
             category: true,
@@ -101,6 +102,7 @@ export async function getLocations({
       orderBy: { updatedAt: "desc" },
       include: {
         assets: true,
+        image: true,
       },
     }),
 

--- a/app/routes/_layout+/locations.$locationId.tsx
+++ b/app/routes/_layout+/locations.$locationId.tsx
@@ -153,6 +153,7 @@ export default function LocationPage() {
               "block h-auto w-full rounded-lg border object-cover 2xl:h-auto",
               location.description ? "rounded-b-none border-b-0" : ""
             )}
+            updatedAt={location.image?.updatedAt}
           />
           {location.description ? (
             <Card className=" mt-0 md:rounded-t-none">

--- a/app/routes/_layout+/locations._index.tsx
+++ b/app/routes/_layout+/locations._index.tsx
@@ -1,4 +1,4 @@
-import type { Asset, Location } from "@prisma/client";
+import type { Asset, Image as ImageDataType, Location } from "@prisma/client";
 import { json } from "@remix-run/node";
 import type { LoaderArgs, V2_MetaFunction } from "@remix-run/node";
 import { useNavigate } from "@remix-run/react";
@@ -103,6 +103,7 @@ export default function LocationsIndexPage() {
 
 interface LocationWithAssets extends Location {
   assets: Asset[];
+  image?: ImageDataType;
 }
 
 const ListItemContent = ({ item }: { item: LocationWithAssets }) => (
@@ -118,6 +119,7 @@ const ListItemContent = ({ item }: { item: LocationWithAssets }) => (
                 "h-full w-full rounded-[4px] border object-cover",
                 item.description ? "rounded-b-none border-b-0" : ""
               )}
+              updatedAt={item.image?.updatedAt}
             />
           </div>
           <div className="flex flex-row items-center gap-2 md:flex-col md:items-start md:gap-0">

--- a/app/utils/date-fns.ts
+++ b/app/utils/date-fns.ts
@@ -1,0 +1,10 @@
+export function getDifferenceInSeconds(
+  dateLeft: Date,
+  dateRight: Date
+): number {
+  const millisecondsDifference = Math.abs(
+    dateLeft.getTime() - dateRight.getTime()
+  );
+  const secondsDifference = millisecondsDifference / 1000;
+  return secondsDifference;
+}


### PR DESCRIPTION
## Description
#401 

## Changes
- If image of location updated within 30 seconds, we add current date and time in image url.
- adding date and time in image url, browser is force to re-fetched the image