### PR TITLE
fix: Fixing issue with linking QR

### DIFF
--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -250,12 +250,12 @@ export async function createAsset({
    * Otherwise, create a new one
    * Here we also need to double check:
    * 1. If the qr code exists
-   * 2. If the qr code belongs to the current user
+   * 2. If the qr code belongs to the current organization
    * 3. If the qr code is not linked to an asset
    */
   const qr = qrId ? await getQr(qrId) : null;
   const qrCodes =
-    qr && qr.userId === userId && qr.assetId === null
+    qr && qr.organizationId === organizationId && qr.assetId === null
       ? { connect: { id: qrId } }
       : {
           create: [


### PR DESCRIPTION
The if case for linking to a orphaned QR code was checking `userId` instead of `organizationId`