### PR TITLE
fix: file upload size management

### DIFF
--- a/app/atoms/atoms-reset-handler.tsx
+++ b/app/atoms/atoms-reset-handler.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useLocation } from "@remix-run/react";
 import { useSetAtom } from "jotai";
+import { fileErrorAtom } from "./file";
 import { setDisabledBulkItemsAtom, setSelectedBulkItemsAtom } from "./list";
 
 /**
@@ -15,12 +16,19 @@ export function AtomsResetHandler() {
   const location = useLocation();
   const resetDisabledItems = useSetAtom(setDisabledBulkItemsAtom);
   const resetSelectedItems = useSetAtom(setSelectedBulkItemsAtom);
+  const resetFileAttom = useSetAtom(fileErrorAtom);
 
   useEffect(() => {
     // Reset when the route changes
     resetDisabledItems([]);
     resetSelectedItems([]);
-  }, [location.pathname, resetDisabledItems, resetSelectedItems]);
+    resetFileAttom(undefined);
+  }, [
+    location.pathname,
+    resetDisabledItems,
+    resetFileAttom,
+    resetSelectedItems,
+  ]);
 
   return null;
 }

--- a/app/atoms/atoms-reset-handler.tsx
+++ b/app/atoms/atoms-reset-handler.tsx
@@ -16,17 +16,17 @@ export function AtomsResetHandler() {
   const location = useLocation();
   const resetDisabledItems = useSetAtom(setDisabledBulkItemsAtom);
   const resetSelectedItems = useSetAtom(setSelectedBulkItemsAtom);
-  const resetFileAttom = useSetAtom(fileErrorAtom);
+  const resetFileAtom = useSetAtom(fileErrorAtom);
 
   useEffect(() => {
     // Reset when the route changes
     resetDisabledItems([]);
     resetSelectedItems([]);
-    resetFileAttom(undefined);
+    resetFileAtom(undefined);
   }, [
     location.pathname,
     resetDisabledItems,
-    resetFileAttom,
+    resetFileAtom,
     resetSelectedItems,
   ]);
 

--- a/app/atoms/file.ts
+++ b/app/atoms/file.ts
@@ -1,33 +1,51 @@
 import type { ChangeEvent } from "react";
 import { atom } from "jotai";
-import { MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
+import {
+  ASSET_MAX_IMAGE_UPLOAD_SIZE,
+  DEFAULT_MAX_IMAGE_UPLOAD_SIZE,
+} from "~/utils/constants";
 import { verifyAccept } from "~/utils/verify-file-accept";
 
 export const fileErrorAtom = atom<string | undefined>(undefined);
 
-/** Validates the file atom */
-export const validateFileAtom = atom(
-  null,
-  (_get, set, event: ChangeEvent<HTMLInputElement>) => {
+export const createValidateFileAtom = (options: {
+  maxSize: number;
+  sizeErrorMessage: string;
+  allowedTypesErrorMessage: string;
+}) =>
+  atom(null, (_get, set, event: ChangeEvent<HTMLInputElement>) => {
     set(fileErrorAtom, () => {
       const file = event?.target?.files?.[0];
       if (file) {
         const allowedType = verifyAccept(file.type, event.target.accept);
-        const allowedSize = file.size < MAX_IMAGE_UPLOAD_SIZE;
+        const allowedSize = file.size < options.maxSize;
 
         if (!allowedType) {
           event.target.value = "";
-          return `Allowed file types are: PNG, JPG or JPEG`;
+          return options.allowedTypesErrorMessage;
         }
 
         if (!allowedSize) {
           /** Clean the field */
           event.target.value = "";
-          return "Max file size is 8MB";
+          return options.sizeErrorMessage;
         }
 
         return undefined;
       }
     });
-  }
-);
+  });
+
+// Default instance with 4MB limit
+export const defaultValidateFileAtom = createValidateFileAtom({
+  maxSize: DEFAULT_MAX_IMAGE_UPLOAD_SIZE, // 4MB
+  sizeErrorMessage: "Max file size is 4MB",
+  allowedTypesErrorMessage: "Allowed file types are: PNG, JPG or JPEG",
+});
+
+// For asset image uploads we allow 8MB
+export const assetImageValidateFileAtom = createValidateFileAtom({
+  maxSize: ASSET_MAX_IMAGE_UPLOAD_SIZE, // 8MB
+  sizeErrorMessage: "Max file size is 8MB",
+  allowedTypesErrorMessage: "Allowed file types are: PNG, JPG or JPEG",
+});

--- a/app/components/assets/form.tsx
+++ b/app/components/assets/form.tsx
@@ -11,7 +11,7 @@ import type { Tag } from "react-tag-autocomplete";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { updateDynamicTitleAtom } from "~/atoms/dynamic-title-atom";
-import { fileErrorAtom, validateFileAtom } from "~/atoms/file";
+import { fileErrorAtom, assetImageValidateFileAtom } from "~/atoms/file";
 import type { loader } from "~/routes/_layout+/assets.$assetId_.edit";
 import { ACCEPT_SUPPORTED_IMAGES } from "~/utils/constants";
 import type { CustomFieldZodSchema } from "~/utils/custom-fields";
@@ -126,7 +126,7 @@ export const AssetForm = ({
   const disabled = isFormProcessing(navigation.state);
 
   const fileError = useAtomValue(fileErrorAtom);
-  const [, validateFile] = useAtom(validateFileAtom);
+  const [, validateFile] = useAtom(assetImageValidateFileAtom);
   const [, updateDynamicTitle] = useAtom(updateDynamicTitleAtom);
 
   const { currency } = useLoaderData<typeof loader>();

--- a/app/components/kits/form.tsx
+++ b/app/components/kits/form.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { updateDynamicTitleAtom } from "~/atoms/dynamic-title-atom";
-import { fileErrorAtom, validateFileAtom } from "~/atoms/file";
+import { fileErrorAtom, defaultValidateFileAtom } from "~/atoms/file";
 import { ACCEPT_SUPPORTED_IMAGES } from "~/utils/constants";
 import { isFormProcessing } from "~/utils/form";
 import { tw } from "~/utils/tw";
@@ -48,7 +48,7 @@ export default function KitsForm({
 
   const fileError = useAtomValue(fileErrorAtom);
   const [, updateDynamicTitle] = useAtom(updateDynamicTitleAtom);
-  const [, validateFile] = useAtom(validateFileAtom);
+  const [, validateFile] = useAtom(defaultValidateFileAtom);
 
   const zo = useZorm("NewKitForm", NewKitFormSchema);
 

--- a/app/components/location/form.tsx
+++ b/app/components/location/form.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { updateDynamicTitleAtom } from "~/atoms/dynamic-title-atom";
-import { fileErrorAtom, validateFileAtom } from "~/atoms/file";
+import { fileErrorAtom, defaultValidateFileAtom } from "~/atoms/file";
 import type { action as editLocationAction } from "~/routes/_layout+/locations.$locationId_.edit";
 import type { action as newLocationAction } from "~/routes/_layout+/locations.new";
 import { ACCEPT_SUPPORTED_IMAGES } from "~/utils/constants";
@@ -48,7 +48,7 @@ export const LocationForm = ({ name, address, description }: Props) => {
   const disabled = isFormProcessing(navigation.state);
 
   const fileError = useAtomValue(fileErrorAtom);
-  const [, validateFile] = useAtom(validateFileAtom);
+  const [, validateFile] = useAtom(defaultValidateFileAtom);
   const [, updateName] = useAtom(updateDynamicTitleAtom);
   const actionData = useActionData<
     typeof newLocationAction | typeof editLocationAction

--- a/app/components/workspace/edit-form.tsx
+++ b/app/components/workspace/edit-form.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { updateDynamicTitleAtom } from "~/atoms/dynamic-title-atom";
-import { fileErrorAtom, validateFileAtom } from "~/atoms/file";
+import { fileErrorAtom, defaultValidateFileAtom } from "~/atoms/file";
 import type { loader } from "~/routes/_layout+/account-details.workspace.$workspaceId.edit";
 import { ACCEPT_SUPPORTED_IMAGES } from "~/utils/constants";
 import { isFormProcessing } from "~/utils/form";
@@ -65,7 +65,7 @@ export const WorkspaceEditForm = ({
   const zo = useZorm("NewQuestionWizardScreen", schema);
   const disabled = isFormProcessing(navigation.state);
   const fileError = useAtomValue(fileErrorAtom);
-  const [, validateFile] = useAtom(validateFileAtom);
+  const [, validateFile] = useAtom(defaultValidateFileAtom);
   const [, updateTitle] = useAtom(updateDynamicTitleAtom);
 
   return (

--- a/app/components/workspace/form.tsx
+++ b/app/components/workspace/form.tsx
@@ -5,7 +5,7 @@ import { useAtom, useAtomValue } from "jotai";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { updateDynamicTitleAtom } from "~/atoms/dynamic-title-atom";
-import { fileErrorAtom, validateFileAtom } from "~/atoms/file";
+import { defaultValidateFileAtom, fileErrorAtom } from "~/atoms/file";
 import { useSearchParams } from "~/hooks/search-params";
 import type { loader } from "~/routes/_layout+/account-details.workspace.new";
 import { ACCEPT_SUPPORTED_IMAGES } from "~/utils/constants";
@@ -46,7 +46,7 @@ export const WorkspaceForm = ({ name, currency, children }: Props) => {
   const zo = useZorm("NewQuestionWizardScreen", NewWorkspaceFormSchema);
   const disabled = isFormProcessing(navigation.state);
   const fileError = useAtomValue(fileErrorAtom);
-  const [, validateFile] = useAtom(validateFileAtom);
+  const [, validateFile] = useAtom(defaultValidateFileAtom);
   const [, updateTitle] = useAtom(updateDynamicTitleAtom);
   const nameFieldRef = useRef<HTMLInputElement>(null);
 

--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -1019,9 +1019,12 @@ export async function updateAssetMainImage({
       });
     }
   } catch (cause) {
+    const isShelfError = isLikeShelfError(cause);
     throw new ShelfError({
       cause,
-      message: "Something went wrong while updating asset main image",
+      message: isShelfError
+        ? cause.message
+        : "Something went wrong while updating asset main image",
       additionalData: { assetId, userId },
       label,
     });

--- a/app/routes/_layout+/account-details.general.tsx
+++ b/app/routes/_layout+/account-details.general.tsx
@@ -6,7 +6,7 @@ import { useActionData, useNavigation } from "@remix-run/react";
 import { useAtom, useAtomValue } from "jotai";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
-import { fileErrorAtom, validateFileAtom } from "~/atoms/file";
+import { fileErrorAtom, defaultValidateFileAtom } from "~/atoms/file";
 import { Form } from "~/components/custom-form";
 import FormRow from "~/components/forms/form-row";
 import Input from "~/components/forms/input";
@@ -349,7 +349,7 @@ export default function UserPage() {
     getValidationErrors<typeof UpdateFormSchema>(data?.error)?.username
       ?.message || zo.errors.username()?.message;
   const fileError = useAtomValue(fileErrorAtom);
-  const [, validateFile] = useAtom(validateFileAtom);
+  const [, validateFile] = useAtom(defaultValidateFileAtom);
 
   return (
     <div className="mb-2.5 flex flex-col justify-between bg-white md:rounded md:border md:border-gray-200 md:px-6 md:py-5">

--- a/app/routes/_layout+/locations.$locationId_.edit.tsx
+++ b/app/routes/_layout+/locations.$locationId_.edit.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from "~/components/shared/button";
 import { getLocation, updateLocation } from "~/modules/location/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
-import { MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
+import { DEFAULT_MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
 import { data, error, getParams, parseData } from "~/utils/http.server";
@@ -112,7 +112,9 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     const formDataFile = await unstable_parseMultipartFormData(
       clonedRequest,
-      unstable_createMemoryUploadHandler({ maxPartSize: MAX_IMAGE_UPLOAD_SIZE })
+      unstable_createMemoryUploadHandler({
+        maxPartSize: DEFAULT_MAX_IMAGE_UPLOAD_SIZE,
+      })
     );
 
     const file = formDataFile.get("image") as File | null;

--- a/app/routes/_layout+/locations.new.tsx
+++ b/app/routes/_layout+/locations.new.tsx
@@ -21,7 +21,7 @@ import {
 
 import { createLocation } from "~/modules/location/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
-import { MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
+import { DEFAULT_MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
 import { data, error, parseData } from "~/utils/http.server";
@@ -96,7 +96,9 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     const formDataFile = await unstable_parseMultipartFormData(
       request,
-      unstable_createMemoryUploadHandler({ maxPartSize: MAX_IMAGE_UPLOAD_SIZE })
+      unstable_createMemoryUploadHandler({
+        maxPartSize: DEFAULT_MAX_IMAGE_UPLOAD_SIZE,
+      })
     );
 
     const file = formDataFile.get("image") as File | null;

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -13,7 +13,8 @@ export const ACCEPT_SUPPORTED_IMAGES =
   "image/png,.png,image/jpeg,.jpg,.jpeg,android/force-camera-workaround";
 
 /** For image uploads */
-export const MAX_IMAGE_UPLOAD_SIZE = 8 * 1024 * 1024; // 8MB in bytes
+export const DEFAULT_MAX_IMAGE_UPLOAD_SIZE = 4 * 1024 * 1024; // 4MB in bytes
+export const ASSET_MAX_IMAGE_UPLOAD_SIZE = 8 * 1024 * 1024; // 8MB in bytes
 
 /** Default date format */
 export const DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm";

--- a/app/utils/storage.server.ts
+++ b/app/utils/storage.server.ts
@@ -6,7 +6,7 @@ import type { LRUCache } from "lru-cache";
 import type { ResizeOptions } from "sharp";
 
 import { getSupabaseAdmin } from "~/integrations/supabase/client";
-import { MAX_IMAGE_UPLOAD_SIZE } from "./constants";
+import { ASSET_MAX_IMAGE_UPLOAD_SIZE } from "./constants";
 import { cropImage } from "./crop-image";
 import { SUPABASE_URL } from "./env";
 import type { AdditionalData, ErrorLabel } from "./error";
@@ -189,6 +189,20 @@ export async function parseFileFormData({
           return undefined;
         }
 
+        const fileSize = await calculateAsyncIterableSize(data);
+        if (fileSize > ASSET_MAX_IMAGE_UPLOAD_SIZE) {
+          throw new ShelfError({
+            cause: null,
+            title: "File too large",
+            message: `Image file size exceeds maximum allowed size of ${
+              ASSET_MAX_IMAGE_UPLOAD_SIZE / (1024 * 1024)
+            }MB`,
+            additionalData: { filename, contentType, bucketName },
+            label,
+            shouldBeCaptured: false,
+          });
+        }
+
         const fileExtension = filename?.split(".").pop();
         const uploadedFilePaths = await uploadFile(data, {
           filename: `${newFileName}.${fileExtension}`,
@@ -225,8 +239,9 @@ export async function parseFileFormData({
   } catch (cause) {
     throw new ShelfError({
       cause,
-      message:
-        "Something went wrong while uploading the file. Please try again or contact support.",
+      message: isLikeShelfError(cause)
+        ? cause.message
+        : "Something went wrong while uploading the file. Please try again or contact support.",
       label,
     });
   }
@@ -328,11 +343,11 @@ export async function uploadImageFromUrl(
     }
 
     const imageBlob = await response.blob();
-    if (imageBlob.size > MAX_IMAGE_UPLOAD_SIZE) {
+    if (imageBlob.size > ASSET_MAX_IMAGE_UPLOAD_SIZE) {
       throw new ShelfError({
         cause: null,
         message: `Image file size exceeds maximum allowed size of ${
-          MAX_IMAGE_UPLOAD_SIZE / (1024 * 1024)
+          ASSET_MAX_IMAGE_UPLOAD_SIZE / (1024 * 1024)
         }MB`,
         additionalData: { imageUrl, size: imageBlob.size },
         label,
@@ -471,4 +486,15 @@ export async function deleteAssetImage({
       })
     );
   }
+}
+
+// Utility function to get size from AsyncIterable<Uint8Array>
+export async function calculateAsyncIterableSize(
+  data: AsyncIterable<Uint8Array>
+): Promise<number> {
+  let totalSize = 0;
+  for await (const chunk of data) {
+    totalSize += chunk.byteLength;
+  }
+  return totalSize;
 }


### PR DESCRIPTION
- update atom that validates file upload size on the front-end to be dynamic, as we have different file sizes in different cases
- implement 2 atoms based on the new validation way - one for default and one for asset images
- update constants to manage max image size
- add server side validations for asset image file uploading
- make sure file validation atom is reset on route change
- create a new helper function that calculates Async Iterable file size