### PR TITLE
Fix Docker build failure by copying prisma.config.ts to release stage

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -36,6 +36,7 @@ COPY --from=build /src/node_modules /src/node_modules
 COPY --from=build /src/app/database /src/app/database
 COPY --from=build /src/build /src/build
 COPY --from=build /src/package.json /src/package.json
+COPY --from=build /src/prisma.config.ts /src/prisma.config.ts
 COPY --from=build /src/docker-entrypoint.sh /src/docker-entrypoint.sh
 
 RUN chmod +x /src/docker-entrypoint.sh


### PR DESCRIPTION
The Docker build was failing because prisma.config.ts wasn't being copied to the final release stage of the Docker image. This caused the container to fail at startup when running 'npm run db:deploy' since Prisma couldn't find the schema configuration.

Fixed by adding COPY instruction to copy prisma.config.ts from the build stage to the release stage, ensuring Prisma can locate the schema at app/database/schema.prisma during container startup.

Resolves: https://github.com/Shelf-nu/shelf.nu/issues/1980