### PR TITLE
fix(eslint): add root:true to prevent duplicate plugin resolution

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": [
     "@typescript-eslint",


### PR DESCRIPTION
ESLint traverses parent directories for config files, which causes a duplicate @typescript-eslint plugin error when using git worktrees. Adding root:true stops the upward config search.