### PR TITLE
feat: optional required tags for bookings

### DIFF
--- a/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
+++ b/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
@@ -12,6 +12,7 @@ import { BookingFormSchema } from "~/components/booking/forms/forms-schema";
 import { BulkUpdateDialogContent } from "~/components/bulk-update-dialog/bulk-update-dialog";
 import { Button } from "~/components/shared/button";
 import { Card } from "~/components/shared/card";
+import { TagsAutocomplete } from "~/components/tag/tags-autocomplete";
 import { useBookingSettings } from "~/hooks/use-booking-settings";
 import { useUserData } from "~/hooks/use-user-data";
 import { useWorkingHours } from "~/hooks/use-working-hours";
@@ -22,15 +23,24 @@ import { getValidationErrors } from "~/utils/http";
 import { userCanViewSpecificCustody } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
 
 export default function CreateBookingForSelectedAssetsDialog() {
-  const { currentOrganization, teamMembers } =
+  const { currentOrganization, teamMembers, tagsData } =
     useLoaderData<AssetIndexLoaderData>();
+  const tagsSuggestions = tagsData.tags.map((tag) => ({
+    label: tag.name,
+    value: tag.id,
+  }));
   const selectedAssets = useAtomValue(selectedBulkItemsAtom);
   const workingHoursData = useWorkingHours(currentOrganization.id);
   const { workingHours } = workingHoursData;
-  const { bufferStartTime } = useBookingSettings();
+  const { bufferStartTime, tagsRequired } = useBookingSettings();
   const zo = useZorm(
     "CreateBookingWithAssets",
-    BookingFormSchema({ action: "new", workingHours, bufferStartTime })
+    BookingFormSchema({
+      action: "new",
+      workingHours,
+      bufferStartTime,
+      tagsRequired,
+    })
   );
 
   const { startDate, endDate: defaultEndDate } = getBookingDefaultStartEndTimes(
@@ -121,7 +131,19 @@ export default function CreateBookingForSelectedAssetsDialog() {
                 }
               />
             </Card>
-            <Card className="m-0 mb-2">
+
+            <Card className="m-0 mb-2 overflow-visible">
+              <TagsAutocomplete
+                existingTags={[]}
+                suggestions={tagsSuggestions}
+                required={tagsRequired}
+                error={
+                  validationErrors?.tags?.message || zo.errors.tags()?.message
+                }
+              />
+            </Card>
+
+            <Card className="m-0">
               <DescriptionField
                 description={undefined}
                 fieldName={zo.fields.description()}

--- a/app/components/booking/buffer/buffer-settings.tsx
+++ b/app/components/booking/buffer/buffer-settings.tsx
@@ -10,7 +10,6 @@ import { Spinner } from "~/components/shared/spinner";
 import { useDisabled } from "~/hooks/use-disabled";
 import type { BookingSettingsActionData } from "~/routes/_layout+/settings.bookings";
 import { getValidationErrors } from "~/utils/http";
-import { tw } from "~/utils/tw";
 
 export const BufferSettingsSchema = z.object({
   bufferStartTime: z.coerce
@@ -36,7 +35,7 @@ export function BufferSettings({
   );
 
   return (
-    <Card className={tw("my-0")}>
+    <Card>
       <div className="mb-4 border-b pb-4">
         <h3 className="text-text-lg font-semibold">{header.title}</h3>
         <p className="text-sm text-gray-600">{header.subHeading}</p>

--- a/app/components/booking/forms/edit-booking-form.tsx
+++ b/app/components/booking/forms/edit-booking-form.tsx
@@ -105,7 +105,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
         bookingStatus?.isOverdue ||
         bookingStatus?.isCancelled
     );
-  const { bufferStartTime } = useBookingSettings();
+  const { bufferStartTime, tagsRequired } = useBookingSettings();
 
   const zo = useZorm(
     "NewQuestionWizardScreen",
@@ -115,6 +115,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
       status,
       workingHours: workingHours,
       bufferStartTime,
+      tagsRequired,
     })
   );
 
@@ -365,6 +366,10 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
                   }
                   existingTags={tags}
                   className="mb-2.5"
+                  required={tagsRequired}
+                  error={
+                    validationErrors?.tags?.message || zo.errors.tags()?.message
+                  }
                 />
 
                 <DescriptionField

--- a/app/components/booking/forms/fields/tag-field.tsx
+++ b/app/components/booking/forms/fields/tag-field.tsx
@@ -8,12 +8,16 @@ type TagFieldProps = {
   className?: string;
   existingTags: Pick<Tag, "id" | "name">[];
   disabled?: boolean;
+  required?: boolean;
+  error?: string;
 };
 
 export default function TagField({
   className,
   existingTags,
   disabled,
+  required = false,
+  error,
 }: TagFieldProps) {
   const { tags } = useLoaderData<{ tags: Tag[] }>();
 
@@ -39,6 +43,8 @@ export default function TagField({
         valueKey="value"
         name="tags"
         disabled={disabled}
+        required={required}
+        error={error}
       />
     </FormRow>
   );

--- a/app/components/booking/forms/forms-schema.ts
+++ b/app/components/booking/forms/forms-schema.ts
@@ -195,7 +195,7 @@ export function BookingFormSchema({
       ),
     startDate: z.coerce.date().optional(),
     endDate: z.coerce.date().optional(),
-    tags: tagsRequired 
+    tags: tagsRequired
       ? z.string().min(1, "At least one tag is required")
       : z.string().optional(),
   });

--- a/app/components/booking/forms/forms-schema.ts
+++ b/app/components/booking/forms/forms-schema.ts
@@ -134,6 +134,7 @@ interface BookingFormSchemaParams {
   status?: BookingStatus;
   workingHours: any; // Accept any type, normalize internally
   bufferStartTime: number; // Required buffer parameter
+  tagsRequired: boolean; // Whether tags are required for bookings
 }
 
 /**
@@ -163,6 +164,7 @@ export function BookingFormSchema({
   status,
   workingHours: rawWorkingHours,
   bufferStartTime,
+  tagsRequired,
 }: BookingFormSchemaParams) {
   // Transform and validate working hours data
   const workingHours = normalizeWorkingHoursForValidation(rawWorkingHours);
@@ -193,7 +195,9 @@ export function BookingFormSchema({
       ),
     startDate: z.coerce.date().optional(),
     endDate: z.coerce.date().optional(),
-    tags: z.string().optional(),
+    tags: tagsRequired 
+      ? z.string().min(1, "At least one tag is required")
+      : z.string().optional(),
   });
 
   // Create enhanced date schemas with working hours and buffer validation

--- a/app/components/booking/forms/new-booking-form.tsx
+++ b/app/components/booking/forms/new-booking-form.tsx
@@ -57,7 +57,7 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
   // Fetch working hours for validation
   const workingHoursData = useWorkingHours(currentOrganization.id);
   const { workingHours } = workingHoursData;
-  const { bufferStartTime } = useBookingSettings();
+  const { bufferStartTime, tagsRequired } = useBookingSettings();
   const { startDate, endDate: defaultEndDate } = getBookingDefaultStartEndTimes(
     workingHours,
     bufferStartTime
@@ -72,6 +72,7 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
       action: "new",
       workingHours: workingHours,
       bufferStartTime,
+      tagsRequired,
     })
   );
 
@@ -102,6 +103,7 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
   const validationErrors = getValidationErrors<BookingFormSchemaType>(
     fetcher.data?.error
   );
+
   return (
     <div>
       <fetcher.Form ref={zo.ref} method="post" action={action}>
@@ -155,6 +157,10 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
                 <TagsAutocomplete
                   existingTags={[]}
                   suggestions={tagsSuggestions}
+                  required={tagsRequired}
+                  error={
+                    validationErrors?.tags?.message || zo.errors.tags()?.message
+                  }
                 />
               </Card>
               <Card className="m-0">

--- a/app/components/booking/tags-required/tags-required-settings.tsx
+++ b/app/components/booking/tags-required/tags-required-settings.tsx
@@ -1,11 +1,18 @@
 import { useFetcher } from "@remix-run/react";
 import { useZorm } from "react-zorm";
+import z from "zod";
 import FormRow from "~/components/forms/form-row";
 import { Switch } from "~/components/forms/switch";
 import { Card } from "~/components/shared/card";
 import { useDisabled } from "~/hooks/use-disabled";
-import { TagsRequiredSettingsSchema } from "~/modules/working-hours/zod-utils";
 import { tw } from "~/utils/tw";
+
+export const TagsRequiredSettingsSchema = z.object({
+  tagsRequired: z
+    .string()
+    .transform((val) => val === "on")
+    .default("false"),
+});
 
 export function TagsRequiredSettings({
   header,

--- a/app/components/booking/tags-required/tags-required-settings.tsx
+++ b/app/components/booking/tags-required/tags-required-settings.tsx
@@ -1,0 +1,63 @@
+import { useFetcher } from "@remix-run/react";
+import { useZorm } from "react-zorm";
+import FormRow from "~/components/forms/form-row";
+import { Switch } from "~/components/forms/switch";
+import { Card } from "~/components/shared/card";
+import { useDisabled } from "~/hooks/use-disabled";
+import { TagsRequiredSettingsSchema } from "~/modules/working-hours/zod-utils";
+import { tw } from "~/utils/tw";
+
+export function TagsRequiredSettings({
+  header,
+  defaultValue = false,
+}: {
+  header: { title: string; subHeading?: string };
+  defaultValue: boolean;
+}) {
+  const fetcher = useFetcher();
+  const disabled = useDisabled();
+  const zo = useZorm("TagsRequiredForm", TagsRequiredSettingsSchema);
+
+  return (
+    <Card className={tw("my-0")}>
+      <div className="mb-4 border-b pb-4">
+        <h3 className="text-text-lg font-semibold">{header.title}</h3>
+        <p className="text-sm text-gray-600">{header.subHeading}</p>
+      </div>
+      <div>
+        <fetcher.Form
+          ref={zo.ref}
+          method="post"
+          onChange={(e) => fetcher.submit(e.currentTarget)}
+        >
+          <FormRow
+            rowLabel="Require tags for bookings"
+            subHeading={
+              <div>
+                When enabled, users must add at least one tag to their bookings.
+                This helps with categorization and organization of bookings.
+              </div>
+            }
+            className="border-b-0 pb-[10px] pt-0"
+          >
+            <div className="flex flex-col items-center gap-2">
+              <Switch
+                name={zo.fields.tagsRequired()}
+                disabled={disabled}
+                defaultChecked={defaultValue}
+                title="Require tags for bookings"
+              />
+              <label
+                htmlFor={`tagsRequired-${zo.fields.tagsRequired()}`}
+                className=" hidden text-gray-500"
+              >
+                Require tags for bookings
+              </label>
+            </div>
+          </FormRow>
+          <input type="hidden" value="updateTagsRequired" name="intent" />
+        </fetcher.Form>
+      </div>
+    </Card>
+  );
+}

--- a/app/components/multi-select/multi-select.tsx
+++ b/app/components/multi-select/multi-select.tsx
@@ -21,6 +21,7 @@ type MultiSelectProps<T> = {
   tooltip?: { title: string; content: string };
   placeholder?: string;
   hideLabel?: boolean;
+  required?: boolean;
 };
 
 export default function MultiSelect<T>({
@@ -36,6 +37,7 @@ export default function MultiSelect<T>({
   tooltip,
   placeholder,
   hideLabel = false,
+  required = false,
 }: MultiSelectProps<T>) {
   /* This is a workaround for the SSR issue with react-tag-autocomplete */
   if (typeof document === "undefined") {
@@ -85,7 +87,9 @@ export default function MultiSelect<T>({
 
       <div className={tw("flex min-w-48 flex-col", className)}>
         <div className="flex items-center justify-between">
-          <InnerLabel hideLg={hideLabel}>{label}</InnerLabel>
+          <InnerLabel hideLg={hideLabel} required={required}>
+            {label}
+          </InnerLabel>
 
           <When truthy={!!tooltip}>
             <Tooltip>

--- a/app/components/tag/tags-autocomplete.tsx
+++ b/app/components/tag/tags-autocomplete.tsx
@@ -11,11 +11,15 @@ export const TagsAutocomplete = ({
   suggestions,
   disabled = false,
   hideLabel = false,
+  error,
+  required = false,
 }: {
   existingTags: Tag[];
   suggestions: TagSuggestion[];
   disabled?: boolean;
   hideLabel?: boolean;
+  error?: string;
+  required?: boolean;
 }) => (
   <MultiSelect
     className="w-full"
@@ -27,5 +31,7 @@ export const TagsAutocomplete = ({
     name="tags"
     disabled={disabled}
     hideLabel={hideLabel}
+    error={error}
+    required={required}
   />
 );

--- a/app/components/working-hours/toggle-working-hours-form.tsx
+++ b/app/components/working-hours/toggle-working-hours-form.tsx
@@ -17,7 +17,7 @@ export function EnableWorkingHoursForm({
   const fetcher = useFetcher();
   const zo = useZorm("EnableWorkingHoursForm", WorkingHoursToggleSchema);
   return (
-    <Card>
+    <Card className="mt-0">
       <div className="mb-4 border-b pb-4">
         <h3 className="text-text-lg font-semibold">{header.title}</h3>
         <p className="text-sm text-gray-600">{header.subHeading}</p>
@@ -34,7 +34,6 @@ export function EnableWorkingHoursForm({
               <div>Working hours will be enabled for your workspace.</div>
             }
             className="border-b-0 pb-[10px] pt-0"
-            required
           >
             <div className="flex flex-col items-center gap-2">
               <Switch

--- a/app/database/migrations/20250717094237_add_tags_required_flag_to_booking_settings/migration.sql
+++ b/app/database/migrations/20250717094237_add_tags_required_flag_to_booking_settings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BookingSettings" ADD COLUMN     "tagsRequired" BOOLEAN NOT NULL DEFAULT false;

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -902,6 +902,7 @@ model BookingSettings {
   id String @id @default(cuid())
 
   bufferStartTime Int @default(0) // Buffer time in hours for bookings. This is used to prevent short term bookings
+  tagsRequired Boolean @default(false) // Whether tags are required for bookings
 
   // Relationships
   organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)

--- a/app/modules/asset/data.server.ts
+++ b/app/modules/asset/data.server.ts
@@ -34,6 +34,7 @@ import { getAllSelectedValuesFromFilters } from "./utils.server";
 import type { Column } from "../asset-index-settings/helpers";
 import { getActiveCustomFields } from "../custom-field/service.server";
 import type { OrganizationFromUser } from "../organization/service.server";
+import { getTagsForBookingTagsFilter } from "../tag/service.server";
 import { getTeamMemberForCustodianFilter } from "../team-member/service.server";
 import { getOrganizationTierLimit } from "../tier/service.server";
 
@@ -111,6 +112,7 @@ export async function simpleModeLoader({
       teamMembers,
       totalTeamMembers,
     },
+    tagsData,
   ] = await Promise.all([
     getOrganizationTierLimit({
       organizationId,
@@ -143,6 +145,9 @@ export async function simpleModeLoader({
           : undefined,
       isSelfService,
       userId,
+    }),
+    getTagsForBookingTagsFilter({
+      organizationId,
     }),
   ]);
 
@@ -220,6 +225,8 @@ export async function simpleModeLoader({
        * */
       customFields: [],
       kits: [] as Kit[],
+      // Those tags are used for the tags autocomplete on the booking form
+      tagsData,
     }),
     {
       headers,
@@ -291,6 +298,7 @@ export async function advancedModeLoader({
     teamMembersData,
     kits,
     totalKits,
+    tagsData,
   ] = await Promise.all([
     getOrganizationTierLimit({
       organizationId,
@@ -329,6 +337,10 @@ export async function advancedModeLoader({
           : 12,
     }),
     db.kit.count({ where: { organizationId } }),
+    // Tags for booking form
+    getTagsForBookingTagsFilter({
+      organizationId,
+    }),
   ]);
 
   if (role === OrganizationRoles.SELF_SERVICE) {
@@ -400,6 +412,7 @@ export async function advancedModeLoader({
       totalKits,
       tags,
       totalTags,
+      tagsData,
     }),
     {
       headers,

--- a/app/modules/booking-settings/service.server.ts
+++ b/app/modules/booking-settings/service.server.ts
@@ -47,7 +47,8 @@ export async function updateBookingSettings({
 }) {
   try {
     const updateData: { bufferStartTime?: number; tagsRequired?: boolean } = {};
-    if (bufferStartTime !== undefined) updateData.bufferStartTime = bufferStartTime;
+    if (bufferStartTime !== undefined)
+      updateData.bufferStartTime = bufferStartTime;
     if (tagsRequired !== undefined) updateData.tagsRequired = tagsRequired;
 
     const bookingSettings = await db.bookingSettings.update({

--- a/app/modules/booking-settings/service.server.ts
+++ b/app/modules/booking-settings/service.server.ts
@@ -15,11 +15,13 @@ export async function getBookingSettingsForOrganization(
       update: {},
       create: {
         bufferStartTime: 0,
+        tagsRequired: false,
         organizationId,
       },
       select: {
         id: true,
         bufferStartTime: true,
+        tagsRequired: true,
       },
     });
 
@@ -37,17 +39,24 @@ export async function getBookingSettingsForOrganization(
 export async function updateBookingSettings({
   organizationId,
   bufferStartTime,
+  tagsRequired,
 }: {
   organizationId: string;
-  bufferStartTime: number;
+  bufferStartTime?: number;
+  tagsRequired?: boolean;
 }) {
   try {
+    const updateData: { bufferStartTime?: number; tagsRequired?: boolean } = {};
+    if (bufferStartTime !== undefined) updateData.bufferStartTime = bufferStartTime;
+    if (tagsRequired !== undefined) updateData.tagsRequired = tagsRequired;
+
     const bookingSettings = await db.bookingSettings.update({
       where: { organizationId },
-      data: { bufferStartTime },
+      data: updateData,
       select: {
         id: true,
         bufferStartTime: true,
+        tagsRequired: true,
       },
     });
 
@@ -56,7 +65,7 @@ export async function updateBookingSettings({
     throw new ShelfError({
       cause,
       message: "Failed to update booking settings configuration",
-      additionalData: { organizationId, bufferStartTime },
+      additionalData: { organizationId, bufferStartTime, tagsRequired },
       label,
     });
   }

--- a/app/modules/working-hours/zod-utils.ts
+++ b/app/modules/working-hours/zod-utils.ts
@@ -10,13 +10,6 @@ export const WorkingHoursToggleSchema = z.object({
     .default("false"),
 });
 
-export const TagsRequiredSettingsSchema = z.object({
-  tagsRequired: z
-    .string()
-    .transform((val) => val === "on")
-    .default("false"),
-});
-
 // Base time string schema with proper validation
 const TimeStringSchema = z
   .string()

--- a/app/modules/working-hours/zod-utils.ts
+++ b/app/modules/working-hours/zod-utils.ts
@@ -10,6 +10,13 @@ export const WorkingHoursToggleSchema = z.object({
     .default("false"),
 });
 
+export const TagsRequiredSettingsSchema = z.object({
+  tagsRequired: z
+    .string()
+    .transform((val) => val === "on")
+    .default("false"),
+});
+
 // Base time string schema with proper validation
 const TimeStringSchema = z
   .string()

--- a/app/routes/_layout+/admin-dashboard+/$userId.tsx
+++ b/app/routes/_layout+/admin-dashboard+/$userId.tsx
@@ -329,8 +329,7 @@ export default function Area51UserPage() {
           : null;
     }
   };
-  const hasSubscription =
-    (customer?.subscriptions?.total_count ?? 0) > 0;
+  const hasSubscription = (customer?.subscriptions?.total_count ?? 0) > 0;
 
   return user ? (
     <div>

--- a/app/routes/_layout+/bookings.$bookingId.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.tsx
@@ -456,7 +456,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       select: { id: true, status: true },
     });
     const workingHours = await getWorkingHoursForOrganization(organizationId);
-    const { bufferStartTime } =
+    const { bufferStartTime, tagsRequired } =
       await getBookingSettingsForOrganization(organizationId);
     switch (intent) {
       case "save": {
@@ -469,6 +469,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             hints,
             workingHours,
             bufferStartTime,
+            tagsRequired,
           }),
           {
             additionalData: { userId, id, organizationId, role },
@@ -526,6 +527,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             status: basicBookingInfo.status,
             workingHours,
             bufferStartTime,
+            tagsRequired,
           }),
           {
             additionalData: { userId, id, organizationId, role },

--- a/app/routes/_layout+/bookings.new.tsx
+++ b/app/routes/_layout+/bookings.new.tsx
@@ -124,7 +124,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
     const intent = formData.get("intent") as string;
     const hints = getHints(request);
     const workingHours = await getWorkingHoursForOrganization(organizationId);
-    const { bufferStartTime } =
+    const { bufferStartTime, tagsRequired } =
       await getBookingSettingsForOrganization(organizationId);
     const payload = parseData(
       formData,
@@ -133,6 +133,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
         action: "new",
         workingHours,
         bufferStartTime,
+        tagsRequired,
       }),
       {
         additionalData: { userId, organizationId },

--- a/app/routes/_layout+/settings.bookings.tsx
+++ b/app/routes/_layout+/settings.bookings.tsx
@@ -10,7 +10,10 @@ import {
   BufferSettings,
   BufferSettingsSchema,
 } from "~/components/booking/buffer/buffer-settings";
-import { TagsRequiredSettings } from "~/components/booking/tags-required/tags-required-settings";
+import {
+  TagsRequiredSettings,
+  TagsRequiredSettingsSchema,
+} from "~/components/booking/tags-required/tags-required-settings";
 import { ErrorContent } from "~/components/errors";
 import type { HeaderData } from "~/components/layout/header/types";
 import { Overrides } from "~/components/working-hours/overrides/overrides";
@@ -31,7 +34,6 @@ import type { WeeklyScheduleJson } from "~/modules/working-hours/types";
 import { parseWeeklyScheduleFromFormData } from "~/modules/working-hours/utils";
 import {
   CreateOverrideFormSchema,
-  TagsRequiredSettingsSchema,
   WeeklyScheduleSchema,
   WorkingHoursToggleSchema,
 } from "~/modules/working-hours/zod-utils";


### PR DESCRIPTION
- add a flag in BookingSettings to control whether tags are required
- create a form in settings.booking to toggle the tagsRequired flag
- update action and schema in settings.booking to support the new toggle
- update BookingFormSchema to receive tagsRequired and handle it accordingly
- update all booking forms to receive the new props and properly render the tags field with the required option handled
- update asset index loaders to load not only tags for asset filters but also tags for bookings form
- update MultiSelect component to receive a 'required' prop
- update TagsAutocomplete to receive an error and required props