### PR TITLE
feat: allow linking of QR codes on import

### DIFF
--- a/app/components/assets/import-content.tsx
+++ b/app/components/assets/import-content.tsx
@@ -112,6 +112,35 @@ export const ImportContent = () => (
       <b>"cf:purchase date, type:date"</b>
     </div>
 
+    <h4 className="mt-2">Importing with QR codes</h4>
+    <div>
+      You also have the option to se a Shelf QR code for each asset. This is
+      very valuable if you already have Shelf QR codes printed and you want to
+      link them to the assets you are importing.
+      <br />
+      This feature comes with the following limitations:
+      <ul className="list-inside list-disc pl-4">
+        <li>
+          <b>Existing code</b> - the QR code needs to already exist in shelf
+        </li>
+        <li>
+          <b>No duplicate codes</b> - the qrId needs to be unique for each asset
+        </li>
+        <li>
+          <b>No linked codes</b> - the qrId needs not be linked to any asset or
+          kit
+        </li>
+        <li>
+          <b>QR ownership</b> - the QR code needs to be either unclaimed or
+          belong to the organization you are trying to import it to.
+        </li>
+      </ul>
+      If no <b>"qrId"</b> is used a new QR code will be generated.
+      <br />
+      If you are interesting in receiving some unclaimed or unlinked codes, feel
+      free to get in touch with support and we can provide those for you.
+    </div>
+
     <h4 className="mt-2">Extra considerations</h4>
     <ul className="list-inside list-disc">
       <li>

--- a/app/components/assets/import-content.tsx
+++ b/app/components/assets/import-content.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from "react";
 import { useRef, useState } from "react";
 import { useFetcher } from "@remix-run/react";
+import type { QRCodePerImportedAsset } from "~/modules/qr/service.server";
 import type { action } from "~/routes/_layout+/assets.import";
 import { isFormProcessing } from "~/utils/form";
 import { tw } from "~/utils/tw";
@@ -18,6 +19,7 @@ import {
   AlertDialogTrigger,
 } from "../shared/modal";
 import { WarningBox } from "../shared/warning-box";
+import { Table, Td, Th, Tr } from "../table";
 
 export const ImportBackup = () => (
   <>
@@ -212,6 +214,43 @@ export const FileForm = ({ intent, url }: { intent: string; url?: string }) => {
             <div>
               <h5 className="text-red-500">{data.error.title}</h5>
               <p className="text-red-500">{data.error.message}</p>
+              {data?.error?.additionalData?.duplicateCodes ? (
+                <BrokenQrCodesTable
+                  title="Duplicate codes"
+                  data={
+                    data.error.additionalData
+                      .duplicateCodes as QRCodePerImportedAsset[]
+                  }
+                />
+              ) : null}
+              {data?.error?.additionalData?.nonExistentCodes ? (
+                <BrokenQrCodesTable
+                  title="Non existent codes"
+                  data={
+                    data.error.additionalData
+                      .nonExistentCodes as QRCodePerImportedAsset[]
+                  }
+                />
+              ) : null}
+              {data?.error?.additionalData?.linkedCodes ? (
+                <BrokenQrCodesTable
+                  title="Already linked codes"
+                  data={
+                    data.error.additionalData
+                      .linkedCodes as QRCodePerImportedAsset[]
+                  }
+                />
+              ) : null}
+              {data?.error?.additionalData?.connectedToOtherOrgs ? (
+                <BrokenQrCodesTable
+                  title="Some codes do not belong to this organization"
+                  data={
+                    data.error.additionalData
+                      .connectedToOtherOrgs as QRCodePerImportedAsset[]
+                  }
+                />
+              ) : null}
+
               <p className="mt-2">
                 Please fix your CSV file and try again. If the issue persists,
                 don't hesitate to get in touch with us.
@@ -261,3 +300,33 @@ export const FileForm = ({ intent, url }: { intent: string; url?: string }) => {
     </fetcher.Form>
   );
 };
+
+function BrokenQrCodesTable({
+  title,
+  data,
+}: {
+  title: string;
+  data: QRCodePerImportedAsset[];
+}) {
+  return (
+    <div className="mt-3">
+      <h5>{title}</h5>
+      <Table className="mt-1 [&_td]:p-1 [&_th]:p-1">
+        <thead>
+          <Tr>
+            <Th>Asset title</Th>
+            <Th>QR ID</Th>
+          </Tr>
+        </thead>
+        <tbody>
+          {data.map((code: { title: string; qrId: string }) => (
+            <Tr key={code.title}>
+              <Td>{code.title}</Td>
+              <Td>{code.qrId}</Td>
+            </Tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}

--- a/app/modules/qr/service.server.ts
+++ b/app/modules/qr/service.server.ts
@@ -17,6 +17,7 @@ import { id } from "~/utils/id/id.server";
 import { getParamsValues } from "~/utils/list";
 // eslint-disable-next-line import/no-cycle
 import { generateCode } from "./utils.server";
+import type { CreateAssetFromContentImportPayload } from "../asset/types";
 import { generateRandomCode } from "../invite/helpers";
 
 const label: ErrorLabel = "QR";
@@ -485,4 +486,129 @@ export async function getQrCodeMaps({
     console.error("Error generating QR code maps:", err);
   }
   return finalMap;
+}
+
+/** Extracts qrCodes from data and checks their validity for import
+ * You can only import unclaimed or unlinked codes
+ * - For non-existing codes - we can allow them to be imported
+ * - For linked codes - we don't allow any imports
+ * - For unlinked - we can only allowed if the code is already claimed within the current workspace the user is trying to import to
+ * - For unclaimed - there are not really any limitations we need to place. This should work directly
+ */
+
+export type QRCodePerImportedAsset = {
+  title: string;
+  qrId: string;
+};
+
+export async function parseQrCodesFromImportData({
+  data,
+  userId,
+  organizationId,
+}: {
+  data: CreateAssetFromContentImportPayload[];
+  userId: User["id"];
+  organizationId: Organization["id"];
+}) {
+  try {
+    const qrCodePerAsset = data
+      .map((asset) => {
+        if (asset.qrId) {
+          return {
+            title: asset.title,
+            qrId: asset.qrId,
+          };
+        }
+        return null;
+      })
+      .filter((asset) => asset !== null); // Filter out null values
+
+    const codes = await db.qr.findMany({
+      where: {
+        id: {
+          in: qrCodePerAsset.map((asset) => asset?.qrId),
+        },
+      },
+    });
+
+    /** Check for any codes that are present more than 1 time in the data */
+    const duplicateCodes = qrCodePerAsset.filter(
+      (asset, index, self) =>
+        self.findIndex((t) => t?.qrId === asset?.qrId) !== index
+    );
+
+    if (duplicateCodes.length) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Some of the QR codes you are trying to import are present more than once in the data. Please make sure each QR code is only present once.",
+        additionalData: { duplicateCodes },
+        label,
+      });
+    }
+
+    /** Check if any of the codes are non-existent */
+    const nonExistentCodes = qrCodePerAsset.filter(
+      (asset) => !codes.find((code) => code.id === asset?.qrId) && asset?.qrId
+    );
+
+    if (nonExistentCodes.length) {
+      throw new ShelfError({
+        cause: null,
+        message: "Some of the QR codes you are trying to import do not exist",
+        additionalData: { nonExistentCodes },
+        label,
+      });
+    }
+
+    /** Check for codes already linked to asset or kit. Returns QRCodePerImportedAsset[] */
+    const linkedCodes = qrCodePerAsset.filter((asset) =>
+      codes.find(
+        (code) => code.id === asset?.qrId && (code.assetId || code.kitId)
+      )
+    );
+    if (linkedCodes.length) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Some of the QR codes you are trying to import are already linked to an asset or a kit. Please use unlinkned or unclaimed codes for your import.",
+        additionalData: { linkedCodes },
+        label,
+      });
+    }
+
+    /** Check for codes linked to other any organization and the organization is different than the current one */
+    const connectedToOtherOrgs = qrCodePerAsset.filter((asset) =>
+      codes.find(
+        (code) =>
+          code.id === asset?.qrId &&
+          code.organizationId &&
+          code.organizationId !== organizationId
+      )
+    );
+    if (connectedToOtherOrgs.length) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Some of the QR codes you are trying to import don't belong to your current organization. You can only import codes that are unclaimed, unlinked or linked to your organization.",
+        additionalData: { connectedToOtherOrgs },
+        label,
+      });
+    }
+
+    return qrCodePerAsset;
+  } catch (cause) {
+    const isShelfError = isLikeShelfError(cause);
+    throw new ShelfError({
+      cause,
+      message: isShelfError ? cause.message : "Failed to get qr codes",
+      additionalData: {
+        data,
+        userId,
+        organizationId,
+        ...(isShelfError && cause.additionalData),
+      },
+      label,
+    });
+  }
 }

--- a/public/static/shelf.nu-example-asset-import-from-content.csv
+++ b/public/static/shelf.nu-example-asset-import-from-content.csv
@@ -1,3 +1,3 @@
-title,description,kit,category,tags,location,valuation,custodian,"cf: Serial number,type:text","cf:brand, type:option","cf:purchase date, type:date"
-AMD Ryzen,"CPU from my new home PC",Home PC,CPU,"High priority, small",Sofia office,100,John,WQE239123d,amd,02/22/2024
-"Macbook Pro.","New laptop",Working gear,Laptop,"High priority, mid-size",Dutch office,2500,Thea,43543we23d,apple,03/12/2022
+qrId,title,description,kit,category,tags,location,valuation,custodian,"cf: Serial number,type:text","cf:brand, type:option","cf:purchase date, type:date"
+abcde12345,AMD Ryzen,"CPU from my new home PC",Home PC,CPU,"High priority, small",Sofia office,100,John,WQE239123d,amd,02/22/2024
+12345abcde"Macbook Pro.","New laptop",Working gear,Laptop,"High priority, mid-size",Dutch office,2500,Thea,43543we23d,apple,03/12/2022


### PR DESCRIPTION
Resolves #1290 

This needs to be tested. It is deployed to staging. 
We have quite a few error scenarios. Here is what we are already handling in the code. Let me know if I missed an edge case as that could be.

Error cases to test 
1. Duplicate codes - multiple assets having the same code
2. Non existent codes - codes that don't exist in shelf
3. Linked codes - codes that are already linked to an asset or kit
4. Belonging to other org - codes that are part of other organizations
5. Empty - doing an import where `qrId` is added only for some of the assets being imported
6. No qrId column - when the `qrId` column is completely missing from the import file.