### PR TITLE
fix: prevent client-side crash on user assets list page

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
@@ -25,7 +25,8 @@ export function useAssetAvailabilityData(items: Items) {
   const { timeZone } = useHints();
 
   const { resources, events } = useMemo(() => {
-    const resources = items.map((item) => ({
+    const safeItems = items ?? [];
+    const resources = safeItems.map((item) => ({
       id: item.id,
       title: item.title,
       extendedProps: {
@@ -38,7 +39,7 @@ export function useAssetAvailabilityData(items: Items) {
       },
     }));
 
-    const events = items
+    const events = safeItems
       .map((asset) => {
         if (!asset.bookings) {
           return [];

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -23,7 +23,7 @@ import {
   TagUseFor,
 } from "@prisma/client";
 import { LRUCache } from "lru-cache";
-import { redirect, type LoaderFunctionArgs } from "react-router";
+import type { LoaderFunctionArgs } from "react-router";
 import { extractStoragePath } from "~/components/assets/asset-image/utils";
 import type {
   SortingDirection,
@@ -3952,16 +3952,11 @@ export async function getUserAssetsTabLoaderData({
   organizationId: Organization["id"];
 }) {
   try {
-    const { filters, redirectNeeded } = await getFiltersFromRequest(
+    const { filters } = await getFiltersFromRequest(
       request,
       organizationId,
       { name: "assetFilter_v2", path: "/" } // Use root path for RR7 single fetch
     );
-
-    if (filters && redirectNeeded) {
-      const cookieParams = new URLSearchParams(filters);
-      return redirect(`/assets?${cookieParams.toString()}`);
-    }
 
     const filtersSearchParams = new URLSearchParams(filters);
     filtersSearchParams.set("teamMember", userId);


### PR DESCRIPTION
Remove erroneous redirect in `getUserAssetsTabLoaderData` that returned a `Response` object instead of data when filter cookies were present, causing items to be undefined and crashing with "Cannot read properties of undefined (reading 'map')".

Also add defensive fallback `(items ?? [])` in `useAssetAvailabilityData` as defense-in-depth.