### PR TITLE
fix(audit): let admins/owners cancel audits they did not create

### DIFF
--- a/apps/webapp/app/components/audit/actions-dropdown.tsx
+++ b/apps/webapp/app/components/audit/actions-dropdown.tsx
@@ -87,9 +87,14 @@ const ConditionalActionsDropdown = () => {
   // Admin/owner can delete archived audits (archive-first safety contract).
   const canDeleteAudit = isAdminOrOwner && isArchived;
 
-  // Only the creator can cancel an audit, and only if it's not already completed or cancelled
+  // The audit's creator can always cancel it. Workspace admins/owners can
+  // also cancel any audit in the org so team-managed audits don't get stuck
+  // when the creator is unavailable — matches archive/delete permissions.
   const canCancelAudit =
-    isCreator && !isCompleted && !isCancelled && !isArchived;
+    (isCreator || isAdminOrOwner) &&
+    !isCompleted &&
+    !isCancelled &&
+    !isArchived;
 
   function handleMenuClose() {
     setOpen(false);

--- a/apps/webapp/app/modules/audit/email-helpers.ts
+++ b/apps/webapp/app/modules/audit/email-helpers.ts
@@ -70,11 +70,17 @@ export const auditAssignedEmailContent = (args: BasicAuditEmailContentArgs) =>
   });
 
 /**
- * Email content when an audit is cancelled.
+ * Builds the plain-text body for the audit-cancelled email.
  *
  * `cancelledByName` is the user who actually performed the cancellation —
  * may differ from `creatorName` (the audit's original creator) when an
  * admin/owner cancels an audit a team member created.
+ *
+ * @param args - Standard audit email args plus the resolved canceller name.
+ * @param args.cancelledByName - Display name of the acting canceller, used
+ *   in the body sentence ("cancelled by {cancelledByName}").
+ * @returns The full plain-text email body produced by
+ *   {@link baseAuditTextEmailContent}.
  */
 export const auditCancelledEmailContent = (
   args: BasicAuditEmailContentArgs & { cancelledByName: string }
@@ -208,7 +214,25 @@ export async function sendAuditAssignedEmail({
 }
 
 /**
- * Sends cancellation emails to all assignees (excluding the creator)
+ * Sends an "audit cancelled" email to each provided recipient.
+ *
+ * Recipient construction (assigneesToNotify) is the caller's responsibility —
+ * the service decides who to notify. This function only handles delivery and
+ * fan-out: per recipient it builds the plain-text + HTML versions, calls
+ * {@link sendEmail}, and logs success or wraps any per-send failure in a
+ * {@link ShelfError} via {@link Logger.error}. Failures for one recipient do
+ * not stop sends to the others.
+ *
+ * @param args
+ * @param args.audit - Audit record with the metadata embedded in the email
+ *   (name, dueDate, organization, asset count, etc.).
+ * @param args.assigneesToNotify - Recipients with email + display fields.
+ *   Pass an empty array to skip sending entirely.
+ * @param args.cancelledByName - Display name of the acting canceller. May
+ *   differ from `audit.createdBy` when an admin/owner cancels someone
+ *   else's audit; recipients see this name in the body, not the creator's.
+ * @param args.hints - Client hints used to localise dates in the email.
+ * @returns void. Per-recipient send errors are logged, not thrown.
  */
 export function sendAuditCancelledEmails({
   audit,

--- a/apps/webapp/app/modules/audit/email-helpers.ts
+++ b/apps/webapp/app/modules/audit/email-helpers.ts
@@ -70,12 +70,18 @@ export const auditAssignedEmailContent = (args: BasicAuditEmailContentArgs) =>
   });
 
 /**
- * Email content when an audit is cancelled
+ * Email content when an audit is cancelled.
+ *
+ * `cancelledByName` is the user who actually performed the cancellation —
+ * may differ from `creatorName` (the audit's original creator) when an
+ * admin/owner cancels an audit a team member created.
  */
-export const auditCancelledEmailContent = (args: BasicAuditEmailContentArgs) =>
+export const auditCancelledEmailContent = (
+  args: BasicAuditEmailContentArgs & { cancelledByName: string }
+) =>
   baseAuditTextEmailContent({
     ...args,
-    emailContent: `The audit "${args.auditName}" has been cancelled by ${args.creatorName}. This audit is no longer active.`,
+    emailContent: `The audit "${args.auditName}" has been cancelled by ${args.cancelledByName}. This audit is no longer active.`,
   });
 
 /**
@@ -207,6 +213,7 @@ export async function sendAuditAssignedEmail({
 export function sendAuditCancelledEmails({
   audit,
   assigneesToNotify,
+  cancelledByName,
   hints,
 }: {
   audit: AuditForEmail;
@@ -219,6 +226,12 @@ export function sendAuditCancelledEmails({
       displayName?: string | null;
     };
   }>;
+  /**
+   * Display name of the user who actually cancelled the audit. May differ
+   * from the original creator when an admin/owner cancels someone else's
+   * audit — recipients see the real canceller, not the creator.
+   */
+  cancelledByName: string;
   hints: ClientHint;
 }) {
   const creatorName = resolveUserDisplayName(audit.createdBy);
@@ -244,6 +257,7 @@ export function sendAuditCancelledEmails({
           auditName: audit.name,
           assetsCount: assetCount,
           creatorName,
+          cancelledByName,
           description: audit.description,
           dueDate: audit.dueDate,
           hints,

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -1569,5 +1569,45 @@ describe("audit service", () => {
 
       expect(recipientIds).not.toContain(creatorId);
     });
+
+    it("falls back to 'a workspace admin' when an admin with no resolvable name cancels", async () => {
+      mockDb.user.findFirst.mockResolvedValueOnce({
+        firstName: null,
+        lastName: null,
+        displayName: null,
+      });
+
+      await cancelAuditSession({
+        auditSessionId,
+        organizationId,
+        userId: adminId,
+        isAdminOrOwner: true,
+        hints,
+      });
+
+      expect(sendAuditCancelledEmails).toHaveBeenCalledWith(
+        expect.objectContaining({ cancelledByName: "a workspace admin" })
+      );
+    });
+
+    it("falls back to 'the audit creator' when the creator has no resolvable name", async () => {
+      mockDb.user.findFirst.mockResolvedValueOnce({
+        firstName: null,
+        lastName: null,
+        displayName: null,
+      });
+
+      await cancelAuditSession({
+        auditSessionId,
+        organizationId,
+        userId: creatorId,
+        isAdminOrOwner: false,
+        hints,
+      });
+
+      expect(sendAuditCancelledEmails).toHaveBeenCalledWith(
+        expect.objectContaining({ cancelledByName: "the audit creator" })
+      );
+    });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -51,10 +51,18 @@ vi.mock("./email-helpers", () => ({
   sendAuditCompletedEmail: vi.fn(),
 }));
 
-// why: cancelAuditReminders calls scheduler.cancel via QueueNames; mock the whole module to avoid pg-boss
+// why: cancelAuditReminders calls scheduler.cancel via QueueNames; mock the whole module to avoid pg-boss.
+// Keys mirror the real enum at apps/webapp/app/utils/scheduler.server.ts so tests touching
+// scheduleNextAuditJob (which references QueueNames.auditQueue) don't diverge from production shape.
 vi.mock("~/utils/scheduler.server", () => ({
   scheduler: { cancel: vi.fn().mockResolvedValue(undefined) },
-  QueueNames: { auditReminder: "audit-reminder" },
+  QueueNames: {
+    emailQueue: "email-queue",
+    bookingQueue: "booking-queue",
+    auditQueue: "audit-queue",
+    assetsQueue: "assets-queue",
+    addonTrialQueue: "addon-trial-queue",
+  },
 }));
 
 vi.mock("~/database/db.server", () => {
@@ -62,6 +70,7 @@ vi.mock("~/database/db.server", () => {
     auditSession: {
       create: vi.fn(),
       findUnique: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
       findFirst: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
@@ -105,6 +114,7 @@ const mockDb = db as unknown as {
   auditSession: {
     create: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
+    findUniqueOrThrow: ReturnType<typeof vi.fn>;
     findFirst: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
@@ -1397,7 +1407,10 @@ describe("audit service", () => {
     beforeEach(() => {
       // Default: audit exists, has no scheduler ref so cancelAuditReminders no-ops.
       mockDb.auditSession.findUnique.mockResolvedValue(baseAudit);
-      mockDb.auditSession.update.mockResolvedValue({
+      // Atomic transition succeeds (count: 1) and the post-update re-fetch
+      // returns the cancelled row.
+      mockDb.auditSession.updateMany.mockResolvedValue({ count: 1 });
+      mockDb.auditSession.findUniqueOrThrow.mockResolvedValue({
         ...baseAudit,
         status: AuditStatus.CANCELLED,
         cancelledAt: new Date(),
@@ -1421,8 +1434,20 @@ describe("audit service", () => {
         })
       ).resolves.toMatchObject({ status: AuditStatus.CANCELLED });
 
-      expect(mockDb.auditSession.update).toHaveBeenCalledWith({
-        where: { id: auditSessionId },
+      // Atomic transition: status guard prevents overwriting a row that
+      // raced into a terminal state between the read-check and the write.
+      expect(mockDb.auditSession.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: auditSessionId,
+          organizationId,
+          status: {
+            notIn: [
+              AuditStatus.COMPLETED,
+              AuditStatus.CANCELLED,
+              AuditStatus.ARCHIVED,
+            ],
+          },
+        },
         data: { status: AuditStatus.CANCELLED, cancelledAt: expect.any(Date) },
       });
     });
@@ -1453,7 +1478,7 @@ describe("audit service", () => {
         message: expect.stringMatching(/creator or a workspace admin/),
       });
 
-      expect(mockDb.auditSession.update).not.toHaveBeenCalled();
+      expect(mockDb.auditSession.updateMany).not.toHaveBeenCalled();
     });
 
     it("still rejects when the audit is already COMPLETED, even for an admin", async () => {
@@ -1568,6 +1593,30 @@ describe("audit service", () => {
       );
 
       expect(recipientIds).not.toContain(creatorId);
+    });
+
+    it("throws 409 when a concurrent transition wins the race (transition.count === 0)", async () => {
+      // Simulate: status read passed (PENDING), but between then and the
+      // updateMany call, another request flipped the audit to COMPLETED.
+      // The atomic where-clause guard refuses to overwrite, count returns 0.
+      mockDb.auditSession.updateMany.mockResolvedValueOnce({ count: 0 });
+
+      await expect(
+        cancelAuditSession({
+          auditSessionId,
+          organizationId,
+          userId: creatorId,
+          isAdminOrOwner: false,
+          hints,
+        })
+      ).rejects.toMatchObject({
+        status: 409,
+        message: expect.stringMatching(/Audit status changed/),
+      });
+
+      // Side effects must not fire on a failed transition.
+      expect(mockDb.auditNote.create).not.toHaveBeenCalled();
+      expect(sendAuditCancelledEmails).not.toHaveBeenCalled();
     });
 
     it("falls back to 'a workspace admin' when an admin with no resolvable name cancels", async () => {

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
+import { sendAuditCancelledEmails } from "./email-helpers";
 import {
   createAuditSession,
   addAssetsToAudit,
@@ -1404,6 +1405,7 @@ describe("audit service", () => {
       mockDb.user.findFirst.mockResolvedValue({
         firstName: "Acting",
         lastName: "User",
+        displayName: null,
       });
       mockDb.auditNote.create.mockResolvedValue({ id: "note-1" });
     });
@@ -1469,6 +1471,103 @@ describe("audit service", () => {
           hints,
         })
       ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it("attributes the cancellation email to the actual canceller, not the creator", async () => {
+      await cancelAuditSession({
+        auditSessionId,
+        organizationId,
+        userId: adminId,
+        isAdminOrOwner: true,
+        hints,
+      });
+
+      expect(sendAuditCancelledEmails).toHaveBeenCalledWith(
+        expect.objectContaining({ cancelledByName: "Acting User" })
+      );
+    });
+
+    it("notifies the creator when an admin cancels their audit", async () => {
+      // Audit has one assignee (other than the admin or creator) so we can
+      // assert both the assignee and the creator end up in the notify list.
+      const assigneeUser = {
+        email: "assignee@example.com",
+        firstName: "Assigned",
+        lastName: "Person",
+        displayName: null,
+      };
+      mockDb.auditSession.findUnique.mockResolvedValueOnce({
+        ...baseAudit,
+        assignments: [{ userId: "user-assignee", user: assigneeUser }],
+      });
+
+      await cancelAuditSession({
+        auditSessionId,
+        organizationId,
+        userId: adminId,
+        isAdminOrOwner: true,
+        hints,
+      });
+
+      const call = (
+        sendAuditCancelledEmails as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls.at(-1)?.[0];
+      const recipientIds = call.assigneesToNotify.map(
+        (a: { userId: string }) => a.userId
+      );
+
+      expect(recipientIds).toContain("user-assignee");
+      expect(recipientIds).toContain(creatorId);
+      expect(recipientIds).not.toContain(adminId);
+    });
+
+    it("does not double-notify the creator when they are also an assignee", async () => {
+      const creatorAsAssignee = {
+        email: "creator@example.com",
+        firstName: "Created",
+        lastName: "By",
+        displayName: "Created By",
+      };
+      mockDb.auditSession.findUnique.mockResolvedValueOnce({
+        ...baseAudit,
+        assignments: [{ userId: creatorId, user: creatorAsAssignee }],
+      });
+
+      await cancelAuditSession({
+        auditSessionId,
+        organizationId,
+        userId: adminId,
+        isAdminOrOwner: true,
+        hints,
+      });
+
+      const call = (
+        sendAuditCancelledEmails as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls.at(-1)?.[0];
+      const creatorEntries = call.assigneesToNotify.filter(
+        (a: { userId: string }) => a.userId === creatorId
+      );
+
+      expect(creatorEntries).toHaveLength(1);
+    });
+
+    it("does not notify the creator when the creator cancels their own audit", async () => {
+      await cancelAuditSession({
+        auditSessionId,
+        organizationId,
+        userId: creatorId,
+        isAdminOrOwner: false,
+        hints,
+      });
+
+      const call = (
+        sendAuditCancelledEmails as unknown as ReturnType<typeof vi.fn>
+      ).mock.calls.at(-1)?.[0];
+      const recipientIds = call.assigneesToNotify.map(
+        (a: { userId: string }) => a.userId
+      );
+
+      expect(recipientIds).not.toContain(creatorId);
     });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -12,6 +12,7 @@ import {
   getPendingAuditsForOrganization,
   getAuditWhereInput,
   bulkArchiveAudits,
+  cancelAuditSession,
   deleteAuditSession,
   bulkDeleteAudits,
 } from "./service.server";
@@ -41,6 +42,18 @@ vi.mock("~/utils/markdoc-wrappers", () => ({
 vi.mock("~/modules/activity-event/service.server", () => ({
   recordEvent: vi.fn().mockResolvedValue(undefined),
   recordEvents: vi.fn().mockResolvedValue(undefined),
+}));
+
+// why: cancellation triggers email + scheduler side effects we don't exercise in service unit tests
+vi.mock("./email-helpers", () => ({
+  sendAuditCancelledEmails: vi.fn(),
+  sendAuditCompletedEmail: vi.fn(),
+}));
+
+// why: cancelAuditReminders calls scheduler.cancel via QueueNames; mock the whole module to avoid pg-boss
+vi.mock("~/utils/scheduler.server", () => ({
+  scheduler: { cancel: vi.fn().mockResolvedValue(undefined) },
+  QueueNames: { auditReminder: "audit-reminder" },
 }));
 
 vi.mock("~/database/db.server", () => {
@@ -1347,6 +1360,115 @@ describe("audit service", () => {
           message: expect.stringMatching(/Failed to bulk delete audits/),
         });
       });
+    });
+  });
+
+  describe("cancelAuditSession permission", () => {
+    const auditSessionId = "audit-1";
+    const organizationId = "org-1";
+    const creatorId = "user-creator";
+    const adminId = "user-admin";
+    const stranger = "user-stranger";
+    const hints = {
+      timeZone: "UTC",
+      hourFormat: "24",
+      locale: "en-US",
+    } as unknown as Parameters<typeof cancelAuditSession>[0]["hints"];
+
+    const baseAudit = {
+      id: auditSessionId,
+      name: "Floor 2 PC Audit",
+      organizationId,
+      createdById: creatorId,
+      status: AuditStatus.PENDING,
+      activeSchedulerReference: null,
+      createdBy: {
+        email: "creator@example.com",
+        firstName: "Created",
+        lastName: "By",
+        displayName: "Created By",
+      },
+      organization: { owner: { email: "owner@example.com" } },
+      assignments: [],
+      _count: { assets: 5 },
+    };
+
+    beforeEach(() => {
+      // Default: audit exists, has no scheduler ref so cancelAuditReminders no-ops.
+      mockDb.auditSession.findUnique.mockResolvedValue(baseAudit);
+      mockDb.auditSession.update.mockResolvedValue({
+        ...baseAudit,
+        status: AuditStatus.CANCELLED,
+        cancelledAt: new Date(),
+      });
+      mockDb.user.findFirst.mockResolvedValue({
+        firstName: "Acting",
+        lastName: "User",
+      });
+      mockDb.auditNote.create.mockResolvedValue({ id: "note-1" });
+    });
+
+    it("lets the creator cancel their own audit (legacy behavior)", async () => {
+      await expect(
+        cancelAuditSession({
+          auditSessionId,
+          organizationId,
+          userId: creatorId,
+          isAdminOrOwner: false,
+          hints,
+        })
+      ).resolves.toMatchObject({ status: AuditStatus.CANCELLED });
+
+      expect(mockDb.auditSession.update).toHaveBeenCalledWith({
+        where: { id: auditSessionId },
+        data: { status: AuditStatus.CANCELLED, cancelledAt: expect.any(Date) },
+      });
+    });
+
+    it("lets an admin/owner cancel an audit they did not create", async () => {
+      await expect(
+        cancelAuditSession({
+          auditSessionId,
+          organizationId,
+          userId: adminId,
+          isAdminOrOwner: true,
+          hints,
+        })
+      ).resolves.toMatchObject({ status: AuditStatus.CANCELLED });
+    });
+
+    it("rejects a non-creator non-admin with 403", async () => {
+      await expect(
+        cancelAuditSession({
+          auditSessionId,
+          organizationId,
+          userId: stranger,
+          isAdminOrOwner: false,
+          hints,
+        })
+      ).rejects.toMatchObject({
+        status: 403,
+        message: expect.stringMatching(/creator or a workspace admin/),
+      });
+
+      expect(mockDb.auditSession.update).not.toHaveBeenCalled();
+    });
+
+    it("still rejects when the audit is already COMPLETED, even for an admin", async () => {
+      mockDb.auditSession.findUnique.mockResolvedValueOnce({
+        ...baseAudit,
+        status: AuditStatus.COMPLETED,
+      });
+
+      await expect(
+        cancelAuditSession({
+          auditSessionId,
+          organizationId,
+          userId: adminId,
+          isAdminOrOwner: true,
+          hints,
+        })
+      ).rejects.toMatchObject({ status: 400 });
     });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2019,11 +2019,20 @@ export async function cancelAuditSession({
       });
     }
 
-    // Use email helper to send cancellation emails with HTML template
+    // Use email helper to send cancellation emails with HTML template.
+    // The fallback is role-aware: when the acting user has no resolvable
+    // display name (e.g. a freshly-created account), pick a label that
+    // matches who actually cancelled — "a workspace admin" for the
+    // admin/owner branch, "the audit creator" otherwise. Avoids the
+    // earlier hard-coded "an admin" mis-attributing creator-cancels.
+    const resolvedCancellerName = resolveUserDisplayName(actingUser);
+    const fallbackCancellerName = isAdminOrOwner
+      ? "a workspace admin"
+      : "the audit creator";
     sendAuditCancelledEmails({
       audit: auditSession,
       assigneesToNotify,
-      cancelledByName: resolveUserDisplayName(actingUser) || "an admin",
+      cancelledByName: resolvedCancellerName || fallbackCancellerName,
       hints,
     });
 

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1825,19 +1825,33 @@ export function requireAuditAssigneeForBaseSelfService({
 }
 
 /**
- * Cancels an audit session
- * Only the creator can cancel an audit
- * Cannot cancel if audit is already COMPLETED or CANCELLED
+ * Cancels an audit session.
+ *
+ * The creator of an audit can always cancel it. Workspace admins and owners
+ * can also cancel any audit in their org (regardless of who created it) so
+ * that team-managed audits don't get stuck when the creator is unavailable
+ * or no longer responsible — this matches archive/delete permissions.
+ *
+ * Cannot cancel an audit that is already COMPLETED, CANCELLED, or ARCHIVED.
+ *
+ * @param isAdminOrOwner - Whether the acting user is admin/owner in the
+ *   audit's organization. The route layer derives this from the workspace
+ *   role and passes it in; the service trusts it.
+ * @throws {ShelfError} 404 if the audit isn't found, 403 if the user is
+ *   neither the creator nor an admin/owner, 400 if the audit is in a
+ *   terminal status that can't be cancelled.
  */
 export async function cancelAuditSession({
   auditSessionId,
   organizationId,
   userId,
+  isAdminOrOwner,
   hints,
 }: {
   auditSessionId: string;
   organizationId: string;
   userId: string;
+  isAdminOrOwner: boolean;
   hints: ClientHint;
 }) {
   try {
@@ -1893,11 +1907,14 @@ export async function cancelAuditSession({
       organizationId,
     });
 
-    // Check if user is the creator
-    if (auditSession.createdById !== userId) {
+    // Allow the creator to cancel their own audit. Also allow workspace
+    // admins/owners to cancel any audit in the org — needed when team
+    // members create audits the supervisor needs to clean up later.
+    if (auditSession.createdById !== userId && !isAdminOrOwner) {
       throw new ShelfError({
         cause: null,
-        message: "Only the audit creator can cancel the audit",
+        message:
+          "Only the audit creator or a workspace admin/owner can cancel the audit",
         additionalData: {
           auditSessionId,
           userId,

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -24,6 +24,7 @@ import { Logger } from "~/utils/logger";
 import { wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import { QueueNames, scheduler } from "~/utils/scheduler.server";
 import { removePublicFile } from "~/utils/storage.server";
+import { resolveUserDisplayName } from "~/utils/user";
 
 import type { AuditFilterType } from "./audit-filter-utils";
 import {
@@ -1945,10 +1946,11 @@ export async function cancelAuditSession({
       data: { status: AuditStatus.CANCELLED, cancelledAt: new Date() },
     });
 
-    // Fetch acting user's info for the activity note
+    // Fetch acting user's info for the activity note + email attribution.
+    // displayName is selected so resolveUserDisplayName picks it up.
     const actingUser = await db.user.findFirst({
       where: { id: userId },
-      select: { firstName: true, lastName: true },
+      select: { firstName: true, lastName: true, displayName: true },
     });
 
     // Create activity note for cancellation
@@ -1975,15 +1977,53 @@ export async function cancelAuditSession({
       auditSessionId,
     });
 
-    // Send cancellation email to assignees (excluding creator)
-    const assigneesToNotify = auditSession.assignments.filter(
-      (assignment) => assignment.userId !== userId && assignment.user.email
+    // Build the notify list for the cancellation email:
+    //  - All assignees other than the canceller (existing behavior)
+    //  - PLUS the audit creator when they didn't cancel themselves and
+    //    aren't already an assignee — without this branch, an admin
+    //    cancelling a team member's audit would silently fail to inform
+    //    the creator that their audit was killed.
+    const assigneesToNotify: Array<{
+      userId: string;
+      user: {
+        email: string;
+        firstName: string | null;
+        lastName: string | null;
+        displayName?: string | null;
+      };
+    }> = auditSession.assignments
+      .filter(
+        (assignment) => assignment.userId !== userId && assignment.user.email
+      )
+      .map((assignment) => ({
+        userId: assignment.userId,
+        user: assignment.user,
+      }));
+
+    const creatorAlreadyNotified = assigneesToNotify.some(
+      (a) => a.userId === auditSession.createdById
     );
+    if (
+      auditSession.createdById !== userId &&
+      !creatorAlreadyNotified &&
+      auditSession.createdBy.email
+    ) {
+      assigneesToNotify.push({
+        userId: auditSession.createdById,
+        user: {
+          email: auditSession.createdBy.email,
+          firstName: auditSession.createdBy.firstName,
+          lastName: auditSession.createdBy.lastName,
+          displayName: auditSession.createdBy.displayName,
+        },
+      });
+    }
 
     // Use email helper to send cancellation emails with HTML template
     sendAuditCancelledEmails({
       audit: auditSession,
       assigneesToNotify,
+      cancelledByName: resolveUserDisplayName(actingUser) || "an admin",
       hints,
     });
 

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1940,10 +1940,43 @@ export async function cancelAuditSession({
       });
     }
 
-    // Update audit status to CANCELLED
-    const updatedAudit = await db.auditSession.update({
+    // Atomic state transition guarded by status. The earlier read-then-check
+    // is informational only — between that read and this write, a concurrent
+    // complete/archive could land. updateMany with a status guard prevents
+    // overwriting a now-terminal audit and skips the side effects (note,
+    // event, email, reminder cancel) when nothing actually changed. Same
+    // pattern the delete path uses.
+    const cancelledAt = new Date();
+    const transition = await db.auditSession.updateMany({
+      where: {
+        id: auditSessionId,
+        organizationId,
+        status: {
+          notIn: [
+            AuditStatus.COMPLETED,
+            AuditStatus.CANCELLED,
+            AuditStatus.ARCHIVED,
+          ],
+        },
+      },
+      data: { status: AuditStatus.CANCELLED, cancelledAt },
+    });
+
+    if (transition.count !== 1) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Audit status changed before cancellation could complete. Please refresh and try again.",
+        additionalData: { auditSessionId, organizationId },
+        label,
+        status: 409,
+      });
+    }
+
+    // Re-fetch to return the up-to-date row (preserves the previous return
+    // contract — callers expect the AuditSession back).
+    const updatedAudit = await db.auditSession.findUniqueOrThrow({
       where: { id: auditSessionId },
-      data: { status: AuditStatus.CANCELLED, cancelledAt: new Date() },
     });
 
     // Fetch acting user's info for the activity note + email attribution.

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -207,6 +207,9 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         auditSessionId: auditId,
         organizationId,
         userId,
+        // Admin/owner is the inverse of self-service/base in this codebase.
+        // Allows non-creator admin/owners to cancel team-managed audits.
+        isAdminOrOwner: !isSelfServiceOrBase,
         hints,
       });
 

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -142,6 +142,10 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         auditSessionId: auditId,
         organizationId,
         userId,
+        // Admin/owner is the inverse of self-service/base in this codebase.
+        // Passing it through lets the service allow non-creator admin/owners
+        // to cancel — matches archive/delete permissions.
+        isAdminOrOwner: !isSelfServiceOrBase,
         hints,
       });
 


### PR DESCRIPTION
## Need

Toby (ResQ, ~125 audits/month) [reported via email](https://github.com/Shelf-nu/shelf.nu/pull/2434) on 2026-04-20 that the **Cancel** action was missing on his overdue audits even though it appeared on others.

## Diagnosis

"Overdue" is a derived display badge, not a status — `audit-status-badge-with-overdue.tsx` just renders a red label when `dueDate < now` on a non-terminal audit. The actual status underneath stays PENDING / ACTIVE. So overdue itself never affected cancel logic.

The real bug: **cancel was gated on creator only.**

- `actions-dropdown.tsx`: `canCancelAudit = isCreator && !isCompleted && !isCancelled && !isArchived`
- `service.server.ts cancelAuditSession`: `if (auditSession.createdById !== userId) throw 403`

Toby is workspace admin/owner. His team members create audits. The audits he could still cancel were ones *he* created (recent PENDINGs). The audits he couldn't cancel were his team's, which had been around long enough to age into overdue. Correlation, not causation.

## Fix

Extend the cancel gate to also allow admin/owner — matches archive (#2438) and delete (#2494) permissions. Three layers:

| File | Change |
|---|---|
| `service.server.ts` `cancelAuditSession` | new `isAdminOrOwner: boolean` param; rejects unless `userId === createdById \|\| isAdminOrOwner` |
| `audits.$auditId.tsx` cancel-audit intent | passes `isAdminOrOwner: !isSelfServiceOrBase` |
| `audits.$auditId.overview.tsx` cancel-audit intent | passes `isAdminOrOwner: !isSelfServiceOrBase` |
| `actions-dropdown.tsx` | `canCancelAudit = (isCreator \|\| isAdminOrOwner) && !isCompleted && !isCancelled && !isArchived` |

Terminal-state guards (`COMPLETED`, `CANCELLED`, `ARCHIVED`) and the `assertAuditNotArchived` invariant are unchanged.

## Test plan

- [ ] As workspace owner, cancel a PENDING audit a team member created → succeeds
- [ ] As workspace admin, cancel an ACTIVE audit a team member created → succeeds
- [ ] As workspace admin, cancel an OVERDUE PENDING audit a team member created → succeeds (Toby's case)
- [ ] As creator, cancel my own PENDING audit → still works
- [ ] As BASE / SELF_SERVICE non-creator, attempt to cancel → 403, no Cancel button visible
- [ ] As admin, attempt to cancel a COMPLETED audit → 400 (still rejected — terminal)
- [ ] As admin, attempt to cancel an ARCHIVED audit → 403 from `assertAuditNotArchived`

## Tests

4 new unit tests in `service.server.test.ts`:
- creator can cancel their own (legacy behavior preserved)
- admin/owner can cancel a non-self-created audit
- non-creator non-admin rejected with 403
- COMPLETED status still rejects even for admin (400)

Existing audit tests unaffected. 62/62 passing. `pnpm turbo typecheck` clean. `pnpm webapp:lint` clean.

## Customer

Closes the cancel-overdue gap reported by Toby Liversedge (ResQ Limited).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace admins and owners (in addition to creators) can see and use the “Cancel audit” action when audits are not in terminal states.

* **Bug Fixes / Notifications**
  * Cancellation emails now attribute who cancelled, include the creator when appropriate, exclude the canceller from recipients, and avoid duplicates.
  * Cancellation is blocked for terminal audits and applied atomically; concurrent state changes return a conflict.

* **Tests**
  * Added tests for permission paths, concurrency failure, status transitions, and notification attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->