### PR TITLE
fix(location): enforce org scope on asset and kit relational mutations

### DIFF
--- a/apps/webapp/app/modules/location/service.location-notes.test.ts
+++ b/apps/webapp/app/modules/location/service.location-notes.test.ts
@@ -13,9 +13,13 @@ const dbMocks = vi.hoisted(() => ({
   },
   asset: {
     findMany: vi.fn(),
+    // why: org-scope assertion in updateLocationAssets calls db.asset.count
+    count: vi.fn(),
   },
   kit: {
     findMany: vi.fn(),
+    // why: org-scope assertion in updateLocationKits calls db.kit.count
+    count: vi.fn(),
   },
   user: {
     findFirstOrThrow: vi.fn(),
@@ -67,23 +71,29 @@ vi.mock("~/utils/list", async () => {
   return { ...actual, ALL_SELECTED_KEY: "__ALL__" };
 });
 
-vi.mock("~/utils/error", () => ({
-  ShelfError: class ShelfError extends Error {
+vi.mock("~/utils/error", () => {
+  class ShelfError extends Error {
     constructor(config: any) {
       super(config.message || "ShelfError");
       Object.assign(this, config);
     }
-  },
-  isLikeShelfError: () => false,
-  isNotFoundError: () => false,
-  maybeUniqueConstraintViolation: (
-    _cause: unknown,
-    _label: string,
-    _meta?: any
-  ) => {
-    throw _cause;
-  },
-}));
+  }
+  return {
+    ShelfError,
+    // why: production behavior re-throws known ShelfErrors so callers see the
+    // original status (e.g. 403 from the org-scope guard) instead of a
+    // generic 500 wrap from the outer catch
+    isLikeShelfError: (cause: unknown) => cause instanceof ShelfError,
+    isNotFoundError: () => false,
+    maybeUniqueConstraintViolation: (
+      _cause: unknown,
+      _label: string,
+      _meta?: any
+    ) => {
+      throw _cause;
+    },
+  };
+});
 
 const {
   updateLocation,
@@ -118,6 +128,14 @@ describe("location service activity logging", () => {
       lastName: "Doe",
     });
     dbMocks.kit.findMany.mockResolvedValue([]);
+    // why: assertion helpers count submitted IDs; default to "all authorized"
+    // so happy-path tests don't have to wire it up explicitly
+    dbMocks.asset.count.mockImplementation(({ where }: any) =>
+      Promise.resolve(where?.id?.in?.length ?? 0)
+    );
+    dbMocks.kit.count.mockImplementation(({ where }: any) =>
+      Promise.resolve(where?.id?.in?.length ?? 0)
+    );
     locationNoteMocks.createSystemLocationNote.mockResolvedValue(undefined);
     locationNoteMocks.createLocationNote.mockResolvedValue(undefined);
     createNoteMock.mockResolvedValue(undefined);
@@ -204,6 +222,77 @@ describe("location service activity logging", () => {
     });
   });
 
+  describe("updateLocationAssets cross-organization guard", () => {
+    it("rejects when an assetId does not belong to the caller's organization", async () => {
+      // Caller submitted two IDs but only one belongs to the org
+      dbMocks.asset.count.mockResolvedValueOnce(1);
+
+      await expect(
+        updateLocationAssets({
+          assetIds: ["asset-mine", "asset-foreign"],
+          organizationId: "org-1",
+          locationId: "loc-1",
+          userId: "user-1",
+          request: new Request("https://example.com"),
+          removedAssetIds: [],
+        })
+      ).rejects.toMatchObject({ status: 403 });
+
+      expect(dbMocks.location.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects when a removedAssetId does not belong to the caller's organization", async () => {
+      dbMocks.asset.count.mockResolvedValueOnce(0);
+
+      await expect(
+        updateLocationAssets({
+          assetIds: [],
+          organizationId: "org-1",
+          locationId: "loc-1",
+          userId: "user-1",
+          request: new Request("https://example.com"),
+          removedAssetIds: ["asset-foreign"],
+        })
+      ).rejects.toMatchObject({ status: 403 });
+
+      expect(dbMocks.location.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects when ALL_SELECTED expansion is paired with a foreign removedAssetId", async () => {
+      // ALL_SELECTED expansion still funnels through the assertion which
+      // checks both arrays. The foreign ID in removedAssetIds must trip 403.
+      dbMocks.asset.findMany.mockResolvedValueOnce([{ id: "asset-mine" }]);
+      // count over { asset-mine, asset-foreign } returns 1 (foreign missing)
+      dbMocks.asset.count.mockResolvedValueOnce(1);
+
+      await expect(
+        updateLocationAssets({
+          assetIds: ["__ALL__"],
+          organizationId: "org-1",
+          locationId: "loc-1",
+          userId: "user-1",
+          request: new Request("https://example.com"),
+          removedAssetIds: ["asset-foreign"],
+        })
+      ).rejects.toMatchObject({ status: 403 });
+
+      expect(dbMocks.location.update).not.toHaveBeenCalled();
+    });
+
+    it("skips the count query when no IDs are submitted", async () => {
+      await updateLocationAssets({
+        assetIds: [],
+        organizationId: "org-1",
+        locationId: "loc-1",
+        userId: "user-1",
+        request: new Request("https://example.com"),
+        removedAssetIds: [],
+      });
+
+      expect(dbMocks.asset.count).not.toHaveBeenCalled();
+    });
+  });
+
   describe("updateLocationKits", () => {
     it("records notes when kits are assigned", async () => {
       dbMocks.location.findUniqueOrThrow.mockResolvedValueOnce({
@@ -245,6 +334,55 @@ describe("location service activity logging", () => {
           content: expect.stringContaining("Shoot Kit"),
         })
       );
+    });
+  });
+
+  describe("updateLocationKits cross-organization guard", () => {
+    it("rejects when a kitId does not belong to the caller's organization", async () => {
+      dbMocks.kit.count.mockResolvedValueOnce(1);
+
+      await expect(
+        updateLocationKits({
+          locationId: "loc-1",
+          kitIds: ["kit-mine", "kit-foreign"],
+          removedKitIds: [],
+          organizationId: "org-1",
+          userId: "user-1",
+          request: new Request("https://example.com"),
+        })
+      ).rejects.toMatchObject({ status: 403 });
+
+      expect(dbMocks.location.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects when a removedKitId does not belong to the caller's organization", async () => {
+      dbMocks.kit.count.mockResolvedValueOnce(0);
+
+      await expect(
+        updateLocationKits({
+          locationId: "loc-1",
+          kitIds: [],
+          removedKitIds: ["kit-foreign"],
+          organizationId: "org-1",
+          userId: "user-1",
+          request: new Request("https://example.com"),
+        })
+      ).rejects.toMatchObject({ status: 403 });
+
+      expect(dbMocks.location.update).not.toHaveBeenCalled();
+    });
+
+    it("skips the count query when no kit IDs are submitted", async () => {
+      await updateLocationKits({
+        locationId: "loc-1",
+        kitIds: [],
+        removedKitIds: [],
+        organizationId: "org-1",
+        userId: "user-1",
+        request: new Request("https://example.com"),
+      });
+
+      expect(dbMocks.kit.count).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -56,6 +56,86 @@ import { getUserByID } from "../user/service.server";
 const label: ErrorLabel = "Location";
 const MAX_LOCATION_DEPTH = 12;
 
+/**
+ * SECURITY: Asserts that every supplied asset ID belongs to `organizationId`.
+ *
+ * Service-layer defense-in-depth guard for the location ↔ asset mutation
+ * helpers (`updateLocationAssets`). Without this check, Prisma's 1:N
+ * `connect`/`disconnect` on `Location.assets` happily accepts cross-org
+ * `assetId`s supplied via the form payload — silently reparenting a victim's
+ * asset out of their workspace (CWE-862 / IDOR).
+ *
+ * @throws {ShelfError} 403 if any of `ids` does not belong to `organizationId`
+ */
+async function assertAssetsInOrganization({
+  ids,
+  organizationId,
+  additionalData,
+}: {
+  ids: Asset["id"][];
+  organizationId: Organization["id"];
+  additionalData?: Record<string, unknown>;
+}): Promise<void> {
+  if (ids.length === 0) return;
+
+  const authorizedCount = await db.asset.count({
+    where: { id: { in: ids }, organizationId },
+  });
+
+  if (authorizedCount !== ids.length) {
+    throw new ShelfError({
+      cause: null,
+      title: "Unauthorized",
+      message:
+        "You are not authorized to modify one or more of the selected assets.",
+      additionalData: { ...additionalData, organizationId, ids },
+      label,
+      status: 403,
+      shouldBeCaptured: false,
+    });
+  }
+}
+
+/**
+ * SECURITY: Asserts that every supplied kit ID belongs to `organizationId`.
+ *
+ * Service-layer defense-in-depth guard for the location ↔ kit mutation
+ * helpers (`updateLocationKits`). Without this check, Prisma's 1:N
+ * `connect`/`disconnect` on `Location.kits` happily accepts cross-org
+ * `kitId`s supplied via the form payload — silently reparenting a victim's
+ * kit (and its cascading assets) out of their workspace (CWE-862 / IDOR).
+ *
+ * @throws {ShelfError} 403 if any of `ids` does not belong to `organizationId`
+ */
+async function assertKitsInOrganization({
+  ids,
+  organizationId,
+  additionalData,
+}: {
+  ids: Kit["id"][];
+  organizationId: Organization["id"];
+  additionalData?: Record<string, unknown>;
+}): Promise<void> {
+  if (ids.length === 0) return;
+
+  const authorizedCount = await db.kit.count({
+    where: { id: { in: ids }, organizationId },
+  });
+
+  if (authorizedCount !== ids.length) {
+    throw new ShelfError({
+      cause: null,
+      title: "Unauthorized",
+      message:
+        "You are not authorized to modify one or more of the selected kits.",
+      additionalData: { ...additionalData, organizationId, ids },
+      label,
+      status: 403,
+      shouldBeCaptured: false,
+    });
+  }
+}
+
 export async function getLocation(
   params: Pick<Location, "id"> & {
     organizationId: Organization["id"];
@@ -1543,6 +1623,18 @@ export async function updateLocationAssets({
     }
 
     /**
+     * SECURITY: every submitted asset ID (add or remove) must belong to the
+     * caller's organization. Without this guard, Prisma's `connect`/`disconnect`
+     * on `Location.assets` accepts cross-org IDs, silently reparenting another
+     * workspace's asset to the caller's location (CWE-862).
+     */
+    await assertAssetsInOrganization({
+      ids: Array.from(new Set([...assetIds, ...removedAssetIds])),
+      organizationId,
+      additionalData: { userId, locationId },
+    });
+
+    /**
      * Filter out assets already at this location - they don't need notes
      * since no actual change is happening for them.
      */
@@ -1655,6 +1747,9 @@ export async function updateLocationAssets({
       location,
     });
   } catch (cause) {
+    if (isLikeShelfError(cause)) {
+      throw cause;
+    }
     throw new ShelfError({
       cause,
       message: "Something went wrong while updating the location assets.",
@@ -1742,6 +1837,19 @@ export async function updateLocationKits({
         ]),
       ];
     }
+
+    /**
+     * SECURITY: every submitted kit ID (add or remove) must belong to the
+     * caller's organization. Without this guard, Prisma's `connect`/`disconnect`
+     * on `Location.kits` accepts cross-org IDs, silently reparenting another
+     * workspace's kit (and its cascading assets) to the caller's location
+     * (CWE-862).
+     */
+    await assertKitsInOrganization({
+      ids: Array.from(new Set([...kitIds, ...removedKitIds])),
+      organizationId,
+      additionalData: { userId, locationId },
+    });
 
     /**
      * Filter out kits already at this location - they don't need notes
@@ -2025,6 +2133,9 @@ export async function updateLocationKits({
       }
     }
   } catch (cause) {
+    if (isLikeShelfError(cause)) {
+      throw cause;
+    }
     throw new ShelfError({
       cause,
       message: "Something went wrong while updating the location kits.",


### PR DESCRIPTION
The `updateLocationAssets` and `updateLocationKits` service helpers passed form-supplied IDs straight into Prisma `connect`/`disconnect` on `Location.assets` / `Location.kits` without verifying they belonged to the caller's organization. An attacker could substitute a victim's `assetId` (or `kitId`) into the manage-assets / manage-kits POST and silently reparent that resource to their own location (CWE-862, IDOR).

Add private `assertAssetsInOrganization` / `assertKitsInOrganization` helpers that issue a single `count` query and throw 403 when the supplied IDs include any outside the caller's org. Invoke them inside both service helpers right after ALL_SELECTED expansion, validating the deduped union of both add and remove arrays. Re-throw known ShelfErrors from the outer catch so the 403 reaches the route's `makeShelfError` instead of being masked as a 500.

Mirrors the `assertBookingInOrganization` precedent from `booking-note/service.server.ts`. Protects all seven call sites of these service helpers (manage-assets, manage-kits, single-remove, bulk-remove, scan flow, locations.kits.tsx) at the mutation site.

Tests cover: foreign assetId rejection, foreign removedAssetId rejection, ALL_SELECTED with injected foreign ID, empty-array short-circuit, and the symmetric set for kits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added authorization checks to prevent adding or removing assets and kits to locations without proper organization ownership verification. Unauthorized attempts now return a 403 error.

* **Tests**
  * Added comprehensive test coverage for asset and kit authorization validation with org-scope checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->