### PR TITLE
fix(companion): declare collected data types in iOS privacy manifest

### DIFF
--- a/apps/companion/ios/Shelf/PrivacyInfo.xcprivacy
+++ b/apps/companion/ios/Shelf/PrivacyInfo.xcprivacy
@@ -41,7 +41,68 @@
 		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeEmailAddress</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeName</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherUserContent</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## TL;DR

`apps/companion/ios/Shelf/PrivacyInfo.xcprivacy` currently ships with an **empty `NSPrivacyCollectedDataTypes` array**, while the app actually collects user email, name, user ID, photos, and free-form user content (notes / descriptions / custom field values).

This PR fills in those five entries to match reality. **Manifest-only change.** No runtime code, no schema, no API surface, no migration touched.

---

## Need

Apple's privacy manifest (`PrivacyInfo.xcprivacy`) ships **inside the binary** and is parsed by App Review during submission. When the declared `NSPrivacyCollectedDataTypes` set is smaller than what the app demonstrably collects, App Review rejects with a *Privacy — Data Collection* note before the build reaches Beta App Review or production.

This is **not a TestFlight blocker** — the current empty manifest does not stop internal testing — but it **is a public App Store submission blocker**.

Apple's reference for the file and identifier set:
- https://developer.apple.com/documentation/bundleresources/privacy-manifest-files
- https://developer.apple.com/documentation/bundleresources/privacy-manifest-files/describing-data-use-in-privacy-manifests

---

## What changes

Populates `NSPrivacyCollectedDataTypes` with 5 declarations. **All five share the same shape:**

| Field | Value | Why |
|---|---|---|
| `NSPrivacyCollectedDataTypeLinked` | `true` | Every datum the companion stores is keyed to the signed-in Shelf user. |
| `NSPrivacyCollectedDataTypeTracking` | `false` | Companion does no cross-app/cross-site tracking; no ad SDKs; `NSPrivacyTracking` is already `false`. |
| `NSPrivacyCollectedDataTypePurposes` | `[AppFunctionality]` | None of this data feeds analytics, personalization, or advertising — it is the product. |

The five declared types:

| Apple identifier | What it covers in our app | Code corroboration |
|---|---|---|
| `NSPrivacyCollectedDataTypeEmailAddress` | The address the user signs in with via Supabase Auth | `apps/companion/lib/auth-context.tsx:54` (`supabase.auth.signInWithPassword`), `apps/companion/app/(auth)/login.tsx:30` (`useState` for email field) |
| `NSPrivacyCollectedDataTypeName` | `firstName` / `lastName` returned by the org context, surfaced in the Settings tab | `apps/companion/lib/org-context.tsx:20-21` |
| `NSPrivacyCollectedDataTypeUserID` | Supabase auth `user.id` persisted via `expo-secure-store` to keep the session alive | `apps/companion/lib/supabase.ts` (SecureStore session) + every authenticated API call in `apps/companion/lib/api/*` |
| `NSPrivacyCollectedDataTypePhotosorVideos` | Asset images chosen from the photo library or captured via the camera, uploaded to Supabase Storage | `apps/companion/hooks/use-image-upload.ts:71-77`, `apps/companion/app/(tabs)/assets/new.tsx:287-293` (`expo-image-picker` `launchCameraAsync` / `launchImageLibraryAsync`) |
| `NSPrivacyCollectedDataTypeOtherUserContent` | Asset notes, asset descriptions, and custom field values authored in-app | `apps/companion/components/asset-detail/notes-section.tsx`, `apps/companion/lib/api/asset-mutations.ts:64-68` (`description`, `customFields`), `apps/companion/components/asset-edit/custom-field-input.tsx` |

These are exactly the data types the webapp already collects from the same users — the companion is a thin client over the Shelf API, so the manifest needs to reflect that.

---

## Impact analysis — codebase

**Zero functional impact.** The privacy manifest is metadata Apple reads at submission/runtime; nothing in our TypeScript, native code, or build pipeline reads it.

| Surface | Affected? | Reasoning |
|---|---|---|
| Runtime behavior (UI, navigation, API calls) | No | The file isn't imported by any JS/TS. |
| Native iOS code | No | We have no custom Swift/Obj-C reading the manifest. |
| Build / EAS pipeline | No | `eas build` copies the file verbatim into the IPA; no transform. |
| Webapp / database / migrations | No | Mobile-only file. |
| TestFlight users | No | Existing builds remain valid; this change is for the next IPA. |
| Bundle size | +~1.4 KB of XML inside the IPA | Negligible. |

`grep -rn "PrivacyInfo" apps/ packages/` returns only the file itself — nothing else in the repo depends on it.

---

## Risk

- **Risk of merging:** Effectively zero. The XML parses cleanly (`plutil -lint` passes locally), the identifier strings come from Apple's published list, and the file is not on any code path.
- **Risk of *not* merging:** Certain App Store rejection on the first public submission, costing us a Beta App Review round-trip plus another EAS build.

Worst-case escape hatch: if Apple complains about any individual declaration (e.g., the casing of `PhotosorVideos` vs `PhotosOrVideos` — Apple has used both in different docs over time), the fix is a one-line edit to this same file. Fully reversible with `git revert`.

---

## What this PR is *not* doing

- **Not** changing `NSPrivacyAccessedAPITypes` — the existing 4 declarations (FileTimestamp, UserDefaults, DiskSpace, SystemBootTime) are correct and untouched.
- **Not** flipping `NSPrivacyTracking` — stays `false` (no IDFA, no `AppTrackingTransparency` prompt).
- **Not** introducing `NSPrivacyTrackingDomains` — we have no third-party trackers in the companion.
- **Not** touching `Info.plist` usage descriptions (`NSCameraUsageDescription`, `NSPhotoLibraryUsageDescription`) — those already exist.
- **Not** touching the Apple Privacy Nutrition Labels in App Store Connect. Those must be filled in to match this manifest when we submit (separate ASC task, on me).

---

## Test plan

- [x] `plutil -lint apps/companion/ios/Shelf/PrivacyInfo.xcprivacy` → `OK` locally.
- [x] `plutil -p` round-trip shows all 5 dictionaries with `Linked=1`, `Tracking=0`, purpose `AppFunctionality`.
- [ ] Next EAS Build picks up the file (no Expo config change needed — `ios/` is autoreleased into the iOS project).
- [ ] EAS Submit -> App Store Connect processes the binary without a "Privacy — Data Collection" reject.

---

## Forward note for the launch checklist

Whoever fills in the **Apple Privacy Nutrition Labels** questionnaire in App Store Connect must answer it consistently with this manifest:

- Email Address, Name, User ID, Photos or Videos, Other User Content → all *Collected*, all *Linked to the user*, all *Not used for tracking*, purpose *App Functionality*.

If we ever add analytics, advertising, or third-party SDKs that collect data, **both** the ASC questionnaire **and** this file must be updated in the same PR.

---

## References

- Apple, *Describing data use in privacy manifests* — https://developer.apple.com/documentation/bundleresources/privacy-manifest-files/describing-data-use-in-privacy-manifests
- Apple, *Privacy manifest files* (overview) — https://developer.apple.com/documentation/bundleresources/privacy-manifest-files
- Apple, *App privacy details on the App Store* — https://developer.apple.com/app-store/app-privacy-details/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated privacy data collection declarations to specify collected data categories including email addresses, names, user IDs, photos or videos, and other user-generated content, with appropriate linking and tracking flags configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2536)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->