### PR TITLE
refactor: remove timestamp from duplicated assets name

### DIFF
--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -1729,7 +1729,7 @@ export async function duplicateAsset({
     for (const i of [...Array(amountOfDuplicates)].keys()) {
       const duplicatedAsset = await createAsset({
         ...payload,
-        title: `${asset.title} (copy ${amountOfDuplicates > 1 ? i : ""})`,
+        title: `${asset.title} (copy ${amountOfDuplicates > 1 ? i + 1 : ""})`,
         customFieldsValues: extractedCustomFieldValues,
       });
 


### PR DESCRIPTION
There was a timestamp appended to the name of each duplicated asset. This is not necessary and was causing frustrations
and confusion with users.