### PR TITLE
refactor: remove redundant custody extraInclude in kit loader

### DIFF
--- a/app/routes/_layout+/kits.$kitId.tsx
+++ b/app/routes/_layout+/kits.$kitId.tsx
@@ -124,23 +124,6 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
               availableToBook: true,
             },
           },
-          custody: {
-            select: {
-              custodian: {
-                include: {
-                  user: {
-                    select: {
-                      id: true,
-                      firstName: true,
-                      lastName: true,
-                      profilePicture: true,
-                      email: true,
-                    },
-                  },
-                },
-              },
-            },
-          },
           qrCodes: true,
           ...(canUseBarcodes && {
             barcodes: {
@@ -168,7 +151,6 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         dateStyle: "short",
         timeStyle: "short",
       }).format(kit.custody.createdAt);
-
       custody = {
         ...kit.custody,
         dateDisplay,


### PR DESCRIPTION
The custody field was being selected in both `GET_KIT_STATIC_INCLUDES` and `extraInclude`, causing redundancy. Removed the extra custody select since `GET_KIT_STATIC_INCLUDES` already provides all necessary custody fields including `createdAt`.
Moreover this resolves #2024 as the extra include was not selecting `createdAt` so that was causing a bug.