### PR TITLE
Handle command palette links for registered and NRM members

### DIFF
--- a/app/components/layout/command-palette/command-palette.test.tsx
+++ b/app/components/layout/command-palette/command-palette.test.tsx
@@ -6,6 +6,7 @@ import {
   getKitCommandValue,
   getLocationCommandValue,
   getTeamMemberCommandValue,
+  getTeamMemberHref,
   type AssetSearchResult,
   type BookingSearchResult,
   type KitSearchResult,
@@ -176,5 +177,55 @@ describe("getTeamMemberCommandValue", () => {
     expect(value).toContain("member-202");
     expect(value).toContain("Jane Smith");
     expect(value).not.toContain("null");
+  });
+});
+
+describe("getTeamMemberHref", () => {
+  const registeredMember: TeamMemberSearchResult = {
+    id: "member-202",
+    name: "Jane Smith",
+    email: "jane@example.com",
+    firstName: "Jane",
+    lastName: "Smith",
+    userId: "user-123",
+  };
+
+  const nrmMember: TeamMemberSearchResult = {
+    id: "member-303",
+    name: "John Appleseed",
+    email: null,
+    firstName: null,
+    lastName: null,
+    userId: null,
+  };
+
+  it("routes registered team members to their user settings page", () => {
+    expect(getTeamMemberHref(registeredMember)).toBe(
+      "/settings/team/users/user-123"
+    );
+  });
+
+  it("routes non-registered members to the NRM edit modal", () => {
+    expect(getTeamMemberHref(nrmMember)).toBe(
+      "/settings/team/nrm/member-303/edit"
+    );
+  });
+
+  it("falls back to the registered list when a user id is missing", () => {
+    expect(
+      getTeamMemberHref({
+        ...registeredMember,
+        userId: "",
+      })
+    ).toBe("/settings/team/users");
+  });
+
+  it("falls back to the NRM list when an NRM id is missing", () => {
+    expect(
+      getTeamMemberHref({
+        ...nrmMember,
+        id: "",
+      })
+    ).toBe("/settings/team/nrm");
   });
 });

--- a/app/components/layout/command-palette/command-palette.tsx
+++ b/app/components/layout/command-palette/command-palette.tsx
@@ -94,6 +94,7 @@ export type TeamMemberSearchResult = {
   email: string | null;
   firstName: string | null;
   lastName: string | null;
+  userId: string | null;
 };
 
 type QuickCommand = {
@@ -394,6 +395,24 @@ export function getTeamMemberCommandValue(member: TeamMemberSearchResult) {
   ].filter(Boolean);
 
   return [`member-${member.id}`, ...searchableFields].join(" ").trim();
+}
+
+export function getTeamMemberHref(member: TeamMemberSearchResult) {
+  const trimmedUserId = member.userId?.trim();
+  if (trimmedUserId) {
+    return `/settings/team/users/${trimmedUserId}`;
+  }
+
+  if (typeof member.userId === "string") {
+    return "/settings/team/users";
+  }
+
+  const trimmedMemberId = member.id?.trim();
+  if (trimmedMemberId) {
+    return `/settings/team/nrm/${trimmedMemberId}/edit`;
+  }
+
+  return "/settings/team/nrm";
 }
 
 export function CommandPalette() {
@@ -714,9 +733,7 @@ export function CommandPalette() {
               <CommandItem
                 key={member.id}
                 value={getTeamMemberCommandValue(member)}
-                onSelect={() =>
-                  handleSelect(`/settings/team/members/${member.id}`)
-                }
+                onSelect={() => handleSelect(getTeamMemberHref(member))}
                 className="gap-3"
               >
                 <UserIcon className="size-4 text-gray-500" />

--- a/app/routes/api+/command-palette.search.ts
+++ b/app/routes/api+/command-palette.search.ts
@@ -339,6 +339,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
           email: member.user?.email || null,
           firstName: member.user?.firstName || null,
           lastName: member.user?.lastName || null,
+          userId: member.userId,
         })),
       })
     );


### PR DESCRIPTION
## Summary
- include the related userId in command palette team member search results so the client can differentiate registered users from NRMs
- update the command palette helper to link registered members to `/settings/team/users/:userId` and NRMs to their edit modal, with safe fallbacks
- extend the command palette tests to cover the registered, NRM, and fallback navigation branches

## Testing
- npm run test -- command-palette

------
https://chatgpt.com/codex/tasks/task_b_68de78fd7b348326983efa7f0337e497