### PR TITLE
fix(reports): render DateCell dates in workspace locale via DateS

### DIFF
--- a/apps/webapp/app/components/reports/report-table.tsx
+++ b/apps/webapp/app/components/reports/report-table.tsx
@@ -27,6 +27,7 @@ import {
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 
 import { AssetImage } from "~/components/assets/asset-image";
+import { DateS } from "~/components/shared/date";
 import { tw } from "~/utils/tw";
 
 export interface ReportTableProps<TData> {
@@ -286,6 +287,12 @@ export function StatusCell({
 
 /**
  * Date cell renderer with consistent formatting.
+ *
+ * Delegates to the shared {@link DateS} component so dates render in the
+ * user's locale + timezone (from `useHints()`) rather than a hardcoded
+ * `en-US` format — per the CLAUDE.md "Date Display" rule that all UI dates
+ * must go through `DateS`. The outer span preserves `tabular-nums` column
+ * alignment in report tables.
  */
 export function DateCell({ date }: { date: Date | null }) {
   if (!date) {
@@ -294,11 +301,10 @@ export function DateCell({ date }: { date: Date | null }) {
 
   return (
     <span className="tabular-nums">
-      {date.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })}
+      <DateS
+        date={date}
+        options={{ month: "short", day: "numeric", year: "numeric" }}
+      />
     </span>
   );
 }


### PR DESCRIPTION
## Need

`DateCell` — the shared date renderer used in every report table — calls `date.toLocaleDateString("en-US", ...)` directly, hardcoding the US format for every workspace. Customers on en-GB, fr-FR, de-DE, ja-JP, etc. see `"Mar 11, 2026"` instead of the locale-appropriate format. Same root-cause class as the currency hardcoding fixed in #2526.

## Hypothesis / root cause

Direct violation of the CLAUDE.md "Date Display" rule:

> **Always use the `DateS` component** (`apps/webapp/app/components/shared/date.tsx`) for displaying dates in the UI. Do not use raw `toLocaleDateString()` or other custom date formatting.

Fix is mechanical: delegate to `<DateS>`, which already reads locale + timezone from `useHints()`.

## Whole-codebase audit (before scoping)

Grep for every `toLocaleDateString` / `Intl.DateTimeFormat` in the webapp returned ~30 sites. Categorized before deciding scope:

| Category | Sites | This PR? | Why |
|---|---|---|---|
| **UI dates in reports (DateS mandate applies)** | `report-table.tsx` (DateCell), `timeframe-picker.tsx:307`, `compliance-hero.tsx:46` | ✅ **DateCell only** | DateCell is the highest-leverage site (used by every report table). Other 2 have different surrounding context (button labels, chart axis) — atomic follow-up PRs. |
| **UI dates outside reports (DateS mandate also applies)** | `command-palette/command-palette.tsx:733,787,789` (bare `toLocaleDateString()` with no args) | ❌ deferred | Same rule violation but command palette is a separate feature surface. Worth its own atomic PR to avoid blast radius. |
| **Email templates** (`emails/stripe/*.tsx`) | 10 sites | ❌ different fix path | Server-rendered React Email templates have no React hooks — `DateS`/`useHints` don't work. Needs locale threaded through email props from the call site. Different problem, separate PR. |
| **Server-side string formatters** (audit logs, report data, chart axis labels) | `modules/audit/helpers.server.ts` (×3), `modules/reports/timeframe.ts` (×2), `modules/reports/helpers.server.ts` (×3-4), `utils/stripe.server.ts:803`, `routes/_layout+/admin-dashboard+/users.tsx:155`, `modules/asset-filter-presets/format-filter-summary.ts:263` | ❌ different fix path | These format strings that get stored or embedded server-side — fix is `getLocale(request)` argument, not `DateS`. Separate PR class. |
| **Already locale-aware** (not violations) | `utils/calendar.ts` (uses `"default"`), `utils/date-fns.ts` (uses `undefined`), `utils/client-hints.tsx:193` (uses `locale` param) | n/a | These are correct as-is. |
| **Tests asserting en-US date format** | none found | n/a | No test regressions risk from this change. |

**Pattern verified against existing convention**: `apps/webapp/app/components/reports/at-risk-bookings.tsx:191` already uses `<DateS date={...} options={{month: "short", day: "numeric", ...}} />`. This PR matches that pattern exactly.

## Scope decision

> Per the no-scope-drift discipline: ship the smallest correct fix for the most-used surface, then file the rest as separate atomic PRs.

This PR fixes **only** `DateCell` in `report-table.tsx`. It's the single highest-leverage site — every report table that displays a date column uses it (Asset Inventory, Custody Snapshot, Idle Assets, Overdue Items, Asset Utilization).

The 2 sibling reports-area sites + the command-palette violations are real bugs but deliberately deferred so each receives focused review.

## Change

| File | Change |
|---|---|
| `apps/webapp/app/components/reports/report-table.tsx` | Import `DateS`. Replace `DateCell`'s inline `toLocaleDateString("en-US", ...)` with `<DateS date={date} options={{ month: "short", day: "numeric", year: "numeric" }} />`. Outer `<span className="tabular-nums">` preserved for column alignment. |

**+11 / −5 LOC, one file.**

## Verification (headless Playwright on this branch)

Booted `pnpm webapp:dev` on this branch, navigated to `/reports/asset-inventory` with a headless Chrome whose `navigator.language === "en-GB"`. Read the "Created" column directly from the DOM:

| Row | Rendered `Created` cell |
|---|---|
| Logitech Keyboard | `6 May 2026` |
| N95 MASKS | `6 May 2026` |

Format is **`DD MMM YYYY` (en-GB)**, not `May 6, 2026` (en-US). Confirms `<DateS>` reads `useHints().locale` correctly when invoked inside a TanStack `flexRender` cell — no Provider/context issue. Side-by-side reference (same Date, different locales):

```js
new Date(2026, 4, 6).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
// → "May 6, 2026"  (pre-fix, hardcoded)
new Date(2026, 4, 6).toLocaleDateString("en-GB", { month: "short", day: "numeric", year: "numeric" });
// → "6 May 2026"  (post-fix, via DateS + useHints)
```

## Test plan

- [x] `pnpm --filter @shelf/webapp validate` — lint, format, typecheck, **1965 tests pass**
- [x] Headless Playwright verification with en-GB (above)
- [ ] Reviewer: switch to fr-FR or ja-JP → confirm appropriate locale rendering across all 5 reports that use date columns
- [ ] Reviewer: scan diff for any cell stylistic regression — column alignment, vertical spacing in the "Last Used" / "Assigned" / "Due Date" / "Created" columns of each report

## Follow-ups already identified

These will land as separate atomic PRs (one per surface), in priority order:

1. `reports/timeframe-picker.tsx:307` — date in timeframe picker button labels
2. `reports/compliance-hero.tsx:46` — date range in chart axis label
3. `command-palette/command-palette.tsx:733,787,789` — date display in command palette items
4. Email templates locale awareness (10 sites, different fix path — pass `recipientLocale` through email props)
5. Server-side string formatters (audit logs, chart axis labels) — different fix path using `getLocale(request)`

## Notes for reviewer

- `DateS` returns `null` for null dates, but `DateCell` already short-circuits the null case to render its own em-dash placeholder, so behavior is preserved.
- Nested span structure (`<span class="tabular-nums"><span>{date}</span></span>`) matches how the existing `at-risk-bookings.tsx` wraps `DateS` — happy to refactor if you prefer a `className` prop on `DateS` instead.
- This PR is independent of #2526 and merges cleanly in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified date formatting in report tables by adopting a shared date component, ensuring consistent locale and timezone-aware date display throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2529)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->