### PR TITLE
FIX QR codes page redirect in admin dashboard

### DIFF
--- a/app/routes/_layout+/admin-dashboard+/qrs.tsx
+++ b/app/routes/_layout+/admin-dashboard+/qrs.tsx
@@ -43,8 +43,8 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     /** We do this to get all the batches ever created so we can have the filter */
     const batches = await db.printBatch.findMany();
 
-    if (page > totalPages) {
-      return redirect("/admin-dashboard");
+    if (totalPages > 0 && page > totalPages) {
+      return redirect("/admin-dashboard/qrs?page=1");
     }
 
     const header: HeaderData = {


### PR DESCRIPTION
# Fix QR codes page redirect in admin dashboard

## Problem
Clicking the "QR codes" tab in the admin dashboard was redirecting to `/admin-dashboard` instead of showing the QR codes page. This was caused by having no QR codes in the DB.

## Root Cause
The pagination logic was redirecting when `page > totalPages`. With no QR codes in the database, `totalPages` was 0, causing the condition `1 > 0` to trigger an immediate redirect.

## Solution
Updated the redirect condition to:
```typescript
if (totalPages > 0 && page > totalPages) {
  return redirect("/admin-dashboard/qrs?page=1");
}
```

Now the page loads correctly even when the QR codes table is empty.
