### PR TITLE
feat: add fallback invite link to email

### DIFF
--- a/app/emails/invite-template.test.ts
+++ b/app/emails/invite-template.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { invitationTemplateString } from "~/emails/invite-template";
+import type { InviteWithInviterAndOrg } from "~/modules/invite/types";
+
+const invite = {
+  id: "invite-id",
+  inviteeEmail: "carlos@example.com",
+  inviter: {
+    firstName: "Alice",
+    lastName: "Doe",
+  },
+  organization: {
+    name: "Shelf Org",
+  },
+} as InviteWithInviterAndOrg;
+
+describe("invitationTemplateString", () => {
+  it("includes a fallback invite URL", () => {
+    const token = "test-token";
+    const html = invitationTemplateString({
+      invite,
+      token,
+      extraMessage: null,
+    });
+
+    const expectedUrl = `${process.env.SERVER_URL}/accept-invite/${invite.id}?token=${token}`;
+
+    expect(html).toContain(
+      `Or paste this link into your browser: ${expectedUrl}`
+    );
+  });
+});

--- a/app/emails/invite-template.tsx
+++ b/app/emails/invite-template.tsx
@@ -89,6 +89,10 @@ export function InvitationEmailTemplate({
           >
             Accept the invite
           </Button>
+          <Text style={{ ...styles.p, margin: "16px 0" }}>
+            Or paste this link into your browser:{" "}
+            {`${SERVER_URL}/accept-invite/${invite.id}?token=${token}`}
+          </Text>
           <Text style={{ ...styles.p, marginBottom: "24px" }}>
             Once you’re done setting up your account, you'll be able to access
             the workspace and start exploring features like Asset Explorer,


### PR DESCRIPTION
## Summary
- add fallback invite link text to the workspace invitation email
- cover the invitation email renderer with a test that asserts the fallback URL

## Testing
- npm run test -- invite-template

------
https://chatgpt.com/codex/tasks/task_b_6902007dbc18832687a11ece54111bc3