### PR TITLE
feat(audit): duplicate completed/cancelled/archived audits

### DIFF
--- a/apps/webapp/app/components/audit/actions-dropdown.tsx
+++ b/apps/webapp/app/components/audit/actions-dropdown.tsx
@@ -87,6 +87,11 @@ const ConditionalActionsDropdown = () => {
   // Admin/owner can delete archived audits (archive-first safety contract).
   const canDeleteAudit = isAdminOrOwner && isArchived;
 
+  // Admin/owner can duplicate completed, cancelled, or archived audits — i.e.
+  // any terminal state. Pending/active audits should be edited instead.
+  const canDuplicateAudit =
+    isAdminOrOwner && (isCompleted || isCancelled || isArchived);
+
   // Only the creator can cancel an audit, and only if it's not already completed or cancelled
   const canCancelAudit =
     isCreator && !isCompleted && !isCancelled && !isArchived;
@@ -218,6 +223,22 @@ const ConditionalActionsDropdown = () => {
                     }}
                   >
                     Archive
+                  </Button>
+                </div>
+              </When>
+
+              <When truthy={canDuplicateAudit}>
+                <div className="border-b px-0 py-1 md:p-0">
+                  <Button
+                    variant="link"
+                    className="justify-start px-4 py-3 text-gray-700 hover:bg-slate-100 hover:text-gray-700"
+                    width="full"
+                    to={`/audits/${session.id}/duplicate`}
+                    onClick={handleMenuClose}
+                  >
+                    <span className="flex items-center gap-2">
+                      Duplicate audit
+                    </span>
                   </Button>
                 </div>
               </When>

--- a/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
@@ -38,7 +38,8 @@ export function DuplicateAuditDialog() {
         </p>
         <p>
           A new audit will be created with the same name, description, and
-          assets. Assignments, notes, scans, and due date will not be copied.
+          assets. Assignments, notes, scans, images, and due date will not be
+          copied.
         </p>
       </div>
 

--- a/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
@@ -1,0 +1,94 @@
+/**
+ * Duplicate Audit Dialog
+ *
+ * Confirmation UI for duplicating an audit session. Renders inline
+ * as child route content (not a modal overlay). Shows warnings when
+ * some original assets no longer exist, and blocks duplication when
+ * all assets are gone.
+ *
+ * @see {@link file://./../../routes/_layout+/audits.$auditId.duplicate.tsx}
+ */
+import { Form, useActionData, useLoaderData } from "react-router";
+import { useDisabled } from "~/hooks/use-disabled";
+import type { loader } from "~/routes/_layout+/audits.$auditId.duplicate";
+import { Button } from "../shared/button";
+
+/**
+ * Renders the duplicate audit confirmation view with asset availability
+ * warnings. Used as the default export of the duplicate route.
+ */
+export function DuplicateAuditDialog() {
+  const { audit, originalAssetCount, availableAssetCount, droppedAssetCount } =
+    useLoaderData<typeof loader>();
+  const actionData = useActionData<{ error?: { message: string } }>();
+  const disabled = useDisabled();
+
+  const allAssetsGone = availableAssetCount === 0;
+
+  return (
+    <div className="mt-4">
+      <h3 className="mb-2 text-lg font-semibold">
+        Duplicate Audit: {audit.name}
+      </h3>
+
+      <div className="mb-4 text-sm text-gray-500">
+        <p className="mb-2">
+          You&apos;re about to duplicate the audit{" "}
+          <strong className="text-gray-900">{audit.name}</strong>.
+        </p>
+        <p>
+          A new audit will be created with the same name, description, and
+          assets. Assignments, notes, scans, and due date will not be copied.
+        </p>
+      </div>
+
+      {/* Warning when some assets are missing */}
+      {droppedAssetCount > 0 && !allAssetsGone && (
+        <div className="mb-4 rounded-md border border-yellow-300 bg-yellow-50 p-4">
+          <p className="text-sm text-yellow-800">
+            {droppedAssetCount} of {originalAssetCount} assets from the original
+            audit no longer exist and will not be included.
+          </p>
+        </div>
+      )}
+
+      {/* Error when ALL assets are gone */}
+      {allAssetsGone && (
+        <div className="mb-4 rounded-md border border-red-300 bg-red-50 p-4">
+          <p className="text-sm text-red-700">
+            None of the original assets exist anymore. Cannot duplicate this
+            audit.
+          </p>
+        </div>
+      )}
+
+      {/* Server-side action errors */}
+      {actionData?.error && (
+        <div className="mb-4 rounded-md bg-red-50 p-4">
+          <p className="text-sm text-red-500">{actionData.error.message}</p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="secondary"
+          className="flex-1"
+          disabled={disabled}
+          to=".."
+        >
+          Cancel
+        </Button>
+
+        <Form method="POST" className="flex-1">
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={disabled || allAssetsGone}
+          >
+            {disabled ? "Duplicating..." : "Confirm"}
+          </Button>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
@@ -62,9 +62,11 @@ export function DuplicateAuditDialog() {
         </div>
       )}
 
-      {/* Server-side action errors */}
+      {/* Server-side action errors. role="alert" so screen readers announce
+          the message — this branch only renders after submit, so unlike the
+          warning/error banners above it isn't present on initial paint. */}
       {actionData?.error && (
-        <div className="mb-4 rounded-md bg-red-50 p-4">
+        <div role="alert" className="mb-4 rounded-md bg-red-50 p-4">
           <p className="text-sm text-red-500">{actionData.error.message}</p>
         </div>
       )}

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -14,6 +14,7 @@ import {
   bulkArchiveAudits,
   deleteAuditSession,
   bulkDeleteAudits,
+  duplicateAuditSession,
 } from "./service.server";
 
 // why: storage.server calls Supabase over HTTP; mock so delete tests stay offline
@@ -1346,6 +1347,196 @@ describe("audit service", () => {
           status: 500,
           message: expect.stringMatching(/Failed to bulk delete audits/),
         });
+      });
+    });
+  });
+
+  describe("duplicateAuditSession", () => {
+    const baseInput = {
+      auditSessionId: "audit-original",
+      organizationId: "org-1",
+      userId: "user-duplicator",
+    };
+
+    const originalAudit = {
+      id: "audit-original",
+      name: "Hull PC Bank Audit",
+      description: "Quarterly check",
+      organizationId: "org-1",
+      createdById: "user-1",
+      status: AuditStatus.COMPLETED,
+      scopeMeta: { contextType: "tag", contextName: "Canary PCs" },
+      targetId: null,
+      assets: [
+        { assetId: "asset-1" },
+        { assetId: "asset-2" },
+        { assetId: "asset-3" },
+      ],
+    };
+
+    beforeEach(() => {
+      // Original audit lookup — overridden per test for not-found cases.
+      mockDb.auditSession.findFirst.mockResolvedValue(originalAudit);
+
+      // Default: all assets still exist.
+      mockDb.asset.findMany.mockResolvedValue([
+        { id: "asset-1", title: "PC #1" },
+        { id: "asset-2", title: "PC #2" },
+        { id: "asset-3", title: "PC #3" },
+      ]);
+
+      // createAuditSession internals (called by duplicateAuditSession).
+      mockDb.auditSession.create.mockResolvedValue({
+        id: "audit-copy",
+        name: `${originalAudit.name} (Copy)`,
+        description: originalAudit.description,
+        organizationId: "org-1",
+        createdById: baseInput.userId,
+        expectedAssetCount: 3,
+        foundAssetCount: 0,
+        missingAssetCount: 3,
+        unexpectedAssetCount: 0,
+        startedAt: null,
+        completedAt: null,
+        cancelledAt: null,
+        status: AuditStatus.PENDING,
+        scopeMeta: originalAudit.scopeMeta,
+        targetId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      mockDb.auditSession.findUnique.mockResolvedValue({
+        id: "audit-copy",
+        name: `${originalAudit.name} (Copy)`,
+        description: originalAudit.description,
+        organizationId: "org-1",
+        createdById: baseInput.userId,
+        expectedAssetCount: 3,
+        foundAssetCount: 0,
+        missingAssetCount: 3,
+        unexpectedAssetCount: 0,
+        status: AuditStatus.PENDING,
+        scopeMeta: originalAudit.scopeMeta,
+        targetId: null,
+        startedAt: null,
+        completedAt: null,
+        cancelledAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        assignments: [],
+      });
+      mockDb.auditAsset.createMany.mockResolvedValue({ count: 3 });
+      mockDb.auditAsset.findMany.mockResolvedValue([
+        { id: "aa-1", assetId: "asset-1" },
+        { id: "aa-2", assetId: "asset-2" },
+        { id: "aa-3", assetId: "asset-3" },
+      ]);
+    });
+
+    it("creates a (Copy) audit and reports zero dropped assets when all assets still exist", async () => {
+      const result = await duplicateAuditSession(baseInput);
+
+      expect(mockDb.auditSession.findFirst).toHaveBeenCalledWith({
+        where: { id: "audit-original", organizationId: "org-1" },
+        include: { assets: { select: { assetId: true } } },
+      });
+
+      // The validateExistingAssetIds query — drives dropped-asset counting.
+      expect(mockDb.asset.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: ["asset-1", "asset-2", "asset-3"] },
+          organizationId: "org-1",
+        },
+        select: { id: true },
+      });
+
+      // createAuditSession received the (Copy) name and scopeMeta as-is.
+      expect(mockDb.auditSession.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: "Hull PC Bank Audit (Copy)",
+          description: "Quarterly check",
+          organizationId: "org-1",
+          createdById: baseInput.userId,
+          scopeMeta: originalAudit.scopeMeta,
+        }),
+      });
+
+      // Due date and assignments must NOT carry over (PRD).
+      const createCall = mockDb.auditSession.create.mock.calls[0][0];
+      expect(createCall.data.dueDate).toBeUndefined();
+      expect(mockDb.auditAssignment.createMany).not.toHaveBeenCalled();
+
+      expect(result).toEqual({
+        newSession: expect.objectContaining({ id: "audit-copy" }),
+        droppedAssetCount: 0,
+        originalAssetCount: 3,
+      });
+    });
+
+    it("succeeds with a non-zero droppedAssetCount when some assets no longer exist", async () => {
+      // Only 2 of 3 assets still exist in the org.
+      mockDb.asset.findMany.mockResolvedValueOnce([
+        { id: "asset-1", title: "PC #1" },
+        { id: "asset-2", title: "PC #2" },
+      ]);
+      // createAuditSession's own asset existence check — must match the
+      // filtered list it's called with.
+      mockDb.asset.findMany.mockResolvedValueOnce([
+        { id: "asset-1", title: "PC #1" },
+        { id: "asset-2", title: "PC #2" },
+      ]);
+
+      const result = await duplicateAuditSession(baseInput);
+
+      expect(result.droppedAssetCount).toBe(1);
+      expect(result.originalAssetCount).toBe(3);
+      expect(result.newSession).toMatchObject({ id: "audit-copy" });
+    });
+
+    it("throws a 400 ShelfError when no original assets remain", async () => {
+      mockDb.asset.findMany.mockResolvedValueOnce([]);
+
+      await expect(duplicateAuditSession(baseInput)).rejects.toMatchObject({
+        status: 400,
+        message: expect.stringMatching(/None of the original assets/),
+      });
+
+      // Must not have attempted to create anything.
+      expect(mockDb.auditSession.create).not.toHaveBeenCalled();
+    });
+
+    it("throws a 404 ShelfError when the source audit is not found", async () => {
+      mockDb.auditSession.findFirst.mockResolvedValueOnce(null);
+
+      await expect(duplicateAuditSession(baseInput)).rejects.toMatchObject({
+        status: 404,
+        message: expect.stringMatching(/Audit not found/),
+      });
+
+      expect(mockDb.auditSession.create).not.toHaveBeenCalled();
+    });
+
+    it("preserves scopeMeta as-is even when it is null", async () => {
+      mockDb.auditSession.findFirst.mockResolvedValueOnce({
+        ...originalAudit,
+        scopeMeta: null,
+      });
+
+      await duplicateAuditSession(baseInput);
+
+      expect(mockDb.auditSession.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ scopeMeta: undefined }),
+      });
+    });
+
+    it("wraps unknown causes in a 500 ShelfError", async () => {
+      mockDb.auditSession.findFirst.mockRejectedValueOnce(
+        new Error("DB exploded")
+      );
+
+      await expect(duplicateAuditSession(baseInput)).rejects.toMatchObject({
+        status: 500,
+        message: expect.stringMatching(/Something went wrong/),
       });
     });
   });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -1377,6 +1377,12 @@ describe("audit service", () => {
     };
 
     beforeEach(() => {
+      // Match the clearAllMocks pattern every other nested suite uses, so
+      // mock state can't leak in either direction. clearAllMocks resets
+      // call history; mockResolvedValue assignments below re-establish what
+      // each test relies on.
+      vi.clearAllMocks();
+
       // Original audit lookup — overridden per test for not-found cases.
       mockDb.auditSession.findFirst.mockResolvedValue(originalAudit);
 

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -1367,6 +1367,8 @@ describe("audit service", () => {
       status: AuditStatus.COMPLETED,
       scopeMeta: { contextType: "tag", contextName: "Canary PCs" },
       targetId: null,
+      // Prisma's `where: { expected: true }` filter is applied at query time;
+      // the mock returns only the expected rows the service is meant to see.
       assets: [
         { assetId: "asset-1" },
         { assetId: "asset-2" },
@@ -1436,9 +1438,13 @@ describe("audit service", () => {
     it("creates a (Copy) audit and reports zero dropped assets when all assets still exist", async () => {
       const result = await duplicateAuditSession(baseInput);
 
+      // The include must filter to expected:true so unexpected scan rows
+      // don't get promoted into the duplicate's scope.
       expect(mockDb.auditSession.findFirst).toHaveBeenCalledWith({
         where: { id: "audit-original", organizationId: "org-1" },
-        include: { assets: { select: { assetId: true } } },
+        include: {
+          assets: { where: { expected: true }, select: { assetId: true } },
+        },
       });
 
       // The validateExistingAssetIds query — drives dropped-asset counting.
@@ -1537,6 +1543,43 @@ describe("audit service", () => {
       await expect(duplicateAuditSession(baseInput)).rejects.toMatchObject({
         status: 500,
         message: expect.stringMatching(/Something went wrong/),
+      });
+    });
+
+    it.each([
+      ["PENDING", AuditStatus.PENDING],
+      ["ACTIVE", AuditStatus.ACTIVE],
+    ])(
+      "rejects duplication of a %s audit with a 400 (server-side guard)",
+      async (_label, status) => {
+        mockDb.auditSession.findFirst.mockResolvedValueOnce({
+          ...originalAudit,
+          status,
+        });
+
+        await expect(duplicateAuditSession(baseInput)).rejects.toMatchObject({
+          status: 400,
+          message: expect.stringMatching(
+            /completed, cancelled, or archived audits can be duplicated/
+          ),
+        });
+
+        expect(mockDb.auditSession.create).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each([
+      ["COMPLETED", AuditStatus.COMPLETED],
+      ["CANCELLED", AuditStatus.CANCELLED],
+      ["ARCHIVED", AuditStatus.ARCHIVED],
+    ])("allows duplication of a %s audit", async (_label, status) => {
+      mockDb.auditSession.findFirst.mockResolvedValueOnce({
+        ...originalAudit,
+        status,
+      });
+
+      await expect(duplicateAuditSession(baseInput)).resolves.toMatchObject({
+        newSession: expect.objectContaining({ id: "audit-copy" }),
       });
     });
   });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -3129,10 +3129,16 @@ export type DuplicateAuditResult = {
  * Duplicates an audit session into a new PENDING audit.
  *
  * Copies the original audit's name (with `" (Copy)"` suffix), description, and
- * `scopeMeta` as-is. Assets are taken from the original audit's
- * {@link AuditAsset} records and validated to still exist in the org —
- * missing assets are silently dropped and reported via `droppedAssetCount`.
- * If every asset is gone, throws so the caller can show a blocking error.
+ * `scopeMeta` as-is. Only the originally-expected assets carry over —
+ * unexpected scan records (`AuditAsset.expected: false`) are excluded so the
+ * duplicate's scope matches the source. Surviving asset IDs are validated
+ * against the org; missing ones are silently dropped and reported via
+ * `droppedAssetCount`. If every expected asset is gone, throws so the caller
+ * can show a blocking error.
+ *
+ * Refuses non-terminal audits (PENDING / ACTIVE) with a 400 — the dropdown
+ * gate is client-side, so the service enforces the contract for direct
+ * POSTs that bypass the UI.
  *
  * Assignments, notes, scans, images, and the due date are NOT copied — the
  * new audit starts clean. Creator is set to `userId`.
@@ -3141,7 +3147,8 @@ export type DuplicateAuditResult = {
  * @param organizationId - Workspace scoping
  * @param userId - User performing the duplication (becomes creator)
  * @returns The new audit session and missing-asset counts for warning UX
- * @throws {ShelfError} 404 if the audit isn't found, 400 if every asset is gone
+ * @throws {ShelfError} 404 if the audit isn't found, 400 if the source is not
+ *   in a terminal status, 400 if every original asset is gone
  */
 export async function duplicateAuditSession({
   auditSessionId,
@@ -3156,7 +3163,10 @@ export async function duplicateAuditSession({
     const originalAudit = await db.auditSession.findFirst({
       where: { id: auditSessionId, organizationId },
       include: {
-        assets: { select: { assetId: true } },
+        // Only the originally-scoped assets carry over. AuditAsset rows
+        // also include unexpected scans (`expected: false`) — those must
+        // not be promoted to expected in the duplicate.
+        assets: { where: { expected: true }, select: { assetId: true } },
       },
     });
 
@@ -3167,6 +3177,28 @@ export async function duplicateAuditSession({
         additionalData: { auditSessionId, organizationId },
         label,
         status: 404,
+      });
+    }
+
+    // Defense in depth: the dropdown gates on terminal status, but a direct
+    // POST could still hit this service for a PENDING/ACTIVE audit. Mirrors
+    // the pattern archive/delete already enforce server-side.
+    if (
+      originalAudit.status !== AuditStatus.COMPLETED &&
+      originalAudit.status !== AuditStatus.CANCELLED &&
+      originalAudit.status !== AuditStatus.ARCHIVED
+    ) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Only completed, cancelled, or archived audits can be duplicated.",
+        additionalData: {
+          auditSessionId,
+          organizationId,
+          status: originalAudit.status,
+        },
+        label,
+        status: 400,
       });
     }
 

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -3115,6 +3115,19 @@ export async function bulkDeleteAudits({
   }
 }
 
+/**
+ * Audit statuses that allow duplication. Source of truth shared between
+ * the duplicate-audit route loader (UX guard so we don't render the dialog
+ * for a non-terminal audit) and {@link duplicateAuditSession} (defense in
+ * depth against direct POSTs). Keep these in sync — the loader and service
+ * both reference this constant.
+ */
+export const DUPLICATE_AUDIT_ALLOWED_STATUSES = [
+  AuditStatus.COMPLETED,
+  AuditStatus.CANCELLED,
+  AuditStatus.ARCHIVED,
+] as const satisfies readonly AuditStatus[];
+
 /** Result returned from {@link duplicateAuditSession}. */
 export type DuplicateAuditResult = {
   /** The newly created audit session. */
@@ -3184,9 +3197,9 @@ export async function duplicateAuditSession({
     // POST could still hit this service for a PENDING/ACTIVE audit. Mirrors
     // the pattern archive/delete already enforce server-side.
     if (
-      originalAudit.status !== AuditStatus.COMPLETED &&
-      originalAudit.status !== AuditStatus.CANCELLED &&
-      originalAudit.status !== AuditStatus.ARCHIVED
+      !DUPLICATE_AUDIT_ALLOWED_STATUSES.includes(
+        originalAudit.status as (typeof DUPLICATE_AUDIT_ALLOWED_STATUSES)[number]
+      )
     ) {
       throw new ShelfError({
         cause: null,

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -3114,3 +3114,127 @@ export async function bulkDeleteAudits({
     });
   }
 }
+
+/** Result returned from {@link duplicateAuditSession}. */
+export type DuplicateAuditResult = {
+  /** The newly created audit session. */
+  newSession: AuditSession;
+  /** Number of assets that were dropped because they no longer exist. */
+  droppedAssetCount: number;
+  /** Total number of assets in the original audit. */
+  originalAssetCount: number;
+};
+
+/**
+ * Duplicates an audit session into a new PENDING audit.
+ *
+ * Copies the original audit's name (with `" (Copy)"` suffix), description, and
+ * `scopeMeta` as-is. Assets are taken from the original audit's
+ * {@link AuditAsset} records and validated to still exist in the org —
+ * missing assets are silently dropped and reported via `droppedAssetCount`.
+ * If every asset is gone, throws so the caller can show a blocking error.
+ *
+ * Assignments, notes, scans, images, and the due date are NOT copied — the
+ * new audit starts clean. Creator is set to `userId`.
+ *
+ * @param auditSessionId - ID of the audit to duplicate
+ * @param organizationId - Workspace scoping
+ * @param userId - User performing the duplication (becomes creator)
+ * @returns The new audit session and missing-asset counts for warning UX
+ * @throws {ShelfError} 404 if the audit isn't found, 400 if every asset is gone
+ */
+export async function duplicateAuditSession({
+  auditSessionId,
+  organizationId,
+  userId,
+}: {
+  auditSessionId: string;
+  organizationId: string;
+  userId: string;
+}): Promise<DuplicateAuditResult> {
+  try {
+    const originalAudit = await db.auditSession.findFirst({
+      where: { id: auditSessionId, organizationId },
+      include: {
+        assets: { select: { assetId: true } },
+      },
+    });
+
+    if (!originalAudit) {
+      throw new ShelfError({
+        cause: null,
+        message: "Audit not found.",
+        additionalData: { auditSessionId, organizationId },
+        label,
+        status: 404,
+      });
+    }
+
+    const originalAssetCount = originalAudit.assets.length;
+    const resolvedAssetIds = await validateExistingAssetIds(
+      originalAudit.assets.map((a) => a.assetId),
+      organizationId
+    );
+
+    const droppedAssetCount = originalAssetCount - resolvedAssetIds.length;
+
+    if (resolvedAssetIds.length === 0) {
+      throw new ShelfError({
+        cause: null,
+        message: "None of the original assets exist anymore. Cannot duplicate.",
+        additionalData: { auditSessionId, organizationId },
+        label,
+        status: 400,
+      });
+    }
+
+    const { session: newSession } = await createAuditSession({
+      name: `${originalAudit.name} (Copy)`,
+      description: originalAudit.description,
+      assetIds: resolvedAssetIds,
+      organizationId,
+      createdById: userId,
+      // PRD: scopeMeta copied as-is. The DB column is Json?, the typed surface
+      // is AuditScopeMeta — cast through and let createAuditSession persist it.
+      scopeMeta: (originalAudit.scopeMeta ?? null) as AuditScopeMeta | null,
+    });
+
+    return {
+      newSession,
+      droppedAssetCount,
+      originalAssetCount,
+    };
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: isLikeShelfError(cause)
+        ? cause.message
+        : "Something went wrong while duplicating the audit.",
+      additionalData: { auditSessionId, organizationId, userId },
+      label,
+      status: isLikeShelfError(cause) ? cause.status : 500,
+    });
+  }
+}
+
+/**
+ * Returns the subset of `assetIds` that still exist in the given organization.
+ * Used by {@link duplicateAuditSession} to drop assets that have been deleted
+ * or moved to another org since the original audit was created.
+ */
+async function validateExistingAssetIds(
+  assetIds: string[],
+  organizationId: string
+): Promise<string[]> {
+  if (assetIds.length === 0) return [];
+
+  const existingAssets = await db.asset.findMany({
+    where: {
+      id: { in: assetIds },
+      organizationId,
+    },
+    select: { id: true },
+  });
+
+  return existingAssets.map((a) => a.id);
+}

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -3217,9 +3217,10 @@ export async function bulkDeleteAudits({
 /**
  * Audit statuses that allow duplication. Source of truth shared between
  * the duplicate-audit route loader (UX guard so we don't render the dialog
- * for a non-terminal audit) and {@link duplicateAuditSession} (defense in
- * depth against direct POSTs). Keep these in sync — the loader and service
- * both reference this constant.
+ * for a non-terminal audit) and {@link duplicateAuditSession} (the service
+ * contract for any caller — route action, background job, future internal
+ * use). Keep these in sync — the loader and service both reference this
+ * constant.
  */
 export const DUPLICATE_AUDIT_ALLOWED_STATUSES = [
   AuditStatus.COMPLETED,
@@ -3249,8 +3250,8 @@ export type DuplicateAuditResult = {
  * can show a blocking error.
  *
  * Refuses non-terminal audits (PENDING / ACTIVE) with a 400 — the dropdown
- * gate is client-side, so the service enforces the contract for direct
- * POSTs that bypass the UI.
+ * gate is client-side, so the service owns the contract for any caller
+ * (route action, background jobs, future internal callers).
  *
  * Assignments, notes, scans, images, and the due date are NOT copied — the
  * new audit starts clean. Creator is set to `userId`.
@@ -3292,9 +3293,9 @@ export async function duplicateAuditSession({
       });
     }
 
-    // Defense in depth: the dropdown gates on terminal status, but a direct
-    // POST could still hit this service for a PENDING/ACTIVE audit. Mirrors
-    // the pattern archive/delete already enforce server-side.
+    // Defense in depth: the route loader/action also check terminal status,
+    // but the service owns the contract for any internal caller (background
+    // jobs, future routes). Mirrors the pattern archive/delete enforce.
     if (
       !DUPLICATE_AUDIT_ALLOWED_STATUSES.includes(
         originalAudit.status as (typeof DUPLICATE_AUDIT_ALLOWED_STATUSES)[number]
@@ -3349,14 +3350,13 @@ export async function duplicateAuditSession({
       originalAssetCount,
     };
   } catch (cause) {
+    if (isLikeShelfError(cause)) throw cause;
     throw new ShelfError({
       cause,
-      message: isLikeShelfError(cause)
-        ? cause.message
-        : "Something went wrong while duplicating the audit.",
+      message: "Something went wrong while duplicating the audit.",
       additionalData: { auditSessionId, organizationId, userId },
       label,
-      status: isLikeShelfError(cause) ? cause.status : 500,
+      status: 500,
     });
   }
 }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
@@ -31,8 +31,26 @@ import { requirePermission } from "~/utils/roles.server";
 
 const paramsSchema = z.object({ auditId: z.string() });
 
+/**
+ * Sets the document title for the duplicate-audit route.
+ *
+ * @returns React Router meta descriptor with the page title.
+ */
 export const meta = () => [{ title: appendToMetaTitle("Duplicate audit") }];
 
+/**
+ * Loader for the duplicate-audit route.
+ *
+ * Pre-checks the source audit so the dialog can render the correct state
+ * (clean / warning / blocking error) before the user submits. Enforces
+ * permission, terminal-status, and existence — counts how many of the
+ * original audit's expected assets still exist in the org.
+ *
+ * @param args - React Router loader args (request, context, params).
+ * @returns Payload with the audit name + asset counts for the dialog.
+ * @throws {ShelfError} 404 if the audit isn't found, 400 if it's not in a
+ *   terminal status, or whatever {@link requirePermission} throws on auth.
+ */
 export async function loader({ request, context, params }: LoaderFunctionArgs) {
   const { userId } = context.getSession();
   const { auditId } = getParams(params, paramsSchema);
@@ -113,6 +131,17 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
   }
 }
 
+/**
+ * Action for the duplicate-audit route.
+ *
+ * Performs the duplication via {@link duplicateAuditSession}, fires a
+ * success notification, and redirects to the new audit's overview page.
+ * Errors are normalised through {@link makeShelfError} and returned as
+ * the route's `actionData.error` so the dialog can display them.
+ *
+ * @param args - React Router action args (request, context, params).
+ * @returns Redirect to the new audit on success, or an error payload.
+ */
 export async function action({ request, context, params }: ActionFunctionArgs) {
   const { userId } = context.getSession();
   const { auditId } = getParams(params, paramsSchema);
@@ -145,6 +174,10 @@ export async function action({ request, context, params }: ActionFunctionArgs) {
   }
 }
 
+/**
+ * Default route component — renders the {@link DuplicateAuditDialog}
+ * which reads the loader payload and posts to the action on confirm.
+ */
 export default function DuplicateAudit() {
   return <DuplicateAuditDialog />;
 }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
@@ -12,6 +12,7 @@
  * @see {@link file://./../../modules/audit/service.server.ts} duplicateAuditSession
  * @see {@link file://./../../components/audit/duplicate-audit-dialog.tsx}
  */
+import { AuditStatus } from "@prisma/client";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, redirect } from "react-router";
 import { z } from "zod";
@@ -20,7 +21,7 @@ import { db } from "~/database/db.server";
 import { duplicateAuditSession } from "~/modules/audit/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
-import { makeShelfError } from "~/utils/error";
+import { makeShelfError, ShelfError } from "~/utils/error";
 import { payload, error, getParams } from "~/utils/http.server";
 import {
   PermissionAction,
@@ -47,12 +48,39 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
     const audit = await db.auditSession.findFirst({
       where: { id: auditId, organizationId },
       include: {
-        assets: { select: { assetId: true } },
+        // Mirror the service: only originally-expected assets count toward
+        // the duplicate. Unexpected scans (`expected: false`) are not part
+        // of the source's scope.
+        assets: { where: { expected: true }, select: { assetId: true } },
       },
     });
 
     if (!audit) {
-      throw new Error("Audit not found.");
+      throw new ShelfError({
+        cause: null,
+        message: "Audit not found.",
+        additionalData: { auditId },
+        label: "Audit",
+        status: 404,
+      });
+    }
+
+    // Mirror the service-side terminal-status guard so navigating directly
+    // to the duplicate route for a PENDING/ACTIVE audit shows a clean error
+    // instead of the dialog.
+    if (
+      audit.status !== AuditStatus.COMPLETED &&
+      audit.status !== AuditStatus.CANCELLED &&
+      audit.status !== AuditStatus.ARCHIVED
+    ) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Only completed, cancelled, or archived audits can be duplicated.",
+        additionalData: { auditId, status: audit.status },
+        label: "Audit",
+        status: 400,
+      });
     }
 
     const originalAssetCount = audit.assets.length;

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
@@ -1,0 +1,122 @@
+/**
+ * Audit Duplication Route
+ *
+ * Child route that handles duplicating an audit session into a new PENDING
+ * audit. The loader pre-checks asset availability so the dialog can render
+ * the correct state (clean, warning, or blocking error) before the user
+ * submits. The action performs the duplication and redirects to the new
+ * audit's overview page.
+ *
+ * Mirrors `bookings.$bookingId.overview.duplicate.tsx`.
+ *
+ * @see {@link file://./../../modules/audit/service.server.ts} duplicateAuditSession
+ * @see {@link file://./../../components/audit/duplicate-audit-dialog.tsx}
+ */
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import { data, redirect } from "react-router";
+import { z } from "zod";
+import { DuplicateAuditDialog } from "~/components/audit/duplicate-audit-dialog";
+import { db } from "~/database/db.server";
+import { duplicateAuditSession } from "~/modules/audit/service.server";
+import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { sendNotification } from "~/utils/emitter/send-notification.server";
+import { makeShelfError } from "~/utils/error";
+import { payload, error, getParams } from "~/utils/http.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+
+const paramsSchema = z.object({ auditId: z.string() });
+
+export const meta = () => [{ title: appendToMetaTitle("Duplicate audit") }];
+
+export async function loader({ request, context, params }: LoaderFunctionArgs) {
+  const { userId } = context.getSession();
+  const { auditId } = getParams(params, paramsSchema);
+
+  try {
+    const { organizationId } = await requirePermission({
+      userId,
+      request,
+      entity: PermissionEntity.audit,
+      action: PermissionAction.create,
+    });
+
+    const audit = await db.auditSession.findFirst({
+      where: { id: auditId, organizationId },
+      include: {
+        assets: { select: { assetId: true } },
+      },
+    });
+
+    if (!audit) {
+      throw new Error("Audit not found.");
+    }
+
+    const originalAssetCount = audit.assets.length;
+
+    // Count which of the original audit's assets still exist in the org.
+    // The action path re-runs the same check inside duplicateAuditSession;
+    // this loader query is read-only and exists to populate dialog state.
+    const availableAssetCount =
+      originalAssetCount === 0
+        ? 0
+        : await db.asset.count({
+            where: {
+              id: { in: audit.assets.map((a) => a.assetId) },
+              organizationId,
+            },
+          });
+
+    const droppedAssetCount = originalAssetCount - availableAssetCount;
+
+    return payload({
+      showModal: true,
+      audit: { id: audit.id, name: audit.name },
+      originalAssetCount,
+      availableAssetCount,
+      droppedAssetCount,
+    });
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId });
+    throw reason;
+  }
+}
+
+export async function action({ request, context, params }: ActionFunctionArgs) {
+  const { userId } = context.getSession();
+  const { auditId } = getParams(params, paramsSchema);
+
+  try {
+    const { organizationId } = await requirePermission({
+      userId,
+      request,
+      entity: PermissionEntity.audit,
+      action: PermissionAction.create,
+    });
+
+    const { newSession } = await duplicateAuditSession({
+      auditSessionId: auditId,
+      organizationId,
+      userId,
+    });
+
+    sendNotification({
+      title: "Audit duplicated",
+      senderId: userId,
+      icon: { name: "success", variant: "success" },
+      message: `Audit "${newSession.name}" has been created.`,
+    });
+
+    return redirect(`/audits/${newSession.id}/overview`);
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId });
+    return data(error(reason), { status: reason.status });
+  }
+}
+
+export default function DuplicateAudit() {
+  return <DuplicateAuditDialog />;
+}

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
@@ -12,13 +12,15 @@
  * @see {@link file://./../../modules/audit/service.server.ts} duplicateAuditSession
  * @see {@link file://./../../components/audit/duplicate-audit-dialog.tsx}
  */
-import { AuditStatus } from "@prisma/client";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, redirect } from "react-router";
 import { z } from "zod";
 import { DuplicateAuditDialog } from "~/components/audit/duplicate-audit-dialog";
 import { db } from "~/database/db.server";
-import { duplicateAuditSession } from "~/modules/audit/service.server";
+import {
+  DUPLICATE_AUDIT_ALLOWED_STATUSES,
+  duplicateAuditSession,
+} from "~/modules/audit/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -85,11 +87,12 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
 
     // Mirror the service-side terminal-status guard so navigating directly
     // to the duplicate route for a PENDING/ACTIVE audit shows a clean error
-    // instead of the dialog.
+    // instead of the dialog. Same constant the service references — keeps
+    // the loader UX guard and the service contract from drifting.
     if (
-      audit.status !== AuditStatus.COMPLETED &&
-      audit.status !== AuditStatus.CANCELLED &&
-      audit.status !== AuditStatus.ARCHIVED
+      !DUPLICATE_AUDIT_ALLOWED_STATUSES.includes(
+        audit.status as (typeof DUPLICATE_AUDIT_ALLOWED_STATUSES)[number]
+      )
     ) {
       throw new ShelfError({
         cause: null,
@@ -177,6 +180,8 @@ export async function action({ request, context, params }: ActionFunctionArgs) {
 /**
  * Default route component — renders the {@link DuplicateAuditDialog}
  * which reads the loader payload and posts to the action on confirm.
+ *
+ * @returns The duplicate-audit confirmation dialog route element.
  */
 export default function DuplicateAudit() {
   return <DuplicateAuditDialog />;


### PR DESCRIPTION
## Need

Closes the last open feature in PRD #2434 (Duplicate audit). Archive (#2438, #2481) and Delete (#2494) shipped earlier; without Duplicate, IT teams running 100+ recurring audits/month have no way to start a fresh round from a completed one without rebuilding the asset list by hand.

## Hypothesis

Adding a "Duplicate audit" action on terminal-state audits (COMPLETED, CANCELLED, ARCHIVED) lets users re-run an audit without re-selecting assets. Missing assets are reported as a warning — only when *every* original asset is gone do we block.

## What changed

- `duplicateAuditSession()` in `service.server.ts` — copies name (with " (Copy)" suffix), description, and `scopeMeta` as-is; re-validates the original audit's asset IDs against the current org and drops missing ones; throws 400 if every asset is gone.
- New route `audits.$auditId.duplicate.tsx` — loader pre-counts available assets so the dialog renders the right state before the user submits; action calls the service and redirects to the new audit.
- `duplicate-audit-dialog.tsx` — three states: clean, yellow warning with dropped count, blocking red error with disabled submit.
- Actions dropdown — "Duplicate audit" entry, gated on `isAdminOrOwner && (isCompleted || isCancelled || isArchived)` per PRD line 73.

## Diverges from PRD

The PRD describes re-resolving assets via `targetId` / `scopeMeta` (lines 47–69), but no production audit-creation route persists those fields today, so the re-resolution branch would be unreachable. Stripping it keeps the feature testable and avoids dead paths. Re-enabling scope-based re-resolution is a follow-up that requires `audits.start.ts` to start persisting `targetId` / `scopeMeta` first.

## Test plan

- [ ] Duplicate from COMPLETED audit → new PENDING audit with `(Copy)` suffix and same assets
- [ ] Duplicate from CANCELLED audit → same
- [ ] Duplicate from ARCHIVED audit → same
- [ ] Delete one source asset, then duplicate → yellow warning with correct count, proceed succeeds
- [ ] Delete all source assets, then duplicate → red blocking error, submit disabled
- [ ] Non-admin user → no Duplicate action visible
- [ ] PENDING / ACTIVE audit → no Duplicate action visible (Edit/Cancel are the right actions for those)
- [ ] After confirm, new audit has cleared assignments, no notes, no scans, no images, due date null

## Tests

6 unit tests in `service.server.test.ts`:
- happy path (all assets exist, droppedAssetCount = 0)
- partial-missing (some assets gone, succeeds with droppedAssetCount > 0)
- all-missing (400 ShelfError, no create attempted)
- audit-not-found (404 ShelfError)
- scopeMeta = null preserved as-is
- unknown-cause wrapped in 500 ShelfError

Existing 58 audit-service tests unaffected. Full audit module: 64/64 passing. `pnpm turbo typecheck` clean. `pnpm webapp:lint` clean.

## Out of scope (follow-ups)

- Bulk duplicate — not in PRD.
- "Re-use audit" feature with auto-archive of the previous audit + month-suffix naming (per Toby's 2026-04-14 answers) — separate ticket; semantically distinct from Duplicate.
- Persisting `targetId` / `scopeMeta` in `audits.start.ts` to enable scope-based asset re-resolution.

## Closes

Part of #2434.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit duplication: “Duplicate audit” menu action opens a confirmation dialog, creates a new audit named with " (Copy)", preserves description and scope metadata, then redirects to the new audit overview with a success notice.

* **Permissions & Validation**
  * Only admins/owners may duplicate audits in terminal states (Completed/Cancelled/Archived). UI warns if some assets are missing and blocks duplication if no original assets remain; dropped/original asset counts shown.

* **Tests**
  * Added tests for happy path, validation, and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2522)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->