### PR TITLE
changed env variable used for pg-boss connecting to DB

### DIFF
--- a/app/utils/scheduler.server.ts
+++ b/app/utils/scheduler.server.ts
@@ -1,5 +1,5 @@
 import PgBoss from "pg-boss";
-import { DIRECT_URL, NODE_ENV } from "../utils/env";
+import { DATABASE_URL, NODE_ENV } from "../utils/env";
 
 let scheduler!: PgBoss;
 
@@ -10,12 +10,12 @@ declare global {
 export const init = async () => {
   if (!scheduler) {
     if (NODE_ENV === "production") {
-      scheduler = new PgBoss(DIRECT_URL);
+      scheduler = new PgBoss(DATABASE_URL);
     } else {
       if (!global.scheduler) {
         global.scheduler = new PgBoss({
           max: 5,
-          connectionString: DIRECT_URL,
+          connectionString: DATABASE_URL,
           newJobCheckIntervalSeconds: 60 * 5,
           noScheduling: true, //need to remove it, if we use cron schedulers in the future, but it comes with a cost of 2 additional polling every minute
         });


### PR DESCRIPTION
Currently its connecting via the DIRECT_URL but that should not be the case as this is only used for prisma. We need to use the DATABASE_URL as that connects to the supabase pooler.