### PR TITLE
feat(assets): add visual indicators for required custom fields on edit page

### DIFF
--- a/app/components/forms/form-row.tsx
+++ b/app/components/forms/form-row.tsx
@@ -4,7 +4,7 @@ import SubHeading from "../shared/sub-heading";
 
 interface Props {
   /** Label to be rendered on the left side of the row */
-  rowLabel: string;
+  rowLabel: string | ReactNode;
   children: ReactNode;
   className?: string;
   subHeading?: string | JSX.Element;


### PR DESCRIPTION
Improve UX for users editing assets by surfacing required custom field
requirements immediately on page load, before form submission attempts.

Previously, users were unaware of required custom fields until they tried
to save changes, leading to unexpected validation errors appearing below
the fold. This implementation provides clear, immediate feedback about
which fields must be completed.

Features:
- Display error state for empty required custom fields on page load
- Add "Required by admin" badge to distinguish custom required fields
  from base required fields (e.g., asset name)
- Show warning banner when required custom fields are incomplete
- Maintain existing form validation behavior on submission

Technical changes:
- Updated FormRow component to accept ReactNode for flexible labels
- Optimized custom field value retrieval with useCallback/useMemo
- Added client-side validation for required field detection

The implementation is frontend-only with no backend or database changes.
Only users with asset update permissions are affected, as the edit page
already requires this permission at the route level.
