### PR TITLE
fix(sentry): suppress 4xx-equivalent and aborted-request noise

### DIFF
--- a/apps/webapp/app/entry.client.tsx
+++ b/apps/webapp/app/entry.client.tsx
@@ -31,12 +31,17 @@ if (window.env?.SENTRY_DSN) {
         return null;
       }
 
-      // Suppress consecutive HTTP on /assets/new — React Router form + revalidation
+      // Suppress consecutive HTTP on /assets/new. The route inherently
+      // chains form submit + revalidation + image upload across multiple
+      // HTTP spans, which Sentry's perf detector groups as
+      // `performance_consecutive_http`. Drop any transaction on this route
+      // that includes the form-data submit span — the previous threshold
+      // (`> 1` matching spans) was too narrow and let most events through.
       if (event.transaction === "/assets/new") {
-        const assetNewSpans = spans.filter(
+        const hasAssetNewDataSpan = spans.some(
           (s) => s.description?.includes("/assets/new.data")
         );
-        if (assetNewSpans.length > 1) {
+        if (hasAssetNewDataSpan) {
           return null;
         }
       }
@@ -44,27 +49,59 @@ if (window.env?.SENTRY_DSN) {
       return event;
     },
     beforeSend(event) {
-      // Always send errors from the error boundary — these are user-visible
-      // crashes that must be searchable by the Error ID shown to the user.
-      // Sentry.captureException() returns the event ID synchronously before
-      // beforeSend runs, so filtering here would silently drop the event
-      // while the UI still displays the (now-orphaned) Error ID.
+      const message = event.exception?.values?.[0]?.value || "";
+
+      // Hard-filter browser/framework quirks that are not actionable even
+      // when they bubble up through React Router's error boundary. These
+      // are stream-decode races, React reconciliation aborts mid-navigation,
+      // and browser-extension DOM mutation collisions — all known noise
+      // with no app-side fix. Tradeoff: when one of these surfaces in the
+      // UI, the displayed Error ID will not exist in Sentry. That is
+      // acceptable here because the error itself is not actionable; the
+      // user is told to retry, and Sentry would only collect duplicate
+      // reports of the same untriageable race.
+      const hardIgnoredPatterns = [
+        "Unable to decode turbo-stream",
+        "Error in input stream",
+      ];
+      if (hardIgnoredPatterns.some((pattern) => message.includes(pattern))) {
+        return null;
+      }
+
+      // Same hard-filter for the NotFoundError variants from React DOM
+      // reconciliation (`removeChild`/`insertBefore` on a non-child).
+      // These reach the error boundary because they happen during commit.
+      if (
+        event.exception?.values?.some(
+          (v) =>
+            v.type === "NotFoundError" &&
+            (v.value?.includes("removeChild") ||
+              v.value?.includes("insertBefore"))
+        )
+      ) {
+        return null;
+      }
+
+      // Always send remaining errors from the error boundary — these are
+      // user-visible crashes that must be searchable by the Error ID shown
+      // to the user. Sentry.captureException() returns the event ID
+      // synchronously before beforeSend runs, so filtering past this point
+      // would silently drop the event while the UI still displays the
+      // (now-orphaned) Error ID.
       if (event.tags?.source === "error-boundary") {
         return event;
       }
 
-      const message = event.exception?.values?.[0]?.value || "";
-
       // Filter browser compatibility / extension errors (not actionable).
-      // "Expected fetcher: " and "No result found for routeId" are React Router
-      // internal races during navigation, not actionable from app code.
+      // "Expected fetcher: " and "No result found for routeId" are React
+      // Router internal races during navigation. "Cannot submit a <button>"
+      // is a fetcher.submit edge case from React Router's form helper.
       const ignoredPatterns = [
         "feature named",
         "Unexpected identifier 'https'",
-        "Unable to decode turbo-stream",
-        "Error in input stream",
         "Expected fetcher: ",
         "No result found for routeId",
+        "Cannot submit a <button>",
       ];
       if (ignoredPatterns.some((pattern) => message.includes(pattern))) {
         return null;
@@ -84,18 +121,6 @@ if (window.env?.SENTRY_DSN) {
         message.includes("AbortError") ||
         message.includes("The operation was aborted") ||
         message.includes("Fetch is aborted")
-      ) {
-        return null;
-      }
-
-      // Filter DOM errors from browser extensions (removeChild/insertBefore on non-child)
-      if (
-        event.exception?.values?.some(
-          (v) =>
-            v.type === "NotFoundError" &&
-            (v.value?.includes("removeChild") ||
-              v.value?.includes("insertBefore"))
-        )
       ) {
         return null;
       }

--- a/apps/webapp/app/entry.client.tsx
+++ b/apps/webapp/app/entry.client.tsx
@@ -55,12 +55,16 @@ if (window.env?.SENTRY_DSN) {
 
       const message = event.exception?.values?.[0]?.value || "";
 
-      // Filter browser compatibility / extension errors (not actionable)
+      // Filter browser compatibility / extension errors (not actionable).
+      // "Expected fetcher: " and "No result found for routeId" are React Router
+      // internal races during navigation, not actionable from app code.
       const ignoredPatterns = [
         "feature named",
         "Unexpected identifier 'https'",
         "Unable to decode turbo-stream",
         "Error in input stream",
+        "Expected fetcher: ",
+        "No result found for routeId",
       ];
       if (ignoredPatterns.some((pattern) => message.includes(pattern))) {
         return null;
@@ -71,12 +75,15 @@ if (window.env?.SENTRY_DSN) {
         return null;
       }
 
-      // Filter client-side network errors (not actionable)
+      // Filter client-side network errors and aborted requests (not actionable)
       if (
         message.includes("Load failed") ||
         message.includes("Failed to fetch") ||
         message.includes("NetworkError") ||
-        message.includes("fetch failed")
+        message.includes("fetch failed") ||
+        message.includes("AbortError") ||
+        message.includes("The operation was aborted") ||
+        message.includes("Fetch is aborted")
       ) {
         return null;
       }

--- a/apps/webapp/app/hooks/use-position.ts
+++ b/apps/webapp/app/hooks/use-position.ts
@@ -19,12 +19,13 @@ export const usePosition = () => {
 
   useEffect(() => {
     if (navigator && navigator.geolocation && scanId) {
+      // The error callback must be a function or omitted; passing `null` makes
+      // WebKit throw a `TypeError: Argument 2 ('errorCallback') ... must be a
+      // function`. Use `undefined` to opt out cleanly. The caller doesn't
+      // surface geolocation errors anyway, so a no-op handler is unnecessary.
       navigator.geolocation.getCurrentPosition(
-        // Success function
         (position) => setPosition(position.coords),
-        // Error function
-        null,
-        // Options. See MDN for details.
+        undefined,
         {
           enableHighAccuracy: true,
           timeout: 5000,

--- a/apps/webapp/app/modules/asset-reminder/service.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/service.server.ts
@@ -287,6 +287,7 @@ export async function editAssetReminder({
       cause,
       message,
       label,
+      shouldBeCaptured: !isNotFoundError(cause),
     });
   }
 }
@@ -310,6 +311,7 @@ export async function deleteAssetReminder({
         ? "Reminder not found or you are viewing in wrong organization."
         : "Something went wrong while deleting reminder.",
       label,
+      shouldBeCaptured: !isNotFoundError(cause),
     });
   }
 }

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -923,6 +923,7 @@ export async function reserveBooking({
           label,
           message:
             "Booking not found. Are you sure it exists in current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -1164,6 +1165,7 @@ export async function checkoutBooking({
           label,
           message:
             "Booking not found, are you sure it exists in current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -1433,6 +1435,7 @@ export async function checkinBooking({
           label,
           message:
             "Booking not found, are you sure it exists in current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -1820,6 +1823,7 @@ export async function partialCheckinBooking({
           label,
           message:
             "Booking not found, are you sure it exists in current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -2317,6 +2321,7 @@ export async function archiveBooking({
           title: "Not found",
           message:
             "Booking not found, are you sure it exists in current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -2386,6 +2391,7 @@ export async function cancelBooking({
           label,
           message:
             "Booking not found. Are you sure it exists in current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -2515,6 +2521,7 @@ export async function revertBookingToDraft({
           label,
           message:
             "Booking not found, are you sure the booking exists in current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -2603,6 +2610,7 @@ export async function extendBooking({
           label,
           message:
             "Booking not found. Are you sure it exists in the current workspace?",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 

--- a/apps/webapp/app/modules/booking/worker.server.ts
+++ b/apps/webapp/app/modules/booking/worker.server.ts
@@ -5,7 +5,7 @@ import { db } from "~/database/db.server";
 import { bookingUpdatesTemplateString } from "~/emails/bookings-updates-template";
 import { sendEmail } from "~/emails/mail.server";
 import { getTimeRemainingMessage } from "~/utils/date-fns";
-import { ShelfError } from "~/utils/error";
+import { isNotFoundError, ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
 import { wrapBookingStatusForNote } from "~/utils/markdoc-wrappers";
 import { QueueNames, scheduler } from "~/utils/scheduler.server";
@@ -39,6 +39,7 @@ const checkoutReminder = async ({ data }: PgBoss.Job<SchedulerData>) => {
         message: "Booking not found",
         additionalData: { data, work: data.eventType },
         label: "Booking",
+        shouldBeCaptured: !isNotFoundError(cause),
       });
     });
 
@@ -106,6 +107,7 @@ const checkinReminder = async ({ data }: PgBoss.Job<SchedulerData>) => {
         message: "Booking not found",
         additionalData: { data, work: data.eventType },
         label: "Booking",
+        shouldBeCaptured: !isNotFoundError(cause),
       });
     });
 

--- a/apps/webapp/app/modules/category/service.server.ts
+++ b/apps/webapp/app/modules/category/service.server.ts
@@ -198,6 +198,7 @@ export async function getCategory({
       additionalData: { id, organizationId },
       label,
       status: 404,
+      shouldBeCaptured: false,
     });
   }
 }

--- a/apps/webapp/app/modules/category/service.server.ts
+++ b/apps/webapp/app/modules/category/service.server.ts
@@ -2,7 +2,11 @@ import type { Category, Organization, Prisma, User } from "@prisma/client";
 import { db } from "~/database/db.server";
 
 import type { ErrorLabel } from "~/utils/error";
-import { ShelfError, maybeUniqueConstraintViolation } from "~/utils/error";
+import {
+  isNotFoundError,
+  ShelfError,
+  maybeUniqueConstraintViolation,
+} from "~/utils/error";
 import { getRandomColor } from "~/utils/get-random-color";
 import { ALL_SELECTED_KEY } from "~/utils/list";
 import type { CreateAssetFromContentImportPayload } from "../asset/types";
@@ -198,7 +202,9 @@ export async function getCategory({
       additionalData: { id, organizationId },
       label,
       status: 404,
-      shouldBeCaptured: false,
+      // Suppress only true Prisma not-found (P2025); let DB / connectivity
+      // failures bubble up to Sentry so we can detect real incidents.
+      shouldBeCaptured: !isNotFoundError(cause),
     });
   }
 }

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -1499,6 +1499,7 @@ export async function relinkKitQrCode({
       message: "Kit not found.",
       label,
       additionalData: { kitId, organizationId, qrId },
+      shouldBeCaptured: false,
     });
   }
 
@@ -1613,6 +1614,7 @@ export async function updateKitLocation({
         cause: null,
         message: "Kit not found",
         label,
+        shouldBeCaptured: false,
       });
     }
 
@@ -2057,6 +2059,7 @@ export async function updateKitAssets({
           additionalData: { kitId, userId, organizationId },
           status: 404,
           label: "Kit",
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 

--- a/apps/webapp/app/modules/location-note/service.server.ts
+++ b/apps/webapp/app/modules/location-note/service.server.ts
@@ -95,6 +95,7 @@ export async function getLocationNotes({
         additionalData: { locationId, organizationId },
         label,
         status: 404,
+        shouldBeCaptured: false,
       });
     }
 

--- a/apps/webapp/app/modules/tag/service.server.ts
+++ b/apps/webapp/app/modules/tag/service.server.ts
@@ -9,7 +9,11 @@ import { TagUseFor } from "@prisma/client";
 import loadash from "lodash";
 import { db } from "~/database/db.server";
 import type { ErrorLabel } from "~/utils/error";
-import { ShelfError, maybeUniqueConstraintViolation } from "~/utils/error";
+import {
+  isNotFoundError,
+  ShelfError,
+  maybeUniqueConstraintViolation,
+} from "~/utils/error";
 import { getRandomColor } from "~/utils/get-random-color";
 import { getCurrentSearchParams } from "~/utils/http.server";
 import { ALL_SELECTED_KEY } from "~/utils/list";
@@ -228,7 +232,9 @@ export async function getTag({
         "The tag you are trying to access does not exist or you do not have permission to access it.",
       additionalData: { id, organizationId },
       label,
-      shouldBeCaptured: false,
+      // Suppress only true Prisma not-found (P2025); let DB / connectivity
+      // failures bubble up to Sentry.
+      shouldBeCaptured: !isNotFoundError(cause),
     });
   }
 }

--- a/apps/webapp/app/modules/tag/service.server.ts
+++ b/apps/webapp/app/modules/tag/service.server.ts
@@ -228,6 +228,7 @@ export async function getTag({
         "The tag you are trying to access does not exist or you do not have permission to access it.",
       additionalData: { id, organizationId },
       label,
+      shouldBeCaptured: false,
     });
   }
 }

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -634,6 +634,7 @@ export async function getTeamMember({
       additionalData: { id, organizationId },
       label,
       status: 404,
+      shouldBeCaptured: false,
     });
   }
 }

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -4,7 +4,7 @@ import type { LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import { updateCookieWithPerPage } from "~/utils/cookies.server";
 import type { ErrorLabel } from "~/utils/error";
-import { ShelfError } from "~/utils/error";
+import { isNotFoundError, ShelfError } from "~/utils/error";
 import { getCurrentSearchParams } from "~/utils/http.server";
 import { ALL_SELECTED_KEY, getParamsValues } from "~/utils/list";
 import { Logger } from "~/utils/logger";
@@ -634,7 +634,9 @@ export async function getTeamMember({
       additionalData: { id, organizationId },
       label,
       status: 404,
-      shouldBeCaptured: false,
+      // Suppress only true Prisma not-found (P2025); let DB / connectivity
+      // failures bubble up to Sentry.
+      shouldBeCaptured: !isNotFoundError(cause),
     });
   }
 }

--- a/apps/webapp/app/modules/user/utils.server.ts
+++ b/apps/webapp/app/modules/user/utils.server.ts
@@ -321,6 +321,7 @@ export async function resolveUserAction(
           cause: null,
           message: "User is not a member of this organization",
           label: "Team",
+          shouldBeCaptured: false,
         });
       }
 

--- a/apps/webapp/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
@@ -98,6 +98,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           },
           label: "Organization",
           status: 403,
+          shouldBeCaptured: false,
         });
       });
 
@@ -216,6 +217,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           },
           label: "Organization",
           status: 403,
+          shouldBeCaptured: false,
         });
       });
 

--- a/apps/webapp/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
@@ -34,7 +34,7 @@ import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { resolveShowShelfBranding } from "~/utils/branding";
 import { DEFAULT_MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
-import { makeShelfError, ShelfError } from "~/utils/error";
+import { isNotFoundError, makeShelfError, ShelfError } from "~/utils/error";
 import {
   assertIsPost,
   payload,
@@ -98,7 +98,10 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           },
           label: "Organization",
           status: 403,
-          shouldBeCaptured: false,
+          // Suppress only the genuine "not owner / not found" case (Prisma
+          // P2025); let DB / connectivity failures bubble up to Sentry as
+          // 5xx so we can detect real incidents.
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -217,7 +220,10 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           },
           label: "Organization",
           status: 403,
-          shouldBeCaptured: false,
+          // Suppress only the genuine "not owner / not found" case (Prisma
+          // P2025); let DB / connectivity failures bubble up to Sentry as
+          // 5xx so we can detect real incidents.
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.note.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.note.tsx
@@ -56,6 +56,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         additionalData: { userId, assetId },
         label: "Assets",
         status: 404,
+        shouldBeCaptured: false,
       });
     }
 

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.note.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.note.tsx
@@ -141,6 +141,7 @@ async function assertLocationBelongsToOrganization({
       status: 404,
       additionalData: { locationId, organizationId },
       label: "Location",
+      shouldBeCaptured: false,
     });
   }
 }

--- a/apps/webapp/app/routes/_layout+/settings.general.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.general.tsx
@@ -243,6 +243,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
             cause: null,
             message: "You are not allowed to edit this organization.",
             label: "Organization",
+            shouldBeCaptured: false,
           });
         }
 
@@ -321,6 +322,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
             cause: null,
             message: "You are not allowed to edit this organization.",
             label: "Organization",
+            shouldBeCaptured: false,
           });
         }
 
@@ -377,6 +379,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
             cause: null,
             message: "You are not allowed to edit this organization.",
             label: "Organization",
+            shouldBeCaptured: false,
           });
         }
 

--- a/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
@@ -56,6 +56,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
         additionalData: { userId, assetIds, custodian },
         label: "Assets",
         status: 404,
+        shouldBeCaptured: false,
       });
     });
 

--- a/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
@@ -6,7 +6,12 @@ import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { getTeamMember } from "~/modules/team-member/service.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
-import { makeShelfError, ShelfError } from "~/utils/error";
+import {
+  isLikeShelfError,
+  isNotFoundError,
+  makeShelfError,
+  ShelfError,
+} from "~/utils/error";
 import { assertIsPost, payload, error, parseData } from "~/utils/http.server";
 import {
   PermissionAction,
@@ -56,7 +61,12 @@ export async function action({ context, request }: ActionFunctionArgs) {
         additionalData: { userId, assetIds, custodian },
         label: "Assets",
         status: 404,
-        shouldBeCaptured: false,
+        // `getTeamMember` already classifies its errors — forward that
+        // decision so DB / connectivity failures inside it still reach
+        // Sentry. Fall back to the Prisma not-found check otherwise.
+        shouldBeCaptured: isLikeShelfError(cause)
+          ? cause.shouldBeCaptured
+          : !isNotFoundError(cause),
       });
     });
 

--- a/apps/webapp/app/routes/api+/kits.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/kits.bulk-actions.ts
@@ -100,6 +100,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
             additionalData: { userId, kitIds, custodian },
             label: "Kit",
             status: 404,
+            shouldBeCaptured: false,
           });
         });
 

--- a/apps/webapp/app/routes/api+/kits.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/kits.bulk-actions.ts
@@ -16,7 +16,12 @@ import {
 import { getTeamMember } from "~/modules/team-member/service.server";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
-import { makeShelfError, ShelfError } from "~/utils/error";
+import {
+  isLikeShelfError,
+  isNotFoundError,
+  makeShelfError,
+  ShelfError,
+} from "~/utils/error";
 import { payload, error, parseData } from "~/utils/http.server";
 import {
   PermissionAction,
@@ -100,7 +105,12 @@ export async function action({ request, context }: ActionFunctionArgs) {
             additionalData: { userId, kitIds, custodian },
             label: "Kit",
             status: 404,
-            shouldBeCaptured: false,
+            // `getTeamMember` already classifies its errors — forward that
+            // decision so DB / connectivity failures inside it still reach
+            // Sentry. Fall back to the Prisma not-found check otherwise.
+            shouldBeCaptured: isLikeShelfError(cause)
+              ? cause.shouldBeCaptured
+              : !isNotFoundError(cause),
           });
         });
 

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -210,7 +210,13 @@ export function isLikeShelfError(cause: unknown): cause is ShelfError {
   );
 }
 
-function isAbortError(cause: unknown) {
+/**
+ * Detects whether an error (or any error in its `cause` chain) represents a
+ * cancelled / aborted request. Used to suppress noise from client disconnects
+ * and stream-handler aborts both in `makeShelfError` and in the Sentry
+ * `beforeSend` hook on the server.
+ */
+export function isAbortError(cause: unknown) {
   if (!cause) {
     return false;
   }

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -224,10 +224,13 @@ export function isAbortError(cause: unknown) {
   if (cause instanceof Error) {
     const name = cause.name?.toLowerCase?.() ?? "";
     const message = cause.message?.toLowerCase?.() ?? "";
-    const code =
-      "code" in cause && typeof (cause as any).code === "string"
-        ? (cause as any).code
-        : "";
+    // Read `code` by narrowing from `unknown` rather than `any` — some error
+    // shapes (Node `ECONNRESET`, AbortSignal, etc.) carry it as a sibling
+    // field. Other browser-side AbortError variants surface their reason via
+    // `message` ("The operation was aborted", "Fetch is aborted") and are
+    // already covered by the message checks below.
+    const codeCandidate: unknown = (cause as { code?: unknown }).code;
+    const code = typeof codeCandidate === "string" ? codeCandidate : "";
 
     if (name === "aborterror") {
       return true;
@@ -236,6 +239,8 @@ export function isAbortError(cause: unknown) {
     if (
       message.includes("call aborted") ||
       message.includes("request aborted") ||
+      message.includes("the operation was aborted") ||
+      message.includes("fetch is aborted") ||
       message === "aborted" ||
       code === "ECONNRESET"
     ) {

--- a/apps/webapp/server/instrument.server.ts
+++ b/apps/webapp/server/instrument.server.ts
@@ -4,7 +4,7 @@ import { type Event, type EventHint } from "@sentry/react-router";
 
 import { SENTRY_DSN } from "~/utils/env";
 import type { ShelfError } from "~/utils/error";
-import { isLikeShelfError } from "~/utils/error";
+import { isAbortError, isLikeShelfError } from "~/utils/error";
 
 if (SENTRY_DSN) {
   Sentry.init({
@@ -56,6 +56,12 @@ function handleBeforeSend<E extends Event>(event: E, hint: EventHint) {
     !(exception instanceof Error) ||
     (isLikeShelfError(exception) && !exception.shouldBeCaptured)
   ) {
+    return null;
+  }
+
+  // Drop aborted-request errors that bypass `makeShelfError` — usually thrown
+  // raw from streaming handlers or middleware when a client disconnects.
+  if (isAbortError(exception)) {
     return null;
   }
 


### PR DESCRIPTION
Cuts low-signal Sentry events from the last 14 days in three groups:

- Server (`instrument.server.ts`) and client (`entry.client.tsx`) Sentry filters now drop AbortError / "operation was aborted" / "Fetch is aborted" plus React Router internal races ("Expected fetcher: ", "No result found for routeId"). `isAbortError` is exported from `utils/error.ts` so server `beforeSend` can reuse the cause-walking logic that `makeShelfError` already relies on.

- ~15 ShelfError throw sites for permission / not-found / ownership checks now set `shouldBeCaptured: false` (or `!isNotFoundError(cause)` where the same wrapper also surfaces real DB failures). Touched files: category, tag, kit (3 sites), location-note, asset-reminder (2 sites, conditional), team-member, booking (8 sites, conditional), booking/worker (2 sites, conditional), user/utils, account-details workspace edit, asset note, location note, settings.general, api+/kits.bulk-actions, api+/assets.bulk-assign-custody.

These outcomes are 4xx-equivalent and were being captured because `shouldBeCaptured` defaults to `true`. No behavior change for users — the errors still propagate and surface to the UI exactly as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better distinguish genuine failures from “not found” cases to reduce false alerts.
  * Suppress aborted/cancelled network errors to reduce noise in error logs.
  * Add additional ignored error patterns to avoid spurious reports.
  * Minor geolocation callback fix to avoid a potential runtime warning.

* **Chores**
  * Hardened and documented abort-detection logic used by server and client error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->