### PR TITLE
fix: resolving issue with update of CF failing

### DIFF
--- a/app/modules/custom-field/service.server.ts
+++ b/app/modules/custom-field/service.server.ts
@@ -150,10 +150,16 @@ export async function updateCustomField(payload: {
       required,
       active,
       options,
-      categories: {
-        set: categories?.map((category) => ({ id: category })),
-      },
     } satisfies Prisma.CustomFieldUpdateInput;
+    const hasCategories = categories && categories.length > 0;
+
+    Object.assign(data, {
+      categories: {
+        set: hasCategories // if categories are empty, remove all categories
+          ? categories.map((category) => ({ id: category }))
+          : [],
+      },
+    });
 
     return await db.customField.update({
       where: { id },

--- a/app/routes/_layout+/settings.custom-fields.$fieldId_.edit.tsx
+++ b/app/routes/_layout+/settings.custom-fields.$fieldId_.edit.tsx
@@ -16,21 +16,27 @@ import Header from "~/components/layout/header";
 import type { HeaderData } from "~/components/layout/header/types";
 import { getAllEntriesForCreateAndEdit } from "~/modules/asset/service.server";
 import {
-  countActiveCustomFields,
   getCustomField,
   updateCustomField,
 } from "~/modules/custom-field/service.server";
-import { getOrganizationTierLimit } from "~/modules/tier/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
-import { makeShelfError, ShelfError } from "~/utils/error";
+import { makeShelfError } from "~/utils/error";
 import { data, error, getParams, parseData } from "~/utils/http.server";
 import {
   PermissionAction,
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
-import { canCreateMoreCustomFields } from "~/utils/subscription.server";
+import { assertUserCanCreateMoreCustomFields } from "~/utils/subscription.server";
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  { title: data ? appendToMetaTitle(data.header.title) : "" },
+];
+
+export const handle = {
+  breadcrumb: () => <span>Edit</span>,
+};
 
 export async function loader({ context, request, params }: LoaderFunctionArgs) {
   const authSession = context.getSession();
@@ -75,14 +81,6 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   }
 }
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => [
-  { title: data ? appendToMetaTitle(data.header.title) : "" },
-];
-
-export const handle = {
-  breadcrumb: () => <span>Edit</span>,
-};
-
 export async function action({ context, request, params }: ActionFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
@@ -109,43 +107,12 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     /** If they are activating a field, we have to make sure that they are not already at the limit */
     const isActivatingField = !field.active && active !== field.active;
+
     if (isActivatingField) {
-      /** Get the tier limit and check if they can export */
-      const tierLimit = await getOrganizationTierLimit({
+      await assertUserCanCreateMoreCustomFields({
         organizationId,
         organizations,
       });
-
-      const totalActiveCustomFields = await countActiveCustomFields({
-        organizationId,
-      });
-
-      const canCreateMore = canCreateMoreCustomFields({
-        tierLimit,
-        totalCustomFields: totalActiveCustomFields,
-      });
-
-      if (!canCreateMore) {
-        throw new ShelfError({
-          cause: null,
-          message:
-            "You have reached your limit of active custom fields. Please upgrade your plan to add more.",
-          additionalData: {
-            userId,
-            active,
-            totalActiveCustomFields,
-            tierLimit,
-            validationErrors: {
-              active: {
-                message: `You have reached your limit of active custom fields. Please upgrade your plan to add more.`,
-              },
-            },
-          },
-          label: "Custom fields",
-          status: 403,
-          shouldBeCaptured: false,
-        });
-      }
     }
 
     await updateCustomField({

--- a/app/utils/subscription.server.ts
+++ b/app/utils/subscription.server.ts
@@ -190,7 +190,8 @@ export const assertUserCanCreateMoreCustomFields = async ({
     throw new ShelfError({
       cause: null,
       title: "Not allowed",
-      message: "Your user cannot create more custom fields",
+      message:
+        "You have reached your limit of active custom fields. Please upgrade your plan to add more.",
       additionalData: { organizationId },
       label,
       shouldBeCaptured: false,


### PR DESCRIPTION
When the user was editing a custom field and turned off the option "Use for select categories", the fields were not getting deactivated.

Resolves: #1373 