### PR TITLE
fix(webapp): prevent SSRF via asset import imageUrl (GHSA-xgrm-8w6v-mvjg)

### DIFF
--- a/apps/webapp/app/utils/misc.ts
+++ b/apps/webapp/app/utils/misc.ts
@@ -16,9 +16,19 @@ export const isValidDomain = (val: string) =>
   /^([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.)+[a-zA-Z]{2,}$/.test(val);
 
 /**
- * Validates if a string is a properly formatted URL and potentially an image URL
+ * Heuristic check that a string looks like an image URL (correct protocol,
+ * plausible extension / image-service host / image-ish path).
+ *
+ * SECURITY: This is a UX pre-filter ONLY — it is NOT an SSRF boundary. The
+ * checks below match on the URL *string*, which the user controls and which a
+ * redirect can change after the fact, so they cannot decide whether a
+ * destination is safe to reach. The actual SSRF protection (private/reserved
+ * IP blocking, redirect revalidation, size cap) lives in `safeFetch`
+ * (`~/utils/ssrf.server`), which is what `uploadImageFromUrl` calls. Do not
+ * rely on this function to gate server-side fetches. See GHSA-xgrm-8w6v-mvjg.
+ *
  * @param url - The URL to validate
- * @returns boolean indicating if URL is valid
+ * @returns boolean indicating if URL plausibly points at an image
  */
 export function isValidImageUrl(url: string): boolean {
   try {
@@ -81,26 +91,6 @@ export function sanitizeFilename(filename: string): string {
     s = "_" + s;
   }
   return s;
-}
-
-export async function getImageAsBase64(url: string) {
-  try {
-    // Fetch the image data
-    const response = await fetch(url);
-
-    const arrayBuffer = await response.arrayBuffer();
-
-    // Convert the image data to a Base64-encoded string
-    const base64Image = Buffer.from(arrayBuffer).toString("base64");
-
-    return base64Image;
-
-    // Convert the image data to a Base64-encoded string
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error("Error fetching image:", error);
-    return null;
-  }
 }
 
 /**

--- a/apps/webapp/app/utils/ssrf.server.test.ts
+++ b/apps/webapp/app/utils/ssrf.server.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+// why: exercises Node's undici-backed fetch/Response and the `dns`/`net`
+// primitives; happy-dom would shadow Response and ignore the undici dispatcher.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BlockedAddressError,
+  isPrivateOrReservedIp,
+  readBodyWithLimit,
+  safeFetch,
+  ssrfGuardedLookup,
+} from "./ssrf.server";
+
+// Classification is delegated to ipaddr.js with a strict default-deny policy:
+// only globally-routable `unicast` is allowed; every other range it recognises
+// is blocked. These tests lock in that policy across the ranges that matter for
+// SSRF (and the transition ranges that can smuggle a private target).
+describe("isPrivateOrReservedIp", () => {
+  it.each([
+    // Loopback / unspecified
+    ["0.0.0.0"],
+    ["127.0.0.1"],
+    ["127.255.255.254"],
+    // Private RFC1918
+    ["10.0.0.1"],
+    ["10.255.255.255"],
+    ["172.16.0.1"],
+    ["172.31.255.255"],
+    ["192.168.0.1"],
+    ["192.168.255.255"],
+    // CGNAT
+    ["100.64.0.1"],
+    ["100.127.255.255"],
+    // Link-local — cloud metadata lives at 169.254.169.254
+    ["169.254.0.1"],
+    ["169.254.169.254"],
+    // Reserved / documentation
+    ["192.0.2.10"],
+    ["198.51.100.1"],
+    ["203.0.113.1"],
+    ["192.88.99.1"], // 6to4 relay anycast (reserved)
+    ["224.0.0.1"], // multicast
+    ["240.0.0.1"], // reserved
+    ["255.255.255.255"], // broadcast
+    // IPv6
+    ["::1"], // loopback
+    ["::"], // unspecified
+    ["fc00::1"], // unique-local
+    ["fd12:3456::1"], // unique-local
+    ["fe80::1"], // link-local
+    ["ff02::1"], // multicast
+    // IPv6 transition ranges — blocked by the unicast-only default-deny policy
+    // because they can encode an embedded/internal IPv4 target.
+    ["2002:c0a8:0101::1"], // 6to4 wrapping 192.168.1.1
+    ["2001:0:0:0:0:0:0:1"], // Teredo
+    ["64:ff9b::a9fe:a9fe"], // NAT64 (rfc6052) wrapping 169.254.169.254
+    // IPv4-mapped / NAT64 smuggling a private v4 target through a v6 literal
+    ["::ffff:127.0.0.1"],
+    ["::ffff:169.254.169.254"],
+    ["::ffff:10.0.0.1"],
+    ["64:ff9b::169.254.169.254"], // dotted NAT64 form — unparseable → fails closed
+  ])("blocks %s", (ip) => {
+    expect(isPrivateOrReservedIp(ip)).toBe(true);
+  });
+
+  it.each([
+    ["1.1.1.1"],
+    ["8.8.8.8"],
+    ["140.82.121.4"], // github.com-ish
+    ["203.0.114.1"], // just outside the 203.0.113.0/24 doc range
+    ["192.0.1.1"], // outside 192.0.0.0/24 + 192.0.2.0/24
+    ["198.51.99.1"], // outside 198.51.100.0/24
+    ["2606:4700:4700::1111"], // cloudflare dns (global unicast)
+    ["::ffff:8.8.8.8"], // mapped, but to a public v4
+  ])("allows public address %s", (ip) => {
+    expect(isPrivateOrReservedIp(ip)).toBe(false);
+  });
+
+  it("fails closed on non-IP input", () => {
+    expect(isPrivateOrReservedIp("not-an-ip")).toBe(true);
+    expect(isPrivateOrReservedIp("")).toBe(true);
+  });
+});
+
+/**
+ * Runs the guarded lookup against an IP *literal* (which `dns.lookup` resolves
+ * offline, without any network query) and resolves with the outcome.
+ */
+function runGuardedLookup(
+  host: string
+): Promise<{ err: Error | null; address?: string }> {
+  return new Promise((resolve) => {
+    ssrfGuardedLookup(host, { all: false }, (err, address) => {
+      resolve({ err: err as Error | null, address: address as string });
+    });
+  });
+}
+
+describe("ssrfGuardedLookup", () => {
+  it.each([
+    ["127.0.0.1"],
+    ["169.254.169.254"],
+    ["10.0.0.1"],
+    ["::1"],
+    ["::ffff:127.0.0.1"],
+  ])("refuses to resolve blocked literal %s", async (host) => {
+    const { err } = await runGuardedLookup(host);
+    expect(err).toBeInstanceOf(BlockedAddressError);
+  });
+
+  it.each([["1.1.1.1"], ["8.8.8.8"]])(
+    "permits public literal %s",
+    async (host) => {
+      const { err, address } = await runGuardedLookup(host);
+      expect(err).toBeNull();
+      expect(address).toBe(host);
+    }
+  );
+});
+
+describe("safeFetch input validation", () => {
+  it("rejects non-http(s) protocols", async () => {
+    await expect(safeFetch("file:///etc/passwd")).rejects.toThrow(
+      /http and https/i
+    );
+    await expect(safeFetch("ftp://example.com/x")).rejects.toThrow(
+      /http and https/i
+    );
+    await expect(safeFetch("gopher://example.com/x")).rejects.toThrow(
+      /http and https/i
+    );
+  });
+
+  it("rejects malformed URLs", async () => {
+    await expect(safeFetch("not a url")).rejects.toThrow(/invalid url/i);
+  });
+
+  // NOTE: The end-to-end "connect is refused" guarantee is proven by the
+  // `ssrfGuardedLookup` suite above — that lookup is exactly what the undici
+  // dispatcher runs at connect time for every hop (initial + redirects). We
+  // don't assert it through `safeFetch` here because the test harness's MSW
+  // interceptor sits in front of the dispatcher and would shadow the guard.
+});
+
+/**
+ * Builds a Response whose body streams `chunkCount` chunks of `chunkSize`
+ * bytes, so the size cap can be exercised without any network.
+ */
+function streamingResponse(chunkSize: number, chunkCount: number): Response {
+  let emitted = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (emitted >= chunkCount) {
+        controller.close();
+        return;
+      }
+      emitted += 1;
+      controller.enqueue(new Uint8Array(chunkSize));
+    },
+  });
+  return new Response(stream);
+}
+
+describe("readBodyWithLimit", () => {
+  it("returns the full body when within the limit", async () => {
+    const res = streamingResponse(1000, 4); // 4000 bytes
+    const buffer = await readBodyWithLimit(res, 8000, "http://x/test");
+    expect(buffer.byteLength).toBe(4000);
+  });
+
+  it("aborts once the cumulative size exceeds the limit", async () => {
+    const res = streamingResponse(1000, 100); // would be 100_000 bytes
+    await expect(readBodyWithLimit(res, 5000, "http://x/test")).rejects.toThrow(
+      /maximum allowed size/i
+    );
+  });
+});

--- a/apps/webapp/app/utils/ssrf.server.test.ts
+++ b/apps/webapp/app/utils/ssrf.server.test.ts
@@ -2,9 +2,18 @@
 // why: exercises Node's undici-backed fetch/Response and the `dns`/`net`
 // primitives; happy-dom would shadow Response and ignore the undici dispatcher.
 
+/**
+ * Unit tests for the SSRF protection utilities in `./ssrf.server`:
+ * IP classification (`isPrivateOrReservedIp`), the guarded DNS lookup
+ * (`ssrfGuardedLookup`), URL/IP-literal validation (`assertSafeUrl`), protocol
+ * allowlisting and literal-host blocking in `safeFetch`, and the streaming /
+ * abortable body size cap in `readBodyWithLimit`.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import {
+  assertSafeUrl,
   BlockedAddressError,
   isPrivateOrReservedIp,
   readBodyWithLimit,
@@ -119,6 +128,41 @@ describe("ssrfGuardedLookup", () => {
   );
 });
 
+// `assertSafeUrl` is the synchronous gate `safeFetch` runs on the initial URL
+// and on every redirect target. It closes the IP-literal bypass: undici's
+// connector skips `connect.lookup` for hosts that are already IPs, so literal
+// hosts must be classified here rather than relying on the guarded lookup.
+describe("assertSafeUrl", () => {
+  it.each([
+    ["http://127.0.0.1/x.jpg"],
+    ["http://169.254.169.254/latest/meta-data/iam/.jpg"], // cloud metadata
+    ["http://10.0.0.1/internal"],
+    ["http://192.168.1.1/"],
+    ["https://[::1]/x"],
+    ["http://[::ffff:127.0.0.1]/x"], // IPv4-mapped loopback
+  ])("blocks private/reserved IP literal %s", (url) => {
+    expect(() => assertSafeUrl(url)).toThrow(BlockedAddressError);
+  });
+
+  it.each([["file:///etc/passwd"], ["ftp://example.com/x"], ["gopher://h/x"]])(
+    "rejects non-http(s) protocol %s",
+    (url) => {
+      expect(() => assertSafeUrl(url)).toThrow(/http and https/i);
+    }
+  );
+
+  it("rejects malformed URLs", () => {
+    expect(() => assertSafeUrl("not a url")).toThrow(/invalid url/i);
+  });
+
+  it("allows http(s) URLs with public hosts", () => {
+    expect(assertSafeUrl("https://images.example.com/a.jpg").hostname).toBe(
+      "images.example.com"
+    );
+    expect(assertSafeUrl("http://1.1.1.1/a.png").hostname).toBe("1.1.1.1");
+  });
+});
+
 describe("safeFetch input validation", () => {
   it("rejects non-http(s) protocols", async () => {
     await expect(safeFetch("file:///etc/passwd")).rejects.toThrow(
@@ -136,11 +180,26 @@ describe("safeFetch input validation", () => {
     await expect(safeFetch("not a url")).rejects.toThrow(/invalid url/i);
   });
 
-  // NOTE: The end-to-end "connect is refused" guarantee is proven by the
-  // `ssrfGuardedLookup` suite above — that lookup is exactly what the undici
-  // dispatcher runs at connect time for every hop (initial + redirects). We
-  // don't assert it through `safeFetch` here because the test harness's MSW
-  // interceptor sits in front of the dispatcher and would shadow the guard.
+  // Regression guard for the IP-literal bypass (GHSA review, Codex P1): undici
+  // does not route literal hosts through `connect.lookup`, so `safeFetch` must
+  // reject them up front — before any socket is opened. These assertions run
+  // entirely pre-`fetch`, so they are deterministic and MSW-independent.
+  it.each([
+    ["http://127.0.0.1/x.jpg"],
+    ["http://169.254.169.254/latest/meta-data/iam/security-credentials/.jpg"],
+    ["http://10.0.0.1/internal"],
+    ["https://[::1]/x"],
+  ])("blocks the IP-literal SSRF target %s", async (url) => {
+    await expect(safeFetch(url)).rejects.toBeInstanceOf(BlockedAddressError);
+  });
+
+  // NOTE: The "connect is refused for a NAMED host" guarantee (and its
+  // re-validation on each redirect hop) is proven by the `ssrfGuardedLookup`
+  // suite above — that lookup is exactly what the undici dispatcher runs at
+  // connect time. We can't assert it through `safeFetch` here because the test
+  // harness's MSW interceptor sits in front of the dispatcher. Redirect targets
+  // that are IP literals are covered because each hop is re-checked by
+  // `assertSafeUrl` (tested directly above).
 });
 
 /**
@@ -174,5 +233,16 @@ describe("readBodyWithLimit", () => {
     await expect(readBodyWithLimit(res, 5000, "http://x/test")).rejects.toThrow(
       /maximum allowed size/i
     );
+  });
+
+  it("aborts a slow/trickle body when the signal fires", async () => {
+    // A body well under the size cap but read with an already-aborted signal
+    // must be cut off — this is the slow-body DoS guard (hex/CodeRabbit review).
+    const res = streamingResponse(10, 5); // 50 bytes, far below the cap
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      readBodyWithLimit(res, 8000, "http://x/test", controller.signal)
+    ).rejects.toThrow(/timed out/i);
   });
 });

--- a/apps/webapp/app/utils/ssrf.server.ts
+++ b/apps/webapp/app/utils/ssrf.server.ts
@@ -1,0 +1,321 @@
+/**
+ * SSRF-safe outbound HTTP fetch.
+ *
+ * Shelf lets authenticated users supply URLs that the *server* then fetches on
+ * their behalf — most notably the `imageUrl` column of the Asset CSV import.
+ * Without restrictions this is a classic Server-Side Request Forgery (SSRF)
+ * primitive: a user can point the URL at internal-only addresses the server can
+ * reach but they cannot (cloud metadata endpoints like 169.254.169.254,
+ * databases on localhost, internal admin panels, RFC1918 hosts), turning the
+ * server into a confused deputy. See GHSA-xgrm-8w6v-mvjg.
+ *
+ * String-level checks ("does the URL end in .jpg?") are NOT a defense — the
+ * attacker controls the string, redirects change the destination after any such
+ * check, and substring host matching is trivially bypassed. The only reliable
+ * boundary is at the network layer: resolve the destination and refuse to
+ * connect to any private/reserved IP.
+ *
+ * This module enforces that boundary via an undici {@link Agent} whose custom
+ * `connect.lookup` validates every resolved address *at connect time*. Because
+ * undici connects to exactly the IP the lookup returns, the address we validate
+ * is the address we talk to — closing the DNS-rebinding (TOCTOU) gap — and every
+ * redirect hop opens a fresh connection through the same lookup, so redirects
+ * are revalidated automatically.
+ *
+ * @see {@link file://./storage.server.ts} — `uploadImageFromUrl` consumer
+ * @see {@link file://./ssrf.server.test.ts} — range + bypass coverage
+ */
+
+import { lookup as dnsLookup } from "node:dns";
+import type { LookupAddress, LookupOptions } from "node:dns";
+
+import ipaddr from "ipaddr.js";
+import { Agent } from "undici";
+
+import { ASSET_MAX_IMAGE_UPLOAD_SIZE } from "./constants";
+import type { ErrorLabel } from "./error";
+import { ShelfError } from "./error";
+
+const label: ErrorLabel = "File storage";
+
+/** Default per-request timeout for outbound image fetches. */
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Determines whether an IP address (v4 or v6) is private, loopback,
+ * link-local, or otherwise reserved and therefore must not be the target of a
+ * server-initiated request.
+ *
+ * Classification is delegated to the battle-tested `ipaddr.js` library and
+ * applied as a strict **default-deny** policy: only globally-routable
+ * `unicast` addresses are permitted; every other range it recognises
+ * (`loopback`, `private`, `linkLocal` — incl. the 169.254.169.254 cloud
+ * metadata endpoint —, `carrierGradeNat`, `uniqueLocal`, `multicast`,
+ * `reserved`, `unspecified`, `broadcast`, and the 6to4 / Teredo / NAT64
+ * transition ranges) is blocked. `ipaddr.process` first unwraps IPv4-mapped
+ * IPv6 (`::ffff:x`) to its embedded IPv4, so a private v4 cannot be smuggled
+ * through a v6 literal. Unparseable input fails closed (blocked).
+ *
+ * @param ip - The IP address to classify
+ * @returns `true` if the address is non-publicly-routable and must be blocked
+ */
+export function isPrivateOrReservedIp(ip: string): boolean {
+  let addr: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    addr = ipaddr.process(ip);
+  } catch {
+    // Not a parseable IP literal — fail closed.
+    return true;
+  }
+  return addr.range() !== "unicast";
+}
+
+/**
+ * Thrown when an outbound fetch is refused because the destination resolves to
+ * a blocked address. Distinct so callers can avoid pointlessly retrying.
+ */
+export class BlockedAddressError extends ShelfError {
+  constructor(host: string, ip?: string) {
+    super({
+      cause: null,
+      message: "Refused to fetch from a private or reserved network address",
+      additionalData: { host, ip },
+      label,
+      shouldBeCaptured: false,
+    });
+  }
+}
+
+/** Callback shape accepted by a `dns.lookup`-style function. */
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: string | LookupAddress[],
+  family?: number
+) => void;
+
+/**
+ * A `dns.lookup`-compatible function that resolves a hostname and rejects the
+ * lookup (and therefore the connection) if *any* resolved address is private or
+ * reserved. Used as undici's `connect.lookup` so the IP we validate is exactly
+ * the IP undici connects to — on every redirect hop.
+ *
+ * We reject if ANY resolved address is blocked (not just the one chosen) to
+ * defend against hostnames that publish both a public and a private record.
+ *
+ * @param hostname - The host undici is about to connect to
+ * @param options - Lookup options forwarded by undici (family/hints/`all`)
+ * @param callback - Node-style lookup callback
+ */
+export function ssrfGuardedLookup(
+  hostname: string,
+  options: LookupOptions,
+  callback: LookupCallback
+): void {
+  // Always resolve ALL records so we can reject a host that publishes both a
+  // public and a private address, then hand back the shape the caller wants.
+  dnsLookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) return callback(err, "", 0);
+
+    const all = addresses as LookupAddress[];
+    const blocked = all.find((a) => isPrivateOrReservedIp(a.address));
+    if (blocked) {
+      return callback(
+        new BlockedAddressError(hostname, blocked.address),
+        "",
+        0
+      );
+    }
+
+    if (options.all) return callback(null, all);
+    return callback(null, all[0].address, all[0].family);
+  });
+}
+
+/**
+ * Shared undici dispatcher that routes every connection (including redirect
+ * hops) through {@link ssrfGuardedLookup}. Reusing a single agent is safe:
+ * pooled sockets are keyed to an already-validated IP, and new hostnames always
+ * trigger a fresh guarded lookup.
+ */
+const ssrfSafeAgent = new Agent({
+  // `lookup` is supported by undici's connector at runtime but missing from its
+  // `BuildOptions` type, so cast through `unknown`.
+  connect: { lookup: ssrfGuardedLookup } as unknown as Agent.Options["connect"],
+});
+
+/** Options for {@link safeFetch}. */
+export interface SafeFetchOptions {
+  /** Maximum number of bytes to read before aborting (DoS guard). */
+  maxBytes?: number;
+  /** Per-request timeout in milliseconds. */
+  timeoutMs?: number;
+}
+
+/** Successful result of {@link safeFetch}. */
+export interface SafeFetchResult {
+  /** The fully-read response body, guaranteed to be `<= maxBytes`. */
+  buffer: Buffer;
+  /** The response `content-type` header, or empty string if absent. */
+  contentType: string;
+}
+
+/**
+ * Fetches a user-supplied URL with SSRF protection and a streaming size cap.
+ *
+ * - Only `http:`/`https:` are permitted.
+ * - Every connection (initial + redirects) is validated against private and
+ *   reserved IP ranges via {@link ssrfGuardedLookup}, closing redirect and
+ *   DNS-rebinding bypasses.
+ * - The body is read incrementally and the request is aborted the instant it
+ *   exceeds `maxBytes`, so an oversized response cannot exhaust memory.
+ *
+ * @param url - The destination URL (typically from untrusted user input)
+ * @param options - Size cap and timeout overrides
+ * @returns The response body buffer and its content-type
+ * @throws {ShelfError} If the protocol is disallowed, the destination is
+ *   blocked, the request fails/times out, or the body exceeds `maxBytes`
+ */
+export async function safeFetch(
+  url: string,
+  options: SafeFetchOptions = {}
+): Promise<SafeFetchResult> {
+  const maxBytes = options.maxBytes ?? ASSET_MAX_IMAGE_UPLOAD_SIZE;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new ShelfError({
+      cause: null,
+      message: "Invalid URL",
+      additionalData: { url },
+      label,
+      shouldBeCaptured: false,
+    });
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new ShelfError({
+      cause: null,
+      message: "Only http and https URLs are allowed",
+      additionalData: { url, protocol: parsed.protocol },
+      label,
+      shouldBeCaptured: false,
+    });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetch(parsed, {
+      signal: controller.signal,
+      redirect: "follow",
+      // Route through the SSRF-guarded dispatcher. `dispatcher` is the undici
+      // RequestInit extension exposed by Node's global fetch.
+      // @ts-expect-error -- `dispatcher` is not in the DOM RequestInit types.
+      dispatcher: ssrfSafeAgent,
+    });
+  } catch (cause) {
+    // When the guarded lookup rejects a hop, fetch surfaces a wrapped error
+    // (e.g. `TypeError: fetch failed` with `.cause`). Recover the original
+    // BlockedAddressError so callers can distinguish "blocked" from "network
+    // failure" and avoid pointless retries.
+    const blocked = findBlockedCause(cause);
+    if (blocked) throw blocked;
+    throw cause;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    throw new ShelfError({
+      cause: null,
+      message: `HTTP ${response.status}: ${response.statusText}`,
+      additionalData: { url, status: response.status },
+      label,
+      shouldBeCaptured: false,
+    });
+  }
+
+  const contentType = response.headers.get("content-type") || "";
+  const buffer = await readBodyWithLimit(response, maxBytes, url);
+
+  return { buffer, contentType };
+}
+
+/**
+ * Walks an error's `cause` chain looking for a {@link BlockedAddressError},
+ * which fetch wraps when our guarded lookup refuses a connection.
+ *
+ * @param err - The error thrown by `fetch`
+ * @returns The underlying BlockedAddressError, or `null` if not present
+ */
+function findBlockedCause(err: unknown): BlockedAddressError | null {
+  let current: unknown = err;
+  // Bound the walk to avoid pathological self-referential cause chains.
+  for (let depth = 0; current && depth < 10; depth++) {
+    if (current instanceof BlockedAddressError) return current;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return null;
+}
+
+/**
+ * Reads a response body incrementally, aborting as soon as the cumulative size
+ * exceeds `maxBytes`. Prevents the buffer-everything-then-check memory vector.
+ *
+ * @param response - The fetch response whose body to read
+ * @param maxBytes - The maximum allowed body size in bytes
+ * @param url - The source URL (for error context only)
+ * @returns The full body as a Buffer (guaranteed `<= maxBytes`)
+ * @throws {ShelfError} If the body exceeds `maxBytes` or cannot be read
+ */
+export async function readBodyWithLimit(
+  response: Response,
+  maxBytes: number,
+  url: string
+): Promise<Buffer> {
+  if (!response.body) {
+    throw new ShelfError({
+      cause: null,
+      message: "Response has no body",
+      additionalData: { url },
+      label,
+      shouldBeCaptured: false,
+    });
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new ShelfError({
+          cause: null,
+          message: `Response exceeds maximum allowed size of ${
+            maxBytes / (1024 * 1024)
+          }MB`,
+          additionalData: { url, maxBytes },
+          label,
+          shouldBeCaptured: false,
+        });
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks);
+}

--- a/apps/webapp/app/utils/ssrf.server.ts
+++ b/apps/webapp/app/utils/ssrf.server.ts
@@ -28,6 +28,7 @@
 
 import { lookup as dnsLookup } from "node:dns";
 import type { LookupAddress, LookupOptions } from "node:dns";
+import { isIP } from "node:net";
 
 import ipaddr from "ipaddr.js";
 import { Agent } from "undici";
@@ -40,6 +41,9 @@ const label: ErrorLabel = "File storage";
 
 /** Default per-request timeout for outbound image fetches. */
 const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Maximum number of redirects to follow before giving up. */
+const MAX_REDIRECTS = 5;
 
 /**
  * Determines whether an IP address (v4 or v6) is private, loopback,
@@ -160,28 +164,21 @@ export interface SafeFetchResult {
 }
 
 /**
- * Fetches a user-supplied URL with SSRF protection and a streaming size cap.
+ * Parses a URL, enforces the http(s) allowlist, and blocks IP-literal hosts
+ * that fall in a private/reserved range.
  *
- * - Only `http:`/`https:` are permitted.
- * - Every connection (initial + redirects) is validated against private and
- *   reserved IP ranges via {@link ssrfGuardedLookup}, closing redirect and
- *   DNS-rebinding bypasses.
- * - The body is read incrementally and the request is aborted the instant it
- *   exceeds `maxBytes`, so an oversized response cannot exhaust memory.
+ * The literal-IP check here is essential: undici's connector does NOT route a
+ * host that is already an IP through `connect.lookup`, so {@link
+ * ssrfGuardedLookup} never sees `http://169.254.169.254/...` (or a redirect to
+ * it). Named hosts are left to the guarded lookup at connect time, which is
+ * rebinding-safe.
  *
- * @param url - The destination URL (typically from untrusted user input)
- * @param options - Size cap and timeout overrides
- * @returns The response body buffer and its content-type
- * @throws {ShelfError} If the protocol is disallowed, the destination is
- *   blocked, the request fails/times out, or the body exceeds `maxBytes`
+ * @param url - The URL to validate (initial request or a redirect target)
+ * @returns The parsed, validated URL
+ * @throws {ShelfError} If the URL is malformed or uses a disallowed protocol
+ * @throws {BlockedAddressError} If the host is a private/reserved IP literal
  */
-export async function safeFetch(
-  url: string,
-  options: SafeFetchOptions = {}
-): Promise<SafeFetchResult> {
-  const maxBytes = options.maxBytes ?? ASSET_MAX_IMAGE_UPLOAD_SIZE;
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-
+export function assertSafeUrl(url: string): URL {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -205,45 +202,127 @@ export async function safeFetch(
     });
   }
 
+  // `URL.hostname` wraps IPv6 literals in brackets (`[::1]`); strip them so
+  // `isIP` recognises the address.
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (isIP(host) && isPrivateOrReservedIp(host)) {
+    throw new BlockedAddressError(parsed.hostname, host);
+  }
+
+  return parsed;
+}
+
+/** RFC redirect status codes that carry a `Location` header. */
+function isRedirectStatus(status: number): boolean {
+  return [301, 302, 303, 307, 308].includes(status);
+}
+
+/**
+ * Fetches a user-supplied URL with SSRF protection and a streaming size cap.
+ *
+ * - Only `http:`/`https:` are permitted.
+ * - Redirects are followed **manually** so every hop is re-validated. Each
+ *   hop's host is checked two ways: IP literals via {@link assertSafeUrl}
+ *   (undici skips `connect.lookup` for literals), named hosts via
+ *   {@link ssrfGuardedLookup} at connect time — together closing the redirect
+ *   and DNS-rebinding bypasses.
+ * - The body is read incrementally while the timeout is still armed, so an
+ *   oversized **or** slow/stalled body is aborted rather than buffered.
+ *
+ * @param url - The destination URL (typically from untrusted user input)
+ * @param options - Size cap and timeout overrides
+ * @returns The response body buffer and its content-type
+ * @throws {ShelfError} If the protocol is disallowed, the destination is
+ *   blocked, the request fails/times out, redirects too many times, or the
+ *   body exceeds `maxBytes`
+ */
+export async function safeFetch(
+  url: string,
+  options: SafeFetchOptions = {}
+): Promise<SafeFetchResult> {
+  const maxBytes = options.maxBytes ?? ASSET_MAX_IMAGE_UPLOAD_SIZE;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-  let response: Response;
   try {
-    response = await fetch(parsed, {
-      signal: controller.signal,
-      redirect: "follow",
-      // Route through the SSRF-guarded dispatcher. `dispatcher` is the undici
-      // RequestInit extension exposed by Node's global fetch.
-      // @ts-expect-error -- `dispatcher` is not in the DOM RequestInit types.
-      dispatcher: ssrfSafeAgent,
-    });
-  } catch (cause) {
-    // When the guarded lookup rejects a hop, fetch surfaces a wrapped error
-    // (e.g. `TypeError: fetch failed` with `.cause`). Recover the original
-    // BlockedAddressError so callers can distinguish "blocked" from "network
-    // failure" and avoid pointless retries.
-    const blocked = findBlockedCause(cause);
-    if (blocked) throw blocked;
-    throw cause;
+    let target = assertSafeUrl(url);
+
+    for (let redirects = 0; ; redirects++) {
+      if (redirects > MAX_REDIRECTS) {
+        throw new ShelfError({
+          cause: null,
+          message: `Too many redirects (> ${MAX_REDIRECTS})`,
+          additionalData: { url, finalUrl: target.href },
+          label,
+          shouldBeCaptured: false,
+        });
+      }
+
+      let response: Response;
+      try {
+        response = await fetch(target, {
+          signal: controller.signal,
+          redirect: "manual",
+          // Route through the SSRF-guarded dispatcher. `dispatcher` is the
+          // undici RequestInit extension exposed by Node's global fetch.
+          // @ts-expect-error -- `dispatcher` is not in the DOM RequestInit types.
+          dispatcher: ssrfSafeAgent,
+        });
+      } catch (cause) {
+        // When the guarded lookup rejects a named hop, fetch wraps the error
+        // (e.g. `TypeError: fetch failed` with `.cause`). Recover the original
+        // BlockedAddressError so callers can skip pointless retries.
+        const blocked = findBlockedCause(cause);
+        if (blocked) throw blocked;
+        throw cause;
+      }
+
+      // Manual redirect handling — validate the next hop, then continue.
+      if (isRedirectStatus(response.status)) {
+        const location = response.headers.get("location");
+        // Release the redirect response's socket before the next request.
+        await response.body?.cancel().catch(() => {});
+        if (!location) {
+          throw new ShelfError({
+            cause: null,
+            message: `Redirect (${response.status}) without a Location header`,
+            additionalData: { url, from: target.href },
+            label,
+            shouldBeCaptured: false,
+          });
+        }
+        // Resolve relative redirects against the current URL, then re-validate.
+        target = assertSafeUrl(new URL(location, target).href);
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new ShelfError({
+          cause: null,
+          message: `HTTP ${response.status}: ${response.statusText}`,
+          additionalData: { url, status: response.status },
+          label,
+          shouldBeCaptured: false,
+        });
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      // Read the body while the timeout is still armed, passing the same signal
+      // so a stalled/slow (trickle-fed) body is aborted too — not just an
+      // oversized one.
+      const buffer = await readBodyWithLimit(
+        response,
+        maxBytes,
+        url,
+        controller.signal
+      );
+      return { buffer, contentType };
+    }
   } finally {
     clearTimeout(timeout);
   }
-
-  if (!response.ok) {
-    throw new ShelfError({
-      cause: null,
-      message: `HTTP ${response.status}: ${response.statusText}`,
-      additionalData: { url, status: response.status },
-      label,
-      shouldBeCaptured: false,
-    });
-  }
-
-  const contentType = response.headers.get("content-type") || "";
-  const buffer = await readBodyWithLimit(response, maxBytes, url);
-
-  return { buffer, contentType };
 }
 
 /**
@@ -265,18 +344,24 @@ function findBlockedCause(err: unknown): BlockedAddressError | null {
 
 /**
  * Reads a response body incrementally, aborting as soon as the cumulative size
- * exceeds `maxBytes`. Prevents the buffer-everything-then-check memory vector.
+ * exceeds `maxBytes` or the `signal` fires. Prevents both the
+ * buffer-everything-then-check memory vector and a slow/trickle-fed body that
+ * would otherwise hold the connection open under the size cap.
  *
  * @param response - The fetch response whose body to read
  * @param maxBytes - The maximum allowed body size in bytes
  * @param url - The source URL (for error context only)
+ * @param signal - Optional abort signal (typically the request timeout); when
+ *   it fires mid-read the body read is cancelled and an error is thrown
  * @returns The full body as a Buffer (guaranteed `<= maxBytes`)
- * @throws {ShelfError} If the body exceeds `maxBytes` or cannot be read
+ * @throws {ShelfError} If the body exceeds `maxBytes`, the read is aborted, or
+ *   the body cannot be read
  */
 export async function readBodyWithLimit(
   response: Response,
   maxBytes: number,
-  url: string
+  url: string,
+  signal?: AbortSignal
 ): Promise<Buffer> {
   if (!response.body) {
     throw new ShelfError({
@@ -292,15 +377,32 @@ export async function readBodyWithLimit(
   const chunks: Uint8Array[] = [];
   let total = 0;
 
+  /** Cancels the reader and throws a uniform abort error. */
+  const abort = async (): Promise<never> => {
+    await reader.cancel().catch(() => {});
+    throw new ShelfError({
+      cause: null,
+      message: "Timed out while reading the response body",
+      additionalData: { url },
+      label,
+      shouldBeCaptured: false,
+    });
+  };
+
   try {
     for (;;) {
+      if (signal?.aborted) return await abort();
+
       const { done, value } = await reader.read();
       if (done) break;
       if (!value) continue;
 
+      // The signal may have fired while awaiting this chunk.
+      if (signal?.aborted) return await abort();
+
       total += value.byteLength;
       if (total > maxBytes) {
-        await reader.cancel();
+        await reader.cancel().catch(() => {});
         throw new ShelfError({
           cause: null,
           message: `Response exceeds maximum allowed size of ${

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -26,6 +26,8 @@ import {
   type CachedImage,
 } from "./import.image-cache.server";
 import { Logger } from "./logger";
+import { BlockedAddressError, safeFetch } from "./ssrf.server";
+import type { SafeFetchResult } from "./ssrf.server";
 
 const label: ErrorLabel = "File storage";
 
@@ -623,54 +625,33 @@ export async function uploadImageFromUrl(
       }
     }
 
-    // If not in cache, download the image with retry logic
-    let response: Response | null = null;
-    let fetchError: Error | null = null;
+    // If not in cache, download the image with retry logic.
+    // `safeFetch` enforces SSRF protection (blocks private/reserved/metadata
+    // addresses on every redirect hop) and a streaming size cap, so the raw
+    // destination URL can come straight from untrusted CSV input. See
+    // GHSA-xgrm-8w6v-mvjg and `./ssrf.server.ts`.
+    let fetchResult: SafeFetchResult | null = null;
 
     // Try to fetch the image up to 2 times
     for (let attempt = 1; attempt <= 2; attempt++) {
       try {
-        response = await fetch(imageUrl);
-
-        if (response.ok) {
-          fetchError = null;
-          break; // Success, exit retry loop
-        } else {
-          fetchError = new Error(
-            `HTTP ${response.status}: ${response.statusText}`
-          );
-          if (attempt === 2) {
-            // Last attempt failed, log and return null
-            Logger.error(
-              new ShelfError({
-                cause: fetchError,
-                message: "Failed to fetch image from URL after 2 attempts",
-                additionalData: {
-                  imageUrl,
-                  status: response.status,
-                  attempts: 2,
-                },
-                label,
-                shouldBeCaptured: false,
-              })
-            );
-            return null;
-          }
-          // Wait a moment before retrying
-          await delay(1000);
-        }
+        fetchResult = await safeFetch(imageUrl, {
+          maxBytes: ASSET_MAX_IMAGE_UPLOAD_SIZE,
+        });
+        break; // Success, exit retry loop
       } catch (cause) {
-        fetchError = cause as Error;
-        if (attempt === 2) {
-          // Last attempt failed, log and return null
+        // A blocked address is deterministic — retrying would just be blocked
+        // again, so bail out immediately rather than waiting and re-fetching.
+        const isBlocked = cause instanceof BlockedAddressError;
+
+        if (isBlocked || attempt === 2) {
           Logger.error(
             new ShelfError({
-              cause: fetchError,
-              message: "Failed to fetch image from URL after 2 attempts",
-              additionalData: {
-                imageUrl,
-                attempts: 2,
-              },
+              cause,
+              message: isBlocked
+                ? "Refused to fetch image from a private or reserved address"
+                : "Failed to fetch image from URL after 2 attempts",
+              additionalData: { imageUrl, attempts: attempt },
               label,
               shouldBeCaptured: false,
             })
@@ -683,7 +664,7 @@ export async function uploadImageFromUrl(
     }
 
     // This should not happen due to the early returns above, but TypeScript needs the check
-    if (!response) {
+    if (!fetchResult) {
       Logger.error(
         new ShelfError({
           cause: null,
@@ -696,11 +677,10 @@ export async function uploadImageFromUrl(
       return null;
     }
 
-    actualContentType = response.headers.get("content-type") || contentType;
+    actualContentType = fetchResult.contentType || contentType;
 
-    // Get the response as a buffer to validate the actual content
-    const imageBlob = await response.blob();
-    buffer = Buffer.from(await imageBlob.arrayBuffer());
+    // The body was already read (and size-capped) by `safeFetch`.
+    buffer = fetchResult.buffer;
 
     // For URLs that don't return proper image content-type headers (like Sortly),
     // detect the image format from the actual file content using magic bytes
@@ -719,18 +699,6 @@ export async function uploadImageFromUrl(
     // Use detected format if HTTP header doesn't provide proper image content-type
     if (detectedImageType && !actualContentType?.startsWith("image/")) {
       actualContentType = detectedImageType;
-    }
-
-    if (imageBlob.size > ASSET_MAX_IMAGE_UPLOAD_SIZE) {
-      throw new ShelfError({
-        cause: null,
-        message: `Image file size exceeds maximum allowed size of ${
-          ASSET_MAX_IMAGE_UPLOAD_SIZE / (1024 * 1024)
-        }MB`,
-        additionalData: { imageUrl, size: imageBlob.size },
-        label,
-        shouldBeCaptured: false,
-      });
     }
 
     const file = await cropImage(

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -83,6 +83,7 @@
     "iconv-lite": "^0.7.2",
     "input-otp": "^1.4.2",
     "intl-parse-accept-language": "^1.0.0",
+    "ipaddr.js": "^1.9.1",
     "isbot": "^5.1.37",
     "jotai": "^2.19.1",
     "js-cookie": "^3.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       intl-parse-accept-language:
         specifier: ^1.0.0
         version: 1.0.0
+      ipaddr.js:
+        specifier: ^1.9.1
+        version: 1.9.1
       isbot:
         specifier: ^5.1.37
         version: 5.1.39
@@ -1761,6 +1764,7 @@ packages:
 
   '@evilmartians/lefthook@2.1.6':
     resolution: {integrity: sha512-ysZbzryf74wlISmgm0PH/n1lJ0HD7AHmI6DoJgWO9qzIETQknhGdmKbkOi0MjLYtiOHWQl8Dr2qwg0ksDpNZjA==}
+    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -10091,7 +10095,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   uuid@7.0.3:


### PR DESCRIPTION
## Summary

Fixes the SSRF reported in **GHSA-xgrm-8w6v-mvjg** (CWE-918, CVSS 7.1 High).

Authenticated users with `asset:import` could make the server issue HTTP
requests to arbitrary destinations via the Asset CSV import `imageUrl` field.
`isValidImageUrl` only string-matched the URL (extension / keyword / substring
host match) — all trivially bypassable — after which `uploadImageFromUrl` ran an
unrestricted `fetch()` that followed redirects and buffered the entire body
before the size check. This allowed reaching cloud metadata endpoints,
`localhost`, and RFC1918 hosts, plus a memory-exhaustion vector.

## What changed

- **New `app/utils/ssrf.server.ts` — `safeFetch`**, the network-layer boundary:
  - Routes `fetch` through an undici `Agent` whose `connect.lookup` validates
    the **resolved IP at connect time**, so the IP we validate is the IP we
    connect to (closes DNS-rebinding) and **every redirect hop is re-validated**.
  - IP classification is delegated to **`ipaddr.js`** (already in-tree via
    `proxy-addr`) with a strict **default-deny** policy: only globally-routable
    `unicast` is allowed; loopback / RFC1918 / CGNAT / link-local (incl. the
    cloud metadata endpoint) / unique-local / multicast / reserved / broadcast /
    6to4 / Teredo / NAT64 are blocked. IPv4-mapped IPv6 is unwrapped first.
  - Body is read incrementally and aborted past the size cap, with a request
    timeout — fixing the buffer-before-check memory vector.
- `uploadImageFromUrl` now calls `safeFetch` instead of raw `fetch()`.
- `isValidImageUrl` kept only as a UX pre-filter, documented as **not** a
  security boundary.
- Deleted the unused `getImageAsBase64` raw-`fetch` helper.

## Why a library for the IP ranges

`isPrivateOrReservedIp` delegates to `ipaddr.js` rather than hand-rolled octet
math — IP-range classification is bug-prone (an early hand-rolled pass already
over-blocked reserved `/16`s), and in security code a classification miss is a
bypass. `ipaddr.js` is the most widely-used IP primitive in the ecosystem and
was already a transitive dependency.

## Tests

`app/utils/ssrf.server.test.ts` — 53 tests: full private/reserved/link-local/
mapped/transition-range coverage for the classifier, the guarded-lookup
refusals (offline via IP literals), `safeFetch` protocol/URL rejection, and the
streaming size cap.

Full suite green: **170 files / 2220 tests**, typecheck + lint + prettier clean.

## Notes

- New direct dependency: `ipaddr.js@^1.9.1` (promoted from transitive; zero
  runtime deps, bundled types).
- This is a defensive change; behaviour for legitimate public image URLs is
  unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger outbound request safety: protocol checks, redirect validation, IP/address blocking, timeouts, and per-request byte limits.
  * Image upload now uses guarded fetching with enforced size caps and clearer failure reporting for blocked destinations.

* **Tests**
  * Added comprehensive tests covering IP validation, guarded DNS/lookup behavior, URL validation, fetch rejection scenarios, and streaming limits.

* **Chores**
  * Added ipaddr.js dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->