### PR TITLE
fix(reports): hoist Top Booked Assets header to fix infinite render loop

### DIFF
--- a/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
+++ b/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
@@ -1721,6 +1721,30 @@ function CustodySnapshotContent({
 // R3: Top Booked Assets Content
 // -----------------------------------------------------------------------------
 
+// why: defined at module scope so the function identity is stable across
+// renders. TanStack's flexRender treats a different `header` function ref as a
+// different component type and remounts the whole subtree — for a header that
+// renders Radix's InfoTooltip, the ref-attach/detach churn triggers
+// setTrigger(...) loops during navigation transitions ("Maximum update depth
+// exceeded" — see SHELF-WEBAPP-1J4).
+function AvgDurationHeader() {
+  return (
+    <span className="flex items-center gap-1">
+      Avg Duration
+      <InfoTooltip
+        iconClassName="size-3.5"
+        content={
+          <p>
+            <strong>Average booking duration</strong> — How long this asset is
+            typically kept per booking. Calculated as total days booked ÷ number
+            of bookings.
+          </p>
+        }
+      />
+    </span>
+  );
+}
+
 function TopBookedAssetsContent({
   rows,
   kpis,
@@ -1775,21 +1799,7 @@ function TopBookedAssetsContent({
     },
     {
       id: "avgDuration",
-      header: () => (
-        <span className="flex items-center gap-1">
-          Avg Duration
-          <InfoTooltip
-            iconClassName="size-3.5"
-            content={
-              <p>
-                <strong>Average booking duration</strong> — How long this asset
-                is typically kept per booking. Calculated as total days booked ÷
-                number of bookings.
-              </p>
-            }
-          />
-        </span>
-      ),
+      header: AvgDurationHeader,
       // Compute average duration for sorting
       accessorFn: (row) =>
         row.bookingCount > 0 ? row.totalDaysBooked / row.bookingCount : 0,


### PR DESCRIPTION
The `avgDuration` column declared `header: () => (...)` inline, so the function identity changed on every render of `TopBookedAssetsContent`. TanStack's `flexRender` calls `React.createElement(headerFn, ctx)`, so the new identity made React unmount + remount the whole InfoTooltip subtree. Each remount re-runs Radix's
`useComposedRefs(forwardedRef, ref, context.onTriggerChange)` — `onTriggerChange` is the parent Tooltip's `setTrigger` setState. The ref attach/detach churn fired `setTrigger(null)` and `setTrigger(node)` repeatedly, and during the navigation transition (`navigation.state` flipping idle → loading → idle as the loader for `?timeframe=all_time` returned) the cycle compounded past React's 50-update guard.

Hoist the header to a module-scoped `AvgDurationHeader` so the component identity is stable. This was the only function-form column header with a Radix tooltip in the route, which matches why the same back-navigation off other reports did not throw.

Fixes SHELF-WEBAPP-1J4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal component structure for the reports page table header to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->