### PR TITLE
Add confirmation dialog before canceling bookings

### DIFF
--- a/app/components/booking/actions-dropdown.tsx
+++ b/app/components/booking/actions-dropdown.tsx
@@ -19,6 +19,7 @@ import {
 import { userHasPermission } from "~/utils/permissions/permission.validator.client";
 import { tw } from "~/utils/tw";
 import { BookingOverviewPDF } from "./booking-overview-pdf";
+import { CancelBookingDialog } from "./cancel-booking-dialog";
 import { DeleteBooking } from "./delete-booking";
 
 import ExtendBookingDialog from "./extend-booking-dialog";
@@ -80,31 +81,7 @@ export const ActionsDropdown = ({ fullWidth }: Props) => {
           <When
             truthy={(isOngoing || isReserved || isOverdue) && canCancelBooking}
           >
-            <DropdownMenuItem asChild>
-              <Button
-                variant="link"
-                className="justify-start text-gray-700 hover:cursor-pointer hover:text-gray-700"
-                width="full"
-                name="intent"
-                value="cancel"
-                as="span"
-                /**
-                 * Here we have to deal with a interesting case that is in a way a conflict between how react works and web platform
-                 * So this button within the react code, is inside a form that is in the parent component, however because its a radix dropdown, it gets rendered within a portal
-                 * So the button is actually rendered outside the form, and when you click on it, it does not submit the form
-                 * So we have to manually submit the data here.
-                 *
-                 * Keep in mind that even though its rendered in the DOM within a portal, react will still detect it as being inside the form, so there could be some hydration errors
-                 */
-                onClick={() => {
-                  const formData = new FormData();
-                  formData.append("intent", "cancel");
-                  submit(formData, { method: "post" });
-                }}
-              >
-                Cancel
-              </Button>
-            </DropdownMenuItem>
+            <CancelBookingDialog bookingName={booking.name} />
           </When>
           <When truthy={canExtendBooking}>
             <ExtendBookingDialog

--- a/app/components/booking/cancel-booking-dialog.tsx
+++ b/app/components/booking/cancel-booking-dialog.tsx
@@ -1,0 +1,83 @@
+import { useSubmit } from "@remix-run/react";
+import { Button } from "~/components/shared/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/shared/modal";
+import { useDisabled } from "~/hooks/use-disabled";
+import { tw } from "~/utils/tw";
+import { AlertIcon } from "../icons/library";
+
+type CancelBookingDialogProps = {
+  bookingName: string;
+};
+
+export function CancelBookingDialog({ bookingName }: CancelBookingDialogProps) {
+  const submit = useSubmit();
+  const disabled = useDisabled();
+
+  function handleConfirm() {
+    const formData = new FormData();
+    formData.append("intent", "cancel");
+    submit(formData, { method: "post" });
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="link"
+          className="justify-start rounded-sm px-2 py-1.5 text-sm font-medium text-gray-700 outline-none hover:bg-slate-100 hover:text-gray-700"
+          width="full"
+          as="span"
+        >
+          Cancel
+        </Button>
+      </AlertDialogTrigger>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="mx-auto md:m-0">
+            <span className="flex size-12 items-center justify-center rounded-full bg-error-50 p-2 text-error-600">
+              <AlertIcon />
+            </span>
+          </div>
+          <AlertDialogTitle>Cancel {bookingName}</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to cancel this booking? This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <div className="flex justify-center gap-2">
+            <AlertDialogCancel asChild>
+              <Button variant="secondary" disabled={disabled}>
+                Go back
+              </Button>
+            </AlertDialogCancel>
+
+            <AlertDialogAction asChild>
+              <Button
+                type="button"
+                className={tw(
+                  "border-error-600 bg-error-600 hover:border-error-800 hover:bg-error-800"
+                )}
+                onClick={handleConfirm}
+                disabled={disabled}
+              >
+                Cancel booking
+              </Button>
+            </AlertDialogAction>
+          </div>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated `CancelBookingDialog` component with an alert dialog confirmation
- wire the cancel option in the booking actions dropdown to the new dialog to avoid accidental cancellations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d52c32254083208a51c4d9b65aec5a