### PR TITLE
fix: kit availability label

### DIFF
--- a/app/components/booking/availability-label.tsx
+++ b/app/components/booking/availability-label.tsx
@@ -226,9 +226,6 @@ export function getKitAvailabilityStatus(
     BookingStatus.OVERDUE,
   ] as BookingStatus[];
 
-  /**
-   * Important to make sure the bookings are overlapping the period of the current booking
-   */
   const someAssetHasUnavailableBooking =
     kitBookings.length > 0 &&
     kitBookings.some(

--- a/app/components/booking/availability-label.tsx
+++ b/app/components/booking/availability-label.tsx
@@ -226,6 +226,9 @@ export function getKitAvailabilityStatus(
     BookingStatus.OVERDUE,
   ] as BookingStatus[];
 
+  /**
+   * Important to make sure the bookings are overlapping the period of the current booking
+   */
   const someAssetHasUnavailableBooking =
     kitBookings.length > 0 &&
     kitBookings.some(

--- a/app/routes/_layout+/bookings.$bookingId.add-kits.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.add-kits.tsx
@@ -111,6 +111,9 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
               availableToBook: true,
               custody: true,
               bookings: {
+                /**
+                 * Important to make sure the bookings are overlapping the period of the current booking
+                 */
                 where: {
                   ...(booking.from &&
                     booking.to && {

--- a/app/routes/_layout+/bookings.$bookingId.add-kits.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.add-kits.tsx
@@ -95,6 +95,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       singular: "kit",
       plural: "kits",
     };
+    const booking = await getBooking({ id: bookingId, organizationId });
+    const bookingKitIds = getKitIdsByAssets(booking.assets);
 
     const { page, perPage, kits, search, totalKits, totalPages } =
       await getPaginatedAndFilterableKits({
@@ -108,14 +110,28 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
               status: true,
               availableToBook: true,
               custody: true,
-              bookings: { select: { id: true, status: true } },
+              bookings: {
+                where: {
+                  ...(booking.from &&
+                    booking.to && {
+                      OR: [
+                        {
+                          from: { lte: booking.from },
+                          to: { gte: booking.to },
+                        },
+                        {
+                          from: { gte: booking.from },
+                          to: { lte: booking.from },
+                        },
+                      ],
+                    }),
+                },
+                select: { id: true, status: true },
+              },
             },
           },
         },
       });
-
-    const booking = await getBooking({ id: bookingId, organizationId });
-    const bookingKitIds = getKitIdsByAssets(booking.assets);
 
     return json(
       data({


### PR DESCRIPTION
The "Already booked" label was showing for any kit that had bookings in the future, because the assets in the query were not scoped based on the current booking start and end date.