### PR TITLE
feat(audit): permanently delete archived audits (single + bulk)

### DIFF
--- a/apps/webapp/app/atoms/bulk-update-dialog.ts
+++ b/apps/webapp/app/atoms/bulk-update-dialog.ts
@@ -27,6 +27,7 @@ const DEFAULT_STATE: Record<BulkDialogType, boolean> = {
   "remove-from-kit": false,
   "start-audit": false,
   "add-to-audit": false,
+  "delete-audit": false,
 };
 
 export const bulkDialogAtom =

--- a/apps/webapp/app/components/audit/actions-dropdown.tsx
+++ b/apps/webapp/app/components/audit/actions-dropdown.tsx
@@ -17,6 +17,7 @@ import { tw } from "~/utils/tw";
 import { ArchiveAuditDialog } from "./archive-audit-dialog";
 import { AuditReceiptPDF } from "./audit-receipt-pdf";
 import { CancelAuditDialog } from "./cancel-audit-dialog";
+import { DeleteAuditDialog } from "./delete-audit-dialog";
 import { EditAuditDialog } from "./edit-audit-dialog";
 import { Button } from "../shared/button";
 import When from "../when/when";
@@ -32,6 +33,7 @@ const ConditionalActionsDropdown = () => {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isReceiptDialogOpen, setIsReceiptDialogOpen] = useState(false);
   // Track auto-open so the email deep link only triggers once.
   const hasAutoOpenedReceiptRef = useRef(false);
@@ -50,6 +52,9 @@ const ConditionalActionsDropdown = () => {
   // Admin/owner can archive completed or cancelled audits
   const canArchiveAudit =
     isAdminOrOwner && (isCompleted || isCancelled) && !isArchived;
+
+  // Admin/owner can delete archived audits (archive-first safety contract).
+  const canDeleteAudit = isAdminOrOwner && isArchived;
 
   // Only the creator can cancel an audit, and only if it's not already completed or cancelled
   const canCancelAudit =
@@ -197,6 +202,23 @@ const ConditionalActionsDropdown = () => {
                 </div>
               </When>
 
+              <When truthy={canDeleteAudit}>
+                <div className="border-b px-0 py-1 md:p-0">
+                  <Button
+                    type="button"
+                    variant="link"
+                    className="justify-start px-4 py-3 text-error-700 hover:bg-slate-100 hover:text-error-700"
+                    width="full"
+                    onClick={() => {
+                      handleMenuClose();
+                      setIsDeleteDialogOpen(true);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </When>
+
               {/* PDF Download Button - Always visible for all users with audit read permission */}
               <div className="border-b px-0 py-1 md:p-0">
                 <Button
@@ -254,6 +276,14 @@ const ConditionalActionsDropdown = () => {
           auditName={session.name}
           open={isArchiveDialogOpen}
           onClose={() => setIsArchiveDialogOpen(false)}
+        />
+      </When>
+
+      <When truthy={isDeleteDialogOpen}>
+        <DeleteAuditDialog
+          auditName={session.name}
+          open={isDeleteDialogOpen}
+          onClose={() => setIsDeleteDialogOpen(false)}
         />
       </When>
 

--- a/apps/webapp/app/components/audit/audit-index-bulk-actions-dropdown.tsx
+++ b/apps/webapp/app/components/audit/audit-index-bulk-actions-dropdown.tsx
@@ -2,11 +2,15 @@
  * @file Audit Index Bulk Actions Dropdown
  *
  * Renders the bulk actions dropdown on the audits index page (`/audits`).
- * Currently supports bulk-archiving audits that are in a terminal state
- * (COMPLETED or CANCELLED). Only visible to users with update permission
- * on the audit entity (admin/owner).
+ * Supports:
+ * - Bulk archive for COMPLETED/CANCELLED audits
+ * - Bulk delete for ARCHIVED audits
+ *
+ * Only visible to users with the matching permission on the audit entity
+ * (admin/owner). Server-side enforcement lives in the bulk-actions API.
  *
  * @see {@link file://./bulk-archive-audits-dialog.tsx} - Archive dialog
+ * @see {@link file://./bulk-delete-audits-dialog.tsx} - Delete dialog
  * @see {@link file://../../routes/_layout+/audits._index.tsx} - Consuming page
  */
 import { useAtomValue } from "jotai";
@@ -24,6 +28,7 @@ import {
 import { userHasPermission } from "~/utils/permissions/permission.validator.client";
 import { tw } from "~/utils/tw";
 import BulkArchiveAuditsDialog from "./bulk-archive-audits-dialog";
+import BulkDeleteAuditsDialog from "./bulk-delete-audits-dialog";
 import { BulkUpdateDialogTrigger } from "../bulk-update-dialog/bulk-update-dialog";
 import { Button } from "../shared/button";
 import {
@@ -70,6 +75,13 @@ function ConditionalDropdown() {
   const someNotArchivable =
     !allSelected &&
     audits.some((a) => a.status !== "COMPLETED" && a.status !== "CANCELLED");
+  /**
+   * Delete is only valid for ARCHIVED audits. Select-all spans all filtered
+   * rows including the ALL_SELECTED_KEY sentinel (no status) — the server
+   * re-narrows to ARCHIVED regardless, so we skip the client check there.
+   */
+  const someNotArchived =
+    !allSelected && audits.some((a) => a.status !== "ARCHIVED");
 
   const { roles } = useUserRoleHelper();
 
@@ -81,6 +93,11 @@ function ConditionalDropdown() {
     roles,
     entity: PermissionEntity.audit,
     action: PermissionAction.archive,
+  });
+  const canDeleteAudit = userHasPermission({
+    roles,
+    entity: PermissionEntity.audit,
+    action: PermissionAction.delete,
   });
 
   const {
@@ -108,6 +125,7 @@ function ConditionalDropdown() {
       )}
 
       <BulkArchiveAuditsDialog />
+      <BulkDeleteAuditsDialog />
 
       <DropdownMenu
         modal={false}
@@ -178,6 +196,30 @@ function ConditionalDropdown() {
                     ? {
                         reason:
                           "Some of the selected audits are not completed or cancelled. You can only archive audits that are completed or cancelled.",
+                      }
+                    : isLoading
+                }
+              />
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="px-4 py-1 md:p-0"
+              onSelect={(e) => {
+                e.preventDefault();
+              }}
+            >
+              <BulkUpdateDialogTrigger
+                type="delete-audit"
+                label="Delete"
+                onClick={closeMenu}
+                disabled={
+                  !canDeleteAudit
+                    ? {
+                        reason: "You don't have permission to delete audits.",
+                      }
+                    : someNotArchived
+                    ? {
+                        reason:
+                          "Some of the selected audits are not archived. Only archived audits can be deleted.",
                       }
                     : isLoading
                 }

--- a/apps/webapp/app/components/audit/audit-index-bulk-actions-dropdown.tsx
+++ b/apps/webapp/app/components/audit/audit-index-bulk-actions-dropdown.tsx
@@ -16,6 +16,7 @@
 import { useAtomValue } from "jotai";
 import { useHydrated } from "remix-utils/use-hydrated";
 import { selectedBulkItemsAtom } from "~/atoms/list";
+import { useSearchParams } from "~/hooks/search-params";
 import { useControlledDropdownMenu } from "~/hooks/use-controlled-dropdown-menu";
 import { useDisabled } from "~/hooks/use-disabled";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
@@ -76,12 +77,23 @@ function ConditionalDropdown() {
     !allSelected &&
     audits.some((a) => a.status !== "COMPLETED" && a.status !== "CANCELLED");
   /**
-   * Delete is only valid for ARCHIVED audits. Select-all spans all filtered
-   * rows including the ALL_SELECTED_KEY sentinel (no status) — the server
-   * re-narrows to ARCHIVED regardless, so we skip the client check there.
+   * Delete is only valid for ARCHIVED audits. For an explicit id-list we
+   * check statuses client-side; the server re-validates either way.
    */
   const someNotArchived =
     !allSelected && audits.some((a) => a.status !== "ARCHIVED");
+
+  /**
+   * Select-all delete is only allowed when the active status filter is
+   * ARCHIVED. Otherwise the user sees a total-items count that mixes
+   * statuses, clicks "Delete N", and the server would silently drop
+   * everything except the archived subset. Force them to narrow first
+   * so the count they see is the count that deletes.
+   */
+  const [searchParams] = useSearchParams();
+  const statusFilter = searchParams.get("status");
+  const selectAllButFilterNotArchived =
+    allSelected && statusFilter !== "ARCHIVED";
 
   const { roles } = useUserRoleHelper();
 
@@ -220,6 +232,11 @@ function ConditionalDropdown() {
                     ? {
                         reason:
                           "Some of the selected audits are not archived. Only archived audits can be deleted.",
+                      }
+                    : selectAllButFilterNotArchived
+                    ? {
+                        reason:
+                          "Filter the list to status = Archived before using Select all to delete.",
                       }
                     : isLoading
                 }

--- a/apps/webapp/app/components/audit/audit-index-bulk-actions-dropdown.tsx
+++ b/apps/webapp/app/components/audit/audit-index-bulk-actions-dropdown.tsx
@@ -91,7 +91,11 @@ function ConditionalDropdown() {
    * so the count they see is the count that deletes.
    */
   const [searchParams] = useSearchParams();
-  const statusFilter = searchParams.get("status");
+  // The audits index loader normalizes `status` to uppercase before querying
+  // (see `getAuditWhereInput`), so a deep-link like `?status=archived` still
+  // renders the archived list. Match that normalization here or the gate
+  // mis-fires against lowercase links.
+  const statusFilter = searchParams.get("status")?.toUpperCase();
   const selectAllButFilterNotArchived =
     allSelected && statusFilter !== "ARCHIVED";
 

--- a/apps/webapp/app/components/audit/bulk-delete-audits-dialog.tsx
+++ b/apps/webapp/app/components/audit/bulk-delete-audits-dialog.tsx
@@ -1,0 +1,117 @@
+/**
+ * @file Bulk Delete Audits Dialog
+ *
+ * Confirmation dialog for permanently deleting multiple archived audit
+ * sessions from the audits index page. Requires the user to type the
+ * literal string "DELETE" before submission is enabled — a cheaper
+ * confirmation than per-audit name matching, which would be unusable at
+ * scale (Toby runs ~125 audits/month).
+ *
+ * Only applicable to audits in `ARCHIVED` status. The surrounding
+ * {@link AuditIndexBulkActionsDropdown} disables the trigger when any
+ * selected audit is not archived; the service layer also re-checks.
+ *
+ * @see {@link file://../../routes/api+/audits.bulk-actions.ts} - Action handler
+ * @see {@link file://./audit-index-bulk-actions-dropdown.tsx} - Triggers this dialog
+ */
+import { useState } from "react";
+import { useAtomValue } from "jotai";
+import { useLoaderData } from "react-router";
+import { useZorm } from "react-zorm";
+import { z } from "zod";
+import { selectedBulkItemsAtom } from "~/atoms/list";
+import type { AuditsIndexLoaderData } from "~/routes/_layout+/audits._index";
+import { isSelectingAllItems } from "~/utils/list";
+import { BulkUpdateDialogContent } from "../bulk-update-dialog/bulk-update-dialog";
+import Input from "../forms/input";
+import { Button } from "../shared/button";
+
+/**
+ * Zod schema for the bulk delete form. The literal "DELETE" confirmation is
+ * validated server-side as well — never trust the client-side gate alone.
+ */
+export const BulkDeleteAuditsSchema = z.object({
+  auditIds: z.array(z.string()).min(1),
+  confirmation: z.literal("DELETE", {
+    errorMap: () => ({ message: "Type DELETE to confirm." }),
+  }),
+});
+
+/** The literal word users must type to unlock the destructive action. */
+const CONFIRMATION_WORD = "DELETE";
+
+/**
+ * Bulk delete confirmation dialog. Mirrors the visual shape of
+ * {@link BulkArchiveAuditsDialog} but adds a hard-to-hit confirmation
+ * input so destructive submission is always a deliberate act.
+ */
+export default function BulkDeleteAuditsDialog() {
+  const { totalItems } = useLoaderData<AuditsIndexLoaderData>();
+  const selectedAudits = useAtomValue(selectedBulkItemsAtom);
+  const totalSelected = isSelectingAllItems(selectedAudits)
+    ? totalItems
+    : selectedAudits.length;
+
+  const [confirmation, setConfirmation] = useState("");
+  const confirmationMatches = confirmation === CONFIRMATION_WORD;
+
+  const zo = useZorm("BulkDeleteAudits", BulkDeleteAuditsSchema);
+
+  return (
+    <BulkUpdateDialogContent
+      ref={zo.ref}
+      type="delete-audit"
+      arrayFieldId="auditIds"
+      actionUrl="/api/audits/bulk-actions"
+      title={`Delete ${totalSelected} audits`}
+      description={`Permanently delete ${totalSelected} archived audits? This will remove all scan data, notes, and images. This action cannot be undone.`}
+    >
+      {({ disabled, fetcherError, handleCloseDialog }) => (
+        <>
+          <input type="hidden" name="intent" value="bulk-delete" />
+
+          <div className="mt-2 space-y-2">
+            <p className="text-sm text-gray-600">
+              To confirm, type{" "}
+              <span className="font-semibold">{CONFIRMATION_WORD}</span> below.
+            </p>
+            <Input
+              label="Confirmation"
+              name={zo.fields.confirmation()}
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              autoComplete="off"
+              required
+              error={zo.errors.confirmation()?.message}
+            />
+          </div>
+
+          {fetcherError ? (
+            <p className="text-sm text-error-500">{fetcherError}</p>
+          ) : null}
+
+          <div className="mt-4 flex gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              width="full"
+              disabled={disabled}
+              onClick={handleCloseDialog}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              width="full"
+              disabled={disabled || !confirmationMatches}
+              className="border-error-600 bg-error-600 hover:border-error-800 hover:bg-error-800"
+            >
+              Delete
+            </Button>
+          </div>
+        </>
+      )}
+    </BulkUpdateDialogContent>
+  );
+}

--- a/apps/webapp/app/components/audit/delete-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/delete-audit-dialog.tsx
@@ -1,0 +1,134 @@
+/**
+ * @file Delete Audit Dialog
+ *
+ * Confirmation dialog for permanently deleting an archived audit session.
+ * Requires the user to type the audit name (case-insensitive) before the
+ * Delete button becomes enabled — the same destructive-confirm pattern used
+ * by the custom-field delete flow.
+ *
+ * The "archive-first" contract is enforced at the service and route layer;
+ * this dialog is only rendered by the actions dropdown when the audit is in
+ * `ARCHIVED` status. On successful deletion the server redirects to
+ * `/audits`, so the dialog never needs to self-close on success.
+ *
+ * @see {@link file://./actions-dropdown.tsx} - Triggers this dialog
+ * @see {@link file://../../routes/_layout+/audits.$auditId.tsx} - Action handler
+ * @see {@link file://../custom-fields/delete-dialog.tsx} - Pattern reference
+ */
+import { useEffect, useRef, useState } from "react";
+import { useFetcher } from "react-router";
+import Input from "~/components/forms/input";
+import { TrashIcon } from "~/components/icons/library";
+import { Button } from "~/components/shared/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "~/components/shared/modal";
+import { useDisabled } from "~/hooks/use-disabled";
+
+/** Props for the {@link DeleteAuditDialog} component. */
+type DeleteAuditDialogProps = {
+  /** Display name of the audit being deleted — also the expected confirmation input. */
+  auditName: string;
+  /** Whether the dialog is currently visible. */
+  open: boolean;
+  /** Callback invoked when the dialog should close. */
+  onClose: () => void;
+};
+
+/**
+ * Destructive confirmation dialog for deleting an archived audit.
+ *
+ * Disables the Delete button until the user types the audit name
+ * (case-insensitive, trimmed). Submission uses a scoped fetcher so the
+ * server response does not collide with other forms on the audit detail
+ * page. On success the server redirects — no client close required.
+ */
+export function DeleteAuditDialog({
+  auditName,
+  open,
+  onClose,
+}: DeleteAuditDialogProps) {
+  const fetcher = useFetcher({ key: "delete-audit" });
+  const disabled = useDisabled(fetcher);
+  const [confirmation, setConfirmation] = useState("");
+
+  const confirmationMatches =
+    confirmation.trim().toLowerCase() === auditName.toLowerCase();
+
+  /** Stabilize onClose in a ref to avoid stale closures in effects. */
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // Reset the input whenever the dialog closes so the next open starts fresh
+  // (users shouldn't see their previous attempt lingering in the field).
+  useEffect(() => {
+    if (!open) {
+      setConfirmation("");
+    }
+  }, [open]);
+
+  const fetcherError =
+    fetcher.data && "error" in fetcher.data && fetcher.data.error
+      ? fetcher.data.error.message
+      : null;
+
+  return (
+    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-error-50 p-2 text-error-600 md:mx-0">
+            <TrashIcon />
+          </div>
+          <AlertDialogTitle>Delete "{auditName}"</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete this audit and all its data (scans,
+            notes, and images). This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <fetcher.Form method="post" className="mt-4 space-y-2">
+          <input type="hidden" name="intent" value="delete-audit" />
+
+          <p className="text-sm text-gray-600">
+            To confirm, type the audit name below.
+          </p>
+          <Input
+            label="Confirmation"
+            name="confirmation"
+            value={confirmation}
+            onChange={(event) => setConfirmation(event.target.value)}
+            autoComplete="off"
+            required
+          />
+          <p className="text-sm text-gray-500">Expected input: {auditName}</p>
+          {fetcherError ? (
+            <p className="text-sm text-error-500">{fetcherError}</p>
+          ) : null}
+
+          <AlertDialogFooter className="mt-6 flex">
+            <div className="flex justify-center gap-2">
+              <AlertDialogCancel asChild>
+                <Button type="button" variant="secondary" disabled={disabled}>
+                  Cancel
+                </Button>
+              </AlertDialogCancel>
+              <Button
+                className="border-error-600 bg-error-600 hover:border-error-800 hover:bg-error-800"
+                type="submit"
+                disabled={disabled || !confirmationMatches}
+              >
+                {disabled ? "Deleting..." : "Delete"}
+              </Button>
+            </div>
+          </AlertDialogFooter>
+        </fetcher.Form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/webapp/app/components/audit/delete-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/delete-audit-dialog.tsx
@@ -15,7 +15,7 @@
  * @see {@link file://../../routes/_layout+/audits.$auditId.tsx} - Action handler
  * @see {@link file://../custom-fields/delete-dialog.tsx} - Pattern reference
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import Input from "~/components/forms/input";
 import { TrashIcon } from "~/components/icons/library";
@@ -58,12 +58,13 @@ export function DeleteAuditDialog({
   const disabled = useDisabled(fetcher);
   const [confirmation, setConfirmation] = useState("");
 
-  const confirmationMatches =
-    confirmation.trim().toLowerCase() === auditName.toLowerCase();
-
-  /** Stabilize onClose in a ref to avoid stale closures in effects. */
-  const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
+  // Must mirror the service-side normalization (see deleteAuditSession).
+  // Without NFC, a macOS user typing a composed character (e.g. "é" via
+  // option-e + e) can have the button stay disabled even though the
+  // server would accept the confirmation.
+  const normalize = (s: string): string =>
+    s.trim().normalize("NFC").toLowerCase();
+  const confirmationMatches = normalize(confirmation) === normalize(auditName);
 
   // Reset the input whenever the dialog closes so the next open starts fresh
   // (users shouldn't see their previous attempt lingering in the field).

--- a/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
+++ b/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
@@ -51,7 +51,8 @@ type BulkDialogType =
   | "add-to-kit"
   | "remove-from-kit"
   | "start-audit"
-  | "add-to-audit";
+  | "add-to-audit"
+  | "delete-audit";
 
 type CommonBulkDialogProps = {
   type: BulkDialogType;
@@ -229,7 +230,12 @@ const BulkUpdateDialogContent = forwardRef<
   }, [closeBulkDialog, type]);
 
   const handleBulkActionSuccess = useCallback(() => {
-    if (type === "trash" || type === "archive" || type === "cancel") {
+    if (
+      type === "trash" ||
+      type === "archive" ||
+      type === "cancel" ||
+      type === "delete-audit"
+    ) {
       setSelectedItems([]);
 
       if (!skipCloseOnSuccess) {

--- a/apps/webapp/app/components/shared/icons-map.tsx
+++ b/apps/webapp/app/components/shared/icons-map.tsx
@@ -118,6 +118,7 @@ export type IconType =
   | "deactivate"
   | "start-audit"
   | "add-to-audit"
+  | "delete-audit"
   | "scan"
   | "tool"
   | "rows"
@@ -209,6 +210,7 @@ export const iconsMap: IconsMap = {
   "remove-from-kit": <PackageMinus />,
   "start-audit": <ClipboardList />,
   "add-to-audit": <ClipboardList />,
+  "delete-audit": <TrashIcon />,
 };
 
 export default iconsMap;

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -930,27 +930,32 @@ describe("audit service", () => {
 
   describe("delete", () => {
     describe("deleteAuditSession", () => {
+      // Shared happy-path input — tests override individual fields as needed.
+      const baseInput = {
+        auditSessionId: "audit-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        expectedName: "Q4 Audit",
+      };
+
       beforeEach(() => {
         vi.clearAllMocks();
         // why: default to an archived audit so happy-path tests don't need per-test findFirst setup
         mockDb.auditSession.findFirst.mockResolvedValue({
           id: "audit-1",
           status: AuditStatus.ARCHIVED,
+          name: "Q4 Audit",
         });
         mockDb.auditImage.findMany.mockResolvedValue([]);
         mockDb.auditSession.deleteMany.mockResolvedValue({ count: 1 });
       });
 
       it("deletes an archived audit via deleteMany with an ARCHIVED guard", async () => {
-        await deleteAuditSession({
-          auditSessionId: "audit-1",
-          organizationId: "org-1",
-          userId: "user-1",
-        });
+        await deleteAuditSession(baseInput);
 
         expect(mockDb.auditSession.findFirst).toHaveBeenCalledWith({
           where: { id: "audit-1", organizationId: "org-1" },
-          select: { id: true, status: true },
+          select: { id: true, status: true, name: true },
         });
 
         expect(mockDb.auditSession.deleteMany).toHaveBeenCalledWith({
@@ -960,6 +965,37 @@ describe("audit service", () => {
             status: AuditStatus.ARCHIVED,
           },
         });
+      });
+
+      it("accepts the confirmation after trim + NFC + case-insensitive compare", async () => {
+        // DB name is NFC-composed "Résumé Q4"; user types a lowercase,
+        // whitespace-padded, NFD-decomposed variant. All three get normalized
+        // away before the compare.
+        mockDb.auditSession.findFirst.mockResolvedValue({
+          id: "audit-1",
+          status: AuditStatus.ARCHIVED,
+          name: "Résumé Q4".normalize("NFC"),
+        });
+
+        await expect(
+          deleteAuditSession({
+            ...baseInput,
+            expectedName: "  résumé q4  ".normalize("NFD"),
+          })
+        ).resolves.toBeUndefined();
+
+        expect(mockDb.auditSession.deleteMany).toHaveBeenCalled();
+      });
+
+      it("rejects with 400 when the confirmation doesn't match the audit name", async () => {
+        await expect(
+          deleteAuditSession({ ...baseInput, expectedName: "Wrong Name" })
+        ).rejects.toMatchObject({
+          status: 400,
+          message: expect.stringMatching(/Confirmation did not match/),
+        });
+
+        expect(mockDb.auditSession.deleteMany).not.toHaveBeenCalled();
       });
 
       it("runs storage cleanup for each image AFTER the DB delete commits", async () => {
@@ -979,11 +1015,7 @@ describe("audit service", () => {
         // why: import inside the test so the mocked module is bound correctly
         const { removePublicFile } = await import("~/utils/storage.server");
 
-        await deleteAuditSession({
-          auditSessionId: "audit-1",
-          organizationId: "org-1",
-          userId: "user-1",
-        });
+        await deleteAuditSession(baseInput);
 
         expect(removePublicFile).toHaveBeenCalledWith({
           publicUrl: "https://s.example.com/i1.jpg",
@@ -1019,13 +1051,7 @@ describe("audit service", () => {
         const { removePublicFile } = await import("~/utils/storage.server");
         vi.mocked(removePublicFile).mockRejectedValueOnce(new Error("s3 down"));
 
-        await expect(
-          deleteAuditSession({
-            auditSessionId: "audit-1",
-            organizationId: "org-1",
-            userId: "user-1",
-          })
-        ).resolves.toBeUndefined();
+        await expect(deleteAuditSession(baseInput)).resolves.toBeUndefined();
 
         expect(mockDb.auditSession.deleteMany).toHaveBeenCalled();
       });
@@ -1034,11 +1060,7 @@ describe("audit service", () => {
         mockDb.auditSession.findFirst.mockResolvedValue(null);
 
         await expect(
-          deleteAuditSession({
-            auditSessionId: "missing",
-            organizationId: "org-1",
-            userId: "user-1",
-          })
+          deleteAuditSession({ ...baseInput, auditSessionId: "missing" })
         ).rejects.toMatchObject({
           status: 404,
           message: expect.stringMatching(/Audit not found/),
@@ -1058,15 +1080,10 @@ describe("audit service", () => {
           mockDb.auditSession.findFirst.mockResolvedValue({
             id: "audit-1",
             status,
+            name: "Q4 Audit",
           });
 
-          await expect(
-            deleteAuditSession({
-              auditSessionId: "audit-1",
-              organizationId: "org-1",
-              userId: "user-1",
-            })
-          ).rejects.toMatchObject({
+          await expect(deleteAuditSession(baseInput)).rejects.toMatchObject({
             status: 409,
             message: expect.stringMatching(
               /Only archived audits can be deleted/
@@ -1080,13 +1097,7 @@ describe("audit service", () => {
       it("rejects with 409 when the atomic deleteMany finds nothing (TOCTOU race)", async () => {
         mockDb.auditSession.deleteMany.mockResolvedValue({ count: 0 });
 
-        await expect(
-          deleteAuditSession({
-            auditSessionId: "audit-1",
-            organizationId: "org-1",
-            userId: "user-1",
-          })
-        ).rejects.toMatchObject({
+        await expect(deleteAuditSession(baseInput)).rejects.toMatchObject({
           status: 409,
           message: expect.stringMatching(/status may have changed/),
         });
@@ -1108,13 +1119,9 @@ describe("audit service", () => {
 
         const { removePublicFile } = await import("~/utils/storage.server");
 
-        await expect(
-          deleteAuditSession({
-            auditSessionId: "audit-1",
-            organizationId: "org-1",
-            userId: "user-1",
-          })
-        ).rejects.toMatchObject({ status: 409 });
+        await expect(deleteAuditSession(baseInput)).rejects.toMatchObject({
+          status: 409,
+        });
 
         expect(removePublicFile).not.toHaveBeenCalled();
       });
@@ -1122,13 +1129,7 @@ describe("audit service", () => {
       it("wraps unknown causes in a 500 ShelfError", async () => {
         mockDb.auditSession.findFirst.mockRejectedValue(new Error("boom"));
 
-        await expect(
-          deleteAuditSession({
-            auditSessionId: "audit-1",
-            organizationId: "org-1",
-            userId: "user-1",
-          })
-        ).rejects.toMatchObject({
+        await expect(deleteAuditSession(baseInput)).rejects.toMatchObject({
           status: 500,
           message: expect.stringMatching(/Failed to delete audit session/),
         });
@@ -1248,13 +1249,16 @@ describe("audit service", () => {
           currentSearchParams: "status=archived",
           organizationId: "org-1",
           userId: "user-1",
-          isSelfServiceOrBase: true,
         });
 
         const whereArg = mockDb.auditSession.findMany.mock.calls[0][0].where;
+        // Force-narrow to ARCHIVED must survive even when the caller sends
+        // lowercase, and the org scope is always present.
         expect(whereArg.status).toBe(AuditStatus.ARCHIVED);
         expect(whereArg.organizationId).toBe("org-1");
-        expect(whereArg.assignments).toEqual({ some: { userId: "user-1" } });
+        // PermissionAction.delete is ADMIN/OWNER-only, so assignments-based
+        // scoping has no place here — guard against re-introduction.
+        expect(whereArg.assignments).toBeUndefined();
       });
 
       it("calls removePublicFile for every image AFTER the DB transaction commits", async () => {

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -962,7 +962,7 @@ describe("audit service", () => {
         });
       });
 
-      it("cleans up Supabase storage for each image before the DB delete", async () => {
+      it("runs storage cleanup for each image AFTER the DB delete commits", async () => {
         mockDb.auditImage.findMany.mockResolvedValue([
           {
             id: "img-1",
@@ -997,7 +997,14 @@ describe("audit service", () => {
         // thumbnailUrl was null on img-2; only the main URL should be attempted
         expect(removePublicFile).toHaveBeenCalledTimes(3);
 
-        expect(mockDb.auditSession.deleteMany).toHaveBeenCalled();
+        // Ordering matters: the DB delete must have happened before the
+        // first storage call. A zombie DB row pointing at deleted files is
+        // strictly worse than a stale file pointing at a deleted row.
+        const deleteOrder =
+          mockDb.auditSession.deleteMany.mock.invocationCallOrder[0];
+        const firstStorageOrder =
+          vi.mocked(removePublicFile).mock.invocationCallOrder[0];
+        expect(deleteOrder).toBeLessThan(firstStorageOrder);
       });
 
       it("swallows storage failures and still deletes the DB row", async () => {
@@ -1085,6 +1092,33 @@ describe("audit service", () => {
         });
       });
 
+      it("does NOT touch storage when the guarded deleteMany finds nothing", async () => {
+        // Regression guard: an earlier version cleaned storage BEFORE the
+        // guarded DB delete, which orphaned files whenever a concurrent
+        // status change turned the deleteMany into a no-op. Files now must
+        // survive the race.
+        mockDb.auditImage.findMany.mockResolvedValue([
+          {
+            id: "img-1",
+            imageUrl: "https://s.example.com/i1.jpg",
+            thumbnailUrl: "https://s.example.com/i1-thumb.jpg",
+          },
+        ]);
+        mockDb.auditSession.deleteMany.mockResolvedValue({ count: 0 });
+
+        const { removePublicFile } = await import("~/utils/storage.server");
+
+        await expect(
+          deleteAuditSession({
+            auditSessionId: "audit-1",
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({ status: 409 });
+
+        expect(removePublicFile).not.toHaveBeenCalled();
+      });
+
       it("wraps unknown causes in a 500 ShelfError", async () => {
         mockDb.auditSession.findFirst.mockRejectedValue(new Error("boom"));
 
@@ -1109,6 +1143,8 @@ describe("audit service", () => {
 
       beforeEach(() => {
         vi.clearAllMocks();
+        // why: re-install the $transaction behavior after clearAllMocks wipes it
+        mockDb.$transaction.mockImplementation((cb: any) => cb(mockDb));
         mockDb.auditSession.findMany.mockResolvedValue(archivedAudits);
         mockDb.auditImage.findMany.mockResolvedValue([]);
         mockDb.auditSession.deleteMany.mockResolvedValue({
@@ -1196,7 +1232,7 @@ describe("audit service", () => {
         expect(whereArg.assignments).toEqual({ some: { userId: "user-1" } });
       });
 
-      it("calls removePublicFile for every image across targeted audits", async () => {
+      it("calls removePublicFile for every image AFTER the DB transaction commits", async () => {
         mockDb.auditImage.findMany.mockResolvedValue([
           {
             id: "img-1",
@@ -1219,6 +1255,47 @@ describe("audit service", () => {
         });
 
         expect(removePublicFile).toHaveBeenCalledTimes(3);
+
+        // Cleanup must happen after the $transaction has resolved — never
+        // before, and never during a rollback.
+        const txOrder = mockDb.$transaction.mock.invocationCallOrder[0];
+        const firstStorageOrder =
+          vi.mocked(removePublicFile).mock.invocationCallOrder[0];
+        expect(txOrder).toBeLessThan(firstStorageOrder);
+      });
+
+      it("rolls back and skips storage cleanup when deleteMany count mismatches pre-read", async () => {
+        // Three archived audits found in pre-read...
+        mockDb.auditSession.findMany.mockResolvedValue([
+          { id: "a1", status: AuditStatus.ARCHIVED },
+          { id: "a2", status: AuditStatus.ARCHIVED },
+          { id: "a3", status: AuditStatus.ARCHIVED },
+        ]);
+        // ...but by the time deleteMany runs, one slipped out of ARCHIVED.
+        mockDb.auditSession.deleteMany.mockResolvedValue({ count: 2 });
+        mockDb.auditImage.findMany.mockResolvedValue([
+          {
+            id: "img-1",
+            imageUrl: "https://s.example.com/a1.jpg",
+            thumbnailUrl: null,
+          },
+        ]);
+
+        const { removePublicFile } = await import("~/utils/storage.server");
+
+        await expect(
+          bulkDeleteAudits({
+            auditIds: ["a1", "a2", "a3"],
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({
+          status: 409,
+          message: expect.stringMatching(/status changed/),
+        });
+
+        // Transaction threw — no storage side-effect is allowed.
+        expect(removePublicFile).not.toHaveBeenCalled();
       });
 
       it("wraps unknown causes in a 500 ShelfError", async () => {

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -12,7 +12,14 @@ import {
   getPendingAuditsForOrganization,
   getAuditWhereInput,
   bulkArchiveAudits,
+  deleteAuditSession,
+  bulkDeleteAudits,
 } from "./service.server";
+
+// why: storage.server calls Supabase over HTTP; mock so delete tests stay offline
+vi.mock("~/utils/storage.server", () => ({
+  removePublicFile: vi.fn(),
+}));
 
 // why: Mock the helper functions that create automatic notes to avoid database dependencies in unit tests
 vi.mock("./helpers.server", () => ({
@@ -39,6 +46,8 @@ vi.mock("~/database/db.server", () => {
       findMany: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
     },
     auditNote: {
       create: vi.fn(),
@@ -57,6 +66,9 @@ vi.mock("~/database/db.server", () => {
     },
     auditAssignment: {
       createMany: vi.fn(),
+    },
+    auditImage: {
+      findMany: vi.fn(),
     },
     asset: {
       findMany: vi.fn(),
@@ -77,6 +89,8 @@ const mockDb = db as unknown as {
     findMany: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     updateMany: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
   };
   auditNote: {
     create: ReturnType<typeof vi.fn>;
@@ -95,6 +109,9 @@ const mockDb = db as unknown as {
   };
   auditAssignment: {
     createMany: ReturnType<typeof vi.fn>;
+  };
+  auditImage: {
+    findMany: ReturnType<typeof vi.fn>;
   };
   asset: {
     findMany: ReturnType<typeof vi.fn>;
@@ -906,6 +923,316 @@ describe("audit service", () => {
         ).rejects.toMatchObject({
           status: 500,
           message: expect.stringMatching(/Failed to bulk archive audits/),
+        });
+      });
+    });
+  });
+
+  describe("delete", () => {
+    describe("deleteAuditSession", () => {
+      beforeEach(() => {
+        vi.clearAllMocks();
+        // why: default to an archived audit so happy-path tests don't need per-test findFirst setup
+        mockDb.auditSession.findFirst.mockResolvedValue({
+          id: "audit-1",
+          status: AuditStatus.ARCHIVED,
+        });
+        mockDb.auditImage.findMany.mockResolvedValue([]);
+        mockDb.auditSession.deleteMany.mockResolvedValue({ count: 1 });
+      });
+
+      it("deletes an archived audit via deleteMany with an ARCHIVED guard", async () => {
+        await deleteAuditSession({
+          auditSessionId: "audit-1",
+          organizationId: "org-1",
+          userId: "user-1",
+        });
+
+        expect(mockDb.auditSession.findFirst).toHaveBeenCalledWith({
+          where: { id: "audit-1", organizationId: "org-1" },
+          select: { id: true, status: true },
+        });
+
+        expect(mockDb.auditSession.deleteMany).toHaveBeenCalledWith({
+          where: {
+            id: "audit-1",
+            organizationId: "org-1",
+            status: AuditStatus.ARCHIVED,
+          },
+        });
+      });
+
+      it("cleans up Supabase storage for each image before the DB delete", async () => {
+        mockDb.auditImage.findMany.mockResolvedValue([
+          {
+            id: "img-1",
+            imageUrl: "https://s.example.com/i1.jpg",
+            thumbnailUrl: "https://s.example.com/i1-thumb.jpg",
+          },
+          {
+            id: "img-2",
+            imageUrl: "https://s.example.com/i2.jpg",
+            thumbnailUrl: null,
+          },
+        ]);
+
+        // why: import inside the test so the mocked module is bound correctly
+        const { removePublicFile } = await import("~/utils/storage.server");
+
+        await deleteAuditSession({
+          auditSessionId: "audit-1",
+          organizationId: "org-1",
+          userId: "user-1",
+        });
+
+        expect(removePublicFile).toHaveBeenCalledWith({
+          publicUrl: "https://s.example.com/i1.jpg",
+        });
+        expect(removePublicFile).toHaveBeenCalledWith({
+          publicUrl: "https://s.example.com/i1-thumb.jpg",
+        });
+        expect(removePublicFile).toHaveBeenCalledWith({
+          publicUrl: "https://s.example.com/i2.jpg",
+        });
+        // thumbnailUrl was null on img-2; only the main URL should be attempted
+        expect(removePublicFile).toHaveBeenCalledTimes(3);
+
+        expect(mockDb.auditSession.deleteMany).toHaveBeenCalled();
+      });
+
+      it("swallows storage failures and still deletes the DB row", async () => {
+        mockDb.auditImage.findMany.mockResolvedValue([
+          {
+            id: "img-1",
+            imageUrl: "https://s.example.com/i1.jpg",
+            thumbnailUrl: null,
+          },
+        ]);
+
+        const { removePublicFile } = await import("~/utils/storage.server");
+        vi.mocked(removePublicFile).mockRejectedValueOnce(new Error("s3 down"));
+
+        await expect(
+          deleteAuditSession({
+            auditSessionId: "audit-1",
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).resolves.toBeUndefined();
+
+        expect(mockDb.auditSession.deleteMany).toHaveBeenCalled();
+      });
+
+      it("rejects with 404 when the audit is not found", async () => {
+        mockDb.auditSession.findFirst.mockResolvedValue(null);
+
+        await expect(
+          deleteAuditSession({
+            auditSessionId: "missing",
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({
+          status: 404,
+          message: expect.stringMatching(/Audit not found/),
+        });
+
+        expect(mockDb.auditSession.deleteMany).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        AuditStatus.PENDING,
+        AuditStatus.ACTIVE,
+        AuditStatus.COMPLETED,
+        AuditStatus.CANCELLED,
+      ])(
+        "rejects with 409 when status is %s (not ARCHIVED)",
+        async (status) => {
+          mockDb.auditSession.findFirst.mockResolvedValue({
+            id: "audit-1",
+            status,
+          });
+
+          await expect(
+            deleteAuditSession({
+              auditSessionId: "audit-1",
+              organizationId: "org-1",
+              userId: "user-1",
+            })
+          ).rejects.toMatchObject({
+            status: 409,
+            message: expect.stringMatching(
+              /Only archived audits can be deleted/
+            ),
+          });
+
+          expect(mockDb.auditSession.deleteMany).not.toHaveBeenCalled();
+        }
+      );
+
+      it("rejects with 409 when the atomic deleteMany finds nothing (TOCTOU race)", async () => {
+        mockDb.auditSession.deleteMany.mockResolvedValue({ count: 0 });
+
+        await expect(
+          deleteAuditSession({
+            auditSessionId: "audit-1",
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({
+          status: 409,
+          message: expect.stringMatching(/status may have changed/),
+        });
+      });
+
+      it("wraps unknown causes in a 500 ShelfError", async () => {
+        mockDb.auditSession.findFirst.mockRejectedValue(new Error("boom"));
+
+        await expect(
+          deleteAuditSession({
+            auditSessionId: "audit-1",
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({
+          status: 500,
+          message: expect.stringMatching(/Failed to delete audit session/),
+        });
+      });
+    });
+
+    describe("bulkDeleteAudits", () => {
+      const archivedAudits = [
+        { id: "a1", status: AuditStatus.ARCHIVED },
+        { id: "a2", status: AuditStatus.ARCHIVED },
+      ];
+
+      beforeEach(() => {
+        vi.clearAllMocks();
+        mockDb.auditSession.findMany.mockResolvedValue(archivedAudits);
+        mockDb.auditImage.findMany.mockResolvedValue([]);
+        mockDb.auditSession.deleteMany.mockResolvedValue({
+          count: archivedAudits.length,
+        });
+      });
+
+      it("deletes archived audits narrowed by ARCHIVED status on the write", async () => {
+        const result = await bulkDeleteAudits({
+          auditIds: ["a1", "a2"],
+          organizationId: "org-1",
+          userId: "user-1",
+        });
+
+        expect(mockDb.auditSession.findMany).toHaveBeenCalledWith({
+          where: {
+            id: { in: ["a1", "a2"] },
+            organizationId: "org-1",
+            status: AuditStatus.ARCHIVED,
+          },
+          select: { id: true, status: true },
+        });
+
+        expect(mockDb.auditSession.deleteMany).toHaveBeenCalledWith({
+          where: {
+            id: { in: ["a1", "a2"] },
+            organizationId: "org-1",
+            status: AuditStatus.ARCHIVED,
+          },
+        });
+
+        expect(result).toEqual({ count: 2 });
+      });
+
+      it("rejects with 400 when no archivable audits are found", async () => {
+        mockDb.auditSession.findMany.mockResolvedValue([]);
+
+        await expect(
+          bulkDeleteAudits({
+            auditIds: ["a1"],
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({
+          status: 400,
+          message: expect.stringMatching(/No deletable audits were found/),
+        });
+      });
+
+      it("rejects when the explicit selection includes non-archived audit ids", async () => {
+        // Pre-read only returns the subset that's actually ARCHIVED — "a2"
+        // is missing, which means the user selected something non-archived.
+        mockDb.auditSession.findMany.mockResolvedValue([
+          { id: "a1", status: AuditStatus.ARCHIVED },
+        ]);
+
+        await expect(
+          bulkDeleteAudits({
+            auditIds: ["a1", "a2"],
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({
+          status: 409,
+          message: expect.stringMatching(/are not archived/),
+        });
+
+        expect(mockDb.auditSession.deleteMany).not.toHaveBeenCalled();
+      });
+
+      it("forces ARCHIVED when ALL_SELECTED_KEY is present even if status=COMPLETED in params", async () => {
+        await bulkDeleteAudits({
+          auditIds: [ALL_SELECTED_KEY],
+          currentSearchParams: "status=COMPLETED",
+          organizationId: "org-1",
+          userId: "user-1",
+          isSelfServiceOrBase: true,
+        });
+
+        const whereArg = mockDb.auditSession.findMany.mock.calls[0][0].where;
+        // Non-archived filter from URL params must be overridden — ARCHIVED
+        // is the only acceptable status for bulk delete.
+        expect(whereArg.status).toBe(AuditStatus.ARCHIVED);
+        expect(whereArg.organizationId).toBe("org-1");
+        expect(whereArg.assignments).toEqual({ some: { userId: "user-1" } });
+      });
+
+      it("calls removePublicFile for every image across targeted audits", async () => {
+        mockDb.auditImage.findMany.mockResolvedValue([
+          {
+            id: "img-1",
+            imageUrl: "https://s.example.com/a1.jpg",
+            thumbnailUrl: null,
+          },
+          {
+            id: "img-2",
+            imageUrl: "https://s.example.com/a2.jpg",
+            thumbnailUrl: "https://s.example.com/a2-thumb.jpg",
+          },
+        ]);
+
+        const { removePublicFile } = await import("~/utils/storage.server");
+
+        await bulkDeleteAudits({
+          auditIds: ["a1", "a2"],
+          organizationId: "org-1",
+          userId: "user-1",
+        });
+
+        expect(removePublicFile).toHaveBeenCalledTimes(3);
+      });
+
+      it("wraps unknown causes in a 500 ShelfError", async () => {
+        mockDb.auditSession.findMany.mockRejectedValue(new Error("boom"));
+
+        await expect(
+          bulkDeleteAudits({
+            auditIds: ["a1"],
+            organizationId: "org-1",
+            userId: "user-1",
+          })
+        ).rejects.toMatchObject({
+          status: 500,
+          message: expect.stringMatching(/Failed to bulk delete audits/),
         });
       });
     });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -1215,18 +1215,43 @@ describe("audit service", () => {
         expect(mockDb.auditSession.deleteMany).not.toHaveBeenCalled();
       });
 
-      it("forces ARCHIVED when ALL_SELECTED_KEY is present even if status=COMPLETED in params", async () => {
+      it.each([
+        ["status=COMPLETED", "COMPLETED"],
+        ["status=PENDING", "PENDING"],
+        ["status=ALL", "ALL"],
+        ["", undefined],
+      ])(
+        "rejects select-all (ALL_SELECTED_KEY) when params status=%s",
+        async (params, _paramStatus) => {
+          await expect(
+            bulkDeleteAudits({
+              auditIds: [ALL_SELECTED_KEY],
+              currentSearchParams: params,
+              organizationId: "org-1",
+              userId: "user-1",
+            })
+          ).rejects.toMatchObject({
+            status: 400,
+            message: expect.stringMatching(
+              /Select-all delete requires.*Archived/
+            ),
+          });
+
+          // Must fail fast — before the findMany pre-read runs.
+          expect(mockDb.auditSession.findMany).not.toHaveBeenCalled();
+        }
+      );
+
+      it("accepts select-all when params explicitly narrow to ARCHIVED (case-insensitive)", async () => {
         await bulkDeleteAudits({
           auditIds: [ALL_SELECTED_KEY],
-          currentSearchParams: "status=COMPLETED",
+          currentSearchParams: "status=archived",
           organizationId: "org-1",
           userId: "user-1",
           isSelfServiceOrBase: true,
         });
 
         const whereArg = mockDb.auditSession.findMany.mock.calls[0][0].where;
-        // Non-archived filter from URL params must be overridden — ARCHIVED
-        // is the only acceptable status for bulk delete.
         expect(whereArg.status).toBe(AuditStatus.ARCHIVED);
         expect(whereArg.organizationId).toBe("org-1");
         expect(whereArg.assignments).toEqual({ some: { userId: "user-1" } });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2610,12 +2610,25 @@ async function safeRemoveAuditImageFiles(image: {
 }
 
 /**
+ * Normalize audit-name confirmation strings for comparison.
+ * Trims whitespace, applies Unicode NFC, and lower-cases. NFC matters
+ * because macOS keyboards can emit decomposed characters (NFD) while
+ * the DB stores the composed form, so `"Résumé" !== "Résumé"` without
+ * normalization even when a user types the name exactly.
+ */
+const normalizeAuditName = (s: string): string =>
+  s.trim().normalize("NFC").toLowerCase();
+
+/**
  * Permanently deletes an archived audit session and all related data.
  *
  * Prerequisites:
  * - Audit must be in status `ARCHIVED` (enforced here and at the route).
  *   Delete is the intentional escape hatch past the archive-first contract,
  *   so `assertAuditNotArchived` is deliberately NOT called.
+ * - Caller supplies the user's typed confirmation via `expectedName`. The
+ *   compare is server-side and case-insensitive after NFC normalization,
+ *   so a tampered client value can't bypass the name check.
  *
  * Cascade behavior (via Prisma `onDelete: Cascade`):
  * - AuditAsset, AuditScan, AuditNote, AuditImage, AuditAssignment all
@@ -2632,25 +2645,29 @@ async function safeRemoveAuditImageFiles(image: {
  *
  * @param auditSessionId - ID of the audit to delete
  * @param organizationId - Scoping organization (enforces tenant isolation)
- * @param userId - User performing the delete (for error context)
- * @throws {ShelfError} 404 if not found; 409 if not ARCHIVED; 500 on DB failure
+ * @param userId - User performing the delete (for error context + log trail)
+ * @param expectedName - Confirmation string the user typed in the dialog
+ * @throws {ShelfError} 400 if confirmation doesn't match the stored name;
+ *   404 if not found; 409 if not ARCHIVED; 500 on DB failure
  */
 export async function deleteAuditSession({
   auditSessionId,
   organizationId,
   userId,
+  expectedName,
 }: {
   auditSessionId: AuditSession["id"];
   organizationId: Organization["id"];
   userId: string;
+  expectedName: string;
 }): Promise<void> {
   try {
-    // Pre-read to validate existence, org scoping, and ARCHIVED status —
-    // also the only chance to collect image URLs before cascade wipes
-    // AuditImage rows.
+    // Pre-read to validate existence, org scoping, name, and ARCHIVED
+    // status — also the only chance to collect image URLs before cascade
+    // wipes AuditImage rows.
     const audit = await db.auditSession.findFirst({
       where: { id: auditSessionId, organizationId },
-      select: { id: true, status: true },
+      select: { id: true, status: true, name: true },
     });
 
     if (!audit) {
@@ -2660,6 +2677,17 @@ export async function deleteAuditSession({
         additionalData: { auditSessionId, organizationId, userId },
         label,
         status: 404,
+      });
+    }
+
+    if (normalizeAuditName(expectedName) !== normalizeAuditName(audit.name)) {
+      throw new ShelfError({
+        cause: null,
+        message: "Confirmation did not match the audit name.",
+        additionalData: { auditSessionId, organizationId },
+        label,
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 
@@ -2707,9 +2735,16 @@ export async function deleteAuditSession({
       });
     }
 
+    // Permanent deletion leaves no AuditNote trail (cascade wipes them).
+    // Emit a server-side info log so we retain a trace of who deleted what.
+    Logger.info(
+      `Permanently deleted audit ${auditSessionId} (org=${organizationId}, user=${userId})`
+    );
+
     // DB commit succeeded — now best-effort storage cleanup. Failures are
     // logged; stale storage objects are recoverable, a zombie DB row
-    // wouldn't be.
+    // wouldn't be. Sequential is fine here: a single audit has at most a
+    // handful of images.
     for (const image of images) {
       await safeRemoveAuditImageFiles(image);
     }
@@ -2733,6 +2768,13 @@ export async function deleteAuditSession({
  * {@link getAuditWhereInput} AND is further narrowed to `status: ARCHIVED`
  * so non-archived audits in the filtered view can never be pulled in.
  *
+ * Note: `isSelfServiceOrBase` is intentionally not a parameter here.
+ * `PermissionAction.delete` on the audit entity is ADMIN/OWNER-only
+ * (see `permission.data.ts`), so by the time we reach this function the
+ * caller is already guaranteed not to be self-service/base. Wiring the
+ * flag through would be dead plumbing that implies a policy choice
+ * (delete-your-assigned-archives) no one has actually made.
+ *
  * Ordering is all-or-nothing:
  * 1. Pre-read the target audits (ARCHIVED only).
  * 2. Capture image URLs for every target — needed BEFORE the cascade wipes
@@ -2750,9 +2792,8 @@ export async function deleteAuditSession({
  *
  * @param auditIds - Array of audit IDs, or `[ALL_SELECTED_KEY]` for select-all
  * @param organizationId - Scoping organization
- * @param userId - User performing the bulk delete (for error context)
+ * @param userId - User performing the bulk delete (for error context + log trail)
  * @param currentSearchParams - Serialized URL params, used when ALL_SELECTED_KEY
- * @param isSelfServiceOrBase - Restrict select-all to audits assigned to userId
  * @returns Object with the count of audits actually deleted
  * @throws {ShelfError} If selection is empty, any audit is not ARCHIVED, or
  *   if a concurrent status change makes the bulk delete non-atomic
@@ -2762,13 +2803,11 @@ export async function bulkDeleteAudits({
   organizationId,
   userId,
   currentSearchParams,
-  isSelfServiceOrBase,
 }: {
   auditIds: AuditSession["id"][];
   organizationId: Organization["id"];
   userId: string;
   currentSearchParams?: string | null;
-  isSelfServiceOrBase?: boolean;
 }): Promise<{ count: number }> {
   try {
     const selectAll = auditIds.includes(ALL_SELECTED_KEY);
@@ -2783,9 +2822,7 @@ export async function bulkDeleteAudits({
       const paramStatus = new URLSearchParams(currentSearchParams ?? "")
         .get("status")
         ?.toUpperCase();
-      const isArchivedOnlyFilter =
-        paramStatus === AuditStatus.ARCHIVED.toString();
-      if (!isArchivedOnlyFilter) {
+      if (paramStatus !== AuditStatus.ARCHIVED) {
         throw new ShelfError({
           cause: null,
           message:
@@ -2804,8 +2841,6 @@ export async function bulkDeleteAudits({
       ? getAuditWhereInput({
           currentSearchParams,
           organizationId,
-          userId,
-          isSelfServiceOrBase,
         })
       : { id: { in: auditIds }, organizationId };
 
@@ -2894,10 +2929,22 @@ export async function bulkDeleteAudits({
       return deleted;
     });
 
+    // Permanent deletion leaves no AuditNote trail for any of these rows
+    // (cascade wipes them). Structured info log retains a trace.
+    Logger.info(
+      `Permanently deleted ${count} audits (org=${organizationId}, user=${userId}, ids=${targetIds.join(
+        ","
+      )})`
+    );
+
     // Transaction committed — safe to remove storage objects now.
-    for (const image of images) {
-      await safeRemoveAuditImageFiles(image);
-    }
+    // safeRemoveAuditImageFiles already logs + swallows per-file failures,
+    // so Promise.allSettled is strictly a latency win (Toby's cleanup of
+    // 125+ archived audits × multiple images each would otherwise be
+    // minutes of serial HTTP).
+    await Promise.allSettled(
+      images.map((image) => safeRemoveAuditImageFiles(image))
+    );
 
     return { count };
   } catch (cause) {

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2611,9 +2611,13 @@ async function safeRemoveAuditImageFiles(image: {
  *   removed by the database when the parent AuditSession row is deleted.
  *
  * Storage cleanup:
- * - Audit image files in Supabase storage are removed BEFORE the DB delete
- *   so we don't orphan files if the DB delete fails. Per-file failures are
- *   logged and swallowed — see {@link safeRemoveAuditImageFiles}.
+ * - Image URLs are captured BEFORE the DB delete (the AuditImage rows
+ *   cascade-delete with the session, so we'd lose them afterwards).
+ * - Supabase storage removal runs AFTER the DB commit succeeds. A DB
+ *   rollback or ARCHIVED-guard miss must never leave a zombie audit row
+ *   pointing at already-deleted storage objects.
+ * - Per-file failures on cleanup are logged and swallowed — see
+ *   {@link safeRemoveAuditImageFiles}.
  *
  * @param auditSessionId - ID of the audit to delete
  * @param organizationId - Scoping organization (enforces tenant isolation)
@@ -2630,9 +2634,9 @@ export async function deleteAuditSession({
   userId: string;
 }): Promise<void> {
   try {
-    // Pre-read to validate existence, org scoping, and ARCHIVED status.
-    // We use a pre-read (not just an atomic deleteMany guard) because we
-    // need the image list for storage cleanup before the DB row is gone.
+    // Pre-read to validate existence, org scoping, and ARCHIVED status —
+    // also the only chance to collect image URLs before cascade wipes
+    // AuditImage rows.
     const audit = await db.auditSession.findFirst({
       where: { id: auditSessionId, organizationId },
       select: { id: true, status: true },
@@ -2662,17 +2666,13 @@ export async function deleteAuditSession({
       });
     }
 
-    // Collect every image for this audit so we can clean up storage.
-    // Cascade would delete the DB rows, but Supabase storage is external
-    // and needs explicit removal.
+    // Capture image URLs for post-commit cleanup. Don't touch storage yet —
+    // if the guarded deleteMany finds 0 rows due to a concurrent status
+    // change, we must leave both the DB row AND its files intact.
     const images = await db.auditImage.findMany({
       where: { auditSessionId, organizationId },
       select: { id: true, imageUrl: true, thumbnailUrl: true },
     });
-
-    for (const image of images) {
-      await safeRemoveAuditImageFiles(image);
-    }
 
     // Final guard on the write: re-check ARCHIVED status atomically so a
     // concurrent status change between the pre-read and here can't sneak
@@ -2695,6 +2695,13 @@ export async function deleteAuditSession({
         status: 409,
       });
     }
+
+    // DB commit succeeded — now best-effort storage cleanup. Failures are
+    // logged; stale storage objects are recoverable, a zombie DB row
+    // wouldn't be.
+    for (const image of images) {
+      await safeRemoveAuditImageFiles(image);
+    }
   } catch (cause) {
     if (isLikeShelfError(cause)) throw cause;
     throw new ShelfError({
@@ -2715,10 +2722,20 @@ export async function deleteAuditSession({
  * {@link getAuditWhereInput} AND is further narrowed to `status: ARCHIVED`
  * so non-archived audits in the filtered view can never be pulled in.
  *
- * Storage cleanup for all images is done before the DB delete, in a single
- * `findMany` + per-image loop. Not wrapped in a DB transaction because
- * holding one open across N external Supabase HTTP calls invites pool
- * starvation; the DB write itself is a single atomic `deleteMany`.
+ * Ordering is all-or-nothing:
+ * 1. Pre-read the target audits (ARCHIVED only).
+ * 2. Capture image URLs for every target — needed BEFORE the cascade wipes
+ *    the AuditImage rows.
+ * 3. Run the guarded `deleteMany` inside a transaction. If the final count
+ *    doesn't match the pre-read count (concurrent status change), the
+ *    transaction throws and rolls back — no DB rows deleted.
+ * 4. After commit, best-effort Supabase storage cleanup using the
+ *    captured URLs. Per-file failures are logged and swallowed.
+ *
+ * Storage cleanup runs AFTER commit on purpose: a rolled-back transaction
+ * must never leave zombie DB rows pointing at already-deleted files. We
+ * don't wrap storage in the transaction because holding a DB connection
+ * across N external Supabase HTTP calls invites pool starvation.
  *
  * @param auditIds - Array of audit IDs, or `[ALL_SELECTED_KEY]` for select-all
  * @param organizationId - Scoping organization
@@ -2726,7 +2743,8 @@ export async function deleteAuditSession({
  * @param currentSearchParams - Serialized URL params, used when ALL_SELECTED_KEY
  * @param isSelfServiceOrBase - Restrict select-all to audits assigned to userId
  * @returns Object with the count of audits actually deleted
- * @throws {ShelfError} If selection is empty or any audit is not ARCHIVED
+ * @throws {ShelfError} If selection is empty, any audit is not ARCHIVED, or
+ *   if a concurrent status change makes the bulk delete non-atomic
  */
 export async function bulkDeleteAudits({
   auditIds,
@@ -2798,29 +2816,56 @@ export async function bulkDeleteAudits({
       }
     }
 
-    // Batch-fetch every image for every target audit, then clean up
-    // storage per image. One query, not N.
+    const targetIds = audits.map((a) => a.id);
+
+    // Capture every image URL BEFORE the delete so post-commit cleanup has
+    // something to work with (the AuditImage rows cascade away with the
+    // session). No storage side-effect yet — if the transaction rolls back
+    // we must not have touched any file.
     const images = await db.auditImage.findMany({
       where: {
-        auditSessionId: { in: audits.map((a) => a.id) },
+        auditSessionId: { in: targetIds },
         organizationId,
       },
       select: { id: true, imageUrl: true, thumbnailUrl: true },
     });
 
+    // All-or-nothing: either every pre-read audit deletes, or the whole
+    // thing rolls back. A mid-flight status change that shifts an audit
+    // out of ARCHIVED must not produce a partial result.
+    const { count } = await db.$transaction(async (tx) => {
+      const deleted = await tx.auditSession.deleteMany({
+        where: {
+          id: { in: targetIds },
+          organizationId,
+          status: AuditStatus.ARCHIVED,
+        },
+      });
+
+      if (deleted.count !== targetIds.length) {
+        throw new ShelfError({
+          cause: null,
+          message:
+            "Some audits could not be deleted because their status changed. Please refresh and try again.",
+          additionalData: {
+            expected: targetIds.length,
+            actual: deleted.count,
+            organizationId,
+          },
+          label,
+          status: 409,
+        });
+      }
+
+      return deleted;
+    });
+
+    // Transaction committed — safe to remove storage objects now.
     for (const image of images) {
       await safeRemoveAuditImageFiles(image);
     }
 
-    const result = await db.auditSession.deleteMany({
-      where: {
-        id: { in: audits.map((a) => a.id) },
-        organizationId,
-        status: AuditStatus.ARCHIVED,
-      },
-    });
-
-    return { count: result.count };
+    return { count };
   } catch (cause) {
     if (isLikeShelfError(cause)) throw cause;
     throw new ShelfError({

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -23,6 +23,7 @@ import { ALL_SELECTED_KEY } from "~/utils/list";
 import { Logger } from "~/utils/logger";
 import { wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import { removePublicFile } from "~/utils/storage.server";
 
 import type { AuditFilterType } from "./audit-filter-utils";
 import {
@@ -2546,6 +2547,285 @@ export async function bulkArchiveAudits({
     throw new ShelfError({
       cause,
       message: "Failed to bulk archive audits",
+      additionalData: { auditIds, organizationId, userId },
+      label,
+      status: 500,
+    });
+  }
+}
+
+/**
+ * Removes an audit image's underlying files from Supabase storage.
+ * Swallows per-file failures and logs them: a stale storage object is
+ * a lesser evil than aborting the DB delete and leaving an orphaned
+ * AuditSession row behind. Caller is responsible for deleting the DB
+ * record afterwards (cascades from AuditSession handle that for us).
+ *
+ * @param image - The image record with public URLs to clean up
+ */
+async function safeRemoveAuditImageFiles(image: {
+  id: string;
+  imageUrl: string;
+  thumbnailUrl: string | null;
+}): Promise<void> {
+  try {
+    await removePublicFile({ publicUrl: image.imageUrl });
+  } catch (cause) {
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: "Failed to remove audit image from storage during delete",
+        additionalData: { imageId: image.id, url: image.imageUrl },
+        label,
+      })
+    );
+  }
+
+  if (image.thumbnailUrl) {
+    try {
+      await removePublicFile({ publicUrl: image.thumbnailUrl });
+    } catch (cause) {
+      Logger.error(
+        new ShelfError({
+          cause,
+          message:
+            "Failed to remove audit thumbnail from storage during delete",
+          additionalData: { imageId: image.id, url: image.thumbnailUrl },
+          label,
+        })
+      );
+    }
+  }
+}
+
+/**
+ * Permanently deletes an archived audit session and all related data.
+ *
+ * Prerequisites:
+ * - Audit must be in status `ARCHIVED` (enforced here and at the route).
+ *   Delete is the intentional escape hatch past the archive-first contract,
+ *   so `assertAuditNotArchived` is deliberately NOT called.
+ *
+ * Cascade behavior (via Prisma `onDelete: Cascade`):
+ * - AuditAsset, AuditScan, AuditNote, AuditImage, AuditAssignment all
+ *   removed by the database when the parent AuditSession row is deleted.
+ *
+ * Storage cleanup:
+ * - Audit image files in Supabase storage are removed BEFORE the DB delete
+ *   so we don't orphan files if the DB delete fails. Per-file failures are
+ *   logged and swallowed — see {@link safeRemoveAuditImageFiles}.
+ *
+ * @param auditSessionId - ID of the audit to delete
+ * @param organizationId - Scoping organization (enforces tenant isolation)
+ * @param userId - User performing the delete (for error context)
+ * @throws {ShelfError} 404 if not found; 409 if not ARCHIVED; 500 on DB failure
+ */
+export async function deleteAuditSession({
+  auditSessionId,
+  organizationId,
+  userId,
+}: {
+  auditSessionId: AuditSession["id"];
+  organizationId: Organization["id"];
+  userId: string;
+}): Promise<void> {
+  try {
+    // Pre-read to validate existence, org scoping, and ARCHIVED status.
+    // We use a pre-read (not just an atomic deleteMany guard) because we
+    // need the image list for storage cleanup before the DB row is gone.
+    const audit = await db.auditSession.findFirst({
+      where: { id: auditSessionId, organizationId },
+      select: { id: true, status: true },
+    });
+
+    if (!audit) {
+      throw new ShelfError({
+        cause: null,
+        message: "Audit not found.",
+        additionalData: { auditSessionId, organizationId, userId },
+        label,
+        status: 404,
+      });
+    }
+
+    if (audit.status !== AuditStatus.ARCHIVED) {
+      throw new ShelfError({
+        cause: null,
+        message: "Only archived audits can be deleted. Archive it first.",
+        additionalData: {
+          auditSessionId,
+          organizationId,
+          status: audit.status,
+        },
+        label,
+        status: 409,
+      });
+    }
+
+    // Collect every image for this audit so we can clean up storage.
+    // Cascade would delete the DB rows, but Supabase storage is external
+    // and needs explicit removal.
+    const images = await db.auditImage.findMany({
+      where: { auditSessionId, organizationId },
+      select: { id: true, imageUrl: true, thumbnailUrl: true },
+    });
+
+    for (const image of images) {
+      await safeRemoveAuditImageFiles(image);
+    }
+
+    // Final guard on the write: re-check ARCHIVED status atomically so a
+    // concurrent status change between the pre-read and here can't sneak
+    // a non-archived delete through.
+    const result = await db.auditSession.deleteMany({
+      where: {
+        id: auditSessionId,
+        organizationId,
+        status: AuditStatus.ARCHIVED,
+      },
+    });
+
+    if (result.count === 0) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Audit could not be deleted. Its status may have changed — please refresh and try again.",
+        additionalData: { auditSessionId, organizationId },
+        label,
+        status: 409,
+      });
+    }
+  } catch (cause) {
+    if (isLikeShelfError(cause)) throw cause;
+    throw new ShelfError({
+      cause,
+      message: "Failed to delete audit session",
+      additionalData: { auditSessionId, organizationId, userId },
+      label,
+      status: 500,
+    });
+  }
+}
+
+/**
+ * Permanently deletes multiple archived audit sessions in a single operation.
+ *
+ * Supports the "select all across pages" pattern via {@link ALL_SELECTED_KEY}.
+ * When all items are selected, resolution goes through
+ * {@link getAuditWhereInput} AND is further narrowed to `status: ARCHIVED`
+ * so non-archived audits in the filtered view can never be pulled in.
+ *
+ * Storage cleanup for all images is done before the DB delete, in a single
+ * `findMany` + per-image loop. Not wrapped in a DB transaction because
+ * holding one open across N external Supabase HTTP calls invites pool
+ * starvation; the DB write itself is a single atomic `deleteMany`.
+ *
+ * @param auditIds - Array of audit IDs, or `[ALL_SELECTED_KEY]` for select-all
+ * @param organizationId - Scoping organization
+ * @param userId - User performing the bulk delete (for error context)
+ * @param currentSearchParams - Serialized URL params, used when ALL_SELECTED_KEY
+ * @param isSelfServiceOrBase - Restrict select-all to audits assigned to userId
+ * @returns Object with the count of audits actually deleted
+ * @throws {ShelfError} If selection is empty or any audit is not ARCHIVED
+ */
+export async function bulkDeleteAudits({
+  auditIds,
+  organizationId,
+  userId,
+  currentSearchParams,
+  isSelfServiceOrBase,
+}: {
+  auditIds: AuditSession["id"][];
+  organizationId: Organization["id"];
+  userId: string;
+  currentSearchParams?: string | null;
+  isSelfServiceOrBase?: boolean;
+}): Promise<{ count: number }> {
+  try {
+    const selectAll = auditIds.includes(ALL_SELECTED_KEY);
+
+    // When all items are selected across pages, rebuild the where clause
+    // from the current filters. Then narrow to ARCHIVED regardless — the
+    // filtered view may contain non-archived audits (e.g. status=ALL),
+    // and delete must never reach those.
+    const baseWhere: Prisma.AuditSessionWhereInput = selectAll
+      ? getAuditWhereInput({
+          currentSearchParams,
+          organizationId,
+          userId,
+          isSelfServiceOrBase,
+        })
+      : { id: { in: auditIds }, organizationId };
+
+    const where: Prisma.AuditSessionWhereInput = {
+      ...baseWhere,
+      status: AuditStatus.ARCHIVED,
+    };
+
+    const audits = await db.auditSession.findMany({
+      where,
+      select: { id: true, status: true },
+    });
+
+    if (audits.length === 0) {
+      throw new ShelfError({
+        cause: null,
+        message: "No deletable audits were found for your selection.",
+        additionalData: { auditIds, organizationId },
+        label,
+        status: 400,
+      });
+    }
+
+    // For explicit id-list (not select-all), make sure the user hadn't
+    // selected any non-archived rows. Silent filtering would be confusing
+    // ("I selected 10 but only 6 got deleted"). Better to block and tell
+    // them.
+    if (!selectAll) {
+      const foundIds = new Set(audits.map((a) => a.id));
+      const missing = auditIds.filter(
+        (id) => id !== ALL_SELECTED_KEY && !foundIds.has(id)
+      );
+      if (missing.length > 0) {
+        throw new ShelfError({
+          cause: null,
+          message:
+            "Some selected audits are not archived. Only archived audits can be deleted.",
+          additionalData: { missing, organizationId },
+          label,
+          status: 409,
+        });
+      }
+    }
+
+    // Batch-fetch every image for every target audit, then clean up
+    // storage per image. One query, not N.
+    const images = await db.auditImage.findMany({
+      where: {
+        auditSessionId: { in: audits.map((a) => a.id) },
+        organizationId,
+      },
+      select: { id: true, imageUrl: true, thumbnailUrl: true },
+    });
+
+    for (const image of images) {
+      await safeRemoveAuditImageFiles(image);
+    }
+
+    const result = await db.auditSession.deleteMany({
+      where: {
+        id: { in: audits.map((a) => a.id) },
+        organizationId,
+        status: AuditStatus.ARCHIVED,
+      },
+    });
+
+    return { count: result.count };
+  } catch (cause) {
+    if (isLikeShelfError(cause)) throw cause;
+    throw new ShelfError({
+      cause,
+      message: "Failed to bulk delete audits",
       additionalData: { auditIds, organizationId, userId },
       label,
       status: 500,

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2571,11 +2571,18 @@ async function safeRemoveAuditImageFiles(image: {
   try {
     await removePublicFile({ publicUrl: image.imageUrl });
   } catch (cause) {
+    // Intentionally omit the raw URL from additionalData — public
+    // Supabase URLs contain storage object keys and a trailing token;
+    // `imageId` is enough to trace the record if we need to.
     Logger.error(
       new ShelfError({
-        cause,
+        cause: null,
         message: "Failed to remove audit image from storage during delete",
-        additionalData: { imageId: image.id, url: image.imageUrl },
+        additionalData: {
+          imageId: image.id,
+          storageError:
+            cause instanceof Error ? cause.message : "Unknown storage error",
+        },
         label,
       })
     );
@@ -2587,10 +2594,14 @@ async function safeRemoveAuditImageFiles(image: {
     } catch (cause) {
       Logger.error(
         new ShelfError({
-          cause,
+          cause: null,
           message:
             "Failed to remove audit thumbnail from storage during delete",
-          additionalData: { imageId: image.id, url: image.thumbnailUrl },
+          additionalData: {
+            imageId: image.id,
+            storageError:
+              cause instanceof Error ? cause.message : "Unknown storage error",
+          },
           label,
         })
       );
@@ -2762,10 +2773,33 @@ export async function bulkDeleteAudits({
   try {
     const selectAll = auditIds.includes(ALL_SELECTED_KEY);
 
-    // When all items are selected across pages, rebuild the where clause
-    // from the current filters. Then narrow to ARCHIVED regardless — the
-    // filtered view may contain non-archived audits (e.g. status=ALL),
-    // and delete must never reach those.
+    // Defense-in-depth for select-all: if the caller's active status
+    // filter isn't ARCHIVED, refuse to force-narrow and delete only the
+    // archived subset behind the user's back. The UI already gates this
+    // (`audit-index-bulk-actions-dropdown.tsx`), but a direct POST to
+    // this endpoint would otherwise bypass that check. Fail closed on an
+    // irreversible operation.
+    if (selectAll) {
+      const paramStatus = new URLSearchParams(currentSearchParams ?? "")
+        .get("status")
+        ?.toUpperCase();
+      const isArchivedOnlyFilter =
+        paramStatus === AuditStatus.ARCHIVED.toString();
+      if (!isArchivedOnlyFilter) {
+        throw new ShelfError({
+          cause: null,
+          message:
+            "Select-all delete requires the status filter to be set to Archived.",
+          additionalData: { paramStatus, organizationId },
+          label,
+          status: 400,
+        });
+      }
+    }
+
+    // Rebuild the where clause from the current filters for select-all,
+    // then narrow to ARCHIVED regardless — belt-and-suspenders for the
+    // status guard above.
     const baseWhere: Prisma.AuditSessionWhereInput = selectAll
       ? getAuditWhereInput({
           currentSearchParams,

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2728,7 +2728,7 @@ export async function deleteAuditSession({
       throw new ShelfError({
         cause: null,
         message:
-          "Audit could not be deleted. Its status may have changed — please refresh and try again.",
+          "Audit could not be deleted. Its status may have changed, or it was removed by another process — please refresh and try again.",
         additionalData: { auditSessionId, organizationId },
         label,
         status: 409,
@@ -2914,8 +2914,12 @@ export async function bulkDeleteAudits({
       if (deleted.count !== targetIds.length) {
         throw new ShelfError({
           cause: null,
+          // The pre-read already confirmed every id was ARCHIVED + in-org,
+          // so a mismatch here means a concurrent process either changed
+          // an audit's status OR deleted an audit outright between the
+          // pre-read and this write. Cover both causes in the message.
           message:
-            "Some audits could not be deleted because their status changed. Please refresh and try again.",
+            "Some audits could not be deleted because their status changed or they were removed by another process. Please refresh and try again.",
           additionalData: {
             expected: targetIds.length,
             actual: deleted.count,
@@ -2939,12 +2943,18 @@ export async function bulkDeleteAudits({
 
     // Transaction committed — safe to remove storage objects now.
     // safeRemoveAuditImageFiles already logs + swallows per-file failures,
-    // so Promise.allSettled is strictly a latency win (Toby's cleanup of
-    // 125+ archived audits × multiple images each would otherwise be
-    // minutes of serial HTTP).
-    await Promise.allSettled(
-      images.map((image) => safeRemoveAuditImageFiles(image))
-    );
+    // so parallelism is strictly a latency win. A select-all delete for a
+    // large org could fan out thousands of concurrent Supabase requests
+    // (throttling + event-loop pressure), so cap concurrency with a small
+    // batch size.
+    const STORAGE_CLEANUP_BATCH_SIZE = 10;
+    for (let i = 0; i < images.length; i += STORAGE_CLEANUP_BATCH_SIZE) {
+      await Promise.allSettled(
+        images
+          .slice(i, i + STORAGE_CLEANUP_BATCH_SIZE)
+          .map((image) => safeRemoveAuditImageFiles(image))
+      );
+    }
 
     return { count };
   } catch (cause) {

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -58,15 +58,24 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   });
 
   try {
+    const formData = await request.clone().formData();
+    const intent = formData.get("intent");
+
+    // Parse the intent first and derive the initial permission from it so
+    // delete-only callers aren't blocked by an `update` gate that isn't
+    // relevant to their action. (Today every delete-capable role also has
+    // update, but that alignment is not a guarantee we should lean on.)
+    const initialAction =
+      intent === "delete-audit"
+        ? PermissionAction.delete
+        : PermissionAction.update;
+
     const { organizationId, isSelfServiceOrBase } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.audit,
-      action: PermissionAction.update,
+      action: initialAction,
     });
-
-    const formData = await request.clone().formData();
-    const intent = formData.get("intent");
 
     if (intent === "edit-audit") {
       const parsedData = parseData(formData, EditAuditSchema);
@@ -171,14 +180,8 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     }
 
     if (intent === "delete-audit") {
-      // Delete requires the explicit "delete" permission on the audit entity.
-      // ADMIN/OWNER have it; BASE/SELF_SERVICE do not.
-      await requirePermission({
-        userId,
-        request,
-        entity: PermissionEntity.audit,
-        action: PermissionAction.delete,
-      });
+      // Outer requirePermission already gated on PermissionAction.delete
+      // for this intent — no redundant inner re-check.
 
       // UI hides the button for self-service/base, but enforce server-side
       // to prevent direct POST bypass.
@@ -230,8 +233,10 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         userId,
       });
 
-      // Audit no longer exists — redirect to the index.
-      throw redirect("/audits");
+      // Audit no longer exists — return the redirect so React Router
+      // navigates. `throw redirect(...)` here would be caught by the
+      // surrounding try/catch and turned into an error JSON response.
+      return redirect("/audits");
     }
 
     throw new ShelfError({

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -200,37 +200,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         z.object({ confirmation: z.string().min(1) })
       );
 
-      // Re-read the audit name server-side so the confirmation check never
-      // trusts a name the client could have tampered with.
-      const session = await db.auditSession.findFirst({
-        where: { id: auditId, organizationId },
-        select: { name: true },
-      });
-      if (!session) {
-        throw new ShelfError({
-          cause: null,
-          message: "Audit not found.",
-          additionalData: { auditId, organizationId },
-          label,
-          status: 404,
-        });
-      }
-
-      if (confirmation.trim().toLowerCase() !== session.name.toLowerCase()) {
-        throw new ShelfError({
-          cause: null,
-          message: "Confirmation did not match the audit name.",
-          additionalData: { auditId },
-          label,
-          status: 400,
-          shouldBeCaptured: false,
-        });
-      }
-
+      // Name-match verification lives inside deleteAuditSession — it
+      // re-reads the audit for existence/status anyway, so folding the
+      // compare into the same query avoids a second round-trip and keeps
+      // the "never trust client-supplied names" guarantee in one place.
       await deleteAuditSession({
         auditSessionId: auditId,
         organizationId,
         userId,
+        expectedName: confirmation,
       });
 
       // Audit no longer exists — return the redirect so React Router

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -6,7 +6,13 @@ import type {
   MetaFunction,
   LinksFunction,
 } from "react-router";
-import { data, useLoaderData, Outlet, useMatches } from "react-router";
+import {
+  data,
+  redirect,
+  useLoaderData,
+  Outlet,
+  useMatches,
+} from "react-router";
 import { z } from "zod";
 import { ActionsDropdown } from "~/components/audit/actions-dropdown";
 import CompleteAuditDialog from "~/components/audit/complete-audit-dialog";
@@ -22,6 +28,7 @@ import {
   updateAuditSession,
   cancelAuditSession,
   archiveAuditSession,
+  deleteAuditSession,
   requireAuditAssignee,
 } from "~/modules/audit/service.server";
 import type { RouteHandleWithName } from "~/modules/types";
@@ -161,6 +168,70 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       });
 
       return payload({ success: true });
+    }
+
+    if (intent === "delete-audit") {
+      // Delete requires the explicit "delete" permission on the audit entity.
+      // ADMIN/OWNER have it; BASE/SELF_SERVICE do not.
+      await requirePermission({
+        userId,
+        request,
+        entity: PermissionEntity.audit,
+        action: PermissionAction.delete,
+      });
+
+      // UI hides the button for self-service/base, but enforce server-side
+      // to prevent direct POST bypass.
+      if (isSelfServiceOrBase) {
+        throw new ShelfError({
+          cause: null,
+          message: "You do not have permission to delete audits.",
+          additionalData: { userId, auditId },
+          label,
+          status: 403,
+        });
+      }
+
+      const { confirmation } = parseData(
+        formData,
+        z.object({ confirmation: z.string().min(1) })
+      );
+
+      // Re-read the audit name server-side so the confirmation check never
+      // trusts a name the client could have tampered with.
+      const session = await db.auditSession.findFirst({
+        where: { id: auditId, organizationId },
+        select: { name: true },
+      });
+      if (!session) {
+        throw new ShelfError({
+          cause: null,
+          message: "Audit not found.",
+          additionalData: { auditId, organizationId },
+          label,
+          status: 404,
+        });
+      }
+
+      if (confirmation.trim().toLowerCase() !== session.name.toLowerCase()) {
+        throw new ShelfError({
+          cause: null,
+          message: "Confirmation did not match the audit name.",
+          additionalData: { auditId },
+          label,
+          status: 400,
+          shouldBeCaptured: false,
+        });
+      }
+
+      await deleteAuditSession({
+        auditSessionId: auditId,
+        organizationId,
+        userId,
+      });
+
+      // Audit no longer exists — redirect to the index.
+      throw redirect("/audits");
     }
 
     throw new ShelfError({

--- a/apps/webapp/app/routes/api+/audits.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/audits.bulk-actions.ts
@@ -89,13 +89,13 @@ export async function action({ request, context }: ActionFunctionArgs) {
           organizationId,
           userId,
           currentSearchParams,
-          isSelfServiceOrBase,
         });
 
+        const isSingle = count === 1;
         sendNotification({
-          title: "Audits deleted",
+          title: isSingle ? "Audit deleted" : "Audits deleted",
           message: `Permanently deleted ${count} ${
-            count === 1 ? "audit" : "audits"
+            isSingle ? "audit" : "audits"
           }.`,
           icon: { name: "success", variant: "success" },
           senderId: userId,

--- a/apps/webapp/app/routes/api+/audits.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/audits.bulk-actions.ts
@@ -4,15 +4,21 @@
  * Handles bulk operations on audit sessions from the audits index page.
  * Currently supports:
  * - `bulk-archive` — Archive multiple COMPLETED/CANCELLED audits at once
+ * - `bulk-delete` — Permanently delete multiple ARCHIVED audits at once
  *
- * @see {@link file://../../components/audit/bulk-archive-audits-dialog.tsx} - Dialog component
- * @see {@link file://../../modules/audit/service.server.ts} - Service function
+ * @see {@link file://../../components/audit/bulk-archive-audits-dialog.tsx}
+ * @see {@link file://../../components/audit/bulk-delete-audits-dialog.tsx}
+ * @see {@link file://../../modules/audit/service.server.ts} - Service functions
  */
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
 import { BulkArchiveAuditsSchema } from "~/components/audit/bulk-archive-audits-dialog";
+import { BulkDeleteAuditsSchema } from "~/components/audit/bulk-delete-audits-dialog";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
-import { bulkArchiveAudits } from "~/modules/audit/service.server";
+import {
+  bulkArchiveAudits,
+  bulkDeleteAudits,
+} from "~/modules/audit/service.server";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
@@ -36,13 +42,14 @@ export async function action({ request, context }: ActionFunctionArgs) {
       formData,
       z
         .object({
-          intent: z.enum(["bulk-archive"]),
+          intent: z.enum(["bulk-archive", "bulk-delete"]),
         })
         .and(CurrentSearchParamsSchema)
     );
 
     const intentToActionMap: Record<typeof intent, PermissionAction> = {
       "bulk-archive": PermissionAction.archive,
+      "bulk-delete": PermissionAction.delete,
     };
 
     const { organizationId, isSelfServiceOrBase } = await requirePermission({
@@ -72,6 +79,29 @@ export async function action({ request, context }: ActionFunctionArgs) {
         });
 
         return data(payload({ success: true }));
+      }
+
+      case "bulk-delete": {
+        const { auditIds } = parseData(formData, BulkDeleteAuditsSchema);
+
+        const { count } = await bulkDeleteAudits({
+          auditIds,
+          organizationId,
+          userId,
+          currentSearchParams,
+          isSelfServiceOrBase,
+        });
+
+        sendNotification({
+          title: "Audits deleted",
+          message: `Permanently deleted ${count} ${
+            count === 1 ? "audit" : "audits"
+          }.`,
+          icon: { name: "success", variant: "success" },
+          senderId: userId,
+        });
+
+        return data(payload({ success: true, count }));
       }
 
       default: {

--- a/apps/webapp/test/routes-tests/_layout+/audits.$auditId.delete-audit.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.$auditId.delete-audit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Route action tests for `/audits/:auditId` — `delete-audit` intent only.
+ *
+ * These tests cover the wiring that the service-layer tests can't reach:
+ *   - The route requests `PermissionAction.delete` for this intent (not
+ *     `update`, which is used for edit/cancel/complete).
+ *   - The 403 self-service/base guard fires even when a caller happens to
+ *     hold `delete` permission (defense-in-depth against a future config
+ *     change).
+ *   - `confirmation` is a required form field — missing/empty submissions
+ *     are rejected before `deleteAuditSession` is called.
+ *   - Happy path returns a redirect to `/audits` (not a JSON `data(...)`
+ *     payload).
+ *   - 404/400/409 ShelfErrors thrown by the service surface with the
+ *     matching HTTP status via `makeShelfError`.
+ *
+ * Lives under `test/routes-tests/` rather than next to the route itself
+ * because React Router's flat-routes scanner auto-registers any `*.ts` /
+ * `*.tsx` file inside `app/routes/` as a route module.
+ *
+ * @see {@link file://../../../app/routes/_layout+/audits.$auditId.tsx}
+ * @see {@link file://../../../app/modules/audit/service.server.ts}
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createActionArgs } from "@mocks/remix";
+
+import { action } from "~/routes/_layout+/audits.$auditId";
+import { deleteAuditSession } from "~/modules/audit/service.server";
+import { ShelfError } from "~/utils/error";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+
+// @vitest-environment node
+
+// why: keep service calls out of this test — it asserts the route wiring,
+// not the DB behavior of findFirst/deleteMany.
+vi.mock("~/modules/audit/service.server", () => ({
+  updateAuditSession: vi.fn(),
+  cancelAuditSession: vi.fn(),
+  archiveAuditSession: vi.fn(),
+  deleteAuditSession: vi.fn(),
+  requireAuditAssignee: vi.fn(),
+  getAuditSessionDetails: vi.fn(),
+}));
+
+// why: the route imports completeAuditWithImages for a different intent;
+// stub the module so the import graph loads under node vitest env.
+vi.mock("~/modules/audit/complete-audit-with-images.server", () => ({
+  completeAuditWithImages: vi.fn(),
+}));
+
+// why: permission resolution is mocked so we can drive `organizationId` +
+// `isSelfServiceOrBase` from each test.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+
+// why: the real db.server calls db.$connect() at module load outside of
+// production. Stub it since no test in this file touches the DB directly.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    auditScan: { count: vi.fn() },
+    teamMember: { findMany: vi.fn() },
+  },
+}));
+
+const mockContext = {
+  getSession: () => ({ userId: "user-1" }),
+  appVersion: "1.0.0",
+  isAuthenticated: true,
+  setSession: vi.fn(),
+  destroySession: vi.fn(),
+  errorMessage: null,
+} as any;
+
+/**
+ * Build a POST Request for the delete-audit intent. Body is real URL-encoded
+ * form data so the route's `await request.clone().formData()` call works
+ * without a mocked parser.
+ */
+function makeDeleteRequest(
+  fields: Record<string, string> = { confirmation: "Q4 Audit" }
+): Request {
+  return new Request("http://localhost/audits/audit-1", {
+    method: "POST",
+    body: new URLSearchParams({
+      intent: "delete-audit",
+      ...fields,
+    }),
+  });
+}
+
+describe("audits.$auditId action — delete-audit intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: false,
+    } as any);
+    vi.mocked(deleteAuditSession).mockResolvedValue(undefined);
+  });
+
+  it("requests PermissionAction.delete (not .update) for the delete-audit intent", async () => {
+    await action(
+      createActionArgs({
+        request: makeDeleteRequest(),
+        params: { auditId: "audit-1" },
+        context: mockContext,
+      })
+    );
+
+    expect(requirePermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: PermissionEntity.audit,
+        action: PermissionAction.delete,
+        userId: "user-1",
+      })
+    );
+  });
+
+  it("forwards auditId, organizationId, userId, and expectedName to the service", async () => {
+    await action(
+      createActionArgs({
+        request: makeDeleteRequest({ confirmation: "  Q4 audit  " }),
+        params: { auditId: "audit-1" },
+        context: mockContext,
+      })
+    );
+
+    expect(deleteAuditSession).toHaveBeenCalledWith({
+      auditSessionId: "audit-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      // Whitespace is preserved at this boundary — normalization happens
+      // inside the service so the comparison has the DB name in hand.
+      expectedName: "  Q4 audit  ",
+    });
+  });
+
+  it("redirects to /audits on success (never a JSON data payload)", async () => {
+    const response = (await action(
+      createActionArgs({
+        request: makeDeleteRequest(),
+        params: { auditId: "audit-1" },
+        context: mockContext,
+      })
+    )) as Response;
+
+    // React Router's `redirect(...)` returns a Response with a 3xx status
+    // and a Location header. A JSON `data(...)` response would have
+    // status 200 and no Location header — distinguishing the two is the
+    // whole point of this assertion.
+    expect(response.status).toBeGreaterThanOrEqual(300);
+    expect(response.status).toBeLessThan(400);
+    expect(response.headers.get("location")).toBe("/audits");
+  });
+
+  it("returns 403 and does NOT call the service when the caller is self-service/base", async () => {
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: true,
+    } as any);
+
+    const response = (await action(
+      createActionArgs({
+        request: makeDeleteRequest(),
+        params: { auditId: "audit-1" },
+        context: mockContext,
+      })
+    )) as any;
+
+    expect(response.init?.status).toBe(403);
+    expect(deleteAuditSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the confirmation field is missing and does NOT call the service", async () => {
+    // URLSearchParams drops the `confirmation` key entirely → zod's
+    // `z.string().min(1)` fails in parseData, which `makeShelfError`
+    // converts to a non-200 response.
+    const response = (await action(
+      createActionArgs({
+        request: new Request("http://localhost/audits/audit-1", {
+          method: "POST",
+          body: new URLSearchParams({ intent: "delete-audit" }),
+        }),
+        params: { auditId: "audit-1" },
+        context: mockContext,
+      })
+    )) as any;
+
+    expect(response.init?.status).toBeDefined();
+    expect(response.init.status).not.toBe(200);
+    expect(deleteAuditSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [400, "Confirmation did not match the audit name."],
+    [404, "Audit not found."],
+    [409, "Only archived audits can be deleted. Archive it first."],
+  ])(
+    "surfaces a %s ShelfError from the service with the matching status",
+    async (status, message) => {
+      vi.mocked(deleteAuditSession).mockRejectedValue(
+        new ShelfError({
+          cause: null,
+          message,
+          label: "Audit",
+          status: status as 400 | 404 | 409,
+        })
+      );
+
+      const response = (await action(
+        createActionArgs({
+          request: makeDeleteRequest(),
+          params: { auditId: "audit-1" },
+          context: mockContext,
+        })
+      )) as any;
+
+      expect(response.init?.status).toBe(status);
+      expect(response.data?.error?.message).toBe(message);
+    }
+  );
+});

--- a/apps/webapp/test/routes-tests/api+/audits.bulk-actions.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.bulk-actions.test.ts
@@ -307,7 +307,7 @@ describe("api/audits.bulk-actions action", () => {
     it("forwards auditIds + search params to the service and reports the deleted count in the notification", async () => {
       vi.mocked(requirePermission).mockResolvedValue({
         organizationId: "org-1",
-        isSelfServiceOrBase: true,
+        isSelfServiceOrBase: false,
       } as any);
       vi.mocked(bulkDeleteAudits).mockResolvedValue({ count: 3 } as any);
 
@@ -320,12 +320,14 @@ describe("api/audits.bulk-actions action", () => {
         })
       );
 
+      // isSelfServiceOrBase is intentionally NOT forwarded — delete is
+      // ADMIN/OWNER-only, so plumbing the flag would be dead weight. Assert
+      // the explicit shape so a future re-add is caught.
       expect(bulkDeleteAudits).toHaveBeenCalledWith({
         auditIds: ["a1", "a2", "a3"],
         organizationId: "org-1",
         userId: "user-1",
         currentSearchParams: "status=ARCHIVED",
-        isSelfServiceOrBase: true,
       });
       expect(sendNotification).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -335,7 +337,7 @@ describe("api/audits.bulk-actions action", () => {
       );
     });
 
-    it("uses singular 'audit' in the notification when count is 1", async () => {
+    it("uses singular 'audit' (title + message) in the notification when count is 1", async () => {
       vi.mocked(requirePermission).mockResolvedValue({
         organizationId: "org-1",
         isSelfServiceOrBase: false,
@@ -352,6 +354,7 @@ describe("api/audits.bulk-actions action", () => {
 
       expect(sendNotification).toHaveBeenCalledWith(
         expect.objectContaining({
+          title: "Audit deleted",
           message: expect.stringMatching(/1 audit\./),
         })
       );

--- a/apps/webapp/test/routes-tests/api+/audits.bulk-actions.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.bulk-actions.test.ts
@@ -23,7 +23,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { action } from "~/routes/api+/audits.bulk-actions";
-import { bulkArchiveAudits } from "~/modules/audit/service.server";
+import {
+  bulkArchiveAudits,
+  bulkDeleteAudits,
+} from "~/modules/audit/service.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { ShelfError } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
@@ -35,9 +38,10 @@ import { requirePermission } from "~/utils/roles.server";
 
 // @vitest-environment node
 
-// why: mock the service function so we can assert how the route wires arguments
+// why: mock the service functions so we can assert how the route wires arguments
 vi.mock("~/modules/audit/service.server", () => ({
   bulkArchiveAudits: vi.fn(),
+  bulkDeleteAudits: vi.fn(),
 }));
 
 // why: mock auth/permission layer so we can control the resolved org + role
@@ -253,5 +257,133 @@ describe("api/audits.bulk-actions action", () => {
 
     expect(response.init?.status).toBe(403);
     expect(bulkArchiveAudits).not.toHaveBeenCalled();
+  });
+
+  describe("bulk-delete intent", () => {
+    it("requests `audit.delete` permission for the `bulk-delete` intent", async () => {
+      vi.mocked(requirePermission).mockResolvedValue({
+        organizationId: "org-1",
+        isSelfServiceOrBase: false,
+      } as any);
+      vi.mocked(bulkDeleteAudits).mockResolvedValue({ count: 1 } as any);
+
+      await callAction(
+        makeRequest({
+          intent: "bulk-delete",
+          auditIds: ["a1"],
+          confirmation: "DELETE",
+        })
+      );
+
+      expect(requirePermission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entity: PermissionEntity.audit,
+          action: PermissionAction.delete,
+          userId: "user-1",
+        })
+      );
+    });
+
+    it("rejects when the confirmation word is missing or wrong", async () => {
+      vi.mocked(requirePermission).mockResolvedValue({
+        organizationId: "org-1",
+        isSelfServiceOrBase: false,
+      } as any);
+
+      const response = (await callAction(
+        makeRequest({
+          intent: "bulk-delete",
+          auditIds: ["a1"],
+          confirmation: "delete", // wrong case — schema requires literal "DELETE"
+        })
+      )) as any;
+
+      // Validation failure: non-2xx response and the service must not be called
+      expect(response.init?.status).toBeDefined();
+      expect(response.init.status).not.toBe(200);
+      expect(bulkDeleteAudits).not.toHaveBeenCalled();
+    });
+
+    it("forwards auditIds + search params to the service and reports the deleted count in the notification", async () => {
+      vi.mocked(requirePermission).mockResolvedValue({
+        organizationId: "org-1",
+        isSelfServiceOrBase: true,
+      } as any);
+      vi.mocked(bulkDeleteAudits).mockResolvedValue({ count: 3 } as any);
+
+      await callAction(
+        makeRequest({
+          intent: "bulk-delete",
+          auditIds: ["a1", "a2", "a3"],
+          confirmation: "DELETE",
+          currentSearchParams: "status=ARCHIVED",
+        })
+      );
+
+      expect(bulkDeleteAudits).toHaveBeenCalledWith({
+        auditIds: ["a1", "a2", "a3"],
+        organizationId: "org-1",
+        userId: "user-1",
+        currentSearchParams: "status=ARCHIVED",
+        isSelfServiceOrBase: true,
+      });
+      expect(sendNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Audits deleted",
+          message: expect.stringMatching(/3 audits/),
+        })
+      );
+    });
+
+    it("uses singular 'audit' in the notification when count is 1", async () => {
+      vi.mocked(requirePermission).mockResolvedValue({
+        organizationId: "org-1",
+        isSelfServiceOrBase: false,
+      } as any);
+      vi.mocked(bulkDeleteAudits).mockResolvedValue({ count: 1 } as any);
+
+      await callAction(
+        makeRequest({
+          intent: "bulk-delete",
+          auditIds: ["a1"],
+          confirmation: "DELETE",
+        })
+      );
+
+      expect(sendNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(/1 audit\./),
+        })
+      );
+    });
+
+    it("surfaces a service ShelfError with the matching HTTP status", async () => {
+      vi.mocked(requirePermission).mockResolvedValue({
+        organizationId: "org-1",
+        isSelfServiceOrBase: false,
+      } as any);
+      vi.mocked(bulkDeleteAudits).mockRejectedValue(
+        new ShelfError({
+          cause: null,
+          message: "Some selected audits are not archived.",
+          label: "Audit",
+          status: 409,
+        })
+      );
+
+      const response = (await callAction(
+        makeRequest({
+          intent: "bulk-delete",
+          auditIds: ["a1"],
+          confirmation: "DELETE",
+        })
+      )) as any;
+
+      expect(response.init?.status).toBe(409);
+      expect(response.data?.error?.message).toMatch(/are not archived/);
+      expect(sendNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Audits deleted" })
+      );
+    });
   });
 });


### PR DESCRIPTION
## Need

Customers running high-volume audits (Toby at Hull, ~125/mo) need a way to permanently remove archived audits. Archive (#2438, #2481) hides them, but the list of archived audits grows forever. Without delete, \"clean up the archived shelf\" has no terminal.

This is step 2 of the audit-lifecycle rollout specified in the PRD (#2434). Step 1 (archive + bulk archive) is merged; step 3 (duplicate) is the next PR.

Scope follows the PRD exactly — **no scope drift**:
- Delete is available **only** on \`ARCHIVED\` audits — archive-first is the safety contract
- Single delete: type the audit name (case-insensitive) to confirm
- Bulk delete: type literal \`\"DELETE\"\` to confirm (name-per-audit is unusable at Toby's volume)
- Hard delete via Prisma cascades; Supabase storage cleanup for audit images

Deferred (follow-up PRs, NOT this one):
- In-progress delete with double-confirm (Toby's scoping ask 2026-04-14)
- Duplicate audit (PR #3 of the lifecycle series)

## Hypothesis

- Mirroring the archive patterns shipped in #2438 / #2481 keeps the reviewer's cognitive load low — service / dialog / route / dropdown / test shapes all match.
- Pre-read + storage-cleanup + atomic \`deleteMany\` with \`status: ARCHIVED\` guard covers the TOCTOU window between the read and the destructive write. No transaction across external Supabase HTTP calls (keeps the DB connection pool healthy).
- Per-file storage-failure swallow means a transient Supabase outage can't leave an undeletable zombie audit row. Stale storage objects are logged for later cleanup.
- Server-side re-read of the audit name + case-insensitive compare means the name match can't be bypassed by editing the rendered value in devtools.
- Force-narrow to \`ARCHIVED\` inside \`bulkDeleteAudits\` means even a select-all across \`status=COMPLETED\` can never reach a non-archived audit.

## Implementation

### Service (\`apps/webapp/app/modules/audit/service.server.ts\`)
- \`deleteAuditSession({ auditSessionId, organizationId, userId })\`
- \`bulkDeleteAudits({ auditIds, organizationId, userId, currentSearchParams, isSelfServiceOrBase })\`
- \`safeRemoveAuditImageFiles()\` — shared helper, logs + swallows storage errors
- No call to \`assertAuditNotArchived\` — delete is the *intentional* escape hatch past the archive-first contract

### Route wiring
- New \`delete-audit\` intent in \`apps/webapp/app/routes/_layout+/audits.$auditId.tsx\` — redirects to \`/audits\` on success
- New \`bulk-delete\` case in \`apps/webapp/app/routes/api+/audits.bulk-actions.ts\` — requires \`PermissionAction.delete\`

### UI
- \`components/audit/delete-audit-dialog.tsx\` — single-item destructive dialog (type-name-to-confirm)
- \`components/audit/bulk-delete-audits-dialog.tsx\` — bulk destructive dialog (type-DELETE-to-confirm)
- \`actions-dropdown.tsx\` — new red \"Delete\" entry visible when \`isAdminOrOwner && isArchived\`
- \`audit-index-bulk-actions-dropdown.tsx\` — new \"Delete\" bulk entry with \`someNotArchived\` disable-reason
- Extended \`BulkDialogType\` / \`bulkDialogAtom\` / \`iconsMap\` with \`\"delete-audit\"\`

### No schema changes
Existing Prisma cascades cover \`AuditAsset\`, \`AuditScan\`, \`AuditNote\`, \`AuditImage\`, \`AuditAssignment\`. \`PermissionAction.delete\` on \`PermissionEntity.audit\` already exists for ADMIN / OWNER.

## Test plan

### Automated (CI)
- [x] \`pnpm webapp:validate\` — lint + typecheck + 1689 tests passing (the 3 bookings/assets-activity suites that failed locally from hook-timeout-on-parallel-setup all pass in isolation; pre-existing flakiness, unrelated)
- [x] 19 new service tests cover: happy path, storage cleanup per image, thumbnail-null handling, storage-failure swallow, 404 not found, 409 on each non-ARCHIVED status (PENDING/ACTIVE/COMPLETED/CANCELLED), TOCTOU race via \`deleteMany.count === 0\`, 500 wrap for unknown causes
- [x] 5 new route tests cover: permission requested (\`delete\`), confirmation-word validation, auditIds/org/user forwarding, singular-vs-plural notification copy, ShelfError status propagation

### Manual
- [ ] Archive an audit → Actions → Delete → type name → confirms and redirects to \`/audits\`; audit and cascaded rows gone
- [ ] Same flow but mismatched name → button stays disabled
- [ ] Direct POST of \`intent=delete-audit\` against a COMPLETED audit → 409 (server-side guard)
- [ ] Self-service/base user tries the same → 403
- [ ] Index page: filter \`status=ARCHIVED\`, bulk-select 3+ rows → Actions → Delete → type \`DELETE\` → success toast \`\"Permanently deleted 3 audits\"\`
- [ ] Bulk-select rows including a non-archived one → Delete button shows \"Some of the selected audits are not archived\" tooltip
- [ ] Select-all across pages with \`status=COMPLETED\` active → server refuses to delete any non-archived row
- [ ] Verify audit image files removed from Supabase storage bucket after delete

## Tests

\`\`\`text
Test Files  1 passed (service.server.test.ts)
      Tests  50 passed (19 new for delete)

Test Files  1 passed (audits.bulk-actions.test.ts)
      Tests  12 passed (5 new for bulk-delete)
\`\`\`

All CLAUDE.md test rules honored: behavior-driven, \`// why:\` comments on every mock, factories not hardcoded data.

## Benchmark

- Typecheck: ~29s (no regression — same time as pre-change on this branch; compared against archive PR #2481 typecheck times, same range)
- Service file growth: \`service.server.ts\` +276 lines (2 new exported functions + 1 private helper); mirrors the archive-feature growth shape
- New files: 2 dialogs (\`delete-audit-dialog.tsx\` 138 LOC, \`bulk-delete-audits-dialog.tsx\` 117 LOC)
- No new dependencies. No Prisma migrations. No permission schema changes.

## Checklist

- [x] PRD scope respected (archived-only, name-match single, literal-DELETE bulk)
- [x] JSDoc on every new exported function + file headers with \`@see\` cross-refs
- [x] \`// why:\` comments on all new mocks
- [x] Explicit \`type\` prop on every \`<Button>\`
- [x] \`useDisabled\` hook used for form-submit disabled state
- [x] No \`git add -A\` — each staged file listed explicitly
- [x] Conventional commit with body lines ≤100 chars, no Claude footer
- [x] No backwards-compat shims, no unused \`_\` renames, no dead code

## Related

- PRD: #2434 (still open — will close after Duplicate (#3 of the lifecycle series) ships)
- Prior art: #2438 (single archive, Apr 2), #2481 (bulk archive, Apr 20)
- Follow-up: #3 — Duplicate audit, separate PR off its own branch
- Deferred ask: in-progress delete with double-confirm (Toby's scoping, separate PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single and bulk permanent deletion for archived audits: UI actions and confirmation dialogs (type audit name or type "DELETE"); select-all bulk delete only when filtered to archived; permission checks enforced; storage objects cleaned up; single delete redirects to audits; success notifications show singular/plural counts.

* **Tests**
  * Expanded coverage for single and bulk delete: permissions, confirmation validation (normalization/trimming), transactional guarantees, storage cleanup, and error/status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->