### PR TITLE
fix(reports): patch edge cases and improve overdue items clarity

### DIFF
--- a/apps/webapp/app/components/reports/report-table.tsx
+++ b/apps/webapp/app/components/reports/report-table.tsx
@@ -364,8 +364,7 @@ export function BooleanCell({
  * Asset name cell with thumbnail image.
  * Provides consistent asset display across all reports.
  *
- * When `assetId` is provided, uses the full `AssetImage` component which
- * automatically refreshes expired Supabase tokens.
+ * Uses AssetImage for automatic Supabase token refresh and placeholder handling.
  */
 export function AssetCell({
   name,
@@ -374,32 +373,16 @@ export function AssetCell({
 }: {
   name: string;
   thumbnailImage: string | null;
-  /** When provided, enables automatic image token refresh via AssetImage */
-  assetId?: string;
+  assetId: string;
 }) {
-  // If we have an assetId, use AssetImage for automatic token refresh
-  if (assetId) {
-    return (
-      <div className="flex items-center gap-3">
-        <AssetImage
-          asset={{
-            id: assetId,
-            thumbnailImage,
-          }}
-          alt="" // Decorative - asset name is displayed in adjacent text
-          className="size-8 shrink-0 rounded object-cover"
-        />
-        <span className="font-medium">{name}</span>
-      </div>
-    );
-  }
-
-  // Fallback: simple img without refresh capability
   return (
     <div className="flex items-center gap-3">
-      <img
-        src={thumbnailImage || "/static/images/asset-placeholder.jpg"}
-        alt=""
+      <AssetImage
+        asset={{
+          id: assetId,
+          thumbnailImage,
+        }}
+        alt="" // Decorative - asset name is displayed in adjacent text
         className="size-8 shrink-0 rounded object-cover"
       />
       <span className="font-medium">{name}</span>

--- a/apps/webapp/app/components/reports/report-table.tsx
+++ b/apps/webapp/app/components/reports/report-table.tsx
@@ -26,6 +26,7 @@ import {
 } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 
+import { AssetImage } from "~/components/assets/asset-image";
 import { tw } from "~/utils/tw";
 
 export interface ReportTableProps<TData> {
@@ -362,14 +363,38 @@ export function BooleanCell({
 /**
  * Asset name cell with thumbnail image.
  * Provides consistent asset display across all reports.
+ *
+ * When `assetId` is provided, uses the full `AssetImage` component which
+ * automatically refreshes expired Supabase tokens.
  */
 export function AssetCell({
   name,
   thumbnailImage,
+  assetId,
 }: {
   name: string;
   thumbnailImage: string | null;
+  /** When provided, enables automatic image token refresh via AssetImage */
+  assetId?: string;
 }) {
+  // If we have an assetId, use AssetImage for automatic token refresh
+  if (assetId) {
+    return (
+      <div className="flex items-center gap-3">
+        <AssetImage
+          asset={{
+            id: assetId,
+            thumbnailImage,
+          }}
+          alt={`Image of ${name}`}
+          className="size-8 shrink-0 rounded object-cover"
+        />
+        <span className="font-medium">{name}</span>
+      </div>
+    );
+  }
+
+  // Fallback: simple img without refresh capability
   return (
     <div className="flex items-center gap-3">
       <img

--- a/apps/webapp/app/components/reports/report-table.tsx
+++ b/apps/webapp/app/components/reports/report-table.tsx
@@ -386,7 +386,7 @@ export function AssetCell({
             id: assetId,
             thumbnailImage,
           }}
-          alt={`Image of ${name}`}
+          alt="" // Decorative - asset name is displayed in adjacent text
           className="size-8 shrink-0 rounded object-cover"
         />
         <span className="font-medium">{name}</span>

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -76,11 +76,21 @@ const COMPLIANCE_GRACE_PERIOD_MS = 15 * 60 * 1000;
 
 /**
  * Check if a booking was returned on-time (within grace period of scheduled end).
+ *
+ * @param scheduledEnd - The scheduled end/due date of the booking
+ * @param completedAt - When the booking was completed (for COMPLETE bookings)
+ * @param status - The booking status (COMPLETE or OVERDUE)
+ * @returns true if booking was returned on-time, false otherwise
  */
 function isBookingOnTime(
   scheduledEnd: Date | null,
-  completedAt: Date | null
+  completedAt: Date | null,
+  status: BookingStatus
 ): boolean {
+  // OVERDUE bookings are never on-time by definition - they haven't been fully returned
+  if (status === "OVERDUE") return false;
+
+  // For COMPLETE bookings: check if completion was within grace period
   if (!scheduledEnd || !completedAt) return true; // No data = assume on-time
   const msLate = completedAt.getTime() - scheduledEnd.getTime();
   return msLate <= COMPLIANCE_GRACE_PERIOD_MS;
@@ -415,7 +425,7 @@ async function fetchBookingComplianceRows(
       scheduledEnd: b.to!,
       actualCheckout: null,
       actualCheckin: null,
-      isOnTime: isBookingOnTime(b.to, b.updatedAt),
+      isOnTime: isBookingOnTime(b.to, b.updatedAt, b.status),
       isOverdue: b.status === "OVERDUE",
       latenessMs,
     };
@@ -591,6 +601,7 @@ async function computeComplianceRate(
 
 /**
  * Categorize completed bookings as on-time or late.
+ * Note: This function only processes COMPLETE bookings, so status is always COMPLETE.
  */
 function categorizeCompletions(
   bookings: { to: Date | null; updatedAt: Date | null }[]
@@ -599,7 +610,8 @@ function categorizeCompletions(
   let late = 0;
 
   for (const booking of bookings) {
-    if (isBookingOnTime(booking.to, booking.updatedAt)) {
+    // All bookings passed here have status COMPLETE (filtered at query time)
+    if (isBookingOnTime(booking.to, booking.updatedAt, "COMPLETE")) {
       onTime++;
     } else {
       late++;
@@ -682,10 +694,10 @@ async function computeComplianceTrend(
 
     // Categorize using same grace period logic as hero
     const onTime = bucketBookings.filter((b) =>
-      isBookingOnTime(b.to, b.updatedAt)
+      isBookingOnTime(b.to, b.updatedAt, b.status)
     ).length;
     const late = bucketBookings.filter(
-      (b) => !isBookingOnTime(b.to, b.updatedAt)
+      (b) => !isBookingOnTime(b.to, b.updatedAt, b.status)
     ).length;
     const total = onTime + late;
 
@@ -810,7 +822,8 @@ async function computeCustodianPerformance(
     const entry = custodianMap.get(key)!;
 
     // Use same grace period logic as hero
-    if (isBookingOnTime(booking.to, booking.updatedAt)) {
+    // All bookings here are COMPLETE (filtered by query), so pass "COMPLETE"
+    if (isBookingOnTime(booking.to, booking.updatedAt, "COMPLETE")) {
       entry.onTime++;
     } else {
       entry.late++;
@@ -960,6 +973,12 @@ async function fetchOverdueRows(
           valuation: true,
         },
       },
+      // Fetch partial check-ins to calculate outstanding assets
+      partialCheckins: {
+        select: {
+          assetIds: true,
+        },
+      },
       _count: {
         select: {
           assets: true,
@@ -982,6 +1001,11 @@ async function fetchOverdueRows(
       0
     );
 
+    // Calculate check-in progress from partial check-ins
+    const checkedInAssetIds = b.partialCheckins.flatMap((pc) => pc.assetIds);
+    const checkedInCount = checkedInAssetIds.length;
+    const uncheckedCount = b._count.assets - checkedInCount;
+
     return {
       id: b.id,
       bookingId: b.id,
@@ -997,6 +1021,8 @@ async function fetchOverdueRows(
         : null,
       custodianId: b.custodianUserId,
       assetCount: b._count.assets,
+      checkedInCount,
+      uncheckedCount,
       scheduledEnd,
       daysOverdue,
       valueAtRisk: valueAtRisk > 0 ? valueAtRisk : null,
@@ -1010,7 +1036,7 @@ async function computeOverdueKpis(
 ): Promise<ReportKpi[]> {
   const now = new Date();
 
-  // Fetch all overdue bookings with asset info
+  // Fetch all overdue bookings with asset info and partial check-ins
   const overdueBookings = await db.booking.findMany({
     where: baseWhere,
     select: {
@@ -1018,6 +1044,11 @@ async function computeOverdueKpis(
       assets: {
         select: {
           valuation: true,
+        },
+      },
+      partialCheckins: {
+        select: {
+          assetIds: true,
         },
       },
       _count: {
@@ -1029,7 +1060,17 @@ async function computeOverdueKpis(
   });
 
   const totalOverdue = overdueBookings.length;
-  const totalAssetsAtRisk = overdueBookings.reduce(
+
+  // Calculate assets still outstanding (not yet returned)
+  const totalAssetsOutstanding = overdueBookings.reduce((sum, b) => {
+    const checkedInCount = b.partialCheckins.flatMap(
+      (pc) => pc.assetIds
+    ).length;
+    return sum + (b._count.assets - checkedInCount);
+  }, 0);
+
+  // Also track total for context in hero subtitle
+  const totalAssetsInBookings = overdueBookings.reduce(
     (sum, b) => sum + b._count.assets,
     0
   );
@@ -1074,12 +1115,14 @@ async function computeOverdueKpis(
     },
     {
       id: "total_assets_at_risk",
-      label: "Assets at Risk",
-      value: totalAssetsAtRisk.toLocaleString(),
-      rawValue: totalAssetsAtRisk,
+      label: "Assets Outstanding",
+      value: totalAssetsOutstanding.toLocaleString(),
+      rawValue: totalAssetsOutstanding,
       format: "number",
       delta: null,
-      deltaType: totalAssetsAtRisk > 0 ? "negative" : "positive",
+      deltaType: totalAssetsOutstanding > 0 ? "negative" : "positive",
+      // Include total for context: "X outstanding across Y total"
+      description: `${totalAssetsOutstanding} still out across ${totalAssetsInBookings} total`,
     },
     {
       id: "total_value_at_risk",
@@ -1883,11 +1926,15 @@ async function fetchTopBookedAssetRows(
   );
 
   for (const booking of bookings) {
+    // Clamp to at least 1 day - handles edge case where to < from (inverted dates)
     const bookingDays =
       booking.from && booking.to
-        ? Math.ceil(
-            (booking.to.getTime() - booking.from.getTime()) /
-              (1000 * 60 * 60 * 24)
+        ? Math.max(
+            1,
+            Math.ceil(
+              (booking.to.getTime() - booking.from.getTime()) /
+                (1000 * 60 * 60 * 24)
+            )
           )
         : 1;
 
@@ -2555,13 +2602,16 @@ export async function monthlyBookingTrendsReport(
     >();
 
     for (const booking of bookings) {
-      const monthKey = `${booking.createdAt.getFullYear()}-${String(
-        booking.createdAt.getMonth() + 1
+      // Use UTC methods for consistent grouping regardless of server timezone
+      const monthKey = `${booking.createdAt.getUTCFullYear()}-${String(
+        booking.createdAt.getUTCMonth() + 1
       ).padStart(2, "0")}`;
       const monthStart = new Date(
-        booking.createdAt.getFullYear(),
-        booking.createdAt.getMonth(),
-        1
+        Date.UTC(
+          booking.createdAt.getUTCFullYear(),
+          booking.createdAt.getUTCMonth(),
+          1
+        )
       );
 
       if (!monthlyData.has(monthKey)) {
@@ -2614,10 +2664,13 @@ export async function monthlyBookingTrendsReport(
     const totalBookings = bookings.length;
     const avgMonthly =
       rows.length > 0 ? Math.round(totalBookings / rows.length) : 0;
-    const peakMonth = rows.reduce(
-      (max, r) => (r.bookingsCreated > max.bookingsCreated ? r : max),
-      rows[0]
-    );
+    // Guard against empty rows - reduce with rows[0] crashes when array is empty
+    const peakMonth =
+      rows.length > 0
+        ? rows.reduce((max, r) =>
+            r.bookingsCreated > max.bookingsCreated ? r : max
+          )
+        : undefined;
 
     // Trend calculation: compare last two months
     const lastTwoMonths = rows.slice(-2);

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -2650,6 +2650,7 @@ export async function monthlyBookingTrendsReport(
           month: data.monthStart.toLocaleDateString("en-US", {
             month: "short",
             year: "numeric",
+            timeZone: "UTC", // Match UTC-based grouping
           }),
           monthStart: data.monthStart,
           bookingsCreated: data.created,

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -970,6 +970,7 @@ async function fetchOverdueRows(
       },
       assets: {
         select: {
+          id: true,
           valuation: true,
         },
       },
@@ -995,18 +996,17 @@ async function fetchOverdueRows(
       Math.ceil(msOverdue / (1000 * 60 * 60 * 24))
     );
 
-    // Sum up asset valuations
-    const valueAtRisk = b.assets.reduce(
-      (sum, asset) => sum + (asset.valuation || 0),
-      0
-    );
-
     // Calculate check-in progress from partial check-ins (dedupe in case of duplicates)
     const checkedInAssetIds = new Set(
       b.partialCheckins.flatMap((pc) => pc.assetIds)
     );
     const checkedInCount = checkedInAssetIds.size;
     const uncheckedCount = Math.max(0, b._count.assets - checkedInCount);
+
+    // Sum valuations only for assets still outstanding (not yet checked in)
+    const valueAtRisk = b.assets
+      .filter((asset) => !checkedInAssetIds.has(asset.id))
+      .reduce((sum, asset) => sum + (asset.valuation || 0), 0);
 
     return {
       id: b.id,
@@ -1045,6 +1045,7 @@ async function computeOverdueKpis(
       to: true,
       assets: {
         select: {
+          id: true,
           valuation: true,
         },
       },
@@ -1077,16 +1078,16 @@ async function computeOverdueKpis(
     0
   );
 
-  // Calculate value at risk
-  const totalValueAtRisk = overdueBookings.reduce(
-    (sum, b) =>
-      sum +
-      b.assets.reduce(
-        (assetSum, asset) => assetSum + (asset.valuation || 0),
-        0
-      ),
-    0
-  );
+  // Calculate value at risk - only for assets still outstanding
+  const totalValueAtRisk = overdueBookings.reduce((sum, b) => {
+    const checkedInAssetIds = new Set(
+      b.partialCheckins.flatMap((pc) => pc.assetIds)
+    );
+    const outstandingValuation = b.assets
+      .filter((asset) => !checkedInAssetIds.has(asset.id))
+      .reduce((assetSum, asset) => assetSum + (asset.valuation || 0), 0);
+    return sum + outstandingValuation;
+  }, 0);
 
   // Calculate days overdue
   const daysOverdueList = overdueBookings.map((b) => {

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -1001,10 +1001,12 @@ async function fetchOverdueRows(
       0
     );
 
-    // Calculate check-in progress from partial check-ins
-    const checkedInAssetIds = b.partialCheckins.flatMap((pc) => pc.assetIds);
-    const checkedInCount = checkedInAssetIds.length;
-    const uncheckedCount = b._count.assets - checkedInCount;
+    // Calculate check-in progress from partial check-ins (dedupe in case of duplicates)
+    const checkedInAssetIds = new Set(
+      b.partialCheckins.flatMap((pc) => pc.assetIds)
+    );
+    const checkedInCount = checkedInAssetIds.size;
+    const uncheckedCount = Math.max(0, b._count.assets - checkedInCount);
 
     return {
       id: b.id,
@@ -1061,12 +1063,12 @@ async function computeOverdueKpis(
 
   const totalOverdue = overdueBookings.length;
 
-  // Calculate assets still outstanding (not yet returned)
+  // Calculate assets still outstanding (not yet returned), deduping asset IDs
   const totalAssetsOutstanding = overdueBookings.reduce((sum, b) => {
-    const checkedInCount = b.partialCheckins.flatMap(
-      (pc) => pc.assetIds
-    ).length;
-    return sum + (b._count.assets - checkedInCount);
+    const checkedInCount = new Set(
+      b.partialCheckins.flatMap((pc) => pc.assetIds)
+    ).size;
+    return sum + Math.max(0, b._count.assets - checkedInCount);
   }, 0);
 
   // Also track total for context in hero subtitle

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -995,9 +995,15 @@ async function fetchOverdueRows(
       Math.ceil(msOverdue / (1000 * 60 * 60 * 24))
     );
 
-    // Calculate check-in progress from partial check-ins (dedupe in case of duplicates)
+    // Calculate check-in progress from partial check-ins.
+    // Intersect with current b.assets so a partial-checkin row referencing an
+    // asset that was later removed from the booking doesn't overcount
+    // checkedInCount and desync it from valueAtRisk (which already filters via b.assets).
+    const currentAssetIds = new Set(b.assets.map((a) => a.id));
     const checkedInAssetIds = new Set(
-      b.partialCheckins.flatMap((pc) => pc.assetIds)
+      b.partialCheckins
+        .flatMap((pc) => pc.assetIds)
+        .filter((id) => currentAssetIds.has(id))
     );
     const checkedInCount = checkedInAssetIds.size;
     const uncheckedCount = Math.max(0, b._count.assets - checkedInCount);
@@ -1063,30 +1069,32 @@ async function computeOverdueKpis(
 
   const totalOverdue = overdueBookings.length;
 
-  // Calculate assets still outstanding (not yet returned), deduping asset IDs
-  const totalAssetsOutstanding = overdueBookings.reduce((sum, b) => {
-    const checkedInCount = new Set(
-      b.partialCheckins.flatMap((pc) => pc.assetIds)
-    ).size;
-    return sum + Math.max(0, b._count.assets - checkedInCount);
-  }, 0);
+  // Compute outstanding asset count and value at risk from the same filtered
+  // set of checked-in IDs (intersected with b.assets) so the two stay in sync
+  // when a partially-checked-in asset is later removed from the booking.
+  let totalAssetsOutstanding = 0;
+  let totalValueAtRisk = 0;
+  for (const b of overdueBookings) {
+    const currentAssetIds = new Set(b.assets.map((a) => a.id));
+    const checkedInAssetIds = new Set(
+      b.partialCheckins
+        .flatMap((pc) => pc.assetIds)
+        .filter((id) => currentAssetIds.has(id))
+    );
+    totalAssetsOutstanding += Math.max(
+      0,
+      b._count.assets - checkedInAssetIds.size
+    );
+    totalValueAtRisk += b.assets
+      .filter((asset) => !checkedInAssetIds.has(asset.id))
+      .reduce((assetSum, asset) => assetSum + (asset.valuation || 0), 0);
+  }
 
   // Also track total for context in hero subtitle
   const totalAssetsInBookings = overdueBookings.reduce(
     (sum, b) => sum + b._count.assets,
     0
   );
-
-  // Calculate value at risk - only for assets still outstanding
-  const totalValueAtRisk = overdueBookings.reduce((sum, b) => {
-    const checkedInAssetIds = new Set(
-      b.partialCheckins.flatMap((pc) => pc.assetIds)
-    );
-    const outstandingValuation = b.assets
-      .filter((asset) => !checkedInAssetIds.has(asset.id))
-      .reduce((assetSum, asset) => assetSum + (asset.valuation || 0), 0);
-    return sum + outstandingValuation;
-  }, 0);
 
   // Calculate days overdue
   const daysOverdueList = overdueBookings.map((b) => {

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -145,7 +145,7 @@ export async function bookingComplianceReport(
     timeframe,
     statusFilter,
     custodianId,
-    locationId,
+    locationId: _locationId, // TODO: Location filter requires join through assets
     page = 1,
     pageSize = 50,
     sortBy = "scheduledEnd",
@@ -179,8 +179,7 @@ export async function bookingComplianceReport(
       where.custodianUserId = custodianId;
     }
 
-    // TODO: Location filter requires join through assets
-    // if (locationId) { ... }
+    // TODO: Location filter requires join through assets (see _locationId)
 
     // Fetch all data in parallel
     const [
@@ -1033,7 +1032,7 @@ async function fetchOverdueRows(
 }
 
 async function computeOverdueKpis(
-  organizationId: string,
+  _organizationId: string,
   baseWhere: Prisma.BookingWhereInput
 ): Promise<ReportKpi[]> {
   const now = new Date();
@@ -1282,7 +1281,7 @@ export async function idleAssetsReport(
  * that was checked out since the cutoff date.
  */
 async function fetchIdleAssetRows(
-  organizationId: string,
+  _organizationId: string,
   assetWhere: Prisma.AssetWhereInput,
   cutoffDate: Date,
   page: number,
@@ -1373,7 +1372,7 @@ async function fetchIdleAssetRows(
  * Count total idle assets matching the criteria.
  */
 async function countIdleAssets(
-  organizationId: string,
+  _organizationId: string,
   assetWhere: Prisma.AssetWhereInput,
   cutoffDate: Date
 ): Promise<number> {
@@ -1695,7 +1694,7 @@ async function fetchCustodyRows(
 }
 
 async function computeCustodyKpis(
-  organizationId: string,
+  _organizationId: string,
   baseWhere: Prisma.CustodyWhereInput
 ): Promise<ReportKpi[]> {
   const now = new Date();
@@ -2124,7 +2123,7 @@ export async function assetDistributionReport(
 
   try {
     // Fetch all distribution data in parallel
-    const [totalAssets, byCategory, byLocation, byStatus, kpis] =
+    const [_totalAssets, byCategory, byLocation, byStatus, kpis] =
       await Promise.all([
         db.asset.count({ where: { organizationId } }),
         computeDistributionByCategory(organizationId),
@@ -2486,7 +2485,7 @@ async function fetchInventoryRows(
 }
 
 async function computeInventoryKpis(
-  organizationId: string,
+  _organizationId: string,
   where: Prisma.AssetWhereInput
 ): Promise<ReportKpi[]> {
   const [totalAssets, totalValue, statusCounts] = await Promise.all([

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -270,6 +270,10 @@ export interface OverdueItemRow {
   custodian: string | null;
   custodianId: string | null;
   assetCount: number;
+  /** Number of assets already checked in (partial returns) */
+  checkedInCount: number;
+  /** Number of assets still outstanding (not yet returned) */
+  uncheckedCount: number;
   scheduledEnd: Date;
   daysOverdue: number;
   /** Total value of assets in this booking (if available) */

--- a/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
+++ b/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
@@ -21,6 +21,7 @@ import {
 } from "react-router";
 
 import { showNotificationAtom } from "~/atoms/notifications";
+import { AssetImage } from "~/components/assets/asset-image";
 import Header from "~/components/layout/header";
 import {
   ReportFooter,
@@ -1220,9 +1221,32 @@ function OverdueItemsContent({
         row.original.custodian || <span className="text-gray-400">—</span>,
     },
     {
-      accessorKey: "assetCount",
+      accessorKey: "uncheckedCount",
       header: "Assets",
-      cell: ({ row }) => <NumberCell value={row.original.assetCount} />,
+      cell: ({ row }) => {
+        const { uncheckedCount, assetCount, checkedInCount } = row.original;
+        const hasPartialReturns = checkedInCount > 0;
+        const progressPercent =
+          assetCount > 0 ? (checkedInCount / assetCount) * 100 : 0;
+
+        return (
+          <div className="flex items-center gap-2">
+            <span className="font-medium tabular-nums">
+              {uncheckedCount}
+              <span className="font-normal text-gray-400"> / {assetCount}</span>
+            </span>
+            {/* Progress bar - shows return progress (green = returned) */}
+            {hasPartialReturns && (
+              <div className="h-2 w-12 overflow-hidden rounded-full bg-gray-200">
+                <div
+                  className="h-full rounded-full bg-green-500"
+                  style={{ width: `${progressPercent}%` }}
+                />
+              </div>
+            )}
+          </div>
+        );
+      },
     },
     {
       accessorKey: "scheduledEnd",
@@ -1296,7 +1320,7 @@ function OverdueItemsContent({
               </span>
               {totalOverdue > 0 ? (
                 <span className="text-xs text-gray-500">
-                  {assetsAtRisk} assets across {totalOverdue} booking
+                  {assetsAtRisk} assets still out across {totalOverdue} booking
                   {totalOverdue !== 1 ? "s" : ""}
                 </span>
               ) : (
@@ -1382,6 +1406,7 @@ function IdleAssetsContent({
         <AssetCell
           name={row.original.assetName}
           thumbnailImage={row.original.thumbnailImage}
+          assetId={row.original.assetId}
         />
       ),
     },
@@ -1548,6 +1573,7 @@ function CustodySnapshotContent({
         <AssetCell
           name={row.original.assetName}
           thumbnailImage={row.original.thumbnailImage}
+          assetId={row.original.assetId}
         />
       ),
     },
@@ -1720,6 +1746,7 @@ function TopBookedAssetsContent({
         <AssetCell
           name={row.original.assetName}
           thumbnailImage={row.original.thumbnailImage}
+          assetId={row.original.assetId}
         />
       ),
     },
@@ -1862,12 +1889,12 @@ function TopBookedAssetsContent({
                   to={`/assets/${topAsset.assetId}`}
                   className="group -mx-1.5 mt-0.5 flex items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-gray-50"
                 >
-                  <img
-                    src={
-                      topAsset.thumbnailImage ||
-                      "/static/images/asset-placeholder.jpg"
-                    }
-                    alt=""
+                  <AssetImage
+                    asset={{
+                      id: topAsset.assetId,
+                      thumbnailImage: topAsset.thumbnailImage,
+                    }}
+                    alt={`Image of ${topAsset.assetName}`}
                     className="size-8 rounded object-cover ring-1 ring-gray-200"
                   />
                   <div className="flex min-w-0 flex-col">
@@ -2058,6 +2085,7 @@ function AssetInventoryContent({
         <AssetCell
           name={row.original.assetName}
           thumbnailImage={row.original.thumbnailImage}
+          assetId={row.original.assetId}
         />
       ),
     },
@@ -2403,6 +2431,7 @@ function AssetUtilizationContent({
         <AssetCell
           name={row.original.assetName}
           thumbnailImage={row.original.thumbnailImage}
+          assetId={row.original.assetId}
         />
       ),
     },
@@ -2569,6 +2598,7 @@ function AssetActivityContent({
         <AssetCell
           name={row.original.assetName}
           thumbnailImage={row.original.thumbnailImage}
+          assetId={row.original.assetId}
         />
       ),
     },


### PR DESCRIPTION
## Summary

- **Monthly Trends**: Use UTC methods for consistent month grouping regardless of server timezone
- **Monthly Trends**: Guard `peakMonth` calculation when rows array is empty to prevent runtime crash
- **Top Booked Assets**: Clamp booking duration to minimum 1 day to handle edge case where `to < from`
- **Overdue Items**: Show check-in progress (X/Y still out) with progress bar instead of just total asset count

## Context

The Overdue Items enhancement makes it immediately clear which bookings need attention. Previously "Valor" (49 assets, 48 returned) looked worse than "Sarah" (3 assets, 0 returned). Now it correctly shows:
- Valor: **1 / 49** with green progress bar (98% returned)
- Sarah: **3 / 3** (0% returned - needs attention)

## Test plan

- [ ] View `/reports/monthly-booking-trends` - verify month grouping is consistent
- [ ] View `/reports/top-booked-assets` - verify no negative durations
- [ ] View `/reports/overdue-items` with live data:
  - Bookings with partial check-ins show `X / Y` with progress bar
  - Hero shows "X assets still out" instead of total
  - Sorting by Assets column works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overdue Items show checked-in vs remaining assets with an optional progress indicator.
  * Report tables show improved asset thumbnails across reports for clearer visuals.

* **Updates**
  * KPI renamed to "Assets Outstanding" with updated hero copy and outstanding-vs-total context.
  * On-time/compliance logic refined to respect booking status and grace periods.
  * Top-booked and monthly trend grouping made more robust and UTC-consistent for accurate counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->