### PR TITLE
Guard quick check-in against conflicting bookings

### DIFF
--- a/app/modules/booking/service.server.test.ts
+++ b/app/modules/booking/service.server.test.ts
@@ -1213,8 +1213,18 @@ describe("checkinBooking", () => {
       ...mockBookingData,
       status: BookingStatus.ONGOING,
       assets: [
-        { id: "asset-1", kitId: null, status: AssetStatus.CHECKED_OUT },
-        { id: "asset-2", kitId: "kit-1", status: AssetStatus.CHECKED_OUT },
+        {
+          id: "asset-1",
+          kitId: null,
+          status: AssetStatus.CHECKED_OUT,
+          bookings: [{ id: "booking-1", status: BookingStatus.ONGOING }],
+        },
+        {
+          id: "asset-2",
+          kitId: "kit-1",
+          status: AssetStatus.CHECKED_OUT,
+          bookings: [{ id: "booking-1", status: BookingStatus.ONGOING }],
+        },
       ],
       partialCheckins: [],
     };
@@ -1239,6 +1249,86 @@ describe("checkinBooking", () => {
     });
 
     expect(result).toEqual(checkedInBooking);
+  });
+
+  it("should reset checked out assets even when partial check-in history exists", async () => {
+    expect.assertions(1);
+
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.OVERDUE,
+      assets: [
+        {
+          id: "asset-1",
+          kitId: null,
+          status: AssetStatus.CHECKED_OUT,
+          bookings: [{ id: "booking-1", status: BookingStatus.OVERDUE }],
+        },
+        {
+          id: "asset-2",
+          kitId: "kit-1",
+          status: AssetStatus.AVAILABLE,
+          bookings: [{ id: "booking-1", status: BookingStatus.OVERDUE }],
+        },
+      ],
+      partialCheckins: [
+        {
+          assetIds: ["asset-1"],
+        },
+      ],
+    };
+
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue({
+      ...mockBooking,
+      status: BookingStatus.COMPLETE,
+    });
+
+    await checkinBooking(mockCheckinParams);
+
+    expect(db.asset.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["asset-1"] } },
+      data: { status: AssetStatus.AVAILABLE },
+    });
+  });
+
+  it("should not reset assets that are checked out in another active booking", async () => {
+    expect.assertions(1);
+
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.OVERDUE,
+      assets: [
+        {
+          id: "asset-1",
+          kitId: null,
+          status: AssetStatus.CHECKED_OUT,
+          bookings: [
+            { id: "booking-1", status: BookingStatus.OVERDUE },
+            { id: "booking-2", status: BookingStatus.ONGOING },
+          ],
+        },
+      ],
+      partialCheckins: [
+        {
+          assetIds: ["asset-1"],
+        },
+      ],
+    };
+
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue({
+      ...mockBooking,
+      status: BookingStatus.COMPLETE,
+    });
+
+    await checkinBooking(mockCheckinParams);
+
+    expect(db.asset.updateMany).not.toHaveBeenCalled();
   });
 
   it("should handle checkin for non-ongoing booking", async () => {

--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -1188,10 +1188,12 @@ export async function checkinBooking({
       .findUniqueOrThrow({
         where: { id, organizationId },
         include: {
-          assets: { select: { id: true, kitId: true, status: true } },
-          partialCheckins: {
+          assets: {
             select: {
-              assetIds: true,
+              id: true,
+              kitId: true,
+              status: true,
+              bookings: { select: { id: true, status: true } },
             },
           },
         },
@@ -1254,19 +1256,27 @@ export async function checkinBooking({
     }
 
     const updatedBooking = await db.$transaction(async (tx) => {
-      // Create set of asset IDs that have been partially checked in
-      const partiallyCheckedInAssetIds = new Set(
-        (bookingFound.partialCheckins || []).flatMap((pc) => pc.assetIds)
-      );
-
-      // Only update assets that are CHECKED_OUT in this booking's context
-      // Skip assets that have partial check-ins (they're effectively available in this booking's context)
       const assetsToCheckin = bookingFound.assets
-        .filter(
-          (asset) =>
-            asset.status === AssetStatus.CHECKED_OUT &&
-            !partiallyCheckedInAssetIds.has(asset.id)
-        )
+        .filter((asset) => {
+          if (asset.status !== AssetStatus.CHECKED_OUT) {
+            return false;
+          }
+
+          const hasActiveBookingConflict = (asset.bookings ?? []).some(
+            (linkedBooking) =>
+              linkedBooking.id !== bookingFound.id &&
+              (linkedBooking.status === BookingStatus.ONGOING ||
+                linkedBooking.status === BookingStatus.OVERDUE)
+          );
+
+          if (hasActiveBookingConflict) {
+            return false;
+          }
+
+          // No other active booking is using this asset, so we can safely
+          // reset its status as part of completing the current booking.
+          return true;
+        })
         .map((asset) => asset.id);
 
       if (assetsToCheckin.length > 0) {


### PR DESCRIPTION
## Summary
- ensure quick check-in only resets assets that remain checked out for the current booking by loading linked booking statuses
- prevent the check-in flow from marking assets available when another active booking still has them checked out
- expand the regression coverage to include conflict scenarios while keeping the partial check-in history reset test

## Testing
- npm run test -- app/modules/booking/service.server.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68dd468da6648320b46c4cb44ababb32