### PR TITLE
Add email search to team members filter

### DIFF
--- a/app/modules/settings/service.server.ts
+++ b/app/modules/settings/service.server.ts
@@ -55,6 +55,7 @@ export async function getPaginatedAndFilterableSettingUsers({
         OR: [
           { firstName: { contains: search, mode: "insensitive" } },
           { lastName: { contains: search, mode: "insensitive" } },
+          { email: { contains: search, mode: "insensitive" } },
         ],
       };
     }

--- a/app/routes/_layout+/settings.team.users.tsx
+++ b/app/routes/_layout+/settings.team.users.tsx
@@ -92,6 +92,11 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
       totalPages,
       modelName,
       organization,
+      searchFieldLabel: "Search by name or email",
+      searchFieldTooltip: {
+        title: "Search team members",
+        text: "Search team members by first name, last name, or email address.",
+      },
     };
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });


### PR DESCRIPTION
## Summary
Enhanced the team members search functionality to include email addresses, allowing users to find team members by their email in addition to first and last names.

## Changes
- **Backend**: Updated `getPaginatedAndFilterableSettingUsers` to include email field in the search filter with case-insensitive matching
- **Frontend**: Updated the settings team users page to:
  - Add descriptive label "Search by name or email" to the search field
  - Include a tooltip explaining the search capability covers first name, last name, and email address

## Implementation Details
- Email search uses the same case-insensitive pattern matching as existing name fields
- User-facing text clearly communicates the expanded search scope through both the field label and tooltip