### PR TITLE
feat(audits): create audits from selected locations

### DIFF
--- a/apps/webapp/app/components/assets/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-start-audit-dialog.tsx
@@ -1,8 +1,6 @@
-import type { ChangeEvent } from "react";
-import { useEffect, useState } from "react";
 import { useAtomValue } from "jotai";
 import { DateTime } from "luxon";
-import { useLoaderData, useNavigate } from "react-router";
+import { useLoaderData } from "react-router";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 
@@ -10,13 +8,12 @@ import {
   selectedBulkItemsAtom,
   selectedBulkItemsCountAtom,
 } from "~/atoms/list";
-import AuditTeamMemberSelector from "~/components/audit/audit-team-member-selector";
+import {
+  StartAuditDialogContent,
+  type StartAuditFetcherData,
+} from "~/components/audit/start-audit-dialog-content";
 import { BulkUpdateDialogContent } from "~/components/bulk-update-dialog/bulk-update-dialog";
-import Input from "~/components/forms/input";
 import type { IndexResponse } from "~/components/list";
-import { Button } from "~/components/shared/button";
-import { Separator } from "~/components/shared/separator";
-import { useDisabled } from "~/hooks/use-disabled";
 import { BaseAuditSchema } from "~/routes/api+/audits.start";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { isSelectingAllItems } from "~/utils/list";
@@ -38,130 +35,6 @@ export const BulkStartAuditSchema = BaseAuditSchema.extend({
     path: ["dueDate"],
   }
 );
-
-const AUDIT_DESCRIPTION_MAX_LENGTH = 1000;
-
-type StartAuditFetcherData = {
-  success?: boolean;
-  redirectTo?: string;
-};
-
-type StartAuditDialogContentProps = {
-  disabled: boolean;
-  handleCloseDialog: () => void;
-  fetcherError?: string;
-  fetcherData?: StartAuditFetcherData;
-  nameField: string;
-  descriptionField: string;
-  dueDateField: string;
-  nameError?: string;
-  descriptionError?: string;
-  dueDateError?: string;
-  assigneeError?: string;
-};
-
-function StartAuditDialogContent({
-  disabled,
-  handleCloseDialog,
-  fetcherError,
-  fetcherData,
-  nameField,
-  descriptionField,
-  dueDateField,
-  nameError,
-  descriptionError,
-  dueDateError,
-  assigneeError,
-}: StartAuditDialogContentProps) {
-  const navigate = useNavigate();
-  const isNavigating = useDisabled();
-  const formDisabled = disabled || isNavigating;
-  const [descriptionLength, setDescriptionLength] = useState(0);
-
-  const handleDescriptionChange = (
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    setDescriptionLength(event.currentTarget.value.length);
-  };
-
-  useEffect(() => {
-    if (!fetcherData?.success || !fetcherData.redirectTo) {
-      return;
-    }
-
-    void navigate(fetcherData.redirectTo);
-  }, [fetcherData, navigate]);
-
-  return (
-    <>
-      <div className="grid grid-cols-1 border-t px-6 pb-4 md:grid-cols-2 md:divide-x">
-        {/* Left column: Form fields */}
-        <div className="py-4 pr-6">
-          <Input
-            name={nameField}
-            label="Audit name"
-            placeholder="Quarterly warehouse audit"
-            error={nameError}
-            required
-            disabled={formDisabled}
-            className="mb-4"
-          />
-
-          <Input
-            name={descriptionField}
-            label="Description"
-            placeholder="Add context that will help auditors (optional)."
-            inputType="textarea"
-            rows={5}
-            maxLength={AUDIT_DESCRIPTION_MAX_LENGTH}
-            error={fetcherError || descriptionError}
-            disabled={formDisabled}
-            className="mb-1"
-            onChange={handleDescriptionChange}
-          />
-          <div className="text-right text-xs text-gray-500">
-            {descriptionLength}/{AUDIT_DESCRIPTION_MAX_LENGTH}
-          </div>
-
-          <Input
-            name={dueDateField}
-            label="Due date"
-            type="datetime-local"
-            error={dueDateError}
-            disabled={formDisabled}
-            className="mt-4"
-          />
-        </div>
-
-        {/* Right column: Team member selector */}
-        <div className="!border-r">
-          <Separator className="md:hidden" />
-          <p className="p-3 pb-0 font-medium">Select assignee (optional).</p>
-          <p className="border-b p-3 ">
-            If no assignee is selected, any admin user can perform the audit.
-            This can also be done by multiple users at different times.
-          </p>
-          <AuditTeamMemberSelector error={assigneeError} />
-        </div>
-      </div>
-
-      {/* Footer buttons */}
-      <div className="flex items-center justify-end gap-2 border-t p-4 pb-0 md:col-span-2">
-        <Button
-          type="button"
-          variant="secondary"
-          disabled={formDisabled}
-          onClick={handleCloseDialog}
-        >
-          Cancel
-        </Button>
-        <Button type="submit" variant="primary" disabled={formDisabled}>
-          Create audit
-        </Button>
-      </div>
-    </>
-  );
-}
 
 export default function BulkStartAuditDialog() {
   const { totalItems } = useLoaderData<IndexResponse>();

--- a/apps/webapp/app/components/audit/new-audit-info-dialog.tsx
+++ b/apps/webapp/app/components/audit/new-audit-info-dialog.tsx
@@ -64,12 +64,13 @@ export function NewAuditInfoDialog() {
                   </div>
                   <div className="flex-1">
                     <h4 className="mb-1 font-medium text-gray-900">
-                      From Location page
+                      From Locations
                     </h4>
                     <p className="mb-3 text-sm text-gray-600">
-                      Audit all assets assigned to a specific location. Ideal
-                      for room-by-room or area-based inventory checks. Use the
-                      actions menu on the Location page to get started.
+                      Audit the assets across one or more locations. Ideal for
+                      room-by-room or area-based inventory checks. Select the
+                      locations you want on the Locations page, then choose
+                      Actions → Create audit.
                     </p>
                     <Button
                       to="/locations"
@@ -93,8 +94,9 @@ export function NewAuditInfoDialog() {
                     <h4 className="mb-1 font-medium text-gray-900">From Kit</h4>
                     <p className="mb-3 text-sm text-gray-600">
                       Audit all assets within a specific kit. Great for
-                      verifying that kit contents are complete. Use the actions
-                      menu on the Kit page to get started.
+                      verifying that kit contents are complete. Open the kit you
+                      want from the Kits page, then choose Actions → Create
+                      audit.
                     </p>
                     <Button
                       to="/kits"

--- a/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
+++ b/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
@@ -1,0 +1,168 @@
+/**
+ * Shared body for the "Start an audit" bulk dialog.
+ *
+ * Renders the audit name / description / due-date inputs, the assignee selector,
+ * and the footer buttons used by every bulk "Create audit" entry point (assets
+ * index, locations index, …). It is intentionally stateless with respect to the
+ * selection: the parent dialog wires the `arrayFieldId` + zorm schema, and this
+ * component only renders the common fields and redirects on a successful submit.
+ *
+ * Lifted out of `~/components/assets/bulk-start-audit-dialog` so the locations
+ * (and any future) bulk-audit dialogs reuse the exact same form, with no change
+ * to the assets runtime behavior.
+ *
+ * @see {@link file://./../assets/bulk-start-audit-dialog.tsx}
+ * @see {@link file://./../location/bulk-start-audit-dialog.tsx}
+ */
+
+import type { ChangeEvent } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+
+import AuditTeamMemberSelector from "~/components/audit/audit-team-member-selector";
+import Input from "~/components/forms/input";
+import { Button } from "~/components/shared/button";
+import { Separator } from "~/components/shared/separator";
+import { useDisabled } from "~/hooks/use-disabled";
+
+/** Maximum length of the optional audit description. */
+export const AUDIT_DESCRIPTION_MAX_LENGTH = 1000;
+
+/** Shape of the fetcher response returned by `/api/audits/start`. */
+export type StartAuditFetcherData = {
+  success?: boolean;
+  redirectTo?: string;
+};
+
+/** Props for {@link StartAuditDialogContent}. */
+export type StartAuditDialogContentProps = {
+  /** Whether the dialog action is in flight (from the bulk-dialog harness). */
+  disabled: boolean;
+  /** Closes the parent dialog. */
+  handleCloseDialog: () => void;
+  /** Server error to surface (shown under the description field). */
+  fetcherError?: string;
+  /** Fetcher response; on success we navigate to `redirectTo`. */
+  fetcherData?: StartAuditFetcherData;
+  /** Zorm field name for the audit name input. */
+  nameField: string;
+  /** Zorm field name for the description input. */
+  descriptionField: string;
+  /** Zorm field name for the due-date input. */
+  dueDateField: string;
+  /** Validation error for the name field. */
+  nameError?: string;
+  /** Validation error for the description field. */
+  descriptionError?: string;
+  /** Validation error for the due-date field. */
+  dueDateError?: string;
+  /** Validation error for the assignee selector. */
+  assigneeError?: string;
+};
+
+/**
+ * The shared inner form for the bulk "Create audit" dialog. On a successful
+ * fetcher response it navigates to the newly-created audit.
+ */
+export function StartAuditDialogContent({
+  disabled,
+  handleCloseDialog,
+  fetcherError,
+  fetcherData,
+  nameField,
+  descriptionField,
+  dueDateField,
+  nameError,
+  descriptionError,
+  dueDateError,
+  assigneeError,
+}: StartAuditDialogContentProps) {
+  const navigate = useNavigate();
+  const isNavigating = useDisabled();
+  const formDisabled = disabled || isNavigating;
+  const [descriptionLength, setDescriptionLength] = useState(0);
+
+  const handleDescriptionChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setDescriptionLength(event.currentTarget.value.length);
+  };
+
+  useEffect(() => {
+    if (!fetcherData?.success || !fetcherData.redirectTo) {
+      return;
+    }
+
+    void navigate(fetcherData.redirectTo);
+  }, [fetcherData, navigate]);
+
+  return (
+    <>
+      <div className="grid grid-cols-1 border-t px-6 pb-4 md:grid-cols-2 md:divide-x">
+        {/* Left column: Form fields */}
+        <div className="py-4 pr-6">
+          <Input
+            name={nameField}
+            label="Audit name"
+            placeholder="Quarterly warehouse audit"
+            error={nameError}
+            required
+            disabled={formDisabled}
+            className="mb-4"
+          />
+
+          <Input
+            name={descriptionField}
+            label="Description"
+            placeholder="Add context that will help auditors (optional)."
+            inputType="textarea"
+            rows={5}
+            maxLength={AUDIT_DESCRIPTION_MAX_LENGTH}
+            error={fetcherError || descriptionError}
+            disabled={formDisabled}
+            className="mb-1"
+            onChange={handleDescriptionChange}
+          />
+          <div className="text-right text-xs text-gray-500">
+            {descriptionLength}/{AUDIT_DESCRIPTION_MAX_LENGTH}
+          </div>
+
+          <Input
+            name={dueDateField}
+            label="Due date"
+            type="datetime-local"
+            error={dueDateError}
+            disabled={formDisabled}
+            className="mt-4"
+          />
+        </div>
+
+        {/* Right column: Team member selector */}
+        <div className="!border-r">
+          <Separator className="md:hidden" />
+          <p className="p-3 pb-0 font-medium">Select assignee (optional).</p>
+          <p className="border-b p-3 ">
+            If no assignee is selected, any admin user can perform the audit.
+            This can also be done by multiple users at different times.
+          </p>
+          <AuditTeamMemberSelector error={assigneeError} />
+        </div>
+      </div>
+
+      {/* Footer buttons */}
+      <div className="flex items-center justify-end gap-2 border-t p-4 pb-0 md:col-span-2">
+        <Button
+          type="button"
+          variant="secondary"
+          disabled={formDisabled}
+          onClick={handleCloseDialog}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" variant="primary" disabled={formDisabled}>
+          Create audit
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
+++ b/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
@@ -16,7 +16,7 @@
  */
 
 import type { ChangeEvent } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useNavigate } from "react-router";
 
 import AuditTeamMemberSelector from "~/components/audit/audit-team-member-selector";
@@ -25,44 +25,63 @@ import { Button } from "~/components/shared/button";
 import { Separator } from "~/components/shared/separator";
 import { useDisabled } from "~/hooks/use-disabled";
 
-/** Maximum length of the optional audit description. */
+/**
+ * Maximum length (in characters) of the optional audit description field.
+ *
+ * Enforces the textarea `maxLength` and drives the live character counter
+ * shown beneath the description input.
+ */
 export const AUDIT_DESCRIPTION_MAX_LENGTH = 1000;
 
-/** Shape of the fetcher response returned by `/api/audits/start`. */
+/**
+ * Shape of the fetcher response returned by `/api/audits/start`.
+ *
+ * @property success - Whether the audit was created successfully.
+ * @property redirectTo - URL of the newly-created audit to navigate to on success.
+ */
 export type StartAuditFetcherData = {
   success?: boolean;
   redirectTo?: string;
 };
 
-/** Props for {@link StartAuditDialogContent}. */
+/**
+ * Props for the {@link StartAuditDialogContent} component.
+ *
+ * @property disabled - Whether the dialog action is in flight (from the bulk-dialog harness).
+ * @property handleCloseDialog - Closes the parent dialog.
+ * @property fetcherError - Server error to surface (shown under the description field).
+ * @property fetcherData - Fetcher response; on success the form navigates to `redirectTo`.
+ * @property nameField - Zorm field name for the audit name input.
+ * @property descriptionField - Zorm field name for the description input.
+ * @property dueDateField - Zorm field name for the due-date input.
+ * @property nameError - Validation error for the name field.
+ * @property descriptionError - Validation error for the description field.
+ * @property dueDateError - Validation error for the due-date field.
+ * @property assigneeError - Validation error for the assignee selector.
+ */
 export type StartAuditDialogContentProps = {
-  /** Whether the dialog action is in flight (from the bulk-dialog harness). */
   disabled: boolean;
-  /** Closes the parent dialog. */
   handleCloseDialog: () => void;
-  /** Server error to surface (shown under the description field). */
   fetcherError?: string;
-  /** Fetcher response; on success we navigate to `redirectTo`. */
   fetcherData?: StartAuditFetcherData;
-  /** Zorm field name for the audit name input. */
   nameField: string;
-  /** Zorm field name for the description input. */
   descriptionField: string;
-  /** Zorm field name for the due-date input. */
   dueDateField: string;
-  /** Validation error for the name field. */
   nameError?: string;
-  /** Validation error for the description field. */
   descriptionError?: string;
-  /** Validation error for the due-date field. */
   dueDateError?: string;
-  /** Validation error for the assignee selector. */
   assigneeError?: string;
 };
 
 /**
- * The shared inner form for the bulk "Create audit" dialog. On a successful
- * fetcher response it navigates to the newly-created audit.
+ * Shared inner form for the bulk "Create audit" dialogs (assets, locations, …).
+ *
+ * Renders the audit name, description (with a live character counter), and
+ * due-date inputs plus the assignee selector and footer buttons. On a
+ * successful fetcher response it navigates to the newly-created audit.
+ *
+ * @param props - See {@link StartAuditDialogContentProps}.
+ * @returns The dialog's form fields and footer buttons.
  */
 export function StartAuditDialogContent({
   disabled,
@@ -81,6 +100,10 @@ export function StartAuditDialogContent({
   const isNavigating = useDisabled();
   const formDisabled = disabled || isNavigating;
   const [descriptionLength, setDescriptionLength] = useState(0);
+  // Unique id so the description input can reference its character counter via
+  // aria-describedby — the dialog body is shared and may render in multiple
+  // contexts, so a static id could collide.
+  const descriptionCounterId = useId();
 
   const handleDescriptionChange = (
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -122,8 +145,13 @@ export function StartAuditDialogContent({
             disabled={formDisabled}
             className="mb-1"
             onChange={handleDescriptionChange}
+            aria-describedby={descriptionCounterId}
           />
-          <div className="text-right text-xs text-gray-500">
+          <div
+            id={descriptionCounterId}
+            className="text-right text-xs text-gray-500"
+            aria-live="polite"
+          >
             {descriptionLength}/{AUDIT_DESCRIPTION_MAX_LENGTH}
           </div>
 

--- a/apps/webapp/app/components/location/bulk-actions-dropdown.tsx
+++ b/apps/webapp/app/components/location/bulk-actions-dropdown.tsx
@@ -1,9 +1,17 @@
 import { useAtomValue } from "jotai";
 import { useHydrated } from "remix-utils/use-hydrated";
 import { selectedBulkItemsCountAtom } from "~/atoms/list";
+import When from "~/components/when/when";
 import { useControlledDropdownMenu } from "~/hooks/use-controlled-dropdown-menu";
+import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { userHasPermission } from "~/utils/permissions/permission.validator.client";
 import { tw } from "~/utils/tw";
 import BulkDeleteDialog from "./bulk-delete-dialog";
+import LocationsBulkStartAuditDialog from "./bulk-start-audit-dialog";
 import { BulkUpdateDialogTrigger } from "../bulk-update-dialog/bulk-update-dialog";
 import { ChevronRight } from "../icons/library";
 import { Button } from "../shared/button";
@@ -36,6 +44,7 @@ export default function BulkActionsDropdown() {
 }
 
 function ConditionalDropdown() {
+  const { roles } = useUserRoleHelper();
   const selectedLocationsCount = useAtomValue(selectedBulkItemsCountAtom);
 
   const disabled = selectedLocationsCount === 0;
@@ -63,6 +72,7 @@ function ConditionalDropdown() {
       )}
 
       <BulkDeleteDialog />
+      <LocationsBulkStartAuditDialog />
 
       <DropdownMenu
         modal={false}
@@ -103,6 +113,27 @@ function ConditionalDropdown() {
           ref={dropdownRef}
         >
           <div className="order fixed bottom-0 left-0 w-screen rounded-b-none rounded-t-[4px] bg-white p-0 text-right md:static md:w-[180px] md:rounded-t-[4px]">
+            <When
+              truthy={userHasPermission({
+                roles,
+                entity: PermissionEntity.audit,
+                action: PermissionAction.create,
+              })}
+            >
+              <DropdownMenuItem
+                className="px-4 py-1 md:p-0"
+                onSelect={(e) => {
+                  e.preventDefault();
+                }}
+              >
+                <BulkUpdateDialogTrigger
+                  type="start-audit"
+                  label="Create audit"
+                  onClick={closeMenu}
+                />
+              </DropdownMenuItem>
+            </When>
+
             <DropdownMenuItem
               className="px-4 py-1 md:p-0"
               onSelect={(e) => {

--- a/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
@@ -1,0 +1,110 @@
+/**
+ * Bulk "Create audit" dialog for the Locations index.
+ *
+ * Mirrors the assets bulk-audit dialog but operates on selected *locations*: the
+ * shared dialog harness posts the selected location IDs as `locationIds[]` (plus
+ * `currentSearchParams`, and the ALL_SELECTED_KEY sentinel on "select all"), and
+ * a hidden `contextType=location` field routes the request to the location
+ * branch of `/api/audits/start`, which resolves the union of assets server-side.
+ *
+ * @see {@link file://./../assets/bulk-start-audit-dialog.tsx} the assets counterpart
+ * @see {@link file://./../../routes/api+/audits.start.ts} server-side resolution
+ */
+
+import { useAtomValue } from "jotai";
+import { DateTime } from "luxon";
+import { useLoaderData } from "react-router";
+import { useZorm } from "react-zorm";
+import { z } from "zod";
+
+import {
+  selectedBulkItemsAtom,
+  selectedBulkItemsCountAtom,
+} from "~/atoms/list";
+import {
+  StartAuditDialogContent,
+  type StartAuditFetcherData,
+} from "~/components/audit/start-audit-dialog-content";
+import { BulkUpdateDialogContent } from "~/components/bulk-update-dialog/bulk-update-dialog";
+import type { IndexResponse } from "~/components/list";
+import { BaseAuditSchema } from "~/routes/api+/audits.start";
+import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { isSelectingAllItems } from "~/utils/list";
+
+/**
+ * Client-side schema for the Locations bulk-audit dialog. The harness injects
+ * the selected location IDs under `locationIds`, so require at least one.
+ * Server-side validation lives in `StartAuditSchema` (`/api/audits/start`).
+ */
+export const LocationsBulkStartAuditSchema = BaseAuditSchema.extend({
+  locationIds: z.array(z.string()).min(1),
+}).refine(
+  (data) => {
+    if (!data.dueDate) return true;
+    const parsed = DateTime.fromFormat(data.dueDate, DATE_TIME_FORMAT);
+    return parsed.isValid && parsed > DateTime.now();
+  },
+  {
+    message: "Due date must be in the future",
+    path: ["dueDate"],
+  }
+);
+
+/**
+ * Renders the "Create audit" dialog wired to the Locations index multi-select.
+ * The audit covers the union of all assets in the selected locations.
+ */
+export default function LocationsBulkStartAuditDialog() {
+  const { totalItems } = useLoaderData<IndexResponse>();
+  const selectedItems = useAtomValue(selectedBulkItemsAtom);
+  const selectedCount = useAtomValue(selectedBulkItemsCountAtom);
+
+  // Show totalItems when "Select All" is used, otherwise the selected count
+  const allSelected = isSelectingAllItems(selectedItems);
+  const displayCount = allSelected ? totalItems : selectedCount;
+
+  const zo = useZorm("LocationsBulkStartAudit", LocationsBulkStartAuditSchema);
+
+  const nameField = zo.fields.name();
+  const descriptionField = zo.fields.description();
+  const dueDateField = zo.fields.dueDate();
+  const nameError = zo.errors.name()?.message;
+  const descriptionError = zo.errors.description()?.message;
+  const dueDateError = zo.errors.dueDate()?.message;
+  const assigneeError = zo.errors.assignee()?.message;
+
+  return (
+    <BulkUpdateDialogContent
+      ref={zo.ref}
+      type="start-audit"
+      className="md:w-[800px]"
+      title="Start an audit"
+      description={`You're about to start an audit covering the assets in ${displayCount} location${
+        displayCount === 1 ? "" : "s"
+      }.`}
+      actionUrl="/api/audits/start"
+      arrayFieldId="locationIds"
+      formClassName="px-0"
+    >
+      {({ disabled, handleCloseDialog, fetcherError, fetcherData }) => (
+        <>
+          {/* Routes the request to the location branch of /api/audits/start */}
+          <input type="hidden" name="contextType" value="location" />
+          <StartAuditDialogContent
+            disabled={disabled}
+            handleCloseDialog={handleCloseDialog}
+            fetcherError={fetcherError}
+            fetcherData={fetcherData as StartAuditFetcherData}
+            nameField={nameField}
+            descriptionField={descriptionField}
+            dueDateField={dueDateField}
+            nameError={nameError}
+            descriptionError={descriptionError}
+            dueDateError={dueDateError}
+            assigneeError={assigneeError}
+          />
+        </>
+      )}
+    </BulkUpdateDialogContent>
+  );
+}

--- a/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
@@ -11,6 +11,12 @@
  * @see {@link file://./../../routes/api+/audits.start.ts} server-side resolution
  */
 
+import {
+  Popover,
+  PopoverContent,
+  PopoverPortal,
+  PopoverTrigger,
+} from "@radix-ui/react-popover";
 import { useAtomValue } from "jotai";
 import { InfoIcon } from "lucide-react";
 import { DateTime } from "luxon";
@@ -28,6 +34,9 @@ import {
 } from "~/components/audit/start-audit-dialog-content";
 import { BulkUpdateDialogContent } from "~/components/bulk-update-dialog/bulk-update-dialog";
 import type { IndexResponse } from "~/components/list";
+import type { ListItemData } from "~/components/list/list-item";
+import { Button } from "~/components/shared/button";
+import { useSearchParams } from "~/hooks/search-params";
 import { BaseAuditSchema } from "~/routes/api+/audits.start";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { isSelectingAllItems } from "~/utils/list";
@@ -52,6 +61,112 @@ export const LocationsBulkStartAuditSchema = BaseAuditSchema.extend({
 );
 
 /**
+ * Confirms the scope of the audit inside the dialog: how many locations are
+ * selected and (for an explicit selection) their names and per-location asset
+ * counts behind a "View list" popover.
+ *
+ * Two modes, driven by `allSelected`:
+ * - **Select all** — we only hold the sentinel client-side, not the names, so
+ *   we show the total count plus the active name search (if any). No list.
+ * - **Explicit selection** — we have each row's `name`, so we show the count
+ *   with a "View list" popover. The popover scrolls, so it scales from a
+ *   handful of locations to 100+ without stretching the dialog.
+ *
+ * @param props.allSelected - Whether "select all" (filtered set) is active
+ * @param props.count - Locations the audit will cover (total when `allSelected`)
+ * @param props.locations - Selected rows; only read when `!allSelected`
+ * @param props.search - Active Locations-list name search (`s`), for select-all copy
+ * @returns A one-line scope summary, with a names popover for explicit selections
+ */
+function SelectedLocationsSummary({
+  allSelected,
+  count,
+  locations,
+  search,
+}: {
+  allSelected: boolean;
+  count: number;
+  locations: ListItemData[];
+  search: string | null;
+}) {
+  const plural = count === 1 ? "" : "s";
+
+  if (allSelected) {
+    return (
+      <p className="text-sm text-gray-700">
+        Auditing assets in{" "}
+        <span className="font-medium">
+          all {count} location{plural}
+        </span>
+        {search ? (
+          <>
+            {" "}
+            matching <span className="font-medium">“{search}”</span>
+          </>
+        ) : null}
+        .
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-gray-700">
+      <span>
+        Auditing assets in{" "}
+        <span className="font-medium">
+          {count} location{plural}
+        </span>
+        .
+      </span>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto p-0 text-sm font-medium"
+          >
+            View list
+          </Button>
+        </PopoverTrigger>
+        <PopoverPortal>
+          <PopoverContent
+            align="start"
+            className="z-[999999] mt-2 max-h-[300px] w-[260px] overflow-y-auto rounded-md border border-gray-200 bg-white shadow-md"
+          >
+            <p className="border-b border-gray-100 px-3 py-2 text-xs font-medium text-gray-500">
+              Selected locations ({count})
+            </p>
+            <ul className="py-1">
+              {locations.map((location) => {
+                // Row data carried from the Locations list (see its loader's
+                // `_count` select). Default to 0 if a row somehow lacks it.
+                const assetCount: number = location._count?.assets ?? 0;
+                return (
+                  <li
+                    key={location.id}
+                    className="flex items-center justify-between gap-3 px-3 py-1.5 text-sm"
+                  >
+                    <span
+                      className="truncate text-gray-700"
+                      title={location.name ?? undefined}
+                    >
+                      {location.name || "Untitled location"}
+                    </span>
+                    <span className="shrink-0 text-xs tabular-nums text-gray-500">
+                      {assetCount} asset{assetCount === 1 ? "" : "s"}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </PopoverContent>
+        </PopoverPortal>
+      </Popover>
+    </div>
+  );
+}
+
+/**
  * Renders the "Create audit" dialog wired to the Locations index multi-select.
  * The audit covers the union of all assets in the selected locations.
  */
@@ -59,10 +174,14 @@ export default function LocationsBulkStartAuditDialog() {
   const { totalItems } = useLoaderData<IndexResponse>();
   const selectedItems = useAtomValue(selectedBulkItemsAtom);
   const selectedCount = useAtomValue(selectedBulkItemsCountAtom);
+  const [searchParams] = useSearchParams();
 
   // Show totalItems when "Select All" is used, otherwise the selected count
   const allSelected = isSelectingAllItems(selectedItems);
   const displayCount = allSelected ? totalItems : selectedCount;
+  // Active name search on the Locations list — only meaningful for "select all",
+  // where it tells the user which filtered set the audit will cover.
+  const search = searchParams.get("s")?.trim() || null;
 
   const zo = useZorm("LocationsBulkStartAudit", LocationsBulkStartAuditSchema);
 
@@ -80,9 +199,7 @@ export default function LocationsBulkStartAuditDialog() {
       type="start-audit"
       className="md:w-[800px]"
       title="Start an audit"
-      description={`You're about to start an audit covering the assets in ${displayCount} location${
-        displayCount === 1 ? "" : "s"
-      }.`}
+      description="Set up an audit for the assets in the locations you selected."
       actionUrl="/api/audits/start"
       arrayFieldId="locationIds"
       formClassName="px-0"
@@ -91,10 +208,17 @@ export default function LocationsBulkStartAuditDialog() {
         <>
           {/* Routes the request to the location branch of /api/audits/start */}
           <input type="hidden" name="contextType" value="location" />
-          {/* Set expectations: the audit covers assets directly assigned to the
-              selected locations only — assets in their sub-locations are not
-              pulled in (the resolver does not walk the location tree here). */}
-          <div className="border-t px-6 py-3">
+          <div className="space-y-3 border-t px-6 py-3">
+            {/* Confirm what's selected so the user can verify scope before submit */}
+            <SelectedLocationsSummary
+              allSelected={allSelected}
+              count={displayCount}
+              locations={selectedItems}
+              search={search}
+            />
+            {/* Set expectations: the audit covers assets directly assigned to the
+                selected locations only — assets in their sub-locations are not
+                pulled in (the resolver does not walk the location tree here). */}
             <div className="flex items-start gap-2 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
               <InfoIcon className="mt-0.5 size-4 shrink-0 text-gray-400" />
               <p>

--- a/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useAtomValue } from "jotai";
+import { InfoIcon } from "lucide-react";
 import { DateTime } from "luxon";
 import { useLoaderData } from "react-router";
 import { useZorm } from "react-zorm";
@@ -90,6 +91,19 @@ export default function LocationsBulkStartAuditDialog() {
         <>
           {/* Routes the request to the location branch of /api/audits/start */}
           <input type="hidden" name="contextType" value="location" />
+          {/* Set expectations: the audit covers assets directly assigned to the
+              selected locations only — assets in their sub-locations are not
+              pulled in (the resolver does not walk the location tree here). */}
+          <div className="border-t px-6 py-3">
+            <div className="flex items-start gap-2 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              <InfoIcon className="mt-0.5 size-4 shrink-0 text-gray-400" />
+              <p>
+                The audit will include every asset directly assigned to the
+                selected location{displayCount === 1 ? "" : "s"}. Assets in
+                sub-locations aren&apos;t included.
+              </p>
+            </div>
+          </div>
           <StartAuditDialogContent
             disabled={disabled}
             handleCloseDialog={handleCloseDialog}

--- a/apps/webapp/app/modules/audit/context-helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+/**
+ * Unit tests for `resolveAssetIdsForLocationSelection` — the resolver behind the
+ * bulk "Create audit" action on the Locations index.
+ *
+ * Covers the security- and correctness-critical behaviors:
+ * - explicit multi-location selection → org-scoped union of asset IDs
+ * - the IDOR guard rejects a foreign/tampered location ID before any asset read
+ * - "select all" resolves the filtered location set (honoring the name search)
+ *   and skips the per-ID guard (the set is org-scoped by construction)
+ * - an empty union surfaces a clear 400 instead of creating an empty audit
+ *
+ * @see {@link file://./context-helpers.server.ts}
+ */
+import { ShelfError } from "~/utils/error";
+import { resolveAssetIdsForLocationSelection } from "./context-helpers.server";
+
+// why: the resolver (and the org guard it calls) hit the global Prisma client;
+// mock it so the suite is DB-free. `vitest.hoisted` makes the spies available
+// inside the (hoisted) mock factory. Each test sets the return values it needs.
+const { locationFindMany, assetFindMany } = vitest.hoisted(() => ({
+  locationFindMany: vitest.fn(),
+  assetFindMany: vitest.fn(),
+}));
+
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    location: { findMany: locationFindMany },
+    asset: { findMany: assetFindMany },
+  },
+}));
+
+const ORG = "org-1";
+const ALL_SELECTED = "all-selected"; // mirrors ALL_SELECTED_KEY in ~/utils/list
+
+beforeEach(() => {
+  locationFindMany.mockReset();
+  assetFindMany.mockReset();
+});
+
+describe("resolveAssetIdsForLocationSelection", () => {
+  it("explicit selection: asserts org ownership, then returns the org-scoped union of asset IDs", async () => {
+    // org guard: both requested locations belong to the org
+    locationFindMany.mockResolvedValueOnce([{ id: "l1" }, { id: "l2" }]);
+    // assets across both locations
+    assetFindMany.mockResolvedValueOnce([
+      { id: "a1" },
+      { id: "a2" },
+      { id: "a3" },
+    ]);
+
+    const result = await resolveAssetIdsForLocationSelection({
+      organizationId: ORG,
+      locationIds: ["l1", "l2"],
+    });
+
+    expect(result).toEqual(["a1", "a2", "a3"]);
+    // asset query is org-scoped and unions the selected locations
+    expect(assetFindMany).toHaveBeenCalledWith({
+      where: { organizationId: ORG, locationId: { in: ["l1", "l2"] } },
+      select: { id: true },
+    });
+  });
+
+  it("rejects a foreign/tampered location ID before reading any assets (IDOR guard)", async () => {
+    // org-scoped guard returns only one of the two requested → count mismatch
+    locationFindMany.mockResolvedValueOnce([{ id: "l1" }]);
+
+    const err = await resolveAssetIdsForLocationSelection({
+      organizationId: ORG,
+      locationIds: ["l1", "l2-foreign"],
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ShelfError);
+    expect(err.status).toBe(400);
+    // the asset query must never run for a tampered selection
+    expect(assetFindMany).not.toHaveBeenCalled();
+  });
+
+  it("select all: resolves the filtered location set honoring the search, with no per-ID guard", async () => {
+    // resolver resolves all matching locations, then their assets
+    locationFindMany.mockResolvedValueOnce([{ id: "l1" }, { id: "l2" }]);
+    assetFindMany.mockResolvedValueOnce([{ id: "a1" }]);
+
+    const result = await resolveAssetIdsForLocationSelection({
+      organizationId: ORG,
+      locationIds: [ALL_SELECTED],
+      currentSearchParams: "s=seaham",
+    });
+
+    expect(result).toEqual(["a1"]);
+    // location set honors the active name search (mirrors the list filter)
+    expect(locationFindMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: ORG,
+        name: { contains: "seaham", mode: "insensitive" },
+      },
+      select: { id: true },
+    });
+  });
+
+  it("throws a clear 400 when none of the selected locations contain assets", async () => {
+    locationFindMany.mockResolvedValueOnce([{ id: "l1" }, { id: "l2" }]); // guard passes
+    assetFindMany.mockResolvedValueOnce([]); // empty union
+
+    const err = await resolveAssetIdsForLocationSelection({
+      organizationId: ORG,
+      locationIds: ["l1", "l2"],
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ShelfError);
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/contain assets/i);
+  });
+});

--- a/apps/webapp/app/modules/audit/context-helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.test.ts
@@ -6,8 +6,9 @@
  * Covers the security- and correctness-critical behaviors:
  * - explicit multi-location selection → org-scoped union of asset IDs
  * - the IDOR guard rejects a foreign/tampered location ID before any asset read
- * - "select all" resolves the filtered location set (honoring the name search)
- *   and skips the per-ID guard (the set is org-scoped by construction)
+ * - "select all" matches assets via a location relation filter (honoring the
+ *   name search) in a single query, skipping the per-ID guard (org-scoped by
+ *   construction)
  * - an empty union surfaces a clear 400 instead of creating an empty audit
  *
  * @see {@link file://./context-helpers.server.ts}
@@ -94,9 +95,7 @@ describe("resolveAssetIdsForLocationSelection", () => {
     expect(assetFindMany).not.toHaveBeenCalled();
   });
 
-  it("select all: resolves the filtered location set honoring the search, with no per-ID guard", async () => {
-    // resolver resolves all matching locations, then their assets
-    locationFindMany.mockResolvedValueOnce([{ id: "l1" }, { id: "l2" }]);
+  it("select all: matches assets via a location relation filter honoring the search (single query, no per-ID guard)", async () => {
     assetFindMany.mockResolvedValueOnce([{ id: "a1" }]);
 
     const result = await resolveAssetIdsForLocationSelection({
@@ -106,14 +105,20 @@ describe("resolveAssetIdsForLocationSelection", () => {
     });
 
     expect(result).toEqual(["a1"]);
-    // location set honors the active name search (mirrors the list filter)
-    expect(locationFindMany).toHaveBeenCalledWith({
+    // one asset query; its `location` relation mirrors the active list filter
+    expect(assetFindMany).toHaveBeenCalledWith({
       where: {
         organizationId: ORG,
-        name: { contains: "seaham", mode: "insensitive" },
+        location: {
+          organizationId: ORG,
+          name: { contains: "seaham", mode: "insensitive" },
+        },
       },
       select: { id: true },
     });
+    // select-all is org-scoped by construction — no separate location lookup
+    // and no per-ID guard
+    expect(locationFindMany).not.toHaveBeenCalled();
   });
 
   it("throws a clear 400 when none of the selected locations contain assets", async () => {

--- a/apps/webapp/app/modules/audit/context-helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.test.ts
@@ -62,6 +62,23 @@ describe("resolveAssetIdsForLocationSelection", () => {
     });
   });
 
+  it("explicit selection: dedupes duplicate location IDs before the asset query", async () => {
+    // guard sees the unique set; resolver must not re-introduce the duplicate
+    locationFindMany.mockResolvedValueOnce([{ id: "l1" }, { id: "l2" }]);
+    assetFindMany.mockResolvedValueOnce([{ id: "a1" }]);
+
+    await resolveAssetIdsForLocationSelection({
+      organizationId: ORG,
+      locationIds: ["l1", "l1", "l2"],
+    });
+
+    // the `in` clause carries each location once, not the raw duplicated input
+    expect(assetFindMany).toHaveBeenCalledWith({
+      where: { organizationId: ORG, locationId: { in: ["l1", "l2"] } },
+      select: { id: true },
+    });
+  });
+
   it("rejects a foreign/tampered location ID before reading any assets (IDOR guard)", async () => {
     // org-scoped guard returns only one of the two requested → count mismatch
     locationFindMany.mockResolvedValueOnce([{ id: "l1" }]);

--- a/apps/webapp/app/modules/audit/context-helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.test.ts
@@ -13,6 +13,7 @@
  * @see {@link file://./context-helpers.server.ts}
  */
 import { ShelfError } from "~/utils/error";
+import { ALL_SELECTED_KEY } from "~/utils/list";
 import { resolveAssetIdsForLocationSelection } from "./context-helpers.server";
 
 // why: the resolver (and the org guard it calls) hit the global Prisma client;
@@ -31,7 +32,6 @@ vitest.mock("~/database/db.server", () => ({
 }));
 
 const ORG = "org-1";
-const ALL_SELECTED = "all-selected"; // mirrors ALL_SELECTED_KEY in ~/utils/list
 
 beforeEach(() => {
   locationFindMany.mockReset();
@@ -84,7 +84,7 @@ describe("resolveAssetIdsForLocationSelection", () => {
 
     const result = await resolveAssetIdsForLocationSelection({
       organizationId: ORG,
-      locationIds: [ALL_SELECTED],
+      locationIds: [ALL_SELECTED_KEY],
       currentSearchParams: "s=seaham",
     });
 

--- a/apps/webapp/app/modules/audit/context-helpers.server.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.ts
@@ -246,9 +246,11 @@ export async function resolveAssetIdsForLocationSelection({
     });
     resolvedLocationIds = locations.map((location) => location.id);
   } else {
-    // Explicit selection from request input — prove org ownership before use
+    // Explicit selection from request input — prove org ownership before use.
+    // Dedupe so duplicate IDs from the client don't bloat the `in` query (and
+    // can't push large selections toward Prisma's bind-parameter ceiling).
     await assertLocationsBelongToOrg({ locationIds, organizationId });
-    resolvedLocationIds = locationIds;
+    resolvedLocationIds = [...new Set(locationIds)];
   }
 
   if (resolvedLocationIds.length === 0) {

--- a/apps/webapp/app/modules/audit/context-helpers.server.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.ts
@@ -1,6 +1,9 @@
 import { db } from "~/database/db.server";
 import { getLocationDescendantIds } from "~/modules/location/descendants.server";
+import { getLocationsWhereInput } from "~/modules/location/utils.server";
 import { ShelfError } from "~/utils/error";
+import { ALL_SELECTED_KEY } from "~/utils/list";
+import { assertLocationsBelongToOrg } from "~/utils/org-validation.server";
 
 /** Context type for audit creation */
 export type AuditContextType = "location" | "kit" | "user";
@@ -200,5 +203,81 @@ export async function getAssetsForUserContext({
   });
 
   // Return just the asset IDs
+  return assets.map((asset) => asset.id);
+}
+
+/**
+ * Resolves the asset IDs to audit from a multi-select of locations on the
+ * Locations index (the bulk "Create audit" action).
+ *
+ * - "Select all" (when `locationIds` contains {@link ALL_SELECTED_KEY}) resolves
+ *   the full set of locations matching the current list filter, mirroring what
+ *   the user sees — see {@link getLocationsWhereInput}.
+ * - An explicit selection is proven to belong to the caller's org first (IDOR
+ *   guard) before use.
+ *
+ * Asset→location is 1:1, so the union across locations needs no dedup. The
+ * asset query is org-scoped, so a tampered/foreign location ID can never leak
+ * another org's assets.
+ *
+ * @param organizationId - The caller's (validated) organization ID
+ * @param locationIds - Selected location IDs (may contain ALL_SELECTED_KEY)
+ * @param currentSearchParams - Serialized Locations-list search params (for select-all)
+ * @returns Asset IDs across the selected locations
+ * @throws {ShelfError} 400 if no locations resolve, or none of them contain assets
+ */
+export async function resolveAssetIdsForLocationSelection({
+  organizationId,
+  locationIds,
+  currentSearchParams,
+}: {
+  organizationId: string;
+  locationIds: string[];
+  currentSearchParams?: string | null;
+}): Promise<string[]> {
+  // Resolve which locations to include in the audit
+  let resolvedLocationIds: string[];
+
+  if (locationIds.includes(ALL_SELECTED_KEY)) {
+    // "Select all" — resolve the full filtered set (org-scoped by construction)
+    const locations = await db.location.findMany({
+      where: getLocationsWhereInput({ organizationId, currentSearchParams }),
+      select: { id: true },
+    });
+    resolvedLocationIds = locations.map((location) => location.id);
+  } else {
+    // Explicit selection from request input — prove org ownership before use
+    await assertLocationsBelongToOrg({ locationIds, organizationId });
+    resolvedLocationIds = locationIds;
+  }
+
+  if (resolvedLocationIds.length === 0) {
+    throw new ShelfError({
+      cause: null,
+      message: "No locations selected for the audit.",
+      status: 400,
+      label: "Audit",
+      shouldBeCaptured: false,
+    });
+  }
+
+  // Union of assets across the selected locations (asset→location is 1:1, so
+  // findMany already returns each asset once — no dedup needed).
+  const assets = await db.asset.findMany({
+    where: { organizationId, locationId: { in: resolvedLocationIds } },
+    select: { id: true },
+  });
+
+  if (assets.length === 0) {
+    throw new ShelfError({
+      cause: null,
+      message:
+        "None of the selected locations contain assets. Add assets before starting an audit.",
+      status: 400,
+      label: "Audit",
+      shouldBeCaptured: false,
+    });
+  }
+
   return assets.map((asset) => asset.id);
 }

--- a/apps/webapp/app/modules/audit/context-helpers.server.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.ts
@@ -1,3 +1,5 @@
+import type { Prisma } from "@prisma/client";
+
 import { db } from "~/database/db.server";
 import { getLocationDescendantIds } from "~/modules/location/descendants.server";
 import { getLocationsWhereInput } from "~/modules/location/utils.server";
@@ -210,21 +212,23 @@ export async function getAssetsForUserContext({
  * Resolves the asset IDs to audit from a multi-select of locations on the
  * Locations index (the bulk "Create audit" action).
  *
- * - "Select all" (when `locationIds` contains {@link ALL_SELECTED_KEY}) resolves
- *   the full set of locations matching the current list filter, mirroring what
- *   the user sees — see {@link getLocationsWhereInput}.
+ * - "Select all" (when `locationIds` contains {@link ALL_SELECTED_KEY}) matches
+ *   assets whose location satisfies the current list filter, mirroring what the
+ *   user sees — see {@link getLocationsWhereInput}. This uses a `location`
+ *   relation filter so it stays a SINGLE query: no need to materialize the
+ *   location IDs into a giant `IN (...)` list.
  * - An explicit selection is proven to belong to the caller's org first (IDOR
- *   guard) before use.
+ *   guard), then scoped by the (deduped) location IDs.
  *
- * Asset→location is 1:1, so the union across locations needs no dedup. The
- * asset query is org-scoped, so a tampered/foreign location ID can never leak
- * another org's assets.
+ * Asset→location is 1:1, so the result needs no dedup. The asset query is always
+ * org-scoped, so a tampered/foreign location ID can never leak another org's
+ * assets.
  *
  * @param organizationId - The caller's (validated) organization ID
  * @param locationIds - Selected location IDs (may contain ALL_SELECTED_KEY)
  * @param currentSearchParams - Serialized Locations-list search params (for select-all)
  * @returns Asset IDs across the selected locations
- * @throws {ShelfError} 400 if no locations resolve, or none of them contain assets
+ * @throws {ShelfError} 400 if none of the selected locations contain assets
  */
 export async function resolveAssetIdsForLocationSelection({
   organizationId,
@@ -235,38 +239,31 @@ export async function resolveAssetIdsForLocationSelection({
   locationIds: string[];
   currentSearchParams?: string | null;
 }): Promise<string[]> {
-  // Resolve which locations to include in the audit
-  let resolvedLocationIds: string[];
+  // Build the org-scoped asset where-clause for the selected locations.
+  let assetWhere: Prisma.AssetWhereInput;
 
   if (locationIds.includes(ALL_SELECTED_KEY)) {
-    // "Select all" — resolve the full filtered set (org-scoped by construction)
-    const locations = await db.location.findMany({
-      where: getLocationsWhereInput({ organizationId, currentSearchParams }),
-      select: { id: true },
-    });
-    resolvedLocationIds = locations.map((location) => location.id);
+    // "Select all" — match assets whose location satisfies the SAME filter the
+    // user sees on the Locations list. A relation filter keeps this one query
+    // (no separate location lookup, no giant IN list). Assets with no location
+    // are naturally excluded, which matches the explicit-selection semantics.
+    assetWhere = {
+      organizationId,
+      location: getLocationsWhereInput({ organizationId, currentSearchParams }),
+    };
   } else {
-    // Explicit selection from request input — prove org ownership before use.
-    // Dedupe so duplicate IDs from the client don't bloat the `in` query (and
-    // can't push large selections toward Prisma's bind-parameter ceiling).
+    // Explicit selection from request input — prove org ownership before use,
+    // then scope by the deduped IDs (schema guarantees at least one).
     await assertLocationsBelongToOrg({ locationIds, organizationId });
-    resolvedLocationIds = [...new Set(locationIds)];
+    assetWhere = {
+      organizationId,
+      locationId: { in: [...new Set(locationIds)] },
+    };
   }
 
-  if (resolvedLocationIds.length === 0) {
-    throw new ShelfError({
-      cause: null,
-      message: "No locations selected for the audit.",
-      status: 400,
-      label: "Audit",
-      shouldBeCaptured: false,
-    });
-  }
-
-  // Union of assets across the selected locations (asset→location is 1:1, so
-  // findMany already returns each asset once — no dedup needed).
+  // Asset→location is 1:1, so findMany already returns each asset once.
   const assets = await db.asset.findMany({
-    where: { organizationId, locationId: { in: resolvedLocationIds } },
+    where: assetWhere,
     select: { id: true },
   });
 

--- a/apps/webapp/app/modules/location/utils.server.ts
+++ b/apps/webapp/app/modules/location/utils.server.ts
@@ -1,0 +1,50 @@
+/**
+ * Location module server-side utilities.
+ *
+ * Houses Prisma `where`-clause builders for the Locations index so that bulk
+ * "select all" operations resolve the SAME filtered set the user currently
+ * sees on screen. Mirrors `getKitsWhereInput` (`~/modules/kit/utils.server`)
+ * and `getAssetsWhereInput` (`~/modules/asset/utils.server`).
+ *
+ * @see {@link file://./service.server.ts} getLocations — the list loader whose filter this mirrors
+ * @see {@link file://./../audit/context-helpers.server.ts} resolveAssetIdsForLocationSelection — consumer for bulk audit
+ */
+
+import type { Location, Prisma } from "@prisma/client";
+
+/**
+ * Builds the Prisma where-clause for the Locations index list from the current
+ * URL search params. The Locations index only supports name search (the `s`
+ * param), so this stays intentionally thin — keep it in lock-step with
+ * {@link file://./service.server.ts} `getLocations` so a filtered "select all"
+ * audits exactly the locations the user can see.
+ *
+ * @param params.organizationId - The caller's (validated) organization ID
+ * @param params.currentSearchParams - Serialized list search params (e.g. `s=room`)
+ * @returns A `Prisma.LocationWhereInput` scoped to the org and active search
+ */
+export function getLocationsWhereInput({
+  organizationId,
+  currentSearchParams,
+}: {
+  organizationId: Location["organizationId"];
+  currentSearchParams?: string | null;
+}): Prisma.LocationWhereInput {
+  const where: Prisma.LocationWhereInput = { organizationId };
+
+  if (!currentSearchParams) {
+    return where;
+  }
+
+  const searchParams = new URLSearchParams(currentSearchParams);
+  const search = searchParams.get("s")?.trim();
+
+  if (search) {
+    where.name = {
+      contains: search,
+      mode: "insensitive",
+    };
+  }
+
+  return where;
+}

--- a/apps/webapp/app/routes/api+/audits.start.test.ts
+++ b/apps/webapp/app/routes/api+/audits.start.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+/**
+ * Contract tests for `StartAuditSchema` — the request validation for
+ * `POST /api/audits/start`.
+ *
+ * The `.refine` is load-bearing: it decides which "create audit" entry points
+ * are accepted (asset-index bulk, single-context detail page, and the locations
+ * multi-select). These tests lock that contract so the new location branch and
+ * the legacy forms can't silently regress.
+ *
+ * @see {@link file://./audits.start.ts}
+ */
+import { StartAuditSchema } from "./audits.start";
+
+// why: importing the route module transitively pulls in ~/database/db.server
+// (Prisma client init) and the audit service; the schema under test never
+// touches them, so hollow mocks keep this suite DB-free and side-effect-free.
+vitest.mock("~/database/db.server", () => ({ db: {} }));
+vitest.mock("~/modules/audit/service.server", () => ({
+  createAuditSession: vitest.fn(),
+  scheduleNextAuditJob: vitest.fn(),
+}));
+
+const base = { name: "Quarterly audit" };
+
+describe("StartAuditSchema", () => {
+  it("accepts a location multi-selection (contextType=location + locationIds)", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      contextType: "location",
+      locationIds: ["l1", "l2"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the select-all sentinel inside locationIds", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      contextType: "location",
+      locationIds: ["all-selected"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still accepts the legacy single-context form (contextType + contextId)", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      contextType: "location",
+      contextId: "l1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still accepts the asset-index bulk form (direct assetIds)", () => {
+    const result = StartAuditSchema.safeParse({ ...base, assetIds: ["a1"] });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects contextType=location with neither contextId nor locationIds", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      contextType: "location",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects locationIds supplied without contextType=location", () => {
+    // why: locationIds only counts when contextType is explicitly "location",
+    // so a stray array without the discriminator must not pass validation.
+    const result = StartAuditSchema.safeParse({ ...base, locationIds: ["l1"] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty selection (no assetIds, no context, no locationIds)", () => {
+    const result = StartAuditSchema.safeParse({ ...base });
+    expect(result.success).toBe(false);
+  });
+
+  it("requires a non-empty audit name", () => {
+    const result = StartAuditSchema.safeParse({
+      name: "",
+      contextType: "location",
+      locationIds: ["l1"],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/webapp/app/routes/api+/audits.start.ts
+++ b/apps/webapp/app/routes/api+/audits.start.ts
@@ -81,7 +81,8 @@ export const StartAuditSchema = BaseAuditSchema.extend({
     return hasAssetIds || hasContext || hasLocationSelection;
   },
   {
-    message: "Either assetIds or context parameters must be provided",
+    message:
+      "Provide assetIds, context parameters (contextType + contextId), or a location selection (contextType=location + locationIds).",
   }
 );
 

--- a/apps/webapp/app/routes/api+/audits.start.ts
+++ b/apps/webapp/app/routes/api+/audits.start.ts
@@ -8,7 +8,10 @@ import { resolveAssetIdsForBulkOperation } from "~/modules/asset/bulk-operations
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { AUDIT_SCHEDULER_EVENTS_ENUM } from "~/modules/audit/constants";
-import { resolveAssetIdsForAudit } from "~/modules/audit/context-helpers.server";
+import {
+  resolveAssetIdsForAudit,
+  resolveAssetIdsForLocationSelection,
+} from "~/modules/audit/context-helpers.server";
 import { sendAuditAssignedEmail } from "~/modules/audit/email-helpers";
 import {
   createAuditSession,
@@ -62,13 +65,20 @@ export const StartAuditSchema = BaseAuditSchema.extend({
   contextType: z.enum(["location", "kit", "user"]).optional(),
   contextId: z.string().optional(),
   contextName: z.string().optional(),
+  // Location IDs - for the bulk "Create audit" action on the Locations index
+  // (multi-select). May contain ALL_SELECTED_KEY when "select all" is active.
+  locationIds: z.array(z.string()).optional(),
   includeChildLocations: z.coerce.boolean().default(false),
 }).refine(
   (data) => {
-    // Must have either assetIds OR context params
+    // Must have assetIds, single-context params, OR a location multi-selection
     const hasAssetIds = data.assetIds && data.assetIds.length > 0;
     const hasContext = data.contextType && data.contextId;
-    return hasAssetIds || hasContext;
+    const hasLocationSelection =
+      data.contextType === "location" &&
+      !!data.locationIds &&
+      data.locationIds.length > 0;
+    return hasAssetIds || hasContext || hasLocationSelection;
   },
   {
     message: "Either assetIds or context parameters must be provided",
@@ -99,19 +109,29 @@ export async function action({ request, context }: ActionFunctionArgs) {
       contextType,
       contextId,
       contextName,
+      locationIds,
       includeChildLocations,
       currentSearchParams,
     } = parseData(formData, StartAuditSchema.and(CurrentSearchParamsSchema), {
       additionalData: { organizationId, userId },
     });
 
-    // Determine if we're selecting all items across multiple pages
-    const isSelectingAll =
+    // Determine if we're selecting all asset rows across multiple pages
+    const isSelectingAllAssets =
       directAssetIds && directAssetIds.includes(ALL_SELECTED_KEY);
 
     let assetIds: string[];
 
-    if (isSelectingAll) {
+    if (contextType === "location" && locationIds && locationIds.length > 0) {
+      // Bulk "Create audit" from the Locations index (multi-select). Resolve
+      // the union of assets across the selected locations server-side — handles
+      // "select all" (honoring the list filter) and asserts explicit IDs.
+      assetIds = await resolveAssetIdsForLocationSelection({
+        organizationId,
+        locationIds,
+        currentSearchParams,
+      });
+    } else if (isSelectingAllAssets) {
       // When "Select All" is used, resolve IDs using bulk operation helper
       // which handles both simple and advanced filter modes
       const settings = await getAssetIndexSettings({

--- a/apps/webapp/app/utils/org-validation.server.test.ts
+++ b/apps/webapp/app/utils/org-validation.server.test.ts
@@ -279,8 +279,11 @@ describe("assertCustomFieldsBelongToOrg", () => {
   });
 });
 
-describe("single-entity guards reject foreign/missing with 404", () => {
-  it("assertTeamMemberBelongsToOrg throws 404 when not found in org", async () => {
+// A foreign/missing single ID is an invalid request input (not a gone
+// resource), so these guards return 400 — consistent with the bulk guards
+// above and the file-level contract.
+describe("single-entity guards reject foreign/missing with 400", () => {
+  it("assertTeamMemberBelongsToOrg throws 400 when not found in org", async () => {
     const tx = txWith({
       teamMember: { findFirst: vitest.fn().mockResolvedValue(null) },
     });
@@ -290,7 +293,7 @@ describe("single-entity guards reject foreign/missing with 404", () => {
     ).catch((e) => e);
 
     expect(err).toBeInstanceOf(ShelfError);
-    expect(err.status).toBe(404);
+    expect(err.status).toBe(400);
     expect(tx.teamMember.findFirst).toHaveBeenCalledWith({
       where: { id: "tm-foreign", organizationId: ORG },
       select: { id: true },
@@ -309,7 +312,7 @@ describe("single-entity guards reject foreign/missing with 404", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("assertCategoryBelongsToOrg throws 404 when foreign/missing", async () => {
+  it("assertCategoryBelongsToOrg throws 400 when foreign/missing", async () => {
     const tx = txWith({
       category: { findFirst: vitest.fn().mockResolvedValue(null) },
     });
@@ -318,10 +321,10 @@ describe("single-entity guards reject foreign/missing with 404", () => {
       tx
     ).catch((e) => e);
     expect(err).toBeInstanceOf(ShelfError);
-    expect(err.status).toBe(404);
+    expect(err.status).toBe(400);
   });
 
-  it("assertLocationBelongsToOrg throws 404 when foreign/missing", async () => {
+  it("assertLocationBelongsToOrg throws 400 when foreign/missing", async () => {
     const tx = txWith({
       location: { findFirst: vitest.fn().mockResolvedValue(null) },
     });
@@ -330,7 +333,8 @@ describe("single-entity guards reject foreign/missing with 404", () => {
       tx
     ).catch((e) => e);
     expect(err).toBeInstanceOf(ShelfError);
-    expect(err.status).toBe(404);
+    expect(err.status).toBe(400);
+    expect(err.title).toBe("Invalid location");
   });
 
   it("assertLocationBelongsToOrg resolves when the location is in the org", async () => {
@@ -344,7 +348,7 @@ describe("single-entity guards reject foreign/missing with 404", () => {
 });
 
 describe("assertUserBelongsToOrg", () => {
-  it("throws 404 when the user is not a member of the org (foreign custodian user)", async () => {
+  it("throws 400 when the user is not a member of the org (foreign custodian user)", async () => {
     const tx = txWith({
       userOrganization: { findFirst: vitest.fn().mockResolvedValue(null) },
     });
@@ -354,7 +358,7 @@ describe("assertUserBelongsToOrg", () => {
     ).catch((e) => e);
 
     expect(err).toBeInstanceOf(ShelfError);
-    expect(err.status).toBe(404);
+    expect(err.status).toBe(400);
     expect(tx.userOrganization.findFirst).toHaveBeenCalledWith({
       where: { userId: "u-foreign", organizationId: ORG },
       select: { id: true },

--- a/apps/webapp/app/utils/org-validation.server.test.ts
+++ b/apps/webapp/app/utils/org-validation.server.test.ts
@@ -20,6 +20,7 @@ import {
   assertTeamMemberBelongsToOrg,
   assertCategoryBelongsToOrg,
   assertLocationBelongsToOrg,
+  assertLocationsBelongToOrg,
   assertUserBelongsToOrg,
 } from "./org-validation.server";
 
@@ -36,7 +37,10 @@ function txWith(overrides: Record<string, any>) {
     tag: { findMany: vitest.fn().mockResolvedValue([]) },
     teamMember: { findFirst: vitest.fn().mockResolvedValue(null) },
     category: { findFirst: vitest.fn().mockResolvedValue(null) },
-    location: { findFirst: vitest.fn().mockResolvedValue(null) },
+    location: {
+      findFirst: vitest.fn().mockResolvedValue(null),
+      findMany: vitest.fn().mockResolvedValue([]),
+    },
     customField: { findMany: vitest.fn().mockResolvedValue([]) },
     userOrganization: { findFirst: vitest.fn().mockResolvedValue(null) },
     ...overrides,
@@ -106,6 +110,70 @@ describe("assertAssetsBelongToOrg", () => {
     expect(err).toBeInstanceOf(ShelfError);
     expect(err.status).toBe(400);
     expect(err.title).toBe("Invalid assets");
+  });
+});
+
+describe("assertLocationsBelongToOrg", () => {
+  it("is a no-op for an empty list (no query issued)", async () => {
+    const tx = txWith({});
+    await expect(
+      assertLocationsBelongToOrg({ locationIds: [], organizationId: ORG }, tx)
+    ).resolves.toBeUndefined();
+    expect(tx.location.findMany).not.toHaveBeenCalled();
+  });
+
+  it("resolves when every location belongs to the org and scopes the query by organizationId", async () => {
+    const tx = txWith({
+      location: {
+        findMany: vitest.fn().mockResolvedValue([{ id: "l1" }, { id: "l2" }]),
+      },
+    });
+
+    await expect(
+      assertLocationsBelongToOrg(
+        { locationIds: ["l1", "l2"], organizationId: ORG },
+        tx
+      )
+    ).resolves.toBeUndefined();
+
+    expect(tx.location.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["l1", "l2"] }, organizationId: ORG },
+      select: { id: true },
+    });
+  });
+
+  it("dedupes input so duplicate IDs don't inflate the expected count", async () => {
+    const tx = txWith({
+      location: { findMany: vitest.fn().mockResolvedValue([{ id: "l1" }]) },
+    });
+
+    await expect(
+      assertLocationsBelongToOrg(
+        { locationIds: ["l1", "l1"], organizationId: ORG },
+        tx
+      )
+    ).resolves.toBeUndefined();
+
+    expect(tx.location.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["l1"] }, organizationId: ORG },
+      select: { id: true },
+    });
+  });
+
+  it("rejects with a 400 ShelfError when any ID is foreign/missing", async () => {
+    // l2 belongs to another org → the org-scoped findMany returns only l1
+    const tx = txWith({
+      location: { findMany: vitest.fn().mockResolvedValue([{ id: "l1" }]) },
+    });
+
+    const err = await assertLocationsBelongToOrg(
+      { locationIds: ["l1", "l2"], organizationId: ORG },
+      tx
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ShelfError);
+    expect(err.status).toBe(400);
+    expect(err.title).toBe("Invalid locations");
   });
 });
 

--- a/apps/webapp/app/utils/org-validation.server.ts
+++ b/apps/webapp/app/utils/org-validation.server.ts
@@ -69,6 +69,10 @@ export type OrgValidationTxClient = {
       where: { id: string; organizationId: string };
       select: { id: true };
     }) => Promise<{ id: string } | null>;
+    findMany: (args: {
+      where: { id: { in: string[] }; organizationId: string };
+      select: { id: true };
+    }) => Promise<{ id: string }[]>;
   };
   customField: {
     findMany: (args: {
@@ -118,6 +122,50 @@ export async function assertAssetsBelongToOrg(
       title: "Invalid assets",
       message:
         "Some of the selected assets do not exist in your workspace. Please reload and try again.",
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+      additionalData: { organizationId },
+    });
+  }
+}
+
+/**
+ * Asserts that every location ID belongs to `organizationId`.
+ *
+ * Plural counterpart to {@link assertLocationBelongsToOrg}, for bulk paths that
+ * accept a list of location IDs from request/form input (e.g. creating an audit
+ * from a multi-select on the Locations index). Dedupes the input so duplicate
+ * IDs don't inflate the expected count. A no-op for an empty list.
+ *
+ * @param params.locationIds - Location IDs sourced from request/form input
+ * @param params.organizationId - The caller's (validated) organization ID
+ * @param tx - Optional Prisma transaction client; defaults to the global `db`
+ * @throws {ShelfError} 400 if any ID is missing or belongs to another org
+ */
+export async function assertLocationsBelongToOrg(
+  {
+    locationIds,
+    organizationId,
+  }: { locationIds: Location["id"][]; organizationId: string },
+  tx?: OrgValidationTxClient
+): Promise<void> {
+  if (locationIds.length === 0) return;
+
+  const client = tx ?? db;
+  const uniqueIds = [...new Set(locationIds)];
+
+  const found = await client.location.findMany({
+    where: { id: { in: uniqueIds }, organizationId },
+    select: { id: true },
+  });
+
+  if (found.length !== uniqueIds.length) {
+    throw new ShelfError({
+      cause: null,
+      title: "Invalid locations",
+      message:
+        "Some of the selected locations do not exist in your workspace. Please reload and try again.",
       label,
       status: 400,
       shouldBeCaptured: false,

--- a/apps/webapp/app/utils/org-validation.server.ts
+++ b/apps/webapp/app/utils/org-validation.server.ts
@@ -262,7 +262,7 @@ export async function assertTagsBelongToOrg(
  * @param params.teamMemberId - Team member ID sourced from request/form input
  * @param params.organizationId - The caller's (validated) organization ID
  * @param tx - Optional Prisma transaction client; defaults to the global `db`
- * @throws {ShelfError} 404 if the team member is missing or in another org
+ * @throws {ShelfError} 400 if the team member is missing or in another org
  */
 export async function assertTeamMemberBelongsToOrg(
   {
@@ -284,7 +284,7 @@ export async function assertTeamMemberBelongsToOrg(
       title: "Team member not found",
       message: "The selected team member could not be found in your workspace.",
       label,
-      status: 404,
+      status: 400,
       shouldBeCaptured: false,
       additionalData: { organizationId, teamMemberId },
     });
@@ -297,7 +297,7 @@ export async function assertTeamMemberBelongsToOrg(
  * @param params.categoryId - Category ID sourced from request/form input
  * @param params.organizationId - The caller's (validated) organization ID
  * @param tx - Optional Prisma transaction client; defaults to the global `db`
- * @throws {ShelfError} 404 if the category is missing or in another org
+ * @throws {ShelfError} 400 if the category is missing or in another org
  */
 export async function assertCategoryBelongsToOrg(
   {
@@ -320,7 +320,7 @@ export async function assertCategoryBelongsToOrg(
       message:
         "The selected category could not be found in your workspace. Please reload and try again.",
       label,
-      status: 404,
+      status: 400,
       shouldBeCaptured: false,
       additionalData: { organizationId, categoryId },
     });
@@ -333,7 +333,7 @@ export async function assertCategoryBelongsToOrg(
  * @param params.locationId - Location ID sourced from request/form input
  * @param params.organizationId - The caller's (validated) organization ID
  * @param tx - Optional Prisma transaction client; defaults to the global `db`
- * @throws {ShelfError} 404 if the location is missing or in another org
+ * @throws {ShelfError} 400 if the location is missing or in another org
  */
 export async function assertLocationBelongsToOrg(
   {
@@ -356,7 +356,7 @@ export async function assertLocationBelongsToOrg(
       message:
         "The selected location could not be found in your workspace. Please reload and try again.",
       label,
-      status: 404,
+      status: 400,
       shouldBeCaptured: false,
       additionalData: { organizationId, locationId },
     });
@@ -374,7 +374,7 @@ export async function assertLocationBelongsToOrg(
  * @param params.userId - User ID sourced from request/form input
  * @param params.organizationId - The caller's (validated) organization ID
  * @param tx - Optional Prisma transaction client; defaults to the global `db`
- * @throws {ShelfError} 404 if the user is not a member of the organization
+ * @throws {ShelfError} 400 if the user is not a member of the organization
  */
 export async function assertUserBelongsToOrg(
   { userId, organizationId }: { userId: User["id"]; organizationId: string },
@@ -394,7 +394,7 @@ export async function assertUserBelongsToOrg(
       message:
         "The selected custodian user is not a member of this workspace. Please reload and try again.",
       label,
-      status: 404,
+      status: 400,
       shouldBeCaptured: false,
       additionalData: { organizationId, userId },
     });

--- a/apps/webapp/test/routes-tests/api+/audits.start.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.start.test.ts
@@ -16,6 +16,7 @@
  * @see {@link file://../../../app/routes/api+/audits.start.ts}
  */
 import { StartAuditSchema } from "~/routes/api+/audits.start";
+import { ALL_SELECTED_KEY } from "~/utils/list";
 
 // why: importing the route module transitively pulls in ~/database/db.server
 // (Prisma client init) and the audit service; the schema under test never
@@ -42,7 +43,7 @@ describe("StartAuditSchema", () => {
     const result = StartAuditSchema.safeParse({
       ...base,
       contextType: "location",
-      locationIds: ["all-selected"],
+      locationIds: [ALL_SELECTED_KEY],
     });
     expect(result.success).toBe(true);
   });

--- a/apps/webapp/test/routes-tests/api+/audits.start.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.start.test.ts
@@ -8,9 +8,14 @@
  * multi-select). These tests lock that contract so the new location branch and
  * the legacy forms can't silently regress.
  *
- * @see {@link file://./audits.start.ts}
+ * Lives under `test/routes-tests/` rather than next to the route itself
+ * because React Router's flat-routes scanner auto-registers any `*.ts` /
+ * `*.tsx` file inside `app/routes/` as a route module and would try to
+ * serve this test file — crashing the dev server on its server-only imports.
+ *
+ * @see {@link file://../../../app/routes/api+/audits.start.ts}
  */
-import { StartAuditSchema } from "./audits.start";
+import { StartAuditSchema } from "~/routes/api+/audits.start";
 
 // why: importing the route module transitively pulls in ~/database/db.server
 // (Prisma client init) and the audit service; the schema under test never


### PR DESCRIPTION
## What & why

Customer report: on **/locations**, selecting locations and opening **Actions** showed only **Delete** — no way to create an audit. Audit-from-location only existed on the location **detail** page; the bulk list dropdown was delete-only, and the "New Audit → From Location" dialog sent users to the list (a dead end).

This adds a bulk **Create audit** action to the Locations index: select one or more locations → **Actions → Create audit** → one audit covering the union of those locations' assets.

## Approach (minimal by design)

Multi-location audit already shipped via the Assets index location filter, so this is a thin bridge to the existing capability rather than a new audit backend:

- **`/api/audits/start`** accepts `contextType=location` + `locationIds[]`; a dedicated handler branch resolves the asset union server-side (`resolveAssetIdsForLocationSelection`).
- **Select all** honors the active list search via a new `getLocationsWhereInput`; explicit IDs are org-scoped through a new plural `assertLocationsBelongToOrg` guard (per the org-scope IDOR rule). The asset query is org-scoped regardless, as a backstop.
- Reuses the shared `BulkUpdateDialogContent` harness and the **unchanged `createAuditSession`**, so audit activity events and assignee email are emitted identically to the existing asset/single-location paths.
- Lifts the shared `StartAuditDialogContent` so the assets and locations dialogs share one form (no change to asset behavior).
- Action gated behind `audit:create`; the **New Audit** info dialog copy is corrected on all three cards.

## Tests & verification

- `pnpm webapp:validate` green (typecheck, lint, 2267 tests). 8 new unit tests cover the resolver (explicit multi-location union, org-scoping, select-all honoring search, empty-union error) and the new org guard.
- Verified end-to-end on a running app: select 2 locations → **Create audit** → dialog posts `locationIds` + `contextType=location` → audit created with exactly the union of their assets → redirected to the audit. No new console errors.

## Out of scope (intentional)

- **Kits** has the identical detail-page-only gap — same pattern (`kitIds` + reuse `getKitsWhereInput`), will follow in a separate PR. The Kit card in the New Audit dialog already points to the kit detail page.
- **Include child locations** in the bulk action — the single-location detail flow still offers it.
- `bulkDeleteLocations` ignores the search filter on "select all" (`modules/location/service.server.ts`); this PR's audit select-all does the filtered-correct thing. Not changing delete here — flagged as a separate cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk audit creation from Locations page with multi-select and select-all support
  * Audit description field now limited to 1,000 characters with live character counter
  * Due date validation now ensures dates are set in the future
  * Audit bulk actions now respect user permissions

* **Improvements**
  * Updated audit creation dialog help text for better clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->