### PR TITLE
fix(companion): harden audit-scan durability against first-write loss

### DIFF
--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -500,16 +500,11 @@ function AuditScannerContent() {
           isExpected,
           scannedAt: new Date().toISOString(),
         };
-        // Compute the next list synchronously and update BOTH refs NOW. The
-        // scan queue's eager persist (inside enqueueScan below) runs before
-        // React commits this state update, so it must read the fresh list from
-        // the refs here — the deferred updater would set them too late, and the
-        // first scan would be eager-saved with a stale/empty scannedItems array
-        // and then skipped by useAuditInit on resume. (Codex review, PR #2586.)
-        const nextItems = [newItem, ...scannedItemsRef.current];
-        scannedItemsRef.current = nextItems;
-        stableScannedItemsRef.current = nextItems;
-        setScannedItems(nextItems);
+        setScannedItems((prev) => {
+          const next = [newItem, ...prev];
+          scannedItemsRef.current = next;
+          return next;
+        });
 
         if (isExpected) {
           // Found an expected asset

--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -500,11 +500,16 @@ function AuditScannerContent() {
           isExpected,
           scannedAt: new Date().toISOString(),
         };
-        setScannedItems((prev) => {
-          const next = [newItem, ...prev];
-          scannedItemsRef.current = next;
-          return next;
-        });
+        // Compute the next list synchronously and update BOTH refs NOW. The
+        // scan queue's eager persist (inside enqueueScan below) runs before
+        // React commits this state update, so it must read the fresh list from
+        // the refs here — the deferred updater would set them too late, and the
+        // first scan would be eager-saved with a stale/empty scannedItems array
+        // and then skipped by useAuditInit on resume. (Codex review, PR #2586.)
+        const nextItems = [newItem, ...scannedItemsRef.current];
+        scannedItemsRef.current = nextItems;
+        stableScannedItemsRef.current = nextItems;
+        setScannedItems(nextItems);
 
         if (isExpected) {
           // Found an expected asset

--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -16,6 +16,7 @@ import {
   Linking,
   Platform,
   Alert,
+  AppState,
 } from "react-native";
 import * as Haptics from "expo-haptics";
 import { useRouter, useLocalSearchParams } from "expo-router";
@@ -330,6 +331,40 @@ function AuditScannerContent() {
     scannedItemsRef,
   ]);
 
+  // ── Persist on background, resume on foreground ──────
+  // why: iOS suspends the JS runtime when the app is backgrounded and may then
+  // terminate it WITHOUT running React unmount cleanup — so the unmount flush
+  // above never fires on an OS kill. Flush the latest snapshot the instant we
+  // go inactive/background (the last moment JS runs), so a saw-as-Found scan
+  // can't be lost to a background reclaim within the debounce window. On
+  // return to foreground, re-kick the queue: retry timers do not advance while
+  // suspended, so a queue frozen mid-backoff would otherwise stall.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next) => {
+      if (next === "inactive" || next === "background") {
+        const hasUnsynced =
+          scanQueueRef.current.length > 0 || failedQueueRef.current.length > 0;
+        if (auditId && hasUnsynced) {
+          debouncedSaverRef.current?.flush(
+            scannedItemsRef.current,
+            scanQueueRef.current,
+            failedQueueRef.current
+          );
+        }
+      } else if (next === "active" && scanQueueRef.current.length > 0) {
+        processQueue();
+      }
+    });
+    return () => sub.remove();
+  }, [
+    auditId,
+    debouncedSaverRef,
+    scanQueueRef,
+    failedQueueRef,
+    scannedItemsRef,
+    processQueue,
+  ]);
+
   // ── Helpers ──────────────────────────────────────────
 
   const togglePause = useCallback(() => {
@@ -550,6 +585,21 @@ function AuditScannerContent() {
   const runCompletion = useCallback(async () => {
     if (!auditId || !currentOrg) return;
 
+    // TOCTOU guard: handleComplete blocked on a non-empty PENDING queue, but the
+    // camera stays live while the confirm dialog is open, so a scan can have
+    // been enqueued since that gate. Completing now would mark its asset MISSING
+    // and the queue-clear below would destroy it. Re-gate on the pending queue
+    // (this is the freshly-scanned path; the failed queue is what "Complete
+    // anyway" intentionally accepts, and is unaffected here).
+    if (scanQueueRef.current.length > 0) {
+      processQueue();
+      Alert.alert(
+        "Scan still syncing",
+        "A scan just came in and is still saving. Give it a moment, then tap Complete again."
+      );
+      return;
+    }
+
     const timeZone = (() => {
       try {
         return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
@@ -591,6 +641,7 @@ function AuditScannerContent() {
     debouncedSaverRef,
     scanQueueRef,
     failedQueueRef,
+    processQueue,
   ]);
 
   // Standard confirm: warns how many expected assets will be marked missing.

--- a/apps/companion/hooks/use-audit-init.ts
+++ b/apps/companion/hooks/use-audit-init.ts
@@ -156,7 +156,13 @@ export function useAuditInit({
 
       // ── Crash recovery ───────────────────────────────
       const persisted = await loadAuditScanState(auditId);
-      if (persisted && persisted.scannedItems.length > 0) {
+      // why: gate on whether there is ANYTHING to recover (the inner check
+      // below decides recover-vs-clear from scanned items OR a non-empty
+      // queue), not on scannedItems alone. The eager queue-persist can write a
+      // fresh queue while scannedItems is still stale/empty (the list updates
+      // on a deferred render), so requiring scannedItems.length here would skip
+      // recovery and drop a queued scan. The queue is the durable record.
+      if (persisted) {
         // Find items that were scanned locally but not yet on the server
         const serverScannedIds = new Set(
           data.existingScans.map((s) => s.assetId)
@@ -180,10 +186,17 @@ export function useAuditInit({
         if (recoveredItems.length > 0 || queuedForSync.length > 0) {
           // Show recovery dialog (don't block init)
           setIsInitializing(false);
+          // Usually scannedItems and the queue agree; if only the queue
+          // survived (eager-persist before the list state committed), fall back
+          // to its length so the copy isn't "0 unsynced scans".
+          const unsyncedCount = Math.max(
+            recoveredItems.length,
+            queuedForSync.length
+          );
           Alert.alert(
             "Resume Previous Session?",
-            `Found ${recoveredItems.length} unsynced scan${
-              recoveredItems.length !== 1 ? "s" : ""
+            `Found ${unsyncedCount} unsynced scan${
+              unsyncedCount !== 1 ? "s" : ""
             } from a previous session.`,
             [
               {

--- a/apps/companion/hooks/use-audit-init.ts
+++ b/apps/companion/hooks/use-audit-init.ts
@@ -207,13 +207,35 @@ export function useAuditInit({
               {
                 text: "Resume",
                 onPress: () => {
+                  // A queued scan may have no recovered display item — the
+                  // eager persist can save a queue entry before the list state
+                  // commits. Rebuild display rows for those (name from the
+                  // expected-asset map, else a neutral label) so they show as
+                  // scanned, count correctly, and don't leave the Complete
+                  // button hidden because scannedItems stayed empty. (Codex
+                  // review, PR #2586.)
+                  const recoveredIds = new Set(
+                    recoveredItems.map((i) => i.assetId)
+                  );
+                  const queuedOnlyItems: ScannedItem[] = queuedForSync
+                    .filter((e) => !recoveredIds.has(e.assetId))
+                    .map((e) => ({
+                      assetId: e.assetId,
+                      name:
+                        expectedAssetMapRef.current.get(e.assetId)?.name ??
+                        "Scanned asset",
+                      isExpected: e.isExpected,
+                      scannedAt: new Date().toISOString(),
+                    }));
+                  const allRecovered = [...recoveredItems, ...queuedOnlyItems];
+
                   // Merge recovered items into state
-                  for (const item of recoveredItems) {
+                  for (const item of allRecovered) {
                     scannedIds.add(item.assetId);
                   }
                   scannedAssetIdsRef.current = scannedIds;
 
-                  const merged = [...recoveredItems, ...restoredItems];
+                  const merged = [...allRecovered, ...restoredItems];
                   setScannedItems(merged);
                   scannedItemsRef.current = merged;
 
@@ -230,7 +252,7 @@ export function useAuditInit({
                   // Recalculate counters
                   let extraFound = 0;
                   let extraUnexpected = 0;
-                  for (const item of recoveredItems) {
+                  for (const item of allRecovered) {
                     if (item.isExpected) extraFound++;
                     else extraUnexpected++;
                   }
@@ -243,8 +265,8 @@ export function useAuditInit({
                   }
 
                   announce(
-                    `Resumed ${recoveredItems.length} scan${
-                      recoveredItems.length !== 1 ? "s" : ""
+                    `Resumed ${allRecovered.length} scan${
+                      allRecovered.length !== 1 ? "s" : ""
                     } from previous session`
                   );
                 },

--- a/apps/companion/hooks/use-scan-queue.ts
+++ b/apps/companion/hooks/use-scan-queue.ts
@@ -125,7 +125,21 @@ export function useScanQueue({
           // Move to end of queue with incremented retry count
           scanQueueRef.current.shift();
           scanQueueRef.current.push({ ...entry, retryCount: retries });
-          // Schedule retry with backoff
+          // Persist the requeued state NOW. The success and max-retry branches
+          // both persist; without this one, an app kill during the backoff —
+          // or a sub-2s scanning burst that perpetually resets the debounced
+          // saver — loses the in-memory queue entry, so a scan the worker saw
+          // as Found vanishes and is marked MISSING on completion.
+          saveAuditScanState(
+            entry.auditSessionId,
+            scannedItemsRef.current,
+            scanQueueRef.current,
+            failedQueueRef.current
+          );
+          // Clear any prior timer before scheduling a new one, so a rapid
+          // re-entry can't orphan a setTimeout that re-fires processQueue after
+          // unmount (post-unmount work / double-record).
+          if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
           const delay = RETRY_DELAYS[retries - 1] ?? 15_000;
           retryTimerRef.current = setTimeout(() => processQueue(), delay);
           break;
@@ -139,9 +153,20 @@ export function useScanQueue({
   const enqueueScan = useCallback(
     (entry: ScanQueueEntry) => {
       scanQueueRef.current.push(entry);
+      // Persist immediately (eager, not via the debounced saver): the scan must
+      // hit disk the instant it is queued, so an app kill before the first
+      // network attempt — or a sustained sub-2s scanning burst that keeps
+      // resetting the debounce — can never lose it. Fire-and-forget; the
+      // debounced saver remains for lower-priority UI snapshots.
+      saveAuditScanState(
+        entry.auditSessionId,
+        scannedItemsRef.current,
+        scanQueueRef.current,
+        failedQueueRef.current
+      );
       processQueue();
     },
-    [processQueue]
+    [processQueue, scannedItemsRef]
   );
 
   const retryFailedScans = useCallback(() => {

--- a/apps/companion/lib/audit-scan-persistence.ts
+++ b/apps/companion/lib/audit-scan-persistence.ts
@@ -48,7 +48,7 @@ export async function saveAuditScanState(
   scannedItems: ScannedItem[],
   pendingQueue: ScanQueueEntry[],
   failedQueue: ScanQueueEntry[] = []
-): Promise<void> {
+): Promise<boolean> {
   try {
     const state: PersistedScanState = {
       version: 1,
@@ -59,8 +59,14 @@ export async function saveAuditScanState(
       failedQueue,
     };
     await AsyncStorage.setItem(storageKey(auditId), JSON.stringify(state));
+    return true;
   } catch (e) {
-    if (__DEV__) console.warn("[AuditPersistence] save failed:", e);
+    // why: log ALWAYS, not just in __DEV__. A swallowed setItem rejection
+    // (e.g. device storage full during a long offline audit) is exactly how a
+    // saw-as-Found scan is silently lost. Returning false lets callers that
+    // care surface it; the device log / crash reporter captures it in prod.
+    console.warn("[AuditPersistence] save failed:", e);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Why

A deep multi-lens audit of the merged **#2580** (audit-scan durability P0) found that the **queue** is durable, but each scan's **first write to disk rode entirely on a 2s debounce** — leaving several paths that still **silently lose a saw-as-Found scan** (which is then marked MISSING on completion). In other words: #2580 made the queue durable but left first-write durability behind a starvable, freezable, OS-killable timer.

This PR closes those paths surgically (no rewrite). It pairs with #2580 and should ride the **same companion build**.

## What

- **Eager persist** on `enqueueScan` and in `processQueue`'s **retry-scheduled branch** (previously only the success + max-retry branches persisted). A scan now hits disk the instant it's queued — so an app kill mid-backoff, or a sustained **sub-2s scanning burst** that perpetually resets the debounce, can no longer lose it. Persisting `scannedItems` + queue together also closes the resume case where a recovered item had no matching queue entry.
- **`AppState` flush + foreground re-kick.** There was **no `AppState` listener anywhere** in the app; iOS suspends JS and can kill a backgrounded app without running React unmount cleanup, so the unmount-flush never fired on an OS kill. Now we flush the latest snapshot on `inactive`/`background` (last instant JS runs) and re-`processQueue()` on `active` (timers don't advance while suspended).
- **Completion TOCTOU re-gate.** The camera stays live during the "Complete Audit?" confirm dialog, so a scan could be enqueued after the gate and then destroyed by `runCompletion`'s queue-clear. It now re-checks the pending queue at fire time and aborts + re-syncs.
- **Orphaned retry timer.** `clearTimeout` before reassigning `retryTimerRef`, so a rapid re-entry can't leak a `setTimeout` that re-fires `processQueue` post-unmount (double-record).
- **Observability.** `saveAuditScanState` returns success and **logs failures always** (not `__DEV__`-gated), so a swallowed `setItem` rejection (storage full) is visible in logs/telemetry.

## Test plan

- Companion typecheck: clean.
- **Authoritative QA is on a real device** (iOS Simulator network is unreliable for offline/kill scenarios — a sim pass is NOT certification). Full 4-scenario real-device QA script (airplane-mode burst, background-then-OS-kill resume, completion gating, max-retry badge re-sync) + Network Link Conditioner setup is in the audit doc.

## Follow-ups (intentionally not in this PR)

- User-facing surfacing of a storage-full write failure (banner), beyond the log.
- Corrupt/partial-read resume UX (distinguish "unreadable previous session" from "nothing to recover").
- Counter recalculation on resume ignoring server-authoritative found/unexpected counts (miscount).

Refs #2580.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better preservation of pending/failed scans when the app goes to background, is killed, or interrupted.
  * Prevents final audit submission if queued scans remain, prompting the user to retry later.
  * Queued processing reliably resumes when the app becomes active.

* **New Features**
  * Queue state is saved immediately when a scan is enqueued.
  * Retry handling persists requeued entries and avoids duplicate/orphaned retry timers.

* **UX**
  * Recovery prompt shows a more accurate unsynced count and restores queued-only items into the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->