### PR TITLE
fix: use correct SEQUENCE value in iCal export

### DIFF
--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.cal[.ics].ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.cal[.ics].ts
@@ -91,7 +91,7 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
       "BEGIN:VEVENT",
       `SUMMARY:${summary}`,
       `UID:${booking.id}`,
-      `SEQUENCE:${Date.now()}`,
+      `SEQUENCE:0`,
       "STATUS:CONFIRMED",
       "TRANSP:TRANSPARENT",
       `DTSTART:${formattedFromDate}`,


### PR DESCRIPTION
The SEQUENCE field should be a simple integer (0 for initial version) according to RFC 5545, not a timestamp from Date.now(). iCal Import into Google Calendar will fail otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar event sequencing in exported .ics files to use proper revision tracking, ensuring calendar clients correctly interpret event updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->