### PR TITLE
feature: add excludeAny for tags filters on advanced index

### DIFF
--- a/app/components/assets/assets-index/advanced-asset-index-filters-and-sorting.tsx
+++ b/app/components/assets/assets-index/advanced-asset-index-filters-and-sorting.tsx
@@ -289,6 +289,14 @@ function AdvancedFilter() {
                 </div>
                 <span className="inline-block align-middle">Add filter</span>
               </Button>
+              <Button
+                variant="block-link-gray"
+                size="xs"
+                className="ml-1"
+                to="mailto:nikolay@shelf.nu?subject=Advanced filtering suggestions"
+              >
+                Need more filtering options?
+              </Button>
             </div>
             <div className="flex items-center justify-between gap-4">
               {filters.length > 0 && (

--- a/app/components/assets/assets-index/advanced-filters/operator-selector.tsx
+++ b/app/components/assets/assets-index/advanced-filters/operator-selector.tsx
@@ -42,6 +42,7 @@ export const operatorsMap: Record<FilterOperator, string[]> = {
   containsAny: ["⊃", "Contains any"],
   matchesAny: ["≈", "Matches any"],
   inDates: ["∈", "In dates"],
+  excludeAny: ["⊄", "Exclude any of"], // New operator with clear meaning for tag exclusion
 };
 
 // Define the allowed operators for each field type
@@ -52,7 +53,7 @@ export const operatorsPerType: FilterDefinition = {
   date: ["is", "isNot", "before", "after", "between", "inDates"],
   number: ["is", "isNot", "gt", "lt", "gte", "lte", "between"],
   enum: ["is", "isNot", "containsAny"],
-  array: ["contains", "containsAll", "containsAny"],
+  array: ["contains", "containsAll", "containsAny", "excludeAny"],
   customField: [], // empty array as customField operators are determined by the actual field type
 };
 

--- a/app/components/assets/assets-index/advanced-filters/schema.ts
+++ b/app/components/assets/assets-index/advanced-filters/schema.ts
@@ -19,6 +19,7 @@ export const filterOperatorSchema = z.enum([
   "containsAny",
   "matchesAny",
   "inDates",
+  "excludeAny",
 ]);
 
 export const filterFieldTypeSchema = z.enum([

--- a/app/modules/asset/query.server.ts
+++ b/app/modules/asset/query.server.ts
@@ -788,6 +788,27 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
       const valuesArray = `{${values.map((v) => `"${v}"`).join(",")}}`;
       return Prisma.sql`${whereClause} AND LOWER(t.name) = ANY(ARRAY(SELECT LOWER(unnest(${valuesArray}::text[]))))`;
     }
+    case "excludeAny": {
+      // Exclude assets that have ANY of the specified tags
+      const values = (filter.value as string).split(",").map((v) => v.trim());
+
+      if (values.includes("untagged")) {
+        // If "untagged" is included, we want to ensure assets have at least one tag
+        return Prisma.sql`${whereClause} AND EXISTS (
+          SELECT 1 FROM "_AssetToTag" att2 
+          WHERE att2."A" = a.id
+        )`;
+      }
+
+      const valuesArray = `{${values.map((v) => `"${v}"`).join(",")}}`;
+      return Prisma.sql`${whereClause} AND NOT EXISTS (
+        SELECT 1 
+        FROM "_AssetToTag" att2
+        JOIN "Tag" t2 ON t2.id = att2."B"
+        WHERE att2."A" = a.id 
+        AND t2.name = ANY(${valuesArray}::text[])
+      )`;
+    }
     default:
       return whereClause;
   }


### PR DESCRIPTION
Allows to filter advanced index by excluding tags.
This PR also adds a small button that allows users to recommend more filtering options to be implemented.