### PR TITLE
fix(webapp): complete partial check-in from records, not global asset status

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -504,6 +504,55 @@ describe("partialCheckinBooking", () => {
     expect(db.partialBookingCheckin.create).not.toHaveBeenCalled();
   });
 
+  it("should complete the booking from partial check-in records when the final batch returns the last outstanding asset, even though every asset reads CHECKED_OUT globally (shared across overlapping bookings)", async () => {
+    expect.assertions(2);
+
+    // Reproduces the production bug. Assets are shared across overlapping
+    // bookings, so an asset returned for THIS booking can be CHECKED_OUT again
+    // by a later booking. Completion must therefore be decided from this
+    // booking's PartialBookingCheckin records (the per-booking source of truth
+    // the progress bar uses), NOT from the assets' global `status`.
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue({
+      ...mockBookingData,
+      assets: [
+        { id: "asset-1", kitId: null },
+        { id: "asset-2", kitId: null },
+        { id: "asset-3", kitId: null },
+      ],
+    });
+
+    // asset-1 and asset-2 were already returned for this booking in earlier
+    // sessions (records exist); asset-3 is the last outstanding asset.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      { assetIds: ["asset-1", "asset-2"] },
+    ]);
+
+    // Every asset still reads CHECKED_OUT globally because other active
+    // bookings hold the same physical items. The old status-based completion
+    // check never matched here, stranding the booking OVERDUE.
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue([
+      { id: "asset-1", status: AssetStatus.CHECKED_OUT },
+      { id: "asset-2", status: AssetStatus.CHECKED_OUT },
+      { id: "asset-3", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    // Final scan returns the last outstanding asset for this booking.
+    const result = await partialCheckinBooking({
+      ...mockPartialCheckinParams,
+      assetIds: ["asset-3"],
+    });
+
+    // The booking is fully returned → it completes via the full check-in path,
+    // which does NOT record another partial check-in. Before the fix, the
+    // status-based early-exit and the `total - currentBatch` count both failed
+    // to recognise completion and left the booking incomplete.
+    expect(db.partialBookingCheckin.create).not.toHaveBeenCalled();
+    expect(result.isComplete).toBe(true);
+  });
+
   it("should throw error when asset is not in booking", async () => {
     expect.assertions(1);
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -553,6 +553,40 @@ describe("partialCheckinBooking", () => {
     expect(result.isComplete).toBe(true);
   });
 
+  it("should reject a batch containing assets not in the booking before taking the completion shortcut", async () => {
+    expect.assertions(2);
+
+    // A batch of [lastOutstandingAsset, unrelatedSameOrgAsset] satisfies the
+    // record-based completion check (it covers every outstanding asset), so
+    // membership MUST be validated first — otherwise the booking would complete
+    // and write notes about an asset that was never on it instead of 400ing.
+    // The mobile endpoint forwards raw assetIds, so this guard matters there.
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue({
+      ...mockBookingData,
+      assets: [
+        { id: "asset-1", kitId: null },
+        { id: "asset-2", kitId: null },
+      ],
+    });
+
+    // asset-1 already recorded → asset-2 is the only outstanding asset.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      { assetIds: ["asset-1"] },
+    ]);
+
+    await expect(
+      partialCheckinBooking({
+        ...mockPartialCheckinParams,
+        assetIds: ["asset-2", "asset-unrelated"],
+      })
+    ).rejects.toThrow(ShelfError);
+
+    // Must not have completed or recorded anything.
+    expect(db.partialBookingCheckin.create).not.toHaveBeenCalled();
+  });
+
   it("should throw error when asset is not in booking", async () => {
     expect.assertions(1);
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2090,6 +2090,29 @@ export async function partialCheckinBooking({
         });
       });
 
+    // Validate that all provided assetIds are actually in the booking BEFORE any
+    // completion shortcut. The early-exit below completes the booking when this
+    // batch covers all outstanding assets; without this guard a batch like
+    // [lastOutstandingAsset, unrelatedSameOrgAsset] would satisfy that check and
+    // complete the booking (writing notes about a non-booking asset) instead of
+    // returning a 400. This matters especially for the mobile endpoint, which
+    // forwards raw assetIds with none of the web drawer's client-side filtering.
+    const bookingAssetIds = new Set(bookingFound.assets.map((a) => a.id));
+    const invalidAssetIds = assetIds.filter(
+      (assetId) => !bookingAssetIds.has(assetId)
+    );
+
+    if (invalidAssetIds.length > 0) {
+      throw new ShelfError({
+        cause: null,
+        status: 400,
+        label,
+        message: `Some assets are not part of this booking: ${invalidAssetIds.join(
+          ", "
+        )}`,
+      });
+    }
+
     // Early exit: if this batch returns every asset still outstanding for THIS
     // booking, run a complete check-in instead of recording another partial one.
     //
@@ -2152,21 +2175,6 @@ export async function partialCheckinBooking({
         remainingAssetCount: 0,
         isComplete: true,
       };
-    }
-
-    // Validate that all provided assetIds are actually in the booking
-    const bookingAssetIds = new Set(bookingFound.assets.map((a) => a.id));
-    const invalidAssetIds = assetIds.filter((id) => !bookingAssetIds.has(id));
-
-    if (invalidAssetIds.length > 0) {
-      throw new ShelfError({
-        cause: null,
-        status: 400,
-        label,
-        message: `Some assets are not part of this booking: ${invalidAssetIds.join(
-          ", "
-        )}`,
-      });
     }
 
     // For kits: only update kit status if ALL assets of a kit are being checked in

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2090,29 +2090,32 @@ export async function partialCheckinBooking({
         });
       });
 
-    // Early exit: If we're checking in all remaining CHECKED_OUT assets, do a complete check-in instead
-    // First, get the current status of all assets in the booking
-    const currentAssetStatuses = await db.asset.findMany({
-      where: {
-        id: { in: bookingFound.assets.map((a) => a.id) },
-        organizationId,
-      },
-      select: { id: true, status: true },
-    });
-
-    // Find assets that are still CHECKED_OUT (not yet checked in)
-    const checkedOutAssets = currentAssetStatuses.filter(
-      (asset) => asset.status === AssetStatus.CHECKED_OUT
-    );
-
-    const checkedOutAssetIds = new Set(checkedOutAssets.map((a) => a.id));
+    // Early exit: if this batch returns every asset still outstanding for THIS
+    // booking, run a complete check-in instead of recording another partial one.
+    //
+    // Completion is decided from this booking's PartialBookingCheckin records —
+    // NOT from the assets' global `status`. Assets are shared across overlapping
+    // bookings, so an asset that was returned for this booking can be
+    // CHECKED_OUT again by a later booking. Keying completion on global status
+    // therefore left the booking stuck ONGOING/OVERDUE even though every item
+    // was returned here (the original bug). The records are the per-booking
+    // source of truth and match what the check-in progress bar shows the user.
+    const alreadyCheckedInAssetIds = await getPartiallyCheckedInAssetIds(id);
+    const recordedAssetIdSet = new Set(alreadyCheckedInAssetIds);
     const providedAssetIds = new Set(assetIds);
 
-    // Check if we're checking in all remaining CHECKED_OUT assets
+    // Booking assets not yet covered by any partial check-in record.
+    const outstandingAssetIds = bookingFound.assets
+      .map((asset) => asset.id)
+      .filter((assetId) => !recordedAssetIdSet.has(assetId));
+
+    // If this batch covers every still-outstanding asset, the booking is fully
+    // returned → run the full check-in (which also cancels schedulers, sends the
+    // completion email, schedules auto-archive, and safely skips assets that are
+    // currently checked out by other active bookings).
     if (
-      checkedOutAssetIds.size > 0 &&
-      checkedOutAssetIds.size === providedAssetIds.size &&
-      [...checkedOutAssetIds].every((id) => providedAssetIds.has(id))
+      bookingFound.assets.length > 0 &&
+      outstandingAssetIds.every((assetId) => providedAssetIds.has(assetId))
     ) {
       // DON'T create PartialBookingCheckin record when doing complete check-in redirect
       // The checkinBooking function will handle the completion properly
@@ -2304,8 +2307,18 @@ export async function partialCheckinBooking({
         },
       });
 
-      const remainingCount =
-        updatedBookingForNote.assets.length - assetIds.length;
+      // Remaining = booking assets not covered by any partial check-in record
+      // (previous sessions + this batch). The old `total - thisBatch` ignored
+      // earlier sessions, so multi-session check-ins reported the wrong count
+      // and could never reach zero. Completion is normally handled by the
+      // record-based early-exit above; this stays consistent as a safety net.
+      const checkedInAfterThisBatch = new Set([
+        ...recordedAssetIdSet,
+        ...assetIds,
+      ]);
+      const remainingCount = updatedBookingForNote.assets.filter(
+        (asset) => !checkedInAfterThisBatch.has(asset.id)
+      ).length;
       const isCompletingBooking = remainingCount === 0;
 
       if (isCompletingBooking) {


### PR DESCRIPTION
A booking returned via the partial check-in scanner could stay OVERDUE/ONGOING with every asset showing as checked in. `partialCheckinBooking` decided completion two ways, both unreliable for assets shared across overlapping bookings:

- the early-exit keyed on `Asset.status === CHECKED_OUT`, but an asset returned for this booking is CHECKED_OUT again the moment a later booking takes the same physical item, so the booking never matched the "all returned" condition;
- the partial-path fallback used `totalAssets - currentBatch`, which ignores assets returned in earlier sessions and so never reaches zero across multiple check-in sessions.

Decide completion from this booking's PartialBookingCheckin records instead — the per-booking source of truth the progress bar already uses. The booking completes when the current batch covers every asset not yet recorded for it, independent of the assets' global status. Completion keeps routing through `checkinBooking`, which already skips assets held by other active bookings. Also fix the partial-path "Remaining" count to subtract all recorded assets (prior sessions + this batch), not just the current batch.

Adds a regression test covering the shared-asset case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected partial check-in completion logic: the system now determines booking completion from that booking’s partial check-in history (which assets remain outstanding) rather than global asset status. This fixes an edge case with overlapping bookings so completions are accurate, avoids spurious partial records, and ensures booking completion status updates only when all outstanding assets for the booking are covered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->