### PR TITLE
Fix pigeon-maps production build import error

### DIFF
--- a/app/components/location/map.tsx
+++ b/app/components/location/map.tsx
@@ -1,5 +1,6 @@
 import { Map, Marker } from "pigeon-maps";
-import { maptiler } from "pigeon-maps/providers";
+// @ts-ignore - Using direct CJS import to fix production build ESM issue
+import { maptiler } from "pigeon-maps/lib/providers.cjs.js";
 import { ClientOnly } from "remix-utils/client-only";
 import { MAPTILER_TOKEN } from "~/utils/env";
 


### PR DESCRIPTION
Update import to use specific CommonJS file path instead of directory import to resolve Node.js ESM module resolution error in production builds.

- Changed from 'pigeon-maps/providers' to 'pigeon-maps/lib/providers.cjs.js'
- Added @ts-ignore to suppress TypeScript declaration file warning
- Resolves ERR_UNSUPPORTED_DIR_IMPORT in production Node.js environment