### PR TITLE
feat(companion): add Universal Links for iOS and Android

### DIFF
--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -11,6 +11,7 @@
     "ios": {
       "supportsTablet": false,
       "bundleIdentifier": "com.shelf.companion",
+      "associatedDomains": ["applinks:app.shelf.nu"],
       "infoPlist": {
         "NSCameraUsageDescription": "Shelf needs camera access to scan QR codes and barcodes on your assets."
       }
@@ -21,7 +22,21 @@
         "backgroundColor": "#FF7809"
       },
       "package": "com.shelf.companion",
-      "permissions": ["android.permission.CAMERA"]
+      "permissions": ["android.permission.CAMERA"],
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "app.shelf.nu",
+              "pathPrefix": "/"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "web": {
       "bundler": "metro",

--- a/apps/webapp/app/routes/.well-known+/apple-app-site-association.ts
+++ b/apps/webapp/app/routes/.well-known+/apple-app-site-association.ts
@@ -1,0 +1,57 @@
+/**
+ * Apple App Site Association (AASA) file for iOS Universal Links
+ *
+ * This file tells iOS which URLs should open in the Shelf Companion app
+ * instead of Safari. Apple fetches this file when the app is installed
+ * to verify the domain-app association.
+ *
+ * @see https://developer.apple.com/documentation/xcode/supporting-associated-domains
+ * @see {@link file://./../../../../companion/lib/deep-links.ts} - Deep link handler
+ */
+
+import { data, type LoaderFunctionArgs } from "react-router";
+
+/** Apple Team ID from Apple Developer Portal */
+const APPLE_TEAM_ID = "27Q4MHFB8K";
+
+/** iOS Bundle Identifier from app.json */
+const IOS_BUNDLE_ID = "com.shelf.companion";
+
+/**
+ * GET /.well-known/apple-app-site-association
+ *
+ * Returns the AASA file that iOS uses to verify Universal Links.
+ * Must be served over HTTPS with content-type application/json.
+ */
+export async function loader(_args: LoaderFunctionArgs) {
+  const aasa = {
+    applinks: {
+      apps: [], // Required to be empty array
+      details: [
+        {
+          appID: `${APPLE_TEAM_ID}.${IOS_BUNDLE_ID}`,
+          paths: [
+            // QR code resolution - opens scanner or shows QR details
+            "/qr/*",
+            // Asset details - opens asset in app
+            "/assets/*",
+            // Booking details - opens booking in app
+            "/bookings/*",
+          ],
+        },
+      ],
+    },
+    // webcredentials allows the app to be associated with saved passwords
+    webcredentials: {
+      apps: [`${APPLE_TEAM_ID}.${IOS_BUNDLE_ID}`],
+    },
+  };
+
+  return data(aasa, {
+    headers: {
+      "Content-Type": "application/json",
+      // Cache for 1 hour - Apple caches this aggressively anyway
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/apps/webapp/app/routes/.well-known+/assetlinks[.]json.ts
+++ b/apps/webapp/app/routes/.well-known+/assetlinks[.]json.ts
@@ -1,0 +1,58 @@
+/**
+ * Digital Asset Links file for Android App Links
+ *
+ * This file tells Android which URLs should open in the Shelf Companion app
+ * instead of Chrome. Google fetches this file when the app is installed
+ * to verify the domain-app association.
+ *
+ * @see https://developer.android.com/training/app-links/verify-android-applinks
+ * @see {@link file://./../../../../companion/lib/deep-links.ts} - Deep link handler
+ */
+
+import { data, type LoaderFunctionArgs } from "react-router";
+
+/** Android Package Name from app.json */
+const ANDROID_PACKAGE_NAME = "com.shelf.companion";
+
+/**
+ * SHA-256 certificate fingerprints for Android signing keys.
+ * These are obtained from EAS Build credentials or your local keystore.
+ *
+ * To get the fingerprint from EAS managed credentials:
+ *   cd apps/companion && eas credentials -p android
+ *   Select "production" profile, then view the keystore details
+ *
+ * To get from a local keystore:
+ *   keytool -list -v -keystore your-keystore.jks -alias your-alias
+ *
+ * Format: "XX:XX:XX:..." (colon-separated uppercase hex)
+ */
+const SHA256_CERT_FINGERPRINTS = [
+  // Production signing key from EAS Build (cS3Aw8Mvxy)
+  "DB:55:17:D9:14:31:DB:06:16:30:0A:73:75:1C:2A:6D:36:6A:06:E4:5C:63:AF:EC:81:BB:61:C9:BB:B4:8A:6B",
+];
+
+/**
+ * GET /.well-known/assetlinks.json
+ *
+ * Returns the Digital Asset Links file that Android uses to verify App Links.
+ * Must be served over HTTPS with content-type application/json.
+ */
+export async function loader(_args: LoaderFunctionArgs) {
+  const assetlinks = SHA256_CERT_FINGERPRINTS.map((fingerprint) => ({
+    relation: ["delegate_permission/common.handle_all_urls"],
+    target: {
+      namespace: "android_app",
+      package_name: ANDROID_PACKAGE_NAME,
+      sha256_cert_fingerprints: [fingerprint],
+    },
+  }));
+
+  return data(assetlinks, {
+    headers: {
+      "Content-Type": "application/json",
+      // Cache for 1 hour
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Enable Universal Links so `https://app.shelf.nu` URLs open in the Shelf Companion app instead of Safari/Chrome.

### Changes

**iOS (`app.json`)**
- Added `associatedDomains: ["applinks:app.shelf.nu"]`

**Android (`app.json`)**  
- Added `intentFilters` with `autoVerify: true` for `https://app.shelf.nu`

**Webapp**
- Created `/.well-known/apple-app-site-association` route (Team ID: `27Q4MHFB8K`)
- Created `/.well-known/assetlinks.json` route (SHA256: `DB:55:17:D9...`)

### URLs that will open in app
- `https://app.shelf.nu/qr/*`
- `https://app.shelf.nu/assets/*`  
- `https://app.shelf.nu/bookings/*`

## ⚠️ Considerations for CTO Review

**Signing Key Stability**
- The Android SHA-256 fingerprint (`DB:55:17:D9...`) is tied to your EAS production keystore
- If this key ever changes (rare), update `assetlinks.json` or Android App Links will silently fail
- Your key won't change unless you explicitly rotate it or enroll in Google Play App Signing

**Caching**
- iOS caches AASA for ~24 hours
- If the `.well-known` routes return errors after deploy, recovery takes a day
- Test with fresh app installs

**Deployment Sequence**
1. Deploy webapp first (makes `.well-known` routes live)
2. Rebuild native apps with `eas build`
3. Test with fresh install on device

## Test plan

- [ ] Deploy webapp to staging
- [ ] Verify `https://staging.app.shelf.nu/.well-known/apple-app-site-association` returns JSON
- [ ] Verify `https://staging.app.shelf.nu/.well-known/assetlinks.json` returns JSON
- [ ] Build iOS/Android with new config
- [ ] Tap `https://app.shelf.nu/qr/xxx` link → should open in app
- [ ] Verify fallback to browser if app not installed