### PR TITLE
fix: updating layout export in root

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,3 @@
-import type { PropsWithChildren } from "react";
 import type { User } from "@prisma/client";
 import type {
   LinksFunction,
@@ -14,6 +13,7 @@ import {
   Scripts,
   ScrollRestoration,
   useLoaderData,
+  useRouteLoaderData,
 } from "@remix-run/react";
 import { withSentry } from "@sentry/remix";
 import nProgressStyles from "nprogress/nprogress.css?url";
@@ -77,8 +77,8 @@ export const loader = ({ request }: LoaderFunctionArgs) =>
 
 export const shouldRevalidate = () => false;
 
-function Document({ children, title }: PropsWithChildren<{ title?: string }>) {
-  const { env } = useLoaderData<typeof loader>();
+export function Layout({ children }: { children: React.ReactNode }) {
+  const data = useRouteLoaderData<typeof loader>("root");
   const nonce = useNonce();
   return (
     <html lang="en" className="h-full">
@@ -88,7 +88,6 @@ function Document({ children, title }: PropsWithChildren<{ title?: string }>) {
         <ClientHintCheck nonce={nonce} />
         <style data-fullcalendar />
         <Meta />
-        {title ? <title>{title}</title> : null}
         <Links />
         <Clarity />
       </head>
@@ -97,7 +96,7 @@ function Document({ children, title }: PropsWithChildren<{ title?: string }>) {
         <ScrollRestoration />
         <script
           dangerouslySetInnerHTML={{
-            __html: `window.env = ${JSON.stringify(env)}`,
+            __html: `window.env = ${JSON.stringify(data?.env)}`,
           }}
         />
         <Scripts />
@@ -110,9 +109,7 @@ function App() {
   useNprogress();
   const { maintenanceMode } = useLoaderData<typeof loader>();
 
-  return (
-    <Document>{maintenanceMode ? <MaintenanceMode /> : <Outlet />}</Document>
-  );
+  return maintenanceMode ? <MaintenanceMode /> : <Outlet />;
 }
 
 export default withSentry(App);

--- a/app/routes/qr+/route.tsx
+++ b/app/routes/qr+/route.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet } from "@remix-run/react";
+import { ErrorContent } from "~/components/errors";
 import { ShelfFullLogo } from "~/components/marketing/logos";
 import { usePosition } from "~/hooks/use-position";
 
@@ -20,3 +21,5 @@ export default function QR() {
     </div>
   );
 }
+
+export const ErrorBoundary = () => <ErrorContent />;


### PR DESCRIPTION
Root route exports were not updated to the latest Remix standard so it was creating an issue with unstyled errors when a certain layout doesnt have error boundary and the errors bubbled up to the root.