### PR TITLE
fix(companion): prevent silent audit scan loss (P0)

### DIFF
--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -570,8 +570,12 @@ function AuditScannerContent() {
     }
 
     // Server accepted completion — only now is it safe to drop the local
-    // recovery snapshot.
+    // recovery snapshot. Clear the in-memory queues too (in place): otherwise
+    // the unmount cleanup would see a non-empty failedQueue on navigate-back and
+    // re-flush a recovery snapshot for an audit that is already completed.
     debouncedSaverRef.current?.cancel();
+    scanQueueRef.current.length = 0;
+    failedQueueRef.current.length = 0;
     await clearAuditScanState(auditId);
 
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
@@ -579,7 +583,15 @@ function AuditScannerContent() {
     Alert.alert("Audit Complete", `"${auditName}" has been completed.`, [
       { text: "OK", onPress: () => router.back() },
     ]);
-  }, [auditId, currentOrg, auditName, router, debouncedSaverRef]);
+  }, [
+    auditId,
+    currentOrg,
+    auditName,
+    router,
+    debouncedSaverRef,
+    scanQueueRef,
+    failedQueueRef,
+  ]);
 
   // Standard confirm: warns how many expected assets will be marked missing.
   const confirmAndComplete = useCallback(() => {

--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -545,29 +545,45 @@ function AuditScannerContent() {
 
   // ── Complete audit ───────────────────────────────────
 
-  const handleComplete = useCallback(() => {
+  // Performs the actual completion request + cleanup. Extracted so it can be
+  // reached both from the normal confirm and the "complete anyway" path.
+  const runCompletion = useCallback(async () => {
     if (!auditId || !currentOrg) return;
 
-    // GUARD: never complete while scans are still un-synced. Completing now
-    // would mark those (locally "Found") assets MISSING on the server — an
-    // irreversible audit-data error. Kick a re-sync and ask the worker to wait.
-    const pendingSync =
-      scanQueueRef.current.length + failedQueueRef.current.length;
-    if (pendingSync > 0) {
-      retryFailedScans();
-      processQueue();
-      Alert.alert(
-        "Scans still syncing",
-        `${pendingSync} scan${pendingSync === 1 ? "" : "s"} ${
-          pendingSync === 1 ? "hasn't" : "haven't"
-        } reached the server yet. Stay on this screen with an internet ` +
-          `connection until syncing finishes, then complete again.`
-      );
+    const timeZone = (() => {
+      try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+      } catch {
+        return "UTC";
+      }
+    })();
+
+    const { error: err } = await api.completeAudit(currentOrg.id, {
+      sessionId: auditId,
+      timeZone,
+    });
+
+    if (err) {
+      // Completion failed — KEEP recovery state so nothing is lost.
+      Alert.alert("Error", err);
       return;
     }
 
-    const remaining = expectedTotal - foundCount;
+    // Server accepted completion — only now is it safe to drop the local
+    // recovery snapshot.
+    debouncedSaverRef.current?.cancel();
+    await clearAuditScanState(auditId);
 
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    playScanSound();
+    Alert.alert("Audit Complete", `"${auditName}" has been completed.`, [
+      { text: "OK", onPress: () => router.back() },
+    ]);
+  }, [auditId, currentOrg, auditName, router, debouncedSaverRef]);
+
+  // Standard confirm: warns how many expected assets will be marked missing.
+  const confirmAndComplete = useCallback(() => {
+    const remaining = expectedTotal - foundCount;
     Alert.alert(
       "Complete Audit",
       remaining > 0
@@ -577,58 +593,65 @@ function AuditScannerContent() {
         : `Complete "${auditName}"?\n\nAll expected assets have been found.`,
       [
         { text: "Cancel", style: "cancel" },
-        {
-          text: "Complete",
-          onPress: async () => {
-            const timeZone = (() => {
-              try {
-                return (
-                  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
-                );
-              } catch {
-                return "UTC";
-              }
-            })();
-
-            const { error: err } = await api.completeAudit(currentOrg.id, {
-              sessionId: auditId,
-              timeZone,
-            });
-
-            if (err) {
-              // Completion failed — KEEP recovery state so nothing is lost.
-              Alert.alert("Error", err);
-              return;
-            }
-
-            // Server accepted completion — only now is it safe to drop the
-            // local recovery snapshot.
-            debouncedSaverRef.current?.cancel();
-            await clearAuditScanState(auditId);
-
-            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-            playScanSound();
-            Alert.alert(
-              "Audit Complete",
-              `"${auditName}" has been completed.`,
-              [{ text: "OK", onPress: () => router.back() }]
-            );
-          },
-        },
+        { text: "Complete", onPress: runCompletion },
       ]
     );
+  }, [auditName, expectedTotal, foundCount, runCompletion]);
+
+  const handleComplete = useCallback(() => {
+    if (!auditId || !currentOrg) return;
+
+    // Scans still actively retrying (transient failures). Completing now would
+    // mark these locally-"Found" assets MISSING on the server, so ask the
+    // worker to wait while syncing continues.
+    const pendingCount = scanQueueRef.current.length;
+    if (pendingCount > 0) {
+      processQueue();
+      Alert.alert(
+        "Scans still syncing",
+        `${pendingCount} scan${pendingCount === 1 ? "" : "s"} ${
+          pendingCount === 1 ? "is" : "are"
+        } still syncing. Stay on this screen with an internet connection, ` +
+          `then complete again.`
+      );
+      return;
+    }
+
+    // Scans that exhausted their retries. These may be permanent failures (an
+    // asset deleted or moved to another workspace returns a 404 that will never
+    // succeed), so we must NOT trap the audit. Offer to retry or to complete
+    // anyway (acknowledging those assets will be marked missing).
+    const failedCount = failedQueueRef.current.length;
+    if (failedCount > 0) {
+      Alert.alert(
+        "Some scans didn't sync",
+        `${failedCount} scan${
+          failedCount === 1 ? "" : "s"
+        } couldn't be saved ` +
+          `to the server after several tries. Retry, or complete anyway ` +
+          `(${failedCount === 1 ? "it" : "they"} will be marked as missing).`,
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Retry sync", onPress: retryFailedScans },
+          {
+            text: "Complete anyway",
+            style: "destructive",
+            onPress: confirmAndComplete,
+          },
+        ]
+      );
+      return;
+    }
+
+    confirmAndComplete();
   }, [
     auditId,
     currentOrg,
-    auditName,
-    expectedTotal,
-    foundCount,
-    router,
-    debouncedSaverRef,
     scanQueueRef,
     failedQueueRef,
-    retryFailedScans,
     processQueue,
+    retryFailedScans,
+    confirmAndComplete,
   ]);
 
   // ── Remaining assets (expected but not yet scanned) ──

--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -148,10 +148,12 @@ function AuditScannerContent() {
   // Callback for when scan is synced - updates React state with auditAssetId
   const handleScanSynced = useCallback(
     (assetId: string, auditAssetId: string) => {
-      // Update the scanned items list
+      // Update the scanned items list (clear any prior sync-failed marker)
       setScannedItemsRef.current?.((prev) =>
         prev.map((item) =>
-          item.assetId === assetId ? { ...item, auditAssetId } : item
+          item.assetId === assetId
+            ? { ...item, auditAssetId, syncFailed: false }
+            : item
         )
       );
       // Also update selectedItem if evidence modal is open for this asset
@@ -162,12 +164,29 @@ function AuditScannerContent() {
     []
   );
 
-  const { scanQueueRef, enqueueScan, processQueue, retryTimerRef } =
-    useScanQueue({
-      orgId: currentOrg?.id,
-      scannedItemsRef: stableScannedItemsRef,
-      onScanSynced: handleScanSynced,
-    });
+  // Callback for when a scan exhausts its retries — surface it in the list so
+  // the worker sees it never reached the server (and completion is blocked).
+  const handleScanFailed = useCallback((assetId: string) => {
+    setScannedItemsRef.current?.((prev) =>
+      prev.map((item) =>
+        item.assetId === assetId ? { ...item, syncFailed: true } : item
+      )
+    );
+  }, []);
+
+  const {
+    scanQueueRef,
+    failedQueueRef,
+    enqueueScan,
+    processQueue,
+    retryFailedScans,
+    retryTimerRef,
+  } = useScanQueue({
+    orgId: currentOrg?.id,
+    scannedItemsRef: stableScannedItemsRef,
+    onScanSynced: handleScanSynced,
+    onScanFailed: handleScanFailed,
+  });
 
   // ── Audit init (extracted hook) ─────────────────────
 
@@ -283,12 +302,33 @@ function AuditScannerContent() {
         clearTimeout(frameHighlightTimer.current);
       if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
       if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
-      // Normal exit — clear persisted state (crash recovery not needed)
-      debouncedSaverRef.current?.cancel();
+      // On exit, only clear persisted state if EVERYTHING has synced. If any
+      // scans are still pending or failed, flush the latest snapshot and KEEP
+      // it — clearing here would discard scans the worker saw as "Found",
+      // which the server then marks MISSING on completion.
+      const hasUnsyncedScans =
+        scanQueueRef.current.length > 0 || failedQueueRef.current.length > 0;
+      if (auditId && hasUnsyncedScans) {
+        debouncedSaverRef.current?.flush(
+          scannedItemsRef.current,
+          scanQueueRef.current,
+          failedQueueRef.current
+        );
+      } else {
+        debouncedSaverRef.current?.cancel();
+        if (auditId) clearAuditScanState(auditId);
+      }
       /* eslint-enable react-hooks/exhaustive-deps */
-      if (auditId) clearAuditScanState(auditId);
     };
-  }, [auditId, toastTimerRef, retryTimerRef, debouncedSaverRef]);
+  }, [
+    auditId,
+    toastTimerRef,
+    retryTimerRef,
+    debouncedSaverRef,
+    scanQueueRef,
+    failedQueueRef,
+    scannedItemsRef,
+  ]);
 
   // ── Helpers ──────────────────────────────────────────
 
@@ -465,7 +505,8 @@ function AuditScannerContent() {
         // 6. Persist to disk for crash recovery (debounced)
         debouncedSaverRef.current?.save(
           scannedItemsRef.current,
-          scanQueueRef.current
+          scanQueueRef.current,
+          failedQueueRef.current
         );
 
         finalizeScan();
@@ -496,6 +537,7 @@ function AuditScannerContent() {
       setUnexpectedCount,
       debouncedSaverRef,
       scanQueueRef,
+      failedQueueRef,
       shouldSkipScan,
       lastScanRef,
     ]
@@ -505,6 +547,24 @@ function AuditScannerContent() {
 
   const handleComplete = useCallback(() => {
     if (!auditId || !currentOrg) return;
+
+    // GUARD: never complete while scans are still un-synced. Completing now
+    // would mark those (locally "Found") assets MISSING on the server — an
+    // irreversible audit-data error. Kick a re-sync and ask the worker to wait.
+    const pendingSync =
+      scanQueueRef.current.length + failedQueueRef.current.length;
+    if (pendingSync > 0) {
+      retryFailedScans();
+      processQueue();
+      Alert.alert(
+        "Scans still syncing",
+        `${pendingSync} scan${pendingSync === 1 ? "" : "s"} ${
+          pendingSync === 1 ? "hasn't" : "haven't"
+        } reached the server yet. Stay on this screen with an internet ` +
+          `connection until syncing finishes, then complete again.`
+      );
+      return;
+    }
 
     const remaining = expectedTotal - foundCount;
 
@@ -520,10 +580,6 @@ function AuditScannerContent() {
         {
           text: "Complete",
           onPress: async () => {
-            // Clear crash recovery state — audit is being completed
-            debouncedSaverRef.current?.cancel();
-            await clearAuditScanState(auditId);
-
             const timeZone = (() => {
               try {
                 return (
@@ -540,9 +596,15 @@ function AuditScannerContent() {
             });
 
             if (err) {
+              // Completion failed — KEEP recovery state so nothing is lost.
               Alert.alert("Error", err);
               return;
             }
+
+            // Server accepted completion — only now is it safe to drop the
+            // local recovery snapshot.
+            debouncedSaverRef.current?.cancel();
+            await clearAuditScanState(auditId);
 
             Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
             playScanSound();
@@ -563,6 +625,10 @@ function AuditScannerContent() {
     foundCount,
     router,
     debouncedSaverRef,
+    scanQueueRef,
+    failedQueueRef,
+    retryFailedScans,
+    processQueue,
   ]);
 
   // ── Remaining assets (expected but not yet scanned) ──

--- a/apps/companion/components/audit/scanned-items-list.tsx
+++ b/apps/companion/components/audit/scanned-items-list.tsx
@@ -26,6 +26,7 @@ export function ScannedItemsList({
     ({ item }: { item: ScannedItem }) => {
       const evidenceCount = (item.notesCount ?? 0) + (item.imagesCount ?? 0);
       const hasEvidence = evidenceCount > 0;
+      const syncFailed = item.syncFailed === true;
 
       return (
         <TouchableOpacity
@@ -34,8 +35,8 @@ export function ScannedItemsList({
           activeOpacity={0.7}
           accessibilityLabel={`${item.name}, ${
             item.isExpected ? "found" : "unexpected"
-          }${
-            hasEvidence ? `, ${evidenceCount} evidence items` : ""
+          }${hasEvidence ? `, ${evidenceCount} evidence items` : ""}${
+            syncFailed ? ", not synced, will retry" : ""
           }. Tap to add notes or photos.`}
           accessibilityRole="button"
         >
@@ -53,9 +54,20 @@ export function ScannedItemsList({
               <Text style={styles.evidenceCount}>{evidenceCount}</Text>
             </View>
           )}
-          <Text style={styles.scannedItemBadge}>
-            {item.isExpected ? "Found" : "Unexpected"}
-          </Text>
+          {syncFailed ? (
+            <View style={styles.syncFailedBadge}>
+              <Ionicons
+                name="cloud-offline-outline"
+                size={12}
+                color={colors.warning}
+              />
+              <Text style={styles.syncFailedText}>Not synced</Text>
+            </View>
+          ) : (
+            <Text style={styles.scannedItemBadge}>
+              {item.isExpected ? "Found" : "Unexpected"}
+            </Text>
+          )}
           <Ionicons name="chevron-forward" size={16} color={colors.muted} />
         </TouchableOpacity>
       );
@@ -148,5 +160,15 @@ const useStyles = createStyles((colors) => ({
     fontSize: fontSize.xs,
     fontWeight: "600",
     color: colors.primary,
+  },
+  syncFailedBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 2,
+  },
+  syncFailedText: {
+    fontSize: fontSize.xs,
+    fontWeight: "600",
+    color: colors.warning,
   },
 }));

--- a/apps/companion/components/audit/scanned-items-list.tsx
+++ b/apps/companion/components/audit/scanned-items-list.tsx
@@ -36,7 +36,7 @@ export function ScannedItemsList({
           accessibilityLabel={`${item.name}, ${
             item.isExpected ? "found" : "unexpected"
           }${hasEvidence ? `, ${evidenceCount} evidence items` : ""}${
-            syncFailed ? ", not synced, will retry" : ""
+            syncFailed ? ", not synced" : ""
           }. Tap to add notes or photos.`}
           accessibilityRole="button"
         >

--- a/apps/companion/hooks/use-audit-init.ts
+++ b/apps/companion/hooks/use-audit-init.ts
@@ -21,6 +21,11 @@ export type ScannedItem = {
   notesCount?: number;
   /** Local count of photos added during this session (optimistic). */
   imagesCount?: number;
+  /**
+   * True when this scan exhausted its sync retries and has not yet reached the
+   * server. Surfaced in the UI and blocks audit completion until re-synced.
+   */
+  syncFailed?: boolean;
 };
 
 export type ScanQueueEntry = {
@@ -159,9 +164,15 @@ export function useAuditInit({
         const recoveredItems = persisted.scannedItems.filter(
           (item) => !serverScannedIds.has(item.assetId)
         );
+        // Re-sync BOTH still-pending scans and scans that previously exhausted
+        // their retries (failedQueue). Without the failedQueue, a scan dropped
+        // after max retries would be merged back into the list as "found" but
+        // never re-submitted — and then marked MISSING on completion.
         const pendingQueue = persisted.pendingQueue || [];
+        const failedQueue = persisted.failedQueue || [];
+        const queuedForSync = [...pendingQueue, ...failedQueue];
 
-        if (recoveredItems.length > 0 || pendingQueue.length > 0) {
+        if (recoveredItems.length > 0 || queuedForSync.length > 0) {
           // Show recovery dialog (don't block init)
           setIsInitializing(false);
           Alert.alert(
@@ -188,9 +199,9 @@ export function useAuditInit({
                   setScannedItems(merged);
                   scannedItemsRef.current = merged;
 
-                  // Requeue pending items for submission
-                  if (pendingQueue.length > 0) {
-                    scanQueueRef.current = pendingQueue.map((e) => ({
+                  // Requeue pending + previously-failed items for submission
+                  if (queuedForSync.length > 0) {
+                    scanQueueRef.current = queuedForSync.map((e) => ({
                       ...e,
                       retryCount: 0,
                     }));

--- a/apps/companion/hooks/use-audit-init.ts
+++ b/apps/companion/hooks/use-audit-init.ts
@@ -170,7 +170,12 @@ export function useAuditInit({
         // never re-submitted — and then marked MISSING on completion.
         const pendingQueue = persisted.pendingQueue || [];
         const failedQueue = persisted.failedQueue || [];
-        const queuedForSync = [...pendingQueue, ...failedQueue];
+        // Exclude anything the server already has: a crash after recordAuditScan
+        // succeeded but before the queue-removal snapshot persisted could leave a
+        // stale entry on disk; re-submitting it would double-record the scan.
+        const queuedForSync = [...pendingQueue, ...failedQueue].filter(
+          (entry) => !serverScannedIds.has(entry.assetId)
+        );
 
         if (recoveredItems.length > 0 || queuedForSync.length > 0) {
           // Show recovery dialog (don't block init)

--- a/apps/companion/hooks/use-scan-queue.ts
+++ b/apps/companion/hooks/use-scan-queue.ts
@@ -151,7 +151,9 @@ export function useScanQueue({
       ...e,
       retryCount: 0,
     }));
-    failedQueueRef.current = [];
+    // Mutate in place — a pending debounced save holds this array reference,
+    // so reassigning it would let a later write repersist already-retried scans.
+    failedQueueRef.current.length = 0;
     scanQueueRef.current.push(...retrying);
     processQueue();
   }, [processQueue]);

--- a/apps/companion/hooks/use-scan-queue.ts
+++ b/apps/companion/hooks/use-scan-queue.ts
@@ -15,12 +15,24 @@ type UseScanQueueParams = {
   scannedItemsRef: React.MutableRefObject<ScannedItem[]>;
   /** Called when a scan is confirmed and auditAssetId is received from server */
   onScanSynced?: (assetId: string, auditAssetId: string) => void;
+  /**
+   * Called when a scan exhausts its retries. The scan is moved to `failedQueueRef`
+   * (never silently dropped) so the UI can surface it and completion can be blocked.
+   */
+  onScanFailed?: (assetId: string) => void;
 };
 
 export type ScanQueueResult = {
   scanQueueRef: React.MutableRefObject<ScanQueueEntry[]>;
+  /**
+   * Scans that exhausted their retries. They are retained (not dropped) so they
+   * can be re-synced and so audit completion can be blocked until empty.
+   */
+  failedQueueRef: React.MutableRefObject<ScanQueueEntry[]>;
   enqueueScan: (entry: ScanQueueEntry) => void;
   processQueue: () => Promise<void>;
+  /** Move all failed scans back into the live queue and re-attempt sync. */
+  retryFailedScans: () => void;
   retryTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
 };
 
@@ -28,8 +40,10 @@ export function useScanQueue({
   orgId,
   scannedItemsRef,
   onScanSynced,
+  onScanFailed,
 }: UseScanQueueParams): ScanQueueResult {
   const scanQueueRef = useRef<ScanQueueEntry[]>([]);
+  const failedQueueRef = useRef<ScanQueueEntry[]>([]);
   const isProcessingQueueRef = useRef(false);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -59,6 +73,8 @@ export function useScanQueue({
             scannedItemsRef.current[itemIndex] = {
               ...scannedItemsRef.current[itemIndex],
               auditAssetId: data.auditAssetId,
+              // A successful (re)sync clears any prior failed marker.
+              syncFailed: false,
             };
           }
           // Notify caller to update React state for re-render
@@ -68,22 +84,40 @@ export function useScanQueue({
         saveAuditScanState(
           entry.auditSessionId,
           scannedItemsRef.current,
-          scanQueueRef.current
+          scanQueueRef.current,
+          failedQueueRef.current
         );
       } catch {
         // Network error — retry with backoff
         const retries = (entry.retryCount ?? 0) + 1;
         if (retries >= MAX_QUEUE_RETRIES) {
-          // Max retries reached — skip this item, move to next
+          // Max retries reached. CRITICAL: never silently drop the scan, or an
+          // asset the worker saw as "Found" is lost and later marked MISSING on
+          // completion. Move it to the failed queue (persisted, re-syncable) and
+          // mark the item so the UI surfaces it and completion can be blocked.
           scanQueueRef.current.shift();
+          failedQueueRef.current.push({ ...entry, retryCount: undefined });
+          // Mark the scanned item directly on the ref (mirrors the success path)
+          // so the persisted snapshot captures the failed state on crash.
+          const failedIndex = scannedItemsRef.current.findIndex(
+            (item) => item.assetId === entry.assetId
+          );
+          if (failedIndex !== -1) {
+            scannedItemsRef.current[failedIndex] = {
+              ...scannedItemsRef.current[failedIndex],
+              syncFailed: true,
+            };
+          }
+          onScanFailed?.(entry.assetId);
           saveAuditScanState(
             entry.auditSessionId,
             scannedItemsRef.current,
-            scanQueueRef.current
+            scanQueueRef.current,
+            failedQueueRef.current
           );
           if (__DEV__)
             console.warn(
-              `[AuditQueue] Giving up on scan after ${MAX_QUEUE_RETRIES} retries:`,
+              `[AuditQueue] Scan failed after ${MAX_QUEUE_RETRIES} retries; moved to failed queue:`,
               entry.assetId
             );
           continue;
@@ -100,7 +134,7 @@ export function useScanQueue({
     }
 
     isProcessingQueueRef.current = false;
-  }, [orgId, scannedItemsRef, onScanSynced]);
+  }, [orgId, scannedItemsRef, onScanSynced, onScanFailed]);
 
   const enqueueScan = useCallback(
     (entry: ScanQueueEntry) => {
@@ -110,10 +144,24 @@ export function useScanQueue({
     [processQueue]
   );
 
+  const retryFailedScans = useCallback(() => {
+    if (failedQueueRef.current.length === 0) return;
+    // Move failed scans back into the live queue with a fresh retry budget.
+    const retrying = failedQueueRef.current.map((e) => ({
+      ...e,
+      retryCount: 0,
+    }));
+    failedQueueRef.current = [];
+    scanQueueRef.current.push(...retrying);
+    processQueue();
+  }, [processQueue]);
+
   return {
     scanQueueRef,
+    failedQueueRef,
     enqueueScan,
     processQueue,
+    retryFailedScans,
     retryTimerRef,
   };
 }

--- a/apps/companion/lib/audit-scan-persistence.ts
+++ b/apps/companion/lib/audit-scan-persistence.ts
@@ -7,6 +7,8 @@ type ScannedItem = {
   name: string;
   isExpected: boolean;
   scannedAt: string;
+  /** True when this scan exhausted its sync retries and is awaiting re-sync. */
+  syncFailed?: boolean;
 };
 
 type ScanQueueEntry = {
@@ -22,6 +24,12 @@ export type PersistedScanState = {
   savedAt: string;
   scannedItems: ScannedItem[];
   pendingQueue: ScanQueueEntry[];
+  /**
+   * Scans that exhausted their retries and must NOT be silently dropped.
+   * Persisted so they survive app kills and are re-queued on resume.
+   * Optional for backward-compat with sessions saved before this field existed.
+   */
+  failedQueue?: ScanQueueEntry[];
 };
 
 // ── Storage key ──────────────────────────────────────────
@@ -38,7 +46,8 @@ const storageKey = (auditId: string) => `${KEY_PREFIX}${auditId}`;
 export async function saveAuditScanState(
   auditId: string,
   scannedItems: ScannedItem[],
-  pendingQueue: ScanQueueEntry[]
+  pendingQueue: ScanQueueEntry[],
+  failedQueue: ScanQueueEntry[] = []
 ): Promise<void> {
   try {
     const state: PersistedScanState = {
@@ -47,6 +56,7 @@ export async function saveAuditScanState(
       savedAt: new Date().toISOString(),
       scannedItems,
       pendingQueue,
+      failedQueue,
     };
     await AsyncStorage.setItem(storageKey(auditId), JSON.stringify(state));
   } catch (e) {
@@ -96,19 +106,32 @@ export function createDebouncedSaver(auditId: string, delayMs = 2000) {
 
   return {
     /** Schedule a debounced save. */
-    save(scannedItems: ScannedItem[], pendingQueue: ScanQueueEntry[]) {
+    save(
+      scannedItems: ScannedItem[],
+      pendingQueue: ScanQueueEntry[],
+      failedQueue: ScanQueueEntry[] = []
+    ) {
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
-        saveAuditScanState(auditId, scannedItems, pendingQueue);
+        saveAuditScanState(auditId, scannedItems, pendingQueue, failedQueue);
         timer = null;
       }, delayMs);
     },
 
     /** Flush immediately (e.g., before unmount). Returns a promise. */
-    flush(scannedItems: ScannedItem[], pendingQueue: ScanQueueEntry[]) {
+    flush(
+      scannedItems: ScannedItem[],
+      pendingQueue: ScanQueueEntry[],
+      failedQueue: ScanQueueEntry[] = []
+    ) {
       if (timer) clearTimeout(timer);
       timer = null;
-      return saveAuditScanState(auditId, scannedItems, pendingQueue);
+      return saveAuditScanState(
+        auditId,
+        scannedItems,
+        pendingQueue,
+        failedQueue
+      );
     },
 
     /** Cancel any pending write without saving. */


### PR DESCRIPTION
## P0 — silent, irreversible audit-data loss

The companion's **offline audit scan queue** could silently lose scans the worker saw as a green **"Found"**, which the server then marks **MISSING** on completion. This corrupts the *audit-of-record* with no error shown — triggered by exactly the flaky connectivity audits run under (warehouses, field, basements). Confirmed by reading the code; found via a contract/flow audit of the web↔mobile seam.

**Platforms:** native app only — **both iOS and Android** (one Expo codebase). The webapp has no offline scan queue, so it is unaffected.

### Two confirmed P0 paths (both client-side)

1. **Complete abandons the queue.** `handleComplete` cleared persisted state and called `completeAudit` *without* draining `scanQueueRef`. Any still-queued scan never reached the server → its asset marked MISSING. (`scan.tsx`)
2. **Drop-after-3-retries.** On max retries the entry was `shift()`-ed and forgotten (only a `__DEV__` warn). It stayed "Found" in the UI, was never recorded, and wasn't even recoverable on Resume (gone from the persisted queue). (`use-scan-queue.ts`)

## What this changes (no server change needed)

- **Never drop a scan.** On max retries, move it to a **persisted `failedQueue`**, mark the item `syncFailed`, and show a **"Not synced"** indicator in the list (breaks the silence).
- **Block completion while anything is unsynced.** `handleComplete` now refuses to complete if `scanQueue` or `failedQueue` is non-empty, kicks a re-sync, and asks the worker to stay connected. This also makes the "N will be marked missing" warning accurate (no un-synced found-items hiding in the count).
- **Clear recovery state only after the server confirms completion** (previously cleared *before* `completeAudit`, which also lost recovery on a failed completion).
- **Resume re-queues pending AND failed scans** (previously only pending → a dropped scan was merged back as "found" but never re-submitted).
- **On exit, keep + flush** the snapshot when scans are unsynced instead of clearing it.

## Files
`use-scan-queue.ts` (failedQueue + retry), `audit-scan-persistence.ts` (persist failedQueue + `syncFailed`), `use-audit-init.ts` (resume re-queues failed), `scan.tsx` (completion guard + clear-after-success + exit flush), `scanned-items-list.tsx` ("Not synced" badge). **+206 / −36.**

## Validation
- `tsc --noEmit` (companion) ✅ · ESLint 0 warnings ✅ · Prettier ✅

## ⚠️ Needs offline-device QA before merge (cannot be verified statically)
1. Scan several assets with **airplane mode toggling** on/off → confirm queued scans sync and none are lost.
2. **Kill + relaunch** mid-sync → Resume re-submits pending *and* failed scans.
3. Attempt **Complete with a pending/failed queue** → completion is blocked with the sync prompt; succeeds once drained.
4. Confirm a max-retry scan shows the **"Not synced"** indicator and is re-synced on reconnect.

## Ownership
`apps/companion` is owned by the mobile team (per repo rules) — flagging for their review/coordination. **Do not merge without the offline-device QA above.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scanned items show a dedicated "Not synced" badge and updated accessibility label when sync permanently fails.
  * Failed scans are retained, can be retried, and are included in resume/requeue behavior after app restore.

* **Bug Fixes**
  * Audit completion now blocks while scans are actively syncing; if failures exist users can retry or complete acknowledging missing items.
  * Crash-recovery persistence now preserves pending and failed scans and only clears local recovery after successful server confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->