### PR TITLE
feat(analytics): server-side PostHog funnel events (signup, paid, cancel)

### DIFF
--- a/apps/webapp/app/integrations/posthog/client.server.ts
+++ b/apps/webapp/app/integrations/posthog/client.server.ts
@@ -1,0 +1,119 @@
+/**
+ * PostHog Server Analytics
+ *
+ * Thin, best-effort wrapper around `posthog-node` for emitting product funnel
+ * events (signup → paid → cancel) from the server. These feed the free→paid
+ * funnel in PostHog so we can measure self-serve conversion — the metric the
+ * marketing site can't see because conversion happens inside the app.
+ *
+ * Design rules (do not relax without discussion):
+ * - **Never throws / never blocks.** Analytics must not be able to break a
+ *   signup or a Stripe webhook. Every capture is wrapped and swallowed.
+ * - **No-op when unconfigured.** If `POSTHOG_API_KEY` is unset (local dev,
+ *   tests, self-host), nothing happens.
+ * - **No PII in properties.** Pass IDs, tiers, amounts — never raw emails.
+ *
+ * @see {@link file://./../../modules/stripe-webhook/handlers.server.ts}
+ * @see {@link file://./../../modules/user/service.server.ts}
+ */
+
+import { PostHog } from "posthog-node";
+
+import { POSTHOG_API_KEY, POSTHOG_HOST } from "~/utils/env";
+import { ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
+
+/** Lazily-initialised singleton. Stays `null` once we know there is no key. */
+let client: PostHog | null = null;
+let initialised = false;
+
+/**
+ * Returns the shared PostHog client, or `null` when `POSTHOG_API_KEY` is not
+ * configured. Initialised once and reused across requests — the server is
+ * long-running, so the library's background flushing applies.
+ *
+ * @returns The PostHog client, or `null` when analytics is disabled.
+ */
+function getPostHogClient(): PostHog | null {
+  if (initialised) {
+    return client;
+  }
+  initialised = true;
+
+  if (!POSTHOG_API_KEY) {
+    client = null;
+    return null;
+  }
+
+  client = new PostHog(POSTHOG_API_KEY, {
+    host: POSTHOG_HOST || "https://us.i.posthog.com",
+    // Low server-side volume: flush each event promptly rather than batching.
+    flushAt: 1,
+    flushInterval: 0,
+  });
+  return client;
+}
+
+/**
+ * The closed set of server-side funnel events and their property shapes.
+ * Keeping this a discriminated union type-checks every call site.
+ */
+export type ServerFunnelEvent =
+  | {
+      event: "signup_completed";
+      properties: { created_with_invite: boolean; is_sso: boolean };
+    }
+  | {
+      event: "upgrade_completed";
+      properties: {
+        tierId: string;
+        billing_cycle: string | null;
+        mrr: number | null;
+        via: "direct" | "upgrade_or_trial_conversion";
+      };
+    }
+  | {
+      event: "subscription_cancelled";
+      properties: { tierId: string };
+    };
+
+/**
+ * Emit a server-side funnel event to PostHog. Best-effort: it does not await,
+ * never throws, and is a silent no-op when PostHog is not configured — so it
+ * is always safe to call from inside signup or a webhook handler.
+ *
+ * @param args - The event name + its typed properties, plus `distinctId`
+ *   (use the Shelf user id so events stitch to one person) and optional
+ *   `groups` for org-level group analytics.
+ */
+export function captureServerEvent(
+  args: ServerFunnelEvent & {
+    distinctId: string;
+    groups?: Record<string, string>;
+  }
+): void {
+  try {
+    const posthog = getPostHogClient();
+    if (!posthog) {
+      return;
+    }
+    posthog.capture({
+      distinctId: args.distinctId,
+      event: args.event,
+      properties: args.properties,
+      groups: args.groups,
+    });
+  } catch (cause) {
+    // why: analytics is best-effort — a transport/logging failure must never
+    // surface to the caller (signup, Stripe webhook). Log and swallow.
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: "Failed to capture server analytics event",
+        additionalData: { event: args.event },
+        label: "Analytics",
+        shouldBeCaptured: false,
+      })
+    );
+  }
+}

--- a/apps/webapp/app/integrations/posthog/client.server.ts
+++ b/apps/webapp/app/integrations/posthog/client.server.ts
@@ -69,7 +69,7 @@ export type ServerFunnelEvent =
         tierId: string;
         billing_cycle: string | null;
         mrr: number | null;
-        via: "direct" | "upgrade_or_trial_conversion";
+        via: "direct" | "upgrade" | "trial_conversion";
       };
     }
   | {

--- a/apps/webapp/app/modules/stripe-webhook/handlers.server.ts
+++ b/apps/webapp/app/modules/stripe-webhook/handlers.server.ts
@@ -39,33 +39,51 @@ const OK = () => new Response(null, { status: 200 });
 
 /**
  * Builds the `upgrade_completed` PostHog properties from a Stripe subscription.
- * Normalises the recurring price to a monthly figure (`mrr`) so yearly and
- * monthly plans are comparable; returns `null` amounts when the plan price is
- * unavailable rather than guessing.
+ * Normalises the recurring price to a monthly figure (`mrr`) so monthly,
+ * yearly, weekly and daily plans are comparable; `mrr` is `null` when the plan
+ * price or interval is unavailable/unrecognised rather than guessing.
  *
  * @param subscription - The Stripe subscription from the webhook event
  * @param tierId - The resolved Shelf tier for the subscription
- * @param via - How the paid conversion happened: a direct subscribe vs an
- *   upgrade / trial-to-paid conversion
+ * @param via - How the paid conversion happened: `direct` (subscribed without a
+ *   trial), `upgrade` (moved to a higher paid tier), or `trial_conversion`
+ *   (a trial transitioned to an active paid subscription)
  * @returns Flat, PII-free property bag for the funnel event
  */
 function buildUpgradeCompletedProps(
   subscription: Stripe.Subscription,
   tierId: string | undefined,
-  via: "direct" | "upgrade_or_trial_conversion"
+  via: "direct" | "upgrade" | "trial_conversion"
 ) {
   const plan = subscription.items.data[0]?.plan;
-  const monthlyAmount =
-    typeof plan?.amount === "number"
-      ? plan.interval === "year"
-        ? Number((plan.amount / 100 / 12).toFixed(2))
-        : plan.amount / 100
-      : null;
+
+  // Normalise the recurring amount to a monthly figure. Unknown intervals fall
+  // through to null so we never report a wrong MRR for an unexpected cadence.
+  let mrr: number | null = null;
+  if (typeof plan?.amount === "number") {
+    const perPeriod = plan.amount / 100;
+    switch (plan.interval) {
+      case "month":
+        mrr = perPeriod;
+        break;
+      case "year":
+        mrr = Number((perPeriod / 12).toFixed(2));
+        break;
+      case "week":
+        mrr = Number(((perPeriod * 52) / 12).toFixed(2));
+        break;
+      case "day":
+        mrr = Number(((perPeriod * 365) / 12).toFixed(2));
+        break;
+      default:
+        mrr = null;
+    }
+  }
 
   return {
     tierId: tierId ?? "unknown",
     billing_cycle: plan?.interval ?? null,
-    mrr: monthlyAmount,
+    mrr,
     via,
   };
 }
@@ -375,6 +393,18 @@ export async function handleSubscriptionUpdated(
     user.tierId
   );
 
+  // A trial converting to paid arrives as a status transition trialing →
+  // active. The trial-creation path already set the user's paid tier, so the
+  // "higher tier" guard below is false for these — detect the transition
+  // explicitly, otherwise every trial-originated paid conversion is missed.
+  const previousStatus = (
+    event.data.previous_attributes as
+      | { status?: Stripe.Subscription.Status }
+      | undefined
+  )?.status;
+  const isTrialConversion =
+    previousStatus === "trialing" && subscription.status === "active";
+
   if (subscription.status === "active" && newSubscriptionIsHigherTier) {
     await db.user
       .update({
@@ -391,16 +421,22 @@ export async function handleSubscriptionUpdated(
           status: 500,
         });
       });
+  }
 
-    // Tier moved up to an active paid plan — an upgrade or trial→paid
-    // conversion. Best-effort funnel event; never blocks the webhook.
+  // Fire upgrade_completed for either a genuine tier upgrade or a trial→paid
+  // conversion. The DB tier (set on the first such event) prevents repeats, so
+  // renewals/no-op updates don't re-emit. Best-effort; never blocks the webhook.
+  if (
+    isTrialConversion ||
+    (subscription.status === "active" && newSubscriptionIsHigherTier)
+  ) {
     captureServerEvent({
       distinctId: user.id,
       event: "upgrade_completed",
       properties: buildUpgradeCompletedProps(
         subscription,
         tierId,
-        "upgrade_or_trial_conversion"
+        isTrialConversion ? "trial_conversion" : "upgrade"
       ),
     });
   }
@@ -468,12 +504,20 @@ export async function handleSubscriptionDeleted(
         });
       });
 
-    // A paying user dropped to free — the churn side of the funnel.
-    captureServerEvent({
-      distinctId: user.id,
-      event: "subscription_cancelled",
-      properties: { tierId: tierId ?? "unknown" },
-    });
+    // Count churn only for users who actually paid. Trial users are placed on
+    // the paid tier at trial start, so the tier guard above also passes for a
+    // mid-trial cancellation — exclude those (still inside the trial window) so
+    // trial abandonment doesn't inflate churn. Best-effort; never blocks.
+    const stillWithinTrial = subscription.trial_end
+      ? subscription.trial_end * 1000 > Date.now()
+      : false;
+    if (!stillWithinTrial) {
+      captureServerEvent({
+        distinctId: user.id,
+        event: "subscription_cancelled",
+        properties: { tierId: tierId ?? "unknown" },
+      });
+    }
 
     // Only reset branding when downgrading from Plus (tier_1) to Free
     if (user.tierId === TierId.tier_1) {

--- a/apps/webapp/app/modules/stripe-webhook/handlers.server.ts
+++ b/apps/webapp/app/modules/stripe-webhook/handlers.server.ts
@@ -8,6 +8,7 @@ import { subscriptionGrantedText } from "~/emails/stripe/subscription-granted";
 import { sendTrialEndsSoonEmail } from "~/emails/stripe/trial-ends-soon";
 import { unpaidInvoiceUserText } from "~/emails/stripe/unpaid-invoice";
 import { sendTeamTrialWelcomeEmail } from "~/emails/stripe/welcome-to-trial";
+import { captureServerEvent } from "~/integrations/posthog/client.server";
 import { scheduleTrialEndsTomorrowEmail } from "~/modules/addon-trial/scheduler.server";
 import { handleAuditAddonWebhook } from "~/modules/audit/addon.server";
 import { handleBarcodeAddonWebhook } from "~/modules/barcode/addon.server";
@@ -35,6 +36,39 @@ import {
 } from "./helpers.server";
 
 const OK = () => new Response(null, { status: 200 });
+
+/**
+ * Builds the `upgrade_completed` PostHog properties from a Stripe subscription.
+ * Normalises the recurring price to a monthly figure (`mrr`) so yearly and
+ * monthly plans are comparable; returns `null` amounts when the plan price is
+ * unavailable rather than guessing.
+ *
+ * @param subscription - The Stripe subscription from the webhook event
+ * @param tierId - The resolved Shelf tier for the subscription
+ * @param via - How the paid conversion happened: a direct subscribe vs an
+ *   upgrade / trial-to-paid conversion
+ * @returns Flat, PII-free property bag for the funnel event
+ */
+function buildUpgradeCompletedProps(
+  subscription: Stripe.Subscription,
+  tierId: string | undefined,
+  via: "direct" | "upgrade_or_trial_conversion"
+) {
+  const plan = subscription.items.data[0]?.plan;
+  const monthlyAmount =
+    typeof plan?.amount === "number"
+      ? plan.interval === "year"
+        ? Number((plan.amount / 100 / 12).toFixed(2))
+        : plan.amount / 100
+      : null;
+
+  return {
+    tierId: tierId ?? "unknown",
+    billing_cycle: plan?.interval ?? null,
+    mrr: monthlyAmount,
+    via,
+  };
+}
 
 // ─── Checkout ──────────────────────────────────────────────
 
@@ -206,6 +240,14 @@ export async function handleSubscriptionCreated(
         });
       });
 
+    // Direct paid conversion (non-trial, non-transfer): a free user just
+    // became paying. Best-effort funnel event — never blocks the webhook.
+    captureServerEvent({
+      distinctId: user.id,
+      event: "upgrade_completed",
+      properties: buildUpgradeCompletedProps(subscription, tierId, "direct"),
+    });
+
     const { emailsToNotify, customerName } = await getCustomerNotificationData({
       customerId,
       user,
@@ -349,6 +391,18 @@ export async function handleSubscriptionUpdated(
           status: 500,
         });
       });
+
+    // Tier moved up to an active paid plan — an upgrade or trial→paid
+    // conversion. Best-effort funnel event; never blocks the webhook.
+    captureServerEvent({
+      distinctId: user.id,
+      event: "upgrade_completed",
+      properties: buildUpgradeCompletedProps(
+        subscription,
+        tierId,
+        "upgrade_or_trial_conversion"
+      ),
+    });
   }
 
   return OK();
@@ -413,6 +467,13 @@ export async function handleSubscriptionDeleted(
           status: 500,
         });
       });
+
+    // A paying user dropped to free — the churn side of the funnel.
+    captureServerEvent({
+      distinctId: user.id,
+      event: "subscription_cancelled",
+      properties: { tierId: tierId ?? "unknown" },
+    });
 
     // Only reset branding when downgrading from Plus (tier_1) to Free
     if (user.tierId === TierId.tier_1) {

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -21,6 +21,7 @@ import { db } from "~/database/db.server";
 
 import { SOFT_DELETED_EMAIL_DOMAIN } from "~/emails/email.worker.server";
 import { sendEmail } from "~/emails/mail.server";
+import { captureServerEvent } from "~/integrations/posthog/client.server";
 import { getSupabaseAdmin } from "~/integrations/supabase/client";
 import {
   deleteAuthAccount,
@@ -676,7 +677,7 @@ export async function createUser(
   const shouldCreatePersonalOrg = !config.disableSignup;
 
   try {
-    return await db.$transaction(
+    const createdUser = await db.$transaction(
       async (tx) => {
         const user = await tx.user.create({
           data: {
@@ -774,6 +775,23 @@ export async function createUser(
       },
       { maxWait: 6000, timeout: 10000 }
     );
+
+    /**
+     * Best-effort funnel analytics: a brand-new account was created. Fire-and-
+     * forget — never throws and is a no-op when PostHog is unconfigured, so it
+     * cannot affect signup. `created_with_invite` / `is_sso` let the funnel
+     * isolate genuine self-serve signups downstream.
+     */
+    captureServerEvent({
+      distinctId: userId,
+      event: "signup_completed",
+      properties: {
+        created_with_invite: Boolean(createdWithInvite),
+        is_sso: Boolean(isSSO),
+      },
+    });
+
+    return createdUser;
   } catch (cause) {
     const isUniqueViolation =
       cause instanceof PrismaClientKnownRequestError && cause.code === "P2002";

--- a/apps/webapp/app/utils/env.ts
+++ b/apps/webapp/app/utils/env.ts
@@ -74,6 +74,8 @@ declare global {
       SHOW_HOW_DID_YOU_FIND_US: string;
       COLLECT_BUSINESS_INTEL: string;
       COOKIE_DOMAIN: string;
+      POSTHOG_API_KEY: string;
+      POSTHOG_HOST: string;
     }
   }
 }
@@ -212,6 +214,21 @@ export const ADMIN_EMAIL = getEnv("ADMIN_EMAIL", {
  * We need this in order to make our webhook work properly.
  */
 export const CUSTOM_INSTALL_CUSTOMERS = getEnv("CUSTOM_INSTALL_CUSTOMERS", {
+  isRequired: false,
+});
+
+/**
+ * PostHog server-side analytics (free→paid funnel events). Optional — when
+ * `POSTHOG_API_KEY` is unset the server analytics client is a no-op (see
+ * ~/integrations/posthog/client.server). `POSTHOG_HOST` defaults to PostHog
+ * US cloud in the client when empty.
+ */
+export const POSTHOG_API_KEY = getEnv("POSTHOG_API_KEY", {
+  isSecret: true,
+  isRequired: false,
+});
+export const POSTHOG_HOST = getEnv("POSTHOG_HOST", {
+  isSecret: true,
   isRequired: false,
 });
 

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -103,7 +103,8 @@ export type FailureReason = {
     | "Asset Scheduler" // Error related to the image import
     | "Audit"
     | "Activity"
-    | "Update";
+    | "Update"
+    | "Analytics";
   /**
    * The message intended for the user.
    * You can add new lines using \n which will be parsed into paragraphs in the html

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -101,6 +101,7 @@
     "pigeon-maps": "^0.22.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
+    "posthog-node": "^5.36.2",
     "prosemirror-commands": "^1.7.1",
     "prosemirror-gapcursor": "^1.4.1",
     "prosemirror-history": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,9 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      posthog-node:
+        specifier: ^5.36.2
+        version: 5.36.2
       prosemirror-commands:
         specifier: ^1.7.1
         version: 1.7.1
@@ -3108,6 +3111,12 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@posthog/core@1.30.8':
+    resolution: {integrity: sha512-rRJxn7UjPR5LWgRwicJgHWD7tu3P2IebdWjGJ1xpXkbNqpFyW+SbSDGjhunmmXXl2c59ejOICtnbrwN6njS1lw==}
+
+  '@posthog/types@1.380.1':
+    resolution: {integrity: sha512-GaeyU1vPxwZvYlSWdpxbLCRPqY2WKUZYUNjBlJHAlaAXbMmCfLgB2cvkwjidr8lhX8nyxINjjvQMiOSSfSSxcg==}
 
   '@prisma/client@6.19.3':
     resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
@@ -8758,6 +8767,15 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-node@5.36.2:
+    resolution: {integrity: sha512-k+URjhZyxR0PJ92JZkYcgyk7+2U+T8r0fnfsQFNkW4GeKcuYH6t13VLzjI+bH4YLSknUuLmDDg4CczGO9nad2Q==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   preact@10.12.1:
     resolution: {integrity: sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==}
 
@@ -13131,6 +13149,12 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@posthog/core@1.30.8':
+    dependencies:
+      '@posthog/types': 1.380.1
+
+  '@posthog/types@1.380.1': {}
 
   '@prisma/client@6.19.3(prisma@6.19.3(magicast@0.3.5)(typescript@6.0.3))(typescript@6.0.3)':
     optionalDependencies:
@@ -19874,6 +19898,10 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  posthog-node@5.36.2:
+    dependencies:
+      '@posthog/core': 1.30.8
 
   preact@10.12.1: {}
 


### PR DESCRIPTION
## What
Adds **best-effort server-side PostHog analytics** and fires the three "day-one" free→paid funnel events. This is the **app-side** half of #2600 (the marketing site only sees the anonymous top-of-funnel click; everything past signup happens here).

- **`signup_completed`** — fired from `createUser` (the new-account path), tagged `created_with_invite` / `is_sso` so genuine self-serve signups can be isolated downstream.
- **`upgrade_completed`** — fired in the Stripe webhook for **non-add-on** subscriptions:
  - `handleSubscriptionCreated` direct-paid branch → `via: "direct"`
  - `handleSubscriptionUpdated` on trial→paid (`trialing → active`) → `via: "trial_conversion"`, and on a move to a higher paid tier → `via: "upgrade"`
  - MRR normalised to monthly. **Renewals are deliberately NOT counted** (`invoice.paid` untouched) — this measures *first* conversion, not recurring billing.
- **`subscription_cancelled`** — fired on `handleSubscriptionDeleted` (non-add-on), **excluding mid-trial cancellations**.

## Safety (this touches auth + billing)
The analytics client **cannot break signup or a webhook**:
- **Never throws, never blocks** — every capture is wrapped + swallowed (logged via `ShelfError`/`Logger`).
- **No-op when `POSTHOG_API_KEY` is unset** — local dev, tests, and self-host do nothing.
- **No PII** in event properties — ids, tiers, amounts only (no raw emails).

New env (optional, secret): `POSTHOG_API_KEY`, `POSTHOG_HOST`.

## ⚠️ Two decisions for review
1. **What counts as a "paid conversion".** Defined as the *first* time a free user becomes paying (direct subscribe, trial→paid, or upgrade), **excluding renewals**. The DB tier acts as a guard so a given upgrade fires once. Adjust here if you'd prefer different semantics.
2. **`signup_completed` fires for all new accounts** (incl. invite-accept and SSO), tagged so analysis can filter to self-serve. Flag if you'd prefer to fire only for non-invite signups.

## Verification
- `pnpm --filter @shelf/webapp typecheck` → exit 0
- `eslint --fix` + `prettier` clean on all changed files
- No new unit tests (wiring into existing paths); did not run the full suite locally.

## Scope
Day-one 3 events only. Fast-follow PR adds `asset_created`, `asset_scanned`, `qr_label_generated`, `team_invite_sent`, `paywall_viewed` for the full funnel. Per the #2600 comment, the PostHog analysis should be set up as a **cohort / conversion-window funnel** (not calendar buckets).

Part of #2600.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented server-side event tracking to automatically capture user account signups, subscription creation and tier upgrades, and subscription cancellations along with associated billing information and metrics.

* **Chores**
  * Added PostHog analytics platform integration with required environment configuration variables for backend analytics operations and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->