### PR TITLE
fix: assign custody validation schema

### DIFF
--- a/app/components/assets/bulk-assign-custody-dialog.tsx
+++ b/app/components/assets/bulk-assign-custody-dialog.tsx
@@ -2,19 +2,17 @@ import { useLoaderData } from "@remix-run/react";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import { createCustodianSchema } from "~/modules/custody/schema";
 import { type loader } from "~/routes/_layout+/assets._index";
 import { tw } from "~/utils/tw";
 import { resolveTeamMemberName } from "~/utils/user";
-import { stringToJSONSchema } from "~/utils/zod";
 import { BulkUpdateDialogContent } from "../bulk-update-dialog/bulk-update-dialog";
 import DynamicSelect from "../dynamic-select/dynamic-select";
 import { Button } from "../shared/button";
 
 export const BulkAssignCustodySchema = z.object({
   assetIds: z.array(z.string()).min(1),
-  custodian: stringToJSONSchema.pipe(
-    z.object({ id: z.string(), name: z.string() })
-  ),
+  custodian: createCustodianSchema(),
 });
 
 export default function BulkAssignCustodyDialog() {

--- a/app/components/kits/bulk-assign-custody-dialog.tsx
+++ b/app/components/kits/bulk-assign-custody-dialog.tsx
@@ -3,18 +3,16 @@ import { useLoaderData } from "@remix-run/react";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import { createCustodianSchema } from "~/modules/custody/schema";
 import { tw } from "~/utils/tw";
 import { resolveTeamMemberName } from "~/utils/user";
-import { stringToJSONSchema } from "~/utils/zod";
 import { BulkUpdateDialogContent } from "../bulk-update-dialog/bulk-update-dialog";
 import DynamicSelect from "../dynamic-select/dynamic-select";
 import { Button } from "../shared/button";
 
 export const BulkAssignKitCustodySchema = z.object({
   kitIds: z.array(z.string()).min(1),
-  custodian: stringToJSONSchema.pipe(
-    z.object({ id: z.string(), name: z.string() })
-  ),
+  custodian: createCustodianSchema(),
 });
 
 export default function BulkAssignCustodyDialog() {

--- a/app/modules/custody/schema.ts
+++ b/app/modules/custody/schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+// Base custodian shape that's common across different uses
+const baseCustodianShape = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export type BaseCustodianShape = z.infer<typeof baseCustodianShape>;
+
+// Helper function to create a customized custodian schema
+export const createCustodianSchema = (errorMessage?: string) =>
+  z.string().transform((str, ctx): z.infer<typeof baseCustodianShape> => {
+    try {
+      const parsed = JSON.parse(str);
+
+      // Validate the shape after parsing
+      const result = baseCustodianShape.safeParse(parsed);
+
+      if (!result.success) {
+        ctx.addIssue({
+          code: "custom",
+          message: errorMessage || "Please select a team member",
+          path: [], // This will show the error at the root level
+        });
+        return z.NEVER;
+      }
+
+      return parsed;
+    } catch (e) {
+      ctx.addIssue({
+        code: "custom",
+        message: errorMessage || "Please select a team member",
+        path: [], // This will show the error at the root level
+      });
+      return z.NEVER;
+    }
+  });
+
+/** Used for assigning singular custody for kit or asset */
+export const AssignCustodySchema = z.object({
+  custodian: createCustodianSchema(),
+});


### PR DESCRIPTION
- create a helper that generates schema for validating custody json object
- implement the updated schema for bulk and singular custody assignment for kit and assets
- implement the updated schema for front-end validations on assign-custody routes for both kit and asset. Before there were only server side validations