### PR TITLE
feat: enhance asset notes with markdoc tags

### DIFF
--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -48,6 +48,7 @@ import {
   wrapKitsWithDataForNote,
   wrapAssetsWithDataForNote,
   wrapUserLinkForNote,
+  wrapLinkForNote,
   wrapBookingStatusForNote,
   wrapCustodianForNote,
   wrapDescriptionForNote,
@@ -2745,6 +2746,11 @@ export async function removeAssets({
           disconnect: assetIds.map((id) => ({ id })),
         },
       },
+      select: {
+        id: true,
+        name: true,
+        status: true,
+      },
     });
     /** When removing an asset from a booking we need to make sure to set their status back to available
      * This is needed because the user is allowed to remove an asset from a booking that is ongoing, which means the asset status will be CHECKED_OUT
@@ -2777,10 +2783,11 @@ export async function removeAssets({
 
     const userForNotes = { firstName, lastName, id: userId };
 
+    const bookingLink = wrapLinkForNote(`/bookings/${b.id}`, b.name);
     await createNotes({
       content: `${wrapUserLinkForNote(
         userForNotes
-      )} removed asset from booking.`,
+      )} removed assets from ${bookingLink}.`,
       type: "UPDATE",
       userId,
       assetIds,

--- a/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -20,8 +20,9 @@ import { setCookie } from "~/utils/cookies.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
-
 import { data, error, getParams, parseData } from "~/utils/http.server";
+import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
+
 import {
   PermissionAction,
   PermissionEntity,
@@ -112,10 +113,17 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       userId,
     });
 
+    const actor = wrapUserLinkForNote({
+      id: authSession.userId,
+      firstName: user?.firstName,
+      lastName: user?.lastName,
+    });
+    const bookingLink = wrapLinkForNote(
+      `/bookings/${booking.id}`,
+      booking.name
+    );
     await createNotes({
-      content: `**${user?.firstName?.trim()} ${user?.lastName?.trim()}** added asset to booking **[${
-        booking.name
-      }](/bookings/${booking.id})**.`,
+      content: `${actor} added assets to ${bookingLink}.`,
       type: "UPDATE",
       userId: authSession.userId,
       assetIds: finalAssetIds,

--- a/app/routes/_layout+/assets.new.tsx
+++ b/app/routes/_layout+/assets.new.tsx
@@ -32,6 +32,7 @@ import {
   getCurrentSearchParams,
   parseData,
 } from "~/utils/http.server";
+import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import {
   PermissionAction,
   PermissionEntity,
@@ -207,18 +208,29 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       senderId: authSession.userId,
     });
 
+    const actor = wrapUserLinkForNote({
+      id: authSession.userId,
+      firstName: asset.user.firstName,
+      lastName: asset.user.lastName,
+    });
     await createNote({
-      content: `Asset was created by **${asset.user.firstName?.trim()} ${asset.user.lastName?.trim()}**`,
+      content: `Asset was created by ${actor}.`,
       type: "UPDATE",
       userId: authSession.userId,
       assetId: asset.id,
     });
 
     if (asset.location) {
+      const assetLink = wrapLinkForNote(
+        `/assets/${asset.id}`,
+        asset.title?.trim() ?? "this asset"
+      );
+      const locationLink = wrapLinkForNote(
+        `/locations/${asset.location.id}`,
+        asset.location.name.trim()
+      );
       await createNote({
-        content: `**${asset.user.firstName?.trim()} ${asset.user.lastName?.trim()}** set the location of **${asset.title?.trim()}** to *[${asset.location.name.trim()}](/locations/${
-          asset.location.id
-        })**`,
+        content: `${actor} set the location of ${assetLink} to ${locationLink}.`,
         type: "UPDATE",
         userId: authSession.userId,
         assetId: asset.id,

--- a/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -75,7 +75,7 @@ import {
   parseData,
 } from "~/utils/http.server";
 import { ALL_SELECTED_KEY, isSelectingAllItems } from "~/utils/list";
-import { wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
+import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import {
   PermissionAction,
   PermissionEntity,
@@ -377,10 +377,11 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       });
 
       /** We create notes for the newly added assets */
+      const bookingLink = wrapLinkForNote(`/bookings/${b.id}`, b.name);
       await createNotes({
-        content: `${wrapUserLinkForNote(user!)} added asset to booking **[${
-          b.name
-        }](/bookings/${b.id})**.`,
+        content: `${wrapUserLinkForNote(
+          user!
+        )} added assets to ${bookingLink}.`,
         type: "UPDATE",
         userId: authSession.userId,
         assetIds: newAssetIds,

--- a/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -75,6 +75,7 @@ import {
   parseData,
 } from "~/utils/http.server";
 import { getParamsValues } from "~/utils/list";
+import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import {
   PermissionAction,
   PermissionEntity,
@@ -674,10 +675,17 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           userId: user.id,
         });
 
+        const actor = wrapUserLinkForNote({
+          id: userId,
+          firstName: user?.firstName,
+          lastName: user?.lastName,
+        });
+        const bookingLink = wrapLinkForNote(
+          `/bookings/${booking.id}`,
+          booking.name
+        );
         await createNotes({
-          content: `**${user?.firstName?.trim()} ${user?.lastName?.trim()}** checked out asset with **[${
-            booking.name
-          }](/bookings/${booking.id})**.`,
+          content: `${actor} checked out assets with ${bookingLink}.`,
           type: "UPDATE",
           userId: user.id,
           assetIds: booking.assets.map((a) => a.id),
@@ -710,10 +718,17 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             specificAssetIds.length > 0 ? specificAssetIds : undefined,
         });
 
+        const actor = wrapUserLinkForNote({
+          id: userId,
+          firstName: user?.firstName,
+          lastName: user?.lastName,
+        });
+        const bookingLink = wrapLinkForNote(
+          `/bookings/${booking.id}`,
+          booking.name
+        );
         await createNotes({
-          content: `**${user?.firstName?.trim()} ${user?.lastName?.trim()}** checked in asset with **[${
-            booking.name
-          }](/bookings/${booking.id})**.`,
+          content: `${actor} checked in assets with ${bookingLink}.`,
           type: "UPDATE",
           userId: user.id,
           assetIds: booking.assets.map((a) => a.id),

--- a/app/routes/_layout+/kits.$kitId.tsx
+++ b/app/routes/_layout+/kits.$kitId.tsx
@@ -47,6 +47,7 @@ import { getDateTimeFormat } from "~/utils/client-hints";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
 import { data, error, getParams, parseData } from "~/utils/http.server";
+import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import { userCanViewSpecificCustody } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
 import {
   PermissionAction,
@@ -300,8 +301,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           });
         }
 
+        const actor = wrapUserLinkForNote({
+          id: userId,
+          firstName: user.firstName,
+          lastName: user.lastName,
+        });
+        const kitLink = wrapLinkForNote(`/kits/${kitId}`, kit.name.trim());
+
         await createNote({
-          content: `**${user.firstName?.trim()} ${user.lastName?.trim()}** removed asset from **[${kit.name.trim()}](/kits/${kitId})**`,
+          content: `${actor} removed the asset from ${kitLink}.`,
           type: "UPDATE",
           userId,
           assetId,


### PR DESCRIPTION
## Summary
- reuse the booking note Markdoc helpers for asset kit change notes and booking asset removal logs to emit linked content
- update custody, booking, and asset creation flows to record structured Markdoc notes with consistent wrappers

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dcf9d1c90483209be49e3bfd6533b8