### PR TITLE
fix(webapp): enforce SELF_SERVICE custody self-restriction in shared services (P1)

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -1,3 +1,4 @@
+import { OrganizationRoles, type AssetIndexSettings } from "@prisma/client";
 import { describe, expect, it, vi, vitest, beforeEach } from "vitest";
 import { extractStoragePath } from "~/components/assets/asset-image/utils";
 import { db } from "~/database/db.server";
@@ -10,7 +11,9 @@ import { ShelfError } from "~/utils/error";
 import { createSignedUrl } from "~/utils/storage.server";
 import {
   bulkAssignAssetTags,
+  bulkAssignCustody,
   bulkDeleteAssets,
+  bulkReleaseCustody,
   bulkUpdateAssetCategory,
   getActiveCustomFieldsForAsset,
   parseAssetValuation,
@@ -45,6 +48,9 @@ vitest.mock("~/database/db.server", () => ({
     },
     qr: {
       update: vitest.fn().mockResolvedValue({}),
+    },
+    teamMember: {
+      findFirst: vitest.fn().mockResolvedValue(null),
     },
   },
 }));
@@ -851,5 +857,58 @@ describe("bulkDeleteAssets", () => {
     });
 
     expect(recordEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe("custody SELF_SERVICE self-restriction (bulk services)", () => {
+  // Settings are unused before the guard throws (asset-id resolution is mocked).
+  const fakeSettings = {} as unknown as AssetIndexSettings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("blocks a SELF_SERVICE user from assigning custody to someone else", async () => {
+    // why: the custodian resolves to a DIFFERENT user than the caller.
+    (db.teamMember.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      { name: "Other Person", user: { id: "other-user" } }
+    );
+
+    await expect(
+      bulkAssignCustody({
+        userId: "me",
+        role: OrganizationRoles.SELF_SERVICE,
+        assetIds: ["asset-1"],
+        custodianId: "tm-other",
+        custodianName: "Other Person",
+        organizationId: "org-1",
+        settings: fakeSettings,
+      })
+    ).rejects.toThrow("Self user can only assign custody to themselves only");
+
+    // The mutation must never run.
+    expect(db.asset.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("blocks a SELF_SERVICE user from releasing someone else's custody", async () => {
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      {
+        id: "asset-1",
+        title: "Asset 1",
+        custody: { id: "c1", custodian: { userId: "other-user" } },
+      },
+    ]);
+
+    await expect(
+      bulkReleaseCustody({
+        userId: "me",
+        role: OrganizationRoles.SELF_SERVICE,
+        assetIds: ["asset-1"],
+        organizationId: "org-1",
+        settings: fakeSettings,
+      })
+    ).rejects.toThrow(
+      "Self service user can only release custody of assets assigned to their user"
+    );
   });
 });

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -19,6 +19,7 @@ import {
   BookingStatus,
   ErrorCorrection,
   KitStatus,
+  OrganizationRoles,
   Prisma,
   TagUseFor,
 } from "@prisma/client";
@@ -3994,6 +3995,7 @@ export async function bulkDeleteAssets({
  */
 export async function bulkAssignCustody({
   userId,
+  role,
   assetIds,
   custodianId,
   custodianName,
@@ -4002,6 +4004,11 @@ export async function bulkAssignCustody({
   settings,
 }: {
   userId: User["id"];
+  /**
+   * Caller's role. Required so the SELF_SERVICE self-restriction is enforced
+   * here for EVERY caller (web + mobile), not duplicated in each route.
+   */
+  role: OrganizationRoles;
   assetIds: Asset["id"][];
   custodianId: TeamMember["id"];
   custodianName: TeamMember["name"];
@@ -4056,6 +4063,24 @@ export async function bulkAssignCustody({
         },
       }),
     ]);
+
+    // Self-service users may only assign custody to themselves. Enforced in the
+    // service so every caller (web + mobile) is covered; previously this lived
+    // only in the web route and the mobile routes bypassed it.
+    if (
+      role === OrganizationRoles.SELF_SERVICE &&
+      custodianTeamMember?.user?.id !== userId
+    ) {
+      throw new ShelfError({
+        cause: null,
+        title: "Action not allowed",
+        message: "Self user can only assign custody to themselves only.",
+        additionalData: { userId, assetIds, custodianId },
+        label: "Assets",
+        status: 403,
+        shouldBeCaptured: false,
+      });
+    }
 
     const assetsNotAvailable = assets.some(
       (asset) => asset.status !== "AVAILABLE"
@@ -4173,12 +4198,18 @@ export async function bulkAssignCustody({
  */
 export async function bulkReleaseCustody({
   userId,
+  role,
   assetIds,
   organizationId,
   currentSearchParams,
   settings,
 }: {
   userId: User["id"];
+  /**
+   * Caller's role. Required so the SELF_SERVICE self-restriction is enforced
+   * here for EVERY caller (web + mobile), not duplicated in each route.
+   */
+  role: OrganizationRoles;
   assetIds: Asset["id"][];
   organizationId: Asset["organizationId"];
   currentSearchParams?: string | null;
@@ -4228,6 +4259,24 @@ export async function bulkReleaseCustody({
         message:
           "There are some assets without custody. Please make sure you are selecting assets with custody.",
         label: "Assets",
+        shouldBeCaptured: false,
+      });
+    }
+
+    // Self-service users may only release custody of assets assigned to them.
+    // Enforced in the service so every caller (web + mobile) is covered.
+    if (
+      role === OrganizationRoles.SELF_SERVICE &&
+      assets.some((asset) => asset.custody?.custodian?.userId !== userId)
+    ) {
+      throw new ShelfError({
+        cause: null,
+        title: "Action not allowed",
+        message:
+          "Self service user can only release custody of assets assigned to their user.",
+        additionalData: { userId, assetIds },
+        label: "Assets",
+        status: 403,
         shouldBeCaptured: false,
       });
     }

--- a/apps/webapp/app/modules/custody/service.server.test.ts
+++ b/apps/webapp/app/modules/custody/service.server.test.ts
@@ -1,0 +1,52 @@
+import { OrganizationRoles } from "@prisma/client";
+import { describe, expect, it, vitest, beforeEach } from "vitest";
+import { db } from "~/database/db.server";
+import { releaseCustody } from "./service.server";
+
+// why: isolate the custody service from the database so we can exercise the
+// SELF_SERVICE self-restriction guard without a real DB.
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    $transaction: vitest
+      .fn()
+      .mockImplementation((callback: (tx: unknown) => unknown) => callback(db)),
+    custody: {
+      findFirst: vitest.fn().mockResolvedValue(null),
+    },
+    asset: {
+      update: vitest.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+// why: avoid emitting real activity events during the test.
+vitest.mock("~/modules/activity-event/service.server", () => ({
+  recordEvent: vitest.fn().mockResolvedValue(undefined),
+}));
+
+describe("releaseCustody SELF_SERVICE self-restriction", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("blocks a SELF_SERVICE user from releasing someone else's custody", async () => {
+    // The asset's current custodian is a DIFFERENT user than the caller.
+    (db.custody.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      custodian: { userId: "other-user" },
+    });
+
+    await expect(
+      releaseCustody({
+        assetId: "asset-1",
+        organizationId: "org-1",
+        userId: "me",
+        role: OrganizationRoles.SELF_SERVICE,
+      })
+    ).rejects.toThrow(
+      "Self service user can only release custody of assets assigned to their user"
+    );
+
+    // The custody must never be released.
+    expect(db.asset.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/custody/service.server.ts
+++ b/apps/webapp/app/modules/custody/service.server.ts
@@ -1,5 +1,5 @@
-import type { Asset } from "@prisma/client";
-import { AssetStatus } from "@prisma/client";
+import type { Asset, User } from "@prisma/client";
+import { AssetStatus, OrganizationRoles } from "@prisma/client";
 import { db } from "~/database/db.server";
 import { recordEvent } from "~/modules/activity-event/service.server";
 import { ShelfError } from "~/utils/error";
@@ -9,15 +9,25 @@ import { ShelfError } from "~/utils/error";
  *
  * @param assetId - The ID of the asset to release custody from
  * @param organizationId - The organization ID
+ * @param userId - The caller's user ID (for the SELF_SERVICE self-restriction)
+ * @param role - The caller's role; SELF_SERVICE may only release their own custody
  * @param activityEvent - Optional activity event data for audit trail
  */
 export async function releaseCustody({
   assetId,
   organizationId,
+  userId,
+  role,
   activityEvent,
 }: {
   assetId: Asset["id"];
   organizationId: Asset["organizationId"];
+  userId: User["id"];
+  /**
+   * Caller's role. Required so the SELF_SERVICE self-restriction is enforced
+   * here for EVERY caller (web + mobile), not duplicated in each route.
+   */
+  role: OrganizationRoles;
   /** Optional activity event data - if provided, records CUSTODY_RELEASED event atomically */
   activityEvent?: {
     actorUserId: string;
@@ -25,6 +35,28 @@ export async function releaseCustody({
     targetUserId?: string;
   };
 }) {
+  // Self-service users may only release custody of assets assigned to them.
+  // Checked BEFORE the transaction so the 403 is returned cleanly — a throw
+  // inside the tx below would be re-wrapped by the catch as a generic error.
+  if (role === OrganizationRoles.SELF_SERVICE) {
+    const current = await db.custody.findFirst({
+      where: { assetId, asset: { organizationId } },
+      select: { custodian: { select: { userId: true } } },
+    });
+    if (current?.custodian?.userId !== userId) {
+      throw new ShelfError({
+        cause: null,
+        title: "Action not allowed",
+        message:
+          "Self service user can only release custody of assets assigned to their user.",
+        additionalData: { userId, assetId },
+        label: "Custody",
+        status: 403,
+        shouldBeCaptured: false,
+      });
+    }
+  }
+
   try {
     // Use transaction to ensure custody release and activity event are atomic
     return await db.$transaction(async (tx) => {

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.release-custody.tsx
@@ -13,7 +13,7 @@ import { getUserByID } from "~/modules/user/service.server";
 import styles from "~/styles/layout/custom-modal.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
-import { ShelfError, makeShelfError } from "~/utils/error";
+import { makeShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
 import { payload, error, getParams, parseData } from "~/utils/http.server";
 import {
@@ -147,23 +147,14 @@ export const action = async ({
     });
     const custodyRecord = assetWithCustody.custody;
 
-    if (isSelfService) {
-      if (custodyRecord?.custodian?.userId !== user.id) {
-        throw new ShelfError({
-          cause: null,
-          title: "Action not allowed",
-          message:
-            "Self service user can only release custody of assets assigned to their user.",
-          additionalData: { userId, assetId },
-          label: "Assets",
-        });
-      }
-    }
-
-    // Pass activity event data to releaseCustody for atomic recording
+    // Pass activity event data to releaseCustody for atomic recording. The
+    // SELF_SERVICE self-restriction is enforced inside releaseCustody so web
+    // and mobile share one implementation.
     const asset = await releaseCustody({
       assetId,
       organizationId,
+      userId,
+      role,
       activityEvent: {
         actorUserId: userId,
         teamMemberId: custodyRecord?.custodian?.id,

--- a/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/assets.bulk-assign-custody.ts
@@ -1,4 +1,3 @@
-import { OrganizationRoles } from "@prisma/client";
 import { data, type ActionFunctionArgs } from "react-router";
 import { BulkAssignCustodySchema } from "~/components/assets/bulk-assign-custody-dialog";
 import { bulkAssignCustody } from "~/modules/asset/service.server";
@@ -48,11 +47,12 @@ export async function action({ context, request }: ActionFunctionArgs) {
       BulkAssignCustodySchema.and(CurrentSearchParamsSchema)
     );
 
-    // Validate that the custodian belongs to the same organization
-    const teamMember = await getTeamMember({
+    // Validate that the custodian belongs to the same organization (early 404).
+    // The SELF_SERVICE self-restriction itself is enforced inside the service.
+    await getTeamMember({
       id: custodian.id,
       organizationId,
-      select: { id: true, userId: true },
+      select: { id: true },
     }).catch((cause) => {
       throw new ShelfError({
         cause,
@@ -70,23 +70,11 @@ export async function action({ context, request }: ActionFunctionArgs) {
       });
     });
 
-    if (
-      role === OrganizationRoles.SELF_SERVICE &&
-      teamMember.userId !== userId
-    ) {
-      throw new ShelfError({
-        cause: null,
-        title: "Action not allowed",
-        message: "Self user can only assign custody to themselves only.",
-        additionalData: { userId, assetIds, custodian },
-        label: "Assets",
-        status: 403,
-        shouldBeCaptured: false,
-      });
-    }
-
+    // SELF_SERVICE self-restriction is enforced inside bulkAssignCustody so
+    // web and mobile share one implementation.
     await bulkAssignCustody({
       userId,
+      role,
       assetIds,
       custodianId: custodian.id,
       custodianName: custodian.name,

--- a/apps/webapp/app/routes/api+/assets.bulk-release-custody.ts
+++ b/apps/webapp/app/routes/api+/assets.bulk-release-custody.ts
@@ -1,12 +1,10 @@
-import { OrganizationRoles } from "@prisma/client";
 import { data, type ActionFunctionArgs } from "react-router";
 import { BulkReleaseCustodySchema } from "~/components/assets/bulk-release-custody-dialog";
-import { db } from "~/database/db.server";
 import { bulkReleaseCustody } from "~/modules/asset/service.server";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
-import { makeShelfError, ShelfError } from "~/utils/error";
+import { makeShelfError } from "~/utils/error";
 import { assertIsPost, payload, error, parseData } from "~/utils/http.server";
 import {
   PermissionAction,
@@ -43,31 +41,11 @@ export async function action({ request, context }: ActionFunctionArgs) {
       BulkReleaseCustodySchema.and(CurrentSearchParamsSchema)
     );
 
-    if (role === OrganizationRoles.SELF_SERVICE) {
-      const custodies = await db.custody.findMany({
-        where: {
-          assetId: { in: assetIds },
-          asset: { organizationId },
-        },
-        select: { custodian: { select: { id: true, userId: true } } },
-      });
-
-      if (custodies.some((custody) => custody.custodian.userId !== userId)) {
-        throw new ShelfError({
-          cause: null,
-          title: "Action not allowed",
-          message:
-            "Self service user can only release custody of assets assigned to their user.",
-          additionalData: { userId, assetIds },
-          label: "Assets",
-          status: 403,
-          shouldBeCaptured: false,
-        });
-      }
-    }
-
+    // SELF_SERVICE self-restriction is enforced inside bulkReleaseCustody so
+    // web and mobile share one implementation.
     await bulkReleaseCustody({
       userId,
+      role,
       assetIds,
       organizationId,
       currentSearchParams,

--- a/apps/webapp/app/routes/api+/mobile+/bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-assign-custody.ts
@@ -82,6 +82,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await bulkAssignCustody({
       userId: user.id,
+      role,
       assetIds,
       custodianId,
       custodianName: teamMember.name,

--- a/apps/webapp/app/routes/api+/mobile+/bulk-release-custody.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-release-custody.ts
@@ -56,6 +56,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await bulkReleaseCustody({
       userId: user.id,
+      role,
       assetIds,
       organizationId,
       currentSearchParams: "",

--- a/apps/webapp/app/routes/api+/mobile+/custody.assign.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custody.assign.ts
@@ -80,6 +80,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await bulkAssignCustody({
       userId: user.id,
+      role,
       assetIds: [assetId],
       custodianId,
       custodianName: teamMember.name,

--- a/apps/webapp/app/routes/api+/mobile+/custody.release.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custody.release.ts
@@ -2,6 +2,7 @@ import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireMobilePermission,
   requireOrganizationAccess,
@@ -32,6 +33,10 @@ export async function action({ request }: ActionFunctionArgs) {
       entity: PermissionEntity.asset,
       action: PermissionAction.custody,
     });
+
+    // Caller's role — required so releaseCustody can enforce the SELF_SERVICE
+    // self-restriction (only release custody of assets assigned to themselves).
+    const { role } = await getMobileUserContext(user.id, organizationId);
 
     const body = await request.json();
     const { assetId } = z
@@ -69,6 +74,8 @@ export async function action({ request }: ActionFunctionArgs) {
     const asset = await releaseCustody({
       assetId,
       organizationId,
+      userId: user.id,
+      role,
       activityEvent: {
         actorUserId: user.id,
         teamMemberId: custodyRecord?.custodian?.id,

--- a/apps/webapp/test/routes-tests/api+/mobile.custody.release.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.custody.release.test.ts
@@ -30,6 +30,7 @@ vitest.mock("~/modules/api/mobile-auth.server", () => ({
   requireMobileAuth: vitest.fn(),
   requireOrganizationAccess: vitest.fn(),
   requireMobilePermission: vitest.fn(),
+  getMobileUserContext: vitest.fn(),
 }));
 
 // why: PR #2533 reads the current custody record before calling
@@ -77,10 +78,12 @@ vitest.mock("~/utils/error", () => ({
   },
 }));
 
+import { OrganizationRoles } from "@prisma/client";
 import {
   requireMobileAuth,
   requireOrganizationAccess,
   requireMobilePermission,
+  getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
 import { releaseCustody } from "~/modules/custody/service.server";
 import { createNote } from "~/modules/note/service.server";
@@ -125,6 +128,13 @@ describe("POST /api/mobile/custody/release", () => {
 
     (requireMobilePermission as any).mockResolvedValue(undefined);
 
+    // Caller's role is read to enforce the SELF_SERVICE self-restriction inside
+    // releaseCustody. ADMIN here so the release is permitted.
+    (getMobileUserContext as any).mockResolvedValue({
+      role: OrganizationRoles.ADMIN,
+      canUseBarcodes: false,
+    });
+
     (releaseCustody as any).mockResolvedValue({
       id: "asset-1",
       title: "Test Laptop",
@@ -159,6 +169,8 @@ describe("POST /api/mobile/custody/release", () => {
     expect(releaseCustody).toHaveBeenCalledWith({
       assetId: "asset-1",
       organizationId: "org-1",
+      userId: "user-1",
+      role: OrganizationRoles.ADMIN,
       activityEvent: {
         actorUserId: "user-1",
         teamMemberId: "team-member-1",

--- a/apps/webapp/test/routes-tests/api.assets.bulk-assign-custody.test.ts
+++ b/apps/webapp/test/routes-tests/api.assets.bulk-assign-custody.test.ts
@@ -2,6 +2,7 @@ import { OrganizationRoles } from "@prisma/client";
 import type { ActionFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { bulkAssignCustody } from "~/modules/asset/service.server";
 import { action } from "~/routes/api+/assets.bulk-assign-custody";
 import { ShelfError } from "~/utils/error";
 import { requirePermission } from "~/utils/roles.server";
@@ -140,7 +141,7 @@ describe("api/assets/bulk-assign-custody", () => {
     expect(mockGetTeamMember).toHaveBeenCalledWith({
       id: "foreign-team-member-123",
       organizationId: "org-1",
-      select: { id: true, userId: true },
+      select: { id: true },
     });
   });
 
@@ -186,11 +187,11 @@ describe("api/assets/bulk-assign-custody", () => {
     expect(mockGetTeamMember).toHaveBeenCalledWith({
       id: "team-member-123",
       organizationId: "org-1",
-      select: { id: true, userId: true },
+      select: { id: true },
     });
   });
 
-  it("prevents self-service users from assigning custody to other team members", async () => {
+  it("forwards the caller's role to the service for self-restriction enforcement", async () => {
     requirePermissionMock.mockResolvedValue({
       organizationId: "org-1",
       role: OrganizationRoles.SELF_SERVICE,
@@ -222,9 +223,14 @@ describe("api/assets/bulk-assign-custody", () => {
       }
     );
 
-    const response = (await action(createActionArgs({ request }))) as any;
+    await action(createActionArgs({ request }));
 
-    expect(response.status).toBe(403);
+    // Enforcement of the SELF_SERVICE self-restriction now lives inside
+    // bulkAssignCustody (unit-tested in asset/service.server.test.ts) so web and
+    // mobile share one implementation. The route's job is to forward the role.
+    expect(bulkAssignCustody).toHaveBeenCalledWith(
+      expect.objectContaining({ role: OrganizationRoles.SELF_SERVICE })
+    );
   });
 
   it("allows self-service users to assign custody to themselves", async () => {


### PR DESCRIPTION
## P1 — within-org privilege escalation (mobile custody)

**SELF_SERVICE users could assign or release custody of *any* asset, to/from *any* team member, via the mobile API.** The web routes enforce a self-restriction (a self-service user may only touch their *own* custody), but the four mobile custody endpoints share the `asset:custody` permission and **skipped that check**:

| | Web (enforced ✅) | Mobile (was missing ❌) |
|---|---|---|
| Assign | `assets.bulk-assign-custody.ts` → 403 if custodian ≠ self | `mobile+/custody.assign.ts`, `mobile+/bulk-assign-custody.ts` |
| Release | `assets.bulk-release-custody.ts` / single → 403 if not own | `mobile+/custody.release.ts`, `mobile+/bulk-release-custody.ts` |

**Scope:** within-org integrity/authz bug (an insider with a SELF_SERVICE seat). **Not** a cross-org leak — multi-tenant org-scoping was already enforced and is unchanged. Found via the web↔mobile contract audit.

## Fix — one enforcement point, compiler-forced

Moved the self-restriction **out of the web route layer and into the shared services** — `bulkAssignCustody`, `bulkReleaseCustody`, `releaseCustody` — each now takes a **required `role` param**. Every caller (web + all 4 mobile routes) must supply it, so the rule lives in exactly one place and a future mobile route can't silently skip it. Removed the now-redundant inline web guards. (`releaseCustody` checks before its transaction so the 403 returns cleanly instead of being re-wrapped by the catch.)

This is the repo's own "org-scope guard" pattern applied to the role check, and the "ask the working sibling first" principle made structural.

## Tests
- **New** unit tests for all three service guards (deny path → 403, mutation never runs): `asset/service.server.test.ts`, `custody/service.server.test.ts`.
- **Updated** the web bulk-assign + mobile release route tests to reflect that enforcement now lives in the service (route forwards `role`).
- **Full webapp suite green: 2135 tests.** tsc / eslint / prettier clean.

## Notes
- Kit custody (`kit/service.server.ts`) is a separate path with its own SELF_SERVICE handling — out of scope, untouched (its tests still pass, including its own 403 assertion).
- Sibling to the audit-scan P0 (#2580) from the same web↔mobile seam audit. Independent; can merge in any order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Self-service users can no longer assign or release custody of assets belonging to other team members. Asset custody operations are now restricted to self-owned assets only.

* **Improvements**
  * Unified custody permission enforcement across web and mobile platforms for consistent authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->