### PR TITLE
Fix: adjust endDate input key to resolve the issue

### DIFF
--- a/app/components/booking/form.tsx
+++ b/app/components/booking/form.tsx
@@ -379,7 +379,7 @@ export function BookingForm({
                   required
                 >
                   <Input
-                    key={endDate}
+                    key={"end-date-input"}
                     label="End Date"
                     type="datetime-local"
                     hideLabel


### PR DESCRIPTION
## Issue
There was an error reported by a user, that when adjusting the `endDate` in the new booking form, the whole page would crash. This issue happened only in safari. 
After some tinkering i found that that because we're using `endDate` as both the key and the value of this controlled input component. When a user types into the input field:

1. The `onChange` handler is triggered
2. `setEndDate` is called with the new value
3. The component re-renders with the new `endDate` value
4. Because `key={endDate}` changes, React completely unmounts and remounts the input component
This creates an infinite loop or state corruption that causes Safari to crash

## Solution

Change the key of the `endDate` input field in the booking form