### PR TITLE
Bugfix(419) - sidebar icon flicker issue

### DIFF
--- a/app/styles/layout/sidebar.css
+++ b/app/styles/layout/sidebar.css
@@ -31,7 +31,7 @@
   }
 
   .collapsed-navigation .bottom {
-    @apply border-none;
+    @apply border-transparent;
   }
 
   .collapsed-navigation .bottom a {

--- a/app/styles/layout/sidebar.css
+++ b/app/styles/layout/sidebar.css
@@ -23,11 +23,7 @@
 
   .collapsed-navigation .menu li a,
   .collapsed-navigation .menu li button {
-    @apply py-3;
-  }
-  .collapsed-navigation .menu li a .icon,
-  .collapsed-navigation .menu li button .icon {
-    @apply ml-0.5;
+    @apply py-2.5;
   }
 
   .collapsed-navigation .logout-btn form {
@@ -36,10 +32,6 @@
 
   .collapsed-navigation .bottom {
     @apply border-none;
-  }
-
-  .collapsed-navigation img {
-    @apply ml-2;
   }
 
   .collapsed-navigation .bottom a {


### PR DESCRIPTION
## Description
#419 

## Changes
- Removed extra margin for icon and image in sidebar
- Bottom section of sidebar, making its border color transparent when sidebar is collapsed. This way menus/items in sidebar will not flicker vertically.

## GIF

![desktop_sidebar](https://github.com/Shelf-nu/shelf.nu/assets/5011197/b13634e8-cd38-41cd-aa8f-0de993f98464)
![mobile_sidebar](https://github.com/Shelf-nu/shelf.nu/assets/5011197/7ec56887-8331-4b2b-97ac-33237b91bbe8)
