### PR TITLE
feat: add prosemirror-based EditorV2

### DIFF
--- a/app/components/editor-v2/editor-v2.tsx
+++ b/app/components/editor-v2/editor-v2.tsx
@@ -1,0 +1,1187 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ChangeEvent, TextareaHTMLAttributes } from "react";
+import "prosemirror-view/style/prosemirror.css";
+import {
+  baseKeymap,
+  toggleMark,
+  setBlockType,
+  wrapIn,
+} from "prosemirror-commands";
+import { history, redo, undo, redoDepth, undoDepth } from "prosemirror-history";
+import {
+  InputRule,
+  inputRules,
+  smartQuotes,
+  textblockTypeInputRule,
+  wrappingInputRule,
+} from "prosemirror-inputrules";
+import { keymap } from "prosemirror-keymap";
+import type { Schema } from "prosemirror-model";
+import {
+  wrapInList,
+  liftListItem,
+  sinkListItem,
+} from "prosemirror-schema-list";
+import { EditorState, Plugin } from "prosemirror-state";
+import type { Command as PMCommand } from "prosemirror-state";
+import { EditorView, Decoration, DecorationSet } from "prosemirror-view";
+import {
+  countRawBlocks,
+  createEditorSchema,
+  parseMarkdoc,
+  serializeMarkdoc,
+} from "~/modules/editor-v2/markdoc-utils";
+import { Logger } from "~/utils/logger";
+import { tw } from "~/utils/tw";
+import { Button } from "../shared/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../shared/modal";
+
+interface EditorV2Props
+  extends Omit<
+    TextareaHTMLAttributes<HTMLTextAreaElement>,
+    "defaultValue" | "onChange"
+  > {
+  label: string;
+  name: string;
+  defaultValue: string;
+  onChange?: (value: string) => void;
+}
+
+type ToolbarBlock =
+  | "paragraph"
+  | "heading1"
+  | "heading2"
+  | "heading3"
+  | "heading4"
+  | "bullet_list"
+  | "ordered_list"
+  | "blockquote"
+  | "raw_block";
+
+interface ToolbarState {
+  block: ToolbarBlock;
+  bold: boolean;
+  italic: boolean;
+  code: boolean;
+  link: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+}
+
+interface BubbleState {
+  visible: boolean;
+  left: number;
+  top: number;
+}
+
+interface SlashState {
+  active: boolean;
+  query: string;
+  from: number;
+  to: number;
+  left: number;
+  top: number;
+}
+
+interface LinkDialogState {
+  open: boolean;
+  href: string;
+  range: { from: number; to: number } | null;
+}
+
+interface RawBlockDialogState {
+  open: boolean;
+  raw: string;
+  pos: number | null;
+}
+
+interface SlashCommandItem {
+  id: string;
+  label: string;
+  description: string;
+  aliases: string[];
+  command: PMCommand;
+}
+
+const placeholderPluginKey = new Plugin({
+  props: {
+    decorations(state) {
+      const placeholder = (state as any).placeholder as string | undefined;
+      if (!placeholder) {
+        return null;
+      }
+      const docIsEmpty =
+        state.doc.childCount === 1 &&
+        state.doc.firstChild?.type.name === "paragraph" &&
+        state.doc.firstChild.childCount === 0;
+      if (!docIsEmpty) {
+        return null;
+      }
+      const deco = Decoration.widget(1, () => {
+        const span = document.createElement("span");
+        span.className = "pointer-events-none text-sm text-gray-400";
+        span.textContent = placeholder;
+        return span;
+      });
+      return DecorationSet.create(state.doc, [deco]);
+    },
+  },
+}) as Plugin & {
+  props: {
+    decorations: (
+      state: EditorState & { placeholder?: string }
+    ) => DecorationSet | null;
+  };
+};
+
+function createInputRules(schema: Schema) {
+  const rules = [
+    textblockTypeInputRule(/^(#{1,4})\s$/, schema.nodes.heading, (match) => ({
+      level: match[1].length,
+    })),
+    wrappingInputRule(/^>\s$/, schema.nodes.blockquote),
+    wrappingInputRule(/^[*-]\s$/, schema.nodes.bullet_list),
+    wrappingInputRule(/^(\d+)\.\s$/, schema.nodes.ordered_list, (match) => ({
+      order: Number.parseInt(match[1], 10),
+    })),
+  ];
+
+  if (schema.nodes.horizontal_rule) {
+    const horizontalRule = schema.nodes.horizontal_rule;
+    rules.push(
+      new InputRule(/^---$/, (state, _match, start, end) => {
+        const { tr } = state;
+        const from = Math.max(0, start - 1);
+        return tr.replaceWith(from, end, horizontalRule.create());
+      })
+    );
+  }
+
+  return [...smartQuotes, ...rules];
+}
+
+function markIsActive(state: EditorState, mark: string) {
+  const { from, $from, to, empty } = state.selection;
+  if (empty) {
+    return (
+      (!!mark &&
+        !!state.storedMarks?.some((stored) => stored.type.name === mark)) ||
+      $from.marks().some((stored) => stored.type.name === mark)
+    );
+  }
+  return state.doc.rangeHasMark(from, to, state.schema.marks[mark]);
+}
+
+function getBlockFromState(state: EditorState): ToolbarBlock {
+  const { $from } = state.selection;
+  for (let depth = $from.depth; depth > 0; depth -= 1) {
+    const node = $from.node(depth);
+    if (node.type.name === "bullet_list") {
+      return "bullet_list";
+    }
+    if (node.type.name === "ordered_list") {
+      return "ordered_list";
+    }
+    if (node.type.name === "blockquote") {
+      return "blockquote";
+    }
+  }
+
+  const parent = $from.parent;
+  if (parent.type.name === "heading") {
+    const level = Math.min(Math.max(parent.attrs.level ?? 1, 1), 4);
+    return `heading${level}` as ToolbarBlock;
+  }
+  if (parent.type.name === "raw_block") {
+    return "raw_block";
+  }
+  return "paragraph";
+}
+
+function createHorizontalRuleCommand(schema: Schema): PMCommand {
+  return (state, dispatch) => {
+    const hr = schema.nodes.horizontal_rule;
+    if (!hr) return false;
+    if (dispatch) {
+      const tr = state.tr.replaceSelectionWith(hr.create());
+      dispatch(tr.scrollIntoView());
+    }
+    return true;
+  };
+}
+
+function sanitizeHref(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+
+  const allowedProtocols = new Set(["http:", "https:", "mailto:", "tel:"]); // minimal allow list
+
+  try {
+    const hasProtocol = /^[a-z]+:/i.test(trimmed);
+    const url = new URL(hasProtocol ? trimmed : `https://${trimmed}`);
+    if (!allowedProtocols.has(url.protocol)) {
+      return "";
+    }
+    if (
+      !hasProtocol &&
+      (url.protocol === "http:" || url.protocol === "https:")
+    ) {
+      return url.href;
+    }
+    return trimmed;
+  } catch {
+    return "";
+  }
+}
+
+function buildKeymap(schema: Schema, openLinkDialog: () => void) {
+  const hardBreak = (state: EditorState, dispatch?: (tr: any) => void) => {
+    const br = schema.nodes.hard_break;
+    if (!br) return false;
+    if (dispatch) {
+      dispatch(state.tr.replaceSelectionWith(br.create()).scrollIntoView());
+    }
+    return true;
+  };
+
+  const linkCommand: PMCommand = () => {
+    openLinkDialog();
+    return true;
+  };
+
+  return {
+    "Mod-b": toggleMark(schema.marks.strong),
+    "Mod-B": toggleMark(schema.marks.strong),
+    "Mod-i": toggleMark(schema.marks.em),
+    "Mod-I": toggleMark(schema.marks.em),
+    "Mod-k": linkCommand,
+    "Mod-K": linkCommand,
+    "Shift-Enter": hardBreak,
+    "Mod-z": undo,
+    "Mod-y": redo,
+    "Mod-Shift-z": redo,
+    Tab: (state, dispatch, view) =>
+      sinkListItem(schema.nodes.list_item)(state, dispatch, view),
+    "Shift-Tab": liftListItem(schema.nodes.list_item),
+  } as Record<string, PMCommand>;
+}
+
+function createSlashCommands(schema: Schema): SlashCommandItem[] {
+  const heading = schema.nodes.heading;
+  const paragraph = schema.nodes.paragraph;
+  const blockquote = schema.nodes.blockquote;
+  const bullet = schema.nodes.bullet_list;
+  const ordered = schema.nodes.ordered_list;
+  const hr = schema.nodes.horizontal_rule;
+
+  const commands: SlashCommandItem[] = [
+    {
+      id: "paragraph",
+      label: "Paragraph",
+      description: "Start with plain text",
+      aliases: ["p"],
+      command: setBlockType(paragraph),
+    },
+    {
+      id: "h1",
+      label: "Heading 1",
+      description: "Large section heading",
+      aliases: ["heading1", "title"],
+      command: setBlockType(heading, { level: 1 }),
+    },
+    {
+      id: "h2",
+      label: "Heading 2",
+      description: "Medium section heading",
+      aliases: ["heading2"],
+      command: setBlockType(heading, { level: 2 }),
+    },
+    {
+      id: "h3",
+      label: "Heading 3",
+      description: "Small section heading",
+      aliases: ["heading3"],
+      command: setBlockType(heading, { level: 3 }),
+    },
+    {
+      id: "h4",
+      label: "Heading 4",
+      description: "Minor section heading",
+      aliases: ["heading4"],
+      command: setBlockType(heading, { level: 4 }),
+    },
+    {
+      id: "bullet-list",
+      label: "Bullet list",
+      description: "Create a bulleted list",
+      aliases: ["ul", "bullet"],
+      command: wrapInList(bullet),
+    },
+    {
+      id: "ordered-list",
+      label: "Numbered list",
+      description: "Create a numbered list",
+      aliases: ["ol", "number"],
+      command: wrapInList(ordered),
+    },
+    {
+      id: "blockquote",
+      label: "Quote",
+      description: "Emphasize with a quote block",
+      aliases: ["quote"],
+      command: wrapIn(blockquote),
+    },
+  ];
+
+  if (hr) {
+    commands.push({
+      id: "divider",
+      label: "Divider",
+      description: "Insert a horizontal rule",
+      aliases: ["divider", "hr"],
+      command: createHorizontalRuleCommand(schema),
+    });
+  }
+
+  return commands;
+}
+
+function filterSlashCommands(commands: SlashCommandItem[], query: string) {
+  if (!query) {
+    return commands;
+  }
+  const normalized = query.toLowerCase();
+  return commands.filter((command) => {
+    if (command.label.toLowerCase().includes(normalized)) {
+      return true;
+    }
+    return command.aliases.some((alias) =>
+      alias.toLowerCase().includes(normalized)
+    );
+  });
+}
+
+interface ToolbarButtonProps {
+  label: string;
+  icon?: string;
+  onClick: () => void;
+  active?: boolean;
+  disabled?: boolean;
+}
+
+function ToolbarButton({
+  label,
+  onClick,
+  active,
+  disabled,
+}: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      className={tw(
+        "inline-flex h-9 items-center justify-center rounded px-2 text-sm font-medium transition",
+        active
+          ? "bg-primary-50 text-primary-700"
+          : "text-gray-600 hover:bg-gray-100",
+        disabled ? "cursor-not-allowed opacity-40" : ""
+      )}
+      aria-label={label}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() => {
+        if (disabled) return;
+        onClick();
+      }}
+      disabled={disabled}
+    >
+      {label}
+    </button>
+  );
+}
+
+interface ParagraphSelectProps {
+  value: ToolbarBlock;
+  onChange: (value: ToolbarBlock) => void;
+}
+
+function ParagraphSelect({ value, onChange }: ParagraphSelectProps) {
+  const normalized = value === "raw_block" ? "paragraph" : value;
+  return (
+    <label className="inline-flex items-center gap-2 text-sm text-gray-600">
+      <span className="sr-only">Paragraph style</span>
+      <select
+        className="h-9 rounded border border-gray-200 bg-white px-2 text-sm text-gray-700 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+        aria-label="Paragraph style"
+        value={normalized}
+        onChange={(event) => onChange(event.target.value as ToolbarBlock)}
+        disabled={value === "raw_block"}
+      >
+        <option value="paragraph">Paragraph</option>
+        <option value="heading1">Heading 1</option>
+        <option value="heading2">Heading 2</option>
+        <option value="heading3">Heading 3</option>
+        <option value="heading4">Heading 4</option>
+        <option value="bullet_list">Bullet list</option>
+        <option value="ordered_list">Numbered list</option>
+        <option value="blockquote">Quote</option>
+      </select>
+    </label>
+  );
+}
+
+interface SlashCommandMenuProps {
+  state: SlashState | null;
+  commands: SlashCommandItem[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  onRun: (command: SlashCommandItem) => void;
+}
+
+function SlashCommandMenu({
+  state,
+  commands,
+  selectedIndex,
+  onSelect,
+  onRun,
+}: SlashCommandMenuProps) {
+  if (!state || !state.active || commands.length === 0) {
+    return null;
+  }
+  return (
+    <div
+      className="fixed z-50 w-64 overflow-hidden rounded-md border border-gray-200 bg-white shadow-xl"
+      style={{ left: state.left, top: state.top }}
+      role="listbox"
+      aria-label="Slash command menu"
+    >
+      <ul className="max-h-64 overflow-y-auto">
+        {commands.map((command, index) => (
+          <li key={command.id}>
+            <button
+              type="button"
+              role="option"
+              aria-selected={selectedIndex === index}
+              className={tw(
+                "block w-full px-3 py-2 text-left text-sm",
+                selectedIndex === index
+                  ? "bg-primary-50 text-primary-700"
+                  : "hover:bg-gray-50"
+              )}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => onRun(command)}
+              onMouseEnter={() => onSelect(index)}
+            >
+              <div className="font-medium">{command.label}</div>
+              <div className="text-xs text-gray-500">{command.description}</div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface BubbleMenuProps {
+  state: BubbleState;
+  onBold: () => void;
+  onItalic: () => void;
+  onLink: () => void;
+  boldActive: boolean;
+  italicActive: boolean;
+}
+
+function BubbleMenu({
+  state,
+  onBold,
+  onItalic,
+  onLink,
+  boldActive,
+  italicActive,
+}: BubbleMenuProps) {
+  if (!state.visible) {
+    return null;
+  }
+  return (
+    <div
+      className="fixed z-50 flex items-center gap-1 rounded-md border border-gray-200 bg-white px-2 py-1 shadow-lg"
+      style={{ left: state.left, top: state.top }}
+      role="toolbar"
+      aria-label="Inline formatting"
+    >
+      <ToolbarButton label="Bold" active={boldActive} onClick={onBold} />
+      <ToolbarButton label="Italic" active={italicActive} onClick={onItalic} />
+      <ToolbarButton label="Link" onClick={onLink} />
+    </div>
+  );
+}
+
+export const EditorV2 = forwardRef<HTMLTextAreaElement, EditorV2Props>(
+  function EditorV2(
+    {
+      defaultValue,
+      label,
+      name,
+      placeholder,
+      disabled,
+      className,
+      maxLength,
+      onBlur,
+      onFocus,
+      onChange,
+      ...textareaProps
+    },
+    ref
+  ) {
+    const { autoFocus: shouldAutoFocus, ...restTextareaProps } =
+      textareaProps as typeof textareaProps & { autoFocus?: boolean };
+    const schema = useMemo(() => createEditorSchema(), []);
+    const editorContainerRef = useRef<HTMLDivElement | null>(null);
+    const viewRef = useRef<EditorView | null>(null);
+  const [markdocValue, setMarkdocValue] = useState(defaultValue);
+  const markdocValueRef = useRef(defaultValue);
+    const [toolbarState, setToolbarState] = useState<ToolbarState>(() => ({
+      block: "paragraph",
+      bold: false,
+      italic: false,
+      code: false,
+      link: false,
+      canUndo: false,
+      canRedo: false,
+    }));
+    const [bubbleState, setBubbleState] = useState<BubbleState>({
+      visible: false,
+      left: 0,
+      top: 0,
+    });
+    const [slashState, setSlashState] = useState<SlashState | null>(null);
+    const [slashIndex, setSlashIndex] = useState(0);
+    const [linkDialog, setLinkDialog] = useState<LinkDialogState>({
+      open: false,
+      href: "",
+      range: null,
+    });
+    const [rawBlockDialog, setRawBlockDialog] = useState<RawBlockDialogState>({
+      open: false,
+      raw: "",
+      pos: null,
+    });
+    const rawBlockTelemetryRef = useRef<number>(0);
+    const commands = useMemo(() => createSlashCommands(schema), [schema]);
+
+    const applyToolbarState = useCallback((state: EditorState) => {
+      const block = getBlockFromState(state);
+      const bold = markIsActive(state, "strong");
+      const italic = markIsActive(state, "em");
+      const code = markIsActive(state, "code");
+      const link = markIsActive(state, "link");
+      const next: ToolbarState = {
+        block,
+        bold,
+        italic,
+        code,
+        link,
+        canUndo: undoDepth(state) > 0,
+        canRedo: redoDepth(state) > 0,
+      };
+      setToolbarState(next);
+    }, []);
+
+    const updateBubble = useCallback((state: EditorState, view: EditorView) => {
+      const { from, to } = state.selection;
+      if (from === to) {
+        setBubbleState((prev) =>
+          prev.visible ? { ...prev, visible: false } : prev
+        );
+        return;
+      }
+      try {
+        const start = view.coordsAtPos(from);
+        const end = view.coordsAtPos(to);
+        const left = (start.left + end.right) / 2 - 60;
+        const top = Math.min(start.top, end.top) - 44;
+        setBubbleState({ visible: true, left, top });
+      } catch {
+        setBubbleState((prev) =>
+          prev.visible ? { ...prev, visible: false } : prev
+        );
+      }
+    }, []);
+
+    const updateSlash = useCallback((state: EditorState, view: EditorView) => {
+      if (!state.selection.empty) {
+        setSlashState(null);
+        return;
+      }
+      const { $from } = state.selection;
+      if (!$from || !$from.parent) {
+        setSlashState(null);
+        return;
+      }
+      const textBefore = $from.parent.textBetween(
+        0,
+        $from.parentOffset,
+        undefined,
+        "\ufffc"
+      );
+      const slashIndex = textBefore.lastIndexOf("/");
+      if (slashIndex === -1) {
+        setSlashState(null);
+        return;
+      }
+      const prefix = textBefore.slice(0, slashIndex);
+      if (prefix && /[^\s]$/.test(prefix)) {
+        setSlashState(null);
+        return;
+      }
+      const query = textBefore.slice(slashIndex + 1);
+      if (!/^[\w-]*$/.test(query)) {
+        setSlashState(null);
+        return;
+      }
+      const from = state.selection.from - query.length - 1;
+      const to = state.selection.from;
+      try {
+        const coords = view.coordsAtPos(from);
+        setSlashState({
+          active: true,
+          query,
+          from,
+          to,
+          left: coords.left,
+          top: coords.bottom + 6,
+        });
+      } catch {
+        setSlashState(null);
+      }
+    }, []);
+
+    const runCommand = useCallback((command: PMCommand) => {
+      const view = viewRef.current;
+      if (!view) return;
+      command(view.state, view.dispatch, view);
+      view.focus();
+    }, []);
+
+    const handleParagraphChange = useCallback(
+      (value: ToolbarBlock) => {
+        const view = viewRef.current;
+        if (!view) return;
+        const { state } = view;
+        switch (value) {
+          case "paragraph":
+            setBlockType(schema.nodes.paragraph)(state, view.dispatch, view);
+            break;
+          case "heading1":
+          case "heading2":
+          case "heading3":
+          case "heading4": {
+            const level = Number(value.replace("heading", ""));
+            setBlockType(schema.nodes.heading, { level })(
+              state,
+              view.dispatch,
+              view
+            );
+            break;
+          }
+          case "bullet_list":
+            wrapInList(schema.nodes.bullet_list)(state, view.dispatch, view);
+            break;
+          case "ordered_list":
+            wrapInList(schema.nodes.ordered_list)(state, view.dispatch, view);
+            break;
+          case "blockquote":
+            wrapIn(schema.nodes.blockquote)(state, view.dispatch, view);
+            break;
+        }
+        view.focus();
+      },
+      [
+        schema.nodes.blockquote,
+        schema.nodes.bullet_list,
+        schema.nodes.heading,
+        schema.nodes.ordered_list,
+        schema.nodes.paragraph,
+      ]
+    );
+
+    const openLinkDialog = useCallback(() => {
+      const view = viewRef.current;
+      if (!view) return;
+      const { state } = view;
+      const { from, to } = state.selection;
+      if (from === to) {
+        return;
+      }
+      const linkMark = schema.marks.link;
+      let href = "";
+      state.doc.nodesBetween(from, to, (node) => {
+        const marks = node.marks || [];
+        const mark = marks.find((m) => m.type === linkMark);
+        if (mark) {
+          href = mark.attrs.href || "";
+          return false;
+        }
+        return true;
+      });
+      setLinkDialog({ open: true, href, range: { from, to } });
+    }, [schema.marks.link]);
+
+    const closeLinkDialog = useCallback(() => {
+      setLinkDialog({ open: false, href: "", range: null });
+    }, []);
+
+    const applyLink = useCallback(() => {
+      const view = viewRef.current;
+      if (!view) return;
+      if (!linkDialog.range) {
+        closeLinkDialog();
+        return;
+      }
+      const href = sanitizeHref(linkDialog.href);
+      const { from, to } = linkDialog.range;
+      const { state } = view;
+      const linkMark = schema.marks.link;
+      view.dispatch(
+        href
+          ? state.tr
+              .addMark(from, to, linkMark.create({ href }))
+              .scrollIntoView()
+          : state.tr.removeMark(from, to, linkMark).scrollIntoView()
+      );
+      closeLinkDialog();
+      view.focus();
+    }, [closeLinkDialog, linkDialog.href, linkDialog.range, schema.marks.link]);
+
+    const applySlashCommand = useCallback(
+      (command: SlashCommandItem) => {
+        const view = viewRef.current;
+        if (!view || !slashState) return;
+        const { from, to } = slashState;
+        const { state } = view;
+        const tr = state.tr.delete(from, to);
+        view.dispatch(tr);
+        command.command(view.state, view.dispatch, view);
+        view.focus();
+        setSlashState(null);
+        setSlashIndex(0);
+      },
+      [slashState]
+    );
+
+    const openRawBlockEditor = useCallback((pos: number, raw: string) => {
+      setRawBlockDialog({ open: true, pos, raw });
+    }, []);
+
+    const applyRawBlockEdit = useCallback(() => {
+      const view = viewRef.current;
+      if (!view || rawBlockDialog.pos == null) {
+        setRawBlockDialog({ open: false, pos: null, raw: "" });
+        return;
+      }
+      const { pos, raw } = rawBlockDialog;
+      const node = view.state.doc.nodeAt(pos);
+      if (!node || node.type.name !== "raw_block") {
+        setRawBlockDialog({ open: false, pos: null, raw: "" });
+        return;
+      }
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, { raw });
+      view.dispatch(tr);
+      view.focus();
+      setRawBlockDialog({ open: false, pos: null, raw: "" });
+    }, [rawBlockDialog]);
+
+    useEffect(() => {
+      if (!editorContainerRef.current) {
+        return;
+      }
+      const initialDoc = parseMarkdoc(defaultValue, schema);
+
+      const view = new EditorView(editorContainerRef.current, {
+        state: EditorState.create({
+          schema,
+          doc: initialDoc,
+          plugins: [
+            history(),
+            inputRules({ rules: createInputRules(schema) }),
+            keymap(buildKeymap(schema, openLinkDialog)),
+            keymap(baseKeymap),
+            placeholderPluginKey,
+          ],
+        }) as EditorState & { placeholder?: string },
+        attributes: {
+          class: tw(
+            "prose prose-sm max-w-none focus:outline-none",
+            disabled ? "pointer-events-none opacity-60" : ""
+          ),
+        },
+        dispatchTransaction: (tr) => {
+          const currentView = (viewRef.current ?? view) as EditorView;
+        const nextState = currentView.state.apply(tr);
+        let nextMarkdoc = markdocValueRef.current;
+        if (tr.docChanged) {
+          nextMarkdoc = serializeMarkdoc(nextState.doc, schema);
+          if (maxLength && nextMarkdoc.length > maxLength) {
+            return;
+          }
+        }
+        currentView.updateState(nextState);
+        if (tr.docChanged) {
+          setMarkdocValue(nextMarkdoc);
+          markdocValueRef.current = nextMarkdoc;
+          onChange?.(nextMarkdoc);
+          const rawCount = countRawBlocks(nextState.doc);
+            if (rawCount > 0 && rawCount !== rawBlockTelemetryRef.current) {
+              Logger.info("editor-v2.raw-blocks", { count: rawCount });
+            }
+            rawBlockTelemetryRef.current = rawCount;
+          }
+          applyToolbarState(nextState);
+          updateBubble(nextState, currentView);
+          updateSlash(nextState, currentView);
+        },
+        editable: () => !disabled,
+        nodeViews: {
+          raw_block: (node, _view, getPos) => {
+            const dom = document.createElement("div");
+            dom.className =
+              "relative rounded border border-dashed border-gray-300 bg-gray-50";
+            const pre = document.createElement("pre");
+            pre.className =
+              "overflow-x-auto whitespace-pre-wrap p-3 text-xs font-mono text-gray-700";
+            pre.textContent = node.attrs.raw ?? "";
+            dom.appendChild(pre);
+            const button = document.createElement("button");
+            button.type = "button";
+            button.className =
+              "absolute right-3 top-3 rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 shadow-sm hover:bg-gray-100";
+            button.textContent = "Edit source";
+            button.addEventListener("mousedown", (event) =>
+              event.preventDefault()
+            );
+            button.addEventListener("click", () => {
+              const resolvedPos =
+                typeof getPos === "function" ? getPos() : getPos;
+              if (typeof resolvedPos === "number") {
+                openRawBlockEditor(resolvedPos, node.attrs.raw ?? "");
+              }
+            });
+            dom.appendChild(button);
+            return {
+              dom,
+              update(updatedNode) {
+                if (updatedNode.type !== node.type) {
+                  return false;
+                }
+                pre.textContent = updatedNode.attrs.raw ?? "";
+                return true;
+              },
+            };
+          },
+        },
+      });
+
+      (view.state as any).placeholder = placeholder;
+      viewRef.current = view;
+    const initialValue = serializeMarkdoc(view.state.doc, schema);
+    setMarkdocValue(initialValue);
+    markdocValueRef.current = initialValue;
+      applyToolbarState(view.state);
+      updateBubble(view.state, view);
+    updateSlash(view.state, view);
+
+      const dom = view.dom as HTMLElement;
+      const handleFocus = (event: FocusEvent) => onFocus?.(event as any);
+      const handleBlur = (event: FocusEvent) => onBlur?.(event as any);
+      dom.addEventListener("focus", handleFocus);
+      dom.addEventListener("blur", handleBlur);
+
+      return () => {
+        dom.removeEventListener("focus", handleFocus);
+        dom.removeEventListener("blur", handleBlur);
+        view.destroy();
+        viewRef.current = null;
+      };
+  }, [
+    applyToolbarState,
+    defaultValue,
+    disabled,
+    maxLength,
+    onBlur,
+    onChange,
+    onFocus,
+    openLinkDialog,
+    openRawBlockEditor,
+    placeholder,
+    schema,
+    updateBubble,
+    updateSlash,
+  ]);
+
+    useEffect(() => {
+      const view = viewRef.current;
+      if (!view) return;
+      const doc = parseMarkdoc(defaultValue, schema);
+      const tr = view.state.tr.replaceWith(
+        0,
+        view.state.doc.content.size,
+        doc.content
+      );
+      view.dispatch(tr);
+    }, [defaultValue, schema]);
+
+    useEffect(() => {
+      const view = viewRef.current;
+      if (!view) return;
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (!slashState || !slashState.active) {
+          return;
+        }
+        const filtered = filterSlashCommands(commands, slashState.query);
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          setSlashIndex((index) => (index + 1) % Math.max(filtered.length, 1));
+        } else if (event.key === "ArrowUp") {
+          event.preventDefault();
+          setSlashIndex(
+            (index) =>
+              (index - 1 + filtered.length) % Math.max(filtered.length, 1)
+          );
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          const command = filtered[slashIndex] ?? filtered[0];
+          if (command) {
+            applySlashCommand(command);
+          }
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          setSlashState(null);
+        }
+      };
+      const dom = view.dom as HTMLElement;
+      dom.addEventListener("keydown", handleKeyDown);
+      return () => {
+        dom.removeEventListener("keydown", handleKeyDown);
+      };
+    }, [applySlashCommand, commands, slashIndex, slashState]);
+
+    useEffect(() => {
+      if (!slashState) {
+        setSlashIndex(0);
+      }
+    }, [slashState]);
+
+    useEffect(() => {
+      if (shouldAutoFocus && viewRef.current) {
+        viewRef.current.focus();
+      }
+    }, [shouldAutoFocus]);
+
+    const filteredCommands = useMemo(
+      () => filterSlashCommands(commands, slashState?.query ?? ""),
+      [commands, slashState]
+    );
+
+    return (
+      <div className={tw("flex flex-col gap-2", className)}>
+        <div className="flex flex-col gap-2 rounded border border-gray-200 bg-white p-3">
+          <div
+            className="flex flex-wrap items-center gap-2"
+            role="toolbar"
+            aria-label="Editor formatting toolbar"
+          >
+            <ToolbarButton
+              label="Undo"
+              onClick={() => runCommand(undo)}
+              disabled={!toolbarState.canUndo}
+            />
+            <ToolbarButton
+              label="Redo"
+              onClick={() => runCommand(redo)}
+              disabled={!toolbarState.canRedo}
+            />
+            <ParagraphSelect
+              value={toolbarState.block}
+              onChange={handleParagraphChange}
+            />
+            <ToolbarButton
+              label="Bold"
+              active={toolbarState.bold}
+              onClick={() => runCommand(toggleMark(schema.marks.strong))}
+            />
+            <ToolbarButton
+              label="Italic"
+              active={toolbarState.italic}
+              onClick={() => runCommand(toggleMark(schema.marks.em))}
+            />
+            <ToolbarButton label="Link" onClick={openLinkDialog} />
+            <ToolbarButton
+              label="Bulleted list"
+              active={toolbarState.block === "bullet_list"}
+              onClick={() => runCommand(wrapInList(schema.nodes.bullet_list))}
+            />
+            <ToolbarButton
+              label="Numbered list"
+              active={toolbarState.block === "ordered_list"}
+              onClick={() => runCommand(wrapInList(schema.nodes.ordered_list))}
+            />
+            <ToolbarButton
+              label="Quote"
+              active={toolbarState.block === "blockquote"}
+              onClick={() => runCommand(wrapIn(schema.nodes.blockquote))}
+            />
+            {schema.nodes.horizontal_rule ? (
+              <ToolbarButton
+                label="Divider"
+                onClick={() => runCommand(createHorizontalRuleCommand(schema))}
+              />
+            ) : null}
+          </div>
+          <div className="relative">
+            <div
+              ref={editorContainerRef}
+              className="min-h-[200px] cursor-text px-2 py-3"
+              data-testid="editor-v2-content"
+            />
+            <BubbleMenu
+              state={bubbleState}
+              onBold={() => runCommand(toggleMark(schema.marks.strong))}
+              onItalic={() => runCommand(toggleMark(schema.marks.em))}
+              onLink={openLinkDialog}
+              boldActive={toolbarState.bold}
+              italicActive={toolbarState.italic}
+            />
+            <SlashCommandMenu
+              state={slashState}
+              commands={filteredCommands}
+              selectedIndex={slashIndex}
+              onSelect={setSlashIndex}
+              onRun={applySlashCommand}
+            />
+          </div>
+        </div>
+        <textarea
+          ref={ref}
+          name={name}
+          value={markdocValue}
+          readOnly
+          hidden
+          disabled={disabled}
+          aria-hidden="true"
+          data-testid="editor-v2-input"
+          {...restTextareaProps}
+        />
+        {maxLength ? (
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>
+              {label} supports Markdown and Markdoc. Use / to access commands.
+            </span>
+            <span
+              className={
+                markdocValue.length > maxLength ? "text-error-600" : ""
+              }
+            >
+              {markdocValue.length}/{maxLength}
+            </span>
+          </div>
+        ) : null}
+        <AlertDialog
+          open={linkDialog.open}
+          onOpenChange={(open) => (open ? null : closeLinkDialog())}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Edit link</AlertDialogTitle>
+              <AlertDialogDescription>
+                Enter the URL for the selected text.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="space-y-3">
+              <label className="block text-sm font-medium text-gray-700">
+                URL
+                <input
+                  type="url"
+                  value={linkDialog.href}
+                  onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                    setLinkDialog((state) => ({
+                      ...state,
+                      href: event.target.value,
+                    }))
+                  }
+                  className="mt-1 w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                  placeholder="https://example.com"
+                />
+              </label>
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel asChild>
+                <Button variant="secondary" type="button">
+                  Cancel
+                </Button>
+              </AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button type="button" onClick={applyLink}>
+                  Apply
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+        <AlertDialog
+          open={rawBlockDialog.open}
+          onOpenChange={(open) =>
+            open ? null : setRawBlockDialog({ open: false, raw: "", pos: null })
+          }
+        >
+          <AlertDialogContent className="max-w-2xl">
+            <AlertDialogHeader>
+              <AlertDialogTitle>Edit raw Markdoc block</AlertDialogTitle>
+              <AlertDialogDescription>
+                Unsupported Markdoc content is preserved as raw blocks. Updating
+                the source will replace the block contents.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="space-y-3">
+              <textarea
+                className="h-48 w-full rounded border border-gray-300 p-2 font-mono text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                value={rawBlockDialog.raw}
+                onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+                  setRawBlockDialog((state) => ({
+                    ...state,
+                    raw: event.target.value,
+                  }))
+                }
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel asChild>
+                <Button variant="secondary" type="button">
+                  Cancel
+                </Button>
+              </AlertDialogCancel>
+              <AlertDialogAction asChild>
+                <Button type="button" onClick={applyRawBlockEdit}>
+                  Save raw block
+                </Button>
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    );
+  }
+);

--- a/app/modules/editor-v2/feature-flag.ts
+++ b/app/modules/editor-v2/feature-flag.ts
@@ -1,0 +1,20 @@
+import { EDITOR_V2_WORKSPACES } from "~/utils/env";
+
+const workspaceList = (EDITOR_V2_WORKSPACES || "")
+  .split(",")
+  .map((id) => id.trim())
+  .filter(Boolean);
+
+const ENABLED_FOR_ALL = workspaceList.includes("*") || workspaceList.includes("all");
+
+export function isEditorV2Enabled(workspaceId: string | null | undefined) {
+  if (!workspaceId) {
+    return false;
+  }
+
+  if (ENABLED_FOR_ALL) {
+    return true;
+  }
+
+  return workspaceList.includes(workspaceId);
+}

--- a/app/modules/editor-v2/markdoc-utils.ts
+++ b/app/modules/editor-v2/markdoc-utils.ts
@@ -1,0 +1,289 @@
+import Markdoc from "@markdoc/markdoc";
+import MarkdownIt from "markdown-it";
+import {
+  defaultMarkdownParser,
+  defaultMarkdownSerializer,
+  MarkdownParser,
+  MarkdownSerializer,
+} from "prosemirror-markdown";
+import { Fragment, Schema, type Node as ProseMirrorNode, type NodeSpec } from "prosemirror-model";
+import { schema as basicSchema } from "prosemirror-schema-basic";
+import { addListNodes } from "prosemirror-schema-list";
+
+const RAW_BLOCK_PLACEHOLDER_PREFIX = "⟦raw:";
+const RAW_BLOCK_PLACEHOLDER_REGEX = /⟦raw:(\d+)⟧/;
+
+const SUPPORTED_MARKDOC_TYPES = new Set([
+  "document",
+  "paragraph",
+  "inline",
+  "text",
+  "strong",
+  "em",
+  "link",
+  "code",
+  "list",
+  "item",
+  "heading",
+  "blockquote",
+  "hr",
+  "fence",
+]);
+
+interface RawBlock {
+  id: number;
+  content: string;
+}
+
+const rawBlockSpec: NodeSpec = {
+  group: "block",
+  atom: true,
+  selectable: true,
+  attrs: {
+    raw: { default: "" },
+  },
+  parseDOM: [
+    {
+      tag: "div[data-raw-block]",
+      getAttrs: (dom) => ({
+        raw: (dom as HTMLElement).getAttribute("data-raw-content") ?? "",
+      }),
+    },
+  ],
+  toDOM: (node) => [
+    "div",
+    {
+      "data-raw-block": "true",
+      "data-raw-content": node.attrs.raw,
+      class: "pm-raw-block",
+    },
+    ["pre", { "aria-label": "Unsupported Markdoc block" }, node.attrs.raw],
+  ],
+};
+
+let cachedSchema: Schema | null = null;
+const serializerCache = new WeakMap<Schema, MarkdownSerializer>();
+
+function buildSchema(): Schema {
+  const headingSpec = {
+    ...basicSchema.spec.nodes.get("heading")!,
+    attrs: { level: { default: 1 } },
+    parseDOM: [
+      { tag: "h1", attrs: { level: 1 } },
+      { tag: "h2", attrs: { level: 2 } },
+      { tag: "h3", attrs: { level: 3 } },
+      { tag: "h4", attrs: { level: 4 } },
+    ],
+    toDOM(node: ProseMirrorNode) {
+      const level = Math.min(Math.max(node.attrs.level, 1), 4);
+      return ["h" + level, 0];
+    },
+  } satisfies NodeSpec;
+
+  let nodes = basicSchema.spec.nodes;
+  nodes = nodes.update("heading", headingSpec);
+  nodes = addListNodes(nodes, "paragraph block*", "block");
+  nodes = nodes.append({ raw_block: rawBlockSpec });
+
+  return new Schema({ nodes, marks: basicSchema.spec.marks });
+}
+
+function getSerializer(schema: Schema): MarkdownSerializer {
+  let serializer = serializerCache.get(schema);
+  if (serializer) {
+    return serializer;
+  }
+
+  serializer = new MarkdownSerializer(
+    {
+      ...defaultMarkdownSerializer.nodes,
+      bullet_list(state, node) {
+        state.renderList(node, "", () => "- ");
+      },
+      raw_block(state, node) {
+        state.ensureNewLine();
+        state.write(node.attrs.raw ?? "");
+        state.closeBlock(node);
+      },
+    },
+    defaultMarkdownSerializer.marks,
+  );
+
+  serializerCache.set(schema, serializer);
+  return serializer;
+}
+
+function createMarkdownParser(schema: Schema, _rawBlocks: RawBlock[]): MarkdownParser {
+  const tokenizer = new MarkdownIt("commonmark", { html: false, breaks: false });
+  const tokens = {
+    ...defaultMarkdownParser.tokens,
+  } satisfies MarkdownParser["tokens"];
+
+  return new MarkdownParser(schema, tokenizer as any, tokens as any);
+}
+
+interface RawSegment {
+  start: number;
+  end: number;
+  content: string;
+}
+
+function computeLineOffsets(markdoc: string): number[] {
+  const offsets: number[] = [0];
+  for (let index = 0; index < markdoc.length; index += 1) {
+    if (markdoc[index] === "\n") {
+      offsets.push(index + 1);
+    }
+  }
+  offsets.push(markdoc.length);
+  return offsets;
+}
+
+function toSegments(markdoc: string): RawSegment[] {
+  const ast = Markdoc.parse(markdoc);
+  const offsets = computeLineOffsets(markdoc);
+  const segments: RawSegment[] = [];
+
+  function visit(node: any) {
+    if (!node) {
+      return;
+    }
+
+    if (!SUPPORTED_MARKDOC_TYPES.has(node.type) && node.inline === false) {
+      const lines: number[] = Array.isArray(node.lines) ? node.lines : [];
+      if (lines.length > 0) {
+        const startLine = Math.min(...lines);
+        const endLine = Math.max(...lines);
+        const start = offsets[Math.max(startLine, 0)] ?? 0;
+        const end = offsets[Math.max(endLine, 0)] ?? markdoc.length;
+        const content = markdoc.slice(start, end);
+        segments.push({ start, end, content });
+        return;
+      }
+    }
+
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        visit(child);
+      }
+    }
+  }
+
+  visit(ast);
+  segments.sort((a, b) => a.start - b.start);
+
+  const deduped: RawSegment[] = [];
+  let lastEnd = -1;
+  for (const segment of segments) {
+    if (segment.start >= lastEnd) {
+      deduped.push(segment);
+      lastEnd = segment.end;
+    }
+  }
+
+  return deduped;
+}
+
+function normalizeRawBlocks(markdoc: string): { text: string; rawBlocks: RawBlock[] } {
+  const segments = toSegments(markdoc);
+  if (segments.length === 0) {
+    return { text: markdoc, rawBlocks: [] };
+  }
+
+  const rawBlocks: RawBlock[] = [];
+  let cursor = 0;
+  let normalized = "";
+
+  segments.forEach((segment) => {
+    if (segment.start < cursor) {
+      return;
+    }
+
+    const id = rawBlocks.length;
+    rawBlocks.push({ id, content: segment.content });
+    normalized += markdoc.slice(cursor, segment.start);
+    if (normalized.length > 0 && !normalized.endsWith("\n")) {
+      normalized += "\n";
+    }
+    const trailingMatch = segment.content.match(/\n*$/);
+    const trailingNewlines = trailingMatch ? trailingMatch[0].length : 0;
+    const requiredTrailing = trailingNewlines >= 2 ? trailingNewlines : 2;
+    const placeholder = `${RAW_BLOCK_PLACEHOLDER_PREFIX}${id}⟧`;
+    normalized += `${placeholder}${"\n".repeat(requiredTrailing)}`;
+    cursor = segment.end;
+  });
+
+  normalized += markdoc.slice(cursor);
+
+  return { text: normalized, rawBlocks };
+}
+
+function replaceRawPlaceholders(
+  node: ProseMirrorNode,
+  schema: Schema,
+  rawBlocks: RawBlock[],
+): ProseMirrorNode {
+  let changed = false;
+  const children: ProseMirrorNode[] = [];
+
+  node.forEach((child) => {
+    let nextNode = child;
+
+    if (child.type.name === "paragraph" && child.childCount === 1) {
+      const first = child.child(0);
+      const text = first.isText ? first.text?.trim() : undefined;
+      const match = text ? text.match(RAW_BLOCK_PLACEHOLDER_REGEX) : null;
+      if (match) {
+        const index = Number.parseInt(match[1], 10);
+        const raw = rawBlocks[index]?.content ?? "";
+        nextNode = schema.nodes.raw_block.create({ raw });
+        changed = true;
+        children.push(nextNode);
+        return;
+      }
+    }
+
+    const replacedChild = replaceRawPlaceholders(child, schema, rawBlocks);
+    if (replacedChild !== child) {
+      nextNode = replacedChild;
+      changed = true;
+    }
+    children.push(nextNode);
+  });
+
+  if (!changed) {
+    return node;
+  }
+
+  return node.copy(Fragment.from(children));
+}
+
+export function createEditorSchema(): Schema {
+  if (!cachedSchema) {
+    cachedSchema = buildSchema();
+  }
+  return cachedSchema;
+}
+
+export function parseMarkdoc(markdoc: string, schema: Schema): ProseMirrorNode {
+  const { text, rawBlocks } = normalizeRawBlocks(markdoc);
+  const parser = createMarkdownParser(schema, rawBlocks);
+  const doc = parser.parse(text);
+  return replaceRawPlaceholders(doc, schema, rawBlocks);
+}
+
+export function serializeMarkdoc(doc: ProseMirrorNode, schema: Schema): string {
+  const serializer = getSerializer(schema);
+  const output = serializer.serialize(doc, { tightLists: true });
+  return output.endsWith("\n") ? output : `${output}\n`;
+}
+
+export function countRawBlocks(doc: ProseMirrorNode): number {
+  let count = 0;
+  doc.descendants((node) => {
+    if (node.type.name === "raw_block") {
+      count += 1;
+    }
+  });
+  return count;
+}

--- a/app/utils/env.ts
+++ b/app/utils/env.ts
@@ -20,6 +20,7 @@ declare global {
       FULL_CALENDAR_LICENSE_KEY: string;
       SHOW_HOW_DID_YOU_FIND_US: string;
       COLLECT_BUSINESS_INTEL: string;
+      EDITOR_V2_WORKSPACES: string;
     };
   }
 }
@@ -60,6 +61,7 @@ declare global {
       FULL_CALENDAR_LICENSE_KEY: string;
       SHOW_HOW_DID_YOU_FIND_US: string;
       COLLECT_BUSINESS_INTEL: string;
+      EDITOR_V2_WORKSPACES: string;
     }
   }
 }
@@ -200,6 +202,11 @@ export const FULL_CALENDAR_LICENSE_KEY = getEnv("FULL_CALENDAR_LICENSE_KEY", {
   isSecret: false,
 });
 
+export const EDITOR_V2_WORKSPACES = getEnv("EDITOR_V2_WORKSPACES", {
+  isSecret: false,
+  isRequired: false,
+});
+
 export const MAINTENANCE_MODE =
   getEnv("MAINTENANCE_MODE", {
     isSecret: false,
@@ -268,5 +275,6 @@ export function getBrowserEnv() {
     FREE_TRIAL_DAYS,
     SUPPORT_EMAIL,
     FULL_CALENDAR_LICENSE_KEY,
+    EDITOR_V2_WORKSPACES,
   };
 }

--- a/docs/editor-v2/schema-mapping.md
+++ b/docs/editor-v2/schema-mapping.md
@@ -1,0 +1,55 @@
+# Editor V2 Schema Mapping
+
+The Editor V2 ProseMirror schema intentionally mirrors the Markdown/Markdoc nodes that we already support in Shelf. The goal is to guarantee a lossless round-trip when converting between Markdoc and ProseMirror, while also preserving unsupported blocks verbatim via the raw block node.
+
+## Block Nodes
+
+| ProseMirror Node       | Markdown/Markdoc Equivalent       | Notes |
+| ---------------------- | --------------------------------- | ----- |
+| `doc`                  | document root                     | unchanged |
+| `paragraph`            | paragraph (`<p>`)                 | default block |
+| `heading` (level 1–4)  | `#`–`####`                        | limited to 4 levels to match product needs |
+| `bullet_list`          | unordered list (`-` / `*`)        | child nodes are `list_item` |
+| `ordered_list`         | ordered list (`1.` etc.)          | supports `order` attribute from Markdown |
+| `list_item`            | list item                         | used inside ordered/bullet lists |
+| `blockquote`           | blockquote (`>`)                  | wraps paragraphs or other blocks |
+| `horizontal_rule`      | divider (`---`)                   | serialized as `---` |
+| `code_block` (`fence`) | fenced code block (`\`\`\``)     | optional language attribute preserved |
+| `raw_block`            | unsupported Markdoc nodes         | stores untouched source text |
+
+## Inline Nodes / Marks
+
+| ProseMirror Mark | Markdown/Markdoc Syntax | Notes |
+| ---------------- | ------------------------ | ----- |
+| `strong`         | `**bold**`               | keyboard shortcut `Cmd/Ctrl+B` |
+| `em`             | `*italic*`               | keyboard shortcut `Cmd/Ctrl+I` |
+| `code`           | `` `inline code` ``      | styled inline node |
+| `link`           | `[text](url)`            | sanitized URL, optional dialog |
+
+## Raw Blocks
+
+Unsupported Markdoc tags (callouts, custom components, etc.) are normalized into placeholder paragraphs during parsing. After the Markdown is parsed, placeholders are replaced with dedicated `raw_block` nodes whose `raw` attribute stores the original Markdoc snippet. Serializing the document writes the raw text back verbatim, preserving whitespace and structure.
+
+Raw blocks are rendered in the editor as bordered, monospace boxes with an “Edit source” button. Editing the block opens a dialog where the raw Markdoc can be updated directly.
+
+## Input Rules and Shortcuts
+
+Common Markdown triggers map to their respective node transformations:
+
+- `#`, `##`, `###`, `####` → headings 1–4
+- `- ` / `* ` → bullet list
+- `1. ` → ordered list
+- `> ` → blockquote
+- `---` → horizontal rule
+- `Shift+Enter` → hard line break
+- `Cmd/Ctrl+B` → bold mark
+- `Cmd/Ctrl+I` → italic mark
+- `Cmd/Ctrl+K` → link dialog
+
+Slash commands (`/h1`, `/h2`, `/ul`, `/ol`, `/quote`, `/divider`) execute the same ProseMirror commands, ensuring identical serialization output.
+
+## Serialization
+
+`serializeMarkdoc` reuses ProseMirror’s Markdown serializer with custom handlers for bullet lists and raw blocks. After every edit we serialize the document back to Markdoc, guaranteeing that the stored value matches what downstream Markdoc consumers expect.
+
+For detailed implementation, see [`app/modules/editor-v2/markdoc-utils.ts`](../../app/modules/editor-v2/markdoc-utils.ts).

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,18 @@
         "pigeon-maps": "^0.21.6",
         "pino": "^8.19.0",
         "pino-pretty": "^10.3.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.5.0",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-markdown": "^1.13.2",
+        "prosemirror-model": "^1.25.3",
+        "prosemirror-schema-basic": "^1.2.4",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-transform": "^1.10.4",
+        "prosemirror-view": "^1.41.2",
         "qrcode-generator": "^1.4.4",
         "react": "18.2.0",
         "react-day-picker": "^8.10.0",
@@ -10184,7 +10196,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
@@ -10226,7 +10237,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/mdx": {
@@ -11695,7 +11705,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -18186,6 +18195,15 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -18479,6 +18497,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -18694,6 +18729,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/media-query-parser": {
       "version": "2.0.2",
@@ -20686,6 +20727,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/outdent": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
@@ -22030,6 +22077,142 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
+      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
+      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
+      "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-markdown/node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
+      "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.4.tgz",
+      "integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.2.tgz",
+      "integrity": "sha512-PGS/jETmh+Qjmre/6vcG7SNHAKiGc4vKOJmHMPRmvcUl7ISuVtrtHmH06UDUwaim4NDJfZfVMl7U7JkMMETa6g==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -22108,6 +22291,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -23274,6 +23466,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.47.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -25635,6 +25833,12 @@
         "node": "*"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
@@ -27011,6 +27215,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,19 @@
     "tiny-invariant": "^1.3.1",
     "ua-parser-js": "^1.0.37",
     "zod": "^3.22.4",
-    "zxing-wasm": "^2.0.1"
+    "zxing-wasm": "^2.0.1",
+    "prosemirror-commands": "^1.7.1",
+    "prosemirror-gapcursor": "^1.3.2",
+    "prosemirror-history": "^1.4.1",
+    "prosemirror-inputrules": "^1.5.0",
+    "prosemirror-keymap": "^1.2.3",
+    "prosemirror-markdown": "^1.13.2",
+    "prosemirror-model": "^1.25.3",
+    "prosemirror-schema-basic": "^1.2.4",
+    "prosemirror-schema-list": "^1.5.1",
+    "prosemirror-state": "^1.4.3",
+    "prosemirror-transform": "^1.10.4",
+    "prosemirror-view": "^1.41.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/test/modules/editor-v2/markdoc-roundtrip.test.ts
+++ b/test/modules/editor-v2/markdoc-roundtrip.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countRawBlocks,
+  createEditorSchema,
+  parseMarkdoc,
+  serializeMarkdoc,
+} from "~/modules/editor-v2/markdoc-utils";
+
+const schema = createEditorSchema();
+
+describe("EditorV2 Markdoc round trip", () => {
+  it("round-trips supported nodes and marks", () => {
+    const source = [
+      "# Title",
+      "",
+      "Paragraph with **bold**, *italic*, `code`, and [link](https://example.com).",
+      "",
+      "## Heading 2",
+      "",
+      "- Item one",
+      "- Item two",
+      "",
+      "1. First",
+      "2. Second",
+      "",
+      "> Quote line",
+      ">",
+      "> Another line",
+      "",
+      "---",
+      "",
+    ].join("\n");
+
+    const parsed = parseMarkdoc(source, schema);
+
+    expect(parsed.type.name).toBe("doc");
+    expect(parsed.childCount).toBeGreaterThan(0);
+    expect(countRawBlocks(parsed)).toBe(0);
+
+    const serialized = serializeMarkdoc(parsed, schema);
+    expect(serialized).toEqual(source);
+  });
+
+  it("preserves unsupported markdoc tags as raw blocks", () => {
+    const source = [
+      "Paragraph before",
+      "",
+      "{% callout title=\"Heads up\" %}",
+      "Content inside",
+      "{% /callout %}",
+      "",
+      "Paragraph after",
+      "",
+    ].join("\n");
+
+    const parsed = parseMarkdoc(source, schema);
+
+    expect(countRawBlocks(parsed)).toBe(1);
+
+    const serialized = serializeMarkdoc(parsed, schema);
+    expect(serialized).toEqual(source);
+  });
+});


### PR DESCRIPTION
## Summary
- add a ProseMirror-powered EditorV2 with formatting toolbar, selection bubble, slash commands, raw block node view, and telemetry logging
- switch the MarkdownEditor to EditorV2 behind the EditorV2 workspace flag and surface sanitized link editing
- document the schema mapping and extend Markdoc utilities for raw block normalization and round-trip serialization

## Testing
- npm run typecheck
- npm run test -- markdoc-roundtrip


------
https://chatgpt.com/codex/tasks/task_b_68e667f9f81883268c1fcf6178d59e44