### PR TITLE
Fix sequential ID migration modal state persistence bug

### DIFF
--- a/app/components/sequential-id-migration-modal.tsx
+++ b/app/components/sequential-id-migration-modal.tsx
@@ -14,13 +14,13 @@ import { Spinner } from "~/components/shared/spinner";
 import type { action } from "~/routes/api+/generate-sequential-ids";
 
 interface SequentialIdMigrationModalProps {
-  isOpen: boolean;
+  organizationId: string;
 }
 
 type MigrationState = "starting" | "running" | "completed" | "error";
 
 export function SequentialIdMigrationModal({
-  isOpen,
+  organizationId,
 }: SequentialIdMigrationModalProps) {
   const fetcher = useFetcher<typeof action>();
   const [state, setState] = useState<MigrationState>("starting");
@@ -28,9 +28,15 @@ export function SequentialIdMigrationModal({
     "Setting up sequential IDs for your organization..."
   );
 
+  // Reset state when organization changes
+  useEffect(() => {
+    setState("starting");
+    setMessage("Setting up sequential IDs for your organization...");
+  }, [organizationId]);
+
   // Auto-start migration when modal opens
   useEffect(() => {
-    if (isOpen && state === "starting") {
+    if (state === "starting") {
       setState("running");
       setMessage("Setting up sequential IDs for your organization...");
       fetcher.submit(
@@ -38,7 +44,7 @@ export function SequentialIdMigrationModal({
         { action: "/api/generate-sequential-ids", method: "post" }
       );
     }
-  }, [isOpen, state, fetcher]);
+  }, [state, fetcher]);
 
   // Handle fetcher response
   useEffect(() => {
@@ -54,10 +60,8 @@ export function SequentialIdMigrationModal({
     }
   }, [fetcher.data]);
 
-  if (!isOpen) return null;
-
   return (
-    <AlertDialog open={isOpen}>
+    <AlertDialog open={true}>
       <AlertDialogContent className="sm:max-w-md">
         <AlertDialogHeader>
           <AlertDialogTitle className="flex items-center gap-3">

--- a/app/routes/_layout+/_layout.tsx
+++ b/app/routes/_layout+/_layout.tsx
@@ -209,8 +209,12 @@ export const meta: MetaFunction<typeof loader> = ({ error }) => {
 
 export default function App() {
   useCrisp();
-  const { disabledTeamOrg, minimizedSidebar, needsSequentialIdMigration } =
-    useLoaderData<typeof loader>();
+  const {
+    disabledTeamOrg,
+    minimizedSidebar,
+    needsSequentialIdMigration,
+    currentOrganizationId,
+  } = useLoaderData<typeof loader>();
   const workspaceSwitching = useAtomValue(switchingWorkspaceAtom);
 
   const renderInstallPwaPromptOnMobile = () =>
@@ -263,9 +267,9 @@ export default function App() {
         </ClientOnly>
 
         {/* Sequential ID Migration Modal */}
-        <SequentialIdMigrationModal
-          isOpen={needsSequentialIdMigration ?? false}
-        />
+        {needsSequentialIdMigration ? (
+          <SequentialIdMigrationModal organizationId={currentOrganizationId} />
+        ) : null}
       </SidebarInset>
     </SidebarProvider>
   );


### PR DESCRIPTION
- Remove isOpen prop and use conditional rendering instead
- Add organizationId prop to reset state when switching organizations
- Prevent flash of old success/error messages between org switches
- Modal now unmounts/remounts cleanly when changing organizations
- Simplified component logic by removing isOpen dependency