### PR TITLE
fix(reports): respect workspace currency and locale across reports and PDF

### DIFF
--- a/apps/webapp/app/components/reports/asset-distribution-content.tsx
+++ b/apps/webapp/app/components/reports/asset-distribution-content.tsx
@@ -12,7 +12,10 @@
 import { useNavigate } from "react-router";
 
 import { DistributionDonut } from "~/components/reports/distribution-donut";
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import type { DistributionBreakdown, ReportKpi } from "~/modules/reports/types";
+import { useHints } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
 
 /** Props for {@link AssetDistributionContent}. */
 type Props = {
@@ -36,6 +39,8 @@ export function AssetDistributionContent({
   distributionBreakdown,
 }: Props) {
   const navigate = useNavigate();
+  const currentOrganization = useCurrentOrganization();
+  const { locale } = useHints();
 
   // Navigate to assets filtered by the clicked item
   // IDs match the special filter values: "uncategorized", "without-location", or actual IDs
@@ -88,7 +93,13 @@ export function AssetDistributionContent({
             <div className="flex flex-col">
               <span className="text-xs text-gray-500">Total Value</span>
               <span className="text-lg font-medium text-gray-900">
-                {totalValue > 0 ? `$${totalValue.toLocaleString()}` : "—"}
+                {totalValue > 0
+                  ? formatCurrency({
+                      value: totalValue,
+                      currency: currentOrganization?.currency ?? "USD",
+                      locale,
+                    })
+                  : "—"}
               </span>
             </div>
           </div>

--- a/apps/webapp/app/components/reports/asset-inventory-content.tsx
+++ b/apps/webapp/app/components/reports/asset-inventory-content.tsx
@@ -20,11 +20,15 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ReportEmptyState } from "~/components/reports/report-empty-state";
 import {
   AssetCell,
+  CurrencyCell,
   DateCell,
   ReportTable,
   StatusCell,
 } from "~/components/reports/report-table";
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import type { AssetInventoryRow, ReportKpi } from "~/modules/reports/types";
+import { useHints } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
 
 /**
  * Map asset status to badge variant.
@@ -109,12 +113,9 @@ const ASSET_INVENTORY_COLUMNS: ColumnDef<AssetInventoryRow>[] = [
   {
     accessorKey: "valuation",
     header: "Value",
-    cell: ({ row }) =>
-      row.original.valuation ? (
-        `$${row.original.valuation.toLocaleString()}`
-      ) : (
-        <span className="text-gray-400">—</span>
-      ),
+    cell: ({ row }) => (
+      <CurrencyCell value={row.original.valuation} treatZeroAsEmpty />
+    ),
   },
   {
     accessorKey: "createdAt",
@@ -148,6 +149,9 @@ export function AssetInventoryContent({
   totalRows,
   onRowClick,
 }: Props) {
+  const currentOrganization = useCurrentOrganization();
+  const { locale } = useHints();
+
   // Stable reference is guaranteed by `ASSET_INVENTORY_COLUMNS` living at
   // module scope (see its JSDoc for why that matters).
   const columns = ASSET_INVENTORY_COLUMNS;
@@ -186,7 +190,13 @@ export function AssetInventoryContent({
             <div className="flex flex-col">
               <span className="text-xs text-gray-500">Total Value</span>
               <span className="text-lg font-medium text-gray-900">
-                {totalValue > 0 ? `$${totalValue.toLocaleString()}` : "—"}
+                {totalValue > 0
+                  ? formatCurrency({
+                      value: totalValue,
+                      currency: currentOrganization?.currency ?? "USD",
+                      locale,
+                    })
+                  : "—"}
               </span>
             </div>
             <div className="flex flex-col">

--- a/apps/webapp/app/components/reports/asset-utilization-content.tsx
+++ b/apps/webapp/app/components/reports/asset-utilization-content.tsx
@@ -22,6 +22,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ReportEmptyState } from "~/components/reports/report-empty-state";
 import {
   AssetCell,
+  CurrencyCell,
   NumberCell,
   ReportTable,
 } from "~/components/reports/report-table";
@@ -86,12 +87,9 @@ const ASSET_UTILIZATION_COLUMNS: ColumnDef<AssetUtilizationRow>[] = [
   {
     accessorKey: "valuation",
     header: "Value",
-    cell: ({ row }) =>
-      row.original.valuation ? (
-        `$${row.original.valuation.toLocaleString()}`
-      ) : (
-        <span className="text-gray-400">—</span>
-      ),
+    cell: ({ row }) => (
+      <CurrencyCell value={row.original.valuation} treatZeroAsEmpty />
+    ),
   },
 ];
 

--- a/apps/webapp/app/components/reports/custody-snapshot-content.tsx
+++ b/apps/webapp/app/components/reports/custody-snapshot-content.tsx
@@ -25,10 +25,14 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ReportEmptyState } from "~/components/reports/report-empty-state";
 import {
   AssetCell,
+  CurrencyCell,
   DateCell,
   ReportTable,
 } from "~/components/reports/report-table";
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import type { CustodySnapshotRow, ReportKpi } from "~/modules/reports/types";
+import { useHints } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
 
 /** Props for {@link CustodySnapshotContent}. */
 type Props = {
@@ -58,6 +62,9 @@ export function CustodySnapshotContent({
   totalRows,
   onRowClick,
 }: Props) {
+  const currentOrganization = useCurrentOrganization();
+  const { locale } = useHints();
+
   // Calculate max days for relative bar width
   const maxDays = Math.max(...rows.map((r) => r.daysInCustody), 1);
 
@@ -128,12 +135,9 @@ export function CustodySnapshotContent({
       {
         accessorKey: "valuation",
         header: "Value",
-        cell: ({ row }) =>
-          row.original.valuation ? (
-            `$${row.original.valuation.toLocaleString()}`
-          ) : (
-            <span className="text-gray-400">—</span>
-          ),
+        cell: ({ row }) => (
+          <CurrencyCell value={row.original.valuation} treatZeroAsEmpty />
+        ),
       },
     ],
     [maxDays]
@@ -178,7 +182,11 @@ export function CustodySnapshotContent({
               <span className="text-xs text-gray-500">Total Value</span>
               <span className="text-lg font-medium text-gray-900">
                 {totalCustodyValue > 0
-                  ? `$${totalCustodyValue.toLocaleString()}`
+                  ? formatCurrency({
+                      value: totalCustodyValue,
+                      currency: currentOrganization?.currency ?? "USD",
+                      locale,
+                    })
                   : "—"}
               </span>
             </div>

--- a/apps/webapp/app/components/reports/idle-assets-content.tsx
+++ b/apps/webapp/app/components/reports/idle-assets-content.tsx
@@ -21,10 +21,14 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ReportEmptyState } from "~/components/reports/report-empty-state";
 import {
   AssetCell,
+  CurrencyCell,
   DateCell,
   ReportTable,
 } from "~/components/reports/report-table";
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import type { IdleAssetRow, ReportKpi } from "~/modules/reports/types";
+import { useHints } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
 import { tw } from "~/utils/tw";
 
 /**
@@ -90,13 +94,8 @@ const IDLE_ASSETS_COLUMNS: ColumnDef<IdleAssetRow>[] = [
   {
     accessorKey: "valuation",
     header: "Value",
-    cell: ({ row }) =>
-      // `!= null` so a real $0 valuation renders as "$0", not "—".
-      row.original.valuation != null ? (
-        `$${row.original.valuation.toLocaleString()}`
-      ) : (
-        <span className="text-gray-400">—</span>
-      ),
+    // A real $0 valuation renders as "$0" (or workspace equivalent), not "—".
+    cell: ({ row }) => <CurrencyCell value={row.original.valuation} />,
   },
 ];
 
@@ -128,6 +127,9 @@ export function IdleAssetsContent({
   timeframeLabel,
   onRowClick,
 }: Props) {
+  const currentOrganization = useCurrentOrganization();
+  const { locale } = useHints();
+
   // Column definitions live at module scope (`IDLE_ASSETS_COLUMNS`) so the
   // array reference — and every cell function inside — is stable across
   // every render. That stability is what prevents TanStack `flexRender`
@@ -180,7 +182,11 @@ export function IdleAssetsContent({
               <span className="text-xs text-gray-500">Total Value</span>
               <span className="text-lg font-medium text-gray-900">
                 {totalIdleValue > 0
-                  ? `$${totalIdleValue.toLocaleString()}`
+                  ? formatCurrency({
+                      value: totalIdleValue,
+                      currency: currentOrganization?.currency ?? "USD",
+                      locale,
+                    })
                   : "—"}
               </span>
             </div>

--- a/apps/webapp/app/components/reports/overdue-items-content.tsx
+++ b/apps/webapp/app/components/reports/overdue-items-content.tsx
@@ -15,11 +15,14 @@
 
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import type { OverdueItemRow, ReportKpi } from "~/modules/reports/types";
+import { useHints } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
 import { tw } from "~/utils/tw";
 
 import { ReportEmptyState } from "./report-empty-state";
-import { ReportTable, DateCell } from "./report-table";
+import { ReportTable, CurrencyCell, DateCell } from "./report-table";
 
 /** Props for the OverdueItemsContent component. */
 type Props = {
@@ -45,6 +48,9 @@ export function OverdueItemsContent({
   totalRows,
   onRowClick,
 }: Props) {
+  const currentOrganization = useCurrentOrganization();
+  const { locale } = useHints();
+
   // Column definitions for overdue items table
   const columns: ColumnDef<OverdueItemRow>[] = [
     {
@@ -117,13 +123,8 @@ export function OverdueItemsContent({
     {
       accessorKey: "valueAtRisk",
       header: "Value",
-      cell: ({ row }) =>
-        // `!= null` so a real $0 value-at-risk renders as "$0", not "—".
-        row.original.valueAtRisk != null ? (
-          `$${row.original.valueAtRisk.toLocaleString()}`
-        ) : (
-          <span className="text-gray-400">—</span>
-        ),
+      // A real $0 value-at-risk renders as "$0" (or workspace equivalent), not "—".
+      cell: ({ row }) => <CurrencyCell value={row.original.valueAtRisk} />,
     },
   ];
 
@@ -178,7 +179,13 @@ export function OverdueItemsContent({
               <div className="flex flex-col">
                 <span className="text-xs text-gray-500">Total Value</span>
                 <span className="text-lg font-medium text-gray-900">
-                  {valueAtRisk > 0 ? `$${valueAtRisk.toLocaleString()}` : "—"}
+                  {valueAtRisk > 0
+                    ? formatCurrency({
+                        value: valueAtRisk,
+                        currency: currentOrganization?.currency ?? "USD",
+                        locale,
+                      })
+                    : "—"}
                 </span>
               </div>
               <div className="flex flex-col">

--- a/apps/webapp/app/components/reports/report-pdf.tsx
+++ b/apps/webapp/app/components/reports/report-pdf.tsx
@@ -23,6 +23,7 @@ import type {
   AssetInventoryPdfMeta,
   CustodySnapshotPdfMeta,
 } from "~/modules/reports/types";
+import { formatCurrency } from "~/utils/currency";
 import { tw } from "~/utils/tw";
 
 export interface ReportPdfProps {
@@ -533,7 +534,11 @@ function AssetInventoryPreview({
           />
           <MetricBox
             label="Total Value"
-            value={`$${pdfMeta.totalValuation.toLocaleString()}`}
+            value={formatCurrency({
+              value: pdfMeta.totalValuation,
+              currency: pdfMeta.currency,
+              locale: pdfMeta.locale,
+            })}
           />
           <MetricBox
             label="Available"
@@ -588,7 +593,13 @@ function AssetInventoryPreview({
                   {row.custodian || "—"}
                 </td>
                 <td className="border-b border-gray-100 p-2 text-right">
-                  {row.valuation ? `$${row.valuation.toLocaleString()}` : "—"}
+                  {row.valuation
+                    ? formatCurrency({
+                        value: row.valuation,
+                        currency: pdfMeta.currency,
+                        locale: pdfMeta.locale,
+                      })
+                    : "—"}
                 </td>
               </tr>
             ))}
@@ -624,7 +635,11 @@ function CustodySnapshotPreview({
           <MetricBox label="Team Members" value={pdfMeta.totalCustodians} />
           <MetricBox
             label="Total Value"
-            value={`$${pdfMeta.totalValuation.toLocaleString()}`}
+            value={formatCurrency({
+              value: pdfMeta.totalValuation,
+              currency: pdfMeta.currency,
+              locale: pdfMeta.locale,
+            })}
           />
         </div>
       </section>
@@ -669,7 +684,13 @@ function CustodySnapshotPreview({
                   {row.daysInCustody}
                 </td>
                 <td className="border-b border-gray-100 p-2 text-right">
-                  {row.valuation ? `$${row.valuation.toLocaleString()}` : "—"}
+                  {row.valuation
+                    ? formatCurrency({
+                        value: row.valuation,
+                        currency: pdfMeta.currency,
+                        locale: pdfMeta.locale,
+                      })
+                    : "—"}
                 </td>
               </tr>
             ))}

--- a/apps/webapp/app/components/reports/report-pdf.tsx
+++ b/apps/webapp/app/components/reports/report-pdf.tsx
@@ -593,13 +593,13 @@ function AssetInventoryPreview({
                   {row.custodian || "—"}
                 </td>
                 <td className="border-b border-gray-100 p-2 text-right">
-                  {row.valuation
-                    ? formatCurrency({
+                  {row.valuation == null
+                    ? "—"
+                    : formatCurrency({
                         value: row.valuation,
                         currency: pdfMeta.currency,
                         locale: pdfMeta.locale,
-                      })
-                    : "—"}
+                      })}
                 </td>
               </tr>
             ))}
@@ -684,13 +684,13 @@ function CustodySnapshotPreview({
                   {row.daysInCustody}
                 </td>
                 <td className="border-b border-gray-100 p-2 text-right">
-                  {row.valuation
-                    ? formatCurrency({
+                  {row.valuation == null
+                    ? "—"
+                    : formatCurrency({
                         value: row.valuation,
                         currency: pdfMeta.currency,
                         locale: pdfMeta.locale,
-                      })
-                    : "—"}
+                      })}
                 </td>
               </tr>
             ))}

--- a/apps/webapp/app/components/reports/report-table.tsx
+++ b/apps/webapp/app/components/reports/report-table.tsx
@@ -27,6 +27,9 @@ import {
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 
 import { AssetImage } from "~/components/assets/asset-image";
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
+import { useHints } from "~/utils/client-hints";
+import { formatCurrency } from "~/utils/currency";
 import { tw } from "~/utils/tw";
 
 export interface ReportTableProps<TData> {
@@ -305,6 +308,11 @@ export function DateCell({ date }: { date: Date | null }) {
 
 /**
  * Number cell renderer with proper alignment.
+ *
+ * For `format="currency"`, the value is rendered in the workspace's configured
+ * currency (read via `useCurrentOrganization`) and the user's locale (read via
+ * `useHints`). Falls back to USD only if the workspace has no currency set,
+ * which should not happen in practice (the Prisma default is USD).
  */
 export function NumberCell({
   value,
@@ -313,6 +321,9 @@ export function NumberCell({
   value: number | null;
   format?: "number" | "currency" | "percent";
 }) {
+  const currentOrganization = useCurrentOrganization();
+  const { locale } = useHints();
+
   if (value === null || value === undefined) {
     return <span className="text-gray-400">—</span>;
   }
@@ -321,23 +332,65 @@ export function NumberCell({
 
   switch (format) {
     case "currency":
-      formatted = new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-      }).format(value);
+      formatted = formatCurrency({
+        value,
+        currency: currentOrganization?.currency ?? "USD",
+        locale,
+      });
       break;
     case "percent":
-      formatted = new Intl.NumberFormat("en-US", {
+      formatted = new Intl.NumberFormat(locale, {
         style: "percent",
         minimumFractionDigits: 0,
         maximumFractionDigits: 1,
       }).format(value / 100);
       break;
     default:
-      formatted = value.toLocaleString();
+      formatted = value.toLocaleString(locale);
   }
 
   return <span className="tabular-nums">{formatted}</span>;
+}
+
+/**
+ * Currency cell renderer for use inside TanStack column definitions that live
+ * at module scope. Reads workspace currency + user locale via hooks so the
+ * column array stays referentially stable across renders (no `useMemo` needed).
+ *
+ * `0` renders as a real "$0" (or workspace equivalent), not the empty
+ * fallback — pass `treatZeroAsEmpty` if the caller prefers the dash for zero.
+ *
+ * @example
+ * { accessorKey: "valuation", cell: ({ row }) => <CurrencyCell value={row.original.valuation} /> }
+ */
+export function CurrencyCell({
+  value,
+  emptyFallback = "—",
+  treatZeroAsEmpty = false,
+}: {
+  /** Numeric value to format. `null`/`undefined` render the empty fallback. */
+  value: number | null | undefined;
+  /** Fallback text when value is missing. Defaults to em-dash. */
+  emptyFallback?: string;
+  /** When true, `0` renders as the empty fallback instead of "$0". */
+  treatZeroAsEmpty?: boolean;
+}) {
+  const currentOrganization = useCurrentOrganization();
+  const { locale } = useHints();
+
+  if (value == null || (treatZeroAsEmpty && value === 0)) {
+    return <span className="text-gray-400">{emptyFallback}</span>;
+  }
+
+  return (
+    <span className="tabular-nums">
+      {formatCurrency({
+        value,
+        currency: currentOrganization?.currency ?? "USD",
+        locale,
+      })}
+    </span>
+  );
 }
 
 /**

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -10,7 +10,7 @@
  * @see {@link file://./helpers.server.ts}
  */
 
-import type { BookingStatus } from "@prisma/client";
+import type { BookingStatus, Currency } from "@prisma/client";
 
 // -----------------------------------------------------------------------------
 // KPI Types
@@ -557,6 +557,16 @@ export interface ReportPdfMetaBase {
   organizationUpdatedAt: Date;
   generatedAt: string;
   totalCount: number;
+  /**
+   * ISO 4217 currency code of the workspace whose data the PDF is rendering.
+   * Used by the PDF renderer to format monetary values via `formatCurrency`.
+   */
+  currency: Currency;
+  /**
+   * BCP 47 locale tag (e.g. `"en-GB"`, `"fr-FR"`) resolved from the request's
+   * client hints. Drives currency + number formatting in the PDF.
+   */
+  locale: string;
 }
 
 /** Data structure for compliance report PDF generation */

--- a/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
+++ b/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
@@ -27,7 +27,7 @@ import type {
   AssetInventoryPdfMeta,
   CustodySnapshotPdfMeta,
 } from "~/modules/reports/types";
-import { getDateTimeFormat } from "~/utils/client-hints";
+import { getDateTimeFormat, getLocale } from "~/utils/client-hints";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   payload,
@@ -125,13 +125,15 @@ export const loader = async ({
       customTo ? new Date(customTo) : undefined
     );
 
-    // Get organization info
+    // Get organization info. `currency` is required so PDF monetary values
+    // render in the workspace's configured currency rather than a hardcoded "$".
     const organization = await db.organization.findUnique({
       where: { id: organizationId },
       select: {
         name: true,
         imageId: true,
         updatedAt: true,
+        currency: true,
       },
     });
 
@@ -143,6 +145,15 @@ export const loader = async ({
         status: 404,
       });
     }
+
+    // Locale drives number + currency formatting inside the PDF renderer.
+    const locale = getLocale(request);
+
+    // Common monetary fields threaded into every pdfMeta variant.
+    const monetaryMeta = {
+      currency: organization.currency,
+      locale,
+    };
 
     // Date formatter - use explicit options to avoid conflict with dateStyle
     // (the utility adds default year/month/day when timeStyle is missing,
@@ -170,6 +181,7 @@ export const loader = async ({
         );
 
         pdfMeta = {
+          ...monetaryMeta,
           reportId,
           reportTitle: reportDef.title,
           reportDescription: reportDef.description,
@@ -235,6 +247,7 @@ export const loader = async ({
         }
 
         pdfMeta = {
+          ...monetaryMeta,
           reportId: "asset-inventory",
           reportTitle: reportDef.title,
           reportDescription: reportDef.description,
@@ -276,6 +289,7 @@ export const loader = async ({
         }
 
         pdfMeta = {
+          ...monetaryMeta,
           reportId: "custody-snapshot",
           reportTitle: reportDef.title,
           reportDescription: reportDef.description,


### PR DESCRIPTION
## Need

A UK customer (GBP workspace) saw `$0.70` instead of `£0.70` on every report and in the PDF export. Customer escalation; "save face" priority.

## Hypothesis / root cause

Reports were built without importing the existing `formatCurrency()` helper at `apps/webapp/app/utils/currency.ts`. **18 sites** hardcode the dollar symbol and/or `en-US` locale and use bare `.toLocaleString()`:

- 13× `` `$${val.toLocaleString()}` `` template literals across 7 in-app report components
- 4× same pattern in the PDF renderer (`report-pdf.tsx`)
- 1× hardcoded `currency: "USD"` + `"en-US"` in the shared `NumberCell` formatter

The pattern was copy-pasted across content components during the Phase-A split refactor (`2840104ac`), then preserved through every later hotfix (#2511–#2514), CTO review (#b01d8226d), and CodeRabbit pass (#cba7941d3). It rendered correctly in every reviewer's environment because **every reviewer's workspace was USD** (the Prisma default).

## Scope (intentionally narrow per no-scope-drift)

Currency only. Same-shape locale bugs identified by the audit but NOT fixed here:

- 53× `.toLocaleString()` calls without a locale arg → number formatting still ignores workspace locale
- 3× raw `toLocaleDateString("en-US", ...)` calls violating the CLAUDE.md `DateS`-component mandate (in `report-table.tsx`, `timeframe-picker.tsx`, `compliance-hero.tsx`)
- Pre-existing 500-vs-404 in the route loader's `default:` case for unknown `reportId`

These will be filed as separate issues. Mixing them into this PR would balloon the diff for an urgent customer-facing fix.

## Changes (10 files, +189 / −51 LOC)

| File | Change |
|---|---|
| `apps/webapp/app/components/reports/report-table.tsx` | Add `<CurrencyCell>` for use in TanStack column defs; reads currency + locale via hooks so module-scoped column arrays stay referentially stable (preserves the render-stability fix from #2514). Fix `NumberCell` currency + percent branches to drop hardcoded `"USD"`/`"en-US"`. |
| `apps/webapp/app/components/reports/{asset-inventory, asset-distribution, custody-snapshot, idle-assets, overdue-items, asset-utilization}-content.tsx` | Thread `useCurrentOrganization()` + `useHints()`; replace 9 hardcoded `$` sites with `<CurrencyCell>` (cells) or `formatCurrency()` (hero/inline). |
| `apps/webapp/app/components/reports/report-pdf.tsx` | Replace 4 hardcoded `$` with `formatCurrency({ value, currency: pdfMeta.currency, locale: pdfMeta.locale })`. |
| `apps/webapp/app/modules/reports/types.ts` | Add `currency: Currency` + `locale: string` to `ReportPdfMetaBase`. |
| `apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx` | Add `currency: true` to the organization select; resolve `locale` via `getLocale(request)`; spread both into the three pdfMeta builders. |

## Test plan

- [x] `pnpm --filter @shelf/webapp validate` — lint, format, typecheck, **1965 tests passing**
- [x] Manual verification with workspace currency = GBP (Carlos's local dev DB):
  - [x] `/reports/asset-inventory` — `£0.70` in hero Total Value + Asset Details row
  - [x] `/reports/custody-snapshot` — no `$` (no monetary data in test workspace; em-dash fallback verified)
  - [x] `/reports/idle-assets` — `£0.70` in hero + table cell
  - [x] `/reports/overdue-items` — no `$` (no overdue items in test workspace)
  - [x] `/reports/distribution` — `£0.70` in hero
  - [x] `/reports/asset-utilization` — `£0.70` in table Value column
  - [x] Asset Inventory PDF preview — `£0.70` in Total Value tile + per-row values (screenshot in dev session)
- [x] **Reviewer**: switch your workspace to a third currency (JPY or EUR is fine) and verify symbol changes on at least one report + the PDF preview.
- [x] **Reviewer**: verify that downloading the PDF (not just previewing) produces the correct currency in the saved file.

## Adversarial test config (process change)

Going forward CTO's primary dev workspace will be **GBP + en-GB by default**. Rationale: this bug existed because every internal Shelf workspace was USD. The next class of locale-sensitive bug (date format, number separators, RTL, etc.) is currently lurking unseen for the same reason. Making at least one internal workspace adversarial means any divergence between dev's currency and the rendered output becomes immediately visible during dev/review.

## Notes for reviewer

- The `CurrencyCell` component lives in `report-table.tsx` rather than a standalone file to keep it next to its sibling cell renderers (`AssetCell`, `DateCell`, `StatusCell`, `NumberCell`). Happy to extract if the reviewer prefers.
- `currentOrganization?.currency ?? "USD"` fallback in seven sites is intentional: defensive default for the (theoretical) case where the org loader hasn't populated yet. The Prisma schema default is also `USD`, so the fallback never displays differently than what the unpopulated path would have shown.
- Pre-commit hooks (commitlint + lefthook) and `pnpm webapp:validate` passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monetary values across reports now honor your organization's configured currency and the UI/request locale for consistent, locale-aware formatting.
  * PDF exports include currency and locale metadata so exported reports match on-screen formatting.
  * Table cells and summary KPIs use a unified currency display: true zeros show as $0 (or equivalent) while absent/non-positive totals render as an em dash.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2526)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->