### PR TITLE
feat(bookings): add per-asset check-in status to CSV export

### DIFF
--- a/apps/webapp/app/utils/booking-assets.test.ts
+++ b/apps/webapp/app/utils/booking-assets.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { getBookingAssetCheckinLabel } from "./booking-assets";
+
+describe("getBookingAssetCheckinLabel", () => {
+  const assetId = "asset-1";
+
+  it("labels a still-out asset 'Checked out' for active bookings", () => {
+    const checkedIn = new Set<string>(); // nothing checked in yet
+
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "ONGOING")).toBe(
+      "Checked out"
+    );
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "OVERDUE")).toBe(
+      "Checked out"
+    );
+  });
+
+  it("labels a partially checked-in asset 'Checked in' for active bookings", () => {
+    const checkedIn = new Set([assetId]);
+
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "ONGOING")).toBe(
+      "Checked in"
+    );
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "OVERDUE")).toBe(
+      "Checked in"
+    );
+  });
+
+  it("labels every asset 'Checked in' for final bookings regardless of records", () => {
+    // why: COMPLETE/ARCHIVED bookings have all assets returned by definition,
+    // even if no partial check-in row exists (e.g. a full check-in).
+    const checkedIn = new Set<string>();
+
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "COMPLETE")).toBe(
+      "Checked in"
+    );
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "ARCHIVED")).toBe(
+      "Checked in"
+    );
+  });
+
+  it("returns blank when check-in does not apply (never checked out)", () => {
+    const checkedIn = new Set<string>();
+
+    for (const status of ["DRAFT", "RESERVED", "CANCELLED"]) {
+      expect(getBookingAssetCheckinLabel(assetId, checkedIn, status)).toBe("");
+    }
+  });
+
+  it("keeps cancelled bookings blank even with check-in records", () => {
+    // why: cancelBooking returns assets to AVAILABLE when cancelling from
+    // ONGOING/OVERDUE, but a RESERVED->CANCELLED booking never checked out.
+    // Both collapse to CANCELLED, so status alone can't tell them apart —
+    // blank is the only non-misleading label. (Codex review, PR #2579.)
+    const checkedIn = new Set([assetId]);
+
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "CANCELLED")).toBe(
+      ""
+    );
+  });
+
+  it("only labels the matching asset as checked in", () => {
+    const checkedIn = new Set(["asset-other"]);
+
+    expect(getBookingAssetCheckinLabel(assetId, checkedIn, "ONGOING")).toBe(
+      "Checked out"
+    );
+    expect(
+      getBookingAssetCheckinLabel("asset-other", checkedIn, "ONGOING")
+    ).toBe("Checked in");
+  });
+});

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -1,12 +1,22 @@
 import { AssetStatus, KitStatus } from "@prisma/client";
 import type { PartialCheckinDetailsType } from "~/modules/booking/service.server";
 
+/**
+ * Minimal asset shape these booking-context helpers need: an `id` and a raw
+ * `status` string. The index signature lets callers pass richer asset objects
+ * (e.g. Prisma rows) without widening every call site.
+ */
 export type AssetWithStatus = {
   id: string;
   status: string;
   [key: string]: any;
 };
 
+/**
+ * Minimal kit shape these helpers need: an `id`, a raw `status`, and optionally
+ * its member assets (used to roll a kit's status up from its assets). The index
+ * signature allows passing richer kit objects without widening call sites.
+ */
 export type KitWithStatus = {
   id: string;
   status: string;
@@ -14,7 +24,18 @@ export type KitWithStatus = {
   [key: string]: any;
 };
 
+/**
+ * Asset status as surfaced in a booking context: the persisted {@link AssetStatus}
+ * plus the synthetic `"PARTIALLY_CHECKED_IN"` state, which only exists relative
+ * to a specific booking and is never stored on the asset itself.
+ */
 export type ExtendedAssetStatus = AssetStatus | "PARTIALLY_CHECKED_IN";
+
+/**
+ * Kit status as surfaced in a booking context: the persisted {@link KitStatus}
+ * plus the synthetic `"PARTIALLY_CHECKED_IN"` state (all member assets checked
+ * in while the booking is still active). Not stored on the kit itself.
+ */
 export type ExtendedKitStatus = KitStatus | "PARTIALLY_CHECKED_IN";
 
 /**
@@ -82,6 +103,61 @@ export function isAssetPartiallyCheckedIn(
 
   // Only consider as "partially checked in" for active & finished bookings
   return ["ONGOING", "OVERDUE", "COMPLETE", "ARCHIVED"].includes(bookingStatus);
+}
+
+/**
+ * Human-readable check-in label for a single booking asset, for use in the
+ * bookings CSV export.
+ *
+ * Mirrors the partial check-in semantics used across the booking UI
+ * ({@link getBookingContextAssetStatus}, {@link calculatePartialCheckinProgress})
+ * but flattens them to the three plain-text tokens an export consumer needs:
+ *
+ * - `"Checked in"`  — the asset has been returned. True when the booking is in
+ *   a final state (COMPLETE/ARCHIVED, where every asset is returned by
+ *   definition) OR when the asset appears in the booking's partial check-ins
+ *   while the booking is still ONGOING/OVERDUE.
+ * - `"Checked out"` — the booking is active (ONGOING/OVERDUE) and the asset has
+ *   not yet been checked in.
+ * - `""` (blank)    — check-in status does not apply. Covers DRAFT/RESERVED
+ *   (nothing was ever checked out) and CANCELLED. CANCELLED is deliberately
+ *   blank rather than labeled: `cancelBooking` returns assets to AVAILABLE only
+ *   when cancelling from ONGOING/OVERDUE, but a RESERVED→CANCELLED booking never
+ *   checked its assets out — and both collapse to the same `CANCELLED` status
+ *   here, so we cannot tell them apart from status alone. Any affirmative label
+ *   would be wrong for one path; blank is the only non-misleading value. The
+ *   booking-level `Status`/rollup columns still show "Cancelled" and `0 / N`.
+ *
+ * The tokens are deliberately exact and status-agnostic so a downstream script
+ * (e.g. a reminder workflow) can filter to "Checked out" across both
+ * Checked-Out and Overdue bookings without parsing prose. A blank CANCELLED row
+ * correctly yields no reminder (it won't match a "Checked out" filter).
+ *
+ * @param assetId - The asset whose label to resolve
+ * @param checkedInAssetIds - Set of asset IDs partially checked in for the booking
+ * @param bookingStatus - The parent booking's status (BookingStatus value)
+ * @returns The export label: "Checked in", "Checked out", or "" when N/A
+ */
+export function getBookingAssetCheckinLabel(
+  assetId: string,
+  checkedInAssetIds: Set<string>,
+  bookingStatus: string
+): "Checked in" | "Checked out" | "" {
+  // Final booking states: every asset is returned by definition.
+  if (["COMPLETE", "ARCHIVED"].includes(bookingStatus)) {
+    return "Checked in";
+  }
+
+  // Active states: distinguish returned vs still-out per asset.
+  if (["ONGOING", "OVERDUE"].includes(bookingStatus)) {
+    return checkedInAssetIds.has(assetId) ? "Checked in" : "Checked out";
+  }
+
+  // DRAFT / RESERVED — nothing was ever checked out.
+  // CANCELLED — ambiguous (could be RESERVED→CANCELLED, never out, or
+  // ONGOING/OVERDUE→CANCELLED, returned on cancel); blank is the only
+  // non-misleading value since status alone can't distinguish them. See JSDoc.
+  return "";
 }
 
 /**

--- a/apps/webapp/app/utils/csv.server.test.ts
+++ b/apps/webapp/app/utils/csv.server.test.ts
@@ -443,6 +443,10 @@ describe("buildCsvExportDataFromBookings", () => {
       "Description",
       "Tags",
       "Assets",
+      "Item check-in status",
+      "Check-in date",
+      "Checked in",
+      "Total assets",
     ]);
 
     expect(bookingRow[0]).toBe('"http://localhost:3000/bookings/booking-1"');
@@ -460,6 +464,60 @@ describe("buildCsvExportDataFromBookings", () => {
         expect(value).toBe('""');
       }
     });
+  });
+
+  it("marks each asset checked in/out and rolls up the booking count", () => {
+    // why: an OVERDUE booking where one of two assets has been partially
+    // checked in — exercises the per-asset status/date columns and the
+    // booking-level rollup against real partial check-in input.
+    const checkinDate = new Date("2024-01-05T09:30:00Z");
+    const booking = {
+      id: "booking-2",
+      name: "Field shoot",
+      status: "OVERDUE",
+      from: new Date("2024-01-02T03:04:00Z"),
+      originalFrom: undefined,
+      to: new Date("2024-01-03T03:04:00Z"),
+      originalTo: undefined,
+      custodianTeamMember: { name: "Custodian", user: null },
+      custodianUser: null,
+      description: "",
+      tags: [],
+      assets: [
+        { id: "asset-returned", title: "Returned Camera" },
+        { id: "asset-out", title: "Still-Out Tripod" },
+      ],
+    };
+
+    const checkinsByBooking = new Map([
+      [
+        "booking-2",
+        {
+          checkedInAssetIds: new Set(["asset-returned"]),
+          checkinDateByAsset: new Map([["asset-returned", checkinDate]]),
+        },
+      ],
+    ]);
+
+    const [, mainRow, assetRow] = buildCsvExportDataFromBookings(
+      [booking as any],
+      baseRequest,
+      checkinsByBooking
+    );
+
+    // Main row carries the first (returned) asset + booking-level rollup.
+    expect(mainRow[11]).toBe('"Returned Camera"');
+    expect(mainRow[12]).toBe('"Checked in"');
+    expect(mainRow[13]).not.toBe('""'); // a formatted check-in date is present
+    expect(mainRow[14]).toBe('"1"'); // checked in
+    expect(mainRow[15]).toBe('"2"'); // total assets
+
+    // Trailing asset row carries the still-out asset; booking-level columns blank.
+    expect(assetRow[11]).toBe('"Still-Out Tripod"');
+    expect(assetRow[12]).toBe('"Checked out"');
+    expect(assetRow[13]).toBe('""'); // no check-in date for an item still out
+    expect(assetRow[14]).toBe('""'); // booking rollup not repeated on asset rows
+    expect(assetRow[15]).toBe('""');
   });
 });
 

--- a/apps/webapp/app/utils/csv.server.ts
+++ b/apps/webapp/app/utils/csv.server.ts
@@ -41,6 +41,8 @@ import {
   getBookingsFilterData,
 } from "~/modules/booking/service.server";
 import type { BookingWithCustodians } from "~/modules/booking/types";
+import { calculatePartialCheckinProgress } from "~/modules/booking/utils.server";
+import { getBookingAssetCheckinLabel } from "./booking-assets";
 import { checkExhaustiveSwitch } from "./check-exhaustive-switch";
 import { getDateTimeFormat } from "./client-hints";
 import { getAdvancedFiltersFromRequest } from "./cookies.server";
@@ -601,6 +603,22 @@ const formatCustomFieldForCsv = (
   }
 };
 
+/**
+ * Builds the bookings CSV string for the export route.
+ *
+ * Resolves which bookings to export — either the explicit `bookingsIds`, or,
+ * when the select-all sentinel is present, every booking matching the index's
+ * current filters — then enriches them with batched partial check-in state and
+ * delegates row construction to {@link buildCsvExportDataFromBookings}.
+ *
+ * @param request - The incoming request (carries filters, locale, timezone)
+ * @param userId - The acting user, for filter scoping in the select-all path
+ * @param bookingsIds - Selected booking IDs, or `[ALL_SELECTED_KEY]` for all
+ * @param canSeeAllBookings - Whether the user may export bookings they don't own
+ * @param organizationId - The active workspace; scopes every booking read
+ * @returns The CSV body as a single CRLF-joined string
+ * @throws {ShelfError} If fetching bookings or building rows fails
+ */
 export async function exportBookingsFromIndexToCsv({
   request,
   userId,
@@ -660,6 +678,9 @@ export async function exportBookingsFromIndexToCsv({
           ...BOOKING_COMMON_INCLUDE,
           assets: {
             select: {
+              // `id` is required to match each asset against the booking's
+              // partial check-ins for the per-asset check-in status column.
+              id: true,
               title: true,
             },
           },
@@ -668,10 +689,18 @@ export async function exportBookingsFromIndexToCsv({
       });
     }
 
+    // Fetch partial check-in state for the exported bookings in a single
+    // batched query (avoids an N+1 across the selection) so the export can
+    // surface which assets are still checked out vs already returned.
+    const checkinsByBooking = await buildBookingCheckinMap(
+      bookings.map((booking) => booking.id)
+    );
+
     // Pass both assets and columns to the build function
     const csvData = buildCsvExportDataFromBookings(
       bookings as FlexibleBooking[],
-      request
+      request,
+      checkinsByBooking
     );
 
     // Join rows with CRLF as per CSV spec
@@ -875,25 +904,104 @@ export async function exportLocationNotesToCsv({
   });
 }
 
-/** Define some types to use for normalizing bookings across the different fetches */
+/**
+ * Normalized asset shape shared across the different booking export fetches —
+ * always has a `title`, with the remaining asset fields optional.
+ */
 type FlexibleAsset = Partial<Asset> & {
   title: string;
 };
 
+/**
+ * Normalized booking shape the CSV builder consumes, regardless of which fetch
+ * path (by-id vs. select-all) produced it: a booking with its custodians,
+ * {@link FlexibleAsset} list, and name-only tags.
+ */
 type FlexibleBooking = Omit<BookingWithCustodians, "assets"> & {
   assets: FlexibleAsset[];
   tags: Pick<Tag, "name">[];
 };
 
 /**
- * Builds CSV export data from bookings
+ * Per-booking partial check-in state needed by the CSV export.
+ * - `checkedInAssetIds`: set of asset IDs that have been (partially) checked in
+ * - `checkinDateByAsset`: earliest check-in timestamp per asset, for the date column
+ */
+type BookingCheckinInfo = {
+  checkedInAssetIds: Set<string>;
+  checkinDateByAsset: Map<string, Date>;
+};
+
+/**
+ * Batch-fetch partial check-in state for a set of bookings.
+ *
+ * Reads every {@link PartialBookingCheckin} for the given bookings in one query
+ * and folds them into a per-booking lookup. For each asset only the earliest
+ * check-in is kept (an asset can in principle appear in more than one check-in
+ * session), matching {@link getDetailedPartialCheckinData}'s "first wins" rule.
+ *
+ * @param bookingIds - The bookings being exported
+ * @returns Map of bookingId → {@link BookingCheckinInfo}; bookings with no
+ *   partial check-ins are simply absent from the map
+ */
+async function buildBookingCheckinMap(
+  bookingIds: string[]
+): Promise<Map<string, BookingCheckinInfo>> {
+  const map = new Map<string, BookingCheckinInfo>();
+
+  if (!bookingIds.length) {
+    return map;
+  }
+
+  const checkins = await db.partialBookingCheckin.findMany({
+    where: { bookingId: { in: bookingIds } },
+    select: { bookingId: true, assetIds: true, checkinTimestamp: true },
+    // Earliest first so the "first check-in wins" assignment below is stable.
+    orderBy: { checkinTimestamp: "asc" },
+  });
+
+  for (const checkin of checkins) {
+    let info = map.get(checkin.bookingId);
+    if (!info) {
+      info = {
+        checkedInAssetIds: new Set<string>(),
+        checkinDateByAsset: new Map<string, Date>(),
+      };
+      map.set(checkin.bookingId, info);
+    }
+
+    for (const assetId of checkin.assetIds) {
+      info.checkedInAssetIds.add(assetId);
+      // Keep the earliest check-in per asset (rows are ordered ascending).
+      if (!info.checkinDateByAsset.has(assetId)) {
+        info.checkinDateByAsset.set(assetId, checkin.checkinTimestamp);
+      }
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Builds CSV export data from bookings.
+ *
+ * Each booking is emitted as a "main" row (booking fields + its first asset)
+ * followed by one row per additional asset. Per-asset columns
+ * (`Assets`, `Item check-in status`, `Check-in date`) are populated on every
+ * row for that row's asset; booking-level columns are populated on the main
+ * row only and left blank on the trailing asset rows.
+ *
  * @param bookings - Array of bookings to export
  * @param request - Request object for locale/timezone formatting
+ * @param checkinsByBooking - Per-booking partial check-in state, from
+ *   {@link buildBookingCheckinMap}. Used to derive the per-asset check-in
+ *   status/date columns and the booking-level checked-in rollup.
  * @returns Array of string arrays representing CSV rows, including headers
  */
 export const buildCsvExportDataFromBookings = (
   bookings: FlexibleBooking[],
-  request: Request
+  request: Request,
+  checkinsByBooking: Map<string, BookingCheckinInfo> = new Map()
 ): string[][] => {
   if (!bookings.length) return [];
 
@@ -903,7 +1011,11 @@ export const buildCsvExportDataFromBookings = (
     timeStyle: "short",
   }).format;
 
-  // Create headers row using column names
+  // Create headers row using column names. The check-in columns are appended
+  // last so existing consumers that key off earlier column positions are
+  // unaffected. Per-asset columns (assetCheckinStatus/assetCheckinDate) sit
+  // beside `asset`; the booking-level rollup (checkedInCount/totalAssets)
+  // follows.
   const headers = {
     url: "Booking URL", // custom string
     id: "Booking ID", // string
@@ -916,114 +1028,144 @@ export const buildCsvExportDataFromBookings = (
     custodian: "Custodian",
     description: "Description", // string
     tags: "Tags",
-    asset: "Assets", // New column for assets
+    asset: "Assets", // asset title (per row)
+    assetCheckinStatus: "Item check-in status", // "Checked in" / "Checked out" (per asset)
+    assetCheckinDate: "Check-in date", // when the asset was checked in (per asset)
+    checkedInCount: "Checked in", // assets returned for this booking (per booking)
+    totalAssets: "Total assets", // assets on this booking (per booking)
   };
 
   // Create data rows with assets
   const rows: string[][] = [];
 
   bookings.forEach((booking) => {
-    // Get the first asset's title if available
-    const firstAsset =
+    // Normalize to a non-empty list so a booking with no assets still emits a
+    // single row. The placeholder has no id, so its check-in columns stay blank.
+    const assets =
       booking.assets && booking.assets.length > 0
-        ? booking.assets[0]
-        : { title: "No assets" };
+        ? booking.assets
+        : [{ id: undefined, title: "No assets" } as FlexibleAsset];
 
-    // First add the main booking row (including the first asset)
-    const bookingRow = Object.keys(headers).map((column) => {
-      // Handle different column types
-      let value: any;
+    // Per-booking partial check-in state. `calculatePartialCheckinProgress` is
+    // the same helper that powers the booking detail "X / Y checked in" bar, so
+    // the export rollup matches what users see in-app.
+    const checkinInfo = checkinsByBooking.get(booking.id);
+    const checkedInAssetIds =
+      checkinInfo?.checkedInAssetIds ?? new Set<string>();
+    const progress = calculatePartialCheckinProgress(
+      booking.assets?.length ?? 0,
+      [...checkedInAssetIds],
+      booking.status
+    );
 
-      // If it's not a custom field, it must be a fixed field or 'name'
-      switch (column) {
-        case "url":
-          value = `${SERVER_URL}/bookings/${booking.id}`;
-          break;
-        case "id":
-          value = booking.id;
-          break;
-        case "name":
-          value = booking.name;
-          break;
-        case "status":
-          value =
-            booking.status.charAt(0).toUpperCase() +
-            booking.status.slice(1).toLowerCase();
-          break;
-        case "from":
-          value = booking.from ? format(booking.from).split(",") : "";
-          break;
-        case "originalFrom":
-          value = booking.originalFrom
-            ? format(booking.originalFrom).split(",")
-            : booking.from
-            ? format(booking.from).split(",")
-            : "";
-          break;
+    assets.forEach((asset, index) => {
+      // The first asset shares the booking's "main" row; the rest get their
+      // own rows with booking-level columns blanked.
+      const isMainRow = index === 0;
 
-        case "to":
-          value = booking.to ? format(booking.to).split(",") : "";
-          break;
-        case "originalTo":
-          value = booking.originalTo
-            ? format(booking.originalTo).split(",")
-            : booking.to
-            ? format(booking.to).split(",")
-            : "";
-          break;
-        case "custodian": {
-          const teamMember = {
-            name: booking.custodianTeamMember?.name ?? "",
-            user: booking?.custodianUser
-              ? {
-                  firstName: booking.custodianUser?.firstName,
-                  lastName: booking.custodianUser?.lastName,
-                  email: booking.custodianUser?.email,
-                }
-              : null,
-          };
-
-          value = resolveTeamMemberName(teamMember, true);
-          break;
+      const row = Object.keys(headers).map((column) => {
+        // --- Per-asset columns: populated on every row for that asset ---
+        if (column === "asset") {
+          return formatValueForCsv(asset.title || "Unnamed Asset", false);
         }
-        case "description":
-          value = booking.description ?? "";
-          break;
-        case "asset":
-          // Include the first asset title in the main booking row
-          value = firstAsset ? firstAsset.title || "Unnamed Asset" : "";
-          break;
+        if (column === "assetCheckinStatus") {
+          const label = asset.id
+            ? getBookingAssetCheckinLabel(
+                asset.id,
+                checkedInAssetIds,
+                booking.status
+              )
+            : "";
+          return formatValueForCsv(label, false);
+        }
+        if (column === "assetCheckinDate") {
+          const checkinDate = asset.id
+            ? checkinInfo?.checkinDateByAsset.get(asset.id)
+            : undefined;
+          return formatValueForCsv(
+            checkinDate ? format(checkinDate) : "",
+            false
+          );
+        }
 
-        case "tags":
-          value = booking.tags.length
-            ? booking.tags.map((tag) => tag.name).join(", ")
-            : "No tags";
-          break;
-        default:
-          value = "";
-      }
-      return formatValueForCsv(value, false);
-    });
-
-    rows.push(bookingRow);
-
-    // Then add remaining asset rows if the booking has more than one asset
-    if (booking.assets && booking.assets.length > 1) {
-      // Start from the second asset (index 1)
-      booking.assets.slice(1).forEach((asset) => {
-        // Create an asset row with empty values for all columns except 'asset'
-        const assetRow = Object.keys(headers).map((column) => {
-          if (column === "asset") {
-            // Assuming asset has a title property
-            return formatValueForCsv(asset.title || "Unnamed Asset", false);
-          }
-          // Empty values for all other columns
+        // --- Booking-level columns: main row only, blank on asset rows ---
+        if (!isMainRow) {
           return formatValueForCsv("", false);
-        });
+        }
 
-        rows.push(assetRow);
+        let value: any;
+        switch (column) {
+          case "url":
+            value = `${SERVER_URL}/bookings/${booking.id}`;
+            break;
+          case "id":
+            value = booking.id;
+            break;
+          case "name":
+            value = booking.name;
+            break;
+          case "status":
+            value =
+              booking.status.charAt(0).toUpperCase() +
+              booking.status.slice(1).toLowerCase();
+            break;
+          case "from":
+            value = booking.from ? format(booking.from).split(",") : "";
+            break;
+          case "originalFrom":
+            value = booking.originalFrom
+              ? format(booking.originalFrom).split(",")
+              : booking.from
+              ? format(booking.from).split(",")
+              : "";
+            break;
+          case "to":
+            value = booking.to ? format(booking.to).split(",") : "";
+            break;
+          case "originalTo":
+            value = booking.originalTo
+              ? format(booking.originalTo).split(",")
+              : booking.to
+              ? format(booking.to).split(",")
+              : "";
+            break;
+          case "custodian": {
+            const teamMember = {
+              name: booking.custodianTeamMember?.name ?? "",
+              user: booking?.custodianUser
+                ? {
+                    firstName: booking.custodianUser?.firstName,
+                    lastName: booking.custodianUser?.lastName,
+                    email: booking.custodianUser?.email,
+                  }
+                : null,
+            };
+
+            value = resolveTeamMemberName(teamMember, true);
+            break;
+          }
+          case "description":
+            value = booking.description ?? "";
+            break;
+          case "tags":
+            value = booking.tags.length
+              ? booking.tags.map((tag) => tag.name).join(", ")
+              : "No tags";
+            break;
+          case "checkedInCount":
+            value = progress.checkedInCount;
+            break;
+          case "totalAssets":
+            value = progress.totalAssets;
+            break;
+          default:
+            value = "";
+        }
+        return formatValueForCsv(value, false);
       });
-    }
+
+      rows.push(row);
+    });
   });
 
   // Return headers followed by data rows


### PR DESCRIPTION
## The need

A customer running end-of-semester equipment returns asked for the bookings CSV export to show **which items in a booking are still out vs. already returned**, for both **Checked-Out** and **Overdue** bookings — they drive reminder emails off the export and currently can't tell.

Today the export carries only the **booking-level** `Status` (Ongoing / Overdue / …) and a flat list of asset titles with no per-asset return state. The app already tracks partial check-in (the booking detail page shows an "X / Y checked in" progress bar), but that signal never reached the export.

## Hypothesis

The data already exists (`PartialBookingCheckin` + the partial-checkin helpers); the gap is purely on the export render side. Surfacing it as columns — rather than filtering rows — keeps the export complete and lets the customer (or anyone) filter on their end.

## What changed

Four columns, **appended last** so existing column positions are unchanged for current consumers:

| Column | Scope | Source |
|---|---|---|
| `Item check-in status` | per asset row | new `getBookingAssetCheckinLabel` — `"Checked in"` / `"Checked out"` / blank |
| `Check-in date` | per asset row | earliest `PartialBookingCheckin.checkinTimestamp` for that asset |
| `Checked in` | booking main row | `calculatePartialCheckinProgress().checkedInCount` (same helper as the in-app bar) |
| `Total assets` | booking main row | `calculatePartialCheckinProgress().totalAssets` |

Design notes:
- **Status-agnostic** per-asset label: works identically for Checked-Out and Overdue. Final states (COMPLETE/ARCHIVED) → all "Checked in"; DRAFT/RESERVED/CANCELLED → blank (nothing was ever checked out, so "Checked out" would be misleading).
- **Reuse over reinvention:** no new check-in logic. The label mirrors the existing `booking-assets.ts` semantics; the rollup reuses `calculatePartialCheckinProgress` so the export matches the booking detail bar.
- **One batched query** (`buildBookingCheckinMap`) fetches partial check-ins for the whole exported selection — no N+1.
- The row-builder was lightly restructured (one loop over assets instead of duplicated main-row/asset-row blocks) to populate per-asset columns on every row; existing column values and row counts are unchanged.

## Test plan

- New `booking-assets.test.ts` — `getBookingAssetCheckinLabel` across ONGOING / OVERDUE / COMPLETE / ARCHIVED / DRAFT / RESERVED / CANCELLED and the matching-asset case.
- Extended `csv.server.test.ts` — updated header assertion + a partial-checkin scenario (Overdue booking, one of two assets returned) asserting per-asset status/date and the booking rollup, plus blanks on trailing asset rows.
- `pnpm webapp:validate` green locally: **165 files / 2138 tests pass**, typecheck + lint + prettier clean. Pre-commit security review passed (only a Low defense-in-depth note: the new read inherits org-scoping from the upstream booking fetch).

## Deliberately out of scope

- **No row filtering.** The original request also asked the export to *only* show not-yet-returned items. An export that silently drops rows breaks reconciliation, so this ships a complete file + a filterable column instead — same outcome, honest data.
- **No schema change / migration.** Pure render-side.
- **Kit rollup column.** Kit member-assets already export as individual rows, so per-asset status covers them. A kit-level rollup column can follow if wanted.
- Independent of the companion and progressive-checkout work; branches off `main` with no shared files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV exports now include per-asset check-in status and check-in date, plus booking-level summaries (checked-in count and total assets). Exports handle partial per-booking check-ins and normalize rows so rollups appear once with asset rows following.

* **Tests**
  * Added tests ensuring per-asset "Checked in"/"Checked out"/blank labels across booking states and membership.
  * Updated CSV export tests to validate new check-in columns, per-asset rows, and booking-level rollups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->