### PR TITLE
fix(companion): declare NSPhotoLibraryUsageDescription in app.json

### DIFF
--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -12,7 +12,8 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.shelf.companion",
       "infoPlist": {
-        "NSCameraUsageDescription": "Shelf needs camera access to scan QR codes and barcodes on your assets."
+        "NSCameraUsageDescription": "Shelf needs camera access to scan QR codes and barcodes on your assets.",
+        "NSPhotoLibraryUsageDescription": "Shelf needs photo access to attach images to your assets."
       }
     },
     "android": {


### PR DESCRIPTION
## What

Adds `NSPhotoLibraryUsageDescription` to `apps/companion/app.json` under
`ios.infoPlist`, alongside the existing camera usage string.

## Why

The iOS photo-library permission string only existed in the generated
`ios/Shelf/Info.plist`, not in `app.json` (the source of truth Expo
regenerates the native project from). A `prebuild:clean` would drop it —
the same class of bug that previously wiped the Swift concurrency Podfile
fix.

Without the string, the next iOS build risks:
- App Store rejection (accessing Photos with no usage description), or
- a crash on the attach-photo-to-asset flow.

## Scope / risk

- iOS-only key; **no Android impact** and **no runtime behavior change**.
- Wording mirrors what already ships in the native plist.
- Takes effect on the next iOS build/prebuild — preventive only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit iOS photo library access permission messaging to provide clearer transparency when the app requests access to your photos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->