### PR TITLE
improvement: webhook automation for free trial

### DIFF
--- a/app/components/subscription/current-plan-details.tsx
+++ b/app/components/subscription/current-plan-details.tsx
@@ -1,5 +1,6 @@
-import { useLoaderData } from "@remix-run/react";
+import { Link, useLoaderData } from "@remix-run/react";
 import type { loader } from "~/routes/_layout+/settings.subscription";
+import { Button } from "../shared";
 
 export const CurrentPlanDetails = () => {
   const { activeProduct, expiration, subscription, isTrialSubscription } =
@@ -31,8 +32,15 @@ export const CurrentPlanDetails = () => {
             ) : (
               <>
                 {" "}
-                Your free trial expires on <b>{expiration.date}</b> at{" "}
-                <b>{expiration.time}</b>
+                Your{" "}
+                <Button
+                  to="https://www.shelf.nu/knowledge-base/free-trial"
+                  target="_blank"
+                  variant="link"
+                >
+                  free trial
+                </Button>{" "}
+                expires on <b>{expiration.date}</b> at <b>{expiration.time}</b>
               </>
             )}
           </p>

--- a/app/components/subscription/current-plan-details.tsx
+++ b/app/components/subscription/current-plan-details.tsx
@@ -2,17 +2,17 @@ import { useLoaderData } from "@remix-run/react";
 import type { loader } from "~/routes/_layout+/settings.subscription";
 
 export const CurrentPlanDetails = () => {
-  const { activeProduct, expiration, activeSubscription } =
+  const { activeProduct, expiration, subscription, isTrialSubscription } =
     useLoaderData<typeof loader>();
 
   return (
     <div>
       <p>
-        You’re currently using the <b>{activeProduct?.name}</b> version of
-        Shelf.
+        You’re currently using the <b>{activeProduct?.name}</b> version of Shelf{" "}
+        {isTrialSubscription ? " on a free trial" : ""}.
       </p>
       <div>
-        {activeSubscription?.canceled_at ? (
+        {subscription?.canceled_at ? (
           <>
             <p>
               Your plan has been canceled and will be active until{" "}
@@ -22,8 +22,19 @@ export const CurrentPlanDetails = () => {
           </>
         ) : (
           <p>
-            Your subscription renews on <b>{expiration.date}</b> at{" "}
-            <b>{expiration.time}</b>
+            {!isTrialSubscription ? (
+              <>
+                {" "}
+                Your subscription renews on <b>{expiration.date}</b> at{" "}
+                <b>{expiration.time}</b>
+              </>
+            ) : (
+              <>
+                {" "}
+                Your free trial expires on <b>{expiration.date}</b> at{" "}
+                <b>{expiration.time}</b>
+              </>
+            )}
           </p>
         )}
       </div>

--- a/app/components/subscription/price-cta.tsx
+++ b/app/components/subscription/price-cta.tsx
@@ -5,17 +5,17 @@ import { Button } from "../shared";
 
 export const PriceCta = ({
   price,
-  activeSubscription,
+  subscription,
 }: {
   price: Price;
-  activeSubscription: Object | null;
+  subscription: Object | null;
 }) => {
   if (price.id === "free") return null;
 
-  if (activeSubscription) {
+  if (subscription) {
     return (
       <CustomerPortalForm
-        buttonText={activeSubscription ? "Manage subscription" : undefined}
+        buttonText={subscription ? "Manage subscription" : undefined}
       />
     );
   }

--- a/app/components/subscription/prices.tsx
+++ b/app/components/subscription/prices.tsx
@@ -59,8 +59,8 @@ export const Price = ({
   price: Price;
   previousPlanName?: string;
 }) => {
-  const { activeSubscription } = useLoaderData<typeof loader>();
-  const activePlan = activeSubscription?.items.data[0]?.plan;
+  const { subscription, isTrialSubscription } = useLoaderData<typeof loader>();
+  const activePlan = subscription?.items.data[0]?.plan;
   const isFreePlan = price.id != "free";
   const features = price.product.metadata.features?.split(",") || [];
 
@@ -71,8 +71,7 @@ export const Price = ({
       <div
         className={tw(
           "mb-8 rounded-2xl border p-8",
-          activePlan?.id === price.id ||
-            (!activeSubscription && price.id === "free")
+          activePlan?.id === price.id || (!subscription && price.id === "free")
             ? "border-primary-500 bg-primary-50"
             : "bg-white"
         )}
@@ -91,9 +90,9 @@ export const Price = ({
               {price.product.name}
             </h2>
             {activePlan?.id === price.id ||
-            (!activeSubscription && price.id === "free") ? (
+            (!subscription && price.id === "free") ? (
               <div className="rounded-2xl bg-primary-50 px-2 py-0.5 text-[12px] font-medium text-primary-700 mix-blend-multiply">
-                Current
+                Current {isTrialSubscription ? "(Free Trial)" : ""}
               </div>
             ) : null}
           </div>
@@ -115,7 +114,7 @@ export const Price = ({
         </div>
       </div>
       <div className="mb-8">
-        <PriceCta price={price} activeSubscription={activeSubscription} />
+        <PriceCta price={price} subscription={subscription} />
       </div>
       {features ? (
         <>

--- a/app/emails/stripe/trial-ends-soon.tsx
+++ b/app/emails/stripe/trial-ends-soon.tsx
@@ -1,0 +1,23 @@
+import type Stripe from "stripe";
+import { SERVER_URL } from "~/utils";
+interface Props {
+  user: { firstName?: string | null; lastName?: string | null; email: string };
+  subscription: Stripe.Subscription;
+}
+
+export const trialEndsSoonText = ({ user, subscription }: Props) => `Howdy ${
+  user.firstName ? user.firstName : ""
+} ${user.lastName ? user.lastName : ""},
+
+Your trial is ending on ${new Date(
+  (subscription.trial_end as number) * 1000 // We force this as we check it before even calling the send email function
+).toLocaleDateString()}. We hope you've enjoyed using Shelf so far. 
+If you want to continue using the premium features, please upgrade to a paid plan to continue using the service. ${SERVER_URL}/settings/subscription
+
+Once you’re done setting up your account, you'll be able to access the workspace and start exploring features like Asset Explorer, Location Tracking, Collaboration, Custom fields and more.
+
+If you have any questions or need assistance, please don't hesitate to contact our support at support@shelf.nu
+
+Thanks,
+The Shelf Team
+`;

--- a/app/emails/stripe/trial-ends-soon.tsx
+++ b/app/emails/stripe/trial-ends-soon.tsx
@@ -9,15 +9,14 @@ export const trialEndsSoonText = ({ user, subscription }: Props) => `Howdy ${
   user.firstName ? user.firstName : ""
 } ${user.lastName ? user.lastName : ""},
 
-Your trial is ending on ${new Date(
+You are reaching the end of your trial period with Shelf, which concludes on ${new Date(
   (subscription.trial_end as number) * 1000 // We force this as we check it before even calling the send email function
-).toLocaleDateString()}. We hope you've enjoyed using Shelf so far. 
-If you want to continue using the premium features, please upgrade to a paid plan to continue using the service. ${SERVER_URL}/settings/subscription
+).toLocaleDateString()}. It's been a pleasure having you explore what Shelf has to offer. To maintain uninterrupted access to our premium features, we invite you to transition to one of our paid plans. You can make this upgrade by visiting your subscription settings: ${SERVER_URL}/settings/subscription .
 
-Once you’re done setting up your account, you'll be able to access the workspace and start exploring features like Asset Explorer, Location Tracking, Collaboration, Custom fields and more.
+Should you have any inquiries or require further assistance, our support team is at your disposal. You can reach us via email at support@shelf.nu.
 
-If you have any questions or need assistance, please don't hesitate to contact our support at support@shelf.nu
+Thank you for considering Shelf for your needs. We look forward to continuing to support your journey.
 
-Thanks,
+Warm regards,
 The Shelf Team
 `;

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -25,8 +25,10 @@ schedulerService
   .init()
   .then(() => {
     registerBookingWorkers();
+  })
+  .finally(() => {
     // eslint-disable-next-line no-console
-    console.log("Scheduler and workers registered");
+    console.log("Scheduler and workers registration completed");
   })
   // eslint-disable-next-line no-console
   .catch((e) => console.error(e));

--- a/app/modules/booking/worker.server.ts
+++ b/app/modules/booking/worker.server.ts
@@ -19,10 +19,7 @@ import type { SchedulerData } from "./types";
 
 /** ===== start: listens and creates chain of jobs for a given booking ===== */
 
-let counter = 0;
 export const registerBookingWorkers = () => {
-  console.log(`called registerBookingWorkers ${++counter} `);
-
   /** Check-out reminder */
   scheduler.work<SchedulerData>(
     schedulerKeys.checkoutReminder,

--- a/app/routes/_auth+/join.tsx
+++ b/app/routes/_auth+/join.tsx
@@ -91,7 +91,7 @@ export async function action({ request }: ActionFunctionArgs) {
   // Handle the results of the sign up
   if (signUpResult.status === "error") {
     return json(
-      { errors: { email: "unable-to-create-account", password: null } },
+      { errors: { email: signUpResult.error, password: null } },
       { status: 500 }
     );
   } else if (

--- a/app/routes/_layout+/settings.subscription.tsx
+++ b/app/routes/_layout+/settings.subscription.tsx
@@ -33,6 +33,7 @@ import {
   getStripeCustomer,
   getActiveProduct,
   getCustomerActiveSubscription,
+  getCustomerTrialSubscription,
 } from "~/utils/stripe.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
@@ -52,19 +53,23 @@ export async function loader({ request }: LoaderFunctionArgs) {
     ? ((await getStripeCustomer(user.customerId)) as CustomerWithSubscriptions)
     : null;
 
+  let subscription = getCustomerActiveSubscription({ customer });
   /** Check if the customer has an active subscription */
-  const activeSubscription = getCustomerActiveSubscription({ customer });
+
+  if (!subscription) {
+    subscription = getCustomerTrialSubscription({ customer });
+  }
 
   /* Get the prices and products from Stripe */
   const prices = await getStripePricesAndProducts();
 
   let activeProduct = null;
-  if (customer && activeSubscription) {
+  if (customer && subscription) {
     /** Get the active subscription ID */
 
     activeProduct = getActiveProduct({
       prices,
-      priceId: activeSubscription?.items.data[0].plan.id,
+      priceId: subscription?.items.data[0].plan.id || null,
     });
   }
 
@@ -73,16 +78,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
     subTitle: "Pick an account plan that fits your workflow.",
     prices,
     customer,
-    activeSubscription,
+    subscription,
     activeProduct,
     expiration: {
       date: new Date(
-        (activeSubscription?.current_period_end as number) * 1000
+        (subscription?.current_period_end as number) * 1000
       ).toLocaleDateString(),
       time: new Date(
-        (activeSubscription?.current_period_end as number) * 1000
+        (subscription?.current_period_end as number) * 1000
       ).toLocaleTimeString(),
     },
+    isTrialSubscription: !!subscription?.trial_end,
   });
 }
 
@@ -130,7 +136,7 @@ export const handle = {
 };
 
 export default function UserPage() {
-  const { title, subTitle, prices, activeSubscription } =
+  const { title, subTitle, prices, subscription } =
     useLoaderData<typeof loader>();
 
   return (
@@ -140,7 +146,7 @@ export default function UserPage() {
           <div className="inline-flex items-center justify-center rounded-full border-[5px] border-solid border-primary-50 bg-primary-100 p-1.5 text-primary">
             <InfoIcon />
           </div>
-          {!activeSubscription ? (
+          {!subscription ? (
             <p className="text-[14px] font-medium text-gray-700">
               You’re currently using the{" "}
               <span className="font-semibold">FREE</span> version of Shelf
@@ -155,13 +161,11 @@ export default function UserPage() {
             <h3 className="text-text-lg font-semibold">{title}</h3>
             <p className="text-sm text-gray-600">{subTitle}</p>
           </div>
-          {activeSubscription && <CustomerPortalForm />}
+          {subscription && <CustomerPortalForm />}
         </div>
 
         <Tabs
-          defaultValue={
-            activeSubscription?.items.data[0]?.plan.interval || "month"
-          }
+          defaultValue={subscription?.items.data[0]?.plan.interval || "month"}
           className="flex w-full flex-col"
         >
           <TabsList className="center mx-auto mb-8">

--- a/app/routes/api+/stripe-webhook.ts
+++ b/app/routes/api+/stripe-webhook.ts
@@ -78,6 +78,28 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         return new Response(null, { status: 200 });
       }
 
+      case "customer.subscription.paused": {
+        /** THis typpically handles expiring of subsciption */
+        const { subscription, customerId, tierId } =
+          await getDataFromStripeEvent(event);
+
+        if (!tierId) throw new Error("No tier ID found");
+
+        /** When its a trial subscription, update the tier of the user
+         * In that case we just set it back to free
+         */
+        if (subscription.status === "paused") {
+          await db.user.update({
+            where: { customerId },
+            data: {
+              tierId: "free",
+            },
+          });
+        }
+
+        return new Response(null, { status: 200 });
+      }
+
       case "customer.subscription.updated": {
         const { customerId, tierId } = await getDataFromStripeEvent(event);
 

--- a/app/routes/api+/stripe-webhook.ts
+++ b/app/routes/api+/stripe-webhook.ts
@@ -23,6 +23,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       process.env.STRIPE_WEBHOOK_ENDPOINT_SECRET
     );
     // Handle the event
+    // Don't forget to enable the events in the Stripe dashboard
     switch (event.type) {
       case "checkout.session.completed": {
         // Here we need to update the user's tier in the database based on the subscription they created

--- a/app/utils/stripe.server.ts
+++ b/app/utils/stripe.server.ts
@@ -208,3 +208,20 @@ export async function fetchStripeSubscription(id: string) {
     expand: ["items.data.plan.product"],
   });
 }
+
+export async function getDataFromStripeEvent(event: Stripe.Event) {
+  // Here we need to update the user's tier in the database based on the subscription they created
+  const subscription = event.data.object as Stripe.Subscription;
+
+  /** Get the product */
+  const productId = subscription.items.data[0].plan.product as string;
+  const product = await stripe.products.retrieve(productId);
+  const customerId = subscription.customer as string;
+  const tierId = product?.metadata?.shelf_tier;
+
+  return {
+    subscription,
+    customerId,
+    tierId,
+  };
+}

--- a/app/utils/stripe.server.ts
+++ b/app/utils/stripe.server.ts
@@ -128,20 +128,22 @@ export const createStripeCustomer = async ({
   email: User["email"];
   userId: User["id"];
 }) => {
-  const { id: customerId } = await stripe.customers.create({
-    email,
-    name,
-    metadata: {
-      userId,
-    },
-  });
+  if (ENABLE_PREMIUM_FEATURES && stripe) {
+    const { id: customerId } = await stripe.customers.create({
+      email,
+      name,
+      metadata: {
+        userId,
+      },
+    });
 
-  await db.user.update({
-    where: { id: userId },
-    data: { customerId },
-  });
+    await db.user.update({
+      where: { id: userId },
+      data: { customerId },
+    });
 
-  return customerId;
+    return customerId;
+  }
 };
 
 /** Fetches customer based on ID */

--- a/app/utils/stripe.server.ts
+++ b/app/utils/stripe.server.ts
@@ -202,6 +202,16 @@ export function getCustomerActiveSubscription({
     customer?.subscriptions?.data.find((sub) => sub.status === "active") || null
   );
 }
+export function getCustomerTrialSubscription({
+  customer,
+}: {
+  customer: CustomerWithSubscriptions | null;
+}) {
+  return (
+    customer?.subscriptions?.data.find((sub) => sub.status === "trialing") ||
+    null
+  );
+}
 
 export async function fetchStripeSubscription(id: string) {
   return await stripe.subscriptions.retrieve(id, {


### PR DESCRIPTION
Currently when a user wants free trial, we just give it via the stripe dashboard. 
However because we don't have hooks to manage free trials, we don't automatically update the DB, which can be a mess as it has to be managed manually now.
The goal of this PR is to automate this, so the sales team can give free subscriptions easily and not worry about cancelling them.

To do:
- [x] Handle a trial subscription being added to a user
- [x] Send email when trial subscription is about to expire
- [x] Handle trial subscription expiring - de-activating it in our db
- [x] Display free trial information on dashboard