### PR TITLE
Fix reminders search default value on asset page

### DIFF
--- a/app/routes/_layout+/assets.$assetId.reminders.tsx
+++ b/app/routes/_layout+/assets.$assetId.reminders.tsx
@@ -30,7 +30,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       action: PermissionAction.read,
     });
 
-    const { reminders, totalReminders, page, perPage, totalPages } =
+    const { reminders, totalReminders, page, perPage, totalPages, search } =
       await getPaginatedAndFilterableReminders({
         organizationId,
         request,
@@ -60,6 +60,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         page,
         perPage,
         totalPages,
+        search,
       })
     );
   } catch (cause) {


### PR DESCRIPTION
## Summary
- include the search query in the asset reminder loader response so the search input hydrates correctly after refresh

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e50b57f3708320bb2ecbf5defed8c2