### PR TITLE
feat(webapp): record handled 4xx as Sentry logs instead of dropping them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ INVITE_TOKEN_SECRET="secret-test-invite"
 SENTRY_ORG="sentry-org"
 SENTRY_PROJECT="sentry-project"
 SENTRY_DSN="sentry-dsn"
+# Optional. Fraction (0–1) of handled 4xx errors recorded to the Sentry Logs
+# trail. Unset/invalid defaults to 1 (keep all). Lower it only as a safety
+# valve if the 4xx log volume threatens the logs quota (e.g. 0.1 = keep 10%,
+# 0 = pause the trail). Read at startup, so a change needs a process restart.
+# SENTRY_HANDLED_4XX_SAMPLE_RATE="1"
 # CHROME_EXECUTABLE_PATH="/usr/bin/chromium"
 
 # Used for sending emails to admins for stuff like Request user delete. Optional. Defaults to support@shelf.nu

--- a/apps/webapp/app/utils/error.test.ts
+++ b/apps/webapp/app/utils/error.test.ts
@@ -1,5 +1,6 @@
 import {
   ShelfError,
+  isHandledClientError,
   isLikeShelfError,
   isPrismaTransientError,
   makeShelfError,
@@ -468,5 +469,42 @@ describe(notAllowedMethod.name, () => {
   it("produces an error that flows through makeShelfError without throwing", () => {
     const error = notAllowedMethod("POST");
     expect(() => makeShelfError(error)).not.toThrow();
+  });
+});
+
+describe(isHandledClientError.name, () => {
+  it("is true for a 4xx ShelfError", () => {
+    for (const status of [400, 401, 403, 404, 405, 409, 429, 499] as const) {
+      expect(
+        isHandledClientError(
+          new ShelfError({ cause: null, message: "x", label: "Assets", status })
+        )
+      ).toBe(true);
+    }
+  });
+
+  it("is false for a 5xx ShelfError and for the default (500) status", () => {
+    expect(
+      isHandledClientError(
+        new ShelfError({
+          cause: null,
+          message: "x",
+          label: "Assets",
+          status: 500,
+        })
+      )
+    ).toBe(false);
+    // No explicit status → ShelfError defaults to 500 → treated as a server error.
+    expect(
+      isHandledClientError(
+        new ShelfError({ cause: null, message: "x", label: "Assets" })
+      )
+    ).toBe(false);
+  });
+
+  it("is false for non-ShelfError values", () => {
+    expect(isHandledClientError(new Error("boom"))).toBe(false);
+    expect(isHandledClientError(null)).toBe(false);
+    expect(isHandledClientError({ status: 400 })).toBe(false);
   });
 });

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -213,6 +213,28 @@ export function isLikeShelfError(cause: unknown): cause is ShelfError {
 }
 
 /**
+ * A "handled client error": a `ShelfError` whose HTTP status is in the 4xx
+ * range. These are expected, user-facing outcomes (failed validation, business
+ * rule violations, not-found, forbidden) — not server faults. We deliberately
+ * keep them OUT of the Sentry error pipeline (they'd burn the small error
+ * quota and alert on non-issues) and instead record them as low-severity
+ * Sentry **logs** (separate quota) so there's still a searchable trail.
+ *
+ * Note: `ShelfError.status` defaults to 500, so anything without an explicit
+ * 4xx status is treated as a server error (captured normally).
+ *
+ * @see {@link file://./../../server/instrument.server.ts} beforeSend — drops these from errors
+ * @see {@link file://./logger.ts} Logger.handledClientError — emits the log trail
+ */
+export function isHandledClientError(cause: unknown): boolean {
+  if (!isLikeShelfError(cause)) {
+    return false;
+  }
+  const status = cause.status ?? 500;
+  return status >= 400 && status < 500;
+}
+
+/**
  * Detects whether an error (or any error in its `cause` chain) represents a
  * cancelled / aborted request. Used to suppress noise from client disconnects
  * and stream-handler aborts both in `makeShelfError` and in the Sentry

--- a/apps/webapp/app/utils/http.server.test.ts
+++ b/apps/webapp/app/utils/http.server.test.ts
@@ -245,6 +245,38 @@ describe(error.name, () => {
 
     expect(Logger.error).toBeCalledWith(cause);
   });
+
+  it("records a handled client error to the log trail", () => {
+    const cause = new ShelfError({
+      cause: null,
+      message: "Validation failed",
+      label: "Request validation",
+      status: 400,
+    });
+
+    error(cause);
+
+    expect(Logger.handledClientError).toBeCalledWith(cause);
+  });
+
+  it("does not log or trail aborted requests (status 499)", () => {
+    // why: client disconnects are intentionally suppressed from both
+    // Logger.error and the 4xx log trail so they don't flood Sentry.
+    // Clear first — earlier tests in this describe call error() and the
+    // Logger mocks accumulate (no beforeEach in this block).
+    vitest.clearAllMocks();
+    const cause = new ShelfError({
+      cause: null,
+      message: "Request aborted",
+      label: "Request aborted",
+      status: 499,
+    });
+
+    error(cause);
+
+    expect(Logger.error).not.toBeCalled();
+    expect(Logger.handledClientError).not.toBeCalled();
+  });
 });
 
 describe(getParams.name, () => {

--- a/apps/webapp/app/utils/http.server.test.ts
+++ b/apps/webapp/app/utils/http.server.test.ts
@@ -24,6 +24,7 @@ import { assertIsDataWithResponseInit } from "../../test/helpers/assertions";
 vitest.mock("./logger", () => ({
   Logger: {
     error: vitest.fn(),
+    handledClientError: vitest.fn(),
   },
 }));
 

--- a/apps/webapp/app/utils/http.server.ts
+++ b/apps/webapp/app/utils/http.server.ts
@@ -286,13 +286,15 @@ export type DataResponse<T extends ResponsePayload = ResponsePayload> =
 export function error(cause: ShelfError, shouldSendNotification = true) {
   if (cause.label !== "Request aborted") {
     Logger.error(cause);
-  }
 
-  // Handled client errors (4xx) are dropped from the Sentry error pipeline
-  // (see handleBeforeSendError); record them as a low-severity log trail
-  // instead so we keep visibility without burning the error quota. No-op for
-  // non-4xx errors.
-  Logger.handledClientError(cause);
+    // Handled client errors (4xx) are dropped from the Sentry error pipeline
+    // (see handleBeforeSendError); record them as a low-severity log trail
+    // instead so we keep visibility without burning the error quota. No-op for
+    // non-4xx errors. Kept inside the abort guard so client disconnects
+    // (status 499 "Request aborted") aren't reintroduced as log noise — they're
+    // intentionally suppressed from both Logger.error and beforeSend.
+    Logger.handledClientError(cause);
+  }
 
   if (
     cause.label !== "Request aborted" &&

--- a/apps/webapp/app/utils/http.server.ts
+++ b/apps/webapp/app/utils/http.server.ts
@@ -288,6 +288,12 @@ export function error(cause: ShelfError, shouldSendNotification = true) {
     Logger.error(cause);
   }
 
+  // Handled client errors (4xx) are dropped from the Sentry error pipeline
+  // (see handleBeforeSendError); record them as a low-severity log trail
+  // instead so we keep visibility without burning the error quota. No-op for
+  // non-4xx errors.
+  Logger.handledClientError(cause);
+
   if (
     cause.label !== "Request aborted" &&
     cause.additionalData?.userId &&

--- a/apps/webapp/app/utils/logger.test.ts
+++ b/apps/webapp/app/utils/logger.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import * as Sentry from "@sentry/react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ShelfError } from "./error";
+import { Logger } from "./logger";
+
+// why: handledClientError emits to Sentry's structured-log API; capture the
+// calls instead of hitting the network. captureException is stubbed too because
+// Logger.error uses it.
+vi.mock("@sentry/react-router", () => ({
+  captureException: vi.fn(),
+  logger: { info: vi.fn() },
+}));
+
+// why: handledClientError early-returns unless a SENTRY_DSN is configured, and
+// the module also reads `env`; provide both so the emit path is exercised.
+vi.mock("./env", () => ({
+  SENTRY_DSN: "https://test@example.ingest.sentry.io/1",
+  env: { NODE_ENV: "test" },
+}));
+
+const make4xx = (overrides: Record<string, unknown> = {}) =>
+  new ShelfError({
+    cause: null,
+    message: "Please select a date in the future",
+    label: "Request validation",
+    status: 400,
+    ...overrides,
+  });
+
+describe("Logger.handledClientError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits a low-severity Sentry log for a 4xx ShelfError", () => {
+    Logger.handledClientError(make4xx());
+
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      "Please select a date in the future",
+      expect.objectContaining({ status: 400, label: "Request validation" })
+    );
+  });
+
+  it("does not emit for a 5xx ShelfError (server fault stays an error event)", () => {
+    Logger.handledClientError(make4xx({ status: 500 }));
+    expect(Sentry.logger.info).not.toHaveBeenCalled();
+  });
+
+  it("attaches the userId when present", () => {
+    Logger.handledClientError(
+      make4xx({ additionalData: { userId: "real-user-1" } })
+    );
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ userId: "real-user-1" })
+    );
+  });
+});

--- a/apps/webapp/app/utils/logger.ts
+++ b/apps/webapp/app/utils/logger.ts
@@ -4,6 +4,21 @@ import pino from "pino";
 import { SENTRY_DSN, env } from "./env";
 import { ShelfError } from "./error";
 
+/**
+ * Fraction of handled 4xx errors to record in the Sentry log trail. Defaults
+ * to 1 (keep all — the 5GB logs quota is ample); dial down via
+ * `SENTRY_HANDLED_4XX_SAMPLE_RATE` (0–1) without a deploy if 4xx volume ever
+ * threatens the quota.
+ *
+ * Note: the recurring curl-pentester sweep is filtered at the Sentry project
+ * level (an inbound/log filter on `browser.name:curl`), not here — the
+ * user-agent isn't available at this emit point.
+ */
+const HANDLED_4XX_SAMPLE_RATE = (() => {
+  const raw = Number(process.env.SENTRY_HANDLED_4XX_SAMPLE_RATE);
+  return Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : 1;
+})();
+
 function serializeError<E extends Error>(error: E): Error {
   if (!(error.cause instanceof Error)) {
     return {
@@ -57,6 +72,48 @@ export class Logger {
     if (SENTRY_DSN) {
       Sentry.captureException(error);
     }
+  }
+
+  /**
+   * Record a handled client error (4xx) as a low-severity Sentry **log**
+   * rather than an error event. Keeps a searchable trail of expected,
+   * user-facing failures (validation, not-found, forbidden, business-rule
+   * conflicts) without consuming the small error-event quota or alerting —
+   * `handleBeforeSendError` drops these from the error pipeline, and they land
+   * on the separate logs quota instead. No-op for anything that isn't a 4xx
+   * `ShelfError`. A sampling rate caps volume so the trail can't be flooded.
+   */
+  static handledClientError(cause: ShelfError) {
+    // 4xx only — client errors. Mirrors `isHandledClientError()` in ./error
+    // (which the Sentry beforeSend hook uses to drop these from the error
+    // pipeline). Inlined here, rather than imported, so this commonly-hit path
+    // doesn't couple logger.ts to ./error's export surface — many tests fully
+    // mock ~/utils/error and a new import would break them. ShelfError.status
+    // defaults to 500, so a missing status is treated as a server error.
+    const status = cause?.status ?? 500;
+    if (!SENTRY_DSN || status < 400 || status >= 500) {
+      return;
+    }
+
+    const userId =
+      typeof cause.additionalData?.userId === "string"
+        ? cause.additionalData.userId
+        : undefined;
+
+    // Sample to protect the logs quota (default keeps all).
+    if (
+      HANDLED_4XX_SAMPLE_RATE < 1 &&
+      Math.random() >= HANDLED_4XX_SAMPLE_RATE
+    ) {
+      return;
+    }
+
+    Sentry.logger.info(cause.message, {
+      label: cause.label,
+      status: cause.status,
+      traceId: cause.traceId,
+      ...(userId ? { userId } : {}),
+    });
   }
 }
 

--- a/apps/webapp/server/instrument.server.ts
+++ b/apps/webapp/server/instrument.server.ts
@@ -18,7 +18,11 @@ import * as Sentry from "@sentry/react-router";
 import { type Event, type EventHint } from "@sentry/react-router";
 
 import { SENTRY_DSN } from "~/utils/env";
-import { isAbortError, isLikeShelfError } from "~/utils/error";
+import {
+  isAbortError,
+  isHandledClientError,
+  isLikeShelfError,
+} from "~/utils/error";
 
 /**
  * Resolve the release identifier for this server process. Read from the
@@ -37,6 +41,10 @@ if (SENTRY_DSN) {
     dsn: SENTRY_DSN,
     release: resolveRelease(),
     environment: process.env.NODE_ENV,
+    // Structured Logs (separate from the error-event quota). Handled 4xx
+    // client errors are emitted here as a low-severity trail instead of being
+    // captured as errors — see Logger.handledClientError + handleBeforeSendError.
+    enableLogs: true,
     integrations: [
       // Emit `span.op:db.sql.prisma` spans for every Prisma query. Requires
       // @prisma/instrumentation (already in the workspace) and Sentry.init
@@ -108,6 +116,14 @@ function handleBeforeSendError<E extends Event>(event: E, hint: EventHint) {
   // Drop aborted-request errors that bypass `makeShelfError` — usually thrown
   // raw from streaming handlers or middleware when a client disconnects.
   if (isAbortError(exception)) {
+    return null;
+  }
+
+  // Handled client errors (4xx) are not server faults. They're recorded as a
+  // low-severity Sentry log trail (Logger.handledClientError) on the separate
+  // logs quota, so keep them OUT of the error-event pipeline entirely — this
+  // also makes PR3's per-site `shouldBeCaptured: false` opt-outs redundant.
+  if (isHandledClientError(exception)) {
     return null;
   }
 


### PR DESCRIPTION
Handled client errors (4xx) were either captured as Sentry error events (noise that burns the free plan's 5k error/month quota and alerts on non-issues) or dropped entirely (no trace). Now they go to Sentry Structured Logs, which use a separate 5GB/month allowance — so we keep a searchable trail of validation / not-found / forbidden / business-rule rejections without touching the error budget.

- `isHandledClientError()` (utils/error): a ShelfError with a 4xx status.
- `handleBeforeSendError` (instrument.server): enable `enableLogs`, and drop 4xx ShelfErrors from the error pipeline (they're logged instead). This also makes PR3's per-site `shouldBeCaptured:false` opt-outs redundant — a later cleanup.
- `Logger.handledClientError` (logger): emits `Sentry.logger.info` for 4xx, with a sample rate (`SENTRY_HANDLED_4XX_SAMPLE_RATE`, default keep-all) so the trail can't be flooded. The 4xx check is inlined (not imported from ./error) to avoid coupling this hot path to a module many tests fully mock.
- `error()` (http.server) calls it on every handled error.

Pentester (curl) noise is filtered at the Sentry project level (inbound/log filter on browser.name:curl), not in code — the user-agent isn't available at the emit point.

Follow-ups (separate): add that Sentry inbound/log filter; simplify parseData + remove the now-redundant PR3 opt-outs once the trail is confirmed in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side (4xx) errors are now classified as "handled" and logged as low-severity entries instead of entering the main error-alert pipeline.

* **Tests**
  * Added unit tests for classification, logging behavior, sampling, and emitted payload contents for handled client errors.

* **Documentation**
  * Example env file documents an optional sample-rate setting for handled 4xx logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->