### PR TITLE
Typo fix: unlinkned -> unlinked

### DIFF
--- a/app/modules/qr/service.server.ts
+++ b/app/modules/qr/service.server.ts
@@ -576,7 +576,7 @@ export async function parseQrCodesFromImportData({
       throw new ShelfError({
         cause: null,
         message:
-          "Some of the QR codes you are trying to import are already linked to an asset or a kit. Please use unlinkned or unclaimed codes for your import.",
+          "Some of the QR codes you are trying to import are already linked to an asset or a kit. Please use unlinked or unclaimed codes for your import.",
         additionalData: { linkedCodes },
         label,
       });

--- a/app/routes/_layout+/admin-dashboard+/org.$organizationId.qr-codes.tsx
+++ b/app/routes/_layout+/admin-dashboard+/org.$organizationId.qr-codes.tsx
@@ -168,7 +168,7 @@ export default function AdminOrgQrCodes() {
               name="intent"
               value="createOrphans"
             >
-              Generate Unlinkned QR codes
+              Generate Unlinked QR codes
             </Button>
           </Form>
           <div className="flex justify-end gap-3">
@@ -180,7 +180,7 @@ export default function AdminOrgQrCodes() {
               className="whitespace-nowrap"
               variant="secondary"
             >
-              Print unlinkned codes
+              Print unlinked codes
             </Button>
             <Button
               to={`/api/${organization.id}/qr-codes.zip`}


### PR DESCRIPTION
Small typo fix I noticed while using a selfhosted instance of shelf.