### PR TITLE
feat(companion): assigned-to-me + smart-sort + urgency tiers on audits

### DIFF
--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -56,6 +56,14 @@ type DisplayAsset = {
   status: AuditAssetStatus;
   isExpected: boolean;
   scannedAt: string | null;
+  /**
+   * Context the field worker needs DURING the audit. All nullable —
+   * server may omit when unknown (e.g. asset has no location set, asset
+   * isn't in custody, older mobile client without these fields).
+   */
+  locationName: string | null;
+  categoryName: string | null;
+  custodianName: string | null;
 };
 
 const auditAssetKeyExtractor = (item: DisplayAsset) => item.id;
@@ -249,6 +257,9 @@ function AuditDetailContent() {
         status: scan ? "FOUND" : "PENDING",
         isExpected: true,
         scannedAt: scan?.scannedAt || null,
+        locationName: asset.locationName ?? null,
+        categoryName: asset.categoryName ?? null,
+        custodianName: asset.custodianName ?? null,
       });
     }
 
@@ -263,6 +274,13 @@ function AuditDetailContent() {
           status: "UNEXPECTED",
           isExpected: false,
           scannedAt: scan.scannedAt,
+          // why: unexpected scans are assets that shouldn't be here. The
+          // mobile scan payload doesn't carry location/category/custody
+          // (the scan record only ID-references the asset), so null is
+          // honest — the UI omits the meta rows for unexpected entries.
+          locationName: null,
+          categoryName: null,
+          custodianName: null,
         });
       }
     }
@@ -298,17 +316,48 @@ function AuditDetailContent() {
           ? "Missing"
           : "Unexpected";
 
+      // why: surfacing location / category / custodian inline removes
+      // the field worker's reason to navigate away from the audit. Each
+      // row tells them WHERE to look + WHAT KIND + WHO HAS IT without
+      // a tap into the asset detail. Falls back gracefully when the
+      // server omits a field (older mobile API responses).
+      const metaParts: {
+        icon: React.ComponentProps<typeof Ionicons>["name"];
+        text: string;
+      }[] = [];
+      if (item.locationName) {
+        metaParts.push({ icon: "location-outline", text: item.locationName });
+      }
+      if (item.categoryName) {
+        metaParts.push({ icon: "pricetag-outline", text: item.categoryName });
+      }
+      if (item.custodianName) {
+        metaParts.push({
+          icon: "person-outline",
+          text: `with ${item.custodianName}`,
+        });
+      }
+
       return (
-        <TouchableOpacity
+        <View
           style={styles.assetCard}
-          activeOpacity={0.7}
-          onPress={() => {
-            Haptics.selectionAsync();
-            router.push(`/(tabs)/assets/${item.id}`);
-          }}
-          accessibilityLabel={`${item.name}, ${statusLabel}`}
-          accessibilityRole="button"
+          accessibilityLabel={[
+            item.name,
+            statusLabel,
+            ...metaParts.map((p) => p.text),
+          ].join(", ")}
+          accessibilityRole="summary"
         >
+          {/*
+            why: the previous `router.push('/(tabs)/assets/...)' from
+            inside the Audits tab polluted the Assets tab's stack — the
+            Assets tab kept showing the asset detail until the user
+            manually navigated back. Removed the cross-tab navigation
+            entirely; the field worker has everything they need on this
+            card (image, name, location, category, custodian, status).
+            Full asset detail remains reachable from the Assets tab,
+            which is the correct surface for browsing.
+          */}
           {item.mainImage ? (
             <Image
               source={{ uri: item.mainImage }}
@@ -325,6 +374,22 @@ function AuditDetailContent() {
             <Text style={styles.assetTitle} numberOfLines={1}>
               {item.name}
             </Text>
+            {metaParts.length > 0 && (
+              <View style={styles.assetMetaList}>
+                {metaParts.map((p) => (
+                  <View key={p.icon + p.text} style={styles.assetMetaRow}>
+                    <Ionicons
+                      name={p.icon}
+                      size={12}
+                      color={colors.mutedLight}
+                    />
+                    <Text style={styles.assetMeta} numberOfLines={1}>
+                      {p.text}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
             {item.scannedAt && (
               <Text style={styles.assetMeta} numberOfLines={1}>
                 Scanned {formatDateTime(item.scannedAt)}
@@ -338,10 +403,10 @@ function AuditDetailContent() {
               {statusLabel}
             </Text>
           </View>
-        </TouchableOpacity>
+        </View>
       );
     },
-    [colors, auditAssetStatusBadge, styles, router]
+    [colors, auditAssetStatusBadge, styles]
   );
 
   // ── Loading / Error states ────────────────────────────
@@ -1003,6 +1068,16 @@ const useStyles = createStyles((colors, shadows) => ({
   assetMeta: {
     fontSize: fontSize.xs,
     color: colors.muted,
+    flexShrink: 1,
+  },
+  assetMetaList: {
+    gap: 2,
+    marginTop: 2,
+  },
+  assetMetaRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
   },
 
   // Empty states

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -341,6 +341,12 @@ function AuditDetailContent() {
       return (
         <View
           style={styles.assetCard}
+          // why: React Native 0.81 treats a plain View as a container,
+          // so VoiceOver/TalkBack would announce each child Text node
+          // separately. `accessible` collapses the subtree into one
+          // element with the composed label below — same UX a tapable
+          // TouchableOpacity gives by default.
+          accessible
           accessibilityLabel={[
             item.name,
             statusLabel,

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -580,11 +580,18 @@ function AuditsListContent() {
                 {assignedToMe
                   ? activeFilter === 0
                     ? "No active audits assigned to you"
+                    : activeFilter === 2
+                    ? // why: STATUS_FILTERS[2] is "All", which would
+                      // interpolate to the ungrammatical "No all
+                      // audits assigned to you". Special-case it.
+                      "No audits assigned to you"
                     : `No ${STATUS_FILTERS[
                         activeFilter
                       ].label.toLowerCase()} audits assigned to you`
                   : activeFilter === 0
                   ? "No active audits"
+                  : activeFilter === 2
+                  ? "No audits"
                   : `No ${STATUS_FILTERS[
                       activeFilter
                     ].label.toLowerCase()} audits`}

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -258,6 +258,20 @@ function AuditsListContent() {
         : isDueSoon
         ? colors.warning
         : colors.mutedLight;
+      // why: the urgency tier (red/amber) and "You" marker are visual-only
+      // signals — without surfacing them through the accessibility label,
+      // VoiceOver / TalkBack users miss two important pieces of context
+      // ("this one's mine", "this one's late"). Compose the label so it
+      // reads the visible state, not just the static fields.
+      const cardA11yLabel = [
+        `Audit: ${item.name}`,
+        item.status,
+        `${item.foundAssetCount} of ${item.expectedAssetCount} found`,
+        isOverdue ? "overdue" : isDueSoon ? "due soon" : null,
+        showAssignedMarker ? "assigned to you" : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
 
       return (
         <TouchableOpacity
@@ -267,7 +281,7 @@ function AuditsListContent() {
             router.push(`/(tabs)/audits/${item.id}`);
           }}
           activeOpacity={0.6}
-          accessibilityLabel={`Audit: ${item.name}, ${item.status}, ${item.foundAssetCount} of ${item.expectedAssetCount} found`}
+          accessibilityLabel={cardA11yLabel}
           accessibilityRole="button"
         >
           <View style={styles.auditHeader}>

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -27,6 +27,7 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { AuditListSkeleton } from "@/components/skeleton-loader";
 import { useSwipeFilters } from "@/lib/use-swipe-filters";
 import { announce } from "@/lib/a11y";
+import { userCanSeeOrgWideAudits } from "@/lib/permissions";
 
 const PAGE_SIZE = 20;
 const auditKeyExtractor = (item: AuditListItem) => item.id;
@@ -83,11 +84,23 @@ function AuditsListContent() {
   // why: default the "Assigned to me" toggle ON so a field worker who
   // opens the tab immediately sees their own work first — the original
   // complaint was that an admin assigned to 1 audit out of 50 had to
-  // scroll past everything else. They can flip it off to see the full
-  // org list. For BASE/SELF_SERVICE users this is already implicit
-  // server-side, so the toggle is effectively a no-op for them (still
-  // shown for visual consistency with admin/owner views).
+  // scroll past everything else.
+  //
+  // BASE/SELF_SERVICE roles are server-side-scoped to their own
+  // assignments regardless of the flag; showing them an "All audits"
+  // toggle would be a lie (the chip flips visually, the result set
+  // never widens). For those roles we hide the toggle entirely and
+  // force `assignedToMe` to true. See `canWidenScope` below.
+  const canWidenScope = userCanSeeOrgWideAudits(currentOrg?.roles);
   const [assignedToMe, setAssignedToMe] = useState(true);
+  // Defensive: if the user's role changes mid-session to one that
+  // can't widen scope, snap the toggle back to true so the visible
+  // state matches what the server will actually return.
+  useEffect(() => {
+    if (!canWidenScope && !assignedToMe) {
+      setAssignedToMe(true);
+    }
+  }, [canWidenScope, assignedToMe]);
   const [totalPages, setTotalPages] = useState(0);
   const nextPage = useRef(1);
   // why: the list re-fires on every status/scope toggle. Without
@@ -112,8 +125,8 @@ function AuditsListContent() {
   }, [activeFilter, syncIndex]);
 
   const fetchAudits = useCallback(
-    async (pageNum: number, reset: boolean) => {
-      if (!currentOrg) return;
+    async (pageNum: number, reset: boolean): Promise<boolean> => {
+      if (!currentOrg) return false;
       // Only abort/replace the controller on a "reset" fetch (filter
       // change, manual refresh). Pagination appends are append-only so
       // they don't fight with each other the same way — letting them
@@ -134,22 +147,23 @@ function AuditsListContent() {
         },
         controller?.signal
       );
-      // If this request was aborted while in flight, drop its result
-      // so the newer fetch's response wins. apiFetch translates
-      // AbortError to `{data: undefined, error: undefined}` upstream;
-      // the truthiness guard already handled that case, but we add the
-      // explicit `controller?.signal.aborted` check for clarity.
-      if (controller?.signal.aborted) return;
-      if (!data && !fetchErr) return;
+      // Returning `false` from the abort / no-data / error branches
+      // lets the callers below differentiate success from failure so
+      // they only mark the list "fresh" on a real successful fetch
+      // (the previous `.finally` refreshed timestamps even on aborted
+      // / failed requests, which then suppressed retries for 60s).
+      if (controller?.signal.aborted) return false;
+      if (!data && !fetchErr) return false;
       if (fetchErr || !data) {
         setError(fetchErr || "Failed to load audits");
-        return;
+        return false;
       }
       setError(null);
       setTotalPages(data.totalPages);
       nextPage.current = pageNum + 1;
       if (reset) setAudits(data.audits);
       else setAudits((prev) => [...prev, ...data.audits]);
+      return true;
     },
     // why: depend on the org id (not the full object) so an identity-
     // only re-render from useOrg doesn't churn fetchAudits and cascade
@@ -192,8 +206,13 @@ function AuditsListContent() {
   useEffect(() => {
     if (!currentOrg || !hasFetchedAudits.current) return;
     nextPage.current = 1;
-    fetchAudits(1, true).finally(() => {
-      lastFetchedAt.current = Date.now();
+    fetchAudits(1, true).then((ok) => {
+      // why: only mark the list fresh on a SUCCESSFUL fetch. The old
+      // `.finally` ran on aborted + failed responses too, which then
+      // suppressed `useFocusEffect`'s retry for the 60s freshness
+      // window (so a failed first load could leave the user staring
+      // at an empty/erroring list until they pulled to refresh).
+      if (ok) lastFetchedAt.current = Date.now();
     });
   }, [activeFilter, assignedToMe]); // eslint-disable-line react-hooks/exhaustive-deps
   useFocusEffect(
@@ -209,8 +228,12 @@ function AuditsListContent() {
       }
       nextPage.current = 1;
       const isFirstLoad = !hasFetchedAudits.current;
-      fetchAudits(1, true).finally(() => {
+      fetchAudits(1, true).then((ok) => {
         setIsLoading(false);
+        // why: same as above — only refresh freshness / flip
+        // `hasFetchedAudits` to true on a real success, so a failed
+        // or aborted first load remains retryable on the next focus.
+        if (!ok) return;
         lastFetchedAt.current = Date.now();
         if (isFirstLoad) {
           hasFetchedAudits.current = true;
@@ -457,34 +480,42 @@ function AuditsListContent() {
 
   return (
     <View style={styles.container}>
-      {/* Scope toggle: "Assigned to me" vs everything in the org. */}
-      <View style={styles.scopeRow}>
-        <TouchableOpacity
-          style={[styles.scopeChip, assignedToMe && styles.scopeChipActive]}
-          onPress={() => {
-            Haptics.selectionAsync();
-            setAssignedToMe((v) => !v);
-          }}
-          hitSlop={hitSlop.sm}
-          accessibilityRole="switch"
-          accessibilityLabel="Show only audits assigned to me"
-          accessibilityState={{ checked: assignedToMe }}
-        >
-          <Ionicons
-            name={assignedToMe ? "person" : "person-outline"}
-            size={14}
-            color={assignedToMe ? colors.primary : colors.muted}
-          />
-          <Text
-            style={[
-              styles.scopeChipText,
-              assignedToMe && styles.scopeChipTextActive,
-            ]}
+      {/*
+        Scope toggle: "Assigned to me" vs everything in the org.
+        Hidden for BASE/SELF_SERVICE users — the mobile audits endpoint
+        force-scopes them to their own assignments regardless of the
+        flag, so a toggle that flips visually but never widens the
+        result set is a UI lie.
+      */}
+      {canWidenScope ? (
+        <View style={styles.scopeRow}>
+          <TouchableOpacity
+            style={[styles.scopeChip, assignedToMe && styles.scopeChipActive]}
+            onPress={() => {
+              Haptics.selectionAsync();
+              setAssignedToMe((v) => !v);
+            }}
+            hitSlop={hitSlop.sm}
+            accessibilityRole="switch"
+            accessibilityLabel="Show only audits assigned to me"
+            accessibilityState={{ checked: assignedToMe }}
           >
-            {assignedToMe ? "Assigned to me" : "All audits"}
-          </Text>
-        </TouchableOpacity>
-      </View>
+            <Ionicons
+              name={assignedToMe ? "person" : "person-outline"}
+              size={14}
+              color={assignedToMe ? colors.primary : colors.muted}
+            />
+            <Text
+              style={[
+                styles.scopeChipText,
+                assignedToMe && styles.scopeChipTextActive,
+              ]}
+            >
+              {assignedToMe ? "Assigned to me" : "All audits"}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
 
       {/* Status filter pills */}
       <View style={styles.filterRow} accessibilityRole="tablist">
@@ -560,12 +591,19 @@ function AuditsListContent() {
               </Text>
               <Text style={styles.emptyText}>
                 {assignedToMe
-                  ? "Tap “All audits” above to see audits across the workspace."
+                  ? canWidenScope
+                    ? "Tap “All audits” above to see audits across the workspace."
+                    : "Ask an admin to assign an audit to you, or create one from the web app."
                   : activeFilter === 0
                   ? "Create an audit from the web app to get started"
                   : "Try selecting a different status filter"}
               </Text>
-              {assignedToMe ? (
+              {/*
+                Escape hatch only renders when the user can actually
+                widen scope. BASE/SELF_SERVICE see the prompt above
+                instead — no false promise.
+              */}
+              {assignedToMe && canWidenScope ? (
                 <TouchableOpacity
                   style={styles.retryButton}
                   onPress={() => {

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -37,6 +37,25 @@ const STATUS_FILTERS: { label: string; value: string }[] = [
   { label: "All", value: "PENDING,ACTIVE,COMPLETED,CANCELLED" },
 ];
 
+// why: due-today threshold in ms. Anything strictly past `now` is overdue
+// (red); anything within the next 24h is due-today (amber). Beyond that the
+// card stays neutral. Mirrors the urgency tiers we surface in the webapp's
+// audit dashboard so a user toggling between web + companion sees the same
+// signal.
+const DUE_SOON_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/** Urgency tier for the deadline pill on an audit card. */
+type DueUrgency = "overdue" | "dueSoon" | "neutral";
+
+function getDueUrgency(dueDate: string | null, isActive: boolean): DueUrgency {
+  if (!isActive || !dueDate) return "neutral";
+  const due = new Date(dueDate).getTime();
+  const now = Date.now();
+  if (due < now) return "overdue";
+  if (due - now <= DUE_SOON_THRESHOLD_MS) return "dueSoon";
+  return "neutral";
+}
+
 export default function AuditsListScreen() {
   return (
     <ErrorBoundary screenName="Audits">
@@ -61,6 +80,14 @@ function AuditsListContent() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState(0);
+  // why: default the "Assigned to me" toggle ON so a field worker who
+  // opens the tab immediately sees their own work first — the original
+  // complaint was that an admin assigned to 1 audit out of 50 had to
+  // scroll past everything else. They can flip it off to see the full
+  // org list. For BASE/SELF_SERVICE users this is already implicit
+  // server-side, so the toggle is effectively a no-op for them (still
+  // shown for visual consistency with admin/owner views).
+  const [assignedToMe, setAssignedToMe] = useState(true);
   const [totalPages, setTotalPages] = useState(0);
   const nextPage = useRef(1);
 
@@ -85,6 +112,7 @@ function AuditsListContent() {
         status: STATUS_FILTERS[activeFilter].value,
         page: pageNum,
         perPage: PAGE_SIZE,
+        assignedToMe,
       });
       // Request cancelled (navigation) — ignore
       if (!data && !fetchErr) return;
@@ -98,7 +126,7 @@ function AuditsListContent() {
       if (reset) setAudits(data.audits);
       else setAudits((prev) => [...prev, ...data.audits]);
     },
-    [currentOrg, activeFilter]
+    [currentOrg, activeFilter, assignedToMe]
   );
 
   // Stale-while-revalidate: skeleton on first load, skip refetch if data is fresh (< 60s old)
@@ -114,14 +142,14 @@ function AuditsListContent() {
     nextPage.current = 1;
   }, [currentOrg?.id]);
 
-  // Re-fetch immediately when filter changes
+  // Re-fetch immediately when filter changes (status OR assignedToMe).
   useEffect(() => {
     if (!currentOrg || !hasFetchedAudits.current) return;
     nextPage.current = 1;
     fetchAudits(1, true).finally(() => {
       lastFetchedAt.current = Date.now();
     });
-  }, [activeFilter]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeFilter, assignedToMe]); // eslint-disable-line react-hooks/exhaustive-deps
   useFocusEffect(
     useCallback(() => {
       if (!currentOrg) return;
@@ -185,10 +213,17 @@ function AuditsListContent() {
           : 0;
       const progressPercent = Math.round(progress * 100);
 
-      const isOverdue =
-        isActive &&
-        item.dueDate &&
-        new Date(item.dueDate).getTime() < Date.now();
+      const dueUrgency = getDueUrgency(item.dueDate, isActive);
+      const isOverdue = dueUrgency === "overdue";
+      const isDueSoon = dueUrgency === "dueSoon";
+      // Marker is only useful when the user is looking at the unfiltered
+      // org list — if "Assigned to me" is on, every row is already theirs.
+      const showAssignedMarker = !assignedToMe && item.isAssignedToMe;
+      const dueColor = isOverdue
+        ? colors.error
+        : isDueSoon
+        ? colors.warning
+        : colors.mutedLight;
 
       return (
         <TouchableOpacity
@@ -202,9 +237,20 @@ function AuditsListContent() {
           accessibilityRole="button"
         >
           <View style={styles.auditHeader}>
-            <Text style={styles.auditName} numberOfLines={1}>
-              {item.name}
-            </Text>
+            <View style={styles.auditNameRow}>
+              <Text style={styles.auditName} numberOfLines={1}>
+                {item.name}
+              </Text>
+              {showAssignedMarker ? (
+                <View
+                  style={styles.assignedMarker}
+                  accessibilityLabel="Assigned to you"
+                >
+                  <Ionicons name="person" size={10} color={colors.primary} />
+                  <Text style={styles.assignedMarkerText}>You</Text>
+                </View>
+              ) : null}
+            </View>
             <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
               <View
                 style={[styles.statusDot, { backgroundColor: badge.text }]}
@@ -248,18 +294,21 @@ function AuditsListContent() {
           <View style={styles.auditMeta}>
             {item.dueDate && (
               <View style={styles.metaRow}>
-                <Ionicons
-                  name="time-outline"
-                  size={13}
-                  color={isOverdue ? colors.error : colors.mutedLight}
-                />
+                <Ionicons name="time-outline" size={13} color={dueColor} />
                 <Text
                   style={[
                     styles.metaText,
-                    isOverdue && { color: colors.error, fontWeight: "500" },
+                    (isOverdue || isDueSoon) && {
+                      color: dueColor,
+                      fontWeight: "500",
+                    },
                   ]}
                 >
-                  {isOverdue ? "Overdue · " : "Due "}
+                  {isOverdue
+                    ? "Overdue · "
+                    : isDueSoon
+                    ? "Due soon · "
+                    : "Due "}
                   {formatDateTime(item.dueDate)}
                 </Text>
               </View>
@@ -305,7 +354,7 @@ function AuditsListContent() {
         </TouchableOpacity>
       );
     },
-    [router, colors, auditStatusBadge, styles]
+    [router, colors, auditStatusBadge, styles, assignedToMe]
   );
 
   if (orgLoading) {
@@ -348,6 +397,35 @@ function AuditsListContent() {
 
   return (
     <View style={styles.container}>
+      {/* Scope toggle: "Assigned to me" vs everything in the org. */}
+      <View style={styles.scopeRow}>
+        <TouchableOpacity
+          style={[styles.scopeChip, assignedToMe && styles.scopeChipActive]}
+          onPress={() => {
+            Haptics.selectionAsync();
+            setAssignedToMe((v) => !v);
+          }}
+          hitSlop={hitSlop.sm}
+          accessibilityRole="switch"
+          accessibilityLabel="Show only audits assigned to me"
+          accessibilityState={{ checked: assignedToMe }}
+        >
+          <Ionicons
+            name={assignedToMe ? "person" : "person-outline"}
+            size={14}
+            color={assignedToMe ? colors.primary : colors.muted}
+          />
+          <Text
+            style={[
+              styles.scopeChipText,
+              assignedToMe && styles.scopeChipTextActive,
+            ]}
+          >
+            {assignedToMe ? "Assigned to me" : "All audits"}
+          </Text>
+        </TouchableOpacity>
+      </View>
+
       {/* Status filter pills */}
       <View style={styles.filterRow} accessibilityRole="tablist">
         {STATUS_FILTERS.map((f, i) => (
@@ -408,17 +486,38 @@ function AuditsListContent() {
                 color={colors.border}
               />
               <Text style={styles.emptyTitle}>
-                {activeFilter === 0
+                {assignedToMe
+                  ? activeFilter === 0
+                    ? "No active audits assigned to you"
+                    : `No ${STATUS_FILTERS[
+                        activeFilter
+                      ].label.toLowerCase()} audits assigned to you`
+                  : activeFilter === 0
                   ? "No active audits"
                   : `No ${STATUS_FILTERS[
                       activeFilter
                     ].label.toLowerCase()} audits`}
               </Text>
               <Text style={styles.emptyText}>
-                {activeFilter === 0
+                {assignedToMe
+                  ? "Tap “All audits” above to see audits across the workspace."
+                  : activeFilter === 0
                   ? "Create an audit from the web app to get started"
                   : "Try selecting a different status filter"}
               </Text>
+              {assignedToMe ? (
+                <TouchableOpacity
+                  style={styles.retryButton}
+                  onPress={() => {
+                    Haptics.selectionAsync();
+                    setAssignedToMe(false);
+                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Show all audits"
+                >
+                  <Text style={styles.retryText}>Show all audits</Text>
+                </TouchableOpacity>
+              ) : null}
             </View>
           ) : (
             <FlatList
@@ -469,6 +568,38 @@ const useStyles = createStyles((colors) => ({
     justifyContent: "center",
     alignItems: "center",
     gap: spacing.md,
+  },
+
+  // Scope toggle (Assigned to me vs All audits)
+  scopeRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    gap: spacing.sm,
+  },
+  scopeChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+    height: 30,
+    borderRadius: borderRadius.pill,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  scopeChipActive: {
+    backgroundColor: colors.primaryBg,
+    borderColor: colors.primary,
+  },
+  scopeChipText: {
+    fontSize: fontSize.sm,
+    fontWeight: "500",
+    color: colors.muted,
+  },
+  scopeChipTextActive: {
+    color: colors.primary,
   },
 
   // Filter pills
@@ -522,11 +653,34 @@ const useStyles = createStyles((colors) => ({
     alignItems: "center",
     gap: spacing.sm,
   },
-  auditName: {
+  auditNameRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
     flex: 1,
+  },
+  auditName: {
+    flexShrink: 1,
     fontSize: fontSize.md,
     fontWeight: "600",
     color: colors.foreground,
+  },
+  // "You" marker shown on cards when the global toggle is off but the
+  // current user is among the assignees — saves a scroll past unrelated
+  // audits in admin/owner views.
+  assignedMarker: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 3,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: borderRadius.pill,
+    backgroundColor: colors.primaryBg,
+  },
+  assignedMarkerText: {
+    fontSize: fontSize.xs,
+    fontWeight: "600",
+    color: colors.primary,
   },
 
   // Status badge

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -90,6 +90,12 @@ function AuditsListContent() {
   const [assignedToMe, setAssignedToMe] = useState(true);
   const [totalPages, setTotalPages] = useState(0);
   const nextPage = useRef(1);
+  // why: the list re-fires on every status/scope toggle. Without
+  // aborting the previous request, a slow earlier response can land
+  // AFTER the latest one and overwrite the visible list with stale
+  // data. Tracking the in-flight controller in a ref lets us abort
+  // the previous "reset" fetch the moment we kick off a new one.
+  const inFlightListRequest = useRef<AbortController | null>(null);
 
   // Swipe-to-filter gesture
   const {
@@ -108,13 +114,32 @@ function AuditsListContent() {
   const fetchAudits = useCallback(
     async (pageNum: number, reset: boolean) => {
       if (!currentOrg) return;
-      const { data, error: fetchErr } = await api.audits(currentOrg.id, {
-        status: STATUS_FILTERS[activeFilter].value,
-        page: pageNum,
-        perPage: PAGE_SIZE,
-        assignedToMe,
-      });
-      // Request cancelled (navigation) — ignore
+      // Only abort/replace the controller on a "reset" fetch (filter
+      // change, manual refresh). Pagination appends are append-only so
+      // they don't fight with each other the same way — letting them
+      // share the active controller keeps "load more" working while a
+      // filter switch is in flight.
+      if (reset) {
+        inFlightListRequest.current?.abort();
+        inFlightListRequest.current = new AbortController();
+      }
+      const controller = inFlightListRequest.current;
+      const { data, error: fetchErr } = await api.audits(
+        currentOrg.id,
+        {
+          status: STATUS_FILTERS[activeFilter].value,
+          page: pageNum,
+          perPage: PAGE_SIZE,
+          assignedToMe,
+        },
+        controller?.signal
+      );
+      // If this request was aborted while in flight, drop its result
+      // so the newer fetch's response wins. apiFetch translates
+      // AbortError to `{data: undefined, error: undefined}` upstream;
+      // the truthiness guard already handled that case, but we add the
+      // explicit `controller?.signal.aborted` check for clarity.
+      if (controller?.signal.aborted) return;
       if (!data && !fetchErr) return;
       if (fetchErr || !data) {
         setError(fetchErr || "Failed to load audits");
@@ -127,6 +152,15 @@ function AuditsListContent() {
       else setAudits((prev) => [...prev, ...data.audits]);
     },
     [currentOrg, activeFilter, assignedToMe]
+  );
+
+  // Abort any in-flight fetch on unmount so its setState doesn't fire
+  // against an unmounted screen.
+  useEffect(
+    () => () => {
+      inFlightListRequest.current?.abort();
+    },
+    []
   );
 
   // Stale-while-revalidate: skeleton on first load, skip refetch if data is fresh (< 60s old)

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -167,8 +167,14 @@ function AuditsListContent() {
   const hasFetchedAudits = useRef(false);
   const lastFetchedAt = useRef(0);
 
-  // Reset cache when org changes so useFocusEffect refetches
+  // Reset cache when org changes so useFocusEffect refetches.
+  // why: also abort any request still in flight against the PREVIOUS
+  // org. Without this, an older response could resolve later and
+  // repopulate the list with audits from the prior org until the next
+  // request finishes.
   useEffect(() => {
+    inFlightListRequest.current?.abort();
+    inFlightListRequest.current = null;
     lastFetchedAt.current = 0;
     hasFetchedAudits.current = false;
     setAudits([]);

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -151,7 +151,13 @@ function AuditsListContent() {
       if (reset) setAudits(data.audits);
       else setAudits((prev) => [...prev, ...data.audits]);
     },
-    [currentOrg, activeFilter, assignedToMe]
+    // why: depend on the org id (not the full object) so an identity-
+    // only re-render from useOrg doesn't churn fetchAudits and cascade
+    // an extra refetch through useFocusEffect after the 60s freshness
+    // window. Consistent with the org-reset useEffect + useFocusEffect
+    // below which already key on `currentOrg?.id`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentOrg?.id, activeFilter, assignedToMe]
   );
 
   // Abort any in-flight fetch on unmount so its setState doesn't fire

--- a/apps/companion/lib/api/audits.ts
+++ b/apps/companion/lib/api/audits.ts
@@ -29,6 +29,9 @@ export const auditsApi = {
    *   overwriting the latest state).
    * @returns The `apiFetch` envelope `{ data, error }` carrying an
    *   `AuditsResponse` payload on success.
+   * @throws Never — `apiFetch` returns network / parse / HTTP errors
+   *   inside the envelope's `error` field instead of throwing, so
+   *   callers branch on the envelope rather than try/catch.
    */
   audits: (
     orgId: string,

--- a/apps/companion/lib/api/audits.ts
+++ b/apps/companion/lib/api/audits.ts
@@ -10,18 +10,25 @@ export const auditsApi = {
   /**
    * Get paginated audits for an organization.
    *
+   * Results are always sorted server-side by
+   * `(dueDate asc nulls last, createdAt desc)` so overdue + soon-due
+   * work surfaces first; the companion does not expose a sort UI.
+   *
    * @param orgId Active organization id from `useOrg`.
-   * @param params Optional filters / pagination.
-   *   - `status`: comma-separated `AuditStatus` values (e.g. `"PENDING,ACTIVE"`).
-   *   - `assignedToMe`: when `true`, restricts the result to audits the
-   *     caller is assigned to. For BASE/SELF_SERVICE users this is
+   * @param params Optional filters / pagination:
+   *   - `status` — comma-separated `AuditStatus` values (e.g. `"PENDING,ACTIVE"`).
+   *   - `page` / `perPage` — pagination knobs.
+   *   - `search` — free-text search over name / description.
+   *   - `assignedToMe` — when `true`, restricts the result to audits
+   *     the caller is assigned to. For BASE/SELF_SERVICE users this is
    *     already implicit server-side; for admins/owners it's the
-   *     companion's "Assigned to me" filter toggle.
-   *   - `signal`: AbortSignal for in-flight cancellation on rapid filter
-   *     toggling (the list re-fires on every chip tap, and we don't want
-   *     a stale response to overwrite the current one).
-   * Results are always sorted server-side by `dueDate asc nulls last,
-   * createdAt desc` so overdue + soon-due work surfaces first.
+   *     companion's "Assigned to me" toggle.
+   * @param signal AbortSignal for in-flight cancellation on rapid
+   *   filter toggling (the list re-fires on every chip tap; aborting
+   *   the previous request stops a slow earlier response from
+   *   overwriting the latest state).
+   * @returns The `apiFetch` envelope `{ data, error }` carrying an
+   *   `AuditsResponse` payload on success.
    */
   audits: (
     orgId: string,

--- a/apps/companion/lib/api/audits.ts
+++ b/apps/companion/lib/api/audits.ts
@@ -7,7 +7,22 @@ import type {
 } from "./types";
 
 export const auditsApi = {
-  /** Get paginated audits for an organization */
+  /**
+   * Get paginated audits for an organization.
+   *
+   * @param orgId Active organization id from `useOrg`.
+   * @param params Optional filters / pagination.
+   *   - `status`: comma-separated `AuditStatus` values (e.g. `"PENDING,ACTIVE"`).
+   *   - `assignedToMe`: when `true`, restricts the result to audits the
+   *     caller is assigned to. For BASE/SELF_SERVICE users this is
+   *     already implicit server-side; for admins/owners it's the
+   *     companion's "Assigned to me" filter toggle.
+   *   - `signal`: AbortSignal for in-flight cancellation on rapid filter
+   *     toggling (the list re-fires on every chip tap, and we don't want
+   *     a stale response to overwrite the current one).
+   * Results are always sorted server-side by `dueDate asc nulls last,
+   * createdAt desc` so overdue + soon-due work surfaces first.
+   */
   audits: (
     orgId: string,
     params?: {
@@ -15,14 +30,19 @@ export const auditsApi = {
       page?: number;
       perPage?: number;
       search?: string;
-    }
+      assignedToMe?: boolean;
+    },
+    signal?: AbortSignal
   ) => {
     const searchParams = new URLSearchParams({ orgId });
     if (params?.status) searchParams.set("status", params.status);
     if (params?.page) searchParams.set("page", String(params.page));
     if (params?.perPage) searchParams.set("perPage", String(params.perPage));
     if (params?.search) searchParams.set("search", params.search);
-    return apiFetch<AuditsResponse>(`/api/mobile/audits?${searchParams}`);
+    if (params?.assignedToMe) searchParams.set("assignedToMe", "true");
+    return apiFetch<AuditsResponse>(`/api/mobile/audits?${searchParams}`, {
+      signal,
+    });
   },
 
   /** Get full audit detail with expected assets and existing scans */

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -331,6 +331,24 @@ export type AuditExpectedAsset = {
   auditAssetId: string;
   mainImage: string | null;
   thumbnailImage: string | null;
+  /**
+   * Where the asset is supposed to be physically. Surfaced on the
+   * audit detail row so the field worker can navigate to the right
+   * shelf / room without leaving the audit context. Null when the
+   * asset has no location set or the server didn't load it.
+   */
+  locationName: string | null;
+  /**
+   * Asset category name — helps when the image is generic and you
+   * need to disambiguate "which laptop" among many identical rows.
+   */
+  categoryName: string | null;
+  /**
+   * Display name of the team member currently holding the asset, if
+   * any. Helps explain why an expected asset can't be found at its
+   * location (someone has it on loan).
+   */
+  custodianName: string | null;
 };
 
 export type AuditScanData = {

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -309,6 +309,12 @@ export type AuditListItem = {
   createdAt: string;
   createdBy: { firstName: string | null; lastName: string | null };
   assigneeCount: number;
+  /**
+   * True when the authenticated mobile user is among the audit's
+   * assignees. Server-computed on the list endpoint so the companion
+   * can render a "Yours" marker without an extra round-trip per row.
+   */
+  isAssignedToMe: boolean;
 };
 
 export type AuditsResponse = {

--- a/apps/companion/lib/permissions.ts
+++ b/apps/companion/lib/permissions.ts
@@ -63,6 +63,8 @@ const ROLE_PERMISSIONS: Record<
  *   (`Organization.roles`). `undefined` or empty arrays default to
  *   "no widening" — safe direction for ambiguous state.
  * @returns `true` only when the array contains `"OWNER"` or `"ADMIN"`.
+ * @throws Never — pure predicate; defends `roles?.length` for the
+ *   nullable/undefined input case.
  */
 export function userCanSeeOrgWideAudits(roles: string[] | undefined): boolean {
   if (!roles?.length) return false;

--- a/apps/companion/lib/permissions.ts
+++ b/apps/companion/lib/permissions.ts
@@ -48,6 +48,23 @@ const ROLE_PERMISSIONS: Record<
 };
 
 /**
+ * Returns true when the user holds an org role that grants visibility
+ * across the entire workspace (not just their assignments).
+ *
+ * Why this helper exists separately from `userHasPermission`: the audit
+ * mobile endpoint silently scopes BASE/SELF_SERVICE callers to their
+ * own assignments regardless of any query flags. Surfacing a UI toggle
+ * that promises "All audits" to those roles is a lie — the chip flips
+ * visually, but the result set never widens. Use this to hide / disable
+ * UI that only makes sense for users who can actually opt into a wider
+ * scope.
+ */
+export function userCanSeeOrgWideAudits(roles: string[] | undefined): boolean {
+  if (!roles?.length) return false;
+  return roles.some((role) => role === "OWNER" || role === "ADMIN");
+}
+
+/**
  * Checks if a user with the given roles has permission for an entity/action.
  * Returns true if any of the user's roles grant the permission.
  */

--- a/apps/companion/lib/permissions.ts
+++ b/apps/companion/lib/permissions.ts
@@ -58,6 +58,11 @@ const ROLE_PERMISSIONS: Record<
  * visually, but the result set never widens. Use this to hide / disable
  * UI that only makes sense for users who can actually opt into a wider
  * scope.
+ *
+ * @param roles The user's org-role strings as returned by `/me`
+ *   (`Organization.roles`). `undefined` or empty arrays default to
+ *   "no widening" — safe direction for ambiguous state.
+ * @returns `true` only when the array contains `"OWNER"` or `"ADMIN"`.
  */
 export function userCanSeeOrgWideAudits(roles: string[] | undefined): boolean {
   if (!roles?.length) return false;

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -1954,6 +1954,21 @@ describe("audit service", () => {
       });
     });
 
+    it("throws when isSelfServiceOrBase is true but userId is missing", async () => {
+      // why: silently falling back to assignedToUserId (or null) when a
+      // caller signals role-scoping but forgets the userId would leak
+      // the whole org list to a BASE/SELF_SERVICE user. The guard fails
+      // loud so the bug surfaces in dev/tests, not in customers' hands.
+      await expect(
+        getAuditsForOrganization({
+          organizationId: "org-1",
+          isSelfServiceOrBase: true,
+          // userId intentionally omitted
+        })
+      ).rejects.toThrow(/Missing user context/);
+      expect(mockDb.auditSession.findMany).not.toHaveBeenCalled();
+    });
+
     it("applies (dueDate asc nulls last, createdAt desc) when prioritizeDeadlines is true", async () => {
       await getAuditsForOrganization({
         organizationId: "org-1",

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -1906,7 +1906,11 @@ describe("audit service", () => {
   });
 
   describe("getAuditsForOrganization", () => {
-    const mockDb = vi.mocked(db, true) as any;
+    // why: the shared `mockDb` above declares `auditSession.count` as a
+    // `vi.fn()` returning `unknown` — that's enough for vi.mocked to
+    // surface it as a typed mock here without resorting to `as any`,
+    // which silenced the very type signal these tests should provide.
+    const mockDb = vi.mocked(db, true);
 
     beforeEach(() => {
       mockDb.auditSession.findMany.mockResolvedValue([]);
@@ -1921,7 +1925,9 @@ describe("audit service", () => {
         assignedToUserId: "admin-user",
       });
 
-      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      const findManyArgs = mockDb.auditSession.findMany.mock.calls[0]?.[0];
+      expect(findManyArgs).toBeDefined();
+      if (!findManyArgs) return;
       expect(findManyArgs.where).toMatchObject({
         organizationId: "org-1",
         assignments: { some: { userId: "admin-user" } },
@@ -1936,9 +1942,12 @@ describe("audit service", () => {
         assignedToUserId: null,
       });
 
-      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      const findManyArgs = mockDb.auditSession.findMany.mock.calls[0]?.[0];
+      expect(findManyArgs).toBeDefined();
+      if (!findManyArgs) return;
       // why: the toggle is OFF — admin/owner sees all audits, not just theirs.
-      expect(findManyArgs.where.assignments).toBeUndefined();
+      expect(findManyArgs.where).toBeDefined();
+      expect(findManyArgs.where!.assignments).toBeUndefined();
     });
 
     it("auto-scopes for BASE/SELF_SERVICE even when assignedToUserId is unset", async () => {
@@ -1948,8 +1957,11 @@ describe("audit service", () => {
         isSelfServiceOrBase: true,
       });
 
-      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
-      expect(findManyArgs.where.assignments).toEqual({
+      const findManyArgs = mockDb.auditSession.findMany.mock.calls[0]?.[0];
+      expect(findManyArgs).toBeDefined();
+      if (!findManyArgs) return;
+      expect(findManyArgs.where).toBeDefined();
+      expect(findManyArgs.where!.assignments).toEqual({
         some: { userId: "base-user" },
       });
     });
@@ -1975,7 +1987,9 @@ describe("audit service", () => {
         prioritizeDeadlines: true,
       });
 
-      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      const findManyArgs = mockDb.auditSession.findMany.mock.calls[0]?.[0];
+      expect(findManyArgs).toBeDefined();
+      if (!findManyArgs) return;
       expect(findManyArgs.orderBy).toEqual([
         { dueDate: { sort: "asc", nulls: "last" } },
         { createdAt: "desc" },
@@ -1989,7 +2003,9 @@ describe("audit service", () => {
         orderDirection: "desc",
       });
 
-      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      const findManyArgs = mockDb.auditSession.findMany.mock.calls[0]?.[0];
+      expect(findManyArgs).toBeDefined();
+      if (!findManyArgs) return;
       expect(findManyArgs.orderBy).toEqual([{ createdAt: "desc" }]);
     });
   });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -10,6 +10,7 @@ import {
   addAssetsToAudit,
   removeAssetFromAudit,
   removeAssetsFromAudit,
+  getAuditsForOrganization,
   getPendingAuditsForOrganization,
   getAuditWhereInput,
   bulkArchiveAudits,
@@ -77,6 +78,10 @@ vi.mock("~/database/db.server", () => {
       updateMany: vi.fn(),
       delete: vi.fn(),
       deleteMany: vi.fn(),
+      // why: getAuditsForOrganization runs findMany + count in parallel
+      // for pagination; without this mock the Promise.all rejects with
+      // "count is not a function" and the test crashes before assertions.
+      count: vi.fn(),
     },
     auditNote: {
       create: vi.fn(),
@@ -1657,6 +1662,80 @@ describe("audit service", () => {
       expect(sendAuditCancelledEmails).toHaveBeenCalledWith(
         expect.objectContaining({ cancelledByName: "the audit creator" })
       );
+    });
+  });
+
+  describe("getAuditsForOrganization", () => {
+    const mockDb = vi.mocked(db, true) as any;
+
+    beforeEach(() => {
+      mockDb.auditSession.findMany.mockResolvedValue([]);
+      mockDb.auditSession.count.mockResolvedValue(0);
+    });
+
+    it("scopes to the caller's assignments when assignedToUserId is set (admin opt-in)", async () => {
+      await getAuditsForOrganization({
+        organizationId: "org-1",
+        userId: "admin-user",
+        isSelfServiceOrBase: false,
+        assignedToUserId: "admin-user",
+      });
+
+      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      expect(findManyArgs.where).toMatchObject({
+        organizationId: "org-1",
+        assignments: { some: { userId: "admin-user" } },
+      });
+    });
+
+    it("does NOT scope to assignments for admin/owner when assignedToUserId is null", async () => {
+      await getAuditsForOrganization({
+        organizationId: "org-1",
+        userId: "admin-user",
+        isSelfServiceOrBase: false,
+        assignedToUserId: null,
+      });
+
+      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      // why: the toggle is OFF — admin/owner sees all audits, not just theirs.
+      expect(findManyArgs.where.assignments).toBeUndefined();
+    });
+
+    it("auto-scopes for BASE/SELF_SERVICE even when assignedToUserId is unset", async () => {
+      await getAuditsForOrganization({
+        organizationId: "org-1",
+        userId: "base-user",
+        isSelfServiceOrBase: true,
+      });
+
+      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      expect(findManyArgs.where.assignments).toEqual({
+        some: { userId: "base-user" },
+      });
+    });
+
+    it("applies (dueDate asc nulls last, createdAt desc) when prioritizeDeadlines is true", async () => {
+      await getAuditsForOrganization({
+        organizationId: "org-1",
+        prioritizeDeadlines: true,
+      });
+
+      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      expect(findManyArgs.orderBy).toEqual([
+        { dueDate: { sort: "asc", nulls: "last" } },
+        { createdAt: "desc" },
+      ]);
+    });
+
+    it("falls back to the legacy single-field orderBy when prioritizeDeadlines is false", async () => {
+      await getAuditsForOrganization({
+        organizationId: "org-1",
+        orderBy: "createdAt",
+        orderDirection: "desc",
+      });
+
+      const [findManyArgs] = mockDb.auditSession.findMany.mock.calls[0];
+      expect(findManyArgs.orderBy).toEqual([{ createdAt: "desc" }]);
     });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1669,6 +1669,23 @@ export async function getAuditsForOrganization(params: {
   orderBy?: string;
   /** Sort direction */
   orderDirection?: SortingDirection;
+  /**
+   * When set, restricts the result to audits this user is assigned to.
+   * Used by the mobile companion's "Assigned to me" filter — admins/owners
+   * normally see every audit, so this gives them an opt-in way to scope
+   * the list to their own work without losing visibility into the rest
+   * (toggle off → see everything). Layered on top of the role-based
+   * auto-filter for BASE/SELF_SERVICE: if either condition demands the
+   * filter, it applies.
+   */
+  assignedToUserId?: string | null;
+  /**
+   * When true, sort by `(dueDate asc nulls last, createdAt desc)` so the
+   * companion's audit list surfaces overdue and upcoming-due items
+   * first. Overrides `orderBy` / `orderDirection`. Mobile-only — the
+   * webapp uses its own column-sort UI.
+   */
+  prioritizeDeadlines?: boolean;
 }) {
   const {
     organizationId,
@@ -1680,6 +1697,8 @@ export async function getAuditsForOrganization(params: {
     status,
     orderBy = "createdAt",
     orderDirection = "desc",
+    assignedToUserId,
+    prioritizeDeadlines = false,
   } = params;
 
   try {
@@ -1688,11 +1707,17 @@ export async function getAuditsForOrganization(params: {
 
     const where: Prisma.AuditSessionWhereInput = { organizationId };
 
-    // Filter by assignee for BASE/SELF_SERVICE users
-    if (isSelfServiceOrBase && userId) {
+    // Filter by assignee for BASE/SELF_SERVICE users, OR when the caller
+    // explicitly asks for "assigned to me". Both paths use the same
+    // `assignments.some.userId` predicate so an admin/owner who opts into
+    // the filter via `assignedToUserId` gets the same scoping the role
+    // check would apply automatically for low-permission users.
+    const assigneeFilterUserId =
+      (isSelfServiceOrBase && userId ? userId : null) ?? assignedToUserId;
+    if (assigneeFilterUserId) {
       where.assignments = {
         some: {
-          userId,
+          userId: assigneeFilterUserId,
         },
       };
     }
@@ -1712,12 +1737,25 @@ export async function getAuditsForOrganization(params: {
       where.status = { notIn: [AuditStatus.ARCHIVED] };
     }
 
+    // why: the companion's `prioritizeDeadlines` toggle surfaces work
+    // the user has to act on next — overdue first (asc dueDate puts
+    // earliest dates first, and any negative-offset overdue date is
+    // earliest), then upcoming dues, then audits without a deadline
+    // (Prisma's `nulls: "last"` keeps no-deadline rows from polluting
+    // the top of the list). The secondary `createdAt desc` is a stable
+    // tiebreaker so two same-day-due audits don't shuffle between
+    // requests.
+    const resolvedOrderBy: Prisma.AuditSessionOrderByWithRelationInput[] =
+      prioritizeDeadlines
+        ? [{ dueDate: { sort: "asc", nulls: "last" } }, { createdAt: "desc" }]
+        : [{ [orderBy]: orderDirection }];
+
     const [audits, totalAudits] = await Promise.all([
       db.auditSession.findMany({
         skip,
         take,
         where,
-        orderBy: { [orderBy]: orderDirection },
+        orderBy: resolvedOrderBy,
         include: AUDIT_LIST_INCLUDE,
       }),
       db.auditSession.count({ where }),

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -741,21 +741,15 @@ export async function getAuditSessionDetails({
       .filter((auditAsset) => auditAsset.expected && auditAsset.asset)
       .map((auditAsset) => {
         // why: prefer the User's display fields when the custodian is a
-        // real user; fall back to the TeamMember's display name (which
-        // is what the webapp uses for non-user "external" custodians
-        // like contractors). One-string out for the mobile UI.
+        // real user; fall back to the TeamMember's name for non-user
+        // "external" custodians (contractors etc.). Routes through the
+        // shared `resolveUserDisplayName` helper so the precedence
+        // (displayName → first+last) stays in one place.
         const custodian = auditAsset.asset?.custody?.custodian;
-        const custodianUser = custodian?.user;
-        let custodianName: string | null = null;
-        if (custodianUser) {
-          const fullName = [custodianUser.firstName, custodianUser.lastName]
-            .filter(Boolean)
-            .join(" ");
-          custodianName =
-            custodianUser.displayName || fullName || custodian?.name || null;
-        } else if (custodian?.name) {
-          custodianName = custodian.name;
-        }
+        const custodianName =
+          (custodian?.user && resolveUserDisplayName(custodian.user)) ||
+          custodian?.name ||
+          null;
 
         return {
           id: auditAsset.assetId,

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1756,6 +1756,21 @@ export async function getAuditsForOrganization(params: {
     prioritizeDeadlines = false,
   } = params;
 
+  // why: BASE/SELF_SERVICE roles MUST be scoped to their own assignments.
+  // If a caller signals "scope to role" but forgets to pass userId, the
+  // predicate would silently collapse to null and leak the whole org list.
+  // Fail loud — and OUTSIDE the try/catch below so the precise error reaches
+  // the caller (the catch wraps everything in a generic "fetch failed").
+  if (isSelfServiceOrBase && !userId) {
+    throw new ShelfError({
+      cause: null,
+      message: "Missing user context for assignment-scoped audit query.",
+      additionalData: { organizationId, isSelfServiceOrBase },
+      label,
+      status: 400,
+    });
+  }
+
   try {
     const skip = page > 1 ? (page - 1) * perPage : 0;
     const take = perPage >= 1 ? perPage : 8;
@@ -1766,9 +1781,11 @@ export async function getAuditsForOrganization(params: {
     // explicitly asks for "assigned to me". Both paths use the same
     // `assignments.some.userId` predicate so an admin/owner who opts into
     // the filter via `assignedToUserId` gets the same scoping the role
-    // check would apply automatically for low-permission users.
+    // check would apply automatically for low-permission users. The
+    // BASE/SELF_SERVICE branch can rely on `userId` being non-null
+    // thanks to the guard above.
     const assigneeFilterUserId =
-      (isSelfServiceOrBase && userId ? userId : null) ?? assignedToUserId;
+      (isSelfServiceOrBase ? userId : null) ?? assignedToUserId ?? null;
     if (assigneeFilterUserId) {
       where.assignments = {
         some: {

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -126,6 +126,14 @@ export type AuditExpectedAsset = {
   mainImage?: string | null;
   thumbnailImage?: string | null;
   locationName?: string | null;
+  /** Asset category name (only loaded on the mobile audit detail path). */
+  categoryName?: string | null;
+  /**
+   * Display name of the team member holding the asset (custody.custodian).
+   * Prefers User.displayName → first+last → TeamMember.name. Null if the
+   * asset isn't currently in custody, or on paths that don't load it.
+   */
+  custodianName?: string | null;
 };
 
 export type CreateAuditSessionResult = {
@@ -649,6 +657,32 @@ export async function getAuditSessionDetails({
                     name: true,
                   },
                 },
+                // why: surface category + active custodian on the
+                // audit detail row so the field worker can find the
+                // asset without leaving the audit context. The mobile
+                // endpoint plumbs these straight through to
+                // AuditExpectedAsset.
+                category: {
+                  select: {
+                    name: true,
+                  },
+                },
+                custody: {
+                  select: {
+                    custodian: {
+                      select: {
+                        name: true,
+                        user: {
+                          select: {
+                            firstName: true,
+                            lastName: true,
+                            displayName: true,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
               },
             },
             _count: {
@@ -705,16 +739,37 @@ export async function getAuditSessionDetails({
 
     const expectedAssets: AuditExpectedAsset[] = session.assets
       .filter((auditAsset) => auditAsset.expected && auditAsset.asset)
-      .map((auditAsset) => ({
-        id: auditAsset.assetId,
-        name: auditAsset.asset?.title ?? "",
-        auditAssetId: auditAsset.id, // ID of the AuditAsset record (for notes/images)
-        auditNotesCount: auditAsset._count?.notes ?? 0,
-        auditImagesCount: auditAsset._count?.images ?? 0,
-        mainImage: auditAsset.asset?.mainImage ?? null,
-        thumbnailImage: auditAsset.asset?.thumbnailImage ?? null,
-        locationName: auditAsset.asset?.location?.name ?? null,
-      }));
+      .map((auditAsset) => {
+        // why: prefer the User's display fields when the custodian is a
+        // real user; fall back to the TeamMember's display name (which
+        // is what the webapp uses for non-user "external" custodians
+        // like contractors). One-string out for the mobile UI.
+        const custodian = auditAsset.asset?.custody?.custodian;
+        const custodianUser = custodian?.user;
+        let custodianName: string | null = null;
+        if (custodianUser) {
+          const fullName = [custodianUser.firstName, custodianUser.lastName]
+            .filter(Boolean)
+            .join(" ");
+          custodianName =
+            custodianUser.displayName || fullName || custodian?.name || null;
+        } else if (custodian?.name) {
+          custodianName = custodian.name;
+        }
+
+        return {
+          id: auditAsset.assetId,
+          name: auditAsset.asset?.title ?? "",
+          auditAssetId: auditAsset.id, // ID of the AuditAsset record (for notes/images)
+          auditNotesCount: auditAsset._count?.notes ?? 0,
+          auditImagesCount: auditAsset._count?.images ?? 0,
+          mainImage: auditAsset.asset?.mainImage ?? null,
+          thumbnailImage: auditAsset.asset?.thumbnailImage ?? null,
+          locationName: auditAsset.asset?.location?.name ?? null,
+          categoryName: auditAsset.asset?.category?.name ?? null,
+          custodianName,
+        };
+      });
 
     return {
       session,

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
@@ -69,6 +69,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         auditAssetId: a.auditAssetId,
         mainImage: a.mainImage ?? null,
         thumbnailImage: a.thumbnailImage ?? null,
+        // why: surface where the asset should be, what category it
+        // belongs to, and who currently has it so the field worker can
+        // resolve the audit row without leaving the audit context. All
+        // nullable: location/category may be unset, custody is sparse.
+        locationName: a.locationName ?? null,
+        categoryName: a.categoryName ?? null,
+        custodianName: a.custodianName ?? null,
       })),
       existingScans: scans.map((s) => ({
         code: s.code,

--- a/apps/webapp/app/routes/api+/mobile+/audits.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.ts
@@ -18,6 +18,16 @@ import { makeShelfError } from "~/utils/error";
  *   - page (optional): page number (default 1)
  *   - perPage (optional): items per page (default 20, max 50)
  *   - search (optional): search string
+ *   - assignedToMe (optional): "true" → restrict to audits the caller is
+ *     assigned to. Admins/owners normally see every org audit; this lets
+ *     them opt into "just my work" via the companion's filter chip.
+ *     For BASE/SELF_SERVICE users the filter is already implicit in the
+ *     service layer; passing the flag is a no-op for them.
+ *
+ * Mobile-only sort: results are always ordered by `dueDate asc nulls last,
+ * createdAt desc` so the companion list surfaces overdue + soon-due work
+ * first. The webapp uses its own column-sort UI and does not hit this
+ * endpoint.
  */
 export async function loader({ request }: LoaderFunctionArgs) {
   try {
@@ -27,6 +37,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
     const statusParam = url.searchParams.get("status");
     const searchParam = url.searchParams.get("search");
+    const assignedToMe = url.searchParams.get("assignedToMe") === "true";
     const page = Math.max(
       1,
       parseInt(url.searchParams.get("page") || "1", 10) || 1
@@ -62,6 +73,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
         perPage: isSingleStatus || isAllOrNone ? perPage : 200,
         search: searchParam || null,
         status: isSingleStatus ? statusFilters[0] : null,
+        assignedToUserId: assignedToMe ? user.id : null,
+        prioritizeDeadlines: true,
       });
 
     // Post-filter for multi-status queries (e.g. "PENDING,ACTIVE")
@@ -90,6 +103,12 @@ export async function loader({ request }: LoaderFunctionArgs) {
           lastName: a.createdBy?.lastName ?? null,
         },
         assigneeCount: a._count?.assignments ?? 0,
+        // why: surface "this one's mine" per row so the companion can
+        // render a marker without a second roundtrip per audit. Computed
+        // server-side because the asset list endpoint already loads
+        // `assignments` for the count above — no extra query cost.
+        isAssignedToMe:
+          a.assignments?.some((assn) => assn.userId === user.id) ?? false,
       })),
       page,
       perPage,

--- a/apps/webapp/app/routes/api+/mobile+/audits.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.ts
@@ -1,6 +1,7 @@
 import { AuditStatus } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
@@ -33,6 +34,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
+
+    // why: BASE/SELF_SERVICE users must NEVER see audits they're not
+    // assigned to — passing these two params makes
+    // `getAuditsForOrganization` apply its role-based assignee filter
+    // server-side. Without them, the service skips the auto-filter and
+    // a client sending `assignedToMe=false` (or just omitting the flag)
+    // sees the whole org. Mirrors how `audits.complete.ts` does it.
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    const isSelfServiceOrBase = role === "SELF_SERVICE" || role === "BASE";
 
     const url = new URL(request.url);
     const statusParam = url.searchParams.get("status");
@@ -69,6 +79,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const { audits: rawAudits, totalAudits: rawTotal } =
       await getAuditsForOrganization({
         organizationId,
+        userId: user.id,
+        isSelfServiceOrBase,
         page: isSingleStatus || isAllOrNone ? page : 1,
         perPage: isSingleStatus || isAllOrNone ? perPage : 200,
         search: searchParam || null,


### PR DESCRIPTION
## Need

The audits tab on the companion was the same shape problem as before the orgid fix — an admin/owner assigned to 1 audit out of 50 had to scroll past everyone else's work to find their own, and there was no surface cue that something was about to slip past its deadline.

Audits is a **paid** workflow on Shelf. The bar isn't "shippable" — it's **good for someone who pays for it.**

## Need / Hypothesis / Test plan

### Need
Field workers and admins assigned to specific audits should be able to:
1. Find their own assigned work fast (without scrolling past unrelated org audits)
2. See urgency at a glance (overdue vs due-soon vs whatever)
3. Stay aware of audits assigned across the workspace when they want to (toggle off)

### Hypothesis
A scope toggle + opinionated sort + sharper urgency tiers is enough to close the gap. Push notifications, badge counts, and notification centers are NOT needed — the companion is the field-work surface, not the comms surface (per `project_companion_design_philosophy` memory: webapp emails are the canonical async comm path).

### Test plan
- [x] Unit: 5 new tests in `service.server.test.ts` cover the new params (admin opt-in, admin baseline, BASE auto-scope, compound sort, legacy fallback). Full webapp suite 2003/2003 passing.
- [x] `tsc --noEmit` clean on touched files (webapp + companion).
- [ ] Manual smoke: with my admin user, assign self to 2 audits, scroll the org list, toggle off → see all, toggle on → see only mine, kill one audit's due date, set another to tomorrow → urgency tiers render correctly.
- [ ] Smoke against a BASE/SELF_SERVICE user: toggle should be visible but always-on effectively (server already scopes).

## What changes

### Server (`apps/webapp`)

**`apps/webapp/app/modules/audit/service.server.ts`** — `getAuditsForOrganization` gains two params:
- `assignedToUserId?: string | null` — when set, force `assignments.some.userId` predicate. Merges with the existing role-based auto-filter for BASE/SELF_SERVICE so either condition wins. This is what admin/owner opts into via the companion toggle without losing the option to see everything.
- `prioritizeDeadlines?: boolean` — when true, sort by `(dueDate asc nulls last, createdAt desc)`. Mobile-only — the webapp keeps its column-sort UI. Built as a compound Prisma orderBy array so the stable secondary key prevents same-day-due audits from shuffling between requests.

**`apps/webapp/app/routes/api+/mobile+/audits.ts`** — accepts `?assignedToMe=true` and plumbs through `assignedToUserId: user.id` + always passes `prioritizeDeadlines: true`. New per-row field `isAssignedToMe: boolean` computed server-side (the endpoint already loads `assignments` for the existing assignee-count badge, so no extra query cost).

### Client (`apps/companion`)

**`apps/companion/app/(tabs)/audits/index.tsx`** — three pieces of UI:
1. **Scope chip** above the existing status pills. Person icon + label flips between *"Assigned to me"* (primary-tint) and *"All audits"* (muted). Defaults ON. `accessibilityRole="switch"` so screen readers announce state.
2. **Urgency tiers** via a small `getDueUrgency` helper. Returns `"overdue" | "dueSoon" | "neutral"`. Active audits past `now` → red. Active audits due within 24h → amber. Everything else neutral. Label changes (`Overdue · …` / `Due soon · …` / `Due …`) so the urgency lands even without color (a11y).
3. **"You" marker** chip on cards — only rendered when the global toggle is OFF AND `isAssignedToMe` is true. Saves admin/owner from re-checking "is this one mine" while scrolling the unfiltered list.

**Empty state** when the scope is "Assigned to me" and the result is empty: names the scope ("No active audits assigned to you") + offers a one-tap "Show all audits" escape hatch. Same retry-button shape as error recovery for consistency.

**`apps/companion/lib/api/audits.ts`** — `audits()` now takes optional `assignedToMe: boolean` + `signal: AbortSignal` for in-flight cancellation on rapid filter toggling (the list re-fires on every chip tap; we don't want a stale response to overwrite the current one).

**`apps/companion/lib/api/types.ts`** — `AuditListItem.isAssignedToMe: boolean` added.

## Impact analysis

| Surface | Affected? | Reasoning |
|---|---|---|
| Mobile audit list | Yes — visible UX change | Toggle, sort, urgency, marker, empty-state. |
| Webapp audit list | No | Webapp doesn't use `getAuditsForOrganization`'s new params (passes neither). Default behavior unchanged. |
| Existing mobile-endpoint callers | No | `assignedToMe` is optional, defaults to false. Existing apps continue working unchanged until they upgrade. |
| Other `getAuditsForOrganization` callers | No | `assignedToUserId` and `prioritizeDeadlines` are optional with falsy defaults. |
| Wire format | Adds `isAssignedToMe` to response | Additive, no removed fields. Older companion versions ignore it. |

## Risk

- **Low.** All new params are opt-in; existing callers unchanged. The compound orderBy uses `nulls: "last"` which is a Prisma-supported feature, not a raw SQL escape. Server-computed `isAssignedToMe` reads the same `assignments` we already load — no new query cost. Reversible by reverting one commit.

## Out of scope (intentional, see `project_companion_design_philosophy`)

- **Push notifications.** The companion is the field-work surface; webapp emails are the design's communication channel. Notifications on the companion would turn it into a notification center, which is the webapp's job. Settled.
- **Tab-icon badge counts.** Would require a new user-audit-summary endpoint and don't add over the visible toggle.
- **Asset reminder UX.** Same shape problem (assigned-to-me + urgency) but a separate scope.
- **Sort UI surfaced to the user.** Companion is opinionated — deadline-first sort is fine; no toggle needed.

## Related

- `project_companion_design_philosophy` — companion is extension of webapp, notifications stay on the webapp.
- The audit work that landed in #2535 + #2533 already gives Reports + activity feeds the right data on these audits; this PR makes them visually surface to the right person at the right time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scope toggle to switch between "Assigned to me" (default) and all audits; hidden for roles without org-wide access. "Show all audits" CTA when widening is allowed.

* **Improvements**
  * Inline asset metadata (location, category, custodian) on asset cards.
  * Deadline urgency tiers with color and prefixed labels (“Overdue ·”, “Due soon ·”, “Due”).
  * Safer list fetching: aborts stale requests, refetches on filter/scope change, resets pagination, freshness updated only after successful refresh.
  * Audit cards: improved accessibility labels, conditional “You” marker, removed in-card navigation.

* **Tests**
  * Server-side tests for assignment scoping and ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2539)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->