### PR TITLE
fix: resolve select-all bug with filters in advanced mode

### DIFF
--- a/app/modules/asset/bulk-operations-helper.server.ts
+++ b/app/modules/asset/bulk-operations-helper.server.ts
@@ -1,0 +1,163 @@
+import type { Asset, AssetIndexSettings } from "@prisma/client";
+import { Prisma } from "@prisma/client";
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+import { getParamsValues, ALL_SELECTED_KEY } from "~/utils/list";
+import { generateWhereClause, parseFilters } from "./query.server";
+import { getAssetsWhereInput } from "./utils.server";
+import type { Column } from "../asset-index-settings/helpers";
+
+const label = "Assets";
+
+/**
+ * Gets asset IDs matching advanced filters - optimized for bulk operations
+ *
+ * Uses the same filter parsing and where clause generation as the advanced
+ * paginated query, but returns only IDs without expensive joins/aggregations.
+ *
+ * NOTE: Still requires the same LEFT JOINs as main query because
+ * generateWhereClause can reference joined tables (e.g., c.name, t.id, tm.name)
+ *
+ * @param organizationId - Organization to scope query
+ * @param filters - URL search params string with advanced filters
+ * @param settings - Asset index settings with columns configuration
+ * @param availableToBookOnly - Filter to bookable assets only (for self-service)
+ * @returns Promise resolving to array of asset IDs matching the filters
+ */
+async function getAdvancedFilteredAssetIds({
+  organizationId,
+  filters,
+  settings,
+  availableToBookOnly = false,
+}: {
+  organizationId: string;
+  filters: string;
+  settings: AssetIndexSettings;
+  availableToBookOnly?: boolean;
+}): Promise<string[]> {
+  try {
+    const searchParams = new URLSearchParams(filters);
+    const paramsValues = getParamsValues(searchParams);
+    const { search } = paramsValues;
+
+    const settingColumns = settings.columns as Column[];
+    const parsedFilters = parseFilters(filters, settingColumns);
+
+    // Generate WHERE clause (reuses existing logic)
+    const whereClause = generateWhereClause(
+      organizationId,
+      search,
+      parsedFilters,
+      undefined, // no specific assetIds filter
+      availableToBookOnly
+    );
+
+    // Minimal query: only SELECT id, but include necessary joins
+    // Joins are needed because WHERE clause may reference: c.name, l.name, t.id, tm.name, etc.
+    const query = Prisma.sql`
+      SELECT DISTINCT a.id
+      FROM public."Asset" a
+      LEFT JOIN public."Category" c ON a."categoryId" = c.id
+      LEFT JOIN public."Location" l ON a."locationId" = l.id
+      LEFT JOIN public."_AssetToTag" att ON a.id = att."A"
+      LEFT JOIN public."Tag" t ON att."B" = t.id
+      LEFT JOIN public."Custody" cu ON cu."assetId" = a.id
+      LEFT JOIN public."TeamMember" tm ON cu."teamMemberId" = tm.id
+      LEFT JOIN public."User" u ON tm."userId" = u.id
+      ${whereClause}
+    `;
+
+    const results = await db.$queryRaw<Array<{ id: string }>>(query);
+    return results.map((r) => r.id);
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Something went wrong while fetching asset IDs",
+      additionalData: { organizationId, filters, availableToBookOnly },
+      label,
+    });
+  }
+}
+
+/**
+ * Resolves asset IDs for bulk operations in both simple and advanced modes
+ *
+ * This is the single source of truth for determining which assets to operate on
+ * when performing bulk operations. It handles three scenarios:
+ *
+ * 1. Specific selection: Returns provided IDs as-is
+ * 2. Select all (simple mode): Queries with simple filters (status, category, tags, etc.)
+ * 3. Select all (advanced mode): Queries with advanced filters (custom fields, operators)
+ *
+ * @param assetIds - Array of asset IDs (may contain ALL_SELECTED_KEY)
+ * @param organizationId - Organization ID to scope query
+ * @param currentSearchParams - URL search params string with active filters
+ * @param settings - Asset index settings (determines mode and columns)
+ * @returns Promise resolving to array of asset IDs to operate on
+ *
+ * @example
+ * // Specific selection
+ * const ids = await resolveAssetIdsForBulkOperation({
+ *   assetIds: ["id1", "id2", "id3"],
+ *   organizationId,
+ *   currentSearchParams: null,
+ *   settings,
+ * });
+ * // Returns: ["id1", "id2", "id3"]
+ *
+ * @example
+ * // Select all with filters in advanced mode
+ * const ids = await resolveAssetIdsForBulkOperation({
+ *   assetIds: ["all-selected"],
+ *   organizationId,
+ *   currentSearchParams: "cf_SerialNumber=contains:ABC&status=is:AVAILABLE",
+ *   settings: { mode: "ADVANCED", columns: [...] },
+ * });
+ * // Returns: ["id1", "id5", "id12"] // All assets matching filters
+ */
+export async function resolveAssetIdsForBulkOperation({
+  assetIds,
+  organizationId,
+  currentSearchParams,
+  settings,
+}: {
+  assetIds: Asset["id"][];
+  organizationId: Asset["organizationId"];
+  currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
+}): Promise<string[]> {
+  // Case 1: Specific selection - return IDs as-is
+  if (!assetIds.includes(ALL_SELECTED_KEY)) {
+    return assetIds;
+  }
+
+  // Case 2: Select all - use mode from settings
+  // IMPORTANT: We must respect settings.mode as the source of truth
+  // If someone has advanced syntax in URL but settings say SIMPLE,
+  // we ignore the advanced filters (they may be from old bookmark/shared link)
+  const isAdvancedMode = settings.mode === "ADVANCED";
+
+  if (isAdvancedMode && currentSearchParams) {
+    // ADVANCED MODE: Use dedicated function for advanced filters
+    return getAdvancedFilteredAssetIds({
+      organizationId,
+      filters: currentSearchParams,
+      settings,
+      availableToBookOnly: false, // Set based on user role if needed
+    });
+  } else {
+    // SIMPLE MODE: Use simple where clause
+    // Note: getAssetsWhereInput will safely ignore any advanced filter syntax
+    const where = getAssetsWhereInput({
+      organizationId,
+      currentSearchParams,
+    });
+
+    const assets = await db.asset.findMany({
+      where,
+      select: { id: true },
+    });
+
+    return assets.map((a) => a.id);
+  }
+}

--- a/app/modules/asset/data.server.ts
+++ b/app/modules/asset/data.server.ts
@@ -75,6 +75,18 @@ export async function simpleModeLoader({
 }: Props) {
   const { locale, timeZone } = getClientHint(request);
   const isSelfService = role === OrganizationRoles.SELF_SERVICE;
+
+  // Check if URL contains advanced filter syntax (from browser back button or old bookmark)
+  const urlParams = getCurrentSearchParams(request).toString();
+  const hasAdvancedSyntax =
+    /(is|contains|gt|lt|gte|lte|eq|ne|startsWith|endsWith):/.test(urlParams);
+
+  if (hasAdvancedSyntax) {
+    // URL has advanced syntax but we're in simple mode - redirect to clean URL
+    // This handles browser back button after mode switch
+    return redirect("/assets");
+  }
+
   /** Parse filters */
   const {
     filters,

--- a/app/modules/asset/service.server.ts
+++ b/app/modules/asset/service.server.ts
@@ -81,7 +81,7 @@ import { getCurrentSearchParams } from "~/utils/http.server";
 import { id } from "~/utils/id/id.server";
 import * as importImageCacheServer from "~/utils/import.image-cache.server";
 import type { CachedImage } from "~/utils/import.image-cache.server";
-import { ALL_SELECTED_KEY, getParamsValues } from "~/utils/list";
+import { getParamsValues } from "~/utils/list";
 import { Logger } from "~/utils/logger";
 import {
   wrapUserLinkForNote,
@@ -96,6 +96,7 @@ import {
 } from "~/utils/storage.server";
 
 import { resolveTeamMemberName } from "~/utils/user";
+import { resolveAssetIdsForBulkOperation } from "./bulk-operations-helper.server";
 import { assetIndexFields } from "./fields";
 import {
   CUSTOM_FIELD_SEARCH_PATHS,
@@ -118,7 +119,6 @@ import type {
 } from "./types";
 import {
   formatAssetsRemindersDates,
-  getAssetsWhereInput,
   getLocationUpdateNoteContent,
   getCustomFieldUpdateNoteContent,
   detectPotentialChanges,
@@ -2755,25 +2755,31 @@ export async function bulkDeleteAssets({
   organizationId,
   userId,
   currentSearchParams,
+  settings,
 }: {
   assetIds: Asset["id"][];
   organizationId: Asset["organizationId"];
   userId: User["id"];
   currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
 }) {
   try {
-    /**
-     * If we are selecting all assets in list then we have to consider other filters too
-     */
-    const where: Prisma.AssetWhereInput = assetIds.includes(ALL_SELECTED_KEY)
-      ? getAssetsWhereInput({ organizationId, currentSearchParams })
-      : { id: { in: assetIds }, organizationId };
+    // Resolve IDs (works for both simple and advanced mode)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
 
     /**
      * We have to remove the images of assets so we have to make this query first
      */
     const assets = await db.asset.findMany({
-      where,
+      where: {
+        id: { in: resolvedIds },
+        organizationId,
+      },
       select: { id: true, mainImage: true },
     });
 
@@ -2823,6 +2829,7 @@ export async function bulkCheckOutAssets({
   custodianName,
   organizationId,
   currentSearchParams,
+  settings,
 }: {
   userId: User["id"];
   assetIds: Asset["id"][];
@@ -2830,21 +2837,26 @@ export async function bulkCheckOutAssets({
   custodianName: TeamMember["name"];
   organizationId: Asset["organizationId"];
   currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
 }) {
   try {
-    /**
-     * If we are selecting all assets in list then we have to consider other filters too
-     */
-    const where: Prisma.AssetWhereInput = assetIds.includes(ALL_SELECTED_KEY)
-      ? getAssetsWhereInput({ organizationId, currentSearchParams })
-      : { id: { in: assetIds }, organizationId };
+    // Resolve IDs (works for both simple and advanced mode)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
 
     /**
      * In order to make notes for the assets we have to make this query to get info about assets
      */
     const [assets, user, custodianTeamMember] = await Promise.all([
       db.asset.findMany({
-        where,
+        where: {
+          id: { in: resolvedIds },
+          organizationId,
+        },
         select: { id: true, title: true, status: true },
       }),
       getUserByID(userId, {
@@ -2946,26 +2958,32 @@ export async function bulkCheckInAssets({
   assetIds,
   organizationId,
   currentSearchParams,
+  settings,
 }: {
   userId: User["id"];
   assetIds: Asset["id"][];
   organizationId: Asset["organizationId"];
   currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
 }) {
   try {
-    /**
-     * If we are selecting all assets in list then we have to consider other filters too
-     */
-    const where: Prisma.AssetWhereInput = assetIds.includes(ALL_SELECTED_KEY)
-      ? getAssetsWhereInput({ organizationId, currentSearchParams })
-      : { id: { in: assetIds }, organizationId };
+    // Resolve IDs (works for both simple and advanced mode)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
 
     /**
      * In order to make notes for the assets we have to make this query to get info about assets
      */
     const [assets, user] = await Promise.all([
       db.asset.findMany({
-        where,
+        where: {
+          id: { in: resolvedIds },
+          organizationId,
+        },
         select: {
           id: true,
           title: true,
@@ -3065,25 +3083,31 @@ export async function bulkUpdateAssetLocation({
   organizationId,
   newLocationId,
   currentSearchParams,
+  settings,
 }: {
   userId: User["id"];
   assetIds: Asset["id"][];
   organizationId: Asset["organizationId"];
   newLocationId?: Location["id"] | null;
   currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
 }) {
   try {
-    /**
-     * If we are selecting all assets in list then we have to consider other filters too
-     */
-    const where: Prisma.AssetWhereInput = assetIds.includes(ALL_SELECTED_KEY)
-      ? getAssetsWhereInput({ organizationId, currentSearchParams })
-      : { id: { in: assetIds }, organizationId };
+    // Resolve IDs (works for both simple and advanced mode)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
 
     /** We have to create notes for all the assets so we have make this query */
     const [assets, user] = await Promise.all([
       db.asset.findMany({
-        where,
+        where: {
+          id: { in: resolvedIds },
+          organizationId,
+        },
         select: {
           id: true,
           title: true,
@@ -3179,23 +3203,29 @@ export async function bulkUpdateAssetCategory({
   organizationId,
   categoryId,
   currentSearchParams,
+  settings,
 }: {
   userId: string;
   assetIds: Asset["id"][];
   organizationId: Asset["organizationId"];
   categoryId: Asset["categoryId"];
   currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
 }) {
   try {
-    /**
-     * If we are selecting all assets in list then we have to consider other filters too
-     */
-    const where: Prisma.AssetWhereInput = assetIds.includes(ALL_SELECTED_KEY)
-      ? getAssetsWhereInput({ organizationId, currentSearchParams })
-      : { id: { in: assetIds }, organizationId };
+    // Resolve IDs (works for both simple and advanced mode)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
 
     await db.asset.updateMany({
-      where,
+      where: {
+        id: { in: resolvedIds },
+        organizationId,
+      },
       data: {
         /** If nothing is selected then we have to remove the relation and set category to null */
         categoryId: !categoryId ? null : categoryId,
@@ -3220,6 +3250,7 @@ export async function bulkAssignAssetTags({
   tagsIds,
   currentSearchParams,
   remove,
+  settings,
 }: {
   userId: string;
   assetIds: Asset["id"][];
@@ -3227,20 +3258,18 @@ export async function bulkAssignAssetTags({
   tagsIds: string[];
   currentSearchParams?: string | null;
   remove: boolean;
+  settings: AssetIndexSettings;
 }) {
   try {
-    const shouldUpdateAll = assetIds.includes(ALL_SELECTED_KEY);
-    let _assetIds = assetIds;
+    // Resolve IDs (works for both simple and advanced mode)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
 
-    if (shouldUpdateAll) {
-      const allOrgAssetIds = await db.asset.findMany({
-        where: getAssetsWhereInput({ organizationId, currentSearchParams }),
-        select: { id: true },
-      });
-      _assetIds = allOrgAssetIds.map((a) => a.id);
-    }
-
-    const updatePromises = _assetIds.map((id) =>
+    const updatePromises = resolvedIds.map((id) =>
       db.asset.update({
         where: { id, organizationId },
         data: {
@@ -3273,21 +3302,28 @@ export async function bulkMarkAvailability({
   assetIds,
   type,
   currentSearchParams,
+  settings,
 }: {
   organizationId: Asset["organizationId"];
   assetIds: Asset["id"][];
   type: "available" | "unavailable";
   currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
 }) {
   try {
-    /* If we are selecting all assets in list then we have to consider other filters too */
-    const where: Prisma.AssetWhereInput = assetIds.includes(ALL_SELECTED_KEY)
-      ? getAssetsWhereInput({ organizationId, currentSearchParams })
-      : { id: { in: assetIds }, organizationId };
+    // Resolve IDs (works for both simple and advanced mode)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
 
+    // Simple, consistent where clause
     await db.asset.updateMany({
       where: {
-        ...where,
+        id: { in: resolvedIds },
+        organizationId,
         availableToBook: type === "unavailable",
       },
       data: { availableToBook: type === "available" },

--- a/app/routes/_layout+/admin-dashboard+/org.$organizationId.assets.tsx
+++ b/app/routes/_layout+/admin-dashboard+/org.$organizationId.assets.tsx
@@ -8,6 +8,7 @@ import {
   updateAssetsWithBookingCustodians,
 } from "~/modules/asset/service.server";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
+import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
@@ -106,11 +107,18 @@ export async function action({ context, request }: ActionFunctionArgs) {
       "bulk-delete": PermissionAction.delete,
     };
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, canUseBarcodes } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.asset,
       action: intent2ActionMap[intent],
+    });
+
+    // Fetch asset index settings to determine mode
+    const settings = await getAssetIndexSettings({
+      userId,
+      organizationId,
+      canUseBarcodes,
     });
 
     switch (intent) {
@@ -127,6 +135,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
           organizationId,
           userId,
           currentSearchParams,
+          settings,
         });
 
         sendNotification({

--- a/app/routes/_layout+/assets._index.tsx
+++ b/app/routes/_layout+/assets._index.tsx
@@ -157,11 +157,18 @@ export async function action({ context, request }: ActionFunctionArgs) {
       "bulk-delete": PermissionAction.delete,
     };
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, canUseBarcodes } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.asset,
       action: intent2ActionMap[intent],
+    });
+
+    // Fetch asset index settings to determine mode
+    const settings = await getAssetIndexSettings({
+      userId,
+      organizationId,
+      canUseBarcodes,
     });
 
     switch (intent) {
@@ -178,6 +185,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
           organizationId,
           userId,
           currentSearchParams,
+          settings,
         });
 
         sendNotification({

--- a/app/routes/api+/assets.bulk-assign-tags.ts
+++ b/app/routes/api+/assets.bulk-assign-tags.ts
@@ -2,6 +2,7 @@ import { json, type ActionFunctionArgs } from "@remix-run/node";
 import { BulkUpdateTagsSchema } from "~/components/assets/bulk-assign-tags-dialog";
 import { bulkAssignAssetTags } from "~/modules/asset/service.server";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
+import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -28,11 +29,18 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     const formData = await request.formData();
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, canUseBarcodes } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.asset,
       action: PermissionAction.update,
+    });
+
+    // Fetch asset index settings to determine mode
+    const settings = await getAssetIndexSettings({
+      userId,
+      organizationId,
+      canUseBarcodes,
     });
 
     // Validate form data using combined schema
@@ -52,6 +60,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
       organizationId,
       currentSearchParams,
       remove,
+      settings,
     });
 
     sendNotification({

--- a/app/routes/api+/assets.bulk-remove-from-kits.ts
+++ b/app/routes/api+/assets.bulk-remove-from-kits.ts
@@ -1,6 +1,7 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { BulkRemoveFromKitsSchema } from "~/components/assets/bulk-remove-from-kits";
+import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { bulkRemoveAssetsFromKits } from "~/modules/kit/service.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
@@ -17,11 +18,18 @@ export async function action({ context, request }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, canUseBarcodes } = await requirePermission({
       request,
       userId,
       entity: PermissionEntity.asset,
       action: PermissionAction.update,
+    });
+
+    // Fetch asset index settings to determine mode
+    const settings = await getAssetIndexSettings({
+      userId,
+      organizationId,
+      canUseBarcodes,
     });
 
     const { assetIds } = parseData(
@@ -37,6 +45,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
       userId,
       organizationId,
       request,
+      settings,
     });
 
     sendNotification({

--- a/docs/select-all-pattern.md
+++ b/docs/select-all-pattern.md
@@ -50,10 +50,19 @@ Every bulk operation using `ALL_SELECTED_KEY` follows this pattern:
 1. Component Layer (Button/Form)
    ↓ Passes: assetIds + currentSearchParams
 2. Route/API Layer (Loader/Action)
-   ↓ Extracts and forwards parameters
+   ↓ Fetches settings + Extracts and forwards parameters
 3. Service Layer (Business Logic)
-   ↓ Builds where clause with getAssetsWhereInput
+   ↓ Uses resolveAssetIdsForBulkOperation helper (handles both simple & advanced mode)
 ```
+
+### Important: Simple vs Advanced Mode
+
+Shelf has two index modes that require different filtering approaches:
+
+- **Simple Mode**: Uses Prisma where clauses (`Prisma.AssetWhereInput`)
+- **Advanced Mode**: Uses raw SQL queries with filter parsing
+
+The `resolveAssetIdsForBulkOperation` helper (see below) handles both modes automatically, ensuring consistent behavior across all bulk operations.
 
 ### 1. Component Layer: Pass Search Params
 
@@ -105,122 +114,201 @@ export function ExportAssetsButton() {
 **Key Requirements:**
 
 - Extract both `assetIds` and `currentSearchParams` from request
-- Pass both to service layer functions
-- Use a descriptive parameter name (e.g., `assetIndexCurrentSearchParams`)
+- **Fetch asset index settings** using `getAssetIndexSettings`
+- Use `canUseBarcodes` from `requirePermission` (don't access `currentOrganization.barcodesEnabled`)
+- Pass settings to service layer functions
+- Use a descriptive parameter name (e.g., `currentSearchParams`)
 
-**Example:** `app/routes/_layout+/assets.export.$fileName[.csv].tsx`
+**Example:** `app/routes/api+/assets.bulk-mark-availability.ts`
 
 ```typescript
-export const loader = async ({ context, request }: LoaderFunctionArgs) => {
-  const searchParams = getCurrentSearchParams(request);
-  const assetIds = searchParams.get("assetIds");
-  const assetIndexCurrentSearchParams = searchParams.get(
-    "assetIndexCurrentSearchParams"
+import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
+
+export async function action({ context, request }: ActionFunctionArgs) {
+  const { userId } = context.getSession();
+
+  // Get canUseBarcodes directly from requirePermission
+  const { organizationId, canUseBarcodes } = await requirePermission({
+    request,
+    userId,
+    entity: PermissionEntity.asset,
+    action: PermissionAction.update,
+  });
+
+  // Fetch asset index settings to determine mode (SIMPLE or ADVANCED)
+  const settings = await getAssetIndexSettings({
+    userId,
+    organizationId,
+    canUseBarcodes, // Use from requirePermission, not currentOrganization.barcodesEnabled
+  });
+
+  const { assetIds, type, currentSearchParams } = parseData(
+    await request.formData(),
+    BulkMarkAvailabilitySchema.and(CurrentSearchParamsSchema)
   );
 
-  const csvString = await exportAssetsFromIndexToCsv({
-    request,
+  await bulkMarkAvailability({
+    organizationId,
     assetIds,
-    settings,
-    currentOrganization,
-    assetIndexCurrentSearchParams, // Pass filter context
+    type,
+    currentSearchParams, // Pass filter context
+    settings, // Pass settings for mode detection
   });
 
-  return new Response(csvString, {
-    status: 200,
-    headers: { "content-type": "text/csv" },
-  });
-};
-```
-
-### 3. Service Layer: Build Where Clause
-
-**Key Requirements:**
-
-- Check if `assetIds` includes `ALL_SELECTED_KEY`
-- When true, use `currentSearchParams` to build filter where clause
-- Use `getAssetsWhereInput` helper (or equivalent for other entities)
-- When false, use specific IDs only
-
-**Example:** `app/utils/csv.server.ts`
-
-```typescript
-import { ALL_SELECTED_KEY } from "./list";
-import { getAssetsWhereInput } from "~/modules/asset/utils.server";
-
-export async function exportAssetsFromIndexToCsv({
-  request,
-  assetIds,
-  settings,
-  currentOrganization,
-  assetIndexCurrentSearchParams,
-}: {
-  request: Request;
-  assetIds: string;
-  settings: AssetIndexSettings;
-  currentOrganization: Pick<
-    Organization,
-    "id" | "barcodesEnabled" | "currency"
-  >;
-  assetIndexCurrentSearchParams: string | null;
-}) {
-  // Make an array of the ids and check if we have to take all
-  const ids = assetIds.split(",");
-  const takeAll = ids.includes(ALL_SELECTED_KEY);
-
-  /**
-   * When taking all with filters (select all button), use the current page's search params
-   * Otherwise, use cookie-based filters from the request
-   */
-  const filtersToUse =
-    takeAll && assetIndexCurrentSearchParams
-      ? assetIndexCurrentSearchParams
-      : (
-          await getAdvancedFiltersFromRequest(
-            request,
-            currentOrganization.id,
-            settings
-          )
-        ).filters;
-
-  const { assets } = await getAdvancedPaginatedAndFilterableAssets({
-    request,
-    organizationId: currentOrganization.id,
-    filters: filtersToUse,
-    settings,
-    takeAll,
-    assetIds: takeAll ? undefined : ids,
-    canUseBarcodes: currentOrganization.barcodesEnabled ?? false,
-  });
-
-  // ... build and return CSV
+  return json(data({ success: true }));
 }
 ```
 
-**Alternative Pattern (for simpler cases):**
+**Important Notes:**
 
-When not using advanced filters, directly use `getAssetsWhereInput`:
+- ✅ Always use `canUseBarcodes` from `requirePermission`
+- ❌ Never use `currentOrganization.barcodesEnabled`
+- ✅ Fetch settings in every route that does bulk operations
+- ✅ Pass `settings` to service functions for mode detection
+
+### 3. Service Layer: Use the Helper Function
+
+**Key Requirements:**
+
+- Use `resolveAssetIdsForBulkOperation` helper to resolve IDs
+- Import the helper at the **top of the file** (no dynamic imports)
+- Pass `assetIds`, `organizationId`, `currentSearchParams`, and `settings`
+- The helper automatically handles both Simple and Advanced modes
+- Use resolved IDs in your bulk operations
+
+**Example:** `app/modules/asset/service.server.ts`
 
 ```typescript
-import { getAssetsWhereInput } from "~/modules/asset/utils.server";
+// ✅ Import at top of file
+import { resolveAssetIdsForBulkOperation } from "./bulk-operations-helper.server";
 
-// In your service function
-const assetIds = searchParams.getAll("assetIds");
-
-// Build where clause based on ALL_SELECTED_KEY
-const where: Prisma.AssetWhereInput = assetIds.includes(ALL_SELECTED_KEY)
-  ? getAssetsWhereInput({
+export async function bulkMarkAvailability({
+  organizationId,
+  assetIds,
+  type,
+  currentSearchParams,
+  settings,
+}: {
+  organizationId: Asset["organizationId"];
+  assetIds: Asset["id"][];
+  type: "available" | "unavailable";
+  currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
+}) {
+  try {
+    // Step 1: Resolve IDs using the helper (handles both modes)
+    const resolvedIds = await resolveAssetIdsForBulkOperation({
+      assetIds,
       organizationId,
-      currentSearchParams: searchParams.toString(),
-    })
-  : { id: { in: assetIds }, organizationId };
+      currentSearchParams,
+      settings,
+    });
 
-const assets = await db.asset.findMany({ where });
+    // Step 2: Use resolved IDs in your bulk operation
+    await db.asset.updateMany({
+      where: {
+        id: { in: resolvedIds },
+        organizationId,
+        availableToBook: type === "unavailable",
+      },
+      data: { availableToBook: type === "available" },
+    });
+
+    return true;
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Failed to update asset availability",
+      additionalData: { assetIds, organizationId, type },
+      label: "Assets",
+    });
+  }
+}
 ```
 
-## Helper Function: getAssetsWhereInput
+**Important: No Dynamic Imports**
 
-Located in `app/modules/asset/utils.server.ts`, this function builds a Prisma where clause from URL search parameters:
+```typescript
+// ❌ WRONG - Do not use dynamic imports
+const { resolveAssetIdsForBulkOperation } = await import(
+  "./bulk-operations-helper.server"
+);
+
+// ✅ CORRECT - Import at top of file
+import { resolveAssetIdsForBulkOperation } from "./bulk-operations-helper.server";
+```
+
+## Helper Functions
+
+### resolveAssetIdsForBulkOperation
+
+**Location:** `app/modules/asset/bulk-operations-helper.server.ts`
+
+This is the **main helper** for all bulk operations. It automatically handles both Simple and Advanced modes.
+
+```typescript
+export async function resolveAssetIdsForBulkOperation({
+  assetIds,
+  organizationId,
+  currentSearchParams,
+  settings,
+}: {
+  assetIds: Asset["id"][];
+  organizationId: Asset["organizationId"];
+  currentSearchParams?: string | null;
+  settings: AssetIndexSettings;
+}): Promise<string[]> {
+  // Case 1: Specific selection - return IDs as-is
+  if (!assetIds.includes(ALL_SELECTED_KEY)) {
+    return assetIds;
+  }
+
+  // Case 2: Select all - resolve based on mode
+  const isAdvancedMode = settings.mode === "ADVANCED";
+
+  if (isAdvancedMode && currentSearchParams) {
+    // Advanced mode: Use raw SQL with filter parsing
+    return getAdvancedFilteredAssetIds({
+      organizationId,
+      currentSearchParams,
+      settings,
+    });
+  } else {
+    // Simple mode: Use Prisma where clause
+    const where = getAssetsWhereInput({
+      organizationId,
+      currentSearchParams,
+    });
+
+    const assets = await db.asset.findMany({
+      where,
+      select: { id: true },
+    });
+
+    return assets.map((a) => a.id);
+  }
+}
+```
+
+**How it works:**
+
+1. If `ALL_SELECTED_KEY` is **not** present → returns the provided IDs directly
+2. If `ALL_SELECTED_KEY` **is** present → resolves all matching IDs:
+   - **Advanced mode**: Uses `getAdvancedFilteredAssetIds` with raw SQL
+   - **Simple mode**: Uses `getAssetsWhereInput` with Prisma
+
+**Benefits:**
+
+- ✅ Single source of truth for ID resolution
+- ✅ Handles both modes automatically
+- ✅ Compatible with `updateMany`, `deleteMany`, etc.
+- ✅ Consistent behavior across all bulk operations
+
+### getAssetsWhereInput
+
+**Location:** `app/modules/asset/utils.server.ts`
+
+This function builds a Prisma where clause from URL search parameters (used in **Simple mode**):
 
 ```typescript
 export function getAssetsWhereInput({
@@ -270,33 +358,74 @@ export function getAssetsWhereInput({
 
 ## Existing Implementations
 
-Reference these working examples in the codebase:
+All asset bulk operations now use the `resolveAssetIdsForBulkOperation` helper pattern:
 
-### 1. Export Assets (Advanced Mode)
+### Asset Bulk Operations (Using Helper)
 
-- **Button:** `app/components/assets/assets-index/export-assets-button.tsx`
-- **Route:** `app/routes/_layout+/assets.export.$fileName[.csv].tsx`
-- **Service:** `app/utils/csv.server.ts` → `exportAssetsFromIndexToCsv`
+All these operations follow the same pattern shown above:
 
-### 2. Bulk Delete Assets
+1. **bulkMarkAvailability** - Mark assets as available/unavailable
 
-- **Action:** `app/routes/_layout+/assets._index.tsx` (action function)
-- **Service:** `app/modules/asset/service.server.ts` → `bulkDeleteAssets`
+   - Route: `app/routes/api+/assets.bulk-mark-availability.ts`
+   - Service: `app/modules/asset/service.server.ts`
 
-### 3. Bulk QR Code Download
+2. **bulkUpdateAssetLocation** - Update location for multiple assets
 
-- **API:** `app/routes/api+/assets.get-assets-for-bulk-qr-download.ts`
-- Uses `getAssetsWhereInput` directly
+   - Route: `app/routes/api+/assets.bulk-update-location.ts`
+   - Service: `app/modules/asset/service.server.ts`
 
-### 4. Export Bookings
+3. **bulkUpdateAssetCategory** - Update category for multiple assets
 
-- **Button:** `app/components/booking/export-bookings-button.tsx`
-- **Service:** `app/utils/csv.server.ts` → `exportBookingsFromIndexToCsv`
+   - Route: `app/routes/api+/assets.bulk-update-category.ts`
+   - Service: `app/modules/asset/service.server.ts`
 
-### 5. Export Team Members (NRMs)
+4. **bulkAssignAssetTags** - Assign/remove tags for multiple assets
 
-- **Button:** `app/components/nrm/export-nrm-button.tsx`
-- **Service:** `app/utils/csv.server.ts` → `exportNRMsToCsv`
+   - Route: `app/routes/api+/assets.bulk-assign-tags.ts`
+   - Service: `app/modules/asset/service.server.ts`
+
+5. **bulkCheckOutAssets** (bulkAssignCustody) - Assign custody
+
+   - Route: `app/routes/api+/assets.bulk-assign-custody.ts`
+   - Service: `app/modules/asset/service.server.ts`
+
+6. **bulkCheckInAssets** (bulkReleaseCustody) - Release custody
+
+   - Route: `app/routes/api+/assets.bulk-release-custody.ts`
+   - Service: `app/modules/asset/service.server.ts`
+
+7. **bulkRemoveAssetsFromKits** - Remove assets from kits
+
+   - Route: `app/routes/api+/assets.bulk-remove-from-kits.ts`
+   - Service: `app/modules/kit/service.server.ts`
+
+8. **bulkDeleteAssets** - Delete multiple assets
+   - Route: `app/routes/_layout+/assets._index.tsx` (action)
+   - Route: `app/routes/_layout+/admin-dashboard+/org.$organizationId.assets.tsx` (action)
+   - Service: `app/modules/asset/service.server.ts`
+
+### Other Select All Implementations
+
+These use different patterns appropriate to their use case:
+
+- **Export Assets** - Uses advanced filtering directly
+
+  - Button: `app/components/assets/assets-index/export-assets-button.tsx`
+  - Route: `app/routes/_layout+/assets.export.$fileName[.csv].tsx`
+  - Service: `app/utils/csv.server.ts` → `exportAssetsFromIndexToCsv`
+
+- **Bulk QR Code Download** - Uses `getAssetsWhereInput` directly
+
+  - API: `app/routes/api+/assets.get-assets-for-bulk-qr-download.ts`
+
+- **Export Bookings**
+
+  - Button: `app/components/booking/export-bookings-button.tsx`
+  - Service: `app/utils/csv.server.ts` → `exportBookingsFromIndexToCsv`
+
+- **Export Team Members (NRMs)**
+  - Button: `app/components/nrm/export-nrm-button.tsx`
+  - Service: `app/utils/csv.server.ts` → `exportNRMsToCsv`
 
 ## Common Pitfalls
 
@@ -403,17 +532,50 @@ if (allSelected) {
 **2. Route/API:**
 
 ```typescript
-const currentSearchParams = searchParams.get("currentSearchParams");
-// Pass to service layer
+import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
+
+// Get canUseBarcodes from requirePermission
+const { organizationId, canUseBarcodes } = await requirePermission({...});
+
+// Fetch settings
+const settings = await getAssetIndexSettings({
+  userId,
+  organizationId,
+  canUseBarcodes,
+});
+
+// Extract params
+const { assetIds, currentSearchParams } = parseData(formData, schema);
+
+// Pass to service
+await bulkOperation({
+  assetIds,
+  organizationId,
+  currentSearchParams,
+  settings,
+});
 ```
 
 **3. Service:**
 
 ```typescript
-const takeAll = ids.includes(ALL_SELECTED_KEY);
-const where = takeAll
-  ? getAssetsWhereInput({ organizationId, currentSearchParams })
-  : { id: { in: ids }, organizationId };
+import { resolveAssetIdsForBulkOperation } from "./bulk-operations-helper.server";
+
+// Resolve IDs (handles both Simple and Advanced mode)
+const resolvedIds = await resolveAssetIdsForBulkOperation({
+  assetIds,
+  organizationId,
+  currentSearchParams,
+  settings,
+});
+
+// Use resolved IDs in your operation
+await db.asset.updateMany({
+  where: { id: { in: resolvedIds }, organizationId },
+  data: {
+    /* your updates */
+  },
+});
 ```
 
 ## Related Documentation

--- a/test/routes-tests/api.assets.bulk-assign-custody.test.ts
+++ b/test/routes-tests/api.assets.bulk-assign-custody.test.ts
@@ -41,10 +41,18 @@ vi.mock("~/utils/http.server", () => ({
   parseData: vi.fn().mockImplementation((formData) => {
     const assetIds = JSON.parse(formData.get("assetIds") || "[]");
     const custodian = JSON.parse(formData.get("custodian") || "{}");
-    return { assetIds, custodian };
+    const currentSearchParams = formData.get("currentSearchParams") || null;
+    return { assetIds, custodian, currentSearchParams };
   }),
   data: vi.fn((x) => ({ success: true, ...x })),
   error: vi.fn((x) => ({ error: x })),
+}));
+
+// why: mocking asset index settings without database lookups
+vi.mock("~/modules/asset-index-settings/service.server", () => ({
+  getAssetIndexSettings: vi.fn().mockResolvedValue({
+    mode: "SIMPLE",
+  }),
 }));
 
 // why: mocking json response helper for testing route handler status codes
@@ -91,6 +99,7 @@ describe("api/assets/bulk-assign-custody", () => {
     requirePermissionMock.mockResolvedValue({
       organizationId: "org-1",
       role: OrganizationRoles.ADMIN,
+      canUseBarcodes: false,
     } as any);
 
     // Custodian not found due to org filter
@@ -130,6 +139,7 @@ describe("api/assets/bulk-assign-custody", () => {
     requirePermissionMock.mockResolvedValue({
       organizationId: "org-1",
       role: OrganizationRoles.ADMIN,
+      canUseBarcodes: false,
     } as any);
 
     // Valid team member from same org
@@ -172,6 +182,7 @@ describe("api/assets/bulk-assign-custody", () => {
     requirePermissionMock.mockResolvedValue({
       organizationId: "org-1",
       role: OrganizationRoles.SELF_SERVICE,
+      canUseBarcodes: false,
     } as any);
 
     // Valid team member from same org, but different user
@@ -208,6 +219,7 @@ describe("api/assets/bulk-assign-custody", () => {
     requirePermissionMock.mockResolvedValue({
       organizationId: "org-1",
       role: OrganizationRoles.SELF_SERVICE,
+      canUseBarcodes: false,
     } as any);
 
     // Valid team member from same org, same user


### PR DESCRIPTION
This commit fixes critical issues with the select-all pattern when using bulk operations across paginated results:

1. Select-all with filters in advanced mode now works correctly
   - Created `resolveAssetIdsForBulkOperation` helper that handles both simple and advanced filtering modes
   - Helper respects settings.mode as single source of truth
   - Updated all 8 bulk operations to use consistent pattern

2. Browser back button protection
   - Added validation in `simpleModeLoader` to detect advanced filter syntax in URL when user is in SIMPLE mode
   - Redirects to clean URL to prevent Prisma errors
   - Handles scenario: user switches mode → clicks back button → URL has wrong syntax for current mode

3. Code improvements
   - Removed dynamic imports (not allowed with Vite)
   - Changed routes to use `canUseBarcodes` directly from `requirePermission`
   - Updated documentation with new helper pattern
   - Fixed test mocks to include required settings parameter

Changes:
- New file: bulk-operations-helper.server.ts with ID resolution logic
- Updated: all bulk operation functions to accept settings parameter
- Updated: `simpleModeLoader` with URL validation
- Updated: 8 route files to fetch and pass settings
- Updated: select-all-pattern.md documentation
- Fixed: test mocks for bulk-assign-custody

All bulk operations affected:
- bulkMarkAvailability
- bulkUpdateLocation
- bulkUpdateCategory
- bulkAssignTags
- bulkAssignCustody
- bulkReleaseCustody
- bulkRemoveFromKits
- bulkDeleteAssets

Resolves issue where advanced filters like status=is:AVAILABLE caused invalid Prisma queries when user's settings were in SIMPLE mode.