### PR TITLE
refactor(edit-asset): match new.tsx — raw strings, server coerces (closes Donko's loop)

### DIFF
--- a/apps/companion/app/(tabs)/assets/edit.tsx
+++ b/apps/companion/app/(tabs)/assets/edit.tsx
@@ -25,7 +25,7 @@ import {
 import { useRouter, useLocalSearchParams, Stack } from "expo-router";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
-import { api, type MobileCustomFieldType } from "@/lib/api";
+import { api } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
@@ -38,55 +38,26 @@ import { CustomFieldInput } from "@/components/asset-edit/custom-field-input";
 import { ValuationField } from "@/components/asset-edit/valuation-field";
 
 /**
- * Server-accepted wire type for a single custom-field update entry's
- * `value` field. The webapp's mobile asset.update Zod schema is:
- *   `z.union([z.string(), z.number(), z.boolean(), z.null()])`
- * so this is a raw primitive, NOT `{ raw: ... }`. The previous wrapped
- * shape (which shipped before this hotfix) was rejected by Zod parse
- * for every type, surfacing as the generic "Sorry, something went
- * wrong" 500 in the companion UI.
- */
-type CustomFieldPayloadValue = string | number | boolean | null;
-
-/**
  * Build the JSON value payload for a single custom field update.
  *
- * Returns `null` for empty values so the server clears the field. For
- * NUMBER / AMOUNT, a non-numeric string parses to `null` (treated as a
- * clear) so the user can't ship a malformed number to the server.
+ * Mirrors the CREATE flow's `buildCustomFieldsPayload` in `new.tsx`:
+ * send the form's raw string for every field type, let the SERVER do
+ * the coercion. The webapp's `buildMobileCustomFieldPayload` is the
+ * single source of truth for BOOLEAN string → boolean normalization,
+ * and the downstream `buildCustomFieldValue` handles number / date
+ * parsing. Replicating coercion client-side here would duplicate that
+ * logic and drift over time (which is what the previous `{ raw: ... }`
+ * wrapper was trying to do — and got it wrong, the wrapped shape was
+ * rejected by Zod).
  *
- * Matches the mobile create endpoint's wire format (raw primitives):
- * the server's shared `buildMobileCustomFieldPayload` helper coerces
- * `"true"`/`"false"` strings on BOOLEAN fields, so we emit real
- * booleans here to keep the contract explicit.
- *
- * @param type  The field's declared type from the canonical
- *              `MobileCustomFieldType` union — narrowed so the switch
- *              is exhaustively checkable.
  * @param value The string value from the form input.
- * @returns     A `string`, `number`, `boolean`, or `null` (clear).
+ * @returns     The raw string when present, or `null` to clear the
+ *              field on the server side (matches the partial-update
+ *              contract: null = explicit clear, absence = "not
+ *              touched").
  */
-function buildCustomFieldPayloadValue(
-  type: MobileCustomFieldType,
-  value: string
-): CustomFieldPayloadValue {
-  if (!value.trim()) return null; // null to clear the field
-
-  switch (type) {
-    case "BOOLEAN":
-      return value === "true";
-    case "DATE":
-      return value;
-    case "AMOUNT":
-    case "NUMBER": {
-      const num = parseFloat(value);
-      return isNaN(num) ? null : num;
-    }
-    case "TEXT":
-    case "MULTILINE_TEXT":
-    case "OPTION":
-      return value;
-  }
+function buildCustomFieldPayloadValue(value: string): string | null {
+  return value.trim() ? value : null;
 }
 
 /**
@@ -205,7 +176,7 @@ export default function EditAssetScreen() {
       .filter((cf) => cf.value !== cf.originalValue)
       .map((cf) => ({
         id: cf.id,
-        value: buildCustomFieldPayloadValue(cf.type, cf.value),
+        value: buildCustomFieldPayloadValue(cf.value),
       }));
     if (changedCustomFields.length > 0) {
       payload.customFields = changedCustomFields;

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.update.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.update.test.ts
@@ -365,7 +365,7 @@ describe("POST /api/mobile/asset/update", () => {
       expect((result as unknown as Response).status).toBe(200);
     });
 
-    it("accepts a raw number for NUMBER / AMOUNT values", async () => {
+    it("accepts a raw STRING for NUMBER / AMOUNT values (companion sends strings; server coerces)", async () => {
       (getActiveCustomFields as any).mockResolvedValue([
         { id: "cf-qty", name: "Qty", type: "NUMBER", required: false },
       ]);
@@ -380,14 +380,14 @@ describe("POST /api/mobile/asset/update", () => {
 
       const request = createRequest({
         assetId: "asset-1",
-        customFields: [{ id: "cf-qty", value: 42 }],
+        customFields: [{ id: "cf-qty", value: "42" }],
       });
       const result = await action(createActionArgs({ request }));
 
       expect((result as unknown as Response).status).toBe(200);
     });
 
-    it("accepts a raw boolean for BOOLEAN values", async () => {
+    it("accepts a raw STRING for BOOLEAN values (server coerces 'true'/'false')", async () => {
       (getActiveCustomFields as any).mockResolvedValue([
         {
           id: "cf-warranty",
@@ -407,7 +407,7 @@ describe("POST /api/mobile/asset/update", () => {
 
       const request = createRequest({
         assetId: "asset-1",
-        customFields: [{ id: "cf-warranty", value: true }],
+        customFields: [{ id: "cf-warranty", value: "true" }],
       });
       const result = await action(createActionArgs({ request }));
 


### PR DESCRIPTION
## Need

Donko on the now-merged P0 hotfix (PR #2547):
> \`buildCustomFieldPayloadValue\` is interesting, I thought we already have something that does the same.

He was right. This PR closes the loop he opened.

## What landed in #2547

The merged hotfix has \`buildCustomFieldPayloadValue\` doing typed client-side coercion (\`string | number | boolean | null\` per field type). It worked against the Zod schema and unblocked customers — but duplicated coercion logic that already lives canonically on the server, and diverged from how the CREATE flow (\`new.tsx\`) handles the same problem.

## What this PR does

Aligns EDIT to match CREATE exactly. The companion sends the form's raw string for every field type; the webapp's existing \`buildMobileCustomFieldPayload\` is the single coercion source (BOOLEAN "true"/"false" → boolean), and downstream \`buildCustomFieldValue\` handles number/date parsing.

```ts
// Before (22 lines of typed coercion):
function buildCustomFieldPayloadValue(type, value): CustomFieldPayloadValue {
  if (!value.trim()) return null;
  switch (type) {
    case "BOOLEAN":  return value === "true";
    case "DATE":     return value;
    case "AMOUNT":
    case "NUMBER":   { const num = parseFloat(value); return isNaN(num) ? null : num; }
    case "TEXT":
    case "MULTILINE_TEXT":
    case "OPTION":   return value;
  }
}

// After (3 lines, raw-string passthrough):
function buildCustomFieldPayloadValue(value: string): string | null {
  return value.trim() ? value : null;
}
```

## Customer-facing impact

**None.** This is a pure refactor — the P0 is already fixed in #2547. Both shapes (typed coercion AND raw-string passthrough) pass the server's Zod schema validation. This PR makes the codebase consistent, not the behaviour different.

## Why it matters anyway

- Single coercion source = no drift when a new custom-field type is added
- EDIT now reads like CREATE — the pattern is teachable
- 22 lines → 3 lines

## Tests

The 4 wire-contract regression tests in \`mobile.asset.update.test.ts\` already lock the contract. Updated their NUMBER and BOOLEAN cases to assert what's actually sent now (\`"42"\` / \`"true"\` strings, not coerced primitives) — same shape \`new.tsx\` has always sent.

- \`tsc --noEmit\` clean on the touched files
- \`expo lint\` clean
- Full webapp suite: 2013/2013 passing locally

## Lesson saved

The original P0 fix was correct-but-divergent because I asked "what's the right shape per the schema?" instead of "what does the working sibling do?" Saved as \`feedback_sibling_first.md\` in my memory: before designing a fix, check the working-equivalent path. If you find yourself writing a substantial typed helper to "make this work," it's probably documenting (and reinforcing) a divergence you should delete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified custom field value handling in asset editing to use basic string processing instead of type-specific conversions.

* **Tests**
  * Updated test cases to align with the simplified string-based custom field value handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2548)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->