### PR TITLE
fix: removed AssetSearchView

### DIFF
--- a/app/components/layout/sidebar/parent-nav-item.tsx
+++ b/app/components/layout/sidebar/parent-nav-item.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "@remix-run/react";
+import { NavLink, useNavigate } from "@remix-run/react";
 import { ChevronDownIcon } from "lucide-react";
 import invariant from "tiny-invariant";
 import {
@@ -22,6 +22,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  useSidebar,
 } from "./sidebar";
 
 type ParentNavItemProps = {
@@ -35,6 +36,8 @@ export default function ParentNavItem({
   tooltip,
   closeIfMobile,
 }: ParentNavItemProps) {
+  const { open } = useSidebar();
+  const navigate = useNavigate();
   const isAnyChildActive = useIsAnyRouteActive(
     route.children.map((child) => child.to)
   );
@@ -46,6 +49,9 @@ export default function ParentNavItem({
   );
 
   function handleClick() {
+    if (!open) {
+      navigate(firstChildRoute.to);
+    }
     closeIfMobile && closeIfMobile();
   }
 

--- a/app/database/migrations/20241218134155_add_indexes_for_better_asset_search_performance/migration.sql
+++ b/app/database/migrations/20241218134155_add_indexes_for_better_asset_search_performance/migration.sql
@@ -1,0 +1,8 @@
+-- Migration: add_asset_search_indexes
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Add compound index for title and description using gin_trgm_ops
+CREATE INDEX "Asset_title_description_idx" ON public."Asset" USING gin (title gin_trgm_ops, description gin_trgm_ops);
+
+-- Add index for team member name search
+CREATE INDEX "TeamMember_name_idx" ON public."TeamMember" USING gin (name gin_trgm_ops);

--- a/app/database/migrations/20241218134451_remove_asset_search_view/migration.sql
+++ b/app/database/migrations/20241218134451_remove_asset_search_view/migration.sql
@@ -1,0 +1,2 @@
+-- Migration: remove_asset_search_view
+DROP VIEW IF EXISTS public."AssetSearchView";

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -6,7 +6,7 @@ datasource db {
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["views", "fullTextSearch"]
+  previewFeatures = ["fullTextSearch"]
 }
 
 model Image {
@@ -113,23 +113,11 @@ model Asset {
   reports         ReportFound[]
   tags            Tag[]
   customFields    AssetCustomFieldValue[]
-  assetSearchView AssetSearchView?
   bookings        Booking[]
 
   //@@unique([title, organizationId]) //prisma doesnt support case insensitive unique index yet
 }
 
-view AssetSearchView {
-  id           String @id @default(cuid())
-  searchVector String
-
-  // Relationships
-  asset   Asset  @relation(fields: [assetId], references: [id])
-  assetId String @unique
-
-  // Datetime
-  createdAt DateTime @default(now())
-}
 
 enum AssetStatus {
   AVAILABLE

--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -189,341 +189,15 @@ const unavailableBookingStatuses = [
 ];
 
 /**
- * Fetches assets from AssetSearchView
- * This is used to have a more advanced search however its less performant
+ * Fetches assets directly from the asset table with enhanced search capabilities
+ * @param params Search and filtering parameters for asset queries
+ * @returns Assets and total count matching the criteria
  */
-async function getAssetsFromView(params: {
-  organizationId: Organization["id"];
-  /** Page number. Starts at 1 */
-  page: number;
-  /** Assets to be loaded per page */
-
-  orderBy: SortingOptions;
-  orderDirection: SortingDirection;
-  perPage?: number;
-  search?: string | null;
-  categoriesIds?: Category["id"][] | null;
-  tagsIds?: Tag["id"][] | null;
-  status?: Asset["status"] | null;
-  hideUnavailable?: Asset["availableToBook"];
-  bookingFrom?: Booking["from"];
-  bookingTo?: Booking["to"];
-  unhideAssetsBookigIds?: Booking["id"][];
-  locationIds?: Location["id"][] | null;
-  teamMemberIds?: TeamMember["id"][] | null;
-  extraInclude?: Prisma.AssetInclude;
-}) {
-  let {
-    organizationId,
-    orderBy,
-    orderDirection,
-    page = 1,
-    perPage = 8,
-    search,
-    categoriesIds,
-    tagsIds,
-    status,
-    bookingFrom,
-    bookingTo,
-    hideUnavailable,
-    unhideAssetsBookigIds, // works in conjuction with hideUnavailable, to show currentbooking assets
-    locationIds,
-    teamMemberIds,
-    extraInclude,
-  } = params;
-
-  try {
-    const skip = page > 1 ? (page - 1) * perPage : 0;
-    const take = perPage >= 1 && perPage <= 100 ? perPage : 20; // min 1 and max 25 per page
-
-    /** Default value of where. Takes the assets belonging to current user */
-    let where: Prisma.AssetSearchViewWhereInput = {
-      asset: {
-        organizationId,
-        // Ensure asset exists
-        id: { not: undefined },
-      },
-    };
-
-    /** If the search string exists, add it to the where object */
-    if (search) {
-      try {
-        const words = search
-          .replace(/([()&|!':><])/g, "\\$1")
-          .trim()
-          .replace(/ +/g, " ")
-          .split(" ")
-          .map((w) => {
-            const trimmed = w.trim();
-            return trimmed ? trimmed + ":*" : "";
-          })
-          .filter(Boolean)
-          .join(" & ");
-
-        where.searchVector = {
-          search: words || undefined, // Prevent empty search causing DB error
-        };
-      } catch (error) {
-        // Log error but allow query to continue without search filter
-        Logger.error(
-          new ShelfError({
-            cause: error,
-            message: "Failed to parse search string for tsquery",
-            additionalData: { search },
-            label: "Assets",
-          })
-        );
-      }
-    }
-
-    if (status && where.asset) {
-      where.asset.status = status;
-    }
-
-    if (categoriesIds && categoriesIds.length > 0 && where.asset) {
-      if (categoriesIds.includes("uncategorized")) {
-        where.asset.OR = [
-          {
-            categoryId: {
-              in: categoriesIds,
-            },
-          },
-          {
-            categoryId: null,
-          },
-        ];
-      } else {
-        where.asset.categoryId = {
-          in: categoriesIds,
-        };
-      }
-    }
-
-    if (hideUnavailable && where.asset) {
-      //not disabled for booking
-      where.asset.availableToBook = true;
-      //not assigned to team meber
-      where.asset.custody = null;
-      if (bookingFrom && bookingTo) {
-        //reserved during that time
-        where.asset.bookings = {
-          none: {
-            ...(unhideAssetsBookigIds?.length && {
-              id: { notIn: unhideAssetsBookigIds },
-            }),
-            status: { in: unavailableBookingStatuses },
-            OR: [
-              {
-                from: { lte: bookingTo },
-                to: { gte: bookingFrom },
-              },
-              {
-                from: { gte: bookingFrom },
-                to: { lte: bookingTo },
-              },
-            ],
-          },
-        };
-      }
-    }
-    if (hideUnavailable === true && (!bookingFrom || !bookingTo)) {
-      throw new ShelfError({
-        cause: null,
-        message: "booking dates are needed to hide unavailable assets",
-        additionalData: {
-          hideUnavailable,
-          bookingFrom,
-          bookingTo,
-        },
-        label,
-      });
-    }
-    if (bookingFrom && bookingTo && where.asset) {
-      where.asset.availableToBook = true;
-    }
-
-    if (tagsIds && tagsIds.length > 0 && where.asset) {
-      // Check if 'untagged' is part of the selected tag IDs
-      if (tagsIds.includes("untagged")) {
-        // Remove 'untagged' from the list of tags
-        tagsIds = tagsIds.filter((id) => id !== "untagged");
-
-        // Filter for assets that are untagged only
-        where.asset.OR = [
-          ...(where.asset.OR || []), // Preserve existing AND conditions if any
-          { tags: { none: {} } }, // Include assets with no tags
-        ];
-      }
-
-      // If there are other tags specified, apply AND condition
-      if (tagsIds.length > 0) {
-        where.asset.OR = [
-          ...(where.asset.OR || []), // Preserve existing AND conditions if any
-          { tags: { some: { id: { in: tagsIds } } } }, // Filter by remaining tags
-        ];
-      }
-    }
-
-    if (locationIds && locationIds.length > 0 && where.asset) {
-      // Check if 'without-location' is part of the selected location IDs
-      if (locationIds.includes("without-location")) {
-        // Remove 'without-location' from the list of locations
-        locationIds = locationIds.filter((id) => id !== "without-location");
-
-        // Filter for assets that have no location only
-        where.asset.OR = [
-          ...(where.asset.OR || []), // Preserve existing OR conditions if any
-          { locationId: null }, // Include assets with no location
-        ];
-      }
-
-      // If there are other locations specified, apply OR condition
-      if (locationIds.length > 0) {
-        where.asset.OR = [
-          ...(where.asset.OR || []), // Preserve existing OR conditions if any
-          { locationId: { in: locationIds } }, // Filter by remaining locations
-        ];
-      }
-    }
-
-    if (teamMemberIds && teamMemberIds.length > 0 && where.asset) {
-      // Check if "without-custody" is selected
-      const hasWithoutCustody = teamMemberIds.includes("without-custody");
-      // Check if there are other specific team members
-      const hasSpecificTeamMembers = teamMemberIds.some(
-        (id) => id !== "without-custody"
-      );
-      if (hasWithoutCustody && hasSpecificTeamMembers) {
-        // If both conditions are true, logically ensure no results are returned
-        where.asset.AND = [
-          //@ts-expect-error
-          ...(where.asset.AND ?? []),
-          { custody: { is: null } }, // Assets without custody
-          {
-            custody: {
-              teamMemberId: {
-                in: teamMemberIds.filter((id) => id !== "without-custody"),
-              },
-            },
-          }, // Assets with specific team members
-        ];
-      } else {
-        // Combine conditions using AND to ensure all filters apply together
-        where.asset.AND = [
-          // Preserve any existing AND conditions
-          ...(where.asset.AND ?? []),
-          hasWithoutCustody
-            ? {
-                /** If without custody is selected, get assets without custody  */
-                custody: { is: null },
-              }
-            : {
-                // Use OR to match assets that are in custody of specified team members
-                OR: [
-                  // Assets directly assigned to the specified team members
-                  { custody: { teamMemberId: { in: teamMemberIds } } },
-                  // Assets assigned to the specified team members through an ongoing or overdue booking
-                  {
-                    bookings: {
-                      some: {
-                        custodianTeamMemberId: { in: teamMemberIds },
-                        status: { in: ["ONGOING", "OVERDUE"] },
-                      },
-                    },
-                  },
-                  // Assets assigned to a user who is a member of the specified team through an ongoing or overdue booking
-                  {
-                    bookings: {
-                      some: {
-                        custodianUserId: { in: teamMemberIds },
-                        status: { in: ["ONGOING", "OVERDUE"] },
-                      },
-                    },
-                  },
-                  // Assets in custody of a user who is in the specified team
-                  { custody: { custodian: { userId: { in: teamMemberIds } } } },
-                ],
-              },
-        ];
-      }
-    }
-
-    /**
-     * User should only see the assets without kits for hideUnavailable true
-     */
-    if (hideUnavailable === true && where.asset) {
-      where.asset.kit = null;
-    }
-    const ASSET_INDEX_FIELDS = assetIndexFields({
-      bookingFrom,
-      bookingTo,
-      unavailableBookingStatuses,
-    });
-    const [assetSearch, totalAssets] = await Promise.all([
-      /** Get the assets */
-      db.assetSearchView.findMany({
-        skip,
-        take,
-        where,
-        include: {
-          asset: {
-            include: {
-              ...ASSET_INDEX_FIELDS,
-              ...extraInclude,
-            },
-          },
-        },
-        orderBy: { asset: { [orderBy]: orderDirection } },
-      }),
-
-      /** Count them */
-      db.assetSearchView.count({ where }),
-    ]);
-
-    // Filter out null assets while logging errors for monitoring
-    const validAssets = assetSearch.filter((result) => {
-      if (!result.asset) {
-        Logger.error(
-          new ShelfError({
-            cause: null,
-            message: "Found AssetSearchView record without associated asset",
-            label: "Assets",
-            additionalData: {
-              searchViewRecord: result,
-              organizationId,
-              query: "getAssetsFromView",
-              where,
-            },
-          })
-        );
-        return false;
-      }
-      return true;
-    });
-
-    return {
-      assets: validAssets.map((result) => result.asset),
-      totalAssets: totalAssets,
-    };
-  } catch (cause) {
-    throw new ShelfError({
-      cause,
-      message: "Something went wrong while fetching assets from view",
-      additionalData: { ...params },
-      label,
-    });
-  }
-}
-
 async function getAssets(params: {
   organizationId: Organization["id"];
-  /** Page number. Starts at 1 */
   page: number;
-
   orderBy: SortingOptions;
   orderDirection: SortingDirection;
-
-  /** Assets to be loaded per page */
   perPage?: number;
   search?: string | null;
   categoriesIds?: Category["id"][] | null;
@@ -551,46 +225,70 @@ async function getAssets(params: {
     bookingFrom,
     bookingTo,
     hideUnavailable,
-    unhideAssetsBookigIds, // works in conjuction with hideUnavailable, to show currentbooking assets
+    unhideAssetsBookigIds,
     teamMemberIds,
     extraInclude,
   } = params;
 
   try {
     const skip = page > 1 ? (page - 1) * perPage : 0;
-    const take = perPage >= 1 && perPage <= 100 ? perPage : 20; // min 1 and max 100 per page
+    const take = perPage >= 1 && perPage <= 100 ? perPage : 20;
 
-    /** Default value of where. Takes the assetss belonging to current user */
     let where: Prisma.AssetWhereInput = { organizationId };
 
-    /** If the search string exists, add it to the where object */
     if (search) {
-      where.title = {
-        contains: search.toLowerCase().trim(),
-        mode: "insensitive",
-      };
+      const searchTerms = search
+        .toLowerCase()
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean);
+
+      where.OR = searchTerms.map((term) => ({
+        OR: [
+          // Search in asset fields
+          { title: { contains: term, mode: "insensitive" } },
+          { description: { contains: term, mode: "insensitive" } },
+          // Search in related category
+          { category: { name: { contains: term, mode: "insensitive" } } },
+          // Search in related location
+          { location: { name: { contains: term, mode: "insensitive" } } },
+          // Search in related tags
+          { tags: { some: { name: { contains: term, mode: "insensitive" } } } },
+          // Search in custodian names
+          {
+            custody: {
+              custodian: {
+                OR: [
+                  { name: { contains: term, mode: "insensitive" } },
+                  {
+                    user: {
+                      OR: [
+                        { firstName: { contains: term, mode: "insensitive" } },
+                        { lastName: { contains: term, mode: "insensitive" } },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }));
     }
 
     if (status) {
       where.status = status;
     }
 
-    if (categoriesIds && categoriesIds.length > 0) {
+    if (categoriesIds?.length) {
       if (categoriesIds.includes("uncategorized")) {
         where.OR = [
-          {
-            categoryId: {
-              in: categoriesIds,
-            },
-          },
-          {
-            categoryId: null,
-          },
+          ...(where.OR ?? []),
+          { categoryId: { in: categoriesIds } },
+          { categoryId: null },
         ];
       } else {
-        where.categoryId = {
-          in: categoriesIds,
-        };
+        where.categoryId = { in: categoriesIds };
       }
     }
 
@@ -698,71 +396,20 @@ async function getAssets(params: {
     }
 
     const [assets, totalAssets] = await Promise.all([
-      /** Get the assets */
       db.asset.findMany({
         skip,
         take,
         where,
         include: {
-          kit: true,
-          category: true,
-          tags: true,
-          location: {
-            select: {
-              name: true,
-            },
-          },
-          custody: {
-            select: {
-              custodian: {
-                select: {
-                  userId: true,
-                  name: true,
-                  user: {
-                    select: {
-                      email: true,
-                      firstName: true,
-                      lastName: true,
-                      profilePicture: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
-          ...(bookingTo && bookingFrom
-            ? {
-                bookings: {
-                  where: {
-                    status: { in: unavailableBookingStatuses },
-                    OR: [
-                      {
-                        from: { lte: bookingTo },
-                        to: { gte: bookingFrom },
-                      },
-                      {
-                        from: { gte: bookingFrom },
-                        to: { lte: bookingTo },
-                      },
-                    ],
-                  },
-                  take: 1, //just to show in UI if its booked, so take only 1, also at a given slot only 1 booking can be created for an asset
-                  select: {
-                    from: true,
-                    to: true,
-                    status: true,
-                    id: true,
-                    name: true,
-                  },
-                },
-              }
-            : {}),
+          ...assetIndexFields({
+            bookingFrom,
+            bookingTo,
+            unavailableBookingStatuses,
+          }),
           ...extraInclude,
         },
         orderBy: { [orderBy]: orderDirection },
       }),
-
-      /** Count them */
       db.asset.count({ where }),
     ]);
 
@@ -1599,7 +1246,6 @@ export async function getPaginatedAndFilterableAssets({
   extraInclude,
   excludeCategoriesQuery = false,
   excludeTagsQuery = false,
-  excludeSearchFromView = false,
   excludeLocationQuery = false,
   filters = "",
   isSelfService,
@@ -1613,11 +1259,7 @@ export async function getPaginatedAndFilterableAssets({
   excludeTagsQuery?: boolean;
   excludeLocationQuery?: boolean;
   filters?: string;
-  /**
-   * Set to true if you want the query to be performed by directly accessing the assets table
-   *  instead of the AssetSearchView
-   */
-  excludeSearchFromView?: boolean;
+
   isSelfService?: boolean;
   userId?: string;
 }) {
@@ -1699,9 +1341,7 @@ export async function getPaginatedAndFilterableAssets({
       }),
     ]);
 
-    let getFunction = getAssetsFromView;
-
-    let getParams = {
+    const { assets, totalAssets } = await getAssets({
       organizationId,
       page,
       perPage,
@@ -1718,12 +1358,8 @@ export async function getPaginatedAndFilterableAssets({
       locationIds,
       teamMemberIds,
       extraInclude,
-    };
-    if (excludeSearchFromView) {
-      getFunction = getAssets;
-    }
+    });
 
-    const { assets, totalAssets } = await getFunction(getParams);
     const totalPages = Math.ceil(totalAssets / perPage);
 
     return {
@@ -1754,7 +1390,6 @@ export async function getPaginatedAndFilterableAssets({
         organizationId,
         excludeCategoriesQuery,
         excludeTagsQuery,
-        excludeSearchFromView,
         paramsValues,
         getAllEntries,
       },

--- a/app/routes/_layout+/locations.$locationId.add-assets.tsx
+++ b/app/routes/_layout+/locations.$locationId.add-assets.tsx
@@ -101,7 +101,6 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     } = await getPaginatedAndFilterableAssets({
       request,
       organizationId,
-      excludeSearchFromView: true,
     });
 
     const modelName = {


### PR DESCRIPTION
We have been facing a lot of query errors and performance issues with the `AssetSearchView`. It was considerably slower than the normal search so I have taken the decision to drop it and replace it with prisma queries that create the same functionality. Based on my tests this is already way more performant than the view.

What has been done:
- removed function that searches in view for asset index
- updated getAssets to do the same as the search view but by using OR to search in all fields
- updated assetIndexFields to properly reflect the fields needed for the asset index
- removed AssetSearchView from schema
- created migration to remove AssetSearchView from DB
- created migration to add some more indexes to even better improve performance of simple asset index
- fixed a small bug with buttons in sidebar when its folded