### PR TITLE
fix: wrong usage of transaction when bulk deleting locations

### DIFF
--- a/app/modules/location/service.server.ts
+++ b/app/modules/location/service.server.ts
@@ -371,7 +371,7 @@ export async function bulkDeleteLocations({
       const locationWithImages = locations.filter(
         (location) => !!location.imageId
       );
-      await db.image.deleteMany({
+      await tx.image.deleteMany({
         where: {
           id: {
             in: locationWithImages.map((location) => {


### PR DESCRIPTION
Wrong usage of transaction was causing an error. Fixes #1415