### PR TITLE
chore(companion): move EXPO_PUBLIC env vars to EAS, drop from eas.json

### DIFF
--- a/apps/companion/eas.json
+++ b/apps/companion/eas.json
@@ -18,20 +18,10 @@
       "distribution": "internal",
       "ios": {
         "simulator": false
-      },
-      "env": {
-        "EXPO_PUBLIC_API_URL": "https://app.shelf.nu",
-        "EXPO_PUBLIC_SUPABASE_URL": "https://nmmqcuiasekdacmhwsxk.supabase.co",
-        "EXPO_PUBLIC_SUPABASE_ANON_PUBLIC": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5tbXFjdWlhc2VrZGFjbWh3c3hrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODQ3NjY5NzcsImV4cCI6MjAwMDM0Mjk3N30.oJgybPmL8Y2naFbCABPAL9-sWF3cm6FFJETeyHu1hTc"
       }
     },
     "production": {
-      "autoIncrement": true,
-      "env": {
-        "EXPO_PUBLIC_API_URL": "https://app.shelf.nu",
-        "EXPO_PUBLIC_SUPABASE_URL": "https://nmmqcuiasekdacmhwsxk.supabase.co",
-        "EXPO_PUBLIC_SUPABASE_ANON_PUBLIC": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im5tbXFjdWlhc2VrZGFjbWh3c3hrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODQ3NjY5NzcsImV4cCI6MjAwMDM0Mjk3N30.oJgybPmL8Y2naFbCABPAL9-sWF3cm6FFJETeyHu1hTc"
-      }
+      "autoIncrement": true
     }
   },
   "submit": {


### PR DESCRIPTION
## Need

Follow-up to @DonKoko's review on #2583: we shouldn't hardcode config values in the repo, even public ones. `apps/companion/eas.json` inlined the API URL, Supabase URL and Supabase anon key into the `preview` and `production` build profiles.

## What changed

- Created the three vars as **EAS environment variables** (plaintext, `preview` + `production`) on `@shelfassetmanagement/shelf-companion`, so EAS injects them at build time:
  - `EXPO_PUBLIC_API_URL`
  - `EXPO_PUBLIC_SUPABASE_URL`
  - `EXPO_PUBLIC_SUPABASE_ANON_PUBLIC`
- Removed the inline `env` blocks from the `preview` and `production` profiles in `eas.json`.
- Left `development`'s `EXPO_PUBLIC_API_URL=http://localhost:3000` in place — a local convenience, not a credential.

## Not a secret (just hygiene)

To be explicit: this is **not** a security fix. `EXPO_PUBLIC_*` vars are inlined into the client bundle by Expo regardless of source, and the key is the Supabase **anon/public** key (JWT `role: anon`), not `service_role`. The only change is that the values now live in EAS instead of the repo.

## Test plan

- [x] `eas.json` is valid JSON; `preview`/`production` no longer carry `env`.
- [x] EAS vars verified present for both environments (`eas env:list`).
- [ ] Confirm the next `preview`/`production` build resolves the vars from EAS (will be exercised by the upcoming production build + on-device QA before App Store submit).

> Do not merge — leaving to the team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production build configuration for the companion app by streamlining the build profile settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->