### PR TITLE
feat: User soft delete

### DIFF
--- a/app/components/assets/asset-custody-card.tsx
+++ b/app/components/assets/asset-custody-card.tsx
@@ -25,7 +25,10 @@ export function CustodyCard({
         id: string;
         name: string;
         from: string | null;
-        custodianUser: Omit<User, "createdAt" | "updatedAt"> | null;
+        custodianUser: Omit<
+          User,
+          "createdAt" | "updatedAt" | "deletedAt"
+        > | null;
         custodianTeamMember: Omit<
           TeamMember,
           "createdAt" | "updatedAt" | "deletedAt"

--- a/app/components/assets/notes/note.tsx
+++ b/app/components/assets/notes/note.tsx
@@ -8,7 +8,7 @@ import { ActionsDopdown } from "./actions-dropdown";
 
 export type NoteWithDate = WithDateFields<NoteType, string> & {
   dateDisplay: string;
-  user: {
+  user?: {
     firstName: string;
     lastName: string;
   };
@@ -36,7 +36,9 @@ export const Comment = ({ note }: { note: NoteWithDate; when?: boolean }) => (
     <header className="flex justify-between border-b px-3.5 py-3 text-text-xs md:text-text-sm">
       <div>
         <span className="commentator font-medium text-gray-900">
-          {note.user?.firstName} {note.user?.lastName}
+          {note.user
+            ? `${note.user?.firstName} ${note.user?.lastName}`
+            : "Unknown"}
         </span>{" "}
         <span className="text-gray-600">{timeAgo(note.createdAt)}</span>
       </div>

--- a/app/database/migrations/20240816120345_adding_cascading_deletes_for_user_and_organizations/migration.sql
+++ b/app/database/migrations/20240816120345_adding_cascading_deletes_for_user_and_organizations/migration.sql
@@ -1,0 +1,71 @@
+-- DropForeignKey
+ALTER TABLE "Asset" DROP CONSTRAINT "Asset_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "AssetCustomFieldValue" DROP CONSTRAINT "AssetCustomFieldValue_customFieldId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Booking" DROP CONSTRAINT "Booking_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Category" DROP CONSTRAINT "Category_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CustomField" DROP CONSTRAINT "CustomField_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Invite" DROP CONSTRAINT "Invite_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Kit" DROP CONSTRAINT "Kit_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Location" DROP CONSTRAINT "Location_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Organization" DROP CONSTRAINT "Organization_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Tag" DROP CONSTRAINT "Tag_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "TeamMember" DROP CONSTRAINT "TeamMember_organizationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserOrganization" DROP CONSTRAINT "UserOrganization_organizationId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Asset" ADD CONSTRAINT "Asset_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tag" ADD CONSTRAINT "Tag_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Location" ADD CONSTRAINT "Location_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMember" ADD CONSTRAINT "TeamMember_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Organization" ADD CONSTRAINT "Organization_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserOrganization" ADD CONSTRAINT "UserOrganization_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CustomField" ADD CONSTRAINT "CustomField_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AssetCustomFieldValue" ADD CONSTRAINT "AssetCustomFieldValue_customFieldId_fkey" FOREIGN KEY ("customFieldId") REFERENCES "CustomField"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invite" ADD CONSTRAINT "Invite_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Booking" ADD CONSTRAINT "Booking_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Kit" ADD CONSTRAINT "Kit_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/app/database/migrations/20240816121348_add_more_cascading_deletes_for_user/migration.sql
+++ b/app/database/migrations/20240816121348_add_more_cascading_deletes_for_user/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "UserOrganization" DROP CONSTRAINT "UserOrganization_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "UserOrganization" ADD CONSTRAINT "UserOrganization_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/app/database/migrations/20240816131518_updating_note_user_relationship/migration.sql
+++ b/app/database/migrations/20240816131518_updating_note_user_relationship/migration.sql
@@ -1,0 +1,38 @@
+-- DropForeignKey
+ALTER TABLE "Category" DROP CONSTRAINT "Category_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "CustomField" DROP CONSTRAINT "CustomField_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Image" DROP CONSTRAINT "Image_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Kit" DROP CONSTRAINT "Kit_createdById_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Note" DROP CONSTRAINT "Note_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Tag" DROP CONSTRAINT "Tag_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "Note" ALTER COLUMN "userId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Image" ADD CONSTRAINT "Image_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Category" ADD CONSTRAINT "Category_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tag" ADD CONSTRAINT "Tag_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Note" ADD CONSTRAINT "Note_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CustomField" ADD CONSTRAINT "CustomField_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Kit" ADD CONSTRAINT "Kit_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/app/database/migrations/20240820122636_add_deleted_at_to_user_for_soft_delete/migration.sql
+++ b/app/database/migrations/20240820122636_add_deleted_at_to_user_for_soft_delete/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -25,7 +25,7 @@ model Image {
   ownerOrg   Organization @relation("owner", fields: [ownerOrgId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   ownerOrgId String
 
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  user   User   @relation(fields: [userId], references: [id],  onUpdate: Cascade)
   userId String
 }
 
@@ -92,7 +92,7 @@ model Asset {
   // Relationships
   user           User         @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   userId         String
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
   category       Category?    @relation(fields: [categoryId], references: [id])
   categoryId     String?
@@ -143,12 +143,12 @@ model Category {
 
   // Relationships
   assets Asset[]
-  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  user   User    @relation(fields: [userId], references: [id], onUpdate: Cascade)
   userId String
 
   customFields CustomField[]
 
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
   //@@unique([lower(name), organizationId]) //prisma doesnt support case insensitive unique index yet
@@ -162,9 +162,9 @@ model Tag {
   //relations
   assets Asset[]
   userId String
-  user   User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  user   User    @relation(fields: [userId], references: [id], onUpdate: Cascade)
 
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
   // Datetime
@@ -184,8 +184,8 @@ model Note {
   updatedAt DateTime @updatedAt
 
   // Relationships
-  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  userId  String
+  user    User?   @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: SetNull)
+  userId  String?
   asset   Asset  @relation(fields: [assetId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   assetId String
 }
@@ -311,7 +311,7 @@ model Location {
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   userId String
 
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
   assets Asset[]
@@ -339,11 +339,11 @@ model TeamMember {
   id   String @id @unique @default(cuid())
   name String
 
-  organization    Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization    Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId  String
   custodies       Custody[]
   receivedInvites Invite[]
-  user            User?        @relation(fields: [userId], references: [id], onUpdate: Cascade)
+  user            User?        @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: SetNull)
   userId          String?
   kitCustodies    KitCustody[]
 
@@ -372,7 +372,7 @@ model Organization {
   name String           @default("Personal")
   type OrganizationType @default(PERSONAL)
 
-  owner    User     @relation(fields: [userId], references: [id], onUpdate: Cascade)
+  owner    User     @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade) 
   userId   String
   currency Currency @default(USD)
 
@@ -406,9 +406,9 @@ model Organization {
 model UserOrganization {
   id String @id @unique @default(cuid())
 
-  user           User         @relation(fields: [userId], references: [id], onUpdate: Cascade)
+  user           User         @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   userId         String
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
   roles     OrganizationRoles[]
@@ -484,7 +484,7 @@ model TierLimit {
 // CustomTierLimit is used for users which has Tier with ID: custom
 model CustomTierLimit {
   id               String   @id @unique @default(cuid())
-  user             User?    @relation(fields: [userId], references: [id])
+  user             User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
   userId           String?  @unique // This is the foreign key
   canImportAssets  Boolean  @default(true)
   canExportAssets  Boolean  @default(true)
@@ -507,10 +507,10 @@ model CustomField {
   options String[]
 
   // Relationships
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
-  createdBy User   @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  createdBy User   @relation(fields: [userId], references: [id], onUpdate: Cascade)
   userId    String
 
   categories Category[]
@@ -541,7 +541,7 @@ model AssetCustomFieldValue {
   asset   Asset  @relation(fields: [assetId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   assetId String
 
-  customField   CustomField @relation(fields: [customFieldId], references: [id], onUpdate: Cascade)
+  customField   CustomField @relation(fields: [customFieldId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   customFieldId String
 
   // Datetime
@@ -588,7 +588,7 @@ model Invite {
   //relations
   inviter           User         @relation("inviter", fields: [inviterId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   inviterId         String
-  organization      Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization      Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId    String
   inviteeUser       User?        @relation("invitee", fields: [inviteeUserId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   inviteeUserId     String?
@@ -650,7 +650,7 @@ model Booking {
   custodianTeamMember   TeamMember? @relation(fields: [custodianTeamMemberId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   custodianTeamMemberId String?
 
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
   assets Asset[]
@@ -677,10 +677,10 @@ model Kit {
   qrCodes Qr[]
   reports ReportFound[]
 
-  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade)
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
-  createdBy   User   @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  createdBy   User   @relation(fields: [createdById], references: [id])
   createdById String
 
   createdAt DateTime @default(now())

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -46,6 +46,9 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // Used to flag if the user is soft deleted
+  deletedAt DateTime?
+
   // Relationships
 
   assets            Asset[]

--- a/app/modules/user/service.server.ts
+++ b/app/modules/user/service.server.ts
@@ -769,6 +769,7 @@ export async function updateProfilePicture({
  *   - Booking
  *   - TeamMember
  *   - Image
+ * 2. Delete all organizations the user owns. This will cascade the deleting of related entries
  * 3. Delete the auth account of the user
  * 4. Send email that the user is deleted
  */

--- a/app/modules/user/service.server.ts
+++ b/app/modules/user/service.server.ts
@@ -9,6 +9,7 @@ import { config } from "~/config/shelf.config";
 import type { ExtendedPrismaClient } from "~/database/db.server";
 import { db } from "~/database/db.server";
 
+import { sendEmail } from "~/emails/mail.server";
 import {
   deleteAuthAccount,
   createEmailAuthAccount,
@@ -936,6 +937,14 @@ export async function deleteUser(id: User["id"]) {
         where: { id },
       });
     });
+    /** Delete the auth account */
+    await deleteAuthAccount(id);
+
+    void sendEmail({
+      to: user.email,
+      subject: "Your account has been deleted",
+      text: `Your shelf account has been deleted. \n\n Kind regards, \n Shelf Team\n\n`,
+    });
   } catch (cause) {
     if (
       cause instanceof PrismaClientKnownRequestError &&
@@ -952,9 +961,6 @@ export async function deleteUser(id: User["id"]) {
       });
     }
   }
-
-  /** Delete the auth account */
-  await deleteAuthAccount(id);
 }
 
 export { defaultUserCategories };

--- a/app/routes/_layout+/account-details.general.tsx
+++ b/app/routes/_layout+/account-details.general.tsx
@@ -11,9 +11,9 @@ import { Form } from "~/components/custom-form";
 import FormRow from "~/components/forms/form-row";
 import Input from "~/components/forms/input";
 import { Button } from "~/components/shared/button";
-import { DeleteUser } from "~/components/user/delete-user";
 import PasswordResetForm from "~/components/user/password-reset-form";
 import ProfilePicture from "~/components/user/profile-picture";
+import { RequestDeleteUser } from "~/components/user/request-delete-user";
 
 import { sendEmail } from "~/emails/mail.server";
 import { useUserData } from "~/hooks/use-user-data";
@@ -307,7 +307,7 @@ export default function UserPage() {
         <p className="text-sm text-gray-600">
           Send a request to delete your account.
         </p>
-        <DeleteUser />
+        <RequestDeleteUser />
       </div>
     </div>
   );

--- a/app/routes/_layout+/admin-dashboard+/$userId.tsx
+++ b/app/routes/_layout+/admin-dashboard+/$userId.tsx
@@ -18,6 +18,7 @@ import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
 import { Spinner } from "~/components/shared/spinner";
 import { Table, Td, Tr } from "~/components/table";
+import { DeleteUser } from "~/components/user/delete-user";
 import { db } from "~/database/db.server";
 import { updateUserTierId } from "~/modules/tier/service.server";
 import { deleteUser, getUserByID } from "~/modules/user/service.server";
@@ -122,22 +123,9 @@ export const action = async ({
     const { intent } = parseData(
       await request.clone().formData(),
       z.object({
-        intent: z.enum(["updateTier", "updateCustomTierDetails"]),
+        intent: z.enum(["updateTier", "updateCustomTierDetails", "deleteUser"]),
       })
     );
-
-    if (isDelete(request)) {
-      await deleteUser(shelfUserId);
-
-      sendNotification({
-        title: "User deleted",
-        message: "The user has been deleted successfully",
-        icon: { name: "trash", variant: "error" },
-        senderId: userId,
-      });
-
-      return redirect("/admin-dashboard");
-    }
 
     switch (intent) {
       case "updateTier": {
@@ -186,6 +174,18 @@ export const action = async ({
 
         break;
       }
+      case "deleteUser":
+        if (isDelete(request)) {
+          await deleteUser(shelfUserId);
+
+          sendNotification({
+            title: "User deleted",
+            message: "The user has been deleted successfully",
+            icon: { name: "trash", variant: "error" },
+            senderId: userId,
+          });
+          return redirect("/admin-dashboard/users");
+        }
     }
 
     return json(data(null));
@@ -206,6 +206,7 @@ export default function Area51UserPage() {
       <div>
         <div className="flex justify-between">
           <h1>User: {user?.email}</h1>
+          <DeleteUser />
         </div>
         <div className="flex gap-2">
           <div className="w-[400px]">

--- a/app/routes/_layout+/admin-dashboard+/$userId.tsx
+++ b/app/routes/_layout+/admin-dashboard+/$userId.tsx
@@ -21,7 +21,7 @@ import { Table, Td, Tr } from "~/components/table";
 import { DeleteUser } from "~/components/user/delete-user";
 import { db } from "~/database/db.server";
 import { updateUserTierId } from "~/modules/tier/service.server";
-import { deleteUser, getUserByID } from "~/modules/user/service.server";
+import { softDeleteUser, getUserByID } from "~/modules/user/service.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
@@ -182,7 +182,7 @@ export const action = async ({
       }
       case "deleteUser":
         if (isDelete(request)) {
-          await deleteUser(shelfUserId);
+          await softDeleteUser(shelfUserId);
 
           sendNotification({
             title: "User deleted",


### PR DESCRIPTION

To prevent database issues and data loss, we do soft delete.
To comply with regulations, we will destroy all personal data related to the user

To soft delete the user we do the following:
1. Update the user email to: `deleted+{randomId}@deleted.shelf.nu`
2. Update the user username to: `deleted+{randomId}`
3. Update the user `firstName` to: Deleted
4. Update the user `lastName` to: User
5. Delete the user's profile picture
6. Remove all relations to organizations the user is part of but doesnt own
7. Move all entities the user created inside organizations the user is part of but doesnt own to the owner of the organization

