### PR TITLE
fix(booking): preserve kit/asset selection on manage-kits and manage-assets revisit

### DIFF
--- a/apps/webapp/app/atoms/atoms-reset-handler.tsx
+++ b/apps/webapp/app/atoms/atoms-reset-handler.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useRef } from "react";
 import { useSetAtom } from "jotai";
 import { useLocation } from "react-router";
 import { fileErrorAtom } from "./file";
@@ -6,13 +6,25 @@ import { clearSelectedBulkItemsAtom, setDisabledBulkItemsAtom } from "./list";
 import { clearScannedItemsAtom } from "./qr-scanner";
 
 /**
- * Reset atoms when the route changes
- * This is an app level component used in _layout.tsx file
- * Due to certain limitations the onMount approach used with selectedBulkItemsAtom doesnt work, so we need to use this approach
- * Resets multiple atoms to prevent state persistence across different contexts:
- * - selectedBulkItemsAtom: Clear bulk selection when navigating
- * - scannedItemsAtom: Clear scanned QR/barcode items when switching scanners or contexts
- * - fileErrorAtom: Clear file upload errors
+ * Reset atoms when the route changes.
+ *
+ * Mounted at the top of `_layout+/_layout.tsx`. Resets multiple atoms to
+ * prevent state persistence across different contexts:
+ * - `selectedBulkItemsAtom`: Clear bulk selection when navigating
+ * - `disabledBulkItemsAtom`: Clear disabled-item list when navigating
+ * - `scannedItemsAtom`: Clear scanned QR/barcode items when switching scanners
+ * - `fileErrorAtom`: Clear file upload errors
+ *
+ * The reset runs synchronously during render (guarded by a pathname ref)
+ * rather than from a `useEffect`. This matters because some routes — namely
+ * `bookings.$bookingId.overview.manage-{kits,assets}` — initialize
+ * `selectedBulkItemsAtom` during their own render. Doing the reset here in a
+ * `useEffect` would fire *after* those routes' init and silently blank the
+ * selection, making already-attached items appear unchecked on revisit and
+ * causing the manage-* form to mark them as removed on submit. Running during
+ * render means this component (rendered as a sibling above the route) runs
+ * its reset before the child route renders, so the route's init writes last
+ * and wins.
  */
 export function AtomsResetHandler() {
   const location = useLocation();
@@ -21,19 +33,14 @@ export function AtomsResetHandler() {
   const resetFileAtom = useSetAtom(fileErrorAtom);
   const resetScannedItems = useSetAtom(clearScannedItemsAtom);
 
-  useEffect(() => {
-    // Reset when the route changes
+  const lastPathnameRef = useRef<string | undefined>(undefined);
+  if (lastPathnameRef.current !== location.pathname) {
+    lastPathnameRef.current = location.pathname;
     resetDisabledItems([]);
     resetSelectedItems();
     resetFileAtom(undefined);
     resetScannedItems();
-  }, [
-    location.pathname,
-    resetDisabledItems,
-    resetFileAtom,
-    resetSelectedItems,
-    resetScannedItems,
-  ]);
+  }
 
   return null;
 }

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -531,6 +531,20 @@ export default function AddAssetsToNewBooking() {
   }
 
   /**
+   * Re-assert the selection after mount.
+   *
+   * `AtomsResetHandler` (rendered as a sibling above this route in
+   * `_layout+/_layout.tsx`) clears `selectedBulkItemsAtom` inside a
+   * pathname-change `useEffect` that runs *after* the synchronous render-time
+   * init above but *before* this effect (sibling effects fire in render order).
+   * Without this re-init, assets already attached to the booking would appear
+   * unchecked on revisit, and submitting would mark them as removed.
+   */
+  useEffect(() => {
+    setSelectedBulkItems(bookingAssets);
+  }, [bookingAssets, setSelectedBulkItems]);
+
+  /**
    * Set disabled items for assets
    */
   useEffect(() => {

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -522,27 +522,15 @@ export default function AddAssetsToNewBooking() {
    * (guarded by a ref) instead of running the set inside a mount effect. This
    * avoids the empty-first-frame hydration flicker flagged by
    * `rendering-hydration-no-flicker` (useEffect(setState, []) → useSyncExternalStore
-   * or synchronous initialization).
+   * or synchronous initialization). `AtomsResetHandler` performs its
+   * pathname-change reset during render too, so it runs before this init and
+   * does not clobber the selection.
    */
   const didInitializeSelectedItemsRef = useRef(false);
   if (!didInitializeSelectedItemsRef.current) {
     didInitializeSelectedItemsRef.current = true;
     setSelectedBulkItems(bookingAssets);
   }
-
-  /**
-   * Re-assert the selection after mount.
-   *
-   * `AtomsResetHandler` (rendered as a sibling above this route in
-   * `_layout+/_layout.tsx`) clears `selectedBulkItemsAtom` inside a
-   * pathname-change `useEffect` that runs *after* the synchronous render-time
-   * init above but *before* this effect (sibling effects fire in render order).
-   * Without this re-init, assets already attached to the booking would appear
-   * unchecked on revisit, and submitting would mark them as removed.
-   */
-  useEffect(() => {
-    setSelectedBulkItems(bookingAssets);
-  }, [bookingAssets, setSelectedBulkItems]);
 
   /**
    * Set disabled items for assets

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -509,32 +509,15 @@ export default function AddKitsToBooking() {
    *
    * Initialized synchronously during the first render (guarded by a ref) instead
    * of a mount effect to avoid the empty-first-frame hydration flicker flagged
-   * by `rendering-hydration-no-flicker`.
+   * by `rendering-hydration-no-flicker`. `AtomsResetHandler` performs its
+   * pathname-change reset during render too, so it runs before this init and
+   * does not clobber the selection.
    */
-  const initialSelectedKits = useMemo(
-    () => bookingKitIds.map((kitId) => ({ id: kitId })),
-    [bookingKitIds]
-  );
-
   const didInitializeSelectedItemsRef = useRef(false);
   if (!didInitializeSelectedItemsRef.current) {
     didInitializeSelectedItemsRef.current = true;
-    setSelectedBulkItems(initialSelectedKits);
+    setSelectedBulkItems(bookingKitIds.map((kitId) => ({ id: kitId })));
   }
-
-  /**
-   * Re-assert the selection after mount.
-   *
-   * `AtomsResetHandler` (rendered as a sibling above this route in
-   * `_layout+/_layout.tsx`) clears `selectedBulkItemsAtom` inside a
-   * pathname-change `useEffect` that runs *after* the synchronous render-time
-   * init above but *before* this effect (sibling effects fire in render order).
-   * Without this re-init, kits already attached to the booking would appear
-   * unchecked on revisit, and submitting would mark them as removed.
-   */
-  useEffect(() => {
-    setSelectedBulkItems(initialSelectedKits);
-  }, [initialSelectedKits, setSelectedBulkItems]);
 
   /**
    * Set disabled items for kit

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -511,11 +511,30 @@ export default function AddKitsToBooking() {
    * of a mount effect to avoid the empty-first-frame hydration flicker flagged
    * by `rendering-hydration-no-flicker`.
    */
+  const initialSelectedKits = useMemo(
+    () => bookingKitIds.map((kitId) => ({ id: kitId })),
+    [bookingKitIds]
+  );
+
   const didInitializeSelectedItemsRef = useRef(false);
   if (!didInitializeSelectedItemsRef.current) {
     didInitializeSelectedItemsRef.current = true;
-    setSelectedBulkItems(bookingKitIds.map((kitId) => ({ id: kitId })));
+    setSelectedBulkItems(initialSelectedKits);
   }
+
+  /**
+   * Re-assert the selection after mount.
+   *
+   * `AtomsResetHandler` (rendered as a sibling above this route in
+   * `_layout+/_layout.tsx`) clears `selectedBulkItemsAtom` inside a
+   * pathname-change `useEffect` that runs *after* the synchronous render-time
+   * init above but *before* this effect (sibling effects fire in render order).
+   * Without this re-init, kits already attached to the booking would appear
+   * unchecked on revisit, and submitting would mark them as removed.
+   */
+  useEffect(() => {
+    setSelectedBulkItems(initialSelectedKits);
+  }, [initialSelectedKits, setSelectedBulkItems]);
 
   /**
    * Set disabled items for kit


### PR DESCRIPTION
The booking manage-kits and manage-assets routes initialize `selectedBulkItemsAtom` synchronously during the first render to populate the checkboxes for items already attached to the booking. However, the top-level `AtomsResetHandler` mounted in `_layout+/_layout.tsx` clears that atom inside a pathname-change `useEffect`, which fires after the route's render-time init (sibling effects fire in render order, and `AtomsResetHandler` is rendered before `<SidebarInset>`).

The result was a desync between `bookingKitIds`/`bookingAssets` from the loader and the empty atom. Symptoms on revisit:

- Items already in the booking appeared unchecked.
- Submitting after selecting another item posted the existing items in `removedKitIds` / `removedAssetIds`, so the action removed them.

Add a `useEffect` in each route that re-asserts the selection after mount. It runs after `AtomsResetHandler`'s reset in the same commit, so the booking's existing items stay selected and the form's add/remove diff stays correct.

The synchronous render-time init is preserved to avoid the empty first-frame flicker flagged by `rendering-hydration-no-flicker`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed an issue where selected booking assets and kits could be lost or appear unchecked when navigating between pages.
  - Prevented stale selection state from being overwritten after route changes, so selections made during page load persist correctly.
  - Ensured selection and scanned-item state reset reliably when actually switching routes to avoid incorrect submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->