### PR TITLE
feat(mobile): support required custom fields on asset create

### DIFF
--- a/apps/companion/app/(tabs)/assets/new.tsx
+++ b/apps/companion/app/(tabs)/assets/new.tsx
@@ -1,4 +1,20 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+/**
+ * Create-asset screen.
+ *
+ * Renders the form for creating a new asset (title, description, optional
+ * image, category, location, and category-scoped custom fields). The custom
+ * field definitions are fetched on mount and whenever the category changes;
+ * required fields are enforced client-side BEFORE submit so the user sees
+ * a clear, immediate message instead of a 400 round-trip. The server enforces
+ * the same contract — the client check is purely a UX improvement, but a
+ * critical one: if the custom-fields fetch fails the screen surfaces the
+ * error and blocks submission rather than silently skipping the guard.
+ *
+ * @see {@link file://../../../hooks/use-edit-asset-form.ts} for the parallel
+ *   pattern used on the edit screen.
+ */
+
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import {
   View,
   Text,
@@ -91,6 +107,14 @@ export default function CreateAssetScreen() {
     Record<string, string>
   >({});
   const [isCustomFieldsLoading, setIsCustomFieldsLoading] = useState(false);
+  // why: surfacing the fetch failure is critical — without it the required-
+  // field client guard silently becomes a no-op (empty `customFieldDefs`),
+  // letting the user submit a payload the server will reject.
+  const [customFieldsError, setCustomFieldsError] = useState<string | null>(
+    null
+  );
+  // Bumped on each retry to re-run the load effect without changing org/cat.
+  const [customFieldsRetryNonce, setCustomFieldsRetryNonce] = useState(0);
 
   // ── Load categories ─────────────────────────────
   const loadCategories = useCallback(async () => {
@@ -117,15 +141,23 @@ export default function CreateAssetScreen() {
   // ── Load custom fields for the selected category ──
   // Re-runs whenever the chosen category changes (including "no category").
   // Any existing values for fields that no longer apply to the new category
-  // are pruned so we don't accidentally send stale data on submit.
+  // are pruned so we don't accidentally send stale data on submit. Uses an
+  // AbortController so a fast category change cancels the in-flight request
+  // (avoiding a stale response clobbering a newer one) and surfaces errors
+  // explicitly so submit is blocked instead of silently bypassed.
   useEffect(() => {
     if (!currentOrg) return;
-    let cancelled = false;
+    const controller = new AbortController();
     setIsCustomFieldsLoading(true);
+    setCustomFieldsError(null);
     api
-      .customFields(currentOrg.id, selectedCategory?.id)
-      .then(({ data }) => {
-        if (cancelled) return;
+      .customFields(currentOrg.id, selectedCategory?.id, controller.signal)
+      .then(({ data, error }) => {
+        if (controller.signal.aborted) return;
+        if (error) {
+          setCustomFieldsError(error);
+          return;
+        }
         const defs = data?.customFields ?? [];
         setCustomFieldDefs(defs);
         // Drop any values whose definition is no longer in scope
@@ -138,13 +170,25 @@ export default function CreateAssetScreen() {
           return next;
         });
       })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setCustomFieldsError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load custom fields. Please retry."
+        );
+      })
       .finally(() => {
-        if (!cancelled) setIsCustomFieldsLoading(false);
+        if (!controller.signal.aborted) setIsCustomFieldsLoading(false);
       });
     return () => {
-      cancelled = true;
+      controller.abort();
     };
-  }, [currentOrg, selectedCategory?.id]);
+  }, [currentOrg, selectedCategory?.id, customFieldsRetryNonce]);
+
+  const retryLoadCustomFields = useCallback(() => {
+    setCustomFieldsRetryNonce((n) => n + 1);
+  }, []);
 
   useEffect(() => {
     loadCategories();
@@ -276,6 +320,21 @@ export default function CreateAssetScreen() {
     }
   };
 
+  // ── Stable onChange handlers per custom field ──
+  // why: passing a new inline arrow on every render forces React to treat
+  // each `CustomFieldInput` as having new props, defeating any memoization
+  // and re-running effects inside it. We build one handler per field id and
+  // cache them so a value change in field A doesn't re-create handlers for
+  // fields B…Z. The map is rebuilt only when the set of field IDs changes.
+  const customFieldChangeHandlers = useMemo(() => {
+    const handlers: Record<string, (val: string) => void> = {};
+    for (const def of customFieldDefs) {
+      handlers[def.id] = (val: string) =>
+        setCustomFieldValues((prev) => ({ ...prev, [def.id]: val }));
+    }
+    return handlers;
+  }, [customFieldDefs]);
+
   // ── Build the custom-fields payload from the local string map ──
   // Empty strings are dropped so we don't send "I touched the input then
   // cleared it" — the server treats absence as "no value." For required
@@ -298,6 +357,25 @@ export default function CreateAssetScreen() {
       return;
     }
     if (!currentOrg) return;
+
+    // why: block submit if the custom-field definitions failed to load —
+    // otherwise the required-field guard below silently passes on an empty
+    // `customFieldDefs` array, letting the user POST a payload the server
+    // will then reject with 400.
+    if (customFieldsError) {
+      Alert.alert(
+        "Cannot create asset",
+        "Custom fields failed to load. Please retry before submitting."
+      );
+      return;
+    }
+    if (isCustomFieldsLoading) {
+      Alert.alert(
+        "Please wait",
+        "Custom fields are still loading. Try again in a moment."
+      );
+      return;
+    }
 
     // why: enforce required custom fields BEFORE hitting the server so the
     // user sees a clear, immediate message instead of a 400 round-trip. The
@@ -380,7 +458,11 @@ export default function CreateAssetScreen() {
     ]);
   };
 
-  const canSubmit = title.trim().length >= 2 && !isSubmitting;
+  const canSubmit =
+    title.trim().length >= 2 &&
+    !isSubmitting &&
+    !isCustomFieldsLoading &&
+    !customFieldsError;
 
   return (
     <KeyboardAvoidingView
@@ -702,6 +784,36 @@ export default function CreateAssetScreen() {
               Loading custom fields…
             </Text>
           </View>
+        ) : customFieldsError ? (
+          <View style={styles.customFieldsErrorBox}>
+            <Ionicons
+              name="alert-circle-outline"
+              size={18}
+              color={colors.error}
+            />
+            <View style={styles.customFieldsErrorBody}>
+              <Text
+                style={styles.customFieldsErrorText}
+                accessibilityRole="alert"
+                accessibilityLiveRegion="polite"
+              >
+                Couldn&apos;t load custom fields. Submission is disabled until
+                this succeeds.
+              </Text>
+              <Text style={styles.customFieldsErrorDetail}>
+                {customFieldsError}
+              </Text>
+              <TouchableOpacity
+                onPress={retryLoadCustomFields}
+                accessibilityRole="button"
+                accessibilityLabel="Retry loading custom fields"
+                style={styles.customFieldsRetryButton}
+              >
+                <Ionicons name="refresh" size={14} color={colors.primary} />
+                <Text style={styles.customFieldsRetryText}>Retry</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
         ) : customFieldDefs.length > 0 ? (
           <View style={styles.customFieldsSection}>
             <Text style={styles.sectionLabel}>Custom Fields</Text>
@@ -722,11 +834,11 @@ export default function CreateAssetScreen() {
                     name: def.name,
                     type: def.type,
                     helpText: def.helpText,
+                    required: def.required,
+                    options: def.options,
                   }}
                   value={customFieldValues[def.id] ?? ""}
-                  onChange={(val) =>
-                    setCustomFieldValues((prev) => ({ ...prev, [def.id]: val }))
-                  }
+                  onChange={customFieldChangeHandlers[def.id]}
                 />
               </View>
             ))}
@@ -984,6 +1096,42 @@ const useStyles = createStyles((colors, shadows) => ({
   customFieldsLoadingText: {
     fontSize: fontSize.sm,
     color: colors.muted,
+  },
+  customFieldsErrorBox: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.sm,
+    marginTop: spacing.md,
+    paddingTop: spacing.lg,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  customFieldsErrorBody: {
+    flex: 1,
+    gap: spacing.xs,
+  },
+  customFieldsErrorText: {
+    fontSize: fontSize.base,
+    color: colors.error,
+    fontWeight: "600",
+  },
+  customFieldsErrorDetail: {
+    fontSize: fontSize.sm,
+    color: colors.muted,
+  },
+  customFieldsRetryButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    alignSelf: "flex-start",
+    marginTop: spacing.xs,
+  },
+  customFieldsRetryText: {
+    fontSize: fontSize.base,
+    color: colors.primary,
+    fontWeight: "600",
   },
 
   // ── Bottom bar ────────────────────────────────

--- a/apps/companion/app/(tabs)/assets/new.tsx
+++ b/apps/companion/app/(tabs)/assets/new.tsx
@@ -17,12 +17,18 @@ import { useRouter } from "expo-router";
 import { useNavigation } from "@react-navigation/native";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
-import { api, type Category, type Location } from "@/lib/api";
+import {
+  api,
+  type Category,
+  type Location,
+  type MobileCustomFieldDefinition,
+} from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { labelForRequired } from "@/lib/a11y";
+import { CustomFieldInput } from "@/components/asset-edit/custom-field-input";
 
 // expo-image-picker requires native module — lazy-loaded to avoid crash
 // if the dev client hasn't been rebuilt yet
@@ -71,6 +77,21 @@ export default function CreateAssetScreen() {
   const [categorySearch, setCategorySearch] = useState("");
   const [locationSearch, setLocationSearch] = useState("");
 
+  // ── Custom fields state ─────────────────────────
+  // Definitions are fetched whenever the selected category changes; values
+  // are stored as a flat id -> string map so the same string representation
+  // works for every input type (BOOLEAN serialises to "true"/"false", DATE
+  // is an ISO string, OPTION is the option text, etc). The shape matches
+  // what useEditAssetForm uses for the edit screen — keeps both screens'
+  // logic parallel.
+  const [customFieldDefs, setCustomFieldDefs] = useState<
+    MobileCustomFieldDefinition[]
+  >([]);
+  const [customFieldValues, setCustomFieldValues] = useState<
+    Record<string, string>
+  >({});
+  const [isCustomFieldsLoading, setIsCustomFieldsLoading] = useState(false);
+
   // ── Load categories ─────────────────────────────
   const loadCategories = useCallback(async () => {
     if (!currentOrg) return;
@@ -93,6 +114,38 @@ export default function CreateAssetScreen() {
     setIsLocationsLoading(false);
   }, [currentOrg]);
 
+  // ── Load custom fields for the selected category ──
+  // Re-runs whenever the chosen category changes (including "no category").
+  // Any existing values for fields that no longer apply to the new category
+  // are pruned so we don't accidentally send stale data on submit.
+  useEffect(() => {
+    if (!currentOrg) return;
+    let cancelled = false;
+    setIsCustomFieldsLoading(true);
+    api
+      .customFields(currentOrg.id, selectedCategory?.id)
+      .then(({ data }) => {
+        if (cancelled) return;
+        const defs = data?.customFields ?? [];
+        setCustomFieldDefs(defs);
+        // Drop any values whose definition is no longer in scope
+        const validIds = new Set(defs.map((d) => d.id));
+        setCustomFieldValues((prev) => {
+          const next: Record<string, string> = {};
+          for (const id of Object.keys(prev)) {
+            if (validIds.has(id)) next[id] = prev[id];
+          }
+          return next;
+        });
+      })
+      .finally(() => {
+        if (!cancelled) setIsCustomFieldsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentOrg, selectedCategory?.id]);
+
   useEffect(() => {
     loadCategories();
     loadLocations();
@@ -107,7 +160,8 @@ export default function CreateAssetScreen() {
     description.trim().length > 0 ||
     !!selectedCategory ||
     !!selectedLocation ||
-    !!imageUri;
+    !!imageUri ||
+    Object.values(customFieldValues).some((v) => v.trim() !== "");
 
   useEffect(() => {
     if (!hasUnsavedChanges || didSubmitRef.current) return;
@@ -222,6 +276,20 @@ export default function CreateAssetScreen() {
     }
   };
 
+  // ── Build the custom-fields payload from the local string map ──
+  // Empty strings are dropped so we don't send "I touched the input then
+  // cleared it" — the server treats absence as "no value." For required
+  // fields the absence is exactly what triggers the client-side guard.
+  const buildCustomFieldsPayload = useCallback(() => {
+    return customFieldDefs
+      .map((def) => {
+        const raw = customFieldValues[def.id];
+        if (raw === undefined || raw.trim() === "") return null;
+        return { id: def.id, value: raw };
+      })
+      .filter((cf): cf is { id: string; value: string } => cf !== null);
+  }, [customFieldDefs, customFieldValues]);
+
   // ── Submit ──────────────────────────────────────
   const handleSubmit = async () => {
     const trimmedTitle = title.trim();
@@ -231,12 +299,34 @@ export default function CreateAssetScreen() {
     }
     if (!currentOrg) return;
 
+    // why: enforce required custom fields BEFORE hitting the server so the
+    // user sees a clear, immediate message instead of a 400 round-trip. The
+    // server enforces the same contract — this is just a UX improvement.
+    const missingRequired = customFieldDefs
+      .filter((def) => def.required)
+      .filter((def) => {
+        const raw = customFieldValues[def.id];
+        return raw === undefined || raw.trim() === "";
+      })
+      .map((def) => def.name);
+    if (missingRequired.length > 0) {
+      Alert.alert(
+        "Missing required fields",
+        `Please fill in: ${missingRequired.join(", ")}`
+      );
+      return;
+    }
+
+    const customFieldsPayload = buildCustomFieldsPayload();
+
     setIsSubmitting(true);
     const { data, error } = await api.createAsset(currentOrg.id, {
       title: trimmedTitle,
       description: description.trim() || undefined,
       categoryId: selectedCategory?.id,
       locationId: selectedLocation?.id,
+      customFields:
+        customFieldsPayload.length > 0 ? customFieldsPayload : undefined,
     });
 
     setIsSubmitting(false);
@@ -284,6 +374,7 @@ export default function CreateAssetScreen() {
           setSelectedLocation(null);
           setImageUri(null);
           setImageMimeType("image/jpeg");
+          setCustomFieldValues({});
         },
       },
     ]);
@@ -602,6 +693,45 @@ export default function CreateAssetScreen() {
             </View>
           )}
         </View>
+
+        {/* ── Custom Fields (scoped to selected category) ────────── */}
+        {isCustomFieldsLoading ? (
+          <View style={styles.customFieldsLoading}>
+            <ActivityIndicator size="small" color={colors.muted} />
+            <Text style={styles.customFieldsLoadingText}>
+              Loading custom fields…
+            </Text>
+          </View>
+        ) : customFieldDefs.length > 0 ? (
+          <View style={styles.customFieldsSection}>
+            <Text style={styles.sectionLabel}>Custom Fields</Text>
+            {customFieldDefs.map((def) => (
+              <View key={def.id} style={styles.field}>
+                <Text style={styles.label}>
+                  {def.name}
+                  {def.required ? (
+                    <Text style={styles.required}> *</Text>
+                  ) : null}
+                  {def.helpText ? (
+                    <Text style={styles.helpText}> — {def.helpText}</Text>
+                  ) : null}
+                </Text>
+                <CustomFieldInput
+                  field={{
+                    id: def.id,
+                    name: def.name,
+                    type: def.type,
+                    helpText: def.helpText,
+                  }}
+                  value={customFieldValues[def.id] ?? ""}
+                  onChange={(val) =>
+                    setCustomFieldValues((prev) => ({ ...prev, [def.id]: val }))
+                  }
+                />
+              </View>
+            ))}
+          </View>
+        ) : null}
       </ScrollView>
 
       {/* ── Bottom action bar ──────────────────────── */}
@@ -819,6 +949,41 @@ const useStyles = createStyles((colors, shadows) => ({
     width: 10,
     height: 10,
     borderRadius: 5,
+  },
+
+  // ── Custom fields ──────────────────────────────
+  customFieldsSection: {
+    marginTop: spacing.md,
+    paddingTop: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  sectionLabel: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.muted,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: spacing.md,
+  },
+  helpText: {
+    fontWeight: "400",
+    color: colors.mutedLight,
+    fontSize: fontSize.sm,
+  },
+  customFieldsLoading: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingVertical: spacing.lg,
+    paddingTop: spacing.lg,
+    marginTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  customFieldsLoadingText: {
+    fontSize: fontSize.sm,
+    color: colors.muted,
   },
 
   // ── Bottom bar ────────────────────────────────

--- a/apps/companion/app/(tabs)/assets/new.tsx
+++ b/apps/companion/app/(tabs)/assets/new.tsx
@@ -106,7 +106,13 @@ export default function CreateAssetScreen() {
   const [customFieldValues, setCustomFieldValues] = useState<
     Record<string, string>
   >({});
-  const [isCustomFieldsLoading, setIsCustomFieldsLoading] = useState(false);
+  // why: start as `true` so the brief window between first render and the
+  // fetch effect setting it explicitly can't be exploited by a very fast
+  // tap on Create. Without this, `canSubmit` and the `handleSubmit` guard
+  // both see `false` for one render cycle, opening a microsecond-wide
+  // submit-bypass for the client-side required-fields check. The server
+  // still rejects via 400, but proper UX shows the inline warning first.
+  const [isCustomFieldsLoading, setIsCustomFieldsLoading] = useState(true);
   // why: surfacing the fetch failure is critical — without it the required-
   // field client guard silently becomes a no-op (empty `customFieldDefs`),
   // letting the user submit a payload the server will reject.

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -1,26 +1,96 @@
-import { View, Text, TextInput, Switch } from "react-native";
+/**
+ * CustomFieldInput
+ *
+ * Renders the correct input control for a Shelf custom field based on the
+ * field's `type`. Used by the asset create (`new.tsx`) and edit (`edit.tsx`)
+ * screens. Keeps both screens visually and behaviourally consistent and
+ * centralises accessibility metadata so a single fix here improves both
+ * call sites.
+ *
+ * Supported types:
+ * - `BOOLEAN`         — native `Switch` with a "Yes"/"No" label.
+ * - `MULTILINE_TEXT`  — multi-line `TextInput`.
+ * - `DATE`            — single-line `TextInput` with `YYYY-MM-DD` placeholder.
+ * - `NUMBER`/`AMOUNT` — numeric keyboard, strips non-numeric chars on input.
+ * - `OPTION`          — tap-to-open dropdown picker over `field.options`.
+ *                       Falls back to a plain text input when options are
+ *                       missing (degraded but safe — see below).
+ * - everything else   — plain single-line `TextInput`.
+ *
+ * @see {@link file://../../lib/api/types.ts MobileCustomFieldDefinition}
+ */
+
+import { useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Switch,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
-import { fontSize, borderRadius } from "@/lib/constants";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { labelForRequired } from "@/lib/a11y";
 
+/**
+ * Field metadata consumed by `CustomFieldInput`. `required` defaults to
+ * `false` when omitted so call sites that don't track required-ness (e.g.
+ * the edit screen, which derives state from `AssetDetail.customFields`)
+ * still type-check without changes.
+ */
 type CustomFieldInputProps = {
   field: {
     id: string;
     name: string;
     type: string;
     helpText: string | null;
+    required?: boolean;
+    options?: string[] | null;
   };
   value: string;
   onChange: (value: string) => void;
+  /**
+   * Optional inline error. Appended to the `accessibilityLabel` so screen
+   * readers announce the failure alongside the field name.
+   */
+  error?: string;
 };
 
+/**
+ * Render the right input control for a single custom field.
+ *
+ * @param field    Definition (id / name / type / helpText / required / options).
+ * @param value    Current string value from the parent form's id → value map.
+ * @param onChange Setter invoked with the new string value on every change.
+ * @param error    Optional inline error; appended to the accessibility label.
+ */
 export function CustomFieldInput({
   field,
   value,
   onChange,
+  error,
 }: CustomFieldInputProps) {
   const { colors } = useTheme();
   const styles = useStyles();
+
+  const required = field.required === true;
+  // `labelForRequired` appends ", required" to the label so VoiceOver and
+  // TalkBack announce required-ness. We do this instead of
+  // `accessibilityState.required` because React Native's AccessibilityState
+  // type doesn't include `required` (it's an ARIA/web concept). Same for
+  // `invalid` — we surface errors visually only and via the label here.
+  const baseLabel = required ? labelForRequired(field.name) : field.name;
+  const accessibilityLabel = error
+    ? `${baseLabel}, invalid: ${error}`
+    : baseLabel;
+  // `accessibilityHint` adds extra context spoken AFTER the label
+  // (e.g. "Visible to all team members"). Surfaces helpText to AT users
+  // without cluttering the visual layout further.
+  const accessibilityHint = field.helpText ?? undefined;
 
   switch (field.type) {
     case "BOOLEAN":
@@ -34,9 +104,10 @@ export function CustomFieldInput({
             onValueChange={(val) => onChange(val ? "true" : "false")}
             trackColor={{ true: colors.primary, false: colors.gray300 }}
             thumbColor={colors.white}
-            accessibilityLabel={`${field.name}: ${
+            accessibilityLabel={`${accessibilityLabel}: ${
               value === "true" ? "Yes" : "No"
             }`}
+            accessibilityHint={accessibilityHint}
           />
         </View>
       );
@@ -51,7 +122,8 @@ export function CustomFieldInput({
           multiline
           numberOfLines={3}
           textAlignVertical="top"
-          accessibilityLabel={field.name}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint={accessibilityHint}
         />
       );
     case "DATE":
@@ -62,7 +134,8 @@ export function CustomFieldInput({
           onChangeText={onChange}
           placeholder="YYYY-MM-DD"
           placeholderTextColor={colors.placeholderText}
-          accessibilityLabel={field.name}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint={accessibilityHint}
         />
       );
     case "AMOUNT":
@@ -78,10 +151,21 @@ export function CustomFieldInput({
           placeholder="0"
           placeholderTextColor={colors.placeholderText}
           keyboardType="decimal-pad"
-          accessibilityLabel={field.name}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint={accessibilityHint}
         />
       );
-    default: // TEXT, OPTION, etc.
+    case "OPTION":
+      return (
+        <OptionDropdown
+          field={field}
+          value={value}
+          onChange={onChange}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint={accessibilityHint}
+        />
+      );
+    default: // TEXT and any unknown future types
       return (
         <TextInput
           style={styles.input}
@@ -89,10 +173,131 @@ export function CustomFieldInput({
           onChangeText={onChange}
           placeholder={`Enter ${field.name.toLowerCase()}...`}
           placeholderTextColor={colors.placeholderText}
-          accessibilityLabel={field.name}
+          accessibilityLabel={accessibilityLabel}
+          accessibilityHint={accessibilityHint}
         />
       );
   }
+}
+
+/**
+ * Dropdown picker for `OPTION` custom fields.
+ *
+ * Matches the look-and-feel of the Category / Location pickers in `new.tsx`:
+ * a `TouchableOpacity` showing the current selection that expands inline
+ * into a scrollable list. If `field.options` is missing or empty (server
+ * misconfiguration or older data), gracefully degrades to a plain text
+ * input so the user is never locked out of editing the field.
+ */
+function OptionDropdown({
+  field,
+  value,
+  onChange,
+  accessibilityLabel,
+  accessibilityHint,
+}: {
+  field: CustomFieldInputProps["field"];
+  value: string;
+  onChange: (value: string) => void;
+  accessibilityLabel: string;
+  accessibilityHint: string | undefined;
+}) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+  const [open, setOpen] = useState(false);
+
+  const options = field.options ?? [];
+
+  // Degraded fallback: if no options are configured, render a plain text
+  // input so the screen is still usable.
+  if (options.length === 0) {
+    return (
+      <TextInput
+        style={styles.input}
+        value={value}
+        onChangeText={onChange}
+        placeholder={`Enter ${field.name.toLowerCase()}...`}
+        placeholderTextColor={colors.placeholderText}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
+      />
+    );
+  }
+
+  return (
+    <View>
+      <TouchableOpacity
+        style={styles.pickerButton}
+        onPress={() => setOpen((o) => !o)}
+        accessibilityRole="button"
+        accessibilityLabel={
+          value
+            ? `${accessibilityLabel}: ${value}, tap to change`
+            : `${accessibilityLabel}, tap to choose`
+        }
+        accessibilityHint={accessibilityHint}
+        accessibilityState={{ expanded: open }}
+      >
+        <Text
+          style={value ? styles.pickerSelectedText : styles.pickerPlaceholder}
+        >
+          {value || "Select an option..."}
+        </Text>
+        <Ionicons
+          name={open ? "chevron-up" : "chevron-down"}
+          size={18}
+          color={colors.mutedLight}
+        />
+      </TouchableOpacity>
+
+      {open && (
+        <View style={styles.pickerDropdown}>
+          <ScrollView nestedScrollEnabled keyboardShouldPersistTaps="handled">
+            {options.map((opt) => {
+              const selected = opt === value;
+              return (
+                <TouchableOpacity
+                  key={opt}
+                  style={[
+                    styles.pickerItem,
+                    selected && styles.pickerItemSelected,
+                  ]}
+                  onPress={() => {
+                    onChange(selected ? "" : opt);
+                    setOpen(false);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected }}
+                >
+                  <Text style={styles.pickerItemText}>{opt}</Text>
+                  {selected && (
+                    <Ionicons
+                      name="checkmark"
+                      size={18}
+                      color={colors.iconActive}
+                    />
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </ScrollView>
+          {value && (
+            <TouchableOpacity
+              style={styles.pickerClear}
+              onPress={() => {
+                onChange("");
+                setOpen(false);
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`Clear ${field.name}`}
+            >
+              <Text style={styles.pickerClearText}>Clear selection</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      )}
+    </View>
+  );
 }
 
 const useStyles = createStyles((colors, shadows) => ({
@@ -126,5 +331,68 @@ const useStyles = createStyles((colors, shadows) => ({
   switchLabel: {
     fontSize: fontSize.lg,
     color: colors.foreground,
+  },
+
+  // ── Dropdown (mirrors picker styles from new.tsx) ──────────
+  pickerButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    ...shadows.sm,
+  },
+  pickerPlaceholder: {
+    fontSize: fontSize.lg,
+    color: colors.mutedLight,
+    flex: 1,
+  },
+  pickerSelectedText: {
+    fontSize: fontSize.lg,
+    color: colors.foreground,
+    fontWeight: "500",
+    flex: 1,
+  },
+  pickerDropdown: {
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.sm,
+    marginTop: spacing.xs,
+    maxHeight: 220,
+    ...shadows.md,
+  },
+  pickerItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+    gap: spacing.sm,
+  },
+  pickerItemSelected: {
+    backgroundColor: colors.backgroundTertiary,
+  },
+  pickerItemText: {
+    flex: 1,
+    fontSize: fontSize.base,
+    color: colors.foreground,
+  },
+  pickerClear: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    alignItems: "center",
+  },
+  pickerClearText: {
+    fontSize: fontSize.sm,
+    color: colors.error,
+    fontWeight: "500",
   },
 }));

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -63,10 +63,19 @@ type CustomFieldInputProps = {
 /**
  * Render the right input control for a single custom field.
  *
+ * Selects the appropriate component per `field.type` (boolean toggle,
+ * multiline text, numeric input, OPTION dropdown, default text input).
+ * Each branch threads `accessibilityLabel` (via `labelForRequired` when
+ * `required`) and `accessibilityHint` (from `helpText`) so VoiceOver /
+ * TalkBack announce the field correctly.
+ *
  * @param field    Definition (id / name / type / helpText / required / options).
  * @param value    Current string value from the parent form's id → value map.
  * @param onChange Setter invoked with the new string value on every change.
  * @param error    Optional inline error; appended to the accessibility label.
+ * @returns A React Native input component wired to `value` / `onChange`.
+ * @throws Never — branches without a matching `field.type` fall back to a
+ *   plain text input so unknown / future types remain usable.
  */
 export function CustomFieldInput({
   field,

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -31,6 +31,7 @@ import {
   StyleSheet,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import type { MobileCustomFieldType } from "@/lib/api";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
@@ -46,7 +47,14 @@ type CustomFieldInputProps = {
   field: {
     id: string;
     name: string;
-    type: string;
+    /**
+     * Field type from the canonical {@link MobileCustomFieldType} union.
+     * Using the literal union (not `string`) catches casing mismatches at
+     * compile time — the most common confusion is webapp internals using
+     * lowercase identifiers while the database / mobile API contract is
+     * uppercase.
+     */
+    type: MobileCustomFieldType;
     helpText: string | null;
     required?: boolean;
     options?: string[] | null;
@@ -262,11 +270,15 @@ function OptionDropdown({
       {open && (
         <View style={styles.pickerDropdown}>
           <ScrollView nestedScrollEnabled keyboardShouldPersistTaps="handled">
-            {options.map((opt) => {
+            {options.map((opt, index) => {
               const selected = opt === value;
               return (
                 <TouchableOpacity
-                  key={opt}
+                  // why: index in the key guards against duplicate option
+                  // labels (we don't enforce uniqueness server-side).
+                  // Without it React's reconciliation would mis-attribute
+                  // selection state on collision.
+                  key={`${opt}-${index}`}
                   style={[
                     styles.pickerItem,
                     selected && styles.pickerItemSelected,

--- a/apps/companion/hooks/use-edit-asset-form.ts
+++ b/apps/companion/hooks/use-edit-asset-form.ts
@@ -1,5 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
-import { api, type AssetDetail, type Category, type Location } from "@/lib/api";
+import {
+  api,
+  type AssetDetail,
+  type Category,
+  type Location,
+  type MobileCustomFieldType,
+} from "@/lib/api";
 
 /** Extract a displayable string value from a custom field's stored value */
 function extractCustomFieldValue(cf: AssetDetail["customFields"][0]): string {
@@ -28,7 +34,7 @@ function extractCustomFieldValue(cf: AssetDetail["customFields"][0]): string {
 export type CustomFieldState = {
   id: string; // customField.id
   name: string;
-  type: string;
+  type: MobileCustomFieldType;
   helpText: string | null;
   value: string; // string representation for editing
   originalValue: string;
@@ -141,7 +147,12 @@ export function useEditAssetForm(
                 return {
                   id: cf.customField.id,
                   name: cf.customField.name,
-                  type: cf.customField.type,
+                  // why: AssetDetail's response shape declares `type: string`
+                  // (kept loose to match the API contract verbatim). At this
+                  // narrow construction point we know the server only emits
+                  // valid MobileCustomFieldType identifiers, so we narrow
+                  // here once and downstream code stays type-safe.
+                  type: cf.customField.type as MobileCustomFieldType,
                   helpText: cf.customField.helpText,
                   value: rawVal,
                   originalValue: rawVal,

--- a/apps/companion/lib/api/asset-mutations.ts
+++ b/apps/companion/lib/api/asset-mutations.ts
@@ -1,9 +1,22 @@
+/**
+ * Asset mutation API helpers.
+ *
+ * Thin wrappers around `apiFetch` / `apiUpload` for the create / update /
+ * delete / image-upload endpoints, plus the supporting picker endpoints
+ * (`categories`, `customFields`). All helpers return the structured
+ * `{ data, error }` envelope from `apiFetch` — they never throw.
+ *
+ * @see {@link file://./client.ts} for the underlying transport and how
+ *   `options.signal` is plumbed through for cancellation.
+ */
+
 import { apiFetch, apiUpload } from "./client";
 import { cachedApiFetch } from "./cache";
 import type {
   CategoriesResponse,
   CreateAssetResponse,
   CustomFieldsResponse,
+  CustomFieldValue,
   UpdateAssetPayload,
   UpdateAssetResponse,
   DeleteAssetResponse,
@@ -21,12 +34,19 @@ export const assetMutationsApi = {
    * to render the right inputs (including required indicators) for the
    * currently selected category. Pass `categoryId = undefined` (or omit) to
    * get the fields that apply to assets with no category.
+   *
+   * @param signal Optional `AbortSignal`. When the caller's effect cleans up
+   *   (e.g. the user changes the category before the previous request
+   *   completes), aborting prevents a stale response from clobbering the
+   *   newer one. Forwarded to `apiFetch` which already chains it onto its
+   *   internal timeout controller.
    */
-  customFields: (orgId: string, categoryId?: string) => {
+  customFields: (orgId: string, categoryId?: string, signal?: AbortSignal) => {
     const params = new URLSearchParams({ orgId });
     if (categoryId) params.set("categoryId", categoryId);
     return apiFetch<CustomFieldsResponse>(
-      `/api/mobile/custom-fields?${params}`
+      `/api/mobile/custom-fields?${params}`,
+      { signal }
     );
   },
 
@@ -45,7 +65,7 @@ export const assetMutationsApi = {
       categoryId?: string;
       locationId?: string;
       valuation?: number;
-      customFields?: { id: string; value: any }[];
+      customFields?: { id: string; value: CustomFieldValue }[];
     }
   ) =>
     apiFetch<CreateAssetResponse>(`/api/mobile/asset/create?orgId=${orgId}`, {

--- a/apps/companion/lib/api/asset-mutations.ts
+++ b/apps/companion/lib/api/asset-mutations.ts
@@ -3,6 +3,7 @@ import { cachedApiFetch } from "./cache";
 import type {
   CategoriesResponse,
   CreateAssetResponse,
+  CustomFieldsResponse,
   UpdateAssetPayload,
   UpdateAssetResponse,
   DeleteAssetResponse,
@@ -14,7 +15,28 @@ export const assetMutationsApi = {
   categories: (orgId: string) =>
     cachedApiFetch<CategoriesResponse>(`/api/mobile/categories?orgId=${orgId}`),
 
-  /** Create a new asset (quick creation -- title required, rest optional) */
+  /**
+   * Get the active custom field definitions for the org, optionally filtered
+   * to those that apply to `categoryId`. Used by the create / edit screens
+   * to render the right inputs (including required indicators) for the
+   * currently selected category. Pass `categoryId = undefined` (or omit) to
+   * get the fields that apply to assets with no category.
+   */
+  customFields: (orgId: string, categoryId?: string) => {
+    const params = new URLSearchParams({ orgId });
+    if (categoryId) params.set("categoryId", categoryId);
+    return apiFetch<CustomFieldsResponse>(
+      `/api/mobile/custom-fields?${params}`
+    );
+  },
+
+  /**
+   * Create a new asset. Title is required; description / category / location
+   * / valuation are optional. If the chosen category has any custom fields
+   * with `required: true`, every required field MUST be present in the
+   * `customFields` payload — otherwise the server returns 400 with the
+   * missing field names. Mirrors the webapp create form contract.
+   */
   createAsset: (
     orgId: string,
     payload: {
@@ -23,6 +45,7 @@ export const assetMutationsApi = {
       categoryId?: string;
       locationId?: string;
       valuation?: number;
+      customFields?: { id: string; value: any }[];
     }
   ) =>
     apiFetch<CreateAssetResponse>(`/api/mobile/asset/create?orgId=${orgId}`, {

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -408,6 +408,16 @@ export type CreateAssetResponse = {
   };
 };
 
+/**
+ * Server-accepted scalar value for a custom field on create / update.
+ * The webapp coerces these into the appropriate stored representation:
+ * - string  → TEXT / MULTILINE_TEXT / DATE (ISO) / OPTION (option text)
+ * - number  → NUMBER / AMOUNT
+ * - boolean → BOOLEAN
+ * - null    → clear the value (UPDATE only)
+ */
+export type CustomFieldValue = string | number | boolean | null;
+
 export type UpdateAssetPayload = {
   assetId: string;
   title?: string;
@@ -416,7 +426,12 @@ export type UpdateAssetPayload = {
   newLocationId?: string;
   currentLocationId?: string;
   valuation?: number | null;
-  customFields?: { id: string; value: any }[];
+  /**
+   * Custom field updates. Each entry is the customField `id` (NOT the asset's
+   * custom-field-value row id) plus the new value. Omitted fields are left
+   * unchanged on the server.
+   */
+  customFields?: { id: string; value: CustomFieldValue }[];
 };
 
 /**
@@ -424,6 +439,21 @@ export type UpdateAssetPayload = {
  * `GET /api/mobile/custom-fields`. The companion uses this shape to render
  * the right input (via `CustomFieldInput`) and to enforce required-ness
  * client-side before submitting the create / update payload.
+ *
+ * Field semantics:
+ * - `id`        — stable CustomField primary key; used as the dictionary
+ *                 key on the form's local id → value map.
+ * - `name`      — human-readable label shown above the input.
+ * - `type`      — one of `TEXT`, `MULTILINE_TEXT`, `BOOLEAN`, `DATE`,
+ *                 `NUMBER`, `AMOUNT`, `OPTION`. Drives input rendering.
+ * - `helpText`  — optional hint shown next to the label (and forwarded as
+ *                 an `accessibilityHint` to screen readers).
+ * - `required`  — when true, the create / update screens block submit
+ *                 until a non-empty value is provided. The server enforces
+ *                 the same contract; the client check is a UX improvement.
+ * - `options`   — only populated for `type === "OPTION"`. The allowed set
+ *                 of values the user may pick from. Empty array / null for
+ *                 every other type.
  */
 export type MobileCustomFieldDefinition = {
   id: string;
@@ -434,6 +464,11 @@ export type MobileCustomFieldDefinition = {
   options: string[] | null;
 };
 
+/**
+ * Response payload for `GET /api/mobile/custom-fields?orgId=...&categoryId=...`.
+ * Returns the full set of active custom-field definitions that apply to the
+ * selected category (or to "no category" when `categoryId` is omitted).
+ */
 export type CustomFieldsResponse = {
   customFields: MobileCustomFieldDefinition[];
 };

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -419,6 +419,25 @@ export type UpdateAssetPayload = {
   customFields?: { id: string; value: any }[];
 };
 
+/**
+ * Definition of an active custom field as returned by
+ * `GET /api/mobile/custom-fields`. The companion uses this shape to render
+ * the right input (via `CustomFieldInput`) and to enforce required-ness
+ * client-side before submitting the create / update payload.
+ */
+export type MobileCustomFieldDefinition = {
+  id: string;
+  name: string;
+  type: string;
+  helpText: string | null;
+  required: boolean;
+  options: string[] | null;
+};
+
+export type CustomFieldsResponse = {
+  customFields: MobileCustomFieldDefinition[];
+};
+
 export type UpdateAssetResponse = {
   asset: {
     id: string;

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -455,10 +455,26 @@ export type UpdateAssetPayload = {
  *                 of values the user may pick from. Empty array / null for
  *                 every other type.
  */
+/**
+ * Discriminated union of all supported custom-field types. Keeping this as
+ * a literal union (not `string`) catches typos at compile time — the most
+ * common confusion is webapp internals using lowercase identifiers
+ * (`"option"`, `"boolean"`) while the database and this API contract use
+ * uppercase. Add a new constant here when introducing a new field type.
+ */
+export type MobileCustomFieldType =
+  | "TEXT"
+  | "MULTILINE_TEXT"
+  | "BOOLEAN"
+  | "DATE"
+  | "NUMBER"
+  | "AMOUNT"
+  | "OPTION";
+
 export type MobileCustomFieldDefinition = {
   id: string;
   name: string;
-  type: string;
+  type: MobileCustomFieldType;
   helpText: string | null;
   required: boolean;
   options: string[] | null;

--- a/apps/webapp/app/modules/api/mobile-custom-fields.server.ts
+++ b/apps/webapp/app/modules/api/mobile-custom-fields.server.ts
@@ -1,0 +1,111 @@
+/**
+ * Mobile Custom Fields helpers
+ *
+ * Shared validation + reshape logic for the mobile asset create/update
+ * routes when they accept a `customFields: [{ id, value }]` payload.
+ *
+ * Lives in `modules/api/` because it's transport-layer plumbing — it sits
+ * between the incoming JSON body and the existing
+ * `extractCustomFieldValuesFromPayload` helper that both create and update
+ * already go through. The webapp form path bypasses this file entirely;
+ * it has its own form-data → zod (`mergedSchema`) pipeline.
+ *
+ * Why a shared module: the create and update routes used to duplicate
+ * BOOLEAN normalisation + unknown-id rejection + the `cf-{id}` reshape
+ * verbatim. Drifting them is silent — if a new custom-field type is added
+ * tomorrow and only one route is updated, the other regresses. This file
+ * is the single source of truth for that transport step.
+ *
+ * @see {@link file://./../../utils/custom-fields.ts} — `extractCustomFieldValuesFromPayload`
+ * @see {@link file://./../../routes/api+/mobile+/asset.create.ts}
+ * @see {@link file://./../../routes/api+/mobile+/asset.update.ts}
+ * @see {@link file://./../../routes/api+/mobile+/custom-fields.ts}
+ */
+
+/**
+ * Sentinel value used in mobile API requests to mean "no category" /
+ * "uncategorized". Standardised so both client and server agree on the
+ * exact string and renaming it in the future only touches this constant.
+ */
+export const UNCATEGORIZED_SENTINEL = "uncategorized" as const;
+
+/**
+ * Minimal shape of a custom field definition this helper needs. We
+ * deliberately don't depend on the full Prisma `CustomField` row so the
+ * helper can be reused with the trimmed `select`ed shapes the mobile
+ * routes use.
+ */
+type CustomFieldDefShape = {
+  id: string;
+  type: string;
+};
+
+/**
+ * Result of {@link buildMobileCustomFieldPayload}. A tagged union so the
+ * caller pattern-matches against `ok` rather than checking for an
+ * exception or a magic value.
+ */
+export type BuildMobileCustomFieldPayloadResult =
+  | { ok: true; payload: Record<string, unknown> }
+  | { ok: false; unknownId: string };
+
+/**
+ * Validates a mobile-submitted `customFields` array against the active
+ * definitions for the relevant category and reshapes it into the
+ * `cf-{id}` keyed form that
+ * {@link file://./../../utils/custom-fields.ts | `extractCustomFieldValuesFromPayload`}
+ * expects.
+ *
+ * Performs the cross-cutting concerns shared by mobile create + update:
+ *
+ * 1. **Rejects unknown ids up front.** If the caller submits a `cf.id`
+ *    not in `defs`, returns `{ ok: false, unknownId }`. Without this,
+ *    `extractCustomFieldValuesFromPayload` deref's a missing definition
+ *    via a non-null assertion and crashes as a 500.
+ *
+ * 2. **Normalises BOOLEAN string values.** The companion's
+ *    `CustomFieldInput` emits `"true"` / `"false"` strings; the webapp's
+ *    `buildCustomFieldValue` recognises `"yes"` / `"no"` strings or real
+ *    booleans, but NOT `"true"` / `"false"`. Without the normalisation
+ *    required BOOLEAN fields pass the non-empty required check then get
+ *    silently dropped to `undefined` and persisted as `null`.
+ *
+ * The "required field totality" check (create) and the "no explicit
+ * clear of a required field" check (update) are layered by the calling
+ * route on top of this helper; this helper is shape-and-coerce only.
+ *
+ * @param submitted - The `customFields` array from the parsed request body.
+ * @param defs - Active custom-field definitions for the relevant category
+ *   (already filtered by org + active flag + category by the caller).
+ * @returns A tagged union: `{ ok: true, payload }` with the `cf-{id}`
+ *   keyed payload on success, or `{ ok: false, unknownId }` when the
+ *   caller submitted a `cf.id` that isn't in `defs`.
+ */
+export function buildMobileCustomFieldPayload(
+  submitted: { id: string; value: unknown }[],
+  defs: CustomFieldDefShape[]
+): BuildMobileCustomFieldPayloadResult {
+  const defById = new Map(defs.map((def) => [def.id, def]));
+
+  const unknown = submitted.find((cf) => !defById.has(cf.id));
+  if (unknown) {
+    return { ok: false, unknownId: unknown.id };
+  }
+
+  const payload = Object.fromEntries(
+    submitted.map((cf) => {
+      const def = defById.get(cf.id)!;
+      // why: CustomFieldInput emits "true"/"false" strings for BOOLEAN
+      // fields, but buildCustomFieldValue recognises only "yes"/"no" or
+      // real booleans. Normalise here so required BOOLEAN values
+      // survive the coercion step instead of being dropped to undefined.
+      const value =
+        def.type === "BOOLEAN" && typeof cf.value === "string"
+          ? cf.value === "true"
+          : cf.value;
+      return [`cf-${cf.id}`, value];
+    })
+  );
+
+  return { ok: true, payload };
+}

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -6,6 +6,8 @@ import {
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
 import { createAsset } from "~/modules/asset/service.server";
+import { getActiveCustomFields } from "~/modules/custom-field/service.server";
+import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
 import { makeShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -16,7 +18,10 @@ import {
  * POST /api/mobile/asset/create
  *
  * Quick asset creation from mobile.
- * Only title is required. QR code is auto-generated.
+ * Title is required. QR code is auto-generated. If the chosen category has
+ * any custom fields with `required: true`, the caller MUST submit a value
+ * for each — otherwise the request is rejected with HTTP 400 and the names
+ * of the missing fields. Mirrors the webapp create form's contract.
  *
  * Body: {
  *   title: string (required, min 2 chars)
@@ -24,6 +29,7 @@ import {
  *   categoryId?: string
  *   locationId?: string
  *   valuation?: number
+ *   customFields?: { id: string; value: any }[]
  * }
  */
 export async function action({ request }: ActionFunctionArgs) {
@@ -39,15 +45,79 @@ export async function action({ request }: ActionFunctionArgs) {
     });
 
     const body = await request.json();
-    const { title, description, categoryId, locationId, valuation } = z
+    const {
+      title,
+      description,
+      categoryId,
+      locationId,
+      valuation,
+      customFields,
+    } = z
       .object({
         title: z.string().min(2, "Title must be at least 2 characters"),
         description: z.string().optional(),
         categoryId: z.string().optional(),
         locationId: z.string().optional(),
         valuation: z.number().optional(),
+        customFields: z
+          .array(
+            z.object({
+              id: z.string(),
+              value: z.any(),
+            })
+          )
+          .optional(),
       })
       .parse(body);
+
+    // why: every category may have its own set of required custom fields.
+    // We always fetch the active definitions for the chosen category (or
+    // for "no category" if none provided) so we can enforce required-ness
+    // and coerce the submitted values against the canonical type/shape
+    // before persisting. Mirrors the webapp create form's mergedSchema +
+    // extractCustomFieldValuesFromPayload pipeline so mobile and web share
+    // the same data-integrity guarantees.
+    const customFieldDef = await getActiveCustomFields({
+      organizationId,
+      category: categoryId ?? null,
+    });
+
+    const submittedById = new Map(
+      (customFields ?? []).map((cf) => [cf.id, cf.value])
+    );
+    const missingRequired: string[] = [];
+    for (const def of customFieldDef) {
+      if (!def.required) continue;
+      const submitted = submittedById.get(def.id);
+      if (submitted === undefined || submitted === null || submitted === "") {
+        missingRequired.push(def.name);
+      }
+    }
+    if (missingRequired.length > 0) {
+      return data(
+        {
+          error: {
+            message: `Missing required custom field${
+              missingRequired.length === 1 ? "" : "s"
+            }: ${missingRequired.join(", ")}`,
+          },
+        },
+        { status: 400 }
+      );
+    }
+
+    let customFieldsValues;
+    if (customFields && customFields.length > 0) {
+      // The helper expects a flat object with cf-{id} keys (form-data shape).
+      // Reshape the mobile array into that contract.
+      const cfPayload = Object.fromEntries(
+        customFields.map((cf) => [`cf-${cf.id}`, cf.value])
+      );
+      customFieldsValues = extractCustomFieldValuesFromPayload({
+        payload: cfPayload,
+        customFieldDef,
+      });
+    }
 
     const asset = await createAsset({
       title,
@@ -57,6 +127,7 @@ export async function action({ request }: ActionFunctionArgs) {
       categoryId: categoryId || null,
       locationId: locationId || undefined,
       valuation: valuation ?? null,
+      customFieldsValues,
     });
 
     return data({

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -25,6 +25,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { buildMobileCustomFieldPayload } from "~/modules/api/mobile-custom-fields.server";
 import { createAsset } from "~/modules/asset/service.server";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
@@ -125,25 +126,9 @@ export async function action({ request }: ActionFunctionArgs) {
       category: categoryId ?? null,
     });
 
-    const defById = new Map(customFieldDef.map((def) => [def.id, def]));
-
-    // why: reject unknown ids up front. extractCustomFieldValuesFromPayload
-    // would otherwise throw deep in buildCustomFieldValue when it dereferences
-    // a missing definition — a 500 instead of an actionable 400.
-    if (customFields) {
-      const unknown = customFields.find((cf) => !defById.has(cf.id));
-      if (unknown) {
-        return data(
-          {
-            error: {
-              message: `Unknown custom field id: ${unknown.id}`,
-            },
-          },
-          { status: 400 }
-        );
-      }
-    }
-
+    // why: enforce required-field totality at CREATE time. The matching check
+    // on update is intentionally narrower (only blocks explicit clears) — see
+    // the docstring on the update route for rationale.
     const submittedById = new Map(
       (customFields ?? []).map((cf) => [cf.id, cf.value])
     );
@@ -177,28 +162,24 @@ export async function action({ request }: ActionFunctionArgs) {
 
     let customFieldsValues;
     if (customFields && customFields.length > 0) {
-      // The helper expects a flat object with cf-{id} keys (form-data shape).
-      // Reshape the mobile array into that contract.
-      // why: `CustomFieldInput` on the companion side emits "true"/"false"
-      // strings for booleans, but `buildCustomFieldValue` only recognises
-      // "yes"/"no" (or real booleans). Normalise here so the pipeline matches
-      // the webapp form's contract.
-      const cfPayload = Object.fromEntries(
-        customFields.map((cf) => {
-          const def = defById.get(cf.id);
-          let value = cf.value;
-          if (def?.type === "BOOLEAN") {
-            if (value === true || value === "true") {
-              value = true;
-            } else if (value === false || value === "false") {
-              value = false;
-            }
-          }
-          return [`cf-${cf.id}`, value];
-        })
-      );
+      // why: unknown-id rejection + BOOLEAN normalisation + cf-{id} reshape
+      // live in a shared helper now (both create and update use it). Removes
+      // ~40 lines of duplicated logic and the drift surface that came with
+      // it. See `mobile-custom-fields.server.ts` for the why behind each
+      // transformation step.
+      const built = buildMobileCustomFieldPayload(customFields, customFieldDef);
+      if (!built.ok) {
+        return data(
+          {
+            error: {
+              message: `Unknown custom field id: ${built.unknownId}`,
+            },
+          },
+          { status: 400 }
+        );
+      }
       customFieldsValues = extractCustomFieldValuesFromPayload({
-        payload: cfPayload,
+        payload: built.payload,
         customFieldDef,
       });
     }

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -1,5 +1,25 @@
+/**
+ * Mobile Asset Create API
+ *
+ * Endpoint backing the companion app's quick-create flow. Mirrors the webapp's
+ * create form contract: enforces required custom fields for the chosen
+ * category, validates submitted custom-field values against the canonical
+ * type/shape, and produces a fully persisted asset via `createAsset`.
+ *
+ * Security notes:
+ * - `categoryId` is verified against the caller's organization before it is
+ *   used to filter active custom fields (prevents cross-org probing).
+ * - Submitted custom-field ids are intersected with the active definitions
+ *   so unknown ids fail fast (HTTP 400) rather than reaching the persistence
+ *   helper.
+ *
+ * @see {@link file://./../../../utils/custom-fields.ts} — `buildCustomFieldValue`, `extractCustomFieldValuesFromPayload`
+ * @see {@link file://./../../../modules/custom-field/service.server.ts} — `getActiveCustomFields`
+ * @see {@link file://./../../../modules/asset/service.server.ts} — `createAsset`
+ */
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
   requireMobilePermission,
@@ -29,8 +49,15 @@ import {
  *   categoryId?: string
  *   locationId?: string
  *   valuation?: number
- *   customFields?: { id: string; value: any }[]
+ *   customFields?: { id: string; value: string | number | boolean | null }[]
  * }
+ *
+ * @param args - React Router action args (carrying the incoming request).
+ * @returns A JSON response with the created asset's id/title on success, or
+ *   `{ error: { message } }` with an appropriate HTTP status on failure:
+ *   - 400 Invalid category / unknown custom field id / missing required fields
+ *   - 401/403 Auth or permission errors (surfaced by `requireMobileAuth` /
+ *     `requireMobilePermission`)
  */
 export async function action({ request }: ActionFunctionArgs) {
   try {
@@ -63,12 +90,28 @@ export async function action({ request }: ActionFunctionArgs) {
           .array(
             z.object({
               id: z.string(),
-              value: z.any(),
+              value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
             })
           )
           .optional(),
       })
       .parse(body);
+
+    // why: a categoryId from the request body is attacker-controlled. Without
+    // verifying it belongs to the caller's organization we'd happily use it to
+    // probe `getActiveCustomFields` for category metadata across tenants.
+    if (categoryId) {
+      const category = await db.category.findFirst({
+        where: { id: categoryId, organizationId },
+        select: { id: true },
+      });
+      if (!category) {
+        return data(
+          { error: { message: "Invalid category" } },
+          { status: 400 }
+        );
+      }
+    }
 
     // why: every category may have its own set of required custom fields.
     // We always fetch the active definitions for the chosen category (or
@@ -82,6 +125,25 @@ export async function action({ request }: ActionFunctionArgs) {
       category: categoryId ?? null,
     });
 
+    const defById = new Map(customFieldDef.map((def) => [def.id, def]));
+
+    // why: reject unknown ids up front. extractCustomFieldValuesFromPayload
+    // would otherwise throw deep in buildCustomFieldValue when it dereferences
+    // a missing definition — a 500 instead of an actionable 400.
+    if (customFields) {
+      const unknown = customFields.find((cf) => !defById.has(cf.id));
+      if (unknown) {
+        return data(
+          {
+            error: {
+              message: `Unknown custom field id: ${unknown.id}`,
+            },
+          },
+          { status: 400 }
+        );
+      }
+    }
+
     const submittedById = new Map(
       (customFields ?? []).map((cf) => [cf.id, cf.value])
     );
@@ -89,7 +151,14 @@ export async function action({ request }: ActionFunctionArgs) {
     for (const def of customFieldDef) {
       if (!def.required) continue;
       const submitted = submittedById.get(def.id);
-      if (submitted === undefined || submitted === null || submitted === "") {
+      // why: treat whitespace-only strings as missing. Without `.trim()` a
+      // caller could submit "   " and bypass the required check.
+      if (
+        submitted === undefined ||
+        submitted === null ||
+        submitted === "" ||
+        (typeof submitted === "string" && submitted.trim() === "")
+      ) {
         missingRequired.push(def.name);
       }
     }
@@ -110,8 +179,23 @@ export async function action({ request }: ActionFunctionArgs) {
     if (customFields && customFields.length > 0) {
       // The helper expects a flat object with cf-{id} keys (form-data shape).
       // Reshape the mobile array into that contract.
+      // why: `CustomFieldInput` on the companion side emits "true"/"false"
+      // strings for booleans, but `buildCustomFieldValue` only recognises
+      // "yes"/"no" (or real booleans). Normalise here so the pipeline matches
+      // the webapp form's contract.
       const cfPayload = Object.fromEntries(
-        customFields.map((cf) => [`cf-${cf.id}`, cf.value])
+        customFields.map((cf) => {
+          const def = defById.get(cf.id);
+          let value = cf.value;
+          if (def?.type === "BOOLEAN") {
+            if (value === true || value === "true") {
+              value = true;
+            } else if (value === false || value === "false") {
+              value = false;
+            }
+          }
+          return [`cf-${cf.id}`, value];
+        })
       );
       customFieldsValues = extractCustomFieldValuesFromPayload({
         payload: cfPayload,

--- a/apps/webapp/app/routes/api+/mobile+/asset.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update.ts
@@ -117,7 +117,12 @@ export async function action({ request }: ActionFunctionArgs) {
       // miss required fields or reject legitimate values. Fetching here also
       // doubles as the cross-org existence check (returns 404 if the asset
       // isn't visible to the caller's organization).
-      let effectiveCategoryId: string | null = categoryId ?? null;
+      // why: normalize the documented "uncategorized" sentinel to null so
+      // getActiveCustomFields receives the same shape downstream code expects.
+      // Without this, validation runs against the literal string and rejects
+      // legitimate uncategorized field updates with false "unknown id" errors.
+      let effectiveCategoryId: string | null =
+        categoryId === "uncategorized" ? null : categoryId ?? null;
       if (categoryId === undefined) {
         const existing = await db.asset.findUnique({
           where: { id: assetId, organizationId },

--- a/apps/webapp/app/routes/api+/mobile+/asset.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update.ts
@@ -1,5 +1,25 @@
+/**
+ * Mobile Asset Update API
+ *
+ * Endpoint backing the companion app's edit/update flow. Updates are partial:
+ * only fields included in the request body are changed. When custom fields
+ * are part of the patch we enforce two invariants that mirror the webapp:
+ *
+ * 1. Required custom fields cannot be explicitly cleared (null / empty string).
+ * 2. Submitted custom-field ids must belong to the org's active definitions
+ *    for the asset's category — unknown ids are rejected with HTTP 400.
+ *
+ * For category resolution we prefer the body's `categoryId` (the caller is
+ * actively changing the category) and fall back to the asset's persisted
+ * `categoryId` so we validate against the right set of definitions.
+ *
+ * @see {@link file://./../../../utils/custom-fields.ts} — `buildCustomFieldValue`, `extractCustomFieldValuesFromPayload`
+ * @see {@link file://./../../../modules/custom-field/service.server.ts} — `getActiveCustomFields`
+ * @see {@link file://./../../../modules/asset/service.server.ts} — `updateAsset`
+ */
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
   requireMobilePermission,
@@ -28,8 +48,17 @@ import {
  *   newLocationId?: string (pass "" to clear)
  *   currentLocationId?: string (needed to detect location change)
  *   valuation?: number | null (pass null to clear)
- *   customFields?: { id: string; value: any }[] (custom field updates)
+ *   customFields?: { id: string; value: string | number | boolean | null }[]
  * }
+ *
+ * @param args - React Router action args (carrying the incoming request).
+ * @returns A JSON response with the updated asset's id/title/description on
+ *   success, or `{ error: { message } }` with an appropriate HTTP status on
+ *   failure:
+ *   - 400 Unknown custom field id / attempt to clear required field
+ *   - 404 Asset not found in the caller's organization
+ *   - 401/403 Auth or permission errors (surfaced by `requireMobileAuth` /
+ *     `requireMobilePermission`)
  */
 export async function action({ request }: ActionFunctionArgs) {
   try {
@@ -69,7 +98,7 @@ export async function action({ request }: ActionFunctionArgs) {
           .array(
             z.object({
               id: z.string(),
-              value: z.any(),
+              value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
             })
           )
           .optional(),
@@ -82,23 +111,64 @@ export async function action({ request }: ActionFunctionArgs) {
     // Mirrors how the webapp edit form processes form data.
     let customFieldsValues;
     if (customFields && customFields.length > 0) {
+      // why: if the caller didn't supply categoryId but is updating custom
+      // fields, we MUST validate against the asset's persisted category —
+      // otherwise we'd resolve definitions for "uncategorized" and either
+      // miss required fields or reject legitimate values. Fetching here also
+      // doubles as the cross-org existence check (returns 404 if the asset
+      // isn't visible to the caller's organization).
+      let effectiveCategoryId: string | null = categoryId ?? null;
+      if (categoryId === undefined) {
+        const existing = await db.asset.findUnique({
+          where: { id: assetId, organizationId },
+          select: { categoryId: true },
+        });
+        if (!existing) {
+          return data(
+            { error: { message: "Asset not found" } },
+            { status: 404 }
+          );
+        }
+        effectiveCategoryId = existing.categoryId;
+      }
+
       const customFieldDef = await getActiveCustomFields({
         organizationId,
-        category: categoryId ?? null,
+        category: effectiveCategoryId,
       });
+
+      const defById = new Map(customFieldDef.map((def) => [def.id, def]));
+
+      // why: reject unknown ids up front. extractCustomFieldValuesFromPayload
+      // would otherwise throw deep in buildCustomFieldValue when it
+      // dereferences a missing definition.
+      const unknown = customFields.find((cf) => !defById.has(cf.id));
+      if (unknown) {
+        return data(
+          {
+            error: {
+              message: `Unknown custom field id: ${unknown.id}`,
+            },
+          },
+          { status: 400 }
+        );
+      }
 
       // why: reject attempts to explicitly clear a required custom field on
       // update. We can't enforce "every required field has a value" here
       // because update is partial — the caller may only be touching some
-      // fields. But if they EXPLICITLY send null/"" for a required field,
-      // that's a contract violation we should block server-side.
+      // fields. But if they EXPLICITLY send null/""/whitespace for a
+      // required field, that's a contract violation we should block
+      // server-side.
       const violatedRequired: string[] = [];
       for (const def of customFieldDef) {
         if (!def.required) continue;
         const submitted = customFields.find((cf) => cf.id === def.id);
         if (
           submitted !== undefined &&
-          (submitted.value === null || submitted.value === "")
+          (submitted.value === null ||
+            (typeof submitted.value === "string" &&
+              submitted.value.trim() === ""))
         ) {
           violatedRequired.push(def.name);
         }
@@ -118,8 +188,23 @@ export async function action({ request }: ActionFunctionArgs) {
 
       // The helper expects a flat object with cf-{id} keys (form-data shape).
       // Reshape the mobile array into that contract.
+      // why: `CustomFieldInput` on the companion side emits "true"/"false"
+      // strings for booleans, but `buildCustomFieldValue` only recognises
+      // "yes"/"no" (or real booleans). Normalise here so the pipeline matches
+      // the webapp form's contract.
       const cfPayload = Object.fromEntries(
-        customFields.map((cf) => [`cf-${cf.id}`, cf.value])
+        customFields.map((cf) => {
+          const def = defById.get(cf.id);
+          let value = cf.value;
+          if (def?.type === "BOOLEAN") {
+            if (value === true || value === "true") {
+              value = true;
+            } else if (value === false || value === "false") {
+              value = false;
+            }
+          }
+          return [`cf-${cf.id}`, value];
+        })
       );
 
       customFieldsValues = extractCustomFieldValuesFromPayload({

--- a/apps/webapp/app/routes/api+/mobile+/asset.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update.ts
@@ -87,6 +87,35 @@ export async function action({ request }: ActionFunctionArgs) {
         category: categoryId ?? null,
       });
 
+      // why: reject attempts to explicitly clear a required custom field on
+      // update. We can't enforce "every required field has a value" here
+      // because update is partial — the caller may only be touching some
+      // fields. But if they EXPLICITLY send null/"" for a required field,
+      // that's a contract violation we should block server-side.
+      const violatedRequired: string[] = [];
+      for (const def of customFieldDef) {
+        if (!def.required) continue;
+        const submitted = customFields.find((cf) => cf.id === def.id);
+        if (
+          submitted !== undefined &&
+          (submitted.value === null || submitted.value === "")
+        ) {
+          violatedRequired.push(def.name);
+        }
+      }
+      if (violatedRequired.length > 0) {
+        return data(
+          {
+            error: {
+              message: `Cannot clear required custom field${
+                violatedRequired.length === 1 ? "" : "s"
+              }: ${violatedRequired.join(", ")}`,
+            },
+          },
+          { status: 400 }
+        );
+      }
+
       // The helper expects a flat object with cf-{id} keys (form-data shape).
       // Reshape the mobile array into that contract.
       const cfPayload = Object.fromEntries(

--- a/apps/webapp/app/routes/api+/mobile+/asset.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update.ts
@@ -13,6 +13,14 @@
  * actively changing the category) and fall back to the asset's persisted
  * `categoryId` so we validate against the right set of definitions.
  *
+ * **Required-field totality is enforced at CREATE time only.** This update
+ * path is intentionally narrower: it blocks *explicit clears* of required
+ * fields but does NOT detect "this update changed the category to one whose
+ * required fields aren't all populated on the asset." That mirrors the
+ * webapp edit form's behaviour today (partial updates). If a caller wants
+ * "make sure this asset still satisfies its category's required fields"
+ * semantics, that's a separate validation step at the call site.
+ *
  * @see {@link file://./../../../utils/custom-fields.ts} — `buildCustomFieldValue`, `extractCustomFieldValuesFromPayload`
  * @see {@link file://./../../../modules/custom-field/service.server.ts} — `getActiveCustomFields`
  * @see {@link file://./../../../modules/asset/service.server.ts} — `updateAsset`
@@ -25,6 +33,10 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import {
+  UNCATEGORIZED_SENTINEL,
+  buildMobileCustomFieldPayload,
+} from "~/modules/api/mobile-custom-fields.server";
 import { updateAsset } from "~/modules/asset/service.server";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
@@ -117,12 +129,12 @@ export async function action({ request }: ActionFunctionArgs) {
       // miss required fields or reject legitimate values. Fetching here also
       // doubles as the cross-org existence check (returns 404 if the asset
       // isn't visible to the caller's organization).
-      // why: normalize the documented "uncategorized" sentinel to null so
+      // why: normalize the documented UNCATEGORIZED_SENTINEL to null so
       // getActiveCustomFields receives the same shape downstream code expects.
       // Without this, validation runs against the literal string and rejects
       // legitimate uncategorized field updates with false "unknown id" errors.
       let effectiveCategoryId: string | null =
-        categoryId === "uncategorized" ? null : categoryId ?? null;
+        categoryId === UNCATEGORIZED_SENTINEL ? null : categoryId ?? null;
       if (categoryId === undefined) {
         const existing = await db.asset.findUnique({
           where: { id: assetId, organizationId },
@@ -141,23 +153,6 @@ export async function action({ request }: ActionFunctionArgs) {
         organizationId,
         category: effectiveCategoryId,
       });
-
-      const defById = new Map(customFieldDef.map((def) => [def.id, def]));
-
-      // why: reject unknown ids up front. extractCustomFieldValuesFromPayload
-      // would otherwise throw deep in buildCustomFieldValue when it
-      // dereferences a missing definition.
-      const unknown = customFields.find((cf) => !defById.has(cf.id));
-      if (unknown) {
-        return data(
-          {
-            error: {
-              message: `Unknown custom field id: ${unknown.id}`,
-            },
-          },
-          { status: 400 }
-        );
-      }
 
       // why: reject attempts to explicitly clear a required custom field on
       // update. We can't enforce "every required field has a value" here
@@ -191,29 +186,25 @@ export async function action({ request }: ActionFunctionArgs) {
         );
       }
 
-      // The helper expects a flat object with cf-{id} keys (form-data shape).
-      // Reshape the mobile array into that contract.
-      // why: `CustomFieldInput` on the companion side emits "true"/"false"
-      // strings for booleans, but `buildCustomFieldValue` only recognises
-      // "yes"/"no" (or real booleans). Normalise here so the pipeline matches
-      // the webapp form's contract.
-      const cfPayload = Object.fromEntries(
-        customFields.map((cf) => {
-          const def = defById.get(cf.id);
-          let value = cf.value;
-          if (def?.type === "BOOLEAN") {
-            if (value === true || value === "true") {
-              value = true;
-            } else if (value === false || value === "false") {
-              value = false;
-            }
-          }
-          return [`cf-${cf.id}`, value];
-        })
-      );
+      // why: unknown-id rejection + BOOLEAN normalisation + cf-{id} reshape
+      // live in a shared helper now (both create and update use it). Removes
+      // ~40 lines of duplicated logic and the drift surface that came with
+      // it. See `mobile-custom-fields.server.ts` for the why behind each
+      // transformation step.
+      const built = buildMobileCustomFieldPayload(customFields, customFieldDef);
+      if (!built.ok) {
+        return data(
+          {
+            error: {
+              message: `Unknown custom field id: ${built.unknownId}`,
+            },
+          },
+          { status: 400 }
+        );
+      }
 
       customFieldsValues = extractCustomFieldValuesFromPayload({
-        payload: cfPayload,
+        payload: built.payload,
         customFieldDef,
       });
     }

--- a/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
@@ -83,9 +83,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
         helpText: cf.helpText,
         required: cf.required,
         // why: `options` is only meaningful for OPTION fields per the schema
-        // contract (non-nullable String[] but empty for other types). Hide it
-        // for non-OPTION fields so mobile clients don't render empty pickers.
-        options: cf.type === "OPTION" ? cf.options : undefined,
+        // contract (non-nullable String[] but empty for other types). Emit
+        // `null` for non-OPTION fields so the JSON response always carries
+        // the key and matches the companion's exported
+        // `MobileCustomFieldDefinition.options: string[] | null` shape.
+        options: cf.type === "OPTION" ? cf.options : null,
         updatedAt: cf.updatedAt.toISOString(),
       })),
     });

--- a/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
@@ -17,6 +17,7 @@ import {
   requireMobileAuth,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { UNCATEGORIZED_SENTINEL } from "~/modules/api/mobile-custom-fields.server";
 import { makeShelfError } from "~/utils/error";
 
 /**
@@ -44,7 +45,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
     const categoryIdRaw = url.searchParams.get("categoryId");
     const categoryId =
-      categoryIdRaw && categoryIdRaw !== "uncategorized" ? categoryIdRaw : null;
+      categoryIdRaw && categoryIdRaw !== UNCATEGORIZED_SENTINEL
+        ? categoryIdRaw
+        : null;
 
     // why: prefer an explicit `select` over reusing `getActiveCustomFields`
     // (which returns the full row). This guarantees we never leak

--- a/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
@@ -1,9 +1,22 @@
+/**
+ * Mobile Custom Fields API
+ *
+ * Endpoint backing the companion app's create/edit forms: returns the active
+ * custom-field definitions the caller should render for the given category.
+ *
+ * Uses an explicit `select` so we never accidentally leak fields that aren't
+ * meant for the client (e.g. `userId`, `organizationId`, `deletedAt`). If new
+ * fields are added to the response, prefer extending the `select` here.
+ *
+ * @see {@link file://./../../../modules/custom-field/service.server.ts} — `getActiveCustomFields`
+ * @see {@link file://../../../../../../packages/database/prisma/schema.prisma} — `CustomField` model
+ */
 import { data, type LoaderFunctionArgs } from "react-router";
+import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
-import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { makeShelfError } from "~/utils/error";
 
 /**
@@ -16,6 +29,12 @@ import { makeShelfError } from "~/utils/error";
  *
  * `categoryId` may be omitted or set to "uncategorized" to fetch only
  * fields that apply to assets with no category.
+ *
+ * @param args - React Router loader args (carrying the incoming request).
+ * @returns A JSON response with `{ customFields: [...] }` on success. Each
+ *   entry exposes only the fields the mobile client needs (no userId /
+ *   organizationId / deletedAt). On failure, returns
+ *   `{ error: { message } }` with an appropriate HTTP status.
  */
 export async function loader({ request }: LoaderFunctionArgs) {
   try {
@@ -27,9 +46,33 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const categoryId =
       categoryIdRaw && categoryIdRaw !== "uncategorized" ? categoryIdRaw : null;
 
-    const fields = await getActiveCustomFields({
-      organizationId,
-      category: categoryId,
+    // why: prefer an explicit `select` over reusing `getActiveCustomFields`
+    // (which returns the full row). This guarantees we never leak
+    // organizationId / userId / deletedAt to the mobile client and keeps
+    // the response schema close to the call site for easy auditing.
+    const fields = await db.customField.findMany({
+      where: {
+        organizationId,
+        active: { equals: true },
+        deletedAt: null,
+        ...(typeof categoryId === "string"
+          ? {
+              OR: [
+                { categories: { none: {} } },
+                { categories: { some: { id: categoryId } } },
+              ],
+            }
+          : { categories: { none: {} } }),
+      },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        helpText: true,
+        required: true,
+        options: true,
+        updatedAt: true,
+      },
     });
 
     return data({
@@ -39,7 +82,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
         type: cf.type,
         helpText: cf.helpText,
         required: cf.required,
-        options: cf.options ?? null,
+        // why: `options` is only meaningful for OPTION fields per the schema
+        // contract (non-nullable String[] but empty for other types). Hide it
+        // for non-OPTION fields so mobile clients don't render empty pickers.
+        options: cf.type === "OPTION" ? cf.options : undefined,
+        updatedAt: cf.updatedAt.toISOString(),
       })),
     });
   } catch (cause) {

--- a/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custom-fields.ts
@@ -1,0 +1,52 @@
+import { data, type LoaderFunctionArgs } from "react-router";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { getActiveCustomFields } from "~/modules/custom-field/service.server";
+import { makeShelfError } from "~/utils/error";
+
+/**
+ * GET /api/mobile/custom-fields?orgId=X&categoryId=Y
+ *
+ * Returns the active custom field definitions for the organization,
+ * optionally filtered to those that apply to `categoryId`. The mobile
+ * create screen calls this when the user picks a category so it can
+ * render the right inputs (including required indicators).
+ *
+ * `categoryId` may be omitted or set to "uncategorized" to fetch only
+ * fields that apply to assets with no category.
+ */
+export async function loader({ request }: LoaderFunctionArgs) {
+  try {
+    const { user } = await requireMobileAuth(request);
+    const organizationId = await requireOrganizationAccess(request, user.id);
+
+    const url = new URL(request.url);
+    const categoryIdRaw = url.searchParams.get("categoryId");
+    const categoryId =
+      categoryIdRaw && categoryIdRaw !== "uncategorized" ? categoryIdRaw : null;
+
+    const fields = await getActiveCustomFields({
+      organizationId,
+      category: categoryId,
+    });
+
+    return data({
+      customFields: fields.map((cf) => ({
+        id: cf.id,
+        name: cf.name,
+        type: cf.type,
+        helpText: cf.helpText,
+        required: cf.required,
+        options: cf.options ?? null,
+      })),
+    });
+  } catch (cause) {
+    const reason = makeShelfError(cause);
+    return data(
+      { error: { message: reason.message } },
+      { status: reason.status }
+    );
+  }
+}

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
@@ -37,6 +37,30 @@ vi.mock("~/modules/asset/service.server", () => ({
   createAsset: vi.fn(),
 }));
 
+// why: route verifies `categoryId` belongs to the caller's org via the DB
+// before trusting it. Mock the DB so tests can simulate "category exists"
+// (default) and "category not in org" without hitting Postgres.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    category: {
+      findFirst: vi.fn().mockResolvedValue({ id: "cat-42" }),
+    },
+  },
+}));
+
+// why: avoid hitting the DB to load org custom field defs; tests control the
+// returned defs per-case to exercise the required-field validation contract.
+vi.mock("~/modules/custom-field/service.server", () => ({
+  getActiveCustomFields: vi.fn().mockResolvedValue([]),
+}));
+
+// why: spy on the validator so we can assert it received the org-scoped defs
+// and the cf-{id} reshape from the mobile array contract. Default returns []
+// so it acts as a pass-through that doesn't surprise the route.
+vi.mock("~/utils/custom-fields", () => ({
+  extractCustomFieldValuesFromPayload: vi.fn(() => []),
+}));
+
 // why: error utility — we mock to control error formatting in tests
 vi.mock("~/utils/error", () => ({
   makeShelfError: vi.fn((cause: any) => ({
@@ -58,6 +82,9 @@ import {
   requireMobilePermission,
 } from "~/modules/api/mobile-auth.server";
 import { createAsset } from "~/modules/asset/service.server";
+import { getActiveCustomFields } from "~/modules/custom-field/service.server";
+import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
+import { db } from "~/database/db.server";
 
 const mockUser = {
   id: "user-1",
@@ -66,8 +93,14 @@ const mockUser = {
   lastName: "User",
 };
 
-function createRequest(body: Record<string, unknown>) {
-  return new Request("http://localhost/api/mobile/asset/create?orgId=org-1", {
+function createRequest(
+  body: Record<string, unknown>,
+  { orgId = "org-1" }: { orgId?: string } = {}
+) {
+  const url = orgId
+    ? `http://localhost/api/mobile/asset/create?orgId=${orgId}`
+    : "http://localhost/api/mobile/asset/create";
+  return new Request(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -87,6 +120,10 @@ describe("POST /api/mobile/asset/create", () => {
     });
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    (getActiveCustomFields as any).mockResolvedValue([]);
+    (extractCustomFieldValuesFromPayload as any).mockReturnValue([]);
+    // Default: any category referenced by tests exists in the caller's org.
+    (db.category.findFirst as any).mockResolvedValue({ id: "cat-1" });
   });
 
   it("should create an asset and return its id and title", async () => {
@@ -132,5 +169,196 @@ describe("POST /api/mobile/asset/create", () => {
 
     expect(result instanceof Response).toBe(true);
     expect((result as unknown as Response).status).toBe(403);
+  });
+
+  describe("required custom fields contract", () => {
+    it("rejects with 400 and the field name when a required field is missing", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        {
+          id: "cf-serial",
+          name: "Serial Number",
+          required: true,
+        },
+      ]);
+
+      const request = createRequest({ title: "New Laptop" });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(400);
+      const body = await (result as unknown as Response).json();
+      expect(body.error.message).toContain("Serial Number");
+      expect(createAsset).not.toHaveBeenCalled();
+    });
+
+    it("creates the asset when a required field is present with a non-empty value", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        {
+          id: "cf-serial",
+          name: "Serial Number",
+          required: true,
+        },
+      ]);
+      (extractCustomFieldValuesFromPayload as any).mockReturnValue([
+        { id: "cf-serial", value: { raw: "SN-123" } },
+      ]);
+      (createAsset as any).mockResolvedValue({
+        id: "asset-1",
+        title: "New Laptop",
+      });
+
+      const request = createRequest({
+        title: "New Laptop",
+        customFields: [{ id: "cf-serial", value: "SN-123" }],
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(200);
+      expect(createAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customFieldsValues: [{ id: "cf-serial", value: { raw: "SN-123" } }],
+        })
+      );
+    });
+
+    it("rejects with 400 when a required field is explicitly set to null", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        {
+          id: "cf-serial",
+          name: "Serial Number",
+          required: true,
+        },
+      ]);
+
+      const request = createRequest({
+        title: "New Laptop",
+        customFields: [{ id: "cf-serial", value: null }],
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(400);
+      const body = await (result as unknown as Response).json();
+      expect(body.error.message).toContain("Serial Number");
+      expect(createAsset).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 400 when a required field is explicitly set to empty string", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        {
+          id: "cf-serial",
+          name: "Serial Number",
+          required: true,
+        },
+      ]);
+
+      const request = createRequest({
+        title: "New Laptop",
+        customFields: [{ id: "cf-serial", value: "" }],
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(400);
+      const body = await (result as unknown as Response).json();
+      expect(body.error.message).toContain("Serial Number");
+      expect(createAsset).not.toHaveBeenCalled();
+    });
+
+    it("lists every missing required field in the error message", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        { id: "cf-a", name: "Serial Number", required: true },
+        { id: "cf-b", name: "Asset Tag", required: true },
+        { id: "cf-c", name: "Description", required: false },
+      ]);
+
+      const request = createRequest({ title: "New Laptop" });
+      const result = await action(createActionArgs({ request }));
+
+      expect((result as unknown as Response).status).toBe(400);
+      const body = await (result as unknown as Response).json();
+      expect(body.error.message).toContain("Serial Number");
+      expect(body.error.message).toContain("Asset Tag");
+      expect(body.error.message).not.toContain("Description");
+      expect(createAsset).not.toHaveBeenCalled();
+    });
+
+    it("calls getActiveCustomFields with category: null when no categoryId is provided", async () => {
+      (createAsset as any).mockResolvedValue({ id: "asset-1", title: "T" });
+
+      const request = createRequest({ title: "Test Asset" });
+      await action(createActionArgs({ request }));
+
+      expect(getActiveCustomFields).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        category: null,
+      });
+    });
+
+    it("calls getActiveCustomFields with the provided categoryId", async () => {
+      (createAsset as any).mockResolvedValue({ id: "asset-1", title: "T" });
+      (db.category.findFirst as any).mockResolvedValue({ id: "cat-42" });
+
+      const request = createRequest({
+        title: "Test Asset",
+        categoryId: "cat-42",
+      });
+      await action(createActionArgs({ request }));
+
+      expect(getActiveCustomFields).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        category: "cat-42",
+      });
+    });
+
+    it("rejects with 400 'Invalid category' when categoryId is not in the caller's org", async () => {
+      // why: the route verifies categoryId belongs to org via db.category
+      // .findFirst — returning null means the id is unknown / cross-org.
+      (db.category.findFirst as any).mockResolvedValue(null);
+
+      const request = createRequest({
+        title: "Test Asset",
+        categoryId: "cat-from-another-org",
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(400);
+      const body = await (result as unknown as Response).json();
+      expect(body.error.message).toContain("Invalid category");
+      expect(getActiveCustomFields).not.toHaveBeenCalled();
+      expect(createAsset).not.toHaveBeenCalled();
+    });
+
+    it("normalises BOOLEAN required field 'true' string to boolean true", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        {
+          id: "cf-active",
+          name: "Active",
+          type: "BOOLEAN",
+          required: true,
+        },
+      ]);
+      // Capture the payload the helper saw so we can assert the normalised value.
+      let receivedPayload: Record<string, unknown> | undefined;
+      (extractCustomFieldValuesFromPayload as any).mockImplementation(
+        (args: { payload: Record<string, unknown> }) => {
+          receivedPayload = args.payload;
+          return [{ id: "cf-active", value: { raw: true } }];
+        }
+      );
+      (createAsset as any).mockResolvedValue({ id: "asset-1", title: "T" });
+
+      const request = createRequest({
+        title: "New Laptop",
+        customFields: [{ id: "cf-active", value: "true" }],
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(200);
+      expect(receivedPayload).toEqual({ "cf-cf-active": true });
+    });
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.update.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.update.test.ts
@@ -37,6 +37,17 @@ vi.mock("~/modules/asset/service.server", () => ({
   updateAsset: vi.fn(),
 }));
 
+// why: when categoryId is omitted from the body, the route looks up the
+// asset's persisted category to resolve the right custom-field defs.
+// Mocking the DB lets tests control that lookup without hitting Postgres.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    asset: {
+      findUnique: vi.fn().mockResolvedValue({ categoryId: null }),
+    },
+  },
+}));
+
 // why: avoid hitting the DB to load org custom field defs
 vi.mock("~/modules/custom-field/service.server", () => ({
   getActiveCustomFields: vi.fn().mockResolvedValue([]),
@@ -70,6 +81,7 @@ import {
 import { updateAsset } from "~/modules/asset/service.server";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
+import { db } from "~/database/db.server";
 
 const mockUser = {
   id: "user-1",
@@ -99,6 +111,7 @@ describe("POST /api/mobile/asset/update", () => {
     });
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    (db.asset.findUnique as any).mockResolvedValue({ categoryId: null });
   });
 
   it("should update an asset and return the updated data", async () => {
@@ -158,6 +171,13 @@ describe("POST /api/mobile/asset/update", () => {
   });
 
   it("validates customFields against org-scoped definitions before update", async () => {
+    // why: route now rejects unknown custom-field ids up front. Provide
+    // matching defs so we exercise the validator path the test cares about.
+    const defs = [
+      { id: "cf-text-1", name: "Notes", type: "TEXT", required: false },
+      { id: "cf-num-1", name: "Quantity", type: "NUMBER", required: false },
+    ];
+    (getActiveCustomFields as any).mockResolvedValue(defs);
     (updateAsset as any).mockResolvedValue({
       id: "asset-1",
       title: "T",
@@ -188,7 +208,104 @@ describe("POST /api/mobile/asset/update", () => {
         "cf-cf-text-1": "hello",
         "cf-cf-num-1": 42,
       },
-      customFieldDef: [],
+      customFieldDef: defs,
+    });
+  });
+
+  describe("required custom fields contract", () => {
+    it("rejects with 400 when explicitly clearing a required field to null", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        { id: "cf-serial", name: "Serial Number", required: true },
+      ]);
+
+      const request = createRequest({
+        assetId: "asset-1",
+        customFields: [{ id: "cf-serial", value: null }],
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(400);
+      const body = await (result as unknown as Response).json();
+      expect(body.error.message).toContain(
+        "Cannot clear required custom field"
+      );
+      expect(body.error.message).toContain("Serial Number");
+      expect(updateAsset).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 400 when explicitly clearing a required field to empty string", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        { id: "cf-serial", name: "Serial Number", required: true },
+      ]);
+
+      const request = createRequest({
+        assetId: "asset-1",
+        customFields: [{ id: "cf-serial", value: "" }],
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(400);
+      const body = await (result as unknown as Response).json();
+      expect(body.error.message).toContain("Serial Number");
+      expect(updateAsset).not.toHaveBeenCalled();
+    });
+
+    it("allows a partial update that omits required field ids entirely", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        { id: "cf-serial", name: "Serial Number", required: true },
+      ]);
+      (updateAsset as any).mockResolvedValue({
+        id: "asset-1",
+        title: "New Title",
+        description: null,
+      });
+
+      // Only touching title — required custom field is left untouched. Update
+      // is partial, so this must succeed.
+      const request = createRequest({
+        assetId: "asset-1",
+        title: "New Title",
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(200);
+      expect(updateAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "asset-1",
+          title: "New Title",
+        })
+      );
+    });
+
+    it("allows setting a required field to a new non-empty value", async () => {
+      (getActiveCustomFields as any).mockResolvedValue([
+        { id: "cf-serial", name: "Serial Number", required: true },
+      ]);
+      (extractCustomFieldValuesFromPayload as any).mockReturnValue([
+        { id: "cf-serial", value: { raw: "SN-NEW" } },
+      ]);
+      (updateAsset as any).mockResolvedValue({
+        id: "asset-1",
+        title: "T",
+        description: null,
+      });
+
+      const request = createRequest({
+        assetId: "asset-1",
+        customFields: [{ id: "cf-serial", value: "SN-NEW" }],
+      });
+      const result = await action(createActionArgs({ request }));
+
+      expect(result instanceof Response).toBe(true);
+      expect((result as unknown as Response).status).toBe(200);
+      expect(updateAsset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customFieldsValues: [{ id: "cf-serial", value: { raw: "SN-NEW" } }],
+        })
+      );
     });
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile.custom-fields.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.custom-fields.test.ts
@@ -1,0 +1,228 @@
+import { loader } from "~/routes/api+/mobile+/custom-fields";
+import { createLoaderArgs } from "@mocks/remix";
+
+// @vitest-environment node
+
+// why: mocking Remix's data() function to return Response objects for React Router v7 single fetch
+const createDataMock = vi.hoisted(() => {
+  return () =>
+    vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: {
+          "Content-Type": "application/json",
+          ...(init?.headers || {}),
+        },
+      });
+    });
+});
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    data: createDataMock(),
+  };
+});
+
+// why: external auth — we don't want to hit Supabase in tests
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+}));
+
+// why: external database — the loader calls `db.customField.findMany`
+// directly to control the `select` shape. Mocking the DB lets tests assert
+// on the `where` clause (category-filter contract) without hitting Postgres.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    customField: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
+// why: error utility — we mock to control error formatting in tests so we
+// can assert on the route's status/message behaviour without coupling to
+// the real ShelfError internals.
+vi.mock("~/utils/error", () => ({
+  makeShelfError: vi.fn((cause: any) => ({
+    message: cause?.message || "Unknown error",
+    status: cause?.status || 500,
+  })),
+  ShelfError: class ShelfError extends Error {
+    status: number;
+    constructor(opts: any) {
+      super(opts.message);
+      this.status = opts.status || 500;
+    }
+  },
+}));
+
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { db } from "~/database/db.server";
+
+const mockUser = {
+  id: "user-1",
+  email: "test@example.com",
+  firstName: "Test",
+  lastName: "User",
+};
+
+function createRequest({
+  orgId,
+  categoryId,
+}: { orgId?: string; categoryId?: string } = {}) {
+  const params = new URLSearchParams();
+  if (orgId) params.set("orgId", orgId);
+  if (categoryId !== undefined) params.set("categoryId", categoryId);
+  const qs = params.toString();
+  const url = `http://localhost/api/mobile/custom-fields${qs ? `?${qs}` : ""}`;
+  return new Request(url, {
+    headers: { Authorization: "Bearer test-token" },
+  });
+}
+
+describe("GET /api/mobile/custom-fields", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (requireMobileAuth as any).mockResolvedValue({
+      user: mockUser,
+      authUser: { id: "auth-user-1", email: mockUser.email },
+    });
+    (requireOrganizationAccess as any).mockResolvedValue("org-1");
+    (db.customField.findMany as any).mockResolvedValue([]);
+  });
+
+  it("returns 400 when orgId is missing (propagated from requireOrganizationAccess)", async () => {
+    const missingOrgError = new Error(
+      "Missing organization ID. Pass orgId as query param or x-shelf-organization header."
+    );
+    (missingOrgError as any).status = 400;
+    (requireOrganizationAccess as any).mockRejectedValue(missingOrgError);
+
+    const request = createRequest();
+    const result = await loader(createLoaderArgs({ request }));
+
+    expect(result instanceof Response).toBe(true);
+    expect((result as unknown as Response).status).toBe(400);
+    expect(db.customField.findMany).not.toHaveBeenCalled();
+  });
+
+  it("scopes uncategorized-only fields when no categoryId is provided", async () => {
+    const request = createRequest({ orgId: "org-1" });
+    await loader(createLoaderArgs({ request }));
+
+    // Without a category, the route must return ONLY uncategorized fields —
+    // i.e. those with no related categories at all.
+    expect(db.customField.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: "org-1",
+          categories: { none: {} },
+        }),
+      })
+    );
+  });
+
+  it("treats categoryId='uncategorized' as null (uncategorized-only fields)", async () => {
+    const request = createRequest({
+      orgId: "org-1",
+      categoryId: "uncategorized",
+    });
+    await loader(createLoaderArgs({ request }));
+
+    expect(db.customField.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: "org-1",
+          categories: { none: {} },
+        }),
+      })
+    );
+  });
+
+  it("with a real categoryId returns fields scoped to that category OR uncategorized", async () => {
+    const request = createRequest({
+      orgId: "org-1",
+      categoryId: "cat-42",
+    });
+    await loader(createLoaderArgs({ request }));
+
+    expect(db.customField.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: "org-1",
+          OR: [
+            { categories: { none: {} } },
+            { categories: { some: { id: "cat-42" } } },
+          ],
+        }),
+      })
+    );
+  });
+
+  it("returns each field shaped with id, name, type, helpText, required, options", async () => {
+    (db.customField.findMany as any).mockResolvedValue([
+      {
+        id: "cf-1",
+        name: "Serial Number",
+        type: "TEXT",
+        helpText: "Where to find it",
+        required: true,
+        options: [],
+        updatedAt: new Date("2026-01-01T00:00:00Z"),
+      },
+      {
+        id: "cf-2",
+        name: "Condition",
+        type: "OPTION",
+        helpText: null,
+        required: false,
+        options: ["new", "used"],
+        updatedAt: new Date("2026-01-02T00:00:00Z"),
+      },
+    ]);
+
+    const request = createRequest({ orgId: "org-1" });
+    const result = await loader(createLoaderArgs({ request }));
+
+    expect(result instanceof Response).toBe(true);
+    const body = await (result as unknown as Response).json();
+    expect(Array.isArray(body.customFields)).toBe(true);
+    expect(body.customFields).toHaveLength(2);
+
+    for (const cf of body.customFields) {
+      expect(cf).toHaveProperty("id");
+      expect(cf).toHaveProperty("name");
+      expect(cf).toHaveProperty("type");
+      expect(cf).toHaveProperty("helpText");
+      expect(cf).toHaveProperty("required");
+      // `options` is only emitted for OPTION fields; for TEXT it must be
+      // absent (undefined) so JSON.stringify drops it from the payload.
+      if (cf.type === "OPTION") {
+        expect(cf).toHaveProperty("options");
+      }
+    }
+
+    expect(body.customFields[0]).toMatchObject({
+      id: "cf-1",
+      name: "Serial Number",
+      type: "TEXT",
+      helpText: "Where to find it",
+      required: true,
+    });
+    expect(body.customFields[1]).toMatchObject({
+      id: "cf-2",
+      name: "Condition",
+      type: "OPTION",
+      helpText: null,
+      required: false,
+      options: ["new", "used"],
+    });
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/mobile.custom-fields.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.custom-fields.test.ts
@@ -202,10 +202,15 @@ describe("GET /api/mobile/custom-fields", () => {
       expect(cf).toHaveProperty("type");
       expect(cf).toHaveProperty("helpText");
       expect(cf).toHaveProperty("required");
-      // `options` is only emitted for OPTION fields; for TEXT it must be
-      // absent (undefined) so JSON.stringify drops it from the payload.
+      // `options` is always present in the JSON response; it is the actual
+      // option array for OPTION fields and `null` for every other type. This
+      // keeps the wire shape in sync with the companion's exported
+      // `MobileCustomFieldDefinition.options: string[] | null` type.
+      expect(cf).toHaveProperty("options");
       if (cf.type === "OPTION") {
-        expect(cf).toHaveProperty("options");
+        expect(Array.isArray(cf.options)).toBe(true);
+      } else {
+        expect(cf.options).toBeNull();
       }
     }
 
@@ -215,6 +220,7 @@ describe("GET /api/mobile/custom-fields", () => {
       type: "TEXT",
       helpText: "Where to find it",
       required: true,
+      options: null,
     });
     expect(body.customFields[1]).toMatchObject({
       id: "cf-2",


### PR DESCRIPTION
Closes #2532.

## Need

Per the discussion in #2532: mobile asset create was bypassing the workspace's required-custom-field contract. The mobile `POST /api/mobile/asset/create` route accepted only `title/description/categoryId/locationId/valuation` — it didn't accept `customFields` at all and never called `getActiveCustomFields`. The companion's create screen mirrored the gap (no UI for custom fields). The webapp form enforced this; mobile silently violated it.

This PR closes that gap end to end: server + client + types + UX.

## Hypothesis

Adding `customFields` support to the mobile create route (mirroring the existing update route) plus a small new endpoint that returns the active custom-field definitions for a category gives the companion everything it needs to render and validate the same form the webapp does. Required-field enforcement on the server is the safety net; client-side validation is the UX.

## Diff scope (6 files, +364/-5)

### Server-side

#### New: `apps/webapp/app/routes/api+/mobile+/custom-fields.ts`
`GET /api/mobile/custom-fields?orgId=X&categoryId=Y`. Returns the active custom-field definitions for the org, optionally filtered to a category. Used by the companion to render the right inputs (with required indicators) for the selected category.

#### Modified: `apps/webapp/app/routes/api+/mobile+/asset.create.ts`
- Schema now accepts optional `customFields: { id, value }[]`.
- Always fetches `getActiveCustomFields({ organizationId, category })` for the chosen category (or null/uncategorized).
- Enforces required: any required field missing/null/empty returns **HTTP 400** with the missing field names in the error message.
- Passes `customFieldsValues` (built via `extractCustomFieldValuesFromPayload` — same helper the webapp uses) into `createAsset`.

#### Modified: `apps/webapp/app/routes/api+/mobile+/asset.update.ts`
- Tightens existing custom-field handling: explicitly clearing a required field (sending `null` or `""`) is now rejected with **HTTP 400**.
- Partial updates that simply don't touch a required field remain allowed — enforcing "no required field ends up null after this update" requires reading current DB state and is out of scope for this PR (filed for follow-up).

### Client-side (companion)

#### Modified: `apps/companion/lib/api/asset-mutations.ts`
- New `customFields(orgId, categoryId?)` method calls the new endpoint.
- `createAsset()` payload now accepts `customFields: { id, value }[]`.

#### Modified: `apps/companion/lib/api/types.ts`
- New exports: `MobileCustomFieldDefinition`, `CustomFieldsResponse`.

#### Modified: `apps/companion/app/(tabs)/assets/new.tsx`
- Loads custom-field definitions whenever the selected category changes (and on "no category").
- Renders each definition with the existing `CustomFieldInput` component, marks required fields with an asterisk + uses `helpText` as inline guidance.
- Validates required-ness on submit **before** hitting the network — gives the user immediate feedback instead of a round-trip 400.
- Prunes stale values when the user switches categories (so we don't accidentally send custom-field values that no longer apply).
- The unsaved-changes guard and the "Create Another" reset both account for custom-field state.

## Verification

- [x] `pnpm db:generate && pnpm --filter @shelf/webapp typecheck` — clean, exit 0
- [x] `pnpm --filter @shelf/companion exec tsc --noEmit` — same 11 pre-existing tech-debt errors on `main` (tab-bar testIDs, underscore-prefixed unused props, etc.), **zero new errors from this PR**
- [x] Lefthook pre-commit hooks: eslint, prettier, commitlint all pass
- [ ] Manual smoke test on TestFlight build: create asset in a workspace that has a required custom field — verify (a) field appears on create screen, (b) submit blocked client-side when empty, (c) server returns 400 with the field name when client check is bypassed, (d) asset persists correctly when filled
- [ ] Existing `mobile.asset.create.test.ts` / `mobile.asset.update.test.ts` tests — CI will run them. Existing assertions should be unaffected; may need to add coverage for the new required-validation paths in a follow-up.

## Behavioural changes worth highlighting

1. **Creating an asset in a category with required custom fields used to succeed silently with NULL values. It now blocks with a clear error message.** This is a strict tightening of the API contract.
2. **The "Create Another" button on the companion now also clears custom-field state** so the next asset starts blank.
3. **Updating an asset and explicitly clearing a required custom field is now rejected.** Previously it succeeded silently.

## Out of scope (future PRs)

- Reading current DB state on update to detect "this update would leave a required field NULL" (requires extra query; not free).
- Adding test coverage for the new required-field paths (recommend follow-up PR).
- Migrating `asset.update-location.ts` and other bespoke routes onto the `updateAsset` helper for full event/note/required parity (called out in #2533).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset creation: category-scoped custom fields in the Create Asset screen with loading, error/retry, help text, required labels, new input types (dropdown with clear, switches, numeric/date/multiline), accessibility hints, and “Create Another” clearing.

* **Validation / Bug Fixes**
  * Client/server validation for required custom fields, block submit while defs load, prune stale values, treat non-empty custom values as unsaved changes, normalize boolean/text inputs.

* **API**
  * Mobile endpoints to fetch scoped custom-field definitions and accept/validate typed customFields payloads for create/update.

* **Tests**
  * Expanded coverage for fetch, create/update flows, loader, and required-field contract.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2534)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->