### PR TITLE
improvement: handle 'availableToBook' on asset import

### DIFF
--- a/app/components/assets/import-content.tsx
+++ b/app/components/assets/import-content.tsx
@@ -141,16 +141,18 @@ export const ImportContent = () => (
       free to get in touch with support and we can provide those for you.
     </div>
 
-    <h4 className="mt-2">Extra considerations</h4>
-    <ul className="list-inside list-disc">
-      <li>
-        The first row of the sheet will be ignored. Use it to describe the
-        columns as in the example sheet.
-      </li>
-      <li>
-        If any of the data in the file is invalid, the whole import will fail
-      </li>
-    </ul>
+    <div>
+      <h4 className="mt-2">Extra considerations</h4>
+      <ul className="list-inside list-disc pl-4">
+        <li>
+          The first row of the sheet will be ignored. Use it to describe the
+          columns as in the example sheet.
+        </li>
+        <li>
+          If any of the data in the file is invalid, the whole import will fail
+        </li>
+      </ul>
+    </div>
     <FileForm intent={"content"} />
   </>
 );

--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -818,6 +818,7 @@ export async function createAsset({
   customFieldsValues,
   organizationId,
   valuation,
+  availableToBook = true,
 }: Pick<
   Asset,
   "description" | "title" | "categoryId" | "userId" | "valuation"
@@ -829,6 +830,7 @@ export async function createAsset({
   custodian?: TeamMember["id"];
   customFieldsValues?: ShelfAssetCustomFieldValueType[];
   organizationId: Organization["id"];
+  availableToBook?: Asset["availableToBook"];
 }) {
   try {
     /** User connection data */
@@ -880,6 +882,7 @@ export async function createAsset({
       qrCodes,
       valuation,
       organization,
+      availableToBook,
     };
 
     /** If a categoryId is passed, link the category to the asset. */
@@ -1940,6 +1943,7 @@ export async function createAssetsFromContentImport({
             : undefined,
         valuation: asset.valuation ? +asset.valuation : null,
         customFieldsValues,
+        availableToBook: asset?.bookable !== "no",
       });
     }
   } catch (cause) {

--- a/app/modules/asset/types.ts
+++ b/app/modules/asset/types.ts
@@ -53,6 +53,7 @@ export interface CreateAssetFromContentImportPayload
   tags: string[];
   location?: string;
   custodian?: string;
+  bookable?: "yes" | "no";
 }
 export interface CreateAssetFromBackupImportPayload
   extends Record<string, any> {

--- a/app/routes/_layout+/assets.import.tsx
+++ b/app/routes/_layout+/assets.import.tsx
@@ -47,7 +47,7 @@ export const action = async ({ context, request }: ActionFunctionArgs) => {
     const { intent } = parseData(
       await request.clone().formData(),
       z.object({
-        intent: z.enum(["backup", "content"]),
+        intent: z.enum(["content"]),
       })
     );
 
@@ -59,27 +59,17 @@ export const action = async ({ context, request }: ActionFunctionArgs) => {
         message: "CSV file is empty",
         additionalData: { intent },
         label: "Assets",
+        shouldBeCaptured: false,
       });
     }
 
-    switch (intent) {
-      case "backup": {
-        throw new ShelfError({
-          cause: null,
-          message: "This feature is not available for you",
-          label: "Assets",
-        });
-      }
-      case "content": {
-        const contentData = extractCSVDataFromContentImport(csvData);
-        await createAssetsFromContentImport({
-          data: contentData,
-          userId,
-          organizationId,
-        });
-        return json(data(null));
-      }
-    }
+    const contentData = extractCSVDataFromContentImport(csvData);
+    await createAssetsFromContentImport({
+      data: contentData,
+      userId,
+      organizationId,
+    });
+    return json(data(null));
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
     return json(error(reason), { status: reason.status });

--- a/public/static/shelf.nu-example-asset-import-from-content.csv
+++ b/public/static/shelf.nu-example-asset-import-from-content.csv
@@ -1,3 +1,3 @@
-qrId,title,description,kit,category,tags,location,valuation,custodian,"cf: Serial number,type:text","cf:brand, type:option","cf:purchase date, type:date"
-abcde12345,AMD Ryzen,"CPU from my new home PC",Home PC,CPU,"High priority, small",Sofia office,100,John,WQE239123d,amd,02/22/2024
-12345abcde"Macbook Pro.","New laptop",Working gear,Laptop,"High priority, mid-size",Dutch office,2500,Thea,43543we23d,apple,03/12/2022
+qrId,title,description,kit,category,tags,location,valuation,custodian,bookable,"cf: Serial number,type:text","cf:brand, type:option","cf:purchase date, type:date"
+abcde12345,AMD Ryzen,"CPU from my new home PC",Home PC,CPU,"High priority, small",Sofia office,100,John,yes,WQE239123d,amd,02/22/2024
+12345abcde,"Macbook Pro.","New laptop",Working gear,Laptop,"High priority, mid-size",Dutch office,2500,Thea,no,43543we23d,apple,03/12/2022


### PR DESCRIPTION
- allow for user to choose if an asset is bookable via import
- simply add a column called 'bookable' to your csv sheet and use 'yes' || 'no' as value
- update the example file to include this column
- handle cases where value is left empty or column is not added at all. Default value is true as with normal asset create