### PR TITLE
fix: allow booking extension when returned assets have conflicts

### DIFF
--- a/app/components/booking/extend-booking-dialog.tsx
+++ b/app/components/booking/extend-booking-dialog.tsx
@@ -129,6 +129,9 @@ export default function ExtendBookingDialog({
               />
 
               <When truthy={!!fetcher?.data?.error}>
+                <div className="text-sm text-error-500">
+                  {fetcher?.data?.error?.message}
+                </div>
                 {fetcher.data?.error?.additionalData?.clashingBookings && (
                   <ul className="mb-4 mt-1 list-inside list-disc pl-4">
                     {(


### PR DESCRIPTION
Fixed bug where extending partially returned bookings failed if already-returned assets were reserved/checked-out in other bookings. The extension validation now only checks conflicts for actively checked-out assets, not returned ones.

Also fixed extend booking dialog to properly display error messages before the clashing bookings list.

Changes:
- Filter assets to only active (CHECKED_OUT/IN_CUSTODY) status
- Exclude assets in partialCheckins from conflict validation
- Use database join for partialCheckins data (performance)
- Add validation to prevent extension when all assets are returned
- Add 4 comprehensive test cases for partial return scenarios
- Display error message in extend booking dialog

Performance: Optimized to use single query with join instead of separate queries for partial checkin data.