### PR TITLE
fix(companion): native date picker + complete custom fields on asset edit

### DIFF
--- a/apps/companion/app/(tabs)/assets/edit.tsx
+++ b/apps/companion/app/(tabs)/assets/edit.tsx
@@ -83,6 +83,19 @@ export default function EditAssetScreen() {
       );
       return;
     }
+    // why: `form.customFields` is empty (or stale, mid-category-switch) while
+    // defs are loading, so the required-field filter below would silently
+    // produce `[]` and let the save through. Belt-and-suspenders with the
+    // `canSubmit` disable on the button: the button is disabled, but if the
+    // user somehow triggers submit anyway (rapid double-tap before the
+    // disable lands), this guard still catches it. Mirrors `new.tsx`.
+    if (form.isCustomFieldsLoading) {
+      Alert.alert(
+        "Please wait",
+        "Custom fields are still loading. Try again in a moment."
+      );
+      return;
+    }
     const missingRequired = form.customFields
       .filter((cf) => cf.required && !cf.value.trim())
       .map((cf) => cf.name);
@@ -169,7 +182,11 @@ export default function EditAssetScreen() {
     ]);
   };
 
-  const canSubmit = form.title.trim().length >= 2 && !form.isSubmitting;
+  const canSubmit =
+    form.title.trim().length >= 2 &&
+    !form.isSubmitting &&
+    !form.isCustomFieldsLoading &&
+    !form.customFieldsError;
 
   // ── Loading state ───────────────────────────────
   if (form.isLoadingAsset) {

--- a/apps/companion/app/(tabs)/assets/edit.tsx
+++ b/apps/companion/app/(tabs)/assets/edit.tsx
@@ -1,3 +1,16 @@
+/**
+ * EditAssetScreen
+ *
+ * Asset edit form for the mobile companion. Mirrors the create flow
+ * (`assets/new.tsx`) but starts from a server-loaded baseline and submits
+ * a partial-update payload containing only changed fields. Hooks into
+ * `useEditAssetForm` for state, `useFormValidation` for the dirty-state
+ * unsaved-changes guard, and `CustomFieldInput` (shared with create) for
+ * each custom-field row.
+ *
+ * @see {@link file://../../../hooks/use-edit-asset-form.ts useEditAssetForm}
+ * @see {@link file://../../../components/asset-edit/custom-field-input.tsx CustomFieldInput}
+ */
 import {
   View,
   Text,
@@ -43,6 +56,17 @@ function buildCustomFieldPayloadValue(type: string, value: string): any {
   }
 }
 
+/**
+ * The asset edit screen rendered at `/assets/[id]/edit`.
+ *
+ * Loads the asset + custom-field definitions, renders the editable form,
+ * validates required fields client-side before submit, and dispatches a
+ * partial-update payload through `api.updateAsset` containing only the
+ * fields that actually changed (so the server's audit log stays clean).
+ *
+ * @returns The edit form JSX, or a centered loading / error placeholder
+ *          while the asset is being fetched.
+ */
 export default function EditAssetScreen() {
   const router = useRouter();
   const { id: assetId } = useLocalSearchParams<{ id: string }>();

--- a/apps/companion/app/(tabs)/assets/edit.tsx
+++ b/apps/companion/app/(tabs)/assets/edit.tsx
@@ -72,6 +72,28 @@ export default function EditAssetScreen() {
     }
     if (!currentOrg || !assetId) return;
 
+    // why: enforce required custom fields BEFORE hitting the server so the
+    // user sees a focused message naming the empty fields instead of a
+    // generic 400. The server enforces the same contract — see the webapp's
+    // mergedSchema validation.
+    if (form.customFieldsError) {
+      Alert.alert(
+        "Custom Fields Unavailable",
+        "We couldn't load the custom field definitions. Please retry before saving."
+      );
+      return;
+    }
+    const missingRequired = form.customFields
+      .filter((cf) => cf.required && !cf.value.trim())
+      .map((cf) => cf.name);
+    if (missingRequired.length > 0) {
+      Alert.alert(
+        "Missing required fields",
+        `Please fill in: ${missingRequired.join(", ")}.`
+      );
+      return;
+    }
+
     form.setIsSubmitting(true);
 
     // Build payload with only changed fields
@@ -323,24 +345,43 @@ export default function EditAssetScreen() {
           />
 
           {/* ── Custom Fields ──────────────────────────── */}
-          {form.customFields.length > 0 && (
+          {(form.customFields.length > 0 ||
+            form.isCustomFieldsLoading ||
+            form.customFieldsError) && (
             <View style={styles.customFieldsSection}>
               <Text style={styles.sectionLabel}>Custom Fields</Text>
-              {form.customFields.map((cf) => (
-                <View key={cf.id} style={styles.field}>
-                  <Text style={styles.label}>
-                    {cf.name}
-                    {cf.helpText ? (
-                      <Text style={styles.helpText}> — {cf.helpText}</Text>
-                    ) : null}
-                  </Text>
-                  <CustomFieldInput
-                    field={cf}
-                    value={cf.value}
-                    onChange={(val) => form.updateCustomField(cf.id, val)}
-                  />
+              {form.isCustomFieldsLoading && form.customFields.length === 0 ? (
+                <Text style={styles.helpText}>Loading custom fields…</Text>
+              ) : form.customFieldsError ? (
+                <View>
+                  <Text style={styles.helpText}>{form.customFieldsError}</Text>
+                  <TouchableOpacity
+                    onPress={form.retryLoadCustomFields}
+                    accessibilityRole="button"
+                  >
+                    <Text style={styles.retryLink}>Retry</Text>
+                  </TouchableOpacity>
                 </View>
-              ))}
+              ) : (
+                form.customFields.map((cf) => (
+                  <View key={cf.id} style={styles.field}>
+                    <Text style={styles.label}>
+                      {cf.name}
+                      {cf.required ? (
+                        <Text style={styles.required}> *</Text>
+                      ) : null}
+                      {cf.helpText ? (
+                        <Text style={styles.helpText}> — {cf.helpText}</Text>
+                      ) : null}
+                    </Text>
+                    <CustomFieldInput
+                      field={cf}
+                      value={cf.value}
+                      onChange={(val) => form.updateCustomField(cf.id, val)}
+                    />
+                  </View>
+                ))
+              )}
             </View>
           )}
         </ScrollView>
@@ -568,5 +609,11 @@ const useStyles = createStyles((colors, shadows) => ({
     fontWeight: "400",
     color: colors.mutedLight,
     fontSize: fontSize.sm,
+  },
+  retryLink: {
+    fontSize: fontSize.sm,
+    color: colors.primary,
+    fontWeight: "500",
+    marginTop: spacing.xs,
   },
 }));

--- a/apps/companion/app/(tabs)/assets/edit.tsx
+++ b/apps/companion/app/(tabs)/assets/edit.tsx
@@ -25,7 +25,7 @@ import {
 import { useRouter, useLocalSearchParams, Stack } from "expo-router";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
-import { api } from "@/lib/api";
+import { api, type MobileCustomFieldType } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
@@ -37,8 +37,26 @@ import { PickerField } from "@/components/asset-edit/picker-field";
 import { CustomFieldInput } from "@/components/asset-edit/custom-field-input";
 import { ValuationField } from "@/components/asset-edit/valuation-field";
 
-/** Build the JSON value payload for a custom field update */
-function buildCustomFieldPayloadValue(type: string, value: string): any {
+/** The shape the server expects for a single custom-field update entry. */
+type CustomFieldPayloadValue = { raw: string | number | boolean } | null;
+
+/**
+ * Build the JSON value payload for a single custom field update.
+ *
+ * Returns `null` for empty values so the server clears the field. For
+ * NUMBER / AMOUNT, a non-numeric string parses to `null` (treated as a
+ * clear) so the user can't ship a malformed number to the server.
+ *
+ * @param type  The field's declared type from the canonical
+ *              `MobileCustomFieldType` union — narrowed so the switch is
+ *              exhaustively checkable.
+ * @param value The string value from the form input.
+ * @returns     `{ raw: ... }` on success, or `null` to clear the field.
+ */
+function buildCustomFieldPayloadValue(
+  type: MobileCustomFieldType,
+  value: string
+): CustomFieldPayloadValue {
   if (!value.trim()) return null; // null to clear the field
 
   switch (type) {
@@ -51,7 +69,9 @@ function buildCustomFieldPayloadValue(type: string, value: string): any {
       const num = parseFloat(value);
       return isNaN(num) ? null : { raw: num };
     }
-    default:
+    case "TEXT":
+    case "MULTILINE_TEXT":
+    case "OPTION":
       return { raw: value };
   }
 }

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -151,6 +151,7 @@ export function CustomFieldInput({
       return (
         <DateFieldInput
           fieldId={field.id}
+          fieldName={field.name}
           value={value}
           onChange={onChange}
           accessibilityLabel={accessibilityLabel}
@@ -341,6 +342,7 @@ function OptionDropdown({
  */
 function DateFieldInput({
   fieldId,
+  fieldName,
   value,
   onChange,
   accessibilityLabel,
@@ -348,6 +350,15 @@ function DateFieldInput({
 }: {
   /** customField.id — used to scope the picker's testID per field. */
   fieldId: string;
+  /**
+   * Plain field name (no error-suffix). Used for the Clear button's
+   * accessibility label so VoiceOver doesn't re-announce the field's
+   * error state when reading the clear action — `accessibilityLabel`
+   * (the parent-computed one) already includes `", invalid: <error>"`
+   * when an error is present, which would make the clear control sound
+   * invalid.
+   */
+  fieldName: string;
   value: string;
   onChange: (value: string) => void;
   accessibilityLabel: string;
@@ -458,7 +469,7 @@ function DateFieldInput({
             setOpen(false);
           }}
           accessibilityRole="button"
-          accessibilityLabel={`Clear ${accessibilityLabel}`}
+          accessibilityLabel={`Clear ${fieldName}`}
         >
           <Text style={styles.pickerClearText}>Clear date</Text>
         </TouchableOpacity>

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -421,6 +421,29 @@ function DateFieldInput({
           />
         </View>
       )}
+
+      {/*
+        Always-visible clear affordance when the field has a value. Mirrors
+        the OptionDropdown's `pickerClear` pattern but sits OUTSIDE the
+        `open` branch because on Android the picker is a modal dialog —
+        anything inside `open` is hidden behind the OS sheet, so there'd
+        be no UI window to surface "Clear" via that path. For optional
+        DATE fields, this is the only way to send `null` and reset the
+        server-side value (see `buildCustomFieldPayloadValue`).
+      */}
+      {value ? (
+        <TouchableOpacity
+          style={styles.dateClearRow}
+          onPress={() => {
+            onChange("");
+            setOpen(false);
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={`Clear ${accessibilityLabel}`}
+        >
+          <Text style={styles.pickerClearText}>Clear date</Text>
+        </TouchableOpacity>
+      ) : null}
     </View>
   );
 }
@@ -524,6 +547,15 @@ const useStyles = createStyles((colors, shadows) => ({
   // Inline DateTimePicker (iOS) wrapper — gives the calendar room to
   // breathe under the field button without colliding with the next field.
   dateInlineWrap: {
+    marginTop: spacing.xs,
+  },
+  // Clear affordance row below the date picker button — only rendered when
+  // the field has a value. Sits outside the picker open/closed state so
+  // Android (modal dialog) users can still clear without opening the picker.
+  dateClearRow: {
+    alignSelf: "flex-end",
+    paddingVertical: spacing.xs,
+    paddingHorizontal: 4,
     marginTop: spacing.xs,
   },
 }));

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -10,7 +10,7 @@
  * Supported types:
  * - `BOOLEAN`         — native `Switch` with a "Yes"/"No" label.
  * - `MULTILINE_TEXT`  — multi-line `TextInput`.
- * - `DATE`            — single-line `TextInput` with `YYYY-MM-DD` placeholder.
+ * - `DATE`            — native date picker (iOS inline / Android dialog).
  * - `NUMBER`/`AMOUNT` — numeric keyboard, strips non-numeric chars on input.
  * - `OPTION`          — tap-to-open dropdown picker over `field.options`.
  *                       Falls back to a plain text input when options are
@@ -20,7 +20,7 @@
  * @see {@link file://../../lib/api/types.ts MobileCustomFieldDefinition}
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -29,7 +29,11 @@ import {
   TouchableOpacity,
   ScrollView,
   StyleSheet,
+  Platform,
 } from "react-native";
+import DateTimePicker, {
+  type DateTimePickerEvent,
+} from "@react-native-community/datetimepicker";
 import { Ionicons } from "@expo/vector-icons";
 import type { MobileCustomFieldType } from "@/lib/api";
 import { useTheme } from "@/lib/theme-context";
@@ -145,12 +149,9 @@ export function CustomFieldInput({
       );
     case "DATE":
       return (
-        <TextInput
-          style={styles.input}
+        <DateFieldInput
           value={value}
-          onChangeText={onChange}
-          placeholder="YYYY-MM-DD"
-          placeholderTextColor={colors.placeholderText}
+          onChange={onChange}
           accessibilityLabel={accessibilityLabel}
           accessibilityHint={accessibilityHint}
         />
@@ -321,6 +322,109 @@ function OptionDropdown({
   );
 }
 
+/**
+ * Native date picker for `DATE` custom fields.
+ *
+ * Closed state mirrors the `OptionDropdown` look-and-feel (same `pickerButton`
+ * style + chevron-equivalent calendar icon) so the form reads consistently.
+ * Tap reveals the platform-native picker:
+ *
+ * - iOS: inline calendar below the field. Auto-collapses on selection so the
+ *   form stays scannable; re-opening is one tap away.
+ * - Android: native modal dialog (provided by the OS), auto-closes itself.
+ *
+ * The wire format is `YYYY-MM-DD` (matches `MobileCustomFieldType.DATE`
+ * server contract — see `lib/api/types.ts`). Parsing the existing value uses
+ * local-time `Date` construction to avoid the UTC-shift footgun (e.g. a
+ * stored "2026-01-15" rendering as Jan 14 in negative-UTC timezones).
+ */
+function DateFieldInput({
+  value,
+  onChange,
+  accessibilityLabel,
+  accessibilityHint,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  accessibilityLabel: string;
+  accessibilityHint: string | undefined;
+}) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+  const [open, setOpen] = useState(false);
+
+  const dateValue = useMemo(() => {
+    if (!value) return new Date();
+    // Parse `YYYY-MM-DD` as a local date (NOT `new Date(value)`, which
+    // interprets the bare date as UTC midnight and shifts the day in
+    // negative-offset timezones).
+    const [y, m, d] = value.split("-").map(Number);
+    if (!y || !m || !d) return new Date();
+    return new Date(y, m - 1, d);
+  }, [value]);
+
+  const handleChange = (
+    event: DateTimePickerEvent,
+    selected: Date | undefined
+  ) => {
+    // Android's native dialog dismisses itself; sync our wrapper state.
+    if (Platform.OS === "android") {
+      setOpen(false);
+    }
+    if (event.type === "dismissed") {
+      return;
+    }
+    if (selected) {
+      const y = selected.getFullYear();
+      const m = String(selected.getMonth() + 1).padStart(2, "0");
+      const d = String(selected.getDate()).padStart(2, "0");
+      onChange(`${y}-${m}-${d}`);
+      // iOS inline picker stays open by default — close it on selection so
+      // the form remains scannable. Re-tapping the field re-opens it.
+      if (Platform.OS === "ios") {
+        setOpen(false);
+      }
+    }
+  };
+
+  return (
+    <View>
+      <TouchableOpacity
+        style={styles.pickerButton}
+        onPress={() => setOpen((o) => !o)}
+        accessibilityRole="button"
+        accessibilityLabel={
+          value
+            ? `${accessibilityLabel}: ${value}, tap to change`
+            : `${accessibilityLabel}, tap to choose`
+        }
+        accessibilityHint={accessibilityHint}
+        accessibilityState={{ expanded: open }}
+      >
+        <Text
+          style={value ? styles.pickerSelectedText : styles.pickerPlaceholder}
+        >
+          {value || "Select date..."}
+        </Text>
+        <Ionicons name="calendar-outline" size={18} color={colors.mutedLight} />
+      </TouchableOpacity>
+
+      {open && (
+        <View style={Platform.OS === "ios" ? styles.dateInlineWrap : undefined}>
+          <DateTimePicker
+            testID="custom-field-date-picker"
+            value={dateValue}
+            mode="date"
+            display={Platform.OS === "ios" ? "inline" : "default"}
+            onChange={handleChange}
+            accentColor={colors.primary}
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
 const useStyles = createStyles((colors, shadows) => ({
   input: {
     backgroundColor: colors.white,
@@ -415,5 +519,11 @@ const useStyles = createStyles((colors, shadows) => ({
     fontSize: fontSize.sm,
     color: colors.error,
     fontWeight: "500",
+  },
+
+  // Inline DateTimePicker (iOS) wrapper — gives the calendar room to
+  // breathe under the field button without colliding with the next field.
+  dateInlineWrap: {
+    marginTop: spacing.xs,
   },
 }));

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -150,6 +150,7 @@ export function CustomFieldInput({
     case "DATE":
       return (
         <DateFieldInput
+          fieldId={field.id}
           value={value}
           onChange={onChange}
           accessibilityLabel={accessibilityLabel}
@@ -339,11 +340,14 @@ function OptionDropdown({
  * stored "2026-01-15" rendering as Jan 14 in negative-UTC timezones).
  */
 function DateFieldInput({
+  fieldId,
   value,
   onChange,
   accessibilityLabel,
   accessibilityHint,
 }: {
+  /** customField.id — used to scope the picker's testID per field. */
+  fieldId: string;
   value: string;
   onChange: (value: string) => void;
   accessibilityLabel: string;
@@ -427,7 +431,7 @@ function DateFieldInput({
       {open && (
         <View style={Platform.OS === "ios" ? styles.dateInlineWrap : undefined}>
           <DateTimePicker
-            testID="custom-field-date-picker"
+            testID={`custom-field-date-picker-${fieldId}`}
             value={dateValue}
             mode="date"
             display={Platform.OS === "ios" ? "inline" : "default"}

--- a/apps/companion/components/asset-edit/custom-field-input.tsx
+++ b/apps/companion/components/asset-edit/custom-field-input.tsx
@@ -360,7 +360,22 @@ function DateFieldInput({
     // negative-offset timezones).
     const [y, m, d] = value.split("-").map(Number);
     if (!y || !m || !d) return new Date();
-    return new Date(y, m - 1, d);
+    // why: the truthiness check above lets through nonsense like
+    // "2026-13-99" or "2026-02-30" — JS's Date constructor silently
+    // overflows (2026-02-30 → 2026-03-02), which would render a
+    // confusing date on the picker. Construct, then verify the
+    // round-trip matches the input. If a server bug ever ships a bad
+    // YYYY-MM-DD string, this falls back to "today" instead of a
+    // silently wrong date.
+    const parsed = new Date(y, m - 1, d);
+    if (
+      parsed.getFullYear() !== y ||
+      parsed.getMonth() + 1 !== m ||
+      parsed.getDate() !== d
+    ) {
+      return new Date();
+    }
+    return parsed;
   }, [value]);
 
   const handleChange = (

--- a/apps/companion/hooks/use-edit-asset-form.ts
+++ b/apps/companion/hooks/use-edit-asset-form.ts
@@ -1,3 +1,26 @@
+/**
+ * useEditAssetForm
+ *
+ * Centralises all state and side-effects for the asset edit screen:
+ *   - Loads the existing asset (title / description / category / location /
+ *     valuation) into editable form fields.
+ *   - Loads the org's full active custom-field definitions, scoped to the
+ *     asset's category, and joins them with the asset's saved values to
+ *     produce the rendered field list (so fields the asset has never had
+ *     a value for still appear, just like on the create screen).
+ *   - Tracks the user's unsaved edits separately from the asset's saved
+ *     values so a category switch (which reloads the defs) can preserve
+ *     keystrokes for fields still in scope.
+ *   - Loads picker data (categories, locations) for the select inputs.
+ *
+ * Owned by `apps/companion/app/(tabs)/assets/edit.tsx`. The hook returns a
+ * single state-shape object (`EditAssetFormState`) instead of N tuples so
+ * the screen can spread / destructure cleanly.
+ *
+ * @see {@link file://../../app/(tabs)/assets/edit.tsx EditAssetScreen}
+ * @see {@link file://../components/asset-edit/custom-field-input.tsx CustomFieldInput}
+ */
+
 import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   api,
@@ -8,7 +31,17 @@ import {
   type MobileCustomFieldType,
 } from "@/lib/api";
 
-/** Extract a displayable string value from a custom field's stored value */
+/**
+ * Extract a displayable string value from a custom field's stored value.
+ *
+ * The webapp persists each custom field as a `{ raw, valueText }` blob
+ * whose shape depends on `customField.type`. This helper normalises it to
+ * the string form the mobile form inputs work with.
+ *
+ * @param cf  An entry from `AssetDetail.customFields`.
+ * @returns   The string the user should see in the input. Empty string
+ *            when the field has no value yet.
+ */
 function extractCustomFieldValue(cf: AssetDetail["customFields"][0]): string {
   const val = cf.value;
   if (val === null || val === undefined) return "";
@@ -32,23 +65,50 @@ function extractCustomFieldValue(cf: AssetDetail["customFields"][0]): string {
   }
 }
 
+/**
+ * Per-field state rendered by the edit form's custom-fields section.
+ *
+ * Joined from three sources in the hook:
+ *   - `id` / `name` / `type` / `helpText` / `required` / `options` come from
+ *     the org's `MobileCustomFieldDefinition` (so we know required-ness
+ *     and OPTION choices regardless of whether the asset has a saved value).
+ *   - `originalValue` is the asset's saved value at load time, used by
+ *     `useFormValidation` to detect dirty state for the unsaved-changes guard.
+ *   - `value` reflects the user's in-progress edit (falls back to
+ *     `originalValue` when the user hasn't touched the field).
+ */
 export type CustomFieldState = {
-  id: string; // customField.id
+  /** The customField (definition) id, NOT the asset's AssetCustomFieldValue id. */
+  id: string;
+  /** Human-readable label rendered above the input. */
   name: string;
+  /** Field type — drives which `CustomFieldInput` branch renders. */
   type: MobileCustomFieldType;
+  /** Optional hint shown next to the label and as `accessibilityHint`. */
   helpText: string | null;
   /** Sourced from the org's custom-field definition, not from the asset. */
   required: boolean;
   /** Allowed values for OPTION fields; null/empty for every other type. */
   options: string[] | null;
-  value: string; // string representation for editing
+  /** Current string value the user is editing. */
+  value: string;
+  /** Original saved value at load time. Used to detect dirty state. */
   originalValue: string;
 };
 
+/**
+ * The full state surface `useEditAssetForm` returns to the edit screen.
+ *
+ * Grouped by concern (loading, form fields, custom fields, picker data,
+ * submission). The screen destructures whatever it needs; nothing here is
+ * optional — every field is always present.
+ */
 export type EditAssetFormState = {
-  // Loading / error
+  /** True while the initial asset fetch is in flight. */
   isLoadingAsset: boolean;
+  /** Asset-load failure message; null on success. */
   loadError: string | null;
+  /** The asset as returned by the server. Used as the baseline for diffs. */
   originalAsset: AssetDetail | null;
 
   // Form fields
@@ -64,10 +124,15 @@ export type EditAssetFormState = {
   setValuation: (v: string) => void;
 
   // Custom fields
+  /** Derived: org defs ⨯ asset saved values ⨯ user's in-progress edits. */
   customFields: CustomFieldState[];
+  /** Update a single custom field's in-progress edit. */
   updateCustomField: (cfId: string, newValue: string) => void;
+  /** True while custom-field definitions are being fetched. */
   isCustomFieldsLoading: boolean;
+  /** Custom-fields fetch failure message; null on success. */
   customFieldsError: string | null;
+  /** Manual retry trigger for the defs fetch. */
   retryLoadCustomFields: () => void;
 
   // Picker data
@@ -81,6 +146,19 @@ export type EditAssetFormState = {
   setIsSubmitting: (v: boolean) => void;
 };
 
+/**
+ * Initialise the asset edit form.
+ *
+ * Performs three independent fetches (asset detail, categories, locations)
+ * plus a fourth that depends on the asset's category (custom-field defs).
+ * Returns a stable state-shape object the screen renders from.
+ *
+ * @param assetId The asset id from the route param. The hook is a no-op
+ *                until both this and `orgId` are defined.
+ * @param orgId   The active organisation id from `useOrg`. Must match the
+ *                org the asset belongs to (the asset endpoint enforces this).
+ * @returns       The full edit-form state surface — see {@link EditAssetFormState}.
+ */
 export function useEditAssetForm(
   assetId: string | undefined,
   orgId: string | undefined

--- a/apps/companion/hooks/use-edit-asset-form.ts
+++ b/apps/companion/hooks/use-edit-asset-form.ts
@@ -213,6 +213,16 @@ export function useEditAssetForm(
     const controller = new AbortController();
     setIsCustomFieldsLoading(true);
     setCustomFieldsError(null);
+    // why: clear the stale defs at the start of each fetch so the
+    // `customFields` useMemo briefly returns `[]` during the reload
+    // window. Without this, a category change shows fields from the
+    // OLD category until the new fetch resolves, and any keystrokes the
+    // user makes in that window are keyed by the old defs' ids and
+    // become orphaned once the new defs land. `customFieldEdits` is
+    // intentionally NOT cleared — keystrokes for fields that survive
+    // the category change (same id) should be preserved across the
+    // reload (the documented behaviour above).
+    setCustomFieldDefs([]);
     api
       .customFields(orgId, selectedCategory?.id, controller.signal)
       .then(({ data, error }) => {

--- a/apps/companion/hooks/use-edit-asset-form.ts
+++ b/apps/companion/hooks/use-edit-asset-form.ts
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   api,
   type AssetDetail,
   type Category,
   type Location,
+  type MobileCustomFieldDefinition,
   type MobileCustomFieldType,
 } from "@/lib/api";
 
@@ -36,6 +37,10 @@ export type CustomFieldState = {
   name: string;
   type: MobileCustomFieldType;
   helpText: string | null;
+  /** Sourced from the org's custom-field definition, not from the asset. */
+  required: boolean;
+  /** Allowed values for OPTION fields; null/empty for every other type. */
+  options: string[] | null;
   value: string; // string representation for editing
   originalValue: string;
 };
@@ -61,6 +66,9 @@ export type EditAssetFormState = {
   // Custom fields
   customFields: CustomFieldState[];
   updateCustomField: (cfId: string, newValue: string) => void;
+  isCustomFieldsLoading: boolean;
+  customFieldsError: string | null;
+  retryLoadCustomFields: () => void;
 
   // Picker data
   categories: Category[];
@@ -95,7 +103,29 @@ export function useEditAssetForm(
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // ── Custom fields state ───────────────────────
-  const [customFields, setCustomFields] = useState<CustomFieldState[]>([]);
+  // Org-scoped definitions (full list, filtered by selected category).
+  // Sourced from `api.customFields` — NOT from the asset, so we see fields
+  // the asset has never had a value for. Required-ness and OPTION choices
+  // live here too.
+  const [customFieldDefs, setCustomFieldDefs] = useState<
+    MobileCustomFieldDefinition[]
+  >([]);
+  const [isCustomFieldsLoading, setIsCustomFieldsLoading] = useState(false);
+  // why: surfacing the fetch failure is critical — without it the required-
+  // field client guard silently becomes a no-op on an empty defs array,
+  // letting the user submit a payload the server then rejects.
+  const [customFieldsError, setCustomFieldsError] = useState<string | null>(
+    null
+  );
+  // Manual retry trigger for the defs fetch (analogous to new.tsx).
+  const [customFieldsRetryNonce, setCustomFieldsRetryNonce] = useState(0);
+
+  // In-progress user edits keyed by customField id. Kept separately from
+  // the asset's saved values so a category change (which reloads the defs)
+  // doesn't blow away the user's unsaved typing for fields still in scope.
+  const [customFieldEdits, setCustomFieldEdits] = useState<
+    Record<string, string>
+  >({});
 
   // ── Picker data ─────────────────────────────────
   const [categories, setCategories] = useState<Category[]>([]);
@@ -137,29 +167,11 @@ export function useEditAssetForm(
           if (a.valuation != null && a.valuation > 0) {
             setValuation(String(a.valuation));
           }
-
-          // Populate custom fields
-          if (a.customFields?.length) {
-            const cfStates: CustomFieldState[] = a.customFields
-              .filter((cf) => cf.customField.active !== false)
-              .map((cf) => {
-                const rawVal = extractCustomFieldValue(cf);
-                return {
-                  id: cf.customField.id,
-                  name: cf.customField.name,
-                  // why: AssetDetail's response shape declares `type: string`
-                  // (kept loose to match the API contract verbatim). At this
-                  // narrow construction point we know the server only emits
-                  // valid MobileCustomFieldType identifiers, so we narrow
-                  // here once and downstream code stays type-safe.
-                  type: cf.customField.type as MobileCustomFieldType,
-                  helpText: cf.customField.helpText,
-                  value: rawVal,
-                  originalValue: rawVal,
-                };
-              });
-            setCustomFields(cfStates);
-          }
+          // why: custom-field state is now derived from `customFieldDefs`
+          // (the org's full active set, filtered by the asset's category)
+          // joined with the asset's saved values. Population happens in the
+          // `customFields` useMemo below — not here — so that fields the
+          // asset has never had a value for still render on the form.
         }
       })
       .catch(() => {
@@ -192,12 +204,75 @@ export function useEditAssetForm(
     loadLocations();
   }, [loadCategories, loadLocations]);
 
+  // ── Load custom field definitions ───────────────
+  // Mirrors `new.tsx` so the edit screen sees the full set of applicable
+  // org custom fields (not just those the asset has a saved value for),
+  // and so `required` / `options` come straight from the server contract.
+  useEffect(() => {
+    if (!orgId) return;
+    const controller = new AbortController();
+    setIsCustomFieldsLoading(true);
+    setCustomFieldsError(null);
+    api
+      .customFields(orgId, selectedCategory?.id, controller.signal)
+      .then(({ data, error }) => {
+        if (controller.signal.aborted) return;
+        if (error) {
+          setCustomFieldsError(error);
+          return;
+        }
+        setCustomFieldDefs(data?.customFields ?? []);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setCustomFieldsError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load custom fields. Please retry."
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setIsCustomFieldsLoading(false);
+      });
+    return () => {
+      controller.abort();
+    };
+  }, [orgId, selectedCategory?.id, customFieldsRetryNonce]);
+
+  const retryLoadCustomFields = useCallback(() => {
+    setCustomFieldsRetryNonce((n) => n + 1);
+  }, []);
+
   // ── Custom field helpers ────────────────────────
-  const updateCustomField = (cfId: string, newValue: string) => {
-    setCustomFields((prev) =>
-      prev.map((cf) => (cf.id === cfId ? { ...cf, value: newValue } : cf))
-    );
-  };
+  // Derived state: join org defs with the asset's saved values + the user's
+  // unsaved edits. Defs are the source of truth for name / type / required /
+  // options / helpText; the asset provides `originalValue` (per-field
+  // baseline used by `useFormValidation` to detect dirty state); the edits
+  // map provides the live value while the user is typing.
+  const customFields = useMemo<CustomFieldState[]>(() => {
+    if (!originalAsset) return [];
+    return customFieldDefs.map((def) => {
+      const existing = originalAsset.customFields.find(
+        (cf) => cf.customField.id === def.id
+      );
+      const originalValue = existing ? extractCustomFieldValue(existing) : "";
+      return {
+        id: def.id,
+        name: def.name,
+        type: def.type,
+        helpText: def.helpText,
+        required: def.required,
+        options: def.options,
+        // Prefer the live edit; fall back to the asset's saved value.
+        value: customFieldEdits[def.id] ?? originalValue,
+        originalValue,
+      };
+    });
+  }, [customFieldDefs, customFieldEdits, originalAsset]);
+
+  const updateCustomField = useCallback((cfId: string, newValue: string) => {
+    setCustomFieldEdits((prev) => ({ ...prev, [cfId]: newValue }));
+  }, []);
 
   return {
     isLoadingAsset,
@@ -215,6 +290,9 @@ export function useEditAssetForm(
     setValuation,
     customFields,
     updateCustomField,
+    isCustomFieldsLoading,
+    customFieldsError,
+    retryLoadCustomFields,
     categories,
     locations,
     isCategoriesLoading,

--- a/apps/companion/package.json
+++ b/apps/companion/package.json
@@ -23,6 +23,7 @@
     "@expo/ngrok": "^4.1.3",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "^3.0.1",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: ^3.0.1
         version: 3.0.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
+      '@react-native-community/datetimepicker':
+        specifier: 8.4.4
+        version: 8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
       '@react-native-community/netinfo':
         specifier: 11.4.1
         version: 11.4.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))
@@ -3778,6 +3781,19 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  '@react-native-community/datetimepicker@8.4.4':
+    resolution: {integrity: sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==}
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native-community/netinfo@11.4.1':
     resolution: {integrity: sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==}
@@ -13794,6 +13810,14 @@ snapshots:
       idb: 8.0.3
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0)
+
+  '@react-native-community/datetimepicker@8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0)
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(graphql@16.13.2)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
 
   '@react-native-community/netinfo@11.4.1(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))':
     dependencies:


### PR DESCRIPTION
## TL;DR

Three custom-field UX bugs caught while dogfooding TestFlight build #4 on a real phone:

1. **`DATE` custom fields had no picker.** User had to hand-type `YYYY-MM-DD`. Now uses a native picker (`@react-native-community/datetimepicker` 8.4.4 — the SDK-54-compatible version).
2. **Edit screen hid fields the asset had never had a value for.** If an org had 5 custom fields but the asset only had 2 filled in, only those 2 rendered. Now fetches the full org defs and joins with the asset's saved values, so the edit form shows the same fields the create form does.
3. **Edit screen had no required marker and no submit guard.** User couldn't tell which fields the server would reject. Added the same `*` marker `new.tsx` uses on the Title field, plus a pre-submit alert that names the missing required fields.

All three reproduce on a real iPhone in build #4. Screenshot of the offending edit screen: only "Purchase date" and "Internal ID" visible, no `*` on Purchase date, plain-text input for the date.

---

## Need

For App Store launch, the custom-fields surface needs to be at least as usable as it is on the webapp. Today it isn't — three independent gaps are obvious within 30 seconds of dogfooding:

- iOS users expect a native date picker for date fields. Hand-typing `YYYY-MM-DD` is a fail.
- The edit screen quietly omits fields the user just filled in on create, which makes "edit my mistake" impossible without going to the webapp.
- Required fields are silent on edit — the user has no idea what the server will reject, and the request will fail server-side instead of failing fast in the UI.

These are not 1.1 polish; they're "the app is broken" feedback.

---

## What changes

### 1. Native date picker for `DATE` custom fields

`apps/companion/components/asset-edit/custom-field-input.tsx`

- Adds `DateFieldInput` component using `@react-native-community/datetimepicker`.
- Closed state mirrors the existing `OptionDropdown` look (same `pickerButton` style + calendar icon) so the form reads consistently.
- iOS: inline calendar below the field, auto-collapses on selection so the form stays scannable.
- Android: native modal dialog (provided by the OS), auto-closes itself.
- Wire format unchanged — still `YYYY-MM-DD`, matches `MobileCustomFieldType.DATE` server contract (`lib/api/types.ts:414`).
- Local-time `Date` construction in the parser to avoid the negative-UTC day-shift footgun (`new Date("2026-01-15")` parses as UTC midnight → renders as Jan 14 in `UTC-05:00` etc.).

### 2. Complete custom-field list on edit

`apps/companion/hooks/use-edit-asset-form.ts`

- Now fetches `api.customFields(orgId, categoryId)` — the same call `new.tsx` uses — and uses the defs as the source of truth for `name` / `type` / `required` / `options` / `helpText`.
- `customFields` becomes derived state (`useMemo`) joining: org defs ⨯ asset's saved values ⨯ user's in-progress edits.
- Re-fetches when the asset's category changes (mirrors `new.tsx`).
- User's typed values are preserved across category switches for fields still in scope (kept separately as `customFieldEdits`, not stomped on each defs refresh).
- `CustomFieldState` gains `required: boolean` and `options: string[] | null` — both already on `MobileCustomFieldDefinition`.

### 3. Required marker + client-side submit guard

`apps/companion/app/(tabs)/assets/edit.tsx`

- Required fields now show a red `*` (same `styles.required` already used on the Title field — no new styling primitives).
- Submit blocks with an alert naming the missing required fields if any are empty, mirroring `new.tsx`'s pattern.
- Loading / error UI for the defs fetch (same loading/retry treatment `new.tsx` uses), so a transient network failure surfaces a "Retry" affordance instead of silently rendering an empty section.

---

## Code corroboration

| Claim | File / line |
|---|---|
| `CustomFieldInput` is shared between create and edit screens | `custom-field-input.tsx:5-8` JSDoc |
| `MobileCustomFieldDefinition` carries `required` + `options` from the server | `lib/api/types.ts:474-481` |
| `api.customFields(orgId, categoryId)` is the canonical defs fetch | `lib/api/asset-mutations.ts:44` |
| `new.tsx` already does the defs fetch + required-check + retry UI | `app/(tabs)/assets/new.tsx:155-193`, `386-401` |
| `DATE` wire format is `YYYY-MM-DD` string | `lib/api/types.ts:414` |

---

## Impact analysis — codebase

| Surface | Affected? | Reasoning |
|---|---|---|
| Create screen (`new.tsx`) | Indirectly improved | Same `CustomFieldInput` component, so the date picker fix also lands here. No prop changes — `new.tsx`'s `customFieldDefs` already has `required` + `options`. |
| Edit screen (`edit.tsx`) | Yes — visible fix + new submit guard | Required marker + missing-required Alert + loading/error state for defs fetch. |
| Shared `CustomFieldInput` | One new branch component (`DateFieldInput`), all other branches unchanged | DATE was a `TextInput`; now delegates to `DateFieldInput`. |
| `useEditAssetForm` hook | `customFields` shape extended with `required` + `options`; populated via defs fetch + memo | The hook's existing public surface (`customFields[]` + `updateCustomField`) is preserved — `useFormValidation` keeps working because it only reads `value` / `originalValue`. |
| Server contract | Unchanged | DATE wire format identical (`YYYY-MM-DD`). No new endpoint, no new payload key. |
| Native iOS build | Yes — new native dep | `@react-native-community/datetimepicker` 8.4.4 (SDK-54-compatible). Requires a fresh EAS build to pick up. |
| Native Android build | Yes — same dep | Picks up via Expo's autolinking, no manual config plugin. |
| Webapp | No | Mobile-only change. |
| Tests | None broken | No unit/E2E tests existed against the previous date-text-input behaviour. |

`tsc --noEmit` on the companion package reports zero errors from any of the three touched files (a handful of unrelated pre-existing errors persist in tabs/scanner/audit screens — out of scope).

---

## Why this is one PR, not three

All three fixes are the same surface area (custom-fields UX on edit), share the same review context (one reviewer mental model), and one of them (defs-fetch refactor) is a prerequisite for the required-marker work. Splitting would mean three CTO review rounds for one user complaint.

---

## Risk

- **iOS date picker:** Apple's `UIDatePicker` `inline` mode is iOS 14+. Companion's `Info.plist` deployment target is iOS 15.1, so we're fine.
- **Android date picker:** Native dialog is on every Android version we support. Auto-closes on selection — confirmed against `@react-native-community/datetimepicker` 8.4.4 docs.
- **Defs fetch failure on edit:** Same retry treatment as `new.tsx`, plus we block submit if defs failed to load (so a transient network hiccup doesn't silently let the user save without seeing required fields).
- **Day-shift bug from naive `new Date(value)`:** Explicitly avoided in the parser — local-time `Date(y, m-1, d)` construction.
- **Reversibility:** 100%. Revert the commit, rebuild, ship.

---

## Test plan

- [x] `pnpm --filter @shelf/companion exec tsc --noEmit` → zero errors from touched files.
- [ ] On a fresh EAS build (build #5), create an asset with a date custom field → picker appears → pick date → value saves.
- [ ] On the same asset, edit → picker appears with the saved date pre-selected → change → save.
- [ ] On an asset in a workspace with a required custom field that was created BEFORE the field was made required → edit screen shows the required marker and blocks save until the field is filled in.
- [ ] Switch the asset's category to one with a different custom-field set → custom fields list refreshes, user's typed values are preserved for fields still in scope.
- [ ] Toggle airplane mode mid-edit → defs fetch fails → "Retry" affordance appears → toggle airplane mode off → tap Retry → fields load.

---

## Out of scope

- Migrating `new.tsx`'s `customFieldDefs` / `customFieldValues` pair to the same derived-state pattern. The pattern is now consistent enough between the two screens that a follow-up unification PR is doable, but not required.
- Inline error display on individual fields (we surface required-failures via Alert, matching `new.tsx`).
- Bulk-edit custom fields. Separate feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native date pickers for date fields (iOS inline, Android modal) with an always-visible Clear-date control; dates saved as YYYY‑MM‑DD.
  * Custom Fields UI now shows loading, error (with Retry) and editable states; required fields show an asterisk.

* **Improvements**
  * Form tracks custom-field loading/error state with manual retry; Save is blocked while fields fail/load or required fields are blank.
  * Custom-field inputs normalize values: empty → cleared, numeric inputs parsed or sent as null.

* **Bug Fixes**
  * Date parsing/formatting corrected to avoid UTC day shifts.

* **Chores**
  * Added native datetime picker dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2537)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->