### PR TITLE
fix(webapp): guard empty teamMembers[0] access on user/custody pages

### DIFF
--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx
@@ -123,6 +123,23 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         });
       });
 
+    // A self-service user can only take custody for themselves. If they have
+    // no team-member profile in this workspace there is nothing to assign, so
+    // short-circuit instead of rendering a dead-end modal whose POST would then
+    // fail validation. Normally unreachable (a self-service user has their own
+    // member row), but guards the empty-teamMembers anomaly behind the
+    // SHELF-WEBAPP-1MM crash class.
+    if (role === OrganizationRoles.SELF_SERVICE && teamMembers.length === 0) {
+      sendNotification({
+        title: "Cannot take custody",
+        message:
+          "You don't have a team member profile in this workspace, so custody can't be assigned to you. Please contact your workspace admin.",
+        icon: { name: "x", variant: "error" },
+        senderId: userId,
+      });
+      return redirect(`/assets/${assetId}`);
+    }
+
     const totalTeamMembers = await db.teamMember.count({ where });
 
     return payload({

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.assign-custody.tsx
@@ -358,7 +358,7 @@ export default function Custody() {
             <DynamicSelect
               hidden={isSelfService}
               defaultValue={
-                isSelfService
+                isSelfService && teamMembers?.length > 0
                   ? JSON.stringify({
                       id: teamMembers[0].id,
                       name: resolveTeamMemberName(teamMembers[0]),

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx
@@ -146,6 +146,23 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         });
       });
 
+    // A self-service user can only take custody for themselves. If they have
+    // no team-member profile in this workspace there is nothing to assign, so
+    // short-circuit instead of rendering a dead-end modal whose POST would then
+    // fail validation. Normally unreachable (a self-service user has their own
+    // member row), but guards the empty-teamMembers anomaly behind the
+    // SHELF-WEBAPP-1MM crash class.
+    if (role === OrganizationRoles.SELF_SERVICE && teamMembers.length === 0) {
+      sendNotification({
+        title: "Cannot take custody",
+        message:
+          "You don't have a team member profile in this workspace, so custody can't be assigned to you. Please contact your workspace admin.",
+        icon: { name: "x", variant: "error" },
+        senderId: userId,
+      });
+      return redirect(`/kits/${kitId}`);
+    }
+
     const totalTeamMembers = await db.teamMember.count({ where });
 
     return payload({

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.assign-custody.tsx
@@ -362,7 +362,7 @@ export default function GiveKitCustody() {
             showSearch={!isSelfService}
             disabled={disabled || isSelfService}
             defaultValue={
-              isSelfService
+              isSelfService && teamMembers?.length > 0
                 ? JSON.stringify({
                     id: teamMembers[0].id,
                     name: resolveTeamMemberName(teamMembers[0]),

--- a/apps/webapp/app/routes/_layout+/settings.team.users.$userId.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.$userId.tsx
@@ -184,7 +184,7 @@ export default function UserPage() {
           <TeamUsersActionsDropdown
             userId={user.id}
             email={user.email}
-            teamMemberId={user.teamMembers[0].id}
+            teamMemberId={user.teamMembers?.[0]?.id}
             inviteStatus={user?.teamMembers?.[0]?.receivedInvites?.[0]?.status}
             isSSO={user.sso}
             customTrigger={(disabled) => (


### PR DESCRIPTION
The team-user detail page crashed with "Cannot read properties of undefined (reading 'id')" (Sentry SHELF-WEBAPP-1MM) because it read `user.teamMembers[0].id` without null-safety while the very next line already used optional chaining. A user with no team-member row took down the page via the error boundary.

- settings.team.users.$userId.tsx: `user.teamMembers?.[0]?.id` (teamMemberId is already an optional prop).
- kits/assets assign-custody routes: gate the self-service defaultValue on `teamMembers?.length > 0` before reading `teamMembers[0]`, matching the guard the scanner assign-custody drawer already uses.

The scanner drawer was already guarded, so it's unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented modals for custody assignment from opening for self-service users with no team members; users now see an error message and are redirected.
  * Stopped automatic preselection when no team members exist, avoiding invalid selections.
  * Fixed team-member dropdown actions to no longer error when a user has no associated team members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->