### PR TITLE
fix: wrong parsing of field definition on import

### DIFF
--- a/app/utils/custom-fields.ts
+++ b/app/utils/custom-fields.ts
@@ -202,7 +202,8 @@ export const getDefinitionFromCsvHeader = (
   let type =
     defArr.find((e) => e.toLowerCase().startsWith("type:"))?.substring(5) ||
     "text"; //"text"
-  type = type.replace(/\s+/g, "").toUpperCase();
+
+  type = type.trim().replace(/\s+/g, "_").toUpperCase();
   return {
     name,
     active: true,


### PR DESCRIPTION
Issue with parsing field definition names in csv header was leading to a failure when importing multiline text. Has been resolved.