### PR TITLE
Add location overview tab and valuation aggregation

### DIFF
--- a/app/modules/location/service.server.test.ts
+++ b/app/modules/location/service.server.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+vi.mock("~/database/db.server", () => ({
+  db: {
+    asset: {
+      aggregate: vi.fn(),
+    },
+  },
+}));
+
+const { db } = await import("~/database/db.server");
+const { getLocationTotalValuation } = await import("./service.server");
+
+const aggregateMock = vi.mocked(db.asset.aggregate);
+
+describe("getLocationTotalValuation", () => {
+  beforeEach(() => {
+    aggregateMock.mockReset();
+  });
+
+  it("returns the aggregated valuation for all assets in a location", async () => {
+    aggregateMock.mockResolvedValue({ _sum: { valuation: 1234.56 } });
+
+    const total = await getLocationTotalValuation({ locationId: "loc-123" });
+
+    expect(aggregateMock).toHaveBeenCalledWith({
+      _sum: { valuation: true },
+      where: { locationId: "loc-123" },
+    });
+    expect(total).toBe(1234.56);
+  });
+
+  it("returns 0 when no valuation data is available", async () => {
+    aggregateMock.mockResolvedValue({ _sum: { valuation: null } });
+
+    const total = await getLocationTotalValuation({ locationId: "loc-123" });
+
+    expect(total).toBe(0);
+  });
+});

--- a/app/modules/location/service.server.ts
+++ b/app/modules/location/service.server.ts
@@ -239,6 +239,19 @@ export async function getLocations(params: {
   }
 }
 
+export async function getLocationTotalValuation({
+  locationId,
+}: {
+  locationId: Location["id"];
+}) {
+  const result = await db.asset.aggregate({
+    _sum: { valuation: true },
+    where: { locationId },
+  });
+
+  return result._sum.valuation ?? 0;
+}
+
 export async function createLocation({
   name,
   description,

--- a/app/routes/_layout+/locations.$locationId.overview.test.tsx
+++ b/app/routes/_layout+/locations.$locationId.overview.test.tsx
@@ -1,0 +1,170 @@
+import type { Currency } from "@prisma/client";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import {
+  getLocation,
+  getLocationTotalValuation,
+} from "~/modules/location/service.server";
+import { getClientHint, getDateTimeFormat } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+import LocationOverview, { loader } from "./locations.$locationId.overview";
+
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+
+vi.mock("~/modules/location/service.server", () => ({
+  getLocation: vi.fn(),
+  getLocationTotalValuation: vi.fn(),
+}));
+
+const mockDateFormatter = vi.fn(() => "formatted-date");
+
+vi.mock("~/utils/client-hints", () => ({
+  getClientHint: vi.fn(() => ({ locale: "en-GB", timeZone: "UTC" })),
+  getDateTimeFormat: vi.fn(() => ({ format: mockDateFormatter })),
+}));
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual("@remix-run/react");
+
+  return {
+    ...(actual as Record<string, unknown>),
+    useLoaderData: vi.fn(),
+  };
+});
+
+const requirePermissionMock = vi.mocked(requirePermission);
+const getLocationMock = vi.mocked(getLocation);
+const getLocationTotalValuationMock = vi.mocked(getLocationTotalValuation);
+const getClientHintMock = vi.mocked(getClientHint);
+const getDateTimeFormatMock = vi.mocked(getDateTimeFormat);
+const useLoaderDataMock = vi.mocked(useLoaderData);
+
+function createLoaderArgs(
+  overrides: Partial<LoaderFunctionArgs> = {}
+): LoaderFunctionArgs {
+  return {
+    context: {
+      getSession: () => ({ userId: "user-123" }),
+    },
+    params: { locationId: "loc-123" },
+    request: new Request("https://example.com/locations/loc-123/overview"),
+    ...overrides,
+  } as LoaderFunctionArgs;
+}
+
+describe("locations.$locationId.overview loader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns formatted location data with total valuation", async () => {
+    requirePermissionMock.mockResolvedValue({
+      organizationId: "org-1",
+      userOrganizations: [],
+      currentOrganization: { id: "org-1", currency: "USD" as Currency },
+    });
+
+    getLocationMock.mockResolvedValue({
+      location: {
+        id: "loc-123",
+        name: "Main Warehouse",
+        createdAt: new Date("2024-01-01T12:34:56Z"),
+      },
+    });
+
+    getLocationTotalValuationMock.mockResolvedValue(9876.54);
+
+    const args = createLoaderArgs({
+      request: new Request("https://example.com", {
+        headers: {
+          "accept-language": "en-GB",
+          cookie: "CH-time-zone=UTC",
+        },
+      }),
+    });
+
+    const response = await loader(args);
+    const result = await response.json();
+
+    expect(requirePermissionMock).toHaveBeenCalledWith({
+      userId: "user-123",
+      request: args.request,
+      entity: PermissionEntity.location,
+      action: PermissionAction.read,
+    });
+
+    expect(getLocationMock).toHaveBeenCalledWith({
+      id: "loc-123",
+      organizationId: "org-1",
+      request: args.request,
+      userOrganizations: [],
+    });
+    expect(getLocationTotalValuationMock).toHaveBeenCalledWith({
+      locationId: "loc-123",
+    });
+
+    expect(getClientHintMock).toHaveBeenCalledWith(args.request);
+    expect(getDateTimeFormatMock).toHaveBeenCalledWith(args.request, {
+      dateStyle: "short",
+      timeStyle: "short",
+    });
+    expect(mockDateFormatter).toHaveBeenCalledWith(
+      new Date("2024-01-01T12:34:56Z")
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: null,
+        location: expect.objectContaining({
+          id: "loc-123",
+          createdAt: "formatted-date",
+        }),
+        totalValue: 9876.54,
+        locale: "en-GB",
+        currentOrganization: expect.objectContaining({ currency: "USD" }),
+      })
+    );
+  });
+});
+
+describe("LocationOverview component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the overview card with formatted values", () => {
+    useLoaderDataMock.mockReturnValue({
+      location: {
+        id: "loc-123",
+        createdAt: "formatted-date",
+      },
+      totalValue: 12345.6,
+      currentOrganization: { currency: "USD" as Currency },
+      locale: "en-US",
+    });
+
+    render(<LocationOverview />);
+
+    expect(screen.getByText("ID")).toBeInTheDocument();
+    expect(screen.getByText("loc-123")).toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("formatted-date")).toBeInTheDocument();
+
+    const formattedValue = formatCurrency({
+      value: 12345.6,
+      currency: "USD" as Currency,
+      locale: "en-US",
+    });
+    expect(screen.getByText(formattedValue)).toBeInTheDocument();
+  });
+});

--- a/app/routes/_layout+/locations.$locationId.overview.tsx
+++ b/app/routes/_layout+/locations.$locationId.overview.tsx
@@ -1,0 +1,131 @@
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import { z } from "zod";
+import type { HeaderData } from "~/components/layout/header/types";
+import { Card } from "~/components/shared/card";
+import { InfoTooltip } from "~/components/shared/info-tooltip";
+import {
+  getLocation,
+  getLocationTotalValuation,
+} from "~/modules/location/service.server";
+import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { getClientHint, getDateTimeFormat } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
+import { makeShelfError } from "~/utils/error";
+import { data, error, getParams } from "~/utils/http.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+
+const paramsSchema = z.object({ locationId: z.string() });
+
+export async function loader({ context, request, params }: LoaderFunctionArgs) {
+  const authSession = context.getSession();
+  const { userId } = authSession;
+  const { locationId: id } = getParams(params, paramsSchema, {
+    additionalData: { userId },
+  });
+
+  try {
+    const { organizationId, userOrganizations, currentOrganization } =
+      await requirePermission({
+        userId,
+        request,
+        entity: PermissionEntity.location,
+        action: PermissionAction.read,
+      });
+
+    const { locale } = getClientHint(request);
+    const { location } = await getLocation({
+      id,
+      organizationId,
+      userOrganizations,
+      request,
+    });
+    const totalValue = await getLocationTotalValuation({ locationId: id });
+
+    const header: HeaderData = {
+      title: `${location.name}'s overview`,
+    };
+
+    return json(
+      data({
+        location: {
+          ...location,
+          createdAt: getDateTimeFormat(request, {
+            dateStyle: "short",
+            timeStyle: "short",
+          }).format(location.createdAt),
+        },
+        totalValue,
+        locale,
+        currentOrganization,
+        header,
+      })
+    );
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId, locationId: id });
+    throw json(error(reason), { status: reason.status });
+  }
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  { title: data ? appendToMetaTitle(data.header.title) : "" },
+];
+
+export const handle = {
+  breadcrumb: () => "Overview",
+};
+
+export default function LocationOverview() {
+  const { location, totalValue, locale, currentOrganization } =
+    useLoaderData<typeof loader>();
+
+  return (
+    <Card className="mt-0 px-[-4] py-[-5] md:border">
+      <ul className="item-information">
+        <li className="w-full border-b-[1.1px] border-b-gray-100 p-4 last:border-b-0 md:flex">
+          <span className="w-1/4 text-[14px] font-medium text-gray-900">
+            ID
+          </span>
+          <div className="mt-1 w-3/5 text-gray-600 md:mt-0">{location.id}</div>
+        </li>
+        <li className="w-full border-b-[1.1px] border-b-gray-100 p-4 last:border-b-0 md:flex">
+          <span className="w-1/4 text-[14px] font-medium text-gray-900">
+            Created
+          </span>
+          <div className="mt-1 w-3/5 text-gray-600 md:mt-0">
+            {location.createdAt}
+          </div>
+        </li>
+        <li className="w-full border-b-[1.1px] border-b-gray-100 p-4 last:border-b-0 md:flex">
+          <span className="w-1/4 text-[14px] font-medium text-gray-900">
+            Total value{" "}
+            <InfoTooltip
+              iconClassName="size-4"
+              content={
+                <>
+                  <h6>Total value</h6>
+                  <p>
+                    A sum of all assets' values stored at this location. If no
+                    assets are present, this will be zero.
+                  </p>
+                </>
+              }
+            />
+          </span>
+          <div className="mt-1 whitespace-pre-wrap text-gray-600 md:mt-0 md:w-3/5">
+            {formatCurrency({
+              value: totalValue,
+              locale,
+              currency: currentOrganization.currency,
+            })}
+          </div>
+        </li>
+      </ul>
+    </Card>
+  );
+}

--- a/app/routes/_layout+/locations.$locationId.tsx
+++ b/app/routes/_layout+/locations.$locationId.tsx
@@ -167,6 +167,7 @@ export default function LocationPage() {
 
   const items = [
     { to: "assets", content: "Assets" },
+    { to: "overview", content: "Overview" },
     { to: "kits", content: "Kits" },
   ];
 


### PR DESCRIPTION
## Summary
- add a location overview route that loads formatted metadata and renders an overview card with ID, created date, and total asset value
- compute location total valuation via a dedicated service helper with unit coverage
- expose the Overview tab alongside existing Assets and Kits tabs on the location page and add route/component tests

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68ca7b4d6b0c8326b7a17286b05223db