### PR TITLE
ci: add Prisma generate step before vitest for pnpm path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,10 @@ jobs:
         with:
           useLockFile: false
 
+      - name: 🔧 Generate Prisma client
+        if: steps.pm.outputs.agent == 'pnpm'
+        run: pnpm --filter @shelf/database run db:generate
+
       - name: ⚡ Run vitest (pnpm)
         if: steps.pm.outputs.agent == 'pnpm'
         run: pnpm --filter @shelf/webapp test -- --run


### PR DESCRIPTION
The vitest command uses --filter to run directly in the webapp, bypassing turbo's task dependency graph. Unlike lint and typecheck which go through turbo (and get ^build deps resolved), vitest never triggers @shelf/database build, so Prisma types are missing.