### PR TITLE
fix(sentry): finish weekly cleanup — wrap-aware not-found, hard-filte…

### DIFF
--- a/apps/webapp/app/entry.client.tsx
+++ b/apps/webapp/app/entry.client.tsx
@@ -31,12 +31,17 @@ if (window.env?.SENTRY_DSN) {
         return null;
       }
 
-      // Suppress consecutive HTTP on /assets/new — React Router form + revalidation
+      // Suppress consecutive HTTP on /assets/new. The route inherently
+      // chains form submit + revalidation + image upload across multiple
+      // HTTP spans, which Sentry's perf detector groups as
+      // `performance_consecutive_http`. Drop any transaction on this route
+      // that includes the form-data submit span — the previous threshold
+      // (`> 1` matching spans) was too narrow and let most events through.
       if (event.transaction === "/assets/new") {
-        const assetNewSpans = spans.filter(
+        const hasAssetNewDataSpan = spans.some(
           (s) => s.description?.includes("/assets/new.data")
         );
-        if (assetNewSpans.length > 1) {
+        if (hasAssetNewDataSpan) {
           return null;
         }
       }
@@ -44,44 +49,28 @@ if (window.env?.SENTRY_DSN) {
       return event;
     },
     beforeSend(event) {
-      // Always send errors from the error boundary — these are user-visible
-      // crashes that must be searchable by the Error ID shown to the user.
-      // Sentry.captureException() returns the event ID synchronously before
-      // beforeSend runs, so filtering here would silently drop the event
-      // while the UI still displays the (now-orphaned) Error ID.
-      if (event.tags?.source === "error-boundary") {
-        return event;
-      }
-
       const message = event.exception?.values?.[0]?.value || "";
 
-      // Filter browser compatibility / extension errors (not actionable)
-      const ignoredPatterns = [
-        "feature named",
-        "Unexpected identifier 'https'",
+      // Hard-filter browser/framework quirks that are not actionable even
+      // when they bubble up through React Router's error boundary. These
+      // are stream-decode races, React reconciliation aborts mid-navigation,
+      // and browser-extension DOM mutation collisions — all known noise
+      // with no app-side fix. Tradeoff: when one of these surfaces in the
+      // UI, the displayed Error ID will not exist in Sentry. That is
+      // acceptable here because the error itself is not actionable; the
+      // user is told to retry, and Sentry would only collect duplicate
+      // reports of the same untriageable race.
+      const hardIgnoredPatterns = [
         "Unable to decode turbo-stream",
         "Error in input stream",
       ];
-      if (ignoredPatterns.some((pattern) => message.includes(pattern))) {
+      if (hardIgnoredPatterns.some((pattern) => message.includes(pattern))) {
         return null;
       }
 
-      // Filter non-Error promise rejections with value: false
-      if (message === "false") {
-        return null;
-      }
-
-      // Filter client-side network errors (not actionable)
-      if (
-        message.includes("Load failed") ||
-        message.includes("Failed to fetch") ||
-        message.includes("NetworkError") ||
-        message.includes("fetch failed")
-      ) {
-        return null;
-      }
-
-      // Filter DOM errors from browser extensions (removeChild/insertBefore on non-child)
+      // Same hard-filter for the NotFoundError variants from React DOM
+      // reconciliation (`removeChild`/`insertBefore` on a non-child).
+      // These reach the error boundary because they happen during commit.
       if (
         event.exception?.values?.some(
           (v) =>
@@ -93,8 +82,62 @@ if (window.env?.SENTRY_DSN) {
         return null;
       }
 
-      // Filter unknown/empty error messages (no actionable info)
+      // Hard-filter client-side network errors and aborted requests
+      // regardless of source — they bubble up through React Router's error
+      // boundary when a route loader's fetch is interrupted, but they are
+      // *never* actionable from app code (user closed the tab, lost
+      // connection, hit back, or the browser cancelled an in-flight load).
+      // Same Error-ID tradeoff as the hard-filtered patterns above. Also
+      // check `exception.type` for `AbortError` — Sentry serializes the
+      // error name into `.type` separately from `.value` (the message),
+      // and some AbortErrors arrive with empty/generic messages.
+      if (
+        message.includes("Load failed") ||
+        message.includes("Failed to fetch") ||
+        message.includes("NetworkError") ||
+        message.includes("fetch failed") ||
+        message.includes("AbortError") ||
+        message.includes("The operation was aborted") ||
+        message.includes("Fetch is aborted") ||
+        event.exception?.values?.some((v) => v.type === "AbortError")
+      ) {
+        return null;
+      }
+
+      // Hard-filter `<unknown>` messages: these carry no signal, and the
+      // error-boundary path produces them when the failure has no
+      // serializable shape (cross-origin script errors, etc.).
       if (message === "<unknown>") {
+        return null;
+      }
+
+      // Always send remaining errors from the error boundary — these are
+      // user-visible crashes that must be searchable by the Error ID shown
+      // to the user. Sentry.captureException() returns the event ID
+      // synchronously before beforeSend runs, so filtering past this point
+      // would silently drop the event while the UI still displays the
+      // (now-orphaned) Error ID.
+      if (event.tags?.source === "error-boundary") {
+        return event;
+      }
+
+      // Filter browser compatibility / extension errors (not actionable).
+      // "Expected fetcher: " and "No result found for routeId" are React
+      // Router internal races during navigation. "Cannot submit a <button>"
+      // is a fetcher.submit edge case from React Router's form helper.
+      const ignoredPatterns = [
+        "feature named",
+        "Unexpected identifier 'https'",
+        "Expected fetcher: ",
+        "No result found for routeId",
+        "Cannot submit a <button>",
+      ];
+      if (ignoredPatterns.some((pattern) => message.includes(pattern))) {
+        return null;
+      }
+
+      // Filter non-Error promise rejections with value: false
+      if (message === "false") {
         return null;
       }
 

--- a/apps/webapp/app/modules/asset-reminder/service.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/service.server.ts
@@ -296,7 +296,14 @@ export async function editAssetReminder({
       cause,
       message,
       label,
-      shouldBeCaptured: !isNotFoundError(cause),
+      // Forward the inner ShelfError's decision when the cause is already
+      // a ShelfError — otherwise this wrapper re-captures intentional 4xx
+      // throws like the stale-team-member validator (`shouldBeCaptured:
+      // false`) or the "Edit is not allowed" guard above. Fall back to the
+      // Prisma not-found check for raw causes.
+      shouldBeCaptured: isLikeShelfError(cause)
+        ? cause.shouldBeCaptured
+        : !isNotFoundError(cause),
     });
   }
 }
@@ -320,7 +327,11 @@ export async function deleteAssetReminder({
         ? "Reminder not found or you are viewing in wrong organization."
         : "Something went wrong while deleting reminder.",
       label,
-      shouldBeCaptured: !isNotFoundError(cause),
+      // Forward the inner ShelfError's decision when present so this
+      // wrapper does not re-capture intentional 4xx throws.
+      shouldBeCaptured: isLikeShelfError(cause)
+        ? cause.shouldBeCaptured
+        : !isNotFoundError(cause),
     });
   }
 }

--- a/apps/webapp/app/modules/asset-reminder/service.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/service.server.ts
@@ -109,11 +109,20 @@ async function validateTeamMembersForReminder(
   });
 
   if (teamMembersWithUserCount !== teamMembers.length) {
+    // Stale form state: a team member the user selected has since been
+    // removed, lost their linked user account, or never belonged to this
+    // workspace. This is a 4xx, not a 5xx — surface it without paging.
     throw new ShelfError({
       cause: null,
       label,
       message:
-        "Something went wrong while validating team members for reminder. Please contact support",
+        "One or more selected team members are no longer available. Please refresh the page and pick recipients again.",
+      additionalData: {
+        requestedTeamMemberCount: teamMembers.length,
+        validTeamMemberCount: teamMembersWithUserCount,
+      },
+      status: 400,
+      shouldBeCaptured: false,
     });
   }
 }
@@ -287,6 +296,7 @@ export async function editAssetReminder({
       cause,
       message,
       label,
+      shouldBeCaptured: !isNotFoundError(cause),
     });
   }
 }
@@ -310,6 +320,7 @@ export async function deleteAssetReminder({
         ? "Reminder not found or you are viewing in wrong organization."
         : "Something went wrong while deleting reminder.",
       label,
+      shouldBeCaptured: !isNotFoundError(cause),
     });
   }
 }

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -168,6 +168,7 @@ export async function fetchAllAuditPdfRelatedData(
           message: "You don't have permission to view this audit",
           status: 403,
           label: "Audit",
+          shouldBeCaptured: false,
         });
       }
     }

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1753,6 +1753,7 @@ export function requireAuditAssigneeForBaseSelfService({
         additionalData: { auditId, userId },
         status: 403,
         label,
+        shouldBeCaptured: false,
       });
     }
   }

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -210,7 +210,13 @@ export function isLikeShelfError(cause: unknown): cause is ShelfError {
   );
 }
 
-function isAbortError(cause: unknown) {
+/**
+ * Detects whether an error (or any error in its `cause` chain) represents a
+ * cancelled / aborted request. Used to suppress noise from client disconnects
+ * and stream-handler aborts both in `makeShelfError` and in the Sentry
+ * `beforeSend` hook on the server.
+ */
+export function isAbortError(cause: unknown) {
   if (!cause) {
     return false;
   }
@@ -218,10 +224,13 @@ function isAbortError(cause: unknown) {
   if (cause instanceof Error) {
     const name = cause.name?.toLowerCase?.() ?? "";
     const message = cause.message?.toLowerCase?.() ?? "";
-    const code =
-      "code" in cause && typeof (cause as any).code === "string"
-        ? (cause as any).code
-        : "";
+    // Read `code` by narrowing from `unknown` rather than `any` — some error
+    // shapes (Node `ECONNRESET`, AbortSignal, etc.) carry it as a sibling
+    // field. Other browser-side AbortError variants surface their reason via
+    // `message` ("The operation was aborted", "Fetch is aborted") and are
+    // already covered by the message checks below.
+    const codeCandidate: unknown = (cause as { code?: unknown }).code;
+    const code = typeof codeCandidate === "string" ? codeCandidate : "";
 
     if (name === "aborterror") {
       return true;
@@ -230,6 +239,8 @@ function isAbortError(cause: unknown) {
     if (
       message.includes("call aborted") ||
       message.includes("request aborted") ||
+      message.includes("the operation was aborted") ||
+      message.includes("fetch is aborted") ||
       message === "aborted" ||
       code === "ECONNRESET"
     ) {
@@ -310,6 +321,21 @@ function hasTransientCause(error: unknown): boolean {
 }
 
 /**
+ * Walks the cause chain of an error to detect if a Prisma `P2025`
+ * (record-not-found) error is buried inside ShelfError wrappers. Used by
+ * `makeShelfError` so that a `prisma.x.update()` failure on a
+ * deleted-since-load record collapses to a 404 even when a service-layer
+ * `try/catch` already re-wrapped it as a generic 5xx ShelfError.
+ */
+function hasNotFoundCause(error: unknown): boolean {
+  if (isNotFoundError(error)) return true;
+  if (typeof error === "object" && error !== null && "cause" in error) {
+    return hasNotFoundCause((error as { cause: unknown }).cause);
+  }
+  return false;
+}
+
+/**
  * This function is used to check if the error is a zod validation error.
  */
 export function isZodValidationError(cause: unknown) {
@@ -350,6 +376,29 @@ export function makeShelfError(
     });
   }
 
+  // Detect Prisma `P2025` (record not found) anywhere in the cause chain —
+  // even when a service-layer `try/catch` already re-wrapped it as a generic
+  // 5xx ShelfError. Race conditions like "asset deleted between form load
+  // and submit" surface here, and they belong as 404s, not as paged 5xxs.
+  // We preserve the wrapper's user-facing message + label when present so
+  // the toast still says "Booking not found, are you sure …" rather than
+  // a generic message; only the status and capture decision change.
+  // Callers can force capture with an explicit `shouldBeCaptured: true`.
+  if (hasNotFoundCause(cause)) {
+    const wrapper = isLikeShelfError(cause) ? cause : null;
+    return new ShelfError({
+      cause,
+      message: wrapper?.message ?? "The requested resource could not be found.",
+      label: wrapper?.label ?? "Unknown",
+      additionalData: {
+        ...(wrapper?.additionalData ?? {}),
+        ...additionalData,
+      },
+      status: 404,
+      shouldBeCaptured: shouldBeCaptured ?? false,
+    });
+  }
+
   if (isLikeShelfError(cause)) {
     // copy the original error and fill in the maybe missing fields like status or traceId
     return new ShelfError({
@@ -360,23 +409,6 @@ export function makeShelfError(
       },
       shouldBeCaptured:
         "shouldBeCaptured" in cause ? cause.shouldBeCaptured : shouldBeCaptured,
-    });
-  }
-
-  // Bare Prisma `P2025` (record not found) reaching the catch-all path means
-  // a route did `findUniqueOrThrow().catch(makeShelfError)` without wrapping
-  // the not-found case explicitly. Surface a 404 and skip Sentry capture by
-  // default — these are user-facing "the thing you asked for doesn't exist"
-  // outcomes, not engineering bugs. Callers can still force capture with
-  // an explicit `shouldBeCaptured: true` argument.
-  if (isNotFoundError(cause)) {
-    return new ShelfError({
-      cause,
-      message: "The requested resource could not be found.",
-      additionalData,
-      label: "Unknown",
-      status: 404,
-      shouldBeCaptured: shouldBeCaptured ?? false,
     });
   }
 


### PR DESCRIPTION
…r network noise

Closes the long tail of unresolved Sentry issues left after PRs #2496 and #2497 by tightening four orthogonal pieces:

- `makeShelfError`: add `hasNotFoundCause` (mirrors `hasTransientCause`) so any Prisma `P2025` buried inside a service-layer ShelfError wrapper collapses to a 404 with capture suppressed. The previous bare-P2025 branch handled `findUniqueOrThrow().catch(makeShelfError)` only; this version also catches `createBooking`, `updateAssetCustody`, `updateBookingNotificationRecipients`, `bulkDeleteKits`, `bulkDeleteCategories`, etc. — anywhere a wrapper rethrows the original P2025 as the new ShelfError's `cause`. The wrapper's message + label are preserved so toasts stay specific. Catches issues 1BP, 1GX, 1GT, 1G3, 1G2, 1GA, 1GY, 1G4, 1FQ, 1FP, 17P, and the cascading `/assets.data` chain (1H8, 1H7, 1H6, 1H5, 1H4, 1H3) seen 16 hours ago.
- `entry.client.tsx`: move `Load failed` / `Failed to fetch` / `NetworkError` / `fetch failed` / `AbortError` (message + type) / `<unknown>` filters above the error-boundary early-exit. They were bypassed because every error-boundary event short-circuits filtering. Tradeoff documented inline: Error IDs surfaced for these patterns will not exist in Sentry, but the errors aren't actionable anyway. Catches issues 1AX (50 events), 1EB, 1FZ, 1FS, 1FY, 1GE, 1GP, 1FX, 1H9, 1GC, 1GD, 1FH, 1H2, 1D7. Also re-applies the missing `event.exception?.values?.some((v) => v.type === "AbortError")` type check so AbortErrors with empty messages are caught.
- `validateTeamMembersForReminder` (asset-reminder service): the count-mismatch path now throws a 400 with `shouldBeCaptured: false` and a friendlier "team members no longer available" message. The previous 500 + "contact support" was misleading — the real cause is stale form state (a team member was removed between picker render and submit). Catches issue 1H0.
- Audit permission throws (`pdf-helpers.ts`, `service.server.ts`): add `shouldBeCaptured: false` to the two "You don't have permission to view this audit" 403 sites. These are deliberate 4xx outcomes, not engineering bugs. Catches issue 1FR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise in error reporting by improving suppression rules for performance traces and UI errors, and by broadening abort/error detection to avoid spurious captures.
  * Asset reminder recipient validation now returns clearer 400 responses when selections are stale/invalid.
  * Certain audit access denials now consistently produce uncaptured 403 errors.
  * Improved mapping of nested “not found” database errors to user-facing 404s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->