### PR TITLE
Fix: working hours override date display timezone issue

### DIFF
--- a/app/components/shared/date.tsx
+++ b/app/components/shared/date.tsx
@@ -1,4 +1,52 @@
+import { format } from "date-fns";
 import { getDateTimeFormatFromHints, useHints } from "~/utils/client-hints";
+
+/**
+ * Formats a date using locale-specific formatting without timezone conversion.
+ * Used for absolute dates that should display exactly as stored (e.g., working hours overrides).
+ */
+function formatAbsoluteDate(
+  date: string | Date,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  // Extract just the date part and create a local date
+  let dateToFormat: Date;
+  if (typeof date === "string") {
+    // Extract date-only part if it's a datetime string
+    const dateOnly = date.includes("T") ? date.split("T")[0] : date;
+    // Parse as local date components to completely avoid timezone interpretation
+    const [year, month, day] = dateOnly.split("-").map(Number);
+    dateToFormat = new Date(year, month - 1, day);
+  } else {
+    dateToFormat = date;
+  }
+
+  // Convert Intl.DateTimeFormatOptions to date-fns format string
+  let formatString = "yyyy-MM-dd"; // default format
+  if (options) {
+    let parts = [];
+    if (options.weekday === "long") parts.push("EEEE");
+    else if (options.weekday === "short") parts.push("EEE");
+    else if (options.weekday === "narrow") parts.push("EEEEE");
+
+    if (options.month === "long") parts.push("MMMM");
+    else if (options.month === "short") parts.push("MMM");
+    else if (options.month === "numeric") parts.push("M");
+    else if (options.month === "2-digit") parts.push("MM");
+
+    if (options.day === "numeric") parts.push("d");
+    else if (options.day === "2-digit") parts.push("dd");
+
+    if (options.year === "numeric") parts.push("yyyy");
+    else if (options.year === "2-digit") parts.push("yy");
+
+    if (parts.length > 0) {
+      formatString = parts.join(", ");
+    }
+  }
+
+  return format(dateToFormat, formatString);
+}
 
 /**
  * Component that renders date based on the users locale and timezone.
@@ -9,6 +57,7 @@ export const DateS = ({
   date,
   options,
   includeTime = false,
+  localeOnly = false,
 }: {
   date: string | Date;
   /**
@@ -22,8 +71,27 @@ export const DateS = ({
    * When true, adds time formatting options (hour, minute) to the date format
    */
   includeTime?: boolean;
+  /**
+   * Whether to format the date based on locale only, without timezone conversion.
+   * Use this for absolute dates like working hours overrides that represent
+   * real-world, location-specific dates that should not change based on user timezone.
+   */
+  localeOnly?: boolean;
 }) => {
   const hints = useHints();
+
+  // Handle locale-only formatting (no timezone conversion)
+  if (localeOnly) {
+    if (includeTime) {
+      // eslint-disable-next-line no-console
+      console.warn("includeTime is not supported with localeOnly formatting");
+    }
+
+    const formattedDate = formatAbsoluteDate(date, options);
+    return <span>{formattedDate}</span>;
+  }
+
+  // Standard timezone-aware formatting
   let d = date;
   if (typeof date === "string") {
     d = new Date(date);

--- a/app/components/shared/date.tsx
+++ b/app/components/shared/date.tsx
@@ -22,27 +22,42 @@ function formatAbsoluteDate(
   }
 
   // Convert Intl.DateTimeFormatOptions to date-fns format string
-  let formatString = "yyyy-MM-dd"; // default format
+  let formatString: string;
+
   if (options) {
     let parts = [];
+
+    // Build format parts in logical order
     if (options.weekday === "long") parts.push("EEEE");
     else if (options.weekday === "short") parts.push("EEE");
     else if (options.weekday === "narrow") parts.push("EEEEE");
 
-    if (options.month === "long") parts.push("MMMM");
-    else if (options.month === "short") parts.push("MMM");
-    else if (options.month === "numeric") parts.push("M");
-    else if (options.month === "2-digit") parts.push("MM");
+    // Month and day should be together without comma
+    let datePartFormat = "";
+    if (options.month === "long") datePartFormat += "MMMM";
+    else if (options.month === "short") datePartFormat += "MMM";
+    else if (options.month === "numeric") datePartFormat += "M";
+    else if (options.month === "2-digit") datePartFormat += "MM";
 
-    if (options.day === "numeric") parts.push("d");
-    else if (options.day === "2-digit") parts.push("dd");
+    if (options.day === "numeric") datePartFormat += " d";
+    else if (options.day === "2-digit") datePartFormat += " dd";
+
+    if (datePartFormat) parts.push(datePartFormat);
 
     if (options.year === "numeric") parts.push("yyyy");
     else if (options.year === "2-digit") parts.push("yy");
 
     if (parts.length > 0) {
       formatString = parts.join(", ");
+    } else {
+      // Fallback if no valid parts found
+      formatString = "PPP"; // date-fns long localized date format
     }
+  } else {
+    // Default locale-aware format when no options provided
+    // Use date-fns localized format that adapts to locale
+    // PPP = long localized date format (e.g., "April 29th, 2023" in en-US, "29 avril 2023" in fr-FR)
+    formatString = "PPP";
   }
 
   return format(dateToFormat, formatString);

--- a/app/components/working-hours/overrides/override-preview.tsx
+++ b/app/components/working-hours/overrides/override-preview.tsx
@@ -38,6 +38,7 @@ export function OverridePreview({ override }: OverridePreviewProps) {
           <span className="font-semibold text-gray-900">
             <DateS
               date={override.date}
+              localeOnly
               options={{
                 weekday: "long",
                 year: "numeric",

--- a/app/components/working-hours/working-hours-preview-dialog.tsx
+++ b/app/components/working-hours/working-hours-preview-dialog.tsx
@@ -138,6 +138,7 @@ const OverridesSection = ({ overrides }: OverridesSectionProps) => {
               <h4 className="text-sm font-semibold text-gray-900">
                 <DateS
                   date={override.date}
+                  localeOnly
                   options={{
                     weekday: "long",
                     month: "long",


### PR DESCRIPTION
Working hours overrides were displaying incorrect dates due to timezone conversion during formatting. Users selecting "August 29th" would see "August 28th" displayed in certain timezones (e.g., US Eastern).

Changes made:
- Add localeOnly prop to DateS component for timezone-neutral formatting
- Create formatAbsoluteDate utility function using date-fns
- Parse date strings manually to avoid timezone interpretation
- Apply localeOnly formatting to working hours override components
- Preserve all Intl.DateTimeFormatOptions (weekday, month, etc.) in absolute formatting

Technical approach:
- Extract date-only part from datetime strings (2025-08-29T00:00:00.000Z → 2025-08-29)
- Parse as local date components: new Date(year, month-1, day)
- Use date-fns format() with converted format strings to avoid timezone issues
- Maintain locale-aware formatting while preventing timezone adjustment

Working hours overrides now display exactly the date stored in the database, ensuring "August 29th" always shows as "August 29th" regardless of user timezone.