### PR TITLE
fix(companion): pass orgId to mobile asset endpoints (detail + add-note)

### DIFF
--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -68,7 +68,7 @@ export default function AssetDetailScreen() {
     setIsLoading,
     fetchAsset,
     onRefresh,
-  } = useAssetData(id);
+  } = useAssetData(id, currentOrg?.id);
 
   // Custody actions
   const {

--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -130,9 +130,10 @@ export default function AssetDetailScreen() {
   // ── Notes Action ────────────────────────────────────
 
   const handlePostNote = async () => {
-    if (!asset || !noteText.trim() || isPostingNote) return;
+    const orgId = currentOrg?.id;
+    if (!asset || !noteText.trim() || isPostingNote || !orgId) return;
     setIsPostingNote(true);
-    const { error: err } = await api.addNote(asset.id, noteText.trim());
+    const { error: err } = await api.addNote(asset.id, noteText.trim(), orgId);
     if (err) {
       Alert.alert("Error", err);
     } else {

--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -437,6 +437,11 @@ export default function AssetDetailScreen() {
             onChangeNoteText={setNoteText}
             onPostNote={handlePostNote}
             isPostingNote={isPostingNote}
+            // why: surface the no-org-context state to the user. Without
+            // this, `handlePostNote` silently early-returns on missing
+            // orgId and the tap feels broken. The disabled state + hint
+            // label is the visible feedback.
+            canPostNote={!!currentOrg?.id}
           />
         </ScrollView>
       </KeyboardAvoidingView>

--- a/apps/companion/components/asset-detail/notes-section.tsx
+++ b/apps/companion/components/asset-detail/notes-section.tsx
@@ -18,6 +18,14 @@ interface NotesSectionProps {
   onChangeNoteText: (text: string) => void;
   onPostNote: () => void;
   isPostingNote: boolean;
+  /**
+   * When `false` the post-note input and button are disabled with a hint
+   * label. The parent uses this to surface the case where the workspace
+   * context (`currentOrg`) hasn't resolved yet — without it the user can
+   * type a note, tap Post, and silently get nothing because the parent
+   * `handlePostNote` early-returns on missing `orgId`.
+   */
+  canPostNote?: boolean;
 }
 
 export const NotesSection = memo(function NotesSection({
@@ -26,9 +34,12 @@ export const NotesSection = memo(function NotesSection({
   onChangeNoteText,
   onPostNote,
   isPostingNote,
+  canPostNote = true,
 }: NotesSectionProps) {
   const { colors } = useTheme();
   const styles = useStyles();
+
+  const postDisabled = !noteText.trim() || isPostingNote || !canPostNote;
 
   return (
     <View style={styles.sectionContainer}>
@@ -42,21 +53,31 @@ export const NotesSection = memo(function NotesSection({
           style={styles.noteInput}
           value={noteText}
           onChangeText={onChangeNoteText}
-          placeholder="Add a note..."
+          placeholder={canPostNote ? "Add a note..." : "Loading workspace…"}
           placeholderTextColor={colors.placeholderText}
+          editable={canPostNote}
           multiline
           maxLength={5000}
           accessibilityLabel="Add a note"
+          accessibilityHint={
+            canPostNote ? undefined : "Workspace context is still loading."
+          }
         />
         <TouchableOpacity
           style={[
             styles.notePostBtn,
-            (!noteText.trim() || isPostingNote) && styles.notePostBtnDisabled,
+            postDisabled && styles.notePostBtnDisabled,
           ]}
           onPress={onPostNote}
-          disabled={!noteText.trim() || isPostingNote}
+          disabled={postDisabled}
           accessibilityLabel="Post note"
+          accessibilityHint={
+            canPostNote
+              ? undefined
+              : "Disabled until the workspace context loads."
+          }
           accessibilityRole="button"
+          accessibilityState={{ disabled: postDisabled }}
         >
           {isPostingNote ? (
             <ActivityIndicator size="small" color={colors.primaryForeground} />

--- a/apps/companion/hooks/use-asset-data.ts
+++ b/apps/companion/hooks/use-asset-data.ts
@@ -14,14 +14,18 @@ interface UseAssetDataReturn {
   onRefresh: () => Promise<void>;
 }
 
-export function useAssetData(assetId: string): UseAssetDataReturn {
+export function useAssetData(
+  assetId: string,
+  orgId: string | undefined
+): UseAssetDataReturn {
   const [asset, setAsset] = useState<AssetDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchAsset = useCallback(async () => {
-    const { data, error: fetchErr } = await api.asset(assetId);
+    if (!orgId) return;
+    const { data, error: fetchErr } = await api.asset(assetId, orgId);
     // Request cancelled (navigation) — ignore
     if (!data && !fetchErr) return;
     if (fetchErr || !data) {
@@ -31,7 +35,7 @@ export function useAssetData(assetId: string): UseAssetDataReturn {
       setAsset(data.asset);
       setError(null);
     }
-  }, [assetId]);
+  }, [assetId, orgId]);
 
   useEffect(() => {
     setIsLoading(true);

--- a/apps/companion/hooks/use-asset-data.ts
+++ b/apps/companion/hooks/use-asset-data.ts
@@ -14,6 +14,25 @@ interface UseAssetDataReturn {
   onRefresh: () => Promise<void>;
 }
 
+/**
+ * Owns the data fetch + lifecycle for the asset-detail screen.
+ *
+ * Both `assetId` and `orgId` are required by the underlying API; the hook
+ * is tolerant of `orgId` being briefly `undefined` (e.g. while the
+ * `OrgProvider` hydrates `currentOrg` after sign-in) by keeping
+ * `isLoading: true` and deferring the fetch until the value arrives.
+ * Without this guard the screen would flash a stale "Asset not found"
+ * error state in the gap between first render and org-context resolution.
+ *
+ * @param assetId - Identifier of the asset to fetch.
+ * @param orgId - Caller's current workspace id. When `undefined`, the
+ *   hook waits (keeps `isLoading: true`, no fetch fired, no error set).
+ *   Once it becomes defined the fetch runs automatically via the effect
+ *   dependency.
+ * @returns The current asset / loading / error state plus stable
+ *   imperative setters for downstream callers that need to refresh or
+ *   override.
+ */
 export function useAssetData(
   assetId: string,
   orgId: string | undefined
@@ -38,9 +57,15 @@ export function useAssetData(
   }, [assetId, orgId]);
 
   useEffect(() => {
+    // why: when orgId is briefly undefined (org context still hydrating)
+    // we deliberately do nothing — `isLoading` stays at its initial / last
+    // `true` so the screen keeps showing the skeleton instead of flashing
+    // an "Asset not found" error state. The effect re-runs automatically
+    // when orgId resolves because `fetchAsset` closes over it.
+    if (!orgId) return;
     setIsLoading(true);
     fetchAsset().finally(() => setIsLoading(false));
-  }, [fetchAsset]);
+  }, [fetchAsset, orgId]);
 
   const onRefresh = async () => {
     setIsRefreshing(true);

--- a/apps/companion/hooks/use-edit-asset-form.ts
+++ b/apps/companion/hooks/use-edit-asset-form.ts
@@ -99,10 +99,10 @@ export function useEditAssetForm(
 
   // ── Load existing asset ─────────────────────────
   useEffect(() => {
-    if (!assetId) return;
+    if (!assetId || !orgId) return;
     setIsLoadingAsset(true);
     api
-      .asset(assetId)
+      .asset(assetId, orgId)
       .then(({ data, error }) => {
         if (error || !data) {
           setLoadError(error || "Failed to load asset");
@@ -157,7 +157,7 @@ export function useEditAssetForm(
       .finally(() => {
         setIsLoadingAsset(false);
       });
-  }, [assetId]);
+  }, [assetId, orgId]);
 
   // ── Load categories & locations ─────────────────
   const loadCategories = useCallback(async () => {

--- a/apps/companion/lib/api/assets.ts
+++ b/apps/companion/lib/api/assets.ts
@@ -79,7 +79,23 @@ export const assetsApi = {
       : cachedApiFetch<LocationsResponse>(path);
   },
 
-  /** Add a comment note to an asset */
+  /**
+   * Post a user-authored comment note to an asset's activity log. The
+   * mobile add-note route requires `orgId` to scope the action to the
+   * caller's workspace — passing it as a query param matches the rest of
+   * the org-scoped mobile API surface (`asset`, `assets`, `barcode`,
+   * etc.).
+   *
+   * @param assetId - Identifier of the asset to attach the note to.
+   * @param content - Trimmed note body. Caller should validate non-empty
+   *   before invoking; the server will reject empty content but the
+   *   round-trip is wasteful.
+   * @param orgId - Caller's current workspace id. Required by the server;
+   *   client callers should not invoke this when the value isn't available
+   *   (the asset-detail screen disables the Post button until it is).
+   * @returns `{ note }` on success or `{ error }` on failure (per
+   *   `apiFetch`'s envelope).
+   */
   addNote: (assetId: string, content: string, orgId: string) =>
     apiFetch<{ note: AssetNote }>(`/api/mobile/asset/add-note?orgId=${orgId}`, {
       method: "POST",

--- a/apps/companion/lib/api/assets.ts
+++ b/apps/companion/lib/api/assets.ts
@@ -69,8 +69,8 @@ export const assetsApi = {
   },
 
   /** Add a comment note to an asset */
-  addNote: (assetId: string, content: string) =>
-    apiFetch<{ note: AssetNote }>("/api/mobile/asset/add-note", {
+  addNote: (assetId: string, content: string, orgId: string) =>
+    apiFetch<{ note: AssetNote }>(`/api/mobile/asset/add-note?orgId=${orgId}`, {
       method: "POST",
       body: JSON.stringify({ assetId, content }),
     }),

--- a/apps/companion/lib/api/assets.ts
+++ b/apps/companion/lib/api/assets.ts
@@ -31,7 +31,18 @@ export const assetsApi = {
     return apiFetch<AssetsResponse>(`/api/mobile/assets?${searchParams}`);
   },
 
-  /** Get full asset details */
+  /**
+   * Get full details for a single asset. The mobile asset-detail route
+   * requires `orgId` to scope the lookup to the caller's workspace —
+   * passing it as a query param is the standard pattern across the mobile
+   * API (matches `assets`, `barcode`, `teamMembers`, etc.).
+   *
+   * @param assetId - Identifier of the asset to fetch.
+   * @param orgId - Caller's current workspace id. Required by the server;
+   *   client callers should not invoke this when the value isn't available.
+   * @returns `{ asset }` on success or `{ error }` on failure (per
+   *   `apiFetch`'s envelope).
+   */
   asset: (assetId: string, orgId: string) =>
     apiFetch<{ asset: AssetDetail }>(
       `/api/mobile/assets/${assetId}?orgId=${orgId}`

--- a/apps/companion/lib/api/assets.ts
+++ b/apps/companion/lib/api/assets.ts
@@ -32,8 +32,10 @@ export const assetsApi = {
   },
 
   /** Get full asset details */
-  asset: (assetId: string) =>
-    apiFetch<{ asset: AssetDetail }>(`/api/mobile/assets/${assetId}`),
+  asset: (assetId: string, orgId: string) =>
+    apiFetch<{ asset: AssetDetail }>(
+      `/api/mobile/assets/${assetId}?orgId=${orgId}`
+    ),
 
   /** Resolve a QR code to an asset */
   qr: (qrId: string) => apiFetch<QrResponse>(`/api/mobile/qr/${qrId}`),


### PR DESCRIPTION
## Need

Two related bugs surfacing from TestFlight testing of the companion app:

1. **Asset detail** (`GET /api/mobile/assets/:assetId`): opening any asset from the list or via a scan returned `"Missing organization ID. Pass orgId as query param or x-shelf-organization header."`.
2. **Add note** (`POST /api/mobile/asset/add-note`): adding a comment to an asset's activity log from the companion returned the same error.

Both go through `requireOrganizationAccess` on the webapp side, both companion methods were calling without passing `orgId`.

## Hypothesis

The webapp's mobile-auth module (`apps/webapp/app/modules/api/mobile-auth.server.ts:requireOrganizationAccess`) requires `orgId` via query param or `x-shelf-organization` header. The companion's `api.asset(id)` and `api.addNote(id, content)` weren't passing it — unlike `api.assets(orgId, ...)`, `api.audits()`, `api.bookings()`, etc., which do. Adding `orgId` to these two methods resolves it without any server-side changes.

## Diff scope (4 files, ~20 lines)

- `apps/companion/lib/api/assets.ts` — `asset(id, orgId)` and `addNote(id, content, orgId)` both append `?orgId=`
- `apps/companion/hooks/use-asset-data.ts` — accepts orgId, threads through, guards undefined
- `apps/companion/hooks/use-edit-asset-form.ts` — same threading + guard
- `apps/companion/app/(tabs)/assets/[id].tsx` — passes `currentOrg?.id` to `useAssetData`; `handlePostNote` guards on `currentOrg?.id` before calling `api.addNote`

## Full audit of companion API → webapp orgId requirements

After missing `addNote` on the first pass, I mapped every companion api method against every webapp route that calls `requireOrganizationAccess`. Results:

- **Broken (fixed by this PR):** `assetsApi.asset()`, `assetsApi.addNote()`
- **Already correct** (passing orgId): `assets()`, `barcode()`, `teamMembers()`, `locations()`, `categories()`, `createAsset()`, `updateAsset()`, `deleteAsset()`, `updateImage()`, `assignCustody()`, `releaseCustody()`, `updateLocation()`, all `bulk*` methods, `dashboard()`, `bookings()`, `booking()`, `checkoutBooking()`, `checkinBooking()`, `partialCheckinBooking()`, `audits()`, `audit()`, `recordAuditScan()`, `completeAudit()`.
- **Not required** (route doesn't call `requireOrganizationAccess`): `qr()`, `me()`.

No other broken calls remain.

## Verification status (honest)

**Done:**
- [x] Typecheck (`pnpm --filter @shelf/companion exec tsc --noEmit`): zero new errors. The pre-existing `use-edit-asset-form.ts:105` "Expected 2 arguments, but got 1" error from before this PR is now resolved. 11 pre-existing tech-debt errors on `main` remain (unrelated: `tabBarTestID`, `borderRadius.full`, underscore-prefixed unused props, scanner-error-boundary colors).
- [x] Lefthook pre-commit hooks pass: eslint-companion, prettier, commitlint.
- [x] Code review: traced **every** caller of `api.asset()` and `api.addNote()` in `apps/companion/`. Updated both call sites.
- [x] Full audit of companion API ↔ webapp orgId contract (see table above).

**Not yet verified — DO NOT MERGE until these pass:**
- [ ] EAS Build #2 (with addNote fix) processes through ASC → installs on phone
- [ ] Open asset from list → loads cleanly
- [ ] Scan QR → tap asset → loads cleanly
- [ ] Edit asset → form populates
- [ ] **Add note from asset activity log → posts cleanly** (the new repro path)

## Forward compatibility

If the webapp ever drops `requireOrganizationAccess` from these routes (e.g. derives org from the entity itself like `qr.$qrId.ts` already does), the extra `?orgId=` becomes harmless unused noise. No coordinated deploy required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Asset loading and note actions are now scoped to the active workspace/organization so data and operations use the current org context.

* **Bug Fixes**
  * Asset detail and edit views defer loading until workspace context is available.
  * Note input and post button are disabled with an updated placeholder and accessibility hint while workspace context is unresolved; posting is prevented until an org is present.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2530)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->