### PR TITLE
improvement: rework logic and functionality of SSO

### DIFF
--- a/app/modules/auth/service.server.ts
+++ b/app/modules/auth/service.server.ts
@@ -172,8 +172,33 @@ export async function signInWithSSO(domain: string) {
   }
 }
 
+/**
+ * Helper function to check if user is SSO-only and throw appropriate error
+ * @param email User's email address
+ * @throws ShelfError if user exists and is SSO-only
+ */
+async function validateNonSSOUser(email: string) {
+  const user = await db.user.findUnique({
+    where: { email: email.toLowerCase() },
+    select: { sso: true },
+  });
+
+  if (user?.sso) {
+    throw new ShelfError({
+      cause: null,
+      title: "SSO User",
+      message:
+        "This email address is associated with an SSO account. Please use SSO login instead.",
+      additionalData: { email },
+      label: "Auth",
+    });
+  }
+}
+
 export async function sendOTP(email: string) {
   try {
+    await validateNonSSOUser(email);
+
     const { error } = await getSupabaseAdmin().auth.signInWithOtp({
       email,
       options: {
@@ -202,6 +227,8 @@ export async function sendOTP(email: string) {
 
 export async function sendResetPasswordLink(email: string) {
   try {
+    await validateNonSSOUser(email);
+
     await getSupabaseAdmin().auth.resetPasswordForEmail(email, {
       redirectTo: `${SERVER_URL}/reset-password`,
     });

--- a/app/modules/user/service.server.ts
+++ b/app/modules/user/service.server.ts
@@ -1,4 +1,4 @@
-import type { Organization, SsoDetails, User } from "@prisma/client";
+import type { Organization, User } from "@prisma/client";
 import { Prisma, Roles, OrganizationRoles } from "@prisma/client";
 import type { ITXClientDenyList } from "@prisma/client/runtime/library";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
@@ -283,8 +283,6 @@ export async function createUserFromSSO(
     });
   }
 }
-
-type OrganizationWithSsoDetails = Organization & { ssoDetails: SsoDetails };
 
 /**
  * Updates an existing SSO user on subsequent logins.

--- a/app/modules/user/service.server.ts
+++ b/app/modules/user/service.server.ts
@@ -186,6 +186,26 @@ export async function createUserOrAttachOrg({
   }
 }
 
+/**
+ * Creates a new user from SSO authentication or handles subsequent logins.
+ *
+ * This function handles two SSO scenarios:
+ * 1. Pure SSO: User authenticates via SSO but their workspace access is managed manually through invites
+ * 2. SCIM SSO: User authenticates via SSO and their workspace access is managed through IDP group mappings
+ *
+ * All SSO users get a personal workspace and can be invited to other workspaces manually,
+ * even if no organizations are configured to use their email domain.
+ *
+ * @param authSession - The authentication session from Supabase containing user ID and email
+ * @param userData - User data received from the SSO provider
+ * @param userData.firstName - User's first name from SSO provider
+ * @param userData.lastName - User's last name from SSO provider
+ * @param userData.groups - Array of group IDs the user belongs to in the IDP
+ *
+ * @returns Object containing the created/updated user and their first organization (if any)
+ * @throws ShelfError if user creation/update fails
+ */
+
 export async function createUserFromSSO(
   authSession: AuthSession,
   userData: {
@@ -196,10 +216,11 @@ export async function createUserFromSSO(
 ) {
   try {
     const { email, userId } = authSession;
+
     const { firstName, lastName, groups } = userData;
     const domain = email.split("@")[1];
 
-    // When we are inviting normal users to the org, we create a teamMember so we need to handle it in this case as well
+    // Create user with personal workspace - all users get this now
     const user = await createUser({
       email,
       firstName,
@@ -209,49 +230,56 @@ export async function createUserFromSSO(
       isSSO: true,
     });
 
+    // Find organizations that use this email domain for SSO
     const organizations = await getOrganizationsBySsoDomain(domain);
 
-    for (let org of organizations) {
-      const { ssoDetails } = org;
-      if (!ssoDetails) {
-        throw new ShelfError({
-          cause: null,
-          title: "Organization doesnt have SSO",
-          message:
-            "It looks like the organization you're trying to log in to doesn't have SSO enabled.",
-          additionalData: { org, domain },
-          label,
-        });
-      }
-      const role = getRoleFromGroupId(ssoDetails, groups);
-      if (role) {
-        // Attach the user to the org with the correct role
-        await createUserOrgAssociation(db, {
-          userId: user.id,
-          organizationIds: [org.id], // org.id instead of orgIds
-          roles: [role], // role instead of roles
-        });
+    // No organizations using this domain is perfectly valid for Pure SSO
+    // User can still log in and will be able to access workspaces through invites
+    if (organizations.length > 0) {
+      // Process SCIM access for organizations that have group mappings
+      for (const org of organizations) {
+        const { ssoDetails } = org;
+        if (!ssoDetails) continue;
+
+        // Check if this organization uses SCIM (has group mappings)
+        const hasGroupMappings = !!(
+          ssoDetails.adminGroupId ||
+          ssoDetails.baseUserGroupId ||
+          ssoDetails.selfServiceGroupId
+        );
+
+        if (hasGroupMappings) {
+          const role = getRoleFromGroupId(ssoDetails, groups);
+          if (role) {
+            await createUserOrgAssociation(db, {
+              userId: user.id,
+              organizationIds: [org.id],
+              roles: [role],
+            });
+
+            await createTeamMember({
+              name: `${firstName} ${lastName}`,
+              organizationId: org.id,
+              userId,
+            });
+          }
+        }
       }
     }
 
-    /** Create teamMember for each organization */
-    await db.teamMember.createMany({
-      data: organizations.map((org) => ({
-        name: `${firstName} ${lastName}`,
-        organizationId: org.id,
-        userId,
-      })),
-    });
-
-    return { user, org: organizations[0] };
-  } catch (cause) {
+    // Return the user and org (if any SCIM orgs exist)
+    // For pure SSO with no org mappings, org will be null
+    return { user, org: organizations[0] || null };
+  } catch (cause: any) {
     throw new ShelfError({
       cause,
-      message: isLikeShelfError(cause)
-        ? cause.message
-        : `There was an issue with creating/attaching user with email: ${authSession.email}`,
-      additionalData: { email: authSession.email, userId: authSession.userId },
-      label,
+      message: `Failed to create SSO user: ${cause.message}`,
+      additionalData: {
+        email: authSession.email,
+        userId: authSession.userId,
+        domain: authSession.email.split("@")[1],
+      },
+      label: "Auth",
     });
   }
 }
@@ -259,12 +287,22 @@ export async function createUserFromSSO(
 type OrganizationWithSsoDetails = Organization & { ssoDetails: SsoDetails };
 
 /**
- * Compares the existing user with the sso claims returned on login and update is correctly.
- * Cases we need to handle:
- * 1. Name changes
- * 2. Removing user from orgs
- * 3. Adding user to orgs
- * 4. Changing user role in orgs
+ * Updates an existing SSO user on subsequent logins.
+ * Handles both Pure SSO and SCIM SSO scenarios:
+ *
+ * For Pure SSO users:
+ * - Updates their name if changed in IDP
+ * - Maintains their personal workspace and manual workspace invites
+ *
+ * For SCIM SSO users:
+ * - Updates their name if changed in IDP
+ * - Updates their workspace access based on current IDP group membership
+ * - Maintains their personal workspace regardless of group membership
+ *
+ * @param authSession - The authentication session from Supabase
+ * @param existingUser - The existing user record from our database
+ * @param userData - Updated user data from SSO provider
+ * @returns Object containing updated user and org (if any SCIM orgs exist)
  */
 export async function updateUserFromSSO(
   authSession: AuthSession,
@@ -277,16 +315,12 @@ export async function updateUserFromSSO(
     groups: string[];
   }
 ) {
-  try {
-    const { email, userId } = authSession;
-    const { firstName, lastName, groups } = userData;
-    const { firstName: oldFirstName, lastName: oldLastName } = existingUser;
-    const domain = email.split("@")[1];
-    /** Those are the organizations linked to the SSO domain */
-    const domainOrganizations = (await getOrganizationsBySsoDomain(
-      domain
-    )) as OrganizationWithSsoDetails[];
+  const { email, userId } = authSession;
+  const { firstName, lastName, groups } = userData;
+  const { firstName: oldFirstName, lastName: oldLastName } = existingUser;
+  const domain = email.split("@")[1];
 
+  try {
     let user = existingUser;
 
     /** If either the first or last name are different, update them */
@@ -306,46 +340,56 @@ export async function updateUserFromSSO(
     const existingUserOrganizations = existingUser.userOrganizations;
 
     /**
-     * Compare the domainOrganizations with the groups the user is trying to log in to
-     * by checking the ssoDetails
-     * The desired organizations is an array or organization that the user should belong to
+     * Find all organizations that use this domain for SSO
+     * For Pure SSO users or domains without configured orgs,
+     * this will return an empty array which is fine
      */
-    const desiredOrganizations = domainOrganizations.filter((org) => {
+    const domainOrganizations = await getOrganizationsBySsoDomain(domain);
+
+    // If no organizations use this domain or no groups provided,
+    // just return the updated user - this is the Pure SSO case
+    if (domainOrganizations.length === 0 || !groups?.length) {
+      return { user, org: null };
+    }
+
+    /** Process SCIM organization access if any orgs have group mappings */
+    for (const org of domainOrganizations) {
       const { ssoDetails } = org;
+      if (!ssoDetails) continue;
 
-      return (
-        /** If the sso details are present, we can safely assume that the ids are both strings */
-        groups.includes(ssoDetails.adminGroupId as string) ||
-        groups.includes(ssoDetails.selfServiceGroupId as string)
+      // Check if this organization uses SCIM
+      const hasGroupMappings = !!(
+        ssoDetails.adminGroupId ||
+        ssoDetails.baseUserGroupId ||
+        ssoDetails.selfServiceGroupId
       );
-    });
-    const desiredOrganizationsIds = desiredOrganizations.map((org) => org.id);
 
-    /**
-     * Iterate over the user's existing organizations
-     * 1. If the user still belongs to org, double check the roles
-     * 2. If the user doesnt belong to the org, revoke their access
-     * */
-    for (const existingUserOrganization of existingUserOrganizations) {
-      const { id } = existingUserOrganization.organization;
-      // Check if the user still belongs to the organization
-      if (desiredOrganizationsIds.includes(id)) {
-        // The user still belongs to the organization
-        // Here we need to check if the role is still the same and update it if it's not
-        const ssoDetails = (
-          existingUserOrganization.organization as OrganizationWithSsoDetails
-        ).ssoDetails; // Its safe to assume that the ssoDetails are present
+      if (hasGroupMappings) {
+        // Get the desired role based on current group membership
         const desiredRole = getRoleFromGroupId(ssoDetails, groups);
-        const currentRole = existingUserOrganization.roles[0];
 
-        if (currentRole !== desiredRole) {
-          // Update the role
-          await db.userOrganization
-            .update({
+        // Check if user currently has access to this org
+        const existingOrgAccess = existingUserOrganizations.find(
+          (uo) => uo.organization.id === org.id
+        );
+
+        if (existingOrgAccess) {
+          // User already has access to this org
+          const currentRole = existingOrgAccess.roles[0];
+
+          if (!desiredRole) {
+            // User lost all group access, revoke org access
+            await revokeAccessToOrganization({
+              userId: user.id,
+              organizationId: org.id,
+            });
+          } else if (currentRole !== desiredRole) {
+            // Update role if it changed
+            await db.userOrganization.update({
               where: {
                 userId_organizationId: {
                   userId: user.id,
-                  organizationId: id,
+                  organizationId: org.id,
                 },
               },
               data: {
@@ -353,67 +397,49 @@ export async function updateUserFromSSO(
                   set: [desiredRole],
                 },
               },
-            })
-            .catch((cause) => {
-              throw new ShelfError({
-                cause,
-                message: "Failed to update user organization",
-                additionalData: { userId: user.id, organizationId: id },
-                label,
-              });
             });
+          }
+        } else if (desiredRole) {
+          // User gained access to this org
+          await createUserOrgAssociation(db, {
+            userId: user.id,
+            organizationIds: [org.id],
+            roles: [desiredRole],
+          });
+
+          await createTeamMember({
+            name: `${firstName} ${lastName}`,
+            organizationId: org.id,
+            userId,
+          });
         }
-      } else {
-        // The user no longer belongs to the organization
-        // Remove the user from the organization
-        await revokeAccessToOrganization({
-          userId: user.id,
-          organizationId: id,
-        });
       }
     }
 
-    // Check if there are any new organizations that the user belongs to
-    for (const desiredOrg of desiredOrganizations) {
-      if (
-        !existingUser.userOrganizations.some(
-          (organization) => organization.organization.id === desiredOrg.id
-        )
-      ) {
-        const { ssoDetails } = desiredOrg;
+    // Find first org with SCIM access (if any) for redirect purposes
+    const firstScimOrg = domainOrganizations.find(
+      (org) =>
+        org.ssoDetails &&
+        (org.ssoDetails.adminGroupId ||
+          org.ssoDetails.baseUserGroupId ||
+          org.ssoDetails.selfServiceGroupId)
+    );
 
-        // Get the correct role based on the id
-        const role = getRoleFromGroupId(ssoDetails, groups);
-        // Add the user to the organization
-        await createUserOrgAssociation(db, {
-          userId: user.id,
-          organizationIds: [desiredOrg.id], // org.id instead of orgIds
-          roles: [role], // role instead of roles
-        });
-
-        /**
-         * Create the team member
-         *
-         * NOTE: There is a case where there could already been a team member created for the user in the past,
-         * however, we cannot be sure if the name is still the same and if its the same real life person
-         * so we create a new team meber for the user
-         */
-        await createTeamMember({
-          name: `${firstName} ${lastName}`,
-          organizationId: desiredOrg.id,
-          userId,
-        });
-      }
-    }
-
-    return { user, org: desiredOrganizations[0] };
+    return {
+      user,
+      org: firstScimOrg || null,
+    };
   } catch (cause) {
     throw new ShelfError({
       cause,
       message: isLikeShelfError(cause)
         ? cause.message
-        : `There was an issue with creating/attaching user with email: ${authSession.email}`,
-      additionalData: { email: authSession.email, userId: authSession.userId },
+        : `Failed to update SSO user: ${email}`,
+      additionalData: {
+        email,
+        userId,
+        domain,
+      },
       label,
     });
   }
@@ -445,10 +471,9 @@ export async function createUser(
   } = payload;
 
   /**
-   * We only create a personal org for non-SSO users
-   * and if the signup is not disabled
+   * We only create a personal org if the signup is not disabled
    * */
-  const shouldCreatePersonalOrg = !isSSO && !config.disableSignup;
+  const shouldCreatePersonalOrg = !config.disableSignup;
 
   try {
     return await db.$transaction(

--- a/app/utils/error.ts
+++ b/app/utils/error.ts
@@ -81,6 +81,7 @@ export type FailureReason = {
     | "Tier"
     | "User"
     | "Scanner"
+    | "SSO"
     | "Kit"
     | "Note"
     // Other kinds of errors

--- a/app/utils/sso.server.ts
+++ b/app/utils/sso.server.ts
@@ -1,6 +1,9 @@
 import type { AuthSession } from "server/session";
 import { db } from "~/database/db.server";
-import { getAuthUserById } from "~/modules/auth/service.server";
+import {
+  deleteAuthAccount,
+  getAuthUserById,
+} from "~/modules/auth/service.server";
 import { INCLUDE_SSO_DETAILS_VIA_USER_ORGANIZATION } from "~/modules/user/fields";
 import {
   createUserFromSSO,
@@ -9,11 +12,28 @@ import {
 import { ShelfError } from "./error";
 
 /**
- * This resolves the correct org we should redirec the user to
+ * This resolves the correct org we should redirect the user to
  * Also it handles:
  * - Creating a new user if the user doesn't exist
  * - Throwing an error if the user is already connected to an email account
- * - Linking the user to the correct org
+ * - Linking the user to the correct org if SCIM is configured
+ *
+ * Cases to handle:
+ * - [x] Auth Account & User exists in our database - we just login the user
+ * - [x] Auth Account exists but User doesn't exist in our database - we create a new user connecting it to authUser and login the user
+ * - [x] Auth Account(SSO version) doesn't exist but User exists in our database - We show an error as we dont allow SSO users to have an email based identity
+ * - [x] Auth account exists but is not present in IDP - an employee gets removed from an app. This is handled by IDP
+ * - [x] Auth account DOESN'T exist and is not added to IDP - this is handled by IDP. They give an error if its not authenticated
+ * - [x] User tries to reset password for a user that is only SSO
+ * - [x] User tries to use normal login for a user that is only SSO - we Dont actually need to check that because SSO users will not have a password they know. As long as we dont allow them to change pwd it should be fine.
+ *
+ * New cases for Pure SSO:
+ * - [ ] User signs up with SSO from a domain that has no org configured - should create user with personal workspace only
+ * - [ ] User signs up with SSO from domain that has org with SCIM - should create user with personal workspace and add to org based on groups
+ * - [ ] User signs up with SSO from domain that has org without SCIM - should create user with personal workspace only
+ * - [ ] User with SSO gets invited to a workspace - should be able to accept invite
+ * - [ ] Existing SSO user's domain gets configured for SCIM - on next login should get org access based on groups
+ * - [ ] SCIM user loses all group access - should keep personal workspace but lose org access
  */
 export async function resolveUserAndOrgForSsoCallback({
   authSession,
@@ -26,83 +46,62 @@ export async function resolveUserAndOrgForSsoCallback({
   lastName: string;
   groups: string[];
 }) {
-  /**
-   * Cases to handle:
-   * - [x] Auth Account & User exists in our database - we just login the user
-   * - [x] Auth Account exists but User doesn't exist in our database - we create a new user connecting it to authUser and login the user
-   * - [x] Auth Account(SSO version) doesn't exist but User exists in our database - We show an error as we dont allow SSO users to have an email based identity
-   * - [x] Auth account exists but is not present in IDP - an employee gets removed from an app. This is handled by IDP
-   * - [x] Auth account DOESN'T exist and is not added to IDP - this is handled by IDP. They give an error if its not authenticated
-   * - [x] User tries to reset password for a user that is only SSO
-   * - [x] User tries to use normal login for a user that is only SSO - we Dont actually need to check that because SSO users will not habe a password they know. As long as we dont allow them to change pwd it should be fine.
-   */
-
-  let org;
-
-  /** Look if the user already exists
-   * Also get the userOrgs as if we need them for setting the correct cookie
-   */
-  let user = await db.user.findUnique({
-    where: {
-      email: authSession.email,
-    },
-    include: {
-      ...INCLUDE_SSO_DETAILS_VIA_USER_ORGANIZATION,
-    },
-  });
-
-  /** Sign up case */
-  if (!user) {
-    /**
-     * If the user doesnt exist, we create a new one and link to the org which has the domain the user used to log in */
-    const response = await createUserFromSSO(authSession, {
-      firstName,
-      lastName,
-      groups,
+  try {
+    // First check if user exists
+    let user = await db.user.findUnique({
+      where: {
+        email: authSession.email,
+      },
+      include: {
+        ...INCLUDE_SSO_DETAILS_VIA_USER_ORGANIZATION,
+      },
     });
-    user = response.user;
-    org = response.org; // This is the org that the user got linked to
-  } else {
-    /**
-     * Login case
-     *  - update the names
-     *  - update the groups
-     * if they are changed in the IDP
-     */
 
-    const response = await updateUserFromSSO(authSession, user, {
-      firstName,
-      lastName,
-      groups,
+    // If user exists, check if they're trying to convert from email to SSO
+    if (user) {
+      const authUser = await getAuthUserById(user.id);
+      if (authUser?.app_metadata?.provider === "email") {
+        throw new ShelfError({
+          cause: null,
+          title: "User already exists",
+          message:
+            "It looks like the email you're using is linked to a personal account in Shelf. Please contact our support team to update your personal workspace to a different email account.",
+          label: "Auth",
+        });
+      }
+
+      // Existing SSO user - update their info
+      const response = await updateUserFromSSO(authSession, user, {
+        firstName,
+        lastName,
+        groups,
+      });
+      return { user: response.user, org: response.org };
+    }
+
+    // New user case - create them with SSO
+    try {
+      const response = await createUserFromSSO(authSession, {
+        firstName,
+        lastName,
+        groups,
+      });
+      return { user: response.user, org: response.org };
+    } catch (createError) {
+      // If user creation fails, clean up the auth account
+      await deleteAuthAccount(authSession.userId);
+      throw createError;
+    }
+  } catch (cause: any) {
+    throw new ShelfError({
+      cause,
+      title: cause.title || "Authentication failed",
+      message: cause.message || "Failed to authenticate user",
+      additionalData: {
+        email: authSession.email,
+        domain: authSession.email.split("@")[1],
+      },
+      label: "Auth",
     });
-    user = response.user;
-    org = response.org;
-
-    if (!org) {
-      throw new ShelfError({
-        cause: null,
-        title: "Organization not found",
-        message:
-          "It looks like the organization you're trying to log in to is not found. Please contact our support team to get access to your organization.",
-        additionalData: { org, user, domain: authSession.email.split("@")[1] },
-        label: "Auth",
-      });
-    }
-    /** We check if there is already a auth user with the same id of the user we found
-     * If the user is already connected to an email account, we should throw an error
-     * Because we dont allow SSO users to have an email based identity
-     * @TODO at this point we already have an SSO auth.user created. We need to delete them to keep the app clean.
-     */
-    const authUser = await getAuthUserById(user.id);
-    if (authUser?.app_metadata?.provider === "email") {
-      throw new ShelfError({
-        cause: null,
-        title: "User already exists",
-        message:
-          "It looks like the email you're using is linked to a personal account in Shelf. Please contact our support team to update your personal workspace to a different email account.",
-        label: "Auth",
-      });
-    }
   }
-  return { user, org };
 }


### PR DESCRIPTION
This PR aims to achieve a way more flexible usage of SSO.

**Currently:** Shelf SSO only works with SCIM, so the users are required to setup groups and role access via their IDP

**New:** The goal is to remove this limitation and have also a pure SSO implementation, where users just login with SSO but their access to workspace is managed within shelf itself.

This requires a lot of testing and cases to handle as we want it to be as flexible as possible for all our users that want to take advantage of SSO.

### Changes
- allowed users to register with pure SSO, without SCIM
- personal orgs are now also created for SSO users
- dont allow SSO users to reset pwd or login via OTP
- add SSO label for errors
- make groups to not be required when doing SSO login. Without groups the user is basically just doing pure SSO without SCIM
- allow users who are signed up via SSO but their email domain doesnt have SCIM to be invited via normal invite process
- create validation functions that check the logic on whether invite should be allowed
- create helper functions that check auth.sso_domains in order to know if a domain is allowed for sso
- block SSO invites for emails from domains that have SSO without SCIM but are not registered