### PR TITLE
chore(companion): bump version to 1.0.1

### DIFF
--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shelf",
     "slug": "shelf-companion",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "shelf",

--- a/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
+++ b/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/companion/ios/Shelf/Info.plist
+++ b/apps/companion/ios/Shelf/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
Bumps the companion marketing version 1.0.0 → 1.0.1 for the next App Store release.

The 1.0.0 train is closed (build 13 is released), so App Store Connect rejects new 1.0.0 builds (ITMS-90062 / 90186). This release carries the audit scan-durability fix (#2586), audits redesign (#2583) and env→EAS cleanup (#2588).

Bumped in all three sources (the committed native `ios/` dir overrides app.json, so all must change):
- `app.json` → `expo.version`
- `ios/Shelf/Info.plist` → `CFBundleShortVersionString`
- `ios/Shelf.xcodeproj/project.pbxproj` → `MARKETING_VERSION` (×2)

Build number is handled by EAS remote autoIncrement.

> Do not merge — leaving to the team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped app version to 1.0.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->