### PR TITLE
Fix: bug with lru cache on import

### DIFF
--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -1942,15 +1942,16 @@ export async function createAssetsFromContentImport({
             mainImageExpiration = oneDayFromNow();
           }
         } catch (cause) {
+          // This catch block should rarely be reached now since uploadImageFromUrl returns null instead of throwing
+          // But we keep it for any unexpected errors in createSignedUrl or other operations
           const isShelfError = isLikeShelfError(cause);
 
-          // Log the error but don't stop the import process
           Logger.error(
             new ShelfError({
               cause,
               message: isShelfError
                 ? `${cause?.message} for asset: ${asset.title}`
-                : `Failed to upload image for asset ${asset.title}`,
+                : `Unexpected error during image processing for asset ${asset.title}`,
               additionalData: { imageUrl: asset.imageUrl, assetId },
               label: "Assets",
             })

--- a/app/utils/storage.server.ts
+++ b/app/utils/storage.server.ts
@@ -370,27 +370,29 @@ export async function uploadImageFromUrl(
     // If not in cache, download the image with retry logic
     let response: Response | null = null;
     let fetchError: Error | null = null;
-    
+
     // Try to fetch the image up to 2 times
     for (let attempt = 1; attempt <= 2; attempt++) {
       try {
         response = await fetch(imageUrl);
-        
+
         if (response.ok) {
           fetchError = null;
           break; // Success, exit retry loop
         } else {
-          fetchError = new Error(`HTTP ${response.status}: ${response.statusText}`);
+          fetchError = new Error(
+            `HTTP ${response.status}: ${response.statusText}`
+          );
           if (attempt === 2) {
             // Last attempt failed, log and return null
             Logger.error(
               new ShelfError({
                 cause: fetchError,
                 message: "Failed to fetch image from URL after 2 attempts",
-                additionalData: { 
-                  imageUrl, 
+                additionalData: {
+                  imageUrl,
                   status: response.status,
-                  attempts: 2
+                  attempts: 2,
                 },
                 label,
                 shouldBeCaptured: false,
@@ -399,7 +401,7 @@ export async function uploadImageFromUrl(
             return null;
           }
           // Wait a moment before retrying
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise((resolve) => setTimeout(resolve, 1000));
         }
       } catch (cause) {
         fetchError = cause as Error;
@@ -409,9 +411,9 @@ export async function uploadImageFromUrl(
             new ShelfError({
               cause: fetchError,
               message: "Failed to fetch image from URL after 2 attempts",
-              additionalData: { 
-                imageUrl, 
-                attempts: 2
+              additionalData: {
+                imageUrl,
+                attempts: 2,
               },
               label,
               shouldBeCaptured: false,
@@ -420,7 +422,7 @@ export async function uploadImageFromUrl(
           return null;
         }
         // Wait a moment before retrying
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await new Promise((resolve) => setTimeout(resolve, 1000));
       }
     }
 
@@ -513,7 +515,7 @@ export async function uploadImageFromUrl(
     return data.path;
   } catch (cause) {
     const isShelfError = isLikeShelfError(cause);
-    
+
     // Log the error and return null instead of throwing
     // This allows the import process to continue without the image
     Logger.error(
@@ -527,7 +529,7 @@ export async function uploadImageFromUrl(
         shouldBeCaptured: isShelfError ? cause.shouldBeCaptured : true,
       })
     );
-    
+
     return null; // Return null to indicate failure, allowing import to continue
   }
 }

--- a/app/utils/storage.server.ts
+++ b/app/utils/storage.server.ts
@@ -328,7 +328,7 @@ export async function uploadImageFromUrl(
   imageUrl: string,
   { filename, contentType, bucketName, resizeOptions }: UploadOptions,
   cache?: LRUCache<string, CachedImage>
-) {
+): Promise<string | null> {
   try {
     let buffer: Buffer;
     let actualContentType: string;
@@ -367,25 +367,75 @@ export async function uploadImageFromUrl(
       }
     }
 
-    // If not in cache, download the image
-    const response = await fetch(imageUrl).catch((cause) => {
-      throw new ShelfError({
-        cause,
-        message: "Failed to fetch image from URL",
-        additionalData: { imageUrl },
-        label,
-        shouldBeCaptured: false,
-      });
-    });
+    // If not in cache, download the image with retry logic
+    let response: Response | null = null;
+    let fetchError: Error | null = null;
+    
+    // Try to fetch the image up to 2 times
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        response = await fetch(imageUrl);
+        
+        if (response.ok) {
+          fetchError = null;
+          break; // Success, exit retry loop
+        } else {
+          fetchError = new Error(`HTTP ${response.status}: ${response.statusText}`);
+          if (attempt === 2) {
+            // Last attempt failed, log and return null
+            Logger.error(
+              new ShelfError({
+                cause: fetchError,
+                message: "Failed to fetch image from URL after 2 attempts",
+                additionalData: { 
+                  imageUrl, 
+                  status: response.status,
+                  attempts: 2
+                },
+                label,
+                shouldBeCaptured: false,
+              })
+            );
+            return null;
+          }
+          // Wait a moment before retrying
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        }
+      } catch (cause) {
+        fetchError = cause as Error;
+        if (attempt === 2) {
+          // Last attempt failed, log and return null
+          Logger.error(
+            new ShelfError({
+              cause: fetchError,
+              message: "Failed to fetch image from URL after 2 attempts",
+              additionalData: { 
+                imageUrl, 
+                attempts: 2
+              },
+              label,
+              shouldBeCaptured: false,
+            })
+          );
+          return null;
+        }
+        // Wait a moment before retrying
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
 
-    if (!response.ok) {
-      throw new ShelfError({
-        cause: null,
-        message: "Failed to fetch image from URL",
-        shouldBeCaptured: false,
-        additionalData: { imageUrl, status: response.status },
-        label,
-      });
+    // This should not happen due to the early returns above, but TypeScript needs the check
+    if (!response) {
+      Logger.error(
+        new ShelfError({
+          cause: null,
+          message: "Unexpected null response after retry loop",
+          additionalData: { imageUrl },
+          label,
+          shouldBeCaptured: false,
+        })
+      );
+      return null;
     }
 
     actualContentType = response.headers.get("content-type") || contentType;
@@ -463,15 +513,22 @@ export async function uploadImageFromUrl(
     return data.path;
   } catch (cause) {
     const isShelfError = isLikeShelfError(cause);
-    throw new ShelfError({
-      cause,
-      message: isShelfError
-        ? cause.message
-        : "Failed to process and upload image from URL",
-      additionalData: { imageUrl, filename, contentType, bucketName },
-      label,
-      shouldBeCaptured: isShelfError ? cause.shouldBeCaptured : true,
-    });
+    
+    // Log the error and return null instead of throwing
+    // This allows the import process to continue without the image
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: isShelfError
+          ? cause.message
+          : "Failed to process and upload image from URL",
+        additionalData: { imageUrl, filename, contentType, bucketName },
+        label,
+        shouldBeCaptured: isShelfError ? cause.shouldBeCaptured : true,
+      })
+    );
+    
+    return null; // Return null to indicate failure, allowing import to continue
   }
 }
 


### PR DESCRIPTION
- When image `sizeCalculation` fails, it was returning null which is invalid value for the cache so it was breaking. WE set the default size to 0 if it returns null
- if image download fails when importing, skip the image and don't throw an error just continue the process