### PR TITLE
feat(audits): create audits from selected kits

### DIFF
--- a/apps/webapp/app/components/audit/new-audit-info-dialog.tsx
+++ b/apps/webapp/app/components/audit/new-audit-info-dialog.tsx
@@ -91,7 +91,9 @@ export function NewAuditInfoDialog() {
                     <PackageIcon className="size-5 text-green-600" />
                   </div>
                   <div className="flex-1">
-                    <h4 className="mb-1 font-medium text-gray-900">From Kit</h4>
+                    <h4 className="mb-1 font-medium text-gray-900">
+                      From Kits
+                    </h4>
                     <p className="mb-3 text-sm text-gray-600">
                       Audit the assets across one or more kits. Great for
                       verifying that kit contents are complete. Select kits on

--- a/apps/webapp/app/components/audit/new-audit-info-dialog.tsx
+++ b/apps/webapp/app/components/audit/new-audit-info-dialog.tsx
@@ -93,10 +93,9 @@ export function NewAuditInfoDialog() {
                   <div className="flex-1">
                     <h4 className="mb-1 font-medium text-gray-900">From Kit</h4>
                     <p className="mb-3 text-sm text-gray-600">
-                      Audit all assets within a specific kit. Great for
-                      verifying that kit contents are complete. Open the kit you
-                      want from the Kits page, then choose Actions → Create
-                      audit.
+                      Audit the assets across one or more kits. Great for
+                      verifying that kit contents are complete. Select kits on
+                      the Kits page, then choose Actions → Create audit.
                     </p>
                     <Button
                       to="/kits"

--- a/apps/webapp/app/components/kits/bulk-actions-dropdown.tsx
+++ b/apps/webapp/app/components/kits/bulk-actions-dropdown.tsx
@@ -18,6 +18,7 @@ import BulkAssignCustodyDialog from "./bulk-assign-custody-dialog";
 import BulkDeleteDialog from "./bulk-delete-dialog";
 import KitBulkLocationUpdateDialog from "./bulk-location-update-dialog";
 import BulkReleaseCustodyDialog from "./bulk-release-custody-dialog";
+import KitsBulkStartAuditDialog from "./bulk-start-audit-dialog";
 import { BulkUpdateDialogTrigger } from "../bulk-update-dialog/bulk-update-dialog";
 import { ChevronRight } from "../icons/library";
 import { Button } from "../shared/button";
@@ -137,6 +138,16 @@ function ConditionalDropdown() {
         <BulkReleaseCustodyDialog />
       </When>
 
+      <When
+        truthy={userHasPermission({
+          roles,
+          entity: PermissionEntity.audit,
+          action: PermissionAction.create,
+        })}
+      >
+        <KitsBulkStartAuditDialog />
+      </When>
+
       <DropdownMenu
         modal={false}
         onOpenChange={(open) => {
@@ -176,6 +187,27 @@ function ConditionalDropdown() {
           ref={dropdownRef}
         >
           <div className="order fixed bottom-0 left-0 w-screen rounded-b-none rounded-t-[4px] bg-white p-0 text-right md:static md:w-[180px] md:rounded-t-[4px]">
+            <When
+              truthy={userHasPermission({
+                roles,
+                entity: PermissionEntity.audit,
+                action: PermissionAction.create,
+              })}
+            >
+              <DropdownMenuItem
+                className="px-4 py-1 md:p-0"
+                onSelect={(e) => {
+                  e.preventDefault();
+                }}
+              >
+                <BulkUpdateDialogTrigger
+                  type="start-audit"
+                  label="Create audit"
+                  onClick={closeMenu}
+                />
+              </DropdownMenuItem>
+            </When>
+
             <When
               truthy={userHasPermission({
                 roles,

--- a/apps/webapp/app/components/kits/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/kits/bulk-start-audit-dialog.tsx
@@ -12,7 +12,14 @@
  * @see {@link file://./../../routes/api+/audits.start.ts} server-side resolution
  */
 
+import {
+  Popover,
+  PopoverContent,
+  PopoverPortal,
+  PopoverTrigger,
+} from "@radix-ui/react-popover";
 import { useAtomValue } from "jotai";
+import { InfoIcon } from "lucide-react";
 import { DateTime } from "luxon";
 import { useLoaderData } from "react-router";
 import { useZorm } from "react-zorm";
@@ -28,6 +35,9 @@ import {
 } from "~/components/audit/start-audit-dialog-content";
 import { BulkUpdateDialogContent } from "~/components/bulk-update-dialog/bulk-update-dialog";
 import type { IndexResponse } from "~/components/list";
+import type { ListItemData } from "~/components/list/list-item";
+import { Button } from "~/components/shared/button";
+import { useSearchParams } from "~/hooks/search-params";
 import { BaseAuditSchema } from "~/routes/api+/audits.start";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { isSelectingAllItems } from "~/utils/list";
@@ -52,6 +62,112 @@ export const KitsBulkStartAuditSchema = BaseAuditSchema.extend({
 );
 
 /**
+ * Confirms the scope of the audit inside the dialog: how many kits are selected
+ * and (for an explicit selection) their names and per-kit asset counts behind a
+ * "View list" popover.
+ *
+ * Two modes, driven by `allSelected`:
+ * - **Select all** — we only hold the sentinel client-side, not the names, so
+ *   we show the total count plus the active name search (if any). No list.
+ * - **Explicit selection** — we have each row's `name`, so we show the count
+ *   with a "View list" popover. The popover scrolls, so it scales from a handful
+ *   of kits to 100+ without stretching the dialog.
+ *
+ * @param props.allSelected - Whether "select all" (filtered set) is active
+ * @param props.count - Kits the audit will cover (total when `allSelected`)
+ * @param props.kits - Selected rows; only read when `!allSelected`
+ * @param props.search - Active Kits-list name search (`s`), for select-all copy
+ * @returns A one-line scope summary, with a names popover for explicit selections
+ */
+function SelectedKitsSummary({
+  allSelected,
+  count,
+  kits,
+  search,
+}: {
+  allSelected: boolean;
+  count: number;
+  kits: ListItemData[];
+  search: string | null;
+}) {
+  const plural = count === 1 ? "" : "s";
+
+  if (allSelected) {
+    return (
+      <p className="text-sm text-gray-700">
+        Auditing assets in{" "}
+        <span className="font-medium">
+          all {count} kit{plural}
+        </span>
+        {search ? (
+          <>
+            {" "}
+            matching <span className="font-medium">“{search}”</span>
+          </>
+        ) : null}
+        .
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-gray-700">
+      <span>
+        Auditing assets in{" "}
+        <span className="font-medium">
+          {count} kit{plural}
+        </span>
+        .
+      </span>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto p-0 text-sm font-medium"
+          >
+            View list
+          </Button>
+        </PopoverTrigger>
+        <PopoverPortal>
+          <PopoverContent
+            align="start"
+            className="z-[999999] mt-2 max-h-[300px] w-[260px] overflow-y-auto rounded-md border border-gray-200 bg-white shadow-md"
+          >
+            <p className="border-b border-gray-100 px-3 py-2 text-xs font-medium text-gray-500">
+              Selected kits ({count})
+            </p>
+            <ul className="py-1">
+              {kits.map((kit) => {
+                // Row data carried from the Kits list (see its loader's `_count`
+                // select). Default to 0 if a row somehow lacks it.
+                const assetCount: number = kit._count?.assets ?? 0;
+                return (
+                  <li
+                    key={kit.id}
+                    className="flex items-center justify-between gap-3 px-3 py-1.5 text-sm"
+                  >
+                    <span
+                      className="truncate text-gray-700"
+                      title={kit.name ?? undefined}
+                    >
+                      {kit.name || "Untitled kit"}
+                    </span>
+                    <span className="shrink-0 text-xs tabular-nums text-gray-500">
+                      {assetCount} asset{assetCount === 1 ? "" : "s"}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </PopoverContent>
+        </PopoverPortal>
+      </Popover>
+    </div>
+  );
+}
+
+/**
  * Renders the "Create audit" dialog wired to the Kits index multi-select.
  * The audit covers the union of all assets in the selected kits.
  */
@@ -59,10 +175,14 @@ export default function KitsBulkStartAuditDialog() {
   const { totalItems } = useLoaderData<IndexResponse>();
   const selectedItems = useAtomValue(selectedBulkItemsAtom);
   const selectedCount = useAtomValue(selectedBulkItemsCountAtom);
+  const [searchParams] = useSearchParams();
 
   // Show totalItems when "Select All" is used, otherwise the selected count
   const allSelected = isSelectingAllItems(selectedItems);
   const displayCount = allSelected ? totalItems : selectedCount;
+  // Active name search on the Kits list — only meaningful for "select all",
+  // where it tells the user which filtered set the audit will cover.
+  const search = searchParams.get("s")?.trim() || null;
 
   const zo = useZorm("KitsBulkStartAudit", KitsBulkStartAuditSchema);
 
@@ -80,9 +200,7 @@ export default function KitsBulkStartAuditDialog() {
       type="start-audit"
       className="md:w-[800px]"
       title="Start an audit"
-      description={`You're about to start an audit covering the assets in ${displayCount} kit${
-        displayCount === 1 ? "" : "s"
-      }.`}
+      description="Set up an audit for the assets in the kits you selected."
       actionUrl="/api/audits/start"
       arrayFieldId="kitIds"
       formClassName="px-0"
@@ -91,6 +209,24 @@ export default function KitsBulkStartAuditDialog() {
         <>
           {/* Routes the request to the kit branch of /api/audits/start */}
           <input type="hidden" name="contextType" value="kit" />
+          <div className="space-y-3 border-t px-6 py-3">
+            {/* Confirm what's selected so the user can verify scope before submit */}
+            <SelectedKitsSummary
+              allSelected={allSelected}
+              count={displayCount}
+              kits={selectedItems}
+              search={search}
+            />
+            {/* Set expectations: the audit captures the assets currently in the
+                selected kit(s) at creation time. */}
+            <div className="flex items-start gap-2 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              <InfoIcon className="mt-0.5 size-4 shrink-0 text-gray-400" />
+              <p>
+                The audit will include every asset currently in the selected kit
+                {displayCount === 1 ? "" : "s"}.
+              </p>
+            </div>
+          </div>
           <StartAuditDialogContent
             disabled={disabled}
             handleCloseDialog={handleCloseDialog}

--- a/apps/webapp/app/components/kits/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/kits/bulk-start-audit-dialog.tsx
@@ -1,0 +1,111 @@
+/**
+ * Bulk "Create audit" dialog for the Kits index.
+ *
+ * Mirrors the assets bulk-audit dialog but operates on selected *kits*: the
+ * shared dialog harness posts the selected kit IDs as `kitIds[]` (plus
+ * `currentSearchParams`, and the ALL_SELECTED_KEY sentinel on "select all"), and
+ * a hidden `contextType=kit` field routes the request to the kit branch of
+ * `/api/audits/start`, which resolves the union of assets server-side.
+ *
+ * @see {@link file://./../assets/bulk-start-audit-dialog.tsx} the assets counterpart
+ * @see {@link file://./../location/bulk-start-audit-dialog.tsx} the locations counterpart
+ * @see {@link file://./../../routes/api+/audits.start.ts} server-side resolution
+ */
+
+import { useAtomValue } from "jotai";
+import { DateTime } from "luxon";
+import { useLoaderData } from "react-router";
+import { useZorm } from "react-zorm";
+import { z } from "zod";
+
+import {
+  selectedBulkItemsAtom,
+  selectedBulkItemsCountAtom,
+} from "~/atoms/list";
+import {
+  StartAuditDialogContent,
+  type StartAuditFetcherData,
+} from "~/components/audit/start-audit-dialog-content";
+import { BulkUpdateDialogContent } from "~/components/bulk-update-dialog/bulk-update-dialog";
+import type { IndexResponse } from "~/components/list";
+import { BaseAuditSchema } from "~/routes/api+/audits.start";
+import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { isSelectingAllItems } from "~/utils/list";
+
+/**
+ * Client-side schema for the Kits bulk-audit dialog. The harness injects the
+ * selected kit IDs under `kitIds`, so require at least one. Server-side
+ * validation lives in `StartAuditSchema` (`/api/audits/start`).
+ */
+export const KitsBulkStartAuditSchema = BaseAuditSchema.extend({
+  kitIds: z.array(z.string()).min(1),
+}).refine(
+  (data) => {
+    if (!data.dueDate) return true;
+    const parsed = DateTime.fromFormat(data.dueDate, DATE_TIME_FORMAT);
+    return parsed.isValid && parsed > DateTime.now();
+  },
+  {
+    message: "Due date must be in the future",
+    path: ["dueDate"],
+  }
+);
+
+/**
+ * Renders the "Create audit" dialog wired to the Kits index multi-select.
+ * The audit covers the union of all assets in the selected kits.
+ */
+export default function KitsBulkStartAuditDialog() {
+  const { totalItems } = useLoaderData<IndexResponse>();
+  const selectedItems = useAtomValue(selectedBulkItemsAtom);
+  const selectedCount = useAtomValue(selectedBulkItemsCountAtom);
+
+  // Show totalItems when "Select All" is used, otherwise the selected count
+  const allSelected = isSelectingAllItems(selectedItems);
+  const displayCount = allSelected ? totalItems : selectedCount;
+
+  const zo = useZorm("KitsBulkStartAudit", KitsBulkStartAuditSchema);
+
+  const nameField = zo.fields.name();
+  const descriptionField = zo.fields.description();
+  const dueDateField = zo.fields.dueDate();
+  const nameError = zo.errors.name()?.message;
+  const descriptionError = zo.errors.description()?.message;
+  const dueDateError = zo.errors.dueDate()?.message;
+  const assigneeError = zo.errors.assignee()?.message;
+
+  return (
+    <BulkUpdateDialogContent
+      ref={zo.ref}
+      type="start-audit"
+      className="md:w-[800px]"
+      title="Start an audit"
+      description={`You're about to start an audit covering the assets in ${displayCount} kit${
+        displayCount === 1 ? "" : "s"
+      }.`}
+      actionUrl="/api/audits/start"
+      arrayFieldId="kitIds"
+      formClassName="px-0"
+    >
+      {({ disabled, handleCloseDialog, fetcherError, fetcherData }) => (
+        <>
+          {/* Routes the request to the kit branch of /api/audits/start */}
+          <input type="hidden" name="contextType" value="kit" />
+          <StartAuditDialogContent
+            disabled={disabled}
+            handleCloseDialog={handleCloseDialog}
+            fetcherError={fetcherError}
+            fetcherData={fetcherData as StartAuditFetcherData}
+            nameField={nameField}
+            descriptionField={descriptionField}
+            dueDateField={dueDateField}
+            nameError={nameError}
+            descriptionError={descriptionError}
+            dueDateError={dueDateError}
+            assigneeError={assigneeError}
+          />
+        </>
+      )}
+    </BulkUpdateDialogContent>
+  );
+}

--- a/apps/webapp/app/modules/audit/context-helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.test.ts
@@ -1,32 +1,40 @@
 // @vitest-environment node
 /**
- * Unit tests for `resolveAssetIdsForLocationSelection` — the resolver behind the
- * bulk "Create audit" action on the Locations index.
+ * Unit tests for the bulk "Create audit" resolvers behind the multi-select on
+ * the Locations index (`resolveAssetIdsForLocationSelection`) and the Kits
+ * index (`resolveAssetIdsForKitSelection`).
  *
- * Covers the security- and correctness-critical behaviors:
- * - explicit multi-location selection → org-scoped union of asset IDs
- * - the IDOR guard rejects a foreign/tampered location ID before any asset read
- * - "select all" resolves the filtered location set (honoring the name search)
- *   and skips the per-ID guard (the set is org-scoped by construction)
+ * Covers the security- and correctness-critical behaviors for each:
+ * - explicit multi-select → org-scoped union of asset IDs
+ * - the IDOR guard rejects a foreign/tampered ID before any asset read
+ * - "select all" resolves the filtered set (honoring the list filter — name
+ *   search for locations, status for kits) and skips the per-ID guard (the set
+ *   is org-scoped by construction)
  * - an empty union surfaces a clear 400 instead of creating an empty audit
  *
  * @see {@link file://./context-helpers.server.ts}
  */
 import { ShelfError } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
-import { resolveAssetIdsForLocationSelection } from "./context-helpers.server";
+import {
+  resolveAssetIdsForKitSelection,
+  resolveAssetIdsForLocationSelection,
+} from "./context-helpers.server";
 
-// why: the resolver (and the org guard it calls) hit the global Prisma client;
-// mock it so the suite is DB-free. `vitest.hoisted` makes the spies available
-// inside the (hoisted) mock factory. Each test sets the return values it needs.
-const { locationFindMany, assetFindMany } = vitest.hoisted(() => ({
+// why: the resolvers (and the org guards they call) hit the global Prisma
+// client; mock it so the suite is DB-free. `vitest.hoisted` makes the spies
+// available inside the (hoisted) mock factory. Each test sets the return values
+// it needs.
+const { locationFindMany, kitFindMany, assetFindMany } = vitest.hoisted(() => ({
   locationFindMany: vitest.fn(),
+  kitFindMany: vitest.fn(),
   assetFindMany: vitest.fn(),
 }));
 
 vitest.mock("~/database/db.server", () => ({
   db: {
     location: { findMany: locationFindMany },
+    kit: { findMany: kitFindMany },
     asset: { findMany: assetFindMany },
   },
 }));
@@ -35,6 +43,7 @@ const ORG = "org-1";
 
 beforeEach(() => {
   locationFindMany.mockReset();
+  kitFindMany.mockReset();
   assetFindMany.mockReset();
 });
 
@@ -106,6 +115,79 @@ describe("resolveAssetIdsForLocationSelection", () => {
     const err = await resolveAssetIdsForLocationSelection({
       organizationId: ORG,
       locationIds: ["l1", "l2"],
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ShelfError);
+    expect(err.status).toBe(400);
+    expect(err.message).toMatch(/contain assets/i);
+  });
+});
+
+describe("resolveAssetIdsForKitSelection", () => {
+  it("explicit selection: asserts org ownership, then returns the org-scoped union of asset IDs", async () => {
+    // org guard: both requested kits belong to the org
+    kitFindMany.mockResolvedValueOnce([{ id: "k1" }, { id: "k2" }]);
+    // assets across both kits
+    assetFindMany.mockResolvedValueOnce([
+      { id: "a1" },
+      { id: "a2" },
+      { id: "a3" },
+    ]);
+
+    const result = await resolveAssetIdsForKitSelection({
+      organizationId: ORG,
+      kitIds: ["k1", "k2"],
+    });
+
+    expect(result).toEqual(["a1", "a2", "a3"]);
+    // asset query is org-scoped and unions the selected kits
+    expect(assetFindMany).toHaveBeenCalledWith({
+      where: { organizationId: ORG, kitId: { in: ["k1", "k2"] } },
+      select: { id: true },
+    });
+  });
+
+  it("rejects a foreign/tampered kit ID before reading any assets (IDOR guard)", async () => {
+    // org-scoped guard returns only one of the two requested → count mismatch
+    kitFindMany.mockResolvedValueOnce([{ id: "k1" }]);
+
+    const err = await resolveAssetIdsForKitSelection({
+      organizationId: ORG,
+      kitIds: ["k1", "k2-foreign"],
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ShelfError);
+    expect(err.status).toBe(400);
+    // the asset query must never run for a tampered selection
+    expect(assetFindMany).not.toHaveBeenCalled();
+  });
+
+  it("select all: resolves the filtered kit set honoring the status filter, with no per-ID guard", async () => {
+    // resolver resolves all matching kits, then their assets
+    kitFindMany.mockResolvedValueOnce([{ id: "k1" }, { id: "k2" }]);
+    assetFindMany.mockResolvedValueOnce([{ id: "a1" }]);
+
+    const result = await resolveAssetIdsForKitSelection({
+      organizationId: ORG,
+      kitIds: [ALL_SELECTED_KEY],
+      currentSearchParams: "status=AVAILABLE",
+    });
+
+    expect(result).toEqual(["a1"]);
+    // kit set honors the active status filter (mirrors the list filter)
+    expect(kitFindMany).toHaveBeenCalledWith({
+      where: { organizationId: ORG, status: "AVAILABLE" },
+      select: { id: true },
+    });
+  });
+
+  it("throws a clear 400 when none of the selected kits contain assets", async () => {
+    kitFindMany.mockResolvedValueOnce([{ id: "k1" }, { id: "k2" }]); // guard passes
+    assetFindMany.mockResolvedValueOnce([]); // empty union
+
+    const err = await resolveAssetIdsForKitSelection({
+      organizationId: ORG,
+      kitIds: ["k1", "k2"],
     }).catch((e) => e);
 
     expect(err).toBeInstanceOf(ShelfError);

--- a/apps/webapp/app/modules/audit/context-helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.test.ts
@@ -183,9 +183,24 @@ describe("resolveAssetIdsForKitSelection", () => {
     expect(assetFindMany).not.toHaveBeenCalled();
   });
 
-  it("select all: resolves the filtered kit set honoring the status filter, with no per-ID guard", async () => {
-    // resolver resolves all matching kits, then their assets
+  it("explicit selection: dedupes duplicate kit IDs before the asset query", async () => {
+    // guard sees the unique set; resolver must not re-introduce the duplicate
     kitFindMany.mockResolvedValueOnce([{ id: "k1" }, { id: "k2" }]);
+    assetFindMany.mockResolvedValueOnce([{ id: "a1" }]);
+
+    await resolveAssetIdsForKitSelection({
+      organizationId: ORG,
+      kitIds: ["k1", "k1", "k2"],
+    });
+
+    // the `in` clause carries each kit once, not the raw duplicated input
+    expect(assetFindMany).toHaveBeenCalledWith({
+      where: { organizationId: ORG, kitId: { in: ["k1", "k2"] } },
+      select: { id: true },
+    });
+  });
+
+  it("select all: matches assets via a kit relation filter honoring the status filter (single query, no per-ID guard)", async () => {
     assetFindMany.mockResolvedValueOnce([{ id: "a1" }]);
 
     const result = await resolveAssetIdsForKitSelection({
@@ -195,11 +210,17 @@ describe("resolveAssetIdsForKitSelection", () => {
     });
 
     expect(result).toEqual(["a1"]);
-    // kit set honors the active status filter (mirrors the list filter)
-    expect(kitFindMany).toHaveBeenCalledWith({
-      where: { organizationId: ORG, status: "AVAILABLE" },
+    // one asset query; its `kit` relation mirrors the active list filter
+    expect(assetFindMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: ORG,
+        kit: { organizationId: ORG, status: "AVAILABLE" },
+      },
       select: { id: true },
     });
+    // select-all is org-scoped by construction — no separate kit lookup and no
+    // per-ID guard
+    expect(kitFindMany).not.toHaveBeenCalled();
   });
 
   it("throws a clear 400 when none of the selected kits contain assets", async () => {

--- a/apps/webapp/app/modules/audit/context-helpers.server.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.ts
@@ -1,9 +1,13 @@
 import { db } from "~/database/db.server";
+import { getKitsWhereInput } from "~/modules/kit/utils.server";
 import { getLocationDescendantIds } from "~/modules/location/descendants.server";
 import { getLocationsWhereInput } from "~/modules/location/utils.server";
 import { ShelfError } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
-import { assertLocationsBelongToOrg } from "~/utils/org-validation.server";
+import {
+  assertKitsBelongToOrg,
+  assertLocationsBelongToOrg,
+} from "~/utils/org-validation.server";
 
 /** Context type for audit creation */
 export type AuditContextType = "location" | "kit" | "user";
@@ -273,6 +277,82 @@ export async function resolveAssetIdsForLocationSelection({
       cause: null,
       message:
         "None of the selected locations contain assets. Add assets before starting an audit.",
+      status: 400,
+      label: "Audit",
+      shouldBeCaptured: false,
+    });
+  }
+
+  return assets.map((asset) => asset.id);
+}
+
+/**
+ * Resolves the asset IDs to audit from a multi-select of kits on the Kits index
+ * (the bulk "Create audit" action).
+ *
+ * - "Select all" (when `kitIds` contains {@link ALL_SELECTED_KEY}) resolves the
+ *   full set of kits matching the current list filter, mirroring what the user
+ *   sees — see {@link getKitsWhereInput} (which honors the Kits list `s` /
+ *   `status` / `teamMember` filters).
+ * - An explicit selection is proven to belong to the caller's org first (IDOR
+ *   guard) before use.
+ *
+ * Asset→kit is 1:1, so the union across kits needs no dedup. The asset query is
+ * org-scoped, so a tampered/foreign kit ID can never leak another org's assets.
+ *
+ * @param organizationId - The caller's (validated) organization ID
+ * @param kitIds - Selected kit IDs (may contain ALL_SELECTED_KEY)
+ * @param currentSearchParams - Serialized Kits-list search params (for select-all)
+ * @returns Asset IDs across the selected kits
+ * @throws {ShelfError} 400 if no kits resolve, or none of them contain assets
+ */
+export async function resolveAssetIdsForKitSelection({
+  organizationId,
+  kitIds,
+  currentSearchParams,
+}: {
+  organizationId: string;
+  kitIds: string[];
+  currentSearchParams?: string | null;
+}): Promise<string[]> {
+  // Resolve which kits to include in the audit
+  let resolvedKitIds: string[];
+
+  if (kitIds.includes(ALL_SELECTED_KEY)) {
+    // "Select all" — resolve the full filtered set (org-scoped by construction)
+    const kits = await db.kit.findMany({
+      where: getKitsWhereInput({ organizationId, currentSearchParams }),
+      select: { id: true },
+    });
+    resolvedKitIds = kits.map((kit) => kit.id);
+  } else {
+    // Explicit selection from request input — prove org ownership before use
+    await assertKitsBelongToOrg({ kitIds, organizationId });
+    resolvedKitIds = kitIds;
+  }
+
+  if (resolvedKitIds.length === 0) {
+    throw new ShelfError({
+      cause: null,
+      message: "No kits selected for the audit.",
+      status: 400,
+      label: "Audit",
+      shouldBeCaptured: false,
+    });
+  }
+
+  // Union of assets across the selected kits (asset→kit is 1:1, so findMany
+  // already returns each asset once — no dedup needed).
+  const assets = await db.asset.findMany({
+    where: { organizationId, kitId: { in: resolvedKitIds } },
+    select: { id: true },
+  });
+
+  if (assets.length === 0) {
+    throw new ShelfError({
+      cause: null,
+      message:
+        "None of the selected kits contain assets. Add assets before starting an audit.",
       status: 400,
       label: "Audit",
       shouldBeCaptured: false,

--- a/apps/webapp/app/modules/audit/context-helpers.server.ts
+++ b/apps/webapp/app/modules/audit/context-helpers.server.ts
@@ -289,21 +289,23 @@ export async function resolveAssetIdsForLocationSelection({
  * Resolves the asset IDs to audit from a multi-select of kits on the Kits index
  * (the bulk "Create audit" action).
  *
- * - "Select all" (when `kitIds` contains {@link ALL_SELECTED_KEY}) resolves the
- *   full set of kits matching the current list filter, mirroring what the user
- *   sees — see {@link getKitsWhereInput} (which honors the Kits list `s` /
- *   `status` / `teamMember` filters).
+ * - "Select all" (when `kitIds` contains {@link ALL_SELECTED_KEY}) matches assets
+ *   whose kit satisfies the current list filter, mirroring what the user sees —
+ *   see {@link getKitsWhereInput} (which honors the Kits list `s` / `status` /
+ *   `teamMember` filters). This uses a `kit` relation filter so it stays a
+ *   SINGLE query: no need to materialize the kit IDs into a giant `IN (...)`
+ *   list.
  * - An explicit selection is proven to belong to the caller's org first (IDOR
- *   guard) before use.
+ *   guard), then scoped by the (deduped) kit IDs.
  *
- * Asset→kit is 1:1, so the union across kits needs no dedup. The asset query is
+ * Asset→kit is 1:1, so the result needs no dedup. The asset query is always
  * org-scoped, so a tampered/foreign kit ID can never leak another org's assets.
  *
  * @param organizationId - The caller's (validated) organization ID
  * @param kitIds - Selected kit IDs (may contain ALL_SELECTED_KEY)
  * @param currentSearchParams - Serialized Kits-list search params (for select-all)
  * @returns Asset IDs across the selected kits
- * @throws {ShelfError} 400 if no kits resolve, or none of them contain assets
+ * @throws {ShelfError} 400 if none of the selected kits contain assets
  */
 export async function resolveAssetIdsForKitSelection({
   organizationId,
@@ -314,36 +316,31 @@ export async function resolveAssetIdsForKitSelection({
   kitIds: string[];
   currentSearchParams?: string | null;
 }): Promise<string[]> {
-  // Resolve which kits to include in the audit
-  let resolvedKitIds: string[];
+  // Build the org-scoped asset where-clause for the selected kits.
+  let assetWhere: Prisma.AssetWhereInput;
 
   if (kitIds.includes(ALL_SELECTED_KEY)) {
-    // "Select all" — resolve the full filtered set (org-scoped by construction)
-    const kits = await db.kit.findMany({
-      where: getKitsWhereInput({ organizationId, currentSearchParams }),
-      select: { id: true },
-    });
-    resolvedKitIds = kits.map((kit) => kit.id);
+    // "Select all" — match assets whose kit satisfies the SAME filter the user
+    // sees on the Kits list. A relation filter keeps this one query (no separate
+    // kit lookup, no giant IN list). Assets with no kit are naturally excluded,
+    // which matches the explicit-selection semantics.
+    assetWhere = {
+      organizationId,
+      kit: getKitsWhereInput({ organizationId, currentSearchParams }),
+    };
   } else {
-    // Explicit selection from request input — prove org ownership before use
+    // Explicit selection from request input — prove org ownership before use,
+    // then scope by the deduped IDs (schema guarantees at least one).
     await assertKitsBelongToOrg({ kitIds, organizationId });
-    resolvedKitIds = kitIds;
+    assetWhere = {
+      organizationId,
+      kitId: { in: [...new Set(kitIds)] },
+    };
   }
 
-  if (resolvedKitIds.length === 0) {
-    throw new ShelfError({
-      cause: null,
-      message: "No kits selected for the audit.",
-      status: 400,
-      label: "Audit",
-      shouldBeCaptured: false,
-    });
-  }
-
-  // Union of assets across the selected kits (asset→kit is 1:1, so findMany
-  // already returns each asset once — no dedup needed).
+  // Asset→kit is 1:1, so findMany already returns each asset once.
   const assets = await db.asset.findMany({
-    where: { organizationId, kitId: { in: resolvedKitIds } },
+    where: assetWhere,
     select: { id: true },
   });
 

--- a/apps/webapp/app/routes.ts
+++ b/apps/webapp/app/routes.ts
@@ -8,6 +8,11 @@ import { flatRoutes } from "remix-flat-routes";
 
 export default remixRoutesOptionAdapter((defineRoutes) =>
   flatRoutes("routes", defineRoutes, {
-    ignoredRouteFiles: ["**/.*", "**/*.test.server.ts"], // Ignore dot files and test files
+    // Ignore dot files and ALL test files. The glob must cover plain `*.test.ts`
+    // / `*.test.tsx` (not just `*.test.server.ts`) — otherwise a co-located route
+    // test like `audits.start.test.ts` is treated as a route module and bundled
+    // into the SSR server build, which then throws "vitest is not defined" at
+    // runtime (the test-only global doesn't exist outside the vitest env).
+    ignoredRouteFiles: ["**/.*", "**/*.test.*"],
   })
 );

--- a/apps/webapp/app/routes/api+/audits.start.test.ts
+++ b/apps/webapp/app/routes/api+/audits.start.test.ts
@@ -5,8 +5,8 @@
  *
  * The `.refine` is load-bearing: it decides which "create audit" entry points
  * are accepted (asset-index bulk, single-context detail page, and the locations
- * multi-select). These tests lock that contract so the new location branch and
- * the legacy forms can't silently regress.
+ * and kits multi-selects). These tests lock that contract so the new location
+ * and kit branches and the legacy forms can't silently regress.
  *
  * @see {@link file://./audits.start.ts}
  */
@@ -42,6 +42,24 @@ describe("StartAuditSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a kit multi-selection (contextType=kit + kitIds)", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      contextType: "kit",
+      kitIds: ["k1", "k2"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the select-all sentinel inside kitIds", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      contextType: "kit",
+      kitIds: ["all-selected"],
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("still accepts the legacy single-context form (contextType + contextId)", () => {
     const result = StartAuditSchema.safeParse({
       ...base,
@@ -68,6 +86,21 @@ describe("StartAuditSchema", () => {
     // why: locationIds only counts when contextType is explicitly "location",
     // so a stray array without the discriminator must not pass validation.
     const result = StartAuditSchema.safeParse({ ...base, locationIds: ["l1"] });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects contextType=kit with neither contextId nor kitIds", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      contextType: "kit",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects kitIds supplied without contextType=kit", () => {
+    // why: kitIds only counts when contextType is explicitly "kit", so a stray
+    // array without the discriminator must not pass validation.
+    const result = StartAuditSchema.safeParse({ ...base, kitIds: ["k1"] });
     expect(result.success).toBe(false);
   });
 

--- a/apps/webapp/app/routes/api+/audits.start.ts
+++ b/apps/webapp/app/routes/api+/audits.start.ts
@@ -89,7 +89,7 @@ export const StartAuditSchema = BaseAuditSchema.extend({
   },
   {
     message:
-      "Provide assetIds, context parameters (contextType + contextId), or a location selection (contextType=location + locationIds).",
+      "Provide assetIds, context parameters (contextType + contextId), a location selection (contextType=location + locationIds), or a kit selection (contextType=kit + kitIds).",
   }
 );
 

--- a/apps/webapp/app/routes/api+/audits.start.ts
+++ b/apps/webapp/app/routes/api+/audits.start.ts
@@ -10,6 +10,7 @@ import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.se
 import { AUDIT_SCHEDULER_EVENTS_ENUM } from "~/modules/audit/constants";
 import {
   resolveAssetIdsForAudit,
+  resolveAssetIdsForKitSelection,
   resolveAssetIdsForLocationSelection,
 } from "~/modules/audit/context-helpers.server";
 import { sendAuditAssignedEmail } from "~/modules/audit/email-helpers";
@@ -68,17 +69,23 @@ export const StartAuditSchema = BaseAuditSchema.extend({
   // Location IDs - for the bulk "Create audit" action on the Locations index
   // (multi-select). May contain ALL_SELECTED_KEY when "select all" is active.
   locationIds: z.array(z.string()).optional(),
+  // Kit IDs - for the bulk "Create audit" action on the Kits index
+  // (multi-select). May contain ALL_SELECTED_KEY when "select all" is active.
+  kitIds: z.array(z.string()).optional(),
   includeChildLocations: z.coerce.boolean().default(false),
 }).refine(
   (data) => {
-    // Must have assetIds, single-context params, OR a location multi-selection
+    // Must have assetIds, single-context params, a location multi-selection,
+    // OR a kit multi-selection
     const hasAssetIds = data.assetIds && data.assetIds.length > 0;
     const hasContext = data.contextType && data.contextId;
     const hasLocationSelection =
       data.contextType === "location" &&
       !!data.locationIds &&
       data.locationIds.length > 0;
-    return hasAssetIds || hasContext || hasLocationSelection;
+    const hasKitSelection =
+      data.contextType === "kit" && !!data.kitIds && data.kitIds.length > 0;
+    return hasAssetIds || hasContext || hasLocationSelection || hasKitSelection;
   },
   {
     message: "Either assetIds or context parameters must be provided",
@@ -110,6 +117,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
       contextId,
       contextName,
       locationIds,
+      kitIds,
       includeChildLocations,
       currentSearchParams,
     } = parseData(formData, StartAuditSchema.and(CurrentSearchParamsSchema), {
@@ -129,6 +137,15 @@ export async function action({ request, context }: ActionFunctionArgs) {
       assetIds = await resolveAssetIdsForLocationSelection({
         organizationId,
         locationIds,
+        currentSearchParams,
+      });
+    } else if (contextType === "kit" && kitIds && kitIds.length > 0) {
+      // Bulk "Create audit" from the Kits index (multi-select). Resolve the
+      // union of assets across the selected kits server-side — handles "select
+      // all" (honoring the list filter) and asserts explicit IDs.
+      assetIds = await resolveAssetIdsForKitSelection({
+        organizationId,
+        kitIds,
         currentSearchParams,
       });
     } else if (isSelectingAllAssets) {

--- a/apps/webapp/app/utils/org-validation.server.test.ts
+++ b/apps/webapp/app/utils/org-validation.server.test.ts
@@ -19,6 +19,7 @@ import {
   assertTagsBelongToOrg,
   assertTeamMemberBelongsToOrg,
   assertCategoryBelongsToOrg,
+  assertKitsBelongToOrg,
   assertLocationBelongsToOrg,
   assertLocationsBelongToOrg,
   assertUserBelongsToOrg,
@@ -41,6 +42,7 @@ function txWith(overrides: Record<string, any>) {
       findFirst: vitest.fn().mockResolvedValue(null),
       findMany: vitest.fn().mockResolvedValue([]),
     },
+    kit: { findMany: vitest.fn().mockResolvedValue([]) },
     customField: { findMany: vitest.fn().mockResolvedValue([]) },
     userOrganization: { findFirst: vitest.fn().mockResolvedValue(null) },
     ...overrides,
@@ -174,6 +176,64 @@ describe("assertLocationsBelongToOrg", () => {
     expect(err).toBeInstanceOf(ShelfError);
     expect(err.status).toBe(400);
     expect(err.title).toBe("Invalid locations");
+  });
+});
+
+describe("assertKitsBelongToOrg", () => {
+  it("is a no-op for an empty list (no query issued)", async () => {
+    const tx = txWith({});
+    await expect(
+      assertKitsBelongToOrg({ kitIds: [], organizationId: ORG }, tx)
+    ).resolves.toBeUndefined();
+    expect(tx.kit.findMany).not.toHaveBeenCalled();
+  });
+
+  it("resolves when every kit belongs to the org and scopes the query by organizationId", async () => {
+    const tx = txWith({
+      kit: {
+        findMany: vitest.fn().mockResolvedValue([{ id: "k1" }, { id: "k2" }]),
+      },
+    });
+
+    await expect(
+      assertKitsBelongToOrg({ kitIds: ["k1", "k2"], organizationId: ORG }, tx)
+    ).resolves.toBeUndefined();
+
+    expect(tx.kit.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["k1", "k2"] }, organizationId: ORG },
+      select: { id: true },
+    });
+  });
+
+  it("dedupes input so duplicate IDs don't inflate the expected count", async () => {
+    const tx = txWith({
+      kit: { findMany: vitest.fn().mockResolvedValue([{ id: "k1" }]) },
+    });
+
+    await expect(
+      assertKitsBelongToOrg({ kitIds: ["k1", "k1"], organizationId: ORG }, tx)
+    ).resolves.toBeUndefined();
+
+    expect(tx.kit.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["k1"] }, organizationId: ORG },
+      select: { id: true },
+    });
+  });
+
+  it("rejects with a 400 ShelfError when any ID is foreign/missing", async () => {
+    // k2 belongs to another org → the org-scoped findMany returns only k1
+    const tx = txWith({
+      kit: { findMany: vitest.fn().mockResolvedValue([{ id: "k1" }]) },
+    });
+
+    const err = await assertKitsBelongToOrg(
+      { kitIds: ["k1", "k2"], organizationId: ORG },
+      tx
+    ).catch((e) => e);
+
+    expect(err).toBeInstanceOf(ShelfError);
+    expect(err.status).toBe(400);
+    expect(err.title).toBe("Invalid kits");
   });
 });
 

--- a/apps/webapp/app/utils/org-validation.server.ts
+++ b/apps/webapp/app/utils/org-validation.server.ts
@@ -23,6 +23,7 @@
 import type {
   Asset,
   Category,
+  Kit,
   Location,
   Tag,
   TeamMember,
@@ -69,6 +70,12 @@ export type OrgValidationTxClient = {
       where: { id: string; organizationId: string };
       select: { id: true };
     }) => Promise<{ id: string } | null>;
+    findMany: (args: {
+      where: { id: { in: string[] }; organizationId: string };
+      select: { id: true };
+    }) => Promise<{ id: string }[]>;
+  };
+  kit: {
     findMany: (args: {
       where: { id: { in: string[] }; organizationId: string };
       select: { id: true };
@@ -166,6 +173,46 @@ export async function assertLocationsBelongToOrg(
       title: "Invalid locations",
       message:
         "Some of the selected locations do not exist in your workspace. Please reload and try again.",
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+      additionalData: { organizationId },
+    });
+  }
+}
+
+/**
+ * Asserts that every kit ID belongs to `organizationId`.
+ *
+ * For bulk paths that accept a list of kit IDs from request/form input (e.g.
+ * creating an audit from a multi-select on the Kits index). Dedupes the input
+ * so duplicate IDs don't inflate the expected count. A no-op for an empty list.
+ *
+ * @param params.kitIds - Kit IDs sourced from request/form input
+ * @param params.organizationId - The caller's (validated) organization ID
+ * @param tx - Optional Prisma transaction client; defaults to the global `db`
+ * @throws {ShelfError} 400 if any ID is missing or belongs to another org
+ */
+export async function assertKitsBelongToOrg(
+  { kitIds, organizationId }: { kitIds: Kit["id"][]; organizationId: string },
+  tx?: OrgValidationTxClient
+): Promise<void> {
+  if (kitIds.length === 0) return;
+
+  const client = tx ?? db;
+  const uniqueIds = [...new Set(kitIds)];
+
+  const found = await client.kit.findMany({
+    where: { id: { in: uniqueIds }, organizationId },
+    select: { id: true },
+  });
+
+  if (found.length !== uniqueIds.length) {
+    throw new ShelfError({
+      cause: null,
+      title: "Invalid kits",
+      message:
+        "Some of the selected kits do not exist in your workspace. Please reload and try again.",
       label,
       status: 400,
       shouldBeCaptured: false,

--- a/apps/webapp/test/routes-tests/api+/audits.start.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.start.test.ts
@@ -61,7 +61,7 @@ describe("StartAuditSchema", () => {
     const result = StartAuditSchema.safeParse({
       ...base,
       contextType: "kit",
-      kitIds: ["all-selected"],
+      kitIds: [ALL_SELECTED_KEY],
     });
     expect(result.success).toBe(true);
   });


### PR DESCRIPTION
Adds a bulk **Create audit** action to the Kits index (`/kits`), mirroring the locations equivalent in #2614. Previously an audit could only be started from a single kit's detail page; the bulk multi-select **Actions** menu now creates one audit covering the **union of assets across the selected kits**.

> **Stacked on #2614.** The base branch is `feat/audits-from-locations`, so the diff here is kit-only and reuses that PR's shared audit infra (`start-audit-dialog-content`, `StartAuditSchema`, the org-validation guards). Re-target to `main` once #2614 merges.

### Backend
- **`api+/audits.start.ts`** — `StartAuditSchema` gains optional `kitIds`; the `.refine` accepts `contextType === "kit"` + `kitIds`; a dedicated handler branch (before the existing select-all / else) calls the new resolver.
- **`modules/audit/context-helpers.server.ts`** — `resolveAssetIdsForKitSelection`: select-all resolves via `getKitsWhereInput` (honors the kits list `s` / `status` / `teamMember` filters — not name-only); explicit IDs are proven in-org via the new `assertKitsBelongToOrg`; assets are then unioned org-scoped (`asset→kit` is 1:1, so no dedup). Empty union → clear 400.
- **`utils/org-validation.server.ts`** — new plural `assertKitsBelongToOrg` (count-compare, 400 "Invalid kits"), mirroring `assertLocationsBelongToOrg` / `assertAssetsBelongToOrg`; adds a `kit.findMany` surface to `OrgValidationTxClient`.

### Frontend
- **New `components/kits/bulk-start-audit-dialog.tsx`** — clone of the locations dialog with `arrayFieldId="kitIds"`, a hidden `contextType=kit`, "…assets in N kit(s)" copy, reusing the shared `start-audit-dialog-content` body. No child-locations checkbox.
- **`components/kits/bulk-actions-dropdown.tsx`** — renders the dialog and the trigger behind a **new** `audit.create` `<When>` gate (kept separate from the existing kit-permission gates).
- **`components/audit/new-audit-info-dialog.tsx`** — the Kit card now points users at the bulk Kits flow ("Select kits on the Kits page, then choose Actions → Create audit").

### ⚠️ Included infra fix (also affects #2614)
The first commit (`fix(routing): …`) is **not** kit-specific. #2614 added `routes/api+/audits.start.test.ts`, but `app/routes.ts` only ignored `*.test.server.ts` — so that plainly-named `.test.ts` was treated as a route and bundled into the **SSR server build**, crashing **every page** at runtime with `vitest is not defined`. CI stayed green because `validate` never boots the server. Broadened `ignoredRouteFiles` to `**/*.test.*` (the intent the existing comment already states). **Consider cherry-picking this commit onto #2614**, since that branch carries the bug on its own.

### Tests
- `context-helpers.server.test.ts` — kit resolver: org-scoped union, IDOR guard rejecting a foreign kit ID before any asset read, select-all honoring a `status` filter, empty-union 400.
- `org-validation.server.test.ts` — `assertKitsBelongToOrg`: empty no-op, org-scoped query shape, input dedup, foreign-ID 400.
- `audits.start.test.ts` — `StartAuditSchema` kit contract (accepts a kit selection and the select-all sentinel; rejects `kitIds` without `contextType=kit`).

### Verification
- ✅ `pnpm webapp:validate` green — typecheck + lint + **2287 unit tests** (incl. 12 new kit tests).
- ✅ `/kits` SSR-renders cleanly after the routing fix.
- ✅ **Live end-to-end** (local dev): created 2 kits — Kit A with 2 assets, Kit B with 1 — selected both on `/kits` → the new **Create audit** item appears in the Actions menu → the resulting audit covered the exact **union of all 3 assets** (overview shows `Expected: 3`, all 3 assets listed). Verified both via the UI dropdown and via the exact request the dialog posts to `/api/audits/start` (`contextType=kit` + `kitIds[]`), which returned `{ success: true, redirectTo: "/audits/…" }`.

Refs #2614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk audit creation directly from the Kits page by selecting one or more kits.

* **UI/UX Updates**
  * Updated audit creation dialog to clarify multi-kit audit capability with revised labeling and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->