### PR TITLE
docs: specify preset view enum and rls step

### DIFF
--- a/docs/saved-filter-presets/api-contract.md
+++ b/docs/saved-filter-presets/api-contract.md
@@ -1,0 +1,100 @@
+# Saved Asset Filter Presets – Action Contract
+
+## Overview
+The MVP reuses the existing advanced asset index Remix route (`app/routes/_layout+/assets._index.tsx`) for every preset operation. Instead of creating new API routes, the page action handles discriminated form submissions identified by an `intent` field. All requests originate from Remix forms or fetchers, inheriting CSRF protection and the current authenticated session.
+
+## Shared Requirements
+- Session user must belong to the active organization and have advanced asset index access (validated by existing loader guard).
+- Every submission includes `intent` plus the fields listed below. Payloads may be submitted as standard form posts (`application/x-www-form-urlencoded`) or `FormData` when using fetchers.
+- Responses are JSON payloads with shape `{ presetActionResult }` alongside HTTP status codes mirroring existing Remix error helpers.
+- When the feature flag `ENABLE_SAVED_ASSET_FILTERS` is disabled, the action rejects preset intents with `404` to avoid leaking the feature.
+
+## Intents
+
+### `intent=createPreset`
+Creates a preset owned by the submitting user.
+
+**Fields**
+- `name` (string, required, trimmed, 1–60 chars)
+- `query` (string, required) – sanitized query string taken from `cleanParamsForCookie`.
+- `view` (string, required) – current advanced view (`table`, `availability`, etc.).
+
+**Responses**
+- `201 Created` with
+  ```json
+  {
+    "presetActionResult": {
+      "preset": {
+        "id": "cuid123",
+        "name": "California cameras",
+        "query": "category=camera&location=ca",
+        "view": "table"
+      },
+      "presets": [ /* refreshed list for UI */ ]
+    }
+  }
+  ```
+- `400 Bad Request` with validation message when the name is empty, exceeds 60 characters, duplicates an existing preset (case-insensitive), or the per-user limit (20) has been reached.
+- `403 Forbidden` if the user no longer has advanced access for the organization.
+
+### `intent=renamePreset`
+Renames an existing preset owned by the submitting user.
+
+**Fields**
+- `presetId` (string, required)
+- `name` (string, required, 1–60 chars)
+
+**Responses**
+- `200 OK` with updated preset list.
+- `404 Not Found` if the preset does not belong to the user or organization.
+- `409 Conflict` when the new name collides with another preset owned by the user.
+
+### `intent=deletePreset`
+Deletes a preset owned by the submitting user.
+
+**Fields**
+- `presetId` (string, required)
+
+**Responses**
+- `200 OK` with refreshed preset list after removal.
+- `404 Not Found` if the preset is missing or owned by another user.
+
+### `intent=listPresets` (internal refresh)
+Fetches the latest presets without mutating data. Used by `useFetcher` after successful actions to refresh UI state.
+
+**Fields**
+- none beyond `intent`
+
+**Responses**
+- `200 OK` with `presets` array.
+
+## Loader Contract
+When the action succeeds or the page loads, the loader returns:
+```json
+{
+  "savedPresets": [
+    {
+      "id": "cuid123",
+      "name": "California cameras",
+      "query": "category=camera&location=ca",
+      "view": "table"
+    }
+  ],
+  "presetLimit": 20
+}
+```
+If the feature flag is off or the user lacks advanced access, `savedPresets` is an empty array and `presetLimit` is omitted.
+
+## Error Envelope
+Errors reuse the existing `ShelfError` JSON format:
+```json
+{
+  "error": {
+    "message": "Preset name already exists",
+    "code": "PRESET_DUPLICATE_NAME"
+  }
+}
+```
+
+## Telemetry
+For the MVP, log events using existing server-side logger hooks when `createPreset` or `deletePreset` succeeds. Additional analytics can be layered on later without contract changes.

--- a/docs/saved-filter-presets/backlog.md
+++ b/docs/saved-filter-presets/backlog.md
@@ -1,0 +1,24 @@
+# Saved Asset Filter Presets – Backlog & Sprint Plan
+
+## Sprint 1 – Server Foundations
+1. **S1-T1:** Draft failing migration tests validating that `AssetFilterPreset` exists with expected columns (id, organizationId, ownerId, name, query, view, timestamps).
+2. **S1-T2:** Write failing Vitest specs for `asset-filter-presets/service.server.ts` covering create/list/rename/delete behaviors, duplicate-name handling, and per-user limit enforcement.
+3. **S1-T3:** Implement Prisma schema, run migration, and add service code until tests pass.
+4. **S1-T4:** Add failing action tests for the advanced asset index route verifying each `intent` (`createPreset`, `renamePreset`, `deletePreset`, `listPresets`).
+5. **S1-T5:** Update the Remix action/loader to satisfy intent tests and surface presets in loader data.
+
+## Sprint 2 – Frontend Integration
+1. **S2-T1:** Create failing component tests for `AssetFilterPresetsMenu`, `SavePresetDialog`, and rename/delete flows using React Testing Library.
+2. **S2-T2:** Implement UI components and provider hooks until the component tests pass.
+3. **S2-T3:** Enhance toolbar integration tests to ensure presets appear when the feature flag is on and remain hidden otherwise.
+4. **S2-T4:** Wire toast notifications and error handling consistent with existing patterns.
+
+## Sprint 3 – E2E & Launch Prep
+1. **S3-T1:** Author failing Playwright spec covering create → apply → rename → delete for a single user.
+2. **S3-T2:** Make any remaining polish changes (loading states, accessibility tweaks) until the E2E passes reliably.
+3. **S3-T3:** Document rollout steps, update release notes, and prepare customer-facing enablement material.
+4. **S3-T4:** Execute manual QA checklist from the UX doc and confirm feature-flag toggling works in staging.
+
+## Cross-Cutting Tasks
+- **CC-T1:** Add structured logging for preset creation and deletion once server code lands.
+- **CC-T2:** Coordinate feature flag rollout schedule with product and customer success after staging validation.

--- a/docs/saved-filter-presets/database.md
+++ b/docs/saved-filter-presets/database.md
@@ -1,0 +1,53 @@
+# Saved Asset Filter Presets – Database & Migration Spec
+
+## Objective
+Define the minimal persistence layer required to store private saved filter presets for the advanced asset index while keeping the door open for future expansion.
+
+## Prisma Schema Changes
+```prisma
+enum AssetFilterPresetView {
+  TABLE        @map("table")
+  AVAILABILITY @map("availability")
+}
+
+model AssetFilterPreset {
+  id             String   @id @default(cuid())
+  organizationId String
+  ownerId        String
+  name           String
+  query          String
+  view           AssetFilterPresetView @default(TABLE)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  owner        User         @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, ownerId, name], map: "asset_filter_presets_owner_name_unique")
+  @@index([organizationId, ownerId], map: "asset_filter_presets_owner_lookup_idx")
+}
+```
+
+### Notes
+- `query` stores the sanitized query string returned from `cleanParamsForCookie`, ensuring presets replay exactly what today’s URL-based workflow expects.
+- `view` is backed by the `AssetFilterPresetView` enum so we only persist supported layouts (`table` or `availability`) and can evolve the enum safely in future migrations.
+- No `isShared`, `mode`, or `lastUsedAt` columns in the MVP to minimize risk and writes; these can be added in future migrations when needed.
+
+## Migration Plan
+1. Update `app/database/schema.prisma` with the enum + model above (enum must appear before the model in the file so Prisma emits the correct dependency order).
+2. Generate the migration with `npm run db:prepare-migration -- saved-filter-presets` and confirm the SQL creates the enum before the table, then the foreign keys in the correct order.
+3. Append the standard RLS enablement statements for the new table (mirror the pattern from the latest asset-related migration) after the generated SQL before committing.
+4. Run `npm run db:migrate` locally to validate the migration and regenerate the Prisma client.
+5. Ensure feature-flagged code paths guard all usage so environments without the migration remain stable until deployment.
+
+## Rollback Strategy
+- Use the Prisma down migration (auto-generated) to drop the table if issues arise.
+- Because the feature is behind `ENABLE_SAVED_ASSET_FILTERS`, disabling the flag prevents runtime lookups if rollback is required.
+
+## Data Retention & Limits
+- Enforce a per-user cap of 20 presets at the service layer to keep queries light and the UI manageable.
+- Future retention policies (e.g., pruning unused presets) can be layered on later without schema changes.
+
+## Open Questions
+- Do we want to track usage ordering in the MVP? **Decision**: no—avoid extra writes until the feature proves value.
+- Should preset names be case-insensitive? **Recommendation**: normalize via Prisma query (e.g., convert to lower case on comparison) within service logic; no additional index needed today.

--- a/docs/saved-filter-presets/frontend-ux.md
+++ b/docs/saved-filter-presets/frontend-ux.md
@@ -1,0 +1,64 @@
+# Saved Asset Filter Presets – Frontend UX Flow
+
+## Overview
+Layer a lightweight preset manager onto the advanced asset index toolbar so users can store and recall their own filter combinations without copying URLs. The MVP keeps all interactions inside the existing Remix route and avoids shared/favorite concepts to reduce integration risk.
+
+## Entry Points
+1. **Toolbar Save Button** – primary action labeled “Save current filters”.
+2. **Presets Menu Button** – secondary button that opens a dropdown listing the user’s presets.
+3. **Empty State Callout** – inline message within the dropdown inviting users to create their first preset.
+
+## User Flows
+
+### Save a Preset
+1. User fine-tunes filters; URL and cookies already reflect the selection via `useAdvancedSearchParams`.
+2. Selecting “Save current filters” opens a modal dialog with:
+   - Name input (prefilled with heuristic like `"<primary filter> preset"`).
+   - Context copy clarifying presets are private to the user.
+3. Submitting the form posts to the page action with `intent=createPreset`.
+4. On success, the dialog closes, the dropdown list is revalidated via `fetcher.submit({ intent: 'listPresets' })`, and a toast confirms creation.
+5. Validation errors (duplicate name, limit exceeded, empty field) render inline under the name input.
+
+### Apply a Preset
+1. User opens the presets menu.
+2. Menu lists presets sorted alphabetically, each row showing the preset name and a secondary icon button for “More actions”.
+3. Clicking the preset name navigates to `/assets?${query}` using a Remix `<Link>` so the loader naturally rehydrates filters and the cookie state stays in sync.
+4. The dropdown closes automatically after navigation.
+
+### Manage Presets
+- **Rename**: Selecting “Rename” from the row’s more-actions menu opens the same modal in rename mode. On submit, post `intent=renamePreset` and refresh the list.
+- **Delete**: Selecting “Delete” opens a lightweight confirmation dialog that submits `intent=deletePreset`. Success removes the item from the dropdown immediately.
+- Presets remain private; there is no sharing, favorite, or pinning behavior in the MVP.
+
+## Component Breakdown
+- `AssetFilterPresetsProvider` – optional helper that exposes loader data and fetcher helpers to child components.
+- `SavePresetDialog` – controlled modal reused for both create and rename flows (driven by props `mode: 'create' | 'rename'`).
+- `AssetFilterPresetsMenu` – button + dropdown list; leverages existing `DropdownMenu` primitive.
+- `PresetListItem` – renders a preset row with primary navigation link and an overflow menu for rename/delete.
+- `DeletePresetDialog` – confirmation dialog reused from other asset flows.
+
+## Visual Design & States
+- Buttons follow design-system variants (`primary` for save, `secondary` for menu).
+- Dropdown uses standard menu styling with focus rings and keyboard navigation provided by shared primitives.
+- Empty state message: “No presets yet. Save your current filters to reuse them later.” plus inline “Save preset” button.
+- Loading: when fetchers are busy, display a subtle spinner in the menu button and disable destructive actions.
+- Error toasts reuse existing `useToast` hook for unexpected failures; validation stays inline inside dialogs.
+
+## Accessibility
+- Dialogs rely on the shared ARIA-compliant `Dialog` component.
+- Dropdown items support arrow/enter/escape navigation and announce the total count for screen readers.
+- Provide descriptive `aria-label` text for rename/delete buttons (e.g., “Rename preset California cameras”).
+
+## Responsive Behavior
+- On small screens the presets button collapses to an icon with tooltip; the dropdown converts to a full-width sheet to match other toolbar menus.
+- Modals become full-screen on mobile with sticky footer actions to keep the submit button accessible.
+
+## Feature Flag Handling
+- Wrap the entire toolbar enhancement with `if (!flags.enableSavedAssetFilters) return null;` so we avoid rendering partially wired UI.
+- The dropdown should gracefully handle an empty list both when the flag is off (loader returns empty array) and when the user has no presets.
+
+## QA Checklist
+- Create → apply → rename → delete works end-to-end without page reload issues.
+- Validation messaging appears for duplicate names and limit reached.
+- Keyboard-only workflow covers opening menu, selecting preset, and triggering rename/delete dialogs.
+- Mobile layout keeps actions reachable and ensures dialogs are scrollable when the keyboard is visible.

--- a/docs/saved-filter-presets/permissions.md
+++ b/docs/saved-filter-presets/permissions.md
@@ -1,0 +1,34 @@
+# Saved Asset Filter Presets – Permissions Matrix
+
+## Overview
+Saved presets are private records tied to the combination of organization and owner. The MVP keeps authorization simple by allowing only the creator (and optional organization admins via existing policies) to manage a preset. There is no organization-wide sharing yet.
+
+## Roles & Capabilities
+| Role | Can View Presets | Can Create | Can Rename | Can Delete | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Organization Member with advanced access | Own presets | Yes (within active org) | Yes (own presets) | Yes (own presets) | Must pass `requireAdvancedModeAccess` and belong to the organization. |
+| Organization Admin | Own presets | Yes | Optional: may be allowed to delete/rename any preset depending on existing admin policy. Default stance is owner-only unless explicitly enabled. |
+| Other organization members | None | No | No | No | Presets are private, so other members never see them. |
+| External / unauthenticated user | None | No | No | No | Blocked by session + loader guards. |
+
+## Enforcement Points
+1. **Service Layer (`asset-filter-presets/service.server.ts`)**
+   - Validate `organizationId` and `ownerId` against the authenticated session.
+   - Enforce owner-only mutations unless an admin override is explicitly passed in.
+   - Apply per-user preset limits before writing.
+2. **Loader (`assets._index` advanced loader)**
+   - Filter database query to the authenticated user’s presets only.
+   - Return empty array if advanced access fails or the feature flag is disabled.
+3. **Action Handler (`assets._index` action)**
+   - Branch on `intent` values and ensure the targeted preset belongs to the session user before rename/delete.
+   - Surface `404` instead of `403` when the preset is missing or belongs to another user to avoid information leaks.
+4. **Feature Flag**
+   - `ENABLE_SAVED_ASSET_FILTERS` wraps loader/action logic, preventing access when the feature is not rolled out.
+
+## Auditing
+- Log `preset_created` and `preset_deleted` events with `userId` and `organizationId` to existing application logs.
+- No shared visibility means we can defer more granular auditing until we introduce collaborative features.
+
+## Future Considerations
+- When organization-wide sharing is introduced, expand the matrix with visibility roles and possibly a join table for per-user favorites.
+- Evaluate whether admins should inherit full control or remain scoped to owner-only operations based on customer feedback.

--- a/docs/saved-filter-presets/test-plan.md
+++ b/docs/saved-filter-presets/test-plan.md
@@ -1,0 +1,55 @@
+# Saved Asset Filter Presets – TDD Test Plan
+
+## Guiding Principles
+- Write failing tests before implementing functionality at every layer.
+- Focus on the private-presets MVP: no sharing, favorites, or analytics writes.
+- Reuse existing Remix testing helpers and database factories for consistency.
+
+## Test Suites
+
+### 1. Migration & Schema Tests (`prisma/tests/asset-filter-presets.migration.test.ts`)
+- Assert the Prisma client exposes `assetFilterPreset` model with expected columns.
+- Verify unique constraint on `(organizationId, ownerId, name)` using migration test harness.
+
+### 2. Service Layer (`app/modules/asset-filter-presets/service.server.test.ts`)
+- `createPreset` saves sanitized query/view, enforces 20 preset limit, and rejects duplicates (case-insensitive).
+- `listPresetsForUser` returns only the requesting user’s presets and respects organization scoping.
+- `renamePreset` updates the name when owned by the user and rejects non-existent or foreign presets with `NotFound` error.
+- `deletePreset` removes a preset and ignores ids outside the user/org scope with `NotFound`.
+- Validation: blank name, overly long name (>60 chars), or empty query produce specific `ShelfError` codes.
+
+### 3. Remix Action (`app/routes/_layout+/assets._index.action.test.ts`)
+- Each `intent` (`createPreset`, `renamePreset`, `deletePreset`, `listPresets`) branches correctly and returns JSON payload.
+- Feature flag disabled → each preset intent returns `404`.
+- Unauthorized session (no advanced access) receives `403` for create/rename/delete and an empty list for loader requests.
+- Successful create/rename/delete responses trigger preset list refresh with updated data.
+
+### 4. Loader (`app/routes/_layout+/assets._index.loader.test.ts`)
+- Loader includes `savedPresets` array with the user’s presets when the flag is on.
+- Loader returns empty array when user has none or lacks advanced access.
+- Flag off removes presets data from the loader output.
+
+### 5. Component Tests (`app/components/asset-filter-presets/*.test.tsx`)
+- `AssetFilterPresetsMenu` renders presets alphabetically and fires navigation callback on click.
+- `SavePresetDialog` shows inline validation errors returned from action payload.
+- Rename flow reuses the dialog and pre-fills the existing name.
+- Delete confirmation disables submit while the fetcher is pending and hides the preset afterward.
+
+### 6. E2E (Playwright) (`test/e2e/saved-filter-presets.spec.ts`)
+- Scenario: user saves a preset, applies it (URL updates), renames it, then deletes it; final state shows empty list.
+- Negative: creating a duplicate name surfaces validation toast without creating an extra preset.
+- Feature flag off: presets UI never renders.
+
+## Tooling & Setup
+- Seed test database with organizations/users via existing factory helpers.
+- Add utility `buildPresetQuery()` that mirrors `cleanParamsForCookie` output for test fixtures.
+- Use Remix testing utilities to create authenticated sessions in route tests.
+
+## Regression Coverage
+- Run `npm run test`, `npm run lint`, and `npm run typecheck` before merging.
+- Include the new Playwright spec in CI’s saved filters feature flag suite.
+
+## Exit Criteria
+- All new tests pass consistently (no flakes) locally and in CI.
+- Coverage for `service.server.ts` ≥90% lines/branches.
+- Manual QA checklist (from UX doc) completed on staging with feature flag enabled and disabled.


### PR DESCRIPTION
## Summary
- pivot the database spec to a lean private-only `AssetFilterPreset` model with minimal columns and now call out the enum-backed `view` field plus RLS enablement requirements
- redefine the action contract, UX flow, permissions, and backlog around reuse of the existing assets index route with create/rename/delete intents only
- refresh the TDD test plan to cover migration, service, action, component, and E2E suites for the private preset experience

## Testing
- npm run db:generate-type
- npm run lint -- --fix
- npm run format
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68cbc725db5c8326becf0776c0596575