### PR TITLE
chore(companion): app-store-submission hardening

### DIFF
--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -9,7 +9,7 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "bundleIdentifier": "com.shelf.companion",
       "infoPlist": {
         "NSCameraUsageDescription": "Shelf needs camera access to scan QR codes and barcodes on your assets."

--- a/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
+++ b/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -370,7 +370,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Shelf/Shelf-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -401,7 +401,7 @@
 				PRODUCT_NAME = Shelf;
 				SWIFT_OBJC_BRIDGING_HEADER = "Shelf/Shelf-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/apps/companion/ios/Shelf/Info.plist
+++ b/apps/companion/ios/Shelf/Info.plist
@@ -55,8 +55,6 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Shelf needs camera access to scan QR codes and barcodes on your assets.</string>
-	<key>NSFaceIDUsageDescription</key>
-	<string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Shelf needs photo access to attach images to your assets.</string>
 	<key>NSUserActivityTypes</key>


### PR DESCRIPTION
## Need

Pre-submission cleanup for the 1.0 App Store release. None of these are required for TestFlight (the current TestFlight builds work without these), but all are required — or strongly preferable — for App Review on App Store submission.

## Scope (3 files, 5 ins / 7 del)

### 1. Drop iPad support

Decision from 2026-05-01: ship phone-only, defer iPad to v1.1.

- `apps/companion/app.json` → `supportsTablet: false`
- `apps/companion/ios/Shelf.xcodeproj/project.pbxproj` → `TARGETED_DEVICE_FAMILY = "1"` on both Debug + Release targets (was `"1,2"`)

**Why both files:** Expo manages `app.json` via prebuild, but since `ios/` is committed in this repo, EAS Build uses the checked-in `pbxproj` directly — so both source of truth needed updating.

**Effect:** Apple Review won't expect iPad screenshots in App Store Connect, and won't apply iPad-specific UX scrutiny.

### 2. Strip placeholder `NSFaceIDUsageDescription`

`apps/companion/ios/Shelf/Info.plist` — removed:

```xml
<key>NSFaceIDUsageDescription</key>
<string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
```

The app does **not** use Face ID — `expo-local-authentication` is not a dependency. Placeholder permission strings (still containing `$(PRODUCT_NAME)` substitution syntax) get flagged by reviewers, especially when the permission is unused. If we add Face ID support later, we re-add the key with a real reason string.

### 3. `MARKETING_VERSION` consistency

`apps/companion/ios/Shelf.xcodeproj/project.pbxproj` → `MARKETING_VERSION = 1.0.0` on both targets (was `1.0`).

Matches `CFBundleShortVersionString = 1.0.0` in `Info.plist` and the version field in `app.json`. ASC submission tooling validates these match.

## Verification

- [x] Diff reviewed — 3 files, 5/7, all changes intentional
- [x] No code changes — pure config/manifest edits
- [ ] EAS Build (production profile) from this branch picks up the new settings (will verify on the next build cycle, not the in-flight `923f2dc3...` build)
- [ ] App opens on phone only (iPad simulator/device should refuse to install or show as compatible-only)

## Independence from the orgId fix

This PR is **independent** of #2530 (`fix/companion-asset-detail-orgid`). No file overlap. Either can merge first; both should be in `main` before the EAS Build that will go to App Store submission.

The currently-in-flight EAS Build (`923f2dc3-4f5d-4067-8c8b-2aa9a8c0bc0c`) was kicked off from the orgId branch and does **not** include these hardening edits — that's intentional, since this build is only for TestFlight verification of the runtime fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility Changes**
  * App is now iPhone-only; iPad and tablet support has been removed
  * Removed Face ID requirement; camera access remains for QR/barcode scanning

* **Chores**
  * Updated iOS app version to semantic versioning format

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2531)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->