### PR TITLE
fix(ci): re-attach HEAD before react-doctor scan so --diff actually works

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -41,6 +41,15 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
+      - name: 🪢 Re-attach HEAD to a named branch
+        # actions/checkout leaves us on a DETACHED HEAD when given a sha.
+        # react-doctor's --diff path calls `git rev-parse --abbrev-ref HEAD`
+        # to find the current branch; in detached state that returns the
+        # literal "HEAD", which the CLI interprets as "no branch" and silently
+        # falls back to scanning the FULL codebase. Re-attaching HEAD to a
+        # named ref restores the diff path.
+        run: git switch -C react-doctor-pr-head
+
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
actions/checkout@v4 with `ref: <sha>` leaves the working tree on a detached HEAD. react-doctor's --diff path detects the current branch via `git rev-parse --abbrev-ref HEAD`; in detached state that returns the literal string "HEAD", which the CLI interprets as "no branch detected" and silently falls back to scanning the FULL codebase instead of just the changed files.

The visible symptom on PRs (e.g. #2504): a PR that touches only package.json + pnpm-lock.yaml — zero source-file changes — produced a comment listing 1 error + 33 warnings on unrelated files across the codebase, and red-statused the PR via the deferred residual no-derived-state-effect in organization-selector.tsx.

Fix: after checkout, run `git switch -C react-doctor-pr-head` to put HEAD back on a named ref. react-doctor's getCurrentBranch then returns that branch name, getDiffInfo succeeds, and --diff properly limits the scan to files changed vs origin/<base>.

Verified locally by reading the cli.js source (resolveDiffMode at ~L2619 logs "No feature branch or uncommitted changes detected. Running full scan." on null diffInfo) and the workflow log of run 25094777992 contains exactly that warning line — that's how this was diagnosed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed branch detection in the CI/CD workflow to ensure diff-based analysis operates correctly instead of unintentionally performing full-codebase scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->