### PR TITLE
fix: autocomplete hints in login form

### DIFF
--- a/app/routes/_auth+/login.tsx
+++ b/app/routes/_auth+/login.tsx
@@ -156,7 +156,7 @@ export default function IndexLoginForm() {
             autoFocus={true}
             name={zo.fields.email()}
             type="email"
-            autoComplete="email"
+            autoComplete="username"
             disabled={disabled}
             inputClassName="w-full"
             error={zo.errors.email()?.message || data?.error.message}
@@ -167,7 +167,7 @@ export default function IndexLoginForm() {
           placeholder="**********"
           data-test-id="password"
           name={zo.fields.password()}
-          autoComplete="new-password"
+          autoComplete="current-password"
           disabled={disabled}
           inputClassName="w-full"
           error={zo.errors.password()?.message || data?.error.message}


### PR DESCRIPTION
Email username fields should use `autocomplete="username"`, not `autocomplete="email"`. There's a comment from a W3C autofill spec contributor here that clarifies this: https://github.com/whatwg/html/issues/4445#issuecomment-552040052

Without these changes, the password manager I use (KeePassXC) refuses to autofill the login form.

Thank you!