### PR TITLE
feat: request signatures before custody assignment

### DIFF
--- a/apps/webapp/app/components/assets/bulk-assign-custody-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-assign-custody-dialog.tsx
@@ -13,6 +13,10 @@ import { Button } from "../shared/button";
 export const BulkAssignCustodySchema = z.object({
   assetIds: z.array(z.string()).min(1),
   custodian: createCustodianSchema(),
+  requireSignedCustody: z
+    .literal("on")
+    .optional()
+    .transform((value) => value === "on"),
 });
 
 export default function BulkAssignCustodyDialog() {
@@ -77,6 +81,19 @@ export default function BulkAssignCustodyDialog() {
               <p className="text-sm text-error-500">
                 {zo.errors.custodian()?.message}
               </p>
+            ) : null}
+            {!isSelfService ? (
+              <label className="mt-4 flex items-start gap-3 text-sm text-gray-700">
+                <input
+                  type="checkbox"
+                  name={zo.fields.requireSignedCustody()}
+                  className="mt-1"
+                  disabled={disabled}
+                />
+                <span>
+                  Require this custodian to sign before custody is assigned
+                </span>
+              </label>
             ) : null}
             {fetcherError ? (
               <p className="text-sm text-error-500">{fetcherError}</p>

--- a/apps/webapp/app/emails/signed-custody-request-template.tsx
+++ b/apps/webapp/app/emails/signed-custody-request-template.tsx
@@ -1,0 +1,97 @@
+import {
+  Button,
+  Container,
+  Head,
+  Html,
+  render,
+  Text,
+} from "@react-email/components";
+import { config } from "~/config/shelf.config";
+import { SUPPORT_EMAIL } from "~/utils/env";
+import { CustomEmailFooter } from "./components/custom-footer";
+import { LogoForEmail } from "./logo";
+import { styles } from "./styles";
+
+interface Props {
+  assetTitle: string;
+  organizationName: string;
+  recipientEmail: string;
+  recipientName: string;
+  signingUrl: string;
+  customEmailFooter?: string | null;
+}
+
+export function SignedCustodyRequestEmailTemplate({
+  assetTitle,
+  organizationName,
+  recipientEmail,
+  recipientName,
+  signingUrl,
+  customEmailFooter,
+}: Props) {
+  const { emailPrimaryColor } = config;
+
+  return (
+    <Html>
+      <Head>
+        <title>Signature required for custody assignment</title>
+      </Head>
+
+      <Container
+        style={{ padding: "32px 16px", maxWidth: "600px", margin: "0 auto" }}
+      >
+        <LogoForEmail />
+
+        <div style={{ paddingTop: "8px" }}>
+          <Text style={{ marginBottom: "24px", ...styles.p }}>
+            Howdy {recipientName},
+            <br />
+            <strong>{organizationName}</strong> needs your signature before{" "}
+            <strong>{assetTitle}</strong> can be assigned to your custody.
+          </Text>
+
+          <Text style={{ ...styles.p, marginBottom: "24px" }}>
+            Review the custody agreement, then type or draw your signature to
+            accept responsibility for the asset.
+          </Text>
+
+          <Button
+            href={signingUrl}
+            style={{
+              backgroundColor: emailPrimaryColor,
+              borderRadius: "6px",
+              color: "#ffffff",
+              display: "inline-block",
+              fontSize: "14px",
+              fontWeight: 600,
+              padding: "10px 16px",
+              textDecoration: "none",
+            }}
+          >
+            Review and sign
+          </Button>
+
+          <Text style={{ ...styles.p, marginTop: "24px" }}>
+            If you think this is a mistake, contact the workspace administrator
+            or Shelf support at {SUPPORT_EMAIL}.
+          </Text>
+
+          <Text style={{ marginBottom: "32px", ...styles.p }}>
+            Thanks, <br />
+            The Shelf team
+          </Text>
+
+          <CustomEmailFooter footerText={customEmailFooter} />
+
+          <Text style={{ fontSize: "14px", color: "#344054" }}>
+            This is an automatic email sent from shelf.nu to{" "}
+            <span style={{ color: emailPrimaryColor }}>{recipientEmail}</span>.
+          </Text>
+        </div>
+      </Container>
+    </Html>
+  );
+}
+
+export const signedCustodyRequestTemplateString = (props: Props) =>
+  render(<SignedCustodyRequestEmailTemplate {...props} />);

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -43,6 +43,11 @@ import {
   getCategory,
 } from "~/modules/category/service.server";
 import {
+  createSignedCustodyRequests,
+  sendSignedCustodyRequestEmails,
+  shouldRequestSignedCustody,
+} from "~/modules/custody/signed-custody.server";
+import {
   createCustomFieldsIfNotExists,
   getActiveCustomFields,
   upsertCustomField,
@@ -3670,6 +3675,7 @@ export async function bulkAssignCustody({
   organizationId,
   currentSearchParams,
   settings,
+  requireSignedCustody = false,
 }: {
   userId: User["id"];
   assetIds: Asset["id"][];
@@ -3678,6 +3684,7 @@ export async function bulkAssignCustody({
   organizationId: Asset["organizationId"];
   currentSearchParams?: string | null;
   settings: AssetIndexSettings;
+  requireSignedCustody?: boolean;
 }) {
   try {
     // Resolve IDs (works for both simple and advanced mode)
@@ -3691,37 +3698,50 @@ export async function bulkAssignCustody({
     /**
      * In order to make notes for the assets we have to make this query to get info about assets
      */
-    const [assets, user, custodianTeamMember] = await Promise.all([
-      db.asset.findMany({
-        where: {
-          id: { in: resolvedIds },
-          organizationId,
-        },
-        select: { id: true, title: true, status: true },
-      }),
-      getUserByID(userId, {
-        select: {
-          id: true,
-          firstName: true,
-          lastName: true,
-          displayName: true,
-        } satisfies Prisma.UserSelect,
-      }),
-      db.teamMember.findUnique({
-        where: { id: custodianId },
-        select: {
-          name: true,
-          user: {
-            select: {
-              id: true,
-              firstName: true,
-              lastName: true,
-              displayName: true,
+    const [assets, user, custodianTeamMember, organization] = await Promise.all(
+      [
+        db.asset.findMany({
+          where: {
+            id: { in: resolvedIds },
+            organizationId,
+          },
+          select: { id: true, title: true, status: true },
+        }),
+        getUserByID(userId, {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            displayName: true,
+          } satisfies Prisma.UserSelect,
+        }),
+        db.teamMember.findUnique({
+          where: { id: custodianId },
+          select: {
+            name: true,
+            user: {
+              select: {
+                id: true,
+                email: true,
+                firstName: true,
+                lastName: true,
+                displayName: true,
+              },
             },
           },
-        },
-      }),
-    ]);
+        }),
+        db.organization.findUniqueOrThrow({
+          where: { id: organizationId },
+          select: {
+            id: true,
+            name: true,
+            customEmailFooter: true,
+            enableSignedCustodyOnAssignment: true,
+            requireCustodySignatureOnAssignment: true,
+          },
+        }),
+      ]
+    );
 
     const assetsNotAvailable = assets.some(
       (asset) => asset.status !== "AVAILABLE"
@@ -3735,6 +3755,44 @@ export async function bulkAssignCustody({
         label: "Assets",
         shouldBeCaptured: false,
       });
+    }
+
+    if (
+      custodianTeamMember &&
+      (requireSignedCustody ||
+        shouldRequestSignedCustody({
+          organization,
+          custodianUserEmail: custodianTeamMember.user?.email,
+        })) &&
+      !!custodianTeamMember.user?.email
+    ) {
+      const signedRequests = await db.$transaction(async (tx) =>
+        createSignedCustodyRequests({
+          tx,
+          assets,
+          organizationId,
+          requestedBy: user,
+          teamMember: {
+            id: custodianId,
+            name: custodianTeamMember.name,
+            user: custodianTeamMember.user,
+          },
+        })
+      );
+
+      await sendSignedCustodyRequestEmails({
+        requests: signedRequests,
+        recipientEmail: custodianTeamMember.user!.email,
+        recipientName:
+          resolveUserDisplayName(custodianTeamMember.user) || custodianName,
+        organizationName: organization.name,
+        customEmailFooter: organization.customEmailFooter,
+      });
+
+      return {
+        assigned: 0,
+        pendingSignatureRequests: signedRequests.length,
+      };
     }
 
     /**
@@ -3801,7 +3859,10 @@ export async function bulkAssignCustody({
       );
     });
 
-    return true;
+    return {
+      assigned: assets.length,
+      pendingSignatureRequests: 0,
+    };
   } catch (cause) {
     const message =
       cause instanceof ShelfError

--- a/apps/webapp/app/modules/custody/signed-custody.server.ts
+++ b/apps/webapp/app/modules/custody/signed-custody.server.ts
@@ -1,0 +1,321 @@
+import crypto from "node:crypto";
+import { AssetStatus, SignedCustodyRequestStatus } from "@prisma/client";
+import { db } from "~/database/db.server";
+import { sendEmail } from "~/emails/mail.server";
+import { signedCustodyRequestTemplateString } from "~/emails/signed-custody-request-template";
+import { recordEvent } from "~/modules/activity-event/service.server";
+import { SERVER_URL } from "~/utils/env";
+import { ShelfError } from "~/utils/error";
+import {
+  wrapCustodianForNote,
+  wrapUserLinkForNote,
+} from "~/utils/markdoc-wrappers";
+
+type SignedCustodyRequestEmail = {
+  token: string;
+  asset: { title: string };
+};
+
+type TransactionClient = Parameters<Parameters<typeof db.$transaction>[0]>[0];
+
+export function shouldRequestSignedCustody({
+  organization,
+  custodianUserEmail,
+}: {
+  organization: {
+    enableSignedCustodyOnAssignment: boolean;
+    requireCustodySignatureOnAssignment: boolean;
+  };
+  custodianUserEmail?: string | null;
+}) {
+  return (
+    organization.enableSignedCustodyOnAssignment &&
+    organization.requireCustodySignatureOnAssignment &&
+    !!custodianUserEmail
+  );
+}
+
+export async function createSignedCustodyRequests({
+  tx,
+  assets,
+  organizationId,
+  requestedBy,
+  teamMember,
+}: {
+  tx: TransactionClient;
+  assets: { id: string; title: string }[];
+  organizationId: string;
+  requestedBy: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+  };
+  teamMember: {
+    id: string;
+    name: string;
+    user: {
+      id: string;
+      firstName: string | null;
+      lastName: string | null;
+    } | null;
+  };
+}) {
+  const assetIds = assets.map((asset) => asset.id);
+
+  await tx.signedCustodyRequest.updateMany({
+    where: {
+      assetId: { in: assetIds },
+      status: SignedCustodyRequestStatus.PENDING,
+    },
+    data: { status: SignedCustodyRequestStatus.CANCELLED },
+  });
+
+  const actor = wrapUserLinkForNote({
+    id: requestedBy.id,
+    firstName: requestedBy.firstName,
+    lastName: requestedBy.lastName,
+  });
+
+  const custodianDisplay = wrapCustodianForNote({ teamMember });
+
+  const requests = await Promise.all(
+    assets.map((asset) =>
+      tx.signedCustodyRequest.create({
+        data: {
+          token: crypto.randomBytes(32).toString("hex"),
+          organizationId,
+          assetId: asset.id,
+          teamMemberId: teamMember.id,
+          requestedById: requestedBy.id,
+        },
+        select: {
+          id: true,
+          token: true,
+          asset: { select: { title: true } },
+        },
+      })
+    )
+  );
+
+  await tx.note.createMany({
+    data: assets.map((asset) => ({
+      content: `${actor} requested a signed custody acceptance from ${custodianDisplay}.`,
+      type: "UPDATE",
+      userId: requestedBy.id,
+      assetId: asset.id,
+    })),
+  });
+
+  return requests;
+}
+
+export async function sendSignedCustodyRequestEmails({
+  requests,
+  recipientEmail,
+  recipientName,
+  organizationName,
+  customEmailFooter,
+}: {
+  requests: SignedCustodyRequestEmail[];
+  recipientEmail: string;
+  recipientName: string;
+  organizationName: string;
+  customEmailFooter?: string | null;
+}) {
+  for (const request of requests) {
+    const signingUrl = `${SERVER_URL}/custody/sign/${request.token}`;
+    const html = await signedCustodyRequestTemplateString({
+      assetTitle: request.asset.title,
+      organizationName,
+      recipientEmail,
+      recipientName,
+      signingUrl,
+      customEmailFooter,
+    });
+
+    sendEmail({
+      to: recipientEmail,
+      subject: `Signature required for ${request.asset.title} custody`,
+      text: `Howdy ${recipientName},
+
+${organizationName} needs your signature before ${
+        request.asset.title
+      } can be assigned to your custody.
+
+Review and sign the custody agreement:
+${signingUrl}
+
+Thanks,
+The Shelf team
+${customEmailFooter ? `\n---\n${customEmailFooter}` : ""}`,
+      html,
+    });
+  }
+}
+
+export async function completeSignedCustodyRequest({
+  token,
+  signerUserId,
+  signerName,
+  signatureDataUrl,
+  signerIp,
+  signerUserAgent,
+}: {
+  token: string;
+  signerUserId: string;
+  signerName: string;
+  signatureDataUrl?: string | null;
+  signerIp?: string | null;
+  signerUserAgent?: string | null;
+}) {
+  return db.$transaction(async (tx) => {
+    const request = await tx.signedCustodyRequest.findUnique({
+      where: { token },
+      include: {
+        asset: { select: { id: true, title: true, status: true } },
+        teamMember: {
+          select: {
+            id: true,
+            name: true,
+            user: {
+              select: {
+                id: true,
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+        requestedBy: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+    });
+
+    if (!request) {
+      throw new ShelfError({
+        cause: null,
+        title: "Signature request not found",
+        message: "This custody signature request could not be found.",
+        label: "Custody",
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (request.teamMember.user?.id !== signerUserId) {
+      throw new ShelfError({
+        cause: null,
+        title: "Action not allowed",
+        message:
+          "This custody signature request was sent to a different Shelf user.",
+        label: "Custody",
+        status: 403,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (request.status === SignedCustodyRequestStatus.SIGNED) {
+      return request;
+    }
+
+    if (request.status !== SignedCustodyRequestStatus.PENDING) {
+      throw new ShelfError({
+        cause: null,
+        title: "Signature request is no longer active",
+        message: "This custody signature request is no longer active.",
+        label: "Custody",
+        status: 409,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (request.asset.status !== AssetStatus.AVAILABLE) {
+      throw new ShelfError({
+        cause: null,
+        title: "Asset is no longer available",
+        message:
+          "This asset is no longer available for custody assignment. Please contact the workspace administrator.",
+        label: "Custody",
+        status: 409,
+        shouldBeCaptured: false,
+      });
+    }
+
+    await tx.custody.deleteMany({ where: { assetId: request.assetId } });
+
+    await tx.asset.update({
+      where: { id: request.assetId, organizationId: request.organizationId },
+      data: {
+        status: AssetStatus.IN_CUSTODY,
+        custody: {
+          create: {
+            custodian: { connect: { id: request.teamMemberId } },
+          },
+        },
+      },
+      select: { id: true },
+    });
+
+    const updatedRequest = await tx.signedCustodyRequest.update({
+      where: { id: request.id },
+      data: {
+        status: SignedCustodyRequestStatus.SIGNED,
+        signerName,
+        signatureDataUrl,
+        signerIp,
+        signerUserAgent,
+        signedAt: new Date(),
+      },
+      include: {
+        asset: { select: { id: true, title: true } },
+        teamMember: {
+          select: {
+            id: true,
+            name: true,
+            user: {
+              select: {
+                id: true,
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const custodianDisplay = wrapCustodianForNote({
+      teamMember: request.teamMember,
+    });
+
+    await tx.note.create({
+      data: {
+        content: `${custodianDisplay} signed the custody agreement and accepted custody.`,
+        type: "UPDATE",
+        userId: request.requestedById,
+        assetId: request.assetId,
+      },
+    });
+
+    await recordEvent(
+      {
+        organizationId: request.organizationId,
+        actorUserId: request.requestedById,
+        action: "CUSTODY_ASSIGNED",
+        entityType: "ASSET",
+        entityId: request.assetId,
+        assetId: request.assetId,
+        teamMemberId: request.teamMemberId,
+        targetUserId: request.teamMember.user?.id ?? undefined,
+      },
+      tx
+    );
+
+    return updatedRequest;
+  });
+}

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx
@@ -21,6 +21,11 @@ import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { recordEvent } from "~/modules/activity-event/service.server";
 import { getAsset } from "~/modules/asset/service.server";
 import { AssignCustodySchema } from "~/modules/custody/schema";
+import {
+  createSignedCustodyRequests,
+  sendSignedCustodyRequestEmails,
+  shouldRequestSignedCustody,
+} from "~/modules/custody/signed-custody.server";
 import { createNote } from "~/modules/note/service.server";
 import { getTeamMember } from "~/modules/team-member/service.server";
 import { getUserByID } from "~/modules/user/service.server";
@@ -45,9 +50,16 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
-import { resolveTeamMemberName } from "~/utils/user";
+import { resolveTeamMemberName, resolveUserDisplayName } from "~/utils/user";
 
 export const meta = () => [{ title: appendToMetaTitle("Assign custody") }];
+
+const AssignCustodyWithSignatureSchema = AssignCustodySchema.extend({
+  requireSignedCustody: z
+    .literal("on")
+    .optional()
+    .transform((value) => value === "on"),
+});
 
 export async function loader({ context, request, params }: LoaderFunctionArgs) {
   const authSession = context.getSession();
@@ -154,9 +166,9 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     const isSelfService = role === OrganizationRoles.SELF_SERVICE;
 
-    const { custodian } = parseData(
+    const { custodian, requireSignedCustody } = parseData(
       await request.formData(),
-      AssignCustodySchema,
+      AssignCustodyWithSignatureSchema,
       {
         additionalData: { userId, assetId },
         message: "Please select a team member",
@@ -190,6 +202,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         user: {
           select: {
             id: true,
+            email: true,
             firstName: true,
             lastName: true,
             displayName: true,
@@ -218,6 +231,88 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         additionalData: { userId, assetId, custodianId },
         label: "Assets",
       });
+    }
+
+    const organization = await db.organization.findUniqueOrThrow({
+      where: { id: organizationId },
+      select: {
+        id: true,
+        name: true,
+        customEmailFooter: true,
+        enableSignedCustodyOnAssignment: true,
+        requireCustodySignatureOnAssignment: true,
+      },
+    });
+
+    if (
+      (requireSignedCustody ||
+        shouldRequestSignedCustody({
+          organization,
+          custodianUserEmail: custodianTeamMember.user?.email,
+        })) &&
+      !!custodianTeamMember.user?.email
+    ) {
+      const signedRequests = await db
+        .$transaction(async (tx) => {
+          const asset = await tx.asset.findFirstOrThrow({
+            where: { id: assetId, organizationId },
+            select: { id: true, title: true, status: true },
+          });
+
+          if (asset.status !== AssetStatus.AVAILABLE) {
+            throw new ShelfError({
+              cause: null,
+              title: "Asset is unavailable",
+              message:
+                "This asset is no longer available for custody assignment.",
+              additionalData: { userId, assetId, custodianId },
+              label: "Assets",
+              status: 409,
+              shouldBeCaptured: false,
+            });
+          }
+
+          return createSignedCustodyRequests({
+            tx,
+            assets: [asset],
+            organizationId,
+            requestedBy: user,
+            teamMember: {
+              id: custodianId,
+              name: custodianDisplayName,
+              user: custodianTeamMember.user,
+            },
+          });
+        })
+        .catch((cause) => {
+          throw new ShelfError({
+            cause,
+            message:
+              "Something went wrong while creating the custody signature request.",
+            additionalData: { userId, assetId, custodianId },
+            label: "Assets",
+          });
+        });
+
+      await sendSignedCustodyRequestEmails({
+        requests: signedRequests,
+        recipientEmail: custodianTeamMember.user!.email,
+        recipientName:
+          resolveUserDisplayName(custodianTeamMember.user) ||
+          custodianDisplayName,
+        organizationName: organization.name,
+        customEmailFooter: organization.customEmailFooter,
+      });
+
+      sendNotification({
+        title: `Signature request sent to ${custodianDisplayName}`,
+        message:
+          "Custody will be assigned after the custodian signs the agreement.",
+        icon: { name: "success", variant: "success" },
+        senderId: userId,
+      });
+
+      return redirect(`/assets/${assetId}`);
     }
 
     /** Assign custody to an asset inside a transaction so that the
@@ -335,7 +430,7 @@ export default function Custody() {
   const actionData = useActionData<typeof action>();
   const transition = useNavigation();
   const disabled = isFormProcessing(transition.state);
-  const zo = useZorm("BulkAssignCustody", AssignCustodySchema);
+  const zo = useZorm("BulkAssignCustody", AssignCustodyWithSignatureSchema);
   const { isSelfService } = useUserRoleHelper();
   const error = zo.errors.custodian()?.message || actionData?.error?.message;
 
@@ -391,6 +486,20 @@ export default function Custody() {
           </div>
           {error ? (
             <div className="-mt-8 mb-8 text-sm text-error-500">{error}</div>
+          ) : null}
+
+          {!isSelfService ? (
+            <label className="-mt-4 mb-8 flex items-start gap-3 text-left text-sm text-gray-700">
+              <input
+                type="checkbox"
+                name={zo.fields.requireSignedCustody()}
+                className="mt-1"
+                disabled={disabled}
+              />
+              <span>
+                Require this custodian to sign before custody is assigned
+              </span>
+            </label>
           ) : null}
 
           {firstReservedBookingId ? (

--- a/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
@@ -103,7 +103,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
         : `Assets are now in custody of ${custodian.name}`,
       message: result.pendingSignatureRequests
         ? "Custody will be assigned after the custodian signs the agreement."
-        : "Remember, these assets will be unavailable until it is manually checked in.",
+        : "Remember, these assets will be unavailable until they are manually released.",
       icon: { name: "success", variant: "success" },
       senderId: userId,
     });

--- a/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
@@ -43,10 +43,11 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     const formData = await request.formData();
 
-    const { assetIds, custodian, currentSearchParams } = parseData(
-      formData,
-      BulkAssignCustodySchema.and(CurrentSearchParamsSchema)
-    );
+    const { assetIds, custodian, currentSearchParams, requireSignedCustody } =
+      parseData(
+        formData,
+        BulkAssignCustodySchema.and(CurrentSearchParamsSchema)
+      );
 
     // Validate that the custodian belongs to the same organization
     const teamMember = await getTeamMember({
@@ -85,7 +86,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
       });
     }
 
-    await bulkAssignCustody({
+    const result = (await bulkAssignCustody({
       userId,
       assetIds,
       custodianId: custodian.id,
@@ -93,12 +94,16 @@ export async function action({ context, request }: ActionFunctionArgs) {
       organizationId,
       currentSearchParams,
       settings,
-    });
+      requireSignedCustody,
+    })) ?? { assigned: assetIds.length, pendingSignatureRequests: 0 };
 
     sendNotification({
-      title: `Assets are now in custody of ${custodian.name}`,
-      message:
-        "Remember, these assets will be unavailable until it is manually checked in.",
+      title: result.pendingSignatureRequests
+        ? `Signature request sent to ${custodian.name}`
+        : `Assets are now in custody of ${custodian.name}`,
+      message: result.pendingSignatureRequests
+        ? "Custody will be assigned after the custodian signs the agreement."
+        : "Remember, these assets will be unavailable until it is manually checked in.",
       icon: { name: "success", variant: "success" },
       senderId: userId,
     });

--- a/apps/webapp/app/routes/custody+/_public+/sign.$token.tsx
+++ b/apps/webapp/app/routes/custody+/_public+/sign.$token.tsx
@@ -8,18 +8,19 @@ import {
   redirect,
   useActionData,
   useLoaderData,
-  useNavigation,
 } from "react-router";
 import { z } from "zod";
 import { ErrorContent } from "~/components/errors";
 import { Button } from "~/components/shared/button";
 import { db } from "~/database/db.server";
+import { useDisabled } from "~/hooks/use-disabled";
 import { completeSignedCustodyRequest } from "~/modules/custody/signed-custody.server";
 import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { setCookie } from "~/utils/cookies.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
+import { getValidationErrors } from "~/utils/http";
 import {
   assertIsPost,
   error,
@@ -29,10 +30,22 @@ import {
 } from "~/utils/http.server";
 
 const ParamsSchema = z.object({ token: z.string().min(1) });
+const MAX_SIGNATURE_DATA_URL_LENGTH = 250_000;
 
 const SignCustodySchema = z.object({
   signerName: z.string().trim().min(1, "Please type your name"),
-  signatureDataUrl: z.string().optional(),
+  signatureDataUrl: z.preprocess(
+    (value) =>
+      typeof value === "string" && value.trim() === "" ? undefined : value,
+    z
+      .string()
+      .max(MAX_SIGNATURE_DATA_URL_LENGTH, "Signature image is too large")
+      .regex(
+        /^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/,
+        "Signature image must be a PNG data URL"
+      )
+      .optional()
+  ),
 });
 
 export const meta = () => [
@@ -76,6 +89,10 @@ async function getSignatureRequest(token: string) {
   }
 
   return request;
+}
+
+function getTrustedSignerIp(request: Request) {
+  return request.headers.get("fly-client-ip");
 }
 
 export async function loader({ context, params, request }: LoaderFunctionArgs) {
@@ -139,7 +156,7 @@ export async function action({ context, params, request }: ActionFunctionArgs) {
       signerUserId: authSession.userId,
       signerName,
       signatureDataUrl,
-      signerIp: request.headers.get("x-forwarded-for"),
+      signerIp: getTrustedSignerIp(request),
       signerUserAgent: request.headers.get("user-agent"),
     });
 
@@ -168,8 +185,10 @@ export const ErrorBoundary = () => <ErrorContent />;
 export default function SignCustodyAgreement() {
   const { signatureRequest } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
-  const disabled = navigation.state !== "idle";
+  const disabled = useDisabled();
+  const validationErrors = getValidationErrors<typeof SignCustodySchema>(
+    actionData?.error
+  );
   const alreadySigned =
     signatureRequest.status === SignedCustodyRequestStatus.SIGNED;
 
@@ -208,9 +227,19 @@ export default function SignCustodyAgreement() {
                 placeholder={signatureRequest.teamMember.name}
                 disabled={disabled}
               />
+              {validationErrors?.signerName?.message ? (
+                <span className="text-sm font-normal text-error-600">
+                  {validationErrors.signerName.message}
+                </span>
+              ) : null}
             </label>
 
             <SignaturePad disabled={disabled} />
+            {validationErrors?.signatureDataUrl?.message ? (
+              <p className="text-sm text-error-600">
+                {validationErrors.signatureDataUrl.message}
+              </p>
+            ) : null}
 
             {actionData?.error?.message ? (
               <p className="text-sm text-error-600">

--- a/apps/webapp/app/routes/custody+/_public+/sign.$token.tsx
+++ b/apps/webapp/app/routes/custody+/_public+/sign.$token.tsx
@@ -1,3 +1,8 @@
+/**
+ * Public custody agreement signing route for pending signed custody requests.
+ *
+ * @file
+ */
 import { useEffect, useRef, useState } from "react";
 import type { PointerEvent } from "react";
 import { SignedCustodyRequestStatus } from "@prisma/client";
@@ -48,6 +53,11 @@ const SignCustodySchema = z.object({
   ),
 });
 
+/**
+ * Builds page metadata for the signed custody agreement route.
+ *
+ * @returns Route meta descriptors.
+ */
 export const meta = () => [
   { title: appendToMetaTitle("Sign custody agreement") },
 ];
@@ -95,6 +105,13 @@ function getTrustedSignerIp(request: Request) {
   return request.headers.get("fly-client-ip");
 }
 
+/**
+ * Loads a signed custody request for the authenticated assignee.
+ *
+ * @param args - Remix loader arguments including route params, request, and auth context.
+ * @returns The signature request payload or a redirect to sign in.
+ * @throws ShelfError when the token is unknown or belongs to a different Shelf user.
+ */
 export async function loader({ context, params, request }: LoaderFunctionArgs) {
   const { token } = getParams(params, ParamsSchema, {
     additionalData: { token: params.token },
@@ -128,6 +145,13 @@ export async function loader({ context, params, request }: LoaderFunctionArgs) {
   }
 }
 
+/**
+ * Completes a pending signed custody request and selects the request organization.
+ *
+ * @param args - Remix action arguments including form data and auth context.
+ * @returns A redirect to the accepted asset, or validation/error data.
+ * @throws ShelfError when request validation or completion fails.
+ */
 export async function action({ context, params, request }: ActionFunctionArgs) {
   const { token } = getParams(params, ParamsSchema, {
     additionalData: { token: params.token },
@@ -180,8 +204,18 @@ export async function action({ context, params, request }: ActionFunctionArgs) {
   }
 }
 
+/**
+ * Renders the route error UI.
+ *
+ * @returns The shared error content component.
+ */
 export const ErrorBoundary = () => <ErrorContent />;
 
+/**
+ * Renders the custody agreement review and signature form.
+ *
+ * @returns The signed custody agreement page.
+ */
 export default function SignCustodyAgreement() {
   const { signatureRequest } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
@@ -189,8 +223,8 @@ export default function SignCustodyAgreement() {
   const validationErrors = getValidationErrors<typeof SignCustodySchema>(
     actionData?.error
   );
-  const alreadySigned =
-    signatureRequest.status === SignedCustodyRequestStatus.SIGNED;
+  const isPending =
+    signatureRequest.status === SignedCustodyRequestStatus.PENDING;
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center px-6 py-12">
@@ -213,11 +247,7 @@ export default function SignCustodyAgreement() {
           <p className="whitespace-pre-line">{signatureRequest.documentBody}</p>
         </section>
 
-        {alreadySigned ? (
-          <p className="text-sm text-gray-700">
-            This agreement has already been signed.
-          </p>
-        ) : (
+        {isPending ? (
           <Form method="post" className="flex flex-col gap-4">
             <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
               Type your name
@@ -251,6 +281,12 @@ export default function SignCustodyAgreement() {
               Accept custody
             </Button>
           </Form>
+        ) : (
+          <p className="text-sm text-gray-700">
+            {signatureRequest.status === SignedCustodyRequestStatus.SIGNED
+              ? "This agreement has already been signed."
+              : "This agreement is no longer pending."}
+          </p>
         )}
       </div>
     </main>
@@ -276,9 +312,11 @@ function SignaturePad({ disabled }: { disabled: boolean }) {
   const getPoint = (event: PointerEvent<HTMLCanvasElement>) => {
     const canvas = event.currentTarget;
     const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
     return {
-      x: event.clientX - rect.left,
-      y: event.clientY - rect.top,
+      x: (event.clientX - rect.left) * scaleX,
+      y: (event.clientY - rect.top) * scaleY,
     };
   };
 

--- a/apps/webapp/app/routes/custody+/_public+/sign.$token.tsx
+++ b/apps/webapp/app/routes/custody+/_public+/sign.$token.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useRef, useState } from "react";
+import type { PointerEvent } from "react";
+import { SignedCustodyRequestStatus } from "@prisma/client";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
+import {
+  data,
+  Form,
+  redirect,
+  useActionData,
+  useLoaderData,
+  useNavigation,
+} from "react-router";
+import { z } from "zod";
+import { ErrorContent } from "~/components/errors";
+import { Button } from "~/components/shared/button";
+import { db } from "~/database/db.server";
+import { completeSignedCustodyRequest } from "~/modules/custody/signed-custody.server";
+import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
+import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { setCookie } from "~/utils/cookies.server";
+import { sendNotification } from "~/utils/emitter/send-notification.server";
+import { makeShelfError, ShelfError } from "~/utils/error";
+import {
+  assertIsPost,
+  error,
+  getParams,
+  parseData,
+  payload,
+} from "~/utils/http.server";
+
+const ParamsSchema = z.object({ token: z.string().min(1) });
+
+const SignCustodySchema = z.object({
+  signerName: z.string().trim().min(1, "Please type your name"),
+  signatureDataUrl: z.string().optional(),
+});
+
+export const meta = () => [
+  { title: appendToMetaTitle("Sign custody agreement") },
+];
+
+async function getSignatureRequest(token: string) {
+  const request = await db.signedCustodyRequest.findUnique({
+    where: { token },
+    include: {
+      organization: { select: { id: true, name: true } },
+      asset: { select: { id: true, title: true, status: true } },
+      teamMember: {
+        select: {
+          id: true,
+          name: true,
+          userId: true,
+          user: {
+            select: {
+              id: true,
+              email: true,
+              firstName: true,
+              lastName: true,
+              displayName: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!request) {
+    throw new ShelfError({
+      cause: null,
+      title: "Signature request not found",
+      message: "This custody signature request could not be found.",
+      label: "Custody",
+      status: 404,
+      shouldBeCaptured: false,
+    });
+  }
+
+  return request;
+}
+
+export async function loader({ context, params, request }: LoaderFunctionArgs) {
+  const { token } = getParams(params, ParamsSchema, {
+    additionalData: { token: params.token },
+  });
+
+  try {
+    const signatureRequest = await getSignatureRequest(token);
+
+    if (!context.isAuthenticated) {
+      const redirectTo = new URL(request.url).pathname;
+      return redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+    }
+
+    const authSession = context.getSession();
+    if (signatureRequest.teamMember.userId !== authSession.userId) {
+      throw new ShelfError({
+        cause: null,
+        title: "Action not allowed",
+        message:
+          "This custody signature request was sent to a different Shelf user.",
+        label: "Custody",
+        status: 403,
+        shouldBeCaptured: false,
+      });
+    }
+
+    return payload({ signatureRequest });
+  } catch (cause) {
+    const reason = makeShelfError(cause, { token });
+    throw data(error(reason), { status: reason.status });
+  }
+}
+
+export async function action({ context, params, request }: ActionFunctionArgs) {
+  const { token } = getParams(params, ParamsSchema, {
+    additionalData: { token: params.token },
+  });
+
+  try {
+    assertIsPost(request);
+
+    if (!context.isAuthenticated) {
+      return redirect(`/login?redirectTo=/custody/sign/${token}`);
+    }
+
+    const authSession = context.getSession();
+    const formData = await request.formData();
+    const { signerName, signatureDataUrl } = parseData(
+      formData,
+      SignCustodySchema,
+      {
+        additionalData: { token, userId: authSession.userId },
+        shouldBeCaptured: false,
+      }
+    );
+
+    const signedRequest = await completeSignedCustodyRequest({
+      token,
+      signerUserId: authSession.userId,
+      signerName,
+      signatureDataUrl,
+      signerIp: request.headers.get("x-forwarded-for"),
+      signerUserAgent: request.headers.get("user-agent"),
+    });
+
+    sendNotification({
+      title: "Custody accepted",
+      message: `${signedRequest.asset.title} is now assigned to your custody.`,
+      icon: { name: "success", variant: "success" },
+      senderId: authSession.userId,
+    });
+
+    return redirect(`/assets/${signedRequest.asset.id}`, {
+      headers: [
+        setCookie(
+          await setSelectedOrganizationIdCookie(signedRequest.organizationId)
+        ),
+      ],
+    });
+  } catch (cause) {
+    const reason = makeShelfError(cause, { token });
+    return data(error(reason), { status: reason.status });
+  }
+}
+
+export const ErrorBoundary = () => <ErrorContent />;
+
+export default function SignCustodyAgreement() {
+  const { signatureRequest } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const disabled = navigation.state !== "idle";
+  const alreadySigned =
+    signatureRequest.status === SignedCustodyRequestStatus.SIGNED;
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center px-6 py-12">
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <p className="mb-2 text-sm font-medium text-gray-600">
+          {signatureRequest.organization.name}
+        </p>
+        <h1 className="mb-3 text-2xl font-semibold text-gray-900">
+          Custody agreement
+        </h1>
+        <p className="mb-6 text-gray-700">
+          Review and sign before accepting custody of{" "}
+          <strong>{signatureRequest.asset.title}</strong>.
+        </p>
+
+        <section className="mb-6 rounded-md border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+          <h2 className="mb-2 text-base font-semibold text-gray-900">
+            {signatureRequest.documentTitle}
+          </h2>
+          <p className="whitespace-pre-line">{signatureRequest.documentBody}</p>
+        </section>
+
+        {alreadySigned ? (
+          <p className="text-sm text-gray-700">
+            This agreement has already been signed.
+          </p>
+        ) : (
+          <Form method="post" className="flex flex-col gap-4">
+            <label className="flex flex-col gap-2 text-sm font-medium text-gray-700">
+              Type your name
+              <input
+                name="signerName"
+                className="rounded-md border border-gray-300 px-3 py-2 text-base text-gray-900"
+                placeholder={signatureRequest.teamMember.name}
+                disabled={disabled}
+              />
+            </label>
+
+            <SignaturePad disabled={disabled} />
+
+            {actionData?.error?.message ? (
+              <p className="text-sm text-error-600">
+                {actionData.error.message}
+              </p>
+            ) : null}
+
+            <Button type="submit" disabled={disabled}>
+              Accept custody
+            </Button>
+          </Form>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function SignaturePad({ disabled }: { disabled: boolean }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [drawing, setDrawing] = useState(false);
+  const [signatureDataUrl, setSignatureDataUrl] = useState("");
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    context.lineWidth = 2;
+    context.lineCap = "round";
+    context.strokeStyle = "#101828";
+  }, []);
+
+  const getPoint = (event: PointerEvent<HTMLCanvasElement>) => {
+    const canvas = event.currentTarget;
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  };
+
+  const persistSignature = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setSignatureDataUrl(canvas.toDataURL("image/png"));
+  };
+
+  const clearSignature = () => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    if (!canvas || !context) return;
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    setSignatureDataUrl("");
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="signature-pad"
+          className="text-sm font-medium text-gray-700"
+        >
+          Draw your signature
+        </label>
+        <button
+          type="button"
+          className="text-sm font-medium text-primary-600"
+          onClick={clearSignature}
+          disabled={disabled}
+        >
+          Clear
+        </button>
+      </div>
+      <canvas
+        id="signature-pad"
+        ref={canvasRef}
+        width={720}
+        height={180}
+        className="h-40 w-full touch-none rounded-md border border-gray-300 bg-white"
+        onPointerDown={(event) => {
+          if (disabled) return;
+          event.currentTarget.setPointerCapture(event.pointerId);
+          const point = getPoint(event);
+          const context = event.currentTarget.getContext("2d");
+          context?.beginPath();
+          context?.moveTo(point.x, point.y);
+          setDrawing(true);
+        }}
+        onPointerMove={(event) => {
+          if (!drawing || disabled) return;
+          const point = getPoint(event);
+          const context = event.currentTarget.getContext("2d");
+          context?.lineTo(point.x, point.y);
+          context?.stroke();
+          persistSignature();
+        }}
+        onPointerUp={() => {
+          setDrawing(false);
+          persistSignature();
+        }}
+        onPointerCancel={() => setDrawing(false)}
+      />
+      <input type="hidden" name="signatureDataUrl" value={signatureDataUrl} />
+    </div>
+  );
+}

--- a/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
+++ b/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
@@ -2,7 +2,12 @@ import { OrganizationRoles, AssetStatus } from "@prisma/client";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createOrganization } from "@factories";
+import {
+  createAsset,
+  createOrganization,
+  createTeamMember,
+  createUser,
+} from "@factories";
 import {
   action,
   loader,
@@ -418,24 +423,39 @@ describe("assets.$assetId.overview.assign-custody action", () => {
       userOrganizations: [{ organizationId: "org-1" }],
     } as any);
 
+    mockOrganizationFindUniqueOrThrow.mockResolvedValue(
+      createOrganization({
+        id: "org-1",
+        name: "Test Org",
+        customEmailFooter: null,
+        enableSignedCustodyOnAssignment: true,
+        requireCustodySignatureOnAssignment: true,
+      })
+    );
+
     mockGetTeamMember.mockResolvedValue({
-      id: "team-member-123",
-      name: "Valid Team Member",
-      userId: "user-456",
-      user: {
+      ...createTeamMember({
+        id: "team-member-123",
+        name: "Valid Team Member",
+        userId: "user-456",
+        organizationId: "org-1",
+      }),
+      user: createUser({
         id: "user-456",
         email: "custodian@example.com",
         firstName: "Valid",
         lastName: "Member",
-        displayName: "Valid Member",
-      },
+      }),
     });
 
-    mockAssetFindFirstOrThrow.mockResolvedValue({
-      id: "asset-123",
-      title: "Test Asset",
-      status: AssetStatus.AVAILABLE,
-    });
+    mockAssetFindFirstOrThrow.mockResolvedValue(
+      createAsset({
+        id: "asset-123",
+        title: "Test Asset",
+        organizationId: "org-1",
+        status: AssetStatus.AVAILABLE,
+      })
+    );
 
     const formData = new FormData();
     formData.set(
@@ -459,11 +479,11 @@ describe("assets.$assetId.overview.assign-custody action", () => {
     expect(signedCustodyMocks.createSignedCustodyRequests).toHaveBeenCalledWith(
       expect.objectContaining({
         assets: [
-          {
+          expect.objectContaining({
             id: "asset-123",
             title: "Test Asset",
             status: AssetStatus.AVAILABLE,
-          },
+          }),
         ],
         organizationId: "org-1",
         teamMember: expect.objectContaining({

--- a/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
+++ b/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
@@ -2,6 +2,7 @@ import { OrganizationRoles, AssetStatus } from "@prisma/client";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createOrganization } from "@factories";
 import {
   action,
   loader,
@@ -24,6 +25,7 @@ const dbMocks = vi.hoisted(() => {
       count: vi.fn(),
     },
     organization: {
+      // why: action reads organization custody-signing settings before assignment
       findUniqueOrThrow: vi.fn(),
     },
     custody: {
@@ -182,13 +184,15 @@ beforeEach(() => {
   } as any);
   createNoteMock.mockResolvedValue(undefined as any);
   sendNotificationMock.mockReturnValue(undefined as any);
-  mockOrganizationFindUniqueOrThrow.mockResolvedValue({
-    id: "org-1",
-    name: "Test Org",
-    customEmailFooter: null,
-    enableSignedCustodyOnAssignment: false,
-    requireCustodySignatureOnAssignment: false,
-  });
+  mockOrganizationFindUniqueOrThrow.mockResolvedValue(
+    createOrganization({
+      id: "org-1",
+      name: "Test Org",
+      customEmailFooter: null,
+      enableSignedCustodyOnAssignment: false,
+      requireCustodySignatureOnAssignment: false,
+    })
+  );
 });
 
 describe("assets.$assetId.overview.assign-custody loader", () => {
@@ -303,24 +307,12 @@ describe("assets.$assetId.overview.assign-custody action", () => {
 
     expect((response as Response).status).toBe(404);
 
-    expect(mockGetTeamMember).toHaveBeenCalledWith({
-      id: "foreign-team-member-123",
-      organizationId: "org-1",
-      select: {
-        id: true,
-        name: true,
-        userId: true,
-        user: {
-          select: {
-            id: true,
-            email: true,
-            firstName: true,
-            lastName: true,
-            displayName: true,
-          },
-        },
-      },
-    });
+    expect(mockGetTeamMember).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "foreign-team-member-123",
+        organizationId: "org-1",
+      })
+    );
 
     expect(mockAssetUpdate).not.toHaveBeenCalled();
     expect(createNoteMock).not.toHaveBeenCalled();
@@ -365,24 +357,12 @@ describe("assets.$assetId.overview.assign-custody action", () => {
 
     expect((response as Response).status).toBe(302); // Redirect on success
 
-    expect(mockGetTeamMember).toHaveBeenCalledWith({
-      id: "team-member-123",
-      organizationId: "org-1",
-      select: {
-        id: true,
-        name: true,
-        userId: true,
-        user: {
-          select: {
-            id: true,
-            email: true,
-            firstName: true,
-            lastName: true,
-            displayName: true,
-          },
-        },
-      },
-    });
+    expect(mockGetTeamMember).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "team-member-123",
+        organizationId: "org-1",
+      })
+    );
 
     expect(mockAssetUpdate).toHaveBeenCalledWith({
       where: { id: "asset-123", organizationId: "org-1" },

--- a/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
+++ b/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
@@ -23,6 +23,9 @@ const dbMocks = vi.hoisted(() => {
       findMany: vi.fn(),
       count: vi.fn(),
     },
+    organization: {
+      findUniqueOrThrow: vi.fn(),
+    },
     custody: {
       // why: action now clears stale custody before assignment
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
@@ -44,6 +47,9 @@ vi.mock("~/database/db.server", () => ({
     teamMember: {
       findMany: dbMocks.teamMember.findMany,
       count: dbMocks.teamMember.count,
+    },
+    organization: {
+      findUniqueOrThrow: dbMocks.organization.findUniqueOrThrow,
     },
     custody: {
       deleteMany: dbMocks.custody.deleteMany,
@@ -114,6 +120,8 @@ const mockAssetFindUnique = dbMocks.asset.findUnique;
 const mockAssetUpdate = dbMocks.asset.update;
 const mockTeamMemberFindMany = dbMocks.teamMember.findMany;
 const mockTeamMemberCount = dbMocks.teamMember.count;
+const mockOrganizationFindUniqueOrThrow =
+  dbMocks.organization.findUniqueOrThrow;
 const mockGetTeamMember = teamMemberServiceMocks.getTeamMember;
 
 const requirePermissionMock = vi.mocked(requirePermission);
@@ -160,6 +168,7 @@ beforeEach(() => {
   mockAssetUpdate.mockReset();
   mockTeamMemberFindMany.mockReset();
   mockTeamMemberCount.mockReset();
+  mockOrganizationFindUniqueOrThrow.mockReset();
   mockGetTeamMember.mockReset();
 
   // Reset service mocks
@@ -173,6 +182,13 @@ beforeEach(() => {
   } as any);
   createNoteMock.mockResolvedValue(undefined as any);
   sendNotificationMock.mockReturnValue(undefined as any);
+  mockOrganizationFindUniqueOrThrow.mockResolvedValue({
+    id: "org-1",
+    name: "Test Org",
+    customEmailFooter: null,
+    enableSignedCustodyOnAssignment: false,
+    requireCustodySignatureOnAssignment: false,
+  });
 });
 
 describe("assets.$assetId.overview.assign-custody loader", () => {
@@ -297,6 +313,7 @@ describe("assets.$assetId.overview.assign-custody action", () => {
         user: {
           select: {
             id: true,
+            email: true,
             firstName: true,
             lastName: true,
             displayName: true,
@@ -358,6 +375,7 @@ describe("assets.$assetId.overview.assign-custody action", () => {
         user: {
           select: {
             id: true,
+            email: true,
             firstName: true,
             lastName: true,
             displayName: true,

--- a/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
+++ b/apps/webapp/test/routes-tests/assets.$assetId.overview.assign-custody.test.tsx
@@ -18,6 +18,7 @@ const dbMocks = vi.hoisted(() => {
   return {
     asset: {
       findUnique: vi.fn(),
+      findFirstOrThrow: vi.fn(),
       update: vi.fn(),
     },
     teamMember: {
@@ -39,11 +40,18 @@ const teamMemberServiceMocks = vi.hoisted(() => ({
   getTeamMember: vi.fn(),
 }));
 
+const signedCustodyMocks = vi.hoisted(() => ({
+  createSignedCustodyRequests: vi.fn(),
+  sendSignedCustodyRequestEmails: vi.fn(),
+  shouldRequestSignedCustody: vi.fn(),
+}));
+
 // why: testing route handler without executing actual database operations
 vi.mock("~/database/db.server", () => ({
   db: {
     asset: {
       findUnique: dbMocks.asset.findUnique,
+      findFirstOrThrow: dbMocks.asset.findFirstOrThrow,
       update: dbMocks.asset.update,
     },
     teamMember: {
@@ -60,7 +68,10 @@ vi.mock("~/database/db.server", () => ({
     $transaction: vi.fn((cb: (tx: unknown) => unknown) =>
       cb({
         custody: { deleteMany: dbMocks.custody.deleteMany },
-        asset: { update: dbMocks.asset.update },
+        asset: {
+          findFirstOrThrow: dbMocks.asset.findFirstOrThrow,
+          update: dbMocks.asset.update,
+        },
       })
     ),
   },
@@ -84,6 +95,14 @@ vi.mock("~/modules/user/service.server", () => ({
 // why: testing team member organization validation without database lookups
 vi.mock("~/modules/team-member/service.server", () => ({
   getTeamMember: teamMemberServiceMocks.getTeamMember,
+}));
+
+// why: testing signed-custody branching without sending emails or writing request rows
+vi.mock("~/modules/custody/signed-custody.server", () => ({
+  createSignedCustodyRequests: signedCustodyMocks.createSignedCustodyRequests,
+  sendSignedCustodyRequestEmails:
+    signedCustodyMocks.sendSignedCustodyRequestEmails,
+  shouldRequestSignedCustody: signedCustodyMocks.shouldRequestSignedCustody,
 }));
 
 // why: testing custody assignment without creating actual notes
@@ -119,6 +138,7 @@ vi.mock("react-router", async () => {
 });
 
 const mockAssetFindUnique = dbMocks.asset.findUnique;
+const mockAssetFindFirstOrThrow = dbMocks.asset.findFirstOrThrow;
 const mockAssetUpdate = dbMocks.asset.update;
 const mockTeamMemberFindMany = dbMocks.teamMember.findMany;
 const mockTeamMemberCount = dbMocks.teamMember.count;
@@ -167,6 +187,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   mockAssetFindUnique.mockReset();
+  mockAssetFindFirstOrThrow.mockReset();
   mockAssetUpdate.mockReset();
   mockTeamMemberFindMany.mockReset();
   mockTeamMemberCount.mockReset();
@@ -184,6 +205,16 @@ beforeEach(() => {
   } as any);
   createNoteMock.mockResolvedValue(undefined as any);
   sendNotificationMock.mockReturnValue(undefined as any);
+  signedCustodyMocks.createSignedCustodyRequests.mockResolvedValue([
+    {
+      token: "signed-request-token",
+      asset: { title: "Test Asset" },
+    },
+  ]);
+  signedCustodyMocks.sendSignedCustodyRequestEmails.mockResolvedValue(
+    undefined
+  );
+  signedCustodyMocks.shouldRequestSignedCustody.mockReturnValue(false);
   mockOrganizationFindUniqueOrThrow.mockResolvedValue(
     createOrganization({
       id: "org-1",
@@ -378,6 +409,89 @@ describe("assets.$assetId.overview.assign-custody action", () => {
     });
 
     expect(createNoteMock).toHaveBeenCalled();
+  });
+
+  it("creates a pending signed custody request instead of assigning custody immediately when a signature is required", async () => {
+    requirePermissionMock.mockResolvedValue({
+      organizationId: "org-1",
+      role: OrganizationRoles.ADMIN,
+      userOrganizations: [{ organizationId: "org-1" }],
+    } as any);
+
+    mockGetTeamMember.mockResolvedValue({
+      id: "team-member-123",
+      name: "Valid Team Member",
+      userId: "user-456",
+      user: {
+        id: "user-456",
+        email: "custodian@example.com",
+        firstName: "Valid",
+        lastName: "Member",
+        displayName: "Valid Member",
+      },
+    });
+
+    mockAssetFindFirstOrThrow.mockResolvedValue({
+      id: "asset-123",
+      title: "Test Asset",
+      status: AssetStatus.AVAILABLE,
+    });
+
+    const formData = new FormData();
+    formData.set(
+      "custodian",
+      JSON.stringify({ id: "team-member-123", name: "Valid Team Member" })
+    );
+    formData.set("requireSignedCustody", "on");
+
+    const request = new Request(
+      "https://example.com/assets/asset-123/overview/assign-custody",
+      { method: "POST", body: formData }
+    );
+
+    const response = await action(createActionArgs({ request }));
+
+    expect((response as Response).status).toBe(302);
+    expect(mockAssetFindFirstOrThrow).toHaveBeenCalledWith({
+      where: { id: "asset-123", organizationId: "org-1" },
+      select: { id: true, title: true, status: true },
+    });
+    expect(signedCustodyMocks.createSignedCustodyRequests).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assets: [
+          {
+            id: "asset-123",
+            title: "Test Asset",
+            status: AssetStatus.AVAILABLE,
+          },
+        ],
+        organizationId: "org-1",
+        teamMember: expect.objectContaining({
+          id: "team-member-123",
+          name: "Valid Team Member",
+          user: expect.objectContaining({
+            email: "custodian@example.com",
+          }),
+        }),
+      })
+    );
+    expect(
+      signedCustodyMocks.sendSignedCustodyRequestEmails
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientEmail: "custodian@example.com",
+        organizationName: "Test Org",
+      })
+    );
+    expect(mockAssetUpdate).not.toHaveBeenCalled();
+    expect(dbMocks.custody.deleteMany).not.toHaveBeenCalled();
+    expect(createNoteMock).not.toHaveBeenCalled();
+    expect(sendNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          "Custody will be assigned after the custodian signs the agreement.",
+      })
+    );
   });
 
   it("prevents self-service users from assigning custody to other team members", async () => {

--- a/packages/database/prisma/migrations/20260515023000_add_signed_custody_requests/migration.sql
+++ b/packages/database/prisma/migrations/20260515023000_add_signed_custody_requests/migration.sql
@@ -21,7 +21,7 @@ CREATE TABLE "SignedCustodyRequest" (
     "organizationId" TEXT NOT NULL,
     "assetId" TEXT NOT NULL,
     "teamMemberId" TEXT NOT NULL,
-    "requestedById" TEXT NOT NULL,
+    "requestedById" TEXT,
     "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMPTZ(3) NOT NULL,
 
@@ -36,6 +36,12 @@ CREATE INDEX "SignedCustodyRequest_organizationId_idx" ON "SignedCustodyRequest"
 
 -- CreateIndex
 CREATE INDEX "SignedCustodyRequest_assetId_idx" ON "SignedCustodyRequest"("assetId");
+
+-- CreateIndex
+CREATE INDEX "SignedCustodyRequest_assetId_status_idx" ON "SignedCustodyRequest"("assetId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SignedCustodyRequest_one_pending_per_asset_idx" ON "SignedCustodyRequest"("assetId") WHERE "status" = 'PENDING';
 
 -- CreateIndex
 CREATE INDEX "SignedCustodyRequest_teamMemberId_idx" ON "SignedCustodyRequest"("teamMemberId");
@@ -56,4 +62,4 @@ ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_assetId_
 ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_teamMemberId_fkey" FOREIGN KEY ("teamMemberId") REFERENCES "TeamMember"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260515023000_add_signed_custody_requests/migration.sql
+++ b/packages/database/prisma/migrations/20260515023000_add_signed_custody_requests/migration.sql
@@ -56,10 +56,10 @@ CREATE INDEX "SignedCustodyRequest_status_idx" ON "SignedCustodyRequest"("status
 ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_assetId_fkey" FOREIGN KEY ("assetId") REFERENCES "Asset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_assetId_fkey" FOREIGN KEY ("assetId") REFERENCES "Asset"("id") ON DELETE NO ACTION ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_teamMemberId_fkey" FOREIGN KEY ("teamMemberId") REFERENCES "TeamMember"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_teamMemberId_fkey" FOREIGN KEY ("teamMemberId") REFERENCES "TeamMember"("id") ON DELETE NO ACTION ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260515023000_add_signed_custody_requests/migration.sql
+++ b/packages/database/prisma/migrations/20260515023000_add_signed_custody_requests/migration.sql
@@ -1,0 +1,59 @@
+-- CreateEnum
+CREATE TYPE "SignedCustodyRequestStatus" AS ENUM ('PENDING', 'SIGNED', 'CANCELLED');
+
+-- AlterTable
+ALTER TABLE "Organization"
+ADD COLUMN "enableSignedCustodyOnAssignment" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "requireCustodySignatureOnAssignment" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "SignedCustodyRequest" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "status" "SignedCustodyRequestStatus" NOT NULL DEFAULT 'PENDING',
+    "documentTitle" TEXT NOT NULL DEFAULT 'Custody agreement',
+    "documentBody" TEXT NOT NULL DEFAULT 'Please review and sign to accept custody of this asset.',
+    "signerName" TEXT,
+    "signatureDataUrl" TEXT,
+    "signerIp" TEXT,
+    "signerUserAgent" TEXT,
+    "signedAt" TIMESTAMPTZ(3),
+    "organizationId" TEXT NOT NULL,
+    "assetId" TEXT NOT NULL,
+    "teamMemberId" TEXT NOT NULL,
+    "requestedById" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3) NOT NULL,
+
+    CONSTRAINT "SignedCustodyRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SignedCustodyRequest_token_key" ON "SignedCustodyRequest"("token");
+
+-- CreateIndex
+CREATE INDEX "SignedCustodyRequest_organizationId_idx" ON "SignedCustodyRequest"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "SignedCustodyRequest_assetId_idx" ON "SignedCustodyRequest"("assetId");
+
+-- CreateIndex
+CREATE INDEX "SignedCustodyRequest_teamMemberId_idx" ON "SignedCustodyRequest"("teamMemberId");
+
+-- CreateIndex
+CREATE INDEX "SignedCustodyRequest_requestedById_idx" ON "SignedCustodyRequest"("requestedById");
+
+-- CreateIndex
+CREATE INDEX "SignedCustodyRequest_status_idx" ON "SignedCustodyRequest"("status");
+
+-- AddForeignKey
+ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_assetId_fkey" FOREIGN KEY ("assetId") REFERENCES "Asset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_teamMemberId_fkey" FOREIGN KEY ("teamMemberId") REFERENCES "TeamMember"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SignedCustodyRequest" ADD CONSTRAINT "SignedCustodyRequest_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -34,20 +34,20 @@ model Image {
 }
 
 model User {
-  id                    String  @id @default(cuid())
-  email                 String  @unique
-  username              String  @unique @default(cuid())
-  firstName             String?
-  lastName              String?
-  displayName           String?
-  profilePicture        String?
-  usedFreeTrial         Boolean @default(false)
-  onboarded             Boolean @default(false)
-  customerId            String? @unique // Stripe customer id
-  sso                   Boolean @default(false)
-  createdWithInvite     Boolean @default(false) // Set to true if the user was created by being invited to a workspace
-  skipSubscriptionCheck Boolean @default(false) // Set to true if the user has opted out of subscription checks
-  hasUnpaidInvoice     Boolean @default(false) // Set via Stripe webhooks when invoice payment fails
+  id                     String  @id @default(cuid())
+  email                  String  @unique
+  username               String  @unique @default(cuid())
+  firstName              String?
+  lastName               String?
+  displayName            String?
+  profilePicture         String?
+  usedFreeTrial          Boolean @default(false)
+  onboarded              Boolean @default(false)
+  customerId             String? @unique // Stripe customer id
+  sso                    Boolean @default(false)
+  createdWithInvite      Boolean @default(false) // Set to true if the user was created by being invited to a workspace
+  skipSubscriptionCheck  Boolean @default(false) // Set to true if the user has opted out of subscription checks
+  hasUnpaidInvoice       Boolean @default(false) // Set via Stripe webhooks when invoice payment fails
   warnForNoPaymentMethod Boolean @default(false) // Set when subscription is transferred to a user without a payment method
 
   // Last selected organization for cross-device workspace persistence
@@ -62,37 +62,37 @@ model User {
   deletedAt DateTime?
 
   // Relationships
-  assets             Asset[]
-  categories         Category[]
-  notes              Note[]
-  bookingNotes      BookingNote[]      @relation("BookingNoteUser")
-  auditNotes        AuditNote[]        @relation("AuditNoteUser")
-  locationNotes     LocationNote[]     @relation("LocationNoteUser")
-  qrCodes            Qr[]
-  scans              Scan[]
-  tags               Tag[]
-  roles              Role[]
-  locations          Location[]
-  images             Image[]
-  organizations      Organization[]
-  customFields       CustomField[]
-  sentInvites        Invite[]           @relation("inviter")
-  receivedInvites    Invite[]           @relation("invitee")
-  teamMembers        TeamMember[]
-  userOrganizations  UserOrganization[]
-  bookings           Booking[]          @relation("creator")
-  custodies          Booking[]          @relation("custodian")
-  createdKits        Kit[]
-  tierId             TierId             @default(free)
-  tier               Tier               @relation(fields: [tierId], references: [id])
-  assetReminders     AssetReminder[]
-  contact            UserContact?
-  businessIntel      UserBusinessIntel?
-  auditsCreated      AuditSession[]
-  auditAssignments   AuditAssignment[]
-  auditAssetsScanned AuditAsset[]
-  auditScans         AuditScan[]
-  auditImagesUploaded AuditImage[] @relation("AuditImageUploader")
+  assets                         Asset[]
+  categories                     Category[]
+  notes                          Note[]
+  bookingNotes                   BookingNote[]          @relation("BookingNoteUser")
+  auditNotes                     AuditNote[]            @relation("AuditNoteUser")
+  locationNotes                  LocationNote[]         @relation("LocationNoteUser")
+  qrCodes                        Qr[]
+  scans                          Scan[]
+  tags                           Tag[]
+  roles                          Role[]
+  locations                      Location[]
+  images                         Image[]
+  organizations                  Organization[]
+  customFields                   CustomField[]
+  sentInvites                    Invite[]               @relation("inviter")
+  receivedInvites                Invite[]               @relation("invitee")
+  teamMembers                    TeamMember[]
+  userOrganizations              UserOrganization[]
+  bookings                       Booking[]              @relation("creator")
+  custodies                      Booking[]              @relation("custodian")
+  createdKits                    Kit[]
+  tierId                         TierId                 @default(free)
+  tier                           Tier                   @relation(fields: [tierId], references: [id])
+  assetReminders                 AssetReminder[]
+  contact                        UserContact?
+  businessIntel                  UserBusinessIntel?
+  auditsCreated                  AuditSession[]
+  auditAssignments               AuditAssignment[]
+  auditAssetsScanned             AuditAsset[]
+  auditScans                     AuditScan[]
+  auditImagesUploaded            AuditImage[]           @relation("AuditImageUploader")
   signedCustodyRequestsRequested SignedCustodyRequest[] @relation("SignedCustodyRequestedBy")
 
   // @deprecated - Historical data only. New entries go to UserBusinessIntel table
@@ -209,18 +209,18 @@ model Asset {
   kit            Kit?         @relation(fields: [kitId], references: [id])
   kitId          String?
 
-  custody      Custody?
+  custody               Custody?
   signedCustodyRequests SignedCustodyRequest[]
-  notes        Note[]
-  qrCodes      Qr[]
-  barcodes     Barcode[]
-  reports      ReportFound[]
-  tags         Tag[]
-  customFields AssetCustomFieldValue[]
-  bookings     Booking[]
-  reminders    AssetReminder[]
-  auditEntries AuditAsset[]
-  auditScans   AuditScan[]
+  notes                 Note[]
+  qrCodes               Qr[]
+  barcodes              Barcode[]
+  reports               ReportFound[]
+  tags                  Tag[]
+  customFields          AssetCustomFieldValue[]
+  bookings              Booking[]
+  reminders             AssetReminder[]
+  auditEntries          AuditAsset[]
+  auditScans            AuditScan[]
 
   // Unique constraint for organization-scoped sequential IDs
   @@unique([organizationId, sequentialId], name: "asset_org_sequential_unique")
@@ -644,19 +644,19 @@ model TeamMember {
   id   String @id @default(cuid())
   name String
 
-  organization    Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  organizationId  String
-  custodies       Custody[]
+  organization          Organization           @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  organizationId        String
+  custodies             Custody[]
   signedCustodyRequests SignedCustodyRequest[]
-  receivedInvites Invite[]
-  user            User?        @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: SetNull)
-  userId          String?
-  kitCustodies    KitCustody[]
+  receivedInvites       Invite[]
+  user                  User?                  @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: SetNull)
+  userId                String?
+  kitCustodies          KitCustody[]
 
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  deletedAt      DateTime?
-  bookings       Booking[]
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  deletedAt       DateTime?
+  bookings        Booking[]
   assetReminders  AssetReminder[]
   teamMemberNotes TeamMemberNote[]
 
@@ -703,11 +703,11 @@ model SignedCustodyRequest {
   documentTitle String @default("Custody agreement")
   documentBody  String @default("Please review and sign to accept custody of this asset.") @db.Text
 
-  signerName      String?
-  signatureDataUrl String? @db.Text
-  signerIp        String?
-  signerUserAgent String? @db.Text
-  signedAt        DateTime? @db.Timestamptz(3)
+  signerName       String?
+  signatureDataUrl String?   @db.Text
+  signerIp         String?
+  signerUserAgent  String?   @db.Text
+  signedAt         DateTime? @db.Timestamptz(3)
 
   organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
@@ -718,14 +718,15 @@ model SignedCustodyRequest {
   teamMember   TeamMember @relation(fields: [teamMemberId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   teamMemberId String
 
-  requestedBy   User   @relation("SignedCustodyRequestedBy", fields: [requestedById], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  requestedById String
+  requestedBy   User?   @relation("SignedCustodyRequestedBy", fields: [requestedById], references: [id], onUpdate: Cascade, onDelete: SetNull)
+  requestedById String?
 
   createdAt DateTime @default(now()) @db.Timestamptz(3)
   updatedAt DateTime @updatedAt @db.Timestamptz(3)
 
   @@index([organizationId])
   @@index([assetId])
+  @@index([assetId, status])
   @@index([teamMemberId])
   @@index([requestedById])
   @@index([status])
@@ -770,9 +771,9 @@ model Organization {
   usedBarcodeTrial  Boolean   @default(false) // Set once a 7-day free barcode trial is activated (prevents reuse)
 
   // Audit add-on (per-organization, managed via Stripe subscription)
-  auditsEnabled    Boolean   @default(false) // If true, this organization can use audit functionality
-  auditsEnabledAt  DateTime? // Track when audit feature was enabled
-  usedAuditTrial   Boolean   @default(false) // Set once a 7-day free audit trial is activated (prevents reuse)
+  auditsEnabled   Boolean   @default(false) // If true, this organization can use audit functionality
+  auditsEnabledAt DateTime? // Track when audit feature was enabled
+  usedAuditTrial  Boolean   @default(false) // Set once a 7-day free audit trial is activated (prevents reuse)
 
   // This is used to disable the workspace for the user. It is set to true when the user leaves the workspace
   workspaceDisabled Boolean @default(false) // If true, the workspace is disabled and the user cannot access it
@@ -795,13 +796,13 @@ model Organization {
   assetReminders     AssetReminder[]
   assetFilterPresets AssetFilterPreset[]
 
-  auditSessions      AuditSession[]
-  auditImages        AuditImage[]
+  auditSessions AuditSession[]
+  auditImages   AuditImage[]
 
-  usersWithLastSelected User[] @relation("lastSelectedOrg")
-  roleChangeLogs      RoleChangeLog[]
-  teamMemberNotes     TeamMemberNote[]
-  activityEvents      ActivityEvent[]
+  usersWithLastSelected User[]                 @relation("lastSelectedOrg")
+  roleChangeLogs        RoleChangeLog[]
+  teamMemberNotes       TeamMemberNote[]
+  activityEvents        ActivityEvent[]
   signedCustodyRequests SignedCustodyRequest[]
 
   // Migration flag to track if sequential IDs have been generated for this organization's existing assets
@@ -1280,12 +1281,12 @@ model BookingSettings {
   autoArchiveBookings Boolean @default(false) // Whether to automatically archive completed bookings
   autoArchiveDays     Int     @default(2) // Number of days after completion before auto-archiving
 
-  requireExplicitCheckinForAdmin      Boolean @default(false) // When true, admins must use explicit check-in (scanner) instead of quick check-in
+  requireExplicitCheckinForAdmin       Boolean @default(false) // When true, admins must use explicit check-in (scanner) instead of quick check-in
   requireExplicitCheckinForSelfService Boolean @default(false) // When true, self-service users must use explicit check-in (scanner) instead of quick check-in
 
   // Notification settings
-  notifyBookingCreator     Boolean @default(true) // Whether the booking creator receives email notifications
-  notifyAdminsOnNewBooking Boolean @default(true) // Whether all admins receive a notification when a booking is reserved
+  notifyBookingCreator     Boolean      @default(true) // Whether the booking creator receives email notifications
+  notifyAdminsOnNewBooking Boolean      @default(true) // Whether all admins receive a notification when a booking is reserved
   alwaysNotifyTeamMembers  TeamMember[] @relation("BookingSettingsAlwaysNotify") // Team members who always receive ALL booking email notifications
 
   // Relationships
@@ -1614,10 +1615,10 @@ model AuditSession {
   missingAssetCount    Int @default(0)
   unexpectedAssetCount Int @default(0)
 
-  startedAt   DateTime?
-  dueDate     DateTime?
-  completedAt DateTime?
-  cancelledAt DateTime?
+  startedAt                DateTime?
+  dueDate                  DateTime?
+  completedAt              DateTime?
+  cancelledAt              DateTime?
   activeSchedulerReference String?
 
   createdBy      User         @relation(fields: [createdById], references: [id])
@@ -1678,9 +1679,9 @@ model AuditAsset {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  scans AuditScan[]
+  scans  AuditScan[]
   images AuditImage[]
-  notes AuditNote[]
+  notes  AuditNote[]
 
   @@unique([auditSessionId, assetId])
   @@index([status])

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -93,6 +93,7 @@ model User {
   auditAssetsScanned AuditAsset[]
   auditScans         AuditScan[]
   auditImagesUploaded AuditImage[] @relation("AuditImageUploader")
+  signedCustodyRequestsRequested SignedCustodyRequest[] @relation("SignedCustodyRequestedBy")
 
   // @deprecated - Historical data only. New entries go to UserBusinessIntel table
   referralSource String? // "How did you hear about us?" field.
@@ -209,6 +210,7 @@ model Asset {
   kitId          String?
 
   custody      Custody?
+  signedCustodyRequests SignedCustodyRequest[]
   notes        Note[]
   qrCodes      Qr[]
   barcodes     Barcode[]
@@ -645,6 +647,7 @@ model TeamMember {
   organization    Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId  String
   custodies       Custody[]
+  signedCustodyRequests SignedCustodyRequest[]
   receivedInvites Invite[]
   user            User?        @relation(fields: [userId], references: [id], onUpdate: Cascade, onDelete: SetNull)
   userId          String?
@@ -686,6 +689,48 @@ model Custody {
   @@index([teamMemberId])
 }
 
+enum SignedCustodyRequestStatus {
+  PENDING
+  SIGNED
+  CANCELLED
+}
+
+model SignedCustodyRequest {
+  id     String                     @id @default(cuid())
+  token  String                     @unique
+  status SignedCustodyRequestStatus @default(PENDING)
+
+  documentTitle String @default("Custody agreement")
+  documentBody  String @default("Please review and sign to accept custody of this asset.") @db.Text
+
+  signerName      String?
+  signatureDataUrl String? @db.Text
+  signerIp        String?
+  signerUserAgent String? @db.Text
+  signedAt        DateTime? @db.Timestamptz(3)
+
+  organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  organizationId String
+
+  asset   Asset  @relation(fields: [assetId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  assetId String
+
+  teamMember   TeamMember @relation(fields: [teamMemberId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  teamMemberId String
+
+  requestedBy   User   @relation("SignedCustodyRequestedBy", fields: [requestedById], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  requestedById String
+
+  createdAt DateTime @default(now()) @db.Timestamptz(3)
+  updatedAt DateTime @updatedAt @db.Timestamptz(3)
+
+  @@index([organizationId])
+  @@index([assetId])
+  @@index([teamMemberId])
+  @@index([requestedById])
+  @@index([status])
+}
+
 model Organization {
   id   String           @id @default(cuid())
   name String           @default("Personal")
@@ -715,6 +760,9 @@ model Organization {
   selfServiceCanSeeBookings Boolean @default(false) // If true, the self service users can see bookings that are not theirs
   baseUserCanSeeCustody     Boolean @default(false) // If true, the base users can see the custody of assets inside the organization
   baseUserCanSeeBookings    Boolean @default(false) // If true, the base users can see the bookings that are not theirs
+
+  enableSignedCustodyOnAssignment     Boolean @default(false)
+  requireCustodySignatureOnAssignment Boolean @default(false)
 
   // Barcode add-on (per-organization, managed via Stripe subscription)
   barcodesEnabled   Boolean   @default(false) // If true, this organization can use barcode functionality
@@ -754,6 +802,7 @@ model Organization {
   roleChangeLogs      RoleChangeLog[]
   teamMemberNotes     TeamMemberNote[]
   activityEvents      ActivityEvent[]
+  signedCustodyRequests SignedCustodyRequest[]
 
   // Migration flag to track if sequential IDs have been generated for this organization's existing assets
   hasSequentialIdsMigrated Boolean @default(false)

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -712,10 +712,10 @@ model SignedCustodyRequest {
   organization   Organization @relation(fields: [organizationId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   organizationId String
 
-  asset   Asset  @relation(fields: [assetId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  asset   Asset  @relation(fields: [assetId], references: [id], onUpdate: Cascade, onDelete: NoAction)
   assetId String
 
-  teamMember   TeamMember @relation(fields: [teamMemberId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  teamMember   TeamMember @relation(fields: [teamMemberId], references: [id], onUpdate: Cascade, onDelete: NoAction)
   teamMemberId String
 
   requestedBy   User?   @relation("SignedCustodyRequestedBy", fields: [requestedById], references: [id], onUpdate: Cascade, onDelete: SetNull)


### PR DESCRIPTION
## Summary
- add pending signed custody requests with audit metadata and migration
- send registered custodians an email link before custody is finalized
- add a signed custody acceptance page with typed/drawn signature capture
- wire single and bulk custody assignment flows to request a signature before assigning custody

Closes #499

## Verification
- `pnpm db:generate`
- `pnpm --filter @shelf/webapp typecheck`
- `pnpm webapp:test -- --run api.assets.bulk-assign-custody assets.$assetId.overview.assign-custody`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "Require custodian to sign before custody is assigned" in bulk-assign UI; can create pending signature requests and track counts.
  * Recipient signing page with name input, drawn signature capture, and acceptance flow.

* **Emails**
  * New styled signature-request email with CTA and optional custom footer.

* **Database**
  * Persistent signed-custody request model and org feature flags to control behavior.

* **API / Notifications**
  * Bulk assign returns assigned vs pending-signature counts and adapts success messages.

* **Tests**
  * Updated route tests and mocks for signed-custody behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2549)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

/claim #499

## Demo
A short runtime video is not attached from this environment. The implemented flow is covered by route tests for both paths: direct custody assignment and pending signed-custody request creation. The PR also includes the public signing route, typed/drawn signature capture, email template, and database persistence needed to exercise the flow in a seeded app environment.