### PR TITLE
test: exercise react-doctor PR check

### DIFF
--- a/apps/webapp/app/components/__react-doctor-ci-test__.tsx
+++ b/apps/webapp/app/components/__react-doctor-ci-test__.tsx
@@ -1,0 +1,40 @@
+/**
+ * THROWAWAY — exists only to exercise the react-doctor PR check.
+ *
+ * Intentionally introduces:
+ *   - 1 error    → react-doctor/no-derived-state-effect (useState mirroring
+ *                  a prop via useEffect)
+ *   - 1 warning  → jsx-a11y/no-autofocus
+ *   - 1 warning  → react-doctor/no-array-index-as-key
+ *
+ * This file is NOT imported anywhere. It will be reverted before the test
+ * PR is closed. Do not merge.
+ */
+
+import { useEffect, useState } from "react";
+
+type Props = { value: string };
+
+export function ReactDoctorCITest({ value }: Props) {
+  const [mirrored, setMirrored] = useState(value);
+
+  // no-derived-state-effect: mirroring a prop into state via useEffect.
+  useEffect(() => {
+    setMirrored(value);
+  }, [value]);
+
+  const items = ["a", "b", "c"];
+
+  return (
+    <div>
+      {/* jsx-a11y/no-autofocus warning */}
+      <input autoFocus />
+      {items.map((item, i) => (
+        // no-array-index-as-key warning
+        <span key={i}>
+          {item} {mirrored}
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Purpose

Verify the new react-doctor PR workflow added in `ci-implement-react-doctor`. Adds a throwaway component that intentionally trips:

- **1 error** — `react-doctor/no-derived-state-effect`
- **1 warning** — `jsx-a11y/no-autofocus`
- **1 warning** — `react-doctor/no-array-index-as-key`

## Expected behaviour

- The `🩺 React Doctor` status check should run and **fail (red)**.
- A sticky PR comment should appear summarising the 1 error + 2 warnings.
- Inline annotations should appear on the file in the diff view (Files tab).

## Do not merge

This PR is purely a check-validation harness. Once the workflow is verified, close (don't merge) and delete the branch. The throwaway component is not imported anywhere.