### PR TITLE
fix(reports): make report drill-down filter in Advanced mode

### DIFF
--- a/apps/webapp/app/components/reports/distribution-donut.tsx
+++ b/apps/webapp/app/components/reports/distribution-donut.tsx
@@ -39,23 +39,6 @@ export interface DistributionDonutProps {
 }
 
 /**
- * Sentinel ids the distribution helpers return for entities with no value
- * in the grouped column (e.g. assets with no location, uncategorized assets).
- *
- * In Simple mode these translate to `locationId IS NULL` server-side; the
- * Advanced mode where-clause builder does not yet have an equivalent `isNull`
- * operator, so the legend item is rendered as a non-clickable label until
- * proper null-filter semantics land. Tracked as follow-up.
- *
- * @see helpers.server.ts `computeDistributionByLocation`, `computeDistributionByCategory`
- */
-const SENTINEL_IDS = new Set([
-  "without-location",
-  "uncategorized",
-  "without-custody",
-]);
-
-/**
  * Color palette for distribution charts.
  * Uses a harmonious progression from warm to cool colors.
  */
@@ -174,51 +157,48 @@ export function DistributionDonut({
 
         {/* Legend */}
         <div className="w-full space-y-1">
-          {legendItems.map((item, index) => {
-            const itemClickable = isClickable && !SENTINEL_IDS.has(item.id);
-            return (
-              <button
-                key={item.id}
-                type="button"
-                onClick={itemClickable ? () => onItemClick?.(item) : undefined}
-                disabled={!itemClickable}
-                className={tw(
-                  "-mx-2 flex w-full items-center justify-between rounded-md px-2 py-1.5",
-                  itemClickable &&
-                    "cursor-pointer transition-colors hover:bg-gray-50",
-                  !itemClickable && "cursor-default"
-                )}
-              >
-                <div className="flex min-w-0 items-center gap-2">
-                  <span
-                    className="size-2.5 shrink-0 rounded-full"
-                    style={{
-                      backgroundColor: getColorValue(
-                        DISTRIBUTION_COLORS[index % DISTRIBUTION_COLORS.length]
-                      ),
-                    }}
-                  />
-                  <span
-                    className={tw(
-                      "truncate text-sm",
-                      itemClickable ? "text-gray-900" : "text-gray-700"
-                    )}
-                    title={item.groupName}
-                  >
-                    {item.groupName}
-                  </span>
-                </div>
-                <div className="ml-2 flex shrink-0 items-center gap-2">
-                  <span className="text-sm font-semibold tabular-nums text-gray-900">
-                    {item.assetCount}
-                  </span>
-                  <span className="text-xs text-gray-500">
-                    ({item.percentage.toFixed(0)}%)
-                  </span>
-                </div>
-              </button>
-            );
-          })}
+          {legendItems.map((item, index) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onItemClick?.(item)}
+              disabled={!isClickable}
+              className={tw(
+                "-mx-2 flex w-full items-center justify-between rounded-md px-2 py-1.5",
+                isClickable &&
+                  "cursor-pointer transition-colors hover:bg-gray-50",
+                !isClickable && "cursor-default"
+              )}
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <span
+                  className="size-2.5 shrink-0 rounded-full"
+                  style={{
+                    backgroundColor: getColorValue(
+                      DISTRIBUTION_COLORS[index % DISTRIBUTION_COLORS.length]
+                    ),
+                  }}
+                />
+                <span
+                  className={tw(
+                    "truncate text-sm",
+                    isClickable ? "text-gray-900" : "text-gray-700"
+                  )}
+                  title={item.groupName}
+                >
+                  {item.groupName}
+                </span>
+              </div>
+              <div className="ml-2 flex shrink-0 items-center gap-2">
+                <span className="text-sm font-semibold tabular-nums text-gray-900">
+                  {item.assetCount}
+                </span>
+                <span className="text-xs text-gray-500">
+                  ({item.percentage.toFixed(0)}%)
+                </span>
+              </div>
+            </button>
+          ))}
 
           {/* Expand/collapse toggle */}
           {canExpand && (

--- a/apps/webapp/app/components/reports/distribution-donut.tsx
+++ b/apps/webapp/app/components/reports/distribution-donut.tsx
@@ -39,6 +39,23 @@ export interface DistributionDonutProps {
 }
 
 /**
+ * Sentinel ids the distribution helpers return for entities with no value
+ * in the grouped column (e.g. assets with no location, uncategorized assets).
+ *
+ * In Simple mode these translate to `locationId IS NULL` server-side; the
+ * Advanced mode where-clause builder does not yet have an equivalent `isNull`
+ * operator, so the legend item is rendered as a non-clickable label until
+ * proper null-filter semantics land. Tracked as follow-up.
+ *
+ * @see helpers.server.ts `computeDistributionByLocation`, `computeDistributionByCategory`
+ */
+const SENTINEL_IDS = new Set([
+  "without-location",
+  "uncategorized",
+  "without-custody",
+]);
+
+/**
  * Color palette for distribution charts.
  * Uses a harmonious progression from warm to cool colors.
  */
@@ -157,48 +174,51 @@ export function DistributionDonut({
 
         {/* Legend */}
         <div className="w-full space-y-1">
-          {legendItems.map((item, index) => (
-            <button
-              key={item.id}
-              type="button"
-              onClick={() => onItemClick?.(item)}
-              disabled={!isClickable}
-              className={tw(
-                "-mx-2 flex w-full items-center justify-between rounded-md px-2 py-1.5",
-                isClickable &&
-                  "cursor-pointer transition-colors hover:bg-gray-50",
-                !isClickable && "cursor-default"
-              )}
-            >
-              <div className="flex min-w-0 items-center gap-2">
-                <span
-                  className="size-2.5 shrink-0 rounded-full"
-                  style={{
-                    backgroundColor: getColorValue(
-                      DISTRIBUTION_COLORS[index % DISTRIBUTION_COLORS.length]
-                    ),
-                  }}
-                />
-                <span
-                  className={tw(
-                    "truncate text-sm",
-                    isClickable ? "text-gray-900" : "text-gray-700"
-                  )}
-                  title={item.groupName}
-                >
-                  {item.groupName}
-                </span>
-              </div>
-              <div className="ml-2 flex shrink-0 items-center gap-2">
-                <span className="text-sm font-semibold tabular-nums text-gray-900">
-                  {item.assetCount}
-                </span>
-                <span className="text-xs text-gray-500">
-                  ({item.percentage.toFixed(0)}%)
-                </span>
-              </div>
-            </button>
-          ))}
+          {legendItems.map((item, index) => {
+            const itemClickable = isClickable && !SENTINEL_IDS.has(item.id);
+            return (
+              <button
+                key={item.id}
+                type="button"
+                onClick={itemClickable ? () => onItemClick?.(item) : undefined}
+                disabled={!itemClickable}
+                className={tw(
+                  "-mx-2 flex w-full items-center justify-between rounded-md px-2 py-1.5",
+                  itemClickable &&
+                    "cursor-pointer transition-colors hover:bg-gray-50",
+                  !itemClickable && "cursor-default"
+                )}
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <span
+                    className="size-2.5 shrink-0 rounded-full"
+                    style={{
+                      backgroundColor: getColorValue(
+                        DISTRIBUTION_COLORS[index % DISTRIBUTION_COLORS.length]
+                      ),
+                    }}
+                  />
+                  <span
+                    className={tw(
+                      "truncate text-sm",
+                      itemClickable ? "text-gray-900" : "text-gray-700"
+                    )}
+                    title={item.groupName}
+                  >
+                    {item.groupName}
+                  </span>
+                </div>
+                <div className="ml-2 flex shrink-0 items-center gap-2">
+                  <span className="text-sm font-semibold tabular-nums text-gray-900">
+                    {item.assetCount}
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    ({item.percentage.toFixed(0)}%)
+                  </span>
+                </div>
+              </button>
+            );
+          })}
 
           {/* Expand/collapse toggle */}
           {canExpand && (

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -1638,16 +1638,29 @@ interface CustodySnapshotArgs {
 export async function custodySnapshotReport(
   args: CustodySnapshotArgs
 ): Promise<ReportPayload<CustodySnapshotRow>> {
-  const { organizationId, teamMemberId, page = 1, pageSize = 50 } = args;
+  const {
+    organizationId,
+    teamMemberId,
+    locationId,
+    page = 1,
+    pageSize = 50,
+  } = args;
 
   const startTime = performance.now();
 
   try {
-    // Build where clause for custody records
+    // Build where clause for custody records. Location filtering operates on
+    // the underlying asset; the `"without-location"` sentinel mirrors the
+    // Simple-mode Assets index convention for "no location set".
+    const assetWhere: Prisma.AssetWhereInput = { organizationId };
+    if (locationId === "without-location") {
+      assetWhere.locationId = null;
+    } else if (locationId) {
+      assetWhere.locationId = locationId;
+    }
+
     const where: Prisma.CustodyWhereInput = {
-      asset: {
-        organizationId,
-      },
+      asset: assetWhere,
     };
 
     if (teamMemberId) {

--- a/apps/webapp/app/utils/cookies.server.test.ts
+++ b/apps/webapp/app/utils/cookies.server.test.ts
@@ -96,6 +96,22 @@ describe("getAdvancedFiltersFromRequest", () => {
     expect(result.redirectNeeded).toBe(true);
   });
 
+  it("drops malformed operator-form values instead of coercing them to `is:<malformed>`", async () => {
+    // Regression: a value containing `:` whose prefix isn't a valid operator
+    // (e.g. `?status=foo:AVAILABLE`) used to be silently dropped by the old
+    // validator. The normalizer must not promote it to `is:foo:AVAILABLE` —
+    // that would split downstream to operator=`is`, value=`foo` and crash the
+    // status enum cast in `parseFilters`. Caught by Codex on PR #2540.
+    const result = await getAdvancedFiltersFromRequest(
+      makeRequest("?status=foo:AVAILABLE"),
+      ORG_ID,
+      settings
+    );
+
+    expect(result.filters).toBe("");
+    expect(result.redirectNeeded).toBe(true);
+  });
+
   it("returns empty state when no URL params and no cookie", async () => {
     const result = await getAdvancedFiltersFromRequest(
       makeRequest(""),

--- a/apps/webapp/app/utils/cookies.server.test.ts
+++ b/apps/webapp/app/utils/cookies.server.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the Advanced-mode filter normalizer.
+ *
+ * Regression coverage for the report drill-down bug where bare column-filter
+ * values (e.g. `?location=<uuid>`, emitted by the Asset Distribution donut)
+ * were silently dropped instead of normalized to operator form (`is:<uuid>`),
+ * making drill-down a no-op for any workspace in Advanced mode.
+ *
+ * @see {@link file://./cookies.server.ts}
+ */
+import type { AssetIndexSettings } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+// why: cookies.server pulls in modules whose transitive imports try to
+// initialize the Prisma client at import time, which throws when no DB is
+// reachable. The function under test never touches the DB.
+vi.mock("~/database/db.server", () => ({ db: {} }));
+
+import { getAdvancedFiltersFromRequest } from "./cookies.server";
+
+const ORG_ID = "org-test";
+
+/** Minimal settings stub with the column names exercised by the tests. */
+const settings = {
+  columns: [
+    { name: "location", visible: true, position: 0 },
+    { name: "category", visible: true, position: 1 },
+    { name: "status", visible: true, position: 2 },
+  ],
+} as unknown as AssetIndexSettings;
+
+const makeRequest = (query: string) =>
+  new Request(`https://app.example.com/assets${query}`);
+
+describe("getAdvancedFiltersFromRequest", () => {
+  it("normalizes a bare column value to `is:<value>` and signals redirect", async () => {
+    const result = await getAdvancedFiltersFromRequest(
+      makeRequest("?location=loc-uuid"),
+      ORG_ID,
+      settings
+    );
+
+    expect(result.filters).toBe("location=is%3Aloc-uuid");
+    expect(result.redirectNeeded).toBe(true);
+    expect(result.serializedCookie).toBeDefined();
+  });
+
+  it("normalizes multiple bare column values (location, category, status)", async () => {
+    const result = await getAdvancedFiltersFromRequest(
+      makeRequest("?location=loc-1&category=cat-1&status=AVAILABLE"),
+      ORG_ID,
+      settings
+    );
+
+    const params = new URLSearchParams(result.filters);
+    expect(params.get("location")).toBe("is:loc-1");
+    expect(params.get("category")).toBe("is:cat-1");
+    expect(params.get("status")).toBe("is:AVAILABLE");
+    expect(result.redirectNeeded).toBe(true);
+  });
+
+  it("passes operator-prefixed values through unchanged", async () => {
+    const result = await getAdvancedFiltersFromRequest(
+      makeRequest("?status=is%3AAVAILABLE"),
+      ORG_ID,
+      settings
+    );
+
+    expect(result.filters).toBe("status=is%3AAVAILABLE");
+    expect(result.redirectNeeded).toBe(false);
+  });
+
+  it("leaves non-column params (page, search) untouched", async () => {
+    const result = await getAdvancedFiltersFromRequest(
+      makeRequest("?page=2&s=keyboard&location=loc-uuid"),
+      ORG_ID,
+      settings
+    );
+
+    const params = new URLSearchParams(result.filters);
+    expect(params.get("page")).toBe("2");
+    expect(params.get("s")).toBe("keyboard");
+    expect(params.get("location")).toBe("is:loc-uuid");
+  });
+
+  it("drops empty column values cleanly without producing `is:` (URL gets cleaned via redirect)", async () => {
+    const result = await getAdvancedFiltersFromRequest(
+      makeRequest("?location="),
+      ORG_ID,
+      settings
+    );
+
+    // The empty value is not echoed back as `is:` and not retained. The
+    // redirect fires so the browser URL no longer carries the empty filter.
+    expect(result.filters).toBe("");
+    expect(result.redirectNeeded).toBe(true);
+  });
+
+  it("returns empty state when no URL params and no cookie", async () => {
+    const result = await getAdvancedFiltersFromRequest(
+      makeRequest(""),
+      ORG_ID,
+      settings
+    );
+
+    expect(result.filters).toBe("");
+    expect(result.redirectNeeded).toBe(false);
+    expect(result.serializedCookie).toBeUndefined();
+  });
+});

--- a/apps/webapp/app/utils/cookies.server.ts
+++ b/apps/webapp/app/utils/cookies.server.ts
@@ -250,7 +250,7 @@ export async function getAdvancedFiltersFromRequest(
     const validatedParams = new URLSearchParams();
     const columnNames = (settings.columns as Column[]).map((col) => col.name);
 
-    // Validate each filter parameter
+    // Normalize each filter parameter
     new URLSearchParams(filters).forEach((value, key) => {
       // Non-column params (like page, search) pass through without validation
       if (!columnNames.includes(key as any)) {
@@ -258,9 +258,17 @@ export async function getAdvancedFiltersFromRequest(
         return;
       }
 
-      // Column filters must match advanced filter format (e.g., "is:AVAILABLE")
+      // Column filters in operator form (e.g., "is:AVAILABLE") pass through.
       if (advancedFilterFormatSchema.safeParse(value).success) {
         validatedParams.append(key, value);
+        return;
+      }
+
+      // Bare-value column filters (e.g. from report drill-down or external deep
+      // links: `?location=<uuid>`) get normalized to `is:<value>`. Silently
+      // dropping them previously broke drill-down in Advanced-mode workspaces.
+      if (value) {
+        validatedParams.append(key, `is:${value}`);
       }
     });
 
@@ -287,17 +295,20 @@ export async function getAdvancedFiltersFromRequest(
       const validatedParams = new URLSearchParams();
       const columnNames = (settings.columns as Column[]).map((col) => col.name);
 
-      // Validate each filter from cookie
+      // Normalize each filter from cookie (mirrors CASE 1; see comments above)
       new URLSearchParams(filters).forEach((value, key) => {
-        // Non-column params pass through
         if (!columnNames.includes(key as any)) {
           validatedParams.append(key, value);
           return;
         }
 
-        // Column filters must match advanced filter format
         if (advancedFilterFormatSchema.safeParse(value).success) {
           validatedParams.append(key, value);
+          return;
+        }
+
+        if (value) {
+          validatedParams.append(key, `is:${value}`);
         }
       });
 

--- a/apps/webapp/app/utils/cookies.server.ts
+++ b/apps/webapp/app/utils/cookies.server.ts
@@ -230,6 +230,12 @@ export const createAdvancedAssetFilterCookie = (orgId: string) =>
  * silently — which previously broke drill-down for Advanced-mode workspaces.
  * Non-column params (page, search, etc.) pass through unchanged.
  *
+ * Values that contain a `:` but fail operator validation are treated as
+ * **malformed operator attempts** and dropped, preserving the previous
+ * reject-unknown-operator semantics. Otherwise downstream code would split
+ * something like `?status=foo:AVAILABLE` into operator=`is`, value=`foo`
+ * and try to cast `foo` to the AssetStatus enum at query time.
+ *
  * Used by both the URL path (CASE 1) and the cookie path (CASE 2) of
  * {@link getAdvancedFiltersFromRequest}.
  */
@@ -247,7 +253,10 @@ function normalizeAdvancedFilterParams(
       normalized.append(key, value);
       return;
     }
-    if (value) {
+    // Only promote unambiguous bare values. A `:` indicates the caller meant
+    // operator form; if it didn't validate above, the operator is unknown and
+    // we keep the old "drop malformed" behavior rather than coercing it.
+    if (value && !value.includes(":")) {
       normalized.append(key, `is:${value}`);
     }
   });

--- a/apps/webapp/app/utils/cookies.server.ts
+++ b/apps/webapp/app/utils/cookies.server.ts
@@ -222,6 +222,39 @@ export const createAdvancedAssetFilterCookie = (orgId: string) =>
   });
 
 /**
+ * Normalize a filter param string for the Advanced-mode Assets index.
+ *
+ * Column filters not in operator form (e.g. `?location=<uuid>` emitted by
+ * report drill-downs or external deep links) are promoted to `is:<value>`
+ * so downstream filter parsing applies them rather than dropping them
+ * silently — which previously broke drill-down for Advanced-mode workspaces.
+ * Non-column params (page, search, etc.) pass through unchanged.
+ *
+ * Used by both the URL path (CASE 1) and the cookie path (CASE 2) of
+ * {@link getAdvancedFiltersFromRequest}.
+ */
+function normalizeAdvancedFilterParams(
+  filters: string,
+  columnNames: string[]
+): URLSearchParams {
+  const normalized = new URLSearchParams();
+  new URLSearchParams(filters).forEach((value, key) => {
+    if (!columnNames.includes(key)) {
+      normalized.append(key, value);
+      return;
+    }
+    if (advancedFilterFormatSchema.safeParse(value).success) {
+      normalized.append(key, value);
+      return;
+    }
+    if (value) {
+      normalized.append(key, `is:${value}`);
+    }
+  });
+  return normalized;
+}
+
+/**
  * Gets and validates advanced filters from request parameters
  * Ensures URL parameters match the expected advanced filter format
  * @param request - The incoming request
@@ -243,35 +276,12 @@ export async function getAdvancedFiltersFromRequest(
   const cookieHeader = request.headers.get("Cookie");
   const advancedAssetFilterCookie =
     createAdvancedAssetFilterCookie(organizationId);
+  const columnNames = (settings.columns as Column[]).map((col) => col.name);
 
   // CASE 1: URL has filters
   // Validate them, save to cookie, and return (with redirect if validation changed params)
   if (filters) {
-    const validatedParams = new URLSearchParams();
-    const columnNames = (settings.columns as Column[]).map((col) => col.name);
-
-    // Normalize each filter parameter
-    new URLSearchParams(filters).forEach((value, key) => {
-      // Non-column params (like page, search) pass through without validation
-      if (!columnNames.includes(key as any)) {
-        validatedParams.append(key, value);
-        return;
-      }
-
-      // Column filters in operator form (e.g., "is:AVAILABLE") pass through.
-      if (advancedFilterFormatSchema.safeParse(value).success) {
-        validatedParams.append(key, value);
-        return;
-      }
-
-      // Bare-value column filters (e.g. from report drill-down or external deep
-      // links: `?location=<uuid>`) get normalized to `is:<value>`. Silently
-      // dropping them previously broke drill-down in Advanced-mode workspaces.
-      if (value) {
-        validatedParams.append(key, `is:${value}`);
-      }
-    });
-
+    const validatedParams = normalizeAdvancedFilterParams(filters, columnNames);
     const validatedParamsString = validatedParams.toString();
     const cleanedFilters = cleanParamsForCookie(validatedParamsString);
 
@@ -292,26 +302,10 @@ export async function getAdvancedFiltersFromRequest(
     filters = (await advancedAssetFilterCookie.parse(cookieHeader)) || "";
 
     if (filters) {
-      const validatedParams = new URLSearchParams();
-      const columnNames = (settings.columns as Column[]).map((col) => col.name);
-
-      // Normalize each filter from cookie (mirrors CASE 1; see comments above)
-      new URLSearchParams(filters).forEach((value, key) => {
-        if (!columnNames.includes(key as any)) {
-          validatedParams.append(key, value);
-          return;
-        }
-
-        if (advancedFilterFormatSchema.safeParse(value).success) {
-          validatedParams.append(key, value);
-          return;
-        }
-
-        if (value) {
-          validatedParams.append(key, `is:${value}`);
-        }
-      });
-
+      const validatedParams = normalizeAdvancedFilterParams(
+        filters,
+        columnNames
+      );
       const validatedParamsString = validatedParams.toString();
       const cleanedFilters = cleanParamsForCookie(validatedParamsString);
 


### PR DESCRIPTION
## Need

Customer (IT supervisor at a UK org, ~5k assets / 207 locations) reported that clicking a slice on the **Asset Distribution** donut took him to the Assets index, but the list was **not filtered** to the slice he clicked. Confirmed via live reproduction on a workspace in Advanced mode: clicking "Storage Room Second Floor" emitted `/assets?location=<uuid>`, the server stripped the param via a redirect, and the user landed on the unfiltered index.

The drill-down works in Simple mode. The bug is exclusively in Advanced mode.

## Hypothesis (confirmed)

`getAdvancedFiltersFromRequest` in `apps/webapp/app/utils/cookies.server.ts` validates each column filter against `advancedFilterFormatSchema`, which requires the operator form (`is:<value>`). Bare values (the form everything historically emits — report drill-down, external deep links, hard-coded `?status=ONGOING` links) failed validation and were **silently dropped**. The loader then set `redirectNeeded = true` and redirected to a URL built from the cookie state, clobbering the user's intent. The same fix path also unblocked Custody Snapshot's `locationId` parameter, which the route was plumbing in but the helper was destructuring and ignoring.

## Changes

- **`cookies.server.ts`** — Validator now **normalizes** bare column-filter values to `is:<value>` instead of dropping them. Operator-prefixed values pass through unchanged. **Values containing `:` that fail operator validation are treated as malformed operator attempts and dropped** (preserving the pre-PR drop-on-fail semantics), so something like `?status=foo:AVAILABLE` cannot get coerced into `is:foo:AVAILABLE` and crash the downstream enum cast. The CASE 1 + CASE 2 loops share a single private `normalizeAdvancedFilterParams` helper. The redirect still fires when normalization changed the params, preserving cookie persistence and URL shareability.

- **`helpers.server.ts`** — `custodySnapshotReport` now destructures and applies `locationId`. The function's interface had been declaring the parameter and the route had been plumbing it in (from `?location=<uuid>`), but the function body silently dropped it. The `without-location` sentinel maps to `locationId IS NULL`, matching Simple-mode convention.

- **`distribution-donut.tsx`** — No defensive changes. The asset query layer (`query.server.ts:492-993`) already translates the `without-location` / `uncategorized` / `without-custody` sentinels to `IS NULL` SQL, so the donut handler's bare-value URLs flow through correctly once the normalizer prepends `is:`.

## Test plan

- [x] 7 new vitest unit tests (`cookies.server.test.ts`) covering: operator pass-through, bare promotion, multi-dim normalization (location/category/status), non-column param passthrough, empty-value handling, cookie-empty case.
- [x] All 2004 vitest tests still pass.
- [x] `pnpm webapp:typecheck` clean.
- [x] Manual repro in Advanced mode: clicking "Storage Room Second Floor" slice → URL becomes `/assets?location=is%3A<uuid>`, list filters to 1 asset, "Storage Room Second Floor" chip appears.
- [x] Manual regression in Simple mode: same click → URL `/assets?location=<uuid>` (unchanged), 1 asset, chip visible.
- [x] Sentinel drill-down in Advanced mode: clicking "No Location" → URL `/assets?location=is:without-location`, list filters to the 1 asset whose `locationId` is null. (Backend has `IS NULL` translation since before this PR; the normalizer makes the donut's bare-value URL reach it.)
- [x] Custody Snapshot manual checks:
  - `/reports/custody-snapshot` → 1 row (the asset in custody)
  - `/reports/custody-snapshot?location=<storage-room-uuid>` → 0 rows (asset is not at that location, correctly filtered)
  - `/reports/custody-snapshot?location=without-location` → 1 row (sentinel → IS NULL branch)

## Cross-report audit (separate sub-agents)

I ran a parallel audit of all 10 reports to find adjacent gaps of the same nature. Findings:

| Report | Status |
|---|---|
| Asset Distribution (this PR) | ✅ Fixed |
| Custody Snapshot (this PR) | ✅ Fixed |
| Asset Inventory, Idle Assets, Asset Activity, Asset Utilization, Booking Compliance, Top Booked Assets, Monthly Trends, Overdue Items | Navigate to detail pages (no filter params emitted) — unaffected |
| `at-risk-bookings.tsx` | Emits bare `?status=ONGOING` to `/bookings`. **Works today** because Bookings has no Advanced mode. Tracked in #2543 as a contract-inheritance constraint for any future Bookings Advanced-mode PR. |

## Follow-ups filed

- **#2543** — Bookings Advanced-mode contract inheritance. If/when Bookings grows an Advanced mode, the bare-value normalization contract must inherit; `at-risk-bookings.tsx` will otherwise break the same way.
- **#2542** — Reports capability-gap design pass. Asset Utilization bar-chart drill-down, Custody Snapshot custodian column → custodian detail, Monthly Trends month → bookings drill-down, etc. Not bugs, capability nits — needs a design decision before implementation.

## Unrelated CI noise

- **#2544** — React Doctor sticky comment misreports clean runs as "scan may have failed". The actual check is green on this PR (`100/100`); only the bot's comment is misleading. Workflow logic bug at `.github/workflows/react-doctor.yml:91`. Not blocking.

## Out of scope

- The two-mode Simple/Advanced architecture itself. The normalizer change makes the URL grammar mode-agnostic for the common case (bare equality), which is most of what's worth fixing here. A bigger UX call (kill the toggle entirely? progressive operator disclosure à la Linear/Notion?) deserves its own design conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custody snapshot reports now correctly filter assets by their assigned location, improving report accuracy.
  * Advanced filter parameters are now properly normalized and validated, with improved handling of various input formats and edge cases.

* **Tests**
  * Added comprehensive test coverage for advanced filter parameter normalization and validation logic to ensure consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2540)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->