### PR TITLE
fix: multiple issues with bookings and custodian selector

### DIFF
--- a/app/components/assets/assets-index/advanced-filters/value-field.tsx
+++ b/app/components/assets/assets-index/advanced-filters/value-field.tsx
@@ -540,7 +540,7 @@ function CustodyEnumField({
     },
     transformItem: (item: any) => item,
     renderItem: (item: any) => resolveTeamMemberName(item, true),
-    initialDataKey: "rawTeamMembers",
+    initialDataKey: "teamMembers",
     countKey: "totalTeamMembers",
     label: "Filter by custodian",
     hideLabel: true,

--- a/app/components/assets/assets-index/filters.tsx
+++ b/app/components/assets/assets-index/filters.tsx
@@ -146,14 +146,10 @@ export function AssetIndexFilters({
                   queryKey: "name",
                   deletedAt: null,
                 }}
-                transformItem={(item) => ({
-                  ...item,
-                  id: item.metadata?.userId ? item.metadata.userId : item.id,
-                })}
                 renderItem={(item) => resolveTeamMemberName(item, true)}
                 label="Filter by custodian"
                 placeholder="Search team members"
-                initialDataKey="rawTeamMembers"
+                initialDataKey="teamMembers"
                 countKey="totalTeamMembers"
                 withoutValueItem={{
                   id: "without-custody",

--- a/app/components/assets/bulk-assign-custody-dialog.tsx
+++ b/app/components/assets/bulk-assign-custody-dialog.tsx
@@ -19,7 +19,7 @@ export default function BulkAssignCustodyDialog() {
   const zo = useZorm("BulkAssignCustody", BulkAssignCustodySchema);
 
   const { isSelfService } = useUserRoleHelper();
-  const { rawTeamMembers } = useLoaderData<typeof loader>();
+  const { teamMembers } = useLoaderData<typeof loader>();
 
   return (
     <BulkUpdateDialogContent
@@ -38,10 +38,10 @@ export default function BulkAssignCustodyDialog() {
             <DynamicSelect
               hidden={isSelfService}
               defaultValue={
-                isSelfService && rawTeamMembers?.length > 0
+                isSelfService && teamMembers?.length > 0
                   ? JSON.stringify({
-                      id: rawTeamMembers[0].id,
-                      name: resolveTeamMemberName(rawTeamMembers[0]),
+                      id: teamMembers[0].id,
+                      name: resolveTeamMemberName(teamMembers[0]),
                     })
                   : undefined
               }
@@ -53,7 +53,7 @@ export default function BulkAssignCustodyDialog() {
               }}
               fieldName="custodian"
               contentLabel="Team members"
-              initialDataKey="rawTeamMembers"
+              initialDataKey="teamMembers"
               countKey="totalTeamMembers"
               placeholder="Select a team member"
               allowClear
@@ -62,7 +62,10 @@ export default function BulkAssignCustodyDialog() {
                 ...item,
                 id: JSON.stringify({
                   id: item.id,
-                  //If there is a user, we use its name, otherwise we use the name of the team member
+                  /**
+                   * This is parsed on the server, because we need the name to create the note.
+                   * @TODO This should be refactored to send the name as some metadata, instaed of like this
+                   */
                   name: resolveTeamMemberName(item),
                 }),
               })}

--- a/app/components/booking/form.tsx
+++ b/app/components/booking/form.tsx
@@ -137,7 +137,7 @@ export function BookingForm({
   description,
 }: BookingFormData) {
   const navigation = useNavigation();
-  const { rawTeamMembers } = useLoaderData<typeof loader>();
+  const { teamMembers } = useLoaderData<typeof loader>();
 
   /** If there is noId, that means we are creating a new booking */
   const isNewBooking = !id;
@@ -183,7 +183,7 @@ export function BookingForm({
   }, [endDate]);
 
   /** This is used when we have selfSErvice or Base as we are setting the default */
-  const defaultTeamMember = rawTeamMembers?.find(
+  const defaultTeamMember = teamMembers?.find(
     (m) => m.userId === custodianRef || m.id === custodianRef
   );
 
@@ -386,7 +386,7 @@ export function BookingForm({
                     defaultTeamMember
                       ? JSON.stringify({
                           id: defaultTeamMember?.id,
-                          name: defaultTeamMember?.name,
+                          name: resolveTeamMemberName(defaultTeamMember),
                         })
                       : undefined
                   }
@@ -400,7 +400,7 @@ export function BookingForm({
                   }}
                   fieldName="custodian"
                   contentLabel="Team members"
-                  initialDataKey="rawTeamMembers"
+                  initialDataKey="teamMembers"
                   countKey="totalTeamMembers"
                   placeholder="Select a team member"
                   allowClear

--- a/app/components/list/pagination/index.tsx
+++ b/app/components/list/pagination/index.tsx
@@ -63,7 +63,7 @@ export const Pagination = ({ className }: { className?: string }) => {
             of
           </span>
           <span className="whitespace-nowrap text-[14px] font-semibold text-gray-700">
-            {totalPages || Math.ceil(totalItems / perPage)}
+            {Math.ceil(totalPages) || Math.ceil(totalItems / perPage)}
           </span>
         </div>
 

--- a/app/modules/asset/data.server.ts
+++ b/app/modules/asset/data.server.ts
@@ -106,7 +106,6 @@ export async function simpleModeLoader({
       totalLocations,
       teamMembers,
       totalTeamMembers,
-      rawTeamMembers,
     },
   ] = await Promise.all([
     getOrganizationTierLimit({
@@ -184,7 +183,6 @@ export async function simpleModeLoader({
       totalLocations,
       teamMembers,
       totalTeamMembers,
-      rawTeamMembers,
       filters,
       organizationId,
       locale,

--- a/app/modules/team-member/service.server.ts
+++ b/app/modules/team-member/service.server.ts
@@ -6,9 +6,21 @@ import type { ErrorLabel } from "~/utils/error";
 import { ShelfError } from "~/utils/error";
 import { getCurrentSearchParams } from "~/utils/http.server";
 import { ALL_SELECTED_KEY, getParamsValues } from "~/utils/list";
+import { Logger } from "~/utils/logger";
 import type { CreateAssetFromContentImportPayload } from "../asset/types";
 
 const label: ErrorLabel = "Team Member";
+type TeamMemberWithUserData = Prisma.TeamMemberGetPayload<{
+  include: {
+    user: {
+      select: {
+        firstName: true;
+        lastName: true;
+        email: true;
+      };
+    };
+  };
+}>;
 
 export async function createTeamMember({
   name,
@@ -253,7 +265,7 @@ export async function getTeamMemberForCustodianFilter({
         db.teamMember.count({ where: { organizationId, deletedAt: null } }),
       ]);
 
-    const allTeamMembers = [
+    const teamMembers = [
       ...teamMembersSelected,
       ...teamMemberExcludedSelected,
     ].sort((a, b) => {
@@ -272,18 +284,11 @@ export async function getTeamMemberForCustodianFilter({
       return aName.localeCompare(bName);
     });
 
-    /**
-     * If teamMember has a user associated then we have to use that user's id
-     * otherwise we have to use teamMember's id
-     */
-    const combinedTeamMembers = allTeamMembers.map((teamMember) => ({
-      ...teamMember,
-      id: teamMember.userId ? teamMember.userId : teamMember.id,
-    }));
+    // /** Checks and fixes teamMember names if they are broken */
+    void fixTeamMembersNames(teamMembers);
 
     return {
-      teamMembers: combinedTeamMembers,
-      rawTeamMembers: allTeamMembers,
+      teamMembers,
       totalTeamMembers,
     };
   } catch (cause) {
@@ -353,6 +358,61 @@ export async function bulkDeleteNRMs({
     throw new ShelfError({
       cause,
       message,
+      label,
+    });
+  }
+}
+
+/**
+ * Checks if the team member name is empty. If it is, it is considered invalid and the team member id is returned
+ * @param teamMember Contains the team member data
+ * @returns teamMember.id if the name is empty
+ */
+function validateTeamMemberName(teamMember: TeamMemberWithUserData) {
+  if (!teamMember.name || teamMember.name.trim() === "") {
+    return teamMember.id;
+  }
+}
+
+/**
+ * Fixes team members with invalid names. THis runs as void on the background so it doenst block the main thread
+ * @param teamMembers  Array of team members with user data
+ */
+function fixTeamMembersNames(teamMembers: TeamMemberWithUserData[]) {
+  try {
+    const teamMembersWithEmptyNames = teamMembers.filter(
+      validateTeamMemberName
+    );
+    /** If there are none, just return */
+    if (teamMembersWithEmptyNames.length === 0) return;
+
+    /** If there are broken ones, log them so we know what is going on. If this keeps on appearing in the logs that means its an ongoing issue and the cause should be found. */
+    Logger.error(
+      new ShelfError({
+        cause: null,
+        message: "Team members with empty names found",
+        additionalData: { teamMembersWithEmptyNames },
+        label,
+      })
+    );
+
+    /**
+     * Itterate over the members and update them without awaiting
+     * Just in case we check again
+     */
+    teamMembersWithEmptyNames.forEach((teamMember) => {
+      const name = teamMember.user
+        ? `${teamMember.user.firstName} ${teamMember.user.lastName}`
+        : "Unknown name";
+      void db.teamMember.update({
+        where: { id: teamMember.id },
+        data: { name },
+      });
+    });
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Failed to fix team members names",
       label,
     });
   }

--- a/app/routes/_layout+/admin-dashboard+/org.$organizationId.assets.tsx
+++ b/app/routes/_layout+/admin-dashboard+/org.$organizationId.assets.tsx
@@ -49,7 +49,6 @@ export const loader = async ({
       totalLocations,
       teamMembers,
       totalTeamMembers,
-      rawTeamMembers,
     } = await getPaginatedAndFilterableAssets({
       request,
       organizationId,
@@ -83,7 +82,6 @@ export const loader = async ({
         totalLocations,
         teamMembers,
         totalTeamMembers,
-        rawTeamMembers,
       })
     );
   } catch (cause) {

--- a/app/routes/_layout+/bookings.$bookingId.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.tsx
@@ -193,6 +193,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     const header: HeaderData = {
       title: `Edit | ${booking.name}`,
     };
+    const totalPages = Math.ceil(totalAssets / perPage);
 
     return json(
       data({
@@ -203,7 +204,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         page,
         totalItems: totalAssets,
         perPage,
-        totalPages: totalAssets / perPage,
+        totalPages,
         ...teamMembersData,
         bookingFlags,
       }),

--- a/app/routes/_layout+/locations.$locationId.tsx
+++ b/app/routes/_layout+/locations.$locationId.tsx
@@ -83,7 +83,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     });
 
     const totalItems = totalAssetsWithinLocation;
-    const totalPages = totalAssetsWithinLocation / perPage;
+    const totalPages = Math.ceil(totalAssetsWithinLocation / perPage);
 
     const header: HeaderData = {
       title: location.name,

--- a/app/routes/_layout+/settings.team.users.$userId.assets.tsx
+++ b/app/routes/_layout+/settings.team.users.$userId.assets.tsx
@@ -66,10 +66,8 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
       totalTags,
       locations,
       totalLocations,
-      teamMembers,
-      totalTeamMembers,
-      rawTeamMembers,
     } = await getPaginatedAndFilterableAssets({
+      // @TODO this is a good example where we dont need the teamMembers so we should modify the function to allow skipping it from query as it can be very heavy. This should be done for every case where we dont use teamMembers
       request,
       organizationId,
       filters: filtersSearchParams.toString(),
@@ -98,9 +96,6 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
         totalTags,
         locations,
         totalLocations,
-        teamMembers,
-        totalTeamMembers,
-        rawTeamMembers,
         modelName,
       }),
       {


### PR DESCRIPTION
- make sure to use `resolveTeamMemberName` in the booking for as name was not being displayed correctly
- create a helper type: `TeamMemberWithUserData`
- create a function that checks and updates corrupted team members: `fixTeamMembersNames`
- fixing a weird thing in getTeamMemberForCustodianFilter. It was doing some `combinedTeamMembers` where it was using the `userId` as the id in a `TeamMember[]`
- removed all uses or `rawTeamMembers` as we seem to not need it anymore