### PR TITLE
fix: dont allow to have kit with CHECKED_OUT status and no assets inside it

### DIFF
--- a/app/components/kits/remove-asset-from-kit.tsx
+++ b/app/components/kits/remove-asset-from-kit.tsx
@@ -2,6 +2,7 @@ import type { Asset } from "@prisma/client";
 import { Form } from "../custom-form";
 import Icon from "../icons/icon";
 import { Button } from "../shared/button";
+import { ControlledActionButton } from "../shared/controlled-action-button";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -17,14 +18,22 @@ export default function RemoveAssetFromKit({ asset }: { asset: Asset }) {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button
-          variant="link"
-          icon="trash"
-          className="justify-start rounded-sm px-2 py-1.5 text-sm font-medium text-gray-700 outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 hover:bg-slate-100 hover:text-gray-700"
-          width="full"
-        >
-          Remove
-        </Button>
+        <ControlledActionButton
+          canUseFeature={asset.status !== "CHECKED_OUT"}
+          buttonContent={{
+            title: "Remove",
+            message:
+              "You cannot remove this asset from the kit because it is currently checked out. Please check in the kit first, then try again",
+          }}
+          buttonProps={{
+            variant: "link",
+            icon: "trash",
+            className:
+              "justify-start rounded-sm px-2 py-1.5 text-sm font-medium text-gray-700 outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 hover:bg-slate-100 hover:text-gray-700",
+            width: "full",
+          }}
+          skipCta={true}
+        />
       </AlertDialogTrigger>
 
       <AlertDialogContent>

--- a/app/modules/kit/service.server.ts
+++ b/app/modules/kit/service.server.ts
@@ -584,6 +584,7 @@ export async function updateKitsWithBookingCustodians<T extends Kit>(
           },
         });
       } else {
+        resolvedKits.push(kit);
         /** This case should never happen because there must be a custodianUser or custodianTeamMember assigned to a booking */
         Logger.error(
           new ShelfError({


### PR DESCRIPTION
- made it not allowed to remove assets from kit, if they are checked out
- made it so even if that case happens again it should not break the kit index if the kit has 0 assets