### PR TITLE
fix: issues with adding asset to bookings 

### DIFF
--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -2531,15 +2531,17 @@ export async function getAvailableAssetsIdsForBooking(
   try {
     const selectedAssets = await db.asset.findMany({
       where: { id: { in: assetIds } },
-      select: { status: true, id: true, kit: true },
+      select: { status: true, id: true, kitId: true },
     });
-    if (selectedAssets.some((asset) => asset.kit)) {
+
+    if (selectedAssets.some((asset) => asset.kitId)) {
       throw new ShelfError({
         cause: null,
         message: "Cannot add assets that belong to a kit.",
         label: "Booking",
       });
     }
+
     return selectedAssets.map((asset) => asset.id);
   } catch (cause: ShelfError | any) {
     throw new ShelfError({

--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -915,14 +915,37 @@ export async function updateBookingAssets({
   assetIds: Asset["id"][];
 }) {
   try {
-    return await db.booking.update({
-      where: { id, organizationId },
-      data: {
-        assets: {
-          connect: assetIds.map((id) => ({ id })),
+    const booking = await db.$transaction(async (tx) => {
+      const b = await tx.booking.update({
+        where: { id, organizationId },
+        data: {
+          assets: {
+            connect: assetIds.map((id) => ({ id })),
+          },
         },
-      },
+        select: {
+          id: true,
+          name: true,
+          status: true,
+        },
+      });
+
+      /**
+       *  When adding an asset to a booking, we need to update the status of the asset to CHECKED_OUT if the booking is ONGOING or OVERDUE
+       */
+      if (
+        b.status === BookingStatus.ONGOING ||
+        b.status === BookingStatus.OVERDUE
+      ) {
+        await db.asset.updateMany({
+          where: { id: { in: assetIds }, organizationId },
+          data: { status: AssetStatus.CHECKED_OUT },
+        });
+      }
+      return b;
     });
+
+    return booking;
   } catch (cause) {
     throw new ShelfError({
       cause,


### PR DESCRIPTION
- if the booking was ongoing or overdue, the status of the asset was not synced
- when creating notes for adding assets, we were creating them for all assets in the booking, not just the ones we added, so if an asset was already in the booking it would still get a new note it was added. This was resolved for kits as well