### PR TITLE
feat: custodian filtering on bookings index

### DIFF
--- a/app/components/booking/booking-assets-column.tsx
+++ b/app/components/booking/booking-assets-column.tsx
@@ -5,7 +5,7 @@ import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { useLoaderData } from "@remix-run/react";
 import { useBookingStatusHelpers } from "~/hooks/use-booking-status";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
-import type { BookingWithCustodians } from "~/routes/_layout+/bookings";
+import type { BookingWithCustodians } from "~/modules/booking/types";
 import type { AssetWithBooking } from "~/routes/_layout+/bookings.$bookingId.add-assets";
 import { tw } from "~/utils/tw";
 import { groupBy } from "~/utils/utils";

--- a/app/components/booking/kit-row-actions-dropdown.tsx
+++ b/app/components/booking/kit-row-actions-dropdown.tsx
@@ -1,7 +1,7 @@
 import type { Kit } from "@prisma/client";
 import { Form, useLoaderData } from "@remix-run/react";
 import { useBookingStatusHelpers } from "~/hooks/use-booking-status";
-import type { BookingWithCustodians } from "~/routes/_layout+/bookings";
+import type { BookingWithCustodians } from "~/modules/booking/types";
 import { tw } from "~/utils/tw";
 import { TrashIcon, VerticalDotsIcon } from "../icons/library";
 import { Button } from "../shared/button";

--- a/app/components/booking/remove-asset-from-booking.tsx
+++ b/app/components/booking/remove-asset-from-booking.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogTrigger,
 } from "~/components/shared/modal";
 import { useBookingStatusHelpers } from "~/hooks/use-booking-status";
-import type { BookingWithCustodians } from "~/routes/_layout+/bookings";
+import type { BookingWithCustodians } from "~/modules/booking/types";
 import { isFormProcessing } from "~/utils/form";
 import { tw } from "~/utils/tw";
 import { Form } from "../custom-form";

--- a/app/components/dynamic-dropdown/dynamic-dropdown.tsx
+++ b/app/components/dynamic-dropdown/dynamic-dropdown.tsx
@@ -161,7 +161,7 @@ export default function DynamicDropdown({
                   <Button
                     icon="x"
                     variant="tertiary"
-                    disabled={Boolean(searchQuery)}
+                    disabled={!searchQuery || searchQuery === ""}
                     onClick={() => {
                       resetModelFiltersFetcher();
                       setSearchQuery("");

--- a/app/modules/booking/types.ts
+++ b/app/modules/booking/types.ts
@@ -29,3 +29,13 @@ export type BookingUpdateIntent =
   | "checkIn"
   | "archive"
   | "cancel";
+
+export type BookingWithCustodians = Prisma.BookingGetPayload<{
+  include: {
+    assets: true;
+    from: true;
+    to: true;
+    custodianUser: true;
+    custodianTeamMember: true;
+  };
+}>;

--- a/app/modules/types.ts
+++ b/app/modules/types.ts
@@ -22,3 +22,8 @@ export interface SearchableIndexResponse {
     text: string;
   };
 }
+
+export type RouteHandleWithName = {
+  name?: string;
+  [key: string]: any;
+};

--- a/app/routes/_layout+/bookings.$bookingId.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.tsx
@@ -30,6 +30,7 @@ import {
 import { createNotes } from "~/modules/note/service.server";
 import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
 import { getTeamMemberForCustodianFilter } from "~/modules/team-member/service.server";
+import type { RouteHandleWithName } from "~/modules/types";
 import { getUserByID } from "~/modules/user/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
@@ -54,7 +55,6 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
-import type { RouteHandleWithName } from "./bookings";
 import { bookingStatusColorMap } from "./bookings";
 
 export async function loader({ context, request, params }: LoaderFunctionArgs) {

--- a/app/routes/_layout+/bookings.$bookingId.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.tsx
@@ -33,6 +33,7 @@ import { getTeamMemberForCustodianFilter } from "~/modules/team-member/service.s
 import type { RouteHandleWithName } from "~/modules/types";
 import { getUserByID } from "~/modules/user/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { bookingStatusColorMap } from "~/utils/bookings";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getClientHint, getHints } from "~/utils/client-hints";
 import {
@@ -55,7 +56,6 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
-import { bookingStatusColorMap } from "./bookings";
 
 export async function loader({ context, request, params }: LoaderFunctionArgs) {
   const authSession = context.getSession();

--- a/app/routes/_layout+/calendar.tsx
+++ b/app/routes/_layout+/calendar.tsx
@@ -33,6 +33,7 @@ import When from "~/components/when/when";
 import { useViewportHeight } from "~/hooks/use-viewport-height";
 import calendarStyles from "~/styles/layout/calendar.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { bookingStatusColorMap } from "~/utils/bookings";
 import {
   getStatusClasses,
   isOneDayEvent,
@@ -48,7 +49,6 @@ import {
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
 import { tw } from "~/utils/tw";
-import { bookingStatusColorMap } from "./bookings";
 
 export function links() {
   return [{ rel: "stylesheet", href: calendarStyles }];

--- a/app/routes/_layout+/settings.team.invites.tsx
+++ b/app/routes/_layout+/settings.team.invites.tsx
@@ -19,6 +19,7 @@ import { db } from "~/database/db.server";
 
 import { getPaginatedAndFilterableSettingInvites } from "~/modules/invite/service.server";
 import type { TeamMembersWithUserOrInvite } from "~/modules/settings/service.server";
+import type { RouteHandleWithName } from "~/modules/types";
 import { resolveUserAction } from "~/modules/user/utils.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -29,7 +30,6 @@ import {
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
 import { tw } from "~/utils/tw";
-import type { RouteHandleWithName } from "./bookings";
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
   const authSession = context.getSession();

--- a/app/routes/_layout+/settings.team.users.tsx
+++ b/app/routes/_layout+/settings.team.users.tsx
@@ -19,6 +19,7 @@ import { db } from "~/database/db.server";
 
 import type { TeamMembersWithUserOrInvite } from "~/modules/settings/service.server";
 import { getPaginatedAndFilterableSettingUsers } from "~/modules/settings/service.server";
+import type { RouteHandleWithName } from "~/modules/types";
 import { resolveUserAction } from "~/modules/user/utils.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -29,7 +30,6 @@ import {
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
 import { tw } from "~/utils/tw";
-import type { RouteHandleWithName } from "./bookings";
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
   const authSession = context.getSession();

--- a/app/utils/bookings.ts
+++ b/app/utils/bookings.ts
@@ -23,3 +23,13 @@ export function canUserManageBookingAssets(
     !cantManageAssetsAsSelfService
   );
 }
+
+export const bookingStatusColorMap: { [key in BookingStatus]: string } = {
+  DRAFT: "#667085",
+  RESERVED: "#175CD3",
+  ONGOING: "#7A5AF8",
+  OVERDUE: "#B54708",
+  COMPLETE: "#17B26A",
+  ARCHIVED: "#667085",
+  CANCELLED: "#667085",
+};


### PR DESCRIPTION
**New**
- added custodian dropdown component to bookings index
- updated bookings index loader queries to load the required data for custodian filtering
- updated getBookings to receive array of custodianTeamMemberIds instead of just 1
- updated bookings index to pass the array of teamMemberIds to the getBookings function


**Fixes**
- fixed removed some types and helpers exports from bookings route file as it was breaking HMR
- fix types exported from wrong file, causing HMR failure
- fixed disabled state in search field inside DynamicDropdown