### PR TITLE
Fix partial check-in progress display for COMPLETE and ARCHIVED bookings

### DIFF
--- a/app/components/booking/booking-assets-column.tsx
+++ b/app/components/booking/booking-assets-column.tsx
@@ -17,6 +17,7 @@ import { ListHeader } from "../list/list-header";
 import { ListItem } from "../list/list-item";
 import ListTitle from "../list/list-title";
 import { Button } from "../shared/button";
+import { InfoTooltip } from "../shared/info-tooltip";
 import TextualDivider from "../shared/textual-divider";
 import { Table, Th } from "../table";
 import { BookingPagination } from "./booking-pagination";
@@ -41,14 +42,16 @@ export function BookingAssetsColumn() {
   // Determine if we should show the check-in columns
   const shouldShowCheckinColumns = useMemo(() => {
     // const currentStatusFilter = searchParams.get("status");
-    const isOngoing =
+    const hasValidStatus =
       booking.status === BookingStatus.ONGOING ||
-      booking.status === BookingStatus.OVERDUE;
+      booking.status === BookingStatus.OVERDUE ||
+      booking.status === BookingStatus.COMPLETE ||
+      booking.status === BookingStatus.ARCHIVED;
     const hasPartialCheckins = partialCheckinProgress?.hasPartialCheckins;
     // const isNotCheckedOutFilter =
     //   currentStatusFilter !== AssetStatus.CHECKED_OUT;
 
-    return isOngoing && hasPartialCheckins;
+    return hasValidStatus && hasPartialCheckins;
     // && isNotCheckedOutFilter;
   }, [
     booking.status,
@@ -194,8 +197,30 @@ export function BookingAssetsColumn() {
                     <Th>Category</Th>
                     {shouldShowCheckinColumns && (
                       <>
-                        <Th className="whitespace-nowrap">Checked in on</Th>
-                        <Th className="whitespace-nowrap">Checked in by</Th>
+                        <Th className="whitespace-nowrap">
+                          Checked in on{" "}
+                          <InfoTooltip
+                            iconClassName="size-4"
+                            content={
+                              <p>
+                                Shows the date when the assset was checked in
+                                via a partial check-in.
+                              </p>
+                            }
+                          />
+                        </Th>
+                        <Th className="whitespace-nowrap">
+                          Checked in by{" "}
+                          <InfoTooltip
+                            iconClassName="size-4"
+                            content={
+                              <p>
+                                Shows the user who checked in the asset via a
+                                partial check-in.
+                              </p>
+                            }
+                          />
+                        </Th>
                       </>
                     )}
                     <Th> </Th>

--- a/app/components/booking/booking-assets-column.tsx
+++ b/app/components/booking/booking-assets-column.tsx
@@ -203,7 +203,7 @@ export function BookingAssetsColumn() {
                             iconClassName="size-4"
                             content={
                               <p>
-                                Shows the date when the assset was checked in
+                                Shows the date when the asset was checked in
                                 via a partial check-in.
                               </p>
                             }

--- a/app/modules/booking/utils.server.ts
+++ b/app/modules/booking/utils.server.ts
@@ -90,8 +90,24 @@ export function formatBookingsDates(bookings: Booking[], request: Request) {
  */
 export function calculatePartialCheckinProgress(
   totalAssets: number,
-  checkedInAssetIds: string[]
+  checkedInAssetIds: string[],
+  bookingStatus?: BookingStatus
 ) {
+  // For final booking statuses, always show 100% progress
+  if (
+    bookingStatus === BookingStatus.COMPLETE ||
+    bookingStatus === BookingStatus.ARCHIVED
+  ) {
+    return {
+      totalAssets,
+      checkedInCount: totalAssets,
+      uncheckedCount: 0,
+      progressPercentage: 100,
+      hasPartialCheckins: totalAssets > 0,
+      checkedInAssetIds,
+    };
+  }
+
   const checkedInCount = checkedInAssetIds.length;
   const uncheckedCount = totalAssets - checkedInCount;
   const progressPercentage =

--- a/app/routes/_layout+/bookings.$bookingId.checkin-assets.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.checkin-assets.tsx
@@ -98,7 +98,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
 
     const partialCheckinProgress = calculatePartialCheckinProgress(
       totalBookingAssets,
-      checkedInAssetIds
+      checkedInAssetIds,
+      booking.status
     );
 
     const title = `Scan assets to check in | ${booking.name}`;

--- a/app/routes/_layout+/bookings.$bookingId.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.tsx
@@ -417,7 +417,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
 
     const partialCheckinProgress = calculatePartialCheckinProgress(
       totalBookingAssets,
-      checkedInAssetIds
+      checkedInAssetIds,
+      booking.status
     );
 
     const modelName = {

--- a/app/utils/booking-assets.ts
+++ b/app/utils/booking-assets.ts
@@ -80,8 +80,8 @@ export function isAssetPartiallyCheckedIn(
     return false;
   }
 
-  // Only consider as "partially checked in" for active bookings
-  return ["ONGOING", "OVERDUE"].includes(bookingStatus);
+  // Only consider as "partially checked in" for active & finished bookings
+  return ["ONGOING", "OVERDUE", "COMPLETE", "ARCHIVED"].includes(bookingStatus);
 }
 
 /**


### PR DESCRIPTION
The booking progress bar was showing incorrect values (e.g., 160/482 instead of 482/482) for completed bookings because the system wasn't properly handling final booking statuses.

Changes made:
- Update calculatePartialCheckinProgress to return 100% progress for COMPLETE/ARCHIVED bookings
- Pass booking status to progress calculation in booking loaders
- Show check-in audit columns for COMPLETE/ARCHIVED bookings to maintain audit trail
- Add helpful tooltips to check-in column headers
- Update asset partial check-in logic to include final statuses

This ensures users see accurate progress (482/482 = 100%) and retain visibility into who checked in assets and when, even after booking completion.

Fixes issue where users couldn't see completion progress or audit information for bookings that were fully checked in via quick check-in functionality.