### PR TITLE
Fix camera fallback for iOS standalone scanner

### DIFF
--- a/app/components/scanner/code-scanner.test.tsx
+++ b/app/components/scanner/code-scanner.test.tsx
@@ -1,16 +1,41 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-
+import { forwardRef } from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import {
-  CodeScanner,
-  handleScannerInputValue,
-} from "~/components/scanner/code-scanner";
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type * as CodeScannerModule from "~/components/scanner/code-scanner";
 import { handleDetection } from "~/components/scanner/utils";
 
-vi.mock("react-webcam", () => ({
-  __esModule: true,
-  default: () => null,
-}));
+type WebcamMockProps = {
+  onUserMedia?: () => void;
+  onUserMediaError?: (error: unknown) => void;
+  videoConstraints?: MediaTrackConstraints;
+};
+
+const webcamMockProps: { current: WebcamMockProps | null } = { current: null };
+
+vi.mock("react-webcam", () => {
+  const MockWebcam = forwardRef<HTMLVideoElement, WebcamMockProps>(
+    (props, _ref) => {
+      if (props) {
+        webcamMockProps.current = props;
+      }
+      return null;
+    }
+  );
+  MockWebcam.displayName = "MockWebcam";
+
+  return {
+    __esModule: true,
+    default: MockWebcam,
+  };
+});
 
 vi.mock("~/components/scanner/success-animation", () => ({
   __esModule: true,
@@ -25,15 +50,47 @@ vi.mock("~/components/scanner/utils", async (importOriginal) => {
   };
 });
 
+let CodeScanner: typeof CodeScannerModule.CodeScanner;
+let handleScannerInputValue: typeof CodeScannerModule.handleScannerInputValue;
+
+const originalNavigator = globalThis.navigator;
+
+beforeAll(async () => {
+  const module = await import("~/components/scanner/code-scanner");
+  CodeScanner = module.CodeScanner;
+  handleScannerInputValue = module.handleScannerInputValue;
+});
+
+beforeEach(() => {
+  // Ensure navigator.mediaDevices is available for tests that rely on it
+  const existingNavigator = globalThis.navigator ?? ({} as Navigator);
+  const navigatorWithMediaDevices = {
+    ...existingNavigator,
+    mediaDevices: {
+      enumerateDevices: vi.fn().mockResolvedValue([]),
+    },
+  } as unknown as Navigator;
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: navigatorWithMediaDevices,
+  });
+});
+
 afterEach(() => {
   vi.clearAllMocks();
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: originalNavigator,
+  });
+  webcamMockProps.current = null;
 });
 
 describe("handleScannerInputValue", () => {
   it("triggers a SAM ID detection when the value matches the pattern", async () => {
     const onSuccess = vi.fn();
 
-    const processed = await handleScannerInputValue({
+    const processed = await handleScannerInputValue!({
       rawValue: "sam-0012",
       paused: false,
       onCodeDetectionSuccess: onSuccess,
@@ -51,7 +108,7 @@ describe("handleScannerInputValue", () => {
   it("returns false and skips detection when the scanner is paused", async () => {
     const onSuccess = vi.fn();
 
-    const processed = await handleScannerInputValue({
+    const processed = await handleScannerInputValue!({
       rawValue: "sam-0012",
       paused: true,
       onCodeDetectionSuccess: onSuccess,
@@ -66,7 +123,7 @@ describe("handleScannerInputValue", () => {
   it("delegates to handleDetection for non SAM inputs", async () => {
     const onSuccess = vi.fn();
 
-    const processed = await handleScannerInputValue({
+    const processed = await handleScannerInputValue!({
       rawValue: "QR123",
       paused: false,
       onCodeDetectionSuccess: onSuccess,
@@ -85,8 +142,10 @@ describe("handleScannerInputValue", () => {
 
 describe("CodeScanner", () => {
   it("shows a custom error title when provided", () => {
+    const Scanner = CodeScanner!;
+
     render(
-      <CodeScanner
+      <Scanner
         onCodeDetectionSuccess={() => {}}
         paused
         setPaused={() => {}}
@@ -100,5 +159,72 @@ describe("CodeScanner", () => {
 
     expect(screen.getByText("SAM ID not found")).toBeInTheDocument();
     expect(screen.getByText("Unable to find SAM ID")).toBeInTheDocument();
+  });
+
+  it("retries camera initialization with a back camera device when facingMode fails", async () => {
+    const enumerateDevicesMock = vi
+      .spyOn(globalThis.navigator.mediaDevices, "enumerateDevices")
+      .mockResolvedValue([
+        {
+          deviceId: "front-camera",
+          kind: "videoinput",
+          label: "Front Camera",
+          groupId: "group-1",
+          toJSON() {
+            return this;
+          },
+        } as MediaDeviceInfo,
+        {
+          deviceId: "back-camera",
+          kind: "videoinput",
+          label: "Ultra Wide Back Camera",
+          groupId: "group-1",
+          toJSON() {
+            return this;
+          },
+        } as MediaDeviceInfo,
+      ]);
+
+    const Scanner = CodeScanner!;
+
+    render(
+      <Scanner
+        onCodeDetectionSuccess={() => {}}
+        paused={false}
+        setPaused={() => {}}
+        scanMessage=""
+        errorMessage=""
+        forceMode="camera"
+        allowNonShelfCodes
+      />
+    );
+
+    await waitFor(() => {
+      expect(webcamMockProps.current).toBeTruthy();
+    });
+
+    expect(webcamMockProps.current?.videoConstraints).toEqual({
+      facingMode: "environment",
+    });
+
+    const initialError = {
+      name: "OverconstrainedError",
+      message: "Requested device not found",
+    } satisfies Pick<DOMException, "name" | "message">;
+
+    await act(async () => {
+      await Promise.resolve(
+        webcamMockProps.current?.onUserMediaError?.(initialError)
+      );
+    });
+
+    await waitFor(() => {
+      expect(webcamMockProps.current?.videoConstraints).toEqual({
+        deviceId: "back-camera",
+      });
+    });
+
+    expect(enumerateDevicesMock).toHaveBeenCalled();
+    expect(screen.queryByText(/Camera error/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- retry camera initialization in `CameraMode` with enumerated devices when environment-facing constraints fail
- reset error state on successful media access to avoid persisting overlay
- refactor CodeScanner tests to mock React Webcam and assert the fallback behavior

## Testing
- npm run test -- code-scanner.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68de3ef935648326b6fddfcf28bc0c51