### PR TITLE
ci(react-doctor): extend react-doctor to the companion app

### DIFF
--- a/.github/scripts/react-doctor-pr-comment.mjs
+++ b/.github/scripts/react-doctor-pr-comment.mjs
@@ -5,29 +5,45 @@
  * filters out the knip dead-code findings (out of scope for PR review),
  * and prints a Markdown comment body to stdout.
  *
- * Invoked from `.github/workflows/react-doctor.yml` after the doctor scan.
+ * Invoked from `.github/workflows/react-doctor.yml` (once per app in the
+ * matrix) after the doctor scan.
  *
  * Usage:
- *   node .github/scripts/react-doctor-pr-comment.mjs <diagnostics-dir> <exit-code>
+ *   node .github/scripts/react-doctor-pr-comment.mjs \
+ *     <diagnostics-dir> <exit-code> [path-prefix]
  *
  * `<diagnostics-dir>` may be empty: react-doctor only writes a diagnostics
  * directory when it has findings to record. The exit code (captured from the
  * CLI via PIPESTATUS in the workflow) disambiguates:
  *   - empty dir + exit 0       → clean scan, no findings
  *   - empty dir + non-zero exit → the CLI itself failed
+ *
+ * `[path-prefix]` is the scanned app dir with a trailing slash (e.g.
+ * `apps/companion/`). react-doctor emits file paths relative to the scanned
+ * dir, so we prepend this to render repo-root-relative links. The app name and
+ * convenience script (`<app>:doctor`) are derived from it. Defaults to the
+ * webapp for backward compatibility.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 
-const HEADER = "## 🩺 React Doctor";
-const FOOTER =
-  "<sub>Run locally with `pnpm webapp:doctor` for a full scan, or " +
-  "`cd apps/webapp && pnpm exec react-doctor . --diff` for the same " +
-  "diff-only view.</sub>";
-
 const diagDir = process.argv[2];
 const exitCode = process.argv[3];
+const pathPrefix = process.argv[4] || "apps/webapp/";
+
+/** App dir without a trailing slash, e.g. "apps/companion". */
+const appDir = pathPrefix.replace(/\/+$/, "");
+/** App name derived from the prefix, e.g. "apps/companion/" → "companion". */
+const appName = appDir.replace(/^apps\//, "") || "webapp";
+/** Root convenience script for a full local scan, e.g. "companion:doctor". */
+const doctorCmd = `${appName}:doctor`;
+
+const HEADER = `## 🩺 React Doctor — ${appName}`;
+const FOOTER =
+  `<sub>Run locally with \`pnpm ${doctorCmd}\` for a full scan, or ` +
+  `\`cd ${appDir} && pnpm exec react-doctor . --diff\` for the same ` +
+  "diff-only view.</sub>";
 
 if (!diagDir) {
   if (exitCode === "0") {
@@ -83,7 +99,7 @@ lines.push("");
 const formatLocation = (d) => {
   const file = d.filePath.startsWith("apps/")
     ? d.filePath
-    : `apps/webapp/${d.filePath}`;
+    : `${pathPrefix}${d.filePath}`;
   const lineSuffix = d.line ? `:${d.line}` : "";
   return `\`${file}${lineSuffix}\``;
 };

--- a/.github/scripts/react-doctor-pr-comment.mjs
+++ b/.github/scripts/react-doctor-pr-comment.mjs
@@ -30,7 +30,10 @@ import path from "node:path";
 
 const diagDir = process.argv[2];
 const exitCode = process.argv[3];
-const pathPrefix = process.argv[4] || "apps/webapp/";
+// Normalize to exactly one trailing slash so callers can pass either
+// "apps/companion" or "apps/companion/" without breaking the rendered links
+// (`${pathPrefix}${d.filePath}`) or the footer `cd` command.
+const pathPrefix = `${(process.argv[4] || "apps/webapp").replace(/\/+$/, "")}/`;
 
 /** App dir without a trailing slash, e.g. "apps/companion". */
 const appDir = pathPrefix.replace(/\/+$/, "");

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -77,8 +77,14 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           APP_DIR: ${{ matrix.app.dir }}
         run: |
-          if git diff --name-only "origin/${BASE_REF}...HEAD" \
-            | grep -q "^${APP_DIR}/"; then
+          # Capture first, then grep a here-string — piping `git diff` into
+          # `grep -q` is unsafe under `bash -eo pipefail`: grep exits on first
+          # match and closes the pipe, git can die with SIGPIPE (141) on large
+          # diffs, and pipefail would surface that 141 as the pipeline status,
+          # flipping the `if` to the else branch (CHANGED=false) for an app
+          # that actually changed.
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          if grep -q "^${APP_DIR}/" <<< "$CHANGED_FILES"; then
             CHANGED=true
           else
             CHANGED=false

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -1,6 +1,8 @@
 name: 🩺 React Doctor
 
-# Runs on every PR that touches webapp source. Two outcomes:
+# Runs on every PR that touches webapp OR companion source. The job fans out
+# over both apps via a matrix; each app is scanned independently and gets its
+# own sticky PR comment. Two outcomes per app:
 #   1. Always posts (or updates) a sticky PR comment summarising findings on
 #      the files changed by this PR.
 #   2. Fails the check if NEW errors are introduced — warnings stay advisory.
@@ -11,6 +13,9 @@ on:
       - "apps/webapp/**/*.ts"
       - "apps/webapp/**/*.tsx"
       - "apps/webapp/package.json"
+      - "apps/companion/**/*.ts"
+      - "apps/companion/**/*.tsx"
+      - "apps/companion/package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/react-doctor.yml"
       - ".github/scripts/react-doctor-pr-comment.mjs"
@@ -26,11 +31,21 @@ jobs:
 
   doctor:
     needs: authorize
-    name: 🩺 React Doctor
+    name: 🩺 React Doctor (${{ matrix.app.name }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+    strategy:
+      # Scan each app independently — a failure on one app must not cancel the
+      # other's scan or its PR comment.
+      fail-fast: false
+      matrix:
+        app:
+          - name: webapp
+            dir: apps/webapp
+          - name: companion
+            dir: apps/companion
     steps:
       - name: 🛑 Cancel previous runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -63,7 +78,7 @@ jobs:
 
       - name: 🩺 Run react-doctor (diff vs base)
         id: doctor
-        working-directory: apps/webapp
+        working-directory: ${{ matrix.app.dir }}
         # Notes:
         #   --diff origin/<base>     — only files changed vs the PR target
         #   --no-dead-code           — knip findings are out of scope here
@@ -97,9 +112,12 @@ jobs:
         env:
           DIAG_PATH: ${{ steps.doctor.outputs.diag_path }}
           EXIT_CODE: ${{ steps.doctor.outputs.exit_code }}
+          # react-doctor emits file paths relative to the scanned dir, so the
+          # comment builder needs the app dir to render repo-root-relative links.
+          PATH_PREFIX: ${{ matrix.app.dir }}/
         run: |
           node .github/scripts/react-doctor-pr-comment.mjs \
-            "$DIAG_PATH" "$EXIT_CODE" \
+            "$DIAG_PATH" "$EXIT_CODE" "$PATH_PREFIX" \
             > "$RUNNER_TEMP/comment.md"
           echo "--- comment preview ---"
           cat "$RUNNER_TEMP/comment.md"
@@ -108,7 +126,9 @@ jobs:
         if: always()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          header: react-doctor
+          # Per-app header so the two matrix jobs maintain separate sticky
+          # comments instead of overwriting each other.
+          header: react-doctor-${{ matrix.app.name }}
           path: ${{ runner.temp }}/comment.md
 
       - name: ❌ Fail if errors introduced

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -65,19 +65,44 @@ jobs:
         # named ref restores the diff path.
         run: git switch -C react-doctor-pr-head
 
+      - name: 🔎 Detect whether this app changed in the PR
+        id: changes
+        # Gate the rest of this matrix leg on whether the app actually has
+        # changes in the PR diff. Without this, a webapp-only PR still posts an
+        # empty "🩺 React Doctor — companion ✅ No new findings" sticky comment
+        # (and vice-versa). Uses the same origin/<base> ref react-doctor's
+        # --diff relies on, so no extra dependency is needed.
+        # BASE_REF is untrusted PR input → passed via env, never inline ${{ }}.
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          APP_DIR: ${{ matrix.app.dir }}
+        run: |
+          if git diff --name-only "origin/${BASE_REF}...HEAD" \
+            | grep -q "^${APP_DIR}/"; then
+            CHANGED=true
+          else
+            CHANGED=false
+          fi
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "App ${APP_DIR} changed in this PR: $CHANGED"
+
       - name: 📦 Setup pnpm
+        if: steps.changes.outputs.changed == 'true'
         uses: pnpm/action-setup@v4
 
       - name: ⎔ Setup node
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: 📥 Install deps
+        if: steps.changes.outputs.changed == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: 🩺 Run react-doctor (diff vs base)
         id: doctor
+        if: steps.changes.outputs.changed == 'true'
         working-directory: ${{ matrix.app.dir }}
         # Notes:
         #   --diff origin/<base>     — only files changed vs the PR target
@@ -108,7 +133,7 @@ jobs:
           exit 0
 
       - name: 📝 Build PR comment body
-        if: always()
+        if: always() && steps.changes.outputs.changed == 'true'
         env:
           DIAG_PATH: ${{ steps.doctor.outputs.diag_path }}
           EXIT_CODE: ${{ steps.doctor.outputs.exit_code }}
@@ -123,7 +148,7 @@ jobs:
           cat "$RUNNER_TEMP/comment.md"
 
       - name: 💬 Post or update PR comment
-        if: always()
+        if: always() && steps.changes.outputs.changed == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           # Per-app header so the two matrix jobs maintain separate sticky
@@ -132,7 +157,7 @@ jobs:
           path: ${{ runner.temp }}/comment.md
 
       - name: ❌ Fail if errors introduced
-        if: steps.doctor.outputs.exit_code != '0'
+        if: steps.changes.outputs.changed == 'true' && steps.doctor.outputs.exit_code != '0'
         run: |
           echo "react-doctor introduced new errors on this PR — see the comment for details."
           exit 1

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -77,18 +77,21 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           APP_DIR: ${{ matrix.app.dir }}
         run: |
-          # Capture first, then grep a here-string — piping `git diff` into
-          # `grep -q` is unsafe under `bash -eo pipefail`: grep exits on first
-          # match and closes the pipe, git can die with SIGPIPE (141) on large
-          # diffs, and pipefail would surface that 141 as the pipeline status,
-          # flipping the `if` to the else branch (CHANGED=false) for an app
-          # that actually changed.
+          # Capture the diff, then test each path with a literal prefix match.
+          # Two reasons to avoid `git diff | grep -q "^${APP_DIR}/"`:
+          #   * pipefail: grep -q exits on first match and closes the pipe; git
+          #     can die with SIGPIPE (141) on large diffs and bash -eo pipefail
+          #     surfaces that 141 — flipping the gate to false for an app that
+          #     actually changed.
+          #   * regex: APP_DIR interpolated into a grep pattern would treat any
+          #     metacharacter as regex. A quoted `case` glob keeps it literal.
           CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
-          if grep -q "^${APP_DIR}/" <<< "$CHANGED_FILES"; then
-            CHANGED=true
-          else
-            CHANGED=false
-          fi
+          CHANGED=false
+          while IFS= read -r file; do
+            case "$file" in
+              "${APP_DIR}"/*) CHANGED=true; break ;;
+            esac
+          done <<< "$CHANGED_FILES"
           echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
           echo "App ${APP_DIR} changed in this PR: $CHANGED"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ Root-level convenience scripts follow the `<app>:<task>` pattern (e.g., `webapp:
 - `pnpm companion:build:ios:device` - Build native iOS + run on physical iPhone
 - `pnpm companion:build:android` - Build native Android + run on device/emulator
 - `pnpm companion:prebuild:clean` - Regenerate iOS native project from Expo config
+- `pnpm companion:doctor` - Run [react-doctor](https://www.react.doctor/) against the companion app (React Native diagnostics: deprecated modules, reanimated, FlatList perf, hook misuse)
 
 See `apps/companion/README.md` for full setup guide (LAN IPs, HTTP mode, device trust).
 
@@ -43,7 +44,7 @@ See `apps/companion/README.md` for full setup guide (LAN IPs, HTTP mode, device 
 - `pnpm turbo typecheck` - TypeScript type checking (all packages)
 - `pnpm run format` - Prettier code formatting (root-level)
 - `pnpm --filter @shelf/webapp validate` - Complete pre-commit validation
-- `pnpm webapp:doctor` - Run [react-doctor](https://www.react.doctor/) against the webapp (React health diagnostics: hook misuse, perf, a11y, architecture). Advisory only — not wired into `validate` or CI gates.
+- `pnpm webapp:doctor` - Run [react-doctor](https://www.react.doctor/) against the webapp (React health diagnostics: hook misuse, perf, a11y, architecture). Not part of `validate` or the pre-commit hook. It **does** run in CI: the `🩺 React Doctor` GitHub Action scans changed files on every PR (matrix over webapp + companion), posts a per-app sticky comment, and fails the check on newly-introduced errors (warnings stay advisory). See [companion:doctor](#companion-app-mobile) for the React Native equivalent.
 
 ### Security Review Agent (pre-commit)
 
@@ -233,7 +234,10 @@ const disabled = useDisabled(fetcher);
 
 ### Silencing react-doctor findings
 
-`pnpm webapp:doctor` is advisory, not a CI gate, but we aim to keep it clean.
+`react-doctor` runs in CI on every PR for both the webapp (`pnpm webapp:doctor`)
+and the companion app (`pnpm companion:doctor`): warnings are advisory, but
+**newly-introduced errors fail the PR check**, so keep both clean. The guidance
+below applies to both apps.
 
 **Important:** `react-doctor` does **not** respect `// eslint-disable-next-line` comments. The only way to silence a finding is to refactor the code so the pattern no longer matches. Standard ESLint disable comments still work for `pnpm webapp:lint` — they just don't help with `pnpm webapp:doctor`.
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The monorepo is managed with pnpm workspaces and Turborepo. The `@shelf/database
 | `pnpm webapp:test`          | Run tests (Vitest)                      |
 | `pnpm webapp:validate`      | Lint + typecheck + test                 |
 | `pnpm webapp:doctor`        | React health scan (react-doctor)        |
+| `pnpm companion:doctor`     | React Native health scan (react-doctor) |
 | `pnpm webapp:setup`         | Generate Prisma client + run migrations |
 | `pnpm db:prepare-migration` | Create a new database migration         |
 | `pnpm db:deploy-migration`  | Apply pending migrations                |

--- a/apps/companion/components/location-picker.tsx
+++ b/apps/companion/components/location-picker.tsx
@@ -7,8 +7,8 @@ import {
   TextInput,
   TouchableOpacity,
   ActivityIndicator,
-  SafeAreaView,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { api, type Location } from "@/lib/api";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";

--- a/apps/companion/components/team-member-picker.tsx
+++ b/apps/companion/components/team-member-picker.tsx
@@ -7,8 +7,8 @@ import {
   TextInput,
   TouchableOpacity,
   ActivityIndicator,
-  SafeAreaView,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { api, type TeamMember } from "@/lib/api";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";

--- a/apps/companion/package.json
+++ b/apps/companion/package.json
@@ -13,6 +13,7 @@
     "prebuild": "expo prebuild",
     "prebuild:clean": "expo prebuild --clean --platform ios",
     "lint": "expo lint",
+    "doctor": "react-doctor .",
     "typecheck": "tsc --noEmit",
     "test:e2e": "cd .maestro/scripts && bash run-all.sh",
     "test:e2e:suite": "cd .maestro/scripts && bash run-suite.sh",
@@ -60,6 +61,7 @@
     "@types/react": "^19.2.14",
     "eslint": "^9.0.0",
     "eslint-config-expo": "~10.0.0",
+    "react-doctor": "0.0.39",
     "typescript": "~5.9.3"
   }
 }

--- a/apps/docs/local-development.md
+++ b/apps/docs/local-development.md
@@ -182,8 +182,12 @@ pnpm db:reset            # Reset database (careful!)
 pnpm turbo lint        # Run ESLint (all packages)
 pnpm run format        # Format code with Prettier
 pnpm webapp:validate   # Run all checks (lint, typecheck, format, tests)
-pnpm webapp:doctor     # React health scan (react-doctor) — advisory, not gated
+pnpm webapp:doctor     # React health scan (react-doctor) — webapp
+pnpm companion:doctor  # React Native health scan (react-doctor) — companion app
 ```
+
+> Both `*:doctor` scans run in CI on every PR (the 🩺 React Doctor action). Warnings
+> are advisory; newly-introduced errors fail the check.
 
 ### Git Hooks (Lefthook)
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "companion:prebuild:clean": "pnpm --filter @shelf/companion prebuild:clean",
     "companion:test:e2e": "pnpm --filter @shelf/companion test:e2e",
     "companion:test:e2e:suite": "pnpm --filter @shelf/companion test:e2e:suite --",
+    "companion:doctor": "pnpm --filter @shelf/companion run doctor",
     "docs:dev": "turbo run dev --filter=@shelf/docs",
     "docs:build": "turbo run build --filter=@shelf/docs",
     "docs:preview": "pnpm --filter @shelf/docs preview",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       eslint-config-expo:
         specifier: ~10.0.0
         version: 10.0.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      react-doctor:
+        specifier: 0.0.39
+        version: 0.0.39(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.6.1))
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -623,7 +626,7 @@ importers:
         version: 6.19.3(magicast@0.3.5)(typescript@6.0.3)
       react-doctor:
         specifier: 0.0.39
-        version: 0.0.39(eslint@8.57.1)
+        version: 0.0.39(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@8.57.1)
       remix-flat-routes:
         specifier: ^0.8.5
         version: 0.8.5
@@ -1758,7 +1761,6 @@ packages:
 
   '@evilmartians/lefthook@2.1.6':
     resolution: {integrity: sha512-ysZbzryf74wlISmgm0PH/n1lJ0HD7AHmI6DoJgWO9qzIETQknhGdmKbkOi0MjLYtiOHWQl8Dr2qwg0ksDpNZjA==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -12845,9 +12847,12 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
@@ -16776,6 +16781,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
+      eslint: 9.39.4(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
       array-includes: 3.1.9
@@ -18220,7 +18236,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  knip@6.9.0:
+  knip@6.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
@@ -18228,7 +18244,7 @@ snapshots:
       jiti: 2.6.1
       minimist: 1.2.8
       oxc-parser: 0.128.0
-      oxc-resolver: 11.19.1
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picomatch: 4.0.4
       smol-toml: 1.6.1
       strip-json-comments: 5.0.3
@@ -18236,6 +18252,9 @@ snapshots:
       unbash: 3.0.0
       yaml: 2.8.3
       zod: 4.4.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   lan-network@0.1.7: {}
 
@@ -19225,7 +19244,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.128.0
       '@oxc-parser/binding-win32-x64-msvc': 0.128.0
 
-  oxc-resolver@11.19.1:
+  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -19243,10 +19262,13 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   oxlint@1.62.0:
     optionalDependencies:
@@ -19776,17 +19798,36 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-doctor@0.0.39(eslint@8.57.1):
+  react-doctor@0.0.39(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@8.57.1):
     dependencies:
       commander: 14.0.3
       eslint-plugin-react-hooks: 7.1.1(eslint@8.57.1)
-      knip: 6.9.0
+      knip: 6.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       ora: 9.4.0
       oxlint: 1.62.0
       picocolors: 1.1.1
       prompts: 2.4.2
       typescript: 6.0.3
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - eslint
+      - oxlint-tsgolint
+      - supports-color
+
+  react-doctor@0.0.39(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      commander: 14.0.3
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
+      knip: 6.9.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      ora: 9.4.0
+      oxlint: 1.62.0
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - eslint
       - oxlint-tsgolint
       - supports-color


### PR DESCRIPTION
Fan the React Doctor GitHub Action out over a matrix of [webapp, companion] so the Expo/React Native code gets the same PR-time health check the webapp already has. react-doctor auto-detects React Native and applies RN-specific rules (deprecated modules, reanimated, FlatList renderItem, Dimensions.get, etc.) on top of the generic React hygiene rules.

- workflow: matrix over both apps (fail-fast: false), parameterized working-directory, path-prefix, and per-app sticky comment header so the two jobs keep separate PR comments. Same gate as webapp: --diff + --fail-on error (errors block, warnings advisory).
- pr-comment script: accepts a path-prefix arg, derives the app name and <app>:doctor command, renders repo-root-relative links. Webapp default unchanged.
- companion: pin react-doctor@0.0.39 (matches webapp) + add doctor script; add companion:doctor root convenience script.
- fix the 2 existing error-level findings so companion starts green: import SafeAreaView from react-native-safe-area-context instead of react-native in team-member-picker and location-picker.
- docs: document companion:doctor and correct the stale "not a CI gate" note (react-doctor does gate PRs on newly-introduced errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI health scan now runs per-app (webapp and companion) with separate, app-scoped PR comments and correct repo-relative links.
  * New local npm scripts to run health scans for each app (webapp and companion).

* **Bug Fixes**
  * Adjusted React Native safe-area usage to the recommended provider.

* **Documentation**
  * Docs and guidance updated to cover companion app scan and CI behavior (failures only on newly introduced errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->