### PR TITLE
fix: base and self service users cannot see bookings

### DIFF
--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -594,12 +594,26 @@ export async function getBookings(params: {
         mode: "insensitive",
       };
     }
-    if (custodianTeamMemberId) {
-      where.custodianTeamMemberId = custodianTeamMemberId;
+
+    /** In the case both are passed, we do an OR */
+    if (custodianTeamMemberId && custodianUserId) {
+      where.OR = [
+        {
+          custodianTeamMemberId,
+        },
+        {
+          custodianUserId,
+        },
+      ];
+    } else {
+      if (custodianTeamMemberId) {
+        where.custodianTeamMemberId = custodianTeamMemberId;
+      }
+      if (custodianUserId) {
+        where.custodianUserId = custodianUserId;
+      }
     }
-    if (custodianUserId) {
-      where.custodianUserId = custodianUserId;
-    }
+
     if (statuses?.length) {
       where.status = {
         in: statuses,


### PR DESCRIPTION
- made sure that for self service and base users we are also querying bookings with teamMemberId
- updated getBookings to support an OR query when both user and teamMember id are passed
- added a feature that when accepting an invite, if there are any bookings attached to the team member, we update them by linking them also to the user