### PR TITLE
feat: adds row level security to _AssetToTag table

### DIFF
--- a/app/database/migrations/20250102153310_enable_row_level_security_for_asset_to_tag/migration.sql
+++ b/app/database/migrations/20250102153310_enable_row_level_security_for_asset_to_tag/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "_AssetToTag" ENABLE row level security;


### PR DESCRIPTION
I have been getting warnings saying row level security is not enabled for `_prisma_migrations` and `_AssetToTag`. I have added a migration to enable it for `_AssetToTag` however I was struggling with `_prisma_migrations` I think due to the table not existing in the "shadow database". I have manually enabled it and things seem to still work so maybe we could add it to the docs or I could play so more with getting a migration working.

![Screenshot 2025-01-02 at 16 42 54](https://github.com/user-attachments/assets/6ecdfcfb-fb19-419f-b71b-da19fc245222)
