### PR TITLE
Feature: 1068 Add a custom asset ID field

### DIFF
--- a/app/components/assets/form.tsx
+++ b/app/components/assets/form.tsx
@@ -56,6 +56,7 @@ export const NewAssetFormSchema = z.object({
     .string()
     .optional()
     .transform((val) => (val ? +val : null)),
+  propertyId: z.string().transform((val) => val.trim()),
   addAnother: z
     .string()
     .optional()
@@ -74,6 +75,7 @@ interface Props {
   valuation?: Asset["valuation"];
   qrId?: Qr["id"] | null;
   tags?: Tag[];
+  propertyId?: Asset["propertyId"];
 }
 
 export const AssetForm = ({
@@ -87,6 +89,7 @@ export const AssetForm = ({
   valuation,
   qrId,
   tags,
+  propertyId,
 }: Props) => {
   const navigation = useNavigation();
 
@@ -369,6 +372,28 @@ export const AssetForm = ({
               {currency}
             </span>
           </div>
+        </FormRow>
+
+        <FormRow
+          rowLabel={"Property ID"}
+          subHeading={
+            <p>
+              Specify the property ID of your asset.
+            </p>
+          }
+          className="border-b-0 pb-[10px]"
+          required={false}
+        >
+          <Input
+            label="Property ID"
+            hideLabel
+            name={zo.fields.propertyId()}
+            disabled={disabled}
+            error={zo.errors.propertyId()?.message}
+            className="w-full"
+            defaultValue={propertyId || ""}
+            required={zodFieldIsRequired(FormSchema.shape.propertyId)}
+          />
         </FormRow>
 
         <AssetCustomFields zo={zo} schema={FormSchema} />

--- a/app/database/migrations/20240617180719_add_property_id/migration.sql
+++ b/app/database/migrations/20240617180719_add_property_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[propertyId]` on the table `Asset` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Asset" ADD COLUMN     "propertyId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Asset_propertyId_key" ON "Asset"("propertyId");

--- a/app/database/migrations/20240617180917_update_search_params/migration.sql
+++ b/app/database/migrations/20240617180917_update_search_params/migration.sql
@@ -1,0 +1,30 @@
+-- Search assets by `propertyId`.
+
+CREATE OR REPLACE VIEW "AssetSearchView" AS
+SELECT
+    a.id,
+    a."createdAt",
+    a.id as "assetId",
+    COALESCE(a.title, '')
+    || ' ' || COALESCE(c.name, '')
+    || ' ' || COALESCE(a.description, '')
+    || ' ' || COALESCE(a."propertyId", '')
+    || ' ' || COALESCE(string_agg(tm.name, ' '), '')
+    || ' ' || COALESCE(string_agg(t.name, ' '), '')
+    || ' ' || COALESCE(l.name, '') as "searchVector"
+FROM
+    public."Asset" a
+LEFT JOIN
+    public."Category" c ON a."categoryId" = c.id
+LEFT JOIN
+    public."Location" l ON a."locationId" = l.id
+LEFT JOIN
+    public."_AssetToTag" atr ON a.id = atr."A"
+LEFT JOIN
+    public."Tag" t ON atr."B" = t.id
+LEFT JOIN
+    public."Custody" custd ON a.id = custd."assetId"
+LEFT JOIN
+    public."TeamMember" tm ON custd."teamMemberId" = tm.id
+GROUP BY
+    a.id, c.id, l.id;

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -79,6 +79,7 @@ model Asset {
   status              AssetStatus @default(AVAILABLE)
   valuation           Float?      @map("value") // Field to store the monetary value of an asset
   availableToBook     Boolean     @default(true)
+  propertyId          String?
 
   // Datetime
   createdAt DateTime @default(now())
@@ -105,6 +106,7 @@ model Asset {
   assetSearchView AssetSearchView?
   bookings        Booking[]
 
+  @@unique([propertyId])
   //@@unique([title, organizationId]) //prisma doesnt support case insensitive unique index yet
 }
 

--- a/app/modules/asset/types.ts
+++ b/app/modules/asset/types.ts
@@ -33,6 +33,7 @@ export interface UpdateAssetPayload {
   userId: User["id"];
   customFieldsValues?: ShelfAssetCustomFieldValueType[];
   valuation?: Asset["valuation"];
+  propertyId?: Asset["propertyId"];
 }
 
 export interface CreateAssetFromContentImportPayload

--- a/app/routes/_layout+/assets.$assetId.overview.tsx
+++ b/app/routes/_layout+/assets.$assetId.overview.tsx
@@ -268,6 +268,15 @@ export default function AssetOverview() {
                 </div>
               </li>
 
+              {asset?.propertyId ? (
+                <li className="flex w-full border-b-[1.1px] border-b-gray-100 p-4">
+                <span className="w-1/4 text-[14px] font-medium text-gray-900">
+                  Property ID
+                </span>
+                <div className="w-3/5 text-gray-600">{asset?.propertyId}</div>
+              </li>
+              ) : null}
+
               {asset?.category ? (
                 <li className="flex w-full border-b-[1.1px] border-b-gray-100 p-4">
                   <span className="w-1/4 text-[14px] font-medium text-gray-900">

--- a/app/routes/_layout+/assets.$assetId_.edit.tsx
+++ b/app/routes/_layout+/assets.$assetId_.edit.tsx
@@ -177,6 +177,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       newLocationId,
       currentLocationId,
       valuation,
+      propertyId,
       addAnother,
     } = payload;
 
@@ -194,6 +195,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       userId: authSession.userId,
       customFieldsValues,
       valuation,
+      propertyId,
     });
 
     sendNotification({
@@ -237,6 +239,7 @@ export default function AssetEditPage() {
           description={asset.description}
           valuation={asset.valuation}
           tags={tags}
+          propertyId={asset.propertyId}
         />
       </div>
     </>

--- a/app/routes/_layout+/assets._index.tsx
+++ b/app/routes/_layout+/assets._index.tsx
@@ -222,7 +222,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         searchFieldLabel: "Search assets",
         searchFieldTooltip: {
           title: "Search your asset database",
-          text: "Search assets based on asset name or description, category, tag, location, custodian name. Simply separate your keywords by a space: 'Laptop lenovo 2020'.",
+          text: "Search assets based on asset name, property ID or description, category, tag, location, custodian name. Simply separate your keywords by a space: 'Laptop lenovo 2020'.",
         },
         totalCategories,
         totalTags,
@@ -402,6 +402,7 @@ export default function AssetIndexPage() {
           headerChildren={
             <>
               <Th className="hidden md:table-cell">Category</Th>
+              <Th className="hidden md:table-cell">Property</Th>
               <Th className="hidden md:table-cell">Tags</Th>
               {!isSelfService ? (
                 <Th className="hidden md:table-cell">Custodian</Th>
@@ -438,7 +439,7 @@ const ListAssetContent = ({
     };
   };
 }) => {
-  const { category, tags, custody, location, kit } = item;
+  const { category, tags, custody, location, kit, propertyId } = item;
   const isSelfService = useUserIsSelfService();
   return (
     <>
@@ -503,6 +504,11 @@ const ListAssetContent = ({
             {"Uncategorized"}
           </Badge>
         )}
+      </Td>
+
+      {/* Property */}
+      <Td className="hidden md:table-cell">
+        {propertyId ? <GrayBadge>{propertyId}</GrayBadge> : null}
       </Td>
 
       {/* Tags */}

--- a/app/routes/_layout+/assets.new.tsx
+++ b/app/routes/_layout+/assets.new.tsx
@@ -159,6 +159,7 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       qrId,
       newLocationId,
       valuation,
+      propertyId,
       addAnother,
     } = payload;
 
@@ -175,6 +176,7 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       qrId,
       tags,
       valuation,
+      propertyId,
       customFieldsValues,
     });
 

--- a/app/routes/_layout+/property.$propertyId.tsx
+++ b/app/routes/_layout+/property.$propertyId.tsx
@@ -1,0 +1,44 @@
+import { LoaderFunctionArgs, json } from "@remix-run/node";
+import { Outlet, redirect } from "@remix-run/react";
+import { getAssetByPropertyId } from "~/modules/asset/service.server";
+import { z } from "zod";
+import { error, getParams } from "~/utils/http.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.validator.server";
+import { requirePermission } from "~/utils/roles.server";
+import { makeShelfError } from "~/utils/error";
+
+export async function loader({ context, request, params }: LoaderFunctionArgs) {
+  const authSession = context.getSession();
+  const { userId } = authSession;
+  const { propertyId } = getParams(params, z.object({ propertyId: z.string() }), {
+    additionalData: { userId },
+  });
+
+  try {
+    const { organizationId } = await requirePermission({
+      userId,
+      request,
+      entity: PermissionEntity.asset,
+      action: PermissionAction.read,
+    });
+
+    const asset = await getAssetByPropertyId({
+      propertyId,
+      organizationId,
+      include: {},
+    });
+
+    return redirect(`/assets/${asset.id}`);
+
+  } catch (cause) {
+    const reason = makeShelfError(cause);
+    throw json(error(reason));
+  }
+}
+
+export default function Property() {
+  return <Outlet />;
+}


### PR DESCRIPTION
Hi! This is my attempt at being useful.

First of all, thank you for this amazing software. The best UI among all existing inventory management systems.

__Full disclosure__: I am a backend dev and have little experience in frontend. This is the first time I'm touching Remix and React.

I do not expect this PR to be merged, this is only to show the general UX of the custom Asset ID feature.

This is a rough naive working PoC for #1068 that adds an optional and unique `propertyId` field to the `Asset` table.

This PR misses a lot of implementation details, types, and does not account for a lot of places where the code should be updated.

### Notes:

* I named the field `propertyId` to avoid confusion with Asset ID. It can be renamed to whatever fits best.
* The position of the asset text field also does not matter.
* If you duplicate an asset that has a Property ID, the duplicate will not have a Property ID set.
* If no property ID is set, the "Property ID" filed in the asset details will not be shown.
* Updated the `searchVector` to search by `propertyId`.
* Added a Property column to the `/assets` page. It's completely optional because it takes up a lot of space.
* I added a `/property/$propertyId` page that redirects to the corresponding asset page if it exists. Otherwise show an "Asset not found" page. The route name is also an example, can be whatever.
* This redirect feature is pretty important since we can make our own QR Code scanner that redirects to an asset page, using an existing ID from our asset stickers.

### Known Issues:

* Creating/editing/duplicating assets with a `propertyId` is handled. I have no idea what other processes are affected.
* The field is unique, and if you try creating an asset with a duplicate `propertyId` it will throw a hardcoded `maybeUniqueConstraintViolation` error that says "Asset __name__ is already taken".

![image](https://github.com/Shelf-nu/shelf.nu/assets/24798198/964259db-04d1-43c9-9520-1e561bfc8151)

### Screenshots of the feature:

On the list of assets:

![image](https://github.com/Shelf-nu/shelf.nu/assets/24798198/40453c53-7ca3-4e1a-a793-f58928e837ed)

Creating/editing an asset:

![image](https://github.com/Shelf-nu/shelf.nu/assets/24798198/c4cc6a7a-ed85-4da7-ab2d-8d32d8fd4368)

On the asset page:

![image](https://github.com/Shelf-nu/shelf.nu/assets/24798198/0fc8cf3c-421d-41d1-a4a1-615947c47042)

Overall, this does not look like a big feature to implement, I'm just unfamiliar with the codebase and the general flow.

Thanks!
