### PR TITLE
fix: remove TEAM type filter from toggleBarcodeEnabled

### DIFF
--- a/app/modules/organization/service.server.ts
+++ b/app/modules/organization/service.server.ts
@@ -500,7 +500,7 @@ export async function toggleBarcodeEnabled({
 }) {
   try {
     return await db.organization.update({
-      where: { id: organizationId, type: OrganizationType.TEAM },
+      where: { id: organizationId },
       data: {
         barcodesEnabled,
         barcodesEnabledAt: barcodesEnabled ? new Date() : null,


### PR DESCRIPTION
The barcode toggle was filtering by `type: TEAM` in the Prisma where clause, causing a P2025 error when toggling barcodes on personal organizations. The type constraint is unnecessary since the admin dashboard should be able to toggle barcodes for any organization type.