### PR TITLE
fix(server): use v8 wildcard syntax for mobile API public path

### DIFF
--- a/apps/webapp/server/index.ts
+++ b/apps/webapp/server/index.ts
@@ -177,7 +177,7 @@ export default createHonoServer<ServerEnv>({
           "/qr/:qrId",
           "/qr/:qrId/not-logged-in",
           "/qr/:qrId/contact-owner",
-          "/api/mobile/:path*", // Mobile companion app API (JWT auth, not cookie)
+          "/api/mobile/*path", // Mobile companion app API (JWT auth, not cookie)
         ],
       })
     );


### PR DESCRIPTION
The `/api/mobile/:path*` pattern uses path-to-regexp v6 quantifier syntax, which was removed in v8 (the version we're on). Server crashed on boot with "Missing parameter name at index 18" inside `protect()` middleware, causing prod deploy healthchecks to fail on rolled machines.

Switched to v8 named-wildcard syntax (`*path`) — matches the existing `/accept-invite/*path` entry on the same list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mobile companion API to ensure proper access to required public endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->