### PR TITLE
feat(security): add baseline security response headers

### DIFF
--- a/apps/webapp/server/index.ts
+++ b/apps/webapp/server/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./middleware";
 import { mobileIpRateLimit } from "./rate-limit";
 import { runWithRequestCache } from "./request-cache.server";
+import { securityHeaders } from "./security-headers";
 import { authSessionKey, createSessionStorage } from "./session";
 import type { FlashData, SessionData } from "./session";
 import { serverTiming } from "./timing.server";
@@ -73,6 +74,18 @@ export default createHonoServer<ServerEnv>({
   /** Disable default logger as we have our own */
   defaultLogger: false,
   getLoadContext,
+  /**
+   * Apply baseline security headers to EVERY response.
+   *
+   * Registered via `beforeAll` (not `configure`) on purpose: `beforeAll` runs
+   * before react-router-hono-server's `serveStatic` handlers, so the
+   * `await next()` inside `securityHeaders()` wraps — and therefore decorates —
+   * static-asset responses too. Those short-circuit at `serveStatic` and never
+   * reach `configure`, so a middleware registered there would miss them.
+   */
+  beforeAll: (app) => {
+    app.use("*", securityHeaders());
+  },
   configure: (server) => {
     // Measure total request duration (dev/staging only, skipped in production).
     // Registered first so it captures time spent in all downstream middleware.

--- a/apps/webapp/server/security-headers.test.ts
+++ b/apps/webapp/server/security-headers.test.ts
@@ -1,0 +1,106 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSecurityHeaders,
+  securityHeaders,
+  CONTENT_SECURITY_POLICY_REPORT_ONLY,
+  PERMISSIONS_POLICY,
+  STRICT_TRANSPORT_SECURITY,
+} from "./security-headers";
+
+describe("buildSecurityHeaders", () => {
+  it("always sets the baseline static headers", () => {
+    const headers = buildSecurityHeaders({ isHttps: false });
+
+    expect(headers["X-Frame-Options"]).toBe("DENY");
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+    expect(headers["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+    expect(headers["Permissions-Policy"]).toBe(PERMISSIONS_POLICY);
+    expect(headers["Content-Security-Policy-Report-Only"]).toBe(
+      CONTENT_SECURITY_POLICY_REPORT_ONLY
+    );
+  });
+
+  it("omits HSTS over http and includes it over https", () => {
+    expect(
+      buildSecurityHeaders({ isHttps: false })["Strict-Transport-Security"]
+    ).toBeUndefined();
+    expect(
+      buildSecurityHeaders({ isHttps: true })["Strict-Transport-Security"]
+    ).toBe(STRICT_TRANSPORT_SECURITY);
+  });
+
+  it("allows camera + geolocation for self and blocks unused sensors", () => {
+    // Both are in active use (scanner + public-QR geolocation) — denying them
+    // would silently break those features.
+    expect(PERMISSIONS_POLICY).toContain("camera=(self)");
+    expect(PERMISSIONS_POLICY).toContain("geolocation=(self)");
+    expect(PERMISSIONS_POLICY).toContain("microphone=()");
+    expect(PERMISSIONS_POLICY).toContain("payment=()");
+  });
+
+  it("does not disable autoplay (subscription-success modal plays a video)", () => {
+    expect(PERMISSIONS_POLICY).not.toContain("autoplay=()");
+    expect(PERMISSIONS_POLICY).toContain("autoplay=(self)");
+  });
+
+  it("ships CSP as report-only scaffolding, not enforcing", () => {
+    expect(CONTENT_SECURITY_POLICY_REPORT_ONLY).toContain(
+      "frame-ancestors 'none'"
+    );
+  });
+});
+
+describe("securityHeaders middleware", () => {
+  /**
+   * A tiny Hono app mirroring the real pipeline: `securityHeaders()` registered
+   * first (as the `beforeAll` hook does), then a short-circuiting static-like
+   * handler and a normal dynamic route. This proves headers land on responses
+   * that never call `next()` (static assets) as well as ordinary ones.
+   */
+  function makeApp() {
+    const app = new Hono();
+    app.use("*", securityHeaders());
+    // Static-like handler: a route that responds without calling downstream,
+    // mirroring serveStatic short-circuiting for an existing file.
+    app.get("/static/*", (c) => c.text("asset"));
+    app.get("/login", (c) => c.html("<h1>login</h1>"));
+    return app;
+  }
+
+  it("sets headers on a normal dynamic response", async () => {
+    const res = await makeApp().request("/login");
+
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin"
+    );
+    expect(res.headers.get("Permissions-Policy")).toContain("camera=(self)");
+    expect(res.headers.get("Content-Security-Policy-Report-Only")).toContain(
+      "frame-ancestors 'none'"
+    );
+  });
+
+  it("sets headers on a short-circuiting static-like response", async () => {
+    const res = await makeApp().request("/static/app.js");
+
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("emits HSTS only when x-forwarded-proto is https", async () => {
+    const app = makeApp();
+
+    const httpRes = await app.request("/login");
+    expect(httpRes.headers.get("Strict-Transport-Security")).toBeNull();
+
+    const httpsRes = await app.request("/login", {
+      headers: { "x-forwarded-proto": "https" },
+    });
+    expect(httpsRes.headers.get("Strict-Transport-Security")).toBe(
+      STRICT_TRANSPORT_SECURITY
+    );
+  });
+});

--- a/apps/webapp/server/security-headers.test.ts
+++ b/apps/webapp/server/security-headers.test.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   buildSecurityHeaders,
+  hostFromUrl,
   securityHeaders,
   CONTENT_SECURITY_POLICY_REPORT_ONLY,
   PERMISSIONS_POLICY,
@@ -11,7 +12,10 @@ import {
 
 describe("buildSecurityHeaders", () => {
   it("always sets the baseline static headers", () => {
-    const headers = buildSecurityHeaders({ isHttps: false });
+    const headers = buildSecurityHeaders({
+      isHttps: false,
+      isCanonicalHost: true,
+    });
 
     expect(headers["X-Frame-Options"]).toBe("DENY");
     expect(headers["X-Content-Type-Options"]).toBe("nosniff");
@@ -22,13 +26,16 @@ describe("buildSecurityHeaders", () => {
     );
   });
 
-  it("omits HSTS over http and includes it over https", () => {
-    expect(
-      buildSecurityHeaders({ isHttps: false })["Strict-Transport-Security"]
-    ).toBeUndefined();
-    expect(
-      buildSecurityHeaders({ isHttps: true })["Strict-Transport-Security"]
-    ).toBe(STRICT_TRANSPORT_SECURITY);
+  it("sets HSTS only when the request is HTTPS AND for the canonical host", () => {
+    const hsts = (isHttps: boolean, isCanonicalHost: boolean) =>
+      buildSecurityHeaders({ isHttps, isCanonicalHost })[
+        "Strict-Transport-Security"
+      ];
+
+    expect(hsts(true, true)).toBe(STRICT_TRANSPORT_SECURITY);
+    expect(hsts(false, true)).toBeUndefined(); // http
+    expect(hsts(true, false)).toBeUndefined(); // non-canonical host (e.g. shortener)
+    expect(hsts(false, false)).toBeUndefined();
   });
 
   it("allows camera + geolocation for self and blocks unused sensors", () => {
@@ -52,7 +59,34 @@ describe("buildSecurityHeaders", () => {
   });
 });
 
+describe("hostFromUrl", () => {
+  it("returns the lowercased host (with port if present)", () => {
+    expect(hostFromUrl("https://app.shelf.nu")).toBe("app.shelf.nu");
+    expect(hostFromUrl("https://APP.Shelf.NU/login")).toBe("app.shelf.nu");
+    expect(hostFromUrl("http://localhost:3000")).toBe("localhost:3000");
+  });
+
+  it("returns null for missing or unparseable input", () => {
+    expect(hostFromUrl(undefined)).toBeNull();
+    expect(hostFromUrl("")).toBeNull();
+    expect(hostFromUrl("not a url")).toBeNull();
+  });
+});
+
 describe("securityHeaders middleware", () => {
+  // why: securityHeaders() reads SERVER_URL once when constructed to resolve the
+  // canonical host, so each test sets it before calling makeApp(). Saved/restored
+  // to avoid leaking between tests.
+  const originalServerUrl = process.env.SERVER_URL;
+
+  beforeEach(() => {
+    process.env.SERVER_URL = "https://app.shelf.nu";
+  });
+
+  afterEach(() => {
+    process.env.SERVER_URL = originalServerUrl;
+  });
+
   /**
    * A tiny Hono app mirroring the real pipeline: `securityHeaders()` registered
    * first (as the `beforeAll` hook does), then a short-circuiting static-like
@@ -70,7 +104,7 @@ describe("securityHeaders middleware", () => {
   }
 
   it("sets headers on a normal dynamic response", async () => {
-    const res = await makeApp().request("/login");
+    const res = await makeApp().request("https://app.shelf.nu/login");
 
     expect(res.headers.get("X-Frame-Options")).toBe("DENY");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
@@ -84,23 +118,36 @@ describe("securityHeaders middleware", () => {
   });
 
   it("sets headers on a short-circuiting static-like response", async () => {
-    const res = await makeApp().request("/static/app.js");
+    const res = await makeApp().request("https://app.shelf.nu/static/app.js");
 
     expect(res.headers.get("X-Frame-Options")).toBe("DENY");
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
   });
 
-  it("emits HSTS only when x-forwarded-proto is https", async () => {
-    const app = makeApp();
-
-    const httpRes = await app.request("/login");
-    expect(httpRes.headers.get("Strict-Transport-Security")).toBeNull();
-
-    const httpsRes = await app.request("/login", {
+  it("emits HSTS for the canonical host over HTTPS", async () => {
+    const res = await makeApp().request("https://app.shelf.nu/login", {
       headers: { "x-forwarded-proto": "https" },
     });
-    expect(httpsRes.headers.get("Strict-Transport-Security")).toBe(
+
+    expect(res.headers.get("Strict-Transport-Security")).toBe(
       STRICT_TRANSPORT_SECURITY
     );
+  });
+
+  it("omits HSTS over http even on the canonical host", async () => {
+    const res = await makeApp().request("https://app.shelf.nu/login");
+
+    expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+  });
+
+  it("omits HSTS on a non-canonical host (e.g. the URL-shortener) even over HTTPS", async () => {
+    // Same server, different host (the short domain) — must NOT be HSTS-pinned.
+    const res = await makeApp().request("https://eam.sh/abc123", {
+      headers: { "x-forwarded-proto": "https" },
+    });
+
+    expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+    // ...but the host-independent headers are still applied.
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
   });
 });

--- a/apps/webapp/server/security-headers.ts
+++ b/apps/webapp/server/security-headers.ts
@@ -1,0 +1,142 @@
+/**
+ * Security response headers
+ *
+ * Defines the baseline set of HTTP security headers applied to *every* response
+ * the webapp emits — HTML documents, single-fetch `.data` requests, static
+ * assets, redirects and error responses alike.
+ *
+ * The middleware is registered through react-router-hono-server's `beforeAll`
+ * hook (see {@link file://./index.ts}). `beforeAll` runs *before* the
+ * framework's `serveStatic` handlers and before the app's `configure`
+ * middleware (incl. `protect`), so its `await next()` wraps the entire request
+ * pipeline. That makes it the single choke point that can decorate
+ * static-asset responses — which short-circuit at `serveStatic` and never reach
+ * `configure` — as well as dynamic ones. (A per-route `headers` export or
+ * `entry.server.tsx` only sees document/loader responses, not static or error
+ * responses, which is why neither is used here.)
+ *
+ * Header choices:
+ * - `Strict-Transport-Security` is only sent over HTTPS (detected via the
+ *   `x-forwarded-proto` header set by the Cloudflare/Fly proxy layer) so local
+ *   http dev and internal health checks never pin HSTS. `preload` is
+ *   intentionally deferred — it's a hard-to-reverse commitment.
+ * - `Content-Security-Policy` ships in **Report-Only** mode with just
+ *   `frame-ancestors 'none'`. A full enforcing policy needs per-request script
+ *   nonces, which are not yet wired into `entry.server.tsx`, so enforcing mode
+ *   would break React Router's inline hydration scripts. `X-Frame-Options:
+ *   DENY` provides the actual (enforced) clickjacking protection meanwhile.
+ * - `Permissions-Policy` denies sensitive features the app doesn't use but
+ *   explicitly allows `camera=(self)` (the QR/barcode scanner —
+ *   `~/components/scanner/code-scanner`) and `geolocation=(self)` (GPS
+ *   coordinates form + the public QR scan-location flow). `autoplay=(self)` is
+ *   kept allowed because the subscription-success modal autoplays a
+ *   same-origin video (`~/components/subscription/successful-subscription-modal`).
+ *
+ * @see {@link file://./index.ts} — registration via `beforeAll`
+ * @see {@link file://./middleware.ts} — the `cache()` middleware whose
+ *   set-headers-after-`next()` idiom this follows
+ */
+import { createMiddleware } from "hono/factory";
+
+/**
+ * Restrictive Permissions-Policy (alphabetised for readability).
+ *
+ * `=()` fully denies a feature; `=(self)` allows it for same-origin only.
+ * Only `autoplay`, `camera` and `geolocation` are allowed (each is in active
+ * use in the webapp); everything else listed is denied. Features not listed
+ * keep the browser default — that's acceptable for low-risk ones, and we
+ * explicitly deny the sensitive sensors/payment/usb surfaces.
+ */
+export const PERMISSIONS_POLICY = [
+  "accelerometer=()",
+  "autoplay=(self)",
+  "browsing-topics=()",
+  "camera=(self)",
+  "geolocation=(self)",
+  "gyroscope=()",
+  "magnetometer=()",
+  "microphone=()",
+  "payment=()",
+  "usb=()",
+].join(", ");
+
+/**
+ * Content-Security-Policy value, shipped via the **Report-Only** header.
+ *
+ * Starts minimal (`frame-ancestors 'none'`) to begin gathering data without
+ * risking breakage. Path to enforcing mode: add script nonces in
+ * `entry.server.tsx`, build out `default-src`/`script-src`/`style-src`/…,
+ * wire a `report-to`/`report-uri` collection endpoint, then move the value to
+ * the enforcing `Content-Security-Policy` header.
+ */
+export const CONTENT_SECURITY_POLICY_REPORT_ONLY = "frame-ancestors 'none'";
+
+/** HSTS: 2 years, include subdomains. `preload` intentionally deferred. */
+export const STRICT_TRANSPORT_SECURITY = "max-age=63072000; includeSubDomains";
+
+/**
+ * Builds the security-header name→value map for a single response.
+ *
+ * @param opts.isHttps - whether the original client connection used HTTPS
+ *   (derived from `x-forwarded-proto`). HSTS is only included when `true`.
+ * @returns header name → value pairs to set on the response
+ */
+export function buildSecurityHeaders({
+  isHttps,
+}: {
+  isHttps: boolean;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Permissions-Policy": PERMISSIONS_POLICY,
+    "Content-Security-Policy-Report-Only": CONTENT_SECURITY_POLICY_REPORT_ONLY,
+  };
+
+  // Only assert HSTS over HTTPS: browsers ignore it over http anyway, and
+  // emitting it on local http dev could pin HSTS for "localhost".
+  if (isHttps) {
+    headers["Strict-Transport-Security"] = STRICT_TRANSPORT_SECURITY;
+  }
+
+  return headers;
+}
+
+/**
+ * Whether the original client request used HTTPS, based on the
+ * `x-forwarded-proto` header set by the Cloudflare/Fly proxy layer. Handles the
+ * comma-separated multi-proxy form (e.g. `"https,http"`) by reading the first
+ * value.
+ *
+ * @param forwardedProto - raw `x-forwarded-proto` header value, if any
+ * @returns `true` when the client-facing connection was HTTPS
+ */
+function isHttpsRequest(forwardedProto: string | undefined): boolean {
+  return (forwardedProto ?? "").split(",")[0].trim().toLowerCase() === "https";
+}
+
+/**
+ * Hono middleware that sets the baseline security headers on every response.
+ *
+ * Headers are set *after* `await next()` (matching the existing `cache()` idiom
+ * in {@link file://./middleware.ts}) so they apply to whatever response
+ * downstream produced — including `serveStatic` short-circuits, redirects from
+ * the `protect` middleware, and rendered error pages. `.set()` (rather than
+ * append/default) ensures our baseline always wins.
+ *
+ * @returns a Hono middleware handler
+ */
+export function securityHeaders() {
+  return createMiddleware(async (c, next) => {
+    await next();
+
+    const headers = buildSecurityHeaders({
+      isHttps: isHttpsRequest(c.req.header("x-forwarded-proto")),
+    });
+
+    for (const [name, value] of Object.entries(headers)) {
+      c.res.headers.set(name, value);
+    }
+  });
+}

--- a/apps/webapp/server/security-headers.ts
+++ b/apps/webapp/server/security-headers.ts
@@ -16,10 +16,15 @@
  * responses, which is why neither is used here.)
  *
  * Header choices:
- * - `Strict-Transport-Security` is only sent over HTTPS (detected via the
- *   `x-forwarded-proto` header set by the Cloudflare/Fly proxy layer) so local
- *   http dev and internal health checks never pin HSTS. `preload` is
- *   intentionally deferred — it's a hard-to-reverse commitment.
+ * - `Strict-Transport-Security` is sent ONLY for the canonical app host
+ *   (the host of `SERVER_URL`) and ONLY over HTTPS (detected via the
+ *   `x-forwarded-proto` header set by the Cloudflare/Fly proxy layer). This is
+ *   deliberately narrow: the same Hono server also answers for the
+ *   URL-shortener host (`process.env.URL_SHORTENER`, handled in
+ *   {@link file://./index.ts}), and for raw platform hosts (e.g. `*.fly.dev`)
+ *   and http health checks. Emitting `includeSubDomains` on any of those would
+ *   pin a domain we don't intend to. `preload` is intentionally deferred — it's
+ *   a hard-to-reverse commitment.
  * - `Content-Security-Policy` ships in **Report-Only** mode with just
  *   `frame-ancestors 'none'`. A full enforcing policy needs per-request script
  *   nonces, which are not yet wired into `entry.server.tsx`, so enforcing mode
@@ -78,13 +83,18 @@ export const STRICT_TRANSPORT_SECURITY = "max-age=63072000; includeSubDomains";
  * Builds the security-header name→value map for a single response.
  *
  * @param opts.isHttps - whether the original client connection used HTTPS
- *   (derived from `x-forwarded-proto`). HSTS is only included when `true`.
- * @returns header name → value pairs to set on the response
+ *   (derived from `x-forwarded-proto`).
+ * @param opts.isCanonicalHost - whether the request targeted the canonical app
+ *   host (the host of `SERVER_URL`).
+ * @returns header name → value pairs to set on the response. HSTS is included
+ *   only when the request is BOTH HTTPS and for the canonical app host.
  */
 export function buildSecurityHeaders({
   isHttps,
+  isCanonicalHost,
 }: {
   isHttps: boolean;
+  isCanonicalHost: boolean;
 }): Record<string, string> {
   const headers: Record<string, string> = {
     "X-Frame-Options": "DENY",
@@ -94,9 +104,11 @@ export function buildSecurityHeaders({
     "Content-Security-Policy-Report-Only": CONTENT_SECURITY_POLICY_REPORT_ONLY,
   };
 
-  // Only assert HSTS over HTTPS: browsers ignore it over http anyway, and
-  // emitting it on local http dev could pin HSTS for "localhost".
-  if (isHttps) {
+  // Assert HSTS only for the canonical app host over HTTPS. The same server
+  // also answers for the URL-shortener host (and raw platform hosts / http
+  // health checks); emitting `includeSubDomains` there would pin domains we
+  // don't intend to. Browsers ignore HSTS over http anyway.
+  if (isHttps && isCanonicalHost) {
     headers["Strict-Transport-Security"] = STRICT_TRANSPORT_SECURITY;
   }
 
@@ -117,22 +129,52 @@ function isHttpsRequest(forwardedProto: string | undefined): boolean {
 }
 
 /**
+ * Extracts the lowercased host (`host:port`) from a URL string.
+ *
+ * @param url - a URL string (e.g. `SERVER_URL`)
+ * @returns the lowercased host, or `null` when absent/unparseable
+ */
+export function hostFromUrl(url: string | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Hono middleware that sets the baseline security headers on every response.
  *
  * Headers are set *after* `await next()` (matching the existing `cache()` idiom
  * in {@link file://./middleware.ts}) so they apply to whatever response
  * downstream produced — including `serveStatic` short-circuits, redirects from
- * the `protect` middleware, and rendered error pages. `.set()` (rather than
- * append/default) ensures our baseline always wins.
+ * the `protect`/`urlShortener` middleware, and rendered error pages. `.set()`
+ * (rather than append/default) ensures our baseline always wins.
+ *
+ * The canonical app host is resolved once from `SERVER_URL` (fixed at boot) and
+ * used to scope HSTS — see {@link buildSecurityHeaders}.
  *
  * @returns a Hono middleware handler
  */
 export function securityHeaders() {
+  const canonicalHost = hostFromUrl(process.env.SERVER_URL);
+
   return createMiddleware(async (c, next) => {
     await next();
 
+    // Prefer the Host header — authoritative behind the Cloudflare/Fly proxy,
+    // and what the urlShortener middleware keys on — falling back to the
+    // request URL's host if the header is somehow absent.
+    const requestHost =
+      c.req.header("host")?.toLowerCase() ?? hostFromUrl(c.req.url);
+
     const headers = buildSecurityHeaders({
       isHttps: isHttpsRequest(c.req.header("x-forwarded-proto")),
+      isCanonicalHost: canonicalHost !== null && requestHost === canonicalHost,
     });
 
     for (const [name, value] of Object.entries(headers)) {


### PR DESCRIPTION
## TL;DR

Adds six standard HTTP security **response headers** to every `app.shelf.nu` response via one small Hono middleware. Low-severity hardening (flagged by our internal `secscan`), corroborated safe against the app's existing features, fully tested, and reversible per line. **Headers only** — the vulnerability-disclosure policy (`security.txt` / `SECURITY.md`) was deliberately left out (see *Out of scope*). Suggested path: merge → **staging first** → verify → promote.

---

## Why this exists

`secscan` (our local scanner) looks at `app.shelf.nu` the way an outside scanner would and surfaced two low-severity gaps: **missing security headers** and **no disclosure channel**. Neither is exploitable. But:

- their absence is the standard trigger for low-effort *"I found an issue on your site, please pay me"* emails, and
- security headers are among the first things an enterprise security questionnaire checks.

This PR closes the **headers** half — the part that makes no commitments and has no real downside. It is not urgent; it's hygiene we can land on our own schedule.

---

## What changes

One new middleware — `apps/webapp/server/security-headers.ts` — registered once in `server/index.ts`:

| Header | Value | Notes |
|---|---|---|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` | Sent **only over HTTPS** (detected via `x-forwarded-proto`), so local http dev / internal health checks never pin HSTS. `preload` deferred. |
| `Content-Security-Policy-Report-Only` | `frame-ancestors 'none'` | **Report-Only** (non-blocking). A full enforcing CSP needs per-request script nonces, which aren't wired into `entry.server.tsx` yet — `X-Frame-Options` provides the enforced clickjacking protection meanwhile. |
| `X-Frame-Options` | `DENY` | |
| `X-Content-Type-Options` | `nosniff` | |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Equals the current browser default. |
| `Permissions-Policy` | deny unused features; allow `camera` / `geolocation` / `autoplay` `=(self)` | The three `=(self)` features are in **active use** — see blast-radius review. |

## Why `beforeAll` (design note)

The middleware is registered through react-router-hono-server's `beforeAll` hook, **not** `configure` or a per-route `headers` export. Verified in the library's node adapter: `beforeAll` runs *before* `serveStatic` and the `protect` middleware, so its `await next()` wraps the whole pipeline and decorates **static-asset, redirect, and error responses** too. A middleware in `configure` would miss static assets (they short-circuit at `serveStatic`); `entry.server.tsx` / route `headers` only see document/loader responses.

---

## Will it break anything? (blast-radius review)

Checked against the rest of the app before shipping — these are the things a restrictive header set typically breaks:

- **Permissions-Policy** allows `camera=(self)` (web QR/barcode scanner — `~/components/scanner`), `geolocation=(self)` (GPS-coordinates form + the public-QR scan-location flow), and `autoplay=(self)` (subscription-success modal video). Denying any of these would silently break a real feature; nothing else the app uses is restricted.
- **X-Frame-Options: DENY / CSP frame-ancestors** — the app has no same-origin framing; the marketing site only *links* to `app.shelf.nu` (never iframes it); and the session cookie is `SameSite=lax`, so the authenticated app already can't function in a cross-origin iframe today. No working embed is affected. (If we ever need a partner to embed a page, that becomes a `frame-ancestors` allowlist — easy follow-up.)
- **nosniff** — the file-serving endpoints set explicit, correct `Content-Type` (image blob, CSV, zip; PDF routes return JSON and render client-side), so nothing relies on MIME sniffing.
- **HSTS** is scoped to `app.shelf.nu` and its subdomains only and sent only over HTTPS — it does **not** affect `shelf.nu` / `www` / `docs` (siblings). The only forward commitment is that subdomains of `app.shelf.nu` stay HTTPS (no known exceptions).
- **Cloudflare** currently sets none of these (per the scan), so no duplicate headers.

Open items only **you** can confirm: any customer embedding a *public* app page cross-origin, and any HTTP-only subdomain under `app.shelf.nu`. I found no evidence of either.

---

## Out of scope (intentional)

- **`security.txt` + `SECURITY.md`** were prototyped, then **excluded and not pushed**. Publishing a vulnerability-disclosure policy is a separate, deliberate decision: it makes scope/recognition commitments that warrant review, and it should also live on the apex `shelf.nu` (a different repo). Happy to revisit as its own change if/when there's a reason.
- **DMARC** — `shelf.nu` is currently `sp=none`; consider `sp=quarantine` so subdomains can't be spoofed. DNS/ops change, not code.

---

## Verification

- Unit + integration tests (`server/security-headers.test.ts`): exact header values, HTTPS-gated HSTS, and coverage of both normal and short-circuiting (static-like) responses.
- `typecheck` + `eslint` + `prettier` + production build all pass.
- Local `curl` confirmed the headers on `200` / `302` redirect / `404` / a static asset, with HSTS appearing only when `x-forwarded-proto: https` is present.

## Suggested rollout

Merge → deploy to **staging** → re-run `secscan` + securityheaders.com (neither can scan localhost) → smoke-test the QR scanner, file/PDF/CSV downloads, and SSO → promote to prod. Each header is a one-line revert if anything surfaces.

## Where to look

The only real logic is `apps/webapp/server/security-headers.ts`; `server/index.ts` just registers it; everything else is tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply baseline HTTP security headers to all server responses (including short-circuited/static responses). Includes Permissions-Policy, Content-Security-Policy (report-only), and conditional HSTS emitted only for HTTPS requests to the canonical host. Middleware runs early to ensure headers wrap static responses.

* **Tests**
  * Added unit and integration tests validating header values, canonical-host and protocol-dependent HSTS behavior, host extraction, and header application for both dynamic and short-circuit routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->