### PR TITLE
improvement: detailed sso user count info in admin dashboard

### DIFF
--- a/app/components/user/sso-user-badge.tsx
+++ b/app/components/user/sso-user-badge.tsx
@@ -1,0 +1,39 @@
+import { GrayBadge } from "../shared/gray-badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../shared/tooltip";
+
+export const SSOUserBadge = ({
+  userId,
+  sso,
+}: {
+  userId: string;
+  sso: boolean;
+}) => {
+  if (!sso) return null;
+
+  return (
+    <TooltipProvider key={userId}>
+      <Tooltip>
+        <TooltipTrigger>
+          <GrayBadge className="ml-2">SSO</GrayBadge>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-72">
+          <h4>SSO user</h4>
+
+          <p className="mt-2">
+            This user is using Single Sign-On (SSO) to log in to Shelf. Their
+            access is managed by an external identity provider. On every login
+            attempt, their permissions and access will be revalidated. If you
+            want to remove them immediately, use the revoke access user action
+            in Shelf. You will still need to remove them from the IDP to make
+            this complete.
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/app/components/workspace/edit-form.tsx
+++ b/app/components/workspace/edit-form.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { updateDynamicTitleAtom } from "~/atoms/dynamic-title-atom";
 import { fileErrorAtom, defaultValidateFileAtom } from "~/atoms/file";
 import { useDisabled } from "~/hooks/use-disabled";
+import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { loader } from "~/routes/_layout+/account-details.workspace.$workspaceId.edit";
 import { ACCEPT_SUPPORTED_IMAGES } from "~/utils/constants";
 import { tw } from "~/utils/tw";
@@ -343,12 +344,13 @@ export const EditWorkspaceSSOSettingsFormSchema = (sso: boolean = false) =>
 
 const WorkspaceSSOEditForm = ({ className }: Props) => {
   const { organization } = useLoaderData<typeof loader>();
+  const { isOwner } = useUserRoleHelper();
   const fetcher = useFetcher({ key: "sso" });
   let schema = EditWorkspaceSSOSettingsFormSchema(organization.enabledSso);
   const zo = useZorm("NewQuestionWizardScreen", schema);
   const disabled = useDisabled(fetcher);
 
-  return organization.enabledSso && organization.ssoDetails ? (
+  return isOwner && organization.enabledSso && organization.ssoDetails ? (
     <fetcher.Form ref={zo.ref} method="post" className="flex flex-col gap-2">
       <Card className={tw("my-0 ", className)}>
         <div className=" border-b pb-5">

--- a/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
+++ b/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
@@ -1,4 +1,4 @@
-import { Currency, OrganizationType } from "@prisma/client";
+import { Currency, OrganizationRoles, OrganizationType } from "@prisma/client";
 import {
   json,
   MaxPartSizeExceededError,
@@ -135,7 +135,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
 
-    await requirePermission({
+    const { role } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.workspace,
@@ -259,6 +259,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         return json({ success: true });
       }
       case "sso": {
+        if (role !== OrganizationRoles.OWNER) {
+          throw new ShelfError({
+            cause: null,
+            title: "Permission denied",
+            message: "You are not allowed to edit SSO settings.",
+            label: "Settings",
+          });
+        }
+
         const { enabledSso } = organization;
         if (!enabledSso) {
           throw new ShelfError({

--- a/app/routes/_layout+/admin-dashboard+/$userId.tsx
+++ b/app/routes/_layout+/admin-dashboard+/$userId.tsx
@@ -500,7 +500,7 @@ const SsoUsersByDomainTable = ({
   if (sortedDomains.length === 0) {
     return (
       <div className="p-4 text-center text-gray-500">
-        No SSO users found workspaces owned by this user.
+        No SSO users found in workspaces owned by this user.
       </div>
     );
   }

--- a/app/routes/_layout+/admin-dashboard+/$userId.tsx
+++ b/app/routes/_layout+/admin-dashboard+/$userId.tsx
@@ -5,6 +5,7 @@ import {
   type Qr,
   type User,
   type CustomTierLimit,
+  OrganizationRoles,
 } from "@prisma/client";
 import type {
   ActionFunctionArgs,
@@ -22,7 +23,7 @@ import { Switch } from "~/components/forms/switch";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
 import { Spinner } from "~/components/shared/spinner";
-import { Table, Td, Tr } from "~/components/table";
+import { Table, Td, Th, Tr } from "~/components/table";
 import { DeleteUser } from "~/components/user/delete-user";
 import { db } from "~/database/db.server";
 import { updateUserTierId } from "~/modules/tier/service.server";
@@ -82,7 +83,23 @@ export const loader = async ({ context, params }: LoaderFunctionArgs) => {
           userId: shelfUserId,
         },
         select: {
-          organization: true,
+          organization: {
+            include: {
+              ssoDetails: true,
+              userOrganizations: {
+                // Include ALL users in each org with SSO enabled so we cna count them
+                where: {
+                  user: {
+                    sso: true,
+                  },
+                },
+                select: {
+                  userId: true,
+                },
+              },
+            },
+          },
+          roles: true,
         },
       })
       .catch((cause) => {
@@ -94,10 +111,48 @@ export const loader = async ({ context, params }: LoaderFunctionArgs) => {
         });
       });
 
+    /** Which organizations of the user have SSO enabled */
+    const organizationsOwnedByUserWithSso = userOrganizations.filter(
+      (uo) =>
+        uo.organization.enabledSso &&
+        uo.organization.ssoDetails &&
+        uo.roles.some((role) => role === OrganizationRoles.OWNER)
+    );
+
+    /** Process the data you already have - no second query needed! */
+    const usersByDomain = organizationsOwnedByUserWithSso.reduce(
+      (acc, uo) => {
+        const domain = uo.organization.ssoDetails?.domain;
+
+        if (domain) {
+          if (!acc[domain]) {
+            acc[domain] = new Set<string>();
+          }
+          // Add all SSO users from this organization
+          uo.organization.userOrganizations.forEach((userOrg) => {
+            acc[domain].add(userOrg.userId);
+          });
+        }
+
+        return acc;
+      },
+      {} as Record<string, Set<string>>
+    );
+
+    /** Convert Sets to counts */
+    const ssoUsersByDomain = Object.entries(usersByDomain).reduce(
+      (acc, [domain, userSet]) => {
+        acc[domain] = userSet.size;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+
     return json(
       data({
         user,
         organizations: userOrganizations.map((uo) => uo.organization),
+        ssoUsersByDomain,
       })
     );
   } catch (cause) {
@@ -219,7 +274,7 @@ export default function Area51UserPage() {
   // Get the loader data type
   type LoaderData = SerializeFrom<typeof loader>;
 
-  const { user, organizations } = useLoaderData<LoaderData>();
+  const { user, organizations, ssoUsersByDomain } = useLoaderData<LoaderData>();
 
   const hasCustomTier =
     user?.tierId === "custom" && user?.customTierLimit !== null;
@@ -265,7 +320,7 @@ export default function Area51UserPage() {
           <h1>User: {user?.email}</h1>
           <DeleteUser />
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-4">
           <div className="w-[400px]">
             <ul className="mt-5">
               {user
@@ -288,6 +343,9 @@ export default function Area51UserPage() {
               <CustomTierDetailsForm customTierLimit={user.customTierLimit!} />
             </div>
           )}
+          <div>
+            <SsoUsersByDomainTable ssoUsersByDomain={ssoUsersByDomain} />
+          </div>
         </div>
       </div>
       <div className="mt-10">
@@ -305,6 +363,9 @@ export default function Area51UserPage() {
               </th>
               <th className="border-b p-4 text-left text-gray-600 md:px-6">
                 Is Owner
+              </th>
+              <th className="border-b p-4 text-left text-gray-600 md:px-6">
+                SSO
               </th>
               <th className="border-b p-4 text-left text-gray-600 md:px-6">
                 Workspace disabled
@@ -327,6 +388,7 @@ export default function Area51UserPage() {
                   <DateS date={org.createdAt} />
                 </Td>
                 <Td>{org.userId === user.id ? "yes" : "no"}</Td>
+                <Td>{org.enabledSso ? "yes" : "no"}</Td>
                 <Td>{org.workspaceDisabled ? "yes" : "no"}</Td>
               </Tr>
             ))}
@@ -423,3 +485,60 @@ function CustomTierDetailsForm({
     </div>
   );
 }
+
+interface SsoUsersByDomainTableProps {
+  ssoUsersByDomain: Record<string, number>;
+}
+const SsoUsersByDomainTable = ({
+  ssoUsersByDomain,
+}: SsoUsersByDomainTableProps) => {
+  // Convert object to array and sort by domain name for consistent display
+  const sortedDomains = Object.entries(ssoUsersByDomain).sort(
+    ([domainA], [domainB]) => domainA.localeCompare(domainB)
+  );
+
+  if (sortedDomains.length === 0) {
+    return (
+      <div className="p-4 text-center text-gray-500">
+        No SSO users found workspaces owned by this user.
+      </div>
+    );
+  }
+
+  const totalUsers = sortedDomains.reduce((sum, [, count]) => sum + count, 0);
+
+  return (
+    <div className="flex flex-col bg-gray-200 p-4">
+      <h4>SSO user count</h4>
+
+      <div className="">
+        <table className="w-full border">
+          <thead className="bg-gray-50">
+            <Tr>
+              <Th className="">Domain</Th>
+              <Th className="whitespace-nowrap">SSO Users</Th>
+            </Tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {sortedDomains.map(([domain, userCount]) => (
+              <Tr key={domain} className="transition-colors hover:bg-gray-50">
+                <Td className="max-w-none">{domain}</Td>
+                <Td className="text-right">{userCount.toLocaleString()}</Td>
+              </Tr>
+            ))}
+          </tbody>
+          <tfoot className="border-t-2 border-gray-200 bg-gray-50">
+            <Tr>
+              <Td className="px-4 py-3 text-sm font-semibold text-gray-800">
+                Total
+              </Td>
+              <Td className="px-4 py-3 text-right font-mono text-sm font-semibold text-gray-800">
+                {totalUsers.toLocaleString()}
+              </Td>
+            </Tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/app/routes/_layout+/admin-dashboard+/org.$organizationId.members.tsx
+++ b/app/routes/_layout+/admin-dashboard+/org.$organizationId.members.tsx
@@ -4,6 +4,7 @@ import { Link, useLoaderData } from "@remix-run/react";
 import { z } from "zod";
 import { DateS } from "~/components/shared/date";
 import { Table, Td, Tr } from "~/components/table";
+import { SSOUserBadge } from "~/components/user/sso-user-badge";
 import { db } from "~/database/db.server";
 import { makeShelfError } from "~/utils/error";
 import { data, error, getParams } from "~/utils/http.server";
@@ -84,7 +85,12 @@ export default function AdminOrgQrCodes() {
               <Td>
                 {member.firstName} {member.lastName}
               </Td>
-              <Td>{member.email}</Td>
+              <Td>
+                <span>
+                  {member.email}{" "}
+                  <SSOUserBadge sso={member.sso} userId={member.id} />
+                </span>
+              </Td>
               <Td>{member.userOrganizations[0].roles.join(" ,")}</Td>
               <Td>
                 <DateS

--- a/app/routes/_layout+/admin-dashboard+/org.$organizationId.tsx
+++ b/app/routes/_layout+/admin-dashboard+/org.$organizationId.tsx
@@ -10,6 +10,7 @@ import {
   useLoaderData,
   useNavigation,
 } from "@remix-run/react";
+import { ChevronLeft } from "lucide-react";
 import { z } from "zod";
 import { FileForm } from "~/components/assets/import-content";
 import { Form } from "~/components/custom-form";
@@ -227,11 +228,20 @@ export default function OrgPage() {
   return (
     <div>
       <h1>{organization.name}</h1>
-      <h3>
-        {" "}
-        Owner: {organization.owner.firstName} {organization.owner.lastName} -{" "}
-        {organization.owner.email}
-      </h3>
+      <div className="flex items-center gap-3">
+        <Button
+          variant="secondary"
+          to={`/admin-dashboard/${organization.owner.id}`}
+          className={"p-2"}
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <h3>
+          {" "}
+          Owner: {organization.owner.firstName} {organization.owner.lastName} -{" "}
+          {organization.owner.email}
+        </h3>
+      </div>
 
       {/* @ts-ignore */}
       {actionData && actionData.message && (

--- a/app/routes/_layout+/settings.team.users.tsx
+++ b/app/routes/_layout+/settings.team.users.tsx
@@ -14,15 +14,10 @@ import { Filters } from "~/components/list/filters";
 import ImportUsersDialog from "~/components/settings/import-users-dialog/import-users-dialog";
 import InviteUserDialog from "~/components/settings/invite-user-dialog";
 import { Button } from "~/components/shared/button";
-import { GrayBadge } from "~/components/shared/gray-badge";
 import { InfoTooltip } from "~/components/shared/info-tooltip";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "~/components/shared/tooltip";
+
 import { Td, Th } from "~/components/table";
+import { SSOUserBadge } from "~/components/user/sso-user-badge";
 import { TeamUsersActionsDropdown } from "~/components/workspace/users-actions-dropdown";
 import { db } from "~/database/db.server";
 
@@ -281,37 +276,9 @@ const TeamMemberDetails = ({
 
         <div>
           {details.email}
-          {details.sso && (
-            <TooltipProvider key={details.id}>
-              <Tooltip>
-                <TooltipTrigger>
-                  <GrayBadge className="ml-2">SSO</GrayBadge>
-                </TooltipTrigger>
-                <TooltipContent side="top" className="max-w-72">
-                  <h4>SSO user</h4>
-
-                  <p className="mt-2">
-                    This user is using Single Sign-On (SSO) to log in to Shelf.
-                    Their access is managed by an external identity provider. On
-                    every login attempt, their permissions and access will be
-                    revalidated. If you want to remove them immediately, use the
-                    revoke access user action in Shelf. You will still need to
-                    remove them from the IDP to make this complete.
-                  </p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
+          <SSOUserBadge sso={details.sso} userId={details.id} />
         </div>
       </div>
     </div>
   </div>
 );
-
-// // export const shouldRevalidate = () => false;
-
-// export default function UserTeamPage() {
-//   return <Outlet />;
-// }
-
-// export const ErrorBoundary = () => <ErrorContent />;


### PR DESCRIPTION
- show a table in the user admin view, that visualizes the count of users with sso enabled for all workspaces owned by said user
- in admin dashboard organization members page, show a label with SSO if a user is sso
- some other small ui updates
- Only allow OWNER to edit organization SSO settings. Closes #1825 