### PR TITLE
Treat asset description text as pre-formatted

### DIFF
--- a/app/routes/_layout+/assets.$assetId.tsx
+++ b/app/routes/_layout+/assets.$assetId.tsx
@@ -298,7 +298,7 @@ export default function AssetDetailsPage() {
           />
           {asset.description ? (
             <Card className="mb-3 mt-0 rounded-t-none border-t-0">
-              <p className=" text-gray-600">{asset.description}</p>
+              <p className="whitespace-pre-wrap text-gray-600">{asset.description}</p>
             </Card>
           ) : null}
           {!isSelfService ? (


### PR DESCRIPTION
Display asset description text with `whitespace-pre-wrap` on asset page. This displays newlines in the asset description while still maintaining text wrapping.

Feel free to close if you have a reason why this shouldn't be the case though!

Old behavior:
![Screenshot_20240413_221546](https://github.com/Shelf-nu/shelf.nu/assets/9571936/d516727b-6b6f-4542-a825-325c591dfb26)

New behavior:
![Screenshot_20240413_221635](https://github.com/Shelf-nu/shelf.nu/assets/9571936/bd5595d5-5574-450f-a138-37d152e7229f)
