### PR TITLE
fix: importing when no teammembers are present as well as handling …

### DIFF
--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -899,7 +899,7 @@ export const createAssetsFromContentImport = async ({
     userId,
   });
 
-  for (const asset of data) {
+  for (let asset of data) {
     const customFieldsValues: ShelfAssetCustomFieldValueType[] = Object.entries(
       asset
     ).reduce((res, [key, val]) => {

--- a/app/modules/team-member/service.server.ts
+++ b/app/modules/team-member/service.server.ts
@@ -46,6 +46,11 @@ export async function createTeamMemberIfNotExists({
       .map((asset) => [asset.custodian, ""])
   );
 
+  // Handle the case where there are no teamMembers
+  if (teamMembers.has(undefined)) {
+    return {};
+  }
+
   // now we loop through the categories and check if they exist
   for (const [teamMember, _] of teamMembers) {
     const existingTeamMember = await db.teamMember.findFirst({

--- a/app/utils/error.ts
+++ b/app/utils/error.ts
@@ -68,11 +68,12 @@ export function handleUniqueConstraintError(cause: any, modelName: string) {
       },
     };
   } else {
-    return {
-      item: null,
-      error: {
-        message: "Something went wrong. Please try again later.",
+    throw new ShelfStackError({
+      message: `Error creating ${modelName}: ${cause}`,
+      cause,
+      metadata: {
+        modelName,
       },
-    };
+    });
   }
 }

--- a/app/utils/import.server.ts
+++ b/app/utils/import.server.ts
@@ -26,7 +26,12 @@ export function getUniqueValuesFromArrayOfObjects({
 
 /** Takes the CSV data from a `content` import and parses it into an object that we can then use to create the entries */
 export function extractCSVDataFromContentImport(data: string[][]) {
-  const keys = data[0] as string[];
+  /**
+   * The first row of the CSV contains the keys for the data
+   * We need to trim the keys to remove any whitespace and special characters and Non-printable characters as it already causes issues with in the past
+   * Non-printable character: The non-printable character you encountered at the beginning of the title property key ('\ufeff') is known as the Unicode BOM (Byte Order Mark).
+   */
+  const keys = data[0].map((key) => key.trim()); // Trim the keys
   const values = data.slice(1) as string[][];
   return values.map((entry) =>
     Object.fromEntries(


### PR DESCRIPTION
…non-printable charaters for csv columns

A user had an issue with importing. After investigating we found out there were 2 issues with importing:

1. If no `custodian` column exists for asset, it would fail as it would try to create `teamMembers` based on broken data
2. When creating the `data` array for creating assets from import, we didn't trim the key of each element and there were some Non-printable characters inside of it.