### PR TITLE
fix(ui): repair settings layout, reports re-render loop, and broken thumbnails

### DIFF
--- a/apps/webapp/app/components/assets/asset-image/component.tsx
+++ b/apps/webapp/app/components/assets/asset-image/component.tsx
@@ -114,12 +114,31 @@ export const AssetImage = ({
     dynamicThumbnailImage || updatedAssetThumbnailImage || thumbnailImage;
   const currentMainImage = updatedAssetMainImage || mainImage;
 
+  // After an image-load error, fall back to the placeholder so users see
+  // something instead of a broken-image icon. Two cases:
+  //   1. Caller passed no `mainImage` (e.g. reports' AssetCell). There's no
+  //      refresh path, so we can't recover the URL — show placeholder
+  //      immediately on error.
+  //   2. Caller passed `mainImage` (asset detail page). We attempt a refresh
+  //      via `refreshImage()`; only fall back if the fetcher finished without
+  //      yielding a usable URL. Avoids flashing the placeholder during the
+  //      refresh window.
+  const refreshYieldedNewUrl =
+    !!dynamicThumbnailImage || !!updatedAssetThumbnailImage;
+  const refreshAttemptFinishedWithoutUrl =
+    imageFetcher.state === "idle" &&
+    imageFetcher.data !== undefined &&
+    !refreshYieldedNewUrl;
+  const shouldShowPlaceholderFallback =
+    isImageError && (!mainImage || refreshAttemptFinishedWithoutUrl);
+
   // Only add cache-buster if we've had an error and attempted refresh
-  const imageUrl =
-    (useThumbnail && currentThumbnail
-      ? currentThumbnail
-      : currentMainImage || "/static/images/asset-placeholder.jpg") +
-    (hasAttemptedRefresh && isImageError ? cacheBuster : "");
+  const imageUrl = shouldShowPlaceholderFallback
+    ? "/static/images/asset-placeholder.jpg"
+    : (useThumbnail && currentThumbnail
+        ? currentThumbnail
+        : currentMainImage || "/static/images/asset-placeholder.jpg") +
+      (hasAttemptedRefresh && isImageError ? cacheBuster : "");
 
   // For preview dialog, also add cache buster only when needed
   const previewImageUrl =
@@ -157,6 +176,14 @@ export const AssetImage = ({
   }, [assetId, thumbnailFetcher]);
 
   const handleImageLoad = () => {
+    // If we already fell back to the placeholder, this `onLoad` is the
+    // placeholder finishing — NOT the real image succeeding. Clearing the
+    // error state here would flip `imageUrl` back to the broken original
+    // URL on the next render, which errors again, which falls back to the
+    // placeholder, which loads, which clears the error… infinite loop.
+    if (shouldShowPlaceholderFallback) {
+      return;
+    }
     // Successfully loaded, clear both loading and error states
     dispatch({ type: "load_success" });
   };
@@ -165,6 +192,10 @@ export const AssetImage = ({
     // Only set error state and trigger refresh once
     if (!isImageError && !hasAttemptedRefreshRef.current) {
       dispatch({ type: "load_error" });
+      // We can only refresh when we have a `mainImage` to re-sign from
+      // (asset detail page and similar full-preview callers). Thumbnail-
+      // only callers (reports' AssetCell, list rows) fall through to the
+      // placeholder fallback in `imageUrl` below — no API call here.
       refreshImage();
     } else {
       dispatch({ type: "load_error" });

--- a/apps/webapp/app/components/layout/sidebar/sidebar.tsx
+++ b/apps/webapp/app/components/layout/sidebar/sidebar.tsx
@@ -397,10 +397,7 @@ const SidebarInset = forwardRef<HTMLDivElement, ComponentProps<"main">>(
       <main
         ref={ref}
         className={tw(
-          // `flex flex-col` lets pages opt into a viewport-bounded layout
-          // (e.g. reports) by adding `flex-1` to a child. Pages without
-          // `flex-1` children continue to render at natural height.
-          "flex h-dvh w-full flex-col overflow-auto bg-gray-25 px-4",
+          "h-dvh w-full overflow-auto bg-gray-25 px-4",
           isAvailabilityView ? (isKitIndex ? "pb-0" : "pb-[46px]") : "pb-10",
           className
         )}

--- a/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
+++ b/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
@@ -8,7 +8,7 @@
  * @see {@link file://../../modules/reports/helpers.server.ts}
  */
 
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useSetAtom } from "jotai";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
@@ -393,45 +393,66 @@ export default function ReportPage() {
 
   const navigate = useNavigate();
 
-  // Navigate to booking when row is clicked
-  const handleBookingRowClick = (row: BookingComplianceRow) => {
-    void navigate(`/bookings/${row.bookingId}`);
-  };
+  // Row-click handlers are wrapped in `useCallback` so their identity is stable
+  // across re-renders. Without this, every ReportPage re-render produced a new
+  // `onRowClick` prop for the report content components, which propagated down
+  // through TanStack `flexRender` and forced AssetCell/AssetImage to remount —
+  // creating an image-fetch storm visible in the network panel.
+  const handleBookingRowClick = useCallback(
+    (row: BookingComplianceRow) => {
+      void navigate(`/bookings/${row.bookingId}`);
+    },
+    [navigate]
+  );
 
-  // Navigate to booking when overdue row is clicked
-  const handleOverdueRowClick = (row: OverdueItemRow) => {
-    void navigate(`/bookings/${row.bookingId}`);
-  };
+  const handleOverdueRowClick = useCallback(
+    (row: OverdueItemRow) => {
+      void navigate(`/bookings/${row.bookingId}`);
+    },
+    [navigate]
+  );
 
-  // Navigate to asset when idle asset row is clicked
-  const handleIdleAssetRowClick = (row: IdleAssetRow) => {
-    void navigate(`/assets/${row.assetId}`);
-  };
+  const handleIdleAssetRowClick = useCallback(
+    (row: IdleAssetRow) => {
+      void navigate(`/assets/${row.assetId}`);
+    },
+    [navigate]
+  );
 
-  // Navigate to asset when custody row is clicked
-  const handleCustodyRowClick = (row: CustodySnapshotRow) => {
-    void navigate(`/assets/${row.assetId}`);
-  };
+  const handleCustodyRowClick = useCallback(
+    (row: CustodySnapshotRow) => {
+      void navigate(`/assets/${row.assetId}`);
+    },
+    [navigate]
+  );
 
-  // Navigate to asset when top booked row is clicked
-  const handleTopBookedRowClick = (row: TopBookedAssetRow) => {
-    void navigate(`/assets/${row.assetId}`);
-  };
+  const handleTopBookedRowClick = useCallback(
+    (row: TopBookedAssetRow) => {
+      void navigate(`/assets/${row.assetId}`);
+    },
+    [navigate]
+  );
 
-  // Navigate to asset when inventory row is clicked
-  const handleInventoryRowClick = (row: AssetInventoryRow) => {
-    void navigate(`/assets/${row.assetId}`);
-  };
+  const handleInventoryRowClick = useCallback(
+    (row: AssetInventoryRow) => {
+      void navigate(`/assets/${row.assetId}`);
+    },
+    [navigate]
+  );
 
-  // Navigate to asset when utilization row is clicked
-  const handleUtilizationRowClick = (row: AssetUtilizationRow) => {
-    void navigate(`/assets/${row.assetId}`);
-  };
+  const handleUtilizationRowClick = useCallback(
+    (row: AssetUtilizationRow) => {
+      void navigate(`/assets/${row.assetId}`);
+    },
+    [navigate]
+  );
 
-  // Navigate to asset when activity row is clicked
-  const handleActivityRowClick = (row: AssetActivityRow) => {
-    void navigate(`/assets/${row.assetId}`);
-  };
+  const handleActivityRowClick = useCallback(
+    (row: AssetActivityRow) => {
+      void navigate(`/assets/${row.assetId}`);
+    },
+    [navigate]
+  );
 
   // Render report content based on report ID
   const renderReportContent = () => {
@@ -605,17 +626,8 @@ export default function ReportPage() {
         </div>
       </Header>
 
-      {/* Content area matching app patterns.
-          `flex-1` cascades from the parent `<main>` (SidebarInset), which is a
-          `flex flex-col h-dvh` container. That makes this column exactly the
-          remaining viewport height under the app Header. Combined with the
-          `flex-1 min-h-0` main content area below, the table card fills the
-          available space and the footer (pagination + computed-in) stays
-          pinned at the bottom of the viewport. */}
-      {/* `-mb-8` cancels most of the SidebarInset's `pb-10`, keeping the
-          pagination footer close to the viewport bottom on report pages
-          without changing the global main padding. */}
-      <div className="flex min-h-0 flex-1 flex-col gap-2 px-4 pb-2 md:-mb-8 md:mt-4 md:px-0">
+      {/* Content area matching app patterns */}
+      <div className="flex flex-1 flex-col gap-2 px-4 pb-4 md:mt-4 md:px-0">
         {/* Filter bar - varies by report type */}
         {showTimeframePicker(reportId) && (
           <div className="flex items-center justify-between rounded border border-gray-200 bg-white px-4 py-3">
@@ -661,15 +673,8 @@ export default function ReportPage() {
           </div>
         )}
 
-        {/* Main content area — `flex-1 min-h-0` lets it grow within the route's
-            flex column and lets children using `flex-1` (e.g. the data table)
-            shrink past their content height to enable internal scrolling. */}
-        <div
-          className={tw(
-            "flex min-h-0 flex-1 flex-col transition-opacity",
-            isLoading && "opacity-60"
-          )}
-        >
+        {/* Main content area */}
+        <div className={tw("transition-opacity", isLoading && "opacity-60")}>
           {hasData ? (
             renderReportContent()
           ) : (
@@ -924,7 +929,7 @@ function BookingComplianceContent({
   ];
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* The Answer */}
       <ComplianceHero
         rate={complianceData?.rate ?? 0}
@@ -935,7 +940,7 @@ function BookingComplianceContent({
       />
 
       {/* Booking details table */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">
             Booking Details
@@ -947,7 +952,6 @@ function BookingComplianceContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           onRowClick={onRowClick}
           manualSorting
           initialSorting={[
@@ -1383,6 +1387,78 @@ function OverdueItemsContent({
 // R4: Idle Assets Content
 // -----------------------------------------------------------------------------
 
+/**
+ * Column definitions for the Idle Assets table, defined at module scope so
+ * the cell function references stay stable across IdleAssetsContent renders.
+ * See the loop bug fix in IdleAssetsContent for context.
+ */
+const IDLE_ASSETS_COLUMNS: ColumnDef<IdleAssetRow>[] = [
+  {
+    accessorKey: "assetName",
+    header: "Asset",
+    cell: ({ row }) => (
+      <AssetCell
+        name={row.original.assetName}
+        thumbnailImage={row.original.thumbnailImage}
+        assetId={row.original.assetId}
+      />
+    ),
+  },
+  {
+    accessorKey: "daysSinceLastUse",
+    header: "Unused For",
+    cell: ({ row }) => {
+      const days = row.original.daysSinceLastUse;
+      return (
+        <span
+          className={tw(
+            "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold",
+            days > 90
+              ? "bg-red-100 text-red-700"
+              : days > 60
+              ? "bg-orange-100 text-orange-700"
+              : "bg-yellow-100 text-yellow-700"
+          )}
+        >
+          {days} days
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "lastBookedAt",
+    header: "Last Used",
+    cell: ({ row }) =>
+      row.original.lastBookedAt ? (
+        <DateCell date={row.original.lastBookedAt} />
+      ) : (
+        <span className="text-gray-400">Never</span>
+      ),
+  },
+  {
+    accessorKey: "category",
+    header: "Category",
+    cell: ({ row }) =>
+      row.original.category || <span className="text-gray-400">—</span>,
+  },
+  {
+    accessorKey: "location",
+    header: "Location",
+    cell: ({ row }) =>
+      row.original.location || <span className="text-gray-400">—</span>,
+  },
+  {
+    accessorKey: "valuation",
+    header: "Value",
+    cell: ({ row }) =>
+      row.original.valuation ? (
+        `$${row.original.valuation.toLocaleString()}`
+      ) : (
+        <span className="text-gray-400">—</span>
+      ),
+  },
+];
+
 function IdleAssetsContent({
   rows,
   kpis,
@@ -1396,74 +1472,17 @@ function IdleAssetsContent({
   timeframeLabel?: string;
   onRowClick?: (row: IdleAssetRow) => void;
 }) {
-  // Column definitions for unused assets table
-  // Order: What → Urgency → Context → Value → Status (tells a story)
-  const columns: ColumnDef<IdleAssetRow>[] = [
-    {
-      accessorKey: "assetName",
-      header: "Asset",
-      cell: ({ row }) => (
-        <AssetCell
-          name={row.original.assetName}
-          thumbnailImage={row.original.thumbnailImage}
-          assetId={row.original.assetId}
-        />
-      ),
-    },
-    {
-      accessorKey: "daysSinceLastUse",
-      header: "Unused For",
-      cell: ({ row }) => {
-        const days = row.original.daysSinceLastUse;
-        return (
-          <span
-            className={tw(
-              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold",
-              days > 90
-                ? "bg-red-100 text-red-700"
-                : days > 60
-                ? "bg-orange-100 text-orange-700"
-                : "bg-yellow-100 text-yellow-700"
-            )}
-          >
-            {days} days
-          </span>
-        );
-      },
-    },
-    {
-      accessorKey: "lastBookedAt",
-      header: "Last Used",
-      cell: ({ row }) =>
-        row.original.lastBookedAt ? (
-          <DateCell date={row.original.lastBookedAt} />
-        ) : (
-          <span className="text-gray-400">Never</span>
-        ),
-    },
-    {
-      accessorKey: "category",
-      header: "Category",
-      cell: ({ row }) =>
-        row.original.category || <span className="text-gray-400">—</span>,
-    },
-    {
-      accessorKey: "location",
-      header: "Location",
-      cell: ({ row }) =>
-        row.original.location || <span className="text-gray-400">—</span>,
-    },
-    {
-      accessorKey: "valuation",
-      header: "Value",
-      cell: ({ row }) =>
-        row.original.valuation ? (
-          `$${row.original.valuation.toLocaleString()}`
-        ) : (
-          <span className="text-gray-400">—</span>
-        ),
-    },
-  ];
+  // Column definitions for unused assets table.
+  // Memoized so cell function refs are stable across re-renders — without
+  // this, TanStack `flexRender` hands React a new component type on every
+  // render, which unmounts/remounts every AssetCell (and thereby its
+  // AssetImage child), causing image fetches to abort and re-issue in a
+  // loop. The deps list is empty because the cells only read from `row` —
+  // they don't capture any closure variables from this component.
+  const columns: ColumnDef<IdleAssetRow>[] = useMemo(
+    () => IDLE_ASSETS_COLUMNS,
+    []
+  );
 
   // Extract KPI values
   const totalIdle =
@@ -1474,7 +1493,7 @@ function IdleAssetsContent({
     (kpis.find((k) => k.id === "total_idle_value")?.rawValue as number) || 0;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* Hero section */}
       <div className="rounded border border-gray-200 bg-white">
         <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
@@ -1519,7 +1538,7 @@ function IdleAssetsContent({
       </div>
 
       {/* Data table */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">Unused Assets</h3>
           <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
@@ -1529,7 +1548,6 @@ function IdleAssetsContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           onRowClick={onRowClick}
           emptyContent={
             <ReportEmptyState
@@ -1645,7 +1663,7 @@ function CustodySnapshotContent({
     (kpis.find((k) => k.id === "avg_days_in_custody")?.rawValue as number) || 0;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* Hero section */}
       <div className="rounded border border-gray-200 bg-white">
         <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
@@ -1690,7 +1708,7 @@ function CustodySnapshotContent({
       </div>
 
       {/* Data table */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">
             Current Assignments
@@ -1702,7 +1720,6 @@ function CustodySnapshotContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           onRowClick={onRowClick}
           emptyContent={
             <ReportEmptyState
@@ -1861,7 +1878,7 @@ function TopBookedAssetsContent({
   const topAsset = topBookedAsset || null;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* Hero section */}
       <div className="rounded border border-gray-200 bg-white">
         <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
@@ -1945,7 +1962,7 @@ function TopBookedAssetsContent({
 
       {/* Data table — fills remaining vertical space inside the route's flex column
           and scrolls internally when row count exceeds the visible area. */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">Top Assets</h3>
           <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
@@ -1955,7 +1972,6 @@ function TopBookedAssetsContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           onRowClick={onRowClick}
           emptyContent={
             <ReportEmptyState
@@ -2155,7 +2171,7 @@ function AssetInventoryContent({
     (kpis.find((k) => k.id === "in_custody_count")?.rawValue as number) || 0;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* Hero section */}
       <div className="rounded border border-gray-200 bg-white">
         <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
@@ -2198,7 +2214,7 @@ function AssetInventoryContent({
       </div>
 
       {/* Data table */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">Assets</h3>
           <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
@@ -2208,7 +2224,6 @@ function AssetInventoryContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           onRowClick={onRowClick}
           emptyContent={
             <ReportEmptyState
@@ -2296,7 +2311,7 @@ function MonthlyBookingTrendsContent({
   const trendDescription = trendKpi?.description;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* Hero section */}
       <div className="rounded border border-gray-200 bg-white">
         <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
@@ -2391,7 +2406,7 @@ function MonthlyBookingTrendsContent({
       )}
 
       {/* Data table */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">
             Monthly Breakdown
@@ -2403,7 +2418,6 @@ function MonthlyBookingTrendsContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           emptyContent={
             <ReportEmptyState
               reason="no_data"
@@ -2502,7 +2516,7 @@ function AssetUtilizationContent({
     (kpis.find((k) => k.id === "avg_utilization")?.rawValue as number) || 0;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* Hero section */}
       <div className="rounded border border-gray-200 bg-white">
         <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
@@ -2557,7 +2571,7 @@ function AssetUtilizationContent({
       </div>
 
       {/* Data table */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">
             Asset Usage Rates
@@ -2569,7 +2583,6 @@ function AssetUtilizationContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           onRowClick={onRowClick}
           emptyContent={
             <ReportEmptyState
@@ -2677,7 +2690,7 @@ function AssetActivityContent({
     kpis.find((k) => k.id === "most_active_asset")?.value || "—";
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4">
+    <div className="flex flex-col gap-4">
       {/* Hero section */}
       <div className="rounded border border-gray-200 bg-white">
         <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
@@ -2747,7 +2760,7 @@ function AssetActivityContent({
       </div>
 
       {/* Data table */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-200 bg-white">
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
         <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
           <h3 className="text-sm font-semibold text-gray-900">
             Recent Activity
@@ -2759,7 +2772,6 @@ function AssetActivityContent({
         <ReportTable
           data={rows}
           columns={columns}
-          fillParent
           onRowClick={onRowClick}
           emptyContent={
             <ReportEmptyState


### PR DESCRIPTION
Three production hotfixes bundled together:

1. Revert global SidebarInset to block layout The feat-reports merge made the global `<main>` element `flex flex-col`, which silently broke layout for every page that used the layout (settings tabs, custom-fields underline, booking settings cards). The commit message claimed routes without `flex-1` children would be unaffected, but making a parent flex changes default child sizing and alignment regardless. Reverts `<main>` to its prior block layout. Reports lose pinned-bottom pagination as a tradeoff (re-implementable in a follow-up without touching the global layout).

2. Stop the AssetImage remount/refetch storm on report routes On `/reports/idle-assets` (and every other report listing assets), every ReportPage re-render produced new arrow-function `handle*RowClick` callbacks. Each report content component received a new `onRowClick` prop, re-rendered, rebuilt its `columns` array with new inline `cell: ({row}) => …` arrows, and TanStack `flexRender` handed React a new component type for every cell. Result: every AssetCell unmounted + remounted on each tick, every AssetImage remounted, every `<img>` started a fresh fetch and got aborted by the next remount. Tens of thousands of `NS_BINDING_ABORTED` requests, DOM teardown errors, and eventually a crashed app. Fix: `useCallback` the eight `handle*RowClick` handlers, hoist `IDLE_ASSETS_COLUMNS` to module scope, and `useMemo` the columns reference inside `IdleAssetsContent`. Other report content components have the same pattern and need the same treatment in a follow-up.

3. Fall back to placeholder when AssetImage can't refresh a stale URL Reports' `AssetCell` only passes `{id, thumbnailImage}` to AssetImage, so `refreshImage()` is a no-op (it requires `mainImage`). When the stored Supabase signed URL's JWT expires, the browser shows a broken- image icon with no recovery path. Fix: when the image errors AND we either have no refresh path (no `mainImage`) or the refresh fetcher finished without yielding a URL, render `/static/images/asset- placeholder.jpg` instead. Guard `handleImageLoad` against clearing the error state when the placeholder itself is what just loaded — without that guard, `imageUrl` flips back to the broken URL on the next render and the cycle repeats. Happy-path callers (image loads first try) hit zero new code; full-preview callers with `mainImage` retain the existing refresh behaviour.

The proper fix for #3 is to re-sign thumbnail URLs in the report loaders before returning them (matching the asset-list loader). That follow-up will make the placeholder fallback a defensive backstop rather than the primary recovery path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset image error handling to prevent infinite loading cycles when images fail to load.

* **Performance**
  * Optimized report page rendering stability and table performance.
  * Improved layout rendering for better responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->