### PR TITLE
fix(webapp): accept dynamic image URLs in asset CSV import

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3113,7 +3113,7 @@ export async function createAssetsFromContentImport({
             throw new ShelfError({
               cause: null,
               message:
-                "Image URL must be a valid http(s) URL. Whether it points to a real image is verified after download.",
+                "Image URL must be a valid http(s) URL, including the https:// prefix.",
               additionalData: { url: asset.imageUrl },
               label: "Assets",
               shouldBeCaptured: false,

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3112,7 +3112,8 @@ export async function createAssetsFromContentImport({
           if (!isValidImageUrl(asset.imageUrl)) {
             throw new ShelfError({
               cause: null,
-              message: "Invalid image format. Please use .png, .jpg, or .jpeg",
+              message:
+                "Image URL must be a valid http(s) URL. Whether it points to a real image is verified after download.",
               additionalData: { url: asset.imageUrl },
               label: "Assets",
               shouldBeCaptured: false,

--- a/apps/webapp/app/utils/misc.test.ts
+++ b/apps/webapp/app/utils/misc.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidImageUrl } from "./misc";
+
+/**
+ * `isValidImageUrl` is a well-formedness pre-filter for the CSV-import image
+ * URL field. It must accept any well-formed http(s) URL — including opaque,
+ * extension-less dynamic image endpoints — and reject only malformed strings
+ * and non-http(s) protocols. Whether the URL actually yields an image is
+ * decided after download (Content-Type + magic bytes), not here, and SSRF
+ * safety lives in `safeFetch`, not here. See GHSA-xgrm-8w6v-mvjg.
+ */
+describe("isValidImageUrl", () => {
+  it("accepts dynamic image endpoints with no extension or known host", () => {
+    // why: real customer case — ASP.NET handler serving image bytes via a
+    // query-string guid, the kind of URL the old string heuristics rejected.
+    expect(
+      isValidImageUrl(
+        "https://rock.kcionline.org/GetImage.ashx?guid=bafe6c61-724b-4c7e-8c49-46a2ec19758e"
+      )
+    ).toBe(true);
+  });
+
+  it("accepts plain http(s) URLs regardless of path or extension", () => {
+    expect(isValidImageUrl("https://example.com/photo.jpg")).toBe(true);
+    expect(isValidImageUrl("http://example.com/anything")).toBe(true);
+    expect(isValidImageUrl("https://example.com")).toBe(true);
+  });
+
+  it("rejects non-http(s) protocols", () => {
+    expect(isValidImageUrl("ftp://example.com/image.png")).toBe(false);
+    expect(isValidImageUrl("javascript:alert(1)")).toBe(false);
+    expect(isValidImageUrl("data:image/png;base64,AAAA")).toBe(false);
+    expect(isValidImageUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects malformed / empty strings", () => {
+    expect(isValidImageUrl("")).toBe(false);
+    expect(isValidImageUrl("not a url")).toBe(false);
+    expect(isValidImageUrl("example.com/image.png")).toBe(false);
+  });
+});

--- a/apps/webapp/app/utils/misc.ts
+++ b/apps/webapp/app/utils/misc.ts
@@ -16,62 +16,33 @@ export const isValidDomain = (val: string) =>
   /^([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.)+[a-zA-Z]{2,}$/.test(val);
 
 /**
- * Heuristic check that a string looks like an image URL (correct protocol,
- * plausible extension / image-service host / image-ish path).
+ * Checks that a string is a well-formed `http:`/`https:` URL we can attempt to
+ * fetch an image from during CSV import.
  *
- * SECURITY: This is a UX pre-filter ONLY — it is NOT an SSRF boundary. The
- * checks below match on the URL *string*, which the user controls and which a
- * redirect can change after the fact, so they cannot decide whether a
- * destination is safe to reach. The actual SSRF protection (private/reserved
- * IP blocking, redirect revalidation, size cap) lives in `safeFetch`
- * (`~/utils/ssrf.server`), which is what `uploadImageFromUrl` calls. Do not
- * rely on this function to gate server-side fetches. See GHSA-xgrm-8w6v-mvjg.
+ * This deliberately does NOT try to guess whether the URL "looks like" an image
+ * from its string (extension / host allow-list / path keywords). Such heuristics
+ * reject legitimate dynamic image endpoints — e.g. ASP.NET handlers like
+ * `https://host/GetImage.ashx?guid=...` that serve real image bytes but have no
+ * extension, no recognizable host, and an opaque path. Whether a URL actually
+ * yields an image is decided authoritatively *after* download by
+ * `uploadImageFromUrl`, which validates the real `Content-Type` header and the
+ * file's magic bytes (`detectImageFormat`).
+ *
+ * SECURITY: This is a well-formedness pre-filter ONLY — it is NOT an SSRF
+ * boundary, and it never was (its old string heuristics were trivially
+ * bypassable; see GHSA-xgrm-8w6v-mvjg). The actual SSRF protection
+ * (private/reserved IP blocking, redirect revalidation, size cap) lives in
+ * `safeFetch` (`~/utils/ssrf.server`), which `uploadImageFromUrl` calls and
+ * which independently re-validates the protocol and resolved IP on every
+ * redirect hop. Do not rely on this function to gate server-side fetches.
  *
  * @param url - The URL to validate
- * @returns boolean indicating if URL plausibly points at an image
+ * @returns boolean indicating if `url` is a well-formed http(s) URL
  */
 export function isValidImageUrl(url: string): boolean {
   try {
     const parsedUrl = new URL(url);
-    // Check if URL has a valid protocol
-    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-      return false;
-    }
-
-    // Check if URL ends with common image extensions
-    const imageExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
-    const hasImageExtension = imageExtensions.some((ext) =>
-      parsedUrl.pathname.toLowerCase().endsWith(ext)
-    );
-
-    // If it has a clear image extension, it's valid
-    if (hasImageExtension) {
-      return true;
-    }
-
-    // Allow URLs from known image services that use dynamic URLs
-    const imageServiceDomains = [
-      "lnk.sortly.co",
-      "cloudinary.com",
-      "amazonaws.com",
-      "googleusercontent.com",
-      "imgur.com",
-      "unsplash.com",
-      "pexels.com",
-    ];
-
-    // Check if the hostname contains any known image service domains
-    const isImageService = imageServiceDomains.some((domain) =>
-      parsedUrl.hostname.includes(domain)
-    );
-
-    // Also check for common image-related path patterns
-    const hasImagePath =
-      /\/(photo|image|img|pic|picture|download|media|asset)/i.test(
-        parsedUrl.pathname
-      );
-
-    return isImageService || hasImagePath;
+    return ["http:", "https:"].includes(parsedUrl.protocol);
   } catch {
     return false;
   }


### PR DESCRIPTION
The `isValidImageUrl` pre-filter rejected legitimate dynamic image endpoints during CSV import — e.g. ASP.NET handlers like `https://host/GetImage.ashx?guid=...` that serve real image bytes but have no file extension, no recognizable host, and an opaque path. A customer's import failed with "Invalid image format" before any fetch was even attempted.

The string heuristics (extension / host allow-list / path keywords) were never a security boundary — they were trivially bypassable, which is the root of GHSA-xgrm-8w6v-mvjg. Since that advisory's fix, the real controls live downstream: `safeFetch` enforces SSRF protection (private/reserved IP blocking, redirect revalidation, size cap) on every hop, and `uploadImageFromUrl` confirms the response is actually an image via Content-Type and magic-byte sniffing. The pre-filter's guess from the URL string is now strictly worse than the authoritative check of the downloaded bytes.

Reduce `isValidImageUrl` to a well-formedness check (parse + require http/https), update the now-misleading error message, and add tests pinning the behavior (customer `.ashx` URL passes; non-http(s) and malformed strings fail). Security posture is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified error message for image URL validation to state URLs must use HTTP(S) and include the https:// prefix.

* **Tests**
  * Added tests covering acceptance/rejection of various URL protocols and malformed inputs for image URL validation.

* **Refactor**
  * Simplified image URL validation to a protocol-based check (pre-filter), with deeper validation performed later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->