### PR TITLE
Improvement: error tracking with sentry

### DIFF
--- a/server/instrument.server.ts
+++ b/server/instrument.server.ts
@@ -84,7 +84,7 @@ function makeSentryContext(event: unknown | null | undefined) {
     },
     tags: {
       label: maybeShelfError.label || "Unknown",
-      traceId: maybeShelfError.traceId,
+      shelf_trace_id: maybeShelfError.traceId,
     },
     extra: {
       ...(maybeShelfError.additionalData || {}),

--- a/server/instrument.server.ts
+++ b/server/instrument.server.ts
@@ -84,7 +84,7 @@ function makeSentryContext(event: unknown | null | undefined) {
     },
     tags: {
       label: maybeShelfError.label || "Unknown",
-      shelf_trace_id: maybeShelfError.traceId,
+      shelf_trace_id: maybeShelfError.traceId || "Unknown",
     },
     extra: {
       ...(maybeShelfError.additionalData || {}),

--- a/server/instrument.server.ts
+++ b/server/instrument.server.ts
@@ -84,6 +84,7 @@ function makeSentryContext(event: unknown | null | undefined) {
     },
     tags: {
       label: maybeShelfError.label || "Unknown",
+      traceId: maybeShelfError.traceId,
     },
     extra: {
       ...(maybeShelfError.additionalData || {}),


### PR DESCRIPTION
Add `shelf_trace_id` to tags for better searching UX