### PR TITLE
feat: implement logMissingFormIntent in order to improve logging of errors on the booking page

### DIFF
--- a/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -83,6 +83,7 @@ import {
   parseData,
 } from "~/utils/http.server";
 import { getParamsValues } from "~/utils/list";
+import { logMissingFormIntent } from "~/utils/logger";
 import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import {
   PermissionAction,
@@ -496,6 +497,8 @@ export const handle = {
   name: "bookings.$bookingId.overview",
 };
 
+
+
 export type BookingPageActionData = typeof action;
 
 export async function action({ context, request, params }: ActionFunctionArgs) {
@@ -511,6 +514,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
   try {
     const formData = await request.formData();
+    logMissingFormIntent({ formData, request, bookingId: id, userId });
     const { intent, checkoutIntentChoice, checkinIntentChoice } = parseData(
       formData,
       z.object({

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -82,3 +82,70 @@ export class RequestTimeLogger {
     Logger.log(`${this.label} took ${duration}ms`);
   }
 }
+
+
+/**
+ * Log the full context when a form submission reaches the server without the expected `intent` field.
+ *
+ * Excludes sensitive headers (cookies/authorization) but preserves all other request metadata and the form payload so we
+ * can diagnose client issues after the fact.
+ */
+export function logMissingFormIntent({
+  formData,
+  request,
+  bookingId,
+  userId,
+}: {
+  formData: FormData;
+  request: Request;
+  bookingId: string;
+  userId: string;
+}) {
+  const intent = formData.get("intent");
+  if (typeof intent === "string" && intent.length > 0) {
+    return;
+  }
+
+  const safeHeaders = Object.fromEntries(
+    Array.from(request.headers.entries()).filter(
+      ([key]) => !["cookie", "authorization"].includes(key.toLowerCase())
+    )
+  );
+
+  const formSnapshot: Record<string, unknown> = {};
+  for (const [key, value] of formData.entries()) {
+    const isFile = typeof File !== "undefined" && value instanceof File;
+    const serialisedValue = isFile
+      ? {
+          kind: "file" as const,
+          name: value.name,
+          size: value.size,
+          type: value.type,
+        }
+      : value;
+
+    if (formSnapshot[key] === undefined) {
+      formSnapshot[key] = serialisedValue;
+    } else if (Array.isArray(formSnapshot[key])) {
+      (formSnapshot[key] as unknown[]).push(serialisedValue);
+    } else {
+      formSnapshot[key] = [formSnapshot[key], serialisedValue];
+    }
+  }
+
+  Logger.error({
+    name: "BookingIntentMissing",
+    message:
+      "Form submitted without an intent field. Capturing request snapshot for investigation.",
+    shouldBeCaptured: true,
+    additionalData: {
+      bookingId,
+      userId,
+      requestUrl: request.url,
+      method: request.method,
+      headers: safeHeaders,
+      formKeys: Array.from(new Set(Array.from(formData.keys()))),
+      formSnapshot,
+    },
+  });
+}


### PR DESCRIPTION
We are having some errors on the booking overview page when a user performs a POST, that say that the intent is missing. After investigating we couldn't find how that is possible so we are implementing a few custom logger function to specifically handle this case so we can get more advanced logs