### PR TITLE
change deploy strategy

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -8,7 +8,7 @@ swap_size_mb = 512
 auto_rollback = true
 
 [deploy]
-strategy = "bluegreen"
+strategy = "rolling"
 
 [env]
 NODE_ENV = "production"


### PR DESCRIPTION
Bluegreen is creating an issue with DB timeouts. It creates new machines which consume connections to the pooler which are not accounted for. This strategy should prevent the issue or at least greatly minimize it.