### PR TITLE
Fix: asset status badge showing wrong booking when asset is partially checked in

### DIFF
--- a/app/components/assets/assets-index/advanced-asset-columns.tsx
+++ b/app/components/assets/assets-index/advanced-asset-columns.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { RenderableTreeNode } from "@markdoc/markdoc";
-import type { Booking, AssetStatus } from "@prisma/client";
+import type { AssetStatus } from "@prisma/client";
 import { CustomFieldType } from "@prisma/client";
 import { HoverCardPortal } from "@radix-ui/react-hover-card";
 import {
@@ -203,13 +203,7 @@ export function AdvancedIndexColumn({
       );
 
     case "status":
-      return (
-        <StatusColumn
-          id={item.id}
-          status={item.status}
-          bookings={item.bookings}
-        />
-      );
+      return <StatusColumn id={item.id} status={item.status} />;
 
     case "description":
       return <DescriptionColumn value={item.description ?? ""} />;
@@ -343,23 +337,10 @@ function TextColumn({
   );
 }
 
-function StatusColumn({
-  id,
-  status,
-  bookings,
-}: {
-  id: string;
-  status: AssetStatus;
-  bookings?: Pick<Booking, "id" | "name" | "status">[];
-}) {
+function StatusColumn({ id, status }: { id: string; status: AssetStatus }) {
   return (
     <Td className="w-full max-w-none whitespace-nowrap">
-      <AssetStatusBadge
-        bookings={bookings}
-        id={id}
-        status={status}
-        availableToBook={true}
-      />
+      <AssetStatusBadge id={id} status={status} availableToBook={true} />
     </Td>
   );
 }

--- a/app/components/booking/availability-label.tsx
+++ b/app/components/booking/availability-label.tsx
@@ -100,12 +100,20 @@ export function AvailabilityLabel({
     hasAssetBookingConflicts(asset, booking.id) &&
     !["ONGOING", "OVERDUE"].includes(booking.status)
   ) {
-    const conflictingBooking = asset?.bookings?.find(
-      (b) =>
-        b.status === BookingStatus.ONGOING ||
-        b.status === BookingStatus.OVERDUE ||
-        b.status === BookingStatus.RESERVED
-    );
+    const conflictingBooking = asset?.bookings
+      ?.filter(
+        (b) =>
+          b.id !== booking.id &&
+          (b.status === BookingStatus.ONGOING ||
+            b.status === BookingStatus.OVERDUE ||
+            b.status === BookingStatus.RESERVED)
+      )
+      .sort((a, b) => {
+        // Sort by 'from' date descending to get the newest booking first
+        const aDate = a.from ? new Date(a.from).getTime() : 0;
+        const bDate = b.from ? new Date(b.from).getTime() : 0;
+        return bDate - aDate;
+      })[0];
     return (
       <AvailabilityBadge
         badgeText={"Already booked"}
@@ -140,10 +148,19 @@ export function AvailabilityLabel({
     /** We get the current active booking that the asset is checked out to so we can use its name in the tooltip contnet
      * NOTE: This will currently not work as we are returning only overlapping bookings with the query. I leave to code and we can solve it by modifying the DB queries: https://github.com/Shelf-nu/shelf.nu/pull/555#issuecomment-1877050925
      */
-    const conflictingBooking = asset?.bookings?.find(
-      (b) =>
-        b.status === BookingStatus.ONGOING || b.status === BookingStatus.OVERDUE
-    );
+    const conflictingBooking = asset?.bookings
+      ?.filter(
+        (b) =>
+          b.id !== booking.id &&
+          (b.status === BookingStatus.ONGOING ||
+            b.status === BookingStatus.OVERDUE)
+      )
+      .sort((a, b) => {
+        // Sort by 'from' date descending to get the newest booking first
+        const aDate = a.from ? new Date(a.from).getTime() : 0;
+        const bDate = b.from ? new Date(b.from).getTime() : 0;
+        return bDate - aDate;
+      })[0];
 
     return (
       <AvailabilityBadge

--- a/app/modules/booking/service.server.test.ts
+++ b/app/modules/booking/service.server.test.ts
@@ -31,6 +31,7 @@ import {
   revertBookingToDraft,
   extendBooking,
   removeAssets,
+  getOngoingBookingForAsset,
   // Test helper functions
   getActionTextFromTransition,
   getSystemActionText,
@@ -2245,3 +2246,204 @@ describe("getSystemActionText", () => {
 // Note: createStatusTransitionNote is well-tested through integration tests above
 // The function is used by reserveBooking, checkoutBooking, checkinBooking, cancelBooking,
 // archiveBooking, revertBookingToDraft, and bulkCancelBookings/bulkArchiveBookings
+
+describe("getOngoingBookingForAsset", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("should return booking when asset is checked out in an ONGOING booking", async () => {
+    expect.assertions(2);
+
+    const mockBooking = {
+      id: "booking-1",
+      name: "Test Booking",
+      status: BookingStatus.ONGOING,
+      organizationId: "org-1",
+    };
+
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockResolvedValue(mockBooking);
+
+    const result = await getOngoingBookingForAsset({
+      assetId: "asset-1",
+      organizationId: "org-1",
+    });
+
+    expect(db.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: "org-1",
+        assets: { some: { id: "asset-1" } },
+        partialCheckins: { none: { assetIds: { has: "asset-1" } } },
+      },
+    });
+    expect(result).toEqual(mockBooking);
+  });
+
+  it("should return booking when asset is checked out in an OVERDUE booking", async () => {
+    expect.assertions(2);
+
+    const mockBooking = {
+      id: "booking-2",
+      name: "Overdue Booking",
+      status: BookingStatus.OVERDUE,
+      organizationId: "org-1",
+    };
+
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockResolvedValue(mockBooking);
+
+    const result = await getOngoingBookingForAsset({
+      assetId: "asset-2",
+      organizationId: "org-1",
+    });
+
+    expect(db.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: "org-1",
+        assets: { some: { id: "asset-2" } },
+        partialCheckins: { none: { assetIds: { has: "asset-2" } } },
+      },
+    });
+    expect(result).toEqual(mockBooking);
+  });
+
+  it("should return null when asset is partially checked in", async () => {
+    expect.assertions(2);
+
+    // Mock that no booking is found because the asset is partially checked in
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockResolvedValue(null);
+
+    const result = await getOngoingBookingForAsset({
+      assetId: "asset-3",
+      organizationId: "org-1",
+    });
+
+    // Verify the query excludes bookings where asset is in partialCheckins
+    expect(db.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: "org-1",
+        assets: { some: { id: "asset-3" } },
+        partialCheckins: { none: { assetIds: { has: "asset-3" } } },
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("should return null when asset is not in any ONGOING or OVERDUE booking", async () => {
+    expect.assertions(2);
+
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockResolvedValue(null);
+
+    const result = await getOngoingBookingForAsset({
+      assetId: "asset-4",
+      organizationId: "org-1",
+    });
+
+    expect(db.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: "org-1",
+        assets: { some: { id: "asset-4" } },
+        partialCheckins: { none: { assetIds: { has: "asset-4" } } },
+      },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("should only consider ONGOING and OVERDUE bookings, not RESERVED or DRAFT", async () => {
+    expect.assertions(1);
+
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockResolvedValue(null);
+
+    await getOngoingBookingForAsset({
+      assetId: "asset-5",
+      organizationId: "org-1",
+    });
+
+    // Verify that only ONGOING and OVERDUE statuses are queried
+    expect(db.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: "org-1",
+        assets: { some: { id: "asset-5" } },
+        partialCheckins: { none: { assetIds: { has: "asset-5" } } },
+      },
+    });
+  });
+
+  it("should filter by organization ID to ensure org isolation", async () => {
+    expect.assertions(1);
+
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockResolvedValue(null);
+
+    await getOngoingBookingForAsset({
+      assetId: "asset-6",
+      organizationId: "org-2",
+    });
+
+    expect(db.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: "org-2",
+        assets: { some: { id: "asset-6" } },
+        partialCheckins: { none: { assetIds: { has: "asset-6" } } },
+      },
+    });
+  });
+
+  it("should throw ShelfError when database query fails", async () => {
+    expect.assertions(1);
+
+    const dbError = new Error("Database connection error");
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockRejectedValue(dbError);
+
+    await expect(
+      getOngoingBookingForAsset({
+        assetId: "asset-7",
+        organizationId: "org-1",
+      })
+    ).rejects.toThrow(ShelfError);
+  });
+
+  it("should handle scenario where asset is checked in one booking but checked out in another", async () => {
+    expect.assertions(2);
+
+    // This is the key bug scenario: asset is checked in one booking (has partial checkin)
+    // and checked out in another. The function should return the booking where it's checked out.
+    const checkedOutBooking = {
+      id: "booking-checked-out",
+      name: "Checked Out Booking",
+      status: BookingStatus.ONGOING,
+      organizationId: "org-1",
+    };
+
+    //@ts-expect-error missing vitest type
+    db.booking.findFirst.mockResolvedValue(checkedOutBooking);
+
+    const result = await getOngoingBookingForAsset({
+      assetId: "asset-8",
+      organizationId: "org-1",
+    });
+
+    // The query should exclude bookings where asset has partial checkin
+    // so we get the right booking
+    expect(db.booking.findFirst).toHaveBeenCalledWith({
+      where: {
+        status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+        organizationId: "org-1",
+        assets: { some: { id: "asset-8" } },
+        partialCheckins: { none: { assetIds: { has: "asset-8" } } },
+      },
+    });
+    expect(result).toEqual(checkedOutBooking);
+  });
+});

--- a/app/modules/booking/service.server.ts
+++ b/app/modules/booking/service.server.ts
@@ -4406,6 +4406,7 @@ export async function getOngoingBookingForAsset({
         status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
         organizationId,
         assets: { some: { id: assetId } },
+        partialCheckins: { none: { assetIds: { has: assetId } } }, // Exclude bookings where this asset has been partially checked in
       },
     });
 

--- a/test/components/booking/availability-label.test.tsx
+++ b/test/components/booking/availability-label.test.tsx
@@ -1,0 +1,156 @@
+import type { Booking } from "@prisma/client";
+import { BookingStatus } from "@prisma/client";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AvailabilityLabel } from "~/components/booking/availability-label";
+import type { AssetWithBooking } from "~/routes/_layout+/bookings.$bookingId.overview.manage-assets";
+import { hasAssetBookingConflicts } from "~/modules/booking/helpers";
+import { useLoaderData } from "@remix-run/react";
+
+vi.mock("@remix-run/react", async () => {
+  const actual =
+    await vi.importActual<typeof import("@remix-run/react")>(
+      "@remix-run/react"
+    );
+
+  return {
+    ...actual,
+    useLoaderData: vi.fn(),
+    Link: ({ children, to, ...props }: any) => (
+      <a href={typeof to === "string" ? to : ""} {...props}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+vi.mock("~/modules/booking/helpers", () => ({
+  hasAssetBookingConflicts: vi.fn(),
+}));
+
+const useLoaderDataMock = vi.mocked(useLoaderData);
+const hasAssetBookingConflictsMock = vi.mocked(hasAssetBookingConflicts);
+
+function createAsset(
+  overrides: Partial<AssetWithBooking> = {}
+): AssetWithBooking {
+  return {
+    id: "asset-1",
+    name: "Camera",
+    description: null,
+    imageId: null,
+    kitId: null,
+    custody: null,
+    categoryId: "category-1",
+    organizationId: "org-1",
+    locationId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    barcode: null,
+    availableToBook: true,
+    requireLabelOnCheckout: false,
+    bookings: [],
+    tags: [],
+    qrCodes: [],
+    qrScanned: "",
+    ...overrides,
+  } as AssetWithBooking;
+}
+
+describe("AvailabilityLabel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useLoaderDataMock.mockReturnValue({
+      booking: {
+        id: "current-booking",
+        name: "Current Booking",
+        status: BookingStatus.RESERVED,
+      } as Booking,
+    });
+    hasAssetBookingConflictsMock.mockReturnValue(true);
+  });
+
+  it("shows the newest conflicting booking in the tooltip", async () => {
+    const asset = createAsset({
+      bookings: [
+        {
+          id: "old-booking",
+          name: "Old Booking",
+          status: BookingStatus.RESERVED,
+          from: new Date("2024-01-01T10:00:00Z"),
+          to: new Date("2024-01-02T10:00:00Z"),
+        } as any,
+        {
+          id: "new-booking",
+          name: "New Booking",
+          status: BookingStatus.ONGOING,
+          from: new Date("2024-02-01T10:00:00Z"),
+          to: new Date("2024-02-02T10:00:00Z"),
+        } as any,
+      ],
+    });
+
+    render(
+      <AvailabilityLabel
+        asset={asset}
+        isCheckedOut={false}
+        isAlreadyAdded={false}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.hover(await screen.findByText("Already booked"));
+
+    const links = await screen.findAllByRole("link", {
+      name: "New Booking",
+    });
+    expect(
+      links.some(
+        (link) => link.getAttribute("href") === "/bookings/new-booking"
+      )
+    ).toBe(true);
+  });
+
+  it("skips the current booking when selecting the conflicting booking", async () => {
+    const asset = createAsset({
+      bookings: [
+        {
+          id: "current-booking",
+          name: "Current Booking",
+          status: BookingStatus.ONGOING,
+          from: new Date("2024-03-01T10:00:00Z"),
+          to: new Date("2024-03-02T10:00:00Z"),
+        } as any,
+        {
+          id: "other-booking",
+          name: "Other Booking",
+          status: BookingStatus.OVERDUE,
+          from: new Date("2024-02-01T10:00:00Z"),
+          to: new Date("2024-02-02T10:00:00Z"),
+        } as any,
+      ],
+    });
+
+    render(
+      <AvailabilityLabel
+        asset={asset}
+        isCheckedOut={false}
+        isAlreadyAdded={false}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.hover(await screen.findByText("Already booked"));
+
+    const links = await screen.findAllByRole("link", {
+      name: "Other Booking",
+    });
+    expect(
+      links.some(
+        (link) => link.getAttribute("href") === "/bookings/other-booking"
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
When an asset was checked in for one booking and checked out in another (both ongoing), the status badge incorrectly showed the booking where the asset was already checked in instead of the one where it was still checked out.

Root cause: The backend query didn't filter out bookings where assets had been partially checked in, and the frontend had complex logic trying to use a bookings prop that lacked partial check-in context.

Changes:
- Backend: Added partialCheckins filter to getOngoingBookingForAsset to exclude bookings where the asset has been partially checked in
- Frontend: Simplified AssetStatusBadge to always use the API call for CHECKED_OUT status, removed unused bookings prop
- Components: Updated all AssetStatusBadge usages to remove the bookings prop
- Availability Label: Fixed conflicting booking selection to filter out current booking and sort by date descending
- Tests: Added comprehensive unit tests for getOngoingBookingForAsset covering all edge cases including the bug scenario