### PR TITLE
Improve inventory value chart responsiveness

### DIFF
--- a/app/components/dashboard/inventory-value-chart.test.tsx
+++ b/app/components/dashboard/inventory-value-chart.test.tsx
@@ -1,0 +1,58 @@
+import { useLoaderData } from "@remix-run/react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import InventoryValueChart from "./inventory-value-chart";
+
+vi.mock("@remix-run/react", async () => {
+  const actual = await vi.importActual("@remix-run/react");
+
+  return {
+    ...(actual as Record<string, unknown>),
+    useLoaderData: vi.fn(),
+  };
+});
+
+const useLoaderDataMock = vi.mocked(useLoaderData);
+
+describe("InventoryValueChart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stacks the progress circle and metrics responsively to avoid overflow", () => {
+    const loaderData = {
+      assets: [
+        { id: "asset-1", valuation: 1000 },
+        { id: "asset-2", valuation: 5000 },
+        { id: "asset-3", valuation: null },
+      ],
+      totalAssets: 3,
+      totalValuation: 123456789012.34,
+      currency: "USD",
+      locale: "en-US",
+    } as unknown;
+
+    useLoaderDataMock.mockReturnValue(loaderData as any);
+
+    render(<InventoryValueChart />);
+
+    const layout = screen.getByTestId("inventory-value-layout");
+
+    expect(layout).toHaveClass("flex-col");
+    expect(layout).toHaveClass("md:flex-row");
+
+    const expectedValue = (loaderData as any).totalValuation.toLocaleString(
+      (loaderData as any).locale,
+      {
+        style: "currency",
+        currency: (loaderData as any).currency,
+      }
+    );
+
+    const valueElement = screen.getByText(expectedValue);
+
+    expect(valueElement).toBeInTheDocument();
+    expect(valueElement).toHaveClass("break-words");
+  });
+});

--- a/app/components/dashboard/inventory-value-chart.tsx
+++ b/app/components/dashboard/inventory-value-chart.tsx
@@ -1,5 +1,5 @@
 import { useLoaderData } from "@remix-run/react";
-import { Text, Flex, ProgressCircle } from "@tremor/react";
+import { Text, ProgressCircle } from "@tremor/react";
 import { ClientOnly } from "remix-utils/client-only";
 import type { loader } from "~/routes/_layout+/dashboard";
 import { EmptyState } from "./empty-state";
@@ -33,10 +33,9 @@ export default function InventoryValueChart() {
       <div className="h-full p-8">
         {valueKnownAssets > 0 ? (
           <div className="space-y-3">
-            <Flex
-              className="space-x-5"
-              justifyContent="evenly"
-              alignItems="end"
+            <div
+              data-testid="inventory-value-layout"
+              className="flex flex-col items-center gap-6 md:flex-row md:items-end md:justify-evenly"
             >
               <ClientOnly
                 fallback={<FallbackLoading className="size-[150px]" />}
@@ -60,18 +59,18 @@ export default function InventoryValueChart() {
                   </ProgressCircle>
                 )}
               </ClientOnly>
-              <div>
+              <div className="min-w-0 text-center md:text-right">
                 <Text className="mb-2 !text-[14px] font-medium text-gray-600">
                   Inventory value
                 </Text>
-                <Text className="mb-3 !text-[30px] font-semibold text-gray-900">
+                <Text className="mb-3 break-words !text-[30px] font-semibold text-gray-900">
                   {(totalValuation || 0).toLocaleString(locale, {
                     style: "currency",
                     currency: currency,
                   })}
                 </Text>
               </div>
-            </Flex>
+            </div>
           </div>
         ) : (
           <EmptyState text="No assets with values exists in database" />


### PR DESCRIPTION
## Summary
- adjust the dashboard inventory value card layout to stack on small screens and prevent horizontal overflow
- allow the value text to wrap while keeping desktop alignment
- add a focused unit test covering the responsive layout expectations

## Testing
- npx vitest run app/components/dashboard/inventory-value-chart.test.tsx
- npm run lint


------
https://chatgpt.com/codex/tasks/task_b_68ce5bd9c5948326a890ea78509d16b2