### PR TITLE
improvement: moved export button

### DIFF
--- a/app/components/assets/export-button.tsx
+++ b/app/components/assets/export-button.tsx
@@ -12,11 +12,13 @@ export const ExportButton = ({
     <ControlledActionButton
       canUseFeature={canExportAssets}
       buttonContent={{
-        title: "Export",
+        title: "Download CSV",
         message: "Exporting is not available on the free tier of shelf.",
       }}
       buttonProps={{
-        to: `export/assets-${new Date().toISOString().slice(0, 10)}.csv`,
+        to: `/assets/export/assets-${new Date()
+          .toISOString()
+          .slice(0, 10)}.csv`,
         variant: "secondary",
         role: "link",
         download: true,

--- a/app/components/shared/controlled-action-button.tsx
+++ b/app/components/shared/controlled-action-button.tsx
@@ -64,7 +64,7 @@ const HoverMessage = ({
     <HoverCard>
       <HoverCardTrigger
         className={tw(
-          "disabled inline-flex grow cursor-not-allowed items-center justify-center border-none p-0 text-left text-text-sm font-semibold text-primary-700 hover:text-primary-800",
+          "disabled inline-flex cursor-not-allowed items-center justify-center border-none p-0 text-left text-text-sm font-semibold text-primary-700 hover:text-primary-800",
           buttonProps?.width === "full" ? "w-full" : ""
         )}
       >

--- a/app/routes/_layout+/_layout.tsx
+++ b/app/routes/_layout+/_layout.tsx
@@ -128,7 +128,7 @@ export default function App() {
               {workspaceSwitching ? (
                 <div className="flex size-full flex-col items-center justify-center text-center">
                   <Spinner />
-                  <p className="mt-2">Switching workspaces...</p>
+                  <p className="mt-2">Activating workspace...</p>
                 </div>
               ) : (
                 <Outlet />

--- a/app/routes/_layout+/assets._index.tsx
+++ b/app/routes/_layout+/assets._index.tsx
@@ -12,7 +12,6 @@ import { useAtom, useAtomValue } from "jotai";
 import { redirect } from "react-router";
 import { AssetImage } from "~/components/assets/asset-image";
 import { AssetStatusBadge } from "~/components/assets/asset-status-badge";
-import { ExportButton } from "~/components/assets/export-button";
 import { ImportButton } from "~/components/assets/import-button";
 import { ChevronRight } from "~/components/icons";
 import Header from "~/components/layout/header";
@@ -46,7 +45,7 @@ import { ShelfStackError } from "~/utils/error";
 import { isPersonalOrg } from "~/utils/organization";
 import { PermissionAction, PermissionEntity } from "~/utils/permissions";
 import { requirePermision } from "~/utils/roles.server";
-import { canExportAssets, canImportAssets } from "~/utils/subscription";
+import { canImportAssets } from "~/utils/subscription";
 
 export interface IndexResponse {
   /** Page number. Starts at 1 */
@@ -97,6 +96,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   const { userId } = authSession;
 
+  // @TODO we shouldnt have to do this. We can combine it with the requirePermission
   const user = await db.user.findUnique({
     where: {
       id: userId,
@@ -202,7 +202,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
       next,
       prev,
       modelName,
-      canExportAssets: canExportAssets(tierLimit),
       canImportAssets: canImportAssets(tierLimit),
       searchFieldLabel: "Search assets",
       searchFieldTooltip: {
@@ -230,7 +229,7 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => [
 
 export default function AssetIndexPage() {
   const navigate = useNavigate();
-  const { canExportAssets, canImportAssets } = useLoaderData<typeof loader>();
+  const { canImportAssets } = useLoaderData<typeof loader>();
   const selectedCategories = useAtomValue(selectedCategoriesAtom);
   const [, clearCategoryFilters] = useAtom(clearCategoryFiltersAtom);
 
@@ -252,7 +251,6 @@ export default function AssetIndexPage() {
       <Header>
         {!isSelfService ? (
           <>
-            <ExportButton canExportAssets={canExportAssets} />
             <ImportButton canImportAssets={canImportAssets} />
             <Button
               to="new"

--- a/app/routes/_layout+/assets.export.$fileName[.csv].tsx
+++ b/app/routes/_layout+/assets.export.$fileName[.csv].tsx
@@ -10,7 +10,6 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     PermissionEntity.asset,
     PermissionAction.export
   );
-
   await assertUserCanExportAssets({ organizationId, organizations });
 
   /** Join the rows with a new line */

--- a/app/routes/_layout+/settings.general.tsx
+++ b/app/routes/_layout+/settings.general.tsx
@@ -339,7 +339,7 @@ export default function GeneralPage() {
       </Form>
 
       <div className=" mb-6">
-        <h4 className="text-text-lg font-semibold">Export</h4>
+        <h4 className="text-text-lg font-semibold">Asset backup</h4>
         <p className=" text-sm text-gray-600">
           Download a backup of your assets. If you want to restore a backup,
           please get in touch with support.
@@ -347,10 +347,8 @@ export default function GeneralPage() {
         <p className=" font-italic mb-2 text-sm text-gray-600">
           IMPORTANT NOTE: QR codes will not be included in the export. Due to
           the nature of how Shelf's QR codes work, they currently cannot be
-          exported with assets because they have unique ids. This means that
-          importing will cause a desctuctive action, deleting all existing qr
-          codes. Currently, importing a backup will just create a new QR code
-          for each asset.
+          exported with assets because they have unique ids. <br />
+          Importing a backup will just create a new QR code for each asset.
         </p>
         <ExportButton canExportAssets={canExportAssets} />
       </div>

--- a/app/utils/subscription.ts
+++ b/app/utils/subscription.ts
@@ -9,7 +9,7 @@ export const canExportAssets = (
   /** If the premium features are not enabled, just return true */
   if (!premiumIsEnabled()) return true;
   if (tierLimit?.canExportAssets === null) return false;
-  return tierLimit?.canExportAssets;
+  return tierLimit?.canExportAssets || false;
 };
 
 /** Important:


### PR DESCRIPTION
More clear UX about what it does. The button should not be called Export and should not be to the Import one as that creates confusion.
This button actually creates a backup of all the assets.