### PR TITLE
Fix: Add kit-custody conflict validation for asset imports

### DIFF
--- a/app/components/assets/import-content.tsx
+++ b/app/components/assets/import-content.tsx
@@ -356,6 +356,44 @@ export const FileForm = ({ intent, url }: { intent: string; url?: string }) => {
                 />
               ) : null}
 
+              {data?.error?.additionalData?.kitCustodyConflicts ? (
+                <table className="mt-4 w-full rounded-md border text-left text-sm">
+                  <thead className="bg-error-100 text-xs">
+                    <tr>
+                      <th scope="col" className="px-2 py-1">
+                        Asset
+                      </th>
+                      <th scope="col" className="px-2 py-1">
+                        Custodian
+                      </th>
+                      <th scope="col" className="px-2 py-1">
+                        Kit
+                      </th>
+                      <th scope="col" className="px-2 py-1">
+                        Issue
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(
+                      data.error.additionalData.kitCustodyConflicts as Array<{
+                        asset: string;
+                        custodian: string;
+                        kit: string;
+                        issue: string;
+                      }>
+                    ).map((conflict, index: number) => (
+                      <tr key={index} className="border-b">
+                        <td className="px-2 py-1">{conflict.asset}</td>
+                        <td className="px-2 py-1">{conflict.custodian}</td>
+                        <td className="px-2 py-1">{conflict.kit}</td>
+                        <td className="px-2 py-1">{conflict.issue}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : null}
+
               {Array.isArray(data?.error?.additionalData?.defectedHeaders) ? (
                 <table className="mt-4 w-full rounded-md border text-left text-sm">
                   <thead className="bg-error-100 text-xs">


### PR DESCRIPTION
Prevents data inconsistencies where assets with custody are imported into:
- Existing kits without custody
- Existing kits with different custodians
- Same kit with multiple custodians in one import

Validation runs before any database operations and shows detailed error table in UI.

Fixes issue where removing assets from kits created inconsistent custody states.