### PR TITLE
Fix organization bug on asset edit

### DIFF
--- a/app/modules/organization/service.server.ts
+++ b/app/modules/organization/service.server.ts
@@ -5,21 +5,10 @@ import { db } from "~/database";
 import { ShelfStackError } from "~/utils/error";
 import { defaultUserCategories } from "../category/default-categories";
 
-export const getOrganization = async ({
-  id,
-  userId,
-}: {
-  id: Organization["id"];
-  userId: User["id"];
-}) =>
+export const getOrganization = async ({ id }: { id: Organization["id"] }) =>
   db.organization.findUnique({
     where: {
       id,
-      owner: {
-        is: {
-          id: userId,
-        },
-      },
     },
   });
 

--- a/app/routes/_layout+/assets.$assetId_.edit.tsx
+++ b/app/routes/_layout+/assets.$assetId_.edit.tsx
@@ -22,7 +22,6 @@ import {
 } from "~/modules/asset";
 
 import { getActiveCustomFields } from "~/modules/custom-field";
-import { getOrganization } from "~/modules/organization";
 import { buildTagsSet } from "~/modules/tag";
 import { assertIsPost, getRequiredParam, slugify } from "~/utils";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
@@ -38,13 +37,12 @@ import { requirePermision } from "~/utils/roles.server";
 export async function loader({ context, request, params }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
-  const { organizationId } = await requirePermision({
+  const { organizationId, currentOrganization } = await requirePermision({
     userId,
     request,
     entity: PermissionEntity.asset,
     action: PermissionAction.update,
   });
-  const organization = await getOrganization({ id: organizationId, userId });
 
   const id = getRequiredParam(params, "assetId");
 
@@ -83,7 +81,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     totalTags: tags.length,
     locations,
     totalLocations,
-    currency: organization?.currency,
+    currency: currentOrganization?.currency,
     customFields,
   });
 }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,6 +5,7 @@ If you prefer using docker for running shelf locally or self hosting your live a
 ## Prerequisites
 
 If you want to run shelf via docker, there are still some prerequisites you need to meet. Because our docker setup doesn't currently support self-hosting supabase, you need to complete the following steps of the general setup:
+
 1. https://github.com/Shelf-nu/shelf.nu/blob/main/docs/get-started.md#development
 2. https://github.com/Shelf-nu/shelf.nu/blob/main/docs/get-started.md#authentication
 


### PR DESCRIPTION
- Made getOrganization only require id
- replaced the query for organization in ._edit to a inline query, scoped by the owner
- removed getOrganization on ._edit as we already have the current organization returned by requirePermission