### PR TITLE
Fix: clicking outside controlled dropdown menu is not closing it

### DIFF
--- a/app/components/assets/actions-dropdown.tsx
+++ b/app/components/assets/actions-dropdown.tsx
@@ -10,6 +10,7 @@ import {
 } from "~/components/shared/dropdown";
 import type { loader } from "~/routes/_layout+/assets.$assetId";
 import { tw } from "~/utils/tw";
+import { useControlledDropdownMenu } from "~/utils/use-controlled-dropdown-menu";
 import { DeleteAsset } from "./delete-asset";
 import { UpdateGpsCoordinatesForm } from "./update-gps-coordinates-form";
 import Icon from "../icons/icon";
@@ -21,16 +22,17 @@ const ConditionalActionsDropdown = () => {
   let [searchParams] = useSearchParams();
   const refIsQrScan = searchParams.get("ref") === "qr";
   const defaultOpen = window.innerWidth <= 640 && refIsQrScan;
-  const [open, setOpen] = useState(defaultOpen);
   const [defaultApplied, setDefaultApplied] = useState(false);
   const assetIsCheckedOut = asset.status === "CHECKED_OUT";
+
+  const [dropdownRef, open, setOpen] = useControlledDropdownMenu(defaultOpen);
 
   useEffect(() => {
     if (defaultOpen && !defaultApplied) {
       setOpen(true);
       setDefaultApplied(true);
     }
-  }, [defaultOpen, defaultApplied]);
+  }, [defaultOpen, defaultApplied, setOpen]);
 
   return (
     <>
@@ -92,6 +94,7 @@ const ConditionalActionsDropdown = () => {
           asChild
           align="end"
           className="order actions-dropdown static w-screen rounded-b-none rounded-t-[4px] bg-white p-0 text-right md:static md:w-[230px] md:rounded-t-[4px]"
+          ref={dropdownRef}
         >
           <div className="order fixed bottom-0 left-0 w-screen rounded-b-none rounded-t-[4px] bg-white p-0 text-right md:static md:w-[180px] md:rounded-t-[4px]">
             <DropdownMenuItem

--- a/app/components/assets/update-gps-coordinates-form.tsx
+++ b/app/components/assets/update-gps-coordinates-form.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import type { SerializeFrom } from "@remix-run/node";
 import { useFetcher, useParams } from "@remix-run/react";
 import { useClientNotification } from "~/hooks/use-client-notification";
@@ -59,6 +58,8 @@ export const UpdateGpsCoordinatesForm = ({
   async function handleSubmit(
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) {
+    callback();
+
     e.preventDefault();
     try {
       const coords = await requestGeoCoordinates();
@@ -79,13 +80,6 @@ export const UpdateGpsCoordinatesForm = ({
       // We dont need to do anything here because we are already showing a notification when the location permissions are rejected
     }
   }
-
-  useEffect(() => {
-    // If the fetcher has data, call the callback to close the dropdown
-    if (fetcher?.data) {
-      callback();
-    }
-  }, [callback, fetcher.data]);
 
   return (
     <Button

--- a/app/components/workspace/nrm-actions-dropdown.tsx
+++ b/app/components/workspace/nrm-actions-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { Prisma } from "@prisma/client";
 import { useLoaderData } from "@remix-run/react";
 import { SendIcon, VerticalDotsIcon } from "~/components/icons/library";
@@ -11,6 +11,7 @@ import {
 
 import type { loader } from "~/routes/_layout+/settings.team";
 import { isPersonalOrg as checkIsPersonalOrg } from "~/utils/organization";
+import { useControlledDropdownMenu } from "~/utils/use-controlled-dropdown-menu";
 import { DeleteMember } from "./delete-member";
 import { ControlledActionButton } from "../shared/controlled-action-button";
 
@@ -28,7 +29,7 @@ export function TeamMembersActionsDropdown({
   }>;
 }) {
   const { organization } = useLoaderData<typeof loader>();
-  const [open, setOpen] = useState(false);
+  const [ref, open, setOpen] = useControlledDropdownMenu(false);
   const isPersonalOrg = useMemo(
     () => checkIsPersonalOrg(organization),
     [organization]
@@ -48,6 +49,7 @@ export function TeamMembersActionsDropdown({
       <DropdownMenuContent
         align="end"
         className="order w-[180px] rounded-md bg-white p-[6px] text-right "
+        ref={ref}
       >
         <DropdownMenuItem className="text-gray-700hover:text-gray-700 p-4 hover:bg-slate-100">
           <ControlledActionButton

--- a/app/components/workspace/users-actions-dropdown.tsx
+++ b/app/components/workspace/users-actions-dropdown.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import type { InviteStatuses, User } from "@prisma/client";
 import { useFetcher } from "@remix-run/react";
 import {
@@ -14,6 +13,7 @@ import {
 } from "~/components/shared/dropdown";
 
 import { isFormProcessing } from "~/utils/form";
+import { useControlledDropdownMenu } from "~/utils/use-controlled-dropdown-menu";
 import { Button } from "../shared/button";
 import { Spinner } from "../shared/spinner";
 
@@ -32,7 +32,7 @@ export function TeamUsersActionsDropdown({
 }) {
   const fetcher = useFetcher();
   const disabled = isFormProcessing(fetcher.state);
-  const [open, setOpen] = useState(false);
+  const [ref, open, setOpen] = useControlledDropdownMenu(false);
 
   return (
     <>
@@ -50,6 +50,7 @@ export function TeamUsersActionsDropdown({
           align="end"
           className="order w-[180px] rounded-md bg-white p-[6px] text-right"
           asChild
+          ref={ref}
         >
           <fetcher.Form
             method="post"

--- a/app/routes/_layout+/assets.$assetId.duplicate.tsx
+++ b/app/routes/_layout+/assets.$assetId.duplicate.tsx
@@ -164,7 +164,7 @@ export default function DuplicateAsset() {
         <Header hideBreadcrumbs classNames="[&>div]:border-b-0" />
 
         <div className="flex flex-col items-center gap-3 ">
-          <div className="flex items-center gap-3 rounded-md border p-4">
+          <div className="flex w-full items-center gap-3 rounded-md border p-4">
             <div className="flex size-12 shrink-0 items-center justify-center">
               <AssetImage
                 asset={{

--- a/app/utils/use-controlled-dropdown-menu.ts
+++ b/app/utils/use-controlled-dropdown-menu.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Hook to control the state of a dropdown menu.
+ * If the user clicks outside the dropdown, it will close.
+ * It is important to add the ref to the DropdownMenuContent component, otherwise it wont work
+ * @param initialState boolean
+ * @returns [React.RefObject<HTMLDivElement>, boolean, React.Dispatch<React.SetStateAction<boolean>>]
+ */
+export function useControlledDropdownMenu(
+  initialState: boolean
+): [
+  React.RefObject<HTMLDivElement>,
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>,
+] {
+  const [isOpen, setOpen] = useState(initialState);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return [ref, isOpen, setOpen];
+}


### PR DESCRIPTION
implemented a custom hook to be used when having DropdownMenu which is controlled. This was needed because of the controlled dropdown menu not auto closing when clicking outside of it