### PR TITLE
fix: booking navigating with command palette

### DIFF
--- a/app/components/booking/forms/edit-booking-form.tsx
+++ b/app/components/booking/forms/edit-booking-form.tsx
@@ -309,6 +309,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
             <div className="w-full lg:w-2/5">
               <div>
                 <NameField
+                  key={id}
                   name={name || undefined}
                   fieldName={zo.fields.name()}
                   disabled={
@@ -327,6 +328,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
               </div>
               <div className="mt-[10px]">
                 <DatesFields
+                  key={`${id}-dates`}
                   startDate={startDate}
                   startDateName={zo.fields.startDate()}
                   startDateError={
@@ -347,6 +349,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
               </div>
               <div className="mt-[10px]">
                 <CustodianField
+                  key={`${id}-custodian`}
                   defaultTeamMember={defaultTeamMember}
                   disabled={
                     disabled ||
@@ -370,6 +373,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
                 )}
               >
                 <TagField
+                  key={`${id}-tags`}
                   disabled={
                     disabled ||
                     isLoadingWorkingHours ||
@@ -387,6 +391,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
                 />
 
                 <DescriptionField
+                  key={`${id}-description`}
                   description={description || undefined}
                   fieldName={zo.fields.description()}
                   disabled={


### PR DESCRIPTION
Added `key` prop to all the fields so when navigating between booking pages using command palette the fields get properly re-rendered.