### PR TITLE
fix: add action to admin transfer ownership route and make component dynamic

### DIFF
--- a/app/components/settings/transfer-ownership-card.tsx
+++ b/app/components/settings/transfer-ownership-card.tsx
@@ -35,6 +35,10 @@ import When from "../when/when";
 
 type TransferOwnershipCardProps = {
   className?: string;
+  /** Form action URL. Defaults to "/settings/general" */
+  action?: string;
+  /** Organization name for confirmation input. If not provided, uses currentOrganization from context */
+  organizationName?: string;
 };
 
 export const TransferOwnershipSchema = z.object({
@@ -53,6 +57,8 @@ export const TransferOwnershipSchema = z.object({
 
 export default function TransferOwnershipCard({
   className,
+  action = "/settings/general",
+  organizationName,
 }: TransferOwnershipCardProps) {
   const { admins } = useLoaderData<typeof loader>();
   const { isOwner } = useUserRoleHelper();
@@ -63,6 +69,9 @@ export default function TransferOwnershipCard({
   >(null);
   const disabled = useDisabled();
   const currentOrganization = useCurrentOrganization();
+
+  // Use provided organizationName or fall back to currentOrganization
+  const confirmationOrgName = organizationName ?? currentOrganization?.name;
 
   const zo = useZorm("TransferOwnership", TransferOwnershipSchema);
 
@@ -114,7 +123,7 @@ export default function TransferOwnershipCard({
               method="POST"
               encType="multipart/form-data"
               ref={zo.ref}
-              action="/settings/general"
+              action={action}
             >
               <input type="hidden" name="intent" value="transfer-ownership" />
 
@@ -177,7 +186,7 @@ export default function TransferOwnershipCard({
                     }}
                   />
                   <p className="text-sm text-gray-500">
-                    Expected input: {currentOrganization?.name}
+                    Expected input: {confirmationOrgName}
                   </p>
                 </div>
 
@@ -222,7 +231,7 @@ export default function TransferOwnershipCard({
                   disabled={
                     !selectedOwner
                       ? { reason: "Please select a new owner." }
-                      : confirmationInput !== currentOrganization?.name
+                      : confirmationInput !== confirmationOrgName
                       ? {
                           reason: "Please type the workspace name to confirm.",
                         }

--- a/app/routes/_layout+/admin-dashboard+/org.$organizationId.transfer-ownership.tsx
+++ b/app/routes/_layout+/admin-dashboard+/org.$organizationId.transfer-ownership.tsx
@@ -1,10 +1,23 @@
-import { data, type LoaderFunctionArgs } from "react-router";
+import {
+  data,
+  redirect,
+  useLoaderData,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from "react-router";
 import z from "zod";
-import TransferOwnershipCard from "~/components/settings/transfer-ownership-card";
-import { getOrganizationAdmins } from "~/modules/organization/service.server";
+import TransferOwnershipCard, {
+  TransferOwnershipSchema,
+} from "~/components/settings/transfer-ownership-card";
+import {
+  getOrganizationAdmins,
+  getOrganizationById,
+  transferOwnership,
+} from "~/modules/organization/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
-import { error, getParams, payload } from "~/utils/http.server";
+import { error, getParams, parseData, payload } from "~/utils/http.server";
 import { requireAdmin } from "~/utils/roles.server";
 
 export const meta = () => [
@@ -20,18 +33,83 @@ export async function loader({ context, params }: LoaderFunctionArgs) {
 
   try {
     await requireAdmin(userId);
-    const admins = await getOrganizationAdmins({ organizationId });
-    return payload({ admins });
+
+    // Fetch admins for the select dropdown and organization for the confirmation input
+    const [admins, organization] = await Promise.all([
+      getOrganizationAdmins({ organizationId }),
+      getOrganizationById(organizationId),
+    ]);
+
+    return payload({
+      admins,
+      organizationId,
+      organizationName: organization.name,
+    });
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
     throw data(error(reason), { status: reason.status });
   }
 }
 
+/**
+ * Handles the transfer ownership form submission.
+ *
+ * This action allows Shelf admins to transfer ownership of any organization
+ * to one of its existing admins. The flow:
+ * 1. Validates that the current user is a Shelf admin
+ * 2. Parses and validates the form data (new owner ID + confirmation checkbox)
+ * 3. Fetches the organization to get its details for the transfer
+ * 4. Calls transferOwnership which updates the org owner and swaps user roles
+ * 5. Sends a success notification and redirects back to the org page
+ */
+export async function action({ context, request, params }: ActionFunctionArgs) {
+  const { userId } = context.getSession();
+  const { organizationId } = getParams(
+    params,
+    z.object({ organizationId: z.string() })
+  );
+
+  try {
+    await requireAdmin(userId);
+
+    const formData = await request.formData();
+    const parsedData = parseData(formData, TransferOwnershipSchema, {
+      additionalData: { userId, organizationId },
+    });
+
+    // Fetch the organization to pass to transferOwnership
+    const currentOrganization = await getOrganizationById(organizationId);
+
+    // Transfer ownership: updates org owner and swaps roles between old and new owner
+    const { newOwner } = await transferOwnership({
+      currentOrganization,
+      newOwnerId: parsedData.newOwner,
+      userId,
+    });
+
+    sendNotification({
+      title: "Ownership transferred",
+      message: `You have successfully transferred ownership of ${currentOrganization.name} to ${newOwner.firstName} ${newOwner.lastName}`,
+      icon: { name: "success", variant: "success" },
+      senderId: userId,
+    });
+
+    return redirect(`/admin-dashboard/org/${organizationId}`);
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId, organizationId });
+    return data(error(reason), { status: reason.status });
+  }
+}
+
 export default function TransferOwnership() {
+  const { organizationId, organizationName } = useLoaderData<typeof loader>();
+
   return (
     <div>
-      <TransferOwnershipCard />
+      <TransferOwnershipCard
+        action={`/admin-dashboard/org/${organizationId}/transfer-ownership`}
+        organizationName={organizationName}
+      />
     </div>
   );
 }


### PR DESCRIPTION
- Add action handler to org.$organizationId.transfer-ownership.tsx that handles transfer-ownership intent for Shelf admins
- Loader now fetches both admins and organization data in parallel
- Make TransferOwnershipCard accept dynamic `action` and `organizationName` props for use in both settings and admin dashboard contexts
- Form action defaults to /settings/general for backward compatibility
- Organization name for confirmation falls back to context when not provided