### PR TITLE
fix: dont allow multiple pending invites for the same org

### DIFF
--- a/app/routes/_layout+/settings.team.users.invite-user.tsx
+++ b/app/routes/_layout+/settings.team.users.invite-user.tsx
@@ -111,6 +111,24 @@ export const action = async ({ context, request }: ActionFunctionArgs) => {
       }
     }
 
+    const existingInvites = await db.invite.findMany({
+      where: {
+        status: "PENDING",
+        inviteeEmail: email,
+        organizationId,
+      },
+    });
+
+    if (existingInvites.length) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "User already has a pending invite. Either resend it or cancel it in order to be able to send a new one.",
+        additionalData: { email, organizationId },
+        label: "Invite",
+      });
+    }
+
     const invite = await createInvite({
       organizationId,
       inviteeEmail: email,
@@ -252,6 +270,13 @@ export default function InviteUser() {
               required
             />
           </div>
+
+          {actionData?.error ? (
+            <div className="text-sm text-error-500">
+              {actionData.error.message}
+            </div>
+          ) : null}
+
           <div className="mt-7 flex gap-1">
             <Button
               variant="secondary"
@@ -267,11 +292,6 @@ export default function InviteUser() {
             </Button>
           </div>
         </Form>
-        {actionData?.error ? (
-          <div className="text-sm text-error-500">
-            {actionData.error.message}
-          </div>
-        ) : null}
       </div>
     </>
   ) : null;


### PR DESCRIPTION
- Make sure to block sending an invite if there are already pending invites the the same email and same workspace
- Display a clear error message to handle this case