### PR TITLE
fix(security): validate location before asset write; fail-safe checkout on legacy cross-org assets

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -1482,21 +1482,13 @@ export async function updateAsset({
 
       const user = await loadUserForNotes();
 
-      // why: hard-reject a foreign location id (cross-org IDOR) using the
-      // shared guard, then fetch the row (still org-scoped) for its name.
-      if (currentLocationId) {
-        await assertLocationBelongsToOrg({
-          locationId: currentLocationId,
-          organizationId,
-        });
-      }
-      if (newLocationId) {
-        await assertLocationBelongsToOrg({
-          locationId: newLocationId,
-          organizationId,
-        });
-      }
-
+      // why: cross-org safety for the location IDs is already enforced
+      // *before* the write — `newLocationId` is hard-validated at the
+      // org-scoped findFirst guard above (it throws 404 before connecting),
+      // and `currentLocationId` only drives a `disconnect` (value unused by
+      // Prisma) plus the org-scoped name lookups below (a foreign id resolves
+      // to null, never leaks). A post-write assert here previously threw a
+      // 404 *after* db.asset.update had already committed — removed.
       const currentLocation = currentLocationId
         ? await db.location.findFirst({
             where: {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -1523,6 +1523,44 @@ describe("checkoutBooking", () => {
     to: futureToDate,
   };
 
+  it("aborts checkout and performs no writes when an attached asset is not in the caller's org", async () => {
+    expect.assertions(3);
+
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.RESERVED,
+      assets: [
+        {
+          id: "asset-1",
+          kitId: null,
+          title: "Asset 1",
+          status: "AVAILABLE",
+          bookings: [],
+        },
+        // legacy cross-org link — belongs to another workspace
+        {
+          id: "foreign-asset",
+          kitId: null,
+          title: "Foreign Asset",
+          status: "AVAILABLE",
+          bookings: [],
+        },
+      ],
+    };
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
+    // org guard: only the in-org asset resolves; "foreign-asset" is absent
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue([{ id: "asset-1" }]);
+
+    await expect(checkoutBooking(mockCheckoutParams)).rejects.toThrow(
+      "Some of the selected assets do not exist in your workspace"
+    );
+    // fail-safe: no status transition, no booking write
+    expect(db.asset.updateMany).not.toHaveBeenCalled();
+    expect(db.booking.update).not.toHaveBeenCalled();
+  });
+
   it("should checkout booking successfully with no conflicts", async () => {
     expect.assertions(2);
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -83,7 +83,16 @@ vitest.mock("~/database/db.server", () => ({
       count: vitest.fn().mockResolvedValue(0),
     },
     asset: {
-      findMany: vitest.fn().mockResolvedValue([]),
+      // why: assertAssetsBelongToOrg (checkout/create cross-org guard) calls
+      // db.asset.findMany({ where:{ id:{ in }, organizationId }, select:{ id }}).
+      // Echo the requested ids so the guard passes for happy-path tests; other
+      // call sites (no id.in) still get [], and tests override per-case.
+      findMany: vitest.fn().mockImplementation((args?: any) => {
+        const ids = args?.where?.id?.in;
+        return Promise.resolve(
+          Array.isArray(ids) ? ids.map((id: string) => ({ id })) : []
+        );
+      }),
       updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
       update: vitest.fn().mockResolvedValue({}),
     },
@@ -1491,6 +1500,19 @@ describe("reserveBooking", () => {
 describe("checkoutBooking", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+    // why: checkoutBooking now runs assertAssetsBelongToOrg over the booking's
+    // assets (right after load, before any asset-derived logic). Echo the
+    // requested ids so the org guard passes and tests can exercise the
+    // conflict / custody / happy-path flows. (clearAllMocks keeps prior
+    // describe implementations, so set this explicitly per describe.)
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+      (args?: any) => {
+        const ids = args?.where?.id?.in;
+        return Promise.resolve(
+          Array.isArray(ids) ? ids.map((id: string) => ({ id })) : []
+        );
+      }
+    );
   });
 
   const mockCheckoutParams = {

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1337,6 +1337,19 @@ export async function checkoutBooking({
         });
       });
 
+    // SECURITY (defense-in-depth): reject checkout if any attached asset is
+    // not in this org BEFORE any asset-derived logic runs. A legacy
+    // pre-remediation cross-org link would otherwise (a) leak the foreign
+    // asset's title through the conflict/custody error messages below, and
+    // (b) let the booking transition while the org-scoped updateMany skips it.
+    // Legitimately-created bookings (assets validated at create/add) pass.
+    if (bookingFound.assets.length > 0) {
+      await assertAssetsBelongToOrg({
+        assetIds: bookingFound.assets.map((a) => a.id),
+        organizationId,
+      });
+    }
+
     /** Server-side conflict validation to prevent race conditions */
     if (from && to && bookingFound.assets) {
       const conflictedAssets = bookingFound.assets.filter((asset) =>
@@ -1431,23 +1444,6 @@ export async function checkoutBooking({
      *
      * Using callback-form transaction to include activity events atomically. */
     await db.$transaction(async (tx) => {
-      // SECURITY (defense-in-depth): a legacy cross-org asset link created
-      // before the org-scoping remediation would otherwise let checkout
-      // transition the booking to ONGOING and emit checkout events for a
-      // foreign asset, while the org-scoped updateMany below silently skips
-      // it (status drift + misleading events). Fail safe: reject checkout if
-      // any attached asset is not in this org. Legitimately-created bookings
-      // (assets validated at create/add time) always pass this.
-      if (bookingFound.assets.length > 0) {
-        await assertAssetsBelongToOrg(
-          {
-            assetIds: bookingFound.assets.map((a) => a.id),
-            organizationId,
-          },
-          tx
-        );
-      }
-
       // SECURITY (cross-org IDOR): scope the status mutation to the caller's
       // organization so it can never flip the status of an asset that lives
       // in another workspace, even if a foreign asset ID slipped into the

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1431,6 +1431,23 @@ export async function checkoutBooking({
      *
      * Using callback-form transaction to include activity events atomically. */
     await db.$transaction(async (tx) => {
+      // SECURITY (defense-in-depth): a legacy cross-org asset link created
+      // before the org-scoping remediation would otherwise let checkout
+      // transition the booking to ONGOING and emit checkout events for a
+      // foreign asset, while the org-scoped updateMany below silently skips
+      // it (status drift + misleading events). Fail safe: reject checkout if
+      // any attached asset is not in this org. Legitimately-created bookings
+      // (assets validated at create/add time) always pass this.
+      if (bookingFound.assets.length > 0) {
+        await assertAssetsBelongToOrg(
+          {
+            assetIds: bookingFound.assets.map((a) => a.id),
+            organizationId,
+          },
+          tx
+        );
+      }
+
       // SECURITY (cross-org IDOR): scope the status mutation to the caller's
       // organization so it can never flip the status of an asset that lives
       // in another workspace, even if a foreign asset ID slipped into the


### PR DESCRIPTION
Follow-up to #2556 (post-merge CodeRabbit round):

- updateAsset: removed the redundant assertLocationBelongsToOrg block that ran AFTER db.asset.update. newLocationId is already hard-validated pre-write by the org-scoped findFirst guard (throws 404 before connecting); currentLocationId only drives a Prisma disconnect + org-scoped name fetch (foreign id -> null, no leak). The post-write asserts added no protection and threw a 404 after the mutation had already committed (misleading failed-looking success).
- checkoutBooking: add a fail-safe assertAssetsBelongToOrg over the booking's assets before the ONGOING transition. A legacy pre-remediation cross-org asset link would otherwise let checkout proceed and emit checkout events for the foreign asset while the org-scoped updateMany silently skipped it.

CodeRabbit kits catch re-wrap + test:286 clearAllMocks triaged as non-issues (ShelfError inherits cause status/message; mocks set in the vi.mock factory) — no change. validate green: 2087/2087, 0 type/lint errors (IDOR rule enforced).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made asset location-change recording more consistent so location-change notes and activity events are reliably created.
  * Added stricter validation during booking checkout to prevent checkouts of assets that don’t belong to the caller’s organization.

* **Tests**
  * Updated tests and mocks to cover the new cross-organization validation and checkout behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->