### PR TITLE
Fix: Prisma config to load environment variables

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
 export default defineConfig({


### PR DESCRIPTION
Add dotenv/config import to prisma.config.ts to ensure environment variables are loaded when using the new Prisma configuration format. This resolves the 'Environment variable not found: DIRECT_URL' error that occurred after migrating from package.json to prisma.config.ts.