### PR TITLE
feat: Implement "uncategorized" for assets

### DIFF
--- a/app/components/assets/form.tsx
+++ b/app/components/assets/form.tsx
@@ -138,7 +138,7 @@ export const AssetForm = ({
         className="border-b-0 pb-[10px]"
         required={zodFieldIsRequired(FormSchema.shape.category)}
       >
-        <CategorySelect defaultValue={category || undefined} />
+        <CategorySelect defaultValue={category || "uncategorized"} />
       </FormRow>
 
       <FormRow

--- a/app/components/category/category-select.tsx
+++ b/app/components/category/category-select.tsx
@@ -62,6 +62,11 @@ export const CategorySelect = ({ defaultValue }: { defaultValue?: string }) => {
                 </div>
 
                 <div className="border-b border-b-gray-300 py-2 ">
+                  <SelectItem value={"uncategorized"} key={"uncategorized"}>
+                    <Badge color={"#808080"} noBg withDot={false}>
+                      Uncategorized
+                    </Badge>
+                  </SelectItem>
                   {refinedCategories.map((c) => (
                     <SelectItem value={c.id} key={c.id}>
                       <Badge color={c.color} noBg withDot={false}>

--- a/app/components/list/filters/category/category-checkbox-dropdown.tsx
+++ b/app/components/list/filters/category/category-checkbox-dropdown.tsx
@@ -40,6 +40,12 @@ export const CategoryCheckboxDropdown = () => {
   const [, setInitialSelect] = useAtom(addInitialSelectedCategoriesAtom);
   const [, clearFilters] = useAtom(clearCategoryFiltersAtom);
 
+  const uncategorizedItemObj: any = {
+    id: "uncategorized",
+    name: "uncategorized",
+    color: "#808080",
+  };
+
   const hasCategories = useMemo(
     () => refinedCategories.length > 0,
     [refinedCategories]
@@ -121,6 +127,11 @@ export const CategoryCheckboxDropdown = () => {
                 )}
               </div>
               <div className="">
+                <CheckboxItem
+                  key={uncategorizedItemObj.id}
+                  category={uncategorizedItemObj}
+                  selected={items}
+                />
                 {refinedCategories.map((c) => (
                   <CheckboxItem key={c.id} category={c} selected={items} />
                 ))}

--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -128,7 +128,7 @@ export async function getAssets({
 
   if (categoriesIds && categoriesIds.length > 0 && where.asset) {
     if (categoriesIds.includes("uncategorized")) {
-      where.OR.asset = [
+      where.asset.OR = [
         {
           categoryId: {
             in: categoriesIds,

--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -230,14 +230,14 @@ export async function createAsset({
     qr && qr.userId === userId && qr.assetId === null
       ? { connect: { id: qrId } }
       : {
-        create: [
-          {
-            version: 0,
-            errorCorrection: ErrorCorrection["L"],
-            user,
-          },
-        ],
-      };
+          create: [
+            {
+              version: 0,
+              errorCorrection: ErrorCorrection["L"],
+              user,
+            },
+          ],
+        };
 
   /** Data object we send via prisma to create Asset */
   const data = {
@@ -361,12 +361,18 @@ export async function updateAsset(payload: UpdateAssetPayload) {
   };
 
   /** Delete the category id from the payload so we can use connect syntax from prisma */
-  if (categoryId) {
+  if (categoryId !== "uncategorized") {
     Object.assign(data, {
       category: {
         connect: {
           id: categoryId,
         },
+      },
+    });
+  } else {
+    Object.assign(data, {
+      category: {
+        disconnect: true,
       },
     });
   }
@@ -616,8 +622,9 @@ export async function duplicateAsset({
 
   for (const i of [...Array(amountOfDuplicates)].keys()) {
     const duplicatedAsset = await createAsset({
-      title: `${asset.title} (copy ${amountOfDuplicates > 1 ? i : ""
-        } ${Date.now()})`,
+      title: `${asset.title} (copy ${
+        amountOfDuplicates > 1 ? i : ""
+      } ${Date.now()})`,
       description: asset.description,
       userId,
       categoryId: asset.categoryId,
@@ -862,10 +869,10 @@ export const createAssetsFromContentImport = async ({
       tags:
         asset.tags.length > 0
           ? {
-            set: asset.tags
-              .filter((t) => tags[t])
-              .map((t) => ({ id: tags[t] })),
-          }
+              set: asset.tags
+                .filter((t) => tags[t])
+                .map((t) => ({ id: tags[t] })),
+            }
           : undefined,
       customFieldsValues,
     });
@@ -1072,8 +1079,8 @@ export const createAssetsFromBackupImport = async ({
         tags:
           asset.tags.length > 0
             ? {
-              connect: asset.tags.map((tag) => ({ id: tags[tag.name] })),
-            }
+                connect: asset.tags.map((tag) => ({ id: tags[tag.name] })),
+              }
             : undefined,
       });
     }
@@ -1129,28 +1136,28 @@ export interface CreateAssetFromBackupImportPayload
   title: string;
   description?: string;
   category:
-  | {
-    id: string;
-    name: string;
-    description: string;
-    color: string;
-    createdAt: string;
-    updatedAt: string;
-    userId: string;
-  }
-  | {};
+    | {
+        id: string;
+        name: string;
+        description: string;
+        color: string;
+        createdAt: string;
+        updatedAt: string;
+        userId: string;
+      }
+    | {};
   tags: {
     name: string;
   }[];
   location:
-  | {
-    name: string;
-    description?: string;
-    address?: string;
-    createdAt: string;
-    updatedAt: string;
-  }
-  | {};
+    | {
+        name: string;
+        description?: string;
+        address?: string;
+        createdAt: string;
+        updatedAt: string;
+      }
+    | {};
   customFields: AssetCustomFieldsValuesWithFields[];
 }
 

--- a/app/routes/_layout+/assets.$assetId.tsx
+++ b/app/routes/_layout+/assets.$assetId.tsx
@@ -61,10 +61,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
    */
   const lastScan = asset.qrCodes[0]?.id
     ? parseScanData({
-      scan: (await getScanByQrId({ qrId: asset.qrCodes[0].id })) || null,
-      userId,
-      request,
-    })
+        scan: (await getScanByQrId({ qrId: asset.qrCodes[0].id })) || null,
+        userId,
+        request,
+      })
     : null;
 
   const notes = asset.notes.map((note) => ({

--- a/app/routes/_layout+/assets.$assetId.tsx
+++ b/app/routes/_layout+/assets.$assetId.tsx
@@ -61,10 +61,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
    */
   const lastScan = asset.qrCodes[0]?.id
     ? parseScanData({
-        scan: (await getScanByQrId({ qrId: asset.qrCodes[0].id })) || null,
-        userId,
-        request,
-      })
+      scan: (await getScanByQrId({ qrId: asset.qrCodes[0].id })) || null,
+      userId,
+      request,
+    })
     : null;
 
   const notes = asset.notes.map((note) => ({
@@ -251,7 +251,18 @@ export default function AssetDetailsPage() {
                     </Badge>
                   </div>
                 </li>
-              ) : null}
+              ) : (
+                <li className="mb-4 flex justify-between">
+                  <span className="text-[12px] font-medium text-gray-600">
+                    Category
+                  </span>
+                  <div className="max-w-[250px]">
+                    <Badge color={"#808080"} withDot={false}>
+                      Uncategorized
+                    </Badge>
+                  </div>
+                </li>
+              )}
               {location ? (
                 <li className="mb-2 flex justify-between">
                   <span className="text-[12px] font-medium text-gray-600">

--- a/app/routes/_layout+/assets._index.tsx
+++ b/app/routes/_layout+/assets._index.tsx
@@ -286,7 +286,11 @@ const ListAssetContent = ({
           <Badge color={category.color} withDot={false}>
             {category.name}
           </Badge>
-        ) : null}
+        ) : (
+          <Badge color={"#808080"} withDot={false}>
+            {"Uncategorized"}
+          </Badge>
+        )}
       </Td>
 
       {/* Tags */}


### PR DESCRIPTION
## Completed tasks in this feature

fixes #450 

- [x] Default category as `Uncategorised` while creating new asset
![image](https://github.com/Shelf-nu/shelf.nu/assets/42497152/64d03634-c2e9-4050-ab11-cbf70758e776)

- [x] Created `Uncategorised` badge in asset index page
![image](https://github.com/Shelf-nu/shelf.nu/assets/42497152/b285c58d-8239-4184-ba9c-e8c1f624968b)

- [x] Created `Uncategorised` badge in single asset page
![image](https://github.com/Shelf-nu/shelf.nu/assets/42497152/6dc215c3-90f1-440f-9db0-97bf60709777)

- [x] Added `Uncategorised` to categories filter
![image](https://github.com/Shelf-nu/shelf.nu/assets/42497152/9b21da29-03a3-4e31-95af-10d44e881e08) 
![image](https://github.com/Shelf-nu/shelf.nu/assets/42497152/0f8970db-0de3-4e7c-bcb9-574b8a7f544a)

- After applying Uncategorised` filter in index page
![image](https://github.com/Shelf-nu/shelf.nu/assets/42497152/627cb99c-22d6-40cc-9b6e-f56915897471)

