### PR TITLE
fix: wrong advanced filter formatting handling

### DIFF
--- a/app/components/assets/assets-index/advanced-filters/operator-selector.tsx
+++ b/app/components/assets/assets-index/advanced-filters/operator-selector.tsx
@@ -25,7 +25,7 @@ function FilterOperatorDisplay({
 }
 
 /** Maps the FilterOperator to a user friendly name */
-const operatorsMap: Record<FilterOperator, string[]> = {
+export const operatorsMap: Record<FilterOperator, string[]> = {
   is: ["=", "is"],
   isNot: ["≠", "Is not"],
   contains: ["∋", "Contains"],

--- a/app/modules/asset/data.server.ts
+++ b/app/modules/asset/data.server.ts
@@ -219,7 +219,7 @@ export async function advancedModeLoader({
     filters,
     serializedCookie: filtersCookie,
     redirectNeeded,
-  } = await getAdvancedFiltersFromRequest(request, organizationId);
+  } = await getAdvancedFiltersFromRequest(request, organizationId, settings);
 
   const currentFilterParams = new URLSearchParams(filters || "");
   const searchParams = filters
@@ -227,9 +227,12 @@ export async function advancedModeLoader({
     : getCurrentSearchParams(request);
   const paramsValues = getParamsValues(searchParams);
   const { teamMemberIds } = paramsValues;
-  if (filters && redirectNeeded) {
+
+  if (redirectNeeded) {
     const cookieParams = new URLSearchParams(filters);
-    return redirect(`/assets?${cookieParams.toString()}`);
+    return redirect(`/assets?${cookieParams.toString()}`, {
+      headers: filtersCookie ? [setCookie(filtersCookie)] : undefined,
+    });
   }
 
   /** Query tierLimit, assets & Asset index settings */

--- a/app/modules/asset/utils.server.ts
+++ b/app/modules/asset/utils.server.ts
@@ -1,6 +1,8 @@
 import type { Asset, AssetStatus, Location, Prisma } from "@prisma/client";
 import { z } from "zod";
+import { filterOperatorSchema } from "~/components/assets/assets-index/advanced-filters/schema";
 import { getParamsValues } from "~/utils/list";
+import type { Column } from "../asset-index-settings/helpers";
 
 export function getLocationUpdateNoteContent({
   currentLocation,
@@ -143,4 +145,63 @@ export function getAssetsWhereInput({
   }
 
   return where;
+}
+
+/**
+ * Schema for validating advanced filter parameter format
+ * Validates the 'operator:value' format and ensures operator is valid
+ */
+export const advancedFilterFormatSchema = z.string().refine(
+  (value) => {
+    const parts = value.split(":");
+    if (parts.length !== 2) return false;
+
+    const [operator] = parts;
+    return filterOperatorSchema.safeParse(operator).success;
+  },
+  {
+    message: "Filter must be in format 'operator:value' with valid operator",
+  }
+);
+
+/**
+ * Validates if a filter value matches the expected advanced filter format
+ * Uses Zod schema for strict type validation
+ * @param value - The filter value to validate
+ * @returns boolean indicating if the value matches advanced filter format
+ */
+function isValidAdvancedFilterFormat(value: string): boolean {
+  return advancedFilterFormatSchema.safeParse(value).success;
+}
+
+/**
+ * Validates and sanitizes URL parameters for advanced index mode
+ * Removes any parameters that don't match the expected advanced filter format
+ * @param searchParams - The URL search parameters to validate
+ * @param columns - The configured columns for advanced index
+ * @returns Validated and sanitized search parameters
+ */
+export function validateAdvancedFilterParams(
+  searchParams: URLSearchParams,
+  columns: Column[]
+): URLSearchParams {
+  const validatedParams = new URLSearchParams();
+  const columnNames = columns.map((col) => col.name);
+
+  // Iterate through all parameters
+  searchParams.forEach((value, key) => {
+    // Preserve non-filter params (pagination, sorting, etc)
+    if (!columnNames.includes(key as any)) {
+      validatedParams.append(key, value);
+      return;
+    }
+
+    // Validate filter format for column parameters
+    if (isValidAdvancedFilterFormat(value)) {
+      validatedParams.append(key, value);
+    }
+    // Invalid format - parameter will be dropped
+  });
+
+  return validatedParams;
 }

--- a/app/utils/csv.server.ts
+++ b/app/utils/csv.server.ts
@@ -250,7 +250,8 @@ export async function exportAssetsFromIndexToCsv({
   /** Parse filters */
   const { filters } = await getAdvancedFiltersFromRequest(
     request,
-    organizationId
+    organizationId,
+    settings
   );
 
   /** Make an array of the ids and check if we have to take all */


### PR DESCRIPTION
## The symptoms and problem

We have found a bug with the advanced index This shouldn't happen but it happened to some of our users, so we need a way to handle it to prevent an error if it happens again.

So lets say you navigate to this url: http://localhost:3000/assets?status=AVAILABLE
But you have advanced index mode active.

The params structure in the advanced index is different, however status is a proper param name. So it was crashing because it was trying to parse AVAILABLE as a advanced index filtering param but it doesnt have the correct format.

THe format in the url above is the one we use on simple index. I am not sure how this leaked to the url params in the case of our user. My only thought is that they already had advanced mode active and they typed in their url bar and this was the automatic URL suggested.

## The Fix

Implemented some functions that validate the format of the params values for params which are within the column filter names. If there are some broken ones, we remove them and reload the page with the cookie updated.