### PR TITLE
feat(email): allow SMTP configuration without authentication

### DIFF
--- a/app/emails/transporter.server.ts
+++ b/app/emails/transporter.server.ts
@@ -15,16 +15,23 @@ declare global {
   var __transporter__: nodemailer.Transporter;
 }
 
+/**
+ * Authentication is required when both SMTP_USER and SMTP_PWD are provided
+ */
+const requiresAuth = SMTP_USER !== "" && SMTP_PWD !== "";
+
 /** We store the port so we can then dynamically set the value of the secure field */
 const port = parseInt(SMTP_PORT) || 465;
 const transporterSettings = {
   host: SMTP_HOST,
   port,
   secure: port === 465, // true for 465, false for other ports
-  auth: {
-    user: SMTP_USER,
-    pass: SMTP_PWD,
-  },
+  ...(requiresAuth && {
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PWD,
+    },
+  }),
   tls: {
     // do not fail on invalid certs
     rejectUnauthorized: true,


### PR DESCRIPTION
Enable nodemailer to work with SMTP servers that don't require authentication. When both SMTP_USER and SMTP_PWD are empty strings, the auth configuration is now conditionally omitted from the transporter settings.

This allows using local SMTP servers or relay services that rely on IP-based authentication rather than username/password credentials.