### PR TITLE
fix(webapp): declare undici as a direct dependency

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -133,6 +133,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tiny-invariant": "^1.3.3",
     "ua-parser-js": "^1.0.41",
+    "undici": "^6.23.0",
     "zod": "^3.25.76",
     "zxing-wasm": "^3.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       ua-parser-js:
         specifier: ^1.0.41
         version: 1.0.41
+      undici:
+        specifier: ^6.23.0
+        version: 6.23.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -10240,7 +10243,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   uuid@7.0.3:


### PR DESCRIPTION
PR #2589 added app/utils/ssrf.server.ts, which imports both `ipaddr.js` and `undici`. That PR promoted `ipaddr.js` from a transitive to a direct dependency but left `undici` transitive-only.

The production Docker build runs `turbo prune @shelf/webapp --docker`, which keeps only dependencies declared in the package's package.json. `ipaddr.js` survived the prune; `undici` did not, so the pruned install lacked it and the Vite/Rollup SSR build failed with:

    [vite]: Rollup failed to resolve import "undici" from
    "app/utils/ssrf.server.ts"

That broke the webapp build, which skipped the Deploy step on every merge since #2589 (2026-06-03) — freezing production on pre-#2589 code (including the SSRF fix itself and the dynamic image-URL import fix). Local dev and CI never caught it because the un-pruned node_modules always resolves undici; only the pruned production build breaks.

Declare `undici` (already locked at 6.23.0) as a direct webapp dependency so `turbo prune` retains it and Vite externalizes it, mirroring how #2589 already handled `ipaddr.js`.

Verified: `turbo prune @shelf/webapp --docker` now includes undici in both the pruned package.json and the pruned lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->