### PR TITLE
fix(layout): gate route SSR on hydration to avoid client-only call crash

### DIFF
--- a/apps/webapp/app/routes/_layout+/_layout.tsx
+++ b/apps/webapp/app/routes/_layout+/_layout.tsx
@@ -17,6 +17,7 @@ import {
   useLoaderData,
 } from "react-router";
 import { ClientOnly } from "remix-utils/client-only";
+import { useHydrated } from "remix-utils/use-hydrated";
 import { AtomsResetHandler } from "~/atoms/atoms-reset-handler";
 import { feedbackModalOpenAtom } from "~/atoms/feedback";
 import { ErrorContent } from "~/components/errors";
@@ -279,11 +280,25 @@ export default function App() {
     currentOrganizationId,
   } = useLoaderData<typeof loader>();
   const fetchers = useFetchers();
-  const workspaceSwitching = fetchers.some(
-    (f) =>
-      f.formAction === CHANGE_CURRENT_ORGANIZATION_ACTION &&
-      (f.state === "submitting" || f.state === "loading")
-  );
+  const isHydrated = useHydrated();
+  // Several authenticated routes (assets._index, kits._index, locations.*, …)
+  // call `userHasPermission` from `permission.validator.client` during their
+  // component render. That module is `.client.ts`, so RR7's vite plugin
+  // stubs every export to `undefined` in the server bundle — calling them
+  // during SSR throws `TypeError: userHasPermission is not a function`.
+  // Until those call sites are lifted into loaders (or wrapped in
+  // ClientOnly), we suppress route SSR rendering by showing the workspace
+  // spinner until the client has hydrated. This matches the prior status
+  // quo, when `switchingWorkspaceAtom` defaulted to `true` and produced the
+  // same one-frame spinner on every full reload.
+  // TODO: lift `userHasPermission` checks into route loaders so SSR works.
+  const workspaceSwitching =
+    !isHydrated ||
+    fetchers.some(
+      (f) =>
+        f.formAction === CHANGE_CURRENT_ORGANIZATION_ACTION &&
+        (f.state === "submitting" || f.state === "loading")
+    );
   const [feedbackModalOpen, setFeedbackModalOpen] = useAtom(
     feedbackModalOpenAtom
   );


### PR DESCRIPTION
PR #2573 replaced switchingWorkspaceAtom (atom(true) initial value) with a useFetchers()-derived workspaceSwitching boolean. The atom side-effect suppressed SSR of route children on every full page load by showing the "Activating workspace..." spinner branch; the new derivation returns false on the server (no in-flight fetchers), so route children now render server-side for the first time.

Several authenticated routes (assets._index, kits._index, locations.*, home, scanner, …) import userHasPermission from permission.validator.client and call it during their component render. RR7's vite plugin stubs all exports of *.client.ts modules to undefined in the server bundle, so SSR throws TypeError: userHasPermission is not a function — visible as "Unexpected Server Error" on cmd+R of those pages (SHELF-WEBAPP-1M0/1M2 through 1MA, 130+ events in ~3h, 29+ users impacted).

Restore the prior SSR-suppression behavior by OR-ing the workspaceSwitching flag with !useHydrated(). Server-rendered HTML shows the spinner, client hydrates and immediately swaps to real content. UX matches the pre-#2573 status quo for full reloads; SPA navigations are unaffected.

Proper follow-up: lift userHasPermission checks into route loaders (or wrap call sites in ClientOnly) so SSR can render the real page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace switching behavior by fixing the indicator to display correctly only after client-side hydration completes. This prevents false display of the "Activating workspace…" status message during server-side rendering and initial page load, ensuring more accurate user feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Shelf-nu/shelf.nu/pull/2576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->