### PR TITLE
fix: new booking modal overflow

### DIFF
--- a/app/components/booking/create-booking-dialog.tsx
+++ b/app/components/booking/create-booking-dialog.tsx
@@ -46,7 +46,10 @@ export default function CreateBookingDialog({
 
       <DialogPortal>
         <Dialog
-          className={tw("overflow-auto lg:w-[600px]", className)}
+          className={tw(
+            "overflow-auto py-0 md:max-h-[85vh] lg:w-[600px]",
+            className
+          )}
           open={isDialogOpen}
           onClose={closeDialog}
           title={


### PR DESCRIPTION
- on smaller screens the new booking modal was not fitting vertically so I added a max height