### PR TITLE
fix(import): handle missing category column in CSV import

### DIFF
--- a/app/modules/category/service.server.ts
+++ b/app/modules/category/service.server.ts
@@ -129,14 +129,9 @@ export async function createCategoriesIfNotExists({
     // first we get all the categories from the assets and make then into an object where the category is the key and the value is an empty string
     const categories = new Map(
       data
-        .filter((asset) => asset.category !== "")
+        .filter((asset) => asset.category)
         .map((asset) => [asset.category, ""])
     );
-
-    // Handle the case where there are no categories
-    if (categories.has(undefined)) {
-      return {};
-    }
 
     // now we loop through the categories and check if they exist
     for (const [category, _] of categories) {

--- a/app/modules/location/service.server.ts
+++ b/app/modules/location/service.server.ts
@@ -875,14 +875,9 @@ export async function createLocationsIfNotExists({
     // first we get all the locations from the assets and make then into an object where the category is the key and the value is an empty string
     const locations = new Map(
       data
-        .filter((asset) => asset.location !== "")
+        .filter((asset) => asset.location)
         .map((asset) => [asset.location, ""])
     );
-
-    // Handle the case where there are no teamMembers
-    if (locations.has(undefined)) {
-      return {};
-    }
 
     // now we loop through the locations and check if they exist
     for (const [location, _] of locations) {


### PR DESCRIPTION
When importing a CSV without a "category" column, the `createCategoriesIfNotExists` function fails because `asset.category` is `undefined`, which passes the `!== ""` filter. This causes `.trim()` to be called on `undefined`.

Added an undefined guard matching the existing pattern used in the location service (`createLocationsIfNotExists`).