### PR TITLE
chore(asset): tighten sort parameter parsing and validation

### DIFF
--- a/apps/webapp/app/modules/asset/filter-parsing.ts
+++ b/apps/webapp/app/modules/asset/filter-parsing.ts
@@ -3,6 +3,7 @@ import type {
   Filter,
   FilterOperator,
 } from "~/components/assets/assets-index/advanced-filters/schema";
+import { isSafeSqlIdentifier } from "~/utils/sql";
 import { getQueryFieldType } from "./field-type-mapping";
 import type { Column } from "../asset-index-settings/helpers";
 
@@ -13,15 +14,6 @@ import type { Column } from "../asset-index-settings/helpers";
 const API_TO_DB_FIELD_MAP: Record<string, string> = {
   valuation: "value",
 };
-
-/**
- * Validates that a filter name is safe for use in raw SQL identifiers.
- * Custom field names (cf_*) are excluded because they're used as
- * parameterized values, not raw SQL identifiers.
- * Non-custom-field names get injected via Prisma.raw() as column names,
- * so they must only contain safe identifier characters.
- */
-const SAFE_SQL_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 /**
  * Parses a filter query string into an array of Filter objects.
@@ -49,7 +41,7 @@ export function parseFilters(
 
       // Non-custom-field names are used in Prisma.raw() as SQL identifiers,
       // so reject names with unsafe characters to prevent SQL syntax errors
-      if (!key.startsWith("cf_") && !SAFE_SQL_IDENTIFIER.test(dbKey)) {
+      if (!key.startsWith("cf_") && !isSafeSqlIdentifier(dbKey)) {
         return;
       }
 

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { locationDescendantsMock } from "@mocks/location-descendants";
 import type { Filter } from "~/components/assets/assets-index/advanced-filters/schema";
+import { ShelfError } from "~/utils/error";
 import {
   assetQueryFragment,
+  generateCustomFieldSelect,
   generateWhereClause,
   parseSortingOptions,
 } from "./query.server";
@@ -10,11 +12,239 @@ import {
 // why: mocking location descendants to avoid database queries during tests
 vi.mock("~/modules/location/descendants.server", () => locationDescendantsMock);
 
+const DEFAULT_FALLBACK_ORDER_BY =
+  'ORDER BY "assetCreatedAt" DESC, "assetId" ASC';
+
 describe("parseSortingOptions", () => {
   it("allows sorting by updatedAt", () => {
     const { orderByClause } = parseSortingOptions(["updatedAt:desc"]);
 
     expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" desc');
+  });
+
+  describe("direction validation", () => {
+    it("normalizes uppercase DESC to desc", () => {
+      const { orderByClause } = parseSortingOptions(["updatedAt:DESC"]);
+      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" desc');
+    });
+
+    it("normalizes mixed-case Desc to desc", () => {
+      const { orderByClause } = parseSortingOptions(["updatedAt:Desc"]);
+      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" desc');
+    });
+
+    // Regression test for GHSA-69xv-wmgg-3qp3: SQL injection via direction.
+    // Invalid directions must throw a 400 — the malicious SQL never reaches
+    // the database and the user gets an explicit error instead of silently
+    // sorting ascending.
+    it("rejects SQL injection payloads in the direction", () => {
+      expect(() =>
+        parseSortingOptions(["updatedAt:asc; DROP TABLE Asset; --"])
+      ).toThrow(ShelfError);
+    });
+
+    // Regression test using the exact PoC shape from the GHSA-69xv-wmgg-3qp3
+    // report. The split(":") only takes the first colon, so the entire
+    // "asc,(SELECT ...)" string lands in `direction` and must be rejected.
+    it("rejects the reporter's exact PoC subquery payload", () => {
+      expect(() =>
+        parseSortingOptions([
+          "createdAt:asc,(SELECT CASE WHEN 1=2 THEN 1 ELSE 1/0 END)",
+        ])
+      ).toThrow(ShelfError);
+    });
+
+    it("throws on an unrecognized direction string", () => {
+      expect(() => parseSortingOptions(["updatedAt:foobar"])).toThrow(
+        ShelfError
+      );
+    });
+
+    it("throws with HTTP 400 status on invalid direction", () => {
+      try {
+        parseSortingOptions(["updatedAt:nope"]);
+        throw new Error("expected parseSortingOptions to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ShelfError);
+        expect((err as ShelfError).status).toBe(400);
+      }
+    });
+
+    it("defaults missing direction to asc", () => {
+      const { orderByClause } = parseSortingOptions(["updatedAt"]);
+      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" asc');
+    });
+
+    it("defaults empty direction to asc", () => {
+      const { orderByClause } = parseSortingOptions(["updatedAt:"]);
+      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" asc');
+    });
+  });
+
+  describe("barcode field validation", () => {
+    it("permits a known-good barcode column", () => {
+      const { orderByClause } = parseSortingOptions(["barcode_Code128:asc"]);
+      expect(orderByClause).toContain("barcode_Code128");
+      expect(orderByClause).toContain("asc");
+    });
+
+    it("drops a barcode field whose suffix contains injection chars", () => {
+      const { orderByClause } = parseSortingOptions([
+        'barcode_Code128";DROP--:asc',
+      ]);
+      expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+      expect(orderByClause).not.toContain("DROP");
+    });
+
+    it("drops a barcode field with empty suffix", () => {
+      const { orderByClause } = parseSortingOptions(["barcode_:asc"]);
+      expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+    });
+
+    it("drops a barcode field with whitespace in the suffix", () => {
+      const { orderByClause } = parseSortingOptions(["barcode_Code 128:asc"]);
+      expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+    });
+  });
+
+  describe("custom field (cf_*) validation", () => {
+    it("permits a simple custom field name", () => {
+      const { orderByClause, customFieldSortings } = parseSortingOptions([
+        "cf_Manufacturer:asc:TEXT",
+      ]);
+      expect(customFieldSortings).toHaveLength(1);
+      expect(customFieldSortings[0].alias).toBe("cf_Manufacturer");
+      expect(orderByClause).toContain("cf_Manufacturer");
+    });
+
+    it("normalizes whitespace in custom field name to underscores", () => {
+      const { customFieldSortings } = parseSortingOptions([
+        "cf_legit name:asc:TEXT",
+      ]);
+      expect(customFieldSortings).toHaveLength(1);
+      expect(customFieldSortings[0].alias).toBe("cf_legit_name");
+    });
+
+    it("drops a custom field name containing injection chars", () => {
+      const { orderByClause, customFieldSortings } = parseSortingOptions([
+        "cf_x;DROP TABLE:asc:TEXT",
+      ]);
+      expect(customFieldSortings).toHaveLength(0);
+      expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+      expect(orderByClause).not.toContain("DROP");
+    });
+
+    it("drops a custom field name containing parentheses", () => {
+      const { orderByClause, customFieldSortings } = parseSortingOptions([
+        "cf_Cost (USD):asc:AMOUNT",
+      ]);
+      expect(customFieldSortings).toHaveLength(0);
+      expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+    });
+
+    it("uses direct sort for DATE fields", () => {
+      const { orderByClause } = parseSortingOptions(["cf_x:asc:DATE"]);
+      expect(orderByClause).toBe("ORDER BY cf_x asc");
+    });
+
+    it("uses ::numeric cast for AMOUNT fields", () => {
+      const { orderByClause } = parseSortingOptions(["cf_x:asc:AMOUNT"]);
+      expect(orderByClause).toBe("ORDER BY cf_x::numeric asc");
+    });
+
+    it("falls through to natural sort for unknown fieldType", () => {
+      const { orderByClause } = parseSortingOptions(["cf_x:asc:bogusType"]);
+      expect(orderByClause).toContain("LOWER(regexp_replace(cf_x");
+    });
+  });
+
+  describe("mixed and edge cases", () => {
+    it("emits valid terms while skipping invalid ones in the same array", () => {
+      const { orderByClause, customFieldSortings } = parseSortingOptions([
+        "updatedAt:desc",
+        "cf_x;DROP:asc:TEXT",
+        "name:asc",
+      ]);
+      expect(customFieldSortings).toHaveLength(0);
+      expect(orderByClause).toContain('"assetUpdatedAt" desc');
+      expect(orderByClause).toContain('"assetTitle"');
+      expect(orderByClause).not.toContain("DROP");
+    });
+
+    it("falls back to default sort when every term is invalid", () => {
+      const { orderByClause } = parseSortingOptions([
+        "evil:asc",
+        "alsoEvil:desc",
+      ]);
+      expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+    });
+
+    it("falls back to default sort for an empty input array", () => {
+      const { orderByClause } = parseSortingOptions([]);
+      expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+    });
+
+    it("uses sequential-id sort expression for sequentialId", () => {
+      const { orderByClause } = parseSortingOptions(["sequentialId:asc"]);
+      expect(orderByClause).toContain('"assetSequentialId"');
+      expect(orderByClause).toContain("LPAD(SPLIT_PART");
+    });
+
+    it("uses custody jsonb path for custody", () => {
+      const { orderByClause } = parseSortingOptions(["custody:desc"]);
+      expect(orderByClause).toContain("custody->>'name'");
+      expect(orderByClause).toContain("desc");
+    });
+
+    // Regression test: `in` walks the prototype chain, so without
+    // Object.hasOwn() field names like "toString" or "constructor" would
+    // resolve to inherited methods and produce broken SQL. Must fall through
+    // to the unknown-field branch instead.
+    it("does not match inherited Object.prototype keys via 'in'", () => {
+      const inheritedKeys = [
+        "toString",
+        "constructor",
+        "hasOwnProperty",
+        "valueOf",
+      ];
+      for (const key of inheritedKeys) {
+        const { orderByClause } = parseSortingOptions([`${key}:asc`]);
+        expect(orderByClause).toBe(DEFAULT_FALLBACK_ORDER_BY);
+      }
+    });
+  });
+});
+
+describe("generateCustomFieldSelect", () => {
+  it("returns Prisma.empty for an empty input", () => {
+    const result = generateCustomFieldSelect([]);
+    // Prisma.empty has no strings/values to interpolate
+    expect(result.strings.join("")).toBe("");
+  });
+
+  it("emits a SELECT subquery for a safe alias", () => {
+    const result = generateCustomFieldSelect([
+      { name: "Manufacturer", valueKey: "raw", alias: "cf_Manufacturer" },
+    ]);
+    expect(result.strings.join("?")).toContain("AS ");
+    expect(result.strings.join("?")).toContain("cf_Manufacturer");
+  });
+
+  // Defense-in-depth: even though parseSortingOptions already validates
+  // aliases, generateCustomFieldSelect must not trust its input. A future
+  // refactor or alternate caller must not be able to inject SQL via cf.alias.
+  it("throws ShelfError when an alias contains unsafe characters", () => {
+    expect(() =>
+      generateCustomFieldSelect([
+        { name: "x", valueKey: "raw", alias: "cf_x; DROP--" },
+      ])
+    ).toThrow(ShelfError);
+  });
+
+  it("throws ShelfError when an alias is empty", () => {
+    expect(() =>
+      generateCustomFieldSelect([{ name: "x", valueKey: "raw", alias: "" }])
+    ).toThrow(ShelfError);
   });
 });
 

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -2,6 +2,9 @@ import { Prisma } from "@prisma/client";
 import type { CustomFieldType } from "@prisma/client";
 
 import type { Filter } from "~/components/assets/assets-index/advanced-filters/schema";
+import { ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
+import { isSafeSqlIdentifier } from "~/utils/sql";
 import { parseFilters } from "./filter-parsing";
 import { expandLocationHierarchyFilters } from "./location-filter.server";
 import type { CustomFieldSorting } from "./types";
@@ -1310,12 +1313,17 @@ const directAssetFields: Record<DirectAssetField, string> = {
  * Generates a PostgreSQL expression for natural sorting of text values
  * Handles case-insensitive comparison and natural number ordering.
  * What is natural sorting? https://en.wikipedia.org/wiki/Natural_sort_order
- * - Ignore case (treat uppercase and lowercase the same) 
- * - Sort numbers as whole values rather than character-by-character 
+ * - Ignore case (treat uppercase and lowercase the same)
+ * - Sort numbers as whole values rather than character-by-character
  * - Place purely alphabetic entries before alphanumeric ones
- 
- * @param columnRef - The column or expression to sort
- * @param direction - Sort direction ('asc' or 'desc')
+ *
+ * SECURITY: `columnRef` and `direction` are interpolated into raw SQL.
+ * Callers MUST pass either a hardcoded literal or a value validated against
+ * `SAFE_SQL_IDENTIFIER` (and an allowlisted direction). Never pass raw user
+ * input here.
+ *
+ * @param columnRef - The column or expression to sort. Caller-validated.
+ * @param direction - Sort direction ('asc' or 'desc'). Caller-validated.
  * @returns SQL string with normalized sorting expression
  */
 function getNormalizedSortExpression(
@@ -1323,24 +1331,35 @@ function getNormalizedSortExpression(
   direction: string
 ): string {
   return `
-    LOWER(regexp_replace(${columnRef}, '([0-9]+)', 
+    LOWER(regexp_replace(${columnRef}, '([0-9]+)',
       lpad(regexp_replace(regexp_replace('\\1', '^0+', ''), '^$', '0'), 12, '0')
     )) ${direction},
     ${columnRef} ${direction}
   `.trim();
 }
 
+/**
+ * Generates a PostgreSQL expression for sorting sequential asset IDs
+ * (e.g. "SAM-1", "SAM-2", "SAM-10") in numeric order.
+ *
+ * SECURITY: `columnRef` and `direction` are interpolated into raw SQL.
+ * Same caller contract as {@link getNormalizedSortExpression}.
+ *
+ * @param columnRef - The column or expression to sort. Caller-validated.
+ * @param direction - Sort direction ('asc' or 'desc'). Caller-validated.
+ * @returns SQL string with sequential-ID sorting expression
+ */
 function getSequentialIdSortExpression(
   columnRef: string,
   direction: string
 ): string {
   return `
-    CASE 
+    CASE
       WHEN ${columnRef} IS NULL THEN 1
       ELSE 0
     END ASC,
-    CASE 
-      WHEN ${columnRef} ~ '^[A-Z]+-[0-9]+$' 
+    CASE
+      WHEN ${columnRef} ~ '^[A-Z]+-[0-9]+$'
       THEN LPAD(SPLIT_PART(${columnRef}, '-', 2), 12, '0')
       ELSE ${columnRef}
     END ${direction},
@@ -1349,8 +1368,59 @@ function getSequentialIdSortExpression(
 }
 
 /**
- * Enhanced sorting options parser with natural sort support
- * Handles case-insensitive sorting with natural number ordering
+ * Allowlist of permitted sort directions.
+ *
+ * The user-supplied direction is normalized to lowercase and compared against
+ * this set before being interpolated into raw SQL. Anything outside this set
+ * defaults to "asc" — never reaches the database verbatim.
+ */
+const VALID_DIRECTIONS = new Set<"asc" | "desc">(["asc", "desc"]);
+
+/**
+ * Normalizes a user-supplied sort direction to "asc" or "desc".
+ *
+ * Behavior:
+ * - Missing or empty direction → defaults to "asc" (legacy URL pattern:
+ *   `?sortBy=name`).
+ * - Recognized direction (any case) → normalized to lowercase.
+ * - Anything else → throws `ShelfError` (HTTP 400). Surfacing the bad
+ *   input is preferred over silently sorting ascending, both for UX
+ *   clarity and because invalid direction is the primary signal that
+ *   someone is poking at the sort param.
+ *
+ * @param raw - The raw direction string from the URL.
+ * @returns A safe lowercase direction.
+ * @throws {ShelfError} When `raw` is non-empty and not a recognized direction.
+ */
+function normalizeDirection(raw: string | undefined): "asc" | "desc" {
+  if (raw === undefined || raw === "") return "asc";
+  const lowered = raw.toLowerCase();
+  if (VALID_DIRECTIONS.has(lowered as "asc" | "desc")) {
+    return lowered as "asc" | "desc";
+  }
+  throw new ShelfError({
+    cause: null,
+    message: `Invalid sort direction: "${raw}". Must be "asc" or "desc".`,
+    title: "Invalid sort direction",
+    additionalData: { direction: raw },
+    label: "Assets",
+    status: 400,
+    shouldBeCaptured: false,
+  });
+}
+
+/**
+ * Enhanced sorting options parser with natural sort support.
+ * Handles case-insensitive sorting with natural number ordering.
+ *
+ * SECURITY: builds a raw SQL `ORDER BY` clause that is later passed to
+ * `Prisma.raw(...)` inside `getAdvancedPaginatedAndFilterableAssets`. Every
+ * value interpolated into the clause must be either a hardcoded literal or
+ * validated against {@link isSafeSqlIdentifier}. Direction is normalized via
+ * {@link normalizeDirection}. Field names that don't match a known branch
+ * (or whose dynamic suffix fails identifier validation) are dropped with a
+ * warning — the caller falls back to the default sort. See GHSA-69xv-wmgg-3qp3.
+ *
  * @param sortBy - Array of sort specifications in format: field:direction[:fieldType]
  * @returns Object containing SQL order by clause and custom field sorting info
  */
@@ -1360,10 +1430,10 @@ export function parseSortingOptions(sortBy: string[]): {
 } {
   const fields = sortBy.map((s) => {
     const [name, direction, fieldType] = s.split(":");
-    return { name, direction, fieldType } as {
-      name: string;
-      direction: "asc" | "desc";
-      fieldType: CustomFieldType;
+    return {
+      name: name ?? "",
+      direction: normalizeDirection(direction),
+      fieldType: fieldType as CustomFieldType,
     };
   });
 
@@ -1371,7 +1441,11 @@ export function parseSortingOptions(sortBy: string[]): {
   const customFieldSortings: CustomFieldSorting[] = [];
 
   for (const field of fields) {
-    if (field.name in directAssetFields) {
+    // Use Object.hasOwn to avoid prototype-chain matches like "toString" or
+    // "constructor", which would otherwise resolve via Object.prototype and
+    // produce broken SQL. Bypassing the unknown-field fallback this way is not
+    // exploitable but creates a DoS / 500 path — keep the allowlist strict.
+    if (Object.hasOwn(directAssetFields, field.name)) {
       const columnName = directAssetFields[field.name as DirectAssetField];
 
       // Special handling for sequential ID sorting
@@ -1407,14 +1481,43 @@ export function parseSortingOptions(sortBy: string[]): {
         getNormalizedSortExpression(`custody->>'name'`, field.direction)
       );
     } else if (field.name.startsWith("barcode_")) {
-      // Handle barcode column sorting
-      const barcodeType = field.name.replace("barcode_", "");
+      // The suffix is interpolated into a SQL identifier (`barcode_<suffix>`),
+      // so it must contain only safe identifier characters. Anything else is
+      // dropped — see GHSA-69xv-wmgg-3qp3.
+      const barcodeType = field.name.slice("barcode_".length);
+      if (!isSafeSqlIdentifier(barcodeType)) {
+        Logger.warn(
+          new ShelfError({
+            cause: null,
+            message: "Skipping sort term: unsafe barcode field name",
+            additionalData: { fieldName: field.name },
+            label: "Assets",
+            shouldBeCaptured: false,
+          })
+        );
+        continue;
+      }
       orderByParts.push(
         getNormalizedSortExpression(`barcode_${barcodeType}`, field.direction)
       );
     } else if (field.name.startsWith("cf_")) {
       const customFieldName = field.name.slice(3);
       const alias = `cf_${customFieldName.replace(/\s+/g, "_")}`;
+      // The alias is interpolated into raw SQL both here (ORDER BY) and in
+      // generateCustomFieldSelect (SELECT ... AS <alias>). Reject any alias
+      // that isn't a safe identifier.
+      if (!isSafeSqlIdentifier(alias)) {
+        Logger.warn(
+          new ShelfError({
+            cause: null,
+            message: "Skipping sort term: unsafe custom field name",
+            additionalData: { fieldName: field.name, alias },
+            label: "Assets",
+            shouldBeCaptured: false,
+          })
+        );
+        continue;
+      }
       customFieldSortings.push({
         name: customFieldName,
         valueKey: "raw",
@@ -1433,8 +1536,15 @@ export function parseSortingOptions(sortBy: string[]): {
         orderByParts.push(getNormalizedSortExpression(alias, field.direction));
       }
     } else {
-      // eslint-disable-next-line no-console
-      console.warn(`Unknown sort field: ${field.name}`);
+      Logger.warn(
+        new ShelfError({
+          cause: null,
+          message: "Skipping sort term: unknown field",
+          additionalData: { fieldName: field.name },
+          label: "Assets",
+          shouldBeCaptured: false,
+        })
+      );
     }
   }
   if (orderByParts.length === 0) {
@@ -1466,20 +1576,43 @@ function isTextColumn(fieldName: string): boolean {
   return textColumns.includes(fieldName as DirectAssetField);
 }
 
+/**
+ * Builds the SELECT-side custom-field subqueries that match the aliases
+ * produced by {@link parseSortingOptions}.
+ *
+ * SECURITY: each alias is interpolated as a raw SQL identifier
+ * (`AS ${Prisma.raw(cf.alias)}`). This is a defense-in-depth guard: the
+ * parser already validates aliases via {@link isSafeSqlIdentifier}, so this
+ * check should never throw in practice. It exists to keep the function
+ * safe under future refactors or alternate callers.
+ *
+ * @throws {ShelfError} If any alias fails identifier validation.
+ */
 export function generateCustomFieldSelect(
   customFieldSortings: CustomFieldSorting[]
 ): Prisma.Sql {
   if (customFieldSortings.length === 0) return Prisma.empty;
 
+  for (const cf of customFieldSortings) {
+    if (!isSafeSqlIdentifier(cf.alias)) {
+      throw new ShelfError({
+        cause: null,
+        message: "Invalid custom field alias for SQL select",
+        additionalData: { alias: cf.alias },
+        label: "Assets",
+      });
+    }
+  }
+
   return Prisma.sql`, ${Prisma.join(
     customFieldSortings.map(
       (cf) =>
         Prisma.sql`(
-      SELECT 
+      SELECT
         CASE ${cf.fieldType}
-          WHEN 'DATE' THEN 
+          WHEN 'DATE' THEN
             (acfv.value->>'valueDate')::timestamp::text
-          WHEN 'BOOLEAN' THEN 
+          WHEN 'BOOLEAN' THEN
             (acfv.value->>'valueBoolean')::boolean::text
           WHEN 'MULTILINE_TEXT' THEN
             (acfv.value->>'valueMultiLineText')::text

--- a/apps/webapp/app/utils/sql.ts
+++ b/apps/webapp/app/utils/sql.ts
@@ -1,0 +1,37 @@
+/**
+ * SQL identifier validation utilities.
+ *
+ * Used wherever a string sourced (directly or transitively) from user input is
+ * about to be interpolated into a raw SQL query as an identifier (column name,
+ * table name, alias). Postgres does not parameterize identifiers — they must be
+ * inlined into the query string — so the only safe option is allowlisting.
+ *
+ * Use this in any code path that calls `Prisma.raw()` or builds a SQL string
+ * passed to `$queryRaw` / `$executeRaw`.
+ *
+ * @see {@link file://./../modules/asset/filter-parsing.ts}
+ * @see {@link file://./../modules/asset/query.server.ts}
+ */
+
+/**
+ * Matches a conservative SQL identifier: must start with a letter or
+ * underscore, followed by letters, digits, or underscores. No quoting,
+ * no dots, no spaces, no operators, no Unicode.
+ *
+ * Rejecting these characters is sufficient to neutralize SQL injection
+ * via raw-interpolated identifiers because the Postgres parser cannot
+ * be steered out of an identifier context with only `[a-zA-Z0-9_]`.
+ *
+ * Kept private to this module — callers should use {@link isSafeSqlIdentifier}.
+ */
+const SAFE_SQL_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Returns true if `value` is safe to inline as a Postgres identifier.
+ *
+ * @param value - Candidate string. Non-strings (undefined, null) return false.
+ * @returns Whether the value matches the safe-identifier rules.
+ */
+export function isSafeSqlIdentifier(value: unknown): value is string {
+  return typeof value === "string" && SAFE_SQL_IDENTIFIER.test(value);
+}


### PR DESCRIPTION
Allowlist the sort direction (asc/desc) and normalize case before it reaches the ORDER BY clause. Validate the dynamic suffix in barcode_* and cf_* field names with a shared isSafeSqlIdentifier predicate so unsafe characters can't end up in raw SQL. Skip unknown or unsafe fields with a structured Logger.warn; surface an explicit invalid direction as a 400 instead of silently sorting ascending.

Use Object.hasOwn for the directAssetFields lookup so prototype keys (toString, constructor, ...) fall through to the unknown-field branch instead of resolving to inherited methods.

Add a defense-in-depth alias guard inside generateCustomFieldSelect so the SELECT-side custom-field interpolation is independently validated.

Extract the SAFE_SQL_IDENTIFIER regex into apps/webapp/app/utils/sql.ts and reuse it from filter-parsing.ts.

Expand unit-test coverage of parseSortingOptions and generateCustomFieldSelect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for sorting and filtering operations to ensure more consistent and reliable behavior.
  * Enhanced robustness of query handling for edge cases and invalid input parameters.
  * Standardized sort direction normalization (uppercase values now handled consistently).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->