### PR TITLE
update: handled a case that was missing with SSO user transition

### DIFF
--- a/app/modules/user/service.server.ts
+++ b/app/modules/user/service.server.ts
@@ -459,6 +459,28 @@ export async function updateUserFromSSO(
             desiredRole
           );
           transitions.push(transition);
+        } else if (desiredRole) {
+          // First create the org association
+          await createUserOrgAssociation(db, {
+            userId: user.id,
+            organizationIds: [org.id],
+            roles: [desiredRole],
+          });
+
+          await createTeamMember({
+            name: `${firstName} ${lastName}`,
+            organizationId: org.id,
+            userId,
+          });
+
+          // Then handle it as a transition from no roles to the desired role
+          const transition = await handleSCIMTransition(
+            userId,
+            org,
+            [], // No previous roles
+            desiredRole
+          );
+          transitions.push(transition);
         }
       }
     }


### PR DESCRIPTION
We had a case that was not handled.

1. User exists as an sso user
2. User was not belonging to any org
3. User permissions get updated to belong to a new org via SCIM
4. User should be automatically updated on next login