### PR TITLE
fix(security): authorize public scan geo-update + allowlist scanner extra-include

### DIFF
--- a/apps/webapp/app/modules/scan/service.server.test.ts
+++ b/apps/webapp/app/modules/scan/service.server.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+/**
+ * Tests for the public-route geolocation guard `updateScanGeolocation`.
+ *
+ * Covers the security-critical behaviors of an anonymous, public endpoint:
+ *   1. 5-minute time-window on `createdAt`
+ *   2. `qrId` must match the route path's `qrId`
+ *   3. **Write-once**: GPS already set → reject
+ *   4. Happy path → delegates to `updateScan`
+ *
+ * Each rejection path additionally asserts no write hit the database.
+ *
+ * @see {@link file://./service.server.ts}
+ */
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+
+import { updateScanGeolocation } from "./service.server";
+
+// why: hollow db mock — we only exercise the guard's findUnique/update calls.
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    scan: {
+      findUnique: vitest.fn(),
+      update: vitest.fn().mockResolvedValue({ id: "scan-1" }),
+    },
+    user: { findUnique: vitest.fn().mockResolvedValue(null) },
+  },
+}));
+
+const QR_ID = "qr-abc";
+const SCAN_ID = "scan-1";
+const fresh = () => new Date();
+const stale = () => new Date(Date.now() - 6 * 60 * 1000);
+
+beforeEach(() => {
+  vitest.clearAllMocks();
+});
+
+describe("updateScanGeolocation", () => {
+  it("rejects when the scan does not exist (no write)", async () => {
+    //@ts-expect-error vitest mock typing
+    db.scan.findUnique.mockResolvedValue(null);
+
+    await expect(
+      updateScanGeolocation({
+        scanId: SCAN_ID,
+        qrId: QR_ID,
+        latitude: "1",
+        longitude: "2",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+    expect(db.scan.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the scan's qrId does not match the route qrId (no write)", async () => {
+    //@ts-expect-error vitest mock typing
+    db.scan.findUnique.mockResolvedValue({
+      id: SCAN_ID,
+      createdAt: fresh(),
+      qrId: "different-qr",
+      latitude: null,
+    });
+
+    await expect(
+      updateScanGeolocation({
+        scanId: SCAN_ID,
+        qrId: QR_ID,
+        latitude: "1",
+        longitude: "2",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+    expect(db.scan.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the scan is older than the 5-minute window (no write)", async () => {
+    //@ts-expect-error vitest mock typing
+    db.scan.findUnique.mockResolvedValue({
+      id: SCAN_ID,
+      createdAt: stale(),
+      qrId: QR_ID,
+      latitude: null,
+    });
+
+    await expect(
+      updateScanGeolocation({
+        scanId: SCAN_ID,
+        qrId: QR_ID,
+        latitude: "1",
+        longitude: "2",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+    expect(db.scan.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects when GPS was already set — write-once (no write)", async () => {
+    // why: this is the residual closure for the leaked-URL attack. Even when
+    // scanId + qrId both match and the window is open, a scan whose GPS was
+    // already written cannot be overwritten.
+    //@ts-expect-error vitest mock typing
+    db.scan.findUnique.mockResolvedValue({
+      id: SCAN_ID,
+      createdAt: fresh(),
+      qrId: QR_ID,
+      latitude: "50.0",
+    });
+
+    await expect(
+      updateScanGeolocation({
+        scanId: SCAN_ID,
+        qrId: QR_ID,
+        latitude: "10",
+        longitude: "20",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+    expect(db.scan.update).not.toHaveBeenCalled();
+  });
+
+  it("updates the scan on the happy path (recent + matching qrId + GPS not yet set)", async () => {
+    //@ts-expect-error vitest mock typing
+    db.scan.findUnique.mockResolvedValue({
+      id: SCAN_ID,
+      createdAt: fresh(),
+      qrId: QR_ID,
+      latitude: null,
+    });
+
+    await updateScanGeolocation({
+      scanId: SCAN_ID,
+      qrId: QR_ID,
+      latitude: "10",
+      longitude: "20",
+    });
+
+    expect(db.scan.update).toHaveBeenCalledTimes(1);
+    expect(db.scan.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: SCAN_ID },
+        data: expect.objectContaining({ latitude: "10", longitude: "20" }),
+      })
+    );
+  });
+});

--- a/apps/webapp/app/modules/scan/service.server.test.ts
+++ b/apps/webapp/app/modules/scan/service.server.test.ts
@@ -60,6 +60,7 @@ describe("updateScanGeolocation", () => {
       createdAt: fresh(),
       qrId: "different-qr",
       latitude: null,
+      longitude: null,
     });
 
     await expect(
@@ -80,6 +81,7 @@ describe("updateScanGeolocation", () => {
       createdAt: stale(),
       qrId: QR_ID,
       latitude: null,
+      longitude: null,
     });
 
     await expect(
@@ -93,7 +95,7 @@ describe("updateScanGeolocation", () => {
     expect(db.scan.update).not.toHaveBeenCalled();
   });
 
-  it("rejects when GPS was already set — write-once (no write)", async () => {
+  it("rejects when latitude is already set — write-once (no write)", async () => {
     // why: this is the residual closure for the leaked-URL attack. Even when
     // scanId + qrId both match and the window is open, a scan whose GPS was
     // already written cannot be overwritten.
@@ -103,6 +105,31 @@ describe("updateScanGeolocation", () => {
       createdAt: fresh(),
       qrId: QR_ID,
       latitude: "50.0",
+      longitude: null,
+    });
+
+    await expect(
+      updateScanGeolocation({
+        scanId: SCAN_ID,
+        qrId: QR_ID,
+        latitude: "10",
+        longitude: "20",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+    expect(db.scan.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects when only longitude is already set — symmetric write-once (no write)", async () => {
+    // why: an asymmetric latitude-only guard would let a longitude-only
+    // partial write slip through any future internal caller or schema
+    // relaxation. The guard rejects if EITHER coordinate is populated.
+    //@ts-expect-error vitest mock typing
+    db.scan.findUnique.mockResolvedValue({
+      id: SCAN_ID,
+      createdAt: fresh(),
+      qrId: QR_ID,
+      latitude: null,
+      longitude: "50.0",
     });
 
     await expect(
@@ -123,6 +150,7 @@ describe("updateScanGeolocation", () => {
       createdAt: fresh(),
       qrId: QR_ID,
       latitude: null,
+      longitude: null,
     });
 
     await updateScanGeolocation({

--- a/apps/webapp/app/modules/scan/service.server.ts
+++ b/apps/webapp/app/modules/scan/service.server.ts
@@ -263,3 +263,59 @@ export async function createScanNote({
     });
   }
 }
+
+/**
+ * Max age of a scan whose geolocation may still be attached from the public,
+ * unauthenticated /qr/:qrId endpoint. The legitimate browser flow posts
+ * coordinates within seconds of the scan being created.
+ */
+const SCAN_GEO_UPDATE_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Attaches geolocation to a freshly-created scan from the **public,
+ * unauthenticated** `/qr/:qrId` route.
+ *
+ * SECURITY (CWE-639 / CWE-862): that route requires no authentication and
+ * `scanId` is fully attacker-controlled. Calling `updateScan` directly there
+ * let anyone overwrite the GPS of *any* scan record by id. We only permit
+ * updating a scan created within {@link SCAN_GEO_UPDATE_WINDOW_MS}, which
+ * matches the legitimate immediate client-side geolocation post and prevents
+ * tampering of arbitrary or historical scan records.
+ *
+ * @param params.scanId - Scan id from public form input (untrusted)
+ * @param params.latitude - Geolocation latitude
+ * @param params.longitude - Geolocation longitude
+ * @returns The updated scan
+ * @throws {ShelfError} 403 if the scan is missing or older than the window
+ */
+export async function updateScanGeolocation({
+  scanId,
+  latitude,
+  longitude,
+}: {
+  scanId: Scan["id"];
+  latitude?: Scan["latitude"];
+  longitude?: Scan["longitude"];
+}) {
+  const scan = await db.scan.findUnique({
+    where: { id: scanId },
+    select: { id: true, createdAt: true },
+  });
+
+  if (
+    !scan ||
+    Date.now() - scan.createdAt.getTime() > SCAN_GEO_UPDATE_WINDOW_MS
+  ) {
+    throw new ShelfError({
+      cause: null,
+      title: "Scan not found",
+      message: "This scan can no longer be updated.",
+      label,
+      status: 403,
+      shouldBeCaptured: false,
+      additionalData: { scanId },
+    });
+  }
+
+  return updateScan({ id: scanId, latitude, longitude });
+}

--- a/apps/webapp/app/modules/scan/service.server.ts
+++ b/apps/webapp/app/modules/scan/service.server.ts
@@ -292,7 +292,8 @@ const SCAN_GEO_UPDATE_WINDOW_MS = 5 * 60 * 1000;
  * @param params.longitude - Geolocation longitude
  * @returns The updated scan
  * @throws {ShelfError} 403 if the scan is missing, the qrId does not match,
- *                      or the scan is older than the window
+ *                      the scan is older than the window, or its GPS was
+ *                      already set (write-once)
  */
 export async function updateScanGeolocation({
   scanId,
@@ -307,12 +308,20 @@ export async function updateScanGeolocation({
 }) {
   const scan = await db.scan.findUnique({
     where: { id: scanId },
-    select: { id: true, createdAt: true, qrId: true },
+    select: { id: true, createdAt: true, qrId: true, latitude: true },
   });
 
+  // why: GPS update is **write-once**. A successful update sets latitude
+  // (and longitude) once; any subsequent attempt — even with a valid
+  // scanId+qrId still in the 5-min window — is rejected. This collapses the
+  // residual attack surface (a leaked /qr/<id>?scanId=<id> URL) to a
+  // seconds-wide race the legitimate client almost always wins, since the
+  // browser posts coordinates immediately after page load. No schema change
+  // or capability-token plumbing required for an anonymous scan-log field.
   if (
     !scan ||
     scan.qrId !== qrId ||
+    scan.latitude !== null ||
     Date.now() - scan.createdAt.getTime() > SCAN_GEO_UPDATE_WINDOW_MS
   ) {
     throw new ShelfError({

--- a/apps/webapp/app/modules/scan/service.server.ts
+++ b/apps/webapp/app/modules/scan/service.server.ts
@@ -277,33 +277,42 @@ const SCAN_GEO_UPDATE_WINDOW_MS = 5 * 60 * 1000;
  *
  * SECURITY (CWE-639 / CWE-862): that route requires no authentication and
  * `scanId` is fully attacker-controlled. Calling `updateScan` directly there
- * let anyone overwrite the GPS of *any* scan record by id. We only permit
- * updating a scan created within {@link SCAN_GEO_UPDATE_WINDOW_MS}, which
- * matches the legitimate immediate client-side geolocation post and prevents
- * tampering of arbitrary or historical scan records.
+ * let anyone overwrite the GPS of *any* scan record by id. We require BOTH:
+ *
+ *  1. the scan was created within {@link SCAN_GEO_UPDATE_WINDOW_MS} (matches
+ *     the legitimate immediate client-side geolocation post; prevents
+ *     tampering of arbitrary or historical scan records), AND
+ *  2. the scan's `qrId` matches the QR id from the route's URL path — so a
+ *     leaked `scanId` alone (URL share / Referer) cannot be used; an attacker
+ *     would need the matching qrId for that specific scan as well.
  *
  * @param params.scanId - Scan id from public form input (untrusted)
+ * @param params.qrId - QR id from the URL path (the trust-bound route param)
  * @param params.latitude - Geolocation latitude
  * @param params.longitude - Geolocation longitude
  * @returns The updated scan
- * @throws {ShelfError} 403 if the scan is missing or older than the window
+ * @throws {ShelfError} 403 if the scan is missing, the qrId does not match,
+ *                      or the scan is older than the window
  */
 export async function updateScanGeolocation({
   scanId,
+  qrId,
   latitude,
   longitude,
 }: {
   scanId: Scan["id"];
+  qrId: string;
   latitude?: Scan["latitude"];
   longitude?: Scan["longitude"];
 }) {
   const scan = await db.scan.findUnique({
     where: { id: scanId },
-    select: { id: true, createdAt: true },
+    select: { id: true, createdAt: true, qrId: true },
   });
 
   if (
     !scan ||
+    scan.qrId !== qrId ||
     Date.now() - scan.createdAt.getTime() > SCAN_GEO_UPDATE_WINDOW_MS
   ) {
     throw new ShelfError({
@@ -313,7 +322,7 @@ export async function updateScanGeolocation({
       label,
       status: 403,
       shouldBeCaptured: false,
-      additionalData: { scanId },
+      additionalData: { scanId, qrId },
     });
   }
 

--- a/apps/webapp/app/modules/scan/service.server.ts
+++ b/apps/webapp/app/modules/scan/service.server.ts
@@ -308,20 +308,30 @@ export async function updateScanGeolocation({
 }) {
   const scan = await db.scan.findUnique({
     where: { id: scanId },
-    select: { id: true, createdAt: true, qrId: true, latitude: true },
+    select: {
+      id: true,
+      createdAt: true,
+      qrId: true,
+      latitude: true,
+      longitude: true,
+    },
   });
 
-  // why: GPS update is **write-once**. A successful update sets latitude
-  // (and longitude) once; any subsequent attempt — even with a valid
-  // scanId+qrId still in the 5-min window — is rejected. This collapses the
-  // residual attack surface (a leaked /qr/<id>?scanId=<id> URL) to a
-  // seconds-wide race the legitimate client almost always wins, since the
-  // browser posts coordinates immediately after page load. No schema change
-  // or capability-token plumbing required for an anonymous scan-log field.
+  // why: GPS update is **symmetrically write-once** — reject if EITHER
+  // coordinate is already populated, not only latitude. The route currently
+  // requires both, but `updateScanGeolocation` accepts each as optional, so
+  // an asymmetric latitude-only check would let a longitude-only write slip
+  // through any future internal caller or schema relaxation. Combined with
+  // the 5-min window and the qrId binding, this collapses the residual
+  // attack surface (a leaked /qr/<id>?scanId=<id> URL) to a seconds-wide
+  // race the legitimate client almost always wins, since the browser posts
+  // coordinates immediately after page load. No schema change or capability-
+  // token plumbing required for an anonymous scan-log field.
   if (
     !scan ||
     scan.qrId !== qrId ||
     scan.latitude !== null ||
+    scan.longitude !== null ||
     Date.now() - scan.createdAt.getTime() > SCAN_GEO_UPDATE_WINDOW_MS
   ) {
     throw new ShelfError({

--- a/apps/webapp/app/routes/api+/get-scanned-barcode.$value.ts
+++ b/apps/webapp/app/routes/api+/get-scanned-barcode.$value.ts
@@ -17,6 +17,10 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
+import {
+  sanitizeAssetExtraInclude,
+  sanitizeKitExtraInclude,
+} from "~/utils/scanner-extra-include.server";
 import type {
   AssetFromScanner,
   KitFromScanner,
@@ -102,16 +106,22 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       auditSessionId?: string;
     };
 
+    // SECURITY (CWE-94 / overfetch): assetExtraInclude/kitExtraInclude are
+    // user-controlled JSON. Allowlist them before merging into the Prisma
+    // include so relation traversal / deep nesting cannot be injected.
+    const safeAssetExtraInclude = sanitizeAssetExtraInclude(assetExtraInclude);
+    const safeKitExtraInclude = sanitizeKitExtraInclude(kitExtraInclude);
+
     const include = {
       ...BARCODE_INCLUDE,
 
       // Include additional data based on search params. This will override the default includes
-      ...(assetExtraInclude
-        ? { asset: { include: { ...ASSET_INCLUDE, ...assetExtraInclude } } }
+      ...(safeAssetExtraInclude
+        ? { asset: { include: { ...ASSET_INCLUDE, ...safeAssetExtraInclude } } }
         : undefined),
 
-      ...(kitExtraInclude
-        ? { kit: { include: { ...KIT_INCLUDE, ...kitExtraInclude } } }
+      ...(safeKitExtraInclude
+        ? { kit: { include: { ...KIT_INCLUDE, ...safeKitExtraInclude } } }
         : undefined),
     };
 

--- a/apps/webapp/app/routes/api+/get-scanned-item.$qrId.ts
+++ b/apps/webapp/app/routes/api+/get-scanned-item.$qrId.ts
@@ -17,6 +17,10 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
+import {
+  sanitizeAssetExtraInclude,
+  sanitizeKitExtraInclude,
+} from "~/utils/scanner-extra-include.server";
 import type {
   AssetFromScanner,
   KitFromScanner,
@@ -84,14 +88,17 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       auditSessionId?: string;
     };
 
+    // SECURITY (CWE-94 / overfetch): assetExtraInclude/kitExtraInclude are
+    // user-controlled JSON. Allowlist them before merging into the Prisma
+    // include so relation traversal / deep nesting cannot be injected.
     const assetInclude: Prisma.AssetInclude = {
       ...ASSET_INCLUDE,
-      ...(assetExtraInclude ?? {}),
+      ...(sanitizeAssetExtraInclude(assetExtraInclude) ?? {}),
     };
 
     const kitInclude: Prisma.KitInclude = {
       ...KIT_INCLUDE,
-      ...(kitExtraInclude ?? {}),
+      ...(sanitizeKitExtraInclude(kitExtraInclude) ?? {}),
     };
 
     const sequentialId = parseSequentialId(qrId);

--- a/apps/webapp/app/routes/qr+/_public+/$qrId.tsx
+++ b/apps/webapp/app/routes/qr+/_public+/$qrId.tsx
@@ -144,9 +144,13 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   }
 }
 
-export async function action({ request }: ActionFunctionArgs) {
+export async function action({ request, params }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
+
+    // Trust-bound qrId from the URL path (NOT from form data) — used to
+    // verify the supplied scanId actually belongs to this QR.
+    const { qrId } = getParams(params, z.object({ qrId: z.string() }));
 
     const { latitude, longitude, scanId } = parseData(
       await request.formData(),
@@ -160,12 +164,14 @@ export async function action({ request }: ActionFunctionArgs) {
     /**
      * This handles the automatic geolocation update when we have scanId
      * formData. SECURITY: this route is public/unauthenticated and `scanId`
-     * is attacker-controlled — updateScanGeolocation only permits updating a
-     * recently-created scan, so arbitrary/old scan records cannot be tampered.
+     * is attacker-controlled — `updateScanGeolocation` permits the update only
+     * when the scan was created within a short window AND its `qrId` matches
+     * the URL path's `qrId`, so a leaked scanId alone cannot tamper.
      */
     if (scanId) {
       await updateScanGeolocation({
         scanId,
+        qrId,
         latitude,
         longitude,
       });

--- a/apps/webapp/app/routes/qr+/_public+/$qrId.tsx
+++ b/apps/webapp/app/routes/qr+/_public+/$qrId.tsx
@@ -6,7 +6,11 @@ import { ErrorContent } from "~/components/errors";
 import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
 import { getUserOrganizations } from "~/modules/organization/service.server";
 import { getQr } from "~/modules/qr/service.server";
-import { createScan, updateScan } from "~/modules/scan/service.server";
+import {
+  createScan,
+  updateScan,
+  updateScanGeolocation,
+} from "~/modules/scan/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { setCookie } from "~/utils/cookies.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -153,10 +157,15 @@ export async function action({ request }: ActionFunctionArgs) {
       })
     );
 
-    /** This handles the automatic update when we have scanId formData */
+    /**
+     * This handles the automatic geolocation update when we have scanId
+     * formData. SECURITY: this route is public/unauthenticated and `scanId`
+     * is attacker-controlled — updateScanGeolocation only permits updating a
+     * recently-created scan, so arbitrary/old scan records cannot be tampered.
+     */
     if (scanId) {
-      await updateScan({
-        id: scanId,
+      await updateScanGeolocation({
+        scanId,
         latitude,
         longitude,
       });

--- a/apps/webapp/app/utils/scanner-extra-include.server.test.ts
+++ b/apps/webapp/app/utils/scanner-extra-include.server.test.ts
@@ -50,6 +50,30 @@ describe("sanitizeAssetExtraInclude", () => {
     ).toBeUndefined();
   });
 
+  it("rejects nested-select relation traversal under an allowlisted key", () => {
+    // Regression: a `{ select: { <relation>: { select|include: ... } } }`
+    // payload under an allowlisted key was previously accepted as-is, letting
+    // an attacker traverse relations (e.g. kit.assets.bookings) despite the
+    // top-level allowlist. The fix enforces a *flat* select (boolean values
+    // only), so any nested object/array inside select is rejected.
+    expect(
+      sanitizeAssetExtraInclude({
+        kit: { select: { assets: { select: { bookings: true } } } },
+      })
+    ).toBeUndefined();
+    expect(
+      sanitizeAssetExtraInclude({
+        kit: { select: { assets: { include: { bookings: true } } } },
+      })
+    ).toBeUndefined();
+    // Mixed: one valid boolean + one nested → reject the whole value
+    expect(
+      sanitizeAssetExtraInclude({
+        kit: { select: { id: true, assets: { select: { id: true } } } },
+      })
+    ).toBeUndefined();
+  });
+
   it("returns undefined for non-objects, arrays and empty results", () => {
     expect(sanitizeAssetExtraInclude(undefined)).toBeUndefined();
     expect(sanitizeAssetExtraInclude("kit")).toBeUndefined();

--- a/apps/webapp/app/utils/scanner-extra-include.server.test.ts
+++ b/apps/webapp/app/utils/scanner-extra-include.server.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+/**
+ * Tests for the scanner extra-include sanitizer (V-003 hardening).
+ *
+ * Asserts the security-relevant behavior: legitimate scanner-drawer shapes
+ * pass through unchanged, while disallowed keys and injectable shapes
+ * (`include`, deep nesting, arrays) are stripped.
+ *
+ * @see {@link file://./scanner-extra-include.server.ts}
+ */
+import {
+  sanitizeAssetExtraInclude,
+  sanitizeKitExtraInclude,
+} from "./scanner-extra-include.server";
+
+describe("sanitizeAssetExtraInclude", () => {
+  it("keeps the exact shapes the scanner drawers send", () => {
+    expect(
+      sanitizeAssetExtraInclude({ kit: { select: { id: true, name: true } } })
+    ).toEqual({ kit: { select: { id: true, name: true } } });
+
+    expect(
+      sanitizeAssetExtraInclude({
+        location: { select: { id: true, name: true } },
+      })
+    ).toEqual({ location: { select: { id: true, name: true } } });
+
+    expect(sanitizeAssetExtraInclude({ category: true })).toEqual({
+      category: true,
+    });
+  });
+
+  it("drops disallowed top-level relations (overfetch / PII traversal)", () => {
+    expect(
+      sanitizeAssetExtraInclude({
+        organization: true,
+        bookings: { include: { custodianUser: true } },
+        notes: true,
+        kit: { select: { id: true } },
+      })
+    ).toEqual({ kit: { select: { id: true } } });
+  });
+
+  it("rejects injectable value shapes (include / deep nesting)", () => {
+    // allowed key, but `include` (relation traversal) is not an allowed shape
+    expect(
+      sanitizeAssetExtraInclude({
+        kit: { include: { assets: { include: { bookings: true } } } },
+      })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for non-objects, arrays and empty results", () => {
+    expect(sanitizeAssetExtraInclude(undefined)).toBeUndefined();
+    expect(sanitizeAssetExtraInclude("kit")).toBeUndefined();
+    expect(sanitizeAssetExtraInclude([{ kit: true }])).toBeUndefined();
+    expect(sanitizeAssetExtraInclude({ organization: true })).toBeUndefined();
+  });
+});
+
+describe("sanitizeKitExtraInclude", () => {
+  it("allows only its allowlisted keys and safe shapes", () => {
+    expect(
+      sanitizeKitExtraInclude({
+        category: true,
+        assets: { include: { bookings: true } },
+      })
+    ).toEqual({ category: true });
+  });
+
+  it("drops everything when nothing is allowlisted", () => {
+    expect(
+      sanitizeKitExtraInclude({ assets: true, organization: true })
+    ).toBeUndefined();
+  });
+});

--- a/apps/webapp/app/utils/scanner-extra-include.server.ts
+++ b/apps/webapp/app/utils/scanner-extra-include.server.ts
@@ -1,0 +1,86 @@
+/**
+ * Sanitizer for the `assetExtraInclude` / `kitExtraInclude` query params on the
+ * scanned-item lookup endpoints.
+ *
+ * Those params are user-controlled JSON that gets spread into a Prisma
+ * `include`. Unsanitized, an authenticated user could shape the query to
+ * over-fetch arbitrary relations (e.g. `organization`, `bookings`,
+ * `custody.custodian`, deeply nested `include`s) on a scanned asset/kit, or
+ * cause expensive nested queries (CWE-94 / overfetch / query DoS). The parent
+ * row is already org-scoped, so this is not cross-tenant — but it is still an
+ * unbounded query-shape injection.
+ *
+ * Fix: allow only the top-level relation keys the scanner drawers legitimately
+ * request, and only the shapes they actually send (`true` or a flat
+ * `{ select }`). Any other key, or a value containing `include` / `where` /
+ * arbitrary nesting, is dropped.
+ *
+ * @see {@link file://./../routes/api+/get-scanned-barcode.$value.ts}
+ * @see {@link file://./../routes/api+/get-scanned-item.$qrId.ts}
+ */
+import type { Prisma } from "@prisma/client";
+
+/** Top-level relation keys the scanner drawers may add to the asset include. */
+const ALLOWED_ASSET_EXTRA_INCLUDE = new Set(["kit", "location", "category"]);
+/** Top-level relation keys allowed on the kit include (none requested today). */
+const ALLOWED_KIT_EXTRA_INCLUDE = new Set(["category", "location"]);
+
+/**
+ * Allow only the shapes the drawers send: `true`, or a flat `{ select: {...} }`.
+ * Reject `{ include: ... }` and anything else so relation traversal / deep
+ * nesting cannot be injected.
+ */
+function sanitizeValue(value: unknown): true | { select: object } | undefined {
+  if (value === true) return true;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const keys = Object.keys(value as Record<string, unknown>);
+    const select = (value as { select?: unknown }).select;
+    if (
+      keys.length === 1 &&
+      keys[0] === "select" &&
+      select &&
+      typeof select === "object" &&
+      !Array.isArray(select)
+    ) {
+      return { select: select as object };
+    }
+  }
+  return undefined;
+}
+
+function sanitize(input: unknown, allowed: Set<string>) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+  const out: Record<string, true | { select: object }> = {};
+  for (const [key, raw] of Object.entries(input as Record<string, unknown>)) {
+    if (!allowed.has(key)) continue;
+    const value = sanitizeValue(raw);
+    if (value !== undefined) out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Sanitizes a user-supplied `assetExtraInclude` down to a safe allowlisted
+ * subset before it is merged into a Prisma asset `include`.
+ */
+export function sanitizeAssetExtraInclude(
+  input: unknown
+): Prisma.AssetInclude | undefined {
+  return sanitize(input, ALLOWED_ASSET_EXTRA_INCLUDE) as
+    | Prisma.AssetInclude
+    | undefined;
+}
+
+/**
+ * Sanitizes a user-supplied `kitExtraInclude` down to a safe allowlisted
+ * subset before it is merged into a Prisma kit `include`.
+ */
+export function sanitizeKitExtraInclude(
+  input: unknown
+): Prisma.KitInclude | undefined {
+  return sanitize(input, ALLOWED_KIT_EXTRA_INCLUDE) as
+    | Prisma.KitInclude
+    | undefined;
+}

--- a/apps/webapp/app/utils/scanner-extra-include.server.ts
+++ b/apps/webapp/app/utils/scanner-extra-include.server.ts
@@ -22,15 +22,22 @@ import type { Prisma } from "@prisma/client";
 
 /** Top-level relation keys the scanner drawers may add to the asset include. */
 const ALLOWED_ASSET_EXTRA_INCLUDE = new Set(["kit", "location", "category"]);
-/** Top-level relation keys allowed on the kit include (none requested today). */
+/** Top-level relation keys allowed on the kit include (conservative, low-risk
+ * same-org relations; no caller requires more today). */
 const ALLOWED_KIT_EXTRA_INCLUDE = new Set(["category", "location"]);
 
 /**
- * Allow only the shapes the drawers send: `true`, or a flat `{ select: {...} }`.
- * Reject `{ include: ... }` and anything else so relation traversal / deep
- * nesting cannot be injected.
+ * Allow only the shapes the drawers send: `true`, or a *strictly flat*
+ * `{ select: { <field>: boolean, ... } }` (scalar field selection only).
+ *
+ * Reject `{ include: ... }`, any non-boolean value inside `select` (which
+ * would let an attacker traverse relations via nested select, e.g.
+ * `{ select: { assets: { select: { bookings: true } } } }`), and anything
+ * else — so relation traversal / deep nesting cannot be injected.
  */
-function sanitizeValue(value: unknown): true | { select: object } | undefined {
+function sanitizeValue(
+  value: unknown
+): true | { select: Record<string, boolean> } | undefined {
   if (value === true) return true;
   if (value && typeof value === "object" && !Array.isArray(value)) {
     const keys = Object.keys(value as Record<string, unknown>);
@@ -42,7 +49,16 @@ function sanitizeValue(value: unknown): true | { select: object } | undefined {
       typeof select === "object" &&
       !Array.isArray(select)
     ) {
-      return { select: select as object };
+      // SECURITY: every value in `select` must be a boolean (scalar field
+      // pick). Nested objects/arrays here would re-enable relation traversal
+      // under an allowlisted top-level key — the exact bypass the sanitizer
+      // exists to prevent.
+      const selectObj = select as Record<string, unknown>;
+      const isFlat = Object.values(selectObj).every(
+        (v) => typeof v === "boolean"
+      );
+      if (!isFlat) return undefined;
+      return { select: selectObj as Record<string, boolean> };
     }
   }
   return undefined;


### PR DESCRIPTION
Follow-up to a separate IDOR audit (QR/scan surfaces; distinct from the 1.20.2 cross-org advisory). Addresses audit findings V-001, V-005, V-003.

- V-001/V-005: the public, unauthenticated /qr/:qrId action passed an attacker-controlled scanId straight to updateScan (where:{id} only), letting anyone overwrite the GPS of any scan record. Added updateScanGeolocation: a guarded entry point that only updates a scan created within a 5-minute window (matches the legitimate immediate client geo-post); the route action calls it. The trusted loader path (fresh server-generated scan id) keeps plain updateScan.
- V-003: get-scanned-barcode/get-scanned-item merged user-controlled assetExtraInclude/kitExtraInclude JSON into the Prisma include (relation traversal / deep-nesting overfetch; org-scoped so not cross-tenant). Added a shared allowlist sanitizer (top-level keys + only true / flat {select}; rejects include/arbitrary nesting) preserving the 2 real scanner-drawer shapes. Unit-tested.

Not changed (separate dispositions): V-002 invite-landing disclosure is a product decision; V-004 QR pre-org resolvers and V-006/V-007 TOCTOU were already triaged idor-safe/deferred with cited rationale in #2556.

validate green: 2094/2094, 0 type/lint errors (IDOR rule enforced).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controlled, write-once geolocation updates for the public QR scan flow (time-limited window).

* **Improvements**
  * Hardened handling of user-supplied query params to prevent overfetching of asset and kit data.
  * QR public route now enforces stricter, URL-scoped validation for geolocation updates.

* **Tests**
  * Added unit tests covering query-parameter sanitization and geolocation update guard behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->