### PR TITLE
Throttle bulk invite email dispatch

### DIFF
--- a/app/modules/invite/service.server.ts
+++ b/app/modules/invite/service.server.ts
@@ -32,6 +32,12 @@ import { createUserOrAttachOrg } from "../user/service.server";
 
 const label: ErrorLabel = "Invite";
 
+const INVITE_EMAIL_BATCH_SIZE = 20;
+const INVITE_EMAIL_BATCH_DELAY_MS = 1_000;
+const INVITE_EMAIL_SPACING_MS = Math.ceil(
+  INVITE_EMAIL_BATCH_DELAY_MS / INVITE_EMAIL_BATCH_SIZE
+);
+
 /**
  * Validates invite based on SSO configuration, considering target organization
  * @param email - Email of the user being invited
@@ -719,9 +725,45 @@ export async function bulkInviteUsers({
       organization: true,
     } satisfies Prisma.InviteInclude;
 
-    let createdInvites: Array<
-      Prisma.InviteGetPayload<{ include: typeof INVITE_INCLUDE }>
-    > = [];
+    type InviteWithRelations = Prisma.InviteGetPayload<{
+      include: typeof INVITE_INCLUDE;
+    }>;
+
+    let createdInvites: InviteWithRelations[] = [];
+
+    const scheduleInviteEmailSending = (
+      invites: InviteWithRelations[],
+      extraInviteMessage?: string | null
+    ) => {
+      invites.forEach((invite, index) => {
+        const batchIndex = Math.floor(index / INVITE_EMAIL_BATCH_SIZE);
+        const positionInBatch = index % INVITE_EMAIL_BATCH_SIZE;
+        const delay =
+          batchIndex * INVITE_EMAIL_BATCH_DELAY_MS +
+          positionInBatch * INVITE_EMAIL_SPACING_MS;
+
+        setTimeout(() => {
+          const token = jwt.sign({ id: invite.id }, INVITE_TOKEN_SECRET, {
+            expiresIn: `${INVITE_EXPIRY_TTL_DAYS}d`,
+          });
+
+          sendEmail({
+            to: invite.inviteeEmail,
+            subject: `✉️ You have been invited to ${invite.organization.name}`,
+            text: inviteEmailText({
+              invite,
+              token,
+              extraMessage: extraInviteMessage,
+            }),
+            html: invitationTemplateString({
+              invite,
+              token,
+              extraMessage: extraInviteMessage,
+            }),
+          });
+        }, delay);
+      });
+    };
 
     await db.$transaction(async (tx) => {
       // Bulk create all required team members
@@ -769,19 +811,9 @@ export async function bulkInviteUsers({
       });
     });
 
-    // Queue emails for sending - no need to await since it's handled by queue
-    createdInvites.forEach((invite) => {
-      const token = jwt.sign({ id: invite.id }, INVITE_TOKEN_SECRET, {
-        expiresIn: `${INVITE_EXPIRY_TTL_DAYS}d`,
-      });
-
-      sendEmail({
-        to: invite.inviteeEmail,
-        subject: `✉️ You have been invited to ${invite.organization.name}`,
-        text: inviteEmailText({ invite, token, extraMessage }),
-        html: invitationTemplateString({ invite, token, extraMessage }),
-      });
-    });
+    if (createdInvites.length > 0) {
+      scheduleInviteEmailSending(createdInvites, extraMessage);
+    }
 
     sendNotification({
       title: "Successfully invited users",


### PR DESCRIPTION
## Summary
- add throttled scheduling for invite email sending so we dispatch at most ~20 recipients per second
- keep invite processing asynchronous to prevent user-facing delays while respecting Resend SMTP rate limits

## Testing
- npm run typecheck -- --pretty false

------
https://chatgpt.com/codex/tasks/task_b_68df992a8c0c8320bb6c7a29278cf7ca