### PR TITLE
refactor: adjust sizing of sidebar menu

### DIFF
--- a/app/components/dashboard/checklist.tsx
+++ b/app/components/dashboard/checklist.tsx
@@ -47,7 +47,9 @@ export default function OnboardingChecklist() {
             <div className="flex h-full items-start justify-between gap-1 rounded border p-4">
               <div className="flex items-start">
                 <div className="mr-3 inline-flex items-center justify-center rounded-full border-[5px] border-solid border-primary-50 bg-primary-100 p-1.5 text-primary">
-                  <AssetsIcon />
+                  <i className="size-5">
+                    <AssetsIcon />
+                  </i>
                 </div>
                 <div className="text-[14px]">
                   <div className="mb-3">
@@ -126,7 +128,9 @@ export default function OnboardingChecklist() {
             <div className="flex h-full items-start justify-between gap-1 rounded border p-4">
               <div className="flex items-start">
                 <div className="mr-3 inline-flex items-center justify-center rounded-full border-[5px] border-solid border-primary-50 bg-primary-100 p-1.5 text-primary">
-                  <TagsIcon />
+                  <i className="size-5">
+                    <TagsIcon />
+                  </i>
                 </div>
                 <div className="text-[14px]">
                   <div className="mb-3">

--- a/app/components/icons/library.tsx
+++ b/app/components/icons/library.tsx
@@ -420,8 +420,9 @@ export function XIcon(props: SVGProps<SVGSVGElement>) {
 
 export const AssetsIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
-    width={20}
-    height={22}
+    width="100%"
+    height="100%"
+    viewBox="0 0 20 22"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
@@ -837,8 +838,11 @@ export const WriteIcon = (props: SVGProps<SVGSVGElement>) => (
 export const TagsIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={20}
-    height={23}
+    // width={20}
+    // height={23}
+    width="100%"
+    height="100%"
+    viewBox="0 0 24 24"
     fill="none"
     {...props}
   >
@@ -1328,8 +1332,8 @@ export const ToolIcon = (props: SVGProps<SVGSVGElement>) => (
 
 export const GraphIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg
-    width="20"
-    height="20"
+    width="100%"
+    height="100%"
     viewBox="0 0 20 20"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/app/components/layout/sidebar/menu-items.tsx
+++ b/app/components/layout/sidebar/menu-items.tsx
@@ -21,7 +21,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
   const [workspaceSwitching] = useAtom(switchingWorkspaceAtom);
 
   const baseMenuItemClasses = tw(
-    "my-1 flex items-center gap-1 rounded p-1 text-[14px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600"
+    "my-1 flex items-center gap-1 rounded p-2 text-[16px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600 lg:p-1 lg:text-[14px]"
   );
 
   return (
@@ -42,7 +42,9 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                 onClick={toggleMobileNav}
                 title={"Admin dashboard"}
               >
-                <i className="icon text-gray-500">🛸</i>
+                <i className="icon inline-flex pl-[5px] text-[14px] text-gray-500">
+                  🛸
+                </i>
                 <span className="text whitespace-nowrap transition duration-200 ease-linear">
                   Admin dashboard
                 </span>
@@ -87,7 +89,8 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                     title: item.title,
                     disabled: workspaceSwitching,
                     className: tw(
-                      "my-1 flex items-center gap-3 rounded border-0 bg-transparent px-3 text-left text-[16px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600",
+                      baseMenuItemClasses,
+                      "my-1 flex items-center border-0 bg-transparent",
                       canUseBookings
                         ? "justify-start focus:ring-0"
                         : "my-0 text-gray-500 hover:bg-gray-50 hover:text-gray-500",
@@ -105,7 +108,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                 <NavLink
                   className={({ isActive }) =>
                     tw(
-                      "my-1 flex items-center gap-3 rounded px-3 py-2.5 text-[16px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600",
+                      baseMenuItemClasses,
                       isActive ? "active bg-primary-50 text-primary-600" : "",
                       workspaceSwitching ? "pointer-events-none" : ""
                     )
@@ -144,7 +147,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                 <NavLink
                   className={({ isActive }) =>
                     tw(
-                      " my-1 flex items-center  gap-3 rounded px-3 py-2.5 text-[16px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600",
+                      baseMenuItemClasses,
                       isActive ? "active bg-primary-50 text-primary-600" : "",
                       workspaceSwitching ? "pointer-events-none" : ""
                     )
@@ -182,7 +185,8 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                 <button
                   type="submit"
                   className={tw(
-                    "crisp-btn mt-1 flex w-full items-center gap-3 rounded px-3 py-2.5 text-[16px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600",
+                    baseMenuItemClasses,
+                    "crisp-btn mt-1 flex w-full items-center",
                     workspaceSwitching ? "pointer-events-none" : ""
                   )}
                 >

--- a/app/components/layout/sidebar/menu-items.tsx
+++ b/app/components/layout/sidebar/menu-items.tsx
@@ -21,7 +21,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
   const [workspaceSwitching] = useAtom(switchingWorkspaceAtom);
 
   const baseMenuItemClasses = tw(
-    "my-1 flex items-center gap-2 rounded px-2 py-1 text-[14px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600"
+    "my-1 flex items-center gap-1 rounded p-1 text-[14px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600"
   );
 
   return (
@@ -33,7 +33,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
               <NavLink
                 className={({ isActive }) =>
                   tw(
-                    "my-1 flex items-center gap-3 rounded px-3 py-2.5 text-[16px] font-semibold text-gray-700 transition-all duration-75 hover:bg-primary-50 hover:text-primary-600",
+                    baseMenuItemClasses,
                     isActive ? "active bg-primary-50 text-primary-600" : "",
                     workspaceSwitching ? "pointer-events-none" : ""
                   )
@@ -58,10 +58,10 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                   canUseFeature={canUseBookings}
                   buttonContent={{
                     title: (
-                      <span className="flex items-center gap-2 rounded ">
+                      <span className="flex items-center gap-1 rounded ">
                         <i
                           className={tw(
-                            "icon inline-flex pl-[2px] text-gray-500",
+                            "icon inline-flex pl-[5px] text-gray-500",
                             !canUseBookings
                               ? "!hover:text-gray-500 !text-gray-500"
                               : ""
@@ -115,7 +115,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                   onClick={toggleMobileNav}
                   title={item.title}
                 >
-                  <i className="icon inline-flex pl-[2px] text-gray-500">
+                  <i className="icon inline-flex pl-[5px] text-gray-500">
                     {item.icon}
                   </i>
                   <span className="text whitespace-nowrap transition duration-200 ease-linear">
@@ -155,7 +155,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                   title={item.title}
                   target={item?.target || undefined}
                 >
-                  <i className="icon inline-flex pl-[2px] text-gray-500">
+                  <i className="icon inline-flex pl-[5px] text-gray-500">
                     {item.icon}
                   </i>
                   <span className="text whitespace-nowrap transition duration-200 ease-linear">
@@ -187,7 +187,7 @@ const MenuItems = ({ fetcher }: { fetcher: FetcherWithComponents<any> }) => {
                     workspaceSwitching ? "pointer-events-none" : ""
                   )}
                 >
-                  <i className="icon inline-flex pl-[2px] text-gray-500">
+                  <i className="icon inline-flex pl-[5px] text-gray-500">
                     <Icon icon="switch" />
                   </i>
                   <span className="text whitespace-nowrap transition duration-200 ease-linear">

--- a/app/components/layout/sidebar/organization-select.tsx
+++ b/app/components/layout/sidebar/organization-select.tsx
@@ -23,7 +23,7 @@ export const OrganizationSelect = ({
     useLoaderData<typeof loader>();
   return (
     <Select name="organizationId" defaultValue={currentOrganizationId}>
-      <SelectTrigger className="w-full px-3 py-2">
+      <SelectTrigger className="w-full px-2 py-1">
         <SelectValue />
       </SelectTrigger>
       <SelectContent position="popper" className="w-full" align="start">

--- a/app/components/layout/sidebar/sidebar.tsx
+++ b/app/components/layout/sidebar/sidebar.tsx
@@ -70,7 +70,7 @@ export default function Sidebar() {
         className={tw(
           `main-navigation fixed top-0 z-30 flex h-screen max-h-screen flex-col border-r border-gray-200 bg-white p-4 shadow-[0px_20px_24px_-4px_rgba(16,24,40,0.08),_0px_8px_8px_-4px_rgba(16,24,40,0.03)] transition-all duration-300 ease-linear md:sticky md:left-0 md:px-4 md:py-8 md:shadow-none md:duration-200`,
           optimisticMinimizedSidebar
-            ? "collapsed-navigation md:w-[82px] md:overflow-hidden"
+            ? "collapsed-navigation md:w-[74px] md:overflow-hidden"
             : "md:left-0 md:w-[250px]",
           isMobileNavOpen ? "left-0 w-[250px] overflow-hidden " : "-left-full"
         )}

--- a/app/styles/layout/sidebar.css
+++ b/app/styles/layout/sidebar.css
@@ -11,8 +11,8 @@
   @apply text-primary-500;
 }
 
-.main-navigation .menu .icon {
-  /* @apply size-[16px]; */
+.main-navigation .menu .icon svg {
+  @apply size-[16px];
 }
 
 @media (min-width: 768px) {
@@ -27,7 +27,7 @@
 
   .collapsed-navigation .menu li a:not(.disabled),
   .collapsed-navigation .menu li button:not(.disabled) {
-    @apply py-2.5;
+    @apply py-1;
   }
 
   .collapsed-navigation .logout-btn form {


### PR DESCRIPTION
@carlosvirreira @jurrejansen, so as we discussed before I was a bit triggered by our sidebar. I feel like the menu items are too huge and the icons are very big and bulky with very wide stroke. Also our icons have different color than the text so that also looks not so great. Especially when i compare it to some other sidebars that look so much cleaner. 

### Mintlify example: 
![Screenshot 2024-06-28 at 15 53 54](https://github.com/Shelf-nu/shelf.nu/assets/7840007/6e058a5a-8811-4c3f-83e2-fd6a3b7051d7)
![Screenshot 2024-06-28 at 15 53 50](https://github.com/Shelf-nu/shelf.nu/assets/7840007/fd1f6bcc-3d0c-4600-b852-534f20dfb7fd)

I also really like how their close/open works.
Also this part is kinda messy in terms of code and I think it should be in general cleaned up and made easier to maintain and work with.

I would also like to consider the idea of using radix icons in the sidebar, as they just work. We dont need to export and do some shenanigans for each icon for it to work. https://www.radix-ui.com/icons

I have deployed this to testapp(https://github.com/Shelf-nu/shelf.nu/actions/runs/9713220465) so u can see it and lmk what u think. Its very experimental for now.