### PR TITLE
fix: calendar nowIndicator

### DIFF
--- a/app/components/assets/assets-index/assets-availability.tsx
+++ b/app/components/assets/assets-index/assets-availability.tsx
@@ -9,7 +9,6 @@ import TitleContainer from "~/components/calendar/title-container";
 import { ViewButtonGroup } from "~/components/calendar/view-button-group";
 import FallbackLoading from "~/components/dashboard/fallback-loading";
 import { Button } from "~/components/shared/button";
-import { useViewportHeight } from "~/hooks/use-viewport-height";
 import type { AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
 import {
   getCalendarTitleAndSubtitle,
@@ -26,14 +25,16 @@ import { AssetImage } from "../asset-image";
 import { AssetStatusBadge } from "../asset-status-badge";
 import { useAssetAvailabilityData } from "./use-asset-availability-data";
 import { CategoryBadge } from "../category-badge";
-import { useHydrated } from "remix-utils/use-hydrated";
+import { useCalendarNowIndicatorFix } from "./use-calendar-now-indicator-fix";
+
+const DEFAULT_CALENDAR_VIEW = "resourceTimelineDay";
+const TARGET_CALENDAR_VIEW = "resourceTimelineMonth";
 
 export default function AssetsAvailability() {
   const { items, modelName, totalItems, perPage, timeZone } =
     useLoaderData<AssetIndexLoaderData>();
   const { singular, plural } = modelName;
   const calendarRef = useRef<FullCalendar>(null);
-  const { isMd } = useViewportHeight();
   const [startingDay, endingDay] = getWeekStartingAndEndingDates(new Date());
 
   const [calendarHeader, setCalendarHeader] = useState<{
@@ -41,14 +42,34 @@ export default function AssetsAvailability() {
     subtitle?: string;
   }>({
     title: "",
-    subtitle: isMd ? undefined : `${startingDay} - ${endingDay}`,
+    subtitle: `${startingDay} - ${endingDay}`,
   });
 
-  const [calendarView, setCalendarView] = useState(
-    isMd ? "resourceTimelineMonth" : "resourceTimelineWeek"
-  );
+  const [calendarView, setCalendarView] = useState(TARGET_CALENDAR_VIEW);
 
   const { resources, events } = useAssetAvailabilityData(items);
+
+  const updateTitle = (viewType = calendarView) => {
+    const calendarApi = calendarRef.current?.getApi();
+    if (calendarApi) {
+      setCalendarHeader(getCalendarTitleAndSubtitle({ viewType, calendarApi }));
+    }
+  };
+
+  /**
+   * IMPORTANT: This hook only works on page relaod. The indicator actually breaks on HMR. This is still pending to be fixed
+   */
+  const {
+    isCalendarReady,
+    handleNowIndicatorDidMount,
+    handleViewDidMount,
+    cleanup,
+  } = useCalendarNowIndicatorFix({
+    resources,
+    calendarRef,
+    targetView: TARGET_CALENDAR_VIEW,
+    setCalendarView,
+  });
 
   function handleViewChange(view: string) {
     setCalendarView(view);
@@ -57,38 +78,13 @@ export default function AssetsAvailability() {
     updateTitle(view);
   }
 
-  const updateTitle = (viewType = calendarView) => {
-    const calendarApi = calendarRef.current?.getApi();
-    if (calendarApi) {
-      setCalendarHeader(getCalendarTitleAndSubtitle({ viewType, calendarApi }));
-    }
+  // Handle normal view changes and scrolling
+  const handleDatesSet = () => {
+    scrollToNow();
   };
-  const isHydrated = useHydrated();
 
-  useEffect(() => {
-    if (isHydrated && calendarRef.current) {
-      const timer = setTimeout(() => {
-        const calendarApi = calendarRef.current?.getApi();
-        if (calendarApi && resources && resources.length > 0) {
-          try {
-            // More aggressive fix - force multiple recalculations
-            calendarApi.updateSize();
-            setTimeout(() => {
-              calendarApi.changeView(calendarView);
-              // Force another updateSize after view change
-              setTimeout(() => calendarApi.updateSize(), 50);
-            }, 50);
-
-            console.log("Applied delayed nowIndicator workaround");
-          } catch (error) {
-            console.warn("Failed to apply delayed workaround:", error);
-          }
-        }
-      }, 300);
-
-      return () => clearTimeout(timer);
-    }
-  }, [isHydrated, resources, calendarView]);
+  // Cleanup timers on unmount
+  useEffect(() => cleanup, [cleanup]);
 
   return (
     <div>
@@ -105,146 +101,166 @@ export default function AssetsAvailability() {
             updateTitle={() => updateTitle(calendarView)}
           />
 
-          {isMd ? (
-            <ViewButtonGroup
-              views={[
-                { label: "Month", value: "resourceTimelineMonth" },
-                { label: "Week", value: "resourceTimelineWeek" },
-                { label: "Day", value: "resourceTimelineDay" },
-              ]}
-              currentView={calendarView}
-              onViewChange={handleViewChange}
-            />
-          ) : null}
+          <ViewButtonGroup
+            views={[
+              { label: "Month", value: "resourceTimelineMonth" },
+              { label: "Week", value: "resourceTimelineWeek" },
+              { label: "Day", value: "resourceTimelineDay" },
+            ]}
+            currentView={calendarView}
+            onViewChange={handleViewChange}
+          />
         </div>
       </div>
 
-      <ClientOnly fallback={<FallbackLoading className="size-36" />}>
-        {() => (
-          <FullCalendar
-            ref={calendarRef}
-            height="auto"
-            timeZone={timeZone}
-            nowIndicator
-            slotEventOverlap
-            eventTimeFormat={{
-              hour: "numeric",
-              minute: "2-digit",
-              meridiem: "short",
-            }}
-            eventMouseEnter={handleEventMouseEnter("resourceTimelineMonth")}
-            eventMouseLeave={handleEventMouseLeave("resourceTimelineMonth")}
-            eventClick={handleEventClick}
-            resourceOrder="none"
-            plugins={[resourceTimelinePlugin]}
-            schedulerLicenseKey={FULL_CALENDAR_LICENSE_KEY}
-            initialView="resourceTimelineMonth"
-            headerToolbar={false}
-            resources={resources}
-            events={events}
-            resourceAreaHeaderContent={
-              <div className="px-2 py-1">
-                <h5 className="text-left capitalize">{plural}</h5>
-
-                <div>
-                  {perPage < totalItems ? (
-                    <p>
-                      {items.length} {items.length > 1 ? plural : singular}{" "}
-                      <span className="text-gray-400">out of {totalItems}</span>
-                    </p>
-                  ) : (
-                    <p>
-                      <span>
-                        {totalItems} {items.length === 1 ? singular : plural}
-                      </span>
-                    </p>
-                  )}
-                </div>
-              </div>
-            }
-            resourceAreaHeaderClassNames="text-md font-semibold text-gray-900"
-            views={{
-              resourceTimelineMonth: {
-                slotLabelFormat: [
-                  { month: "long", year: "numeric" }, // top level: "January 2024"
-                  { weekday: "short", day: "2-digit" }, // bottom level: "Mon 15"
-                ],
-              },
-              resourceTimelineWeek: {
-                slotLabelFormat: [
-                  { weekday: "long", month: "short", day: "numeric" }, // top level: "Monday, Jan 15"
-                  { hour: "numeric", meridiem: "short" }, // bottom level: "2 PM"
-                ],
-              },
-              resourceTimelineDay: {
-                slotLabelFormat: [
-                  { weekday: "short", month: "short", day: "numeric" }, // "Mon, Jan 15"
-                  { hour: "numeric", minute: "2-digit", meridiem: "short" },
-                ], // "2:30 PM"
-              },
-            }}
-            slotLabelFormat={[
-              { month: "long", year: "numeric" }, // top level of text
-              { weekday: "short", day: "2-digit" }, // lower level of text
-            ]}
-            slotLabelClassNames="font-normal text-gray-600"
-            slotMinWidth={100}
-            resourceLabelContent={({ resource }) => (
-              <div className="flex items-center gap-2 px-2">
-                <AssetImage
-                  asset={{
-                    id: resource.id,
-                    mainImage: resource.extendedProps?.mainImage,
-                    thumbnailImage: resource.extendedProps?.thumbnailImage,
-                    mainImageExpiration:
-                      resource.extendedProps?.mainImageExpiration,
-                  }}
-                  alt={resource.title}
-                  className="size-14 rounded border object-cover"
-                  withPreview
-                />
-                <div className="flex flex-col gap-1">
-                  <div className="min-w-0 flex-1 truncate">
-                    <Button
-                      to={`/assets/${resource.id}`}
-                      variant="link"
-                      className="text-left font-medium text-gray-900 hover:text-gray-700"
-                      target={"_blank"}
-                      onlyNewTabIconOnHover={true}
-                    >
-                      {resource.title}
-                    </Button>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <AssetStatusBadge
-                      status={resource.extendedProps?.status}
-                      availableToBook={resource.extendedProps?.availableToBook}
-                    />
-                    <CategoryBadge
-                      category={resource.extendedProps?.category}
-                    />
+      {/* hellow rld */}
+      <div className="relative">
+        <ClientOnly fallback={<CalendarLoadingFallback />}>
+          {() => (
+            <FullCalendar
+              ref={calendarRef}
+              height="auto"
+              timeZone={timeZone}
+              nowIndicator
+              slotEventOverlap
+              eventTimeFormat={{
+                hour: "numeric",
+                minute: "2-digit",
+                meridiem: "short",
+              }}
+              eventMouseEnter={handleEventMouseEnter("resourceTimelineMonth")}
+              eventMouseLeave={handleEventMouseLeave("resourceTimelineMonth")}
+              eventClick={handleEventClick}
+              resourceOrder="none"
+              plugins={[resourceTimelinePlugin]}
+              schedulerLicenseKey={FULL_CALENDAR_LICENSE_KEY}
+              initialView={DEFAULT_CALENDAR_VIEW}
+              headerToolbar={false}
+              resources={resources}
+              events={events}
+              resourceAreaHeaderContent={
+                <div className="px-2 py-1">
+                  <h5 className="text-left capitalize">{plural}</h5>
+                  <div>
+                    {perPage < totalItems ? (
+                      <p>
+                        {items.length} {items.length > 1 ? plural : singular}{" "}
+                        <span className="text-gray-400">
+                          out of {totalItems}
+                        </span>
+                      </p>
+                    ) : (
+                      <p>
+                        <span>
+                          {totalItems} {items.length === 1 ? singular : plural}
+                        </span>
+                      </p>
+                    )}
                   </div>
                 </div>
-              </div>
-            )}
-            eventContent={renderEventCard}
-            eventClassNames={(eventInfo) => {
-              const viewType = eventInfo.view.type;
-              const isOneDay = isOneDayEvent(
-                eventInfo.event.start,
-                eventInfo.event.end
-              );
+              }
+              resourceAreaHeaderClassNames="text-md font-semibold text-gray-900"
+              views={{
+                resourceTimelineMonth: {
+                  slotLabelFormat: [
+                    { month: "long", year: "numeric" },
+                    { weekday: "short", day: "2-digit" },
+                  ],
+                },
+                resourceTimelineWeek: {
+                  slotLabelFormat: [
+                    { weekday: "long", month: "short", day: "numeric" },
+                    { hour: "numeric", meridiem: "short" },
+                  ],
+                },
+                resourceTimelineDay: {
+                  slotLabelFormat: [
+                    { weekday: "short", month: "short", day: "numeric" },
+                    { hour: "numeric", minute: "2-digit", meridiem: "short" },
+                  ],
+                },
+              }}
+              slotLabelFormat={[
+                { month: "long", year: "numeric" },
+                { weekday: "short", day: "2-digit" },
+              ]}
+              slotLabelClassNames="font-normal text-gray-600"
+              slotMinWidth={100}
+              resourceLabelContent={({ resource }) => (
+                <div className="flex items-center gap-2 px-2">
+                  <AssetImage
+                    asset={{
+                      id: resource.id,
+                      mainImage: resource.extendedProps?.mainImage,
+                      thumbnailImage: resource.extendedProps?.thumbnailImage,
+                      mainImageExpiration:
+                        resource.extendedProps?.mainImageExpiration,
+                    }}
+                    alt={resource.title}
+                    className="size-14 rounded border object-cover"
+                    withPreview
+                  />
+                  <div className="flex flex-col gap-1">
+                    <div className="min-w-0 flex-1 truncate">
+                      <Button
+                        to={`/assets/${resource.id}`}
+                        variant="link"
+                        className="text-left font-medium text-gray-900 hover:text-gray-700"
+                        target={"_blank"}
+                        onlyNewTabIconOnHover={true}
+                      >
+                        {resource.title}
+                      </Button>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <AssetStatusBadge
+                        status={resource.extendedProps?.status}
+                        availableToBook={
+                          resource.extendedProps?.availableToBook
+                        }
+                      />
+                      <CategoryBadge
+                        category={resource.extendedProps?.category}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+              eventContent={renderEventCard}
+              eventClassNames={(eventInfo) => {
+                const viewType = eventInfo.view.type;
+                const isOneDay = isOneDayEvent(
+                  eventInfo.event.start,
+                  eventInfo.event.end
+                );
 
-              return getStatusClasses(
-                eventInfo.event.extendedProps.status,
-                isOneDay,
-                viewType
-              );
-            }}
-            datesSet={scrollToNow}
-          />
-        )}
-      </ClientOnly>
+                return getStatusClasses(
+                  eventInfo.event.extendedProps.status,
+                  isOneDay,
+                  viewType
+                );
+              }}
+              nowIndicatorDidMount={handleNowIndicatorDidMount}
+              viewDidMount={handleViewDidMount}
+              datesSet={handleDatesSet}
+            />
+          )}
+        </ClientOnly>
+
+        {/* Loading Overlay */}
+        {!isCalendarReady && <CalendarLoadingFallback />}
+      </div>
+    </div>
+  );
+}
+
+function CalendarLoadingFallback() {
+  return (
+    <div className="absolute inset-0 z-10 flex justify-center bg-white/90">
+      <div className="flex flex-col items-center gap-4 pt-[300px]">
+        <FallbackLoading className="size-16" />
+        <p className="text-sm text-gray-600">Loading calendar...</p>
+      </div>
     </div>
   );
 }

--- a/app/components/assets/assets-index/use-asset-availability-data.ts
+++ b/app/components/assets/assets-index/use-asset-availability-data.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { Booking, TeamMember, User } from "@prisma/client";
+import type { SerializeFrom } from "@remix-run/node";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
@@ -9,7 +10,10 @@ import { toIsoDateTimeToUserTimezone } from "~/utils/date-fns";
 import type { OrganizationPermissionSettings } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
 import { userHasCustodyViewPermission } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
 
-export function useAssetAvailabilityData(items: AssetIndexLoaderData["items"]) {
+type LoaderData = SerializeFrom<AssetIndexLoaderData>;
+type Items = NonNullable<LoaderData["items"]>;
+
+export function useAssetAvailabilityData(items: Items) {
   const { roles } = useUserRoleHelper();
   const organization = useCurrentOrganization();
   const canSeeAllCustody = userHasCustodyViewPermission({

--- a/app/components/assets/assets-index/use-asset-availability-data.ts
+++ b/app/components/assets/assets-index/use-asset-availability-data.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import type { Booking, TeamMember, User } from "@prisma/client";
-import { useLoaderData } from "@remix-run/react";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
@@ -10,8 +9,7 @@ import { toIsoDateTimeToUserTimezone } from "~/utils/date-fns";
 import type { OrganizationPermissionSettings } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
 import { userHasCustodyViewPermission } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
 
-export function useAssetAvailabilityData() {
-  const { items } = useLoaderData<AssetIndexLoaderData>();
+export function useAssetAvailabilityData(items: AssetIndexLoaderData["items"]) {
   const { roles } = useUserRoleHelper();
   const organization = useCurrentOrganization();
   const canSeeAllCustody = userHasCustodyViewPermission({

--- a/app/components/assets/assets-index/use-calendar-now-indicator-fix.ts
+++ b/app/components/assets/assets-index/use-calendar-now-indicator-fix.ts
@@ -1,0 +1,115 @@
+import { useState, useCallback, useRef } from "react";
+import type FullCalendar from "@fullcalendar/react";
+import { scrollToNow } from "~/utils/calendar";
+
+interface UseCalendarNowIndicatorFixOptions {
+  resources: any[] | undefined;
+  calendarRef: React.RefObject<FullCalendar>;
+  targetView: string;
+  setCalendarView: (view: string) => void;
+}
+
+/**
+ * Custom hook to fix the FullCalendar now indicator issue by switching views
+ * and ensuring the calendar is ready for interaction.
+ * The issue is that nowIndicator does not work properly when the default view is not resourceTimelineDay.
+ * This hook switches the view to the target view (resourceTimelineMonth) when the calendar is ready,
+ * and ensures the now indicator is visible. More details about the issue can be found here: https://claude.ai/public/artifacts/18c76b8a-19af-46fd-a596-e37e8c9f8264
+ */
+export function useCalendarNowIndicatorFix({
+  resources,
+  calendarRef,
+  targetView,
+  setCalendarView,
+}: UseCalendarNowIndicatorFixOptions) {
+  const [isCalendarReady, setIsCalendarReady] = useState(false);
+  const [hasInitialViewSwitched, setHasInitialViewSwitched] = useState(false);
+
+  const timersRef = useRef<Set<NodeJS.Timeout>>(new Set());
+
+  const clearAllTimers = useCallback(() => {
+    timersRef.current.forEach((timer) => clearTimeout(timer));
+    timersRef.current.clear();
+  }, []);
+
+  const addTimer = useCallback((timer: NodeJS.Timeout) => {
+    timersRef.current.add(timer);
+  }, []);
+
+  const removeTimer = useCallback((timer: NodeJS.Timeout) => {
+    timersRef.current.delete(timer);
+  }, []);
+
+  const switchToTargetView = useCallback(() => {
+    if (!hasInitialViewSwitched && resources && resources.length > 0) {
+      setHasInitialViewSwitched(true);
+
+      const timer1 = setTimeout(() => {
+        removeTimer(timer1);
+        const calendarApi = calendarRef.current?.getApi();
+        if (calendarApi) {
+          calendarApi.changeView(targetView);
+          setCalendarView(targetView);
+
+          const timer2 = setTimeout(() => {
+            removeTimer(timer2);
+            setIsCalendarReady(true);
+            scrollToNow();
+          }, 150);
+          addTimer(timer2);
+        }
+      }, 50);
+      addTimer(timer1);
+    }
+  }, [
+    hasInitialViewSwitched,
+    resources,
+    targetView,
+    calendarRef,
+    setCalendarView,
+    addTimer,
+    removeTimer,
+  ]);
+
+  const handleNowIndicatorDidMount = useCallback(() => {
+    switchToTargetView();
+  }, [switchToTargetView]);
+
+  const handleViewDidMount = useCallback(
+    (mountInfo: any) => {
+      if (
+        mountInfo.view.type === "resourceTimelineDay" &&
+        !hasInitialViewSwitched &&
+        resources &&
+        resources.length > 0
+      ) {
+        const timer = setTimeout(() => {
+          removeTimer(timer);
+          if (!hasInitialViewSwitched) {
+            switchToTargetView();
+          }
+        }, 200);
+        addTimer(timer);
+      }
+    },
+    [
+      hasInitialViewSwitched,
+      resources,
+      switchToTargetView,
+      addTimer,
+      removeTimer,
+    ]
+  );
+
+  // Cleanup function
+  const cleanup = useCallback(() => {
+    clearAllTimers();
+  }, [clearAllTimers]);
+
+  return {
+    isCalendarReady,
+    handleNowIndicatorDidMount,
+    handleViewDidMount,
+    cleanup,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
     "": {
       "name": "shelf-webapp",
       "dependencies": {
-        "@fullcalendar/core": "^6.1.11",
-        "@fullcalendar/daygrid": "^6.1.11",
-        "@fullcalendar/list": "^6.1.11",
-        "@fullcalendar/react": "^6.1.11",
+        "@fullcalendar/core": "^6.1.17",
+        "@fullcalendar/daygrid": "^6.1.17",
+        "@fullcalendar/list": "^6.1.17",
+        "@fullcalendar/react": "^6.1.17",
         "@fullcalendar/resource-timeline": "^6.1.17",
-        "@fullcalendar/timegrid": "^6.1.15",
+        "@fullcalendar/timegrid": "^6.1.17",
         "@markdoc/markdoc": "^0.4.0",
         "@paralleldrive/cuid2": "^2.2.2",
         "@prisma/client": "^6.2.1",
@@ -3453,9 +3453,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
-      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.0.tgz",
+      "integrity": "sha512-C+3A6sPt8EwUlNwsbT22IoUq0O+wXXA4Sw39UmCATlfa8HVP5r0X/l9xGyELhfSmmO0sjgSAl7qmlCHS6Dkekw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=18.18"
@@ -3474,57 +3474,57 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
-      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.0.tgz",
+      "integrity": "sha512-9aA88Vub9O7zdb52PuJg88cN2GCjfY2I45CIttJe7fS5EyvTRRGE/PDQlbjTG9ij9+leD47fGLQCqYDpyCE5Iw==",
       "devOptional": true,
       "dependencies": {
         "jiti": "2.4.2"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
-      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.0.tgz",
+      "integrity": "sha512-vzVu0Z3DfCzyx0m7LPZgdA/M7opv7B2R7agNLjh1PpIapCqHo/dwoXoj3Kl25A6TkmhexJzOZKedmhpXsMBwGA==",
       "devOptional": true
     },
     "node_modules/@prisma/engines": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
-      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.0.tgz",
+      "integrity": "sha512-g/VL/J+b1rjzvPLZWSjOt/iWX/As44IF65x0XrsvwjD1UI0hLHzDAVx3AJz4k4cNsFzEQqVl/rLa6ICsLy8v5w==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/debug": "6.9.0",
-        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
-        "@prisma/fetch-engine": "6.9.0",
-        "@prisma/get-platform": "6.9.0"
+        "@prisma/debug": "6.10.0",
+        "@prisma/engines-version": "6.10.0-43.aee10d5a411e4360c6d3445ce4810ca65adbf3e8",
+        "@prisma/fetch-engine": "6.10.0",
+        "@prisma/get-platform": "6.10.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
-      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "version": "6.10.0-43.aee10d5a411e4360c6d3445ce4810ca65adbf3e8",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.0-43.aee10d5a411e4360c6d3445ce4810ca65adbf3e8.tgz",
+      "integrity": "sha512-Dy7cS5Sz/kzdj2nrYTiPfycf/ZeQXFoIcXgTLmYHpuDX0rGITEGe7JSTSNnLYRUnjTHerDTPGPJCiDeyb6lPBg==",
       "devOptional": true
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
-      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.0.tgz",
+      "integrity": "sha512-7An09F6Xe886gSwcj1HEY/0LBuD4IR0ZnKbNv4d0kMnmNzGCz+IK4XRnd/yOkiptIks0nF+igLEin5MEoBejfA==",
       "devOptional": true,
       "dependencies": {
-        "@prisma/debug": "6.9.0",
-        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
-        "@prisma/get-platform": "6.9.0"
+        "@prisma/debug": "6.10.0",
+        "@prisma/engines-version": "6.10.0-43.aee10d5a411e4360c6d3445ce4810ca65adbf3e8",
+        "@prisma/get-platform": "6.10.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
-      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.0.tgz",
+      "integrity": "sha512-6xqX2cxC2l0JHySyyFlXZ4QIESeEmkvSJfGy2r/NsQG+vjxBNDrlwDOgh+aQI1ivbgqwFRjSXuUjl/yd2Za2HQ==",
       "devOptional": true,
       "dependencies": {
-        "@prisma/debug": "6.9.0"
+        "@prisma/debug": "6.10.0"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -8013,9 +8013,9 @@
       "optional": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.17.tgz",
-      "integrity": "sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.18.tgz",
+      "integrity": "sha512-KJ65INaxqxmU6EoCiJmRPZC9H9RVWCRd349tXM2M3O5NA7cY6YL7c0bHAHQ93NOfTObEQ004kd2QVHs/r0+m4g==",
       "dev": true
     },
     "node_modules/@types/luxon": {
@@ -11020,9 +11020,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.167",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
-      "integrity": "sha512-LxcRvnYO5ez2bMOFpbuuVuAI5QNeY1ncVytE/KXaL6ZNfzX1yPlAO0nSOyIHx2fVAuUprMqPs/TdVhUFZy7SIQ==",
+      "version": "1.5.170",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.170.tgz",
+      "integrity": "sha512-GP+M7aeluQo9uAyiTCxgIj/j+PrWhMlY7LFVj8prlsPljd0Fdg9AprlfUi+OCSFWy9Y5/2D/Jrj9HS8Z4rpKWA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -11039,9 +11039,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -12440,9 +12440,9 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/exsolve": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.5.tgz",
-      "integrity": "sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.6.tgz",
+      "integrity": "sha512-Q05uIdxhPBVBwK29gcPsl2K220xSBy52TZQPdeYWE0zOs8jM+yJ6y5h7jm6cpAo1p+OOMZRIj/Ftku4EQQBLnQ==",
       "dev": true
     },
     "node_modules/extend": {
@@ -13392,9 +13392,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.7.11.tgz",
-      "integrity": "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.0.tgz",
+      "integrity": "sha512-NoiHrqJxoe1MYXqW+/0/Q4NCizKj2Ivm4KmX8mOSBtw9UJ7KYaOGKkO7csIwO5UlZpfvVRdcgiMb0GGyjEjtcw==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -15017,9 +15017,9 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.12.0.tgz",
-      "integrity": "sha512-DV6TRr+xoPrLSKuGiUcbyLVkoLdNaNNpn6O7+ZC27yQH7BOOIF7l6JKbTCMhfMJuZBVJfL8YRJjlMJ6MZCTggA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.13.0.tgz",
+      "integrity": "sha512-TSSJIvDKsiSPk22889FWk9V4mmjljbizUf8Y2Jhho2j0Mj4zonC6kKwoVLf3oGqYWTZ+oQrd0Cxg6LCmZmPPbQ==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^3.0.0",
@@ -17778,9 +17778,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
-      "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "funding": [
         {
           "type": "opencollective",
@@ -18253,14 +18253,14 @@
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="
     },
     "node_modules/prisma": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
-      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.0.tgz",
+      "integrity": "sha512-hyfwi+HpH2lHlRUj3O6CtWg44D7iuxi/O+xoLIsDjUNvriyFIVlw4a+8facnByZnm4Lt54+ZzJkFvkKBm7bIug==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/config": "6.9.0",
-        "@prisma/engines": "6.9.0"
+        "@prisma/config": "6.10.0",
+        "@prisma/engines": "6.10.0"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -21016,9 +21016,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
-      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
@@ -23460,9 +23460,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.64",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
-      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "cross-spawn": "~7.0.6"
   },
   "dependencies": {
-    "@fullcalendar/core": "^6.1.11",
-    "@fullcalendar/daygrid": "^6.1.11",
-    "@fullcalendar/list": "^6.1.11",
-    "@fullcalendar/react": "^6.1.11",
+    "@fullcalendar/core": "^6.1.17",
+    "@fullcalendar/daygrid": "^6.1.17",
+    "@fullcalendar/list": "^6.1.17",
+    "@fullcalendar/react": "^6.1.17",
     "@fullcalendar/resource-timeline": "^6.1.17",
-    "@fullcalendar/timegrid": "^6.1.15",
+    "@fullcalendar/timegrid": "^6.1.17",
     "@markdoc/markdoc": "^0.4.0",
     "@paralleldrive/cuid2": "^2.2.2",
     "@prisma/client": "^6.2.1",


### PR DESCRIPTION
There is an issue with the `resourceTimeline` of full calendar which has been known since 2022 but has still not been fixed, I can imagine due to complexity. What happens is that when the default view of the resource timeline is anything different than `resourceTimelineDay` the now indicator doesn't get placed on the correct place. 
Here is a link to the full research: https://claude.ai/public/artifacts/18c76b8a-19af-46fd-a596-e37e8c9f8264

So I created a  Custom hook to fix the FullCalendar now indicator issue by switching views and ensuring the calendar is ready for interaction. This hook switches the view to the target view (`resourceTimelineMonth`) when the calendar is ready and ensures the now indicator is visible. This means that default view has to be set to `resourceTimelineDay` so the indicator gets generated properly.