### PR TITLE
RFC: Custody Acknowledgement — Implementation Plan

### DIFF
--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -117,7 +117,18 @@ export const CUSTODY_ACKNOWLEDGEMENT_ADDON = {
 };
 ```
 
-### 2.5 JWT token — reuse INVITE_TOKEN_SECRET
+### 2.5 How feature gating works in practice
+
+The boolean `custodyAcknowledgementEnabled` on the Organization model is just a **switch**. How it gets flipped on is a business decision:
+
+- **Include in Plus/Team by default** → Set to `true` when they subscribe. No extra purchase.
+- **Block for Free tier** → Leave `false`. Show upsell prompting upgrade.
+- **Sell as separate addon** → Wire to Stripe like barcodes/audits (v2 if needed).
+- **Give to everyone** → Set `ENABLE_PREMIUM_FEATURES=false` and the check is bypassed.
+
+For v1, the simplest path: include it in Plus and Team plans automatically. Free users see the upsell to upgrade. No Stripe addon product needed — just set the flag when the user's tier qualifies.
+
+### 2.6 JWT token — reuse INVITE_TOKEN_SECRET
 
 No new env var. We reuse `INVITE_TOKEN_SECRET` but include `purpose: "custody-ack"` in the JWT payload to prevent cross-use with invite tokens.
 
@@ -526,22 +537,25 @@ Handles:
 
 ---
 
-## Phase 12: Organization Settings UI (v1 — feature toggle only)
+## Phase 12: Tier-Based Feature Enablement
 
-### 12.1 Settings route
+### 12.1 Enable for qualifying tiers
 
-**File:** `apps/webapp/app/routes/_layout+/settings.general.tsx`
+The feature is **included in Plus and Team plans** — not a separate addon purchase.
 
-Add the custody acknowledgement toggle to the existing settings page, following the barcodes/audits addon pattern. This is just the on/off toggle managed via Stripe subscription, NOT a default checkbox setting.
+When a user subscribes to Plus or Team (or already has an active subscription), set `custodyAcknowledgementEnabled = true` on their organization. This can be done:
 
-### 12.2 Addon page / trial / Stripe integration
+- In the existing Stripe webhook handler that processes subscription changes
+- Or via a one-time migration for existing Plus/Team orgs
 
-Follow the exact pattern from `app/modules/audit/addon.server.ts`:
-- Trial checkout session
-- Subscription management
-- Webhook handlers for enable/disable
+### 12.2 Upsell for Free tier
 
-**Note:** If the team prefers to ship v1 without Stripe integration, the feature can be enabled via a direct DB toggle (like `barcodesEnabled` before Stripe was integrated). Stripe integration can come in v1.1.
+When a Free tier user encounters the "Require acknowledgement" checkbox:
+- Show a locked/disabled state with an upgrade prompt
+- Link to the subscription/upgrade page
+- Use the `CUSTODY_ACKNOWLEDGEMENT_ADDON` copy from `addon-copy.ts`
+
+No separate Stripe product, no trial flow, no addon management page needed for v1. The feature just comes with the plan.
 
 ---
 
@@ -604,7 +618,7 @@ Follow the exact pattern from `app/modules/audit/addon.server.ts`:
 | Activity note = permanent legal record | Custody records are hard-deleted on release. Rich note with timestamp/IP/method survives. |
 | Reuse INVITE_TOKEN_SECRET | JWT includes `purpose: "custody-ack"` to prevent cross-use. No new env var. |
 | String field for acceptanceMethod | Avoids Prisma enum migration for each new method. Validated at app layer. |
-| Feature gated per-org (addon pattern) | Follows barcode/audit pattern. Free users see upsell. |
+| Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |
 | Self-assignment hides checkbox | Can't corroborate receipt from the person who assigned. |
 | One email per custodian for bulk | Not spammy. One acknowledge-all click. |
 | Kit acknowledgement cascades | One click updates KitCustody + all child Custody records in transaction. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -144,7 +144,7 @@ The boolean `custodyAcknowledgementEnabled` on the Organization model is just a 
 - **Sell as separate add-on** → Wire to Stripe like barcodes/audits (v2 if needed).
 - **Give to everyone** → Set `ENABLE_PREMIUM_FEATURES=false` and the check is bypassed.
 
-For v1, the simplest path: include it in Plus and Team plans automatically. Free users see the upsell to upgrade. No Stripe addon product needed — just set the flag when the user's tier qualifies.
+For v1, the simplest path: include it in Plus and Team plans automatically. Free users see the upsell to upgrade. No Stripe add-on product needed — just set the flag when the user's tier qualifies.
 
 ### 2.6 JWT token — separate CUSTODY_TOKEN_SECRET
 
@@ -266,12 +266,13 @@ export async function recordCustodyAcknowledgement({
   ip,
   userAgent,
   organizationId,
-}: RecordAcknowledgementParams): Promise<Custody>
+}: RecordAcknowledgementParams): Promise<{ transitioned: boolean; custody: Custody }>
 // Conditional update — only transitions from PENDING state:
 //   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
 // If no rows updated → custody was already accepted or declined (idempotent: return current state)
 // Sets: acceptedAt = now(), acceptanceMethod, acceptanceIp, acceptanceUserAgent
-// Returns updated custody with asset + custodian data
+// Returns { transitioned: true, custody } if state changed, { transitioned: false, custody } if already settled
+// Callers MUST check `transitioned` before creating notes or enqueuing emails — prevents duplicates on retry/refresh
 ```
 
 **State transition invariants:**
@@ -757,7 +758,7 @@ const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
     AND "requiresAcceptance" = true
     AND "acceptedAt" IS NULL
     AND "declinedAt" IS NULL
-    AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < ${sixtySecondsAgo})
+    AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < NOW() - INTERVAL '60 seconds')
   RETURNING "tokenVersion"
 `;
 if (!updated) {

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -163,10 +163,10 @@ export async function generateCustodyAcknowledgementToken(custodyId: string): Pr
 
 ```typescript
 export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
-// 1. Increments tokenVersion on ALL custody records in the batch (DB write FIRST)
-// 2. Only AFTER the DB write succeeds: signs JWT with { batchId, purpose: "custody-ack-batch", ver }
+// 1. Reads MAX(tokenVersion) across all batch records, then SETs all to MAX + 1 (normalizes divergent versions)
+// 2. Only AFTER the DB write succeeds: signs JWT with { batchId, purpose: "custody-ack-batch", ver: MAX+1 }
 // 30-day expiry. Used for bulk assign (multiple assets, one link)
-// Persist-before-sign order eliminates the revocation window.
+// SET (not increment) ensures all rows share the same version even if some were individually resent before.
 ```
 
 **Token security:**
@@ -207,7 +207,7 @@ export async function verifyBatchAcknowledgementToken(
 // 4. Enforces single-custodian membership: all records must have same teamMemberId
 //    (prevents cross-custody acknowledgement if batch was somehow corrupted)
 // 5. Validates token rotation on EVERY custody record in the batch:
-//    compares each custody.tokenVersion against token.ver (integer equality)
+//    verifies ALL custody.tokenVersion === token.ver (uniform after SET normalization)
 // 6. Throws if no records found, mixed custodians, or any rotation check fails
 // Returns batchId + full custody list with asset details
 ```
@@ -719,10 +719,7 @@ Token rotation on every resend/copy ensures old links stop working, limiting exp
 const result = await db.custody.updateMany({
   where: {
     id: custodyId,
-    OR: [
-      { updatedAt: { lt: sixtySecondsAgo } },
-      { tokenVersion: 0 }, // never resent before
-    ],
+    updatedAt: { lt: sixtySecondsAgo }, // 60s cooldown since last rotation
   },
   data: { tokenVersion: { increment: 1 } },
 });
@@ -731,7 +728,7 @@ if (result.count === 0) {
 }
 // Only generate new token (with new version) + send email if update succeeded
 ```
-This prevents concurrent requests from both passing the cooldown check. Uses `updatedAt` (auto-set by Prisma on update) as the cooldown timestamp.
+Uses `updatedAt` (auto-set by Prisma on every update) as the cooldown reference. No special-casing for `tokenVersion: 0` — by the time resend is called, initial token generation has already set version ≥ 1.
 
 ---
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -39,6 +39,7 @@ model Custody {
   declinedAt                DateTime?                 // When custodian reported they don't have the item
   declineReason             String?                   // Optional reason from custodian
   tokenVersion              Int       @default(0)      // Monotonic counter — incremented on each resend/rotation. Embedded in JWT, compared on verify.
+  lastTokenRotatedAt        DateTime?                 // When token was last rotated (dedicated cooldown field, not coupled to updatedAt)
   acknowledgementBatchId    String?                   // Groups multiple custody records for bulk acknowledgement
 
   // DateTime
@@ -59,7 +60,6 @@ ALTER TABLE "KitCustody" ADD CONSTRAINT "kit_custody_accept_decline_exclusive"
   CHECK (NOT ("acceptedAt" IS NOT NULL AND "declinedAt" IS NOT NULL));
 ```
 This enforces mutual exclusivity at the database layer — defense-in-depth beyond application logic.
-```
 
 ### 1.2 KitCustody model — add same acknowledgement fields
 
@@ -179,10 +179,12 @@ export async function generateCustodyAcknowledgementToken(custodyId: string): Pr
 export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
 // STRICTLY persist-before-sign, atomic to prevent concurrent races:
 // 1. In a single transaction:
-//    a. SELECT MAX("tokenVersion") FROM "Custody" WHERE "acknowledgementBatchId" = batchId FOR UPDATE (row-level lock)
-//    b. UPDATE all batch rows SET "tokenVersion" = MAX + 1
+//    a. SELECT * FROM "Custody" WHERE "acknowledgementBatchId" = batchId FOR UPDATE
+//       (locks actual rows — prevents concurrent resend from proceeding until this tx completes)
+//    b. Compute MAX(tokenVersion) from the locked rows in application code
+//    c. UPDATE all locked rows SET "tokenVersion" = MAX + 1, "lastTokenRotatedAt" = now()
 // 2. Only AFTER transaction commits: sign JWT with { batchId, purpose: "custody-ack-batch", ver: MAX+1 }
-// 30-day expiry. FOR UPDATE lock prevents concurrent resend requests from minting tokens with same version.
+// 30-day expiry. Row-level FOR UPDATE lock serializes concurrent resend requests.
 ```
 
 **Token security:**
@@ -735,16 +737,22 @@ Token rotation on every resend/copy ensures old links stop working, limiting exp
 const result = await db.custody.updateMany({
   where: {
     id: custodyId,
-    updatedAt: { lt: sixtySecondsAgo }, // 60s cooldown since last rotation
+    OR: [
+      { lastTokenRotatedAt: null },                    // never rotated
+      { lastTokenRotatedAt: { lt: sixtySecondsAgo } }, // 60s cooldown
+    ],
   },
-  data: { tokenVersion: { increment: 1 } },
+  data: {
+    tokenVersion: { increment: 1 },
+    lastTokenRotatedAt: new Date(),
+  },
 });
 if (result.count === 0) {
   throw new ShelfError({ message: "Please wait before resending." });
 }
 // Only generate new token (with new version) + send email if update succeeded
 ```
-Uses `updatedAt` (auto-set by Prisma on every update) as the cooldown reference. No special-casing for `tokenVersion: 0` — by the time resend is called, initial token generation has already set version ≥ 1.
+Uses dedicated `lastTokenRotatedAt` field — not coupled to `updatedAt` which can be triggered by unrelated custody writes.
 
 ---
 
@@ -840,7 +848,7 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Checkbox coercion in Zod schema | HTML checkbox sends `"on"` not `true`. Uses `z.union([z.boolean(), z.literal("on")]).transform()` — follows existing column visibility pattern. |
 | Decline uses same conditional guard as accept | `WHERE acceptedAt IS NULL AND declinedAt IS NULL` — prevents race between concurrent accept/decline. |
 | Single owner for email side effects | Service functions are DB-only. Route actions enqueue emails via pg-boss after commit. Prevents duplicate sends. |
-| Atomic resend cooldown | Single conditional `updateMany` with `updatedAt < 60s ago` + version increment — TOCTOU-safe. |
+| Atomic resend cooldown | Single conditional `updateMany` with dedicated `lastTokenRotatedAt` field — not coupled to `updatedAt`. TOCTOU-safe. |
 | PII cleanup deferred (not an oversight) | Custody hard-delete already purges IP/UA. Notes have no PII. Cron job is trivial to add later if needed. |
 | Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -162,10 +162,10 @@ export async function generateCustodyAcknowledgementToken(custodyId: string): Pr
 ```
 
 ```typescript
-export function generateBatchAcknowledgementToken(batchId: string): string
+export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
 // Signs JWT with { batchId, purpose: "custody-ack-batch" } using CUSTODY_TOKEN_SECRET
 // 30-day expiry. Used for bulk assign (multiple assets, one link)
-// Updates tokenIssuedAt on ALL custody records in the batch
+// Updates tokenIssuedAt on ALL custody records in the batch (async DB write)
 ```
 
 **Token security:**
@@ -212,7 +212,22 @@ export async function verifyBatchAcknowledgementToken(
 // Returns batchId + full custody list with asset details
 ```
 
-### 3.3 Record acknowledgement
+### 3.3b Token verification (kit custody)
+
+```typescript
+export async function verifyKitCustodyAcknowledgementToken(
+  token: string,
+  db: PrismaClient
+): Promise<{ kitCustodyId: string; kitCustody: KitCustodyWithAssets }>
+// 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
+// 2. Checks purpose === "custody-ack-kit"
+// 3. Fetches KitCustody record (NOT Custody) with kit + all child assets + custodian
+// 4. Validates tokenIssuedAt rotation check
+// 5. Throws if KitCustody not found
+// Returns kitCustodyId + full kit custody with child asset details
+```
+
+### 3.4 Record acknowledgement
 
 ```typescript
 export async function recordCustodyAcknowledgement({
@@ -235,7 +250,7 @@ export async function recordCustodyAcknowledgement({
 - If the row was already transitioned, the operation is **idempotent** — returns the existing state without error
 - This eliminates the need for an explicit status enum; the state is derived: pending (`both null`), acknowledged (`acceptedAt set`), declined (`declinedAt set`)
 
-### 3.4 Send acknowledgement email
+### 3.5 Send acknowledgement email
 
 ```typescript
 export async function sendCustodyAcknowledgementEmail({
@@ -253,19 +268,24 @@ export async function sendCustodyAcknowledgementEmail({
 
 ### 3.6 Record decline
 
-Updated from 3.4 — decline now **persists state** on the Custody record:
+Decline uses the **same conditional/idempotent guard** as acknowledge:
 
 ```typescript
 export async function recordCustodyDecline({
   custodyId,
   reason,
   organizationId,
-}: RecordDeclineParams): Promise<void>
-// Updates custody: declinedAt = now(), declineReason = reason
+}: RecordDeclineParams): Promise<{ declined: boolean; custody: Custody }>
+// Conditional update — only transitions from PENDING state:
+//   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
+// If no rows updated → already accepted or declined (idempotent: return current state)
+// Sets: declinedAt = now(), declineReason = reason
 // Does NOT change asset status or delete custody
-// Creates activity log note
-// Sends notification email to assigning admin
+// Does NOT send emails — that is the route action's responsibility (after DB commit)
+// Returns { declined: true/false, custody } so caller knows if transition happened
 ```
+
+**Important — single owner for email side effects:** The `recordCustodyDecline()` function is side-effect-free (DB only). The route action (Phase 5.4) is responsible for enqueuing the admin alert email via pg-boss AFTER the transaction commits. This prevents duplicate emails.
 
 ### 3.7 Create acknowledgement activity note
 
@@ -381,9 +401,10 @@ Add: `"/accept-custody/:custodyId"` (narrow — no wildcard)
 
 1. Extract `token` from search params
 2. Decode token (without full verification) to check `purpose` field
-3. **Branch on token type:**
-   - `purpose === "custody-ack"` → Single flow: call `verifyCustodyAcknowledgementToken(token, db)` (handles signature, expiry, rotation check internally)
-   - `purpose === "custody-ack-batch"` → Batch flow: call `verifyBatchAcknowledgementToken(token, db)` — returns all custodies in the batch with asset details
+3. **Branch on token purpose:**
+   - `purpose === "custody-ack"` → Single flow: `verifyCustodyAcknowledgementToken(token, db)`
+   - `purpose === "custody-ack-batch"` → Batch flow: `verifyBatchAcknowledgementToken(token, db)` — returns all custodies
+   - `purpose === "custody-ack-kit"` → Kit flow: `verifyKitCustodyAcknowledgementToken(token, db)` — returns kit + child assets
 4. Handle error states (see 3.9 error handling table): expired, revoked, not found
 5. If already accepted → render "Already acknowledged" confirmation
 6. If declined → render "Already reported" confirmation
@@ -488,7 +509,8 @@ After acknowledgement:
 Same changes as 6.1 but:
 - Checkbox applies to KitCustody AND all child Custody records
 - One email/link for the kit (not per-asset)
-- Token references the KitCustody ID
+- Token uses `purpose: "custody-ack-kit"` with the KitCustody ID (distinct from single-custody and batch purposes)
+- Requires a dedicated `verifyKitCustodyAcknowledgementToken()` that fetches from `KitCustody` (not `Custody`) and returns kit + child custodies
 
 ### 6.3 Bulk assign custody
 
@@ -507,7 +529,15 @@ Same changes as 6.1 but:
 
 **File:** `apps/webapp/app/modules/custody/schema.ts`
 
-Add `requiresAcceptance: z.boolean().optional().default(false)` to `AssignCustodySchema`.
+Add to `AssignCustodySchema`:
+```typescript
+requiresAcceptance: z
+  .union([z.boolean(), z.literal("on")])
+  .transform((val) => val === true || val === "on")
+  .optional()
+  .default(false),
+```
+**Why coercion:** `parseData` receives `FormData` values as strings. A checked HTML checkbox arrives as `"on"`, not `true`. The `z.boolean()` alone would reject valid submissions. This follows the same pattern used by the column visibility schema in `asset-index-settings/helpers.ts`.
 
 ---
 
@@ -547,6 +577,7 @@ Add to the custody type:
 ```typescript
 requiresAcceptance?: boolean;
 acceptedAt?: Date | string | null;
+declinedAt?: Date | string | null;
 assignedByUserId?: string | null;
 ```
 
@@ -607,7 +638,7 @@ Render:
 
 **File:** `apps/webapp/app/routes/_layout+/assets._index.tsx` (and the advanced mode loader)
 
-Include `requiresAcceptance`, `acceptedAt` in the custody select when loading assets.
+Include `requiresAcceptance`, `acceptedAt`, and `declinedAt` in the custody select when loading assets. All three fields are needed to derive the acknowledgement status (pending vs acknowledged vs disputed vs not required).
 
 ### 9.4 Filter support
 
@@ -675,7 +706,25 @@ Handles:
 
 Token rotation on every resend/copy ensures old links stop working, limiting exposure window.
 
-**Rate limiting:** Enforce a per-custody cooldown (e.g., 1 resend per 60 seconds) to prevent abuse from compromised admin sessions or excessive link churn. Return a clear error: "Please wait before resending. Last sent X seconds ago." Check `tokenIssuedAt` timestamp — if less than 60 seconds ago, reject.
+**Rate limiting (atomic):** Enforce a per-custody cooldown via a single conditional DB update — not a read-then-write (TOCTOU-safe):
+```typescript
+// Single atomic operation — cooldown + rotation in one query:
+const result = await db.custody.updateMany({
+  where: {
+    id: custodyId,
+    OR: [
+      { tokenIssuedAt: null },
+      { tokenIssuedAt: { lt: sixtySecondsAgo } },
+    ],
+  },
+  data: { tokenIssuedAt: now() },
+});
+if (result.count === 0) {
+  throw new ShelfError({ message: "Please wait before resending." });
+}
+// Only generate new token + send email if the update succeeded
+```
+This prevents concurrent requests from both passing the cooldown check.
 
 ---
 
@@ -765,7 +814,12 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Persisted decline state | `declinedAt` + `declineReason` on Custody makes "Disputed" queryable and filterable. |
 | Narrow public path | `/accept-custody/:custodyId` — no wildcard. Minimal exposure surface. |
 | Dedicated CUSTODY_TOKEN_SECRET | Separate secret prevents token confusion with invite tokens (invite verifier doesn't check `purpose`). |
-| Token rotation inside verifier | `verifyCustodyAcknowledgementToken()` checks `tokenIssuedAt` internally — callers cannot forget. |
+| Three token purposes | `custody-ack` (single), `custody-ack-batch` (bulk), `custody-ack-kit` (kit) — each with dedicated verifier fetching from the correct model. |
+| Token rotation inside verifier | `verify*Token()` functions check `tokenIssuedAt` internally — callers cannot forget. |
+| Checkbox coercion in Zod schema | HTML checkbox sends `"on"` not `true`. Uses `z.union([z.boolean(), z.literal("on")]).transform()` — follows existing column visibility pattern. |
+| Decline uses same conditional guard as accept | `WHERE acceptedAt IS NULL AND declinedAt IS NULL` — prevents race between concurrent accept/decline. |
+| Single owner for email side effects | Service functions are DB-only. Route actions enqueue emails via pg-boss after commit. Prevents duplicate sends. |
+| Atomic resend cooldown | Single conditional `updateMany` with `tokenIssuedAt < 60s ago` — TOCTOU-safe, no read-then-write. |
 | PII auto-cleanup after 2 years | Scheduled job nulls IP/UA on old custodies. Covers never-released assignments. |
 | Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -163,9 +163,11 @@ export async function generateCustodyAcknowledgementToken(custodyId: string): Pr
 
 ```typescript
 export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
-// Signs JWT with { batchId, purpose: "custody-ack-batch" } using CUSTODY_TOKEN_SECRET
+// 1. Updates tokenIssuedAt on ALL custody records in the batch (DB write FIRST)
+// 2. Only AFTER the DB write succeeds: signs JWT with { batchId, purpose: "custody-ack-batch" }
 // 30-day expiry. Used for bulk assign (multiple assets, one link)
-// Updates tokenIssuedAt on ALL custody records in the batch (async DB write)
+// Persist-before-sign order eliminates the revocation window where old tokens
+// could still validate before the tokenIssuedAt write lands.
 ```
 
 **Token security:**
@@ -381,6 +383,13 @@ Following the pattern from `app/emails/stripe/audit-trial-welcome.tsx` per CLAUD
 **File:** `apps/webapp/server/index.ts` (publicPaths array)
 
 Add: `"/accept-custody/:custodyId"` (narrow — no wildcard)
+
+**Token-in-URL leak mitigations:**
+Tokens are passed as query params (`?token=...`), which are prone to leakage via referrer headers, browser history, server logs, and analytics. Mitigations:
+- Set `Referrer-Policy: no-referrer` on the acceptance page response headers (prevents token leaking to external resources)
+- Ensure server access logs do NOT log query strings for this route (or redact `token=` param)
+- The 30-day expiry + rotation on resend limits the window of exposure
+- After acknowledgement, the token becomes useless (idempotent, already-accepted state)
 
 ### 5.2 Auth model — two explicit modes
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -258,8 +258,8 @@ export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", {
 
 1. **Feature enablement guard:** When `custodyAcknowledgementEnabled` is set to `true` on an org, validate that `CUSTODY_TOKEN_SECRET` is configured. If not, reject the enablement with a clear error: "Cannot enable custody acknowledgement: CUSTODY_TOKEN_SECRET is not configured." This check runs in:
    - **Stripe webhook handler** (`apps/webapp/app/modules/stripe-webhook/handlers.server.ts`) — for subscription-based enablement
-   - **Organization settings action** (`apps/webapp/app/routes/_layout+/settings.general.tsx`) — if manual toggle is added
-   - Both paths call `validateCustodyTokenSecretConfigured()` from the acknowledgement service before setting the flag to `true`
+   - **Organization settings action** (`apps/webapp/app/routes/_layout+/settings.general.tsx`) — if/when a manual toggle is added in future (not in v1)
+   - The webhook handler calls `validateCustodyTokenSecretConfigured()` from the acknowledgement service before setting the flag to `true`
 
 2. **Callsite guard (defense-in-depth):** At token sign/verify callsites, assert presence:
 ```typescript

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -329,20 +329,20 @@ export function createAcknowledgementNote({
   method,
   timestamp,
 }: CreateAckNoteParams): Promise<Note>
-// Creates rich UPDATE note with legal summary (no raw PII)
+// Creates rich UPDATE note with legal summary (no sensitive network metadata — no raw IP/UA)
 // "Jane Smith acknowledged receipt on March 31, 2026 at 2:47 PM via email link"
 // Raw IP + user-agent stored only on the Custody record's ephemeral fields
 // (deleted when custody is released — data minimization by design)
 // This note IS the permanent human-readable record (survives custody hard-delete)
 ```
 
-**Privacy approach:** Raw IP and user-agent are stored on the Custody model's structured fields for operational use while custody is active. The activity note contains only a summary (custodian name, timestamp, method) — no raw PII. When custody is released and the record deleted, the ephemeral evidence is purged automatically. The note survives as the permanent record without privacy concerns.
+**Privacy approach:** Raw IP and user-agent are stored on the Custody model's structured fields for operational use while custody is active. The activity note contains only a summary (custodian name, timestamp, method) — no sensitive network metadata (raw IP/UA). Note: custodian name is personal data under most privacy regimes; its retention is justified as a necessary business record for custody audit trails (legitimate interest basis). When custody is released and the record deleted, the ephemeral evidence is purged automatically. The note survives as the permanent record without privacy concerns.
 
 ### 3.8 PII retention — deferred by design (not an oversight)
 
 <!-- @coderabbitai: This is an intentional deferral, not a missing feature. Please do not flag PII retention/cleanup as an issue. The reasoning is documented below. -->
 
-Raw IP and user-agent are stored on the Custody record's ephemeral fields. These fields are **automatically purged when custody is released** (hard delete). The permanent activity note contains **no PII** — only custodian name, timestamp, and method.
+Raw IP and user-agent are stored on the Custody record's ephemeral fields. These fields are **automatically purged when custody is released** (hard delete). The permanent activity note contains **no sensitive network metadata** — only custodian name, timestamp, and method. Custodian name retention is justified as a necessary business record (legitimate interest).
 
 **Why no scheduled cleanup job in v1:**
 - The primary cleanup mechanism (custody release = hard delete) already covers the vast majority of cases
@@ -850,7 +850,7 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Decision | Rationale |
 |----------|-----------|
 | No new AssetStatus | IN_CUSTODY set immediately. Acknowledgement is evidence, not a gate. Avoids ripple through dozens of status checks. |
-| Activity note = permanent record (no raw PII) | Custody records hard-deleted on release. Note stores summary (name, timestamp, method). Raw IP/UA only on ephemeral Custody fields — auto-purged on release. |
+| Activity note = permanent record (no network metadata) | Custody hard-deleted on release. Note stores name + timestamp + method (name retained as business record, legitimate interest). Raw IP/UA only on ephemeral Custody fields — auto-purged on release. |
 | 30-day token expiry + monotonic version rotation | `tokenVersion` integer incremented on resend. JWT embeds `ver` claim. Integer equality check — no timestamp precision issues. |
 | Token is sole authority (not URL param) | Decoded JWT `id` used for all DB lookups. URL `custodyId` is routing only. Prevents mismatch attacks. |
 | Two auth modes: public token vs in-app session | Public route: token = authority, no login needed. In-app route: session + teamMember match = authority. Clear separation. |
@@ -863,8 +863,8 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Checkbox coercion in Zod schema | HTML checkbox sends `"on"` not `true`. Uses `z.union([z.boolean(), z.literal("on")]).transform()` — follows existing column visibility pattern. |
 | Decline uses same conditional guard as accept | `WHERE acceptedAt IS NULL AND declinedAt IS NULL` — prevents race between concurrent accept/decline. |
 | Single owner for email side effects | Service functions are DB-only. Route actions enqueue emails via pg-boss after commit. Prevents duplicate sends. |
-| Atomic resend cooldown | Single conditional `updateMany` with dedicated `lastTokenRotatedAt` field — not coupled to `updatedAt`. TOCTOU-safe. |
-| PII cleanup deferred (not an oversight) | Custody hard-delete already purges IP/UA. Notes have no PII. Cron job is trivial to add later if needed. |
+| Atomic resend cooldown | Raw SQL `UPDATE ... RETURNING` with `lastTokenRotatedAt` + `NOW() - INTERVAL '60 seconds'` + state guards. Single query: increment version, enforce cooldown, return new version. TOCTOU-safe, clock-skew safe. |
+| Network metadata cleanup deferred (not an oversight) | Custody hard-delete already purges IP/UA. Notes retain only name (business record). Cron job for long-lived custodies is trivial to add later if needed. |
 | Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |
 | Self-assignment hides checkbox | Can't corroborate receipt from the person who assigned. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -34,6 +34,9 @@ model Custody {
   acceptanceUserAgent       String?                   // Browser user-agent (ephemeral — deleted with custody)
   assignedBy                User?     @relation("custodyAssigner", fields: [assignedByUserId], references: [id], onDelete: SetNull)
   assignedByUserId          String?                   // Who assigned custody (for admin notification routing, SetNull on user delete)
+  // NOTE: Requires inverse relation on User model:
+  //   custodyAssignments Custody[] @relation("custodyAssigner")
+  // Same pattern needed for KitCustody if assignedBy is added there.
   // Fallback: if assignedByUserId is null (user deleted), admin notifications
   // route to the organization owner instead (org.userId is always present)
   declinedAt                DateTime?                 // When custodian reported they don't have the item
@@ -189,14 +192,25 @@ export async function generateCustodyAcknowledgementToken(custodyId: string): Pr
 
 ```typescript
 export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
-// STRICTLY persist-before-sign, atomic to prevent concurrent races:
-// 1. In a single transaction:
-//    a. SELECT * FROM "Custody" WHERE "acknowledgementBatchId" = batchId FOR UPDATE
-//       (locks actual rows — prevents concurrent resend from proceeding until this tx completes)
-//    b. Compute MAX(tokenVersion) from the locked rows in application code
-//    c. UPDATE all locked rows SET "tokenVersion" = MAX + 1, "lastTokenRotatedAt" = now()
-// 2. Only AFTER transaction commits: sign JWT with { batchId, purpose: "custody-ack-batch", ver: MAX+1 }
-// 30-day expiry. Row-level FOR UPDATE lock serializes concurrent resend requests.
+// STRICTLY persist-before-sign, single atomic UPDATE (no separate SELECT):
+// 1. Single SQL statement:
+//    UPDATE "Custody"
+//    SET "tokenVersion" = (SELECT MAX("tokenVersion") + 1 FROM "Custody" WHERE "acknowledgementBatchId" = batchId),
+//        "lastTokenRotatedAt" = NOW()
+//    WHERE "acknowledgementBatchId" = batchId
+//    RETURNING "tokenVersion"
+// 2. Read returned tokenVersion (all rows now share the same value)
+// 3. Sign JWT with { batchId, purpose: "custody-ack-batch", ver: newVersion }
+// 30-day expiry. Single atomic UPDATE — no transaction needed, no app-side MAX computation.
+```
+
+```typescript
+export async function generateKitCustodyAcknowledgementToken(kitCustodyId: string): Promise<string>
+// STRICTLY persist-before-sign:
+// 1. Atomically increment KitCustody.tokenVersion via UPDATE ... RETURNING
+// 2. Also update all child Custody records to same version (single UPDATE with subquery)
+// 3. Sign JWT with { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
+// 30-day expiry.
 ```
 
 **Token security:**
@@ -749,8 +763,13 @@ Accepts `custodyId` (single), `acknowledgementBatchId` (batch), or `kitCustodyId
 
 **Three rotation paths** (matching the three token purposes):
 
-**Single custody resend:**
+**Single custody resend** (only for custodies NOT in a batch or kit):
 ```typescript
+// GUARD: reject if custody belongs to a batch or kit — must use batch/kit resend path instead
+const custody = await db.custody.findUnique({ where: { id: custodyId }, select: { acknowledgementBatchId: true, asset: { select: { kitId: true } } } });
+if (custody?.acknowledgementBatchId) throw new ShelfError({ message: "This asset is part of a bulk assignment. Use batch resend." });
+if (custody?.asset?.kitId) throw new ShelfError({ message: "This asset is part of a kit. Use kit resend." });
+
 const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
   UPDATE "Custody"
   SET "tokenVersion" = "tokenVersion" + 1,
@@ -758,6 +777,7 @@ const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
       "updatedAt" = NOW()
   WHERE "id" = ${custodyId}
     AND "requiresAcceptance" = true
+    AND "acknowledgementBatchId" IS NULL
     AND "acceptedAt" IS NULL AND "declinedAt" IS NULL
     AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < NOW() - INTERVAL '60 seconds')
   RETURNING "tokenVersion"
@@ -797,7 +817,7 @@ All paths: atomic `UPDATE ... RETURNING`, cooldown via `lastTokenRotatedAt` with
 
 ### 12.1 Enable for qualifying tiers
 
-The feature is **included in Plus and Team plans** — not a separate addon purchase.
+The feature is **included in Plus and Team plans** — not a separate add-on purchase.
 
 When a user subscribes to Plus or Team (or already has an active subscription), set `custodyAcknowledgementEnabled = true` on their organization. This can be done:
 
@@ -811,7 +831,7 @@ When a Free tier user encounters the "Require acknowledgement" checkbox:
 - Link to the subscription/upgrade page
 - Use the `CUSTODY_ACKNOWLEDGEMENT_ADDON` copy from `addon-copy.ts`
 
-No separate Stripe product, no trial flow, no addon management page needed for v1. The feature just comes with the plan.
+No separate Stripe product, no trial flow, no add-on management page needed for v1. The feature just comes with the plan.
 
 ---
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -32,7 +32,8 @@ model Custody {
   acceptanceMethod          String?                   // "email_link" | "in_app" | "manual_link"
   acceptanceIp              String?                   // IP address (ephemeral — deleted with custody on release)
   acceptanceUserAgent       String?                   // Browser user-agent (ephemeral — deleted with custody)
-  assignedByUserId          String?                   // Who assigned custody (for admin notification routing)
+  assignedBy                User?     @relation("custodyAssigner", fields: [assignedByUserId], references: [id], onDelete: SetNull)
+  assignedByUserId          String?                   // Who assigned custody (for admin notification routing, SetNull on user delete)
   declinedAt                DateTime?                 // When custodian reported they don't have the item
   declineReason             String?                   // Optional reason from custodian
   tokenIssuedAt             DateTime?                 // When the current token was issued (for invalidation on resend)
@@ -746,7 +747,7 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | 30-day token expiry + rotation on resend | Limits exposure window. `tokenIssuedAt` on Custody rejects old tokens after resend. |
 | Token is sole authority (not URL param) | Decoded JWT `id` used for all DB lookups. URL `custodyId` is routing only. Prevents mismatch attacks. |
 | Two auth modes: public token vs in-app session | Public route: token = authority, no login needed. In-app route: session + teamMember match = authority. Clear separation. |
-| Batch key for bulk acknowledgement | `acknowledgementBatchId` groups custody records. One token covers the batch. Resend/copy-link target the batch reliably. |
+| Batch key for bulk acknowledgement (per-custodian) | `acknowledgementBatchId` groups custody records scoped to a single custodian. Verifier enforces single `teamMemberId` membership — rejects mixed batches. One token covers the batch. |
 | Persisted decline state | `declinedAt` + `declineReason` on Custody makes "Disputed" queryable and filterable. |
 | Narrow public path | `/accept-custody/:custodyId` — no wildcard. Minimal exposure surface. |
 | Dedicated CUSTODY_TOKEN_SECRET | Separate secret prevents token confusion with invite tokens (invite verifier doesn't check `purpose`). |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -103,7 +103,7 @@ export const canUseCustodyAcknowledgement = (org: { custodyAcknowledgementEnable
 
 Add `canUseCustodyAcknowledgement` to the return object, following the `canUseBarcodes`/`canUseAudits` pattern.
 
-### 2.4 Addon copy for upsell UI
+### 2.4 Add-on copy for upsell UI
 
 **File:** `apps/webapp/app/config/addon-copy.ts`
 
@@ -127,7 +127,7 @@ The boolean `custodyAcknowledgementEnabled` on the Organization model is just a 
 
 - **Include in Plus/Team by default** → Set to `true` when they subscribe. No extra purchase.
 - **Block for Free tier** → Leave `false`. Show upsell prompting upgrade.
-- **Sell as separate addon** → Wire to Stripe like barcodes/audits (v2 if needed).
+- **Sell as separate add-on** → Wire to Stripe like barcodes/audits (v2 if needed).
 - **Give to everyone** → Set `ENABLE_PREMIUM_FEATURES=false` and the check is bypassed.
 
 For v1, the simplest path: include it in Plus and Team plans automatically. Free users see the upsell to upgrade. No Stripe addon product needed — just set the flag when the user's tier qualifies.
@@ -181,9 +181,11 @@ export async function verifyCustodyAcknowledgementToken(
 ): Promise<{ id: string; iat: number }>
 // 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
 // 2. Checks purpose === "custody-ack"
-// 3. Fetches custody record, validates tokenIssuedAt <= token.iat (rejects rotated tokens)
-// 4. Throws ShelfError("Token expired") on exp failure
-// 5. Throws ShelfError("Token revoked") if iat < tokenIssuedAt
+// 3. Fetches custody record
+// 4. Normalizes time units: converts Prisma DateTime to Unix seconds
+//    via Math.floor(tokenIssuedAt.getTime() / 1000) before comparing to JWT iat (RFC 7519 = seconds)
+// 5. Throws ShelfError("Token expired") on exp failure
+// 6. Throws ShelfError("Token revoked") if tokenIssuedAtSeconds > token.iat
 // 6. Throws ShelfError("Custody not found") if record doesn't exist
 // Returns custody ID and iat
 // Token rotation check is INSIDE this function — callers cannot forget it
@@ -199,7 +201,10 @@ export async function verifyBatchAcknowledgementToken(
 // 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
 // 2. Checks purpose === "custody-ack-batch"
 // 3. Fetches all custody records with matching acknowledgementBatchId
-// 4. Throws if no records found
+// 4. Validates token rotation on EVERY custody record in the batch:
+//    converts each custody.tokenIssuedAt to Unix seconds, rejects if any tokenIssuedAtSeconds > token.iat
+//    (resend/copy-link updates tokenIssuedAt on all records in batch, invalidating old batch tokens)
+// 5. Throws if no records found or if any rotation check fails
 // Returns batchId + full custody list with asset details
 ```
 
@@ -376,20 +381,19 @@ Add: `"/accept-custody/:custodyId"` (narrow — no wildcard)
 Handle two intents:
 
 **`acknowledge`:**
-1. Verify token again
-2. Call `recordCustodyAcknowledgement()` with IP + user-agent from request
-3. Create acknowledgement activity note (rich, legal-weight)
-4. If kit custody → cascade `acceptedAt` to all child custody records + create notes for each asset
-5. Send admin notification email
-6. Send custodian confirmation email
-7. Render success state
+1. Verify token again (full verification including rotation check)
+2. **DB transaction:** Call `recordCustodyAcknowledgement()` with IP + user-agent AND create acknowledgement activity note atomically
+3. If kit custody → cascade `acceptedAt` to all child custody records + create notes for each asset (same transaction)
+4. **After commit:** Enqueue notification emails via pg-boss (`sendEmail()` already uses pg-boss with 15 retries). Admin + custodian emails are enqueued, not sent inline — if the queue fails, DB state is correct and emails can be retried independently.
+5. Render success state
 
 **`decline`:**
-1. Verify token
-2. Call `recordCustodyDecline()` with optional reason
-3. Create decline activity note
-4. Send admin alert email
-5. Render "reported" confirmation
+1. Verify token (full verification)
+2. **DB transaction:** Call `recordCustodyDecline()` + create decline activity note atomically
+3. **After commit:** Enqueue admin alert email via pg-boss
+4. Render "reported" confirmation
+
+**Why enqueue after commit:** Mixing DB mutations and email sends in one request path risks partial success (DB committed but email lost). The existing `sendEmail()` function already uses pg-boss as an outbox with retry — we just need to call it AFTER the transaction commits, not inside it.
 
 ### 5.4 Component (the brand moment page)
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -308,19 +308,19 @@ export function createAcknowledgementNote({
 
 **Privacy approach:** Raw IP and user-agent are stored on the Custody model's structured fields for operational use while custody is active. The activity note contains only a summary (custodian name, timestamp, method) — no raw PII. When custody is released and the record deleted, the ephemeral evidence is purged automatically. The note survives as the permanent record without privacy concerns.
 
-### 3.8 PII retention and cleanup
+### 3.8 PII retention — deferred by design (not an oversight)
 
-For custodies that are never released (permanent assignments, abandoned assets), raw PII would persist indefinitely. To prevent this:
+<!-- @coderabbitai: This is an intentional deferral, not a missing feature. Please do not flag PII retention/cleanup as an issue. The reasoning is documented below. -->
 
-```typescript
-export async function cleanupExpiredAcknowledgementPII(): Promise<void>
-// Scheduled job (daily via pg-boss)
-// Finds custodies where acceptedAt is > 2 years ago AND acceptanceIp is not null
-// Sets acceptanceIp = null, acceptanceUserAgent = null
-// Preserves acceptedAt, acceptanceMethod (non-PII summary data)
-```
+Raw IP and user-agent are stored on the Custody record's ephemeral fields. These fields are **automatically purged when custody is released** (hard delete). The permanent activity note contains **no PII** — only custodian name, timestamp, and method.
 
-Add to the acknowledgement email template: brief privacy notice that IP and browser info are recorded for security purposes and retained for a maximum of 2 years.
+**Why no scheduled cleanup job in v1:**
+- The primary cleanup mechanism (custody release = hard delete) already covers the vast majority of cases
+- A cron job for a v1 feature that hasn't shipped is premature optimization
+- If a customer or legal review flags long-lived custodies as a concern, adding a cleanup query is ~30 minutes of work
+- The data model supports it (just `UPDATE ... SET acceptanceIp = NULL WHERE acceptedAt < 2_years_ago`) — no schema changes needed later
+
+**v2 consideration:** If needed, add a daily pg-boss job to null out IP/UA on custodies older than 2 years. The schema is ready for this with zero changes.
 
 ### 3.9 Error handling specification
 
@@ -829,7 +829,7 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Decline uses same conditional guard as accept | `WHERE acceptedAt IS NULL AND declinedAt IS NULL` — prevents race between concurrent accept/decline. |
 | Single owner for email side effects | Service functions are DB-only. Route actions enqueue emails via pg-boss after commit. Prevents duplicate sends. |
 | Atomic resend cooldown | Single conditional `updateMany` with `tokenIssuedAt < 60s ago` — TOCTOU-safe, no read-then-write. |
-| PII auto-cleanup after 2 years | Scheduled job nulls IP/UA on old custodies. Covers never-released assignments. |
+| PII cleanup deferred (not an oversight) | Custody hard-delete already purges IP/UA. Notes have no PII. Cron job is trivial to add later if needed. |
 | Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |
 | Self-assignment hides checkbox | Can't corroborate receipt from the person who assigned. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -154,9 +154,12 @@ We do NOT reuse `INVITE_TOKEN_SECRET` because the invite verification path (`acc
 
 Add to `apps/webapp/app/utils/env.ts`:
 ```typescript
-// Lazy — only required when the feature is actually used (token sign/verify callsites).
-// Does NOT crash server startup if unset, allowing phased rollout.
-export const CUSTODY_TOKEN_SECRET = process.env.CUSTODY_TOKEN_SECRET;
+// Optional at startup — only required when acknowledgement feature is used.
+// Follows same pattern as other secrets but won't crash startup if unset.
+export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", {
+  isSecret: true,
+  isOptional: true,
+});
 ```
 At token sign/verify callsites, assert presence:
 ```typescript
@@ -164,6 +167,7 @@ if (!CUSTODY_TOKEN_SECRET) {
   throw new ShelfError({ message: "CUSTODY_TOKEN_SECRET is not configured." });
 }
 ```
+If `getEnv` does not support `isOptional`, add it following the existing pattern — a single boolean that returns `undefined` instead of throwing on missing value.
 
 ---
 
@@ -742,30 +746,27 @@ Token rotation on every resend/copy ensures old links stop working, limiting exp
 
 **Rate limiting (atomic):** Enforce a per-custody cooldown via a single conditional DB update — not a read-then-write (TOCTOU-safe):
 ```typescript
-// Single atomic operation — cooldown + version increment + state guard:
-const result = await db.custody.updateMany({
-  where: {
-    id: custodyId,
-    requiresAcceptance: true,       // must be an ack-enabled custody
-    acceptedAt: null,               // not already acknowledged
-    declinedAt: null,               // not already declined
-    OR: [
-      { lastTokenRotatedAt: null },                    // never rotated
-      { lastTokenRotatedAt: { lt: sixtySecondsAgo } }, // 60s cooldown
-    ],
-  },
-  data: {
-    tokenVersion: { increment: 1 },
-    lastTokenRotatedAt: new Date(),
-  },
-});
-if (result.count === 0) {
-  // Could be: cooldown active, already accepted/declined, or not ack-enabled
-  throw new ShelfError({ message: "Cannot resend: either cooldown active or custody is no longer pending." });
+// Single atomic operation — cooldown + version increment + state guard.
+// Uses raw SQL to atomically increment AND return the new version in one query:
+const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
+  UPDATE "Custody"
+  SET "tokenVersion" = "tokenVersion" + 1,
+      "lastTokenRotatedAt" = NOW(),
+      "updatedAt" = NOW()
+  WHERE "id" = ${custodyId}
+    AND "requiresAcceptance" = true
+    AND "acceptedAt" IS NULL
+    AND "declinedAt" IS NULL
+    AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < ${sixtySecondsAgo})
+  RETURNING "tokenVersion"
+`;
+if (!updated) {
+  throw new ShelfError({ message: "Cannot resend: cooldown active or custody no longer pending." });
 }
-// Only generate new token (with new version) + send email if update succeeded
+const newVersion = updated.tokenVersion;
+// Sign JWT with { id: custodyId, purpose: "custody-ack", ver: newVersion }
 ```
-Guards against: cooldown abuse, resending for already-accepted/declined custody, and resending for non-ack custody. Uses dedicated `lastTokenRotatedAt` — not coupled to `updatedAt`.
+Uses `UPDATE ... RETURNING` to atomically increment + retrieve the new version in a single query. No gap between increment and read. Guards against cooldown abuse, terminal states, and non-ack custody. `lastTokenRotatedAt` is dedicated — not coupled to `updatedAt`.
 
 ---
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -51,6 +51,13 @@ model Custody {
 
   @@index([assetId, teamMemberId], name: "Custody_assetId_teamMemberId_idx")
   @@index([teamMemberId])
+  @@index([acknowledgementBatchId])  // Batch lookups/updates in verification and resend
+
+  // Additional partial indexes (in migration SQL, not Prisma):
+  // CREATE INDEX idx_custody_pending_ack ON "Custody" ("teamMemberId")
+  //   WHERE "requiresAcceptance" = true AND "acceptedAt" IS NULL AND "declinedAt" IS NULL;
+  // CREATE INDEX idx_custody_batch_pending ON "Custody" ("acknowledgementBatchId")
+  //   WHERE "requiresAcceptance" = true AND "acceptedAt" IS NULL AND "declinedAt" IS NULL;
 }
 ```
 
@@ -453,11 +460,14 @@ Tokens are passed as query params (`?token=...`), which are prone to leakage via
 ### 5.3 Loader
 
 1. Extract `token` from search params
-2. Decode token (without full verification) to check `purpose` field
-3. **Branch on token purpose:**
-   - `purpose === "custody-ack"` → Single flow: `verifyCustodyAcknowledgementToken(token, db)`
-   - `purpose === "custody-ack-batch"` → Batch flow: `verifyBatchAcknowledgementToken(token, db)` — returns all custodies
-   - `purpose === "custody-ack-kit"` → Kit flow: `verifyKitCustodyAcknowledgementToken(token, db)` — returns kit + child assets
+2. **Verify signature first, then branch on purpose.** Do NOT use `jwt.decode()` — unverified payloads can be forged.
+   - Call `jwt.verify(token, CUSTODY_TOKEN_SECRET)` once to validate signature + expiry
+   - Read `purpose` from the VERIFIED payload
+3. **Branch on verified purpose:**
+   - `purpose === "custody-ack"` → Single flow: `verifyCustodyAcknowledgementToken(verifiedPayload, db)` (version check + DB fetch)
+   - `purpose === "custody-ack-batch"` → Batch flow: `verifyBatchAcknowledgementToken(verifiedPayload, db)`
+   - `purpose === "custody-ack-kit"` → Kit flow: `verifyKitCustodyAcknowledgementToken(verifiedPayload, db)`
+   - Unknown purpose → reject with error
 4. Handle error states (see 3.9 error handling table): expired, revoked, not found
 5. If already accepted → render "Already acknowledged" confirmation
 6. If declined → render "Already reported" confirmation
@@ -785,9 +795,11 @@ const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
 // Sign with { id: custodyId, purpose: "custody-ack", ver: updated.tokenVersion }
 ```
 
-**Batch resend** (rotates ALL rows in batch atomically):
+**Batch resend** (rotates ALL rows in batch — including already-accepted/declined):
 ```typescript
-// Lock all batch rows, rotate together, return uniform version
+// Rotate ALL rows regardless of state. The verifier checks version on ALL rows,
+// so if one was accepted and keeps the old version, the new batch token breaks.
+// Cooldown check uses MIN(lastTokenRotatedAt) across the batch.
 const rows = await db.$queryRaw`
   UPDATE "Custody"
   SET "tokenVersion" = (
@@ -796,8 +808,13 @@ const rows = await db.$queryRaw`
   "lastTokenRotatedAt" = NOW(), "updatedAt" = NOW()
   WHERE "acknowledgementBatchId" = ${batchId}
     AND "requiresAcceptance" = true
-    AND "acceptedAt" IS NULL AND "declinedAt" IS NULL
-    AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < NOW() - INTERVAL '60 seconds')
+    AND (
+      (SELECT MIN("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+      IS NULL
+      OR
+      (SELECT MIN("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+      < NOW() - INTERVAL '60 seconds'
+    )
   RETURNING "tokenVersion"
 `;
 // Sign with { batchId, purpose: "custody-ack-batch", ver: rows[0].tokenVersion }

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -50,6 +50,17 @@ model Custody {
 }
 ```
 
+**DB CHECK constraint** (in migration SQL, not expressible in Prisma schema):
+```sql
+ALTER TABLE "Custody" ADD CONSTRAINT "custody_accept_decline_exclusive"
+  CHECK (NOT ("acceptedAt" IS NOT NULL AND "declinedAt" IS NOT NULL));
+
+ALTER TABLE "KitCustody" ADD CONSTRAINT "kit_custody_accept_decline_exclusive"
+  CHECK (NOT ("acceptedAt" IS NOT NULL AND "declinedAt" IS NOT NULL));
+```
+This enforces mutual exclusivity at the database layer — defense-in-depth beyond application logic.
+```
+
 ### 1.2 KitCustody model — add same acknowledgement fields
 
 Add identical fields to `KitCustody` for kit-level acknowledgement.
@@ -156,17 +167,22 @@ export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", { isSecret: t
 
 ```typescript
 export async function generateCustodyAcknowledgementToken(custodyId: string): Promise<string>
-// Signs JWT with { id: custodyId, purpose: "custody-ack", ver: custody.tokenVersion } using CUSTODY_TOKEN_SECRET
+// STRICTLY persist-before-sign:
+// 1. Atomically increment tokenVersion and read back new value:
+//    UPDATE "Custody" SET "tokenVersion" = "tokenVersion" + 1 WHERE id = custodyId RETURNING "tokenVersion"
+// 2. Sign JWT with { id: custodyId, purpose: "custody-ack", ver: newVersion } using CUSTODY_TOKEN_SECRET
 // 30-day expiry (exp claim)
-// Increments custody.tokenVersion in DB (invalidates any previous token — no same-second race)
+// The increment-then-sign order guarantees the token is never self-invalidated.
 ```
 
 ```typescript
 export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
-// 1. Reads MAX(tokenVersion) across all batch records, then SETs all to MAX + 1 (normalizes divergent versions)
-// 2. Only AFTER the DB write succeeds: signs JWT with { batchId, purpose: "custody-ack-batch", ver: MAX+1 }
-// 30-day expiry. Used for bulk assign (multiple assets, one link)
-// SET (not increment) ensures all rows share the same version even if some were individually resent before.
+// STRICTLY persist-before-sign, atomic to prevent concurrent races:
+// 1. In a single transaction:
+//    a. SELECT MAX("tokenVersion") FROM "Custody" WHERE "acknowledgementBatchId" = batchId FOR UPDATE (row-level lock)
+//    b. UPDATE all batch rows SET "tokenVersion" = MAX + 1
+// 2. Only AFTER transaction commits: sign JWT with { batchId, purpose: "custody-ack-batch", ver: MAX+1 }
+// 30-day expiry. FOR UPDATE lock prevents concurrent resend requests from minting tokens with same version.
 ```
 
 **Token security:**

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -201,10 +201,11 @@ export async function verifyBatchAcknowledgementToken(
 // 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
 // 2. Checks purpose === "custody-ack-batch"
 // 3. Fetches all custody records with matching acknowledgementBatchId
-// 4. Validates token rotation on EVERY custody record in the batch:
+// 4. Enforces single-custodian membership: all records must have same teamMemberId
+//    (prevents cross-custody acknowledgement if batch was somehow corrupted)
+// 5. Validates token rotation on EVERY custody record in the batch:
 //    converts each custody.tokenIssuedAt to Unix seconds, rejects if any tokenIssuedAtSeconds > token.iat
-//    (resend/copy-link updates tokenIssuedAt on all records in batch, invalidating old batch tokens)
-// 5. Throws if no records found or if any rotation check fails
+// 6. Throws if no records found, mixed custodians, or any rotation check fails
 // Returns batchId + full custody list with asset details
 ```
 
@@ -485,9 +486,10 @@ Same changes as 6.1 but:
 - Accept `requiresAcceptance` parameter
 - Pass through to custody creation
 - Generate a `acknowledgementBatchId` (cuid) and set it on all Custody records in the batch
+- Batch is always **per-custodian** — bulk assign already goes to one custodian, but the batch verifier enforces single-`teamMemberId` membership (rejects if records have mixed custodians)
 - Generate a batch token via `generateBatchAcknowledgementToken(batchId)`
 - One email per custodian with one link covering all assets
-- Acceptance page for batch: queries all custodies with matching `acknowledgementBatchId`, shows list, one "Acknowledge All" click updates all records in transaction
+- Acceptance page for batch: queries all custodies with matching `acknowledgementBatchId`, verifies all belong to same custodian, shows list, one "Acknowledge All" click updates all records in transaction
 
 ### 6.4 Assign custody schema
 
@@ -657,6 +659,8 @@ Handles:
 - Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only)
 
 Token rotation on every resend/copy ensures old links stop working, limiting exposure window.
+
+**Rate limiting:** Enforce a per-custody cooldown (e.g., 1 resend per 60 seconds) to prevent abuse from compromised admin sessions or excessive link churn. Return a clear error: "Please wait before resending. Last sent X seconds ago." Check `tokenIssuedAt` timestamp — if less than 60 seconds ago, reject.
 
 ---
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -448,6 +448,45 @@ export async function recordCustodyAcknowledgement({
 - If the row was already transitioned, the operation is **idempotent** — returns the existing state without error
 - This eliminates the need for an explicit status enum; the state is derived: pending (`both null`), acknowledged (`acceptedAt set`), declined (`declinedAt set`)
 
+### 3.6b Record batch acknowledgement
+
+```typescript
+export async function recordBatchCustodyAcknowledgement({
+  batchId,
+  method,
+  ip,
+  userAgent,
+  organizationId,
+}: RecordBatchAcknowledgementParams): Promise<{ transitionedIds: string[]; custodies: Custody[] }>
+// Updates ALL pending custody records in the batch:
+//   WHERE "acknowledgementBatchId" = batchId AND acceptedAt IS NULL AND declinedAt IS NULL
+//     AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = organizationId)
+// Sets: acceptedAt = now(), acceptanceMethod, acceptanceIp, acceptanceUserAgent
+// Returns list of IDs that actually transitioned (for note creation) + all custodies
+// Already-settled rows are skipped (idempotent)
+```
+
+### 3.6c Record kit custody acknowledgement
+
+```typescript
+export async function recordKitCustodyAcknowledgement({
+  kitCustodyId,
+  method,
+  ip,
+  userAgent,
+  organizationId,
+}: RecordKitAcknowledgementParams): Promise<{ transitioned: boolean; kitCustody: KitCustody; childTransitionedIds: string[] }>
+// In a single transaction:
+// 1. Update KitCustody: acceptedAt = now(), etc.
+//    WHERE id = kitCustodyId AND acceptedAt IS NULL AND declinedAt IS NULL
+// 2. Cascade to child Custody records (pending only):
+//    WHERE assetId IN (SELECT id FROM Asset WHERE kitId = (SELECT kitId FROM KitCustody WHERE id = kitCustodyId))
+//      AND "teamMemberId" = (SELECT "custodianId" FROM "KitCustody" WHERE "id" = kitCustodyId)
+//      AND acceptedAt IS NULL AND declinedAt IS NULL
+//      AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = organizationId)
+// Returns { transitioned, kitCustody, childTransitionedIds } for note/email logic
+```
+
 ### 3.7 Send acknowledgement email
 
 ```typescript
@@ -634,12 +673,14 @@ Handle two intents:
 
 **`acknowledge`:**
 1. Verify token again (full verification including rotation check)
-2. **DB transaction:** Call `recordCustodyAcknowledgement()` — returns `{ transitioned, custody }`
-3. **Only if `transitioned === true`:**
-   - Create acknowledgement activity note (inside same transaction or immediately after)
-   - If kit custody → cascade `acceptedAt` to all child custody records that are still pending (`WHERE acceptedAt IS NULL AND declinedAt IS NULL`) + create notes for each updated asset. Already-settled child rows are skipped to preserve idempotency.
+2. **Branch by token purpose and call the matching record function:**
+   - Single (`custody-ack`): `recordCustodyAcknowledgement()` → `{ transitioned, custody }`
+   - Batch (`custody-ack-batch`): `recordBatchCustodyAcknowledgement()` → `{ transitionedIds, custodies }`
+   - Kit (`custody-ack-kit`): `recordKitCustodyAcknowledgement()` → `{ transitioned, kitCustody, childTransitionedIds }`
+3. **Only for records that actually transitioned:**
+   - Create acknowledgement activity notes (one per transitioned custody/asset)
    - **After commit:** Enqueue admin + custodian notification emails via pg-boss
-4. If `transitioned === false` -> no notes, no emails (idempotent retry — just render current state)
+4. If nothing transitioned → no notes, no emails (idempotent retry — just render current state)
 5. Render success state (shows acknowledgement date regardless of whether this request caused the transition)
 
 **`decline`:**
@@ -1097,7 +1138,7 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 15. `apps/webapp/app/config/addon-copy.ts` — Upsell copy
 16. `apps/webapp/server/logger.ts` — Redact token query param on acceptance routes
 17. `apps/webapp/app/modules/stripe-webhook/handlers.server.ts` — Validate CUSTODY_TOKEN_SECRET on feature enablement
-17. `apps/webapp/app/utils/env.ts` — Add CUSTODY_TOKEN_SECRET
+18. `apps/webapp/app/utils/env.ts` — Add CUSTODY_TOKEN_SECRET
 
 ---
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -38,7 +38,7 @@ model Custody {
   // route to the organization owner instead (org.userId is always present)
   declinedAt                DateTime?                 // When custodian reported they don't have the item
   declineReason             String?                   // Optional reason from custodian
-  tokenIssuedAt             DateTime?                 // When the current token was issued (for invalidation on resend)
+  tokenVersion              Int       @default(0)      // Monotonic counter — incremented on each resend/rotation. Embedded in JWT, compared on verify.
   acknowledgementBatchId    String?                   // Groups multiple custody records for bulk acknowledgement
 
   // DateTime
@@ -156,24 +156,23 @@ export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", { isSecret: t
 
 ```typescript
 export async function generateCustodyAcknowledgementToken(custodyId: string): Promise<string>
-// Signs JWT with { id: custodyId, purpose: "custody-ack" } using CUSTODY_TOKEN_SECRET
+// Signs JWT with { id: custodyId, purpose: "custody-ack", ver: custody.tokenVersion } using CUSTODY_TOKEN_SECRET
 // 30-day expiry (exp claim)
-// Updates custody.tokenIssuedAt = now() in DB (invalidates any previous token)
+// Increments custody.tokenVersion in DB (invalidates any previous token — no same-second race)
 ```
 
 ```typescript
 export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
-// 1. Updates tokenIssuedAt on ALL custody records in the batch (DB write FIRST)
-// 2. Only AFTER the DB write succeeds: signs JWT with { batchId, purpose: "custody-ack-batch" }
+// 1. Increments tokenVersion on ALL custody records in the batch (DB write FIRST)
+// 2. Only AFTER the DB write succeeds: signs JWT with { batchId, purpose: "custody-ack-batch", ver }
 // 30-day expiry. Used for bulk assign (multiple assets, one link)
-// Persist-before-sign order eliminates the revocation window where old tokens
-// could still validate before the tokenIssuedAt write lands.
+// Persist-before-sign order eliminates the revocation window.
 ```
 
 **Token security:**
 - Signed with dedicated `CUSTODY_TOKEN_SECRET` (not shared with invite tokens)
 - 30-day expiry via JWT `exp` claim
-- On resend: new token generated, `tokenIssuedAt` updated on custody record — old tokens rejected
+- On resend: `tokenVersion` incremented, new token embeds new version — old tokens rejected (integer comparison, no timestamp precision issues)
 - Token's decoded `id` is the **sole authority** for DB operations — URL param is for routing only
 - `purpose` field provides defense-in-depth
 
@@ -187,10 +186,9 @@ export async function verifyCustodyAcknowledgementToken(
 // 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
 // 2. Checks purpose === "custody-ack"
 // 3. Fetches custody record
-// 4. Normalizes time units: converts Prisma DateTime to Unix seconds
-//    via Math.floor(tokenIssuedAt.getTime() / 1000) before comparing to JWT iat (RFC 7519 = seconds)
+// 4. Compares JWT `ver` claim against custody.tokenVersion (integer equality — no timestamp precision issues)
 // 5. Throws ShelfError("Token expired") on exp failure
-// 6. Throws ShelfError("Token revoked") if tokenIssuedAtSeconds > token.iat
+// 6. Throws ShelfError("Token revoked") if token.ver !== custody.tokenVersion
 // 6. Throws ShelfError("Custody not found") if record doesn't exist
 // Returns custody ID and iat
 // Token rotation check is INSIDE this function — callers cannot forget it
@@ -209,7 +207,7 @@ export async function verifyBatchAcknowledgementToken(
 // 4. Enforces single-custodian membership: all records must have same teamMemberId
 //    (prevents cross-custody acknowledgement if batch was somehow corrupted)
 // 5. Validates token rotation on EVERY custody record in the batch:
-//    converts each custody.tokenIssuedAt to Unix seconds, rejects if any tokenIssuedAtSeconds > token.iat
+//    compares each custody.tokenVersion against token.ver (integer equality)
 // 6. Throws if no records found, mixed custodians, or any rotation check fails
 // Returns batchId + full custody list with asset details
 ```
@@ -224,7 +222,7 @@ export async function verifyKitCustodyAcknowledgementToken(
 // 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
 // 2. Checks purpose === "custody-ack-kit"
 // 3. Fetches KitCustody record (NOT Custody) with kit + all child assets + custodian
-// 4. Validates tokenIssuedAt rotation check
+// 4. Validates tokenVersion rotation check (integer equality)
 // 5. Throws if KitCustody not found
 // Returns kitCustodyId + full kit custody with child asset details
 ```
@@ -329,7 +327,7 @@ The acceptance route must handle these error states explicitly:
 | Error | Cause | User message |
 |-------|-------|-------------|
 | Token expired | 30-day `exp` claim exceeded | "This link has expired. Contact your admin for a new one." |
-| Token revoked | `iat < tokenIssuedAt` (admin resent) | "This link is no longer valid. A newer link was sent." |
+| Token revoked | `token.ver !== custody.tokenVersion` (admin resent) | "This link is no longer valid. A newer link was sent." |
 | Custody not found | Released between page load and click | "This custody assignment has been released." |
 | Already acknowledged | `acceptedAt` is set | Show confirmation with existing date. |
 | Already declined | `declinedAt` is set | Show "already reported" confirmation. |
@@ -387,7 +385,7 @@ Add: `"/accept-custody/:custodyId"` (narrow — no wildcard)
 **Token-in-URL leak mitigations:**
 Tokens are passed as query params (`?token=...`), which are prone to leakage via referrer headers, browser history, server logs, and analytics. Mitigations:
 - Set `Referrer-Policy: no-referrer` on the acceptance page response headers (prevents token leaking to external resources)
-- Ensure server access logs do NOT log query strings for this route (or redact `token=` param)
+- **Modify `apps/webapp/server/logger.ts`**: The current middleware logs full query strings via `getQueryStrings(c.req.raw.url)`. Add redaction for the `token` param on `/accept-custody` routes (replace value with `[REDACTED]`). **This is an implementation step, not just guidance.**
 - The 30-day expiry + rotation on resend limits the window of exposure
 - After acknowledgement, the token becomes useless (idempotent, already-accepted state)
 
@@ -397,7 +395,7 @@ Tokens are passed as query params (`?token=...`), which are prone to leakage via
 - Token is the authority. No login needed.
 - Extract `token` from search params, verify JWT
 - The decoded `id` from the token is the **sole key** for all DB operations — ignore the URL `custodyId` param for data access (use it only for routing)
-- Also verify `custody.tokenIssuedAt <= token.iat` to reject rotated/old tokens
+- Also verify `token.ver === custody.tokenVersion` to reject rotated/old tokens
 - Works for non-registered members, logged-out users, anyone with the link
 
 **In-app mode** (Phase 10 route — session required):
@@ -709,7 +707,7 @@ Pass to the banner component.
 **New file:** `apps/webapp/app/routes/api+/custody.acknowledgement.ts`
 
 Handles:
-- `POST` with intent `resend-email`: Generates **new** token (rotates — updates `tokenIssuedAt`, invalidating old link), re-sends email
+- `POST` with intent `resend-email`: Increments `tokenVersion`, generates **new** token with new version, re-sends email
 - `POST` with intent `copy-link`: Generates **new** token (rotates), returns the signed URL for clipboard copy
 - Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only)
 
@@ -717,23 +715,23 @@ Token rotation on every resend/copy ensures old links stop working, limiting exp
 
 **Rate limiting (atomic):** Enforce a per-custody cooldown via a single conditional DB update — not a read-then-write (TOCTOU-safe):
 ```typescript
-// Single atomic operation — cooldown + rotation in one query:
+// Single atomic operation — cooldown + version increment in one query:
 const result = await db.custody.updateMany({
   where: {
     id: custodyId,
     OR: [
-      { tokenIssuedAt: null },
-      { tokenIssuedAt: { lt: sixtySecondsAgo } },
+      { updatedAt: { lt: sixtySecondsAgo } },
+      { tokenVersion: 0 }, // never resent before
     ],
   },
-  data: { tokenIssuedAt: now() },
+  data: { tokenVersion: { increment: 1 } },
 });
 if (result.count === 0) {
   throw new ShelfError({ message: "Please wait before resending." });
 }
-// Only generate new token + send email if the update succeeded
+// Only generate new token (with new version) + send email if update succeeded
 ```
-This prevents concurrent requests from both passing the cooldown check.
+This prevents concurrent requests from both passing the cooldown check. Uses `updatedAt` (auto-set by Prisma on update) as the cooldown timestamp.
 
 ---
 
@@ -773,7 +771,7 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 9. `apps/webapp/app/routes/api+/custody.acknowledgement.ts` — Resend/copy-link API
 10. `packages/database/prisma/migrations/[ts]_add_custody_acknowledgement/migration.sql`
 
-### Modified files (16):
+### Modified files (17):
 1. `packages/database/prisma/schema.prisma` — Custody, KitCustody, Organization models
 2. `apps/webapp/server/index.ts` — Add public path
 3. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx` — Checkbox + email logic
@@ -790,6 +788,7 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 14. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx` — Pending note
 15. `apps/webapp/app/utils/roles.server.ts` — Return `canUseCustodyAcknowledgement`
 16. `apps/webapp/app/config/addon-copy.ts` — Upsell copy
+17. `apps/webapp/server/logger.ts` — Redact token query param on acceptance routes
 
 ---
 
@@ -816,7 +815,7 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 |----------|-----------|
 | No new AssetStatus | IN_CUSTODY set immediately. Acknowledgement is evidence, not a gate. Avoids ripple through dozens of status checks. |
 | Activity note = permanent record (no raw PII) | Custody records hard-deleted on release. Note stores summary (name, timestamp, method). Raw IP/UA only on ephemeral Custody fields — auto-purged on release. |
-| 30-day token expiry + rotation on resend | Limits exposure window. `tokenIssuedAt` on Custody rejects old tokens after resend. |
+| 30-day token expiry + monotonic version rotation | `tokenVersion` integer incremented on resend. JWT embeds `ver` claim. Integer equality check — no timestamp precision issues. |
 | Token is sole authority (not URL param) | Decoded JWT `id` used for all DB lookups. URL `custodyId` is routing only. Prevents mismatch attacks. |
 | Two auth modes: public token vs in-app session | Public route: token = authority, no login needed. In-app route: session + teamMember match = authority. Clear separation. |
 | Batch key for bulk acknowledgement (per-custodian) | `acknowledgementBatchId` groups custody records scoped to a single custodian. Verifier enforces single `teamMemberId` membership — rejects mixed batches. One token covers the batch. |
@@ -824,11 +823,11 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Narrow public path | `/accept-custody/:custodyId` — no wildcard. Minimal exposure surface. |
 | Dedicated CUSTODY_TOKEN_SECRET | Separate secret prevents token confusion with invite tokens (invite verifier doesn't check `purpose`). |
 | Three token purposes | `custody-ack` (single), `custody-ack-batch` (bulk), `custody-ack-kit` (kit) — each with dedicated verifier fetching from the correct model. |
-| Token rotation inside verifier | `verify*Token()` functions check `tokenIssuedAt` internally — callers cannot forget. |
+| Token rotation inside verifier | `verify*Token()` functions check `tokenVersion` internally — callers cannot forget. |
 | Checkbox coercion in Zod schema | HTML checkbox sends `"on"` not `true`. Uses `z.union([z.boolean(), z.literal("on")]).transform()` — follows existing column visibility pattern. |
 | Decline uses same conditional guard as accept | `WHERE acceptedAt IS NULL AND declinedAt IS NULL` — prevents race between concurrent accept/decline. |
 | Single owner for email side effects | Service functions are DB-only. Route actions enqueue emails via pg-boss after commit. Prevents duplicate sends. |
-| Atomic resend cooldown | Single conditional `updateMany` with `tokenIssuedAt < 60s ago` — TOCTOU-safe, no read-then-write. |
+| Atomic resend cooldown | Single conditional `updateMany` with `updatedAt < 60s ago` + version increment — TOCTOU-safe. |
 | PII cleanup deferred (not an oversight) | Custody hard-delete already purges IP/UA. Notes have no PII. Cron job is trivial to add later if needed. |
 | Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -37,7 +37,7 @@ model Custody {
   // Fallback: if assignedByUserId is null (user deleted), admin notifications
   // route to the organization owner instead (org.userId is always present)
   declinedAt                DateTime?                 // When custodian reported they don't have the item
-  declineReason             String?                   // Optional reason from custodian
+  declineReason             String?   @db.VarChar(500)  // Optional reason from custodian (trimmed, max 500 chars)
   tokenVersion              Int       @default(0)      // Monotonic counter — incremented on each resend/rotation. Embedded in JWT, compared on verify.
   lastTokenRotatedAt        DateTime?                 // When token was last rotated (dedicated cooldown field, not coupled to updatedAt)
   acknowledgementBatchId    String?                   // Groups multiple custody records for bulk acknowledgement
@@ -154,7 +154,15 @@ We do NOT reuse `INVITE_TOKEN_SECRET` because the invite verification path (`acc
 
 Add to `apps/webapp/app/utils/env.ts`:
 ```typescript
-export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", { isSecret: true });
+// Lazy — only required when the feature is actually used (token sign/verify callsites).
+// Does NOT crash server startup if unset, allowing phased rollout.
+export const CUSTODY_TOKEN_SECRET = process.env.CUSTODY_TOKEN_SECRET;
+```
+At token sign/verify callsites, assert presence:
+```typescript
+if (!CUSTODY_TOKEN_SECRET) {
+  throw new ShelfError({ message: "CUSTODY_TOKEN_SECRET is not configured." });
+}
 ```
 
 ---
@@ -297,7 +305,8 @@ export async function recordCustodyDecline({
 // Conditional update — only transitions from PENDING state:
 //   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
 // If no rows updated → already accepted or declined (idempotent: return current state)
-// Sets: declinedAt = now(), declineReason = reason
+// Validates reason: z.string().trim().max(500).optional()
+// Sets: declinedAt = now(), declineReason = sanitized reason
 // Does NOT change asset status or delete custody
 // Does NOT send emails — that is the route action's responsibility (after DB commit)
 // Returns { declined: true/false, custody } so caller knows if transition happened
@@ -733,10 +742,13 @@ Token rotation on every resend/copy ensures old links stop working, limiting exp
 
 **Rate limiting (atomic):** Enforce a per-custody cooldown via a single conditional DB update — not a read-then-write (TOCTOU-safe):
 ```typescript
-// Single atomic operation — cooldown + version increment in one query:
+// Single atomic operation — cooldown + version increment + state guard:
 const result = await db.custody.updateMany({
   where: {
     id: custodyId,
+    requiresAcceptance: true,       // must be an ack-enabled custody
+    acceptedAt: null,               // not already acknowledged
+    declinedAt: null,               // not already declined
     OR: [
       { lastTokenRotatedAt: null },                    // never rotated
       { lastTokenRotatedAt: { lt: sixtySecondsAgo } }, // 60s cooldown
@@ -748,11 +760,12 @@ const result = await db.custody.updateMany({
   },
 });
 if (result.count === 0) {
-  throw new ShelfError({ message: "Please wait before resending." });
+  // Could be: cooldown active, already accepted/declined, or not ack-enabled
+  throw new ShelfError({ message: "Cannot resend: either cooldown active or custody is no longer pending." });
 }
 // Only generate new token (with new version) + send email if update succeeded
 ```
-Uses dedicated `lastTokenRotatedAt` field — not coupled to `updatedAt` which can be triggered by unrelated custody writes.
+Guards against: cooldown abuse, resending for already-accepted/declined custody, and resending for non-ack custody. Uses dedicated `lastTokenRotatedAt` — not coupled to `updatedAt`.
 
 ---
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -132,9 +132,16 @@ The boolean `custodyAcknowledgementEnabled` on the Organization model is just a 
 
 For v1, the simplest path: include it in Plus and Team plans automatically. Free users see the upsell to upgrade. No Stripe addon product needed — just set the flag when the user's tier qualifies.
 
-### 2.6 JWT token — reuse INVITE_TOKEN_SECRET
+### 2.6 JWT token — separate CUSTODY_TOKEN_SECRET
 
-No new env var. We reuse `INVITE_TOKEN_SECRET` but include `purpose: "custody-ack"` in the JWT payload to prevent cross-use with invite tokens.
+**New env var: `CUSTODY_TOKEN_SECRET`** — a dedicated secret for custody acknowledgement tokens.
+
+We do NOT reuse `INVITE_TOKEN_SECRET` because the invite verification path (`accept-invite.$inviteId.tsx:110-112`) does not validate a `purpose` claim. Sharing secrets would allow custody tokens to pass invite verification — a token confusion vulnerability. Separate secrets eliminate this risk entirely.
+
+Add to `apps/webapp/app/utils/env.ts`:
+```typescript
+export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", { isSecret: true });
+```
 
 ---
 
@@ -145,31 +152,55 @@ No new env var. We reuse `INVITE_TOKEN_SECRET` but include `purpose: "custody-ac
 ### 3.1 Token generation
 
 ```typescript
-export function generateCustodyAcknowledgementToken(custodyId: string): string
-// Signs JWT with { id: custodyId, purpose: "custody-ack", iat: now }
+export async function generateCustodyAcknowledgementToken(custodyId: string): Promise<string>
+// Signs JWT with { id: custodyId, purpose: "custody-ack" } using CUSTODY_TOKEN_SECRET
 // 30-day expiry (exp claim)
-// Updates custody.tokenIssuedAt = now (invalidates any previous token)
+// Updates custody.tokenIssuedAt = now() in DB (invalidates any previous token)
 ```
 
 ```typescript
 export function generateBatchAcknowledgementToken(batchId: string): string
-// Signs JWT with { batchId, purpose: "custody-ack-batch", iat: now }
+// Signs JWT with { batchId, purpose: "custody-ack-batch" } using CUSTODY_TOKEN_SECRET
 // 30-day expiry. Used for bulk assign (multiple assets, one link)
+// Updates tokenIssuedAt on ALL custody records in the batch
 ```
 
 **Token security:**
+- Signed with dedicated `CUSTODY_TOKEN_SECRET` (not shared with invite tokens)
 - 30-day expiry via JWT `exp` claim
-- On resend: new token generated, `tokenIssuedAt` updated on custody record — old tokens rejected by comparing JWT `iat` < `tokenIssuedAt`
-- Token's decoded `id` is the **sole authority** for DB operations — URL param `custodyId` is for routing only, never trusted over the token
-- `purpose` field prevents cross-use with invite tokens
+- On resend: new token generated, `tokenIssuedAt` updated on custody record — old tokens rejected
+- Token's decoded `id` is the **sole authority** for DB operations — URL param is for routing only
+- `purpose` field provides defense-in-depth
 
-### 3.2 Token verification
+### 3.2 Token verification (single custody)
 
 ```typescript
-export function verifyCustodyAcknowledgementToken(token: string): { id: string }
-// Verifies JWT signature + expiry, checks purpose === "custody-ack"
-// Returns custody ID
-// Caller MUST also check custody.tokenIssuedAt <= token.iat to reject rotated tokens
+export async function verifyCustodyAcknowledgementToken(
+  token: string,
+  db: PrismaClient
+): Promise<{ id: string; iat: number }>
+// 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
+// 2. Checks purpose === "custody-ack"
+// 3. Fetches custody record, validates tokenIssuedAt <= token.iat (rejects rotated tokens)
+// 4. Throws ShelfError("Token expired") on exp failure
+// 5. Throws ShelfError("Token revoked") if iat < tokenIssuedAt
+// 6. Throws ShelfError("Custody not found") if record doesn't exist
+// Returns custody ID and iat
+// Token rotation check is INSIDE this function — callers cannot forget it
+```
+
+### 3.3 Token verification (batch)
+
+```typescript
+export async function verifyBatchAcknowledgementToken(
+  token: string,
+  db: PrismaClient
+): Promise<{ batchId: string; custodies: CustodyWithAsset[] }>
+// 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
+// 2. Checks purpose === "custody-ack-batch"
+// 3. Fetches all custody records with matching acknowledgementBatchId
+// 4. Throws if no records found
+// Returns batchId + full custody list with asset details
 ```
 
 ### 3.3 Record acknowledgement
@@ -236,6 +267,33 @@ export function createAcknowledgementNote({
 ```
 
 **Privacy approach:** Raw IP and user-agent are stored on the Custody model's structured fields for operational use while custody is active. The activity note contains only a summary (custodian name, timestamp, method) — no raw PII. When custody is released and the record deleted, the ephemeral evidence is purged automatically. The note survives as the permanent record without privacy concerns.
+
+### 3.8 PII retention and cleanup
+
+For custodies that are never released (permanent assignments, abandoned assets), raw PII would persist indefinitely. To prevent this:
+
+```typescript
+export async function cleanupExpiredAcknowledgementPII(): Promise<void>
+// Scheduled job (daily via pg-boss)
+// Finds custodies where acceptedAt is > 2 years ago AND acceptanceIp is not null
+// Sets acceptanceIp = null, acceptanceUserAgent = null
+// Preserves acceptedAt, acceptanceMethod (non-PII summary data)
+```
+
+Add to the acknowledgement email template: brief privacy notice that IP and browser info are recorded for security purposes and retained for a maximum of 2 years.
+
+### 3.9 Error handling specification
+
+The acceptance route must handle these error states explicitly:
+
+| Error | Cause | User message |
+|-------|-------|-------------|
+| Token expired | 30-day `exp` claim exceeded | "This link has expired. Contact your admin for a new one." |
+| Token revoked | `iat < tokenIssuedAt` (admin resent) | "This link is no longer valid. A newer link was sent." |
+| Custody not found | Released between page load and click | "This custody assignment has been released." |
+| Already acknowledged | `acceptedAt` is set | Show confirmation with existing date. |
+| Already declined | `declinedAt` is set | Show "already reported" confirmation. |
+| Prisma P2025 | Race condition on acknowledge action | "This custody has been released and can no longer be acknowledged." |
 
 ---
 
@@ -304,13 +362,14 @@ Add: `"/accept-custody/:custodyId"` (narrow — no wildcard)
 ### 5.3 Loader
 
 1. Extract `token` from search params
-2. Verify JWT token via `verifyCustodyAcknowledgementToken(token)` — get `custodyId` from decoded token
-3. Fetch custody record using decoded `custodyId` with asset details (title, mainImage, category, sequentialId, organization name)
-4. Verify `custody.tokenIssuedAt <= token.iat` (reject old/rotated tokens)
-5. If custody doesn't exist → render "This custody assignment has been released"
-6. If already accepted → render "Already acknowledged" confirmation
-7. If declined → render "Already reported" confirmation
-8. Return asset details + custody info to component
+2. Decode token (without full verification) to check `purpose` field
+3. **Branch on token type:**
+   - `purpose === "custody-ack"` → Single flow: call `verifyCustodyAcknowledgementToken(token, db)` (handles signature, expiry, rotation check internally)
+   - `purpose === "custody-ack-batch"` → Batch flow: call `verifyBatchAcknowledgementToken(token, db)` — returns all custodies in the batch with asset details
+4. Handle error states (see 3.9 error handling table): expired, revoked, not found
+5. If already accepted → render "Already acknowledged" confirmation
+6. If declined → render "Already reported" confirmation
+7. Return asset details + custody info (single or batch list) to component
 
 ### 5.4 Action
 
@@ -565,9 +624,15 @@ The in-app acknowledge route uses **session-based auth** (see Phase 5.2 for the 
 The acknowledge action needs to work for BASE and SELF_SERVICE users who are the custodian.
 This is NOT a general custody permission — it's: "you can acknowledge YOUR OWN custody."
 
-- Verify that the requesting user's TeamMember ID matches `custody.teamMemberId`
-- No role-based permission check needed — custodian identity is the authority
-- The public token route (Phase 5) does NOT enforce this check — the token IS the authority there
+**Organization-scoped verification (prevents cross-org attacks):**
+1. Get `organizationId` from session context (current workspace)
+2. Find the current user's TeamMember within that org: `db.teamMember.findFirst({ where: { userId, organizationId } })`
+3. When querying pending custodies: scope via `asset: { organizationId }` AND `teamMemberId: currentTeamMember.id`
+4. When acknowledging: verify `custody.teamMemberId === currentTeamMember.id` AND `custody.asset.organizationId === organizationId`
+
+This ensures users cannot acknowledge custodies from other organizations, even if they're a custodian there too.
+
+- The public token route (Phase 5) does NOT enforce org scoping — the token IS the authority there
 
 ### 10.4 Layout integration
 
@@ -676,7 +741,10 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Batch key for bulk acknowledgement | `acknowledgementBatchId` groups custody records. One token covers the batch. Resend/copy-link target the batch reliably. |
 | Persisted decline state | `declinedAt` + `declineReason` on Custody makes "Disputed" queryable and filterable. |
 | Narrow public path | `/accept-custody/:custodyId` — no wildcard. Minimal exposure surface. |
-| Reuse INVITE_TOKEN_SECRET | JWT includes `purpose: "custody-ack"` to prevent cross-use. No new env var. |
+| Dedicated CUSTODY_TOKEN_SECRET | Separate secret prevents token confusion with invite tokens (invite verifier doesn't check `purpose`). |
+| Token rotation inside verifier | `verifyCustodyAcknowledgementToken()` checks `tokenIssuedAt` internally — callers cannot forget. |
+| PII auto-cleanup after 2 years | Scheduled job nulls IP/UA on old custodies. Covers never-released assignments. |
+| Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |
 | Self-assignment hides checkbox | Can't corroborate receipt from the person who assigned. |
 | One email per custodian for bulk | Not spammy. One acknowledge-all click via batch token. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -455,16 +455,22 @@ Handle two intents:
 
 **`acknowledge`:**
 1. Verify token again (full verification including rotation check)
-2. **DB transaction:** Call `recordCustodyAcknowledgement()` with IP + user-agent AND create acknowledgement activity note atomically
-3. If kit custody → cascade `acceptedAt` to all child custody records + create notes for each asset (same transaction)
-4. **After commit:** Enqueue notification emails via pg-boss (`sendEmail()` already uses pg-boss with 15 retries). Admin + custodian emails are enqueued, not sent inline — if the queue fails, DB state is correct and emails can be retried independently.
-5. Render success state
+2. **DB transaction:** Call `recordCustodyAcknowledgement()` — returns `{ transitioned, custody }`
+3. **Only if `transitioned === true`:**
+   - Create acknowledgement activity note (inside same transaction or immediately after)
+   - If kit custody → cascade `acceptedAt` to all child custody records + create notes for each asset
+   - **After commit:** Enqueue admin + custodian notification emails via pg-boss
+4. If `transitioned === false` → no notes, no emails (idempotent retry — just render current state)
+5. Render success state (shows acknowledgement date regardless of whether this request caused the transition)
 
 **`decline`:**
 1. Verify token (full verification)
-2. **DB transaction:** Call `recordCustodyDecline()` + create decline activity note atomically
-3. **After commit:** Enqueue admin alert email via pg-boss
-4. Render "reported" confirmation
+2. **DB transaction:** Call `recordCustodyDecline()` — returns `{ declined, custody }`
+3. **Only if `declined === true`:**
+   - Create decline activity note
+   - **After commit:** Enqueue admin alert email via pg-boss
+4. If `declined === false` → no notes, no emails (idempotent)
+5. Render "reported" confirmation
 
 **Why enqueue after commit:** Mixing DB mutations and email sends in one request path risks partial success (DB committed but email lost). The existing `sendEmail()` function already uses pg-boss as an outbox with retry — we just need to call it AFTER the transaction commits, not inside it.
 
@@ -529,7 +535,8 @@ After acknowledgement:
 
 **Action changes:**
 - Parse new `requiresAcceptance` boolean from form data (add to schema)
-- If `requiresAcceptance`:
+- **Server-side gating:** If `requiresAcceptance` is true, call `validateCustodyAcknowledgementEnabled(currentOrganization)` — throws 403 if feature not enabled. This prevents free-tier users from bypassing UI-only restrictions via crafted form data.
+- If `requiresAcceptance` and feature is enabled:
   - Include `requiresAcceptance: true` and `assignedByUserId: userId` in custody create
   - Generate JWT token
   - If custodian has user with email → send acknowledgement email
@@ -738,17 +745,12 @@ Pass to the banner component.
 
 **New file:** `apps/webapp/app/routes/api+/custody.acknowledgement.ts`
 
-Handles:
-- `POST` with intent `resend-email`: Increments `tokenVersion`, generates **new** token with new version, re-sends email
-- `POST` with intent `copy-link`: Generates **new** token (rotates), returns the signed URL for clipboard copy
-- Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only)
+Accepts `custodyId` (single), `acknowledgementBatchId` (batch), or `kitCustodyId` (kit). Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only).
 
-Token rotation on every resend/copy ensures old links stop working, limiting exposure window.
+**Three rotation paths** (matching the three token purposes):
 
-**Rate limiting (atomic):** Enforce a per-custody cooldown via a single conditional DB update — not a read-then-write (TOCTOU-safe):
+**Single custody resend:**
 ```typescript
-// Single atomic operation — cooldown + version increment + state guard.
-// Uses raw SQL to atomically increment AND return the new version in one query:
 const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
   UPDATE "Custody"
   SET "tokenVersion" = "tokenVersion" + 1,
@@ -756,18 +758,38 @@ const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
       "updatedAt" = NOW()
   WHERE "id" = ${custodyId}
     AND "requiresAcceptance" = true
-    AND "acceptedAt" IS NULL
-    AND "declinedAt" IS NULL
+    AND "acceptedAt" IS NULL AND "declinedAt" IS NULL
     AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < NOW() - INTERVAL '60 seconds')
   RETURNING "tokenVersion"
 `;
-if (!updated) {
-  throw new ShelfError({ message: "Cannot resend: cooldown active or custody no longer pending." });
-}
-const newVersion = updated.tokenVersion;
-// Sign JWT with { id: custodyId, purpose: "custody-ack", ver: newVersion }
+// Sign with { id: custodyId, purpose: "custody-ack", ver: updated.tokenVersion }
 ```
-Uses `UPDATE ... RETURNING` to atomically increment + retrieve the new version in a single query. No gap between increment and read. Guards against cooldown abuse, terminal states, and non-ack custody. `lastTokenRotatedAt` is dedicated — not coupled to `updatedAt`.
+
+**Batch resend** (rotates ALL rows in batch atomically):
+```typescript
+// Lock all batch rows, rotate together, return uniform version
+const rows = await db.$queryRaw`
+  UPDATE "Custody"
+  SET "tokenVersion" = (
+    SELECT MAX("tokenVersion") + 1 FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId}
+  ),
+  "lastTokenRotatedAt" = NOW(), "updatedAt" = NOW()
+  WHERE "acknowledgementBatchId" = ${batchId}
+    AND "requiresAcceptance" = true
+    AND "acceptedAt" IS NULL AND "declinedAt" IS NULL
+    AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < NOW() - INTERVAL '60 seconds')
+  RETURNING "tokenVersion"
+`;
+// Sign with { batchId, purpose: "custody-ack-batch", ver: rows[0].tokenVersion }
+```
+
+**Kit resend** (rotates KitCustody + all child Custody rows):
+```typescript
+// Transaction: rotate KitCustody + all child Custody records together
+// Sign with { kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
+```
+
+All paths: atomic `UPDATE ... RETURNING`, cooldown via `lastTokenRotatedAt` with DB time (`NOW() - INTERVAL`), state guards. Batch/kit resend rotates the **entire group** — never a single row from a group, which would desynchronize versions and break batch/kit verification.
 
 ---
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -34,6 +34,8 @@ model Custody {
   acceptanceUserAgent       String?                   // Browser user-agent (ephemeral — deleted with custody)
   assignedBy                User?     @relation("custodyAssigner", fields: [assignedByUserId], references: [id], onDelete: SetNull)
   assignedByUserId          String?                   // Who assigned custody (for admin notification routing, SetNull on user delete)
+  // Fallback: if assignedByUserId is null (user deleted), admin notifications
+  // route to the organization owner instead (org.userId is always present)
   declinedAt                DateTime?                 // When custodian reported they don't have the item
   declineReason             String?                   // Optional reason from custodian
   tokenIssuedAt             DateTime?                 // When the current token was issued (for invalidation on resend)
@@ -220,9 +222,18 @@ export async function recordCustodyAcknowledgement({
   userAgent,
   organizationId,
 }: RecordAcknowledgementParams): Promise<Custody>
-// Updates custody: acceptedAt = now(), acceptanceMethod, acceptanceIp, acceptanceUserAgent
+// Conditional update — only transitions from PENDING state:
+//   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
+// If no rows updated → custody was already accepted or declined (idempotent: return current state)
+// Sets: acceptedAt = now(), acceptanceMethod, acceptanceIp, acceptanceUserAgent
 // Returns updated custody with asset + custodian data
 ```
+
+**State transition invariants:**
+- `acceptedAt` and `declinedAt` are **mutually exclusive** — a custody cannot be both accepted and declined
+- All state transitions use conditional WHERE clauses (`acceptedAt IS NULL AND declinedAt IS NULL`) to prevent races
+- If the row was already transitioned, the operation is **idempotent** — returns the existing state without error
+- This eliminates the need for an explicit status enum; the state is derived: pending (`both null`), acknowledged (`acceptedAt set`), declined (`declinedAt set`)
 
 ### 3.4 Send acknowledgement email
 
@@ -506,8 +517,11 @@ Add `requiresAcceptance: z.boolean().optional().default(false)` to `AssignCustod
 
 **File:** `apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx`
 
-Before releasing, check if `requiresAcceptance` was true and `acceptedAt` is null.
-If so, include in the release note: "released {custodian}'s custody (acknowledgement was pending)"
+Before releasing, check the acknowledgement state and include it in the release note:
+- `requiresAcceptance && !acceptedAt && !declinedAt` → "released {custodian}'s custody (acknowledgement was pending)"
+- `requiresAcceptance && declinedAt` → "released {custodian}'s custody (custody was disputed)"
+- `requiresAcceptance && acceptedAt` → "released {custodian}'s custody (was acknowledged on {date})"
+- `!requiresAcceptance` → existing behavior, no acknowledgement mention
 
 ### 7.2 Bulk release
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -256,7 +256,10 @@ export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", {
 ```
 **Two-layer validation:**
 
-1. **Feature enablement guard:** When `custodyAcknowledgementEnabled` is set to `true` on an org (via Stripe webhook or admin toggle), validate that `CUSTODY_TOKEN_SECRET` is configured. If not, reject the enablement with a clear error: "Cannot enable custody acknowledgement: CUSTODY_TOKEN_SECRET is not configured." This prevents orgs from entering a broken state.
+1. **Feature enablement guard:** When `custodyAcknowledgementEnabled` is set to `true` on an org, validate that `CUSTODY_TOKEN_SECRET` is configured. If not, reject the enablement with a clear error: "Cannot enable custody acknowledgement: CUSTODY_TOKEN_SECRET is not configured." This check runs in:
+   - **Stripe webhook handler** (`apps/webapp/app/modules/stripe-webhook/handlers.server.ts`) — for subscription-based enablement
+   - **Organization settings action** (`apps/webapp/app/routes/_layout+/settings.general.tsx`) — if manual toggle is added
+   - Both paths call `validateCustodyTokenSecretConfigured()` from the acknowledgement service before setting the flag to `true`
 
 2. **Callsite guard (defense-in-depth):** At token sign/verify callsites, assert presence:
 ```typescript
@@ -1076,7 +1079,7 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 9. `apps/webapp/app/routes/api+/custody.acknowledgement.ts` — Resend/copy-link API
 10. `packages/database/prisma/migrations/[ts]_add_custody_acknowledgement/migration.sql`
 
-### Modified files (17):
+### Modified files (18):
 1. `packages/database/prisma/schema.prisma` — Custody, KitCustody, Organization, User models
 2. `apps/webapp/server/index.ts` — Add public path
 3. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx` — Checkbox + email logic
@@ -1093,6 +1096,7 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 14. `apps/webapp/app/utils/roles.server.ts` — Return `canUseCustodyAcknowledgement`
 15. `apps/webapp/app/config/addon-copy.ts` — Upsell copy
 16. `apps/webapp/server/logger.ts` — Redact token query param on acceptance routes
+17. `apps/webapp/app/modules/stripe-webhook/handlers.server.ts` — Validate CUSTODY_TOKEN_SECRET on feature enablement
 17. `apps/webapp/app/utils/env.ts` — Add CUSTODY_TOKEN_SECRET
 
 ---

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -322,7 +322,9 @@ export async function generateKitCustodyAcknowledgementToken(kitCustodyId: strin
 //    - options: { algorithm: "HS256", expiresIn: "30d", issuer: "shelf-custody", audience: "custody-ack" }
 ```
 
-**Token security:**
+**Token security and org scoping:**
+- Token generation functions (3.1) are called from route actions that already enforce `organizationId` via `requirePermission()`. The SQL UPDATE statements operate on specific custody/kit IDs that were already validated against the org. Adding `organizationId` to the UPDATE WHERE clause would be defense-in-depth but is not strictly required since the caller already validated ownership. The resend API (Phase 11) DOES include explicit org scoping in every query because it accepts raw IDs from request bodies.
+
 - Signed with dedicated `CUSTODY_TOKEN_SECRET` (not shared with invite tokens)
 - Pinned to `algorithm: "HS256"` on both sign and verify — prevents algorithm confusion attacks
 - `issuer: "shelf-custody"` and `audience: "custody-ack"` claims validated on verify — prevents cross-service token reuse

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -27,12 +27,16 @@ model Custody {
   assetId String @unique
 
   // Acknowledgement fields
-  requiresAcceptance  Boolean   @default(false) // Was acknowledgement requested?
-  acceptedAt          DateTime?                 // When custodian acknowledged
-  acceptanceMethod    String?                   // "email_link" | "in_app" | "manual_link"
-  acceptanceIp        String?                   // IP address at time of acknowledgement
-  acceptanceUserAgent String?                   // Browser user-agent string
-  assignedByUserId    String?                   // Who assigned custody (for admin notification routing)
+  requiresAcceptance        Boolean   @default(false) // Was acknowledgement requested?
+  acceptedAt                DateTime?                 // When custodian acknowledged
+  acceptanceMethod          String?                   // "email_link" | "in_app" | "manual_link"
+  acceptanceIp              String?                   // IP address (ephemeral — deleted with custody on release)
+  acceptanceUserAgent       String?                   // Browser user-agent (ephemeral — deleted with custody)
+  assignedByUserId          String?                   // Who assigned custody (for admin notification routing)
+  declinedAt                DateTime?                 // When custodian reported they don't have the item
+  declineReason             String?                   // Optional reason from custodian
+  tokenIssuedAt             DateTime?                 // When the current token was issued (for invalidation on resend)
+  acknowledgementBatchId    String?                   // Groups multiple custody records for bulk acknowledgement
 
   // DateTime
   createdAt DateTime @default(now())
@@ -142,16 +146,30 @@ No new env var. We reuse `INVITE_TOKEN_SECRET` but include `purpose: "custody-ac
 
 ```typescript
 export function generateCustodyAcknowledgementToken(custodyId: string): string
-// Signs JWT with { id: custodyId, purpose: "custody-ack" }
-// No expiry for v1 (token validity = custody record existence)
+// Signs JWT with { id: custodyId, purpose: "custody-ack", iat: now }
+// 30-day expiry (exp claim)
+// Updates custody.tokenIssuedAt = now (invalidates any previous token)
 ```
+
+```typescript
+export function generateBatchAcknowledgementToken(batchId: string): string
+// Signs JWT with { batchId, purpose: "custody-ack-batch", iat: now }
+// 30-day expiry. Used for bulk assign (multiple assets, one link)
+```
+
+**Token security:**
+- 30-day expiry via JWT `exp` claim
+- On resend: new token generated, `tokenIssuedAt` updated on custody record — old tokens rejected by comparing JWT `iat` < `tokenIssuedAt`
+- Token's decoded `id` is the **sole authority** for DB operations — URL param `custodyId` is for routing only, never trusted over the token
+- `purpose` field prevents cross-use with invite tokens
 
 ### 3.2 Token verification
 
 ```typescript
 export function verifyCustodyAcknowledgementToken(token: string): { id: string }
-// Verifies JWT, checks purpose === "custody-ack"
+// Verifies JWT signature + expiry, checks purpose === "custody-ack"
 // Returns custody ID
+// Caller MUST also check custody.tokenIssuedAt <= token.iat to reject rotated tokens
 ```
 
 ### 3.3 Record acknowledgement
@@ -168,20 +186,7 @@ export async function recordCustodyAcknowledgement({
 // Returns updated custody with asset + custodian data
 ```
 
-### 3.4 Record decline
-
-```typescript
-export async function recordCustodyDecline({
-  custodyId,
-  reason,
-  organizationId,
-}: RecordDeclineParams): Promise<void>
-// Does NOT change custody status
-// Creates activity log note: "Custodian reported they don't have this item"
-// Sends notification email to assigning admin
-```
-
-### 3.5 Send acknowledgement email
+### 3.4 Send acknowledgement email
 
 ```typescript
 export async function sendCustodyAcknowledgementEmail({
@@ -197,7 +202,23 @@ export async function sendCustodyAcknowledgementEmail({
 // try/catch + Logger.error + ShelfError pattern
 ```
 
-### 3.6 Create acknowledgement activity note
+### 3.6 Record decline
+
+Updated from 3.4 — decline now **persists state** on the Custody record:
+
+```typescript
+export async function recordCustodyDecline({
+  custodyId,
+  reason,
+  organizationId,
+}: RecordDeclineParams): Promise<void>
+// Updates custody: declinedAt = now(), declineReason = reason
+// Does NOT change asset status or delete custody
+// Creates activity log note
+// Sends notification email to assigning admin
+```
+
+### 3.7 Create acknowledgement activity note
 
 ```typescript
 export function createAcknowledgementNote({
@@ -206,12 +227,15 @@ export function createAcknowledgementNote({
   custodianName,
   method,
   timestamp,
-  ip,
 }: CreateAckNoteParams): Promise<Note>
-// Creates rich UPDATE note with ALL legal details inline
-// "Jane Smith acknowledged receipt on March 31, 2026 at 2:47 PM via email link (IP: x.x.x.x)"
-// This note IS the permanent legal record (survives custody hard-delete)
+// Creates rich UPDATE note with legal summary (no raw PII)
+// "Jane Smith acknowledged receipt on March 31, 2026 at 2:47 PM via email link"
+// Raw IP + user-agent stored only on the Custody record's ephemeral fields
+// (deleted when custody is released — data minimization by design)
+// This note IS the permanent human-readable record (survives custody hard-delete)
 ```
+
+**Privacy approach:** Raw IP and user-agent are stored on the Custody model's structured fields for operational use while custody is active. The activity note contains only a summary (custodian name, timestamp, method) — no raw PII. When custody is released and the record deleted, the ephemeral evidence is purged automatically. The note survives as the permanent record without privacy concerns.
 
 ---
 
@@ -260,18 +284,35 @@ Following the pattern from `app/emails/stripe/audit-trial-welcome.tsx` per CLAUD
 
 **File:** `apps/webapp/server/index.ts` (publicPaths array)
 
-Add: `"/accept-custody/:path*"`
+Add: `"/accept-custody/:custodyId"` (narrow — no wildcard)
 
-### 5.2 Loader
+### 5.2 Auth model — two explicit modes
 
-1. Extract `custodyId` from params, `token` from search params
-2. Verify JWT token via `verifyCustodyAcknowledgementToken(token)`
-3. Fetch custody record with asset details (title, mainImage, category, sequentialId, organization name)
-4. If custody doesn't exist → render "This custody assignment has been released"
-5. If already accepted → render "Already acknowledged" confirmation
-6. Return asset details + custody info to component
+**Public token mode** (this route — no session required):
+- Token is the authority. No login needed.
+- Extract `token` from search params, verify JWT
+- The decoded `id` from the token is the **sole key** for all DB operations — ignore the URL `custodyId` param for data access (use it only for routing)
+- Also verify `custody.tokenIssuedAt <= token.iat` to reject rotated/old tokens
+- Works for non-registered members, logged-out users, anyone with the link
 
-### 5.3 Action
+**In-app mode** (Phase 10 route — session required):
+- User must be logged in
+- Verify that the requesting user's TeamMember ID matches `custody.teamMemberId`
+- No token needed — session identity is the authority
+- Works for BASE, SELF_SERVICE, ADMIN users acknowledging their own custody
+
+### 5.3 Loader
+
+1. Extract `token` from search params
+2. Verify JWT token via `verifyCustodyAcknowledgementToken(token)` — get `custodyId` from decoded token
+3. Fetch custody record using decoded `custodyId` with asset details (title, mainImage, category, sequentialId, organization name)
+4. Verify `custody.tokenIssuedAt <= token.iat` (reject old/rotated tokens)
+5. If custody doesn't exist → render "This custody assignment has been released"
+6. If already accepted → render "Already acknowledged" confirmation
+7. If declined → render "Already reported" confirmation
+8. Return asset details + custody info to component
+
+### 5.4 Action
 
 Handle two intents:
 
@@ -293,7 +334,7 @@ Handle two intents:
 
 ### 5.4 Component (the brand moment page)
 
-```
+```text
 ┌──────────────────────────────────────────┐
 │  [Shelf Logo]                            │
 │                                          │
@@ -322,7 +363,7 @@ Handle two intents:
 ```
 
 After acknowledgement:
-```
+```text
 ┌──────────────────────────────────────────┐
 │  [Shelf Logo]                            │
 │                                          │
@@ -380,8 +421,10 @@ Same changes as 6.1 but:
 
 - Accept `requiresAcceptance` parameter
 - Pass through to custody creation
-- One email per custodian (bulk assign goes to one custodian)
-- Token covers all assets in the batch
+- Generate a `acknowledgementBatchId` (cuid) and set it on all Custody records in the batch
+- Generate a batch token via `generateBatchAcknowledgementToken(batchId)`
+- One email per custodian with one link covering all assets
+- Acceptance page for batch: queries all custodies with matching `acknowledgementBatchId`, shows list, one "Acknowledge All" click updates all records in transaction
 
 ### 6.4 Assign custody schema
 
@@ -431,15 +474,20 @@ assignedByUserId?: string | null;
 
 After the existing "Since {date}" line:
 
-- If `requiresAcceptance && !acceptedAt`:
-  ```
+- If `requiresAcceptance && !acceptedAt && !declinedAt`:
+  ```text
   Awaiting acknowledgement
   [Copy link] · [Resend email]  (conditional on custodian having email)
   ```
 
 - If `requiresAcceptance && acceptedAt`:
-  ```
+  ```text
   Acknowledged {date}
+  ```
+
+- If `requiresAcceptance && declinedAt`:
+  ```text
+  Disputed {date}
   ```
 
 ### 8.3 Copy link button
@@ -484,7 +532,9 @@ Include `requiresAcceptance`, `acceptedAt` in the custody select when loading as
 ### 9.4 Filter support
 
 Add acknowledgement status as a filterable field in advanced mode filters.
-Values: "All", "Pending", "Acknowledged", "Not required"
+Values: "All", "Pending", "Acknowledged", "Disputed", "Not required"
+
+The "Disputed" state is now queryable via `custody.declinedAt IS NOT NULL`.
 
 ---
 
@@ -495,7 +545,7 @@ Values: "All", "Pending", "Acknowledged", "Not required"
 **New file:** `apps/webapp/app/components/custody/acknowledgement-banner.tsx`
 
 A dismissible banner shown at the top of the assets list:
-```
+```text
 You have {count} items awaiting your acknowledgement. [Review & Acknowledge]
 ```
 
@@ -508,14 +558,16 @@ Page listing all of the current user's pending acknowledgements.
 - "Acknowledge" button per item + "Acknowledge All" button
 - Uses `recordCustodyAcknowledgement()` with method "in_app"
 
-### 10.3 Permission bypass for acknowledgement
+### 10.3 Permission bypass for acknowledgement (in-app mode)
+
+The in-app acknowledge route uses **session-based auth** (see Phase 5.2 for the two auth modes).
 
 The acknowledge action needs to work for BASE and SELF_SERVICE users who are the custodian.
 This is NOT a general custody permission — it's: "you can acknowledge YOUR OWN custody."
 
-In the in-app acknowledge route and the public route action:
-- Check that the requesting user's TeamMember ID matches the custody's teamMemberId
-- No role-based permission check needed for acknowledging your own custody
+- Verify that the requesting user's TeamMember ID matches `custody.teamMemberId`
+- No role-based permission check needed — custodian identity is the authority
+- The public token route (Phase 5) does NOT enforce this check — the token IS the authority there
 
 ### 10.4 Layout integration
 
@@ -531,9 +583,11 @@ Pass to the banner component.
 **New file:** `apps/webapp/app/routes/api+/custody.acknowledgement.ts`
 
 Handles:
-- `POST` with intent `resend-email`: Re-generates token, re-sends email
-- `POST` with intent `copy-link`: Returns the signed URL for clipboard copy
+- `POST` with intent `resend-email`: Generates **new** token (rotates — updates `tokenIssuedAt`, invalidating old link), re-sends email
+- `POST` with intent `copy-link`: Generates **new** token (rotates), returns the signed URL for clipboard copy
 - Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only)
+
+Token rotation on every resend/copy ensures old links stop working, limiting exposure window.
 
 ---
 
@@ -615,13 +669,18 @@ No separate Stripe product, no trial flow, no addon management page needed for v
 | Decision | Rationale |
 |----------|-----------|
 | No new AssetStatus | IN_CUSTODY set immediately. Acknowledgement is evidence, not a gate. Avoids ripple through dozens of status checks. |
-| Activity note = permanent legal record | Custody records are hard-deleted on release. Rich note with timestamp/IP/method survives. |
+| Activity note = permanent record (no raw PII) | Custody records hard-deleted on release. Note stores summary (name, timestamp, method). Raw IP/UA only on ephemeral Custody fields — auto-purged on release. |
+| 30-day token expiry + rotation on resend | Limits exposure window. `tokenIssuedAt` on Custody rejects old tokens after resend. |
+| Token is sole authority (not URL param) | Decoded JWT `id` used for all DB lookups. URL `custodyId` is routing only. Prevents mismatch attacks. |
+| Two auth modes: public token vs in-app session | Public route: token = authority, no login needed. In-app route: session + teamMember match = authority. Clear separation. |
+| Batch key for bulk acknowledgement | `acknowledgementBatchId` groups custody records. One token covers the batch. Resend/copy-link target the batch reliably. |
+| Persisted decline state | `declinedAt` + `declineReason` on Custody makes "Disputed" queryable and filterable. |
+| Narrow public path | `/accept-custody/:custodyId` — no wildcard. Minimal exposure surface. |
 | Reuse INVITE_TOKEN_SECRET | JWT includes `purpose: "custody-ack"` to prevent cross-use. No new env var. |
-| String field for acceptanceMethod | Avoids Prisma enum migration for each new method. Validated at app layer. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |
 | Self-assignment hides checkbox | Can't corroborate receipt from the person who assigned. |
-| One email per custodian for bulk | Not spammy. One acknowledge-all click. |
+| One email per custodian for bulk | Not spammy. One acknowledge-all click via batch token. |
 | Kit acknowledgement cascades | One click updates KitCustody + all child Custody records in transaction. |
-| BASE users can acknowledge own custody | Permission bypass: if you ARE the custodian, you can acknowledge. Not a general custody permission. |
+| BASE users can acknowledge own custody | Permission bypass in in-app mode: if you ARE the custodian, you can acknowledge. Not a general custody permission. |
 | Non-registered members get copy-link only | No email field on TeamMember. Admin copies link, sends manually. |
 | Column hidden by default | Opt-in visibility. Admins who use the feature toggle it on. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -63,11 +63,25 @@ model Custody {
 
 **DB CHECK constraint** (in migration SQL, not expressible in Prisma schema):
 ```sql
+-- Mutual exclusivity: cannot be both accepted and declined
 ALTER TABLE "Custody" ADD CONSTRAINT "custody_accept_decline_exclusive"
   CHECK (NOT ("acceptedAt" IS NOT NULL AND "declinedAt" IS NOT NULL));
 
+-- Only ack-enabled custodies can have accept/decline timestamps
+ALTER TABLE "Custody" ADD CONSTRAINT "custody_ack_requires_flag"
+  CHECK (
+    ("requiresAcceptance" = true) OR
+    ("acceptedAt" IS NULL AND "declinedAt" IS NULL)
+  );
+
 ALTER TABLE "KitCustody" ADD CONSTRAINT "kit_custody_accept_decline_exclusive"
   CHECK (NOT ("acceptedAt" IS NOT NULL AND "declinedAt" IS NOT NULL));
+
+ALTER TABLE "KitCustody" ADD CONSTRAINT "kit_custody_ack_requires_flag"
+  CHECK (
+    ("requiresAcceptance" = true) OR
+    ("acceptedAt" IS NULL AND "declinedAt" IS NULL)
+  );
 ```
 This enforces mutual exclusivity at the database layer — defense-in-depth beyond application logic.
 
@@ -197,7 +211,8 @@ export async function generateCustodyAcknowledgementToken(custodyId: string): Pr
 // STRICTLY persist-before-sign:
 // 1. Atomically increment tokenVersion and read back new value:
 //    UPDATE "Custody" SET "tokenVersion" = "tokenVersion" + 1 WHERE id = custodyId RETURNING "tokenVersion"
-// 2. Sign JWT with { id: custodyId, purpose: "custody-ack", ver: newVersion } using CUSTODY_TOKEN_SECRET
+// 2. Guard: if zero rows returned, throw ShelfError("Custody not found")
+// 3. Sign JWT with { id: custodyId, purpose: "custody-ack", ver: newVersion } using CUSTODY_TOKEN_SECRET
 // 30-day expiry (exp claim)
 // The increment-then-sign order guarantees the token is never self-invalidated.
 ```
@@ -807,6 +822,9 @@ const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
     AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < NOW() - INTERVAL '60 seconds')
   RETURNING "tokenVersion"
 `;
+if (!updated) {
+  throw new ShelfError({ message: "Custody not found, already settled, or cooldown active." });
+}
 // Sign with { id: custodyId, purpose: "custody-ack", ver: updated.tokenVersion }
 ```
 
@@ -824,10 +842,10 @@ const rows = await db.$queryRaw`
   WHERE "acknowledgementBatchId" = ${batchId}
     AND "requiresAcceptance" = true
     AND (
-      (SELECT MIN("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+      (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
       IS NULL
       OR
-      (SELECT MIN("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+      (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
       < NOW() - INTERVAL '60 seconds'
     )
   RETURNING "tokenVersion"

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -581,6 +581,7 @@ Add: `"/accept-custody/:custodyId"` (narrow — no wildcard)
 **Token-in-URL leak mitigations:**
 Tokens are passed as query params (`?token=...`), which are prone to leakage via referrer headers, browser history, server logs, and analytics. Mitigations:
 - Set `Referrer-Policy: no-referrer` on the acceptance page response headers (prevents token leaking to external resources)
+- Set `Cache-Control: no-store, private` and `Pragma: no-cache` on both loader and action responses for this route (prevents token-bearing pages from being cached in browser or proxy layers)
 - **Modify `apps/webapp/server/logger.ts`**: The current middleware logs full query strings via `getQueryStrings(c.req.raw.url)`. Add redaction for the `token` param on `/accept-custody` routes (replace value with `[REDACTED]`). **This is an implementation step, not just guidance.**
 - The 30-day expiry + rotation on resend limits the window of exposure
 - After acknowledgement, the token becomes useless (idempotent, already-accepted state)
@@ -625,7 +626,7 @@ Handle two intents:
 2. **DB transaction:** Call `recordCustodyAcknowledgement()` — returns `{ transitioned, custody }`
 3. **Only if `transitioned === true`:**
    - Create acknowledgement activity note (inside same transaction or immediately after)
-   - If kit custody -> cascade `acceptedAt` to all child custody records + create notes for each asset
+   - If kit custody → cascade `acceptedAt` to all child custody records that are still pending (`WHERE acceptedAt IS NULL AND declinedAt IS NULL`) + create notes for each updated asset. Already-settled child rows are skipped to preserve idempotency.
    - **After commit:** Enqueue admin + custodian notification emails via pg-boss
 4. If `transitioned === false` -> no notes, no emails (idempotent retry — just render current state)
 5. Render success state (shows acknowledgement date regardless of whether this request caused the transition)
@@ -915,19 +916,25 @@ Pass to the banner component.
 
 Accepts `custodyId` (single), `acknowledgementBatchId` (batch), or `kitCustodyId` (kit). Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only).
 
+**Multi-tenant safety:** ALL fetch and update queries in this endpoint MUST scope to `organizationId` (from the admin's session) via the `Asset.organizationId` join. This prevents an admin in Org A from rotating tokens for Org B's custodies, even if they somehow obtain a valid custody ID. Permission checks alone are insufficient — raw IDs in request bodies can be forged.
+
 **Three rotation paths** (matching the three token purposes):
 
 **Single custody resend** (only for custodies NOT in a batch or kit):
 ```typescript
 // GUARD: reject if custody belongs to a batch or kit — must use batch/kit resend path instead
 // Check for kit: look for KitCustody with requiresAcceptance = true that covers this asset
-const custody = await db.custody.findUnique({
-  where: { id: custodyId },
+const custody = await db.custody.findFirst({
+  where: {
+    id: custodyId,
+    asset: { organizationId },  // ORG SCOPE: ensures custody belongs to admin's org
+  },
   select: {
     acknowledgementBatchId: true,
-    asset: { select: { kitId: true } }
+    asset: { select: { kitId: true, organizationId: true } }
   }
 });
+if (!custody) throw new ShelfError({ message: "Custody not found." });
 if (custody?.acknowledgementBatchId) throw new ShelfError({ message: "This asset is part of a bulk assignment. Use batch resend." });
 
 // Kit guard: check if a KitCustody exists with requiresAcceptance for this asset's kit
@@ -951,6 +958,7 @@ const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
     AND "acknowledgementBatchId" IS NULL
     AND "acceptedAt" IS NULL AND "declinedAt" IS NULL
     AND ("lastTokenRotatedAt" IS NULL OR "lastTokenRotatedAt" < NOW() - INTERVAL '60 seconds')
+    AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = ${organizationId})
   RETURNING "tokenVersion"
 `;
 if (!updated) {
@@ -978,11 +986,18 @@ const rows = await db.$transaction(async (tx) => {
     "lastTokenRotatedAt" = NOW(), "updatedAt" = NOW()
     WHERE "acknowledgementBatchId" = ${batchId}
       AND "requiresAcceptance" = true
+      AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = ${organizationId})
       AND (
-        (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+        (SELECT MAX("lastTokenRotatedAt") FROM "Custody"
+         WHERE "acknowledgementBatchId" = ${batchId}
+           AND "requiresAcceptance" = true
+           AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = ${organizationId}))
         IS NULL
         OR
-        (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+        (SELECT MAX("lastTokenRotatedAt") FROM "Custody"
+         WHERE "acknowledgementBatchId" = ${batchId}
+           AND "requiresAcceptance" = true
+           AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = ${organizationId}))
         < NOW() - INTERVAL '60 seconds'
       )
     RETURNING "tokenVersion"
@@ -998,6 +1013,7 @@ if (!rows.length) throw new ShelfError({ message: "Batch not found or cooldown a
 // In a single transaction:
 // 1. UPDATE KitCustody SET tokenVersion = tokenVersion + 1, lastTokenRotatedAt = NOW()
 //    WHERE id = kitCustodyId AND requiresAcceptance = true
+//    AND "kitId" IN (SELECT "id" FROM "Kit" WHERE "organizationId" = organizationId)  -- ORG SCOPE
 //    AND (lastTokenRotatedAt IS NULL OR lastTokenRotatedAt < NOW() - INTERVAL '60 seconds')
 //    RETURNING tokenVersion
 // 2. Guard: if zero rows -> throw ShelfError("Kit custody not found or cooldown active")
@@ -1112,7 +1128,7 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 | Atomic resend cooldown | Raw SQL `UPDATE ... RETURNING` with `lastTokenRotatedAt` + `NOW() - INTERVAL '60 seconds'` + state guards. Single query: increment version, enforce cooldown, return new version. TOCTOU-safe, clock-skew safe. |
 | Advisory lock for batch token generation | `pg_advisory_xact_lock(hashtext(batchId))` prevents concurrent calls from reading the same MAX and generating duplicate versions. |
 | Network metadata cleanup deferred (not an oversight) | Custody hard-delete already purges IP/UA. Notes retain only name (business record). Cron job for long-lived custodies is trivial to add later if needed. |
-| Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
+| Org-scoped everywhere | In-app route AND all resend/copy-link queries scope to `organizationId` via asset/kit join. Multi-tenant boundary enforced at query level, not just permission checks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |
 | Self-assignment hides checkbox | Can't corroborate receipt from the person who assigned. |
 | One email per custodian for bulk | Not spammy. One acknowledge-all click via batch token. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -34,14 +34,11 @@ model Custody {
   acceptanceUserAgent       String?                   // Browser user-agent (ephemeral — deleted with custody)
   assignedBy                User?     @relation("custodyAssigner", fields: [assignedByUserId], references: [id], onDelete: SetNull)
   assignedByUserId          String?                   // Who assigned custody (for admin notification routing, SetNull on user delete)
-  // NOTE: Requires inverse relation on User model:
-  //   custodyAssignments Custody[] @relation("custodyAssigner")
-  // Same pattern needed for KitCustody if assignedBy is added there.
   // Fallback: if assignedByUserId is null (user deleted), admin notifications
   // route to the organization owner instead (org.userId is always present)
   declinedAt                DateTime?                 // When custodian reported they don't have the item
   declineReason             String?   @db.VarChar(500)  // Optional reason from custodian (trimmed, max 500 chars)
-  tokenVersion              Int       @default(0)      // Monotonic counter — incremented on each resend/rotation. Embedded in JWT, compared on verify.
+  tokenVersion              Int       @default(0)      // 0 = no token generated; first token uses version 1
   lastTokenRotatedAt        DateTime?                 // When token was last rotated (dedicated cooldown field, not coupled to updatedAt)
   acknowledgementBatchId    String?                   // Groups multiple custody records for bulk acknowledgement
 
@@ -54,14 +51,30 @@ model Custody {
   @@index([acknowledgementBatchId])  // Batch lookups/updates in verification and resend
 
   // Additional partial indexes (in migration SQL, not Prisma):
-  // CREATE INDEX idx_custody_pending_ack ON "Custody" ("teamMemberId")
+  // CREATE INDEX CONCURRENTLY idx_custody_pending_ack ON "Custody" ("teamMemberId")
   //   WHERE "requiresAcceptance" = true AND "acceptedAt" IS NULL AND "declinedAt" IS NULL;
-  // CREATE INDEX idx_custody_batch_pending ON "Custody" ("acknowledgementBatchId")
+  // CREATE INDEX CONCURRENTLY idx_custody_batch_pending ON "Custody" ("acknowledgementBatchId")
   //   WHERE "requiresAcceptance" = true AND "acceptedAt" IS NULL AND "declinedAt" IS NULL;
 }
 ```
 
-**DB CHECK constraint** (in migration SQL, not expressible in Prisma schema):
+**User model — inverse relation (required by Prisma):**
+
+Add to the `User` model in `packages/database/prisma/schema.prisma`:
+
+```prisma
+model User {
+  // ... existing fields ...
+
+  // Custody acknowledgement: tracks which custodies this user assigned
+  custodyAssignments    Custody[]    @relation("custodyAssigner")
+  kitCustodyAssignments KitCustody[] @relation("kitCustodyAssigner")
+}
+```
+
+This inverse relation is required by Prisma for the `assignedBy` relation on both `Custody` and `KitCustody`. Without it, `prisma generate` will fail.
+
+**DB CHECK constraints** (in migration SQL, not expressible in Prisma schema):
 ```sql
 -- Mutual exclusivity: cannot be both accepted and declined
 ALTER TABLE "Custody" ADD CONSTRAINT "custody_accept_decline_exclusive"
@@ -74,6 +87,10 @@ ALTER TABLE "Custody" ADD CONSTRAINT "custody_ack_requires_flag"
     ("acceptedAt" IS NULL AND "declinedAt" IS NULL)
   );
 
+-- declineReason requires declinedAt to be non-null
+ALTER TABLE "Custody" ADD CONSTRAINT "custody_decline_reason_requires_declined"
+  CHECK ("declineReason" IS NULL OR "declinedAt" IS NOT NULL);
+
 ALTER TABLE "KitCustody" ADD CONSTRAINT "kit_custody_accept_decline_exclusive"
   CHECK (NOT ("acceptedAt" IS NOT NULL AND "declinedAt" IS NOT NULL));
 
@@ -82,12 +99,53 @@ ALTER TABLE "KitCustody" ADD CONSTRAINT "kit_custody_ack_requires_flag"
     ("requiresAcceptance" = true) OR
     ("acceptedAt" IS NULL AND "declinedAt" IS NULL)
   );
+
+-- declineReason requires declinedAt to be non-null (KitCustody)
+ALTER TABLE "KitCustody" ADD CONSTRAINT "kit_custody_decline_reason_requires_declined"
+  CHECK ("declineReason" IS NULL OR "declinedAt" IS NOT NULL);
 ```
-This enforces mutual exclusivity at the database layer — defense-in-depth beyond application logic.
+This enforces mutual exclusivity and decline-reason consistency at the database layer — defense-in-depth beyond application logic.
 
-### 1.2 KitCustody model — add same acknowledgement fields
+### 1.2 KitCustody model — add acknowledgement fields
 
-Add identical fields to `KitCustody` for kit-level acknowledgement.
+**File:** `packages/database/prisma/schema.prisma` (KitCustody model)
+
+**Important:** KitCustody uses `custodianId` (not `teamMemberId` like Custody). All field names and relations below reflect the real KitCustody schema.
+
+```prisma
+model KitCustody {
+  id String @id @default(cuid())
+
+  custodian    TeamMember @relation(fields: [custodianId], references: [id])
+  custodianId  String
+
+  kit   Kit    @relation(fields: [kitId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  kitId String @unique
+
+  // Acknowledgement fields
+  requiresAcceptance        Boolean   @default(false)
+  acceptedAt                DateTime?
+  acceptanceMethod          String?
+  acceptanceIp              String?
+  acceptanceUserAgent       String?
+  assignedBy                User?     @relation("kitCustodyAssigner", fields: [assignedByUserId], references: [id], onDelete: SetNull)
+  assignedByUserId          String?
+  declinedAt                DateTime?
+  declineReason             String?   @db.VarChar(500)
+  tokenVersion              Int       @default(0)      // 0 = no token generated; first token uses version 1
+  lastTokenRotatedAt        DateTime?
+  acknowledgementBatchId    String?
+
+  // DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([custodianId])
+  @@index([acknowledgementBatchId])
+}
+```
+
+**Schema difference to remember:** Custody references its custodian as `teamMemberId`, while KitCustody references its custodian as `custodianId`. This difference is important for token verification (Phase 3.4) and kit resend logic (Phase 11).
 
 ### 1.3 Organization model — add feature toggle
 
@@ -107,6 +165,16 @@ usedCustodyAcknowledgementTrial Boolean   @default(false)
 Run: `pnpm db:prepare-migration` then `pnpm db:deploy-migration`
 
 All new columns are nullable or have defaults — zero impact on existing data.
+
+**Important:** Use `CREATE INDEX CONCURRENTLY` for partial indexes (production safety — avoids locking the table during index creation):
+```sql
+-- Run these OUTSIDE the migration transaction (in a separate migration or manually):
+CREATE INDEX CONCURRENTLY idx_custody_pending_ack ON "Custody" ("teamMemberId")
+  WHERE "requiresAcceptance" = true AND "acceptedAt" IS NULL AND "declinedAt" IS NULL;
+CREATE INDEX CONCURRENTLY idx_custody_batch_pending ON "Custody" ("acknowledgementBatchId")
+  WHERE "requiresAcceptance" = true AND "acceptedAt" IS NULL AND "declinedAt" IS NULL;
+```
+Note: `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. Prisma migrations run in a transaction by default, so these indexes must be created in a separate non-transactional migration step or via a raw SQL script.
 
 ---
 
@@ -163,10 +231,10 @@ export const CUSTODY_ACKNOWLEDGEMENT_ADDON = {
 
 The boolean `custodyAcknowledgementEnabled` on the Organization model is just a **switch**. How it gets flipped on is a business decision:
 
-- **Include in Plus/Team by default** → Set to `true` when they subscribe. No extra purchase.
-- **Block for Free tier** → Leave `false`. Show upsell prompting upgrade.
-- **Sell as separate add-on** → Wire to Stripe like barcodes/audits (v2 if needed).
-- **Give to everyone** → Set `ENABLE_PREMIUM_FEATURES=false` and the check is bypassed.
+- **Include in Plus/Team by default** -> Set to `true` when they subscribe. No extra purchase.
+- **Block for Free tier** -> Leave `false`. Show upsell prompting upgrade.
+- **Sell as separate add-on** -> Wire to Stripe like barcodes/audits (v2 if needed).
+- **Give to everyone** -> Set `ENABLE_PREMIUM_FEATURES=false` and the check is bypassed.
 
 For v1, the simplest path: include it in Plus and Team plans automatically. Free users see the upsell to upgrade. No Stripe add-on product needed — just set the flag when the user's tier qualifies.
 
@@ -180,9 +248,10 @@ Add to `apps/webapp/app/utils/env.ts`:
 ```typescript
 // Optional at startup — only required when acknowledgement feature is used.
 // Follows same pattern as other secrets but won't crash startup if unset.
+// The getEnv helper uses isRequired: false to return undefined instead of throwing.
 export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", {
   isSecret: true,
-  isOptional: true,
+  isRequired: false,
 });
 ```
 **Two-layer validation:**
@@ -195,8 +264,6 @@ if (!CUSTODY_TOKEN_SECRET) {
   throw new ShelfError({ message: "CUSTODY_TOKEN_SECRET is not configured." });
 }
 ```
-
-If `getEnv` does not support `isOptional`, add it following the existing pattern — a single boolean that returns `undefined` instead of throwing on missing value.
 
 ---
 
@@ -212,39 +279,53 @@ export async function generateCustodyAcknowledgementToken(custodyId: string): Pr
 // 1. Atomically increment tokenVersion and read back new value:
 //    UPDATE "Custody" SET "tokenVersion" = "tokenVersion" + 1 WHERE id = custodyId RETURNING "tokenVersion"
 // 2. Guard: if zero rows returned, throw ShelfError("Custody not found")
-// 3. Sign JWT with { id: custodyId, purpose: "custody-ack", ver: newVersion } using CUSTODY_TOKEN_SECRET
-// 30-day expiry (exp claim)
+// 3. Sign JWT with:
+//    - payload: { id: custodyId, purpose: "custody-ack", ver: newVersion }
+//    - options: { algorithm: "HS256", expiresIn: "30d", issuer: "shelf-custody", audience: "custody-ack" }
+//    using CUSTODY_TOKEN_SECRET
 // The increment-then-sign order guarantees the token is never self-invalidated.
 ```
 
 ```typescript
 export async function generateBatchAcknowledgementToken(batchId: string): Promise<string>
-// STRICTLY persist-before-sign, single atomic UPDATE (no separate SELECT):
-// 1. Single SQL statement:
+// STRICTLY persist-before-sign, wrapped in advisory lock to prevent concurrency races:
+// 1. Begin transaction with advisory lock:
+//    SELECT pg_advisory_xact_lock(hashtext(batchId))
+// 2. Single SQL statement inside transaction:
 //    UPDATE "Custody"
-//    SET "tokenVersion" = (SELECT MAX("tokenVersion") + 1 FROM "Custody" WHERE "acknowledgementBatchId" = batchId),
+//    SET "tokenVersion" = (
+//      SELECT COALESCE(MAX("tokenVersion"), 0) + 1
+//      FROM "Custody"
+//      WHERE "acknowledgementBatchId" = batchId AND "requiresAcceptance" = true
+//    ),
 //        "lastTokenRotatedAt" = NOW()
-//    WHERE "acknowledgementBatchId" = batchId
+//    WHERE "acknowledgementBatchId" = batchId AND "requiresAcceptance" = true
 //    RETURNING "tokenVersion"
-// 2. Guard: if zero rows returned, throw ShelfError("Batch not found or already fully processed")
-// 3. Read returned tokenVersion from rows[0] (all rows now share the same value)
-// 4. Sign JWT with { batchId, purpose: "custody-ack-batch", ver: newVersion }
-// 30-day expiry. Single atomic UPDATE — no transaction needed, no app-side MAX computation.
+// 3. Guard: if zero rows returned, throw ShelfError("Batch not found or already fully processed")
+// 4. Read returned tokenVersion from rows[0] (all rows now share the same value)
+// 5. Sign JWT with:
+//    - payload: { batchId, purpose: "custody-ack-batch", ver: newVersion }
+//    - options: { algorithm: "HS256", expiresIn: "30d", issuer: "shelf-custody", audience: "custody-ack" }
+// The advisory lock prevents two concurrent calls from seeing the same MAX and generating
+// duplicate token versions. The lock is released when the transaction commits.
 ```
 
 ```typescript
 export async function generateKitCustodyAcknowledgementToken(kitCustodyId: string): Promise<string>
 // STRICTLY persist-before-sign:
 // 1. Atomically increment KitCustody.tokenVersion via UPDATE ... RETURNING
-// 2. Guard: if zero rows → throw ShelfError("KitCustody not found")
+// 2. Guard: if zero rows -> throw ShelfError("KitCustody not found")
 // 3. Update all child Custody records to same version (single UPDATE with subquery)
-// 4. Guard: if zero child rows → throw ShelfError("No child custody records found")
-// 5. Sign JWT with { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
-// 30-day expiry.
+// 4. Guard: if zero child rows -> throw ShelfError("No child custody records found")
+// 5. Sign JWT with:
+//    - payload: { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
+//    - options: { algorithm: "HS256", expiresIn: "30d", issuer: "shelf-custody", audience: "custody-ack" }
 ```
 
 **Token security:**
 - Signed with dedicated `CUSTODY_TOKEN_SECRET` (not shared with invite tokens)
+- Pinned to `algorithm: "HS256"` on both sign and verify — prevents algorithm confusion attacks
+- `issuer: "shelf-custody"` and `audience: "custody-ack"` claims validated on verify — prevents cross-service token reuse
 - 30-day expiry via JWT `exp` claim
 - On resend: `tokenVersion` incremented, new token embeds new version — old tokens rejected (integer comparison, no timestamp precision issues)
 - Token's decoded `id` is the **sole authority** for DB operations — URL param is for routing only
@@ -252,14 +333,37 @@ export async function generateKitCustodyAcknowledgementToken(kitCustodyId: strin
 
 ### 3.2 JWT signature verification (shared entry point)
 
-The loader calls `jwt.verify(token, CUSTODY_TOKEN_SECRET)` ONCE to validate signature + expiry. The verified payload is then passed to purpose-specific verifiers below. This avoids double-verification and ensures purpose branching happens on trusted data.
+The loader calls `jwt.verify(token, CUSTODY_TOKEN_SECRET, { algorithms: ["HS256"], issuer: "shelf-custody", audience: "custody-ack" })` ONCE to validate signature + expiry + issuer + audience. The verified payload is then passed to purpose-specific verifiers below. This avoids double-verification and ensures purpose branching happens on trusted data.
 
 ```typescript
+/** Verified and typed JWT payload from a custody acknowledgement token. */
+type VerifiedCustodyPayload = {
+  /** Present for single and kit tokens — the custody or kitCustody ID */
+  id?: string;
+  /** Present for batch tokens — the acknowledgementBatchId */
+  batchId?: string;
+  /** Token purpose: "custody-ack" | "custody-ack-batch" | "custody-ack-kit" */
+  purpose: string;
+  /** Monotonic token version — compared against DB value on verify */
+  ver: number;
+  /** Standard JWT claims (added by jwt.sign) */
+  iat: number;
+  exp: number;
+  iss: string;
+  aud: string;
+};
+
 export function verifyTokenSignature(token: string): VerifiedCustodyPayload
-// 1. jwt.verify(token, CUSTODY_TOKEN_SECRET) — validates signature + exp
-// 2. Returns typed payload: { id?: string, batchId?: string, purpose: string, ver: number }
+// 1. jwt.verify(token, CUSTODY_TOKEN_SECRET, {
+//      algorithms: ["HS256"],
+//      issuer: "shelf-custody",
+//      audience: "custody-ack",
+//    })
+//    — validates signature + exp + iss + aud
+// 2. Returns typed payload as VerifiedCustodyPayload
 // 3. Throws ShelfError("Token expired") on exp failure
 // 4. Throws ShelfError("Invalid token") on signature failure
+// 5. Throws ShelfError("Invalid token") on issuer/audience mismatch
 // Does NOT do DB checks — that's the purpose-specific verifier's job
 ```
 
@@ -288,6 +392,8 @@ export async function verifyBatchCustodyToken(
 // 1. Asserts payload.purpose === "custody-ack-batch" and payload.batchId exists
 // 2. Fetches all custody records with matching acknowledgementBatchId
 // 3. Enforces single-custodian membership: all records must have same teamMemberId
+//    NOTE: This checks Custody.teamMemberId (not KitCustody.custodianId — batch
+//    verification operates on Custody records, which use teamMemberId)
 // 4. Validates ALL custody.tokenVersion === payload.ver (uniform after SET normalization)
 // 5. Throws if no records found, mixed custodians, or any version mismatch
 // Returns batchId + full custody list with asset details
@@ -302,6 +408,7 @@ export async function verifyKitCustodyToken(
 ): Promise<{ kitCustodyId: string; kitCustody: KitCustodyWithAssets }>
 // 1. Asserts payload.purpose === "custody-ack-kit" and payload.id exists
 // 2. Fetches KitCustody record (NOT Custody) with kit + all child assets + custodian
+//    NOTE: KitCustody uses custodianId (not teamMemberId)
 // 3. Validates payload.ver === kitCustody.tokenVersion (integer equality)
 // 4. Throws if KitCustody not found or version mismatch
 // Returns kitCustodyId + full kit custody with child asset details
@@ -319,7 +426,7 @@ export async function recordCustodyAcknowledgement({
 }: RecordAcknowledgementParams): Promise<{ transitioned: boolean; custody: Custody }>
 // Conditional update — only transitions from PENDING state:
 //   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
-// If no rows updated → custody was already accepted or declined (idempotent: return current state)
+// If no rows updated -> custody was already accepted or declined (idempotent: return current state)
 // Sets: acceptedAt = now(), acceptanceMethod, acceptanceIp, acceptanceUserAgent
 // Returns { transitioned: true, custody } if state changed, { transitioned: false, custody } if already settled
 // Callers MUST check `transitioned` before creating notes or enqueuing emails — prevents duplicates on retry/refresh
@@ -359,7 +466,7 @@ export async function recordCustodyDecline({
 }: RecordDeclineParams): Promise<{ declined: boolean; custody: Custody }>
 // Conditional update — only transitions from PENDING state:
 //   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
-// If no rows updated → already accepted or declined (idempotent: return current state)
+// If no rows updated -> already accepted or declined (idempotent: return current state)
 // Validates reason: z.string().trim().max(500).optional()
 // Sets: declinedAt = now(), declineReason = sanitized reason
 // Does NOT change asset status or delete custody
@@ -372,7 +479,7 @@ export async function recordCustodyDecline({
 ### 3.9 Create acknowledgement activity note
 
 ```typescript
-export function createAcknowledgementNote({
+export async function createAcknowledgementNote({
   userId,
   assetId,
   custodianName,
@@ -398,7 +505,12 @@ Raw IP and user-agent are stored on the Custody record's ephemeral fields. These
 - The primary cleanup mechanism (custody release = hard delete) already covers the vast majority of cases
 - A cron job for a v1 feature that hasn't shipped is premature optimization
 - If a customer or legal review flags long-lived custodies as a concern, adding a cleanup query is ~30 minutes of work
-- The data model supports it (just `UPDATE ... SET acceptanceIp = NULL WHERE acceptedAt < 2_years_ago`) — no schema changes needed later
+- The data model supports it — no schema changes needed later:
+  ```sql
+  UPDATE "Custody"
+  SET "acceptanceIp" = NULL, "acceptanceUserAgent" = NULL
+  WHERE "acceptedAt" < NOW() - INTERVAL '2 years'
+  ```
 
 **v2 consideration:** If needed, add a daily pg-boss job to null out IP/UA on custodies older than 2 years. The schema is ready for this with zero changes.
 
@@ -429,7 +541,7 @@ Following the pattern from `app/emails/stripe/audit-trial-welcome.tsx` per CLAUD
 - "Hey {firstName}," greeting
 - Body: "You've been assigned custody of {assetTitle} by {assignerName} at {orgName}."
 - Asset details: title, category (if any), serial/sequential ID
-- CTA button: "Acknowledge Receipt" → `${SERVER_URL}/accept-custody/${custodyId}?token=${jwt}`
+- CTA button: "Acknowledge Receipt" -> `${SERVER_URL}/accept-custody/${custodyId}?token=${jwt}`
 - Secondary text: "If you don't have this item, click the link above and report it."
 - CustomEmailFooter from org settings
 - Both HTML + plain text exports
@@ -457,6 +569,8 @@ Following the pattern from `app/emails/stripe/audit-trial-welcome.tsx` per CLAUD
 ## Phase 5: Public Acceptance Route
 
 **New file:** `apps/webapp/app/routes/_auth+/accept-custody.$custodyId.tsx`
+
+**Note on `_auth+` prefix:** This route uses the `_auth+` prefix which serves public (unauthenticated) pages. This follows the existing precedent set by `_auth+/accept-invite.$inviteId.tsx` — both are token-authenticated public routes that don't require a session.
 
 ### 5.1 Add to public paths
 
@@ -490,16 +604,16 @@ Tokens are passed as query params (`?token=...`), which are prone to leakage via
 
 1. Extract `token` from search params
 2. **Verify signature first, then branch on purpose.** Do NOT use `jwt.decode()` — unverified payloads can be forged.
-   - Call `verifyTokenSignature(token)` (Phase 3.2) — validates signature + expiry, returns typed verified payload
+   - Call `verifyTokenSignature(token)` (Phase 3.2) — validates signature + expiry + issuer + audience, returns typed verified payload
    - Read `purpose` from the VERIFIED payload
 3. **Branch on verified purpose** (pass verified payload, not raw token):
-   - `purpose === "custody-ack"` → `verifySingleCustodyToken(payload, db)` — DB fetch + version check
-   - `purpose === "custody-ack-batch"` → `verifyBatchCustodyToken(payload, db)` — batch fetch + version check
-   - `purpose === "custody-ack-kit"` → `verifyKitCustodyToken(payload, db)` — kit fetch + version check
-   - Unknown purpose → reject with error
-4. Handle error states (see 3.9 error handling table): expired, revoked, not found
-5. If already accepted → render "Already acknowledged" confirmation
-6. If declined → render "Already reported" confirmation
+   - `purpose === "custody-ack"` -> `verifySingleCustodyToken(payload, db)` — DB fetch + version check
+   - `purpose === "custody-ack-batch"` -> `verifyBatchCustodyToken(payload, db)` — batch fetch + version check
+   - `purpose === "custody-ack-kit"` -> `verifyKitCustodyToken(payload, db)` — kit fetch + version check
+   - Unknown purpose -> reject with error
+4. Handle error states (see section 3.11 error handling table): expired, revoked, not found
+5. If already accepted -> render "Already acknowledged" confirmation
+6. If declined -> render "Already reported" confirmation
 7. Return asset details + custody info (single or batch list) to component
 
 ### 5.4 Action
@@ -511,9 +625,9 @@ Handle two intents:
 2. **DB transaction:** Call `recordCustodyAcknowledgement()` — returns `{ transitioned, custody }`
 3. **Only if `transitioned === true`:**
    - Create acknowledgement activity note (inside same transaction or immediately after)
-   - If kit custody → cascade `acceptedAt` to all child custody records + create notes for each asset
+   - If kit custody -> cascade `acceptedAt` to all child custody records + create notes for each asset
    - **After commit:** Enqueue admin + custodian notification emails via pg-boss
-4. If `transitioned === false` → no notes, no emails (idempotent retry — just render current state)
+4. If `transitioned === false` -> no notes, no emails (idempotent retry — just render current state)
 5. Render success state (shows acknowledgement date regardless of whether this request caused the transition)
 
 **`decline`:**
@@ -522,7 +636,7 @@ Handle two intents:
 3. **Only if `declined === true`:**
    - Create decline activity note
    - **After commit:** Enqueue admin alert email via pg-boss
-4. If `declined === false` → no notes, no emails (idempotent)
+4. If `declined === false` -> no notes, no emails (idempotent)
 5. Render "reported" confirmation
 
 **Why enqueue after commit:** Mixing DB mutations and email sends in one request path risks partial success (DB committed but email lost). The existing `sendEmail()` function already uses pg-boss as an outbox with retry — we just need to call it AFTER the transaction commits, not inside it.
@@ -530,48 +644,48 @@ Handle two intents:
 ### 5.5 Component (the brand moment page)
 
 ```text
-┌──────────────────────────────────────────┐
-│  [Shelf Logo]                            │
-│                                          │
-│  You've been assigned an asset           │
-│                                          │
-│  ┌────────────────────────────────────┐  │
-│  │  [Asset Image]                     │  │
-│  │                                    │  │
-│  │  MacBook Pro 16"                   │  │
-│  │  Category: Electronics             │  │
-│  │  ID: SAM-0042                      │  │
-│  │  Assigned by: Admin Name           │  │
-│  │  Date: March 30, 2026             │  │
-│  └────────────────────────────────────┘  │
-│                                          │
-│  By acknowledging, you confirm you have  │
-│  received this asset.                    │
-│                                          │
-│  ┌────────────────────────────────────┐  │
-│  │      [Acknowledge Receipt]         │  │
-│  └────────────────────────────────────┘  │
-│                                          │
-│  I don't have this item                  │
-│                                          │
-└──────────────────────────────────────────┘
++------------------------------------------+
+|  [Shelf Logo]                            |
+|                                          |
+|  You've been assigned an asset           |
+|                                          |
+|  +------------------------------------+  |
+|  |  [Asset Image]                     |  |
+|  |                                    |  |
+|  |  MacBook Pro 16"                   |  |
+|  |  Category: Electronics             |  |
+|  |  ID: SAM-0042                      |  |
+|  |  Assigned by: Admin Name           |  |
+|  |  Date: March 31, 2026              |  |
+|  +------------------------------------+  |
+|                                          |
+|  By acknowledging, you confirm you have  |
+|  received this asset.                    |
+|                                          |
+|  +------------------------------------+  |
+|  |      [Acknowledge Receipt]         |  |
+|  +------------------------------------+  |
+|                                          |
+|  I don't have this item                  |
+|                                          |
++------------------------------------------+
 ```
 
 After acknowledgement:
 ```text
-┌──────────────────────────────────────────┐
-│  [Shelf Logo]                            │
-│                                          │
-│  ✓ Receipt acknowledged                  │
-│                                          │
-│  You've confirmed receipt of             │
-│  MacBook Pro 16" (SAM-0042)              │
-│  March 31, 2026 at 2:47 PM              │
-│                                          │
-│  A confirmation has been sent to your    │
-│  email.                                  │
-│                                          │
-└──────────────────────────────────────────┘
++------------------------------------------+
+|  [Shelf Logo]                            |
+|                                          |
+|  Receipt acknowledged                    |
+|                                          |
+|  You've confirmed receipt of             |
+|  MacBook Pro 16" (SAM-0042)              |
+|  March 31, 2026 at 2:47 PM              |
+|                                          |
+|  A confirmation has been sent to your    |
+|  email.                                  |
+|                                          |
++------------------------------------------+
 ```
 
 ---
@@ -592,14 +706,14 @@ After acknowledgement:
 - If `requiresAcceptance` and feature is enabled:
   - Include `requiresAcceptance: true` and `assignedByUserId: userId` in custody create
   - Generate JWT token
-  - If custodian has user with email → send acknowledgement email
+  - If custodian has user with email -> send acknowledgement email
   - Store token reference (not in DB — token encodes custody ID, verification is stateless)
 - Modify activity note: if acknowledgement requested, append "(acknowledgement requested)"
 
 **Component changes:**
 - Add checkbox: "Require acknowledgement" (hidden if self-assignment, hidden if feature not enabled)
 - Show upsell block if feature not enabled and org is free tier
-- After submission with acknowledgement for non-registered member → show copy-link dialog/toast with the generated URL
+- After submission with acknowledgement for non-registered member -> show copy-link dialog/toast with the generated URL
 
 ### 6.2 Kit assign custody
 
@@ -648,10 +762,10 @@ requiresAcceptance: z
 **File:** `apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx`
 
 Before releasing, check the acknowledgement state and include it in the release note:
-- `requiresAcceptance && !acceptedAt && !declinedAt` → "released {custodian}'s custody (acknowledgement was pending)"
-- `requiresAcceptance && declinedAt` → "released {custodian}'s custody (custody was disputed)"
-- `requiresAcceptance && acceptedAt` → "released {custodian}'s custody (was acknowledged on {date})"
-- `!requiresAcceptance` → existing behavior, no acknowledgement mention
+- `requiresAcceptance && !acceptedAt && !declinedAt` -> "released {custodian}'s custody (acknowledgement was pending)"
+- `requiresAcceptance && declinedAt` -> "released {custodian}'s custody (custody was disputed)"
+- `requiresAcceptance && acceptedAt` -> "released {custodian}'s custody (was acknowledged on {date})"
+- `!requiresAcceptance` -> existing behavior, no acknowledgement mention
 
 ### 7.2 Bulk release
 
@@ -688,7 +802,7 @@ After the existing "Since {date}" line:
 - If `requiresAcceptance && !acceptedAt && !declinedAt`:
   ```text
   Awaiting acknowledgement
-  [Copy link] · [Resend email]  (conditional on custodian having email)
+  [Copy link] . [Resend email]  (conditional on custodian having email)
   ```
 
 - If `requiresAcceptance && acceptedAt`:
@@ -728,11 +842,11 @@ Add to `defaultFields`: `{ name: "acknowledgement", visible: false, position: ..
 Add `case "acknowledgement":` to the switch statement.
 
 Render:
-- No custody → `<EmptyTableValue />`
-- Custody without `requiresAcceptance` → `<EmptyTableValue />`
-- Pending → Amber badge "Pending" with hover popover: "Sent X days ago. [Copy link] [Resend]"
-- Acknowledged → Green check + date
-- Declined → Red indicator "Disputed"
+- No custody -> `<EmptyTableValue />`
+- Custody without `requiresAcceptance` -> `<EmptyTableValue />`
+- Pending -> Amber badge "Pending" with hover popover: "Sent X days ago. [Copy link] [Resend]"
+- Acknowledged -> Green check + date
+- Declined -> Red indicator "Disputed"
 
 ### 9.3 Asset index loader
 
@@ -806,9 +920,26 @@ Accepts `custodyId` (single), `acknowledgementBatchId` (batch), or `kitCustodyId
 **Single custody resend** (only for custodies NOT in a batch or kit):
 ```typescript
 // GUARD: reject if custody belongs to a batch or kit — must use batch/kit resend path instead
-const custody = await db.custody.findUnique({ where: { id: custodyId }, select: { acknowledgementBatchId: true, asset: { select: { kitId: true } } } });
+// Check for kit: look for KitCustody with requiresAcceptance = true that covers this asset
+const custody = await db.custody.findUnique({
+  where: { id: custodyId },
+  select: {
+    acknowledgementBatchId: true,
+    asset: { select: { kitId: true } }
+  }
+});
 if (custody?.acknowledgementBatchId) throw new ShelfError({ message: "This asset is part of a bulk assignment. Use batch resend." });
-if (custody?.asset?.kitId) throw new ShelfError({ message: "This asset is part of a kit. Use kit resend." });
+
+// Kit guard: check if a KitCustody exists with requiresAcceptance for this asset's kit
+if (custody?.asset?.kitId) {
+  const kitCustody = await db.kitCustody.findUnique({
+    where: { kitId: custody.asset.kitId },
+    select: { requiresAcceptance: true }
+  });
+  if (kitCustody?.requiresAcceptance) {
+    throw new ShelfError({ message: "This asset is part of a kit with acknowledgement. Use kit resend." });
+  }
+}
 
 const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
   UPDATE "Custody"
@@ -825,33 +956,41 @@ const [updated] = await db.$queryRaw<[{ tokenVersion: number }]>`
 if (!updated) {
   throw new ShelfError({ message: "Custody not found, already settled, or cooldown active." });
 }
-// Sign with { id: custodyId, purpose: "custody-ack", ver: updated.tokenVersion }
+// Sign with { id: custodyId, purpose: "custody-ack", ver: updated.tokenVersion,
+//   algorithm: "HS256", issuer: "shelf-custody", audience: "custody-ack" }
 ```
 
 **Batch resend** (rotates ALL rows in batch — including already-accepted/declined):
 ```typescript
 // Rotate ALL rows regardless of state. The verifier checks version on ALL rows,
 // so if one was accepted and keeps the old version, the new batch token breaks.
-// Cooldown check uses MIN(lastTokenRotatedAt) across the batch.
-const rows = await db.$queryRaw`
-  UPDATE "Custody"
-  SET "tokenVersion" = (
-    SELECT MAX("tokenVersion") + 1 FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId}
-  ),
-  "lastTokenRotatedAt" = NOW(), "updatedAt" = NOW()
-  WHERE "acknowledgementBatchId" = ${batchId}
-    AND "requiresAcceptance" = true
-    AND (
-      (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
-      IS NULL
-      OR
-      (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
-      < NOW() - INTERVAL '60 seconds'
-    )
-  RETURNING "tokenVersion"
-`;
+// Wrap in advisory lock to prevent concurrent MAX race condition.
+const rows = await db.$transaction(async (tx) => {
+  await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${batchId}))`;
+  return tx.$queryRaw`
+    UPDATE "Custody"
+    SET "tokenVersion" = (
+      SELECT COALESCE(MAX("tokenVersion"), 0) + 1
+      FROM "Custody"
+      WHERE "acknowledgementBatchId" = ${batchId}
+        AND "requiresAcceptance" = true
+    ),
+    "lastTokenRotatedAt" = NOW(), "updatedAt" = NOW()
+    WHERE "acknowledgementBatchId" = ${batchId}
+      AND "requiresAcceptance" = true
+      AND (
+        (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+        IS NULL
+        OR
+        (SELECT MAX("lastTokenRotatedAt") FROM "Custody" WHERE "acknowledgementBatchId" = ${batchId})
+        < NOW() - INTERVAL '60 seconds'
+      )
+    RETURNING "tokenVersion"
+  `;
+});
 if (!rows.length) throw new ShelfError({ message: "Batch not found or cooldown active." });
-// Sign with { batchId, purpose: "custody-ack-batch", ver: rows[0].tokenVersion }
+// Sign with { batchId, purpose: "custody-ack-batch", ver: rows[0].tokenVersion,
+//   algorithm: "HS256", issuer: "shelf-custody", audience: "custody-ack" }
 ```
 
 **Kit resend** (rotates KitCustody + all child Custody rows):
@@ -861,11 +1000,16 @@ if (!rows.length) throw new ShelfError({ message: "Batch not found or cooldown a
 //    WHERE id = kitCustodyId AND requiresAcceptance = true
 //    AND (lastTokenRotatedAt IS NULL OR lastTokenRotatedAt < NOW() - INTERVAL '60 seconds')
 //    RETURNING tokenVersion
-// 2. Guard: if zero rows → throw ShelfError("Kit custody not found or cooldown active")
+// 2. Guard: if zero rows -> throw ShelfError("Kit custody not found or cooldown active")
 // 3. UPDATE all child Custody records SET tokenVersion = newVersion, lastTokenRotatedAt = NOW()
-//    WHERE assetId IN (SELECT id FROM Asset WHERE kitId = kit.id)
-//    Guard: if zero child rows → throw ShelfError("No child custody records found")
-// 4. After commit: sign with { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
+//    WHERE assetId IN (SELECT id FROM "Asset" WHERE "kitId" = kit.id)
+//      AND "teamMemberId" = (SELECT "custodianId" FROM "KitCustody" WHERE id = kitCustodyId)
+//    Guard: if zero child rows -> throw ShelfError("No child custody records found")
+//    NOTE: The custodian filter (teamMemberId = custodianId) prevents updating custody records
+//    belonging to a different custodian if the kit was reassigned between operations.
+//    Remember: KitCustody uses custodianId, Custody uses teamMemberId.
+// 4. After commit: sign with { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion,
+//      algorithm: "HS256", issuer: "shelf-custody", audience: "custody-ack" }
 ```
 
 All paths: atomic `UPDATE ... RETURNING`, cooldown via `lastTokenRotatedAt` with DB time (`NOW() - INTERVAL`), state guards. Batch/kit resend rotates the **entire group** — never a single row from a group, which would desynchronize versions and break batch/kit verification.
@@ -909,40 +1053,40 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 10. `packages/database/prisma/migrations/[ts]_add_custody_acknowledgement/migration.sql`
 
 ### Modified files (17):
-1. `packages/database/prisma/schema.prisma` — Custody, KitCustody, Organization models
+1. `packages/database/prisma/schema.prisma` — Custody, KitCustody, Organization, User models
 2. `apps/webapp/server/index.ts` — Add public path
 3. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx` — Checkbox + email logic
 4. `apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx` — Same for kits
 5. `apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts` — Bulk assign support
 6. `apps/webapp/app/modules/asset/service.server.ts` — `bulkCheckOutAssets` acknowledgement
 7. `apps/webapp/app/modules/kit/service.server.ts` — Kit custody acknowledgement
-8. `apps/webapp/app/modules/custody/service.server.ts` — No changes to releaseCustody (it already hard-deletes)
-9. `apps/webapp/app/modules/custody/schema.ts` — Add requiresAcceptance to schema
-10. `apps/webapp/app/components/assets/asset-custody-card.tsx` — Show status + actions
-11. `apps/webapp/app/modules/asset-index-settings/helpers.ts` — New column
-12. `apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx` — Render column
-13. `apps/webapp/app/routes/_layout+/assets._index.tsx` — Load acknowledgement data + banner
-14. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx` — Pending note
-15. `apps/webapp/app/utils/roles.server.ts` — Return `canUseCustodyAcknowledgement`
-16. `apps/webapp/app/config/addon-copy.ts` — Upsell copy
-17. `apps/webapp/server/logger.ts` — Redact token query param on acceptance routes
+8. `apps/webapp/app/modules/custody/schema.ts` — Add requiresAcceptance to schema
+9. `apps/webapp/app/components/assets/asset-custody-card.tsx` — Show status + actions
+10. `apps/webapp/app/modules/asset-index-settings/helpers.ts` — New column
+11. `apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx` — Render column
+12. `apps/webapp/app/routes/_layout+/assets._index.tsx` — Load acknowledgement data + banner
+13. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx` — Pending note
+14. `apps/webapp/app/utils/roles.server.ts` — Return `canUseCustodyAcknowledgement`
+15. `apps/webapp/app/config/addon-copy.ts` — Upsell copy
+16. `apps/webapp/server/logger.ts` — Redact token query param on acceptance routes
+17. `apps/webapp/app/utils/env.ts` — Add CUSTODY_TOKEN_SECRET
 
 ---
 
 ## Build & Test Order
 
-1. **Phase 1** → Run migration → `pnpm db:deploy-migration`
-2. **Phase 2-3** → Service + gating (no UI yet) → Run unit tests
-3. **Phase 4** → Email templates (can preview with React Email)
-4. **Phase 5** → Public acceptance route → Manual test with generated JWT
-5. **Phase 6** → Assign custody changes → Test full flow: assign → email → accept
-6. **Phase 7** → Release changes → Test release-with-pending notes
-7. **Phase 8** → Custody card → Visual verification via preview
-8. **Phase 9** → Index column → Visual verification via preview
-9. **Phase 10** → In-app banner + acknowledge page → Test as BASE/SELF_SERVICE user
-10. **Phase 11** → Resend/copy-link API → Test from custody card buttons
-11. **Phase 12** → Settings/stripe (can be deferred)
-12. **Final** → `pnpm webapp:validate` → Full validation pass
+1. **Phase 1** -> Run migration -> `pnpm db:deploy-migration`
+2. **Phase 2-3** -> Service + gating (no UI yet) -> Run unit tests
+3. **Phase 4** -> Email templates (can preview with React Email)
+4. **Phase 5** -> Public acceptance route -> Manual test with generated JWT
+5. **Phase 6** -> Assign custody changes -> Test full flow: assign -> email -> accept
+6. **Phase 7** -> Release changes -> Test release-with-pending notes
+7. **Phase 8** -> Custody card -> Visual verification via preview
+8. **Phase 9** -> Index column -> Visual verification via preview
+9. **Phase 10** -> In-app banner + acknowledge page -> Test as BASE/SELF_SERVICE user
+10. **Phase 11** -> Resend/copy-link API -> Test from custody card buttons
+11. **Phase 12** -> Settings/stripe (can be deferred)
+12. **Final** -> `pnpm webapp:validate` -> Full validation pass
 
 ---
 
@@ -960,11 +1104,13 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 | Narrow public path | `/accept-custody/:custodyId` — no wildcard. Minimal exposure surface. |
 | Dedicated CUSTODY_TOKEN_SECRET | Separate secret prevents token confusion with invite tokens (invite verifier doesn't check `purpose`). |
 | Three token purposes | `custody-ack` (single), `custody-ack-batch` (bulk), `custody-ack-kit` (kit) — each with dedicated verifier fetching from the correct model. |
-| Verify-once-then-dispatch | `verifyTokenSignature()` validates JWT once. Verified payload passed to purpose-specific verifiers for DB checks. No double-verification, no unverified branching. |
+| Verify-once-then-dispatch | `verifyTokenSignature()` validates JWT once (signature + exp + iss + aud). Verified payload passed to purpose-specific verifiers for DB checks. No double-verification, no unverified branching. |
+| Pinned HS256 + issuer/audience | `algorithms: ["HS256"]` prevents algorithm confusion. `issuer` + `audience` claims prevent cross-service token reuse. |
 | Checkbox coercion in Zod schema | HTML checkbox sends `"on"` not `true`. Uses `z.union([z.boolean(), z.literal("on")]).transform()` — follows existing column visibility pattern. |
 | Decline uses same conditional guard as accept | `WHERE acceptedAt IS NULL AND declinedAt IS NULL` — prevents race between concurrent accept/decline. |
 | Single owner for email side effects | Service functions are DB-only. Route actions enqueue emails via pg-boss after commit. Prevents duplicate sends. |
 | Atomic resend cooldown | Raw SQL `UPDATE ... RETURNING` with `lastTokenRotatedAt` + `NOW() - INTERVAL '60 seconds'` + state guards. Single query: increment version, enforce cooldown, return new version. TOCTOU-safe, clock-skew safe. |
+| Advisory lock for batch token generation | `pg_advisory_xact_lock(hashtext(batchId))` prevents concurrent calls from reading the same MAX and generating duplicate versions. |
 | Network metadata cleanup deferred (not an oversight) | Custody hard-delete already purges IP/UA. Notes retain only name (business record). Cron job for long-lived custodies is trivial to add later if needed. |
 | Org-scoped in-app acknowledgement | In-app route verifies custody belongs to current session org. Prevents cross-org attacks. |
 | Feature gated per-org (boolean switch) | Same infra as barcode/audit. Included in Plus/Team by default. Free users see upsell to upgrade. Not a separate purchase — just tier-gated. |
@@ -974,3 +1120,5 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 | BASE users can acknowledge own custody | Permission bypass in in-app mode: if you ARE the custodian, you can acknowledge. Not a general custody permission. |
 | Non-registered members get copy-link only | No email field on TeamMember. Admin copies link, sends manually. |
 | Column hidden by default | Opt-in visibility. Admins who use the feature toggle it on. |
+| Custody vs KitCustody field naming | Custody uses `teamMemberId`, KitCustody uses `custodianId`. Both point to TeamMember. Code must use the correct field name per model. |
+| `_auth+` prefix for public route | Follows existing `accept-invite` precedent — token-authenticated public routes that don't require a session. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -221,8 +221,10 @@ export async function generateBatchAcknowledgementToken(batchId: string): Promis
 export async function generateKitCustodyAcknowledgementToken(kitCustodyId: string): Promise<string>
 // STRICTLY persist-before-sign:
 // 1. Atomically increment KitCustody.tokenVersion via UPDATE ... RETURNING
-// 2. Also update all child Custody records to same version (single UPDATE with subquery)
-// 3. Sign JWT with { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
+// 2. Guard: if zero rows → throw ShelfError("KitCustody not found")
+// 3. Update all child Custody records to same version (single UPDATE with subquery)
+// 4. Guard: if zero child rows → throw ShelfError("No child custody records found")
+// 5. Sign JWT with { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
 // 30-day expiry.
 ```
 
@@ -233,58 +235,64 @@ export async function generateKitCustodyAcknowledgementToken(kitCustodyId: strin
 - Token's decoded `id` is the **sole authority** for DB operations — URL param is for routing only
 - `purpose` field provides defense-in-depth
 
-### 3.2 Token verification (single custody)
+### 3.2 JWT signature verification (shared entry point)
+
+The loader calls `jwt.verify(token, CUSTODY_TOKEN_SECRET)` ONCE to validate signature + expiry. The verified payload is then passed to purpose-specific verifiers below. This avoids double-verification and ensures purpose branching happens on trusted data.
 
 ```typescript
-export async function verifyCustodyAcknowledgementToken(
-  token: string,
-  db: PrismaClient
-): Promise<{ id: string; iat: number }>
-// 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
-// 2. Checks purpose === "custody-ack"
-// 3. Fetches custody record
-// 4. Compares JWT `ver` claim against custody.tokenVersion (integer equality — no timestamp precision issues)
-// 5. Throws ShelfError("Token expired") on exp failure
-// 6. Throws ShelfError("Token revoked") if token.ver !== custody.tokenVersion
-// 6. Throws ShelfError("Custody not found") if record doesn't exist
-// Returns custody ID and iat
-// Token rotation check is INSIDE this function — callers cannot forget it
+export function verifyTokenSignature(token: string): VerifiedCustodyPayload
+// 1. jwt.verify(token, CUSTODY_TOKEN_SECRET) — validates signature + exp
+// 2. Returns typed payload: { id?: string, batchId?: string, purpose: string, ver: number }
+// 3. Throws ShelfError("Token expired") on exp failure
+// 4. Throws ShelfError("Invalid token") on signature failure
+// Does NOT do DB checks — that's the purpose-specific verifier's job
 ```
 
-### 3.3 Token verification (batch)
+### 3.3 Purpose-specific verifier (single custody)
 
 ```typescript
-export async function verifyBatchAcknowledgementToken(
-  token: string,
+export async function verifySingleCustodyToken(
+  payload: VerifiedCustodyPayload,
+  db: PrismaClient
+): Promise<{ custodyId: string; custody: CustodyWithAsset }>
+// 1. Asserts payload.purpose === "custody-ack" and payload.id exists
+// 2. Fetches custody record by payload.id
+// 3. Compares payload.ver against custody.tokenVersion (integer equality)
+// 4. Throws ShelfError("Token revoked") if payload.ver !== custody.tokenVersion
+// 5. Throws ShelfError("Custody not found") if record doesn't exist
+// Returns custody ID + full custody with asset details
+```
+
+### 3.4 Purpose-specific verifier (batch)
+
+```typescript
+export async function verifyBatchCustodyToken(
+  payload: VerifiedCustodyPayload,
   db: PrismaClient
 ): Promise<{ batchId: string; custodies: CustodyWithAsset[] }>
-// 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
-// 2. Checks purpose === "custody-ack-batch"
-// 3. Fetches all custody records with matching acknowledgementBatchId
-// 4. Enforces single-custodian membership: all records must have same teamMemberId
-//    (prevents cross-custody acknowledgement if batch was somehow corrupted)
-// 5. Validates token rotation on EVERY custody record in the batch:
-//    verifies ALL custody.tokenVersion === token.ver (uniform after SET normalization)
-// 6. Throws if no records found, mixed custodians, or any rotation check fails
+// 1. Asserts payload.purpose === "custody-ack-batch" and payload.batchId exists
+// 2. Fetches all custody records with matching acknowledgementBatchId
+// 3. Enforces single-custodian membership: all records must have same teamMemberId
+// 4. Validates ALL custody.tokenVersion === payload.ver (uniform after SET normalization)
+// 5. Throws if no records found, mixed custodians, or any version mismatch
 // Returns batchId + full custody list with asset details
 ```
 
-### 3.3b Token verification (kit custody)
+### 3.5 Purpose-specific verifier (kit custody)
 
 ```typescript
-export async function verifyKitCustodyAcknowledgementToken(
-  token: string,
+export async function verifyKitCustodyToken(
+  payload: VerifiedCustodyPayload,
   db: PrismaClient
 ): Promise<{ kitCustodyId: string; kitCustody: KitCustodyWithAssets }>
-// 1. Verifies JWT signature + expiry using CUSTODY_TOKEN_SECRET
-// 2. Checks purpose === "custody-ack-kit"
-// 3. Fetches KitCustody record (NOT Custody) with kit + all child assets + custodian
-// 4. Validates tokenVersion rotation check (integer equality)
-// 5. Throws if KitCustody not found
+// 1. Asserts payload.purpose === "custody-ack-kit" and payload.id exists
+// 2. Fetches KitCustody record (NOT Custody) with kit + all child assets + custodian
+// 3. Validates payload.ver === kitCustody.tokenVersion (integer equality)
+// 4. Throws if KitCustody not found or version mismatch
 // Returns kitCustodyId + full kit custody with child asset details
 ```
 
-### 3.4 Record acknowledgement
+### 3.6 Record acknowledgement
 
 ```typescript
 export async function recordCustodyAcknowledgement({
@@ -308,7 +316,7 @@ export async function recordCustodyAcknowledgement({
 - If the row was already transitioned, the operation is **idempotent** — returns the existing state without error
 - This eliminates the need for an explicit status enum; the state is derived: pending (`both null`), acknowledged (`acceptedAt set`), declined (`declinedAt set`)
 
-### 3.5 Send acknowledgement email
+### 3.7 Send acknowledgement email
 
 ```typescript
 export async function sendCustodyAcknowledgementEmail({
@@ -324,7 +332,7 @@ export async function sendCustodyAcknowledgementEmail({
 // try/catch + Logger.error + ShelfError pattern
 ```
 
-### 3.6 Record decline
+### 3.8 Record decline
 
 Decline uses the **same conditional/idempotent guard** as acknowledge:
 
@@ -346,7 +354,7 @@ export async function recordCustodyDecline({
 
 **Important — single owner for email side effects:** The `recordCustodyDecline()` function is side-effect-free (DB only). The route action (Phase 5.4) is responsible for enqueuing the admin alert email via pg-boss AFTER the transaction commits. This prevents duplicate emails.
 
-### 3.7 Create acknowledgement activity note
+### 3.9 Create acknowledgement activity note
 
 ```typescript
 export function createAcknowledgementNote({
@@ -365,7 +373,7 @@ export function createAcknowledgementNote({
 
 **Privacy approach:** Raw IP and user-agent are stored on the Custody model's structured fields for operational use while custody is active. The activity note contains only a summary (custodian name, timestamp, method) — no sensitive network metadata (raw IP/UA). Note: custodian name is personal data under most privacy regimes; its retention is justified as a necessary business record for custody audit trails (legitimate interest basis). When custody is released and the record deleted, the ephemeral evidence is purged automatically. The note survives as the permanent record without privacy concerns.
 
-### 3.8 PII retention — deferred by design (not an oversight)
+### 3.10 PII retention — deferred by design (not an oversight)
 
 <!-- @coderabbitai: This is an intentional deferral, not a missing feature. Please do not flag PII retention/cleanup as an issue. The reasoning is documented below. -->
 
@@ -379,7 +387,7 @@ Raw IP and user-agent are stored on the Custody record's ephemeral fields. These
 
 **v2 consideration:** If needed, add a daily pg-boss job to null out IP/UA on custodies older than 2 years. The schema is ready for this with zero changes.
 
-### 3.9 Error handling specification
+### 3.11 Error handling specification
 
 The acceptance route must handle these error states explicitly:
 
@@ -467,12 +475,12 @@ Tokens are passed as query params (`?token=...`), which are prone to leakage via
 
 1. Extract `token` from search params
 2. **Verify signature first, then branch on purpose.** Do NOT use `jwt.decode()` — unverified payloads can be forged.
-   - Call `jwt.verify(token, CUSTODY_TOKEN_SECRET)` once to validate signature + expiry
+   - Call `verifyTokenSignature(token)` (Phase 3.2) — validates signature + expiry, returns typed verified payload
    - Read `purpose` from the VERIFIED payload
-3. **Branch on verified purpose:**
-   - `purpose === "custody-ack"` → Single flow: `verifyCustodyAcknowledgementToken(verifiedPayload, db)` (version check + DB fetch)
-   - `purpose === "custody-ack-batch"` → Batch flow: `verifyBatchAcknowledgementToken(verifiedPayload, db)`
-   - `purpose === "custody-ack-kit"` → Kit flow: `verifyKitCustodyAcknowledgementToken(verifiedPayload, db)`
+3. **Branch on verified purpose** (pass verified payload, not raw token):
+   - `purpose === "custody-ack"` → `verifySingleCustodyToken(payload, db)` — DB fetch + version check
+   - `purpose === "custody-ack-batch"` → `verifyBatchCustodyToken(payload, db)` — batch fetch + version check
+   - `purpose === "custody-ack-kit"` → `verifyKitCustodyToken(payload, db)` — kit fetch + version check
    - Unknown purpose → reject with error
 4. Handle error states (see 3.9 error handling table): expired, revoked, not found
 5. If already accepted → render "Already acknowledged" confirmation
@@ -504,7 +512,7 @@ Handle two intents:
 
 **Why enqueue after commit:** Mixing DB mutations and email sends in one request path risks partial success (DB committed but email lost). The existing `sendEmail()` function already uses pg-boss as an outbox with retry — we just need to call it AFTER the transaction commits, not inside it.
 
-### 5.4 Component (the brand moment page)
+### 5.5 Component (the brand moment page)
 
 ```text
 ┌──────────────────────────────────────────┐
@@ -582,11 +590,11 @@ After acknowledgement:
 
 **File:** `apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx`
 
-Same changes as 6.1 but:
+Same changes as 6.1 including **server-side `validateCustodyAcknowledgementEnabled` check in action**, plus:
 - Checkbox applies to KitCustody AND all child Custody records
 - One email/link for the kit (not per-asset)
 - Token uses `purpose: "custody-ack-kit"` with the KitCustody ID (distinct from single-custody and batch purposes)
-- Requires a dedicated `verifyKitCustodyAcknowledgementToken()` that fetches from `KitCustody` (not `Custody`) and returns kit + child custodies
+- Verification via `verifyKitCustodyToken()` (Phase 3.5) which fetches from `KitCustody` (not `Custody`)
 
 ### 6.3 Bulk assign custody
 
@@ -594,6 +602,7 @@ Same changes as 6.1 but:
 **File:** `apps/webapp/app/modules/asset/service.server.ts` (`bulkCheckOutAssets`)
 
 - Accept `requiresAcceptance` parameter
+- **Server-side gating:** Same `validateCustodyAcknowledgementEnabled` check as 6.1 — prevents bypass via crafted API requests
 - Pass through to custody creation
 - Generate a `acknowledgementBatchId` (cuid) and set it on all Custody records in the batch
 - Batch is always **per-custodian** — bulk assign already goes to one custodian, but the batch verifier enforces single-`teamMemberId` membership (rejects if records have mixed custodians)
@@ -829,8 +838,16 @@ if (!rows.length) throw new ShelfError({ message: "Batch not found or cooldown a
 
 **Kit resend** (rotates KitCustody + all child Custody rows):
 ```typescript
-// Transaction: rotate KitCustody + all child Custody records together
-// Sign with { kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
+// In a single transaction:
+// 1. UPDATE KitCustody SET tokenVersion = tokenVersion + 1, lastTokenRotatedAt = NOW()
+//    WHERE id = kitCustodyId AND requiresAcceptance = true
+//    AND (lastTokenRotatedAt IS NULL OR lastTokenRotatedAt < NOW() - INTERVAL '60 seconds')
+//    RETURNING tokenVersion
+// 2. Guard: if zero rows → throw ShelfError("Kit custody not found or cooldown active")
+// 3. UPDATE all child Custody records SET tokenVersion = newVersion, lastTokenRotatedAt = NOW()
+//    WHERE assetId IN (SELECT id FROM Asset WHERE kitId = kit.id)
+//    Guard: if zero child rows → throw ShelfError("No child custody records found")
+// 4. After commit: sign with { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
 ```
 
 All paths: atomic `UPDATE ... RETURNING`, cooldown via `lastTokenRotatedAt` with DB time (`NOW() - INTERVAL`), state guards. Batch/kit resend rotates the **entire group** — never a single row from a group, which would desynchronize versions and break batch/kit verification.
@@ -925,7 +942,7 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 | Narrow public path | `/accept-custody/:custodyId` — no wildcard. Minimal exposure surface. |
 | Dedicated CUSTODY_TOKEN_SECRET | Separate secret prevents token confusion with invite tokens (invite verifier doesn't check `purpose`). |
 | Three token purposes | `custody-ack` (single), `custody-ack-batch` (bulk), `custody-ack-kit` (kit) — each with dedicated verifier fetching from the correct model. |
-| Token rotation inside verifier | `verify*Token()` functions check `tokenVersion` internally — callers cannot forget. |
+| Verify-once-then-dispatch | `verifyTokenSignature()` validates JWT once. Verified payload passed to purpose-specific verifiers for DB checks. No double-verification, no unverified branching. |
 | Checkbox coercion in Zod schema | HTML checkbox sends `"on"` not `true`. Uses `z.union([z.boolean(), z.literal("on")]).transform()` — follows existing column visibility pattern. |
 | Decline uses same conditional guard as accept | `WHERE acceptedAt IS NULL AND declinedAt IS NULL` — prevents race between concurrent accept/decline. |
 | Single owner for email side effects | Service functions are DB-only. Route actions enqueue emails via pg-boss after commit. Prevents duplicate sends. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -315,7 +315,11 @@ export async function generateKitCustodyAcknowledgementToken(kitCustodyId: strin
 // STRICTLY persist-before-sign:
 // 1. Atomically increment KitCustody.tokenVersion via UPDATE ... RETURNING
 // 2. Guard: if zero rows -> throw ShelfError("KitCustody not found")
-// 3. Update all child Custody records to same version (single UPDATE with subquery)
+// 3. Update child Custody records to same version, scoped by custodian:
+//    UPDATE "Custody" SET "tokenVersion" = newVersion
+//    WHERE "assetId" IN (SELECT "id" FROM "Asset" WHERE "kitId" = kit.id)
+//      AND "teamMemberId" = (SELECT "custodianId" FROM "KitCustody" WHERE "id" = kitCustodyId)
+//    (custodian filter prevents rotating unrelated custody rows if kit was reassigned)
 // 4. Guard: if zero child rows -> throw ShelfError("No child custody records found")
 // 5. Sign JWT with:
 //    - payload: { id: kitCustodyId, purpose: "custody-ack-kit", ver: newVersion }
@@ -916,7 +920,7 @@ Pass to the banner component.
 
 **New file:** `apps/webapp/app/routes/api+/custody.acknowledgement.ts`
 
-Accepts `custodyId` (single), `acknowledgementBatchId` (batch), or `kitCustodyId` (kit). Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only).
+Accepts **exactly one** of `custodyId` (single), `acknowledgementBatchId` (batch), or `kitCustodyId` (kit). Validate with Zod discriminated union or manual XOR check — reject if zero or multiple identifiers are provided. Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only).
 
 **Multi-tenant safety:** ALL fetch and update queries in this endpoint MUST scope to `organizationId` (from the admin's session) via the `Asset.organizationId` join. This prevents an admin in Org A from rotating tokens for Org B's custodies, even if they somehow obtain a valid custody ID. Permission checks alone are insufficient — raw IDs in request bodies can be forged.
 

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -1,0 +1,613 @@
+# Custody Acknowledgement — Implementation Plan
+
+## Overview
+
+Add verifiable proof that a custodian acknowledged receiving an asset. When an admin assigns custody and checks "Require acknowledgement," the system sends an email (or generates a link) and records the custodian's confirmation with legal-weight timestamps.
+
+**Branch:** `feat/custody-acknowledgement` (from `main` at `d7d20c87f`)
+
+---
+
+## Phase 1: Database Schema Changes
+
+### 1.1 Custody model — add acknowledgement fields
+
+**File:** `packages/database/prisma/schema.prisma` (lines 671-687)
+
+Add to the `Custody` model:
+
+```prisma
+model Custody {
+  id String @id @default(cuid())
+
+  custodian    TeamMember @relation(fields: [teamMemberId], references: [id])
+  teamMemberId String
+
+  asset   Asset  @relation(fields: [assetId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  assetId String @unique
+
+  // Acknowledgement fields
+  requiresAcceptance  Boolean   @default(false) // Was acknowledgement requested?
+  acceptedAt          DateTime?                 // When custodian acknowledged
+  acceptanceMethod    String?                   // "email_link" | "in_app" | "manual_link"
+  acceptanceIp        String?                   // IP address at time of acknowledgement
+  acceptanceUserAgent String?                   // Browser user-agent string
+  assignedByUserId    String?                   // Who assigned custody (for admin notification routing)
+
+  // DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([assetId, teamMemberId], name: "Custody_assetId_teamMemberId_idx")
+  @@index([teamMemberId])
+}
+```
+
+### 1.2 KitCustody model — add same acknowledgement fields
+
+Add identical fields to `KitCustody` for kit-level acknowledgement.
+
+### 1.3 Organization model — add feature toggle
+
+**File:** `packages/database/prisma/schema.prisma` (Organization model, after `customEmailFooter`)
+
+```prisma
+// Custody acknowledgement add-on
+custodyAcknowledgementEnabled   Boolean   @default(false)
+custodyAcknowledgementEnabledAt DateTime?
+usedCustodyAcknowledgementTrial Boolean   @default(false)
+```
+
+### 1.4 Migration
+
+**File:** `packages/database/prisma/migrations/[timestamp]_add_custody_acknowledgement/migration.sql`
+
+Run: `pnpm db:prepare-migration` then `pnpm db:deploy-migration`
+
+All new columns are nullable or have defaults — zero impact on existing data.
+
+---
+
+## Phase 2: Feature Gating & Environment
+
+### 2.1 Validator
+
+**New file:** `apps/webapp/app/utils/permissions/custody-acknowledgement.validator.server.ts`
+
+Follow the exact pattern from `audit.validator.server.ts`:
+
+```typescript
+export function canUseCustodyAcknowledgement(org: Pick<Organization, "custodyAcknowledgementEnabled">): boolean
+export function validateCustodyAcknowledgementEnabled(org): void // throws ShelfError if disabled
+```
+
+### 2.2 Subscription helper
+
+**File:** `apps/webapp/app/utils/subscription.server.ts`
+
+Add:
+```typescript
+export const canUseCustodyAcknowledgement = (org: { custodyAcknowledgementEnabled: boolean }) => {
+  if (!premiumIsEnabled) return true;
+  return org.custodyAcknowledgementEnabled;
+};
+```
+
+### 2.3 requirePermission return
+
+**File:** `apps/webapp/app/utils/roles.server.ts`
+
+Add `canUseCustodyAcknowledgement` to the return object, following the `canUseBarcodes`/`canUseAudits` pattern.
+
+### 2.4 Addon copy for upsell UI
+
+**File:** `apps/webapp/app/config/addon-copy.ts`
+
+Add:
+```typescript
+export const CUSTODY_ACKNOWLEDGEMENT_ADDON = {
+  label: "Custody Acknowledgement",
+  description: "Get verifiable proof that team members received their assigned assets.",
+  features: [
+    "Send acknowledgement requests via email or shareable link",
+    "Track acknowledgement status across all assets",
+    "Legal-weight timestamps with IP and method recording",
+    "Activity log entries suitable for compliance and audits",
+  ],
+};
+```
+
+### 2.5 JWT token — reuse INVITE_TOKEN_SECRET
+
+No new env var. We reuse `INVITE_TOKEN_SECRET` but include `purpose: "custody-ack"` in the JWT payload to prevent cross-use with invite tokens.
+
+---
+
+## Phase 3: Acknowledgement Service
+
+**New file:** `apps/webapp/app/modules/custody/acknowledgement.server.ts`
+
+### 3.1 Token generation
+
+```typescript
+export function generateCustodyAcknowledgementToken(custodyId: string): string
+// Signs JWT with { id: custodyId, purpose: "custody-ack" }
+// No expiry for v1 (token validity = custody record existence)
+```
+
+### 3.2 Token verification
+
+```typescript
+export function verifyCustodyAcknowledgementToken(token: string): { id: string }
+// Verifies JWT, checks purpose === "custody-ack"
+// Returns custody ID
+```
+
+### 3.3 Record acknowledgement
+
+```typescript
+export async function recordCustodyAcknowledgement({
+  custodyId,
+  method,      // "email_link" | "in_app" | "manual_link"
+  ip,
+  userAgent,
+  organizationId,
+}: RecordAcknowledgementParams): Promise<Custody>
+// Updates custody: acceptedAt = now(), acceptanceMethod, acceptanceIp, acceptanceUserAgent
+// Returns updated custody with asset + custodian data
+```
+
+### 3.4 Record decline
+
+```typescript
+export async function recordCustodyDecline({
+  custodyId,
+  reason,
+  organizationId,
+}: RecordDeclineParams): Promise<void>
+// Does NOT change custody status
+// Creates activity log note: "Custodian reported they don't have this item"
+// Sends notification email to assigning admin
+```
+
+### 3.5 Send acknowledgement email
+
+```typescript
+export async function sendCustodyAcknowledgementEmail({
+  custody,
+  asset,
+  custodianEmail,
+  assignerName,
+  organizationName,
+  token,
+  customFooter,
+}: SendAckEmailParams): Promise<void>
+// Sends email using the custody acknowledgement template
+// try/catch + Logger.error + ShelfError pattern
+```
+
+### 3.6 Create acknowledgement activity note
+
+```typescript
+export function createAcknowledgementNote({
+  userId,
+  assetId,
+  custodianName,
+  method,
+  timestamp,
+  ip,
+}: CreateAckNoteParams): Promise<Note>
+// Creates rich UPDATE note with ALL legal details inline
+// "Jane Smith acknowledged receipt on March 31, 2026 at 2:47 PM via email link (IP: x.x.x.x)"
+// This note IS the permanent legal record (survives custody hard-delete)
+```
+
+---
+
+## Phase 4: Email Templates
+
+### 4.1 Custodian acknowledgement email
+
+**New file:** `apps/webapp/app/emails/custody-acknowledgement-template.tsx`
+
+Following the pattern from `app/emails/stripe/audit-trial-welcome.tsx` per CLAUDE.md:
+
+- LogoForEmail at top
+- "Hey {firstName}," greeting
+- Body: "You've been assigned custody of {assetTitle} by {assignerName} at {orgName}."
+- Asset details: title, category (if any), serial/sequential ID
+- CTA button: "Acknowledge Receipt" → `${SERVER_URL}/accept-custody/${custodyId}?token=${jwt}`
+- Secondary text: "If you don't have this item, click the link above and report it."
+- CustomEmailFooter from org settings
+- Both HTML + plain text exports
+- Send wrapper function with try/catch + Logger.error + ShelfError
+
+### 4.2 Admin notification email (on acknowledgement)
+
+**New file:** `apps/webapp/app/emails/custody-acknowledged-admin-template.tsx`
+
+- Brief notification: "{custodianName} acknowledged receipt of {assetTitle}"
+- Timestamp of acknowledgement
+- Link to asset detail page
+- CustomEmailFooter
+
+### 4.3 Admin notification email (on decline)
+
+**New file:** `apps/webapp/app/emails/custody-declined-admin-template.tsx`
+
+- Alert: "A dispute was reported on the custody assignment of {assetTitle} to {custodianName}"
+- Reason text if provided
+- Link to asset detail page
+
+---
+
+## Phase 5: Public Acceptance Route
+
+**New file:** `apps/webapp/app/routes/_auth+/accept-custody.$custodyId.tsx`
+
+### 5.1 Add to public paths
+
+**File:** `apps/webapp/server/index.ts` (publicPaths array)
+
+Add: `"/accept-custody/:path*"`
+
+### 5.2 Loader
+
+1. Extract `custodyId` from params, `token` from search params
+2. Verify JWT token via `verifyCustodyAcknowledgementToken(token)`
+3. Fetch custody record with asset details (title, mainImage, category, sequentialId, organization name)
+4. If custody doesn't exist → render "This custody assignment has been released"
+5. If already accepted → render "Already acknowledged" confirmation
+6. Return asset details + custody info to component
+
+### 5.3 Action
+
+Handle two intents:
+
+**`acknowledge`:**
+1. Verify token again
+2. Call `recordCustodyAcknowledgement()` with IP + user-agent from request
+3. Create acknowledgement activity note (rich, legal-weight)
+4. If kit custody → cascade `acceptedAt` to all child custody records + create notes for each asset
+5. Send admin notification email
+6. Send custodian confirmation email
+7. Render success state
+
+**`decline`:**
+1. Verify token
+2. Call `recordCustodyDecline()` with optional reason
+3. Create decline activity note
+4. Send admin alert email
+5. Render "reported" confirmation
+
+### 5.4 Component (the brand moment page)
+
+```
+┌──────────────────────────────────────────┐
+│  [Shelf Logo]                            │
+│                                          │
+│  You've been assigned an asset           │
+│                                          │
+│  ┌────────────────────────────────────┐  │
+│  │  [Asset Image]                     │  │
+│  │                                    │  │
+│  │  MacBook Pro 16"                   │  │
+│  │  Category: Electronics             │  │
+│  │  ID: SAM-0042                      │  │
+│  │  Assigned by: Admin Name           │  │
+│  │  Date: March 30, 2026             │  │
+│  └────────────────────────────────────┘  │
+│                                          │
+│  By acknowledging, you confirm you have  │
+│  received this asset.                    │
+│                                          │
+│  ┌────────────────────────────────────┐  │
+│  │      [Acknowledge Receipt]         │  │
+│  └────────────────────────────────────┘  │
+│                                          │
+│  I don't have this item                  │
+│                                          │
+└──────────────────────────────────────────┘
+```
+
+After acknowledgement:
+```
+┌──────────────────────────────────────────┐
+│  [Shelf Logo]                            │
+│                                          │
+│  ✓ Receipt acknowledged                  │
+│                                          │
+│  You've confirmed receipt of             │
+│  MacBook Pro 16" (SAM-0042)              │
+│  March 31, 2026 at 2:47 PM              │
+│                                          │
+│  A confirmation has been sent to your    │
+│  email.                                  │
+│                                          │
+└──────────────────────────────────────────┘
+```
+
+---
+
+## Phase 6: Assign Custody Route Changes
+
+### 6.1 Single asset assign custody
+
+**File:** `apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx`
+
+**Loader changes:**
+- Add `canUseCustodyAcknowledgement` from `requirePermission` return
+- Pass to component
+
+**Action changes:**
+- Parse new `requiresAcceptance` boolean from form data (add to schema)
+- If `requiresAcceptance`:
+  - Include `requiresAcceptance: true` and `assignedByUserId: userId` in custody create
+  - Generate JWT token
+  - If custodian has user with email → send acknowledgement email
+  - Store token reference (not in DB — token encodes custody ID, verification is stateless)
+- Modify activity note: if acknowledgement requested, append "(acknowledgement requested)"
+
+**Component changes:**
+- Add checkbox: "Require acknowledgement" (hidden if self-assignment, hidden if feature not enabled)
+- Show upsell block if feature not enabled and org is free tier
+- After submission with acknowledgement for non-registered member → show copy-link dialog/toast with the generated URL
+
+### 6.2 Kit assign custody
+
+**File:** `apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx`
+
+Same changes as 6.1 but:
+- Checkbox applies to KitCustody AND all child Custody records
+- One email/link for the kit (not per-asset)
+- Token references the KitCustody ID
+
+### 6.3 Bulk assign custody
+
+**File:** `apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts`
+**File:** `apps/webapp/app/modules/asset/service.server.ts` (`bulkCheckOutAssets`)
+
+- Accept `requiresAcceptance` parameter
+- Pass through to custody creation
+- One email per custodian (bulk assign goes to one custodian)
+- Token covers all assets in the batch
+
+### 6.4 Assign custody schema
+
+**File:** `apps/webapp/app/modules/custody/schema.ts`
+
+Add `requiresAcceptance: z.boolean().optional().default(false)` to `AssignCustodySchema`.
+
+---
+
+## Phase 7: Release Custody Changes
+
+### 7.1 Single asset release
+
+**File:** `apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx`
+
+Before releasing, check if `requiresAcceptance` was true and `acceptedAt` is null.
+If so, include in the release note: "released {custodian}'s custody (acknowledgement was pending)"
+
+### 7.2 Bulk release
+
+**File:** `apps/webapp/app/modules/asset/service.server.ts` (`bulkCheckInAssets`)
+
+Same: capture pending acknowledgement state in release notes.
+
+### 7.3 Kit release
+
+**File:** `apps/webapp/app/modules/kit/service.server.ts`
+
+Same pattern for kit-level release notes.
+
+---
+
+## Phase 8: Custody Card UI Changes
+
+**File:** `apps/webapp/app/components/assets/asset-custody-card.tsx`
+
+### 8.1 Extend custody prop type
+
+Add to the custody type:
+```typescript
+requiresAcceptance?: boolean;
+acceptedAt?: Date | string | null;
+assignedByUserId?: string | null;
+```
+
+### 8.2 Render acknowledgement status
+
+After the existing "Since {date}" line:
+
+- If `requiresAcceptance && !acceptedAt`:
+  ```
+  Awaiting acknowledgement
+  [Copy link] · [Resend email]  (conditional on custodian having email)
+  ```
+
+- If `requiresAcceptance && acceptedAt`:
+  ```
+  Acknowledged {date}
+  ```
+
+### 8.3 Copy link button
+
+Calls an API endpoint or uses a client-side function to generate/retrieve the token URL.
+
+### 8.4 Resend email button
+
+POST to a new API endpoint that re-sends the acknowledgement email (only if custodian has email).
+
+---
+
+## Phase 9: Asset Index Column
+
+### 9.1 Add to fixed fields
+
+**File:** `apps/webapp/app/modules/asset-index-settings/helpers.ts`
+
+Add `"acknowledgement"` to `fixedFields` array (after `"custody"`).
+Add to `columnsLabelsMap`: `acknowledgement: "Acknowledgement"`.
+Add to `defaultFields`: `{ name: "acknowledgement", visible: false, position: ... }` (hidden by default).
+
+### 9.2 Render column
+
+**File:** `apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx`
+
+Add `case "acknowledgement":` to the switch statement.
+
+Render:
+- No custody → `<EmptyTableValue />`
+- Custody without `requiresAcceptance` → `<EmptyTableValue />`
+- Pending → Amber badge "Pending" with hover popover: "Sent X days ago. [Copy link] [Resend]"
+- Acknowledged → Green check + date
+- Declined → Red indicator "Disputed"
+
+### 9.3 Asset index loader
+
+**File:** `apps/webapp/app/routes/_layout+/assets._index.tsx` (and the advanced mode loader)
+
+Include `requiresAcceptance`, `acceptedAt` in the custody select when loading assets.
+
+### 9.4 Filter support
+
+Add acknowledgement status as a filterable field in advanced mode filters.
+Values: "All", "Pending", "Acknowledged", "Not required"
+
+---
+
+## Phase 10: In-App Acknowledgement for Logged-In Users
+
+### 10.1 Acknowledgement banner component
+
+**New file:** `apps/webapp/app/components/custody/acknowledgement-banner.tsx`
+
+A dismissible banner shown at the top of the assets list:
+```
+You have {count} items awaiting your acknowledgement. [Review & Acknowledge]
+```
+
+### 10.2 Acknowledge in-app route
+
+**New file:** `apps/webapp/app/routes/_layout+/custody.acknowledge.tsx`
+
+Page listing all of the current user's pending acknowledgements.
+- Shows asset image, title, assigned date, assigner name
+- "Acknowledge" button per item + "Acknowledge All" button
+- Uses `recordCustodyAcknowledgement()` with method "in_app"
+
+### 10.3 Permission bypass for acknowledgement
+
+The acknowledge action needs to work for BASE and SELF_SERVICE users who are the custodian.
+This is NOT a general custody permission — it's: "you can acknowledge YOUR OWN custody."
+
+In the in-app acknowledge route and the public route action:
+- Check that the requesting user's TeamMember ID matches the custody's teamMemberId
+- No role-based permission check needed for acknowledging your own custody
+
+### 10.4 Layout integration
+
+**File:** `apps/webapp/app/routes/_layout+/assets._index.tsx` (loader)
+
+Add a query for count of pending acknowledgements for the current user's team member.
+Pass to the banner component.
+
+---
+
+## Phase 11: Resend & Copy Link API
+
+**New file:** `apps/webapp/app/routes/api+/custody.acknowledgement.ts`
+
+Handles:
+- `POST` with intent `resend-email`: Re-generates token, re-sends email
+- `POST` with intent `copy-link`: Returns the signed URL for clipboard copy
+- Requires `PermissionAction.custody` on `PermissionEntity.asset` (admin only)
+
+---
+
+## Phase 12: Organization Settings UI (v1 — feature toggle only)
+
+### 12.1 Settings route
+
+**File:** `apps/webapp/app/routes/_layout+/settings.general.tsx`
+
+Add the custody acknowledgement toggle to the existing settings page, following the barcodes/audits addon pattern. This is just the on/off toggle managed via Stripe subscription, NOT a default checkbox setting.
+
+### 12.2 Addon page / trial / Stripe integration
+
+Follow the exact pattern from `app/modules/audit/addon.server.ts`:
+- Trial checkout session
+- Subscription management
+- Webhook handlers for enable/disable
+
+**Note:** If the team prefers to ship v1 without Stripe integration, the feature can be enabled via a direct DB toggle (like `barcodesEnabled` before Stripe was integrated). Stripe integration can come in v1.1.
+
+---
+
+## Files Summary
+
+### New files (10):
+1. `apps/webapp/app/modules/custody/acknowledgement.server.ts` — Core service
+2. `apps/webapp/app/emails/custody-acknowledgement-template.tsx` — Custodian email
+3. `apps/webapp/app/emails/custody-acknowledged-admin-template.tsx` — Admin success email
+4. `apps/webapp/app/emails/custody-declined-admin-template.tsx` — Admin decline alert
+5. `apps/webapp/app/routes/_auth+/accept-custody.$custodyId.tsx` — Public acceptance page
+6. `apps/webapp/app/utils/permissions/custody-acknowledgement.validator.server.ts` — Feature gate
+7. `apps/webapp/app/components/custody/acknowledgement-banner.tsx` — In-app banner
+8. `apps/webapp/app/routes/_layout+/custody.acknowledge.tsx` — In-app acknowledge page
+9. `apps/webapp/app/routes/api+/custody.acknowledgement.ts` — Resend/copy-link API
+10. `packages/database/prisma/migrations/[ts]_add_custody_acknowledgement/migration.sql`
+
+### Modified files (16):
+1. `packages/database/prisma/schema.prisma` — Custody, KitCustody, Organization models
+2. `apps/webapp/server/index.ts` — Add public path
+3. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx` — Checkbox + email logic
+4. `apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx` — Same for kits
+5. `apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts` — Bulk assign support
+6. `apps/webapp/app/modules/asset/service.server.ts` — `bulkCheckOutAssets` acknowledgement
+7. `apps/webapp/app/modules/kit/service.server.ts` — Kit custody acknowledgement
+8. `apps/webapp/app/modules/custody/service.server.ts` — No changes to releaseCustody (it already hard-deletes)
+9. `apps/webapp/app/modules/custody/schema.ts` — Add requiresAcceptance to schema
+10. `apps/webapp/app/components/assets/asset-custody-card.tsx` — Show status + actions
+11. `apps/webapp/app/modules/asset-index-settings/helpers.ts` — New column
+12. `apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx` — Render column
+13. `apps/webapp/app/routes/_layout+/assets._index.tsx` — Load acknowledgement data + banner
+14. `apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx` — Pending note
+15. `apps/webapp/app/utils/roles.server.ts` — Return `canUseCustodyAcknowledgement`
+16. `apps/webapp/app/config/addon-copy.ts` — Upsell copy
+
+---
+
+## Build & Test Order
+
+1. **Phase 1** → Run migration → `pnpm db:deploy-migration`
+2. **Phase 2-3** → Service + gating (no UI yet) → Run unit tests
+3. **Phase 4** → Email templates (can preview with React Email)
+4. **Phase 5** → Public acceptance route → Manual test with generated JWT
+5. **Phase 6** → Assign custody changes → Test full flow: assign → email → accept
+6. **Phase 7** → Release changes → Test release-with-pending notes
+7. **Phase 8** → Custody card → Visual verification via preview
+8. **Phase 9** → Index column → Visual verification via preview
+9. **Phase 10** → In-app banner + acknowledge page → Test as BASE/SELF_SERVICE user
+10. **Phase 11** → Resend/copy-link API → Test from custody card buttons
+11. **Phase 12** → Settings/stripe (can be deferred)
+12. **Final** → `pnpm webapp:validate` → Full validation pass
+
+---
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| No new AssetStatus | IN_CUSTODY set immediately. Acknowledgement is evidence, not a gate. Avoids ripple through dozens of status checks. |
+| Activity note = permanent legal record | Custody records are hard-deleted on release. Rich note with timestamp/IP/method survives. |
+| Reuse INVITE_TOKEN_SECRET | JWT includes `purpose: "custody-ack"` to prevent cross-use. No new env var. |
+| String field for acceptanceMethod | Avoids Prisma enum migration for each new method. Validated at app layer. |
+| Feature gated per-org (addon pattern) | Follows barcode/audit pattern. Free users see upsell. |
+| Self-assignment hides checkbox | Can't corroborate receipt from the person who assigned. |
+| One email per custodian for bulk | Not spammy. One acknowledge-all click. |
+| Kit acknowledgement cascades | One click updates KitCustody + all child Custody records in transaction. |
+| BASE users can acknowledge own custody | Permission bypass: if you ARE the custodian, you can acknowledge. Not a general custody permission. |
+| Non-registered members get copy-link only | No email field on TeamMember. Admin copies link, sends manually. |
+| Column hidden by default | Opt-in visibility. Admins who use the feature toggle it on. |

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -317,7 +317,7 @@ export async function generateKitCustodyAcknowledgementToken(kitCustodyId: strin
 // 2. Guard: if zero rows -> throw ShelfError("KitCustody not found")
 // 3. Update child Custody records to same version, scoped by custodian:
 //    UPDATE "Custody" SET "tokenVersion" = newVersion
-//    WHERE "assetId" IN (SELECT "id" FROM "Asset" WHERE "kitId" = kit.id)
+//    WHERE "assetId" IN (SELECT "id" FROM "Asset" WHERE "kitId" = (SELECT "kitId" FROM "KitCustody" WHERE "id" = kitCustodyId))
 //      AND "teamMemberId" = (SELECT "custodianId" FROM "KitCustody" WHERE "id" = kitCustodyId)
 //    (custodian filter prevents rotating unrelated custody rows if kit was reassigned)
 // 4. Guard: if zero child rows -> throw ShelfError("No child custody records found")
@@ -430,9 +430,10 @@ export async function recordCustodyAcknowledgement({
   userAgent,
   organizationId,
 }: RecordAcknowledgementParams): Promise<{ transitioned: boolean; custody: Custody }>
-// Conditional update — only transitions from PENDING state:
+// Conditional update — only transitions from PENDING state, org-scoped:
 //   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
-// If no rows updated -> custody was already accepted or declined (idempotent: return current state)
+//     AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = organizationId)
+// If no rows updated -> already settled or not in this org (idempotent: return current state)
 // Sets: acceptedAt = now(), acceptanceMethod, acceptanceIp, acceptanceUserAgent
 // Returns { transitioned: true, custody } if state changed, { transitioned: false, custody } if already settled
 // Callers MUST check `transitioned` before creating notes or enqueuing emails — prevents duplicates on retry/refresh
@@ -470,9 +471,10 @@ export async function recordCustodyDecline({
   reason,
   organizationId,
 }: RecordDeclineParams): Promise<{ declined: boolean; custody: Custody }>
-// Conditional update — only transitions from PENDING state:
+// Conditional update — only transitions from PENDING state, org-scoped:
 //   WHERE id = custodyId AND acceptedAt IS NULL AND declinedAt IS NULL
-// If no rows updated -> already accepted or declined (idempotent: return current state)
+//     AND "assetId" IN (SELECT "id" FROM "Asset" WHERE "organizationId" = organizationId)
+// If no rows updated -> already settled or not in this org (idempotent: return current state)
 // Validates reason: z.string().trim().max(500).optional()
 // Sets: declinedAt = now(), declineReason = sanitized reason
 // Does NOT change asset status or delete custody
@@ -1024,7 +1026,7 @@ if (!rows.length) throw new ShelfError({ message: "Batch not found or cooldown a
 //    RETURNING tokenVersion
 // 2. Guard: if zero rows -> throw ShelfError("Kit custody not found or cooldown active")
 // 3. UPDATE all child Custody records SET tokenVersion = newVersion, lastTokenRotatedAt = NOW()
-//    WHERE assetId IN (SELECT id FROM "Asset" WHERE "kitId" = kit.id)
+//    WHERE assetId IN (SELECT id FROM "Asset" WHERE "kitId" = (SELECT "kitId" FROM "KitCustody" WHERE "id" = kitCustodyId))
 //      AND "teamMemberId" = (SELECT "custodianId" FROM "KitCustody" WHERE id = kitCustodyId)
 //    Guard: if zero child rows -> throw ShelfError("No child custody records found")
 //    NOTE: The custodian filter (teamMemberId = custodianId) prevents updating custody records
@@ -1097,7 +1099,7 @@ No separate Stripe product, no trial flow, no add-on management page needed for 
 
 ## Build & Test Order
 
-1. **Phase 1** -> Run migration -> `pnpm db:deploy-migration`
+1. **Phase 1** -> Run migration -> `pnpm db:deploy-migration` -> Then run `CREATE INDEX CONCURRENTLY` statements separately (these cannot run inside Prisma's migration transaction — execute via `psql` or a separate script after migration completes)
 2. **Phase 2-3** -> Service + gating (no UI yet) -> Run unit tests
 3. **Phase 4** -> Email templates (can preview with React Email)
 4. **Phase 5** -> Public acceptance route -> Manual test with generated JWT

--- a/.claude/plans/custody-acknowledgement.md
+++ b/.claude/plans/custody-acknowledgement.md
@@ -171,12 +171,17 @@ export const CUSTODY_TOKEN_SECRET = getEnv("CUSTODY_TOKEN_SECRET", {
   isOptional: true,
 });
 ```
-At token sign/verify callsites, assert presence:
+**Two-layer validation:**
+
+1. **Feature enablement guard:** When `custodyAcknowledgementEnabled` is set to `true` on an org (via Stripe webhook or admin toggle), validate that `CUSTODY_TOKEN_SECRET` is configured. If not, reject the enablement with a clear error: "Cannot enable custody acknowledgement: CUSTODY_TOKEN_SECRET is not configured." This prevents orgs from entering a broken state.
+
+2. **Callsite guard (defense-in-depth):** At token sign/verify callsites, assert presence:
 ```typescript
 if (!CUSTODY_TOKEN_SECRET) {
   throw new ShelfError({ message: "CUSTODY_TOKEN_SECRET is not configured." });
 }
 ```
+
 If `getEnv` does not support `isOptional`, add it following the existing pattern — a single boolean that returns `undefined` instead of throwing on missing value.
 
 ---
@@ -206,8 +211,9 @@ export async function generateBatchAcknowledgementToken(batchId: string): Promis
 //        "lastTokenRotatedAt" = NOW()
 //    WHERE "acknowledgementBatchId" = batchId
 //    RETURNING "tokenVersion"
-// 2. Read returned tokenVersion (all rows now share the same value)
-// 3. Sign JWT with { batchId, purpose: "custody-ack-batch", ver: newVersion }
+// 2. Guard: if zero rows returned, throw ShelfError("Batch not found or already fully processed")
+// 3. Read returned tokenVersion from rows[0] (all rows now share the same value)
+// 4. Sign JWT with { batchId, purpose: "custody-ack-batch", ver: newVersion }
 // 30-day expiry. Single atomic UPDATE — no transaction needed, no app-side MAX computation.
 ```
 
@@ -817,6 +823,7 @@ const rows = await db.$queryRaw`
     )
   RETURNING "tokenVersion"
 `;
+if (!rows.length) throw new ShelfError({ message: "Batch not found or cooldown active." });
 // Sign with { batchId, purpose: "custody-ack-batch", ver: rows[0].tokenVersion }
 ```
 


### PR DESCRIPTION
Implementation plan for **Custody Acknowledgement**. **Plan only, no code.**

Complete rewrite + 4 additional fixes from last review round. Self-audited before opening.

Full plan: `.claude/plans/custody-acknowledgement.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive implementation plan for a custody acknowledgement workflow.
  * Describes user-facing behavior: custodian emails with tokenized links, public acceptance route, in-app acknowledgement UI and banners, status on custody cards and asset index (pending/acknowledged/declined), admin resend/copy-link controls, and rollout/plan tiering guidance.
  * Covers tokenized acceptance/decline flows, privacy/security mitigations, permission gating, and testing/rollout recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->