### PR TITLE
fix: import/export permission assertions now check organization owner.

### DIFF
--- a/app/modules/organization/service.server.ts
+++ b/app/modules/organization/service.server.ts
@@ -167,7 +167,13 @@ export const getUserOrganizations = async ({ userId }: { userId: string }) => {
     where: { userId },
     select: {
       organization: {
-        select: { id: true, type: true, name: true, imageId: true },
+        select: {
+          id: true,
+          type: true,
+          name: true,
+          imageId: true,
+          userId: true,
+        },
       },
     },
   });

--- a/app/routes/_layout+/assets._index.tsx
+++ b/app/routes/_layout+/assets._index.tsx
@@ -4,6 +4,9 @@ import type {
   Tag,
   Custody,
   Organization,
+  User,
+  Tier,
+  TierLimit,
 } from "@prisma/client";
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
@@ -75,6 +78,14 @@ export interface IndexResponse {
   };
 }
 
+type OrganizationWithOwnerTierLimit = Organization & {
+  owner: User & {
+    tier: Tier & {
+      tierLimit: TierLimit;
+    };
+  };
+};
+
 export async function loader({ request }: LoaderFunctionArgs) {
   const authSession = await requireAuthSession(request);
   const { organizationId } = await requireOrganisationId(authSession, request);
@@ -100,6 +111,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
               id: true,
               name: true,
               type: true,
+              owner: {
+                select: {
+                  tier: {
+                    include: { tierLimit: true },
+                  },
+                },
+              },
             },
           },
         },
@@ -109,10 +127,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const organizations = user?.userOrganizations.map(
     (userOrganization) => userOrganization.organization
-  ) as Organization[];
+  ) as OrganizationWithOwnerTierLimit[];
+
   const currentOrganization = organizations.find(
     (org) => org.id === organizationId
-  );
+  ) as OrganizationWithOwnerTierLimit;
+
+  /** For importing we need to check the tier of the org owner rather than currentUser */
+  const ownerTierLimit = currentOrganization?.owner?.tier?.tierLimit;
 
   const {
     search,
@@ -173,8 +195,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       next,
       prev,
       modelName,
-      canExportAssets: canExportAssets(user?.tier?.tierLimit),
-      canImportAssets: canImportAssets(user?.tier?.tierLimit),
+      canExportAssets: canExportAssets(ownerTierLimit),
+      canImportAssets: canImportAssets(ownerTierLimit),
       searchFieldLabel: "Search assets",
       searchFieldTooltip: {
         title: "Search your asset database",

--- a/app/routes/_layout+/assets.export.$fileName[.csv].tsx
+++ b/app/routes/_layout+/assets.export.$fileName[.csv].tsx
@@ -6,10 +6,12 @@ import { exportAssetsToCsv } from "~/utils/csv.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const authSession = await requireAuthSession(request);
-  const { organizationId } = await requireOrganisationId(authSession, request);
-  const { userId } = authSession;
+  const { organizationId, organizations } = await requireOrganisationId(
+    authSession,
+    request
+  );
 
-  await assertUserCanExportAssets({ userId });
+  await assertUserCanExportAssets({ organizationId, organizations });
 
   /** Join the rows with a new line */
   const csvString = await exportAssetsToCsv({ organizationId });

--- a/app/routes/_layout+/assets.import.tsx
+++ b/app/routes/_layout+/assets.import.tsx
@@ -27,7 +27,10 @@ import { extractCSVDataFromContentImport } from "~/utils/import.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const authSession = await requireAuthSession(request);
-  const { organizationId } = await requireOrganisationId(authSession, request);
+  const { organizationId, organizations } = await requireOrganisationId(
+    authSession,
+    request
+  );
   const { userId } = authSession;
 
   const error = {
@@ -38,7 +41,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   };
 
   try {
-    await assertUserCanImportAssets({ userId, organizationId });
+    await assertUserCanImportAssets({ organizationId, organizations });
     const intent = (await request.clone().formData()).get("intent") as
       | "backup"
       | "content";
@@ -81,9 +84,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const authSession = await requireAuthSession(request);
-  const { organizationId } = await requireOrganisationId(authSession, request);
-  const { userId } = authSession;
-  await assertUserCanImportAssets({ userId, organizationId });
+  const { organizationId, organizations } = await requireOrganisationId(
+    authSession,
+    request
+  );
+  await assertUserCanImportAssets({ organizationId, organizations });
 
   return json({
     header: {

--- a/app/routes/api+/admin.export-org-assets.$organizationId.$fileName[.csv].tsx
+++ b/app/routes/api+/admin.export-org-assets.$organizationId.$fileName[.csv].tsx
@@ -1,5 +1,6 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { requireAuthSession } from "~/modules/auth";
+import { requireOrganisationId } from "~/modules/organization/context.server";
 import { assertUserCanExportAssets } from "~/modules/tier";
 import { getRequiredParam } from "~/utils";
 import { exportAssetsToCsv } from "~/utils/csv.server";
@@ -9,9 +10,9 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const authSession = await requireAuthSession(request);
   await requireAdmin(request);
   const organizationId = getRequiredParam(params, "organizationId");
-  const { userId } = authSession;
+  const { organizations } = await requireOrganisationId(authSession, request);
 
-  await assertUserCanExportAssets({ userId });
+  await assertUserCanExportAssets({ organizationId, organizations });
 
   /** Join the rows with a new line */
   const csvString = await exportAssetsToCsv({ organizationId });

--- a/app/utils/subscription.ts
+++ b/app/utils/subscription.ts
@@ -11,6 +11,10 @@ export const canExportAssets = (
   return tierLimit?.canExportAssets;
 };
 
+/** Important:
+ * For this to work properly it needs to receive the tierLimit of the organization owner not the current user
+ * This is because the owner is the one that has the premium package attached to their account
+ */
 export const canImportAssets = (
   tierLimit: { canImportAssets: boolean } | null | undefined
 ) => {


### PR DESCRIPTION
fix: import/export permission assertions now check organization owner's `tierLimits` rather than current user. This allows all members admins of the org to do it