### PR TITLE
fix: reverting docker version to node:22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base Node image
-FROM node:22.20.0-bookworm-slim AS base
+FROM node:22-bookworm-slim AS base
 
 # Set for base and all layer that inherit from it
 ENV PORT="8080"


### PR DESCRIPTION
For some reason when we had set the docker version to `node:22.20.0` that caused the app to non-stop crash. Its similar to an issue we had some time ago with updating node version. It seems like fly is having issues with some specific node versions.