### PR TITLE
fix: add uniqueId in csv data

### DIFF
--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -1803,7 +1803,8 @@ export async function createAssetsFromContentImport({
 
       await createAsset({
         id: assetId, // Pass the pre-generated ID
-        qrId: qrCodesPerAsset.find((item) => item?.title === asset.title)?.qrId,
+        qrId: qrCodesPerAsset.find((item) => item?.uniqueId === asset.uniqueId)
+          ?.qrId,
         organizationId,
         title: asset.title,
         description: asset.description || "",

--- a/app/modules/asset/types.ts
+++ b/app/modules/asset/types.ts
@@ -51,6 +51,7 @@ export interface UpdateAssetPayload {
 
 export interface CreateAssetFromContentImportPayload
   extends Record<string, any> {
+  uniqueId: string; // Unique identifier for the asset in the import (this is generated while parsing the csv file)
   title: string;
   description?: string;
   category?: string;

--- a/app/modules/qr/service.server.ts
+++ b/app/modules/qr/service.server.ts
@@ -524,6 +524,7 @@ export async function parseQrCodesFromImportData({
       .map((asset) => {
         if (asset.qrId) {
           return {
+            uniqueId: asset.uniqueId,
             title: asset.title,
             qrId: asset.qrId,
           };


### PR DESCRIPTION
Our CSV file might contain duplicate data items — for example, asset titles can be repeated across entries.

We were able to identify this issue because one of our clients faced problems while importing assets with duplicate titles and QR code IDs. The QR IDs were not being assigned to the correct assets, leading to data mismatches.

To handle this, we now generate a unique ID for each entry, ensuring that each one can be reliably identified.
This unique ID will be used when creating or updating assets, preventing conflicts and ensuring correct data mapping.