### PR TITLE
Save button & UI improvements

### DIFF
--- a/app/components/assets/custom-fields-inputs.tsx
+++ b/app/components/assets/custom-fields-inputs.tsx
@@ -151,8 +151,8 @@ export default function AssetCustomFields({
               align="start"
             >
               <div className=" max-h-[320px] overflow-auto">
-                {field.options.map((value) => (
-                  <SelectItem value={value} key={value}>
+                {field.options.map((value, index) => (
+                  <SelectItem value={value} key={value + index}>
                     <span className="mr-4 text-[14px] text-gray-700">
                       {value.toLowerCase()}
                     </span>
@@ -178,14 +178,14 @@ export default function AssetCustomFields({
         </Link>
       </div>
       {customFields.length > 0 ? (
-        customFields.map((field) => {
+        customFields.map((field, index) => {
           const value = customFieldsValues?.find(
             (cfv) => cfv.customFieldId === field.id
           )?.value;
           const displayVal = value ? getCustomFieldDisplayValue(value) : "";
           return (
             <FormRow
-              key={field.id}
+              key={field.id + index}
               rowLabel={field.name}
               subHeading={field.helpText ? <p>{field.helpText}</p> : undefined}
               className="border-b-0"

--- a/app/components/assets/form.tsx
+++ b/app/components/assets/form.tsx
@@ -22,10 +22,18 @@ import AssetCustomFields from "./custom-fields-inputs";
 import DynamicSelect from "../dynamic-select/dynamic-select";
 import FormRow from "../forms/form-row";
 import Input from "../forms/input";
+import { AbsolutePositionedHeaderActions } from "../layout/header/absolute-positioned-header-actions";
 import { Button } from "../shared";
+import { ButtonGroup } from "../shared/button-group";
 import { Card } from "../shared/card";
 import { Image } from "../shared/image";
-import { Spinner } from "../shared/spinner";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../shared/tooltip";
 import { TagsAutocomplete } from "../tag/tags-autocomplete";
 
 export const NewAssetFormSchema = z.object({
@@ -47,6 +55,10 @@ export const NewAssetFormSchema = z.object({
     .string()
     .optional()
     .transform((val) => (val ? +val : null)),
+  addAnother: z
+    .string()
+    .optional()
+    .transform((val) => val === "true"),
 });
 
 /** Pass props of the values to be used as default for the form fields */
@@ -113,12 +125,21 @@ export const AssetForm = ({
         className="flex w-full flex-col gap-2"
         encType="multipart/form-data"
       >
+        <AbsolutePositionedHeaderActions className="hidden md:flex">
+          <Actions disabled={disabled} />
+        </AbsolutePositionedHeaderActions>
         {qrId ? (
           <input type="hidden" name={zo.fields.qrId()} value={qrId} />
         ) : null}
-        <div className=" border-b pb-5">
-          <h2 className="mb-1 text-[18px] font-semibold">Basic fields</h2>
-          <p>Basic information about your asset.</p>
+
+        <div className="flex items-start justify-between border-b pb-5">
+          <div className=" ">
+            <h2 className="mb-1 text-[18px] font-semibold">Basic fields</h2>
+            <p>Basic information about your asset.</p>
+          </div>
+          <div className="hidden flex-1 justify-end gap-2 md:flex">
+            <Actions disabled={disabled} />
+          </div>
         </div>
 
         <FormRow
@@ -331,7 +352,7 @@ export const AssetForm = ({
         <FormRow className="border-y-0 pb-0 pt-5" rowLabel="">
           <div className="ml-auto">
             <Button type="submit" disabled={disabled}>
-              {disabled ? <Spinner /> : "Save"}
+              Save
             </Button>
           </div>
         </FormRow>
@@ -339,3 +360,39 @@ export const AssetForm = ({
     </Card>
   );
 };
+
+const Actions = ({ disabled }: { disabled: boolean }) => (
+  <>
+    <ButtonGroup>
+      <Button to=".." variant="secondary" disabled={disabled}>
+        Cancel
+      </Button>
+      <AddAnother disabled={disabled} />
+    </ButtonGroup>
+
+    <Button type="submit" disabled={disabled}>
+      Save
+    </Button>
+  </>
+);
+
+const AddAnother = ({ disabled }: { disabled: boolean }) => (
+  <TooltipProvider delayDuration={100}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="submit"
+          variant="secondary"
+          disabled={disabled}
+          name="addAnother"
+          value="true"
+        >
+          Add another
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <p className="text-sm">Save the asset and add a new one</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/app/components/booking/form.tsx
+++ b/app/components/booking/form.tsx
@@ -17,6 +17,7 @@ import { ActionsDropdown } from "./actions-dropdown";
 import CustodianUserSelect from "../custody/custodian-user-select";
 import FormRow from "../forms/form-row";
 import Input from "../forms/input";
+import { AbsolutePositionedHeaderActions } from "../layout/header/absolute-positioned-header-actions";
 import { Button } from "../shared";
 import { Card } from "../shared/card";
 import { ControlledActionButton } from "../shared/controlled-action-button";
@@ -112,92 +113,94 @@ export function BookingForm({
       <Form ref={zo.ref} method="post">
         {/* Render the actions on top only when the form is not in a modal */}
         {!isModal ? (
-          <div className=" -mx-4 flex w-screen items-center justify-between bg-white px-4 py-2 md:absolute md:right-4 md:top-3 md:m-0 md:w-fit md:justify-end md:border-0 md:bg-transparent md:p-0">
-            <div className=" flex flex-1 gap-2">
-              {/* We only render the actions when we are not on the .new route */}
-              {routeIsNewBooking || (isCompleted && isSelfService) ? null : ( // When the booking is Completed, there are no actions available for selfService so we don't render it
-                // @ts-ignore
-                <ActionsDropdown booking={booking} />
-              )}
+          <AbsolutePositionedHeaderActions>
+            {/* We only render the actions when we are not on the .new route */}
+            {routeIsNewBooking || (isCompleted && isSelfService) ? null : ( // When the booking is Completed, there are no actions available for selfService so we don't render it
+              // @ts-ignore
+              <ActionsDropdown booking={booking} />
+            )}
 
-              {isDraft ? (
-                <Button
-                  type="submit"
-                  disabled={disabled}
-                  variant="secondary"
-                  name="intent"
-                  value="save"
-                  className="grow"
-                >
-                  Save
-                </Button>
-              ) : null}
+            {isDraft ? (
+              <Button
+                type="submit"
+                disabled={disabled}
+                variant="secondary"
+                name="intent"
+                value="save"
+                className="grow"
+                size="sm"
+              >
+                Save
+              </Button>
+            ) : null}
 
-              {/* When booking is draft, we show the reserve button */}
-              {isDraft ? (
-                <ControlledActionButton
-                  canUseFeature={
-                    !disabled &&
-                    hasAssets &&
-                    !hasUnavailableAssets &&
-                    !hasAlreadyBookedAssets
-                  }
-                  buttonContent={{
-                    title: "Reserve",
-                    message: hasUnavailableAssets
-                      ? "You have some assets in your booking that are marked as unavailble. Either remove the assets from this booking or make them available again"
-                      : hasAlreadyBookedAssets
-                      ? "Your booking has assets that are already booked for the desired period. You need to resolve that before you can reserve"
-                      : "You need to add assets to your booking before you can reserve it",
-                  }}
-                  buttonProps={{
-                    type: "submit",
-                    role: "link",
-                    name: "intent",
-                    value: "reserve",
-                    className: "grow",
-                  }}
-                  skipCta={true}
-                />
-              ) : null}
+            {/* When booking is draft, we show the reserve button */}
+            {isDraft ? (
+              <ControlledActionButton
+                canUseFeature={
+                  !disabled &&
+                  hasAssets &&
+                  !hasUnavailableAssets &&
+                  !hasAlreadyBookedAssets
+                }
+                buttonContent={{
+                  title: "Reserve",
+                  message: hasUnavailableAssets
+                    ? "You have some assets in your booking that are marked as unavailble. Either remove the assets from this booking or make them available again"
+                    : hasAlreadyBookedAssets
+                    ? "Your booking has assets that are already booked for the desired period. You need to resolve that before you can reserve"
+                    : "You need to add assets to your booking before you can reserve it",
+                }}
+                buttonProps={{
+                  type: "submit",
+                  role: "link",
+                  name: "intent",
+                  value: "reserve",
+                  className: "grow",
+                  size: "sm",
+                }}
+                skipCta={true}
+              />
+            ) : null}
 
-              {/* When booking is reserved, we show the check-out button */}
-              {isReserved && !isSelfService ? (
-                <ControlledActionButton
-                  canUseFeature={
-                    !disabled &&
-                    !hasUnavailableAssets &&
-                    !hasCheckedOutAssets &&
-                    !hasAssetsInCustody
-                  }
-                  buttonContent={{
-                    title: "Check-out",
-                    message: hasAssetsInCustody
-                      ? "Some assets in this booking are currently in custody. You need to resolve that before you can check-out"
-                      : "Some assets in this booking are not Available because they’re part of an Ongoing or Overdue booking",
-                  }}
-                  buttonProps={{
-                    type: "submit",
-                    name: "intent",
-                    value: "checkOut",
-                    className: "grow",
-                  }}
-                  skipCta={true}
-                />
-              ) : null}
+            {/* When booking is reserved, we show the check-out button */}
+            {isReserved && !isSelfService ? (
+              <ControlledActionButton
+                canUseFeature={
+                  !disabled &&
+                  !hasUnavailableAssets &&
+                  !hasCheckedOutAssets &&
+                  !hasAssetsInCustody
+                }
+                buttonContent={{
+                  title: "Check-out",
+                  message: hasAssetsInCustody
+                    ? "Some assets in this booking are currently in custody. You need to resolve that before you can check-out"
+                    : "Some assets in this booking are not Available because they’re part of an Ongoing or Overdue booking",
+                }}
+                buttonProps={{
+                  type: "submit",
+                  name: "intent",
+                  value: "checkOut",
+                  className: "grow",
+                  size: "sm",
+                }}
+                skipCta={true}
+              />
+            ) : null}
 
-              {(isOngoing || isOverdue) && !isSelfService ? (
-                <Button
-                  type="submit"
-                  name="intent"
-                  value="checkIn"
-                  className="grow"
-                >
-                  Check-in
-                </Button>
-              ) : null}
-            </div>
-          </div>
+            {(isOngoing || isOverdue) && !isSelfService ? (
+              <Button
+                type="submit"
+                name="intent"
+                value="checkIn"
+                className="grow"
+                size="sm"
+              >
+                Check-in
+              </Button>
+            ) : null}
+          </AbsolutePositionedHeaderActions>
         ) : null}
 
         <div className="-mx-4 mb-4 md:mx-0">

--- a/app/components/layout/header/absolute-positioned-header-actions.tsx
+++ b/app/components/layout/header/absolute-positioned-header-actions.tsx
@@ -1,0 +1,19 @@
+import { tw } from "~/utils";
+
+/** Use this component within a module show view to place buttons in the header visually outside the form */
+export const AbsolutePositionedHeaderActions = ({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <div
+    className={tw(
+      " -mx-4 flex w-screen items-center justify-between bg-white px-4 py-2 md:absolute md:right-4 md:top-3 md:m-0 md:w-fit md:justify-end md:border-0 md:bg-transparent md:p-0",
+      className
+    )}
+  >
+    <div className=" flex flex-1 gap-2">{children}</div>
+  </div>
+);

--- a/app/components/list/pagination/per-page-items-select.tsx
+++ b/app/components/list/pagination/per-page-items-select.tsx
@@ -33,7 +33,7 @@ export default function PerPageItemsSelect() {
           ) : null
         )}
         <Select name="per_page" defaultValue={perPage.toString()}>
-          <SelectTrigger className="px-3.5 py-3">
+          <SelectTrigger className="px-3 py-[8.5px]">
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="w-[250px]" position="popper" align="start">

--- a/app/components/location/form.tsx
+++ b/app/components/location/form.tsx
@@ -9,14 +9,26 @@ import { isFormProcessing } from "~/utils";
 import { zodFieldIsRequired } from "~/utils/zod";
 import FormRow from "../forms/form-row";
 import Input from "../forms/input";
+import { AbsolutePositionedHeaderActions } from "../layout/header/absolute-positioned-header-actions";
 import { Button } from "../shared";
+import { ButtonGroup } from "../shared/button-group";
 import { Card } from "../shared/card";
 import { Spinner } from "../shared/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../shared/tooltip";
 
 export const NewLocationFormSchema = z.object({
   name: z.string().min(2, "Name is required"),
   description: z.string(),
   address: z.string(),
+  addAnother: z
+    .string()
+    .optional()
+    .transform((val) => val === "true"),
 });
 
 /** Pass props of the values to be used as default for the form fields */
@@ -50,6 +62,9 @@ export const LocationForm = ({ name, address, description }: Props) => {
         className="flex w-full flex-col gap-2"
         encType="multipart/form-data"
       >
+        <AbsolutePositionedHeaderActions className="hidden md:flex">
+          <Actions disabled={disabled} />
+        </AbsolutePositionedHeaderActions>
         <FormRow
           rowLabel={"Name"}
           className="border-b-0 pb-[10px] pt-0"
@@ -159,3 +174,39 @@ export const LocationForm = ({ name, address, description }: Props) => {
     </Card>
   );
 };
+
+const Actions = ({ disabled }: { disabled: boolean }) => (
+  <>
+    <ButtonGroup>
+      <Button to=".." variant="secondary" disabled={disabled}>
+        Cancel
+      </Button>
+      <AddAnother disabled={disabled} />
+    </ButtonGroup>
+
+    <Button type="submit" disabled={disabled}>
+      Save
+    </Button>
+  </>
+);
+
+const AddAnother = ({ disabled }: { disabled: boolean }) => (
+  <TooltipProvider delayDuration={100}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="submit"
+          variant="secondary"
+          disabled={disabled}
+          name="addAnother"
+          value="true"
+        >
+          Add another
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        <p className="text-sm">Save the location and add a new one</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/app/components/shared/button-group.tsx
+++ b/app/components/shared/button-group.tsx
@@ -1,0 +1,13 @@
+import { tw } from "~/utils";
+
+export const ButtonGroup = ({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) => (
+  <div className={tw("button-group", "inline-flex items-center", className)}>
+    {children}
+  </div>
+);

--- a/app/components/shared/button.tsx
+++ b/app/components/shared/button.tsx
@@ -28,7 +28,7 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
       className = "",
       variant = "primary",
       width = "auto",
-      size = "md",
+      size = "sm",
       attachToInput = false,
       icon,
       disabled = undefined,

--- a/app/routes/_layout+/assets.new.tsx
+++ b/app/routes/_layout+/assets.new.tsx
@@ -1,5 +1,5 @@
 import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
-import { json, redirect } from "@remix-run/node";
+import { json, redirect, redirectDocument } from "@remix-run/node";
 import { useSearchParams } from "@remix-run/react";
 import { useAtomValue } from "jotai";
 import { parseFormAny } from "react-zorm";
@@ -135,8 +135,15 @@ export async function action({ context, request }: LoaderFunctionArgs) {
     );
   }
 
-  const { title, description, category, qrId, newLocationId, valuation } =
-    result.data;
+  const {
+    title,
+    description,
+    category,
+    qrId,
+    newLocationId,
+    valuation,
+    addAnother,
+  } = result.data;
 
   const customFieldsValues = extractCustomFieldValuesFromResults({
     result,
@@ -198,6 +205,10 @@ export async function action({ context, request }: LoaderFunctionArgs) {
     });
   }
 
+  /** If the user used the add-another button, we reload the document to reset the form */
+  if (addAnother) {
+    return redirectDocument(`/assets/new?`);
+  }
   return redirect(`/assets`);
 }
 

--- a/app/routes/_layout+/locations.new.tsx
+++ b/app/routes/_layout+/locations.new.tsx
@@ -6,6 +6,7 @@ import type {
 import {
   json,
   redirect,
+  redirectDocument,
   unstable_createMemoryUploadHandler,
   unstable_parseMultipartFormData,
 } from "@remix-run/node";
@@ -84,7 +85,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
     );
   }
 
-  const { name, description, address } = result.data;
+  const { name, description, address, addAnother } = result.data;
   /** This checks if tags are passed and build the  */
 
   const formDataFile = await unstable_parseMultipartFormData(
@@ -126,6 +127,10 @@ export async function action({ context, request }: ActionFunctionArgs) {
     senderId: authSession.userId,
   });
 
+  /** If the user clicked add-another, reload the document to clear the form */
+  if (addAnother) {
+    return redirectDocument("/locations/new");
+  }
   return redirect(`/locations/${location.id}`);
 }
 

--- a/app/routes/_layout+/settings.team.tsx
+++ b/app/routes/_layout+/settings.team.tsx
@@ -298,7 +298,7 @@ export const action = async ({ context, request }: ActionFunctionArgs) => {
 };
 
 export const handle = {
-  breadcrumb: () => "single",
+  breadcrumb: () => "Team",
 };
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => [

--- a/app/styles/layout/button-group.css
+++ b/app/styles/layout/button-group.css
@@ -1,0 +1,11 @@
+.button-group > * {
+  @apply rounded-none border-l-0;
+}
+
+.button-group > *:first-child {
+  @apply rounded-l border-l;
+}
+
+.button-group > *:last-child {
+  @apply rounded-r hover:rounded-r;
+}

--- a/app/styles/layout/index.css
+++ b/app/styles/layout/index.css
@@ -1,3 +1,4 @@
 @import "breadcrumbs.css";
 @import "sidebar.css";
 @import "tags.css";
+@import "button-group.css";


### PR DESCRIPTION
- Added save button in header and card on creating new asset
- Added save button in header when creating a new location
- Changed global size of buttons to sm from md
- Added add-another and cancel actions for location and asset form
- Created generic component for placing action buttons in header
- Created button-group component
- fixed breadcrumb of settings/team
- Changed size of per-page-select to make it consistent with new button sizes