### PR TITLE
feat(webapp): add kit-as-unit option for booking check-in progress

### DIFF
--- a/apps/webapp/app/components/booking/booking-statistics.tsx
+++ b/apps/webapp/app/components/booking/booking-statistics.tsx
@@ -1,5 +1,8 @@
 import type { BookingStatus, Tag as PrismaTag, User } from "@prisma/client";
-import type { calculatePartialCheckinProgress } from "~/modules/booking/utils.server";
+import type {
+  calculatePartialCheckinProgress,
+  calculateUnitCheckinProgress,
+} from "~/modules/booking/utils.server";
 import { resolveUserDisplayName } from "~/utils/user";
 import { CategoryBadge } from "../assets/category-badge";
 import ItemsWithViewMore from "../list/items-with-view-more";
@@ -31,7 +34,9 @@ export function BookingStatistics({
   allCategories: { id: string; name: string; color: string }[];
   tags: Pick<PrismaTag, "id" | "name" | "color">[];
   creator: Pick<User, "id" | "firstName" | "lastName" | "profilePicture">;
-  partialCheckinProgress?: ReturnType<typeof calculatePartialCheckinProgress>;
+  partialCheckinProgress?:
+    | ReturnType<typeof calculatePartialCheckinProgress>
+    | ReturnType<typeof calculateUnitCheckinProgress>;
   autoArchivedAt?: Date | null;
   status: BookingStatus;
 }) {
@@ -57,9 +62,30 @@ export function BookingStatistics({
               <div className="flex items-center justify-between">
                 <span className="text-sm text-gray-500">Check-in progress</span>
                 <span className="flex min-w-[150px] items-center gap-2 text-right text-sm font-medium">
-                  <span className="whitespace-nowrap">
+                  <span className="flex items-center gap-1 whitespace-nowrap">
                     {partialCheckinProgress.checkedInCount} /{" "}
                     {partialCheckinProgress.totalAssets}
+                    {partialCheckinProgress.countMode === "units" ? (
+                      <>
+                        <span className="text-gray-500">units</span>
+                        <InfoTooltip
+                          iconClassName="size-4"
+                          content={<p>Kits count as one unit</p>}
+                        />
+                      </>
+                    ) : (
+                      <>
+                        <span className="text-gray-500">assets</span>
+                        <InfoTooltip
+                          iconClassName="size-4"
+                          content={
+                            <p>
+                              All assets inside kits are counted individually
+                            </p>
+                          }
+                        />
+                      </>
+                    )}
                   </span>
                   <Progress value={partialCheckinProgress.progressPercentage} />
                 </span>

--- a/apps/webapp/app/components/booking/progressive-checkin-settings.tsx
+++ b/apps/webapp/app/components/booking/progressive-checkin-settings.tsx
@@ -55,6 +55,10 @@ export function ProgressiveCheckinSettings({
   const fetcher = useFetcher();
   const disabled = useDisabled();
   const zo = useZorm("CountKitsAsUnitForm", CountKitsAsUnitSettingsSchema);
+  // Bind the (visually hidden) label to the Switch via a shared id so the
+  // control has a reliable, programmatically-associated accessible name.
+  const countKitsField = zo.fields.countKitsAsSingleUnit();
+  const countKitsFieldId = `countKitsAsSingleUnit-${countKitsField}`;
 
   return (
     <Card>
@@ -80,15 +84,13 @@ export function ProgressiveCheckinSettings({
           >
             <div className="flex flex-col items-center gap-2">
               <Switch
-                name={zo.fields.countKitsAsSingleUnit()}
+                id={countKitsFieldId}
+                name={countKitsField}
                 disabled={disabled}
                 defaultChecked={defaultValue}
                 title="Count each kit as a single unit"
               />
-              <label
-                htmlFor={`countKitsAsSingleUnit-${zo.fields.countKitsAsSingleUnit()}`}
-                className=" hidden text-gray-500"
-              >
+              <label htmlFor={countKitsFieldId} className="sr-only">
                 Count each kit as a single unit
               </label>
             </div>

--- a/apps/webapp/app/components/booking/progressive-checkin-settings.tsx
+++ b/apps/webapp/app/components/booking/progressive-checkin-settings.tsx
@@ -1,0 +1,105 @@
+/**
+ * Progressive Check-in/out Settings
+ *
+ * Renders the workspace booking-settings card for progressive check-in/out
+ * display options. Currently exposes a single auto-saving toggle that controls
+ * whether a kit is counted as one unit (rather than counting the individual
+ * assets inside it) when visualising the progress of a booking's check-in/out.
+ *
+ * The toggle follows the auto-save pattern used by the other booking-settings
+ * switches: flipping the switch immediately submits the enclosing fetcher form,
+ * so there is no explicit Save button.
+ *
+ * @see {@link file://./../../routes/_layout+/settings.bookings.tsx} for the
+ *   loader/action that persists this setting via `updateBookingSettings`.
+ */
+
+import { useFetcher } from "react-router";
+import { useZorm } from "react-zorm";
+import z from "zod";
+import FormRow from "~/components/forms/form-row";
+import { Switch } from "~/components/forms/switch";
+import { Card } from "~/components/shared/card";
+import { useDisabled } from "~/hooks/use-disabled";
+
+/**
+ * Validation schema for the "count each kit as a single unit" toggle.
+ *
+ * The HTML checkbox submits the string `"on"` when checked and omits the field
+ * when unchecked, so we coerce to a boolean and default to `false`.
+ */
+export const CountKitsAsUnitSettingsSchema = z.object({
+  countKitsAsSingleUnit: z
+    .string()
+    .transform((val) => val === "on")
+    .default("false"),
+});
+
+/**
+ * Workspace booking-settings card for progressive check-in/out display options.
+ *
+ * @param props - Component props
+ * @param props.header - Card header content (title and optional sub-heading)
+ * @param props.defaultValue - Current persisted value of `countKitsAsSingleUnit`;
+ *   used as the switch's initial checked state
+ * @returns A card containing the auto-saving "count each kit as a single unit"
+ *   toggle
+ */
+export function ProgressiveCheckinSettings({
+  header,
+  defaultValue = false,
+}: {
+  header: { title: string; subHeading?: string };
+  defaultValue: boolean;
+}) {
+  const fetcher = useFetcher();
+  const disabled = useDisabled();
+  const zo = useZorm("CountKitsAsUnitForm", CountKitsAsUnitSettingsSchema);
+
+  return (
+    <Card>
+      <div className="mb-4 border-b pb-4">
+        <h3 className="text-text-lg font-semibold">{header.title}</h3>
+        <p className="text-sm text-gray-600">{header.subHeading}</p>
+      </div>
+      <div>
+        <fetcher.Form
+          ref={zo.ref}
+          method="post"
+          onChange={(e) => void fetcher.submit(e.currentTarget)}
+        >
+          <FormRow
+            rowLabel="Count each kit as a single unit"
+            subHeading={
+              <div>
+                When visualising the state of a booking, treat each kit as one
+                unit rather than counting the assets inside it.
+              </div>
+            }
+            className="border-b-0 pb-[10px] pt-0"
+          >
+            <div className="flex flex-col items-center gap-2">
+              <Switch
+                name={zo.fields.countKitsAsSingleUnit()}
+                disabled={disabled}
+                defaultChecked={defaultValue}
+                title="Count each kit as a single unit"
+              />
+              <label
+                htmlFor={`countKitsAsSingleUnit-${zo.fields.countKitsAsSingleUnit()}`}
+                className=" hidden text-gray-500"
+              >
+                Count each kit as a single unit
+              </label>
+            </div>
+          </FormRow>
+          <input
+            type="hidden"
+            value="updateCountKitsAsSingleUnit"
+            name="intent"
+          />
+        </fetcher.Form>
+      </div>
+    </Card>
+  );
+}

--- a/apps/webapp/app/components/scanner/drawer/uses/partial-checkin-drawer.tsx
+++ b/apps/webapp/app/components/scanner/drawer/uses/partial-checkin-drawer.tsx
@@ -17,6 +17,7 @@ import CheckinDialog from "~/components/booking/checkin-dialog";
 import { Form } from "~/components/custom-form";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
+import { InfoTooltip } from "~/components/shared/info-tooltip";
 import { Progress } from "~/components/shared/progress";
 import { isBookingEarlyCheckin } from "~/modules/booking/helpers";
 import type { loader } from "~/routes/_layout+/bookings.$bookingId.overview.checkin-assets";
@@ -389,10 +390,14 @@ export default function PartialCheckinDrawer({
       }
       title={
         <div className="text-right">
-          <span className="block text-gray-600">
+          <span className="flex items-center justify-end gap-1 text-gray-600">
             {assetIdsForCheckin.length}/
             {partialCheckinProgress?.uncheckedCount || booking.assets.length}{" "}
             Assets scanned
+            <InfoTooltip
+              iconClassName="size-4"
+              content={<p>All assets inside kits are counted individually</p>}
+            />
           </span>
           <span className="flex h-5 flex-col justify-center font-medium text-gray-900">
             <Progress

--- a/apps/webapp/app/modules/booking-settings/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.test.ts
@@ -293,6 +293,54 @@ describe("updateBookingSettings", () => {
     expect(result).toEqual(updatedSettings);
   });
 
+  it("should update countKitsAsSingleUnit to true", async () => {
+    expect.assertions(2);
+    const updatedSettings = {
+      ...mockBookingSettingsData,
+      countKitsAsSingleUnit: true,
+    };
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.update.mockResolvedValue(updatedSettings);
+
+    const result = await updateBookingSettings({
+      organizationId: mockOrganizationId,
+      countKitsAsSingleUnit: true,
+    });
+
+    // Assert only the mutating intent (where + data) — the select shape is an
+    // implementation detail covered elsewhere.
+    expect(db.bookingSettings.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId: mockOrganizationId },
+        data: { countKitsAsSingleUnit: true },
+      })
+    );
+    expect(result).toEqual(updatedSettings);
+  });
+
+  it("should update countKitsAsSingleUnit to false", async () => {
+    expect.assertions(2);
+    const updatedSettings = {
+      ...mockBookingSettingsData,
+      countKitsAsSingleUnit: false,
+    };
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.update.mockResolvedValue(updatedSettings);
+
+    const result = await updateBookingSettings({
+      organizationId: mockOrganizationId,
+      countKitsAsSingleUnit: false,
+    });
+
+    expect(db.bookingSettings.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId: mockOrganizationId },
+        data: { countKitsAsSingleUnit: false },
+      })
+    );
+    expect(result).toEqual(updatedSettings);
+  });
+
   it("should update maxBookingLength only", async () => {
     expect.assertions(2);
     const updatedSettings = {

--- a/apps/webapp/app/modules/booking-settings/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.test.ts
@@ -57,6 +57,7 @@ describe("getBookingSettingsForOrganization", () => {
         autoArchiveDays: 2,
         requireExplicitCheckinForAdmin: false,
         requireExplicitCheckinForSelfService: false,
+        countKitsAsSingleUnit: false,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         organizationId: mockOrganizationId,
@@ -71,6 +72,7 @@ describe("getBookingSettingsForOrganization", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -121,6 +123,7 @@ describe("getBookingSettingsForOrganization", () => {
         autoArchiveDays: 2,
         requireExplicitCheckinForAdmin: false,
         requireExplicitCheckinForSelfService: false,
+        countKitsAsSingleUnit: false,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         organizationId: mockOrganizationId,
@@ -135,6 +138,7 @@ describe("getBookingSettingsForOrganization", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -216,6 +220,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -265,6 +270,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -314,6 +320,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -363,6 +370,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -420,6 +428,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -471,6 +480,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -525,6 +535,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -574,6 +585,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -696,6 +708,7 @@ describe("updateBookingSettings", () => {
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {

--- a/apps/webapp/app/modules/booking-settings/service.server.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.ts
@@ -171,6 +171,7 @@ export async function updateBookingSettings({
         maxBookingLengthSkipClosedDays,
         autoArchiveBookings,
         autoArchiveDays,
+        countKitsAsSingleUnit,
       },
       label,
     });

--- a/apps/webapp/app/modules/booking-settings/service.server.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.ts
@@ -23,6 +23,7 @@ export async function getBookingSettingsForOrganization(
         autoArchiveDays: 2,
         requireExplicitCheckinForAdmin: false,
         requireExplicitCheckinForSelfService: false,
+        countKitsAsSingleUnit: false,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         organizationId,
@@ -37,6 +38,7 @@ export async function getBookingSettingsForOrganization(
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {
@@ -78,6 +80,7 @@ export async function updateBookingSettings({
   autoArchiveDays,
   requireExplicitCheckinForAdmin,
   requireExplicitCheckinForSelfService,
+  countKitsAsSingleUnit,
   notifyBookingCreator,
   notifyAdminsOnNewBooking,
 }: {
@@ -90,6 +93,7 @@ export async function updateBookingSettings({
   autoArchiveDays?: number;
   requireExplicitCheckinForAdmin?: boolean;
   requireExplicitCheckinForSelfService?: boolean;
+  countKitsAsSingleUnit?: boolean;
   notifyBookingCreator?: boolean;
   notifyAdminsOnNewBooking?: boolean;
 }) {
@@ -113,6 +117,8 @@ export async function updateBookingSettings({
     if (requireExplicitCheckinForSelfService !== undefined)
       updateData.requireExplicitCheckinForSelfService =
         requireExplicitCheckinForSelfService;
+    if (countKitsAsSingleUnit !== undefined)
+      updateData.countKitsAsSingleUnit = countKitsAsSingleUnit;
     if (notifyBookingCreator !== undefined)
       updateData.notifyBookingCreator = notifyBookingCreator;
     if (notifyAdminsOnNewBooking !== undefined)
@@ -131,6 +137,7 @@ export async function updateBookingSettings({
         autoArchiveDays: true,
         requireExplicitCheckinForAdmin: true,
         requireExplicitCheckinForSelfService: true,
+        countKitsAsSingleUnit: true,
         notifyBookingCreator: true,
         notifyAdminsOnNewBooking: true,
         alwaysNotifyTeamMembers: {

--- a/apps/webapp/app/modules/booking/utils.server.test.ts
+++ b/apps/webapp/app/modules/booking/utils.server.test.ts
@@ -57,7 +57,9 @@ describe("calculateUnitCheckinProgress", () => {
     expect(result.checkedInCount).toBe(0);
     expect(result.uncheckedCount).toBe(1);
     expect(result.progressPercentage).toBe(0);
-    expect(result.hasPartialCheckins).toBe(false);
+    // The kit unit is not "checked in", but asset-level check-ins exist, so the
+    // booking page must still surface the progress section + per-asset columns.
+    expect(result.hasPartialCheckins).toBe(true);
   });
 
   it("counts a fully checked-in kit as 1 of 1", () => {

--- a/apps/webapp/app/modules/booking/utils.server.test.ts
+++ b/apps/webapp/app/modules/booking/utils.server.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for booking check-in progress calculation utilities.
+ *
+ * Focuses on {@link calculateUnitCheckinProgress}, which powers the workspace
+ * `countKitsAsSingleUnit` setting: kits are counted as a single unit and a kit
+ * is only "checked in" when ALL of its assets are checked in.
+ *
+ * @see {@link file://./utils.server.ts}
+ */
+import { BookingStatus } from "@prisma/client";
+import { describe, it, expect } from "vitest";
+import { calculateUnitCheckinProgress } from "./utils.server";
+
+/** Convenience builder for a standalone (non-kitted) asset. */
+const standalone = (id: string) => ({ id, kitId: null });
+
+/** Convenience builder for an asset belonging to a kit. */
+const kitted = (id: string, kitId: string) => ({ id, kitId });
+
+describe("calculateUnitCheckinProgress", () => {
+  it("counts standalone-only bookings exactly like asset counting", () => {
+    const assets = [standalone("a1"), standalone("a2"), standalone("a3")];
+
+    const result = calculateUnitCheckinProgress(assets, ["a1", "a2"]);
+
+    expect(result.totalAssets).toBe(3);
+    expect(result.checkedInCount).toBe(2);
+    expect(result.uncheckedCount).toBe(1);
+    expect(result.progressPercentage).toBe(67);
+    expect(result.hasPartialCheckins).toBe(true);
+    expect(result.countMode).toBe("units");
+  });
+
+  it("counts a kit with no checked-in assets as 0 of 1", () => {
+    const assets = [kitted("a1", "kit1"), kitted("a2", "kit1")];
+
+    const result = calculateUnitCheckinProgress(assets, []);
+
+    expect(result.totalAssets).toBe(1);
+    expect(result.checkedInCount).toBe(0);
+    expect(result.uncheckedCount).toBe(1);
+    expect(result.progressPercentage).toBe(0);
+    expect(result.hasPartialCheckins).toBe(false);
+  });
+
+  it("does not count a partially checked-in kit as checked in", () => {
+    const assets = [
+      kitted("a1", "kit1"),
+      kitted("a2", "kit1"),
+      kitted("a3", "kit1"),
+    ];
+
+    // Only some of the kit's assets are checked in -> kit stays unchecked.
+    const result = calculateUnitCheckinProgress(assets, ["a1", "a2"]);
+
+    expect(result.totalAssets).toBe(1);
+    expect(result.checkedInCount).toBe(0);
+    expect(result.uncheckedCount).toBe(1);
+    expect(result.progressPercentage).toBe(0);
+    expect(result.hasPartialCheckins).toBe(false);
+  });
+
+  it("counts a fully checked-in kit as 1 of 1", () => {
+    const assets = [kitted("a1", "kit1"), kitted("a2", "kit1")];
+
+    const result = calculateUnitCheckinProgress(assets, ["a1", "a2"]);
+
+    expect(result.totalAssets).toBe(1);
+    expect(result.checkedInCount).toBe(1);
+    expect(result.uncheckedCount).toBe(0);
+    expect(result.progressPercentage).toBe(100);
+    expect(result.hasPartialCheckins).toBe(true);
+  });
+
+  it("handles mixed standalone + multiple kits with partial states", () => {
+    const assets = [
+      // 2 standalone assets (a1 checked in, a2 not)
+      standalone("a1"),
+      standalone("a2"),
+      // kit1 fully checked in
+      kitted("k1a", "kit1"),
+      kitted("k1b", "kit1"),
+      // kit2 partially checked in (counts as not checked in)
+      kitted("k2a", "kit2"),
+      kitted("k2b", "kit2"),
+      // kit3 none checked in
+      kitted("k3a", "kit3"),
+    ];
+
+    const result = calculateUnitCheckinProgress(assets, [
+      "a1",
+      "k1a",
+      "k1b",
+      "k2a",
+    ]);
+
+    // Units: 2 standalone + 3 kits = 5 total.
+    expect(result.totalAssets).toBe(5);
+    // Checked in: a1 (standalone) + kit1 (fully) = 2.
+    expect(result.checkedInCount).toBe(2);
+    expect(result.uncheckedCount).toBe(3);
+    expect(result.progressPercentage).toBe(40);
+    expect(result.hasPartialCheckins).toBe(true);
+  });
+
+  it("handles an empty booking", () => {
+    const result = calculateUnitCheckinProgress([], []);
+
+    expect(result.totalAssets).toBe(0);
+    expect(result.checkedInCount).toBe(0);
+    expect(result.uncheckedCount).toBe(0);
+    expect(result.progressPercentage).toBe(0);
+    expect(result.hasPartialCheckins).toBe(false);
+  });
+
+  it("forces 100% progress for COMPLETE bookings", () => {
+    const assets = [
+      standalone("a1"),
+      kitted("k1a", "kit1"),
+      kitted("k1b", "kit1"),
+    ];
+
+    // Even though no assets are in the checked-in set, COMPLETE forces 100%.
+    const result = calculateUnitCheckinProgress(
+      assets,
+      [],
+      BookingStatus.COMPLETE
+    );
+
+    // Units: 1 standalone + 1 kit = 2.
+    expect(result.totalAssets).toBe(2);
+    expect(result.checkedInCount).toBe(2);
+    expect(result.uncheckedCount).toBe(0);
+    expect(result.progressPercentage).toBe(100);
+    expect(result.hasPartialCheckins).toBe(true);
+  });
+});

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -52,6 +52,19 @@ export function isBookingExpired({ to }: { to: NonNullable<Booking["to"]> }) {
 
 /**
  * Calculate partial check-in progress data for a booking
+ *
+ * Counts progress at the ASSET granularity: every asset (whether standalone or
+ * inside a kit) contributes one unit toward the total and one unit toward the
+ * checked-in count once it is checked in.
+ *
+ * The returned object carries `countMode: "assets"` so consumers (e.g. the
+ * booking statistics UI) can distinguish it from the unit-based counterpart
+ * {@link calculateUnitCheckinProgress}.
+ *
+ * @param totalAssets - Total number of assets in the booking
+ * @param checkedInAssetIds - IDs of assets that have been checked in
+ * @param bookingStatus - Optional booking status; COMPLETE/ARCHIVED force 100%
+ * @returns Progress data including counts, percentage and `countMode: "assets"`
  */
 export function calculatePartialCheckinProgress(
   totalAssets: number,
@@ -70,6 +83,7 @@ export function calculatePartialCheckinProgress(
       progressPercentage: 100,
       hasPartialCheckins: totalAssets > 0,
       checkedInAssetIds,
+      countMode: "assets" as const,
     };
   }
 
@@ -86,6 +100,108 @@ export function calculatePartialCheckinProgress(
     progressPercentage,
     hasPartialCheckins,
     checkedInAssetIds,
+    countMode: "assets" as const,
+  };
+}
+
+/**
+ * Calculate unit-based check-in progress for a booking.
+ *
+ * Unlike {@link calculatePartialCheckinProgress}, this treats each KIT as a
+ * single unit instead of counting the individual assets inside it. This backs
+ * the workspace `countKitsAsSingleUnit` setting on the booking details
+ * "Check-in progress" bar.
+ *
+ * Counting rules:
+ * - Each standalone asset (`kitId === null`) is one unit. It counts as checked
+ *   in when its id is in `checkedInAssetIds`.
+ * - Each distinct kit is one unit. A kit counts as checked in ONLY when EVERY
+ *   asset belonging to it has been checked in. A partially checked-in kit
+ *   contributes 0 toward the checked-in count.
+ *
+ * The total/checked-in numbers therefore represent UNITS, not assets. To keep a
+ * shape compatible with the asset-based function, the unit total is still
+ * exposed under the `totalAssets` field. The `countMode: "units"` discriminator
+ * lets consumers render unit-aware UI.
+ *
+ * @param bookingAssets - All assets in the booking with their `id` and `kitId`
+ * @param checkedInAssetIds - IDs of assets that have been checked in
+ * @param bookingStatus - Optional booking status; COMPLETE/ARCHIVED force 100%
+ * @returns Progress data including counts, percentage and `countMode: "units"`
+ */
+export function calculateUnitCheckinProgress(
+  bookingAssets: { id: string; kitId: string | null }[],
+  checkedInAssetIds: string[],
+  bookingStatus?: BookingStatus
+) {
+  const checkedInSet = new Set(checkedInAssetIds);
+
+  // Standalone assets: each one is a unit.
+  const standaloneAssets = bookingAssets.filter(
+    (asset) => asset.kitId === null
+  );
+  const standaloneTotal = standaloneAssets.length;
+  const standaloneCheckedIn = standaloneAssets.filter((asset) =>
+    checkedInSet.has(asset.id)
+  ).length;
+
+  // Group kitted assets by their kitId; each distinct kit is a unit.
+  const kitGroups = new Map<string, string[]>();
+  for (const asset of bookingAssets) {
+    if (asset.kitId === null) {
+      continue;
+    }
+    const existing = kitGroups.get(asset.kitId);
+    if (existing) {
+      existing.push(asset.id);
+    } else {
+      kitGroups.set(asset.kitId, [asset.id]);
+    }
+  }
+
+  const distinctKits = kitGroups.size;
+  // A kit is "checked in" only when every one of its assets is checked in.
+  let fullyCheckedInKits = 0;
+  for (const assetIds of kitGroups.values()) {
+    if (assetIds.every((assetId) => checkedInSet.has(assetId))) {
+      fullyCheckedInKits += 1;
+    }
+  }
+
+  // `totalAssets` here represents total UNITS (standalone assets + distinct kits).
+  const totalAssets = standaloneTotal + distinctKits;
+
+  // For final booking statuses, always show 100% progress (mirrors the
+  // asset-based function's early-return behavior exactly).
+  if (
+    bookingStatus === BookingStatus.COMPLETE ||
+    bookingStatus === BookingStatus.ARCHIVED
+  ) {
+    return {
+      totalAssets,
+      checkedInCount: totalAssets,
+      uncheckedCount: 0,
+      progressPercentage: 100,
+      hasPartialCheckins: totalAssets > 0,
+      checkedInAssetIds,
+      countMode: "units" as const,
+    };
+  }
+
+  const checkedInCount = standaloneCheckedIn + fullyCheckedInKits;
+  const uncheckedCount = totalAssets - checkedInCount;
+  const progressPercentage =
+    totalAssets > 0 ? Math.round((checkedInCount / totalAssets) * 100) : 0;
+  const hasPartialCheckins = checkedInCount > 0;
+
+  return {
+    totalAssets,
+    checkedInCount,
+    uncheckedCount,
+    progressPercentage,
+    hasPartialCheckins,
+    checkedInAssetIds,
+    countMode: "units" as const,
   };
 }
 

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -192,7 +192,13 @@ export function calculateUnitCheckinProgress(
   const uncheckedCount = totalAssets - checkedInCount;
   const progressPercentage =
     totalAssets > 0 ? Math.round((checkedInCount / totalAssets) * 100) : 0;
-  const hasPartialCheckins = checkedInCount > 0;
+  // `hasPartialCheckins` is deliberately ASSET-level, not unit-level: it drives
+  // whether the booking page shows the check-in progress section and the
+  // per-asset "checked in on/by" columns. A kit with some (but not all) of its
+  // assets checked in produces a unit `checkedInCount` of 0, yet there ARE
+  // asset-level check-ins to surface — basing this on the kit-unit count would
+  // hide that detail. See BookingAssetsColumn / BookingStatistics.
+  const hasPartialCheckins = checkedInAssetIds.length > 0;
 
   return {
     totalAssets,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -456,6 +456,9 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         bookings: {
           some: { id: booking.id },
         },
+        // SECURITY (cross-org IDOR): scope to the caller's organizationId,
+        // matching the other booking-asset queries in this loader.
+        organizationId,
       },
       select: { id: true, kitId: true },
     });

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -53,7 +53,10 @@ import {
   updateBookingNotificationRecipients,
 } from "~/modules/booking/service.server";
 import { shapeBookingAssets } from "~/modules/booking/shape-booking-assets";
-import { calculatePartialCheckinProgress } from "~/modules/booking/utils.server";
+import {
+  calculatePartialCheckinProgress,
+  calculateUnitCheckinProgress,
+} from "~/modules/booking/utils.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import { createNotes } from "~/modules/note/service.server";
 import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
@@ -443,22 +446,42 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     const allCategories = [...assetCategories, ...kitCategories];
 
     // Calculate partial check-in progress
-    // For progress calculation, we need the TOTAL number of assets in the booking,
-    // not the filtered count from booking.assets (which may be filtered by status)
-    // So we need to get the unfiltered asset count
-    const totalBookingAssets = await db.asset.count({
+    // For progress calculation, we need the TOTAL set of assets in the booking,
+    // not the filtered count from booking.assets (which may be filtered by status).
+    // We fetch the unfiltered assets with their kitId so we can compute either
+    // asset-based or unit-based (kit-as-one) progress depending on the workspace
+    // `countKitsAsSingleUnit` setting.
+    const bookingAssetsForProgress = await db.asset.findMany({
       where: {
         bookings: {
           some: { id: booking.id },
         },
       },
+      select: { id: true, kitId: true },
     });
+    const totalBookingAssets = bookingAssetsForProgress.length;
 
-    const partialCheckinProgress = calculatePartialCheckinProgress(
-      totalBookingAssets,
-      checkedInAssetIds,
-      booking.status
-    );
+    // Read the workspace setting with a lean query. We intentionally avoid
+    // getBookingSettingsForOrganization here because that performs an upsert
+    // write, which is undesirable in a read-only loader path.
+    const bookingSettings = await db.bookingSettings.findUnique({
+      where: { organizationId },
+      select: { countKitsAsSingleUnit: true },
+    });
+    const countKitsAsSingleUnit =
+      bookingSettings?.countKitsAsSingleUnit ?? false;
+
+    const partialCheckinProgress = countKitsAsSingleUnit
+      ? calculateUnitCheckinProgress(
+          bookingAssetsForProgress,
+          checkedInAssetIds,
+          booking.status
+        )
+      : calculatePartialCheckinProgress(
+          totalBookingAssets,
+          checkedInAssetIds,
+          booking.status
+        );
 
     const modelName = {
       singular: "item",

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -445,23 +445,16 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
 
     const allCategories = [...assetCategories, ...kitCategories];
 
-    // Calculate partial check-in progress
-    // For progress calculation, we need the TOTAL set of assets in the booking,
-    // not the filtered count from booking.assets (which may be filtered by status).
-    // We fetch the unfiltered assets with their kitId so we can compute either
-    // asset-based or unit-based (kit-as-one) progress depending on the workspace
-    // `countKitsAsSingleUnit` setting.
-    const bookingAssetsForProgress = await db.asset.findMany({
-      where: {
-        bookings: {
-          some: { id: booking.id },
-        },
-        // SECURITY (cross-org IDOR): scope to the caller's organizationId,
-        // matching the other booking-asset queries in this loader.
-        organizationId,
-      },
-      select: { id: true, kitId: true },
-    });
+    // Calculate partial check-in progress.
+    // `booking.assets` is already the FULL, unfiltered booking asset set — its
+    // `getBooking` include applies no status/search filter (those are page
+    // concerns handled in-memory), and each row carries `id` + `kitId`. So we
+    // reuse it for the progress input instead of a second org-scoped round-trip.
+    // It is org-scoped transitively via the org-scoped `getBooking` fetch.
+    const bookingAssetsForProgress = enhancedBooking.assets.map((asset) => ({
+      id: asset.id,
+      kitId: asset.kitId,
+    }));
     const totalBookingAssets = bookingAssetsForProgress.length;
 
     // Read the workspace setting with a lean query. We intentionally avoid

--- a/apps/webapp/app/routes/_layout+/settings.bookings.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.bookings.tsx
@@ -16,6 +16,10 @@ import {
 } from "~/components/booking/explicit-checkin-settings";
 import { NotificationSettings } from "~/components/booking/notification-settings";
 import {
+  ProgressiveCheckinSettings,
+  CountKitsAsUnitSettingsSchema,
+} from "~/components/booking/progressive-checkin-settings";
+import {
   TagsRequiredSettings,
   TagsRequiredSettingsSchema,
 } from "~/components/booking/tags-required/tags-required-settings";
@@ -139,6 +143,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
         "updateAutoArchiveToggle",
         "updateAutoArchiveDays",
         "updateExplicitCheckin",
+        "updateCountKitsAsSingleUnit",
         "updateNotifyBookingCreator",
         "updateNotifyAdminsOnNewBooking",
         "updateAlwaysNotifyTeamMembers",
@@ -485,6 +490,35 @@ export async function action({ context, request }: ActionFunctionArgs) {
         return data(payload({ success: true }), { status: 200 });
       }
 
+      case "updateCountKitsAsSingleUnit": {
+        const { countKitsAsSingleUnit } = parseData(
+          formData,
+          CountKitsAsUnitSettingsSchema,
+          {
+            additionalData: {
+              intent,
+              organizationId,
+              formData: Object.fromEntries(formData),
+            },
+          }
+        );
+
+        await updateBookingSettings({
+          organizationId,
+          countKitsAsSingleUnit,
+        });
+
+        sendNotification({
+          title: "Settings updated",
+          message:
+            "Progressive check-in counting setting has been updated successfully",
+          icon: { name: "success", variant: "success" },
+          senderId: authSession.userId,
+        });
+
+        return data(payload({ success: true }), { status: 200 });
+      }
+
       default: {
         throw new ShelfError({
           cause: null,
@@ -521,6 +555,18 @@ export default function GeneralPage() {
             bookingSettings.requireExplicitCheckinForSelfService,
         }}
       />
+
+      {/* Progressive check-in/out display options group */}
+      <div>
+        <ProgressiveCheckinSettings
+          header={{
+            title: "Counting options",
+            subHeading:
+              "Choose how kits are counted when visualising booking check-in/out progress.",
+          }}
+          defaultValue={bookingSettings.countKitsAsSingleUnit}
+        />
+      </div>
 
       {/* Tags required settings form */}
       <TagsRequiredSettings

--- a/packages/database/prisma/migrations/20260608120000_add_count_kits_as_single_unit/migration.sql
+++ b/packages/database/prisma/migrations/20260608120000_add_count_kits_as_single_unit/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "BookingSettings"
+  ADD COLUMN "countKitsAsSingleUnit" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1270,6 +1270,9 @@ model BookingSettings {
   requireExplicitCheckinForAdmin      Boolean @default(false) // When true, admins must use explicit check-in (scanner) instead of quick check-in
   requireExplicitCheckinForSelfService Boolean @default(false) // When true, self-service users must use explicit check-in (scanner) instead of quick check-in
 
+  // Progressive check-in/out settings
+  countKitsAsSingleUnit Boolean @default(false) // When true, the booking check-in progress bar treats each kit as one unit instead of counting the assets inside it
+
   // Notification settings
   notifyBookingCreator     Boolean @default(true) // Whether the booking creator receives email notifications
   notifyAdminsOnNewBooking Boolean @default(true) // Whether all admins receive a notification when a booking is reserved


### PR DESCRIPTION
Adds a workspace booking setting that controls how the check-in progress bar counts items, so a booking containing a large kit no longer reads as dozens of missing assets.

- New BookingSettings.countKitsAsSingleUnit boolean (default false) with migration
- Settings UI: auto-save toggle under a new "Progressive check-in/out settings" group
- Booking page progress bar: when ON, each kit counts as one unit (a kit is checked in only once all its assets are), shown with a "units" label + tooltip; default mode shows an "assets" label + tooltip noting assets inside kits are counted individually
- Check-in scanner drawer: matching tooltip added to the "Assets scanned" counter
- New calculateUnitCheckinProgress() helper + unit tests; the existing asset-based path, CSV export, and check-in flow counting are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Count kits as single unit" toggle in booking settings (auto-saves) to switch progress counting mode; appears in a new "Counting options" group.

* **Improvements**
  * Check‑in progress display refreshed with per‑mode layout and inline explanatory tooltips.
  * Scanner drawer counter now shows a tooltip clarifying kit vs. asset counting.
  * Booking overview now respects the selected counting mode.

* **Tests**
  * Added tests covering unit-based check‑in progress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->