### PR TITLE
fix: render duplicate barcode import errors as a grouped table

### DIFF
--- a/app/components/assets/import-content.tsx
+++ b/app/components/assets/import-content.tsx
@@ -529,7 +529,6 @@ function DuplicateBarcodesTable({ data }: { data: DuplicateBarcode[] }) {
         <thead>
           <Tr>
             <Th>Barcode</Th>
-            <Th>Type</Th>
             <Th>Used by assets</Th>
           </Tr>
         </thead>
@@ -537,12 +536,11 @@ function DuplicateBarcodesTable({ data }: { data: DuplicateBarcode[] }) {
           {data.map((barcode) => (
             <Tr key={barcode.value}>
               <Td className="align-top">{barcode.value}</Td>
-              <Td className="align-top">{barcode.type}</Td>
               <Td className="whitespace-normal">
                 <ul className="list-disc pl-4">
                   {barcode.assets.map((asset, i) => (
                     <li key={i}>
-                      {asset.title}: Line {asset.row}
+                      {asset.title} ({asset.type}): Line {asset.row}
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
Replace the comma-separated string of duplicate barcodes with a structured table showing each duplicate barcode, its type, and all assets using it with their CSV line numbers.

- Add DuplicateBarcode type for reuse across service and UI
- Track all assets per barcode value instead of only the last
- Add CSV row numbers to help users locate duplicates
- Render a DuplicateBarcodesTable with bullet-listed assets