### PR TITLE
fix(deps): patch path-to-regexp ReDoS via scoped pnpm override (CVE-2026-4867)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
       "@tremor/react>react-day-picker": "^9.14.0",
       "@tremor/react>react-dom": "19.2.1",
       "cross-spawn": "~7.0.6",
-      "p-map": "4.0.0"
+      "p-map": "4.0.0",
+      "path-to-regexp@<0.1.13": "0.1.13"
     },
     "patchedDependencies": {
       "expo-image@55.0.6": "patches/expo-image@55.0.6.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   '@tremor/react>react-dom': 19.2.1
   cross-spawn: ~7.0.6
   p-map: 4.0.0
+  path-to-regexp@<0.1.13: 0.1.13
 
 patchedDependencies:
   expo-image@55.0.6:
@@ -1743,7 +1744,6 @@ packages:
 
   '@evilmartians/lefthook@2.1.6':
     resolution: {integrity: sha512-ysZbzryf74wlISmgm0PH/n1lJ0HD7AHmI6DoJgWO9qzIETQknhGdmKbkOi0MjLYtiOHWQl8Dr2qwg0ksDpNZjA==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -8365,8 +8365,8 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -17221,7 +17221,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.14.2
       range-parser: 1.2.1
@@ -19317,7 +19317,7 @@ snapshots:
       lru-cache: 11.3.5
       minipass: 7.1.3
 
-  path-to-regexp@0.1.12: {}
+  path-to-regexp@0.1.13: {}
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
The 0.1.x branch of `path-to-regexp` (<0.1.13) is vulnerable to ReDoS via multiple route parameters. Dependabot alert #158 flagged the transitive `0.1.12` copy pulled in by `@react-router/serve`, `react-router-hono-server`, and `@react-router/dev` — i.e. it sits on the production HTTP routing path and would be reachable via any crafted request URL.

Our direct dependency `path-to-regexp@^8.4.2` (used by `apps/webapp/server/middleware.ts`) is on a separate major version line and is not affected by this CVE.

Use a pnpm version-range override `path-to-regexp@<0.1.13: 0.1.13` so only the vulnerable 0.1.x copies are forced to the patched 0.1.13 while the direct 8.x dep and the unrelated 6.x copies (msw, vitest) stay untouched.

Verified via `pnpm webapp:validate` — 2088/2088 tests, lint, typecheck and prettier all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to ensure compatibility and stability across the project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->