### PR TITLE
ci: make test.yml backward-compatible with npm and pnpm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,13 @@ jobs:
         with:
           useLockFile: false
 
-      - name: 🔎 Type check
-        run: ${{ steps.pm.outputs.agent }} run typecheck --if-present
+      - name: 🔎 Type check (pnpm)
+        if: steps.pm.outputs.agent == 'pnpm'
+        run: pnpm run --if-present typecheck
+
+      - name: 🔎 Type check (npm)
+        if: steps.pm.outputs.agent == 'npm'
+        run: npm run typecheck --if-present
 
   vitest:
     needs: authorize


### PR DESCRIPTION
The pull_request_target trigger runs the base branch's workflow against the PR's code. Since the monorepo PR uses pnpm while main uses npm, CI needs to detect and handle both package managers.

Each job now detects the package manager by checking for pnpm-workspace.yaml, conditionally sets up pnpm, and runs the appropriate install/run commands.