### PR TITLE
Add env variable for the SMTP port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,7 @@ FREE_TRIAL_DAYS="14"
 
 SMTP_PWD="super-safe-passw0rd"
 SMTP_HOST="mail.example.com"
+SMTP_PORT=465
 SMTP_USER="some-email@example.com"
 SMTP_FROM="Carlos from shelf.nu" <carlos@shelf.nu>
 

--- a/app/emails/transporter.server.ts
+++ b/app/emails/transporter.server.ts
@@ -1,6 +1,12 @@
 import nodemailer from "nodemailer";
 
-import { NODE_ENV, SMTP_HOST, SMTP_PORT, SMTP_PWD, SMTP_USER } from "../utils/env";
+import {
+  NODE_ENV,
+  SMTP_HOST,
+  SMTP_PORT,
+  SMTP_PWD,
+  SMTP_USER,
+} from "../utils/env";
 
 let transporter: nodemailer.Transporter;
 

--- a/app/emails/transporter.server.ts
+++ b/app/emails/transporter.server.ts
@@ -1,6 +1,6 @@
 import nodemailer from "nodemailer";
 
-import { NODE_ENV, SMTP_HOST, SMTP_PWD, SMTP_USER } from "../utils/env";
+import { NODE_ENV, SMTP_HOST, SMTP_PORT, SMTP_PWD, SMTP_USER } from "../utils/env";
 
 let transporter: nodemailer.Transporter;
 
@@ -11,7 +11,7 @@ declare global {
 
 const transporterSettings = {
   host: SMTP_HOST,
-  port: 465,
+  port: SMTP_PORT || 465,
   secure: true, // true for 465, false for other ports
   auth: {
     user: SMTP_USER,

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -41,7 +41,7 @@ declare global {
       INVITE_TOKEN_SECRET: string;
       SMTP_PWD: string;
       SMTP_HOST: string;
-      SMTP_PORT: string;
+      SMTP_PORT: number;
       SMTP_USER: string;
       SMTP_FROM: string;
       MAINTENANCE_MODE: string;
@@ -61,15 +61,16 @@ type EnvOptions = {
   isSecret?: boolean;
   isRequired?: boolean;
 };
-function getEnv(
-  name: string,
+
+function getEnv<K extends keyof NodeJS.ProcessEnv>(
+  name: K,
   { isRequired, isSecret }: EnvOptions = { isSecret: true, isRequired: true }
-) {
+): NodeJS.ProcessEnv[K] {
   if (isBrowser && isSecret) return "";
 
   const source = (isBrowser ? window.env : process.env) ?? {};
 
-  const value = source[name as keyof typeof source];
+  const value = (source as NodeJS.ProcessEnv)[name];
 
   if (!value && isRequired) {
     throw new ShelfError({
@@ -79,7 +80,7 @@ function getEnv(
     });
   }
 
-  return value;
+  return value as NodeJS.ProcessEnv[K] | undefined;
 }
 
 export const EnvSchema = z.object({

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -41,6 +41,7 @@ declare global {
       INVITE_TOKEN_SECRET: string;
       SMTP_PWD: string;
       SMTP_HOST: string;
+      SMTP_PORT: string;
       SMTP_USER: string;
       SMTP_FROM: string;
       MAINTENANCE_MODE: string;
@@ -124,6 +125,9 @@ export const STRIPE_SECRET_KEY = getEnv("STRIPE_SECRET_KEY", {
 });
 export const SMTP_PWD = getEnv("SMTP_PWD");
 export const SMTP_HOST = getEnv("SMTP_HOST");
+export const SMTP_PORT = getEnv("SMTP_PORT", {
+  isRequired: false,
+});
 export const SMTP_USER = getEnv("SMTP_USER");
 export const SMTP_FROM = getEnv("SMTP_FROM", {
   isRequired: false,

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -29,6 +29,7 @@ This will make sure you have a DATABASE that you are ready to connect to.
      -e 'SERVER_URL=http://localhost:3000' \
      -e 'MAPTILER_TOKEN=maptiler-token' \
      -e 'SMTP_HOST=mail.example.com' \
+     -e 'SMTP_PORT=465' \
      -e 'SMTP_USER=some-email@example.com' \
      -e 'SMTP_FROM="Carlos from shelf.nu" <carlos@shelf.nu>' \
      -e 'SMTP_PWD=super-safe-passw0rd' \

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -65,6 +65,7 @@ SERVER_URL="http://localhost:3000"
 FINGERPRINT="a-custom-host-fingerprint"
 
 SMTP_HOST="smtp.yourhost.com"
+SMTP_PORT=465
 SMTP_USER="you@example.com"
 SMTP_PWD="yourSMTPpassword"
 SMTP_FROM="You from example.com" <you@example.com>
@@ -178,6 +179,7 @@ Prior to your first deployment, you'll need to do a few things:
   fly secrets set FINGERPRINT=$(openssl rand -hex 32)
 
   fly secrets set SMTP_HOST="smtp.yourhost.com"
+  fly secrets set SMTP_PORT=465
   fly secrets set SMTP_USER="you@example.com"
   fly secrets set SMTP_PWD="yourSMTPpassword"
   fly secrets set SMTP_FROM="Carlos from shelf.nu" <carlos@shelf.nu>

--- a/test/setup-test-env.ts
+++ b/test/setup-test-env.ts
@@ -16,6 +16,7 @@ process.env.STRIPE_PUBLIC_KEY = "stripe-public-key";
 process.env.STRIPE_WEBHOOK_ENDPOINT_SECRET = "stripe-endpoint-secret";
 process.env.SMTP_PWD = "super-safe-passw0rd";
 process.env.SMTP_HOST = "mail.example.com";
+process.env.SMTP_PORT = 465;
 process.env.SMTP_USER = "some-email@example.com";
 process.env.MAPTILER_TOKEN = "maptiler-token";
 process.env.MICROSOFT_CLARITY_ID = "microsoft-clarity-id";


### PR DESCRIPTION
Closes https://github.com/Shelf-nu/shelf.nu/issues/1681

This implementation should be fully backwards-compatible, since it falls back to the old default (port 465) if the env variable is not present.