### PR TITLE
fix(webapp): org-scope custom-field IDs on asset create/update (IDOR)

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -15,6 +15,7 @@ import {
   bulkDeleteAssets,
   bulkReleaseCustody,
   bulkUpdateAssetCategory,
+  createAsset,
   getActiveCustomFieldsForAsset,
   parseAssetValuation,
   refreshExpiredAssetImages,
@@ -153,6 +154,12 @@ vitest.mock("~/modules/note/service.server", () => ({
 // why: control custom-field lookup so we can assert org+category scoping
 vitest.mock("~/modules/custom-field/service.server", () => ({
   getActiveCustomFields: vitest.fn(),
+}));
+
+// why: createAsset generates a sequential id via a DB-backed counter; stub it
+// so the create-path test reaches the org-scope guard without DB plumbing.
+vitest.mock("./sequential-id.server", () => ({
+  getNextSequentialId: vitest.fn().mockResolvedValue("TST-0001"),
 }));
 
 describe("relinkAssetQrCode (asset)", () => {
@@ -536,6 +543,35 @@ describe("updateAsset cross-org guards", () => {
     await expect(
       updateAsset({
         id: "asset-1",
+        userId: "user-1",
+        organizationId: "org-A",
+        customFieldsValues: [{ id: "cf-from-org-B", value: { raw: "x" } }],
+      } as any)
+    ).rejects.toThrow(ShelfError);
+
+    expect(db.customField.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["cf-from-org-B"] }, organizationId: "org-A" },
+      select: { id: true },
+    });
+  });
+});
+
+describe("createAsset cross-org guards", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("rejects a customFieldId from a different organization", async () => {
+    expect.assertions(2);
+    // Foreign-org custom field → org-scoped lookup returns nothing → the guard
+    // (run inside the create transaction) rejects before the asset is written.
+    (db.customField.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      []
+    );
+
+    await expect(
+      createAsset({
+        title: "New asset",
         userId: "user-1",
         organizationId: "org-A",
         customFieldsValues: [{ id: "cf-from-org-B", value: { raw: "x" } }],

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -521,6 +521,32 @@ describe("updateAsset cross-org guards", () => {
       select: { id: true },
     });
   });
+
+  it("rejects a customFieldId from a different organization", async () => {
+    expect.assertions(2);
+    // No existing values for this asset; the form references a foreign-org
+    // custom field whose org-scoped lookup returns nothing → guard throws.
+    (
+      db.assetCustomFieldValue.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([]);
+    (db.customField.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      []
+    );
+
+    await expect(
+      updateAsset({
+        id: "asset-1",
+        userId: "user-1",
+        organizationId: "org-A",
+        customFieldsValues: [{ id: "cf-from-org-B", value: { raw: "x" } }],
+      } as any)
+    ).rejects.toThrow(ShelfError);
+
+    expect(db.customField.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["cf-from-org-B"] }, organizationId: "org-A" },
+      select: { id: true },
+    });
+  });
 });
 
 describe("updateAsset custom-field writes", () => {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -1161,22 +1161,24 @@ export async function createAsset({
         });
       }
 
+      /** Custom-field ids referenced by this create. Sourced from form input
+       * and validated for org ownership inside the create transaction below
+       * (cross-org IDOR guard). */
+      let customFieldIdsToValidate: string[] = [];
+
       /** If custom fields are passed, create them */
       if (customFieldsValues && customFieldsValues.length > 0) {
         const customFieldValuesToAdd = customFieldsValues.filter(
           (cf) => !!cf.value
         );
 
-        // SECURITY (cross-org IDOR): the nested `create` below connects each
-        // value to a CustomField by an id sourced from form input, with no org
-        // scoping of its own. Prove every referenced custom field belongs to
-        // this org before writing.
-        await assertCustomFieldsBelongToOrg({
-          customFieldIds: customFieldValuesToAdd
-            .map(({ id }) => id)
-            .filter(Boolean),
-          organizationId,
-        });
+        // SECURITY (cross-org IDOR): these ids get connected to a CustomField
+        // by the nested `create` below, which has no org scoping of its own.
+        // Collected here and validated inside the transaction (see the
+        // assertCustomFieldsBelongToOrg call there).
+        customFieldIdsToValidate = customFieldValuesToAdd
+          .map(({ id }) => id)
+          .filter(Boolean);
 
         Object.assign(data, {
           /** Custom fields here refers to the values, check the Schema for more info */
@@ -1231,6 +1233,15 @@ export async function createAsset({
 
       // Use transaction to ensure asset creation and activity event are atomic
       const asset = await db.$transaction(async (tx) => {
+        // SECURITY (cross-org IDOR): prove every form-supplied custom-field id
+        // belongs to this org before the nested create connects them. Run inside
+        // the tx so the ownership check shares the write's transaction (no-op
+        // when there are no custom-field ids).
+        await assertCustomFieldsBelongToOrg(
+          { customFieldIds: customFieldIdsToValidate, organizationId },
+          tx
+        );
+
         const created = await tx.asset.create({
           data,
           include: {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -104,6 +104,7 @@ import {
 import { isValidImageUrl } from "~/utils/misc";
 import { threeDaysFromNow } from "~/utils/one-week-from-now";
 import {
+  assertCustomFieldsBelongToOrg,
   assertLocationBelongsToOrg,
   assertTagsBelongToOrg,
   assertTeamMemberBelongsToOrg,
@@ -1166,6 +1167,17 @@ export async function createAsset({
           (cf) => !!cf.value
         );
 
+        // SECURITY (cross-org IDOR): the nested `create` below connects each
+        // value to a CustomField by an id sourced from form input, with no org
+        // scoping of its own. Prove every referenced custom field belongs to
+        // this org before writing.
+        await assertCustomFieldsBelongToOrg({
+          customFieldIds: customFieldValuesToAdd
+            .map(({ id }) => id)
+            .filter(Boolean),
+          organizationId,
+        });
+
         Object.assign(data, {
           /** Custom fields here refers to the values, check the Schema for more info */
           customFields: {
@@ -1485,6 +1497,18 @@ export async function updateAsset({
       const customFieldValuesToRemove = customFieldsValuesFromForm.filter(
         (cf) => !cf.value
       );
+
+      // SECURITY (cross-org IDOR): the create/updateMany writes below connect
+      // values to a CustomField by an id sourced from form input. Prove every
+      // referenced custom field belongs to this org before writing. (Removals
+      // go through `deleteMany` scoped to this asset's own value rows, so only
+      // the added/updated ids need the check.)
+      await assertCustomFieldsBelongToOrg({
+        customFieldIds: customFieldValuesToAdd
+          .map(({ id }) => id)
+          .filter(Boolean),
+        organizationId,
+      });
 
       /**
        * Split the writes into create vs update ourselves instead of using a

--- a/apps/webapp/app/utils/org-validation.server.test.ts
+++ b/apps/webapp/app/utils/org-validation.server.test.ts
@@ -15,6 +15,7 @@
 import { ShelfError } from "./error";
 import {
   assertAssetsBelongToOrg,
+  assertCustomFieldsBelongToOrg,
   assertTagsBelongToOrg,
   assertTeamMemberBelongsToOrg,
   assertCategoryBelongsToOrg,
@@ -36,6 +37,7 @@ function txWith(overrides: Record<string, any>) {
     teamMember: { findFirst: vitest.fn().mockResolvedValue(null) },
     category: { findFirst: vitest.fn().mockResolvedValue(null) },
     location: { findFirst: vitest.fn().mockResolvedValue(null) },
+    customField: { findMany: vitest.fn().mockResolvedValue([]) },
     userOrganization: { findFirst: vitest.fn().mockResolvedValue(null) },
     ...overrides,
   } as any;
@@ -129,6 +131,77 @@ describe("assertTagsBelongToOrg", () => {
     expect(err).toBeInstanceOf(ShelfError);
     expect(err.status).toBe(400);
     expect(err.title).toBe("Invalid tags");
+  });
+});
+
+describe("assertCustomFieldsBelongToOrg", () => {
+  it("is a no-op for an empty list (no query issued)", async () => {
+    const tx = txWith({});
+    await expect(
+      assertCustomFieldsBelongToOrg(
+        { customFieldIds: [], organizationId: ORG },
+        tx
+      )
+    ).resolves.toBeUndefined();
+    expect(tx.customField.findMany).not.toHaveBeenCalled();
+  });
+
+  it("resolves and scopes the query by organizationId when all belong to the org", async () => {
+    const tx = txWith({
+      customField: {
+        findMany: vitest.fn().mockResolvedValue([{ id: "cf1" }, { id: "cf2" }]),
+      },
+    });
+
+    await expect(
+      assertCustomFieldsBelongToOrg(
+        { customFieldIds: ["cf1", "cf2"], organizationId: ORG },
+        tx
+      )
+    ).resolves.toBeUndefined();
+
+    expect(tx.customField.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["cf1", "cf2"] }, organizationId: ORG },
+      select: { id: true },
+    });
+  });
+
+  it("dedupes input so duplicate IDs don't inflate the expected count", async () => {
+    const tx = txWith({
+      customField: {
+        findMany: vitest.fn().mockResolvedValue([{ id: "cf1" }]),
+      },
+    });
+
+    await expect(
+      assertCustomFieldsBelongToOrg(
+        { customFieldIds: ["cf1", "cf1"], organizationId: ORG },
+        tx
+      )
+    ).resolves.toBeUndefined();
+
+    expect(tx.customField.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["cf1"] }, organizationId: ORG },
+      select: { id: true },
+    });
+  });
+
+  it("rejects with a 400 ShelfError when a custom field is foreign/missing", async () => {
+    // cf2 belongs to another org → org-scoped findMany returns only cf1
+    const tx = txWith({
+      customField: {
+        findMany: vitest.fn().mockResolvedValue([{ id: "cf1" }]),
+      },
+    });
+
+    const err = await assertCustomFieldsBelongToOrg(
+      { customFieldIds: ["cf1", "cf2"], organizationId: ORG },
+      tx
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ShelfError);
+    expect(err.status).toBe(400);
+    expect(err.title).toBe("Invalid custom fields");
   });
 });
 

--- a/apps/webapp/app/utils/org-validation.server.test.ts
+++ b/apps/webapp/app/utils/org-validation.server.test.ts
@@ -147,6 +147,8 @@ describe("assertCustomFieldsBelongToOrg", () => {
   });
 
   it("resolves and scopes the query by organizationId when all belong to the org", async () => {
+    // why: simulate both requested custom fields existing in the caller's org
+    // so the count matches and the guard resolves.
     const tx = txWith({
       customField: {
         findMany: vitest.fn().mockResolvedValue([{ id: "cf1" }, { id: "cf2" }]),
@@ -167,6 +169,9 @@ describe("assertCustomFieldsBelongToOrg", () => {
   });
 
   it("dedupes input so duplicate IDs don't inflate the expected count", async () => {
+    // why: findMany returns unique rows; the duplicated input ["cf1","cf1"]
+    // must collapse to one expected row, otherwise the guard would falsely
+    // reject a legitimate request.
     const tx = txWith({
       customField: {
         findMany: vitest.fn().mockResolvedValue([{ id: "cf1" }]),
@@ -187,7 +192,8 @@ describe("assertCustomFieldsBelongToOrg", () => {
   });
 
   it("rejects with a 400 ShelfError when a custom field is foreign/missing", async () => {
-    // cf2 belongs to another org → org-scoped findMany returns only cf1
+    // why: cf2 belongs to another org, so the org-scoped findMany returns only
+    // cf1 — the count mismatch is what the guard must reject.
     const tx = txWith({
       customField: {
         findMany: vitest.fn().mockResolvedValue([{ id: "cf1" }]),

--- a/apps/webapp/app/utils/org-validation.server.ts
+++ b/apps/webapp/app/utils/org-validation.server.ts
@@ -70,6 +70,12 @@ export type OrgValidationTxClient = {
       select: { id: true };
     }) => Promise<{ id: string } | null>;
   };
+  customField: {
+    findMany: (args: {
+      where: { id: { in: string[] }; organizationId: string };
+      select: { id: true };
+    }) => Promise<{ id: string }[]>;
+  };
   userOrganization: {
     findFirst: (args: {
       where: { userId: string; organizationId: string };
@@ -112,6 +118,52 @@ export async function assertAssetsBelongToOrg(
       title: "Invalid assets",
       message:
         "Some of the selected assets do not exist in your workspace. Please reload and try again.",
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+      additionalData: { organizationId },
+    });
+  }
+}
+
+/**
+ * Asserts that every custom-field ID belongs to `organizationId`.
+ *
+ * Asset custom-field *values* link a value row to a `CustomField` by id. Those
+ * ids arrive from form/request input and are written via a nested Prisma
+ * `create`/`updateMany` (`createAsset`/`updateAsset`), which has no org scoping
+ * of its own — so a crafted foreign-org custom-field id would otherwise be
+ * attached to the caller's asset (cross-org IDOR). Dedupes first; no-op for an
+ * empty list.
+ *
+ * @param params.customFieldIds - Custom-field IDs sourced from request/form input
+ * @param params.organizationId - The caller's (validated) organization ID
+ * @param tx - Optional Prisma transaction client; defaults to the global `db`
+ * @throws {ShelfError} 400 if any ID is missing or belongs to another org
+ */
+export async function assertCustomFieldsBelongToOrg(
+  {
+    customFieldIds,
+    organizationId,
+  }: { customFieldIds: string[]; organizationId: string },
+  tx?: OrgValidationTxClient
+): Promise<void> {
+  if (customFieldIds.length === 0) return;
+
+  const client = tx ?? db;
+  const uniqueIds = [...new Set(customFieldIds)];
+
+  const found = await client.customField.findMany({
+    where: { id: { in: uniqueIds }, organizationId },
+    select: { id: true },
+  });
+
+  if (found.length !== uniqueIds.length) {
+    throw new ShelfError({
+      cause: null,
+      title: "Invalid custom fields",
+      message:
+        "Some of the selected custom fields do not exist in your workspace. Please reload and try again.",
       label,
       status: 400,
       shouldBeCaptured: false,


### PR DESCRIPTION
Asset custom-field values link a value row to a CustomField by an id sourced from form input, written via a nested Prisma create/updateMany that has no org scoping of its own. A crafted foreign-org custom-field id could therefore be attached to the caller's asset (cross-org IDOR) — the same class the shared org-validation guards exist to close.

Adds assertCustomFieldsBelongToOrg to ~/utils/org-validation.server (mirrors assertTagsBelongToOrg: dedupes, org-scoped findMany count-compare, 400 on mismatch) and calls it before the custom-field writes in both createAsset and updateAsset. Web and mobile asset routes both go through these service functions; the import/duplicate paths resolve ids from org-owned sources and the remaining customFields usages are reads, so they're unaffected.

Tests: unit tests for the new guard (empty no-op, org-scoped query, dedupe, 400 reject) and a wiring test that updateAsset rejects a foreign-org customFieldId.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side validation now prevents assigning custom field values that belong to a different organization during asset creation and updates.

* **Tests**
  * Added unit and integration tests covering validation behavior, deduplication of submitted IDs, and proper error responses for invalid cross-organization custom fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->