### PR TITLE
fix: include all custom field values in asset search

### DIFF
--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -98,6 +98,7 @@ import {
 import { resolveTeamMemberName } from "~/utils/user";
 import { assetIndexFields } from "./fields";
 import {
+  CUSTOM_FIELD_SEARCH_PATHS,
   assetQueryFragment,
   assetQueryJoins,
   assetReturnFragment,
@@ -527,11 +528,13 @@ export async function getAssets(params: {
           {
             customFields: {
               some: {
-                value: {
-                  path: ["valueText"],
-                  string_contains: term,
-                  mode: "insensitive",
-                },
+                OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
+                  value: {
+                    path: [jsonPath],
+                    string_contains: term,
+                    mode: "insensitive",
+                  },
+                })),
               },
             },
           },

--- a/app/utils/stripe.server.ts
+++ b/app/utils/stripe.server.ts
@@ -155,7 +155,7 @@ export async function createStripeCheckoutSession({
   }
 }
 
-/** 
+/**
  * Fetches prices and products from Stripe. Returns empty arrays when premium features are disabled.
  */
 export async function getStripePricesAndProducts() {


### PR DESCRIPTION
Custom fields search was broken. This change makes sure the search properly searches in all custom field values inside the json so that results are returned based on the search query.