### PR TITLE
fix(companion): dismiss custody picker on member select [LAUNCH-BLOCKER]

### DIFF
--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -523,7 +523,14 @@ export default function AssetDetailScreen() {
           <TeamMemberPicker
             visible={showCustodyPicker}
             orgId={currentOrg.id}
-            onSelect={handleAssignCustody}
+            onSelect={(member) => {
+              // Mirror handleLocationSelect: dismiss the picker before the
+              // confirm/assign flow so the user sees the refetched asset
+              // detail and the new custody state — not a stuck member list
+              // with no visible feedback (read as "it didn't work").
+              setShowCustodyPicker(false);
+              handleAssignCustody(member);
+            }}
             onClose={() => setShowCustodyPicker(false)}
           />
           <LocationPicker


### PR DESCRIPTION
## Need

Pre-release dogfood (CTO, 2026-05-19) of build `1.0.0 (12)` — currently submitted to App Review — surfaced one launch-blocker: tapping **Assign Custody** on an asset, picking a member, gave haptic feedback but **no on-screen confirmation and the picker stayed open**. To the user it reads as "it didn't work."

## Root cause (verified)

The custody assignment **persists correctly** (server writes custody + note, asset refetches) — this is **not** data loss. The bug: the custody `TeamMemberPicker` is never dismissed on select. The working sibling `handleLocationSelect` (`app/(tabs)/assets/[id].tsx:120-121`) closes its picker as its first line; the custody path (`onSelect={handleAssignCustody}`, `[id].tsx:526`) never calls `setShowCustodyPicker(false)` (it exists only on the X-button `onClose`). So the (correctly updated) asset detail sits hidden behind a stuck member list.

## Fix

One change, an exact mirror of the proven location flow: dismiss the picker before the confirm/assign flow.

```diff
- onSelect={handleAssignCustody}
+ onSelect={(member) => {
+   setShowCustodyPicker(false);
+   handleAssignCustody(member);
+ }}
```

Pure JS, no native change. `pnpm --filter @shelf/companion typecheck` clean.

## Test plan

- Assign custody to a member → picker dismisses → confirm Alert → on confirm, asset detail shows the new "In Custody Of" row (existing `performAssign` haptic + `fetchAsset()` already handled this; it was just hidden).
- Cancel from the confirm Alert → asset detail visible, no assignment (unchanged).
- Release Custody / Update Location / Add Note paths untouched (location already worked this way; this brings custody to parity).

## Severity / release impact

**Launch-blocker.** Assign Custody is a core field action; "looks broken" on day one = support load + 1-star reviews + users re-tapping (mis-assigning). The companion has **no EAS Update/OTA** (`expo-updates` not installed), so this cannot be hotfixed post-approval — any client fix needs a new build + full review. Therefore 1.0 (build 12) is being pulled from review and **build 13 is cut from this branch** so the first public version is correct. Founder owns the ASC "remove from review" + final resubmit/Submit.

Branch is off current `main` (`fd5889771`), so build 13 = latest main + this fix. Please review/merge so `main` matches the shipped binary. Not merging it myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custody picker now closes immediately after assigning custody to a team member.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->