### PR TITLE
fix(audit): guard AuditScan asset FK with a clean 404

### DIFF
--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -18,6 +18,7 @@ import {
   deleteAuditSession,
   bulkDeleteAudits,
   duplicateAuditSession,
+  recordAuditScan,
 } from "./service.server";
 
 // why: storage.server calls Supabase over HTTP; mock so delete tests stay offline
@@ -105,8 +106,14 @@ vi.mock("~/database/db.server", () => {
     auditImage: {
       findMany: vi.fn(),
     },
+    auditScan: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
     asset: {
       findMany: vi.fn(),
+      findUnique: vi.fn(),
     },
     $transaction: vi.fn(),
   };
@@ -149,8 +156,14 @@ const mockDb = db as unknown as {
   auditImage: {
     findMany: ReturnType<typeof vi.fn>;
   };
+  auditScan: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
   asset: {
     findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
   };
   $transaction: ReturnType<typeof vi.fn>;
 };
@@ -2007,6 +2020,61 @@ describe("audit service", () => {
       expect(findManyArgs).toBeDefined();
       if (!findManyArgs) return;
       expect(findManyArgs.orderBy).toEqual([{ createdAt: "desc" }]);
+    });
+  });
+
+  describe("recordAuditScan asset guard", () => {
+    const scanInput = {
+      auditSessionId: "audit-1",
+      qrId: "qr-1",
+      assetId: "asset-1",
+      isExpected: true,
+      userId: "user-1",
+      organizationId: "org-1",
+    };
+
+    beforeEach(() => {
+      // Valid, org-owned, non-archived session; no prior scan recorded.
+      mockDb.auditSession.findFirst.mockResolvedValue({
+        id: "audit-1",
+        organizationId: "org-1",
+        status: AuditStatus.ACTIVE,
+        foundAssetCount: 0,
+        unexpectedAssetCount: 0,
+        missingAssetCount: 0,
+      });
+      mockDb.auditScan.findFirst.mockResolvedValue(null);
+      mockDb.user.findUnique.mockResolvedValue({
+        id: "user-1",
+        firstName: "Scan",
+        lastName: "User",
+        displayName: "Scan User",
+      });
+    });
+
+    it("returns a non-captured 404 when the scanned asset does not exist", async () => {
+      mockDb.asset.findUnique.mockResolvedValue(null);
+
+      await expect(recordAuditScan(scanInput)).rejects.toMatchObject({
+        status: 404,
+        shouldBeCaptured: false,
+      });
+      // The FK-violating create must never be reached.
+      expect(mockDb.auditScan.create).not.toHaveBeenCalled();
+    });
+
+    it("returns a non-captured 404 when the asset belongs to another org", async () => {
+      mockDb.asset.findUnique.mockResolvedValue({
+        id: "asset-1",
+        title: "Cross-org camera",
+        organizationId: "org-2",
+      });
+
+      await expect(recordAuditScan(scanInput)).rejects.toMatchObject({
+        status: 404,
+        shouldBeCaptured: false,
+      });
+      expect(mockDb.auditScan.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -2076,5 +2076,46 @@ describe("audit service", () => {
       });
       expect(mockDb.auditScan.create).not.toHaveBeenCalled();
     });
+
+    it("validates the asset before the duplicate-scan short-circuit", async () => {
+      // A stale AuditScan row exists for a now-cross-org asset (legacy data
+      // from the previously unguarded path). The org guard must win over the
+      // duplicate-scan early return so the retry cannot report success.
+      mockDb.asset.findUnique.mockResolvedValue({
+        id: "asset-1",
+        title: "Cross-org camera",
+        organizationId: "org-2",
+      });
+      mockDb.auditScan.findFirst.mockResolvedValue({
+        id: "stale-scan-1",
+        auditAssetId: "stale-audit-asset-1",
+      });
+
+      await expect(recordAuditScan(scanInput)).rejects.toMatchObject({
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    });
+
+    it("converts a TOCTOU asset-FK violation into a non-captured 404", async () => {
+      // Guard passes (asset valid at check time)...
+      mockDb.asset.findUnique.mockResolvedValue({
+        id: "asset-1",
+        title: "Valid camera",
+        organizationId: "org-1",
+      });
+      // ...but the asset is deleted before the insert, so the create inside
+      // the transaction throws a Prisma P2003 on AuditScan_assetId_fkey.
+      mockDb.auditScan.create.mockRejectedValue({
+        code: "P2003",
+        meta: { modelName: "AuditScan", constraint: "AuditScan_assetId_fkey" },
+        name: "PrismaClientKnownRequestError",
+      });
+
+      await expect(recordAuditScan(scanInput)).rejects.toMatchObject({
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1144,9 +1144,27 @@ export async function recordAuditScan(
       }),
       db.asset.findUnique({
         where: { id: assetId },
-        select: { id: true, title: true },
+        select: { id: true, title: true, organizationId: true },
       }),
     ]);
+
+    // Guard the AuditScan.assetId foreign key. Without this, a deleted asset,
+    // a cross-org asset, or a bogus id reaches `tx.auditScan.create` and
+    // surfaces as a raw Prisma P2003 (`AuditScan_assetId_fkey`) wrapped in a
+    // captured "Failed to record audit scan". Returning a clean, non-captured
+    // 404 keeps Sentry quiet and gives real users a meaningful message when
+    // they scan something that is not a valid asset in this workspace.
+    if (!scannedAsset || scannedAsset.organizationId !== organizationId) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "The scanned asset could not be found in this workspace. It may have been deleted or belong to a different organization.",
+        additionalData: { auditSessionId, assetId, organizationId },
+        status: 404,
+        shouldBeCaptured: false,
+        label,
+      });
+    }
 
     // Record the scan in a transaction
     const result = await db.$transaction(
@@ -1301,6 +1319,13 @@ export async function recordAuditScan(
 
     return result;
   } catch (cause) {
+    // Preserve already-typed ShelfErrors (e.g. the asset/session 404s above)
+    // so their status and `shouldBeCaptured: false` survive instead of being
+    // re-wrapped into a captured generic 500. Matches the pattern used by
+    // other handlers in this file.
+    if (isLikeShelfError(cause)) {
+      throw cause;
+    }
     throw new ShelfError({
       cause,
       message: "Failed to record audit scan",

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1073,6 +1073,44 @@ export async function getAssetsForAuditSession({
 }
 
 /**
+ * Detects a Prisma P2003 foreign-key violation specifically on the
+ * `AuditScan.assetId` constraint.
+ *
+ * Used to recognise the TOCTOU race where the scanned asset is deleted or
+ * moved to another organization between the pre-transaction guard and
+ * `tx.auditScan.create`. Uses a structural check (rather than
+ * `instanceof Prisma.PrismaClientKnownRequestError`) to stay consistent with
+ * the value-free `@prisma/client` import style used elsewhere in this file,
+ * and narrows to the `assetId` FK so unrelated FK failures (e.g. a deleted
+ * scanning user hitting `scannedById`) are still reported as real errors.
+ *
+ * @param cause - The thrown value from the scan transaction.
+ * @returns `true` only for a P2003 on the AuditScan asset foreign key.
+ */
+function isAuditAssetFkViolation(cause: unknown): boolean {
+  if (typeof cause !== "object" || cause === null) {
+    return false;
+  }
+  const code = "code" in cause ? (cause as { code?: unknown }).code : undefined;
+  if (code !== "P2003") {
+    return false;
+  }
+  const meta = "meta" in cause ? (cause as { meta?: unknown }).meta : undefined;
+  const constraint =
+    typeof meta === "object" && meta !== null && "constraint" in meta
+      ? String((meta as { constraint?: unknown }).constraint)
+      : "";
+  const message =
+    "message" in cause ? String((cause as { message?: unknown }).message) : "";
+  // Prisma reports the constraint in `meta.constraint`; some adapters only
+  // include it in the message text, so check both.
+  return (
+    constraint.includes("AuditScan_assetId_fkey") ||
+    message.includes("AuditScan_assetId_fkey")
+  );
+}
+
+/**
  * Records a scan in the audit session and updates the audit asset status.
  * This allows audits to be persisted and resumed across sessions.
  *
@@ -1109,29 +1147,7 @@ export async function recordAuditScan(
       organizationId,
     });
 
-    // Check if this asset was already scanned in this audit
-    const existingScan = await db.auditScan.findFirst({
-      where: {
-        auditSessionId,
-        assetId,
-      },
-      select: {
-        id: true,
-        auditAssetId: true,
-      },
-    });
-
-    if (existingScan) {
-      // Already scanned, just return current counts
-      return {
-        scanId: existingScan.id,
-        auditAssetId: existingScan.auditAssetId,
-        foundAssetCount: session.foundAssetCount,
-        unexpectedAssetCount: session.unexpectedAssetCount,
-      };
-    }
-
-    // Pre-fetch user and asset data for note creation outside the transaction
+    // Pre-fetch user and asset data for note creation outside the transaction.
     const [scannerUser, scannedAsset] = await Promise.all([
       db.user.findUnique({
         where: { id: userId },
@@ -1154,6 +1170,11 @@ export async function recordAuditScan(
     // captured "Failed to record audit scan". Returning a clean, non-captured
     // 404 keeps Sentry quiet and gives real users a meaningful message when
     // they scan something that is not a valid asset in this workspace.
+    //
+    // This runs BEFORE the duplicate-scan short-circuit on purpose: a stale
+    // AuditScan row pointing at a cross-org/deleted asset (legacy rows from
+    // the previously unguarded path, or imported bad data) must not let a
+    // retry report success and bypass this check.
     if (!scannedAsset || scannedAsset.organizationId !== organizationId) {
       throw new ShelfError({
         cause: null,
@@ -1164,6 +1185,28 @@ export async function recordAuditScan(
         shouldBeCaptured: false,
         label,
       });
+    }
+
+    // Check if this asset was already scanned in this audit
+    const existingScan = await db.auditScan.findFirst({
+      where: {
+        auditSessionId,
+        assetId,
+      },
+      select: {
+        id: true,
+        auditAssetId: true,
+      },
+    });
+
+    if (existingScan) {
+      // Already scanned, just return current counts
+      return {
+        scanId: existingScan.id,
+        auditAssetId: existingScan.auditAssetId,
+        foundAssetCount: session.foundAssetCount,
+        unexpectedAssetCount: session.unexpectedAssetCount,
+      };
     }
 
     // Record the scan in a transaction
@@ -1325,6 +1368,22 @@ export async function recordAuditScan(
     // other handlers in this file.
     if (isLikeShelfError(cause)) {
       throw cause;
+    }
+    // TOCTOU fallback: the pre-transaction guard validated the asset, but it
+    // can still be deleted or moved to another org between that check and
+    // `tx.auditScan.create`. That race surfaces as a Prisma P2003 foreign-key
+    // violation on `AuditScan_assetId_fkey`. Convert it to the same clean,
+    // non-captured 404 the guard returns instead of a captured generic 500.
+    if (isAuditAssetFkViolation(cause)) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "The scanned asset could not be found in this workspace. It may have been deleted or belong to a different organization.",
+        additionalData: { auditSessionId, assetId, organizationId },
+        status: 404,
+        shouldBeCaptured: false,
+        label,
+      });
     }
     throw new ShelfError({
       cause,

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1175,6 +1175,15 @@ export async function recordAuditScan(
     // AuditScan row pointing at a cross-org/deleted asset (legacy rows from
     // the previously unguarded path, or imported bad data) must not let a
     // retry report success and bypass this check.
+    //
+    // why: the residual "asset moved to another org between this read and
+    // `tx.auditScan.create`" race is not reachable here — `Asset.organizationId`
+    // is set at creation and never mutated anywhere in the codebase (org
+    // ownership transfer reassigns an org's owner, not an asset's org). The
+    // only reachable mid-window race is deletion, handled by the P2003
+    // fallback below. An in-transaction SELECT ... FOR UPDATE / composite-FK
+    // migration would add lock contention to this hot scan path to guard an
+    // unreachable state, so it is intentionally out of scope.
     if (!scannedAsset || scannedAsset.organizationId !== organizationId) {
       throw new ShelfError({
         cause: null,


### PR DESCRIPTION
`recordAuditScan` fetched the scanned asset but never validated it before `tx.auditScan.create({ data: { assetId } })`. A deleted asset, a cross-org asset, or a bogus id reached the insert and surfaced as a raw Prisma P2003 (`AuditScan_assetId_fkey`) wrapped into a *captured* "Failed to record audit scan" 500 (SHELF-WEBAPP-1K4). Beyond the recent pentest traffic, a real user scanning a just-deleted or other-org asset mid-audit hits the same path.

- Validate the asset exists and belongs to the audit's organization before the transaction; otherwise throw a non-captured 404 with a meaningful message.
- Preserve already-typed ShelfErrors in the outer catch (matches the `if (isLikeShelfError(cause)) throw cause;` pattern used elsewhere in this file) so the 404s here, the existing "Audit session not found", and the archived-audit guard are no longer re-wrapped into a captured generic 500.
- Add unit coverage for the missing-asset and cross-org cases.

Fixes SHELF-WEBAPP-1K4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added pre-transaction validation so scans for missing or cross-organization assets return a non-captured 404 and prevent creating scan records; foreign-key violations from race conditions are translated to the same clean 404. Preserves existing error types for other failures.

* **Tests**
  * Added tests for the asset validation guard covering cross-org, stale-row, and FK-race scenarios; asserts no scan record is created in failing cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2550)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->