### PR TITLE
fix(webapp): preserve case for ExternalQR barcodes in advanced index filters

### DIFF
--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -633,3 +633,74 @@ describe("assetQueryFragment", () => {
     });
   });
 });
+
+describe("generateWhereClause - barcode value case normalization", () => {
+  const orgId = "test-org-id";
+
+  /**
+   * ExternalQR barcodes are stored with their original case (see
+   * `normalizeBarcodeValue`), so an exact-match filter must NOT uppercase the
+   * supplied value — otherwise `b.value = ...` never matches a lowercase code.
+   * Regression test for the `is` operator dropping ExternalQR matches.
+   */
+  it("preserves original case for ExternalQR with the 'is' operator", () => {
+    const filter: Filter = {
+      name: "barcode_ExternalQR",
+      type: "string",
+      operator: "is",
+      value: "813e1ae5",
+    };
+
+    const result = generateWhereClause(orgId, null, [filter]);
+
+    // The interpolated value must keep its original case for ExternalQR
+    expect(result.values).toContain("813e1ae5");
+    expect(result.values).not.toContain("813E1AE5");
+  });
+
+  it("preserves original case for ExternalQR with the 'isNot' operator", () => {
+    const filter: Filter = {
+      name: "barcode_ExternalQR",
+      type: "string",
+      operator: "isNot",
+      value: "813e1ae5",
+    };
+
+    const result = generateWhereClause(orgId, null, [filter]);
+
+    expect(result.values).toContain("813e1ae5");
+    expect(result.values).not.toContain("813E1AE5");
+  });
+
+  it("preserves original case for ExternalQR with the 'matchesAny' operator", () => {
+    const filter: Filter = {
+      name: "barcode_ExternalQR",
+      type: "string",
+      operator: "matchesAny",
+      value: "813e1ae5,abc9Def0",
+    };
+
+    const result = generateWhereClause(orgId, null, [filter]);
+
+    expect(result.values).toContain("813e1ae5");
+    expect(result.values).toContain("abc9Def0");
+  });
+
+  /**
+   * Non-ExternalQR barcode types (Code128, Code39, …) are stored uppercased,
+   * so their exact-match filters must continue to uppercase the supplied value.
+   */
+  it("uppercases the value for Code128 with the 'is' operator", () => {
+    const filter: Filter = {
+      name: "barcode_Code128",
+      type: "string",
+      operator: "is",
+      value: "abc123",
+    };
+
+    const result = generateWhereClause(orgId, null, [filter]);
+
+    expect(result.values).toContain("ABC123");
+    expect(result.values).not.toContain("abc123");
+  });
+});

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1,7 +1,10 @@
 import { Prisma } from "@prisma/client";
 import type { CustomFieldType } from "@prisma/client";
 
+import type { BarcodeType } from "@prisma/client";
+
 import type { Filter } from "~/components/assets/assets-index/advanced-filters/schema";
+import { normalizeBarcodeValue } from "~/modules/barcode/validation";
 import { ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
 import { isSafeSqlIdentifier } from "~/utils/sql";
@@ -785,10 +788,19 @@ function addRelationFilter(
   if (filter.name.startsWith("barcode_")) {
     const barcodeType = filter.name.split("_")[1]; // Extract the barcode type (Code128, Code39, DataMatrix, etc.)
 
-    // Normalize filter value to uppercase to match how barcodes are stored
+    // Normalize the filter value the SAME way the value is stored
+    // (`normalizeBarcodeValue`): ExternalQR preserves its original case while
+    // every other type is uppercased. Unconditionally uppercasing here broke
+    // exact-match operators (is/isNot/matchesAny) for ExternalQR, whose codes
+    // are stored case-sensitively, so `b.value = '813E1AE5'` never matched a
+    // stored '813e1ae5'. (contains/containsAny were unaffected — ILIKE is
+    // case-insensitive.)
+    const normalizeForType = (value: string) =>
+      normalizeBarcodeValue(barcodeType as BarcodeType, value);
+
     const normalizedValue =
       typeof filter.value === "string"
-        ? filter.value.toUpperCase()
+        ? normalizeForType(filter.value)
         : filter.value;
 
     switch (filter.operator) {
@@ -801,7 +813,7 @@ function addRelationFilter(
       case "matchesAny": {
         const values = (filter.value as string)
           .split(",")
-          .map((v) => v.trim().toUpperCase());
+          .map((v) => normalizeForType(v.trim()));
         const valuesArray = Prisma.join(
           values.map((v) => Prisma.sql`${v}`),
           ", "
@@ -811,7 +823,7 @@ function addRelationFilter(
       case "containsAny": {
         const values = (filter.value as string)
           .split(",")
-          .map((v) => v.trim().toUpperCase());
+          .map((v) => normalizeForType(v.trim()));
         const likeConditions = values.map(
           (value) => Prisma.sql`b.value ILIKE ${`%${value}%`}`
         );

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -26,6 +26,7 @@ import {
   updateBarcodes,
   validateBarcodeUniqueness,
 } from "~/modules/barcode/service.server";
+import { normalizeBarcodeValue } from "~/modules/barcode/validation";
 import { ASSET_MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
 import { updateCookieWithPerPage } from "~/utils/cookies.server";
 import { dateTimeInUnix } from "~/utils/date-time-in-unix";
@@ -170,7 +171,10 @@ export async function createKit({
         barcodes: {
           create: barcodesToAdd.map(({ type, value }) => ({
             type,
-            value: value.toUpperCase(),
+            // Normalize per type (ExternalQR keeps its case, others uppercase)
+            // so stored kit barcodes match what filters/lookups expect — same
+            // rule the asset create path uses via `normalizeBarcodeValue`.
+            value: normalizeBarcodeValue(type, value),
             organizationId,
           })),
         },


### PR DESCRIPTION
The advanced asset-index barcode filter unconditionally uppercased the supplied value before comparing. ExternalQR barcodes are stored case-sensitively (only Code128/Code39/DataMatrix/EAN13 are uppercased), so exact-match operators (is/isNot/matchesAny) never matched a lowercase ExternalQR value — e.g. 'is:813e1ae5' searched for '813E1AE5'. containsAny worked only because ILIKE is case-insensitive, which masked the bug.

Normalize the filter value per barcode type via normalizeBarcodeValue, the same helper the asset create path uses, so filters mirror how values are stored.

Also fix the kit create path, which uppercased barcode values unconditionally and would store ExternalQR codes with the wrong case (asset create already used normalizeBarcodeValue).

Add regression tests covering ExternalQR (is/isNot/matchesAny) and Code128.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression tests for barcode value case handling across different barcode types and filter operators.

* **Bug Fixes**
  * Fixed inconsistent barcode value handling between filtering and storage operations to ensure proper normalization based on barcode type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->