### PR TITLE
fix(webapp): stop capturing expected 4xx validation errors in Sentry 

### DIFF
--- a/apps/webapp/app/modules/asset-reminder/utils.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/utils.server.ts
@@ -34,7 +34,11 @@ export async function resolveRemindersActions({
     case "edit-reminder": {
       const { redirectTo, ...payload } = parseData(
         formData,
-        setReminderSchema.extend({ id: z.string() })
+        setReminderSchema.extend({ id: z.string() }),
+        // Expected user-input validation (e.g. "Please select a date in the
+        // future") — a 400, not a server error. The create path already opts
+        // out; mirror it here (was noise: SHELF-WEBAPP-1ME).
+        { shouldBeCaptured: false }
       );
 
       const hints = getHints(request);

--- a/apps/webapp/app/modules/audit/image.service.server.test.ts
+++ b/apps/webapp/app/modules/audit/image.service.server.test.ts
@@ -124,6 +124,8 @@ describe("audit image service", () => {
       vi.mocked(parseFileFormData).mockResolvedValue(new FormData());
       vi.mocked(db.auditImage.count).mockResolvedValue(3);
 
+      // Expected limit-validation (a 400) — not a server error, so it must
+      // not be captured to Sentry (was noise: SHELF-WEBAPP-1KT).
       await expect(
         uploadAuditImage({
           request: {
@@ -134,7 +136,11 @@ describe("audit image service", () => {
           organizationId: "org-1",
           uploadedById: "user-1",
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        message: "Maximum of 3 images per asset exceeded",
+        status: 400,
+        shouldBeCaptured: false,
+      });
     });
 
     it("validates limit for general audit images (5 max)", async () => {
@@ -142,6 +148,8 @@ describe("audit image service", () => {
       vi.mocked(parseFileFormData).mockResolvedValue(new FormData());
       vi.mocked(db.auditImage.count).mockResolvedValue(5);
 
+      // Expected limit-validation (a 400) — not a server error, so it must
+      // not be captured to Sentry (sibling of SHELF-WEBAPP-1KT).
       await expect(
         uploadAuditImage({
           request: {
@@ -152,7 +160,11 @@ describe("audit image service", () => {
           organizationId: "org-1",
           uploadedById: "user-1",
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({
+        message: "Maximum of 5 general images per audit exceeded",
+        status: 400,
+        shouldBeCaptured: false,
+      });
     });
   });
 

--- a/apps/webapp/app/modules/audit/image.service.server.ts
+++ b/apps/webapp/app/modules/audit/image.service.server.ts
@@ -222,6 +222,10 @@ async function validateImageLimits({
           currentCount: assetImageCount,
         },
         label,
+        status: 400,
+        // Expected limit-validation shown to the user — a 400, not a server
+        // error. Don't capture to Sentry (was noise: SHELF-WEBAPP-1KT).
+        shouldBeCaptured: false,
       });
     }
   } else {
@@ -240,6 +244,10 @@ async function validateImageLimits({
         message: `Maximum of ${MAX_GENERAL_IMAGES_PER_AUDIT} general images per audit exceeded`,
         additionalData: { auditSessionId, currentCount: generalImageCount },
         label,
+        status: 400,
+        // Expected limit-validation shown to the user — a 400, not a server
+        // error. Don't capture to Sentry (sibling of SHELF-WEBAPP-1KT).
+        shouldBeCaptured: false,
       });
     }
   }

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -1695,7 +1695,7 @@ describe("checkoutBooking", () => {
   });
 
   it("should throw error when assets have booking conflicts", async () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
     const mockBooking = {
       ...mockBookingData,
@@ -1723,6 +1723,11 @@ describe("checkoutBooking", () => {
     await expect(checkoutBooking(mockCheckoutParams)).rejects.toThrow(
       "Cannot check out booking. Some assets are already booked or checked out: Asset 1. Please remove conflicted assets and try again."
     );
+    // Expected business-rule conflict — must not be captured to Sentry
+    // (was noise: SHELF-WEBAPP-1KR; mirrors the reserve path).
+    await expect(checkoutBooking(mockCheckoutParams)).rejects.toMatchObject({
+      shouldBeCaptured: false,
+    });
   });
 
   it("should handle checkout for non-reserved booking", async () => {

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1368,7 +1368,12 @@ export async function checkoutBooking({
         throw new ShelfError({
           cause: null,
           label,
+          title: "Booking conflict",
           message: `Cannot check out booking. Some assets are already booked or checked out: ${conflictedAssetNames}${additionalText}. Please remove conflicted assets and try again.`,
+          // Expected business-rule conflict shown to the user — a 400, not a
+          // server error. Mirrors the reserve path above (was noise:
+          // SHELF-WEBAPP-1KR).
+          shouldBeCaptured: false,
         });
       }
     }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -213,6 +213,9 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           additionalData: { auditAssetId },
           label: "Audit",
           status: 400,
+          // Expected user-input validation — a 400, not a server error.
+          // Don't capture to Sentry (was noise: SHELF-WEBAPP-1KS).
+          shouldBeCaptured: false,
         });
       }
 

--- a/apps/webapp/app/routes/_layout+/bookings.new.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.new.tsx
@@ -177,6 +177,10 @@ export async function action({ context, request }: ActionFunctionArgs) {
         isAdminOrOwner,
       }),
       {
+        // Expected user-input validation (e.g. "Start date must be at least N
+        // hours from now") — a 400, not a server error. Don't capture to
+        // Sentry (was noise: SHELF-WEBAPP-1KZ).
+        shouldBeCaptured: false,
         additionalData: { userId, organizationId },
       }
     );

--- a/apps/webapp/app/routes/_welcome+/onboarding.tsx
+++ b/apps/webapp/app/routes/_welcome+/onboarding.tsx
@@ -374,7 +374,12 @@ export async function action({ context, request }: ActionFunctionArgs) {
       createdWithInvite: existingUser.createdWithInvite,
     });
 
-    const payload = parseData(formData, OnboardingFormSchema);
+    const payload = parseData(formData, OnboardingFormSchema, {
+      // Expected user-input validation (e.g. "Field is required.") — a 400,
+      // not a server error. Don't capture to Sentry (was noise:
+      // SHELF-WEBAPP-1KV).
+      shouldBeCaptured: false,
+    });
 
     const {
       jobTitle,


### PR DESCRIPTION
Six recurring Sentry "errors" were actually expected user-input/business-rule
validations (400s) that already show the user a clear message — they shouldn't
be captured. Each throw/parse now sets shouldBeCaptured:false (surgical, the
global parseData default is unchanged):

- SHELF-WEBAPP-1ME "Please select a date in the future" — reminder edit
  parseData (create path already opted out; mirrored on edit).
- SHELF-WEBAPP-1KZ "Start date must be at least N hours from now" — booking
  new parseData.
- SHELF-WEBAPP-1KV "Field is required." — onboarding parseData.
- SHELF-WEBAPP-1KR "Cannot check out booking. Some assets are already
  booked..." — checkout conflict throw (the reserve sibling already opted out;
  added a matching title too).
- SHELF-WEBAPP-1KS "Note content is required" — audit scan note throw.
- SHELF-WEBAPP-1KT "Maximum of N images per asset exceeded" — audit image
  limit throw (+ the general-images sibling); both also get status:400.

Adds/extends server tests asserting the checkout conflict and audit image-limit
errors are non-captured 400s.

Fixes SHELF-WEBAPP-1ME
Fixes SHELF-WEBAPP-1KZ
Fixes SHELF-WEBAPP-1KV
Fixes SHELF-WEBAPP-1KR
Fixes SHELF-WEBAPP-1KS
Fixes SHELF-WEBAPP-1KT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error tracking and reporting consistency across the application by refining how validation errors are handled internally, ensuring expected user-input validation failures are properly categorized in error monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->