### PR TITLE
Fix calendar booking dialog missing custodian default

### DIFF
--- a/app/routes/_layout+/calendar.tsx
+++ b/app/routes/_layout+/calendar.tsx
@@ -142,6 +142,8 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
         currentOrganization,
         ...tagsData,
         modelName,
+        isSelfServiceOrBase,
+        userId,
         searchFieldTooltip: {
           title: "Search your bookings",
           text: parseMarkdownToReact(bookingsSearchFieldTooltipText),


### PR DESCRIPTION
## Summary
- include the self-service flag and current user id in the calendar loader payload
- ensure the create booking dialog on the calendar has access to the custodian defaults like other routes

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e531c8ecac8320b42bc599d707099f