### PR TITLE
Enable tap-to-focus interactions in camera mode

### DIFF
--- a/app/components/scanner/code-scanner.test.tsx
+++ b/app/components/scanner/code-scanner.test.tsx
@@ -1,0 +1,66 @@
+import React, { forwardRef, useEffect, useImperativeHandle } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CodeScanner } from "./code-scanner";
+
+vi.mock("./success-animation", () => ({
+  __esModule: true,
+  default: () => <div data-testid="success-animation" />,
+}));
+
+// Mock react-webcam to expose the forwarded ref and rendered className
+vi.mock("react-webcam", () => {
+  const MockWebcam = forwardRef<any, any>((props, ref) => {
+    const {
+      audio: _audio,
+      videoConstraints: _videoConstraints,
+      onUserMedia,
+      onUserMediaError: _onUserMediaError,
+      ...rest
+    } = props;
+
+    useImperativeHandle(ref, () => ({
+      video: {
+        videoWidth: 1280,
+        videoHeight: 720,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    }));
+
+    useEffect(() => {
+      onUserMedia?.();
+    }, [onUserMedia]);
+
+    return <div data-testid="mock-webcam" {...rest} />;
+  });
+
+  MockWebcam.displayName = "MockWebcam";
+
+  return { __esModule: true, default: MockWebcam };
+});
+
+describe("CodeScanner camera mode", () => {
+  it("leaves pointer events enabled on the webcam surface", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      render(
+        <CodeScanner
+          forceMode="camera"
+          onCodeDetectionSuccess={vi.fn()}
+          paused={false}
+          setPaused={vi.fn()}
+        />
+      );
+
+      const webcam = screen.getByTestId("mock-webcam");
+      expect(webcam).not.toHaveClass("pointer-events-none");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/app/components/scanner/code-scanner.tsx
+++ b/app/components/scanner/code-scanner.tsx
@@ -526,7 +526,7 @@ function CameraMode({
             setIsLoading(false);
           });
         }}
-        className="pointer-events-none size-full object-cover"
+        className="size-full object-cover"
       />
 
       <canvas


### PR DESCRIPTION
## Summary
- add a unit test that verifies the camera-mode webcam surface keeps pointer events enabled for tap-to-focus
- remove the `pointer-events-none` class from the webcam preview so iOS users can trigger manual focus

## Testing
- npm run test -- code-scanner

------
https://chatgpt.com/codex/tasks/task_b_68cad9becbf883269682477c52fab408