### PR TITLE
fix(sentry): suppress auth + not-found wrapper noise

### DIFF
--- a/apps/webapp/app/modules/auth/service.server.ts
+++ b/apps/webapp/app/modules/auth/service.server.ts
@@ -289,8 +289,14 @@ export async function sendOTP(email: string) {
       throw error;
     }
   } catch (cause) {
-    // @ts-expect-error
-    const isRateLimitError = cause.code === "over_email_send_rate_limit";
+    // Read `code` via narrowing instead of `@ts-expect-error` — `cause` is
+    // `unknown`, and a bare property access would throw at runtime if it
+    // were null/undefined.
+    const errorCode =
+      typeof cause === "object" && cause !== null && "code" in cause
+        ? (cause as { code: unknown }).code
+        : undefined;
+    const isRateLimitError = errorCode === "over_email_send_rate_limit";
     // Supabase 504s and intermittent fetch failures resolve on retry.
     const isTransientFetchError = isAuthRetryableFetchError(cause);
     // "Database error finding user" — Supabase backend hiccup, not actionable.

--- a/apps/webapp/app/modules/auth/service.server.ts
+++ b/apps/webapp/app/modules/auth/service.server.ts
@@ -187,23 +187,30 @@ export async function signInWithEmail(email: string, password: string) {
 
     return mapAuthSession(session);
   } catch (cause) {
-    let message =
-      "Something went wrong. Please try again later or contact support.";
-    let shouldBeCaptured = true;
+    const isInvalidCredentials =
+      isAuthApiError(cause) && cause.message === "Invalid login credentials";
+    // Supabase 504s and intermittent fetch failures surface as
+    // `AuthRetryableFetchError`. They resolve on retry and shouldn't page us.
+    const isTransientFetchError = isAuthRetryableFetchError(cause);
+    // "Database error finding user" / similar transient backend hiccups.
+    const isDatabaseError =
+      isAuthApiError(cause) && cause.message.includes("Database error");
+    const isRateLimitError = isAuthApiError(cause) && cause.status === 429;
 
-    if (
-      isAuthApiError(cause) &&
-      cause.message === "Invalid login credentials"
-    ) {
-      message = "Incorrect email or password";
-      shouldBeCaptured = false;
-    }
+    const message = isInvalidCredentials
+      ? "Incorrect email or password"
+      : "Something went wrong. Please try again later or contact support.";
 
     throw new ShelfError({
       cause,
       message,
       label,
-      shouldBeCaptured,
+      shouldBeCaptured: !(
+        isInvalidCredentials ||
+        isTransientFetchError ||
+        isDatabaseError ||
+        isRateLimitError
+      ),
     });
   }
 }
@@ -284,6 +291,17 @@ export async function sendOTP(email: string) {
   } catch (cause) {
     // @ts-expect-error
     const isRateLimitError = cause.code === "over_email_send_rate_limit";
+    // Supabase 504s and intermittent fetch failures resolve on retry.
+    const isTransientFetchError = isAuthRetryableFetchError(cause);
+    // "Database error finding user" — Supabase backend hiccup, not actionable.
+    const isDatabaseError =
+      isAuthApiError(cause) && cause.message.includes("Database error");
+    // SSO-mismatch / similar `validateNonSSOUser` rejections already opt out
+    // via their own `shouldBeCaptured: false` — preserve that decision.
+    const inheritedShouldBeCaptured = isLikeShelfError(cause)
+      ? cause.shouldBeCaptured
+      : undefined;
+
     const fallbackMessage =
       "Something went wrong while sending the OTP. Please try again later or contact support.";
 
@@ -300,7 +318,10 @@ export async function sendOTP(email: string) {
       message: hasUsableMessage ? cause.message : fallbackMessage,
       additionalData: { email },
       label,
-      shouldBeCaptured: isRateLimitError ? false : undefined,
+      shouldBeCaptured:
+        inheritedShouldBeCaptured === false
+          ? false
+          : !(isRateLimitError || isTransientFetchError || isDatabaseError),
     });
   }
 }

--- a/apps/webapp/app/modules/auth/service.server.ts
+++ b/apps/webapp/app/modules/auth/service.server.ts
@@ -296,7 +296,12 @@ export async function sendOTP(email: string) {
       typeof cause === "object" && cause !== null && "code" in cause
         ? (cause as { code: unknown }).code
         : undefined;
-    const isRateLimitError = errorCode === "over_email_send_rate_limit";
+    // Match `signInWithEmail`'s rate-limit handling: cover both the
+    // Supabase OTP-specific `over_email_send_rate_limit` code and the
+    // generic HTTP 429 `AuthApiError` (which can carry a different code).
+    const isRateLimitError =
+      errorCode === "over_email_send_rate_limit" ||
+      (isAuthApiError(cause) && cause.status === 429);
     // Supabase 504s and intermittent fetch failures resolve on retry.
     const isTransientFetchError = isAuthRetryableFetchError(cause);
     // "Database error finding user" — Supabase backend hiccup, not actionable.

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -1495,16 +1495,20 @@ export async function updateLocationAssets({
         },
       })
       .catch((cause) => {
-        throw new ShelfError({
-          cause,
-          message: "Location not found",
-          additionalData: { locationId, userId, organizationId },
-          status: 404,
-          label: "Location",
-          // Suppress only true Prisma not-found (P2025); let DB / connectivity
-          // failures bubble up to Sentry as 5xx.
-          shouldBeCaptured: !isNotFoundError(cause),
-        });
+        // Only the genuine "record not found" path should become a
+        // user-facing 404. Re-throw anything else so the outer try/catch
+        // (or `makeShelfError`) can wrap it as a 5xx with capture enabled.
+        if (isNotFoundError(cause)) {
+          throw new ShelfError({
+            cause,
+            message: "Location not found",
+            additionalData: { locationId, userId, organizationId },
+            status: 404,
+            label: "Location",
+            shouldBeCaptured: false,
+          });
+        }
+        throw cause;
       });
 
     /**
@@ -1689,16 +1693,20 @@ export async function updateLocationKits({
         },
       })
       .catch((cause) => {
-        throw new ShelfError({
-          cause,
-          message: "Location not found",
-          additionalData: { locationId, userId, organizationId },
-          status: 404,
-          label: "Location",
-          // Suppress only true Prisma not-found (P2025); let DB / connectivity
-          // failures bubble up to Sentry as 5xx.
-          shouldBeCaptured: !isNotFoundError(cause),
-        });
+        // Only the genuine "record not found" path should become a
+        // user-facing 404. Re-throw anything else so the outer try/catch
+        // (or `makeShelfError`) can wrap it as a 5xx with capture enabled.
+        if (isNotFoundError(cause)) {
+          throw new ShelfError({
+            cause,
+            message: "Location not found",
+            additionalData: { locationId, userId, organizationId },
+            status: 404,
+            label: "Location",
+            shouldBeCaptured: false,
+          });
+        }
+        throw cause;
       });
 
     /**

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -1501,6 +1501,9 @@ export async function updateLocationAssets({
           additionalData: { locationId, userId, organizationId },
           status: 404,
           label: "Location",
+          // Suppress only true Prisma not-found (P2025); let DB / connectivity
+          // failures bubble up to Sentry as 5xx.
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 
@@ -1692,6 +1695,9 @@ export async function updateLocationKits({
           additionalData: { locationId, userId, organizationId },
           status: 404,
           label: "Location",
+          // Suppress only true Prisma not-found (P2025); let DB / connectivity
+          // failures bubble up to Sentry as 5xx.
+          shouldBeCaptured: !isNotFoundError(cause),
         });
       });
 

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -323,7 +323,7 @@ export function isZodValidationError(cause: unknown) {
 export function makeShelfError(
   cause: unknown,
   additionalData?: AdditionalData,
-  shouldBeCaptured: boolean = true
+  shouldBeCaptured?: boolean
 ) {
   if (isAbortError(cause)) {
     return new ShelfError({
@@ -367,8 +367,8 @@ export function makeShelfError(
   // a route did `findUniqueOrThrow().catch(makeShelfError)` without wrapping
   // the not-found case explicitly. Surface a 404 and skip Sentry capture by
   // default — these are user-facing "the thing you asked for doesn't exist"
-  // outcomes, not engineering bugs. Callers that genuinely want to capture
-  // a not-found can still pass `shouldBeCaptured: true` explicitly.
+  // outcomes, not engineering bugs. Callers can still force capture with
+  // an explicit `shouldBeCaptured: true` argument.
   if (isNotFoundError(cause)) {
     return new ShelfError({
       cause,
@@ -376,17 +376,19 @@ export function makeShelfError(
       additionalData,
       label: "Unknown",
       status: 404,
-      shouldBeCaptured: false,
+      shouldBeCaptured: shouldBeCaptured ?? false,
     });
   }
 
   // 🤷‍♂️ We don't know what this error is, so we create a new default one.
+  // Default to `true` for the unknown-error path: an unrecognised throw
+  // really should reach Sentry unless a caller explicitly opts out.
   return new ShelfError({
     cause,
     message: "Sorry, something went wrong.",
     additionalData,
     label: "Unknown",
-    shouldBeCaptured,
+    shouldBeCaptured: shouldBeCaptured ?? true,
   });
 }
 

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -363,6 +363,23 @@ export function makeShelfError(
     });
   }
 
+  // Bare Prisma `P2025` (record not found) reaching the catch-all path means
+  // a route did `findUniqueOrThrow().catch(makeShelfError)` without wrapping
+  // the not-found case explicitly. Surface a 404 and skip Sentry capture by
+  // default — these are user-facing "the thing you asked for doesn't exist"
+  // outcomes, not engineering bugs. Callers that genuinely want to capture
+  // a not-found can still pass `shouldBeCaptured: true` explicitly.
+  if (isNotFoundError(cause)) {
+    return new ShelfError({
+      cause,
+      message: "The requested resource could not be found.",
+      additionalData,
+      label: "Unknown",
+      status: 404,
+      shouldBeCaptured: false,
+    });
+  }
+
   // 🤷‍♂️ We don't know what this error is, so we create a new default one.
   return new ShelfError({
     cause,


### PR DESCRIPTION
Three related changes that target the highest-volume "Something went wrong" wrappers in the last 14 days of Sentry data:

- `signInWithEmail` (issue 1G8, 53 events) and `sendOTP` (issue 1G9, 9 events) now mirror the existing `createEmailAuthAccount` / `signUpWithEmailPass` pattern: suppress capture for `AuthRetryableFetchError` (Supabase 504s and intermittent fetch failures), `AuthApiError` whose message contains "Database error" (Supabase backend hiccups that resolve on retry), and rate-limit responses. `sendOTP` also forwards an inherited `shouldBeCaptured: false` from `validateNonSSOUser` so SSO-mismatch rejections stay suppressed.

- `updateLocationKits` (issue 1GN, 11 events) and `updateLocationAssets` (issue 1GM, 7 events): the `findUniqueOrThrow().catch` wrappers now gate `shouldBeCaptured` on `!isNotFoundError(cause)` so a deleted-between-load-and-submit location surfaces as a 404 without paging Sentry.

- `makeShelfError` now defaults Prisma `P2025` (record not found) to a 404 with `shouldBeCaptured: false` instead of letting it fall through as "Sorry, something went wrong" with capture enabled. This catches the whole class of routes that do a naked `.catch(makeShelfError)` on a Prisma operation (issue 1GG and several smaller ones). Callers who genuinely want to capture a not-found can still pass `shouldBeCaptured: true` explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication error handling improved: clearer "Incorrect email or password" messaging, broader detection of rate limits and transient/database errors, and suppression of error reporting for those cases.
  * Location updates now return 404 only for truly missing resources; other lookup failures surface as server errors.
  * Error builder defaults updated to treat missing-records as 404 and to refine default error-capture behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->