### PR TITLE
fix: forwardRef on List component

### DIFF
--- a/app/components/list/index.tsx
+++ b/app/components/list/index.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import React from "react";
 import { useLoaderData } from "@remix-run/react";
 import { useAtomValue, useSetAtom } from "jotai";
 import {
@@ -77,17 +78,20 @@ export type ListProps = {
 /**
  * The route is required to export {@link IndexResponse}
  */
-export const List = ({
-  title,
-  ItemComponent,
-  headerChildren,
-  hideFirstHeaderColumn = false,
-  navigate,
-  className,
-  customEmptyStateContent,
-  emptyStateClassName,
-  bulkActions,
-}: ListProps) => {
+export const List = React.forwardRef<HTMLDivElement, ListProps>(function List(
+  {
+    title,
+    ItemComponent,
+    headerChildren,
+    hideFirstHeaderColumn = false,
+    navigate,
+    className,
+    customEmptyStateContent,
+    emptyStateClassName,
+    bulkActions,
+  }: ListProps,
+  ref
+) {
   const { items, totalItems, perPage, modelName } =
     useLoaderData<IndexResponse>();
   const { singular, plural } = modelName;
@@ -114,6 +118,7 @@ export const List = ({
 
   return (
     <div
+      ref={ref}
       className={tw(
         "-mx-4 overflow-x-auto border border-gray-200  bg-white md:mx-0 md:rounded",
         className
@@ -225,4 +230,4 @@ export const List = ({
       )}
     </div>
   );
-};
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
       ignoredRouteFiles: ["**/.*"],
       future: {
         // unstable_fogOfWar: true,
+        // unstable_singleFetch: true,
       },
       routes: async (defineRoutes) => {
         return flatRoutes("routes", defineRoutes);


### PR DESCRIPTION
`List` component is being used `asChild` within the tabs, which creates an issue because of `SlotClone`. Changing the List component to `forwardRef` solves the issue as per recommended here: https://github.com/radix-ui/primitives/issues/1013