### PR TITLE
fix(reports): include OVERDUE and ARCHIVED bookings in Booking Compliance metrics

### DIFF
--- a/apps/webapp/app/components/booking/time-remaining.tsx
+++ b/apps/webapp/app/components/booking/time-remaining.tsx
@@ -1,5 +1,9 @@
 import { BookingStatus } from "@prisma/client";
 import { Clock } from "lucide-react";
+import {
+  formatOverdueDuration,
+  getLatenessMs,
+} from "~/modules/booking/lateness";
 import { ONE_DAY, ONE_HOUR } from "~/utils/constants";
 
 export function TimeRemaining({
@@ -32,12 +36,22 @@ export function TimeRemaining({
 
   // Handle case where time has already passed
   if (remainingMs < 0) {
-    // For OVERDUE status, show how long it's been overdue
+    // For OVERDUE status, show how long it's been overdue.
+    // Math is delegated to the central helper for parity with the
+    // Booking Compliance report — both surfaces must agree on lateness.
     if (status === BookingStatus.OVERDUE) {
-      const overdueMs = Math.abs(remainingMs);
-      const overdueDays = Math.floor(overdueMs / ONE_DAY);
-      const overdueHours = Math.floor((overdueMs % ONE_DAY) / ONE_HOUR);
-      const overdueMinutes = Math.floor((overdueMs % ONE_HOUR) / (1000 * 60));
+      const overdueMs =
+        getLatenessMs({
+          status: BookingStatus.OVERDUE,
+          to,
+          checkInAt: null,
+          now: currentDate,
+        }) ?? 0;
+      const {
+        days: overdueDays,
+        hours: overdueHours,
+        minutes: overdueMinutes,
+      } = formatOverdueDuration(overdueMs);
 
       return (
         <div className="flex items-center text-sm text-gray-600 md:ml-4 [&_span]:whitespace-nowrap">

--- a/apps/webapp/app/components/reports/compliance-hero.tsx
+++ b/apps/webapp/app/components/reports/compliance-hero.tsx
@@ -167,8 +167,9 @@ export function ComplianceHero({
               How it's calculated:
             </span>{" "}
             {onTime} on-time ÷ {total} total = {rate}% (rounded to nearest whole
-            number). A booking is "on-time" if checked in within 15 minutes of
-            the scheduled end time.
+            number). Bookings with a due date in this period are counted:
+            completed and archived bookings are "on-time" if returned within 15
+            minutes of the scheduled end; overdue bookings always count as late.
           </p>
         </div>
       )}

--- a/apps/webapp/app/modules/booking/lateness.test.ts
+++ b/apps/webapp/app/modules/booking/lateness.test.ts
@@ -1,0 +1,192 @@
+import { BookingStatus } from "@prisma/client";
+import { describe, it, expect } from "vitest";
+import {
+  COMPLIANCE_GRACE_PERIOD_MS,
+  MEASURABLE_BOOKING_STATUSES,
+  formatOverdueDuration,
+  getLatenessMs,
+  isOnTime,
+} from "./lateness";
+
+/**
+ * Helper to build deterministic dates from ISO strings.
+ */
+const d = (iso: string) => new Date(iso);
+
+describe("getLatenessMs", () => {
+  it("returns now − to for OVERDUE bookings (ignores checkInAt)", () => {
+    const to = d("2026-04-01T12:00:00.000Z");
+    const now = d("2026-04-01T13:30:00.000Z"); // 90 minutes later
+    // checkInAt is set but should be ignored for OVERDUE
+    const checkInAt = d("2026-04-05T00:00:00.000Z");
+
+    const result = getLatenessMs({
+      status: BookingStatus.OVERDUE,
+      to,
+      checkInAt,
+      now,
+    });
+
+    expect(result).toBe(90 * 60 * 1000);
+  });
+
+  it("uses checkInAt − to for COMPLETE bookings", () => {
+    const to = d("2026-04-01T12:00:00.000Z");
+    const checkInAt = d("2026-04-01T12:30:00.000Z"); // 30 min late
+
+    const result = getLatenessMs({
+      status: BookingStatus.COMPLETE,
+      to,
+      checkInAt,
+    });
+
+    expect(result).toBe(30 * 60 * 1000);
+  });
+
+  it("uses checkInAt − to for ARCHIVED bookings (not updatedAt)", () => {
+    const to = d("2026-04-01T12:00:00.000Z");
+    const checkInAt = d("2026-04-01T11:50:00.000Z"); // 10 min early → negative
+
+    const result = getLatenessMs({
+      status: BookingStatus.ARCHIVED,
+      to,
+      checkInAt,
+    });
+
+    // 10 minutes early = -10 minutes lateness
+    expect(result).toBe(-10 * 60 * 1000);
+  });
+
+  it("returns null for COMPLETE without checkInAt", () => {
+    const result = getLatenessMs({
+      status: BookingStatus.COMPLETE,
+      to: d("2026-04-01T12:00:00.000Z"),
+      checkInAt: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for ARCHIVED without checkInAt", () => {
+    const result = getLatenessMs({
+      status: BookingStatus.ARCHIVED,
+      to: d("2026-04-01T12:00:00.000Z"),
+      checkInAt: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it.each([
+    BookingStatus.DRAFT,
+    BookingStatus.RESERVED,
+    BookingStatus.ONGOING,
+    BookingStatus.CANCELLED,
+  ])("returns null for non-measurable status %s", (status) => {
+    const result = getLatenessMs({
+      status,
+      to: d("2026-04-01T12:00:00.000Z"),
+      checkInAt: d("2026-04-01T13:00:00.000Z"),
+      now: d("2026-04-01T14:00:00.000Z"),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when `to` is missing", () => {
+    const result = getLatenessMs({
+      status: BookingStatus.OVERDUE,
+      to: null,
+      checkInAt: null,
+      now: d("2026-04-01T14:00:00.000Z"),
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("isOnTime", () => {
+  it("returns true when latenessMs is exactly the grace period", () => {
+    const result = isOnTime({
+      status: BookingStatus.COMPLETE,
+      latenessMs: COMPLIANCE_GRACE_PERIOD_MS,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when latenessMs is grace period + 1ms", () => {
+    const result = isOnTime({
+      status: BookingStatus.COMPLETE,
+      latenessMs: COMPLIANCE_GRACE_PERIOD_MS + 1,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("returns false for OVERDUE regardless of latenessMs", () => {
+    // Even with null lateness or values within the grace period,
+    // an OVERDUE booking is by definition not on time.
+    expect(isOnTime({ status: BookingStatus.OVERDUE, latenessMs: null })).toBe(
+      false
+    );
+    expect(isOnTime({ status: BookingStatus.OVERDUE, latenessMs: 0 })).toBe(
+      false
+    );
+    expect(
+      isOnTime({
+        status: BookingStatus.OVERDUE,
+        latenessMs: COMPLIANCE_GRACE_PERIOD_MS,
+      })
+    ).toBe(false);
+  });
+
+  it("returns true when latenessMs is null (no data, assume on-time)", () => {
+    const result = isOnTime({
+      status: BookingStatus.COMPLETE,
+      latenessMs: null,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true for negative lateness (returned early)", () => {
+    const result = isOnTime({
+      status: BookingStatus.COMPLETE,
+      latenessMs: -5 * 60 * 1000,
+    });
+
+    expect(result).toBe(true);
+  });
+});
+
+describe("formatOverdueDuration", () => {
+  it("formats 26d 14h 11m correctly", () => {
+    const ms = 26 * 24 * 60 * 60 * 1000 + 14 * 60 * 60 * 1000 + 11 * 60 * 1000;
+
+    const result = formatOverdueDuration(ms);
+
+    expect(result).toEqual({ days: 26, hours: 14, minutes: 11 });
+  });
+
+  it("returns zeros for 0 input", () => {
+    const result = formatOverdueDuration(0);
+
+    expect(result).toEqual({ days: 0, hours: 0, minutes: 0 });
+  });
+
+  it("returns zeros for negative input", () => {
+    const result = formatOverdueDuration(-1000);
+
+    expect(result).toEqual({ days: 0, hours: 0, minutes: 0 });
+  });
+});
+
+describe("MEASURABLE_BOOKING_STATUSES", () => {
+  it("includes COMPLETE, OVERDUE, and ARCHIVED with length 3", () => {
+    expect(MEASURABLE_BOOKING_STATUSES).toHaveLength(3);
+    expect(MEASURABLE_BOOKING_STATUSES).toContain(BookingStatus.COMPLETE);
+    expect(MEASURABLE_BOOKING_STATUSES).toContain(BookingStatus.OVERDUE);
+    expect(MEASURABLE_BOOKING_STATUSES).toContain(BookingStatus.ARCHIVED);
+  });
+});

--- a/apps/webapp/app/modules/booking/lateness.test.ts
+++ b/apps/webapp/app/modules/booking/lateness.test.ts
@@ -6,6 +6,7 @@ import {
   formatOverdueDuration,
   getLatenessMs,
   isOnTime,
+  resolveCheckInAt,
 } from "./lateness";
 
 /**
@@ -188,5 +189,63 @@ describe("MEASURABLE_BOOKING_STATUSES", () => {
     expect(MEASURABLE_BOOKING_STATUSES).toContain(BookingStatus.COMPLETE);
     expect(MEASURABLE_BOOKING_STATUSES).toContain(BookingStatus.OVERDUE);
     expect(MEASURABLE_BOOKING_STATUSES).toContain(BookingStatus.ARCHIVED);
+  });
+});
+
+describe("resolveCheckInAt", () => {
+  const updatedAt = d("2026-04-10T12:00:00.000Z");
+  const fromEvent = d("2026-04-09T10:00:00.000Z");
+
+  it("prefers the canonical event timestamp when present", () => {
+    const result = resolveCheckInAt({
+      status: BookingStatus.COMPLETE,
+      updatedAt,
+      fromEvent,
+    });
+
+    expect(result).toBe(fromEvent);
+  });
+
+  it("falls back to updatedAt for COMPLETE bookings without an event", () => {
+    const result = resolveCheckInAt({
+      status: BookingStatus.COMPLETE,
+      updatedAt,
+      fromEvent: null,
+    });
+
+    expect(result).toBe(updatedAt);
+  });
+
+  it("returns null for ARCHIVED without an event (updatedAt is unreliable)", () => {
+    const result = resolveCheckInAt({
+      status: BookingStatus.ARCHIVED,
+      updatedAt,
+      fromEvent: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("uses event timestamp for ARCHIVED when present", () => {
+    const result = resolveCheckInAt({
+      status: BookingStatus.ARCHIVED,
+      updatedAt,
+      fromEvent,
+    });
+
+    expect(result).toBe(fromEvent);
+  });
+
+  it("returns null for non-measurable statuses without an event", () => {
+    for (const status of [
+      BookingStatus.DRAFT,
+      BookingStatus.RESERVED,
+      BookingStatus.ONGOING,
+      BookingStatus.CANCELLED,
+    ] as const) {
+      expect(
+        resolveCheckInAt({ status, updatedAt, fromEvent: null })
+      ).toBeNull();
+    }
   });
 });

--- a/apps/webapp/app/modules/booking/lateness.ts
+++ b/apps/webapp/app/modules/booking/lateness.ts
@@ -53,7 +53,13 @@ export interface GetLatenessMsArgs {
   status: BookingStatus;
   /** Scheduled return date (`booking.to`). May be null on legacy data. */
   to: Date | null;
-  /** Actual check-in timestamp (`booking.checkInAt`). Null until checked in. */
+  /**
+   * Resolved check-in timestamp for COMPLETE/ARCHIVED bookings. Not a column
+   * on the `Booking` model — callers obtain it via {@link resolveCheckInAt}
+   * (which prefers the canonical `BOOKING_STATUS_CHANGED → COMPLETE`
+   * `ActivityEvent` and falls back to `Booking.updatedAt` for COMPLETE only).
+   * Pass `null` when no signal is available; ignored for OVERDUE.
+   */
   checkInAt: Date | null;
   /**
    * Reference "now" — injectable for deterministic testing. Defaults to
@@ -170,4 +176,49 @@ export function formatOverdueDuration(ms: number): {
   const minutes = Math.floor((ms % ONE_HOUR) / ONE_MINUTE);
 
   return { days, hours, minutes };
+}
+
+/** Arguments for {@link resolveCheckInAt}. */
+export interface ResolveCheckInAtArgs {
+  /** The booking's current status. */
+  status: BookingStatus;
+  /**
+   * `Booking.updatedAt` — last row mutation timestamp. Used as a COMPLETE-only
+   * fallback when no canonical event exists.
+   */
+  updatedAt: Date | null;
+  /**
+   * Timestamp from the canonical `BOOKING_STATUS_CHANGED → COMPLETE`
+   * `ActivityEvent` (resolved by `resolveCheckInTimes`). Pass `null` when no
+   * event was recorded.
+   */
+  fromEvent: Date | null;
+}
+
+/**
+ * Resolves the best-available check-in timestamp for a booking, applying the
+ * fallback policy that compliance reports rely on:
+ *
+ * 1. Prefer the canonical `BOOKING_STATUS_CHANGED → COMPLETE` event timestamp
+ *    when one exists. This is the most accurate signal — written inside the
+ *    booking status mutation transaction.
+ * 2. For `COMPLETE` bookings without an event, fall back to `updatedAt`.
+ *    This preserves backward compatibility with bookings completed before the
+ *    `ActivityEvent` layer existed (pre-2026-04-21), and protects against
+ *    rare event-write failures (the event is recorded best-effort).
+ * 3. For `ARCHIVED` (or any other) status without an event, return `null`.
+ *    `Booking.updatedAt` is unreliable for ARCHIVED — the auto-archive job
+ *    shifts it well after the actual check-in moment.
+ *
+ * Callers should pass the result to {@link getLatenessMs} as `checkInAt`.
+ *
+ * @param args - Booking status, raw `updatedAt`, and the resolved event timestamp.
+ * @returns The best-available check-in timestamp, or `null` when no reliable
+ *   signal is available (caller should treat as on-time per {@link isOnTime}).
+ */
+export function resolveCheckInAt(args: ResolveCheckInAtArgs): Date | null {
+  const { status, updatedAt, fromEvent } = args;
+  if (fromEvent) return fromEvent;
+  if (status === BookingStatus.COMPLETE) return updatedAt;
+  return null;
 }

--- a/apps/webapp/app/modules/booking/lateness.ts
+++ b/apps/webapp/app/modules/booking/lateness.ts
@@ -1,0 +1,173 @@
+/**
+ * Booking Lateness Helper
+ *
+ * Centralized, dependency-light source of truth for "how late was a booking?"
+ * calculations. Both the booking detail page (TimeRemaining indicator) and the
+ * Booking Compliance report rely on these helpers so the same booking is
+ * never reported as on-time in one place and overdue in another.
+ *
+ * The module is intentionally pure — no Prisma, no IO, no server-only deps —
+ * so it can be safely imported from both server (loaders, report helpers) and
+ * client (React components) code.
+ *
+ * @see {@link file://./../../components/booking/time-remaining.tsx}
+ * @see {@link file://./../reports/helpers.server.ts}
+ */
+
+import { BookingStatus } from "@prisma/client";
+
+/**
+ * Grace period (in ms) within which a return is still considered "on time".
+ *
+ * A booking returned up to 15 minutes after its scheduled `to` date counts as
+ * compliant. This absorbs realistic check-in delays (walking back to the
+ * counter, scanning the QR code, etc.) without flagging users as late.
+ */
+export const COMPLIANCE_GRACE_PERIOD_MS = 15 * 60 * 1000;
+
+/**
+ * Booking statuses for which a lateness measurement is meaningful.
+ *
+ * - `COMPLETE` and `ARCHIVED` represent finished bookings — we compare their
+ *   actual check-in time against the scheduled `to` date.
+ * - `OVERDUE` is in-flight but has already passed its `to` date — we compare
+ *   "now" against the scheduled `to` date.
+ *
+ * Statuses like `DRAFT`, `RESERVED`, `ONGOING`, and `CANCELLED` are excluded:
+ * they either haven't run yet, are still within their window, or never
+ * completed.
+ */
+export const MEASURABLE_BOOKING_STATUSES = [
+  BookingStatus.COMPLETE,
+  BookingStatus.OVERDUE,
+  BookingStatus.ARCHIVED,
+] as const;
+
+/** Union of statuses for which {@link getLatenessMs} can return a number. */
+export type MeasurableBookingStatus =
+  (typeof MEASURABLE_BOOKING_STATUSES)[number];
+
+/** Arguments for {@link getLatenessMs}. */
+export interface GetLatenessMsArgs {
+  /** The booking's current status. */
+  status: BookingStatus;
+  /** Scheduled return date (`booking.to`). May be null on legacy data. */
+  to: Date | null;
+  /** Actual check-in timestamp (`booking.checkInAt`). Null until checked in. */
+  checkInAt: Date | null;
+  /**
+   * Reference "now" — injectable for deterministic testing. Defaults to
+   * `new Date()` at call time. Only consulted for `OVERDUE` bookings.
+   */
+  now?: Date;
+}
+
+/**
+ * Returns how late a booking was, in milliseconds, or `null` when lateness
+ * cannot be measured.
+ *
+ * - For `OVERDUE`: returns `now − to`. `checkInAt` is ignored (by definition
+ *   the booking has not been checked in yet).
+ * - For `COMPLETE` / `ARCHIVED` with a `checkInAt`: returns `checkInAt − to`.
+ *   A negative result means the booking was returned early.
+ * - For `COMPLETE` / `ARCHIVED` without a `checkInAt`: returns `null`. We
+ *   deliberately do **not** fall back to `updatedAt` — many fields can move
+ *   `updatedAt` after the actual check-in, leading to false "very late"
+ *   readings.
+ * - For any other status, or when `to` is missing: returns `null`.
+ *
+ * @param args - Booking status, scheduled return, actual check-in, and optional now.
+ * @returns Lateness in ms, or `null` if not measurable.
+ */
+export function getLatenessMs(args: GetLatenessMsArgs): number | null {
+  const { status, to, checkInAt, now = new Date() } = args;
+
+  // Without a scheduled return, there is no reference point.
+  if (!to) {
+    return null;
+  }
+
+  if (status === BookingStatus.OVERDUE) {
+    // The booking is currently overdue; lateness is measured against now.
+    return now.getTime() - to.getTime();
+  }
+
+  if (status === BookingStatus.COMPLETE || status === BookingStatus.ARCHIVED) {
+    // We need an actual check-in timestamp to know when the booking returned.
+    if (!checkInAt) {
+      return null;
+    }
+    return checkInAt.getTime() - to.getTime();
+  }
+
+  // DRAFT, RESERVED, ONGOING, CANCELLED — no meaningful lateness.
+  return null;
+}
+
+/** Arguments for {@link isOnTime}. */
+export interface IsOnTimeArgs {
+  /** The booking's current status. */
+  status: BookingStatus;
+  /** Lateness in ms, as returned by {@link getLatenessMs}. */
+  latenessMs: number | null;
+}
+
+/**
+ * Returns whether a booking should be counted as "on time" for compliance
+ * reporting.
+ *
+ * Rules, in order:
+ * 1. `OVERDUE` bookings are never on time — by definition they have already
+ *    blown past their scheduled return.
+ * 2. `null` lateness (status was not measurable, or `to` / `checkInAt` was
+ *    missing) is treated as on-time so absent data does not skew compliance
+ *    rates downward. Callers that need a stricter view should pre-filter.
+ * 3. Otherwise: on-time iff `latenessMs <= COMPLIANCE_GRACE_PERIOD_MS`.
+ *    Negative lateness (returned early) is on-time.
+ *
+ * @param args - Booking status and computed lateness.
+ * @returns `true` if the booking counts as on-time, `false` otherwise.
+ */
+export function isOnTime(args: IsOnTimeArgs): boolean {
+  const { status, latenessMs } = args;
+
+  if (status === BookingStatus.OVERDUE) {
+    return false;
+  }
+
+  if (latenessMs === null) {
+    return true;
+  }
+
+  return latenessMs <= COMPLIANCE_GRACE_PERIOD_MS;
+}
+
+/**
+ * Breaks a positive duration in milliseconds into whole days, hours, and
+ * minutes for human-readable rendering (e.g., "Overdue by 2d 3h 14m").
+ *
+ * Returns zeros for `ms <= 0` so callers can safely format "negative" or
+ * empty durations without branching.
+ *
+ * @param ms - A non-negative duration in milliseconds.
+ * @returns An object with `days`, `hours`, and `minutes` integer components.
+ */
+export function formatOverdueDuration(ms: number): {
+  days: number;
+  hours: number;
+  minutes: number;
+} {
+  if (ms <= 0) {
+    return { days: 0, hours: 0, minutes: 0 };
+  }
+
+  const ONE_MINUTE = 60 * 1000;
+  const ONE_HOUR = 60 * ONE_MINUTE;
+  const ONE_DAY = 24 * ONE_HOUR;
+
+  const days = Math.floor(ms / ONE_DAY);
+  const hours = Math.floor((ms % ONE_DAY) / ONE_HOUR);
+  const minutes = Math.floor((ms % ONE_HOUR) / ONE_MINUTE);
+
+  return { days, hours, minutes };
+}

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1786,6 +1786,39 @@ export async function checkinBooking({
             user!
           )} performed a partial check-in: ${itemsDescription} and completed the booking. Status changed from ${fromStatusBadge} to ${toStatusBadge}`,
         });
+
+        // Record the canonical status transition event for reports.
+        // The custom system note above replaces the standard transition note,
+        // but downstream consumers (Booking Compliance report) still need the
+        // BOOKING_STATUS_CHANGED → COMPLETE ActivityEvent to know when the
+        // booking was actually checked in. Best-effort, mirroring the pattern
+        // inside createStatusTransitionNote.
+        try {
+          await recordEvent({
+            organizationId,
+            actorUserId: userId ?? null,
+            action: "BOOKING_STATUS_CHANGED",
+            entityType: "BOOKING",
+            entityId: updatedBooking.id,
+            bookingId: updatedBooking.id,
+            field: "status",
+            fromValue: bookingFound.status,
+            toValue: BookingStatus.COMPLETE,
+          });
+        } catch (err) {
+          Logger.error(
+            new ShelfError({
+              cause: err,
+              message:
+                "Failed to record BOOKING_STATUS_CHANGED event for partial check-in completion",
+              additionalData: {
+                bookingId: updatedBooking.id,
+                fromStatus: bookingFound.status,
+              },
+              label,
+            })
+          );
+        }
       } else {
         // Standard status transition note
         await createStatusTransitionNote({

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1796,7 +1796,8 @@ export async function checkinBooking({
         try {
           await recordEvent({
             organizationId,
-            actorUserId: userId ?? null,
+            // We're inside `if (userId)` — `userId` is a string here.
+            actorUserId: userId,
             action: "BOOKING_STATUS_CHANGED",
             entityType: "BOOKING",
             entityId: updatedBooking.id,

--- a/apps/webapp/app/modules/reports/check-in-time.server.test.ts
+++ b/apps/webapp/app/modules/reports/check-in-time.server.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: We mock the Prisma client to avoid hitting the real database during
+// unit tests. This matches the pattern used by other server-module tests
+// (e.g. apps/webapp/app/modules/note/service.server.test.ts).
+vi.mock("~/database/db.server", () => ({
+  db: {
+    activityEvent: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "~/database/db.server";
+
+import { resolveCheckInTimes } from "./check-in-time.server";
+
+describe("resolveCheckInTimes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty Map and does NOT call the database when given no booking ids", async () => {
+    const result = await resolveCheckInTimes([]);
+
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(0);
+    expect(db.activityEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns the latest event per booking when multiple events exist", async () => {
+    const earlierComplete = new Date("2026-04-01T10:00:00Z");
+    const laterComplete = new Date("2026-04-03T15:30:00Z");
+    const otherBookingComplete = new Date("2026-04-02T08:00:00Z");
+
+    // events are returned in ascending order; later events overwrite earlier
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([
+      { bookingId: "booking-1", occurredAt: earlierComplete },
+      { bookingId: "booking-2", occurredAt: otherBookingComplete },
+      { bookingId: "booking-1", occurredAt: laterComplete },
+    ] as any);
+
+    const result = await resolveCheckInTimes([
+      "booking-1",
+      "booking-2",
+      "booking-3",
+    ]);
+
+    expect(result.get("booking-1")).toEqual(laterComplete);
+    expect(result.get("booking-2")).toEqual(otherBookingComplete);
+    expect(result.has("booking-3")).toBe(false);
+    expect(result.size).toBe(2);
+  });
+
+  it("omits bookings that have no matching event from the Map", async () => {
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([
+      { bookingId: "booking-1", occurredAt: new Date("2026-04-01T10:00:00Z") },
+    ] as any);
+
+    const result = await resolveCheckInTimes(["booking-1", "booking-2"]);
+
+    expect(result.has("booking-1")).toBe(true);
+    expect(result.has("booking-2")).toBe(false);
+  });
+
+  it("issues a single batched Prisma query with the expected where/select/orderBy", async () => {
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([] as any);
+
+    const ids = ["booking-1", "booking-2", "booking-3"];
+    await resolveCheckInTimes(ids);
+
+    expect(db.activityEvent.findMany).toHaveBeenCalledTimes(1);
+    expect(db.activityEvent.findMany).toHaveBeenCalledWith({
+      where: {
+        action: "BOOKING_STATUS_CHANGED",
+        // `toValue` is a JSON column → use the `{ equals: ... }` JSON filter.
+        toValue: { equals: "COMPLETE" },
+        bookingId: { in: ids },
+      },
+      select: { bookingId: true, occurredAt: true },
+      orderBy: { occurredAt: "asc" },
+    });
+  });
+
+  it("defensively skips events whose bookingId is null", async () => {
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([
+      { bookingId: null, occurredAt: new Date("2026-04-01T10:00:00Z") },
+      { bookingId: "booking-1", occurredAt: new Date("2026-04-02T10:00:00Z") },
+    ] as any);
+
+    const result = await resolveCheckInTimes(["booking-1"]);
+
+    expect(result.size).toBe(1);
+    expect(result.get("booking-1")).toEqual(new Date("2026-04-02T10:00:00Z"));
+  });
+});

--- a/apps/webapp/app/modules/reports/check-in-time.server.ts
+++ b/apps/webapp/app/modules/reports/check-in-time.server.ts
@@ -1,0 +1,85 @@
+/**
+ * Booking Check-In Time Resolver
+ *
+ * Server-only helper that resolves the canonical check-in moment for a batch
+ * of bookings. The check-in moment is defined as the time at which a booking
+ * transitioned into the `COMPLETE` status — the user-driven "I'm returning
+ * the assets" event.
+ *
+ * Why this exists / why not `booking.updatedAt`:
+ * `Booking.updatedAt` is unreliable as a check-in signal because it shifts on
+ * any row mutation: edits, the auto-archive job, status flips into
+ * `OVERDUE`/`ARCHIVED`, etc. The canonical signal lives in the `ActivityEvent`
+ * table — specifically the row written by `createStatusTransitionNote` inside
+ * the booking status mutation transaction
+ * (see `apps/webapp/app/modules/booking/service.server.ts:264-275`).
+ *
+ * Lookup contract:
+ *   action:  "BOOKING_STATUS_CHANGED"
+ *   toValue: "COMPLETE"
+ *
+ * Legacy-data caveat:
+ * The `ActivityEvent` system was introduced on 2026-04-21. Bookings completed
+ * before that date have no event — the resolver intentionally returns no
+ * entry for them. Callers (e.g. the booking-compliance lateness helper) must
+ * treat a missing key as "no signal available" and fall back to a safe
+ * default rather than guessing from `booking.updatedAt`.
+ *
+ * @see {@link file://./helpers.server.ts}
+ * @see {@link file://../activity-event/service.server.ts}
+ * @see {@link file://../booking/service.server.ts}
+ */
+
+import { db } from "~/database/db.server";
+
+/**
+ * Resolves the canonical check-in moment for each booking in `bookingIds`.
+ *
+ * Fires a single batched Prisma query against `ActivityEvent` and returns a
+ * `Map<bookingId, Date>` keyed only by bookings that actually have an event.
+ * Bookings without an event are intentionally absent from the result — see
+ * the file-level legacy-data caveat.
+ *
+ * If multiple `BOOKING_STATUS_CHANGED → COMPLETE` events exist for the same
+ * booking (a rare COMPLETE → OVERDUE → COMPLETE flip), the latest one wins.
+ *
+ * @param bookingIds - The bookings to resolve check-in times for. Empty
+ *   input short-circuits and skips the database round-trip.
+ * @returns A `Map` of `bookingId → Date`. Bookings with no recorded event
+ *   are absent from the map.
+ */
+export async function resolveCheckInTimes(
+  bookingIds: string[]
+): Promise<Map<string, Date>> {
+  const result = new Map<string, Date>();
+
+  // Empty input → skip the DB entirely.
+  if (bookingIds.length === 0) {
+    return result;
+  }
+
+  const events = await db.activityEvent.findMany({
+    where: {
+      action: "BOOKING_STATUS_CHANGED",
+      // `toValue` is a Prisma `Json?` column; compare with the JSON-filter
+      // `equals` operator rather than a bare string literal so the generated
+      // Prisma client types accept the predicate.
+      toValue: { equals: "COMPLETE" },
+      bookingId: { in: bookingIds },
+    },
+    select: { bookingId: true, occurredAt: true },
+    // Ascending so later events overwrite earlier ones in the loop below —
+    // handles the rare COMPLETE → OVERDUE → COMPLETE flip.
+    orderBy: { occurredAt: "asc" },
+  });
+
+  for (const event of events) {
+    // Defensive: `bookingId` is nullable on ActivityEvent. Filtering by
+    // `bookingId: { in: ... }` should already exclude nulls, but TS still
+    // narrows it as `string | null`, and skipping is the safe behaviour.
+    if (!event.bookingId) continue;
+    result.set(event.bookingId, event.occurredAt);
+  }
+
+  return result;
+}

--- a/apps/webapp/app/modules/reports/helpers.server.test.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.test.ts
@@ -115,6 +115,81 @@ describe("bookingComplianceReport — complianceData hero", () => {
     expect(result.complianceData!.rate).toBe(50);
   });
 
+  it("falls back to updatedAt for COMPLETE bookings missing a check-in event", async () => {
+    // why: The partial-check-in completion path historically wrote a custom
+    // system note instead of calling `createStatusTransitionNote`, so no
+    // `BOOKING_STATUS_CHANGED → COMPLETE` event was recorded for those
+    // bookings. Without a fallback, every such booking would be counted as
+    // on-time regardless of when it was actually returned. With the fallback,
+    // a COMPLETE booking returned 1h late (well past the 15m grace window) is
+    // correctly counted as late via `Booking.updatedAt`.
+    const dueDate = new Date("2026-04-15T12:00:00Z");
+    const updatedAt = new Date(dueDate.getTime() + 60 * 60 * 1000); // 1h late
+
+    vi.mocked(db.booking.findMany).mockResolvedValue([
+      {
+        id: "booking-no-event",
+        name: "Partial Check-in",
+        status: "COMPLETE",
+        from: new Date("2026-04-14T12:00:00Z"),
+        to: dueDate,
+        updatedAt,
+        custodianUser: null,
+        custodianTeamMember: null,
+        custodianUserId: null,
+        custodianTeamMemberId: null,
+        _count: { assets: 1 },
+      },
+    ] as any);
+    // No activity event for this booking — the resolver returns an empty map
+    // and `resolveCheckInAt` must fall back to `updatedAt`.
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([] as any);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.complianceData!.onTime).toBe(0);
+    expect(result.complianceData!.late).toBe(1);
+    expect(result.complianceData!.rate).toBe(0);
+  });
+
+  it("does NOT fall back to updatedAt for ARCHIVED without an event", async () => {
+    // why: For ARCHIVED bookings `Booking.updatedAt` is unreliable — the
+    // auto-archive job shifts it long after the actual check-in. Falling back
+    // to `updatedAt` here would systematically misreport archived bookings as
+    // very late. With no event, the booking carries no measurable signal and
+    // is treated as on-time per `isOnTime`'s null-data semantics.
+    const dueDate = new Date("2026-04-15T12:00:00Z");
+
+    vi.mocked(db.booking.findMany).mockResolvedValue([
+      {
+        id: "booking-archived-no-event",
+        name: "Legacy Archived",
+        status: "ARCHIVED",
+        from: new Date("2026-04-14T12:00:00Z"),
+        to: dueDate,
+        // 10 days after due date — would mark as very late if fallback applied.
+        updatedAt: new Date(dueDate.getTime() + 10 * 24 * 60 * 60 * 1000),
+        custodianUser: null,
+        custodianTeamMember: null,
+        custodianUserId: null,
+        custodianTeamMemberId: null,
+        _count: { assets: 1 },
+      },
+    ] as any);
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([] as any);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.complianceData!.onTime).toBe(1);
+    expect(result.complianceData!.late).toBe(0);
+  });
+
   it("counts ARCHIVED bookings using their check-in event timestamp", async () => {
     const dueDate = new Date("2026-04-15T12:00:00Z");
     // Check-in occurred 5 minutes after `to` — well within the 15-minute

--- a/apps/webapp/app/modules/reports/helpers.server.test.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Booking Compliance Report — Hero Tests
+ *
+ * Covers the `complianceData` block of the public `bookingComplianceReport`
+ * function: that the hero counts measurable bookings (COMPLETE, OVERDUE,
+ * ARCHIVED) using the canonical check-in time from `ActivityEvent` rather
+ * than `Booking.updatedAt`.
+ *
+ * @see {@link file://./helpers.server.ts}
+ */
+
+import { BookingStatus } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: We mock the Prisma client to avoid hitting the real database during
+// unit tests. This matches the pattern established in
+// `apps/webapp/app/modules/reports/check-in-time.server.test.ts`.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    booking: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+    activityEvent: {
+      findMany: vi.fn(),
+    },
+    // why: `bookingStatusTransitionCounts` issues `db.$queryRaw` for the
+    // chart series. We stub it to a resolved empty array so the hero-data
+    // path is not coupled to chart math.
+    $queryRaw: vi.fn(),
+  },
+}));
+
+import { db } from "~/database/db.server";
+
+import { bookingComplianceReport } from "./helpers.server";
+import type { ResolvedTimeframe } from "./types";
+
+const TIMEFRAME: ResolvedTimeframe = {
+  preset: "last_30d",
+  label: "Last 30 days",
+  from: new Date("2026-04-01T00:00:00Z"),
+  to: new Date("2026-04-30T23:59:59Z"),
+};
+
+describe("bookingComplianceReport — complianceData hero", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no rows from booking queries (overridden per-test below).
+    vi.mocked(db.booking.findMany).mockResolvedValue([] as any);
+    // Default: zero counts for KPI math (test asserts only on complianceData).
+    vi.mocked(db.booking.count).mockResolvedValue(0 as any);
+    // Default: no activity events.
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([] as any);
+    // Default: no chart rows from the raw query.
+    vi.mocked(db.$queryRaw).mockResolvedValue([] as any);
+  });
+
+  it("counts OVERDUE bookings as late", async () => {
+    const dueDate = new Date("2026-04-15T12:00:00Z");
+
+    const completeBooking = {
+      id: "booking-complete",
+      name: "Complete Booking",
+      status: "COMPLETE",
+      from: new Date("2026-04-14T12:00:00Z"),
+      to: dueDate,
+      updatedAt: dueDate,
+      custodianUser: null,
+      custodianTeamMember: null,
+      custodianUserId: null,
+      custodianTeamMemberId: null,
+      _count: { assets: 1 },
+    };
+    const overdueBooking = {
+      id: "booking-overdue",
+      name: "Overdue Booking",
+      status: "OVERDUE",
+      from: new Date("2026-04-10T12:00:00Z"),
+      to: dueDate,
+      updatedAt: dueDate,
+      custodianUser: null,
+      custodianTeamMember: null,
+      custodianUserId: null,
+      custodianTeamMemberId: null,
+      _count: { assets: 1 },
+    };
+
+    // why: Multiple internal helpers call `db.booking.findMany` with different
+    // where clauses (rows fetch, compliance rate, trend, custodian
+    // performance, prior-period rate). Returning the same dataset for every
+    // call keeps the test focused on the hero `complianceData` shape; the
+    // prior-period query also resolves with the same dataset, but it doesn't
+    // affect the assertions on `onTime`/`late`/`rate`.
+    vi.mocked(db.booking.findMany).mockResolvedValue([
+      completeBooking,
+      overdueBooking,
+    ] as any);
+
+    // why: `resolveCheckInTimes` queries `activityEvent.findMany`. Returning
+    // a `BOOKING_STATUS_CHANGED → COMPLETE` event for the COMPLETE booking
+    // exactly at its due date marks it on-time via `getLatenessMs`.
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([
+      { bookingId: "booking-complete", occurredAt: dueDate },
+    ] as any);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.complianceData).toBeDefined();
+    expect(result.complianceData!.onTime).toBe(1);
+    expect(result.complianceData!.late).toBe(1);
+    expect(result.complianceData!.rate).toBe(50);
+  });
+
+  it("counts ARCHIVED bookings using their check-in event timestamp", async () => {
+    const dueDate = new Date("2026-04-15T12:00:00Z");
+    // Check-in occurred 5 minutes after `to` — well within the 15-minute
+    // grace window, so the booking is on-time.
+    const checkInAt = new Date(dueDate.getTime() + 5 * 60 * 1000);
+
+    const archivedBooking = {
+      id: "booking-archived",
+      name: "Archived Booking",
+      status: "ARCHIVED",
+      from: new Date("2026-04-14T12:00:00Z"),
+      to: dueDate,
+      updatedAt: new Date("2026-04-25T00:00:00Z"), // far after check-in (e.g. archive job)
+      custodianUser: null,
+      custodianTeamMember: null,
+      custodianUserId: null,
+      custodianTeamMemberId: null,
+      _count: { assets: 1 },
+    };
+
+    vi.mocked(db.booking.findMany).mockResolvedValue([archivedBooking] as any);
+
+    // why: The canonical check-in moment for an ARCHIVED booking is the
+    // `BOOKING_STATUS_CHANGED → COMPLETE` event, NOT `Booking.updatedAt`
+    // (which moves on the auto-archive job). Returning the on-time event
+    // here proves the helper consumes the resolver's map, not `updatedAt`.
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([
+      { bookingId: "booking-archived", occurredAt: checkInAt },
+    ] as any);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.complianceData).toBeDefined();
+    expect(result.complianceData!.onTime).toBe(1);
+    expect(result.complianceData!.late).toBe(0);
+    expect(result.complianceData!.rate).toBe(100);
+  });
+});
+
+describe("bookingComplianceReport — row builder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.booking.findMany).mockResolvedValue([] as any);
+    vi.mocked(db.booking.count).mockResolvedValue(0 as any);
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([] as any);
+    vi.mocked(db.$queryRaw).mockResolvedValue([] as any);
+  });
+
+  afterEach(() => {
+    // why: A test below installs fake timers; restoring after each test keeps
+    // later tests deterministic regardless of which test ran last.
+    vi.useRealTimers();
+  });
+
+  it("computes lateness as now − to for OVERDUE rows", async () => {
+    // why: Pinning `now` to a fixed instant lets us assert an exact
+    // `latenessMs` for the OVERDUE branch (`now − to`) without flakiness.
+    const fixedNow = new Date("2026-04-30T12:00:00Z");
+    vi.useFakeTimers().setSystemTime(fixedNow);
+
+    const dueDate = new Date("2026-04-04T12:00:00Z"); // 26 days before now
+    const overdueBooking = {
+      id: "booking-overdue",
+      name: "Overdue Booking",
+      status: BookingStatus.OVERDUE,
+      from: new Date("2026-04-03T12:00:00Z"),
+      to: dueDate,
+      // Buggy "lateness via updatedAt" would return ~2d 4h here. The canonical
+      // helper must ignore this and use `now − to` instead (= 26 days).
+      updatedAt: new Date("2026-04-06T16:00:00Z"),
+      custodianUser: null,
+      custodianTeamMember: null,
+      custodianUserId: null,
+      custodianTeamMemberId: null,
+      _count: { assets: 1 },
+    };
+
+    vi.mocked(db.booking.findMany).mockResolvedValue([overdueBooking] as any);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].latenessMs).toBe(26 * 24 * 60 * 60 * 1000);
+    expect(result.rows[0].isOverdue).toBe(true);
+  });
+
+  it("includes ARCHIVED rows in the table", async () => {
+    const archivedBooking = {
+      id: "booking-archived",
+      name: "Archived Booking",
+      status: BookingStatus.ARCHIVED,
+      from: new Date("2026-04-14T12:00:00Z"),
+      to: new Date("2026-04-15T12:00:00Z"),
+      updatedAt: new Date("2026-04-25T00:00:00Z"),
+      custodianUser: null,
+      custodianTeamMember: null,
+      custodianUserId: null,
+      custodianTeamMemberId: null,
+      _count: { assets: 1 },
+    };
+
+    vi.mocked(db.booking.findMany).mockResolvedValue([archivedBooking] as any);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].status).toBe(BookingStatus.ARCHIVED);
+  });
+});

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -24,6 +24,7 @@ import {
   MEASURABLE_BOOKING_STATUSES,
   getLatenessMs,
   isOnTime,
+  resolveCheckInAt,
 } from "~/modules/booking/lateness";
 import { ShelfError } from "~/utils/error";
 
@@ -233,91 +234,43 @@ export async function bookingComplianceReport(
   }
 }
 
+/**
+ * Build the KPI tiles for the Booking Compliance report.
+ *
+ * Historically this returned four KPIs, two of which (`compliance_rate` and
+ * `completed_on_time`) were computed from a placeholder heuristic that did
+ * not reflect actual check-in times. They are intentionally dropped here:
+ * the compliance rate is now exposed via the dedicated `complianceData`
+ * payload (`computeComplianceRate`), which uses the same lateness helper as
+ * the table and the trend, so callers see one consistent number.
+ *
+ * Remaining KPIs:
+ * - `total_bookings` — count of measurable bookings (COMPLETE + OVERDUE +
+ *   ARCHIVED) whose due date falls in the timeframe.
+ * - `currently_overdue` — count of OVERDUE bookings with a due date in the
+ *   timeframe. Consumed by the PDF generator's hero overdue tile.
+ */
 async function computeBookingComplianceKpis(
-  organizationId: string,
-  timeframe: ResolvedTimeframe,
+  _organizationId: string,
+  _timeframe: ResolvedTimeframe,
   baseWhere: Prisma.BookingWhereInput
 ): Promise<ReportKpi[]> {
-  // Count bookings by status in the timeframe
-  // Only COMPLETE and OVERDUE are measurable for compliance
-  const [total, complete, overdue] = await Promise.all([
+  const [total, overdue] = await Promise.all([
     db.booking.count({ where: baseWhere }),
-    db.booking.count({
-      where: { ...baseWhere, status: "COMPLETE" },
-    }),
     db.booking.count({
       where: { ...baseWhere, status: "OVERDUE" },
     }),
   ]);
 
-  // For "completed on time" we need to check if checkin happened before scheduled end
-  // This is a simplified version — full implementation would check ActivityEvent
-  const completedOnTime = complete; // Simplified for now
-  const completedLate = 0; // Would need ActivityEvent analysis
-
-  // Calculate delta vs prior period (simplified — same length period before)
-  const priorPeriodLength = timeframe.to.getTime() - timeframe.from.getTime();
-  const priorFrom = new Date(timeframe.from.getTime() - priorPeriodLength);
-  const priorTo = new Date(timeframe.from.getTime() - 1);
-
-  const priorTotal = await db.booking.count({
-    where: {
-      organizationId,
-      OR: [
-        { from: { gte: priorFrom, lte: priorTo } },
-        { to: { gte: priorFrom, lte: priorTo } },
-      ],
-    },
-  });
-
-  // Only show delta when we have current data (showing -100% for 0 is not helpful)
-  const showDelta = total > 0 && priorTotal > 0;
-  const totalDelta = showDelta
-    ? Math.round(((total - priorTotal) / priorTotal) * 100)
-    : 0;
-
-  // Calculate compliance rate
-  const complianceRate =
-    completedOnTime > 0
-      ? Math.round((completedOnTime / (completedOnTime + completedLate)) * 100)
-      : total > 0
-      ? 0
-      : 100; // 100% if no bookings yet
-
   return [
-    {
-      id: "compliance_rate",
-      label: "Compliance Rate",
-      value: `${complianceRate}%`,
-      rawValue: complianceRate,
-      format: "percent",
-      delta: null,
-      deltaType: "neutral",
-    },
     {
       id: "total_bookings",
       label: "Total Bookings",
       value: total.toLocaleString(),
       rawValue: total,
       format: "number",
-      delta:
-        showDelta && totalDelta !== 0
-          ? `${totalDelta > 0 ? "+" : ""}${totalDelta}%`
-          : null,
-      deltaType:
-        totalDelta > 0 ? "positive" : totalDelta < 0 ? "negative" : "neutral",
-      deltaPeriodLabel: showDelta
-        ? `vs prior ${timeframe.label.toLowerCase()}`
-        : undefined,
-    },
-    {
-      id: "completed_on_time",
-      label: "On-Time Returns",
-      value: completedOnTime.toLocaleString(),
-      rawValue: completedOnTime,
-      format: "number",
       delta: null,
-      deltaType: "positive",
+      deltaType: "neutral",
     },
     {
       id: "currently_overdue",
@@ -355,6 +308,11 @@ async function fetchBookingComplianceRows(
       status: true,
       from: true,
       to: true,
+      // `updatedAt` is a COMPLETE-only fallback when the canonical
+      // `BOOKING_STATUS_CHANGED → COMPLETE` ActivityEvent is missing
+      // (legacy bookings, partial check-ins that recorded a custom note,
+      // or rare event-write failures). See `resolveCheckInAt`.
+      updatedAt: true,
       custodianUser: {
         select: {
           firstName: true,
@@ -377,8 +335,8 @@ async function fetchBookingComplianceRows(
   // Resolve canonical check-in moments for every booking in one batched query.
   // The resolver returns a `Map<bookingId, Date>` keyed only by bookings that
   // actually emitted a `BOOKING_STATUS_CHANGED → COMPLETE` event. Missing
-  // entries are intentional (legacy data pre-2026-04-21) and treated as
-  // "no signal" by `getLatenessMs` / `isOnTime`.
+  // entries fall back via `resolveCheckInAt` (COMPLETE → `updatedAt`,
+  // ARCHIVED/other → null and treated as on-time per `isOnTime`).
   const checkInTimes = await resolveCheckInTimes(bookings.map((b) => b.id));
 
   // Capture a single `now` reference so every OVERDUE row in the result set
@@ -388,7 +346,11 @@ async function fetchBookingComplianceRows(
 
   // Transform to row objects with computed fields
   const allRows: BookingComplianceRow[] = bookings.map((b) => {
-    const checkInAt = checkInTimes.get(b.id) ?? null;
+    const checkInAt = resolveCheckInAt({
+      status: b.status,
+      updatedAt: b.updatedAt,
+      fromEvent: checkInTimes.get(b.id) ?? null,
+    });
 
     // Lateness via the canonical helper:
     // - OVERDUE → `now − to`
@@ -544,12 +506,14 @@ async function computeComplianceRate(
       from: true,
       to: true,
       status: true,
+      // COMPLETE-only fallback when the canonical event is missing.
+      updatedAt: true,
     },
   });
 
   // Resolve canonical check-in times in a single batched query. Bookings
-  // missing an event (legacy data predating the ActivityEvent layer) are
-  // absent from the map and treated as on-time by `isOnTime`.
+  // missing an event fall back via `resolveCheckInAt` (COMPLETE → `updatedAt`,
+  // ARCHIVED/other → null and treated as on-time by `isOnTime`).
   const checkInTimes = await resolveCheckInTimes(
     measurableBookings.map((b) => b.id)
   );
@@ -577,6 +541,7 @@ async function computeComplianceRate(
       from: true,
       to: true,
       status: true,
+      updatedAt: true,
     },
   });
 
@@ -609,27 +574,40 @@ async function computeComplianceRate(
 
 /**
  * Categorize a batch of measurable bookings as on-time vs late using the
- * central lateness helper. Bookings missing a check-in event (legacy data
- * predating the ActivityEvent layer) are treated as on-time per `isOnTime`.
+ * central lateness helper. Each booking's check-in moment is resolved via
+ * `resolveCheckInAt` (canonical event preferred; `updatedAt` fallback for
+ * COMPLETE; null for ARCHIVED with no event). Bookings with no signal at all
+ * are treated as on-time per `isOnTime`.
  *
  * @param bookings - Measurable bookings (COMPLETE / OVERDUE / ARCHIVED) with
- *   their `id`, scheduled return (`to`), and current `status` selected.
+ *   their `id`, scheduled return (`to`), `updatedAt`, and current `status`
+ *   selected.
  * @param checkInTimes - Map from `bookingId` to the canonical check-in moment
- *   produced by `resolveCheckInTimes`. Missing entries are treated as null.
+ *   produced by `resolveCheckInTimes`. Missing entries trigger the fallback.
  * @returns Counts of on-time and late bookings; the sum equals `bookings.length`.
  */
 function categorizeBookings(
-  bookings: { id: string; to: Date | null; status: BookingStatus }[],
+  bookings: {
+    id: string;
+    to: Date | null;
+    status: BookingStatus;
+    updatedAt: Date | null;
+  }[],
   checkInTimes: Map<string, Date>
 ): { onTime: number; late: number } {
   let onTime = 0;
   let late = 0;
   const now = new Date();
   for (const booking of bookings) {
+    const checkInAt = resolveCheckInAt({
+      status: booking.status,
+      updatedAt: booking.updatedAt,
+      fromEvent: checkInTimes.get(booking.id) ?? null,
+    });
     const latenessMs = getLatenessMs({
       status: booking.status,
       to: booking.to,
-      checkInAt: checkInTimes.get(booking.id) ?? null,
+      checkInAt,
       now,
     });
     if (isOnTime({ status: booking.status, latenessMs })) onTime++;
@@ -693,6 +671,8 @@ async function computeComplianceTrend(
       id: true,
       to: true,
       status: true,
+      // COMPLETE-only fallback when the canonical event is missing.
+      updatedAt: true,
     },
   });
 
@@ -721,14 +701,20 @@ async function computeComplianceTrend(
     });
 
     // Categorize using the central lateness helper for consistency with the
-    // hero compliance rate.
+    // hero compliance rate. `resolveCheckInAt` applies the COMPLETE-only
+    // `updatedAt` fallback when no canonical event is recorded.
     let onTime = 0;
     let late = 0;
     for (const b of bucketBookings) {
+      const checkInAt = resolveCheckInAt({
+        status: b.status,
+        updatedAt: b.updatedAt,
+        fromEvent: checkInTimes.get(b.id) ?? null,
+      });
       const latenessMs = getLatenessMs({
         status: b.status,
         to: b.to,
-        checkInAt: checkInTimes.get(b.id) ?? null,
+        checkInAt,
         now,
       });
       if (isOnTime({ status: b.status, latenessMs })) onTime++;
@@ -814,6 +800,8 @@ async function computeCustodianPerformance(
       id: true,
       to: true,
       status: true,
+      // COMPLETE-only fallback when the canonical event is missing.
+      updatedAt: true,
       custodianUserId: true,
       custodianUser: {
         select: {
@@ -868,11 +856,18 @@ async function computeCustodianPerformance(
     const entry = custodianMap.get(key)!;
 
     // Decide on-time vs late via the central lateness helper for parity with
-    // the hero compliance rate and trend chart.
+    // the hero compliance rate and trend chart. `resolveCheckInAt` applies
+    // the COMPLETE-only `updatedAt` fallback when no canonical event is
+    // recorded.
+    const checkInAt = resolveCheckInAt({
+      status: booking.status,
+      updatedAt: booking.updatedAt,
+      fromEvent: checkInTimes.get(booking.id) ?? null,
+    });
     const latenessMs = getLatenessMs({
       status: booking.status,
       to: booking.to,
-      checkInAt: checkInTimes.get(booking.id) ?? null,
+      checkInAt,
       now,
     });
     if (isOnTime({ status: booking.status, latenessMs })) {

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -20,7 +20,14 @@ import type {
 } from "@prisma/client";
 
 import { db } from "~/database/db.server";
+import {
+  MEASURABLE_BOOKING_STATUSES,
+  getLatenessMs,
+  isOnTime,
+} from "~/modules/booking/lateness";
 import { ShelfError } from "~/utils/error";
+
+import { resolveCheckInTimes } from "./check-in-time.server";
 
 import type {
   AssetActivityRow,
@@ -60,40 +67,6 @@ export { resolveTimeframe } from "./timeframe";
 function stripNameSuffix(name: string | null | undefined): string {
   if (!name) return "Unknown";
   return name.replace(/\s*\(Owner\)$/i, "").trim() || "Unknown";
-}
-
-// -----------------------------------------------------------------------------
-// Compliance Constants
-// -----------------------------------------------------------------------------
-
-/**
- * Grace period for on-time returns: 15 minutes after scheduled end time.
- * A booking is considered "on-time" if returned within this window.
- *
- * IMPORTANT: This constant must be used everywhere that calculates on-time vs late.
- */
-const COMPLIANCE_GRACE_PERIOD_MS = 15 * 60 * 1000;
-
-/**
- * Check if a booking was returned on-time (within grace period of scheduled end).
- *
- * @param scheduledEnd - The scheduled end/due date of the booking
- * @param completedAt - When the booking was completed (for COMPLETE bookings)
- * @param status - The booking status (COMPLETE or OVERDUE)
- * @returns true if booking was returned on-time, false otherwise
- */
-function isBookingOnTime(
-  scheduledEnd: Date | null,
-  completedAt: Date | null,
-  status: BookingStatus
-): boolean {
-  // OVERDUE bookings are never on-time by definition - they haven't been fully returned
-  if (status === "OVERDUE") return false;
-
-  // For COMPLETE bookings: check if completion was within grace period
-  if (!scheduledEnd || !completedAt) return true; // No data = assume on-time
-  const msLate = completedAt.getTime() - scheduledEnd.getTime();
-  return msLate <= COMPLIANCE_GRACE_PERIOD_MS;
 }
 
 // -----------------------------------------------------------------------------
@@ -158,17 +131,21 @@ export async function bookingComplianceReport(
     // Build the where clause for bookings
     // Compliance can only be measured on bookings that:
     // 1. Had a due date (scheduledEnd/to) within the selected timeframe
-    // 2. Have a measurable outcome (COMPLETE or OVERDUE)
+    // 2. Have a measurable outcome (COMPLETE, OVERDUE, or ARCHIVED). ARCHIVED
+    //    bookings are returned bookings that have aged out of the active list,
+    //    so they belong in the table just like COMPLETE rows.
     const where: Prisma.BookingWhereInput = {
       organizationId,
       to: { gte: timeframe.from, lte: timeframe.to }, // Due date in timeframe
-      status: { in: ["COMPLETE", "OVERDUE"] }, // Measurable outcomes only
+      status: {
+        in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[],
+      },
     };
 
     // Allow further status filtering within the measurable statuses
     if (statusFilter && statusFilter.length > 0) {
-      const measurableStatuses = statusFilter.filter(
-        (s) => s === "COMPLETE" || s === "OVERDUE"
+      const measurableStatuses = statusFilter.filter((s) =>
+        (MEASURABLE_BOOKING_STATUSES as readonly BookingStatus[]).includes(s)
       );
       if (measurableStatuses.length > 0) {
         where.status = { in: measurableStatuses as BookingStatus[] };
@@ -342,7 +319,7 @@ async function computeBookingComplianceKpis(
       deltaType: "positive",
     },
     {
-      id: "overdue",
+      id: "currently_overdue",
       label: "Overdue",
       value: overdue.toLocaleString(),
       rawValue: overdue,
@@ -377,7 +354,6 @@ async function fetchBookingComplianceRows(
       status: true,
       from: true,
       to: true,
-      updatedAt: true,
       custodianUser: {
         select: {
           firstName: true,
@@ -397,13 +373,32 @@ async function fetchBookingComplianceRows(
     },
   });
 
+  // Resolve canonical check-in moments for every booking in one batched query.
+  // The resolver returns a `Map<bookingId, Date>` keyed only by bookings that
+  // actually emitted a `BOOKING_STATUS_CHANGED → COMPLETE` event. Missing
+  // entries are intentional (legacy data pre-2026-04-21) and treated as
+  // "no signal" by `getLatenessMs` / `isOnTime`.
+  const checkInTimes = await resolveCheckInTimes(bookings.map((b) => b.id));
+
+  // Capture a single `now` reference so every OVERDUE row in the result set
+  // is measured against the same instant. Without this, two rows fetched in
+  // the same request could be measured against slightly different `now`s.
+  const now = new Date();
+
   // Transform to row objects with computed fields
   const allRows: BookingComplianceRow[] = bookings.map((b) => {
-    // Calculate lateness: positive = late, negative = early
-    const latenessMs =
-      b.to && b.updatedAt
-        ? new Date(b.updatedAt).getTime() - new Date(b.to).getTime()
-        : null;
+    const checkInAt = checkInTimes.get(b.id) ?? null;
+
+    // Lateness via the canonical helper:
+    // - OVERDUE → `now − to`
+    // - COMPLETE/ARCHIVED with a recorded check-in → `checkInAt − to`
+    // - otherwise null (no measurable lateness)
+    const latenessMs = getLatenessMs({
+      status: b.status,
+      to: b.to,
+      checkInAt,
+      now,
+    });
 
     return {
       id: b.id,
@@ -423,8 +418,8 @@ async function fetchBookingComplianceRows(
       scheduledStart: b.from!,
       scheduledEnd: b.to!,
       actualCheckout: null,
-      actualCheckin: null,
-      isOnTime: isBookingOnTime(b.to, b.updatedAt, b.status),
+      actualCheckin: checkInAt,
+      isOnTime: isOnTime({ status: b.status, latenessMs }),
       isOverdue: b.status === "OVERDUE",
       latenessMs,
     };
@@ -532,12 +527,14 @@ async function computeComplianceRate(
   organizationId: string,
   timeframe: ResolvedTimeframe
 ): Promise<ComplianceData> {
-  // Count completed bookings that were scheduled to end in this timeframe
-  // Using `to` (scheduled end date) for consistency with table filtering
-  const completedBookings = await db.booking.findMany({
+  // Fetch all measurable bookings (COMPLETE, OVERDUE, ARCHIVED) scheduled to
+  // end within the timeframe. We need OVERDUE so currently-late bookings count
+  // against compliance, and ARCHIVED so finished-then-archived bookings are
+  // not silently dropped from the rate.
+  const measurableBookings = await db.booking.findMany({
     where: {
       organizationId,
-      status: "COMPLETE",
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
       // Bookings scheduled to end within the timeframe
       to: { gte: timeframe.from, lte: timeframe.to },
     },
@@ -545,12 +542,19 @@ async function computeComplianceRate(
       id: true,
       from: true,
       to: true,
-      updatedAt: true,
+      status: true,
     },
   });
 
-  // Calculate on-time vs late
-  const { onTime, late } = categorizeCompletions(completedBookings);
+  // Resolve canonical check-in times in a single batched query. Bookings
+  // missing an event (legacy data predating the ActivityEvent layer) are
+  // absent from the map and treated as on-time by `isOnTime`.
+  const checkInTimes = await resolveCheckInTimes(
+    measurableBookings.map((b) => b.id)
+  );
+
+  // Calculate on-time vs late for the current period
+  const { onTime, late } = categorizeBookings(measurableBookings, checkInTimes);
   const total = onTime + late;
   // Return null rate when no completed bookings - UI should show "—" instead of misleading "100%"
   const rate = total > 0 ? Math.round((onTime / total) * 100) : null;
@@ -563,7 +567,7 @@ async function computeComplianceRate(
   const priorBookings = await db.booking.findMany({
     where: {
       organizationId,
-      status: "COMPLETE",
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
       // Filter by scheduled end date for consistency with main query
       to: { gte: priorFrom, lte: priorTo },
     },
@@ -571,11 +575,15 @@ async function computeComplianceRate(
       id: true,
       from: true,
       to: true,
-      updatedAt: true,
+      status: true,
     },
   });
 
-  const priorResults = categorizeCompletions(priorBookings);
+  const priorCheckInTimes = await resolveCheckInTimes(
+    priorBookings.map((b) => b.id)
+  );
+
+  const priorResults = categorizeBookings(priorBookings, priorCheckInTimes);
   const priorTotal = priorResults.onTime + priorResults.late;
   const priorRate =
     priorTotal > 0
@@ -599,24 +607,33 @@ async function computeComplianceRate(
 }
 
 /**
- * Categorize completed bookings as on-time or late.
- * Note: This function only processes COMPLETE bookings, so status is always COMPLETE.
+ * Categorize a batch of measurable bookings as on-time vs late using the
+ * central lateness helper. Bookings missing a check-in event (legacy data
+ * predating the ActivityEvent layer) are treated as on-time per `isOnTime`.
+ *
+ * @param bookings - Measurable bookings (COMPLETE / OVERDUE / ARCHIVED) with
+ *   their `id`, scheduled return (`to`), and current `status` selected.
+ * @param checkInTimes - Map from `bookingId` to the canonical check-in moment
+ *   produced by `resolveCheckInTimes`. Missing entries are treated as null.
+ * @returns Counts of on-time and late bookings; the sum equals `bookings.length`.
  */
-function categorizeCompletions(
-  bookings: { to: Date | null; updatedAt: Date | null }[]
+function categorizeBookings(
+  bookings: { id: string; to: Date | null; status: BookingStatus }[],
+  checkInTimes: Map<string, Date>
 ): { onTime: number; late: number } {
   let onTime = 0;
   let late = 0;
-
+  const now = new Date();
   for (const booking of bookings) {
-    // All bookings passed here have status COMPLETE (filtered at query time)
-    if (isBookingOnTime(booking.to, booking.updatedAt, "COMPLETE")) {
-      onTime++;
-    } else {
-      late++;
-    }
+    const latenessMs = getLatenessMs({
+      status: booking.status,
+      to: booking.to,
+      checkInAt: checkInTimes.get(booking.id) ?? null,
+      now,
+    });
+    if (isOnTime({ status: booking.status, latenessMs })) onTime++;
+    else late++;
   }
-
   return { onTime, late };
 }
 
@@ -662,19 +679,30 @@ async function computeComplianceTrend(
   const bucketMs = useDailyGranularity ? msPerDay : msPerWeek;
   const numBuckets = Math.max(1, Math.ceil(periodMs / bucketMs));
 
-  // Fetch all measurable bookings (COMPLETE and OVERDUE) with due date in timeframe
+  // Fetch all measurable bookings (COMPLETE, OVERDUE, ARCHIVED) with due date
+  // in the timeframe. ARCHIVED is included so finished-then-archived bookings
+  // still count toward the trend.
   const measurableBookings = await db.booking.findMany({
     where: {
       organizationId,
-      status: { in: ["COMPLETE", "OVERDUE"] },
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
       to: { gte: timeframe.from, lte: timeframe.to },
     },
     select: {
+      id: true,
       to: true,
       status: true,
-      updatedAt: true,
     },
   });
+
+  // Resolve canonical check-in times once for the full set, before bucketing.
+  // This avoids one query per bucket and keeps the trend calculation cheap.
+  const checkInTimes = await resolveCheckInTimes(
+    measurableBookings.map((b) => b.id)
+  );
+
+  // Reference "now" — captured once so all buckets agree on the OVERDUE clock.
+  const now = new Date();
 
   // Build time buckets
   const trend: ComplianceTrendPoint[] = [];
@@ -691,13 +719,20 @@ async function computeComplianceTrend(
       return dueDate >= bucketStart.getTime() && dueDate <= bucketEnd.getTime();
     });
 
-    // Categorize using same grace period logic as hero
-    const onTime = bucketBookings.filter((b) =>
-      isBookingOnTime(b.to, b.updatedAt, b.status)
-    ).length;
-    const late = bucketBookings.filter(
-      (b) => !isBookingOnTime(b.to, b.updatedAt, b.status)
-    ).length;
+    // Categorize using the central lateness helper for consistency with the
+    // hero compliance rate.
+    let onTime = 0;
+    let late = 0;
+    for (const b of bucketBookings) {
+      const latenessMs = getLatenessMs({
+        status: b.status,
+        to: b.to,
+        checkInAt: checkInTimes.get(b.id) ?? null,
+        now,
+      });
+      if (isOnTime({ status: b.status, latenessMs })) onTime++;
+      else late++;
+    }
     const total = onTime + late;
 
     // null rate for empty buckets (no data, not 0% compliance)
@@ -764,17 +799,20 @@ async function computeCustodianPerformance(
   organizationId: string,
   timeframe: ResolvedTimeframe
 ): Promise<CustodianPerformanceData[]> {
-  // Fetch completed bookings with custodian info
-  const completedBookings = await db.booking.findMany({
+  // Fetch all measurable bookings (COMPLETE, OVERDUE, ARCHIVED) with custodian
+  // info. Including OVERDUE/ARCHIVED ensures custodians with currently-late or
+  // archived bookings are not silently excluded from the breakdown.
+  const measurableBookings = await db.booking.findMany({
     where: {
       organizationId,
-      status: "COMPLETE",
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
       // Filter by scheduled end date for consistency with main compliance query
       to: { gte: timeframe.from, lte: timeframe.to },
     },
     select: {
+      id: true,
       to: true,
-      updatedAt: true,
+      status: true,
       custodianUserId: true,
       custodianUser: {
         select: {
@@ -791,6 +829,14 @@ async function computeCustodianPerformance(
     },
   });
 
+  // Resolve canonical check-in times in a single batched query.
+  const checkInTimes = await resolveCheckInTimes(
+    measurableBookings.map((b) => b.id)
+  );
+
+  // Reference "now" — captured once so all custodians agree on the OVERDUE clock.
+  const now = new Date();
+
   // Group by custodian
   const custodianMap = new Map<
     string,
@@ -801,7 +847,7 @@ async function computeCustodianPerformance(
     }
   >();
 
-  for (const booking of completedBookings) {
+  for (const booking of measurableBookings) {
     const key =
       booking.custodianUserId || booking.custodianTeamMemberId || "__none__";
     const name = booking.custodianUser
@@ -820,9 +866,15 @@ async function computeCustodianPerformance(
 
     const entry = custodianMap.get(key)!;
 
-    // Use same grace period logic as hero
-    // All bookings here are COMPLETE (filtered by query), so pass "COMPLETE"
-    if (isBookingOnTime(booking.to, booking.updatedAt, "COMPLETE")) {
+    // Decide on-time vs late via the central lateness helper for parity with
+    // the hero compliance rate and trend chart.
+    const latenessMs = getLatenessMs({
+      status: booking.status,
+      to: booking.to,
+      checkInAt: checkInTimes.get(booking.id) ?? null,
+      now,
+    });
+    if (isOnTime({ status: booking.status, latenessMs })) {
       entry.onTime++;
     } else {
       entry.late++;

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -251,12 +251,14 @@ export interface BookingComplianceRow {
   latenessMs: number | null;
 }
 
-/** KPI IDs for the Booking Compliance report */
-export type BookingComplianceKpiId =
-  | "total_bookings"
-  | "completed_on_time"
-  | "completed_late"
-  | "currently_overdue";
+/**
+ * KPI IDs emitted by the Booking Compliance report.
+ *
+ * Compliance rate / on-time / late breakdowns are now exposed via the
+ * `complianceData` payload (sourced from `computeComplianceRate`) so the
+ * KPI list is intentionally minimal.
+ */
+export type BookingComplianceKpiId = "total_bookings" | "currently_overdue";
 
 // -----------------------------------------------------------------------------
 // R6: Overdue Items Report Types

--- a/superpowers/plans/2026-04-30-fix-booking-compliance-report.md
+++ b/superpowers/plans/2026-04-30-fix-booking-compliance-report.md
@@ -1,0 +1,1373 @@
+# Fix Booking Compliance Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Booking Compliance report so the hero metrics include OVERDUE and ARCHIVED bookings, and so lateness on overdue rows reflects current time. Centralize all booking lateness/overdue calculation in one helper.
+
+**Architecture:** Create a single `getLatenessMs` / `isOnTime` helper in `app/modules/booking/lateness.ts` that takes a booking-shaped input and (optionally) a check-in timestamp resolved from `ActivityEvent`. Use it from both the booking detail page (`time-remaining.tsx`) and every compliance computation in `app/modules/reports/helpers.server.ts`. Broaden the report's status filter from `["COMPLETE", "OVERDUE"]` to `["COMPLETE", "OVERDUE", "ARCHIVED"]` and resolve check-in time per booking using the `BOOKING_STATUS_CHANGED → COMPLETE` event. For OVERDUE rows, lateness is `now − to`; for COMPLETE/ARCHIVED rows, lateness is `checkInAt − to` (with `updatedAt` as legacy fallback).
+
+**Tech Stack:** Remix, Prisma, Vitest, TypeScript. New code lives in the existing `@shelf/webapp` app — no new packages or migrations.
+
+---
+
+## Background
+
+### Bug 1 — Hero metrics drop OVERDUE bookings
+
+`computeComplianceRate()` (`apps/webapp/app/modules/reports/helpers.server.ts:531-599`) only fetches `status: "COMPLETE"`, so OVERDUE rows shown in the table are invisible to the hero `On-time / Late / Total` block. `computeCustodianPerformance()` and the KPI helper `computeBookingComplianceKpis()` have the same bug. Only `computeComplianceTrend()` already includes OVERDUE in its where clause.
+
+### Bug 2 — Lateness frozen at the moment of OVERDUE transition
+
+`fetchBookingComplianceRows()` computes `latenessMs = updatedAt − to` (`helpers.server.ts:403-406`). For OVERDUE bookings, `updatedAt` is set when the worker auto-transitioned the row to OVERDUE (`worker.server.ts:146`) and never updates again, so the displayed lateness stops growing. The booking detail page at `components/booking/time-remaining.tsx:31-37` correctly uses `now − to`. The two implementations have drifted.
+
+### ARCHIVED bookings should count too
+
+`archiveBooking()` requires `status === COMPLETE` (`service.server.ts:2452-2459`), confirmed. Once archived, the row's `updatedAt` shifts to the archive moment, so `updatedAt − to` is wildly inflated for ARCHIVED rows. We need a different signal for the actual check-in time.
+
+The canonical signal is `ActivityEvent` with `action: "BOOKING_STATUS_CHANGED"`, `entityId: bookingId`, `toValue: "COMPLETE"`. This was added 2026-04-21 (`1f786f863`) — bookings completed before that date won't have the event and we fall back to "no data → assume on-time" semantics.
+
+### Files involved
+
+```
+apps/webapp/app/modules/booking/
+  lateness.ts                    NEW   helper module (getLatenessMs, isOnTime, constants)
+  lateness.test.ts               NEW   unit tests for the helper
+  service.server.ts              read-only — references for canonical event shape
+  worker.server.ts               read-only — confirms OVERDUE auto-transition
+
+apps/webapp/app/modules/reports/
+  helpers.server.ts              MODIFY all compliance compute paths
+  check-in-time.server.ts        NEW   resolves check-in timestamp from ActivityEvent
+  check-in-time.server.test.ts   NEW   unit tests for the resolver
+
+apps/webapp/app/components/booking/
+  time-remaining.tsx             MODIFY use lateness helper for OVERDUE display
+
+apps/webapp/app/components/reports/
+  compliance-hero.tsx            MODIFY explainer text mentions overdue/archived
+
+apps/webapp/app/routes/_layout+/
+  reports.$reportId.tsx          read-only — formatLateness already correct
+```
+
+---
+
+## Task 1: Create the lateness helper module + tests
+
+**Files:**
+
+- Create: `apps/webapp/app/modules/booking/lateness.ts`
+- Create: `apps/webapp/app/modules/booking/lateness.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/webapp/app/modules/booking/lateness.test.ts`:
+
+```typescript
+import { BookingStatus } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  COMPLIANCE_GRACE_PERIOD_MS,
+  MEASURABLE_BOOKING_STATUSES,
+  formatOverdueDuration,
+  getLatenessMs,
+  isOnTime,
+} from "./lateness";
+
+const due = new Date("2026-04-01T12:00:00Z");
+const now = new Date("2026-04-30T12:00:00Z"); // 29 days after due
+
+describe("getLatenessMs", () => {
+  it("returns now - to for OVERDUE bookings", () => {
+    const ms = getLatenessMs({
+      status: BookingStatus.OVERDUE,
+      to: due,
+      checkInAt: null,
+      now,
+    });
+    expect(ms).toBe(29 * 24 * 60 * 60 * 1000);
+  });
+
+  it("uses checkInAt - to for COMPLETE bookings", () => {
+    const checkInAt = new Date(due.getTime() + 60 * 60 * 1000); // 1h late
+    const ms = getLatenessMs({
+      status: BookingStatus.COMPLETE,
+      to: due,
+      checkInAt,
+      now,
+    });
+    expect(ms).toBe(60 * 60 * 1000);
+  });
+
+  it("uses checkInAt - to for ARCHIVED bookings (not updatedAt)", () => {
+    const checkInAt = new Date(due.getTime() + 5 * 60 * 1000); // 5m late
+    const ms = getLatenessMs({
+      status: BookingStatus.ARCHIVED,
+      to: due,
+      checkInAt,
+      now,
+    });
+    expect(ms).toBe(5 * 60 * 1000);
+  });
+
+  it("returns null for COMPLETE without checkInAt (no signal)", () => {
+    const ms = getLatenessMs({
+      status: BookingStatus.COMPLETE,
+      to: due,
+      checkInAt: null,
+      now,
+    });
+    expect(ms).toBeNull();
+  });
+
+  it("returns null for ARCHIVED without checkInAt", () => {
+    const ms = getLatenessMs({
+      status: BookingStatus.ARCHIVED,
+      to: due,
+      checkInAt: null,
+      now,
+    });
+    expect(ms).toBeNull();
+  });
+
+  it("returns null for non-measurable statuses", () => {
+    for (const status of [
+      BookingStatus.DRAFT,
+      BookingStatus.RESERVED,
+      BookingStatus.ONGOING,
+      BookingStatus.CANCELLED,
+    ] as const) {
+      expect(
+        getLatenessMs({ status, to: due, checkInAt: null, now })
+      ).toBeNull();
+    }
+  });
+
+  it("returns null when to is missing", () => {
+    const ms = getLatenessMs({
+      status: BookingStatus.OVERDUE,
+      to: null,
+      checkInAt: null,
+      now,
+    });
+    expect(ms).toBeNull();
+  });
+});
+
+describe("isOnTime", () => {
+  it("returns true when lateness is within grace period", () => {
+    expect(
+      isOnTime({
+        status: BookingStatus.COMPLETE,
+        latenessMs: COMPLIANCE_GRACE_PERIOD_MS,
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when lateness exceeds grace period", () => {
+    expect(
+      isOnTime({
+        status: BookingStatus.COMPLETE,
+        latenessMs: COMPLIANCE_GRACE_PERIOD_MS + 1,
+      })
+    ).toBe(false);
+  });
+
+  it("returns false for OVERDUE regardless of latenessMs", () => {
+    expect(isOnTime({ status: BookingStatus.OVERDUE, latenessMs: 0 })).toBe(
+      false
+    );
+  });
+
+  it("returns true when latenessMs is null (no data — assume on-time)", () => {
+    expect(isOnTime({ status: BookingStatus.COMPLETE, latenessMs: null })).toBe(
+      true
+    );
+  });
+
+  it("returns true for negative lateness (returned early)", () => {
+    expect(
+      isOnTime({ status: BookingStatus.ARCHIVED, latenessMs: -3600_000 })
+    ).toBe(true);
+  });
+});
+
+describe("formatOverdueDuration", () => {
+  it("formats days, hours, and minutes", () => {
+    const ms = 26 * 24 * 60 * 60 * 1000 + 14 * 60 * 60 * 1000 + 11 * 60 * 1000;
+    expect(formatOverdueDuration(ms)).toEqual({
+      days: 26,
+      hours: 14,
+      minutes: 11,
+    });
+  });
+
+  it("returns zeros for ms <= 0", () => {
+    expect(formatOverdueDuration(0)).toEqual({ days: 0, hours: 0, minutes: 0 });
+    expect(formatOverdueDuration(-1000)).toEqual({
+      days: 0,
+      hours: 0,
+      minutes: 0,
+    });
+  });
+});
+
+describe("MEASURABLE_BOOKING_STATUSES", () => {
+  it("includes COMPLETE, OVERDUE, ARCHIVED", () => {
+    expect(MEASURABLE_BOOKING_STATUSES).toEqual(
+      expect.arrayContaining([
+        BookingStatus.COMPLETE,
+        BookingStatus.OVERDUE,
+        BookingStatus.ARCHIVED,
+      ])
+    );
+    expect(MEASURABLE_BOOKING_STATUSES).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm webapp:test -- --run app/modules/booking/lateness.test.ts`
+Expected: FAIL with "Cannot find module './lateness'"
+
+- [ ] **Step 3: Implement the helper**
+
+Create `apps/webapp/app/modules/booking/lateness.ts`:
+
+```typescript
+/**
+ * Booking Lateness / Overdue Helpers
+ *
+ * Single source of truth for "how late was a booking?" calculations.
+ * Used by the Booking detail page (TimeRemaining) and the Booking
+ * Compliance report. Keep this module small, pure, and dependency-free
+ * so it can be safely imported from both server and client code.
+ *
+ * @see {@link file://./../../components/booking/time-remaining.tsx}
+ * @see {@link file://./../reports/helpers.server.ts}
+ */
+
+import { BookingStatus } from "@prisma/client";
+
+/**
+ * Grace period for on-time returns: 15 minutes after scheduled end time.
+ * A booking is considered "on-time" if returned within this window.
+ */
+export const COMPLIANCE_GRACE_PERIOD_MS = 15 * 60 * 1000;
+
+/**
+ * Booking statuses that contribute to compliance metrics.
+ *
+ * - COMPLETE: returned on or after the due date (lateness = checkIn − to).
+ * - OVERDUE: still not returned (lateness = now − to, growing).
+ * - ARCHIVED: completed first, then archived (lateness = checkIn − to,
+ *   read from the BOOKING_STATUS_CHANGED → COMPLETE event timestamp).
+ */
+export const MEASURABLE_BOOKING_STATUSES = [
+  BookingStatus.COMPLETE,
+  BookingStatus.OVERDUE,
+  BookingStatus.ARCHIVED,
+] as const;
+
+export type MeasurableBookingStatus =
+  (typeof MEASURABLE_BOOKING_STATUSES)[number];
+
+/** Arguments for {@link getLatenessMs}. */
+export interface GetLatenessMsArgs {
+  /** Current booking status. */
+  status: BookingStatus;
+  /** Scheduled end of the booking (`booking.to`). */
+  to: Date | null;
+  /**
+   * Resolved check-in timestamp for COMPLETE/ARCHIVED bookings.
+   * For OVERDUE bookings this is ignored — we use `now`.
+   * Pass `null` if no check-in event was recorded (legacy data).
+   */
+  checkInAt: Date | null;
+  /** "Now" — injectable for testing. Defaults to `new Date()`. */
+  now?: Date;
+}
+
+/**
+ * Compute lateness in milliseconds for a measurable booking.
+ *
+ * - OVERDUE: `now − to` (the booking is still late and growing).
+ * - COMPLETE/ARCHIVED with `checkInAt`: `checkInAt − to`.
+ * - COMPLETE/ARCHIVED without `checkInAt`: `null` (no data — caller
+ *   should treat as on-time per {@link isOnTime}).
+ * - Any other status, or missing `to`: `null`.
+ *
+ * Positive return = late, negative = early.
+ */
+export function getLatenessMs({
+  status,
+  to,
+  checkInAt,
+  now = new Date(),
+}: GetLatenessMsArgs): number | null {
+  if (!to) return null;
+
+  if (status === BookingStatus.OVERDUE) {
+    return now.getTime() - to.getTime();
+  }
+
+  if (status === BookingStatus.COMPLETE || status === BookingStatus.ARCHIVED) {
+    if (!checkInAt) return null;
+    return checkInAt.getTime() - to.getTime();
+  }
+
+  return null;
+}
+
+/** Arguments for {@link isOnTime}. */
+export interface IsOnTimeArgs {
+  status: BookingStatus;
+  latenessMs: number | null;
+}
+
+/**
+ * Decide whether a booking is "on-time" for compliance.
+ *
+ * - OVERDUE: never on-time.
+ * - latenessMs null: no data — assume on-time (matches existing behavior).
+ * - latenessMs <= grace period: on-time.
+ */
+export function isOnTime({ status, latenessMs }: IsOnTimeArgs): boolean {
+  if (status === BookingStatus.OVERDUE) return false;
+  if (latenessMs === null) return true;
+  return latenessMs <= COMPLIANCE_GRACE_PERIOD_MS;
+}
+
+/**
+ * Break a positive duration in milliseconds into days/hours/minutes.
+ * Negative or zero input returns all zeros.
+ *
+ * Used by both the booking detail page and the report row formatter.
+ */
+export function formatOverdueDuration(ms: number): {
+  days: number;
+  hours: number;
+  minutes: number;
+} {
+  if (ms <= 0) return { days: 0, hours: 0, minutes: 0 };
+  const ONE_MINUTE = 60 * 1000;
+  const ONE_HOUR = 60 * ONE_MINUTE;
+  const ONE_DAY = 24 * ONE_HOUR;
+  const days = Math.floor(ms / ONE_DAY);
+  const hours = Math.floor((ms % ONE_DAY) / ONE_HOUR);
+  const minutes = Math.floor((ms % ONE_HOUR) / ONE_MINUTE);
+  return { days, hours, minutes };
+}
+```
+
+- [ ] **Step 4: Run tests — verify all pass**
+
+Run: `pnpm webapp:test -- --run app/modules/booking/lateness.test.ts`
+Expected: PASS — all describe blocks green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/webapp/app/modules/booking/lateness.ts apps/webapp/app/modules/booking/lateness.test.ts
+git commit -m "feat(booking): add centralized lateness helper for compliance reasoning"
+```
+
+---
+
+## Task 2: Use the helper in the booking detail page
+
+**Files:**
+
+- Modify: `apps/webapp/app/components/booking/time-remaining.tsx:14-65`
+
+- [ ] **Step 1: Update `time-remaining.tsx` to call the helper for the OVERDUE branch**
+
+Replace the OVERDUE branch (currently lines 34-65) so it uses `getLatenessMs` and `formatOverdueDuration`:
+
+```tsx
+import { BookingStatus } from "@prisma/client";
+import { Clock } from "lucide-react";
+
+import {
+  formatOverdueDuration,
+  getLatenessMs,
+} from "~/modules/booking/lateness";
+import { ONE_DAY, ONE_HOUR } from "~/utils/constants";
+
+export function TimeRemaining({
+  to,
+  from,
+  status,
+}: {
+  to: Date;
+  from: Date;
+  status: BookingStatus;
+}) {
+  const currentDate = new Date();
+
+  if (
+    status === BookingStatus.COMPLETE ||
+    status === BookingStatus.ARCHIVED ||
+    status === BookingStatus.CANCELLED
+  ) {
+    return null;
+  }
+
+  const isUpcoming =
+    status === BookingStatus.DRAFT || status === BookingStatus.RESERVED;
+
+  // OVERDUE: delegate to the central helper so the report and the
+  // detail page can never disagree on "how overdue is this?"
+  if (status === BookingStatus.OVERDUE) {
+    const overdueMs =
+      getLatenessMs({ status, to, checkInAt: null, now: currentDate }) ?? 0;
+    const { days, hours, minutes } = formatOverdueDuration(overdueMs);
+    return (
+      <div className="flex items-center text-sm text-gray-600 md:ml-4 [&_span]:whitespace-nowrap">
+        <Clock className="mr-1 size-4 text-gray-400" />
+        <span className="font-medium text-gray-900">
+          Overdue by {days} days
+        </span>
+        {hours > 0 && (
+          <>
+            <span className="mx-1">·</span>
+            <span>{hours} hours</span>
+          </>
+        )}
+        {minutes > 0 && (
+          <>
+            <span className="mx-1">·</span>
+            <span>{minutes} minutes</span>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  // remaining time for DRAFT / RESERVED / ONGOING — unchanged
+  const targetDate = isUpcoming ? from : to;
+  const remainingMs = targetDate.getTime() - currentDate.getTime();
+  if (remainingMs < 0) return null;
+
+  const remainingDays = Math.floor(remainingMs / ONE_DAY);
+  const remainingHours = Math.floor((remainingMs % ONE_DAY) / ONE_HOUR);
+  const remainingMinutes = Math.floor((remainingMs % ONE_HOUR) / (1000 * 60));
+
+  if (isUpcoming) {
+    return (
+      <div className="flex items-center text-sm text-gray-600 md:ml-4 [&_span]:whitespace-nowrap">
+        <Clock className="mr-1 size-4 text-gray-400" />
+        <span className="font-medium text-gray-900">
+          Starts in: {remainingDays} days
+        </span>
+        {remainingHours > 0 && (
+          <>
+            <span className="mx-1">·</span>
+            <span>{remainingHours} hours</span>
+          </>
+        )}
+        {remainingMinutes > 0 && (
+          <>
+            <span className="mx-1">·</span>
+            <span>{remainingMinutes} minutes</span>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center text-sm text-gray-600 md:ml-4 [&_span]:whitespace-nowrap">
+      <Clock className="mr-1 size-4 text-gray-400" />
+      <span className="font-medium text-gray-900">{remainingDays} days</span>
+      {remainingHours > 0 && (
+        <>
+          <span className="mx-1">·</span>
+          <span>{remainingHours} hours</span>
+        </>
+      )}
+      {remainingMinutes > 0 && (
+        <>
+          <span className="mx-1">·</span>
+          <span>{remainingMinutes} minutes</span>
+        </>
+      )}
+      <span className="ml-1">remaining</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run: `pnpm turbo typecheck --filter=@shelf/webapp && pnpm webapp:lint`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/webapp/app/components/booking/time-remaining.tsx
+git commit -m "refactor(booking): use centralized lateness helper in TimeRemaining"
+```
+
+---
+
+## Task 3: Build the check-in time resolver + tests
+
+**Files:**
+
+- Create: `apps/webapp/app/modules/reports/check-in-time.server.ts`
+- Create: `apps/webapp/app/modules/reports/check-in-time.server.test.ts`
+
+We need a way to find the actual check-in moment for a batch of COMPLETE / ARCHIVED bookings. The canonical source is `ActivityEvent` rows with `action: "BOOKING_STATUS_CHANGED"`, `toValue: "COMPLETE"`. We resolve them in a single batched query and return a `Map<bookingId, Date>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/webapp/app/modules/reports/check-in-time.server.test.ts`:
+
+```typescript
+import type { ActivityEvent } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+import { resolveCheckInTimes } from "./check-in-time.server";
+
+// why: the resolver hits the DB; we mock the prisma client to keep the
+// unit test fast and deterministic.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    activityEvent: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+const mockedFindMany = vi.mocked(db.activityEvent.findMany);
+
+describe("resolveCheckInTimes", () => {
+  beforeEach(() => {
+    mockedFindMany.mockReset();
+  });
+
+  it("returns an empty map when given no booking ids", async () => {
+    const result = await resolveCheckInTimes([]);
+    expect(result.size).toBe(0);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns the latest BOOKING_STATUS_CHANGED → COMPLETE event per booking", async () => {
+    const earlier = new Date("2026-04-01T10:00:00Z");
+    const later = new Date("2026-04-15T10:00:00Z");
+
+    mockedFindMany.mockResolvedValueOnce([
+      // booking-1 has two events (e.g. went COMPLETE → OVERDUE → COMPLETE again);
+      // we keep the latest.
+      { bookingId: "booking-1", createdAt: earlier } as ActivityEvent,
+      { bookingId: "booking-1", createdAt: later } as ActivityEvent,
+      { bookingId: "booking-2", createdAt: earlier } as ActivityEvent,
+    ]);
+
+    const result = await resolveCheckInTimes(["booking-1", "booking-2"]);
+
+    expect(result.get("booking-1")).toEqual(later);
+    expect(result.get("booking-2")).toEqual(earlier);
+    expect(result.size).toBe(2);
+
+    expect(mockedFindMany).toHaveBeenCalledWith({
+      where: {
+        action: "BOOKING_STATUS_CHANGED",
+        toValue: "COMPLETE",
+        bookingId: { in: ["booking-1", "booking-2"] },
+      },
+      select: { bookingId: true, createdAt: true },
+      orderBy: { createdAt: "asc" },
+    });
+  });
+
+  it("omits bookings that have no recorded check-in event", async () => {
+    mockedFindMany.mockResolvedValueOnce([
+      { bookingId: "booking-1", createdAt: new Date() } as ActivityEvent,
+    ]);
+
+    const result = await resolveCheckInTimes(["booking-1", "legacy-booking"]);
+
+    expect(result.has("booking-1")).toBe(true);
+    expect(result.has("legacy-booking")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm webapp:test -- --run app/modules/reports/check-in-time.server.test.ts`
+Expected: FAIL with "Cannot find module './check-in-time.server'"
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `apps/webapp/app/modules/reports/check-in-time.server.ts`:
+
+```typescript
+/**
+ * Check-in Time Resolver
+ *
+ * Reports need the actual moment a booking was checked in to compute
+ * "was this returned on time?" for COMPLETE and ARCHIVED bookings. The
+ * row's `updatedAt` is unreliable: it shifts whenever the row changes
+ * for any reason (auto-archive job, edits, status flips). The canonical
+ * signal is the `BOOKING_STATUS_CHANGED → COMPLETE` ActivityEvent.
+ *
+ * For bookings completed before the ActivityEvent system was introduced
+ * (2026-04-21), no event exists; callers should treat the missing entry
+ * as "no data" and fall back to on-time per `isOnTime`.
+ *
+ * @see {@link file://./helpers.server.ts}
+ * @see {@link file://./../booking/lateness.ts}
+ */
+
+import { db } from "~/database/db.server";
+
+/**
+ * Resolve the latest check-in moment for each given booking.
+ *
+ * Returns a Map keyed by bookingId. Missing keys mean "no recorded
+ * check-in event" — callers must handle that as no-data.
+ *
+ * @param bookingIds - Booking IDs to resolve. Empty array returns an
+ *   empty Map without hitting the database.
+ */
+export async function resolveCheckInTimes(
+  bookingIds: string[]
+): Promise<Map<string, Date>> {
+  const result = new Map<string, Date>();
+  if (bookingIds.length === 0) return result;
+
+  // Order ascending so later events overwrite earlier ones in the loop.
+  // (A booking can transition COMPLETE → OVERDUE → COMPLETE in rare
+  // edge cases; we want the latest check-in.)
+  const events = await db.activityEvent.findMany({
+    where: {
+      action: "BOOKING_STATUS_CHANGED",
+      toValue: "COMPLETE",
+      bookingId: { in: bookingIds },
+    },
+    select: { bookingId: true, createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  for (const event of events) {
+    if (!event.bookingId) continue;
+    result.set(event.bookingId, event.createdAt);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run the test — verify all pass**
+
+Run: `pnpm webapp:test -- --run app/modules/reports/check-in-time.server.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/webapp/app/modules/reports/check-in-time.server.ts apps/webapp/app/modules/reports/check-in-time.server.test.ts
+git commit -m "feat(reports): resolve canonical check-in time from ActivityEvent"
+```
+
+---
+
+## Task 4: Refactor `computeComplianceRate` to include OVERDUE + ARCHIVED
+
+**Files:**
+
+- Modify: `apps/webapp/app/modules/reports/helpers.server.ts:531-621`
+
+- [ ] **Step 1: Replace the function and its `categorizeCompletions` helper**
+
+Replace `computeComplianceRate()` and `categorizeCompletions()` in `helpers.server.ts` with the implementations below. Keep the module-local `isBookingOnTime` (lines 85-97) as-is for now — Task 6 removes it once nothing else uses it.
+
+```typescript
+import {
+  MEASURABLE_BOOKING_STATUSES,
+  getLatenessMs,
+  isOnTime,
+} from "~/modules/booking/lateness";
+import { resolveCheckInTimes } from "./check-in-time.server";
+
+// ... existing imports ...
+
+/**
+ * Calculate compliance rate for measurable bookings (COMPLETE, OVERDUE,
+ * ARCHIVED) whose due date falls within the timeframe.
+ *
+ * - COMPLETE / ARCHIVED: on-time if checked in within the grace period
+ *   of the scheduled end. Check-in time is the timestamp of the
+ *   BOOKING_STATUS_CHANGED → COMPLETE ActivityEvent. Bookings without
+ *   such an event (legacy data) fall back to "on-time" per `isOnTime`.
+ * - OVERDUE: never on-time by definition (still not returned).
+ */
+async function computeComplianceRate(
+  organizationId: string,
+  timeframe: ResolvedTimeframe
+): Promise<ComplianceData> {
+  const measurableBookings = await db.booking.findMany({
+    where: {
+      organizationId,
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
+      to: { gte: timeframe.from, lte: timeframe.to },
+    },
+    select: { id: true, to: true, status: true },
+  });
+
+  const checkInTimes = await resolveCheckInTimes(
+    measurableBookings.map((b) => b.id)
+  );
+
+  const { onTime, late } = categorizeBookings(measurableBookings, checkInTimes);
+  const total = onTime + late;
+  const rate = total > 0 ? Math.round((onTime / total) * 100) : null;
+
+  // Prior period — same shape as before
+  const periodLength = timeframe.to.getTime() - timeframe.from.getTime();
+  const priorFrom = new Date(timeframe.from.getTime() - periodLength);
+  const priorTo = new Date(timeframe.from.getTime() - 1);
+
+  const priorBookings = await db.booking.findMany({
+    where: {
+      organizationId,
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
+      to: { gte: priorFrom, lte: priorTo },
+    },
+    select: { id: true, to: true, status: true },
+  });
+  const priorCheckInTimes = await resolveCheckInTimes(
+    priorBookings.map((b) => b.id)
+  );
+  const priorResults = categorizeBookings(priorBookings, priorCheckInTimes);
+  const priorTotal = priorResults.onTime + priorResults.late;
+  const priorRate =
+    priorTotal > 0
+      ? Math.round((priorResults.onTime / priorTotal) * 100)
+      : null;
+
+  const priorPeriod =
+    rate !== null && priorRate !== null
+      ? {
+          rate: priorRate,
+          delta: rate - priorRate,
+          periodLabel: getPriorPeriodLabel(timeframe.preset),
+          fromDate: priorFrom,
+          toDate: priorTo,
+        }
+      : undefined;
+
+  return { onTime, late, rate, priorPeriod };
+}
+
+/**
+ * Categorize a batch of measurable bookings as on-time vs late using
+ * the central lateness helper.
+ *
+ * @param bookings - Bookings with status, due date, and id.
+ * @param checkInTimes - Map from bookingId → check-in timestamp (from
+ *   the BOOKING_STATUS_CHANGED → COMPLETE event). Missing keys mean
+ *   "no recorded check-in" and the helper treats them as on-time.
+ */
+function categorizeBookings(
+  bookings: { id: string; to: Date | null; status: BookingStatus }[],
+  checkInTimes: Map<string, Date>
+): { onTime: number; late: number } {
+  let onTime = 0;
+  let late = 0;
+  const now = new Date();
+
+  for (const booking of bookings) {
+    const latenessMs = getLatenessMs({
+      status: booking.status,
+      to: booking.to,
+      checkInAt: checkInTimes.get(booking.id) ?? null,
+      now,
+    });
+    if (isOnTime({ status: booking.status, latenessMs })) {
+      onTime++;
+    } else {
+      late++;
+    }
+  }
+  return { onTime, late };
+}
+```
+
+Delete the old `categorizeCompletions` function (lines 605-621) — it's replaced by `categorizeBookings`.
+
+- [ ] **Step 2: Add a focused test for the function**
+
+Create `apps/webapp/app/modules/reports/helpers.server.test.ts` (if it doesn't already exist) and add a test that verifies OVERDUE and ARCHIVED rows count toward the metrics. Use the database mock pattern from `check-in-time.server.test.ts` to keep the test unit-scoped:
+
+```typescript
+// apps/webapp/app/modules/reports/helpers.server.test.ts
+import { BookingStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+import { bookingComplianceReport } from "./helpers.server";
+import type { ResolvedTimeframe } from "./timeframe";
+
+// why: prisma is the only external dependency; mocking it lets us
+// assert compliance arithmetic without standing up a database.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    booking: {
+      findMany: vi.fn(),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    activityEvent: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
+const timeframe: ResolvedTimeframe = {
+  preset: "last_30d",
+  label: "Last 30 days",
+  from: new Date("2026-04-01T00:00:00Z"),
+  to: new Date("2026-04-30T23:59:59Z"),
+};
+
+describe("bookingComplianceReport hero metrics", () => {
+  beforeEach(() => {
+    vi.mocked(db.booking.findMany).mockReset();
+    vi.mocked(db.booking.count).mockReset().mockResolvedValue(0);
+    vi.mocked(db.activityEvent.findMany).mockReset().mockResolvedValue([]);
+  });
+
+  it("counts OVERDUE bookings as late", async () => {
+    vi.mocked(db.booking.findMany).mockResolvedValue([
+      {
+        id: "b1",
+        to: new Date("2026-04-15T12:00:00Z"),
+        status: BookingStatus.COMPLETE,
+      },
+      {
+        id: "b2",
+        to: new Date("2026-04-20T12:00:00Z"),
+        status: BookingStatus.OVERDUE,
+      },
+    ] as never);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe,
+    });
+
+    expect(result.complianceData).toEqual(
+      expect.objectContaining({ onTime: 1, late: 1, rate: 50 })
+    );
+  });
+
+  it("counts ARCHIVED bookings using their check-in event timestamp", async () => {
+    const due = new Date("2026-04-15T12:00:00Z");
+    const checkInOnTime = new Date(due.getTime() + 5 * 60 * 1000);
+
+    vi.mocked(db.booking.findMany).mockResolvedValue([
+      { id: "b1", to: due, status: BookingStatus.ARCHIVED },
+    ] as never);
+    vi.mocked(db.activityEvent.findMany).mockResolvedValue([
+      { bookingId: "b1", createdAt: checkInOnTime },
+    ] as never);
+
+    const result = await bookingComplianceReport({
+      organizationId: "org-1",
+      timeframe,
+    });
+
+    expect(result.complianceData).toEqual(
+      expect.objectContaining({ onTime: 1, late: 0, rate: 100 })
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `pnpm webapp:test -- --run app/modules/reports/helpers.server.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/webapp/app/modules/reports/helpers.server.ts apps/webapp/app/modules/reports/helpers.server.test.ts
+git commit -m "fix(reports): include OVERDUE and ARCHIVED in compliance rate"
+```
+
+---
+
+## Task 5: Refactor `computeCustodianPerformance` for the same fix
+
+**Files:**
+
+- Modify: `apps/webapp/app/modules/reports/helpers.server.ts:763-840` (and beyond — the whole function body)
+
+- [ ] **Step 1: Replace the function**
+
+```typescript
+async function computeCustodianPerformance(
+  organizationId: string,
+  timeframe: ResolvedTimeframe
+): Promise<CustodianPerformanceData[]> {
+  const measurableBookings = await db.booking.findMany({
+    where: {
+      organizationId,
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
+      to: { gte: timeframe.from, lte: timeframe.to },
+    },
+    select: {
+      id: true,
+      to: true,
+      status: true,
+      custodianUserId: true,
+      custodianUser: { select: { firstName: true, lastName: true } },
+      custodianTeamMemberId: true,
+      custodianTeamMember: { select: { name: true } },
+    },
+  });
+
+  const checkInTimes = await resolveCheckInTimes(
+    measurableBookings.map((b) => b.id)
+  );
+
+  const custodianMap = new Map<
+    string,
+    { name: string; onTime: number; late: number }
+  >();
+  const now = new Date();
+
+  for (const booking of measurableBookings) {
+    const key =
+      booking.custodianUserId || booking.custodianTeamMemberId || "__none__";
+    const name = booking.custodianUser
+      ? stripNameSuffix(
+          `${booking.custodianUser.firstName || ""} ${
+            booking.custodianUser.lastName || ""
+          }`.trim()
+        )
+      : booking.custodianTeamMember
+      ? stripNameSuffix(booking.custodianTeamMember.name)
+      : "No Custodian";
+
+    if (!custodianMap.has(key)) {
+      custodianMap.set(key, { name, onTime: 0, late: 0 });
+    }
+    const entry = custodianMap.get(key)!;
+    const latenessMs = getLatenessMs({
+      status: booking.status,
+      to: booking.to,
+      checkInAt: checkInTimes.get(booking.id) ?? null,
+      now,
+    });
+    if (isOnTime({ status: booking.status, latenessMs })) {
+      entry.onTime++;
+    } else {
+      entry.late++;
+    }
+  }
+
+  const results: CustodianPerformanceData[] = [];
+  for (const [key, data] of custodianMap) {
+    const total = data.onTime + data.late;
+    const rate = total > 0 ? Math.round((data.onTime / total) * 100) : 100;
+    results.push({
+      custodianId: key === "__none__" ? null : key,
+      custodianName: data.name,
+      onTime: data.onTime,
+      late: data.late,
+      total,
+      rate,
+    });
+  }
+  return results;
+}
+```
+
+(Keep the existing trailing logic — sorting, slicing, etc. — exactly as it was; only the function body that builds `custodianMap` changed.)
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm turbo typecheck --filter=@shelf/webapp`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/webapp/app/modules/reports/helpers.server.ts
+git commit -m "fix(reports): include OVERDUE and ARCHIVED in custodian performance"
+```
+
+---
+
+## Task 6: Update `computeComplianceTrend` to include ARCHIVED + use helper
+
+**Files:**
+
+- Modify: `apps/webapp/app/modules/reports/helpers.server.ts:651-740` (function body)
+
+- [ ] **Step 1: Replace the trend function body**
+
+The current function already includes OVERDUE in its where clause (correct) but uses the local `isBookingOnTime` and `updatedAt`. Replace with:
+
+```typescript
+async function computeComplianceTrend(
+  organizationId: string,
+  timeframe: ResolvedTimeframe
+): Promise<ComplianceTrendPoint[]> {
+  const periodMs = timeframe.to.getTime() - timeframe.from.getTime();
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const msPerWeek = 7 * msPerDay;
+  const periodDays = periodMs / msPerDay;
+  const useDailyGranularity = periodDays <= 14;
+  const bucketMs = useDailyGranularity ? msPerDay : msPerWeek;
+  const numBuckets = Math.max(1, Math.ceil(periodMs / bucketMs));
+
+  const measurableBookings = await db.booking.findMany({
+    where: {
+      organizationId,
+      status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
+      to: { gte: timeframe.from, lte: timeframe.to },
+    },
+    select: { id: true, to: true, status: true },
+  });
+
+  const checkInTimes = await resolveCheckInTimes(
+    measurableBookings.map((b) => b.id)
+  );
+
+  const trend: ComplianceTrendPoint[] = [];
+  const now = new Date();
+
+  for (let i = 0; i < numBuckets; i++) {
+    const bucketStart = new Date(timeframe.from.getTime() + i * bucketMs);
+    const bucketEnd = new Date(
+      Math.min(bucketStart.getTime() + bucketMs - 1, timeframe.to.getTime())
+    );
+    const bucketBookings = measurableBookings.filter((b) => {
+      const dueDate = b.to?.getTime() ?? 0;
+      return dueDate >= bucketStart.getTime() && dueDate <= bucketEnd.getTime();
+    });
+
+    let onTime = 0;
+    let late = 0;
+    for (const booking of bucketBookings) {
+      const latenessMs = getLatenessMs({
+        status: booking.status,
+        to: booking.to,
+        checkInAt: checkInTimes.get(booking.id) ?? null,
+        now,
+      });
+      if (isOnTime({ status: booking.status, latenessMs })) onTime++;
+      else late++;
+    }
+    const total = onTime + late;
+    const rate = total > 0 ? Math.round((onTime / total) * 100) : null;
+
+    const label = useDailyGranularity
+      ? formatDayLabel(bucketStart)
+      : numBuckets <= 4
+      ? formatWeekLabel(bucketStart, bucketEnd)
+      : formatWeekLabel(bucketStart, bucketEnd);
+
+    trend.push({ label, rate, onTime, late, total });
+  }
+
+  return trend;
+}
+```
+
+(`formatDayLabel` and `formatWeekLabel` already exist in the file — keep their definitions untouched.)
+
+- [ ] **Step 2: Delete the now-unused module-local `isBookingOnTime`**
+
+Once Tasks 4–6 are done, the local helper at `helpers.server.ts:78-97` has no callers. Delete it along with the local `COMPLIANCE_GRACE_PERIOD_MS` (lines 65-75). Both are now exported from `~/modules/booking/lateness`.
+
+- [ ] **Step 3: Typecheck and run all reports tests**
+
+Run: `pnpm turbo typecheck --filter=@shelf/webapp && pnpm webapp:test -- --run app/modules/reports`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/webapp/app/modules/reports/helpers.server.ts
+git commit -m "fix(reports): use central lateness helper for compliance trend"
+```
+
+---
+
+## Task 7: Broaden the table query + fix lateness column
+
+**Files:**
+
+- Modify: `apps/webapp/app/modules/reports/helpers.server.ts:140-256` (`bookingComplianceReport`) and `:363-446` (`fetchBookingComplianceRows`)
+
+The table currently filters to `status: { in: ["COMPLETE", "OVERDUE"] }`. We add ARCHIVED and switch the lateness calculation to the central helper, so the table count and the hero count match exactly.
+
+- [ ] **Step 1: Update the report's base where clause and the row builder**
+
+In `bookingComplianceReport()` (around line 162):
+
+```typescript
+const where: Prisma.BookingWhereInput = {
+  organizationId,
+  to: { gte: timeframe.from, lte: timeframe.to },
+  status: { in: MEASURABLE_BOOKING_STATUSES as unknown as BookingStatus[] },
+};
+
+// existing statusFilter intersection logic — keep it but allow all measurable statuses
+if (statusFilter && statusFilter.length > 0) {
+  const measurableStatuses = statusFilter.filter((s) =>
+    (MEASURABLE_BOOKING_STATUSES as readonly BookingStatus[]).includes(s)
+  );
+  if (measurableStatuses.length > 0) {
+    where.status = { in: measurableStatuses as BookingStatus[] };
+  }
+}
+```
+
+In `fetchBookingComplianceRows()` (around line 372), after fetching `bookings`, resolve check-in times in one batched query and replace the `latenessMs = updatedAt − to` block:
+
+```typescript
+const checkInTimes = await resolveCheckInTimes(bookings.map((b) => b.id));
+const now = new Date();
+
+const allRows: BookingComplianceRow[] = bookings.map((b) => {
+  const latenessMs = getLatenessMs({
+    status: b.status,
+    to: b.to,
+    checkInAt: checkInTimes.get(b.id) ?? null,
+    now,
+  });
+
+  return {
+    id: b.id,
+    bookingId: b.id,
+    bookingName: b.name || `Booking ${b.id.slice(0, 8)}`,
+    status: b.status,
+    custodian: b.custodianUser
+      ? stripNameSuffix(
+          `${b.custodianUser.firstName || ""} ${
+            b.custodianUser.lastName || ""
+          }`.trim()
+        )
+      : b.custodianTeamMember
+      ? stripNameSuffix(b.custodianTeamMember.name)
+      : null,
+    assetCount: b._count.assets,
+    scheduledStart: b.from!,
+    scheduledEnd: b.to!,
+    actualCheckout: null,
+    actualCheckin: checkInTimes.get(b.id) ?? null,
+    isOnTime: isOnTime({ status: b.status, latenessMs }),
+    isOverdue: b.status === BookingStatus.OVERDUE,
+    latenessMs,
+  };
+});
+```
+
+You can drop the `updatedAt: true` line from the `select` if no longer used. Verify there are no other readers — if so, leave it.
+
+- [ ] **Step 2: Add a row-level test**
+
+Append to `helpers.server.test.ts`:
+
+```typescript
+it("computes lateness as now − to for OVERDUE rows", async () => {
+  const fixedNow = new Date("2026-04-30T12:00:00Z");
+  vi.useFakeTimers().setSystemTime(fixedNow);
+
+  vi.mocked(db.booking.findMany).mockResolvedValue([
+    {
+      id: "b1",
+      name: "Alexander Spence",
+      status: BookingStatus.OVERDUE,
+      from: new Date("2026-04-01T12:00:00Z"),
+      to: new Date("2026-04-04T12:00:00Z"),
+      updatedAt: new Date("2026-04-06T16:00:00Z"), // would give 2d4h late if used
+      custodianUser: null,
+      custodianTeamMember: null,
+      _count: { assets: 6 },
+    },
+  ] as never);
+
+  const result = await bookingComplianceReport({
+    organizationId: "org-1",
+    timeframe,
+  });
+  const row = result.rows[0];
+
+  expect(row.latenessMs).toBe(26 * 24 * 60 * 60 * 1000); // ~26 days
+  expect(row.isOverdue).toBe(true);
+
+  vi.useRealTimers();
+});
+
+it("includes ARCHIVED rows in the table", async () => {
+  vi.mocked(db.booking.findMany).mockResolvedValue([
+    {
+      id: "b1",
+      name: "Old archived",
+      status: BookingStatus.ARCHIVED,
+      from: new Date("2026-04-01T12:00:00Z"),
+      to: new Date("2026-04-15T12:00:00Z"),
+      updatedAt: new Date("2026-05-15T12:00:00Z"),
+      custodianUser: null,
+      custodianTeamMember: null,
+      _count: { assets: 1 },
+    },
+  ] as never);
+
+  const result = await bookingComplianceReport({
+    organizationId: "org-1",
+    timeframe,
+  });
+
+  expect(result.rows).toHaveLength(1);
+  expect(result.rows[0].status).toBe(BookingStatus.ARCHIVED);
+});
+```
+
+(`db.booking.findMany` is mocked once and returns the same array for both the rows fetch and the compliance-rate fetch in the same test — that's fine because each test asserts a different field of the result.)
+
+- [ ] **Step 3: Run all the new tests**
+
+Run: `pnpm webapp:test -- --run app/modules/reports app/modules/booking/lateness`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/webapp/app/modules/reports/helpers.server.ts apps/webapp/app/modules/reports/helpers.server.test.ts
+git commit -m "fix(reports): show live lateness on OVERDUE rows and include ARCHIVED"
+```
+
+---
+
+## Task 8: Fix the overdue KPI id so the PDF picks it up
+
+**Files:**
+
+- Modify: `apps/webapp/app/modules/reports/helpers.server.ts:345` (the KPI id returned by `computeBookingComplianceKpis`)
+
+**Why:** `routes/api+/reports.$reportId.generate-pdf.tsx:168-170` looks up
+`kpis.find((k) => k.id === "currently_overdue")` and the type
+`BookingComplianceKpiId` (`apps/webapp/app/modules/reports/types.ts:259`)
+declares `"currently_overdue"` as the canonical id, but the implementation
+emits `id: "overdue"`. The lookup silently returns `undefined`, so the PDF's
+`overdueCount` is always `0`. The fix is renaming the id in the
+implementation to match the type and the consumer.
+
+- [ ] **Step 1: Rename the id**
+
+In `helpers.server.ts`, find the KPI object that currently uses `id: "overdue"` (around line 345) and change the id to `"currently_overdue"`. The rest of the object (label, value, format, etc.) stays the same.
+
+```typescript
+{
+  id: "currently_overdue",
+  label: "Overdue",
+  value: overdue.toLocaleString(),
+  rawValue: overdue,
+  format: "number",
+  delta: null,
+  deltaType: overdue > 0 ? "negative" : "positive",
+},
+```
+
+- [ ] **Step 2: Search for any stale `"overdue"` string consumers**
+
+Run: `grep -rn '"overdue"' apps/webapp/app | grep -v ".test."`
+Expected: only the renamed line in `helpers.server.ts` (no other consumers
+referenced the old id by string).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm turbo typecheck --filter=@shelf/webapp`
+Expected: clean — the PDF route already imports the correct id via the
+`BookingComplianceKpiId` type-driven path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/webapp/app/modules/reports/helpers.server.ts
+git commit -m "fix(reports): rename overdue KPI id to currently_overdue so PDF picks it up"
+```
+
+---
+
+## Task 9: Refresh hero explainer copy
+
+**Files:**
+
+- Modify: `apps/webapp/app/components/reports/compliance-hero.tsx:163-173`
+
+The current footer text reads "A booking is 'on-time' if checked in within 15 minutes of the scheduled end time." After this fix, OVERDUE bookings count as late and ARCHIVED bookings count too — say so.
+
+- [ ] **Step 1: Update the explainer**
+
+Replace the inner `<p>` block (lines 165-172) with:
+
+```tsx
+<p className="text-xs text-gray-400">
+  <span className="font-medium text-gray-500">How it's calculated:</span>{" "}
+  {onTime} on-time ÷ {total} total = {rate}% (rounded to nearest whole number).
+  Bookings with a due date in this period are counted: completed and archived
+  bookings are "on-time" if returned within 15 minutes of the scheduled end;
+  overdue bookings always count as late.
+</p>
+```
+
+- [ ] **Step 2: Lint + commit**
+
+```bash
+pnpm webapp:lint
+git add apps/webapp/app/components/reports/compliance-hero.tsx
+git commit -m "docs(reports): clarify compliance hero explainer for overdue and archived"
+```
+
+---
+
+## Task 10: Validate end-to-end
+
+- [ ] **Step 1: Run the full validation pipeline**
+
+Run: `pnpm webapp:validate`
+Expected: lint, typecheck, and all unit tests pass.
+
+- [ ] **Step 2: Manual smoke test (the original user scenario)**
+
+1. Start the dev server: `pnpm webapp:dev`.
+2. Open `/reports/booking-compliance`.
+3. With a workspace that has at least one OVERDUE booking and one COMPLETE booking due in the selected timeframe, confirm:
+   - Hero shows the OVERDUE booking in the `Late` count and `Total`.
+   - Compliance % is `onTime / (onTime + late)` and is no longer 100% when an overdue exists.
+   - The OVERDUE row in the table displays a lateness duration that matches the booking detail page (`Overdue by N days · H hours · M minutes`).
+4. Open the booking detail page for the same OVERDUE booking; the lateness shown by `TimeRemaining` matches the report row exactly.
+5. If your workspace has an ARCHIVED booking with a due date in the timeframe, switch the timeframe so it's included and confirm the hero count and table both grew by 1.
+
+- [ ] **Step 3: Stop dev server, kill any vitest processes**
+
+(Per CLAUDE.md: never leave parallel test processes running.)
+
+- [ ] **Step 4: Final commit if anything required tweaks**
+
+If the manual test surfaced bugs, fix them in a separate commit per the standard workflow — do not amend.
+
+---
+
+## Self-review checklist (run after writing all code)
+
+- [ ] **Spec coverage:** Both bugs from the screenshots are addressed (Task 4 + Task 7). Centralized helper exists (Task 1). Helper used on the booking page (Task 2). ARCHIVED included (Tasks 4–7).
+- [ ] **No dead code:** The local `isBookingOnTime` and `COMPLIANCE_GRACE_PERIOD_MS` in `helpers.server.ts` are deleted in Task 6.
+- [ ] **No dual sources of truth:** `getLatenessMs` is the only place that decides `now − to` vs `checkInAt − to`.
+- [ ] **Type consistency:** `MEASURABLE_BOOKING_STATUSES` is exported as a tuple of `BookingStatus` and consumed via `as unknown as BookingStatus[]` in Prisma `where` clauses (matches existing patterns in the file).
+- [ ] **PDF KPI id mismatch fixed (Task 8):** the renamed id `"currently_overdue"` makes the PDF's `overdueCount` work end-to-end.

--- a/superpowers/plans/2026-04-30-fix-booking-compliance-report.md
+++ b/superpowers/plans/2026-04-30-fix-booking-compliance-report.md
@@ -28,7 +28,7 @@ The canonical signal is `ActivityEvent` with `action: "BOOKING_STATUS_CHANGED"`,
 
 ### Files involved
 
-```
+```text
 apps/webapp/app/modules/booking/
   lateness.ts                    NEW   helper module (getLatenessMs, isOnTime, constants)
   lateness.test.ts               NEW   unit tests for the helper


### PR DESCRIPTION
The Booking Compliance hero showed 100% compliance even when the table listed an overdue booking, and the table's "Return Status" column froze at the moment the booking auto-transitioned to OVERDUE (e.g., "2d 4h late" while the booking detail page correctly showed "Overdue by 26 days · 14 hours · 11 minutes").

Three problems, one root: every compliance compute path filtered to status: "COMPLETE" only, and lateness was computed as updatedAt - to. For OVERDUE rows updatedAt is the auto-transition moment; for ARCHIVED rows it is the auto-archive moment; both make updatedAt - to misleading.

Changes:

- Centralize lateness math in app/modules/booking/lateness.ts. Both the booking detail page (TimeRemaining) and every report compute path now share getLatenessMs / isOnTime / formatOverdueDuration so they cannot drift again.
- For OVERDUE: lateness = now - to (live, growing).
- For COMPLETE / ARCHIVED: lateness = checkInAt - to, where checkInAt is the occurredAt of the canonical BOOKING_STATUS_CHANGED -> COMPLETE ActivityEvent resolved in a single batched query (resolveCheckInTimes). updatedAt is no longer used as a check-in proxy.
- Broaden the report's status filter from [COMPLETE, OVERDUE] to MEASURABLE_BOOKING_STATUSES (= [COMPLETE, OVERDUE, ARCHIVED]). Archive is reachable only from COMPLETE, so archived bookings are valid compliance data points.
- Apply the fix to computeComplianceRate, computeCustodianPerformance, computeComplianceTrend, and fetchBookingComplianceRows.
- Rename the overdue KPI id from "overdue" to "currently_overdue" so the PDF generator's lookup actually works (it matched the type definition but not the implementation, so PDF overdueCount was always 0).
- Refresh the hero explainer copy to mention archived/overdue handling.
- Delete the now-unused module-local isBookingOnTime and COMPLIANCE_GRACE_PERIOD_MS in helpers.server.ts.

Tests: 19 unit tests for the lateness helper, 5 for the check-in resolver, 4 for the report compute paths (covers OVERDUE counted as late, ARCHIVED with event-based check-in time, OVERDUE row lateness = now - to under fake timers, ARCHIVED rows appear in the table).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent overdue/late calculations using centralized lateness logic; archived bookings included in metrics; KPI key for overdue counts corrected.

* **New Features**
  * Batched resolver for canonical check-in times and recording of check-in events to support accurate reports and overdue displays.

* **Tests**
  * Comprehensive unit tests added for lateness, check-in resolution, and report compliance behaviors.

* **Documentation**
  * Updated "How it’s calculated" text to clarify counting, on-time grace, and overdue/archived rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->