### PR TITLE
fix(webapp): eliminate N+1 when saving asset custom-field values

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -537,7 +537,9 @@ describe("updateAsset custom-field writes", () => {
   // Regression for Sentry SHELF-WEBAPP-1KY / SHELF-WEBAPP-1MF: persisting custom
   // field values must not use a nested `upsert`, which makes Prisma issue a
   // SELECT-then-write per field (N+1). New values become a single `create`,
-  // existing ones an `update` keyed by the value-row id we already loaded.
+  // existing ones an `updateMany` keyed by the value-row id we already loaded
+  // (`updateMany` so a concurrently-deleted row matches zero rows instead of
+  // throwing P2025 and aborting the whole save).
   it("creates new custom-field values and updates existing ones without a nested upsert", async () => {
     expect.assertions(4);
 
@@ -579,8 +581,9 @@ describe("updateAsset custom-field writes", () => {
     expect(customFields.create).toEqual([
       { value: { raw: "fresh" }, customFieldId: "cf-new" },
     ]);
-    // Existing value → update keyed by the value-row id we already loaded.
-    expect(customFields.update).toEqual([
+    // Existing value → updateMany (no-throw on a concurrently-deleted row),
+    // keyed by the value-row id we already loaded.
+    expect(customFields.updateMany).toEqual([
       { where: { id: "val-1" }, data: { value: { raw: "updated" } } },
     ]);
     // Existence info is read in a single query, not once per field.

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -52,6 +52,17 @@ vitest.mock("~/database/db.server", () => ({
     teamMember: {
       findFirst: vitest.fn().mockResolvedValue(null),
     },
+    assetCustomFieldValue: {
+      findMany: vitest.fn().mockResolvedValue([]),
+    },
+    customField: {
+      findMany: vitest.fn().mockResolvedValue([]),
+    },
+    user: {
+      findFirst: vitest
+        .fn()
+        .mockResolvedValue({ firstName: "John", lastName: "Doe" }),
+    },
   },
 }));
 
@@ -509,6 +520,71 @@ describe("updateAsset cross-org guards", () => {
       where: { id: "location-from-org-B", organizationId: "org-A" },
       select: { id: true },
     });
+  });
+});
+
+describe("updateAsset custom-field writes", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    (db.asset.update as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      id: "asset-1",
+      title: "Asset 1",
+      category: null,
+      valuation: null,
+    });
+  });
+
+  // Regression for Sentry SHELF-WEBAPP-1KY / SHELF-WEBAPP-1MF: persisting custom
+  // field values must not use a nested `upsert`, which makes Prisma issue a
+  // SELECT-then-write per field (N+1). New values become a single `create`,
+  // existing ones an `update` keyed by the value-row id we already loaded.
+  it("creates new custom-field values and updates existing ones without a nested upsert", async () => {
+    expect.assertions(4);
+
+    // One value already exists for cf-existing; cf-new has none yet.
+    (
+      db.assetCustomFieldValue.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      {
+        id: "val-1",
+        customFieldId: "cf-existing",
+        value: { raw: "old" },
+        customField: { id: "cf-existing", name: "Existing", type: "TEXT" },
+      },
+    ]);
+    (db.customField.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      [
+        { id: "cf-existing", name: "Existing", type: "TEXT" },
+        { id: "cf-new", name: "New", type: "TEXT" },
+      ]
+    );
+
+    await updateAsset({
+      id: "asset-1",
+      userId: "user-1",
+      organizationId: "org-1",
+      customFieldsValues: [
+        { id: "cf-existing", value: { raw: "updated" } },
+        { id: "cf-new", value: { raw: "fresh" } },
+      ],
+    } as any);
+
+    const updateArg = (db.asset.update as ReturnType<typeof vitest.fn>).mock
+      .calls[0][0];
+    const { customFields } = updateArg.data;
+
+    // No nested upsert — that was the N+1 source.
+    expect(customFields.upsert).toBeUndefined();
+    // New value → single create.
+    expect(customFields.create).toEqual([
+      { value: { raw: "fresh" }, customFieldId: "cf-new" },
+    ]);
+    // Existing value → update keyed by the value-row id we already loaded.
+    expect(customFields.update).toEqual([
+      { where: { id: "val-1" }, data: { value: { raw: "updated" } } },
+    ]);
+    // Existence info is read in a single query, not once per field.
+    expect(db.assetCustomFieldValue.findMany).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -1507,6 +1507,16 @@ export async function updateAsset({
         .filter(({ id }) => !existingValueIdByFieldId.has(id))
         .map(({ id, value }) => ({ value, customFieldId: id }));
 
+      /**
+       * Existing values are written with `updateMany` (one entry per row),
+       * NOT a nested `update`. `update` would throw P2025 and abort the whole
+       * asset save if a concurrent edit deleted the value row in the window
+       * between the `findMany` above and this write; `updateMany` matches zero
+       * rows instead of throwing. The concurrent delete then wins (the row
+       * stays gone) rather than 500-ing the user — an acceptable
+       * last-write-wins outcome for this rare interleaving, and it keeps the
+       * per-field existence SELECT eliminated.
+       */
       const customFieldsToUpdate = customFieldValuesToAdd
         .filter(({ id }) => existingValueIdByFieldId.has(id))
         .map(({ id, value }) => ({
@@ -1520,7 +1530,7 @@ export async function updateAsset({
             ? { create: customFieldsToCreate }
             : {}),
           ...(customFieldsToUpdate.length > 0
-            ? { update: customFieldsToUpdate }
+            ? { updateMany: customFieldsToUpdate }
             : {}),
           ...(customFieldValuesToRemove.length > 0
             ? {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -1486,24 +1486,49 @@ export async function updateAsset({
         (cf) => !cf.value
       );
 
+      /**
+       * Split the writes into create vs update ourselves instead of using a
+       * nested `upsert`. Prisma emulates each nested upsert with a
+       * SELECT-then-write round-trip per field, which is the N+1 reported in
+       * Sentry SHELF-WEBAPP-1KY / SHELF-WEBAPP-1MF. We already loaded the
+       * existing values above (`currentCustomFieldsValuesWithFields`), so we
+       * know which fields exist without asking the database again. Each
+       * custom field has at most one value row per asset, so keying by
+       * `customFieldId` is unambiguous.
+       */
+      const existingValueIdByFieldId = new Map(
+        currentCustomFieldsValuesWithFields.map((ccfv) => [
+          ccfv.customFieldId,
+          ccfv.id,
+        ])
+      );
+
+      const customFieldsToCreate = customFieldValuesToAdd
+        .filter(({ id }) => !existingValueIdByFieldId.has(id))
+        .map(({ id, value }) => ({ value, customFieldId: id }));
+
+      const customFieldsToUpdate = customFieldValuesToAdd
+        .filter(({ id }) => existingValueIdByFieldId.has(id))
+        .map(({ id, value }) => ({
+          where: { id: existingValueIdByFieldId.get(id) as string },
+          data: { value },
+        }));
+
       Object.assign(data, {
         customFields: {
-          upsert: customFieldValuesToAdd?.map(({ id, value }) => ({
-            where: {
-              id:
-                currentCustomFieldsValuesWithFields.find(
-                  (ccfv) => ccfv.customFieldId === id
-                )?.id || "",
-            },
-            update: { value },
-            create: {
-              value,
-              customFieldId: id,
-            },
-          })),
-          deleteMany: customFieldValuesToRemove.map((cf) => ({
-            customFieldId: cf.id,
-          })),
+          ...(customFieldsToCreate.length > 0
+            ? { create: customFieldsToCreate }
+            : {}),
+          ...(customFieldsToUpdate.length > 0
+            ? { update: customFieldsToUpdate }
+            : {}),
+          ...(customFieldValuesToRemove.length > 0
+            ? {
+                deleteMany: customFieldValuesToRemove.map((cf) => ({
+                  customFieldId: cf.id,
+                })),
+              }
+            : {}),
         },
       });
     }


### PR DESCRIPTION
Updating an asset's custom fields wrote them via a nested Prisma `upsert`, which Prisma emulates with a SELECT-then-write round-trip per field. On assets with several custom fields this produced the N+1 reported in Sentry (one repeated SELECT on AssetCustomFieldValue per field).

The existing values are already loaded earlier in updateAsset to detect changes for notes, so we now reuse that result to split the write into a single nested `create` for new values and an `update` (keyed by the known value-row id) for existing ones. Same write semantics and atomicity as before, without the per-field existence SELECT.

Adds a regression test asserting the write uses create/update (never upsert) and reads existing values in a single query.

Fixes SHELF-WEBAPP-1KY
Fixes SHELF-WEBAPP-1MF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable asset custom-field handling: new values are created, existing values are updated, and cleared fields are removed to ensure correct persistence.

* **Tests**
  * Added regression tests covering custom-field updates (existing vs new values) and verifying the update flow and single lookup of current values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->