### PR TITLE
fix(assets): prevent Sentry spam from transient Supabase HTML errors

### DIFF
--- a/app/routes/api+/asset.refresh-main-image.ts
+++ b/app/routes/api+/asset.refresh-main-image.ts
@@ -203,12 +203,22 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         });
       } catch (error) {
         // If it fails, log the error and keep the existing URL
+        // Preserve shouldBeCaptured flag if it's already a ShelfError
+        const shouldCapture =
+          error &&
+          typeof error === "object" &&
+          "shouldBeCaptured" in error &&
+          typeof error.shouldBeCaptured === "boolean"
+            ? error.shouldBeCaptured
+            : true;
+
         Logger.error(
           new ShelfError({
             cause: error,
             message: `Failed to refresh main image URL for asset ${assetId}`,
             additionalData: { assetId, mainImagePath, userId },
             label: "Assets",
+            shouldBeCaptured: shouldCapture,
           })
         );
       }
@@ -227,12 +237,22 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
             bucketName: "assets",
           });
         } catch (error) {
+          // Preserve shouldBeCaptured flag if it's already a ShelfError
+          const shouldCapture =
+            error &&
+            typeof error === "object" &&
+            "shouldBeCaptured" in error &&
+            typeof error.shouldBeCaptured === "boolean"
+              ? error.shouldBeCaptured
+              : true;
+
           Logger.error(
             new ShelfError({
               cause: error,
               message: `Failed to refresh thumbnail URL for asset ${assetId}`,
               additionalData: { assetId, thumbnailPath, userId },
               label: "Assets",
+              shouldBeCaptured: shouldCapture,
             })
           );
         }


### PR DESCRIPTION
When Supabase returns HTML error pages (504 timeouts, CDN errors) instead of JSON, the storage client throws StorageUnknownError. Previously, even after retry attempts, these errors were sent to Sentry.

Changes:
- Mark persistent HTML errors as shouldBeCaptured: false in createSignedUrl
- Preserve shouldBeCaptured flag when wrapping errors in refresh-main-image
- Add specific error type for better debugging (persistent_html_error)
- Ensure ShelfErrors are re-thrown as-is to preserve their flags

This prevents transient Supabase infrastructure issues from spamming Sentry while still logging them for debugging and gracefully falling back to existing URLs.

Fixes Sentry issue #7059127706