### PR TITLE
fix(booking): prevent P2028 transaction-not-found on checkout of large bookings

### DIFF
--- a/apps/webapp/app/modules/activity-event/service.server.test.ts
+++ b/apps/webapp/app/modules/activity-event/service.server.test.ts
@@ -1,6 +1,8 @@
 import { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createActivityEventInput } from "@factories";
+
 import { recordEvent, recordEvents } from "./service.server";
 
 // why: testing service logic without hitting the real database
@@ -185,24 +187,8 @@ describe("activity event service", () => {
 
     it("writes all rows in a single createMany call and caches actor snapshots by actorUserId", async () => {
       await recordEvents([
-        {
-          organizationId: "org-1",
-          actorUserId: "user-1",
-          action: "BOOKING_ASSETS_ADDED",
-          entityType: "BOOKING",
-          entityId: "booking-1",
-          bookingId: "booking-1",
-          assetId: "asset-a",
-        },
-        {
-          organizationId: "org-1",
-          actorUserId: "user-1",
-          action: "BOOKING_ASSETS_ADDED",
-          entityType: "BOOKING",
-          entityId: "booking-1",
-          bookingId: "booking-1",
-          assetId: "asset-b",
-        },
+        createActivityEventInput({ assetId: "asset-a" }),
+        createActivityEventInput({ assetId: "asset-b" }),
       ]);
 
       // why: bulk inserts must be a single round-trip to fit inside the
@@ -246,33 +232,18 @@ describe("activity event service", () => {
         } as any);
 
       await recordEvents([
-        {
-          organizationId: "org-1",
+        createActivityEventInput({
           actorUserId: "user-alice",
-          action: "BOOKING_ASSETS_ADDED",
-          entityType: "BOOKING",
-          entityId: "booking-1",
-          bookingId: "booking-1",
           assetId: "asset-a",
-        },
-        {
-          organizationId: "org-1",
+        }),
+        createActivityEventInput({
           actorUserId: "user-bob",
-          action: "BOOKING_ASSETS_ADDED",
-          entityType: "BOOKING",
-          entityId: "booking-1",
-          bookingId: "booking-1",
           assetId: "asset-b",
-        },
-        {
-          organizationId: "org-1",
+        }),
+        createActivityEventInput({
           actorUserId: "user-alice",
-          action: "BOOKING_ASSETS_ADDED",
-          entityType: "BOOKING",
-          entityId: "booking-1",
-          bookingId: "booking-1",
           assetId: "asset-c",
-        },
+        }),
       ]);
 
       // Two unique actors → two user lookups; the repeat hits the cache.
@@ -300,17 +271,7 @@ describe("activity event service", () => {
       activityEventCreateManyMock.mockRejectedValueOnce(new Error("boom"));
 
       await expect(
-        recordEvents([
-          {
-            organizationId: "org-1",
-            actorUserId: "user-1",
-            action: "BOOKING_ASSETS_ADDED",
-            entityType: "BOOKING",
-            entityId: "booking-1",
-            bookingId: "booking-1",
-            assetId: "asset-a",
-          },
-        ])
+        recordEvents([createActivityEventInput({ assetId: "asset-a" })])
       ).rejects.toMatchObject({
         label: "Activity",
         message: "Failed to record activity events.",

--- a/apps/webapp/app/modules/activity-event/service.server.test.ts
+++ b/apps/webapp/app/modules/activity-event/service.server.test.ts
@@ -6,7 +6,7 @@ import { recordEvent, recordEvents } from "./service.server";
 // why: testing service logic without hitting the real database
 vi.mock("~/database/db.server", () => ({
   db: {
-    activityEvent: { create: vi.fn() },
+    activityEvent: { create: vi.fn(), createMany: vi.fn() },
     user: { findUnique: vi.fn() },
   },
 }));
@@ -23,6 +23,9 @@ vi.mock("~/utils/error", () => ({
 
 const mockDb = await import("~/database/db.server");
 const activityEventCreateMock = vi.mocked(mockDb.db.activityEvent.create);
+const activityEventCreateManyMock = vi.mocked(
+  mockDb.db.activityEvent.createMany
+);
 const userFindUniqueMock = vi.mocked(mockDb.db.user.findUnique);
 
 describe("activity event service", () => {
@@ -34,6 +37,7 @@ describe("activity event service", () => {
       displayName: "Jane Doe",
     } as any);
     activityEventCreateMock.mockResolvedValue({} as any);
+    activityEventCreateManyMock.mockResolvedValue({ count: 0 } as any);
   });
 
   describe("recordEvent", () => {
@@ -175,10 +179,11 @@ describe("activity event service", () => {
     it("is a no-op for empty input", async () => {
       await recordEvents([]);
       expect(activityEventCreateMock).not.toHaveBeenCalled();
+      expect(activityEventCreateManyMock).not.toHaveBeenCalled();
       expect(userFindUniqueMock).not.toHaveBeenCalled();
     });
 
-    it("writes one row per input and caches actor snapshots by actorUserId", async () => {
+    it("writes all rows in a single createMany call and caches actor snapshots by actorUserId", async () => {
       await recordEvents([
         {
           organizationId: "org-1",
@@ -200,9 +205,116 @@ describe("activity event service", () => {
         },
       ]);
 
-      // Two writes, one user lookup (cached)
-      expect(activityEventCreateMock).toHaveBeenCalledTimes(2);
+      // why: bulk inserts must be a single round-trip to fit inside the
+      // 5s Prisma interactive-tx budget (Sentry SHELF-WEBAPP-1KN). A
+      // per-row loop blew the budget for large bookings (262 assets).
+      expect(activityEventCreateManyMock).toHaveBeenCalledTimes(1);
+      expect(activityEventCreateMock).not.toHaveBeenCalled();
       expect(userFindUniqueMock).toHaveBeenCalledTimes(1);
+
+      const createManyArg = activityEventCreateManyMock.mock.calls[0][0];
+      // why: Prisma types `data` as `X | X[]`; narrow to array for indexing.
+      const rows =
+        createManyArg.data as Prisma.ActivityEventUncheckedCreateInput[];
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toMatchObject({
+        assetId: "asset-a",
+        action: "BOOKING_ASSETS_ADDED",
+        actorSnapshot: {
+          firstName: "Jane",
+          lastName: "Doe",
+          displayName: "Jane Doe",
+        },
+      });
+      expect(rows[1]).toMatchObject({
+        assetId: "asset-b",
+        action: "BOOKING_ASSETS_ADDED",
+      });
+    });
+
+    it("resolves a distinct snapshot per actorUserId (cache keyed by actor)", async () => {
+      userFindUniqueMock
+        .mockResolvedValueOnce({
+          firstName: "Alice",
+          lastName: "A",
+          displayName: "Alice A",
+        } as any)
+        .mockResolvedValueOnce({
+          firstName: "Bob",
+          lastName: "B",
+          displayName: "Bob B",
+        } as any);
+
+      await recordEvents([
+        {
+          organizationId: "org-1",
+          actorUserId: "user-alice",
+          action: "BOOKING_ASSETS_ADDED",
+          entityType: "BOOKING",
+          entityId: "booking-1",
+          bookingId: "booking-1",
+          assetId: "asset-a",
+        },
+        {
+          organizationId: "org-1",
+          actorUserId: "user-bob",
+          action: "BOOKING_ASSETS_ADDED",
+          entityType: "BOOKING",
+          entityId: "booking-1",
+          bookingId: "booking-1",
+          assetId: "asset-b",
+        },
+        {
+          organizationId: "org-1",
+          actorUserId: "user-alice",
+          action: "BOOKING_ASSETS_ADDED",
+          entityType: "BOOKING",
+          entityId: "booking-1",
+          bookingId: "booking-1",
+          assetId: "asset-c",
+        },
+      ]);
+
+      // Two unique actors → two user lookups; the repeat hits the cache.
+      expect(userFindUniqueMock).toHaveBeenCalledTimes(2);
+      expect(activityEventCreateManyMock).toHaveBeenCalledTimes(1);
+
+      // why: Prisma types `data` as `X | X[]`; narrow to array for indexing.
+      const rows = activityEventCreateManyMock.mock.calls[0][0]
+        .data as Prisma.ActivityEventUncheckedCreateInput[];
+      expect(rows[0]).toMatchObject({
+        actorUserId: "user-alice",
+        actorSnapshot: { firstName: "Alice" },
+      });
+      expect(rows[1]).toMatchObject({
+        actorUserId: "user-bob",
+        actorSnapshot: { firstName: "Bob" },
+      });
+      expect(rows[2]).toMatchObject({
+        actorUserId: "user-alice",
+        actorSnapshot: { firstName: "Alice" },
+      });
+    });
+
+    it("wraps createMany failures in a ShelfError labelled 'Activity'", async () => {
+      activityEventCreateManyMock.mockRejectedValueOnce(new Error("boom"));
+
+      await expect(
+        recordEvents([
+          {
+            organizationId: "org-1",
+            actorUserId: "user-1",
+            action: "BOOKING_ASSETS_ADDED",
+            entityType: "BOOKING",
+            entityId: "booking-1",
+            bookingId: "booking-1",
+            assetId: "asset-a",
+          },
+        ])
+      ).rejects.toMatchObject({
+        label: "Activity",
+        message: "Failed to record activity events.",
+      });
     });
   });
 });

--- a/apps/webapp/app/modules/activity-event/service.server.ts
+++ b/apps/webapp/app/modules/activity-event/service.server.ts
@@ -34,6 +34,10 @@ export type RecordEventTxClient = {
     create: (args: {
       data: Prisma.ActivityEventUncheckedCreateInput;
     }) => Promise<unknown>;
+    createMany: (args: {
+      data: Prisma.ActivityEventUncheckedCreateInput[];
+      skipDuplicates?: boolean;
+    }) => Promise<{ count: number }>;
   };
   user: {
     findUnique: (args: {
@@ -98,6 +102,14 @@ export async function recordEvent(
  * Actor snapshots are memoized per `actorUserId` so we only fetch each user
  * once even when writing many events.
  *
+ * Implementation: snapshots are resolved sequentially (cache hits are sync,
+ * misses are a single `findUnique` per unique actor), then all rows are
+ * written with a single `createMany`. This keeps the call to ~1 round-trip
+ * per unique actor plus 1 for the insert — critical when invoked inside a
+ * `db.$transaction(...)` with its 5-second interactive-tx budget. A previous
+ * per-row `create` loop blew that budget on large bookings (262 assets) and
+ * surfaced as `P2028 Transaction not found` (Sentry SHELF-WEBAPP-1KN).
+ *
  * @param inputs - Array of event payloads
  * @param tx - Optional Prisma transaction client
  * @throws {ShelfError} with label "Activity" on DB failure
@@ -114,16 +126,17 @@ export async function recordEvents(
     // Memoize snapshots per actorUserId — no duplicate user fetches for bulk writes.
     const snapshotCache = new Map<string, ActorSnapshot | null>();
 
+    const rows: Prisma.ActivityEventUncheckedCreateInput[] = [];
     for (const input of inputs) {
       const actorSnapshot = await resolveActorSnapshot(
         input,
         client,
         snapshotCache
       );
-      await client.activityEvent.create({
-        data: toPrismaData(input, actorSnapshot),
-      });
+      rows.push(toPrismaData(input, actorSnapshot));
     }
+
+    await client.activityEvent.createMany({ data: rows });
   } catch (cause) {
     throw new ShelfError({
       cause,

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1438,55 +1438,63 @@ export async function checkoutBooking({
       }).toJSDate();
     }
 
-    /** Keep the transaction lean (writes only) to stay within the 5s
-     * timeout. The heavy read for the return payload is done after commit.
-     * This prevents P2028 timeouts on bookings with many assets.
+    /** Keep the transaction lean (writes only) to stay within the timeout.
+     * The heavy read for the return payload is done after commit.
+     *
+     * Defense-in-depth: bump the interactive-tx timeout from the 5s default
+     * to 15s. Large bookings (262 assets in Sentry SHELF-WEBAPP-1KN) issue
+     * multi-row writes that can creep toward the default ceiling even after
+     * the `recordEvents` bulk-insert fix. `maxWait` stays at the default —
+     * we don't expect connection contention.
      *
      * Using callback-form transaction to include activity events atomically. */
-    await db.$transaction(async (tx) => {
-      // SECURITY (cross-org IDOR): scope the status mutation to the caller's
-      // organization so it can never flip the status of an asset that lives
-      // in another workspace, even if a foreign asset ID slipped into the
-      // booking's asset list.
-      await tx.asset.updateMany({
-        where: {
-          id: { in: bookingFound.assets.map((a) => a.id) },
-          organizationId,
-        },
-        data: { status: AssetStatus.CHECKED_OUT },
-      });
-
-      await tx.booking.update({
-        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: bookingFound id already org-checked via findUniqueOrThrow({where:{id,organizationId}}) at L1265; this is the write on that same proven id
-        where: { id: bookingFound.id },
-        data: dataToUpdate,
-        select: { id: true },
-      });
-
-      if (hasKits) {
-        await tx.kit.updateMany({
-          where: { id: { in: kitIds }, organizationId },
-          data: { status: KitStatus.CHECKED_OUT },
-        });
-      }
-
-      // Activity events — one BOOKING_CHECKED_OUT per asset, inside the tx.
-      // Must be atomic with checkout for audit trail consistency.
-      if (bookingFound.assets.length > 0) {
-        await recordEvents(
-          bookingFound.assets.map((asset) => ({
+    await db.$transaction(
+      async (tx) => {
+        // SECURITY (cross-org IDOR): scope the status mutation to the caller's
+        // organization so it can never flip the status of an asset that lives
+        // in another workspace, even if a foreign asset ID slipped into the
+        // booking's asset list.
+        await tx.asset.updateMany({
+          where: {
+            id: { in: bookingFound.assets.map((a) => a.id) },
             organizationId,
-            actorUserId: userId ?? null,
-            action: "BOOKING_CHECKED_OUT",
-            entityType: "BOOKING",
-            entityId: bookingFound.id,
-            bookingId: bookingFound.id,
-            assetId: asset.id,
-          })),
-          tx
-        );
-      }
-    });
+          },
+          data: { status: AssetStatus.CHECKED_OUT },
+        });
+
+        await tx.booking.update({
+          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: bookingFound id already org-checked via findUniqueOrThrow({where:{id,organizationId}}) at L1265; this is the write on that same proven id
+          where: { id: bookingFound.id },
+          data: dataToUpdate,
+          select: { id: true },
+        });
+
+        if (hasKits) {
+          await tx.kit.updateMany({
+            where: { id: { in: kitIds }, organizationId },
+            data: { status: KitStatus.CHECKED_OUT },
+          });
+        }
+
+        // Activity events — one BOOKING_CHECKED_OUT per asset, inside the tx.
+        // Must be atomic with checkout for audit trail consistency.
+        if (bookingFound.assets.length > 0) {
+          await recordEvents(
+            bookingFound.assets.map((asset) => ({
+              organizationId,
+              actorUserId: userId ?? null,
+              action: "BOOKING_CHECKED_OUT",
+              entityType: "BOOKING",
+              entityId: bookingFound.id,
+              bookingId: bookingFound.id,
+              assetId: asset.id,
+            })),
+            tx
+          );
+        }
+      },
+      { timeout: 15000 }
+    );
 
     /** Build an effective snapshot by merging bookingFound with any fields
      * modified by dataToUpdate (adjusted dates, status). This avoids

--- a/apps/webapp/test/factories/activityEvent.ts
+++ b/apps/webapp/test/factories/activityEvent.ts
@@ -1,0 +1,23 @@
+import type { ActivityEventInput } from "~/modules/activity-event/types";
+
+/**
+ * Factory for creating `ActivityEventInput` test payloads.
+ *
+ * Defaults to a `BOOKING_ASSETS_ADDED` shape — the canonical bulk case
+ * exercised by `recordEvents` — so callers only override the fields that
+ * matter to a given assertion (e.g. `actorUserId`, `assetId`).
+ */
+export function createActivityEventInput(
+  overrides: Partial<ActivityEventInput> = {}
+): ActivityEventInput {
+  return {
+    organizationId: "org-1",
+    actorUserId: "user-1",
+    action: "BOOKING_ASSETS_ADDED",
+    entityType: "BOOKING",
+    entityId: "booking-1",
+    bookingId: "booking-1",
+    assetId: "asset-1",
+    ...overrides,
+  } as ActivityEventInput;
+}

--- a/apps/webapp/test/factories/index.ts
+++ b/apps/webapp/test/factories/index.ts
@@ -7,3 +7,4 @@ export * from "./user";
 export * from "./teamMember";
 export * from "./asset";
 export * from "./organization";
+export * from "./activityEvent";


### PR DESCRIPTION
The checkoutBooking transaction was failing with `P2028 Transaction not found` for bookings with many assets (262 in Sentry SHELF-WEBAPP-1KN). Two compounding issues:

1. `recordEvents` looped serially over N inputs, awaiting one `activityEvent.create()` per row. For 262 assets that is 262 sequential round-trips inside a single interactive transaction — well past Prisma's 5s default tx timeout. Once the engine closed the tx, the next `create()` threw P2028.

2. The `checkoutBooking` $transaction relied on the default 5s timeout, with no headroom for outlier bookings whose lean writes (`updateMany` over hundreds of assets) can themselves approach that ceiling.

Fixes:

- `recordEvents` now resolves all actor snapshots through the existing per-actor cache, then writes every row with a single `createMany` call. ~1 round-trip per unique actor + 1 for the insert, regardless of input size. `RecordEventTxClient` gains the matching `createMany` signature.
- `checkoutBooking` passes `{ timeout: 15000 }` to `db.$transaction` as defense-in-depth. `maxWait` left at the default — connection contention is not expected.

Tests:

- Bulk-insert behaviour now asserted directly (single `createMany`, per-actor cache, error wrapping). Old "one create per row" assertion removed since it encoded the bug.
- Verified RED on the new tests before changing the implementation, then GREEN on the full webapp:validate run (2103/2103).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking checkout reliability by increasing the transaction timeout to reduce delayed responses under load.
* **New Features**
  * Activity/event recording now uses batched persistence for more efficient and reliable writes.
* **Tests**
  * Added factories and expanded tests to cover bulk activity recording, caching of actor snapshots, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->