### PR TITLE
fix(react-doctor): resolve derived-state error and stable-key warnings

### DIFF
--- a/apps/webapp/app/atoms/switching-workspace.ts
+++ b/apps/webapp/app/atoms/switching-workspace.ts
@@ -1,3 +1,0 @@
-import { atom } from "jotai";
-
-export const switchingWorkspaceAtom = atom(true);

--- a/apps/webapp/app/components/errors/error-404-handler.tsx
+++ b/apps/webapp/app/components/errors/error-404-handler.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { CSSProperties } from "react";
 import { useFetcher } from "react-router";
+import { CHANGE_CURRENT_ORGANIZATION_ACTION } from "~/modules/organization/constants";
 import { isFormProcessing } from "~/utils/form";
 import { tw } from "~/utils/tw";
 import type { Error404AdditionalData } from "./utils";
@@ -54,7 +55,7 @@ export default function Error404Handler({
                 to view the {modelLabel}?
               </p>
               <fetcher.Form
-                action="/api/user/change-current-organization"
+                action={CHANGE_CURRENT_ORGANIZATION_ACTION}
                 method="POST"
               >
                 <input
@@ -94,7 +95,7 @@ export default function Error404Handler({
                 switch to workspace to view the team member?
               </p>
               <fetcher.Form
-                action="/api/user/change-current-organization"
+                action={CHANGE_CURRENT_ORGANIZATION_ACTION}
                 method="POST"
                 className="flex flex-col items-center"
               >

--- a/apps/webapp/app/components/layout/sidebar/organization-selector.tsx
+++ b/apps/webapp/app/components/layout/sidebar/organization-selector.tsx
@@ -13,6 +13,7 @@ import {
 import { Image } from "~/components/shared/image";
 import ProfilePicture from "~/components/user/profile-picture";
 import When from "~/components/when/when";
+import { CHANGE_CURRENT_ORGANIZATION_ACTION } from "~/modules/organization/constants";
 import type { loader } from "~/routes/_layout+/_layout";
 import { isFormProcessing } from "~/utils/form";
 import { tw } from "~/utils/tw";
@@ -48,7 +49,7 @@ export default function OrganizationSelector() {
 
     void fetcher.submit(formData, {
       method: "POST",
-      action: "/api/user/change-current-organization",
+      action: CHANGE_CURRENT_ORGANIZATION_ACTION,
     });
   }
 

--- a/apps/webapp/app/components/layout/sidebar/organization-selector.tsx
+++ b/apps/webapp/app/components/layout/sidebar/organization-selector.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
-import { useSetAtom } from "jotai";
 import { useFetcher, useLoaderData } from "react-router";
 import invariant from "tiny-invariant";
-import { switchingWorkspaceAtom } from "~/atoms/switching-workspace";
 import { Button } from "~/components/shared/button";
 import {
   DropdownMenu,
@@ -36,8 +34,6 @@ export default function OrganizationSelector() {
   const fetcher = useFetcher();
   const isSwitchingOrg = isFormProcessing(fetcher.state);
 
-  const setWorkspaceSwitching = useSetAtom(switchingWorkspaceAtom);
-
   const currentOrganization = organizations.find(
     (org) => org.id === currentOrganizationId
   );
@@ -59,13 +55,6 @@ export default function OrganizationSelector() {
   function closeDropdown() {
     setIsDropdownOpen(false);
   }
-
-  useEffect(
-    function setSwitchingWorkspaceAfterFetch() {
-      setWorkspaceSwitching(isSwitchingOrg);
-    },
-    [isSwitchingOrg, setWorkspaceSwitching]
-  );
 
   return (
     <SidebarMenu>

--- a/apps/webapp/app/components/reports/area-chart.tsx
+++ b/apps/webapp/app/components/reports/area-chart.tsx
@@ -158,9 +158,9 @@ export function AreaChart({
             return (
               <div className="rounded border border-gray-200 bg-white px-3 py-2 shadow-lg">
                 <p className="text-xs font-medium text-gray-900">{label}</p>
-                {payload.map((entry, index) => (
+                {payload.map((entry) => (
                   <p
-                    key={index}
+                    key={String(entry.dataKey ?? entry.name)}
                     className="mt-1 text-sm text-gray-600"
                     style={{ color: entry.color }}
                   >

--- a/apps/webapp/app/components/reports/bar-chart.tsx
+++ b/apps/webapp/app/components/reports/bar-chart.tsx
@@ -184,8 +184,11 @@ export function BarChart({
                   {payload[0]?.payload?.name}
                 </p>
                 <div className="mt-1 space-y-1">
-                  {payload.map((entry, idx) => (
-                    <p key={idx} className="flex items-center gap-2 text-sm">
+                  {payload.map((entry) => (
+                    <p
+                      key={String(entry.dataKey ?? entry.name)}
+                      className="flex items-center gap-2 text-sm"
+                    >
                       <span
                         className="size-2 rounded-full"
                         style={{ backgroundColor: entry.color }}

--- a/apps/webapp/app/components/reports/compliance-report-pdf.tsx
+++ b/apps/webapp/app/components/reports/compliance-report-pdf.tsx
@@ -280,8 +280,11 @@ function ComplianceReportPreview({
                 </tr>
               </thead>
               <tbody>
-                {pdfMeta.custodianPerformance.map((c, i) => (
-                  <tr key={i} className="border-b border-gray-100">
+                {pdfMeta.custodianPerformance.map((c) => (
+                  <tr
+                    key={c.custodianName}
+                    className="border-b border-gray-100"
+                  >
                     <td className="py-1.5">{c.custodianName}</td>
                     <td className="py-1.5 text-right">{c.rate}%</td>
                     <td className="py-1.5 text-right">{c.onTime}</td>

--- a/apps/webapp/app/components/reports/compliance-report-pdf.tsx
+++ b/apps/webapp/app/components/reports/compliance-report-pdf.tsx
@@ -282,7 +282,7 @@ function ComplianceReportPreview({
               <tbody>
                 {pdfMeta.custodianPerformance.map((c) => (
                   <tr
-                    key={c.custodianName}
+                    key={c.custodianId ?? c.custodianName}
                     className="border-b border-gray-100"
                   >
                     <td className="py-1.5">{c.custodianName}</td>

--- a/apps/webapp/app/components/reports/report-pdf.tsx
+++ b/apps/webapp/app/components/reports/report-pdf.tsx
@@ -394,7 +394,10 @@ function CompliancePreview({ pdfMeta }: { pdfMeta: CompliancePdfMeta }) {
             </thead>
             <tbody>
               {pdfMeta.custodianPerformance.map((c) => (
-                <tr key={c.custodianName} className="border-b border-gray-100">
+                <tr
+                  key={c.custodianId ?? c.custodianName}
+                  className="border-b border-gray-100"
+                >
                   <td className="py-1.5">{c.custodianName}</td>
                   <td className="py-1.5 text-right">{c.rate}%</td>
                   <td className="py-1.5 text-right">{c.onTime}</td>

--- a/apps/webapp/app/components/reports/report-pdf.tsx
+++ b/apps/webapp/app/components/reports/report-pdf.tsx
@@ -393,8 +393,8 @@ function CompliancePreview({ pdfMeta }: { pdfMeta: CompliancePdfMeta }) {
               </tr>
             </thead>
             <tbody>
-              {pdfMeta.custodianPerformance.map((c, i) => (
-                <tr key={i} className="border-b border-gray-100">
+              {pdfMeta.custodianPerformance.map((c) => (
+                <tr key={c.custodianName} className="border-b border-gray-100">
                   <td className="py-1.5">{c.custodianName}</td>
                   <td className="py-1.5 text-right">{c.rate}%</td>
                   <td className="py-1.5 text-right">{c.onTime}</td>

--- a/apps/webapp/app/components/reports/timeframe-picker.tsx
+++ b/apps/webapp/app/components/reports/timeframe-picker.tsx
@@ -71,6 +71,8 @@ const PRESETS: { id: TimeframePreset; label: string; shortLabel: string }[] = [
   { id: "all_time", label: "All time", shortLabel: "All" },
 ];
 
+const EMPTY_EXCLUDE_PRESETS: TimeframePreset[] = [];
+
 /**
  * Timeframe picker with preset buttons and custom date range.
  *
@@ -81,7 +83,7 @@ export function TimeframePicker({
   value,
   onChange,
   syncToUrl = true,
-  excludePresets = [],
+  excludePresets = EMPTY_EXCLUDE_PRESETS,
   disabled = false,
   className,
 }: TimeframePickerProps) {

--- a/apps/webapp/app/modules/organization/constants.ts
+++ b/apps/webapp/app/modules/organization/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Organization-related constants shared across the webapp.
+ *
+ * @see {@link file://./../../routes/api+/user.change-current-organization.ts}
+ */
+
+/**
+ * Action path for the "switch current organization" fetcher submission.
+ *
+ * Used by the org selector to POST a switch and by `_layout.tsx` to detect
+ * in-flight workspace switches via `useFetchers()`. Keep both sides pointing
+ * at this constant so renaming the route doesn't silently break the loading
+ * state.
+ */
+export const CHANGE_CURRENT_ORGANIZATION_ACTION =
+  "/api/user/change-current-organization";

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -585,6 +585,13 @@ export interface CompliancePdfMeta extends ReportPdfMetaBase {
     periodLabel: string;
   };
   custodianPerformance: Array<{
+    /**
+     * TeamMember id when available — used as the row key in PDF tables.
+     * Falls back to `custodianName` only for legacy rows where the id is
+     * missing; names are NOT unique in the schema and shouldn't be the
+     * primary key.
+     */
+    custodianId: string | null;
     custodianName: string;
     rate: number;
     onTime: number;

--- a/apps/webapp/app/routes/_layout+/_layout.tsx
+++ b/apps/webapp/app/routes/_layout+/_layout.tsx
@@ -1,6 +1,6 @@
 import type { Prisma } from "@prisma/client";
 import { Roles } from "@prisma/client";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom } from "jotai";
 import { ScanBarcodeIcon } from "lucide-react";
 import type {
   LinksFunction,
@@ -13,12 +13,12 @@ import {
   Link,
   NavLink,
   Outlet,
+  useFetchers,
   useLoaderData,
 } from "react-router";
 import { ClientOnly } from "remix-utils/client-only";
 import { AtomsResetHandler } from "~/atoms/atoms-reset-handler";
 import { feedbackModalOpenAtom } from "~/atoms/feedback";
-import { switchingWorkspaceAtom } from "~/atoms/switching-workspace";
 import { ErrorContent } from "~/components/errors";
 
 import FeedbackModal from "~/components/feedback/feedback-modal";
@@ -277,7 +277,12 @@ export default function App() {
     needsSequentialIdMigration,
     currentOrganizationId,
   } = useLoaderData<typeof loader>();
-  const workspaceSwitching = useAtomValue(switchingWorkspaceAtom);
+  const fetchers = useFetchers();
+  const workspaceSwitching = fetchers.some(
+    (f) =>
+      f.formAction === "/api/user/change-current-organization" &&
+      (f.state === "submitting" || f.state === "loading")
+  );
   const [feedbackModalOpen, setFeedbackModalOpen] = useAtom(
     feedbackModalOpenAtom
   );

--- a/apps/webapp/app/routes/_layout+/_layout.tsx
+++ b/apps/webapp/app/routes/_layout+/_layout.tsx
@@ -44,6 +44,7 @@ import { NoSubscription } from "~/components/subscription/no-subscription";
 import { UnpaidInvoiceBanner } from "~/components/subscription/unpaid-invoice-banner";
 import { config } from "~/config/shelf.config";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
+import { CHANGE_CURRENT_ORGANIZATION_ACTION } from "~/modules/organization/constants";
 import {
   getSelectedOrganization,
   setSelectedOrganizationIdCookie,
@@ -280,7 +281,7 @@ export default function App() {
   const fetchers = useFetchers();
   const workspaceSwitching = fetchers.some(
     (f) =>
-      f.formAction === "/api/user/change-current-organization" &&
+      f.formAction === CHANGE_CURRENT_ORGANIZATION_ACTION &&
       (f.state === "submitting" || f.state === "loading")
   );
   const [feedbackModalOpen, setFeedbackModalOpen] = useAtom(

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx
@@ -237,7 +237,10 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       });
     }
 
-    // Use transaction to ensure kit custody assignment and activity events are atomic
+    // why: awaits inside this $transaction MUST run sequentially. tx.kit.update
+    // returns updatedKit.assets which the next two steps consume; Prisma also
+    // serializes queries within a transaction, so Promise.all here would
+    // provide no benefit and could fragment failure semantics.
     const kit = await db.$transaction(async (tx) => {
       const updatedKit = await tx.kit.update({
         where: { id: kitId, organizationId },

--- a/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
+++ b/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
@@ -203,6 +203,7 @@ export const loader = async ({
             .filter((c) => c.total >= 2)
             .slice(0, 10)
             .map((c) => ({
+              custodianId: c.custodianId,
               custodianName: c.custodianName,
               rate: c.rate,
               onTime: c.onTime,


### PR DESCRIPTION
Removes the only React Doctor error and 5 warnings (score 88 → 91).

- organization-selector: drop switchingWorkspaceAtom + useEffect mirror; derive workspace-switching state from useFetchers() in _layout.tsx directly. Also removes the suspect atom(true) initial value that caused a one-frame "Activating workspace..." flash on every full page load.
- reports/{bar,area}-chart: stable keys for recharts tooltip entries via entry.dataKey / entry.name instead of array index.
- reports/{compliance-report,report}-pdf: key custodian rows by name instead of array index.
- reports/timeframe-picker: extract default [] to module-level constant to avoid creating a new array reference every render.
- kits.$kitId.assets.assign-custody: add why: comment on the $transaction block clarifying that sequential awaits are intentional (false positive in async-parallel rule).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified workspace switching logic to make the "Activating workspace..." indicator more reliable.
  * Standardized action handling for workspace changes.

* **Bug Fixes**
  * Improved chart tooltip and report table stability to reduce visual flicker during data updates.
  * Compliance report PDF now includes stable custodian identifiers for more reliable rendering.

* **Style**
  * Consolidated default timeframe preset handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->