### PR TITLE
Fix deployment crashes by downgrading Node.js version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base Node image
-FROM node:22-bookworm-slim AS base
+FROM node:20-bookworm-slim AS base
 
 # Set for base and all layer that inherit from it
 ENV PORT="8080"


### PR DESCRIPTION
Changes Node.js base image from v22 to v20 to resolve database connection issues that started occurring in recent deployments. Node.js v22 appears to have compatibility issues with pg-boss scheduler initialization causing SASL authentication failures.