### PR TITLE
fix(ci): report clean React Doctor scans correctly in PR comment

### DIFF
--- a/.github/scripts/react-doctor-pr-comment.mjs
+++ b/.github/scripts/react-doctor-pr-comment.mjs
@@ -8,7 +8,13 @@
  * Invoked from `.github/workflows/react-doctor.yml` after the doctor scan.
  *
  * Usage:
- *   node .github/scripts/react-doctor-pr-comment.mjs <diagnostics-dir>
+ *   node .github/scripts/react-doctor-pr-comment.mjs <diagnostics-dir> <exit-code>
+ *
+ * `<diagnostics-dir>` may be empty: react-doctor only writes a diagnostics
+ * directory when it has findings to record. The exit code (captured from the
+ * CLI via PIPESTATUS in the workflow) disambiguates:
+ *   - empty dir + exit 0       → clean scan, no findings
+ *   - empty dir + non-zero exit → the CLI itself failed
  */
 
 import fs from "node:fs";
@@ -21,11 +27,18 @@ const FOOTER =
   "diff-only view.</sub>";
 
 const diagDir = process.argv[2];
+const exitCode = process.argv[3];
 
 if (!diagDir) {
+  if (exitCode === "0") {
+    console.log(
+      `${HEADER}\n\n✅ No new findings on the files changed by this PR.\n\n${FOOTER}\n`
+    );
+    process.exit(0);
+  }
   console.log(
-    `${HEADER}\n\nNo diagnostics directory passed — scan may have failed. ` +
-      `Check the workflow logs.\n`
+    `${HEADER}\n\nNo diagnostics directory passed — scan may have failed ` +
+      `(CLI exit ${exitCode || "unknown"}). Check the workflow logs.\n`
   );
   process.exit(0);
 }

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -96,8 +96,10 @@ jobs:
         if: always()
         env:
           DIAG_PATH: ${{ steps.doctor.outputs.diag_path }}
+          EXIT_CODE: ${{ steps.doctor.outputs.exit_code }}
         run: |
-          node .github/scripts/react-doctor-pr-comment.mjs "$DIAG_PATH" \
+          node .github/scripts/react-doctor-pr-comment.mjs \
+            "$DIAG_PATH" "$EXIT_CODE" \
             > "$RUNNER_TEMP/comment.md"
           echo "--- comment preview ---"
           cat "$RUNNER_TEMP/comment.md"


### PR DESCRIPTION
When react-doctor finds no issues (or --diff has no changed source files), the CLI doesn't write a diagnostics directory and the workflow's grep returns empty. The comment script treated empty diag path as failure, producing a misleading "scan may have failed" message on clean PRs.

Pass the CLI exit code to the script so it can distinguish the two cases: empty dir + exit 0 = clean scan; empty dir + non-zero = real failure.

resolved #2544 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PR comment generation to better handle diagnostic tool execution by distinguishing between successful clean scans and CLI failures. Exit code information is now captured and included in comment messages, providing clearer feedback and better visibility when diagnostic tools encounter issues or complete successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->