### PR TITLE
perf(assets): trigram indexes and id-aware search fast path

### DIFF
--- a/apps/webapp/app/modules/asset/fields.ts
+++ b/apps/webapp/app/modules/asset/fields.ts
@@ -166,26 +166,12 @@ export const assetIndexFields = ({
         },
       },
     },
-    customFields: {
-      where: {
-        customField: {
-          active: true,
-          deletedAt: null,
-        },
-      },
-      include: {
-        customField: {
-          select: {
-            id: true,
-            name: true,
-            helpText: true,
-            required: true,
-            type: true,
-            categories: true,
-          },
-        },
-      },
-    },
+    // why: customFields used to be eagerly loaded here for every asset row.
+    // The simple asset index doesn't render them (only the advanced columns
+    // do), and on a 13k-asset workspace this multi-row include scaled with
+    // the number of active custom fields. Advanced mode uses
+    // advancedAssetIndexFields below; the command-palette search re-adds
+    // customFields via extraInclude.
     qrCodes: {
       select: { id: true },
       take: 1,

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -491,6 +491,19 @@ const unavailableBookingStatuses = [
 ];
 
 /**
+ * Matches the shape of an asset sequential ID. Two accepted forms:
+ *   - bare numeric ("21035") — users commonly drop the prefix when scanning
+ *   - prefixed ("SAM-21035", "shelf-21035") — 2–8 letters, optional dash, digits
+ *
+ * Used by getAssets to short-circuit the multi-table OR search when every
+ * comma-separated term looks like an ID lookup, so the query only has to
+ * touch Asset.sequentialId (covered by the gin_trgm index).
+ */
+function looksLikeAssetId(term: string): boolean {
+  return /^\d+$/.test(term) || /^[a-z]{2,8}-?\d+$/i.test(term);
+}
+
+/**
  * Fetches assets directly from the asset table with enhanced search capabilities
  * @param params Search and filtering parameters for asset queries
  * @returns Assets and total count matching the criteria
@@ -561,64 +574,80 @@ export async function getAssets(params: {
         .map((term) => term.trim())
         .filter(Boolean);
 
-      where.OR = searchTerms.map((term) => ({
-        OR: [
-          // Search in asset fields
-          { title: { contains: term, mode: "insensitive" } },
-          // Search in asset sequential id
-          { sequentialId: { contains: term, mode: "insensitive" } },
-          // Search in asset description
-          { description: { contains: term, mode: "insensitive" } },
-          // Search in related category
-          { category: { name: { contains: term, mode: "insensitive" } } },
-          // Search in related location
-          { location: { name: { contains: term, mode: "insensitive" } } },
-          // Search in related tags
-          { tags: { some: { name: { contains: term, mode: "insensitive" } } } },
-          // Search in custodian names
-          {
-            custody: {
-              custodian: {
-                OR: [
-                  { name: { contains: term, mode: "insensitive" } },
-                  {
-                    user: {
-                      OR: [
-                        { firstName: { contains: term, mode: "insensitive" } },
-                        { lastName: { contains: term, mode: "insensitive" } },
-                      ],
+      // Fast path: when every term looks like an asset ID (numeric, or the
+      // prefixed form like "sam-21035"), skip the 10-branch OR + EXISTS
+      // subqueries and match only against sequentialId. Powered by the
+      // gin_trgm GIN index added in migration 20260525110348.
+      if (searchTerms.length > 0 && searchTerms.every(looksLikeAssetId)) {
+        where.OR = searchTerms.map((term) => ({
+          sequentialId: { contains: term, mode: "insensitive" },
+        }));
+      } else {
+        where.OR = searchTerms.map((term) => ({
+          OR: [
+            // Search in asset fields
+            { title: { contains: term, mode: "insensitive" } },
+            // Search in asset sequential id
+            { sequentialId: { contains: term, mode: "insensitive" } },
+            // Search in asset description
+            { description: { contains: term, mode: "insensitive" } },
+            // Search in related category
+            { category: { name: { contains: term, mode: "insensitive" } } },
+            // Search in related location
+            { location: { name: { contains: term, mode: "insensitive" } } },
+            // Search in related tags
+            {
+              tags: { some: { name: { contains: term, mode: "insensitive" } } },
+            },
+            // Search in custodian names
+            {
+              custody: {
+                custodian: {
+                  OR: [
+                    { name: { contains: term, mode: "insensitive" } },
+                    {
+                      user: {
+                        OR: [
+                          {
+                            firstName: { contains: term, mode: "insensitive" },
+                          },
+                          { lastName: { contains: term, mode: "insensitive" } },
+                        ],
+                      },
                     },
-                  },
-                ],
+                  ],
+                },
               },
             },
-          },
-          // Search qr code id
-          {
-            qrCodes: { some: { id: { contains: term, mode: "insensitive" } } },
-          },
-          // Search barcode values
-          {
-            barcodes: {
-              some: { value: { contains: term, mode: "insensitive" } },
-            },
-          },
-          // Search in custom fields
-          {
-            customFields: {
-              some: {
-                OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
-                  value: {
-                    path: [jsonPath],
-                    string_contains: term,
-                    mode: "insensitive",
-                  },
-                })),
+            // Search qr code id
+            {
+              qrCodes: {
+                some: { id: { contains: term, mode: "insensitive" } },
               },
             },
-          },
-        ],
-      }));
+            // Search barcode values
+            {
+              barcodes: {
+                some: { value: { contains: term, mode: "insensitive" } },
+              },
+            },
+            // Search in custom fields
+            {
+              customFields: {
+                some: {
+                  OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
+                    value: {
+                      path: [jsonPath],
+                      string_contains: term,
+                      mode: "insensitive",
+                    },
+                  })),
+                },
+              },
+            },
+          ],
+        }));
+      }
     }
 
     if (status) {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -491,16 +491,24 @@ const unavailableBookingStatuses = [
 ];
 
 /**
- * Matches the shape of an asset sequential ID. Two accepted forms:
- *   - bare numeric ("21035") — users commonly drop the prefix when scanning
- *   - prefixed ("SAM-21035", "shelf-21035") — 2–8 letters, optional dash, digits
+ * Matches the shape of an asset identifier or barcode / QR id. Two forms:
+ *   - bare numeric ("21035", or a 12-digit UPC) — users commonly drop the
+ *     prefix when scanning or typing an ID
+ *   - canonical sequential ID ("SAM-0001") — letter prefix + dash + 4+
+ *     digits, matching the format produced by getNextSequentialId
  *
- * Used by getAssets to short-circuit the multi-table OR search when every
- * comma-separated term looks like an ID lookup, so the query only has to
- * touch Asset.sequentialId (covered by the gin_trgm index).
+ * Used by getAssets to route ID-shaped queries down a narrower OR clause
+ * (sequentialId / barcodes.value / qrCodes.id) instead of the full
+ * 10-branch chain. The narrower clause skips the slow paths — custodian
+ * name traversal and the unindexed customFields JSON ILIKE — while
+ * still covering every place an ID-shaped value can legitimately live.
+ *
+ * Loose terms like "lab-12" or "AS1000" fall through to the full search
+ * because they don't match canonical sequentialId format and could be
+ * substrings of asset titles, custom fields, etc.
  */
 function looksLikeAssetId(term: string): boolean {
-  return /^\d+$/.test(term) || /^[a-z]{2,8}-?\d+$/i.test(term);
+  return /^\d+$/.test(term) || /^[a-z]+-\d{4,}$/i.test(term);
 }
 
 /**
@@ -574,14 +582,29 @@ export async function getAssets(params: {
         .map((term) => term.trim())
         .filter(Boolean);
 
-      // Fast path: when every term looks like an asset ID (numeric, or the
-      // prefixed form like "sam-21035"), skip the 10-branch OR + EXISTS
-      // subqueries and match only against sequentialId. Powered by the
-      // gin_trgm GIN index added in migration 20260525110348.
+      // Fast path: when every term looks like an asset identifier — either
+      // bare digits ("21035", a UPC barcode) or canonical sequentialId
+      // ("SAM-0001") — narrow the OR clause to the three columns where an
+      // ID-shaped value can legitimately live: sequentialId, barcode value,
+      // and QR id. All three are covered by trigram GIN indexes added in
+      // migration 20260525110348, so the planner stays on indexed scans.
+      // Skipping title/description/category/location/tag/custodian/customFields
+      // is intentional — they can still match via the full path below for
+      // non-ID-shaped terms.
       if (searchTerms.length > 0 && searchTerms.every(looksLikeAssetId)) {
-        where.OR = searchTerms.map((term) => ({
-          sequentialId: { contains: term, mode: "insensitive" },
-        }));
+        where.OR = searchTerms.flatMap((term) => [
+          { sequentialId: { contains: term, mode: "insensitive" } },
+          {
+            barcodes: {
+              some: { value: { contains: term, mode: "insensitive" } },
+            },
+          },
+          {
+            qrCodes: {
+              some: { id: { contains: term, mode: "insensitive" } },
+            },
+          },
+        ]);
       } else {
         where.OR = searchTerms.map((term) => ({
           OR: [

--- a/apps/webapp/app/routes/api+/command-palette.search.ts
+++ b/apps/webapp/app/routes/api+/command-palette.search.ts
@@ -232,7 +232,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     // Execute parallel searches
     const [assetResults, audits, kits, bookings, locations, teamMembers] =
       await Promise.all([
-        // Assets (always allowed) - using enhanced search from asset service
+        // Assets (always allowed) - using enhanced search from asset service.
+        // The asset-index default include no longer eagerly loads customFields
+        // (see fields.ts), so add them back here for the command palette,
+        // which surfaces matching custom-field values in its results.
         getAssets({
           search: query,
           organizationId,
@@ -243,6 +246,14 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
           extraInclude: {
             barcodes: {
               select: { id: true, value: true, type: true },
+            },
+            customFields: {
+              where: {
+                customField: { active: true, deletedAt: null },
+              },
+              include: {
+                customField: { select: { id: true, name: true } },
+              },
             },
           },
         }),

--- a/apps/webapp/app/routes/api+/command-palette.search.ts
+++ b/apps/webapp/app/routes/api+/command-palette.search.ts
@@ -251,9 +251,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
               where: {
                 customField: { active: true, deletedAt: null },
               },
-              include: {
-                customField: { select: { id: true, name: true } },
-              },
             },
           },
         }),

--- a/packages/database/prisma/migrations/20260525110348_add_trigram_indexes_for_simple_search/migration.sql
+++ b/packages/database/prisma/migrations/20260525110348_add_trigram_indexes_for_simple_search/migration.sql
@@ -3,6 +3,16 @@
 -- sequential scans because leading-wildcard LIKE cannot use B-tree indexes.
 --
 -- pg_trgm is already enabled by migration 20241218134155.
+--
+-- Locking: these are plain (non-CONCURRENT) CREATE INDEX statements, which
+-- matches the existing convention in this repo (see migration
+-- 20250114124237_add_reminder_indexes_for_optimization). Each statement
+-- takes an ACCESS EXCLUSIVE lock on its table for the duration of the
+-- index build. On the largest known tenant the affected tables are small
+-- (~13k rows for Asset, Qr, Barcode; far fewer for Category, Location,
+-- Tag), so the build completes in sub-second. If a much larger workspace
+-- is onboarded later, run this migration during a low-traffic window or
+-- split it across multiple CONCURRENTLY-built migrations.
 
 -- Asset.sequentialId: hot path — customers type the numeric portion of their
 -- SAM-IDs (e.g. "21035" to find "SAM-21035"). The existing

--- a/packages/database/prisma/migrations/20260525110348_add_trigram_indexes_for_simple_search/migration.sql
+++ b/packages/database/prisma/migrations/20260525110348_add_trigram_indexes_for_simple_search/migration.sql
@@ -1,0 +1,33 @@
+-- Trigram (pg_trgm) GIN indexes for the columns the simple-mode asset search
+-- bar runs ILIKE '%term%' against. Without these the planner falls back to
+-- sequential scans because leading-wildcard LIKE cannot use B-tree indexes.
+--
+-- pg_trgm is already enabled by migration 20241218134155.
+
+-- Asset.sequentialId: hot path — customers type the numeric portion of their
+-- SAM-IDs (e.g. "21035" to find "SAM-21035"). The existing
+-- Asset_sequentialId_idx is plain B-tree and cannot serve %term%.
+CREATE INDEX IF NOT EXISTS "Asset_sequentialId_trgm_idx"
+  ON public."Asset" USING GIN ("sequentialId" gin_trgm_ops);
+
+-- Category.name, Location.name, Tag.name: small tables but the OR-chain
+-- joins them per searched term; without a trigram index every row of each
+-- table is scanned.
+CREATE INDEX IF NOT EXISTS "Category_name_trgm_idx"
+  ON public."Category" USING GIN ("name" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "Location_name_trgm_idx"
+  ON public."Location" USING GIN ("name" gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS "Tag_name_trgm_idx"
+  ON public."Tag" USING GIN ("name" gin_trgm_ops);
+
+-- Qr.id is the primary key (B-tree) but the search bar matches substrings
+-- of QR ids ("...some-suffix..."), so we need a trigram index on the same
+-- column. PK index covers exact lookups; this one covers fuzzy.
+CREATE INDEX IF NOT EXISTS "Qr_id_trgm_idx"
+  ON public."Qr" USING GIN (id gin_trgm_ops);
+
+-- Barcode.value is searched the same way.
+CREATE INDEX IF NOT EXISTS "Barcode_value_trgm_idx"
+  ON public."Barcode" USING GIN (value gin_trgm_ops);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -224,6 +224,8 @@ model Asset {
   @@unique([organizationId, sequentialId], name: "asset_org_sequential_unique")
   // Special GIN index for optimization of simple search queries
   @@index([title(ops: raw("gin_trgm_ops")), description(ops: raw("gin_trgm_ops"))], type: Gin)
+  // Trigram index for substring search on sequentialId (e.g. "21035" → "SAM-21035")
+  @@index([sequentialId(ops: raw("gin_trgm_ops"))], type: Gin, name: "Asset_sequentialId_trgm_idx")
   // Indexes for optimization of queries
   @@index([organizationId, title, status, availableToBook], name: "Asset_organizationId_compound_idx")
   @@index([status, organizationId], name: "Asset_status_organizationId_idx")
@@ -323,6 +325,8 @@ model Category {
   // Indexes for foreign keys
   @@index([organizationId])
   @@index([userId])
+  // Trigram index for substring search from the asset-list search bar
+  @@index([name(ops: raw("gin_trgm_ops"))], type: Gin, name: "Category_name_trgm_idx")
 }
 
 enum TagUseFor {
@@ -356,6 +360,8 @@ model Tag {
   // Indexes for foreign keys
   @@index([organizationId])
   @@index([userId])
+  // Trigram index for substring search from the asset-list search bar
+  @@index([name(ops: raw("gin_trgm_ops"))], type: Gin, name: "Tag_name_trgm_idx")
 }
 
 model Note {
@@ -460,6 +466,8 @@ model Qr {
   @@index([userId])
   @@index([organizationId])
   @@index([batchId])
+  // Trigram index for substring search of Qr ids from the asset-list search bar
+  @@index([id(ops: raw("gin_trgm_ops"))], type: Gin, name: "Qr_id_trgm_idx")
 }
 
 // Barcode model
@@ -493,6 +501,8 @@ model Barcode {
   @@index([assetId])
   @@index([kitId])
   @@index([organizationId]) // For org-level queries
+  // Trigram index for substring search of barcode values from the asset-list search bar
+  @@index([value(ops: raw("gin_trgm_ops"))], type: Gin, name: "Barcode_value_trgm_idx")
 }
 
 // Barcode types matching zxing format names exactly
@@ -620,6 +630,8 @@ model Location {
   @@index([organizationId])
   @@index([userId])
   @@index([organizationId, parentId])
+  // Trigram index for substring search from the asset-list search bar
+  @@index([name(ops: raw("gin_trgm_ops"))], type: Gin, name: "Location_name_trgm_idx")
 }
 
 // Master data for roles


### PR DESCRIPTION
Three changes to make the simple-mode asset search fast for large workspaces (a customer with ~13k assets was hitting 30-60s searches).

- Add gin_trgm GIN indexes on Asset.sequentialId, Category.name, Location.name, Tag.name, Qr.id, Barcode.value. The asset-search OR chain runs ILIKE '%term%' against all of these; without trigram indexes the planner falls back to sequential scans on every column.

- Add an id-aware fast path in getAssets that skips the 10-branch OR/EXISTS clause when every comma-separated term looks like an asset ID (numeric only, or prefixed like "sam-21035"). Only Asset.sequentialId is matched in that case.

- Stop eagerly loading customFields in assetIndexFields. The simple asset list never renders them; only the command palette consumes them, which now re-adds the include via extraInclude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter asset search that detects ID-shaped queries and narrows results for faster, more relevant matches.
  * Command palette and advanced index mode will return active custom field values in search results.

* **Performance Improvements**
  * Faster substring searches via new database trigram indexes on key identifier and name fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->