### PR TITLE
feat(admin): add account status column to users dashboard

### DIFF
--- a/app/modules/user/service.server.ts
+++ b/app/modules/user/service.server.ts
@@ -98,8 +98,8 @@ export async function getUserByID(
       ...(select
         ? { select }
         : include
-          ? { include }
-          : { select: { id: true } }),
+        ? { include }
+        : { select: { id: true } }),
     });
 
     return user;

--- a/app/utils/storage.server.ts
+++ b/app/utils/storage.server.ts
@@ -93,10 +93,9 @@ export async function createSignedUrl({
           Logger.warn(
             new ShelfError({
               cause: error,
-              message:
-                isHtmlError
-                  ? "Supabase returned a non-JSON response while creating a signed URL. Retrying."
-                  : "Supabase request failed while creating a signed URL. Retrying.",
+              message: isHtmlError
+                ? "Supabase returned a non-JSON response while creating a signed URL. Retrying."
+                : "Supabase request failed while creating a signed URL. Retrying.",
               additionalData: {
                 filename: normalizedFilename,
                 bucketName,


### PR DESCRIPTION
Add a new 'Account Status' column to the admin dashboard users table
that displays user role, subscription stage, and trial information in a
single consolidated view.

The status column shows:
- User role (Owner/Member) based on organization ownership or OWNER
  role in UserOrganization
- Subscription stage (Trial/Free/Paid) with specific plan information
  (Plus/Team/Custom)
- Trial end date when applicable (e.g., "Trial - ends Jan 21")

This helps admins quickly identify:
- Who to contact (Owner vs Member)
- Conversion stage (Trial vs Free vs Paid)
- Urgency (Trial end date for follow-up)

Changes:
- Update getPaginatedAndFilterableUsers to include userOrganizations
  with roles and organization details
- Add Stripe subscription fetching in admin users loader to retrieve
  trial end dates from active subscriptions
- Implement getAccountStatus helper function to determine appropriate
  status label based on role, tier, and subscription
- Add Account Status column to users table between Tier and Created at

Example statuses displayed:
- "Owner (Trial - ends Jan 21)"
- "Member (Invited to trial)"
- "Owner (Free)"
- "Owner (Paid - Team)"
- "Member (Invited to paid)"
