### PR TITLE
docs: align preset docs with mvp scope

### DIFF
--- a/docs/saved-filter-presets/api-contract.md
+++ b/docs/saved-filter-presets/api-contract.md
@@ -1,0 +1,106 @@
+# Saved Asset Filter Presets – API Contract
+
+## Overview
+The Remix app will expose REST-style actions for CRUD operations on asset filter presets. Endpoints operate within the context of the authenticated session and current organization. All requests require CSRF-safe Remix form submissions or authenticated fetcher calls.
+
+## Base URL
+`/api/asset-filter-presets`
+
+## Authentication & Authorization
+- Session must include a user with access to the active organization and advanced asset index permissions.
+- Actions validate that the preset belongs to the same organization as the session.
+- Shared presets (`isShared = true`) are readable by any advanced-mode member of the organization, but only the owner or an org admin can modify/delete them.
+
+## Endpoints
+
+### GET `/api/asset-filter-presets`
+Returns presets visible to the current user.
+
+**Query Parameters**
+- `mode` (optional) – defaults to `ADVANCED`; reserved for future use.
+
+**Response 200**
+```json
+{
+  "presets": [
+    {
+      "id": "cuid123",
+      "name": "California cameras",
+      "query": "category=camera&location=ca",
+      "view": "table",
+      "mode": "ADVANCED",
+      "isShared": false,
+      "owner": {
+        "id": "user123",
+        "name": "Alex Johnson"
+      },
+      "lastUsedAt": "2024-05-02T18:30:00.000Z"
+    }
+  ],
+  "limit": 20
+}
+```
+
+### POST `/api/asset-filter-presets`
+Creates a new preset for the current user.
+
+**Request Body (JSON or Remix form data)**
+- `name` (string, 1–80 chars)
+- `query` (string, sanitized query string from URL)
+- `view` (string, required)
+- `mode` (string enum, default `ADVANCED`)
+- `isShared` (boolean, default `false`)
+
+**Responses**
+- `201 Created` with body `{ "preset": { ... } }`
+- `400 Bad Request` on validation failure (duplicate name, over limit, empty query).
+- `403 Forbidden` if user lacks permissions.
+
+### PUT `/api/asset-filter-presets/:presetId`
+Updates preset metadata (rename or toggle sharing).
+
+**Request Body**
+- Optional fields: `name`, `isShared`.
+- At least one field required.
+
+**Responses**
+- `200 OK` with updated preset payload.
+- `404 Not Found` if preset not visible to user.
+- `409 Conflict` if new name collides with existing preset.
+
+### DELETE `/api/asset-filter-presets/:presetId`
+Deletes a preset. Only owner or org admin may delete.
+
+**Responses**
+- `204 No Content` on success.
+- `404 Not Found` if preset not owned/visible.
+
+### POST `/api/asset-filter-presets/:presetId/apply`
+Updates `lastUsedAt` for analytics/order tracking after a preset is applied client-side.
+
+**Responses**
+- `204 No Content` when timestamp update (or throttled no-op) succeeds.
+- `404 Not Found` if preset is not visible to the user.
+
+## Errors
+All errors follow existing `ShelfError` JSON envelope:
+```json
+{
+  "error": {
+    "message": "Preset name already exists",
+    "code": "PRESET_DUPLICATE_NAME"
+  }
+}
+```
+
+## Rate Limiting & Limits
+- Creation fails with `400` and code `PRESET_LIMIT_REACHED` once user hits 20 presets.
+- Apply endpoint may be hit frequently; throttle internal updates to only write when timestamp delta >5 minutes.
+
+## Versioning
+- Endpoints live under `api+/` Remix routes to enable gradual evolution.
+- `mode` parameter allows extension to other filter contexts without breaking clients.
+
+## Telemetry
+- Emit log events (`preset_created`, `preset_applied`, `preset_deleted`) with preset id, organizationId, ownerId.
+- Hook into existing analytics pipeline if available.

--- a/docs/saved-filter-presets/backlog.md
+++ b/docs/saved-filter-presets/backlog.md
@@ -1,0 +1,25 @@
+# Saved Asset Filter Presets – Backlog & Sprint Plan
+
+## Sprint 1 – Foundations
+1. **S1-T1:** Create Prisma schema updates & migration tests (write failing migration tests verifying table presence via Prisma client).
+2. **S1-T2:** Implement service layer tests per TDD plan (failing tests first).
+3. **S1-T3:** Implement service layer functionality to satisfy tests.
+4. **S1-T4:** Write Remix API route tests covering CRUD/apply flows (failing first).
+5. **S1-T5:** Implement API route handlers and update loader to surface presets.
+
+## Sprint 2 – Frontend Integration
+1. **S2-T1:** Draft component tests for dialogs/menu (failing first).
+2. **S2-T2:** Build UI components & hooks to satisfy component tests.
+3. **S2-T3:** Update advanced asset index toolbar integration tests.
+4. **S2-T4:** Implement analytics events & feature flag wiring.
+
+## Sprint 3 – E2E & Polish
+1. **S3-T1:** Write Playwright E2E specs for preset lifecycle (failing first).
+2. **S3-T2:** Implement backend tweaks needed by E2E (e.g., lastUsedAt throttling) and make tests pass.
+3. **S3-T3:** Documentation updates (release notes, admin docs).
+4. **S3-T4:** Manual QA & accessibility verification checklist completion.
+
+## Cross-Cutting Tasks
+- **CC-T1:** Introduce logging hooks for preset actions.
+- **CC-T2:** Update monitoring dashboards with preset metrics (post-launch).
+- **CC-T3:** Coordinate feature flag rollout plan with product & CS teams.

--- a/docs/saved-filter-presets/database.md
+++ b/docs/saved-filter-presets/database.md
@@ -1,0 +1,58 @@
+# Saved Asset Filter Presets – Database & Migration Spec
+
+## Objective
+Define the persistent data structures needed to store and manage saved filter presets for the advanced asset index while minimizing risk to existing data flows.
+
+## Prisma Schema Changes
+```prisma
+model AssetFilterPreset {
+  id              String   @id @default(cuid())
+  organizationId  String
+  ownerId         String
+  name            String
+  query           String
+  view            String
+  mode            AssetFilterPresetMode @default(ADVANCED)
+  isShared        Boolean  @default(false)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  lastUsedAt      DateTime?
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  owner        User         @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, ownerId, name], map: "asset_filter_presets_owner_name_unique")
+  @@index([organizationId, isShared], map: "asset_filter_presets_org_shared_idx")
+  @@index([organizationId, lastUsedAt], map: "asset_filter_presets_last_used_idx")
+}
+
+enum AssetFilterPresetMode {
+  ADVANCED
+  SIMPLE
+}
+```
+
+### Notes
+- `mode` enum is future-proofing for simple index presets without requiring a breaking schema change.
+- `view` stores the current layout (`table`, `availability`, etc.).
+- `query` contains the sanitized query string (canonical `URLSearchParams` order) returned from `cleanParamsForCookie`.
+- `lastUsedAt` enables analytics-based ordering; nullable to avoid writes until first apply.
+
+## Migration Plan
+1. Generate migration script with `npm run db:prepare-migration -- saved-filter-presets`.
+2. Verify generated SQL adds enum before model to satisfy Postgres dependency order.
+3. Confirm indexes are created with descriptive names to avoid collisions.
+4. Run migration locally via `npm run db:migrate` after updating Prisma client.
+5. Backfill is not required; table starts empty.
+
+## Rollback Strategy
+- Use Prisma migration down script (auto-generated) to drop table and enum.
+- Confirm dependent code is behind feature flag `ENABLE_SAVED_ASSET_FILTERS` to prevent runtime errors if rollback occurs.
+
+## Data Retention & Limits
+- Enforce application-level limit of 20 presets per user to reduce storage and UI clutter.
+- Consider background job to prune presets not used for >365 days (future enhancement).
+
+## Open Questions
+- Should `query` be compressed or stored as JSON for readability? **Decision**: keep string to align with existing URL-based workflow.
+- Do we need multi-owner relationships for shared presets? **Decision**: not for MVP; `isShared` flag suffices.

--- a/docs/saved-filter-presets/frontend-ux.md
+++ b/docs/saved-filter-presets/frontend-ux.md
@@ -1,0 +1,73 @@
+# Saved Asset Filter Presets – Frontend UX Flow
+
+## Overview
+Enhance the advanced asset index toolbar with controls to save, apply, and manage filter presets. The flow reuses Remix loader data and fetchers to keep state consistent without introducing client-side stores beyond existing hooks.
+
+## Entry Points
+1. **Toolbar Actions**
+   - `Save current filters` primary button.
+   - `Presets` menu button showing saved filters, grouped by visibility (shared vs. personal).
+2. **Keyboard Shortcuts** (future): placeholder for quick access, not in MVP.
+
+## User Stories & Flows
+
+### Save a Preset
+1. User configures filters; URL and cookies update via `useAdvancedSearchParams`.
+2. Clicking `Save current filters` opens a modal (`<Dialog>` component) with:
+   - Name input (pre-populated with heuristic like `${primaryFilter} preset`).
+   - Toggle `Share with organization` (default off).
+3. Submitting form posts to `POST /api/asset-filter-presets` via `useFetcher`.
+4. On success, modal closes, toast “Preset saved” shows, presets revalidate.
+5. On error, inline form errors display under relevant fields.
+
+### Apply a Preset
+1. User opens `Presets` menu.
+2. Menu lists presets grouped:
+   - Shared with organization (alphabetical).
+   - My presets (alphabetical or last used).
+3. Selecting a preset triggers navigation to `/assets?${query}&view=${view}` using Remix `<Link>` to ensure full reload of loader.
+4. After navigation completes, a background `fetcher.submit` posts to the apply endpoint to update `lastUsedAt`; no redirect is expected in the response.
+
+### Manage Presets
+- **Rename**: Inline action opens small modal, `PUT` request with new name. On success revalidate presets list.
+- **Delete**: Confirmation dialog (reuse existing `ConfirmDialog` component) before sending `DELETE` request.
+- **Toggle Sharing**: Checkbox or switch toggles via `PUT` with `isShared`. Sharing state affects grouping for other members.
+
+## Component Breakdown
+- `AssetFilterPresetsProvider` (new hook) reading loader data and exposing helpers.
+- `AssetFilterPresetsMenu` – menu button + list UI.
+- `SavePresetDialog` – controlled by provider state.
+- `RenamePresetDialog` – reused for rename flow.
+- `DeletePresetDialog` – confirm deletion.
+- `PresetListItem` – row showing name, owner (if shared), actions.
+
+## Visual Design & States
+- Buttons follow design system `Button` variants (`primary` for save, `secondary` for menu).
+- Menu uses `DropdownMenu` component with section headers.
+- Loading states: spinner within dialog buttons while fetchers busy.
+- Empty state: message “No presets yet. Save one to get started.” with CTA button.
+- Error state: inline `FormError` component surfaces `ShelfError` message.
+
+## Accessibility
+- Dialogs use ARIA-compliant `Dialog` component already in app.
+- Menu items support keyboard navigation (arrow keys, enter, escape).
+- Announce success via toast accessible text.
+- Provide `aria-label` for action icons (e.g., “Delete preset”).
+
+## Responsive Behavior
+- On small screens, toolbar collapses; `Presets` button becomes icon-only with tooltip.
+- Dialogs occupy full width on mobile (<640px) with sticky submit bar.
+
+## Data Dependencies
+- Loader must supply `savedPresets`, `limit`, and `canShare` (derived from permissions).
+- Feature flag check wraps the entire UI (`if (!flags.enableSavedAssetFilters) return null`).
+
+## Analytics Hooks
+- Fire `analytics.track('preset_saved', { presetId })` on success.
+- Track menu open, preset apply actions, and sharing toggles for usage metrics.
+
+## QA Checklist
+- Verify saving applies sanitized query by reloading page and confirming filter state.
+- Ensure rename/delete/share actions respect permissions.
+- Test with >10 presets to ensure scrollable menu layout remains usable.
+- Validate keyboard-only workflow end-to-end.

--- a/docs/saved-filter-presets/permissions.md
+++ b/docs/saved-filter-presets/permissions.md
@@ -1,0 +1,38 @@
+# Saved Asset Filter Presets – Permissions Matrix
+
+## Overview
+Saved presets operate within an organization context and must respect existing Shelf authorization helpers. This matrix documents who can perform which actions.
+
+## Roles & Capabilities
+| Role | Can View Presets | Can Create | Can Rename | Can Delete | Can Share | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| Organization Member (Advanced access) | Own presets + shared presets | Yes (own org) | Yes (own presets) | Yes (own presets) | No | Base requirement: must pass `requireAdvancedModeAccess` check. |
+| Organization Admin | All presets in org | Yes | Yes (any preset) | Yes (any preset) | Yes | Admins may manage shared presets on behalf of others. |
+| Owner of preset | Own + shared | Yes | Yes | Yes | Yes (toggle) | Ownership stored via `ownerId`. |
+| Shared recipient | Shared presets | No | No | No | No | Apply-only rights. |
+| External / other org user | None | No | No | No | No | Access blocked during loader/action guard. |
+
+## Enforcement Points
+1. **Service Layer (`asset-filter-presets/service.server.ts`)**
+   - `requireOrganizationMembership` to ensure organization context is valid.
+   - `ensureAdvancedAccess` (wrapper around existing advanced mode guard).
+   - Ownership checks before rename/delete unless user is admin (use `userHasRole('admin')`).
+
+2. **Loader (`assets._index` advanced loader)**
+   - Filter results to presets that are either owned by user or shared (`isShared = true`).
+   - Include admin-managed presets for admin users.
+
+3. **API Routes**
+   - `create`: set `ownerId` = session user; reject if user lacks advanced access.
+   - `update/delete`: ensure `preset.organizationId === session.organizationId` and either `preset.ownerId === session.userId` or `session.isAdmin`.
+
+4. **Feature Flag**
+   - Wrap loader/action UI behind `ENABLE_SAVED_ASSET_FILTERS`. Flag check occurs after permissions to avoid leaking presence of feature to unauthorized users.
+
+## Auditing
+- Log every create/update/delete with `userId`, `organizationId`, `presetId`.
+- Consider exposing audit log entry in admin console (future).
+
+## Future Considerations
+- If presets become shareable across organizations, introduce ACL table with explicit grants.
+- Support per-preset viewer list by expanding schema (not part of MVP).

--- a/docs/saved-filter-presets/test-plan.md
+++ b/docs/saved-filter-presets/test-plan.md
@@ -1,0 +1,54 @@
+# Saved Asset Filter Presets – TDD Test Plan
+
+## Guiding Principles
+- Write failing tests before implementing functionality.
+- Cover service logic, Remix routes, and UI flows with unit, integration, and E2E tests.
+- Reuse existing testing utilities in `test/` and `app/utils/test/`.
+
+## Test Suites
+
+### 1. Service Layer (`app/modules/asset-filter-presets/service.server.test.ts`)
+- `createPreset` saves sanitized query and respects per-user limit (happy path & limit exceeded).
+- Reject duplicate names within same user/org.
+- Require advanced access and organization membership.
+- `listPresetsForUser` returns owned + shared presets.
+- `updatePreset` allows rename/share toggle for owner/admin; rejects unauthorized users.
+- `deletePreset` removes preset and enforces permissions.
+- `applyPreset` updates `lastUsedAt` only when delta >5 min and resolves without mutating stored query/view data.
+
+### 2. Remix Routes (`app/routes/api+/asset-filter-presets.test.ts`)
+- GET returns grouped presets for owner, shared, admin scenarios.
+- POST validates payload (missing name, blank query, duplicate name, over limit).
+- PUT handles rename/share toggles with permission checks.
+- DELETE removes preset; unauthorized returns 403/404.
+- APPLY returns `204` and throttles `lastUsedAt` updates without redirect payload.
+
+### 3. Loader (`app/routes/_layout+/assets._index.test.tsx`)
+- When flag enabled, loader includes `savedPresets` array for advanced users.
+- Users without advanced access receive empty presets array.
+- Feature flag off excludes presets data.
+
+### 4. Component Tests (`app/components/asset-filter-presets/*.test.tsx`)
+- `AssetFilterPresetsMenu` renders visibility sections and handles apply button click.
+- `SavePresetDialog` shows validation errors from action payload.
+- `RenamePresetDialog` submits rename request on confirm.
+- Sharing toggle dispatches fetcher call.
+
+### 5. E2E (Playwright) (`test/e2e/saved-filter-presets.spec.ts`)
+- Scenario: save preset → apply preset → delete preset (same user).
+- Scenario: preset shared by user A visible/applicable to user B.
+- Negative: user B cannot rename/delete user A’s shared preset.
+
+## Tooling & Setup
+- Seed presets in test database using Prisma factory helpers.
+- Use `test/utils/session.server` to mock authenticated sessions.
+- Introduce helper `createPresetParams()` to generate sanitized query strings.
+
+## Regression Coverage
+- Re-run `npm run test` and `npm run lint` before each commit.
+- Add targeted Playwright run for new spec in CI.
+
+## Exit Criteria
+- All new tests pass without flake locally.
+- Code coverage for service module ≥90% (tracked via Vitest coverage if available).
+- QA sign-off on manual checklist from frontend UX doc.


### PR DESCRIPTION
## Summary
- update frontend UX plan to drop unsupported favorites and describe link-driven apply flow with a background timestamp update
- revise API contract so the apply endpoint simply acknowledges lastUsedAt writes instead of returning a redirect URL
- sync the TDD test plan with the sharing-only scope and new apply endpoint behavior

## Testing
- npm run db:generate-type
- npm run lint -- --fix
- npm run format
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68cbc725db5c8326becf0776c0596575