### PR TITLE
fix(assets): make Enter key trigger save instead of add another

### DIFF
--- a/app/components/assets/form.tsx
+++ b/app/components/assets/form.tsx
@@ -603,16 +603,17 @@ const Actions = ({
   referer?: string | null;
 }) => (
   <>
+    {/* Save button is first in DOM order so Enter key triggers it by default */}
+    <Button type="submit" disabled={disabled} className="order-last">
+      Save
+    </Button>
+
     <ButtonGroup>
       <Button to={referer} variant="secondary" disabled={disabled}>
         Cancel
       </Button>
       <AddAnother disabled={disabled} />
     </ButtonGroup>
-
-    <Button type="submit" disabled={disabled}>
-      Save
-    </Button>
   </>
 );
 


### PR DESCRIPTION
Pressing Enter on the new asset form was triggering "Add another" instead of "Save" because browsers click the first submit button in DOM order. Reordered the Save button to appear first in the DOM and used CSS order-last to maintain the visual layout.