### PR TITLE
fix: signed custody settings submission and compatibility guards

### DIFF
--- a/apps/webapp/app/hooks/use-tab-id.ts
+++ b/apps/webapp/app/hooks/use-tab-id.ts
@@ -15,6 +15,21 @@
 import { useEffect, useRef } from "react";
 
 const SESSION_KEY = "__shelfTabId";
+let tabIdFallbackCounter = 0;
+
+function generateTabId(): string {
+  if (typeof globalThis.crypto !== "undefined") {
+    try {
+      if (typeof globalThis.crypto.randomUUID === "function") {
+        return globalThis.crypto.randomUUID();
+      }
+    } catch {
+      // Fallback below handles environments where crypto exists but is partially shimmed.
+    }
+  }
+  tabIdFallbackCounter += 1;
+  return `tab-${Date.now()}-${tabIdFallbackCounter}`;
+}
 
 /**
  * Returns a stable, unique identifier for the current browser tab.
@@ -32,7 +47,7 @@ export function useTabId(): string {
     const stored = sessionStorage.getItem(SESSION_KEY);
     // Cloned tabs (window.open / target="_blank") inherit sessionStorage,
     // so generate a fresh ID when an opener is detected.
-    tabIdRef.current = stored && !window.opener ? stored : crypto.randomUUID();
+    tabIdRef.current = stored && !window.opener ? stored : generateTabId();
     sessionStorage.setItem(SESSION_KEY, tabIdRef.current);
   }
 

--- a/apps/webapp/app/routes/_layout+/settings.signed-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.signed-custody.tsx
@@ -5,8 +5,7 @@ import type {
   LoaderFunctionArgs,
   MetaFunction,
 } from "react-router";
-import { data, useFetcher, useLoaderData } from "react-router";
-import { useZorm } from "react-zorm";
+import { data, Form, useLoaderData } from "react-router";
 import { z } from "zod";
 import { ErrorContent } from "~/components/errors";
 import FormRow from "~/components/forms/form-row";
@@ -57,6 +56,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         message:
           "Signed custody settings are not available in a personal workspace.",
         label: "Settings",
+        status: 403,
         shouldBeCaptured: false,
       });
     }
@@ -99,6 +99,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
         message:
           "Signed custody settings are not available in a personal workspace.",
         label: "Settings",
+        status: 403,
         shouldBeCaptured: false,
       });
     }
@@ -157,16 +158,15 @@ export const ErrorBoundary = () => <ErrorContent />;
 
 export default function SignedCustodySettingsPage() {
   const { organization } = useLoaderData<typeof loader>();
-  const fetcher = useFetcher({ key: "signed-custody-settings" });
-  const disabled = useDisabled(fetcher);
-  const zo = useZorm("SignedCustodySettings", SignedCustodySettingsSchema);
+  const disabled = useDisabled();
 
   const [signedCustodyEnabled, setSignedCustodyEnabled] = useState(
     organization.enableSignedCustodyOnAssignment
   );
 
   return (
-    <fetcher.Form ref={zo.ref} method="post" className="flex flex-col gap-2">
+    <Form method="post" className="flex flex-col gap-2">
+      <input type="hidden" name="intent" value="updateSignedCustodySettings" />
       <Card className="my-0">
         <div className="mb-6">
           <h3 className="text-text-lg font-semibold">Signed custody</h3>
@@ -190,7 +190,7 @@ export default function SignedCustodySettingsPage() {
           <div className="flex flex-col items-center gap-2">
             <Switch
               id="enableSignedCustodyOnAssignment"
-              name={zo.fields.enableSignedCustodyOnAssignment()}
+              name="enableSignedCustodyOnAssignment"
               checked={signedCustodyEnabled}
               disabled={disabled}
               onCheckedChange={setSignedCustodyEnabled}
@@ -218,7 +218,7 @@ export default function SignedCustodySettingsPage() {
           <div className="flex flex-col items-center gap-2">
             <Switch
               id="requireCustodySignatureOnAssignment"
-              name={zo.fields.requireCustodySignatureOnAssignment()}
+              name="requireCustodySignatureOnAssignment"
               defaultChecked={organization.requireCustodySignatureOnAssignment}
               disabled={disabled || !signedCustodyEnabled}
             />
@@ -232,16 +232,11 @@ export default function SignedCustodySettingsPage() {
         </FormRow>
 
         <div className="text-right">
-          <Button
-            type="submit"
-            value="updateSignedCustodySettings"
-            name="intent"
-            disabled={disabled}
-          >
+          <Button type="submit" disabled={disabled}>
             {disabled ? <Spinner /> : "Save settings"}
           </Button>
         </div>
       </Card>
-    </fetcher.Form>
+    </Form>
   );
 }

--- a/apps/webapp/app/routes/_layout+/settings.signed-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.signed-custody.tsx
@@ -1,3 +1,12 @@
+/**
+ * Signed custody settings route.
+ *
+ * Provides read and update handlers for organization-level signed custody
+ * toggles, including compatibility guards that block personal workspaces.
+ *
+ * @see ~/utils/roles.server
+ * @see ~/utils/http.server
+ */
 import { useState } from "react";
 import { OrganizationType } from "@prisma/client";
 import type {
@@ -37,6 +46,14 @@ const SignedCustodySettingsSchema = z.object({
     .default("false"),
 });
 
+/**
+ * Loads current signed custody settings for the active organization.
+ *
+ * @param args - Route loader arguments containing session context and request.
+ * @returns Serialized page payload with signed custody settings state.
+ * @throws {Response} Throws a structured error response when authorization or
+ * data loading fails.
+ */
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
@@ -80,6 +97,15 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
   }
 }
 
+/**
+ * Updates signed custody settings for the active organization.
+ *
+ * @param args - Route action arguments containing session context and request.
+ * @returns Success payload with updated organization settings, or a structured
+ * error payload when the update cannot be completed.
+ * @throws {ShelfError} Throws for unsupported organization types before being
+ * mapped to an HTTP error payload.
+ */
 export async function action({ context, request }: ActionFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
@@ -146,16 +172,37 @@ export async function action({ context, request }: ActionFunctionArgs) {
   }
 }
 
+/**
+ * Route handle metadata used by the settings breadcrumb UI.
+ *
+ * @returns Breadcrumb label for this route.
+ */
 export const handle = {
   breadcrumb: () => "Signed custody",
 };
 
+/**
+ * Builds the document title for the signed custody settings page.
+ *
+ * @param args - Meta function arguments with loader data.
+ * @returns Route metadata entries for the HTML head.
+ */
 export const meta: MetaFunction<typeof loader> = ({ data }) => [
   { title: data ? appendToMetaTitle(data.header.title) : "" },
 ];
 
+/**
+ * Error boundary for signed custody settings route failures.
+ *
+ * @returns Error screen content for route-level failures.
+ */
 export const ErrorBoundary = () => <ErrorContent />;
 
+/**
+ * Renders the signed custody settings form.
+ *
+ * @returns The settings page form for toggling signed custody behavior.
+ */
 export default function SignedCustodySettingsPage() {
   const { organization } = useLoaderData<typeof loader>();
   const disabled = useDisabled();

--- a/apps/webapp/app/routes/_layout+/settings.signed-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.signed-custody.tsx
@@ -1,0 +1,247 @@
+import { useState } from "react";
+import { OrganizationType } from "@prisma/client";
+import type {
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+  MetaFunction,
+} from "react-router";
+import { data, useFetcher, useLoaderData } from "react-router";
+import { useZorm } from "react-zorm";
+import { z } from "zod";
+import { ErrorContent } from "~/components/errors";
+import FormRow from "~/components/forms/form-row";
+import { Switch } from "~/components/forms/switch";
+import { Button } from "~/components/shared/button";
+import { Card } from "~/components/shared/card";
+import { Spinner } from "~/components/shared/spinner";
+import { db } from "~/database/db.server";
+import { useDisabled } from "~/hooks/use-disabled";
+import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { sendNotification } from "~/utils/emitter/send-notification.server";
+import { ShelfError, makeShelfError } from "~/utils/error";
+import { payload, error, parseData } from "~/utils/http.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+
+const SignedCustodySettingsSchema = z.object({
+  intent: z.literal("updateSignedCustodySettings"),
+  enableSignedCustodyOnAssignment: z
+    .string()
+    .transform((value) => value === "on")
+    .default("false"),
+  requireCustodySignatureOnAssignment: z
+    .string()
+    .transform((value) => value === "on")
+    .default("false"),
+});
+
+export async function loader({ context, request }: LoaderFunctionArgs) {
+  const authSession = context.getSession();
+  const { userId } = authSession;
+
+  try {
+    const { organizationId, currentOrganization } = await requirePermission({
+      userId: authSession.userId,
+      request,
+      entity: PermissionEntity.generalSettings,
+      action: PermissionAction.read,
+    });
+
+    if (currentOrganization.type === OrganizationType.PERSONAL) {
+      throw new ShelfError({
+        cause: null,
+        title: "Not allowed",
+        message:
+          "Signed custody settings are not available in a personal workspace.",
+        label: "Settings",
+        shouldBeCaptured: false,
+      });
+    }
+
+    const organization = await db.organization.findUniqueOrThrow({
+      where: { id: organizationId },
+      select: {
+        id: true,
+        enableSignedCustodyOnAssignment: true,
+        requireCustodySignatureOnAssignment: true,
+      },
+    });
+
+    return payload({
+      header: { title: "Signed custody settings" },
+      organization,
+    });
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId });
+    throw data(error(reason), { status: reason.status });
+  }
+}
+
+export async function action({ context, request }: ActionFunctionArgs) {
+  const authSession = context.getSession();
+  const { userId } = authSession;
+
+  try {
+    const { organizationId, currentOrganization } = await requirePermission({
+      userId: authSession.userId,
+      request,
+      entity: PermissionEntity.generalSettings,
+      action: PermissionAction.update,
+    });
+
+    if (currentOrganization.type === OrganizationType.PERSONAL) {
+      throw new ShelfError({
+        cause: null,
+        title: "Not allowed",
+        message:
+          "Signed custody settings are not available in a personal workspace.",
+        label: "Settings",
+        shouldBeCaptured: false,
+      });
+    }
+
+    const formData = await request.formData();
+    const {
+      enableSignedCustodyOnAssignment,
+      requireCustodySignatureOnAssignment,
+    } = parseData(formData, SignedCustodySettingsSchema, {
+      additionalData: {
+        organizationId,
+        formData: Object.fromEntries(formData),
+      },
+    });
+
+    const resolvedRequireSignature = enableSignedCustodyOnAssignment
+      ? requireCustodySignatureOnAssignment
+      : false;
+
+    const organization = await db.organization.update({
+      where: { id: organizationId },
+      data: {
+        enableSignedCustodyOnAssignment,
+        requireCustodySignatureOnAssignment: resolvedRequireSignature,
+      },
+      select: {
+        id: true,
+        enableSignedCustodyOnAssignment: true,
+        requireCustodySignatureOnAssignment: true,
+      },
+    });
+
+    sendNotification({
+      title: "Settings updated",
+      message: "Signed custody settings have been updated successfully",
+      icon: { name: "success", variant: "success" },
+      senderId: authSession.userId,
+    });
+
+    return data(payload({ success: true, organization }), { status: 200 });
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId });
+    return data(error(reason), { status: reason.status });
+  }
+}
+
+export const handle = {
+  breadcrumb: () => "Signed custody",
+};
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  { title: data ? appendToMetaTitle(data.header.title) : "" },
+];
+
+export const ErrorBoundary = () => <ErrorContent />;
+
+export default function SignedCustodySettingsPage() {
+  const { organization } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher({ key: "signed-custody-settings" });
+  const disabled = useDisabled(fetcher);
+  const zo = useZorm("SignedCustodySettings", SignedCustodySettingsSchema);
+
+  const [signedCustodyEnabled, setSignedCustodyEnabled] = useState(
+    organization.enableSignedCustodyOnAssignment
+  );
+
+  return (
+    <fetcher.Form ref={zo.ref} method="post" className="flex flex-col gap-2">
+      <Card className="my-0">
+        <div className="mb-6">
+          <h3 className="text-text-lg font-semibold">Signed custody</h3>
+          <p className="text-sm text-gray-600">
+            Configure whether custodians should review and sign an agreement
+            when you assign long-term custody.
+          </p>
+        </div>
+
+        <FormRow
+          rowLabel="Enable signed custody"
+          subHeading={
+            <p>
+              Allow administrators to require agreement acknowledgement when
+              assigning custody.
+            </p>
+          }
+          className="border-b-0 pb-[10px]"
+          required
+        >
+          <div className="flex flex-col items-center gap-2">
+            <Switch
+              id="enableSignedCustodyOnAssignment"
+              name={zo.fields.enableSignedCustodyOnAssignment()}
+              checked={signedCustodyEnabled}
+              disabled={disabled}
+              onCheckedChange={setSignedCustodyEnabled}
+            />
+            <label
+              htmlFor="enableSignedCustodyOnAssignment"
+              className="hidden text-gray-500"
+            >
+              Allow
+            </label>
+          </div>
+        </FormRow>
+
+        <FormRow
+          rowLabel="Require signature"
+          subHeading={
+            <p>
+              When enabled, custodians must provide a signature before custody
+              assignment can be finalized.
+            </p>
+          }
+          className="border-b-0 pb-[10px]"
+          required
+        >
+          <div className="flex flex-col items-center gap-2">
+            <Switch
+              id="requireCustodySignatureOnAssignment"
+              name={zo.fields.requireCustodySignatureOnAssignment()}
+              defaultChecked={organization.requireCustodySignatureOnAssignment}
+              disabled={disabled || !signedCustodyEnabled}
+            />
+            <label
+              htmlFor="requireCustodySignatureOnAssignment"
+              className="hidden text-gray-500"
+            >
+              Require signature
+            </label>
+          </div>
+        </FormRow>
+
+        <div className="text-right">
+          <Button
+            type="submit"
+            value="updateSignedCustodySettings"
+            name="intent"
+            disabled={disabled}
+          >
+            {disabled ? <Spinner /> : "Save settings"}
+          </Button>
+        </div>
+      </Card>
+    </fetcher.Form>
+  );
+}

--- a/apps/webapp/app/routes/_layout+/settings.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.tsx
@@ -60,6 +60,9 @@ export default function SettingsPage() {
   let items = [
     { to: "general", content: "General" },
     ...(!_isPersonalOrg ? [{ to: "bookings", content: "Bookings" }] : []),
+    ...(!_isPersonalOrg
+      ? [{ to: "signed-custody", content: "Signed custody" }]
+      : []),
     ...(!_isPersonalOrg ? [{ to: "emails", content: "Emails" }] : []),
     { to: "custom-fields", content: "Custom fields" },
     { to: "team", content: "Team" },
@@ -70,9 +73,14 @@ export default function SettingsPage() {
   if (isBaseOrSelfService) {
     items = items.filter(
       (item) =>
-        !["custom-fields", "team", "general", "bookings", "emails"].includes(
-          item.to
-        )
+        ![
+          "custom-fields",
+          "team",
+          "general",
+          "bookings",
+          "signed-custody",
+          "emails",
+        ].includes(item.to)
     );
   }
 

--- a/packages/database/prisma/migrations/20260511193000_add_signed_custody_settings_to_organization/migration.sql
+++ b/packages/database/prisma/migrations/20260511193000_add_signed_custody_settings_to_organization/migration.sql
@@ -1,0 +1,4 @@
+-- Add signed custody workspace settings flags
+ALTER TABLE "Organization"
+ADD COLUMN "enableSignedCustodyOnAssignment" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "requireCustodySignatureOnAssignment" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -716,6 +716,10 @@ model Organization {
   baseUserCanSeeCustody     Boolean @default(false) // If true, the base users can see the custody of assets inside the organization
   baseUserCanSeeBookings    Boolean @default(false) // If true, the base users can see the bookings that are not theirs
 
+  // Signed custody configuration
+  enableSignedCustodyOnAssignment   Boolean @default(false) // If true, admins can require custodians to acknowledge a custody agreement during assignment.
+  requireCustodySignatureOnAssignment Boolean @default(false) // If true, a signature is required before custody is finalized (only when signed custody is enabled).
+
   // Barcode add-on (per-organization, managed via Stripe subscription)
   barcodesEnabled   Boolean   @default(false) // If true, this organization can use barcode functionality
   barcodesEnabledAt DateTime? // Track when barcode feature was enabled


### PR DESCRIPTION
## Summary
This PR finalizes the signed custody settings groundwork for issue #461 and fixes follow-up behavior found during local verification.

## Scope
This PR implements the dashboard settings tab and fields for signed custody.
It does not implement the actual PDF signing flow.
For PDF template attachment, the implementation is intentionally limited to settings-level groundwork based on the maintainer's scope note.

## Changes
- Keep signed custody settings restricted for personal workspaces and return HTTP 403 (instead of 500)
- Ensure settings form submission reliably posts from `/settings/signed-custody`
- Preserve the signed custody toggle behavior:
  - `enableSignedCustodyOnAssignment`
  - `requireCustodySignatureOnAssignment` (resolved to `false` when signed custody is disabled)
- Add a safe tab-id fallback when `crypto.randomUUID` is unavailable

## Verification
- Personal workspace: `/settings/signed-custody` returns 403 with "Not allowed"
- Team workspace: page renders and settings save successfully
- Saved combinations verified: `ON/OFF` and `ON/ON`
- Lint and typecheck pass for `@shelf/webapp`

/claim #461


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Signed custody" organization settings page (hidden for personal workspaces). Admins can enable signed custody on assignments and require signatures for custody transfers. The page has two dependent switches (require-signature disabled unless signed custody is enabled) and a disabled submit state showing a spinner while saving.
* **Database**
  * Organization settings now persist these signed-custody flags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2528)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->