### PR TITLE
fix(working-hours): compare override dates as absolute calendar days

### DIFF
--- a/apps/webapp/app/components/booking/forms/forms-schema.test.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.test.ts
@@ -1,5 +1,5 @@
 import { addHours, addDays, subDays, addMinutes } from "date-fns";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import { BookingFormSchema, ExtendBookingSchema } from "./forms-schema";
 
 /**
@@ -295,5 +295,127 @@ describe("ExtendBookingSchema - time restrictions", () => {
       // Should fail because restrictions should be enforced by default
       expect(result.success).toBe(false);
     });
+  });
+});
+
+/**
+ * Regression tests for working hours override comparison across timezones.
+ *
+ * Working hours overrides are stored as UTC-midnight Date values representing
+ * an absolute calendar date. Previously, validation formatted the override
+ * date with the runtime's local timezone, which shifted the date backwards one
+ * day for users west of UTC. A user in America/Chicago that set a closed-day
+ * override for 4/24 was blocked from booking on 4/23, because the override
+ * Date (UTC midnight 4/24 = 7 PM CDT on 4/23) formatted in local time read as
+ * "2026-04-23" and falsely matched the booking's calendar day.
+ */
+describe("BookingFormSchema - override timezone handling", () => {
+  const ORIGINAL_TZ = process.env.TZ;
+
+  // Force America/Chicago so the test exercises the exact condition the user
+  // reported (CDT, UTC-5 in April). Node honors process.env.TZ dynamically.
+  beforeAll(() => {
+    process.env.TZ = "America/Chicago";
+  });
+
+  afterAll(() => {
+    process.env.TZ = ORIGINAL_TZ;
+  });
+
+  const baseBookingSettings = {
+    bufferStartTime: 0,
+    tagsRequired: false,
+    maxBookingLength: null,
+    maxBookingLengthSkipClosedDays: false,
+  };
+
+  const workingHoursWith424Closed = {
+    enabled: true,
+    weeklySchedule: {
+      "0": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
+      "1": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
+      "2": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
+      "3": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
+      "4": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
+      "5": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
+      "6": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
+    },
+    // Override stored the way createWorkingHoursOverride does: new Date("2026-04-24")
+    // which yields UTC midnight on April 24.
+    overrides: [
+      {
+        id: "override-1",
+        date: new Date("2026-04-24").toISOString(),
+        isOpen: false,
+        openTime: null,
+        closeTime: null,
+        reason: "Closed",
+      },
+    ],
+  };
+
+  it("does not flag a 4/23 booking as closed when the override is for 4/24", () => {
+    const schema = BookingFormSchema({
+      hints: { timeZone: "America/Chicago" } as any,
+      action: "new",
+      workingHours: workingHoursWith424Closed,
+      bookingSettings: baseBookingSettings,
+      isAdminOrOwner: true, // Bypass buffer check so we isolate the override logic
+    });
+
+    // Booking on 4/23 in the user's local time.
+    const startDate = new Date("2026-04-23T17:00:00-05:00"); // 4/23 5 PM CDT
+    const endDate = new Date("2026-04-23T18:00:00-05:00");
+
+    const result = schema.safeParse({
+      name: "Test Booking",
+      startDate,
+      endDate,
+      custodian: JSON.stringify({
+        id: "tm-1",
+        name: "Test User",
+        userId: "user-1",
+      }),
+    });
+
+    const errorMessages = result.success
+      ? []
+      : result.error.errors.map((e) => e.message);
+
+    expect(
+      errorMessages.some((msg) => msg.toLowerCase().includes("closed"))
+    ).toBe(false);
+  });
+
+  it("still flags a 4/24 booking as closed when the override is for 4/24", () => {
+    const schema = BookingFormSchema({
+      hints: { timeZone: "America/Chicago" } as any,
+      action: "new",
+      workingHours: workingHoursWith424Closed,
+      bookingSettings: baseBookingSettings,
+      isAdminOrOwner: true,
+    });
+
+    const startDate = new Date("2026-04-24T10:00:00-05:00");
+    const endDate = new Date("2026-04-24T11:00:00-05:00");
+
+    const result = schema.safeParse({
+      name: "Test Booking",
+      startDate,
+      endDate,
+      custodian: JSON.stringify({
+        id: "tm-1",
+        name: "Test User",
+        userId: "user-1",
+      }),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const errorMessages = result.error.errors.map((e) => e.message);
+      expect(
+        errorMessages.some((msg) => msg.toLowerCase().includes("closed"))
+      ).toBe(true);
+    }
   });
 });

--- a/apps/webapp/app/components/booking/forms/forms-schema.test.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.test.ts
@@ -319,7 +319,14 @@ describe("BookingFormSchema - override timezone handling", () => {
   });
 
   afterAll(() => {
-    process.env.TZ = ORIGINAL_TZ;
+    // Assigning `process.env.TZ = undefined` would write the literal string
+    // "undefined" and leak into other tests in the same vitest worker, so
+    // delete the var when it was originally unset.
+    if (ORIGINAL_TZ === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = ORIGINAL_TZ;
+    }
   });
 
   const baseBookingSettings = {
@@ -329,6 +336,9 @@ describe("BookingFormSchema - override timezone handling", () => {
     maxBookingLengthSkipClosedDays: false,
   };
 
+  // Dates are pinned in 2099 so the "must be in the future" guard never trips
+  // — the TZ boundary scenario (UTC-midnight override on day D matching a
+  // day-D-1 booking in CDT) is year-independent.
   const workingHoursWith424Closed = {
     enabled: true,
     weeklySchedule: {
@@ -340,12 +350,12 @@ describe("BookingFormSchema - override timezone handling", () => {
       "5": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
       "6": { isOpen: true, openTime: "00:00", closeTime: "23:59" },
     },
-    // Override stored the way createWorkingHoursOverride does: new Date("2026-04-24")
+    // Override stored the way createWorkingHoursOverride does: new Date("2099-04-24")
     // which yields UTC midnight on April 24.
     overrides: [
       {
         id: "override-1",
-        date: new Date("2026-04-24").toISOString(),
+        date: new Date("2099-04-24").toISOString(),
         isOpen: false,
         openTime: null,
         closeTime: null,
@@ -364,8 +374,8 @@ describe("BookingFormSchema - override timezone handling", () => {
     });
 
     // Booking on 4/23 in the user's local time.
-    const startDate = new Date("2026-04-23T17:00:00-05:00"); // 4/23 5 PM CDT
-    const endDate = new Date("2026-04-23T18:00:00-05:00");
+    const startDate = new Date("2099-04-23T17:00:00-05:00"); // 4/23 5 PM CDT
+    const endDate = new Date("2099-04-23T18:00:00-05:00");
 
     const result = schema.safeParse({
       name: "Test Booking",
@@ -378,13 +388,10 @@ describe("BookingFormSchema - override timezone handling", () => {
       }),
     });
 
-    const errorMessages = result.success
-      ? []
-      : result.error.errors.map((e) => e.message);
-
-    expect(
-      errorMessages.some((msg) => msg.toLowerCase().includes("closed"))
-    ).toBe(false);
+    // With isAdminOrOwner=true + 24/7 schedule + no matching override, the
+    // booking must parse cleanly. Asserting .success directly guards against
+    // unrelated validation regressions beyond the "closed" message.
+    expect(result.success).toBe(true);
   });
 
   it("still flags a 4/24 booking as closed when the override is for 4/24", () => {
@@ -396,8 +403,8 @@ describe("BookingFormSchema - override timezone handling", () => {
       isAdminOrOwner: true,
     });
 
-    const startDate = new Date("2026-04-24T10:00:00-05:00");
-    const endDate = new Date("2026-04-24T11:00:00-05:00");
+    const startDate = new Date("2099-04-24T10:00:00-05:00");
+    const endDate = new Date("2099-04-24T11:00:00-05:00");
 
     const result = schema.safeParse({
       name: "Test Booking",

--- a/apps/webapp/app/components/booking/forms/forms-schema.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { WorkingHoursData } from "~/modules/working-hours/types";
 import {
   calculateBusinessHoursDuration,
+  getOverrideDateKey,
   normalizeWorkingHoursForValidation,
 } from "~/modules/working-hours/utils";
 import type { getHints } from "~/utils/client-hints";
@@ -29,11 +30,14 @@ function validateWorkingHours(
   const timeString = format(dateTime, "HH:mm");
   const dateString = format(dateTime, "yyyy-MM-dd");
 
-  // Check for date-specific overrides first
-  const override = workingHours.overrides.find((override) => {
-    const overrideDate = format(override.date, "yyyy-MM-dd");
-    return overrideDate === dateString;
-  });
+  // Check for date-specific overrides first. Overrides are stored as
+  // UTC-midnight timestamps that represent an absolute calendar date, so we
+  // read their date key from UTC instead of formatting in the runtime's local
+  // timezone — otherwise a "4/24 closed" override ends up matching a 4/23
+  // booking for any user west of UTC (America/* timezones).
+  const override = workingHours.overrides.find(
+    (override) => getOverrideDateKey(override.date) === dateString
+  );
 
   if (override) {
     if (!override.isOpen) {

--- a/apps/webapp/app/components/working-hours/working-hours-preview-dialog.tsx
+++ b/apps/webapp/app/components/working-hours/working-hours-preview-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { format } from "date-fns";
 import { CalendarDays, Clock, AlertCircle, Info } from "lucide-react";
 import { Dialog, DialogPortal } from "~/components/layout/dialog";
 import { DateS } from "~/components/shared/date";
@@ -9,15 +10,23 @@ import {
   DAY_NAMES,
 } from "~/modules/working-hours/constants";
 import type { WorkingHoursData } from "~/modules/working-hours/types";
+import { getOverrideDateKey } from "~/modules/working-hours/utils";
 import { tw } from "~/utils/tw";
 import { Button } from "../shared/button";
 
-// Check if date is upcoming (within next 30 days)
-const isUpcoming = (dateString: string | Date): boolean => {
-  const date = new Date(dateString);
+// Overrides are absolute calendar dates, so compare them as YYYY-MM-DD strings
+// against today's local calendar day. `new Date("YYYY-MM-DD")` would parse as
+// UTC midnight and incorrectly include/exclude dates near the boundary for
+// users west of UTC.
+const isUpcoming = (dateInput: string | Date): boolean => {
+  const overrideKey = getOverrideDateKey(dateInput);
   const now = new Date();
-  const thirtyDaysFromNow = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
-  return date >= now && date <= thirtyDaysFromNow;
+  const todayKey = format(now, "yyyy-MM-dd");
+  const thirtyDaysOutKey = format(
+    new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000),
+    "yyyy-MM-dd"
+  );
+  return overrideKey >= todayKey && overrideKey <= thirtyDaysOutKey;
 };
 
 interface WeeklyScheduleGridProps {
@@ -96,7 +105,11 @@ interface OverridesSectionProps {
 const OverridesSection = ({ overrides }: OverridesSectionProps) => {
   const upcomingOverrides = overrides
     .filter((override) => isUpcoming(override.date))
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+    // YYYY-MM-DD strings sort lexicographically in calendar order, avoiding
+    // the UTC parsing pitfall above.
+    .sort((a, b) =>
+      getOverrideDateKey(a.date).localeCompare(getOverrideDateKey(b.date))
+    )
     .slice(0, 5); // Show only next 5
 
   if (upcomingOverrides.length === 0) {

--- a/apps/webapp/app/modules/working-hours/types.ts
+++ b/apps/webapp/app/modules/working-hours/types.ts
@@ -1,10 +1,18 @@
 import type { Prisma, WorkingHoursOverride } from "@prisma/client";
 
+/**
+ * Working-hours times are wall-clock "HH:MM" strings (24-hour). They describe
+ * when a physical location is open, so they are always interpreted as local
+ * wall-clock time — there is no timezone conversion at any point. Every time
+ * field on the types below (`openTime`, `closeTime`, `start`, `end`, …)
+ * follows this contract.
+ */
+
 // TypeScript types for JSON schedule
 export interface DaySchedule {
   isOpen: boolean;
-  openTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
-  closeTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  openTime?: string;
+  closeTime?: string;
 }
 
 export interface WeeklyScheduleJson {
@@ -25,8 +33,8 @@ export enum DayOfWeek {
   SATURDAY = 6,
 }
 export interface TimeSlot {
-  openTime: string | null; // Format: "HH:MM" wall-clock (24-hour). See DaySchedule for the wall-clock rationale.
-  closeTime: string | null; // Format: "HH:MM" wall-clock (24-hour). See DaySchedule for the wall-clock rationale.
+  openTime: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
+  closeTime: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
 }
 
 export interface WorkingHoursConfig {
@@ -37,10 +45,28 @@ export interface WorkingHoursConfig {
   updatedAt: Date;
 }
 
+/**
+ * Override shape after passing through the normalize/serialize boundary
+ * (`normalizeWorkingHoursForValidation` or the working-hours API route).
+ * `date` is collapsed from Prisma's UTC-midnight Date to an absolute
+ * "YYYY-MM-DD" string so downstream comparisons cannot re-interpret it in a
+ * local timezone.
+ */
+export type NormalizedWorkingHoursOverride = Omit<
+  WorkingHoursOverride,
+  "date"
+> & {
+  date: string;
+};
+
 export interface WorkingHoursData {
   enabled: boolean;
   weeklySchedule: WeeklyScheduleJson;
-  overrides: WorkingHoursOverride[];
+  // At runtime, `date` may arrive as a Prisma `Date` (server-side raw Prisma
+  // payload) or as a normalized YYYY-MM-DD string (post-normalize, post-API);
+  // both forms are accepted because every comparison site funnels through
+  // `getOverrideDateKey`.
+  overrides: Array<WorkingHoursOverride | NormalizedWorkingHoursOverride>;
 }
 
 export interface WorkingHoursSchedule extends TimeSlot {
@@ -66,8 +92,8 @@ export interface CreateWorkingHoursRequest {
   schedules: Array<{
     dayOfWeek: DayOfWeek;
     isOpen: boolean;
-    openTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
-    closeTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+    openTime?: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
+    closeTime?: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
   }>;
 }
 
@@ -75,23 +101,23 @@ export interface CreateOverrideRequest {
   workingHoursId: string;
   date: string; // ISO date string
   isOpen: boolean;
-  openTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
-  closeTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  openTime?: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
+  closeTime?: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
   reason?: string;
 }
 
 export interface UpdateScheduleRequest {
   scheduleId: string;
   isOpen: boolean;
-  openTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
-  closeTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  openTime?: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
+  closeTime?: string | null; // wall-clock "HH:MM" — see docblock above DaySchedule.
 }
 
 // Utility types for business logic
 export interface BusinessHoursCheck {
   isOpen: boolean;
-  openTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
-  closeTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  openTime?: string; // wall-clock "HH:MM" — see docblock above DaySchedule.
+  closeTime?: string; // wall-clock "HH:MM" — see docblock above DaySchedule.
   source: "schedule" | "override";
   reason?: string; // Only present if from override
 }
@@ -102,8 +128,8 @@ export interface BookingTimeValidation {
     type: "outside_hours" | "closed_day" | "override_closure";
     message: string;
     suggestedTime?: {
-      start: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
-      end: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+      start: string; // wall-clock "HH:MM" — see docblock above DaySchedule.
+      end: string; // wall-clock "HH:MM" — see docblock above DaySchedule.
     };
   }>;
 }

--- a/apps/webapp/app/modules/working-hours/types.ts
+++ b/apps/webapp/app/modules/working-hours/types.ts
@@ -3,8 +3,8 @@ import type { Prisma, WorkingHoursOverride } from "@prisma/client";
 // TypeScript types for JSON schedule
 export interface DaySchedule {
   isOpen: boolean;
-  openTime?: string; // "HH:MM" format (24-hour) in UTC
-  closeTime?: string; // "HH:MM" format (24-hour) in UTC
+  openTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  closeTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
 }
 
 export interface WeeklyScheduleJson {
@@ -25,8 +25,8 @@ export enum DayOfWeek {
   SATURDAY = 6,
 }
 export interface TimeSlot {
-  openTime: string | null; // Format: "HH:MM" (24-hour) in UTC
-  closeTime: string | null; // Format: "HH:MM" (24-hour) in UTC
+  openTime: string | null; // Format: "HH:MM" wall-clock (24-hour). See DaySchedule for the wall-clock rationale.
+  closeTime: string | null; // Format: "HH:MM" wall-clock (24-hour). See DaySchedule for the wall-clock rationale.
 }
 
 export interface WorkingHoursConfig {
@@ -66,8 +66,8 @@ export interface CreateWorkingHoursRequest {
   schedules: Array<{
     dayOfWeek: DayOfWeek;
     isOpen: boolean;
-    openTime?: string | null; // "HH:MM" format (24-hour) in UTC
-    closeTime?: string | null; // "HH:MM" format (24-hour) in UTC
+    openTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+    closeTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
   }>;
 }
 
@@ -75,23 +75,23 @@ export interface CreateOverrideRequest {
   workingHoursId: string;
   date: string; // ISO date string
   isOpen: boolean;
-  openTime?: string | null; // "HH:MM" format (24-hour) in UTC
-  closeTime?: string | null; // "HH:MM" format (24-hour) in UTC
+  openTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  closeTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
   reason?: string;
 }
 
 export interface UpdateScheduleRequest {
   scheduleId: string;
   isOpen: boolean;
-  openTime?: string | null; // "HH:MM" format (24-hour) in UTC
-  closeTime?: string | null; // "HH:MM" format (24-hour) in UTC
+  openTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  closeTime?: string | null; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
 }
 
 // Utility types for business logic
 export interface BusinessHoursCheck {
   isOpen: boolean;
-  openTime?: string; // "HH:MM" format (24-hour) in UTC
-  closeTime?: string; // "HH:MM" format (24-hour) in UTC
+  openTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+  closeTime?: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
   source: "schedule" | "override";
   reason?: string; // Only present if from override
 }
@@ -102,8 +102,8 @@ export interface BookingTimeValidation {
     type: "outside_hours" | "closed_day" | "override_closure";
     message: string;
     suggestedTime?: {
-      start: string; // "HH:MM" format (24-hour) in UTC
-      end: string; // "HH:MM" format (24-hour) in UTC
+      start: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
+      end: string; // "HH:MM" wall-clock time (24-hour). Not a UTC instant — working hours describe when a physical location is open, so they are interpreted as local wall-clock times with no timezone conversion.
     };
   }>;
 }

--- a/apps/webapp/app/modules/working-hours/utils.test.ts
+++ b/apps/webapp/app/modules/working-hours/utils.test.ts
@@ -3,6 +3,7 @@ import {
   calculateBusinessHoursDuration,
   calculateEffectiveEndDate,
   getBookingDefaultStartEndTimes,
+  getOverrideDateKey,
   normalizeWorkingHoursForValidation,
 } from "./utils";
 
@@ -587,5 +588,25 @@ describe("getBookingDefaultStartEndTimes", () => {
       true
     );
     expect(adminUserResult.startDate).toBe("2025-07-25T14:10"); // Current time + 10 minutes (buffer bypassed)
+  });
+});
+
+describe("getOverrideDateKey", () => {
+  // Overrides are stored as UTC-midnight Date values that represent an absolute
+  // calendar date. Formatting them in the runtime's local timezone would shift
+  // the date backwards for users west of UTC (e.g. Central Time), which caused
+  // overrides for day D to match bookings on day D-1.
+  it("returns the YYYY-MM-DD portion of an ISO string", () => {
+    expect(getOverrideDateKey("2026-04-24T00:00:00.000Z")).toBe("2026-04-24");
+  });
+
+  it("returns the stored date for a date-only string", () => {
+    expect(getOverrideDateKey("2026-04-24")).toBe("2026-04-24");
+  });
+
+  it("returns the UTC calendar date for a Date object", () => {
+    // new Date("2026-04-24") stores UTC midnight; in any runtime timezone the
+    // override still refers to the 24th.
+    expect(getOverrideDateKey(new Date("2026-04-24"))).toBe("2026-04-24");
   });
 });

--- a/apps/webapp/app/modules/working-hours/utils.test.ts
+++ b/apps/webapp/app/modules/working-hours/utils.test.ts
@@ -609,4 +609,12 @@ describe("getOverrideDateKey", () => {
     // override still refers to the 24th.
     expect(getOverrideDateKey(new Date("2026-04-24"))).toBe("2026-04-24");
   });
+
+  it("reads the UTC calendar day for a Date not at UTC midnight", () => {
+    // Pins down the "read the UTC day, not the local day" semantic. This Date
+    // is 4/24 23:30 in CDT, which is 4/25 04:30 UTC — we expect the UTC day.
+    expect(getOverrideDateKey(new Date("2026-04-24T23:30:00-05:00"))).toBe(
+      "2026-04-25"
+    );
+  });
 });

--- a/apps/webapp/app/modules/working-hours/utils.ts
+++ b/apps/webapp/app/modules/working-hours/utils.ts
@@ -7,6 +7,26 @@ import type {
 } from "./types";
 
 /**
+ * Returns the YYYY-MM-DD key that identifies an override's calendar date.
+ *
+ * Working hours overrides represent an absolute calendar date with no time
+ * component — the DB column is `@db.Date`, which Prisma hydrates as a Date at
+ * UTC midnight. That Date is only a transport artifact: formatting it in the
+ * runtime's local timezone shifts it one day back for users west of UTC, which
+ * used to make an override for day D match bookings on day D-1. Reading the
+ * date from UTC (or treating an already-YYYY-MM-DD string as-is) preserves the
+ * absolute-date meaning.
+ */
+export function getOverrideDateKey(date: string | Date): string {
+  if (typeof date === "string") {
+    // Handles both date-only ("2026-04-24") and datetime ISO ("2026-04-24T00:00:00.000Z")
+    // inputs — the first 10 characters are the absolute calendar date in both.
+    return date.slice(0, 10);
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+/**
  * Parses form data into WeeklyScheduleJson format
  * Handles the conversion from FormData entries to properly typed schedule object
  */
@@ -67,10 +87,11 @@ export function normalizeWorkingHoursForValidation(
       weeklySchedule: rawWorkingHours.weeklySchedule as WeeklyScheduleJson,
       overrides: (rawWorkingHours.overrides || []).map((override: any) => ({
         id: String(override.id),
-        date:
-          override.date instanceof Date
-            ? override.date.toISOString()
-            : String(override.date),
+        // Overrides represent an absolute calendar date with no time component
+        // (the DB column is `@db.Date`). Normalise to "YYYY-MM-DD" so downstream
+        // comparisons never have to re-interpret a UTC-midnight Date in the
+        // runtime's local timezone.
+        date: getOverrideDateKey(override.date),
         isOpen: Boolean(override.isOpen),
         openTime: override.openTime || null,
         closeTime: override.closeTime || null,
@@ -122,14 +143,13 @@ function findNextWorkingDay(
     const checkDate = new Date(searchDate);
     checkDate.setDate(searchDate.getDate() + i);
 
-    const dateString = checkDate.toISOString().split("T")[0]; // YYYY-MM-DD format
+    const dateString = format(checkDate, "yyyy-MM-dd"); // local calendar date
     const dayOfWeek = checkDate.getDay().toString();
 
     // Check for date-specific override first
-    const override = workingHours.overrides.find((override) => {
-      const overrideDate = new Date(override.date).toISOString().split("T")[0];
-      return overrideDate === dateString;
-    });
+    const override = workingHours.overrides.find(
+      (override) => getOverrideDateKey(override.date) === dateString
+    );
 
     let daySchedule: DaySchedule | null = null;
 
@@ -167,16 +187,13 @@ function findNextWorkingDay(
       let endTime = workingDayEnd;
       if (startTime >= workingDayEnd) {
         // Find working hours for the start time's date
-        const startDateString = startTime.toISOString().split("T")[0];
+        const startDateString = format(startTime, "yyyy-MM-dd");
         const startDayOfWeek = startTime.getDay().toString();
 
         // Check for override on start date
-        const startDayOverride = workingHours.overrides.find((override) => {
-          const overrideDate = new Date(override.date)
-            .toISOString()
-            .split("T")[0];
-          return overrideDate === startDateString;
-        });
+        const startDayOverride = workingHours.overrides.find(
+          (override) => getOverrideDateKey(override.date) === startDateString
+        );
 
         let startDaySchedule: DaySchedule | null = null;
         if (startDayOverride) {
@@ -262,15 +279,15 @@ export function getBookingDefaultStartEndTimes(
     return getOriginalDefaultTimes(now, effectiveBufferStartTime);
   }
 
-  // Get today's date and schedule
-  const todayDateString = now.toISOString().split("T")[0]; // YYYY-MM-DD format
+  // Get today's date and schedule using the runtime's local calendar day so
+  // the match aligns with how the user picks times in the booking form.
+  const todayDateString = format(now, "yyyy-MM-dd");
   const todayDayOfWeek = now.getDay().toString();
 
   // Check for date-specific override first
-  const todayOverride = workingHoursData.overrides.find((override) => {
-    const overrideDate = new Date(override.date).toISOString().split("T")[0];
-    return overrideDate === todayDateString;
-  });
+  const todayOverride = workingHoursData.overrides.find(
+    (override) => getOverrideDateKey(override.date) === todayDateString
+  );
 
   let todaySchedule: DaySchedule | null = null;
 
@@ -430,10 +447,9 @@ export function calculateEffectiveEndDate(
     const dayOfWeek = currentDate.getDay().toString();
 
     // Check for date-specific override first
-    const override = workingHoursData.overrides.find((override) => {
-      const overrideDate = format(override.date, "yyyy-MM-dd");
-      return overrideDate === dateString;
-    });
+    const override = workingHoursData.overrides.find(
+      (override) => getOverrideDateKey(override.date) === dateString
+    );
 
     let isOpen: boolean;
 
@@ -495,10 +511,9 @@ export function calculateBusinessHoursDuration(
     const dayOfWeek = windowStart.getDay().toString();
 
     // Check for date-specific override first
-    const override = workingHoursData.overrides.find((override) => {
-      const overrideDate = format(override.date, "yyyy-MM-dd");
-      return overrideDate === dateString;
-    });
+    const override = workingHoursData.overrides.find(
+      (override) => getOverrideDateKey(override.date) === dateString
+    );
 
     let isOpen: boolean;
     if (override) {

--- a/apps/webapp/app/modules/working-hours/utils.ts
+++ b/apps/webapp/app/modules/working-hours/utils.ts
@@ -16,11 +16,17 @@ import type {
  * used to make an override for day D match bookings on day D-1. Reading the
  * date from UTC (or treating an already-YYYY-MM-DD string as-is) preserves the
  * absolute-date meaning.
+ *
+ * Contract: string inputs must be either date-only ("YYYY-MM-DD") or a UTC ISO
+ * timestamp ("YYYY-MM-DD…Z"). Offset-style strings like
+ * "2026-04-24T23:00:00-05:00" are not supported — producers in this codebase
+ * (the API route and `normalizeWorkingHoursForValidation`) uphold this
+ * invariant.
  */
 export function getOverrideDateKey(date: string | Date): string {
   if (typeof date === "string") {
-    // Handles both date-only ("2026-04-24") and datetime ISO ("2026-04-24T00:00:00.000Z")
-    // inputs — the first 10 characters are the absolute calendar date in both.
+    // The first 10 characters are the absolute calendar date for both
+    // date-only and UTC-ISO forms.
     return date.slice(0, 10);
   }
   return date.toISOString().slice(0, 10);

--- a/apps/webapp/app/routes/api+/$organizationId.working-hours.ts
+++ b/apps/webapp/app/routes/api+/$organizationId.working-hours.ts
@@ -46,7 +46,10 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           ...workingHours,
           overrides: workingHours.overrides.map((override) => ({
             ...override,
-            date: override.date.toISOString(),
+            // Overrides represent an absolute calendar date (no time, no TZ).
+            // Prisma returns `@db.Date` as a UTC-midnight Date; emit just the
+            // YYYY-MM-DD portion so the client never has to re-interpret it.
+            date: override.date.toISOString().slice(0, 10),
           })),
         },
       })

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1375,7 +1375,9 @@ model WorkingHours {
   // Weekly schedule stored as JSON for better performance
   // Format: { "0": { "isOpen": true, "openTime": "09:00", "closeTime": "17:00" }, ... }
   // Keys are day numbers (0=Sunday, 1=Monday, etc.)
-  // Times are stored in "HH:MM" format (24-hour) in UTC
+  // Times are wall-clock "HH:MM" (24-hour) — no timezone conversion. These
+  // describe when the physical location is open, so they are interpreted as
+  // local wall time, not UTC.
   weeklySchedule Json @default("{\"0\":{\"isOpen\":false},\"1\":{\"isOpen\":true,\"openTime\":\"09:00\",\"closeTime\":\"17:00\"},\"2\":{\"isOpen\":true,\"openTime\":\"09:00\",\"closeTime\":\"17:00\"},\"3\":{\"isOpen\":true,\"openTime\":\"09:00\",\"closeTime\":\"17:00\"},\"4\":{\"isOpen\":true,\"openTime\":\"09:00\",\"closeTime\":\"17:00\"},\"5\":{\"isOpen\":true,\"openTime\":\"09:00\",\"closeTime\":\"17:00\"},\"6\":{\"isOpen\":false}}")
 
   // Relationships
@@ -1400,7 +1402,7 @@ model WorkingHoursOverride {
   date   DateTime @db.Date
   isOpen Boolean  @default(false)
 
-  // Times stored in "HH:MM" format (24-hour) in UTC
+  // Wall-clock "HH:MM" (24-hour) — no timezone conversion (see WorkingHours).
   openTime  String? // Format: "09:00"
   closeTime String? // Format: "17:00"
   reason    String?


### PR DESCRIPTION
Working-hours overrides describe a physical-world calendar day ("closed on 4/24") with no timezone component. The DB column is already `@db.Date`, but Prisma hydrates that as a UTC-midnight Date, and validation then formatted it with the runtime's local timezone via `format(override.date, "yyyy-MM-dd")`. For users west of UTC that silently shifted each override one day earlier, so an override for 4/24 matched bookings on 4/23 and produced a spurious "This date is closed" error. The bug only surfaced on the client, since the server runs in UTC and the local-formatted date happened to round-trip.

Treat overrides as absolute dates end-to-end:

- Add `getOverrideDateKey` and route every date comparison through it — the booking form schema, `findNextWorkingDay`, `getBookingDefaultStartEndTimes`, `calculateEffectiveEndDate`, and `calculateBusinessHoursDuration`.
- Normalise `override.date` to a "YYYY-MM-DD" string inside `normalizeWorkingHoursForValidation` and the working-hours API response, so downstream code never sees a Date that could be re-interpreted locally.
- Correct the "in UTC" comments on `openTime`/`closeTime` (in both the Prisma schema and module types) — those are wall-clock strings, not UTC instants.

Regression tests force `TZ=America/Chicago` and assert both directions: a 4/23 booking no longer matches a 4/24 override, and a 4/24 booking still does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect application of working-hours overrides across timezones; override dates now align with absolute calendar dates to prevent wrong-day closures.
  * Upcoming-override detection and ordering now respect local calendar days, improving preview accuracy.

* **Documentation**
  * Clarified that stored working-hours time values are local wall-clock times (HH:MM), not UTC instants.

* **Tests**
  * Added regression tests validating date-normalization and validation behavior around local vs UTC boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->