### PR TITLE
fix(events): close ASSET_KIT_CHANGED + custody/location/category gaps in bulk and cascade paths

### DIFF
--- a/.claude/rules/bulk-event-parity.md
+++ b/.claude/rules/bulk-event-parity.md
@@ -1,0 +1,42 @@
+---
+description: Bulk operations must emit the same activity events as their singular counterparts, including cascade events from relation cleanup
+globs: ["apps/webapp/app/modules/**/*.ts", "apps/webapp/app/routes/**/*.ts"]
+---
+
+When you add or modify a bulk operation (e.g. `bulkRemoveAssetsFromKits`,
+`bulkUpdateAssetCategory`), it must emit the same `ActivityAction` events as
+its singular counterpart — one event per affected entity — and include events
+for **cascade side-effects** (e.g. an `onDelete: SetNull` that unkits assets,
+or a kit-custody cleanup that releases asset custody). Without this, reports
+silently lose rows when users switch from the singular UI to the bulk action.
+
+Use `recordEvents` (plural) inside the same `$transaction` as the mutation.
+Only emit for items that actually changed — fetch the before-state first and
+skip no-op rows.
+
+```typescript
+// ❌ Bad — bulk path silently skips the events the singular path emits
+async function bulkRemoveAssetsFromKits({ assetIds }) {
+  await db.$transaction(async (tx) => {
+    await tx.asset.updateMany({ where: ..., data: { kitId: null } });
+    await tx.note.createMany({ data: ... });
+    // missing: per-asset ASSET_KIT_CHANGED + CUSTODY_RELEASED (cascade)
+  });
+}
+
+// ✅ Good — emit one event per affected item + cascade
+async function bulkRemoveAssetsFromKits({ assetIds }) {
+  const assets = await db.asset.findMany({ select: { id, kit, custody } });
+  await db.$transaction(async (tx) => {
+    await tx.asset.updateMany({ data: { kitId: null } });
+    await recordEvents(
+      assets.filter((a) => a.kit).map((a) => ({
+        action: "ASSET_KIT_CHANGED", assetId: a.id,
+        field: "kitId", fromValue: a.kit.id, toValue: null, ...
+      })),
+      tx,
+    );
+    // also emit CUSTODY_RELEASED for assets whose kit-custody was cleaned up
+  });
+}
+```

--- a/.claude/rules/bulk-event-parity.md
+++ b/.claude/rules/bulk-event-parity.md
@@ -26,7 +26,9 @@ async function bulkRemoveAssetsFromKits({ assetIds }) {
 
 // ✅ Good — emit one event per affected item + cascade
 async function bulkRemoveAssetsFromKits({ assetIds }) {
-  const assets = await db.asset.findMany({ select: { id, kit, custody } });
+  const assets = await db.asset.findMany({
+    select: { id: true, kit: true, custody: true },
+  });
   await db.$transaction(async (tx) => {
     await tx.asset.updateMany({ data: { kitId: null } });
     await recordEvents(

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it, vi, vitest, beforeEach } from "vitest";
 import { extractStoragePath } from "~/components/assets/asset-image/utils";
 import { db } from "~/database/db.server";
 import { getSupabaseAdmin } from "~/integrations/supabase/client";
+import { recordEvents } from "~/modules/activity-event/service.server";
 import { getCategory } from "~/modules/category/service.server";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { getQr } from "~/modules/qr/service.server";
 import { ShelfError } from "~/utils/error";
 import { createSignedUrl } from "~/utils/storage.server";
 import {
+  bulkAssignAssetTags,
+  bulkDeleteAssets,
+  bulkUpdateAssetCategory,
   getActiveCustomFieldsForAsset,
   parseAssetValuation,
   refreshExpiredAssetImages,
@@ -19,10 +23,19 @@ import {
 // why: isolating asset service logic from actual database operations
 vitest.mock("~/database/db.server", () => ({
   db: {
+    $transaction: vitest
+      .fn()
+      .mockImplementation((callback: (tx: unknown) => unknown) => callback(db)),
     asset: {
       findFirst: vitest.fn().mockResolvedValue(null),
       findUnique: vitest.fn().mockResolvedValue(null),
+      findMany: vitest.fn().mockResolvedValue([]),
       update: vitest.fn().mockResolvedValue({}),
+      updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
+      deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
+    },
+    category: {
+      findFirst: vitest.fn().mockResolvedValue(null),
     },
     location: {
       findFirst: vitest.fn().mockResolvedValue(null),
@@ -31,6 +44,23 @@ vitest.mock("~/database/db.server", () => ({
       update: vitest.fn().mockResolvedValue({}),
     },
   },
+}));
+
+// why: avoid emitting real activity events during asset service tests; assert
+// the mock was called with the expected payload instead.
+vitest.mock("~/modules/activity-event/service.server", () => ({
+  recordEvent: vitest.fn().mockResolvedValue(undefined),
+  recordEvents: vitest.fn().mockResolvedValue(undefined),
+}));
+
+// why: avoid resolving real asset IDs from search params; just echo the ids
+// the caller passed in so the test focuses on event emission.
+vitest.mock("./bulk-operations-helper.server", () => ({
+  resolveAssetIdsForBulkOperation: vitest
+    .fn()
+    .mockImplementation(({ assetIds }: { assetIds: string[] }) =>
+      Promise.resolve(assetIds)
+    ),
 }));
 
 // why: control category lookup so we can simulate a cross-org category id
@@ -93,6 +123,11 @@ vitest.mock("~/modules/user/service.server", () => ({
 // why: avoid creating actual notes during relink tests
 vitest.mock("~/modules/note/service.server", () => ({
   createNote: vitest.fn().mockResolvedValue({}),
+  createAssetCategoryChangeNote: vitest.fn().mockResolvedValue({}),
+  createAssetDescriptionChangeNote: vitest.fn().mockResolvedValue({}),
+  createAssetNameChangeNote: vitest.fn().mockResolvedValue({}),
+  createAssetValuationChangeNote: vitest.fn().mockResolvedValue({}),
+  createTagChangeNoteIfNeeded: vitest.fn().mockResolvedValue(undefined),
 }));
 
 // why: control custom-field lookup so we can assert org+category scoping
@@ -578,5 +613,190 @@ describe("getActiveCustomFieldsForAsset", () => {
       organizationId: "org-1",
       category: null,
     });
+  });
+});
+
+describe("bulkUpdateAssetCategory", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("emits ASSET_CATEGORY_CHANGED only for assets whose category actually changes", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([
+      {
+        id: "asset-1",
+        category: { id: "cat-old", name: "Old", color: "#000" },
+      },
+      // already in the target category → should be skipped
+      {
+        id: "asset-2",
+        category: { id: "cat-new", name: "New", color: "#fff" },
+      },
+      // currently uncategorized → should change
+      { id: "asset-3", category: null },
+    ]);
+    //@ts-expect-error mock setup
+    db.category.findFirst.mockResolvedValue({
+      id: "cat-new",
+      name: "New",
+      color: "#fff",
+    });
+
+    await bulkUpdateAssetCategory({
+      userId: "user-1",
+      assetIds: ["asset-1", "asset-2", "asset-3"],
+      organizationId: "org-1",
+      categoryId: "cat-new",
+      // @ts-expect-error settings not relevant for this test
+      settings: {},
+    });
+
+    expect(recordEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          action: "ASSET_CATEGORY_CHANGED",
+          assetId: "asset-1",
+          fromValue: "cat-old",
+          toValue: "cat-new",
+        }),
+        expect.objectContaining({
+          action: "ASSET_CATEGORY_CHANGED",
+          assetId: "asset-3",
+          fromValue: null,
+          toValue: "cat-new",
+        }),
+      ],
+      expect.anything()
+    );
+  });
+
+  it("does not emit events when no asset's category changes", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([
+      { id: "asset-1", category: { id: "cat-new", name: "x", color: "#000" } },
+    ]);
+
+    await bulkUpdateAssetCategory({
+      userId: "user-1",
+      assetIds: ["asset-1"],
+      organizationId: "org-1",
+      categoryId: "cat-new",
+      // @ts-expect-error settings not relevant for this test
+      settings: {},
+    });
+
+    expect(recordEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe("bulkAssignAssetTags", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("emits ASSET_TAGS_CHANGED only for assets whose tag set changed", async () => {
+    expect.assertions(1);
+
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([
+      { id: "asset-1", tags: [{ id: "tag-old", name: "Old" }] },
+      { id: "asset-2", tags: [] },
+    ]);
+
+    (db.asset.update as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce({
+        id: "asset-1",
+        tags: [
+          { id: "tag-old", name: "Old" },
+          { id: "tag-new", name: "New" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: "asset-2",
+        tags: [{ id: "tag-new", name: "New" }],
+      });
+
+    await bulkAssignAssetTags({
+      userId: "user-1",
+      assetIds: ["asset-1", "asset-2"],
+      organizationId: "org-1",
+      tagsIds: ["tag-new"],
+      remove: false,
+      // @ts-expect-error settings not relevant for this test
+      settings: {},
+    });
+
+    expect(recordEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          action: "ASSET_TAGS_CHANGED",
+          assetId: "asset-1",
+          field: "tags",
+        }),
+        expect.objectContaining({
+          action: "ASSET_TAGS_CHANGED",
+          assetId: "asset-2",
+        }),
+      ],
+      expect.anything()
+    );
+  });
+});
+
+describe("bulkDeleteAssets", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("emits ASSET_DELETED per asset before deleteMany", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([
+      { id: "asset-1", mainImage: null },
+      { id: "asset-2", mainImage: null },
+    ]);
+
+    await bulkDeleteAssets({
+      assetIds: ["asset-1", "asset-2"],
+      organizationId: "org-1",
+      userId: "user-1",
+      // @ts-expect-error settings not relevant
+      settings: {},
+    });
+
+    expect(recordEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          action: "ASSET_DELETED",
+          assetId: "asset-1",
+          entityType: "ASSET",
+          entityId: "asset-1",
+        }),
+        expect.objectContaining({
+          action: "ASSET_DELETED",
+          assetId: "asset-2",
+        }),
+      ],
+      expect.anything()
+    );
+  });
+
+  it("does not emit events when no assets resolved", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([]);
+
+    await bulkDeleteAssets({
+      assetIds: [],
+      organizationId: "org-1",
+      userId: "user-1",
+      // @ts-expect-error settings not relevant
+      settings: {},
+    });
+
+    expect(recordEvents).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -40,6 +40,9 @@ vitest.mock("~/database/db.server", () => ({
     location: {
       findFirst: vitest.fn().mockResolvedValue(null),
     },
+    tag: {
+      findMany: vitest.fn().mockResolvedValue([]),
+    },
     qr: {
       update: vitest.fn().mockResolvedValue({}),
     },
@@ -622,7 +625,7 @@ describe("bulkUpdateAssetCategory", () => {
   });
 
   it("emits ASSET_CATEGORY_CHANGED only for assets whose category actually changes", async () => {
-    expect.assertions(1);
+    expect.assertions(2);
     //@ts-expect-error mock setup
     db.asset.findMany.mockResolvedValue([
       {
@@ -654,7 +657,7 @@ describe("bulkUpdateAssetCategory", () => {
     });
 
     expect(recordEvents).toHaveBeenCalledWith(
-      [
+      expect.arrayContaining([
         expect.objectContaining({
           action: "ASSET_CATEGORY_CHANGED",
           assetId: "asset-1",
@@ -667,9 +670,12 @@ describe("bulkUpdateAssetCategory", () => {
           fromValue: null,
           toValue: "cat-new",
         }),
-      ],
+      ]),
       expect.anything()
     );
+    expect(
+      (recordEvents as ReturnType<typeof vitest.fn>).mock.calls[0][0]
+    ).toHaveLength(2);
   });
 
   it("does not emit events when no asset's category changes", async () => {
@@ -690,6 +696,26 @@ describe("bulkUpdateAssetCategory", () => {
 
     expect(recordEvents).not.toHaveBeenCalled();
   });
+
+  it("throws when categoryId belongs to a different organization", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([{ id: "asset-1", category: null }]);
+    // why: emulate a foreign-org category — findFirst is org-scoped, returns null
+    //@ts-expect-error mock setup
+    db.category.findFirst.mockResolvedValue(null);
+
+    await expect(
+      bulkUpdateAssetCategory({
+        userId: "user-1",
+        assetIds: ["asset-1"],
+        organizationId: "org-1",
+        categoryId: "foreign-cat",
+        // @ts-expect-error settings not relevant for this test
+        settings: {},
+      })
+    ).rejects.toThrow(ShelfError);
+  });
 });
 
 describe("bulkAssignAssetTags", () => {
@@ -698,8 +724,10 @@ describe("bulkAssignAssetTags", () => {
   });
 
   it("emits ASSET_TAGS_CHANGED only for assets whose tag set changed", async () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
+    //@ts-expect-error mock setup
+    db.tag.findMany.mockResolvedValue([{ id: "tag-new" }]);
     //@ts-expect-error mock setup
     db.asset.findMany.mockResolvedValue([
       { id: "asset-1", tags: [{ id: "tag-old", name: "Old" }] },
@@ -730,7 +758,7 @@ describe("bulkAssignAssetTags", () => {
     });
 
     expect(recordEvents).toHaveBeenCalledWith(
-      [
+      expect.arrayContaining([
         expect.objectContaining({
           action: "ASSET_TAGS_CHANGED",
           assetId: "asset-1",
@@ -740,9 +768,31 @@ describe("bulkAssignAssetTags", () => {
           action: "ASSET_TAGS_CHANGED",
           assetId: "asset-2",
         }),
-      ],
+      ]),
       expect.anything()
     );
+    expect(
+      (recordEvents as ReturnType<typeof vitest.fn>).mock.calls[0][0]
+    ).toHaveLength(2);
+  });
+
+  it("throws when any tagId belongs to a different organization", async () => {
+    expect.assertions(1);
+    // why: emulate cross-org tag — org-scoped findMany returns fewer rows
+    //@ts-expect-error mock setup
+    db.tag.findMany.mockResolvedValue([{ id: "tag-own" }]);
+
+    await expect(
+      bulkAssignAssetTags({
+        userId: "user-1",
+        assetIds: ["asset-1"],
+        organizationId: "org-1",
+        tagsIds: ["tag-own", "tag-foreign"],
+        remove: false,
+        // @ts-expect-error settings not relevant for this test
+        settings: {},
+      })
+    ).rejects.toThrow(ShelfError);
   });
 });
 
@@ -752,7 +802,7 @@ describe("bulkDeleteAssets", () => {
   });
 
   it("emits ASSET_DELETED per asset before deleteMany", async () => {
-    expect.assertions(1);
+    expect.assertions(2);
     //@ts-expect-error mock setup
     db.asset.findMany.mockResolvedValue([
       { id: "asset-1", mainImage: null },
@@ -768,7 +818,7 @@ describe("bulkDeleteAssets", () => {
     });
 
     expect(recordEvents).toHaveBeenCalledWith(
-      [
+      expect.arrayContaining([
         expect.objectContaining({
           action: "ASSET_DELETED",
           assetId: "asset-1",
@@ -779,9 +829,12 @@ describe("bulkDeleteAssets", () => {
           action: "ASSET_DELETED",
           assetId: "asset-2",
         }),
-      ],
+      ]),
       expect.anything()
     );
+    expect(
+      (recordEvents as ReturnType<typeof vitest.fn>).mock.calls[0][0]
+    ).toHaveLength(2);
   });
 
   it("does not emit events when no assets resolved", async () => {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -4234,13 +4234,28 @@ export async function bulkUpdateAssetCategory({
       return true;
     }
 
-    // Fetch the new category once for note formatting.
+    // Fetch the new category once for note formatting AND to verify it
+    // belongs to this organization. Without this check, a crafted
+    // foreign-org `categoryId` would be written verbatim by `updateMany`.
     const newCategory = newCategoryId
       ? await db.category.findFirst({
           where: { id: newCategoryId, organizationId },
           select: { id: true, name: true, color: true },
         })
       : null;
+
+    if (newCategoryId && !newCategory) {
+      throw new ShelfError({
+        cause: null,
+        title: "Category not found",
+        message:
+          "The category you are trying to use does not exist or you do not have permission to access it.",
+        additionalData: { categoryId: newCategoryId, organizationId, userId },
+        label,
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    }
 
     await db.$transaction(async (tx) => {
       await tx.asset.updateMany({
@@ -4319,6 +4334,29 @@ export async function bulkAssignAssetTags({
 
     if (resolvedIds.length === 0) {
       return true;
+    }
+
+    // Validate that every tag id belongs to this organization before
+    // wiring it into the `connect`/`disconnect` payload. Prisma's nested
+    // `connect: { id }` operation has no org scoping on its own, so a
+    // crafted foreign-org tag id would otherwise be attached/detached.
+    if (tagsIds.length > 0) {
+      const orgTags = await db.tag.findMany({
+        where: { id: { in: tagsIds }, organizationId },
+        select: { id: true },
+      });
+      if (orgTags.length !== new Set(tagsIds).size) {
+        throw new ShelfError({
+          cause: null,
+          title: "Tag not found",
+          message:
+            "One or more selected tags do not exist or you do not have permission to access them.",
+          additionalData: { tagsIds, organizationId, userId },
+          label,
+          status: 404,
+          shouldBeCaptured: false,
+        });
+      }
     }
 
     const loadUserForNotes = createLoadUserForNotes(userId);

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3595,8 +3595,27 @@ export async function bulkDeleteAssets({
     });
 
     try {
-      await db.asset.deleteMany({
-        where: { id: { in: assets.map((asset) => asset.id) } },
+      await db.$transaction(async (tx) => {
+        // Activity events — one ASSET_DELETED per asset, emitted before the
+        // delete so the rows still exist for any cross-ref checks. Mirrors
+        // singular `deleteAsset`.
+        if (assets.length > 0) {
+          await recordEvents(
+            assets.map((asset) => ({
+              organizationId,
+              actorUserId: userId,
+              action: "ASSET_DELETED" as const,
+              entityType: "ASSET" as const,
+              entityId: asset.id,
+              assetId: asset.id,
+            })),
+            tx
+          );
+        }
+
+        await tx.asset.deleteMany({
+          where: { id: { in: assets.map((asset) => asset.id) } },
+        });
       });
 
       /** Deleting images of the assets (if any) */
@@ -4189,16 +4208,77 @@ export async function bulkUpdateAssetCategory({
       settings,
     });
 
-    await db.asset.updateMany({
+    if (resolvedIds.length === 0) {
+      return true;
+    }
+
+    // Fetch before-state so we can emit per-asset events and notes only for
+    // assets whose category actually changes.
+    const newCategoryId = categoryId || null;
+    const assetsBeforeUpdate = await db.asset.findMany({
       where: {
         id: { in: resolvedIds },
         organizationId,
       },
-      data: {
-        /** If nothing is selected then we have to remove the relation and set category to null */
-        categoryId: !categoryId ? null : categoryId,
+      select: {
+        id: true,
+        category: { select: { id: true, name: true, color: true } },
       },
     });
+
+    const assetsThatChange = assetsBeforeUpdate.filter(
+      (asset) => (asset.category?.id ?? null) !== newCategoryId
+    );
+
+    if (assetsThatChange.length === 0) {
+      return true;
+    }
+
+    // Fetch the new category once for note formatting.
+    const newCategory = newCategoryId
+      ? await db.category.findFirst({
+          where: { id: newCategoryId, organizationId },
+          select: { id: true, name: true, color: true },
+        })
+      : null;
+
+    await db.$transaction(async (tx) => {
+      await tx.asset.updateMany({
+        where: { id: { in: assetsThatChange.map((a) => a.id) } },
+        data: { categoryId: newCategoryId },
+      });
+
+      // Activity events — one ASSET_CATEGORY_CHANGED per asset that changed.
+      await recordEvents(
+        assetsThatChange.map((asset) => ({
+          organizationId,
+          actorUserId: userId,
+          action: "ASSET_CATEGORY_CHANGED" as const,
+          entityType: "ASSET" as const,
+          entityId: asset.id,
+          assetId: asset.id,
+          field: "categoryId",
+          fromValue: asset.category?.id ?? null,
+          toValue: newCategoryId,
+        })),
+        tx
+      );
+    });
+
+    // Notes can be created outside the transaction (not critical for atomicity).
+    // Mirrors the singular `updateAsset` flow.
+    const loadUserForNotes = createLoadUserForNotes(userId);
+    await Promise.all(
+      assetsThatChange.map((asset) =>
+        createAssetCategoryChangeNote({
+          assetId: asset.id,
+          userId,
+          previousCategory: asset.category,
+          newCategory,
+          loadUserForNotes,
+        })
+      )
+    );
 
     return true;
   } catch (cause) {
@@ -4266,28 +4346,55 @@ export async function bulkAssignAssetTags({
         }, new Map())
       );
 
-    const updatePromises = resolvedIds.map((id) =>
-      db.asset.update({
-        where: { id, organizationId },
-        data: {
-          tags: {
-            [remove ? "disconnect" : "connect"]: tagsIds.map((tagId) => ({
-              id: tagId,
-            })),
-          },
-        },
-        include: {
-          tags: {
-            select: {
-              id: true,
-              name: true,
+    const updatedAssets = await db.$transaction(async (tx) => {
+      const results = await Promise.all(
+        resolvedIds.map((id) =>
+          tx.asset.update({
+            where: { id, organizationId },
+            data: {
+              tags: {
+                [remove ? "disconnect" : "connect"]: tagsIds.map((tagId) => ({
+                  id: tagId,
+                })),
+              },
             },
-          },
-        },
-      })
-    );
+            include: {
+              tags: { select: { id: true, name: true } },
+            },
+          })
+        )
+      );
 
-    const updatedAssets = await Promise.all(updatePromises);
+      // Activity events — one ASSET_TAGS_CHANGED per asset whose tag set
+      // actually changed. Same shape as the singular `updateAsset` flow.
+      const tagChangeEvents: Parameters<typeof recordEvents>[0] = [];
+      for (const asset of results) {
+        const previousTags = previousTagsByAssetId.get(asset.id) ?? [];
+        const previousTagIds = new Set(previousTags.map((t) => t.id));
+        const currentTagIds = new Set(asset.tags.map((t) => t.id));
+        const setsDiffer =
+          previousTagIds.size !== currentTagIds.size ||
+          [...previousTagIds].some((t) => !currentTagIds.has(t));
+        if (setsDiffer) {
+          tagChangeEvents.push({
+            organizationId,
+            actorUserId: userId,
+            action: "ASSET_TAGS_CHANGED",
+            entityType: "ASSET",
+            entityId: asset.id,
+            assetId: asset.id,
+            field: "tags",
+            fromValue: [...previousTagIds],
+            toValue: [...currentTagIds],
+          });
+        }
+      }
+      if (tagChangeEvents.length > 0) {
+        await recordEvents(tagChangeEvents, tx);
+      }
+
+      return results;
+    });
 
     await Promise.all(
       updatedAssets.map((asset) =>

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -558,7 +558,7 @@ describe("deleteKit", () => {
   });
 
   it("should emit ASSET_KIT_CHANGED per asset that was in the kit", async () => {
-    expect.assertions(2);
+    expect.assertions(3);
     const assetsInKit = [{ id: "asset-1" }, { id: "asset-2" }];
     //@ts-expect-error missing vitest type
     db.kit.delete.mockResolvedValue(mockKitData);
@@ -573,7 +573,7 @@ describe("deleteKit", () => {
 
     expect(recordEvents).toHaveBeenCalledTimes(1);
     expect(recordEvents).toHaveBeenCalledWith(
-      [
+      expect.arrayContaining([
         expect.objectContaining({
           action: "ASSET_KIT_CHANGED",
           assetId: "asset-1",
@@ -590,9 +590,12 @@ describe("deleteKit", () => {
           fromValue: "kit-1",
           toValue: null,
         }),
-      ],
+      ]),
       expect.anything()
     );
+    expect(
+      (recordEvents as ReturnType<typeof vitest.fn>).mock.calls[0][0]
+    ).toHaveLength(2);
   });
 
   it("should not emit events when kit has no assets", async () => {
@@ -647,7 +650,7 @@ describe("bulkDeleteKits", () => {
   });
 
   it("should emit ASSET_KIT_CHANGED per asset across all deleted kits", async () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const kitsToDelete = [
       {
         id: "kit-1",
@@ -670,7 +673,7 @@ describe("bulkDeleteKits", () => {
     });
 
     expect(recordEvents).toHaveBeenCalledWith(
-      [
+      expect.arrayContaining([
         expect.objectContaining({
           action: "ASSET_KIT_CHANGED",
           assetId: "asset-1",
@@ -690,9 +693,12 @@ describe("bulkDeleteKits", () => {
           fromValue: "kit-2",
           toValue: null,
         }),
-      ],
+      ]),
       expect.anything()
     );
+    expect(
+      (recordEvents as ReturnType<typeof vitest.fn>).mock.calls[0][0]
+    ).toHaveLength(3);
   });
 
   it("should not emit events when no kits have assets", async () => {
@@ -718,7 +724,7 @@ describe("bulkRemoveAssetsFromKits", () => {
   });
 
   it("should emit ASSET_KIT_CHANGED for each asset that left a kit", async () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
     const assets = [
       {
@@ -747,7 +753,7 @@ describe("bulkRemoveAssetsFromKits", () => {
     });
 
     expect(recordEvents).toHaveBeenCalledWith(
-      [
+      expect.arrayContaining([
         expect.objectContaining({
           action: "ASSET_KIT_CHANGED",
           assetId: "asset-1",
@@ -762,9 +768,12 @@ describe("bulkRemoveAssetsFromKits", () => {
           fromValue: "kit-2",
           toValue: null,
         }),
-      ],
+      ]),
       expect.anything()
     );
+    expect(
+      (recordEvents as ReturnType<typeof vitest.fn>).mock.calls[0][0]
+    ).toHaveLength(2);
   });
 
   it("should emit CUSTODY_RELEASED for assets whose kit-inherited custody was cleaned up", async () => {

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -22,7 +22,9 @@ import {
   relinkKitQrCode,
   getAvailableKitAssetForBooking,
   updateKitsWithBookingCustodians,
+  bulkRemoveAssetsFromKits,
 } from "./service.server";
+import { recordEvents } from "../activity-event/service.server";
 import { getQr } from "../qr/service.server";
 
 // @vitest-environment node
@@ -50,6 +52,10 @@ vitest.mock("~/database/db.server", () => ({
       findMany: vitest.fn().mockResolvedValue([]),
       update: vitest.fn().mockResolvedValue({}),
       updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
+    },
+    location: {
+      update: vitest.fn().mockResolvedValue({}),
+      findUnique: vitest.fn().mockResolvedValue(null),
     },
     qr: {
       update: vitest.fn().mockResolvedValue({}),
@@ -537,6 +543,8 @@ describe("deleteKit", () => {
     expect.assertions(2);
     //@ts-expect-error missing vitest type
     db.kit.delete.mockResolvedValue(mockKitData);
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue([]);
 
     const result = await deleteKit({
       id: "kit-1",
@@ -547,6 +555,58 @@ describe("deleteKit", () => {
       where: { id: "kit-1", organizationId: "org-1" },
     });
     expect(result).toEqual(mockKitData);
+  });
+
+  it("should emit ASSET_KIT_CHANGED per asset that was in the kit", async () => {
+    expect.assertions(2);
+    const assetsInKit = [{ id: "asset-1" }, { id: "asset-2" }];
+    //@ts-expect-error missing vitest type
+    db.kit.delete.mockResolvedValue(mockKitData);
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue(assetsInKit);
+
+    await deleteKit({
+      id: "kit-1",
+      organizationId: "org-1",
+      actorUserId: "user-1",
+    });
+
+    expect(recordEvents).toHaveBeenCalledTimes(1);
+    expect(recordEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          action: "ASSET_KIT_CHANGED",
+          assetId: "asset-1",
+          kitId: "kit-1",
+          field: "kitId",
+          fromValue: "kit-1",
+          toValue: null,
+          actorUserId: "user-1",
+        }),
+        expect.objectContaining({
+          action: "ASSET_KIT_CHANGED",
+          assetId: "asset-2",
+          kitId: "kit-1",
+          fromValue: "kit-1",
+          toValue: null,
+        }),
+      ],
+      expect.anything()
+    );
+  });
+
+  it("should not emit events when kit has no assets", async () => {
+    expect.assertions(1);
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue([]);
+
+    await deleteKit({
+      id: "kit-1",
+      organizationId: "org-1",
+      actorUserId: "user-1",
+    });
+
+    expect(recordEvents).not.toHaveBeenCalled();
   });
 
   it("should handle deletion errors", async () => {
@@ -569,15 +629,13 @@ describe("bulkDeleteKits", () => {
   });
 
   it("should bulk delete kits successfully", async () => {
-    expect.assertions(2);
+    expect.assertions(1);
     const kitsToDelete = [
-      { id: "kit-1", image: "image1.jpg" },
-      { id: "kit-2", image: null },
+      { id: "kit-1", image: "image1.jpg", assets: [] },
+      { id: "kit-2", image: null, assets: [] },
     ];
     //@ts-expect-error missing vitest type
     db.kit.findMany.mockResolvedValue(kitsToDelete);
-    //@ts-expect-error missing vitest type
-    db.$transaction.mockResolvedValue(true);
 
     await bulkDeleteKits({
       kitIds: ["kit-1", "kit-2"],
@@ -585,11 +643,177 @@ describe("bulkDeleteKits", () => {
       userId: "user-1",
     });
 
-    expect(db.kit.findMany).toHaveBeenCalledWith({
-      where: { id: { in: ["kit-1", "kit-2"] }, organizationId: "org-1" },
-      select: { id: true, image: true },
-    });
     expect(db.$transaction).toHaveBeenCalled();
+  });
+
+  it("should emit ASSET_KIT_CHANGED per asset across all deleted kits", async () => {
+    expect.assertions(1);
+    const kitsToDelete = [
+      {
+        id: "kit-1",
+        image: null,
+        assets: [{ id: "asset-1" }, { id: "asset-2" }],
+      },
+      {
+        id: "kit-2",
+        image: null,
+        assets: [{ id: "asset-3" }],
+      },
+    ];
+    //@ts-expect-error missing vitest type
+    db.kit.findMany.mockResolvedValue(kitsToDelete);
+
+    await bulkDeleteKits({
+      kitIds: ["kit-1", "kit-2"],
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(recordEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          action: "ASSET_KIT_CHANGED",
+          assetId: "asset-1",
+          kitId: "kit-1",
+          fromValue: "kit-1",
+          toValue: null,
+        }),
+        expect.objectContaining({
+          action: "ASSET_KIT_CHANGED",
+          assetId: "asset-2",
+          kitId: "kit-1",
+        }),
+        expect.objectContaining({
+          action: "ASSET_KIT_CHANGED",
+          assetId: "asset-3",
+          kitId: "kit-2",
+          fromValue: "kit-2",
+          toValue: null,
+        }),
+      ],
+      expect.anything()
+    );
+  });
+
+  it("should not emit events when no kits have assets", async () => {
+    expect.assertions(1);
+    //@ts-expect-error missing vitest type
+    db.kit.findMany.mockResolvedValue([
+      { id: "kit-1", image: null, assets: [] },
+    ]);
+
+    await bulkDeleteKits({
+      kitIds: ["kit-1"],
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+
+    expect(recordEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe("bulkRemoveAssetsFromKits", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("should emit ASSET_KIT_CHANGED for each asset that left a kit", async () => {
+    expect.assertions(1);
+
+    const assets = [
+      {
+        id: "asset-1",
+        title: "Asset 1",
+        kit: { id: "kit-1", name: "Kit 1", custody: null },
+        custody: null,
+      },
+      {
+        id: "asset-2",
+        title: "Asset 2",
+        kit: { id: "kit-2", name: "Kit 2", custody: null },
+        custody: null,
+      },
+    ];
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue(assets);
+
+    await bulkRemoveAssetsFromKits({
+      assetIds: ["asset-1", "asset-2"],
+      organizationId: "org-1",
+      userId: "user-1",
+      request: new Request("http://test.com"),
+      // @ts-expect-error settings shape not relevant for this test
+      settings: {},
+    });
+
+    expect(recordEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          action: "ASSET_KIT_CHANGED",
+          assetId: "asset-1",
+          kitId: "kit-1",
+          fromValue: "kit-1",
+          toValue: null,
+        }),
+        expect.objectContaining({
+          action: "ASSET_KIT_CHANGED",
+          assetId: "asset-2",
+          kitId: "kit-2",
+          fromValue: "kit-2",
+          toValue: null,
+        }),
+      ],
+      expect.anything()
+    );
+  });
+
+  it("should emit CUSTODY_RELEASED for assets whose kit-inherited custody was cleaned up", async () => {
+    expect.assertions(1);
+
+    const assets = [
+      {
+        id: "asset-1",
+        title: "Asset 1",
+        kit: {
+          id: "kit-1",
+          name: "Kit 1",
+          custody: { id: "kit-custody-1" },
+        },
+        custody: {
+          id: "custody-1",
+          custodian: {
+            id: "tm-1",
+            name: "Custodian",
+            user: { id: "user-2", firstName: "C", lastName: "U" },
+          },
+        },
+      },
+    ];
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue(assets);
+
+    await bulkRemoveAssetsFromKits({
+      assetIds: ["asset-1"],
+      organizationId: "org-1",
+      userId: "user-1",
+      request: new Request("http://test.com"),
+      // @ts-expect-error settings shape not relevant
+      settings: {},
+    });
+
+    expect(recordEvents).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          action: "CUSTODY_RELEASED",
+          assetId: "asset-1",
+          kitId: "kit-1",
+          teamMemberId: "tm-1",
+          targetUserId: "user-2",
+          meta: { viaKit: true },
+        }),
+      ],
+      expect.anything()
+    );
   });
 });
 

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -718,12 +718,41 @@ export async function getAssetsForKits({
 export async function deleteKit({
   id,
   organizationId,
+  actorUserId,
 }: {
   id: Kit["id"];
   organizationId: Kit["organizationId"];
+  /** Optional — caller-supplied userId for the activity event actor. */
+  actorUserId?: User["id"];
 }) {
   try {
-    return await db.kit.delete({ where: { id, organizationId } });
+    // Fetch assets currently in this kit so we can emit ASSET_KIT_CHANGED
+    // events before the cascade SetNull unkits them.
+    const assetsInKit = await db.asset.findMany({
+      where: { kitId: id, organizationId },
+      select: { id: true },
+    });
+
+    return await db.$transaction(async (tx) => {
+      if (assetsInKit.length > 0) {
+        await recordEvents(
+          assetsInKit.map((asset) => ({
+            organizationId,
+            actorUserId: actorUserId ?? null,
+            action: "ASSET_KIT_CHANGED" as const,
+            entityType: "ASSET" as const,
+            entityId: asset.id,
+            assetId: asset.id,
+            kitId: id,
+            field: "kitId",
+            fromValue: id,
+            toValue: null,
+          })),
+          tx
+        );
+      }
+      return tx.kit.delete({ where: { id, organizationId } });
+    });
   } catch (cause) {
     throw new ShelfError({
       cause,
@@ -1057,13 +1086,40 @@ export async function bulkDeleteKits({
       ? getKitsWhereInput({ organizationId, currentSearchParams })
       : { id: { in: kitIds }, organizationId };
 
-    /** We have to remove the images of the kits so we have to make this query */
+    /** We have to remove the images of the kits and emit per-asset
+     * ASSET_KIT_CHANGED events for the cascade unkit, so we need the
+     * assets of each kit in this query. */
     const kits = await db.kit.findMany({
       where,
-      select: { id: true, image: true },
+      select: {
+        id: true,
+        image: true,
+        assets: { select: { id: true } },
+      },
     });
 
     return await db.$transaction(async (tx) => {
+      // Activity events — one ASSET_KIT_CHANGED per asset that was in a
+      // deleted kit. The asset's kitId becomes null via `onDelete: SetNull`.
+      const unkitEvents: Parameters<typeof recordEvents>[0] = kits.flatMap(
+        (kit) =>
+          kit.assets.map((asset) => ({
+            organizationId,
+            actorUserId: userId,
+            action: "ASSET_KIT_CHANGED" as const,
+            entityType: "ASSET" as const,
+            entityId: asset.id,
+            assetId: asset.id,
+            kitId: kit.id,
+            field: "kitId",
+            fromValue: kit.id,
+            toValue: null,
+          }))
+      );
+      if (unkitEvents.length > 0) {
+        await recordEvents(unkitEvents, tx);
+      }
+
       /** Deleting all kits */
       await tx.kit.deleteMany({
         where: { id: { in: kits.map((kit) => kit.id) } },
@@ -1703,17 +1759,45 @@ export async function updateKitLocation({
     const assetIds = kit.assets.map((asset) => asset.id);
 
     if (newLocationId) {
-      // Connect both kit and its assets to the new location in one update
-      await db.location.update({
-        where: { id: newLocationId },
-        data: {
-          kits: {
-            connect: { id },
+      // Only emit events for assets whose location actually changes.
+      const assetsWithLocationChange = kit.assets.filter(
+        (asset) => (asset.location?.id ?? null) !== newLocationId
+      );
+
+      // Connect both kit and its assets to the new location atomically with
+      // the per-asset ASSET_LOCATION_CHANGED events.
+      await db.$transaction(async (tx) => {
+        await tx.location.update({
+          where: { id: newLocationId },
+          data: {
+            kits: {
+              connect: { id },
+            },
+            assets: {
+              connect: assetIds.map((id) => ({ id })),
+            },
           },
-          assets: {
-            connect: assetIds.map((id) => ({ id })),
-          },
-        },
+        });
+
+        if (userId && assetsWithLocationChange.length > 0) {
+          await recordEvents(
+            assetsWithLocationChange.map((asset) => ({
+              organizationId,
+              actorUserId: userId,
+              action: "ASSET_LOCATION_CHANGED" as const,
+              entityType: "ASSET" as const,
+              entityId: asset.id,
+              assetId: asset.id,
+              kitId: id,
+              locationId: newLocationId,
+              field: "locationId",
+              fromValue: asset.location?.id ?? null,
+              toValue: newLocationId,
+              meta: { viaKit: true },
+            })),
+            tx
+          );
+        }
       });
 
       // Add notes to assets about location update via parent kit
@@ -1751,17 +1835,44 @@ export async function updateKitLocation({
         );
       }
     } else if (!newLocationId && currentLocationId) {
-      // Disconnect both kit and its assets from the current location
-      await db.location.update({
-        where: { id: currentLocationId },
-        data: {
-          kits: {
-            disconnect: { id },
+      // Only emit events for assets that actually had this kit's location.
+      const assetsWithLocationChange = kit.assets.filter(
+        (asset) => asset.location?.id === currentLocationId
+      );
+
+      // Disconnect both kit and its assets atomically with the per-asset
+      // ASSET_LOCATION_CHANGED events.
+      await db.$transaction(async (tx) => {
+        await tx.location.update({
+          where: { id: currentLocationId },
+          data: {
+            kits: {
+              disconnect: { id },
+            },
+            assets: {
+              disconnect: assetIds.map((id) => ({ id })),
+            },
           },
-          assets: {
-            disconnect: assetIds.map((id) => ({ id })),
-          },
-        },
+        });
+
+        if (userId && assetsWithLocationChange.length > 0) {
+          await recordEvents(
+            assetsWithLocationChange.map((asset) => ({
+              organizationId,
+              actorUserId: userId,
+              action: "ASSET_LOCATION_CHANGED" as const,
+              entityType: "ASSET" as const,
+              entityId: asset.id,
+              assetId: asset.id,
+              kitId: id,
+              field: "locationId",
+              fromValue: currentLocationId,
+              toValue: null,
+              meta: { viaKit: true },
+            })),
+            tx
+          );
+        }
       });
 
       // Add notes to assets about location removal via parent kit
@@ -1851,23 +1962,58 @@ export async function bulkUpdateKitLocation({
 
     const actualKitIds = kitsWithAssets.map((kit) => kit.id);
     const allAssets = kitsWithAssets.flatMap((kit) => kit.assets);
+    // Map asset.id → owning kit.id so we can attach `kitId` to each cascade event.
+    const kitIdByAssetId = new Map<string, string>();
+    for (const kit of kitsWithAssets) {
+      for (const asset of kit.assets) {
+        kitIdByAssetId.set(asset.id, kit.id);
+      }
+    }
 
     if (
       newLocationId &&
       newLocationId.trim() !== "" &&
       actualKitIds.length > 0
     ) {
-      // Update location to connect both kits and their assets
-      await db.location.update({
-        where: { id: newLocationId },
-        data: {
-          kits: {
-            connect: actualKitIds.map((id) => ({ id })),
+      // Only emit events for assets whose location actually changes.
+      const assetsWithLocationChange = allAssets.filter(
+        (asset) => (asset.location?.id ?? null) !== newLocationId
+      );
+
+      // Update location to connect both kits and their assets atomically
+      // with the per-asset ASSET_LOCATION_CHANGED events.
+      await db.$transaction(async (tx) => {
+        await tx.location.update({
+          where: { id: newLocationId },
+          data: {
+            kits: {
+              connect: actualKitIds.map((id) => ({ id })),
+            },
+            assets: {
+              connect: allAssets.map((asset) => ({ id: asset.id })),
+            },
           },
-          assets: {
-            connect: allAssets.map((asset) => ({ id: asset.id })),
-          },
-        },
+        });
+
+        if (assetsWithLocationChange.length > 0) {
+          await recordEvents(
+            assetsWithLocationChange.map((asset) => ({
+              organizationId,
+              actorUserId: userId,
+              action: "ASSET_LOCATION_CHANGED" as const,
+              entityType: "ASSET" as const,
+              entityId: asset.id,
+              assetId: asset.id,
+              kitId: kitIdByAssetId.get(asset.id),
+              locationId: newLocationId,
+              field: "locationId",
+              fromValue: asset.location?.id ?? null,
+              toValue: newLocationId,
+              meta: { viaKit: true },
+            })),
+            tx
+          );
+        }
       });
 
       // Create notes for affected assets
@@ -1905,15 +2051,48 @@ export async function bulkUpdateKitLocation({
         );
       }
     } else {
-      // Removing location - set to null and handle cascade
-      await db.kit.updateMany({
-        where,
-        data: {
-          locationId: null,
-        },
+      // Only assets that currently have a location actually change.
+      const assetsWithLocationChange = allAssets.filter(
+        (asset) => asset.location?.id
+      );
+
+      // Removing location - set to null and handle cascade, atomically with
+      // the per-asset ASSET_LOCATION_CHANGED events.
+      await db.$transaction(async (tx) => {
+        await tx.kit.updateMany({
+          where,
+          data: { locationId: null },
+        });
+
+        if (allAssets.length > 0) {
+          await tx.asset.updateMany({
+            where: { id: { in: allAssets.map((asset) => asset.id) } },
+            data: { locationId: null },
+          });
+        }
+
+        if (assetsWithLocationChange.length > 0) {
+          await recordEvents(
+            assetsWithLocationChange.map((asset) => ({
+              organizationId,
+              actorUserId: userId,
+              action: "ASSET_LOCATION_CHANGED" as const,
+              entityType: "ASSET" as const,
+              entityId: asset.id,
+              assetId: asset.id,
+              kitId: kitIdByAssetId.get(asset.id),
+              field: "locationId",
+              fromValue: asset.location!.id,
+              toValue: null,
+              meta: { viaKit: true },
+            })),
+            tx
+          );
+        }
       });
 
-      // Also remove location from assets and create notes
+      // Create individual notes for each asset (asset locations were already
+      // cleared atomically in the transaction above).
       if (allAssets.length > 0) {
         const user = await getUserByID(userId, {
           select: {
@@ -1924,16 +2103,6 @@ export async function bulkUpdateKitLocation({
           } satisfies Prisma.UserSelect,
         });
 
-        await db.asset.updateMany({
-          where: {
-            id: { in: allAssets.map((asset) => asset.id) },
-          },
-          data: {
-            locationId: null,
-          },
-        });
-
-        // Create individual notes for each asset
         await Promise.all(
           allAssets.map((asset) =>
             createNote({
@@ -2290,10 +2459,39 @@ export async function updateKitAssets({
     // Handle location cascade for newly added assets (after kit assignment notes)
     if (newlyAddedAssets.length > 0) {
       if (kit.location) {
-        // Kit has a location, update all newly added assets to that location
-        await db.asset.updateMany({
-          where: { id: { in: newlyAddedAssets.map((asset) => asset.id) } },
-          data: { locationId: kit.location.id },
+        // Kit has a location, update all newly added assets to that location.
+        // Only assets whose location actually changes get an event.
+        const assetsWithLocationChange = newlyAddedAssets.filter(
+          (asset) => asset.location?.id !== kit.location!.id
+        );
+
+        await db.$transaction(async (tx) => {
+          await tx.asset.updateMany({
+            where: { id: { in: newlyAddedAssets.map((asset) => asset.id) } },
+            data: { locationId: kit.location!.id },
+          });
+
+          // Activity events — one ASSET_LOCATION_CHANGED per asset whose
+          // location was changed by the kit-join cascade.
+          if (assetsWithLocationChange.length > 0) {
+            await recordEvents(
+              assetsWithLocationChange.map((asset) => ({
+                organizationId,
+                actorUserId: userId,
+                action: "ASSET_LOCATION_CHANGED" as const,
+                entityType: "ASSET" as const,
+                entityId: asset.id,
+                assetId: asset.id,
+                kitId: kit.id,
+                locationId: kit.location!.id,
+                field: "locationId",
+                fromValue: asset.location?.id ?? null,
+                toValue: kit.location!.id,
+                meta: { viaKit: true },
+              })),
+              tx
+            );
+          }
         });
 
         // Create notes for assets that had their location changed
@@ -2329,9 +2527,32 @@ export async function updateKitAssets({
         );
 
         if (assetsWithLocation.length > 0) {
-          await db.asset.updateMany({
-            where: { id: { in: assetsWithLocation.map((asset) => asset.id) } },
-            data: { locationId: null },
+          await db.$transaction(async (tx) => {
+            await tx.asset.updateMany({
+              where: {
+                id: { in: assetsWithLocation.map((asset) => asset.id) },
+              },
+              data: { locationId: null },
+            });
+
+            // Activity events — one ASSET_LOCATION_CHANGED per asset whose
+            // location was cleared by the kit-join cascade (kit has no location).
+            await recordEvents(
+              assetsWithLocation.map((asset) => ({
+                organizationId,
+                actorUserId: userId,
+                action: "ASSET_LOCATION_CHANGED" as const,
+                entityType: "ASSET" as const,
+                entityId: asset.id,
+                assetId: asset.id,
+                kitId: kit.id,
+                field: "locationId",
+                fromValue: asset.location!.id,
+                toValue: null,
+                meta: { viaKit: true },
+              })),
+              tx
+            );
           });
 
           // Create notes for assets that had their location removed
@@ -2376,22 +2597,46 @@ export async function updateKitAssets({
       kit.custody.custodian.id &&
       assetsToInheritStatus.length > 0
     ) {
-      // Update custody for all assets to inherit kit's custody
-      await Promise.all(
-        assetsToInheritStatus.map((asset) =>
-          db.asset.update({
-            where: { id: asset.id, organizationId },
-            data: {
-              status: AssetStatus.IN_CUSTODY,
-              custody: {
-                create: {
-                  custodian: { connect: { id: kit.custody?.custodian.id } },
+      const inheritedCustodianId = kit.custody.custodian.id;
+      const inheritedTargetUserId = kit.custody.custodian.user?.id;
+
+      // Update custody for all assets to inherit kit's custody, atomically
+      // with the CUSTODY_ASSIGNED events.
+      await db.$transaction(async (tx) => {
+        await Promise.all(
+          assetsToInheritStatus.map((asset) =>
+            tx.asset.update({
+              where: { id: asset.id, organizationId },
+              data: {
+                status: AssetStatus.IN_CUSTODY,
+                custody: {
+                  create: {
+                    custodian: { connect: { id: inheritedCustodianId } },
+                  },
                 },
               },
-            },
-          })
-        )
-      );
+            })
+          )
+        );
+
+        // Activity events — one CUSTODY_ASSIGNED per asset that inherited
+        // kit custody on join. `meta.viaKit` mirrors `bulkAssignKitCustody`.
+        await recordEvents(
+          assetsToInheritStatus.map((asset) => ({
+            organizationId,
+            actorUserId: userId,
+            action: "CUSTODY_ASSIGNED" as const,
+            entityType: "ASSET" as const,
+            entityId: asset.id,
+            assetId: asset.id,
+            kitId: kit.id,
+            teamMemberId: inheritedCustodianId,
+            targetUserId: inheritedTargetUserId,
+            meta: { viaKit: true },
+          })),
+          tx
+        );
+      });
 
       // Create notes for all assets that inherited custody
       const custodianDisplay = kitCustodianDisplay ?? "**Unknown Custodian**";
@@ -2411,6 +2656,8 @@ export async function updateKitAssets({
     if (!addOnly && removedAssets.length && kit.custody?.custodian.id) {
       const custodianDisplay = kitCustodianDisplay ?? "**Unknown Custodian**";
       const assetIds = removedAssets.map((a) => a.id);
+      const releasedCustodianId = kit.custody.custodian.id;
+      const releasedTargetUserId = kit.custody.custodian.user?.id;
 
       // Use transaction for atomicity - prevents orphaned custody records
       await db.$transaction(async (tx) => {
@@ -2422,6 +2669,24 @@ export async function updateKitAssets({
           where: { id: { in: assetIds }, organizationId },
           data: { status: AssetStatus.AVAILABLE },
         });
+
+        // Activity events — one CUSTODY_RELEASED per asset that lost its
+        // kit-inherited custody. `meta.viaKit` mirrors `bulkReleaseKitCustody`.
+        await recordEvents(
+          removedAssets.map((asset) => ({
+            organizationId,
+            actorUserId: userId,
+            action: "CUSTODY_RELEASED" as const,
+            entityType: "ASSET" as const,
+            entityId: asset.id,
+            assetId: asset.id,
+            kitId: kit.id,
+            teamMemberId: releasedCustodianId,
+            targetUserId: releasedTargetUserId,
+            meta: { viaKit: true },
+          })),
+          tx
+        );
       });
 
       // Notes can be created outside transaction (not critical for consistency)
@@ -2537,6 +2802,7 @@ export async function bulkRemoveAssetsFromKits({
             id: true,
             custodian: {
               select: {
+                id: true,
                 name: true,
                 user: {
                   select: {
@@ -2615,6 +2881,46 @@ export async function bulkRemoveAssetsFromKits({
             };
           }),
         });
+      }
+
+      // Activity events — one ASSET_KIT_CHANGED per asset that left a kit.
+      if (assetsRemovedFromKit.length > 0) {
+        await recordEvents(
+          assetsRemovedFromKit.map((asset) => ({
+            organizationId,
+            actorUserId: userId,
+            action: "ASSET_KIT_CHANGED" as const,
+            entityType: "ASSET" as const,
+            entityId: asset.id,
+            assetId: asset.id,
+            kitId: asset.kit!.id,
+            field: "kitId",
+            fromValue: asset.kit!.id,
+            toValue: null,
+          })),
+          tx
+        );
+      }
+
+      // Activity events — one CUSTODY_RELEASED per asset whose kit-inherited
+      // custody was cleaned up. `meta.viaKit` mirrors the kit-custody flows
+      // in `releaseCustody` / `bulkReleaseKitCustody`.
+      if (assetsWhoseKitsInCustody.length > 0) {
+        await recordEvents(
+          assetsWhoseKitsInCustody.map((asset) => ({
+            organizationId,
+            actorUserId: userId,
+            action: "CUSTODY_RELEASED" as const,
+            entityType: "ASSET" as const,
+            entityId: asset.id,
+            assetId: asset.id,
+            kitId: asset.kit?.id,
+            teamMemberId: asset.custody?.custodian.id,
+            targetUserId: asset.custody?.custodian.user?.id ?? undefined,
+            meta: { viaKit: true },
+          })),
+          tx
+        );
       }
     });
 

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
@@ -259,7 +259,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     switch (intent) {
       case "delete": {
-        await deleteKit({ id: kitId, organizationId });
+        await deleteKit({ id: kitId, organizationId, actorUserId: userId });
 
         if (image) {
           await deleteKitImage({ url: image });


### PR DESCRIPTION
Bulk operations and kit-cascade flows were emitting fewer activity events than their singular counterparts, leaving Asset Activity / Custody / Location reports with gaps when users took the bulk action or when a change cascaded through a kit.

Singular/bulk parity fixes:
- bulkRemoveAssetsFromKits: emit ASSET_KIT_CHANGED per asset that left a kit and CUSTODY_RELEASED per kit-custody row cleaned up (both viaKit).
- bulkUpdateAssetCategory: wrap in $transaction, emit ASSET_CATEGORY_CHANGED per changed asset, and write per-asset category-change notes to match the singular updateAsset path.
- bulkAssignAssetTags: wrap in $transaction, emit ASSET_TAGS_CHANGED per asset whose tag set actually changed.
- bulkDeleteAssets: wrap in $transaction, emit ASSET_DELETED per asset before the deleteMany (mirrors singular deleteAsset).

Kit-cascade fixes (gaps that existed in both singular and bulk):
- updateKitAssets: emit CUSTODY_ASSIGNED for assets inheriting kit custody on add, CUSTODY_RELEASED for removed assets losing kit-inherited custody, and ASSET_LOCATION_CHANGED for the kit→asset location cascade. All carry meta.viaKit so reports can distinguish kit-driven transitions.
- updateKitLocation + bulkUpdateKitLocation: wrap in $transaction and emit ASSET_LOCATION_CHANGED per asset whose location cascades to/from the kit.
- deleteKit (now takes optional actorUserId) + bulkDeleteKits: emit ASSET_KIT_CHANGED { fromValue: kit.id, toValue: null } per asset before the onDelete: SetNull cascade unkits them.

Tests:
- kit/service.server.test.ts: assertions for deleteKit, bulkDeleteKits, and bulkRemoveAssetsFromKits event emission.
- asset/service.server.test.ts: new describes for bulkUpdateAssetCategory, bulkAssignAssetTags, bulkDeleteAssets.

Rule:
- .claude/rules/bulk-event-parity.md codifies the pattern so future bulk operations don't silently drop events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Bulk asset and kit operations now emit per-item activity events (deletes, category/tag/location/custody changes) only for actual state changes; events are recorded atomically with the mutation.
  * Tag assignments are validated against the target organization before applying.
  * Kit deletion now accepts optional actor context and deletion flows include kit-inherited custody metadata (meta: { viaKit: true }).

* **Tests**
  * Expanded coverage and mocks for bulk flows, event emission, and cascade behaviors.

* **Documentation**
  * Added guidance defining bulk-event parity requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2535)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->