### PR TITLE
chore: remove unnessary error capturing on sentry

### DIFF
--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -136,13 +136,6 @@ const unavailableBookingStatuses = [
   BookingStatus.OVERDUE,
 ];
 
-// Enhanced type safety for the query result
-type AssetSearchResult = {
-  asset: AssetsFromViewItem | null;
-} & {
-  [K in keyof AssetsFromViewItem]: AssetsFromViewItem[K];
-};
-
 /**
  * Fetches assets from AssetSearchView
  * This is used to have a more advanced search however its less performant

--- a/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -143,6 +143,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const { assetIds, bookingId } = parseData(formData, updateBookingSchema, {
       additionalData: { userId },
       message: "Please select a Booking",
+      shouldBeCaptured: false,
     });
 
     if (!assetIds?.length && !bookingId?.length) {

--- a/app/routes/_layout+/kits.$kitId.add-to-existing-booking.tsx
+++ b/app/routes/_layout+/kits.$kitId.add-to-existing-booking.tsx
@@ -143,6 +143,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const { kitIds, bookingId } = parseData(formData, updateBookingSchema, {
       additionalData: { userId },
       message: "Please select a Booking",
+      shouldBeCaptured: false,
     });
 
     if (!kitIds?.length && !bookingId?.length) {


### PR DESCRIPTION
dont track ui error for not selecting a booking when adding asset to existing booking