### PR TITLE
fix(webapp): prevent P2028 timeouts on bulk asset/booking operations

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -800,6 +800,34 @@ describe("bulkAssignAssetTags", () => {
       })
     ).rejects.toThrow(ShelfError);
   });
+
+  // Regression: the per-asset `update` loop runs inside the interactive tx, so
+  // large selections must not abort with P2028 (Sentry SHELF-WEBAPP-1MH).
+  it("raises the interactive transaction timeout to 15s", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.tag.findMany.mockResolvedValue([{ id: "tag-new" }]);
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([{ id: "asset-1", tags: [] }]);
+    (db.asset.update as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      id: "asset-1",
+      tags: [{ id: "tag-new", name: "New" }],
+    });
+
+    await bulkAssignAssetTags({
+      userId: "user-1",
+      assetIds: ["asset-1"],
+      organizationId: "org-1",
+      tagsIds: ["tag-new"],
+      remove: false,
+      // @ts-expect-error settings not relevant for this test
+      settings: {},
+    });
+
+    expect(db.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 15000,
+    });
+  });
 });
 
 describe("bulkDeleteAssets", () => {
@@ -857,6 +885,26 @@ describe("bulkDeleteAssets", () => {
     });
 
     expect(recordEvents).not.toHaveBeenCalled();
+  });
+
+  // Regression: a bulk delete cascades across every asset relation, so large
+  // selections must not abort with P2028 (Sentry SHELF-WEBAPP-1MJ).
+  it("raises the interactive transaction timeout to 15s", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.asset.findMany.mockResolvedValue([{ id: "asset-1", mainImage: null }]);
+
+    await bulkDeleteAssets({
+      assetIds: ["asset-1"],
+      organizationId: "org-1",
+      userId: "user-1",
+      // @ts-expect-error settings not relevant
+      settings: {},
+    });
+
+    expect(db.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 15000,
+    });
   });
 });
 

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3918,29 +3918,37 @@ export async function bulkDeleteAssets({
     });
 
     try {
-      await db.$transaction(async (tx) => {
-        // Activity events — one ASSET_DELETED per asset, emitted before the
-        // delete so the rows still exist for any cross-ref checks. Mirrors
-        // singular `deleteAsset`.
-        if (assets.length > 0) {
-          await recordEvents(
-            assets.map((asset) => ({
-              organizationId,
-              actorUserId: userId,
-              action: "ASSET_DELETED" as const,
-              entityType: "ASSET" as const,
-              entityId: asset.id,
-              assetId: asset.id,
-            })),
-            tx
-          );
-        }
+      // Defense-in-depth: a bulk delete cascades across every asset relation
+      // (notes, custody, codes, custom-field values, booking joins …), so a
+      // large selection can creep past Prisma's 5s interactive-tx default and
+      // abort with P2028 (Sentry SHELF-WEBAPP-1MJ). Bump the ceiling to 15s,
+      // matching the booking-checkout precedent.
+      await db.$transaction(
+        async (tx) => {
+          // Activity events — one ASSET_DELETED per asset, emitted before the
+          // delete so the rows still exist for any cross-ref checks. Mirrors
+          // singular `deleteAsset`.
+          if (assets.length > 0) {
+            await recordEvents(
+              assets.map((asset) => ({
+                organizationId,
+                actorUserId: userId,
+                action: "ASSET_DELETED" as const,
+                entityType: "ASSET" as const,
+                entityId: asset.id,
+                assetId: asset.id,
+              })),
+              tx
+            );
+          }
 
-        await tx.asset.deleteMany({
-          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: `assets` was fetched on lines 3659-3665 with where { id in resolvedIds, organizationId }; every id here is already org-proven
-          where: { id: { in: assets.map((asset) => asset.id) } },
-        });
-      });
+          await tx.asset.deleteMany({
+            // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: `assets` was fetched on lines 3659-3665 with where { id in resolvedIds, organizationId }; every id here is already org-proven
+            where: { id: { in: assets.map((asset) => asset.id) } },
+          });
+        },
+        { timeout: 15000 }
+      );
 
       /** Deleting images of the assets (if any) */
       const assetsWithImages = assets.filter((asset) => !!asset.mainImage);
@@ -4791,55 +4799,62 @@ export async function bulkAssignAssetTags({
         }, new Map())
       );
 
-    const updatedAssets = await db.$transaction(async (tx) => {
-      const results = await Promise.all(
-        resolvedIds.map((id) =>
-          tx.asset.update({
-            where: { id, organizationId },
-            data: {
-              tags: {
-                [remove ? "disconnect" : "connect"]: tagsIds.map((tagId) => ({
-                  id: tagId,
-                })),
+    // Defense-in-depth: this issues one `asset.update` per selected asset
+    // inside the interactive tx (needed to diff each asset's tag set), so a
+    // large selection serially exhausts Prisma's 5s default and aborts with
+    // P2028 (Sentry SHELF-WEBAPP-1MH). Bump the ceiling to 15s.
+    const updatedAssets = await db.$transaction(
+      async (tx) => {
+        const results = await Promise.all(
+          resolvedIds.map((id) =>
+            tx.asset.update({
+              where: { id, organizationId },
+              data: {
+                tags: {
+                  [remove ? "disconnect" : "connect"]: tagsIds.map((tagId) => ({
+                    id: tagId,
+                  })),
+                },
               },
-            },
-            include: {
-              tags: { select: { id: true, name: true } },
-            },
-          })
-        )
-      );
+              include: {
+                tags: { select: { id: true, name: true } },
+              },
+            })
+          )
+        );
 
-      // Activity events — one ASSET_TAGS_CHANGED per asset whose tag set
-      // actually changed. Same shape as the singular `updateAsset` flow.
-      const tagChangeEvents: Parameters<typeof recordEvents>[0] = [];
-      for (const asset of results) {
-        const previousTags = previousTagsByAssetId.get(asset.id) ?? [];
-        const previousTagIds = new Set(previousTags.map((t) => t.id));
-        const currentTagIds = new Set(asset.tags.map((t) => t.id));
-        const setsDiffer =
-          previousTagIds.size !== currentTagIds.size ||
-          [...previousTagIds].some((t) => !currentTagIds.has(t));
-        if (setsDiffer) {
-          tagChangeEvents.push({
-            organizationId,
-            actorUserId: userId,
-            action: "ASSET_TAGS_CHANGED",
-            entityType: "ASSET",
-            entityId: asset.id,
-            assetId: asset.id,
-            field: "tags",
-            fromValue: [...previousTagIds],
-            toValue: [...currentTagIds],
-          });
+        // Activity events — one ASSET_TAGS_CHANGED per asset whose tag set
+        // actually changed. Same shape as the singular `updateAsset` flow.
+        const tagChangeEvents: Parameters<typeof recordEvents>[0] = [];
+        for (const asset of results) {
+          const previousTags = previousTagsByAssetId.get(asset.id) ?? [];
+          const previousTagIds = new Set(previousTags.map((t) => t.id));
+          const currentTagIds = new Set(asset.tags.map((t) => t.id));
+          const setsDiffer =
+            previousTagIds.size !== currentTagIds.size ||
+            [...previousTagIds].some((t) => !currentTagIds.has(t));
+          if (setsDiffer) {
+            tagChangeEvents.push({
+              organizationId,
+              actorUserId: userId,
+              action: "ASSET_TAGS_CHANGED",
+              entityType: "ASSET",
+              entityId: asset.id,
+              assetId: asset.id,
+              field: "tags",
+              fromValue: [...previousTagIds],
+              toValue: [...currentTagIds],
+            });
+          }
         }
-      }
-      if (tagChangeEvents.length > 0) {
-        await recordEvents(tagChangeEvents, tx);
-      }
+        if (tagChangeEvents.length > 0) {
+          await recordEvents(tagChangeEvents, tx);
+        }
 
-      return results;
-    });
+        return results;
+      },
+      { timeout: 15000 }
+    );
 
     await Promise.all(
       updatedAssets.map((asset) =>

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -3380,8 +3380,8 @@ describe("bulkArchiveBookings", () => {
   // sequential note writes and aborted the commit with P2028 on large
   // selections. Notes are written via the global db (never `tx`), so they were
   // never atomic — they must run AFTER a plain `updateMany`, with no tx.
-  it("archives via a plain updateMany (no interactive tx) and writes one status note per booking", async () => {
-    expect.assertions(3);
+  it("archives via a plain updateMany (no interactive tx) and persists a status note for each booking", async () => {
+    expect.assertions(4);
     //@ts-expect-error mock setup
     db.booking.findMany.mockResolvedValue([
       {
@@ -3409,7 +3409,17 @@ describe("bulkArchiveBookings", () => {
     });
     // The fix removed the interactive transaction entirely for this path.
     expect(db.$transaction).not.toHaveBeenCalled();
-    expect(createSystemBookingNote).toHaveBeenCalledTimes(2);
+
+    // Observable outcome: each archived booking gets its own status note in the
+    // caller's org. `createSystemBookingNote` is the persistence boundary the
+    // suite stubs for booking notes (it forwards to db.bookingNote.create), so
+    // we assert per-booking payload here rather than just a call count.
+    expect(createSystemBookingNote).toHaveBeenCalledWith(
+      expect.objectContaining({ bookingId: "b1", organizationId: "org-1" })
+    );
+    expect(createSystemBookingNote).toHaveBeenCalledWith(
+      expect.objectContaining({ bookingId: "b2", organizationId: "org-1" })
+    );
   });
 
   it("throws if any selected booking is not COMPLETE", async () => {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@prisma/client";
 
 import { db } from "~/database/db.server";
+import { createSystemBookingNote } from "~/modules/booking-note/service.server";
 import * as noteService from "~/modules/note/service.server";
 import { ShelfError } from "~/utils/error";
 import { wrapBookingStatusForNote } from "~/utils/markdoc-wrappers";
@@ -33,6 +34,7 @@ import {
   extendBooking,
   removeAssets,
   getOngoingBookingForAsset,
+  bulkArchiveBookings,
   // Test helper functions
   getActionTextFromTransition,
   getSystemActionText,
@@ -80,6 +82,7 @@ vitest.mock("~/database/db.server", () => ({
       findFirst: vitest.fn().mockResolvedValue(null),
       findMany: vitest.fn().mockResolvedValue([]),
       delete: vitest.fn().mockResolvedValue({}),
+      updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
       count: vitest.fn().mockResolvedValue(0),
     },
     asset: {
@@ -3364,5 +3367,65 @@ describe("getOngoingBookingForAsset", () => {
       },
     });
     expect(result).toEqual(checkedOutBooking);
+  });
+});
+
+describe("bulkArchiveBookings", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  // Regression for Sentry SHELF-WEBAPP-1KQ: the per-booking status notes used
+  // to run inside an interactive transaction, which held the tx open across N
+  // sequential note writes and aborted the commit with P2028 on large
+  // selections. Notes are written via the global db (never `tx`), so they were
+  // never atomic — they must run AFTER a plain `updateMany`, with no tx.
+  it("archives via a plain updateMany (no interactive tx) and writes one status note per booking", async () => {
+    expect.assertions(3);
+    //@ts-expect-error mock setup
+    db.booking.findMany.mockResolvedValue([
+      {
+        id: "b1",
+        status: BookingStatus.COMPLETE,
+        custodianUserId: "u1",
+        activeSchedulerReference: null,
+      },
+      {
+        id: "b2",
+        status: BookingStatus.COMPLETE,
+        custodianUserId: null,
+        activeSchedulerReference: null,
+      },
+    ]);
+
+    await bulkArchiveBookings({
+      bookingIds: ["b1", "b2"],
+      organizationId: "org-1",
+    });
+
+    expect(db.booking.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["b1", "b2"] }, organizationId: "org-1" },
+      data: { status: BookingStatus.ARCHIVED },
+    });
+    // The fix removed the interactive transaction entirely for this path.
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(createSystemBookingNote).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws if any selected booking is not COMPLETE", async () => {
+    expect.assertions(1);
+    //@ts-expect-error mock setup
+    db.booking.findMany.mockResolvedValue([
+      {
+        id: "b1",
+        status: BookingStatus.ONGOING,
+        custodianUserId: null,
+        activeSchedulerReference: null,
+      },
+    ]);
+
+    await expect(
+      bulkArchiveBookings({ bookingIds: ["b1"], organizationId: "org-1" })
+    ).rejects.toThrow(ShelfError);
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -4547,24 +4547,30 @@ export async function bulkArchiveBookings({
       });
     }
 
-    await db.$transaction(async (tx) => {
-      /** Updating status of bookings to ARCHIVED  */
-      await tx.booking.updateMany({
-        where: { id: { in: bookings.map((b) => b.id) }, organizationId },
-        data: { status: BookingStatus.ARCHIVED },
-      });
-
-      /** Create booking status transition notes for each booking */
-      for (const booking of bookings) {
-        await createStatusTransitionNote({
-          bookingId: booking.id,
-          organizationId,
-          fromStatus: booking.status,
-          toStatus: BookingStatus.ARCHIVED,
-          custodianUserId: booking.custodianUserId || undefined,
-        });
-      }
+    /** Update all selected bookings to ARCHIVED. This is a single statement —
+     * atomic on its own — so it needs no interactive transaction. */
+    await db.booking.updateMany({
+      where: { id: { in: bookings.map((b) => b.id) }, organizationId },
+      data: { status: BookingStatus.ARCHIVED },
     });
+
+    /** Create booking status transition notes for each booking.
+     *
+     * Done AFTER the status update, NOT inside an interactive transaction:
+     * `createStatusTransitionNote` writes via the global `db` (not a passed
+     * `tx`), so the previous `$transaction` never made these notes atomic with
+     * the status change. It only held the interactive-tx connection open across
+     * N sequential note writes, which on large selections blew past Prisma's
+     * 5s default and aborted the commit with P2028 (Sentry SHELF-WEBAPP-1KQ). */
+    for (const booking of bookings) {
+      await createStatusTransitionNote({
+        bookingId: booking.id,
+        organizationId,
+        fromStatus: booking.status,
+        toStatus: BookingStatus.ARCHIVED,
+        custodianUserId: booking.custodianUserId || undefined,
+      });
+    }
 
     /** Cancel any active schedulers */
     await Promise.all(bookings.map((b) => cancelScheduler(b)));


### PR DESCRIPTION
Three bulk mutations aborted with Prisma P2028 ("transaction already closed") when run over large selections, because the work inside the 5s interactive-transaction default exceeded the ceiling:

- bulkDeleteAssets: a bulk delete cascades across every asset relation (notes, custody, codes, custom-field values, booking joins). Raise the interactive-tx timeout to 15s, matching the existing booking-checkout precedent.
- bulkAssignAssetTags: issues one asset.update per selected asset inside the tx to diff each asset's tag set. Raise the interactive-tx timeout to 15s.
- bulkArchiveBookings: per-booking status notes ran in a for-loop inside the tx, holding the connection open across N sequential writes. Those notes are written via the global db (never the passed tx), so the transaction bought no atomicity. Move them after a plain updateMany and drop the transaction entirely.

Adds server-side regression tests asserting the raised timeouts and the no-transaction archive path.

Fixes SHELF-WEBAPP-1MJ
Fixes SHELF-WEBAPP-1MH
Fixes SHELF-WEBAPP-1KQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented timeouts during large bulk asset deletion and tag-assignment operations by increasing transaction timeout handling.
  * Made bulk booking archiving more reliable by changing how status updates and follow-up notes are applied to avoid long interactive transactions.

* **Tests**
  * Added regression tests covering bulk asset operations and bulk booking archive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->