### PR TITLE
fix: clear stale husky hooksPath in prepare script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ apps/docs/.vitepress/dist
 
 # Lefthook local overrides
 lefthook-local.yml
+.worktrees/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
-    "prepare": "lefthook install || true",
+    "prepare": "git config --unset core.hooksPath 2>/dev/null; lefthook install || true",
     "webapp:dev": "turbo run dev --filter=@shelf/webapp",
     "webapp:dev:production": "pnpm --filter @shelf/webapp run production:dev",
     "webapp:build": "turbo run build --filter=@shelf/webapp",


### PR DESCRIPTION
Existing contributors may still have core.hooksPath set to .husky/_ from the old husky setup, which prevents lefthook from running. The prepare script now unsets it before installing lefthook, so it self-heals on pnpm install.

Also adds .worktrees/ to .gitignore.