### PR TITLE
feat: format date only based on locale

### DIFF
--- a/app/utils/client-hints.tsx
+++ b/app/utils/client-hints.tsx
@@ -2,6 +2,7 @@
  * This file contains utilities for using client hints for user preference which
  * are needed by the server, but are only known by the browser.
  */
+import { parseISO } from "date-fns";
 import { parseAcceptLanguage } from "intl-parse-accept-language";
 import type { ClientHint } from "~/modules/booking/types";
 import { ShelfError } from "./error";
@@ -177,4 +178,8 @@ export function getLocale(request: Request) {
   });
 
   return locales[0] ?? "en-US";
+}
+
+export function formatDateBasedOnLocaleOnly(value: string, locale: string) {
+  return parseISO(value).toLocaleDateString(locale);
 }

--- a/app/utils/custom-fields.ts
+++ b/app/utils/custom-fields.ts
@@ -4,7 +4,7 @@ import type { ZodRawShape } from "zod";
 import { z } from "zod";
 import type { ShelfAssetCustomFieldValueType } from "~/modules/asset/types";
 import type { ClientHint } from "~/modules/booking/types";
-import { getDateTimeFormatFromHints } from "./client-hints";
+import { formatDateBasedOnLocaleOnly } from "./client-hints";
 import { ShelfError } from "./error";
 
 /** Returns the schema depending on the field type.
@@ -182,9 +182,9 @@ export const getCustomFieldDisplayValue = (
   value: ShelfAssetCustomFieldValueType["value"],
   hints?: ClientHint
 ): string => {
-  if (value.valueDate) {
+  if (value.valueDate && value.raw) {
     return hints
-      ? getDateTimeFormatFromHints(hints).format(new Date(value.valueDate))
+      ? formatDateBasedOnLocaleOnly(value.raw as string, hints.locale)
       : format(new Date(value.valueDate), "PPP"); // Fallback to default date format
   }
   return String(value.raw);


### PR DESCRIPTION
Used for cases where we just need to display a date, with time being irrelevant. 
Native JS always set back the date based on user timezone even if time is irrelevant for us. So we implemented this approach that uses `date-fns` and native `toLocaleDateString`.

Thanks to @rajeshj11 for investigating and helping understand the problem.