### PR TITLE
chore: add ask permission rules for destructive commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,23 @@
       "Read(**/.env.test)",
       "Write(**/.env)",
       "Write(**/.env.*)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git branch -D:*)",
+      "Bash(git clean -f:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git clean -fdx:*)",
+      "Bash(git checkout --:*)",
+      "Bash(rm -rf:*)",
+      "Bash(rm -fr:*)",
+      "Bash(rm -r -f:*)",
+      "Bash(pnpm db:reset:*)",
+      "Bash(prisma migrate reset:*)",
+      "Bash(npx prisma migrate reset:*)",
+      "Bash(pnpm --filter @shelf/database exec prisma migrate reset:*)"
     ]
   }
 }


### PR DESCRIPTION
Adds project-level `ask` rules so Claude Code always prompts for explicit confirmation before running destructive shell commands (git push, git commit, git reset --hard, rm -rf, db:reset, etc.) even in auto mode.

Uses `ask` rather than `deny` so the commands remain available to run with human approval, but Claude can never execute them silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User confirmation now required for potentially destructive operations including git actions (push, commit, hard reset, branch deletion) and database schema reset operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->