### PR TITLE
feat: help users create their first Team workspace

### DIFF
--- a/app/components/subscription/successful-subscription-modal.tsx
+++ b/app/components/subscription/successful-subscription-modal.tsx
@@ -1,67 +1,145 @@
-import { useCallback } from "react";
-import { useLoaderData } from "@remix-run/react";
+import { BellIcon } from "@radix-ui/react-icons";
+import { useBlocker } from "@remix-run/react";
 import { AnimatePresence } from "framer-motion";
 import { useSearchParams } from "~/hooks/search-params";
 
-import type { loader } from "~/routes/_layout+/account-details.subscription";
 import { Button } from "../shared/button";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../shared/modal";
+import { WarningBox } from "../shared/warning-box";
 
 export default function SuccessfulSubscriptionModal() {
-  const [params, setParams] = useSearchParams();
-  const success = params.get("success") || false;
-  const isTeam = params.get("team") || false;
-  const handleBackdropClose = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (e.target !== e.currentTarget) return;
-      params.delete("success");
-      setParams(params);
-    },
-    [params, setParams]
-  );
-
-  const { activeProduct } = useLoaderData<typeof loader>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const success = searchParams.get("success") || false;
+  const isTeam = searchParams.get("team") === "true";
+  const hasExistingWorkspace =
+    searchParams.get("hasExistingWorkspace") === "true";
 
   return (
-    <AnimatePresence>
-      {success ? (
-        <div
-          className="dialog-backdrop !bg-[#364054]/70"
-          onClick={handleBackdropClose}
-        >
-          <dialog
-            className="dialog m-auto h-auto w-[90%] sm:w-[400px]"
-            open={true}
-          >
-            <div className="relative z-10  rounded bg-white p-6 shadow-lg">
-              <video height="200" autoPlay loop muted className="mb-6 rounded">
-                <source src="/static/videos/celebration.mp4" type="video/mp4" />
-              </video>
-              <div className="mb-8 text-center">
-                <h4 className="mb-1 text-[18px] font-semibold">
-                  You are all set!
-                </h4>
-                <p className="text-gray-600">
-                  {activeProduct?.name} features unlocked.{" "}
-                  {isTeam && "Now, create a team workspace."}
-                </p>
-              </div>
-              {isTeam ? (
-                <Button
-                  width="full"
-                  to="/account-details/workspace/new"
-                  variant="primary"
+    <>
+      <AnimatePresence>
+        {success ? (
+          <div className="dialog-backdrop !bg-[#364054]/70">
+            <dialog
+              className="dialog m-auto h-auto w-[90%] sm:w-[400px]"
+              open={true}
+            >
+              <div className="relative z-10  rounded bg-white p-6 shadow-lg">
+                <video
+                  height="200"
+                  autoPlay
+                  loop
+                  muted
+                  className="mb-6 rounded"
                 >
-                  Create your Team workspace
-                </Button>
-              ) : (
-                <Button width="full" to="/assets" variant="primary">
-                  Get started
-                </Button>
-              )}
-            </div>
-          </dialog>
-        </div>
-      ) : null}
-    </AnimatePresence>
+                  <source
+                    src="/static/videos/celebration.mp4"
+                    type="video/mp4"
+                  />
+                </video>
+                <div className="mb-8 text-center">
+                  <h4 className="mb-1 text-[18px] font-semibold">
+                    You are all set!
+                  </h4>
+                  <p className="text-gray-600">
+                    {isTeam ? "Team" : "Plus"} features unlocked.{" "}
+                    {isTeam && !hasExistingWorkspace
+                      ? "Now, it is time to create your team workspace and start adding assets."
+                      : "Now, it is time to start adding assets. Make sure you are in the right workspace."}
+                  </p>
+                </div>
+                {isTeam && !hasExistingWorkspace ? (
+                  <>
+                    <div className="my-4 text-gray-700">
+                      <strong>IMPORTANT</strong>: To use the Team features you
+                      need to use your Team workspace. Make sure to create it
+                      before you continue.
+                    </div>
+                    <Button
+                      width="full"
+                      onClick={() => {
+                        setSearchParams((prev) => {
+                          /** We remove the success param as that controls this modal being visible */
+                          prev.delete("success");
+                          return prev;
+                        });
+                      }}
+                      variant="primary"
+                    >
+                      Create Team workspace
+                    </Button>
+                  </>
+                ) : (
+                  <Button width="full" to="/assets" variant="primary">
+                    Get started
+                  </Button>
+                )}
+              </div>
+            </dialog>
+          </div>
+        ) : null}
+      </AnimatePresence>
+      <AreYouSureModal shouldBlock={isTeam && !hasExistingWorkspace} />
+    </>
   );
+}
+
+function AreYouSureModal({ shouldBlock }: { shouldBlock: boolean }) {
+  // Block navigating elsewhere when data has been entered into the input
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      shouldBlock && currentLocation.pathname !== nextLocation.pathname
+  );
+  return blocker && blocker.state === "blocked" ? (
+    <AlertDialog open={blocker.state === "blocked"}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="mx-auto md:m-0">
+            <span className="flex size-12 items-center justify-center rounded-full bg-error-50 p-2 text-error-600">
+              <BellIcon />
+            </span>
+          </div>
+          <AlertDialogTitle>
+            Are you sure you want to leave the page?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            You just got your team subscription. Do you want to leave without
+            creating a Team workspace?
+          </AlertDialogDescription>
+          <WarningBox className="my-4 ">
+            <>
+              {" "}
+              <strong>IMPORTANT</strong>: To use the Team features you need to
+              use your Team workspace. Make sure to create it before you
+              continue.
+            </>
+          </WarningBox>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <div className="flex w-full flex-col justify-center gap-2">
+            <Button
+              variant="secondary"
+              width="full"
+              onClick={() => blocker.reset()}
+            >
+              No, I want to stay.
+            </Button>
+
+            <Button
+              className="border-error-600 bg-error-600 hover:border-error-800 hover:bg-error-800"
+              onClick={() => blocker.proceed()}
+            >
+              Yes, I don't want a Team workspace
+            </Button>
+          </div>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ) : null;
 }

--- a/app/components/workspace/form.tsx
+++ b/app/components/workspace/form.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { Organization, Currency } from "@prisma/client";
 import { useLoaderData, useNavigation } from "@remix-run/react";
 import { useAtom, useAtomValue } from "jotai";
@@ -5,6 +6,7 @@ import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { updateDynamicTitleAtom } from "~/atoms/dynamic-title-atom";
 import { fileErrorAtom, validateFileAtom } from "~/atoms/file";
+import { useSearchParams } from "~/hooks/search-params";
 import type { loader } from "~/routes/_layout+/account-details.workspace.new";
 import { isFormProcessing } from "~/utils/form";
 import { zodFieldIsRequired } from "~/utils/zod";
@@ -38,12 +40,21 @@ interface Props {
 
 export const WorkspaceForm = ({ name, currency, children }: Props) => {
   const { curriences } = useLoaderData<typeof loader>();
+  const [searchParams] = useSearchParams();
   const navigation = useNavigation();
   const zo = useZorm("NewQuestionWizardScreen", NewWorkspaceFormSchema);
   const disabled = isFormProcessing(navigation.state);
   const fileError = useAtomValue(fileErrorAtom);
   const [, validateFile] = useAtom(validateFileAtom);
   const [, updateTitle] = useAtom(updateDynamicTitleAtom);
+  const nameFieldRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const team = searchParams.get("team");
+    if (!team && nameFieldRef.current) {
+      nameFieldRef.current.focus();
+    }
+  }, [searchParams]);
 
   return (
     <Card className="w-full md:w-min">
@@ -55,6 +66,9 @@ export const WorkspaceForm = ({ name, currency, children }: Props) => {
       >
         <FormRow
           rowLabel={"Name"}
+          subHeading={
+            "Choose a name that represents your Organization. Make it easily recognizable for your team members."
+          }
           className="border-b-0 pb-[10px] pt-0"
           required={zodFieldIsRequired(NewWorkspaceFormSchema.shape.name)}
         >
@@ -70,10 +84,17 @@ export const WorkspaceForm = ({ name, currency, children }: Props) => {
             defaultValue={name || undefined}
             placeholder=""
             required={zodFieldIsRequired(NewWorkspaceFormSchema.shape.name)}
+            ref={nameFieldRef}
           />
         </FormRow>
 
-        <FormRow rowLabel={"Main image"} className="border-b-0">
+        <FormRow
+          rowLabel={"Main image"}
+          className="border-b-0"
+          subHeading={
+            "Used to place your organization's logo or symbol. For best results, use a square image."
+          }
+        >
           <div>
             <p className="hidden lg:block">
               Accepts PNG, JPG or JPEG (max.4 MB)

--- a/app/emails/stripe/welcome-to-trial.tsx
+++ b/app/emails/stripe/welcome-to-trial.tsx
@@ -1,0 +1,173 @@
+import {
+  Html,
+  Text,
+  Link,
+  Head,
+  render,
+  Container,
+} from "@react-email/components";
+import { config } from "~/config/shelf.config";
+import { SERVER_URL } from "~/utils/env";
+import { ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
+import { LogoForEmail } from "../logo";
+import { sendEmail } from "../mail.server";
+import { styles } from "../styles";
+
+export const sendTeamTrialWelcomeEmail = ({ email }: { email: string }) => {
+  try {
+    const subject = `Your Shelf Team Trial is Ready - Next Steps`;
+    const html = welcomeToTrialEmailHtml();
+    const text = welcomeToTrialEmailText();
+
+    void sendEmail({
+      to: email,
+      subject,
+      html,
+      text,
+    });
+  } catch (cause) {
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: "Something went wrong while sending the welcome email",
+        additionalData: { email },
+        label: "User",
+      })
+    );
+  }
+};
+
+/**
+ * THis is the text version of the onboarding email
+ */
+export const welcomeToTrialEmailText = () => `Dear Shelf user,
+Carlos Virreira here, Co-founder of Shelf Asset Management, Inc. I'm thrilled to inform you that your Shelf Team Trial has been activated! This is an excellent step towards more efficient asset management for your team.
+
+To get started with your trial:
+
+Create Your Team Workspace:
+
+Visit https://app.shelf.nu/account-details/workspace to see all your workspaces. You'll find a "NEW WORKSPACE" button enabled - click this to create your team workspace if you haven't already.
+
+
+Add Your First Assets:
+Start populating your inventory to see Shelf in action. Don't forget to try our QR code feature for easy asset tracking.
+
+
+Invite Team Members:
+Collaboration is key. Add your colleagues to truly experience the power of Shelf.
+
+
+Explore Key Features:
+Custom Fields: Tailor Shelf to your specific needs - https://www.shelf.nu/knowledge-base/custom-field-types-in-shelf
+Bookings: Efficiently manage equipment reservations - https://www.shelf.nu/knowledge-base/use-case-scenarios-explaing-our-bookings-feature
+Kits: Group related assets for easier management - https://www.shelf.nu/features/kits
+
+Need help? Our support team is ready to assist you. Check out our Knowledge Base for quick answers, or reach out directly at support@shelf.nu.
+
+Remember, your trial gives you full access to all our premium features. Make the most of it!
+
+Happy asset tracking,
+Carlos Virreira
+Co-founder, Shelf Asset Management, Inc.
+P.S. Have questions or feedback? I'd love to hear from you. Reply directly to this email, and let's chat!
+`;
+
+function WelcomeToTrialEmailTemplate() {
+  const { emailPrimaryColor } = config;
+
+  return (
+    <Html>
+      <Head>
+        <title>Your Shelf Team Trial is Ready - Next Steps</title>
+      </Head>
+
+      <Container style={{ padding: "32px 16px", maxWidth: "100%" }}>
+        <LogoForEmail />
+
+        <div style={{ paddingTop: "8px" }}>
+          Dear Shelf user,
+          <Text style={{ marginBottom: "24px", ...styles.p }}>
+            Carlos Virreira here, Co-founder of Shelf Asset Management, Inc. I'm
+            thrilled to inform you that your Shelf Team Trial has been
+            activated! This is an excellent step towards more efficient asset
+            management for your team.
+            <br />
+            To get started with your trial:
+            <br />
+            <h2>Create Your Team Workspace:</h2>
+          </Text>
+          <ol style={{ ...styles.li }}>
+            <li>
+              Visit{" "}
+              <Link
+                href={`${SERVER_URL}/account-details/workspace`}
+                style={{ color: emailPrimaryColor }}
+              >
+                {SERVER_URL}/account-details/workspace
+              </Link>{" "}
+              to see all your workspaces. You'll find a "NEW WORKSPACE" button
+              enabled - click this to create your team workspace if you haven't
+              already.
+            </li>
+            <li>
+              Add Your First Assets: Start populating your inventory to see
+              Shelf in action. Don't forget to try our QR code feature for easy
+              asset tracking.
+            </li>
+            <li>
+              Invite Team Members: Collaboration is key. Add your colleagues to
+              truly experience the power of Shelf.
+            </li>
+          </ol>
+          <h2>Explore Key Features:</h2>
+          <Link
+            href="https://www.shelf.nu/knowledge-base/custom-field-types-in-shelf"
+            style={{ color: emailPrimaryColor }}
+          >
+            Custom Fields: Tailor Shelf to your specific needs
+          </Link>
+          <br />
+          <Link
+            href="https://www.shelf.nu/knowledge-base/use-case-scenarios-explaing-our-bookings-feature"
+            style={{ color: emailPrimaryColor }}
+          >
+            Bookings: Efficiently manage equipment reservations
+          </Link>
+          <br />
+          <Link
+            href="https://www.shelf.nu/features/kits"
+            style={{ color: emailPrimaryColor }}
+          >
+            Kits: Group related assets for easier management
+          </Link>
+          <br />
+          <Text style={{ marginBottom: "24px", ...styles.p }}>
+            Need help? Our support team is ready to assist you. Check out our
+            Knowledge Base for quick answers, or reach out directly at
+            support@shelf.nu.
+            <br />
+            Remember, your trial gives you full access to all our premium
+            features. Make the most of it!
+            <br />
+            <br />
+            Happy asset tracking, <br />
+            Carlos Virreira <br />
+            Co-founder, Shelf Asset Management, Inc.
+            <br />
+            P.S. Have questions or feedback? I'd love to hear from you. Reply
+            directly to this email, and let's chat!
+          </Text>
+        </div>
+      </Container>
+    </Html>
+  );
+}
+
+/*
+ *The HTML content of an email will be accessed by a server file to send email,
+  we cannot import a TSX component in a server file so we are exporting TSX converted to HTML string using render function by react-email.
+ */
+export const welcomeToTrialEmailHtml = () =>
+  render(<WelcomeToTrialEmailTemplate />);

--- a/app/emails/styles.ts
+++ b/app/emails/styles.ts
@@ -30,4 +30,5 @@ export const styles = {
     marginBottom: "16px",
   },
   p: { fontSize: "16px", color: "#344054" },
+  li: { fontSize: "16px", color: "#344054" },
 };

--- a/app/routes/_layout+/account-details.subscription.tsx
+++ b/app/routes/_layout+/account-details.subscription.tsx
@@ -24,7 +24,7 @@ import SuccessfulSubscriptionModal from "~/components/subscription/successful-su
 import { db } from "~/database/db.server";
 import { getUserTierLimit } from "~/modules/tier/service.server";
 
-import { getUserByID, updateUser } from "~/modules/user/service.server";
+import { getUserByID } from "~/modules/user/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { ENABLE_PREMIUM_FEATURES } from "~/utils/env";
 import { ShelfError, makeShelfError } from "~/utils/error";
@@ -167,11 +167,6 @@ export async function action({ context, request }: ActionFunctionArgs) {
       intent,
       shelfTier,
     });
-
-    /** Update the user flag to mark them for having a trial */
-    if (intent === "trial" && stripeRedirectUrl) {
-      await updateUser({ id: userId, usedFreeTrial: true });
-    }
 
     return redirect(stripeRedirectUrl);
   } catch (cause) {

--- a/app/routes/_layout+/account-details.workspace.new.tsx
+++ b/app/routes/_layout+/account-details.workspace.new.tsx
@@ -11,6 +11,7 @@ import { useAtomValue } from "jotai";
 import { dynamicTitleAtom } from "~/atoms/dynamic-title-atom";
 import Header from "~/components/layout/header";
 import type { HeaderData } from "~/components/layout/header/types";
+import SuccessfulSubscriptionModal from "~/components/subscription/successful-subscription-modal";
 import {
   NewWorkspaceFormSchema,
   WorkspaceForm,
@@ -127,6 +128,8 @@ export default function NewWorkspace() {
     <div>
       <Header title={title} hideBreadcrumbs classNames="-mt-5" />
       <div>
+        <SuccessfulSubscriptionModal />
+
         <WorkspaceForm />
       </div>
     </div>


### PR DESCRIPTION
We have the issue that users get a team trial and continue working in their personal workspace. I have implemented a series of measures to help with that:

1. After user gets team trial or just directly buys team(without having a previous team workspace), they get redirected to `workspace/new`
2. They will be shown a modal informing them about the importance of creating a team workspace and giving some instructions.
3. If they are on the new workspace page and try to leave the page, I have implemented a blocker that asks them if they are sure

![image](https://github.com/user-attachments/assets/b9af22dd-c97d-4c2b-a00d-48e838e7bf9f)

4. Once they get a free trial, they will also receive an email with instructions as requested in #1229 