### PR TITLE
add email queue to handle email sending failures

### DIFF
--- a/app/components/user/request-delete-user.tsx
+++ b/app/components/user/request-delete-user.tsx
@@ -23,7 +23,7 @@ import { TrashIcon } from "../icons/library";
 
 const Schema = z.object({
   email: z.string().email(),
-  reason: z.string().min(10, "Reason is a required field"),
+  reason: z.string().min(3, "Reason is a required field"),
 });
 
 export const RequestDeleteUser = () => {

--- a/app/emails/email.worker.server.ts
+++ b/app/emails/email.worker.server.ts
@@ -1,0 +1,59 @@
+import { transporter } from "~/emails/transporter.server";
+import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import type { EmailPayloadType } from "./types";
+import { SMTP_FROM } from "../utils/env";
+import { ShelfError } from "../utils/error";
+
+export const registerEmailWorkers = async () => {
+  await scheduler.work<EmailPayloadType>(
+    QueueNames.emailQueue,
+    { newJobCheckIntervalSeconds: 60 * 3, teamSize: 2 },
+    async (job) => {
+      await triggerEmail(job.data);
+    }
+  );
+};
+
+export const triggerEmail = async ({
+  to,
+  subject,
+  text,
+  html,
+  from,
+  replyTo,
+}: EmailPayloadType) => {
+  try {
+    // send mail with defined transport object
+    await transporter.sendMail({
+      from: from || SMTP_FROM || `"Shelf" <updates@emails.shelf.nu>`, // sender address
+      replyTo: replyTo || "support@shelf.nu", // reply to
+      to, // list of receivers
+      subject, // Subject line
+      text, // plain text body
+      html: html || "", // html body
+    });
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Unable to send email",
+      additionalData: { to, subject, from },
+      label: "Email",
+    });
+  }
+
+  // verify connection configuration
+  // transporter.verify(function (error) {
+  //   if (error) {
+  //     // eslint-disable-next-line no-console
+  //     console.log(error);
+  //   } else {
+  //     // eslint-disable-next-line no-console
+  //     console.log("Server is ready to take our messages");
+  //   }
+  // });
+
+  // Message sent: <b658f8ca-6296-ccf4-8306-87d57a0b4321@example.com>
+
+  // Preview only available when sending through an Ethereal account
+  // console.log("Preview URL: %s", nodemailer.getTestMessageUrl(info));
+};

--- a/app/emails/email.worker.server.ts
+++ b/app/emails/email.worker.server.ts
@@ -4,10 +4,14 @@ import type { EmailPayloadType } from "./types";
 import { SMTP_FROM } from "../utils/env";
 import { ShelfError } from "../utils/error";
 
+// every node will execute 5 jobs(teamSize) every 3 minutes(newJobCheckIntervalSeconds),
+// increase teamSize if you need better concurrency
+// but keep email provider rate limiting and a potential n/w throughput load on postgress in mind
+// teamSize of 20-25 is a good limit if we need to scale email throughput in the future
 export const registerEmailWorkers = async () => {
   await scheduler.work<EmailPayloadType>(
     QueueNames.emailQueue,
-    { newJobCheckIntervalSeconds: 60 * 3, teamSize: 2 },
+    { newJobCheckIntervalSeconds: 60 * 3, teamSize: 5 },
     async (job) => {
       await triggerEmail(job.data);
     }

--- a/app/emails/mail.server.ts
+++ b/app/emails/mail.server.ts
@@ -1,104 +1,39 @@
-import type { Attachment } from "nodemailer/lib/mailer";
-import { transporter } from "~/emails/transporter.server";
-import { SMTP_FROM } from "../utils/env";
-import { ShelfError } from "../utils/error";
+import { Logger } from "~/utils/logger";
+import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import { triggerEmail } from "./email.worker.server";
+import type { EmailPayloadType } from "./types";
 
-export const sendEmail = async ({
-  to,
-  subject,
-  text,
-  html,
-  attachments,
-  from,
-  replyTo,
-}: {
-  /** Email address of recipient */
-  to: string;
-
-  /** Subject of email */
-  subject: string;
-
-  /** Text content of email */
-  text: string;
-
-  /** HTML content of email */
-  html?: string;
-
-  attachments?: Attachment[];
-
-  /** Override the default sender */
-  from?: string;
-
-  /** Override the default reply to email address */
-  replyTo?: string;
-}) => {
-  try {
-    // send mail with defined transport object
-    await transporter.sendMail({
-      from: from || SMTP_FROM || `"Shelf" <updates@emails.shelf.nu>`, // sender address
-      replyTo: replyTo || "support@shelf.nu", // reply to
-      to, // list of receivers
-      subject, // Subject line
-      text, // plain text body
-      html: html || "", // html body
-      attachments: [...(attachments || [])],
+export const sendEmail = (payload: EmailPayloadType) => {
+  // attempt to send email, push to the queue if it fails
+  triggerEmail(payload).catch((err) => {
+    Logger.warn({
+      err,
+      details: {
+        to: payload.to,
+        subject: payload.subject,
+        from: payload.from,
+      },
+      message: "email sending failed, pushing to the queue",
     });
-  } catch (cause) {
-    throw new ShelfError({
-      cause,
-      message: "Unable to send email",
-      additionalData: { to, subject, from },
-      label: "Email",
-    });
-  }
-
-  // verify connection configuration
-  // transporter.verify(function (error) {
-  //   if (error) {
-  //     // eslint-disable-next-line no-console
-  //     console.log(error);
-  //   } else {
-  //     // eslint-disable-next-line no-console
-  //     console.log("Server is ready to take our messages");
-  //   }
-  // });
-
-  // Message sent: <b658f8ca-6296-ccf4-8306-87d57a0b4321@example.com>
-
-  // Preview only available when sending through an Ethereal account
-  // console.log("Preview URL: %s", nodemailer.getTestMessageUrl(info));
+    void addToQueue(payload);
+  });
 };
 
-/** Utility function to add delay between operations */
-async function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/** Process emails in batches with rate limiting
- * @param emails - Array of email configurations to send
- * @param batchSize - Number of emails to process per batch (default: 2)
- * @param delayMs - Milliseconds to wait between batches (default: 1000ms)
- */
-export async function sendEmailsWithRateLimit(
-  emails: Array<{
-    to: string;
-    subject: string;
-    text: string;
-    html: string;
-  }>,
-  batchSize = 2,
-  delayMs = 1100
-): Promise<void> {
-  for (let i = 0; i < emails.length; i += batchSize) {
-    // Process emails in batches of specified size
-    const batch = emails.slice(i, i + batchSize);
-
-    // Send emails in current batch concurrently
-    await Promise.all(batch.map((email) => sendEmail(email)));
-
-    // If there are more emails to process, add delay before next batch
-    if (i + batchSize < emails.length) {
-      await delay(delayMs);
-    }
+const addToQueue = async (payload: EmailPayloadType) => {
+  try {
+    await scheduler.send(QueueNames.emailQueue, payload, {
+      retryLimit: 5,
+      retryDelay: 5,
+    });
+  } catch (err) {
+    Logger.warn({
+      err,
+      details: {
+        to: payload.to,
+        subject: payload.subject,
+        from: payload.from,
+      },
+      message: "Failed to push email payload to queue",
+    });
   }
-}
+};

--- a/app/emails/types.ts
+++ b/app/emails/types.ts
@@ -16,3 +16,23 @@ export type BookingForEmail = Prisma.BookingGetPayload<{
     };
   };
 }>;
+
+export type EmailPayloadType = {
+  /** Email address of recipient */
+  to: string;
+
+  /** Subject of email */
+  subject: string;
+
+  /** Text content of email */
+  text: string;
+
+  /** HTML content of email */
+  html?: string;
+
+  /** Override the default sender */
+  from?: string;
+
+  /** Override the default reply to email address */
+  replyTo?: string;
+};

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -7,6 +7,7 @@ import { RemixServer } from "@remix-run/react";
 import * as Sentry from "@sentry/remix";
 import { isbot } from "isbot";
 import { renderToPipeableStream } from "react-dom/server";
+import { registerEmailWorkers } from "./emails/email.worker.server";
 import { registerBookingWorkers } from "./modules/booking/worker.server";
 import { ShelfError } from "./utils/error";
 import { Logger } from "./utils/logger";
@@ -22,6 +23,15 @@ schedulerService
         new ShelfError({
           cause,
           message: "Something went wrong while registering booking workers.",
+          label: "Scheduler",
+        })
+      );
+    });
+    await registerEmailWorkers().catch((cause) => {
+      Logger.error(
+        new ShelfError({
+          cause,
+          message: "Something went wrong while registering email workers.",
           label: "Scheduler",
         })
       );

--- a/app/modules/booking/constants.ts
+++ b/app/modules/booking/constants.ts
@@ -1,6 +1,3 @@
-export const schedulerKeys = {
-  bookingQueue: "booking-queue",
-};
 export enum bookingSchedulerEventsEnum {
   checkoutReminder = `booking-checkout-reminder`,
   checkinReminder = `booking-checkin-reminder`,

--- a/app/modules/booking/email-helpers.ts
+++ b/app/modules/booking/email-helpers.ts
@@ -156,44 +156,35 @@ export const checkinReminderEmailContent = ({
     )}.`,
   });
 
-export async function sendCheckinReminder(
+export function sendCheckinReminder(
   booking: BookingForEmail,
   assetCount: number,
   hints: ClientHint
 ) {
-  try {
-    await sendEmail({
-      to: booking.custodianUser!.email,
-      subject: `Checkin reminder (${booking.name}) - shelf.nu`,
-      text: checkinReminderEmailContent({
-        hints,
-        bookingName: booking.name,
-        assetsCount: assetCount,
-        custodian:
-          `${booking.custodianUser!.firstName} ${booking.custodianUser
-            ?.lastName}` || (booking.custodianTeamMember?.name as string),
-        from: booking.from!,
-        to: booking.to!,
-        bookingId: booking.id,
-      }),
-      html: bookingUpdatesTemplateString({
-        booking,
-        heading: `Your booking is due for checkin in ${getTimeRemainingMessage(
-          new Date(booking.to!),
-          new Date()
-        )}.`,
-        assetCount,
-        hints,
-      }),
-    });
-  } catch (cause) {
-    throw new ShelfError({
-      cause,
-      message: "Something went wrong while sending the checkin reminder email",
-      additionalData: { booking },
-      label: "Booking",
-    });
-  }
+  sendEmail({
+    to: booking.custodianUser!.email,
+    subject: `Checkin reminder (${booking.name}) - shelf.nu`,
+    text: checkinReminderEmailContent({
+      hints,
+      bookingName: booking.name,
+      assetsCount: assetCount,
+      custodian:
+        `${booking.custodianUser!.firstName} ${booking.custodianUser
+          ?.lastName}` || (booking.custodianTeamMember?.name as string),
+      from: booking.from!,
+      to: booking.to!,
+      bookingId: booking.id,
+    }),
+    html: bookingUpdatesTemplateString({
+      booking,
+      heading: `Your booking is due for checkin in ${getTimeRemainingMessage(
+        new Date(booking.to!),
+        new Date()
+      )}.`,
+      assetCount,
+      hints,
+    }),
+  });
 }
 
 /**

--- a/app/modules/booking/email-helpers.ts
+++ b/app/modules/booking/email-helpers.ts
@@ -4,7 +4,6 @@ import type { BookingForEmail } from "~/emails/types";
 import { getDateTimeFormatFromHints } from "~/utils/client-hints";
 import { getTimeRemainingMessage } from "~/utils/date-fns";
 import { SERVER_URL } from "~/utils/env";
-import { ShelfError } from "~/utils/error";
 import type { ClientHint } from "./types";
 
 /**

--- a/app/modules/booking/email-helpers.ts
+++ b/app/modules/booking/email-helpers.ts
@@ -162,7 +162,7 @@ export function sendCheckinReminder(
 ) {
   sendEmail({
     to: booking.custodianUser!.email,
-    subject: `Checkin reminder (${booking.name}) - shelf.nu`,
+    subject: `🔔 Checkin reminder (${booking.name}) - shelf.nu`,
     text: checkinReminderEmailContent({
       hints,
       bookingName: booking.name,

--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -1347,7 +1347,6 @@ export async function bulkDeleteBookings({
       }),
     }));
 
-    // Send emails with rate limiting
     return emailConfigs.map(sendEmail);
   } catch (cause) {
     const message =

--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -421,7 +421,7 @@ export async function upsertBooking(
             }
 
             if (data.status === BookingStatus.COMPLETE) {
-              subject = `Booking completed (${res.name}) - shelf.nu`;
+              subject = `🎉 Booking completed (${res.name}) - shelf.nu`;
               text = completedBookingEmailContent({
                 bookingName: res.name,
                 assetsCount: res._count.assets,
@@ -858,7 +858,6 @@ export async function deleteBooking(
       });
     }
 
-    // FIXME: if sendEmail fails updateBookinAssetStates will not be called
     /** Because assets in an active booking have a special status, we need to update them if we delete a booking */
     if (activeBooking) {
       await updateBookingAssetStates(activeBooking, AssetStatus.AVAILABLE);

--- a/app/modules/booking/worker.server.ts
+++ b/app/modules/booking/worker.server.ts
@@ -7,8 +7,8 @@ import { sendEmail } from "~/emails/mail.server";
 import { getTimeRemainingMessage } from "~/utils/date-fns";
 import { ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
-import { scheduler } from "~/utils/scheduler.server";
-import { bookingSchedulerEventsEnum, schedulerKeys } from "./constants";
+import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import { bookingSchedulerEventsEnum } from "./constants";
 import {
   checkoutReminderEmailContent,
   overdueBookingEmailContent,
@@ -38,7 +38,7 @@ const checkoutReminder = async ({ data }: PgBoss.Job<SchedulerData>) => {
   const email = booking.custodianUser?.email;
 
   if (email && booking.from && booking.to) {
-    await sendEmail({
+    sendEmail({
       to: email,
       subject: `🔔 Checkout reminder (${booking.name}) - shelf.nu`,
       text: checkoutReminderEmailContent({
@@ -61,16 +61,6 @@ const checkoutReminder = async ({ data }: PgBoss.Job<SchedulerData>) => {
         assetCount: booking._count.assets,
         hints: data.hints,
       }),
-    }).catch((cause) => {
-      //lets not fail the process because of email failure
-      Logger.warn(
-        new ShelfError({
-          cause,
-          message: "Failed to send checkout reminder email",
-          additionalData: { data, work: data.eventType },
-          label: "Booking",
-        })
-      );
     });
   }
 
@@ -114,11 +104,7 @@ const checkinReminder = async ({ data }: PgBoss.Job<SchedulerData>) => {
     booking.to &&
     booking.status === BookingStatus.ONGOING
   ) {
-    await sendCheckinReminder(booking, booking._count.assets, data.hints).catch(
-      (err) => {
-        Logger.warn(err);
-      }
-    );
+    sendCheckinReminder(booking, booking._count.assets, data.hints);
   }
 
   //schedule the next job
@@ -185,7 +171,7 @@ const overdueReminder = async ({ data }: PgBoss.Job<SchedulerData>) => {
   const email = booking.custodianUser?.email;
 
   if (email) {
-    await sendEmail({
+    sendEmail({
       to: email,
       subject: `Overdue booking (${booking.name}) - shelf.nu`,
       text: overdueBookingEmailContent({
@@ -222,33 +208,30 @@ const event2HandlerMap: Record<
 /** ===== start: listens and creates chain of jobs for a given booking ===== */
 export const registerBookingWorkers = async () => {
   /** Check-out reminder */
-  await scheduler.work<SchedulerData>(
-    schedulerKeys.bookingQueue,
-    async (job) => {
-      const handler = event2HandlerMap[job.data.eventType];
-      if (typeof handler != "function") {
-        Logger.error(
-          new ShelfError({
-            cause: null,
-            message: "Wrong event type received for the scheduled worker",
-            additionalData: { job },
-            label: "Booking",
-          })
-        );
-        return;
-      }
-      try {
-        await handler(job);
-      } catch (cause) {
-        Logger.error(
-          new ShelfError({
-            cause,
-            message: "Something went wrong while executing scheduled work.",
-            additionalData: { data: job.data, work: job.data.eventType },
-            label: "Booking",
-          })
-        );
-      }
+  await scheduler.work<SchedulerData>(QueueNames.bookingQueue, async (job) => {
+    const handler = event2HandlerMap[job.data.eventType];
+    if (typeof handler != "function") {
+      Logger.error(
+        new ShelfError({
+          cause: null,
+          message: "Wrong event type received for the scheduled worker",
+          additionalData: { job },
+          label: "Booking",
+        })
+      );
+      return;
     }
-  );
+    try {
+      await handler(job);
+    } catch (cause) {
+      Logger.error(
+        new ShelfError({
+          cause,
+          message: "Something went wrong while executing scheduled work.",
+          additionalData: { data: job.data, work: job.data.eventType },
+          label: "Booking",
+        })
+      );
+    }
+  });
 };

--- a/app/modules/booking/worker.server.ts
+++ b/app/modules/booking/worker.server.ts
@@ -173,7 +173,7 @@ const overdueReminder = async ({ data }: PgBoss.Job<SchedulerData>) => {
   if (email) {
     sendEmail({
       to: email,
-      subject: `Overdue booking (${booking.name}) - shelf.nu`,
+      subject: `⚠️ Overdue booking (${booking.name}) - shelf.nu`,
       text: overdueBookingEmailContent({
         bookingName: booking.name,
         assetsCount: booking._count.assets,

--- a/app/modules/invite/service.server.ts
+++ b/app/modules/invite/service.server.ts
@@ -250,7 +250,7 @@ export async function createInvite(
       expiresIn: `${INVITE_EXPIRY_TTL_DAYS}d`,
     }); //keep only needed data in token to maintain the size
 
-    await sendEmail({
+    sendEmail({
       to: inviteeEmail,
       subject: `✉️ You have been invited to ${invite.organization.name}`,
       text: inviteEmailText({ invite, token }),

--- a/app/modules/user/utils.server.ts
+++ b/app/modules/user/utils.server.ts
@@ -108,7 +108,7 @@ export async function resolveUserAction(
           });
         });
 
-      await sendEmail({
+      sendEmail({
         to: user.email,
         subject: `Access to ${org.name} has been revoked`,
         text: revokeAccessEmailText({ orgName: org.name }),

--- a/app/routes/_layout+/account-details.general.tsx
+++ b/app/routes/_layout+/account-details.general.tsx
@@ -244,7 +244,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
         }
 
         // Send email with OTP using our email service
-        await sendEmail({
+        sendEmail({
           to: newEmail,
           subject: `🔐 Shelf verification code: ${linkData.properties.email_otp}`,
           text: changeEmailAddressTextEmail({

--- a/app/routes/_layout+/account-details.general.tsx
+++ b/app/routes/_layout+/account-details.general.tsx
@@ -181,13 +181,13 @@ export async function action({ context, request }: ActionFunctionArgs) {
           reason = payload?.reason;
         }
 
-        void sendEmail({
+        sendEmail({
           to: ADMIN_EMAIL || `"Shelf" <updates@emails.shelf.nu>`,
           subject: "Delete account request",
           text: `User with id ${userId} and email ${payload.email} has requested to delete their account. \n User: ${SERVER_URL}/admin-dashboard/${userId} \n\n Reason: ${reason}\n\n`,
         });
 
-        void sendEmail({
+        sendEmail({
           to: payload.email,
           subject: "Delete account request received",
           text: `We have received your request to delete your account. It will be processed within 72 hours.\n\n Kind regards,\nthe Shelf team \n\n`,

--- a/app/routes/_welcome+/onboarding.tsx
+++ b/app/routes/_welcome+/onboarding.tsx
@@ -167,7 +167,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     if (config.sendOnboardingEmail) {
       /** Send onboarding email */
-      await sendEmail({
+      sendEmail({
         from: SMTP_FROM || `"Carlos from shelf.nu" <carlos@emails.shelf.nu>`,
         replyTo: "carlos@shelf.nu",
         to: user.email,

--- a/app/routes/api+/stripe-webhook.ts
+++ b/app/routes/api+/stripe-webhook.ts
@@ -285,7 +285,7 @@ export async function action({ request }: ActionFunctionArgs) {
               });
             });
 
-          await sendEmail({
+          sendEmail({
             to: user.email,
             subject: "Your shelf.nu free trial is ending soon",
             text: trialEndsSoonText({

--- a/app/utils/scheduler.server.ts
+++ b/app/utils/scheduler.server.ts
@@ -1,6 +1,11 @@
 import PgBoss from "pg-boss";
 import { DATABASE_URL, NODE_ENV } from "../utils/env";
 
+export enum QueueNames {
+  emailQueue = "email-queue",
+  bookingQueue = "booking-queue",
+}
+
 let scheduler!: PgBoss;
 
 declare global {


### PR DESCRIPTION
- ability to enqueue failed emails and retry them later
  - **why not push all emails to queue**? because, then we need need to increase pg-boss polling frequency(more queries to postgress every minute), if not users will always have to wait for X minute to receive any email, some tokens/OTPs will have lifetime of X minutes 
- We dont await  `triggerEmail` call inside `sendEmail` anymore, so that any user facing actions can finish without waiting for email send to complete, this is actually a tradeoff, because if email sending fails(1st attempt + 5 retries using queues) user never will be warned, but the case is very unlikely and the benefit supersedes the tradeoff.