### PR TITLE
 fix(webapp): fall back to full asset search when ID-shaped query is empty

### DIFF
--- a/apps/webapp/app/components/booking/booking-statistics.tsx
+++ b/apps/webapp/app/components/booking/booking-statistics.tsx
@@ -67,10 +67,10 @@ export function BookingStatistics({
                     {partialCheckinProgress.totalAssets}
                     {partialCheckinProgress.countMode === "units" ? (
                       <>
-                        <span className="text-gray-500">units</span>
+                        <span className="text-gray-500">items</span>
                         <InfoTooltip
                           iconClassName="size-4"
-                          content={<p>Kits count as one unit</p>}
+                          content={<p>Kits count as one item</p>}
                         />
                       </>
                     ) : (

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -17,6 +17,7 @@ import {
   bulkUpdateAssetCategory,
   createAsset,
   getActiveCustomFieldsForAsset,
+  getAssets,
   parseAssetValuation,
   refreshExpiredAssetImages,
   relinkAssetQrCode,
@@ -34,6 +35,7 @@ vitest.mock("~/database/db.server", () => ({
       findFirst: vitest.fn().mockResolvedValue(null),
       findUnique: vitest.fn().mockResolvedValue(null),
       findMany: vitest.fn().mockResolvedValue([]),
+      count: vitest.fn().mockResolvedValue(0),
       update: vitest.fn().mockResolvedValue({}),
       updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
       deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
@@ -1099,5 +1101,109 @@ describe("custody SELF_SERVICE self-restriction (bulk services)", () => {
     ).rejects.toThrow(
       "Self service user can only release custody of assets assigned to their user"
     );
+  });
+});
+
+describe("getAssets search fallback", () => {
+  const findManyMock = vi.mocked(db.asset.findMany);
+  const countMock = vi.mocked(db.asset.count);
+
+  /** Minimal required params for a simple-index search call. */
+  const baseParams = {
+    organizationId: "org-1",
+    page: 1,
+    perPage: 8,
+    orderBy: "createdAt" as const,
+    orderDirection: "desc" as const,
+  };
+
+  /** The title branch only exists in the full search clause, never the narrow one. */
+  const titleClause = {
+    title: { contains: "103468", mode: "insensitive" },
+  };
+
+  beforeEach(() => {
+    findManyMock.mockReset();
+    countMock.mockReset();
+  });
+
+  it("runs only the narrow indexed clause when an ID-shaped query matches", async () => {
+    // why: first (and only) fetch returns a row, so no fallback is needed.
+    findManyMock.mockResolvedValueOnce([{ id: "a1" }] as never);
+    countMock.mockResolvedValueOnce(1 as never);
+
+    const result = await getAssets({ ...baseParams, search: "103468" });
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const where = (findManyMock.mock.calls[0][0] as any).where;
+    // Narrow clause: sequentialId / barcode / qr only — no title branch.
+    expect(JSON.stringify(where.OR)).not.toContain("title");
+    expect(where.OR).toContainEqual({
+      sequentialId: { contains: "103468", mode: "insensitive" },
+    });
+    expect(result).toEqual({ assets: [{ id: "a1" }], totalAssets: 1 });
+  });
+
+  it("falls back to the full search when the narrow clause matches nothing", async () => {
+    // why: narrow query finds 0 rows; the number is embedded in a title, so the
+    // fallback re-query with the full clause must surface it.
+    findManyMock
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([{ id: "a1" }] as never);
+    countMock
+      .mockResolvedValueOnce(0 as never)
+      .mockResolvedValueOnce(1 as never);
+
+    const result = await getAssets({ ...baseParams, search: "103468" });
+
+    expect(findManyMock).toHaveBeenCalledTimes(2);
+    // The narrow-first behaviour is asserted by the single-query test above;
+    // getAssets mutates and reuses one `where` object across both fetches, so
+    // we can only reliably inspect its final (post-fallback) state here.
+    const secondWhere = (findManyMock.mock.calls[1][0] as any).where;
+    expect(secondWhere.OR[0]).toEqual({
+      OR: expect.arrayContaining([titleClause]),
+    });
+    expect(result).toEqual({ assets: [{ id: "a1" }], totalAssets: 1 });
+  });
+
+  it("does not run the fast path for free-text searches", async () => {
+    // why: "armchair" is not ID-shaped, so the full clause is used directly and
+    // there is never a second query even when zero rows match.
+    findManyMock.mockResolvedValueOnce([] as never);
+    countMock.mockResolvedValueOnce(0 as never);
+
+    await getAssets({ ...baseParams, search: "armchair" });
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const where = (findManyMock.mock.calls[0][0] as any).where;
+    expect(JSON.stringify(where.OR)).toContain("title");
+  });
+
+  it("preserves appended filter clauses when falling back", async () => {
+    // why: the fallback must keep filter OR clauses (here: team-member custody)
+    // appended after the search, or it would return assets outside the filter.
+    findManyMock
+      .mockResolvedValueOnce([] as never)
+      .mockResolvedValueOnce([{ id: "a1" }] as never);
+    countMock
+      .mockResolvedValueOnce(0 as never)
+      .mockResolvedValueOnce(1 as never);
+
+    await getAssets({
+      ...baseParams,
+      search: "103468",
+      teamMemberIds: ["tm-1"],
+    });
+
+    const secondWhere = (findManyMock.mock.calls[1][0] as any).where;
+    // Full search clause swapped in...
+    expect(secondWhere.OR[0]).toEqual({
+      OR: expect.arrayContaining([titleClause]),
+    });
+    // ...and the team-member filter clause survived the fallback.
+    expect(secondWhere.OR).toContainEqual({
+      custody: { teamMemberId: { in: ["tm-1"] } },
+    });
   });
 });

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -583,7 +583,12 @@ export async function getAssets(params: {
     // we re-run with the full clause held here — the number may be embedded in
     // a title, description, or custom field rather than being a real ID.
     let shouldFallbackToFullSearch = false;
-    let fullSearchOr: Prisma.AssetWhereInput["OR"] | undefined;
+    let fullSearchOr: Prisma.AssetWhereInput[] | undefined;
+    // Number of OR entries the narrow search contributed. Later filters
+    // (uncategorized / untagged / without-location / team-member) also append
+    // to `where.OR`, so the fallback re-query replaces only these first
+    // entries with `fullSearchOr` and preserves the appended filter clauses.
+    let narrowSearchOrCount = 0;
 
     if (availableToBookOnly) {
       where.availableToBook = true;
@@ -698,6 +703,9 @@ export async function getAssets(params: {
               },
             },
           ]);
+          // Remember how many entries belong to the search so the fallback can
+          // swap them out without disturbing filter clauses appended later.
+          narrowSearchOrCount = where.OR.length;
         } else {
           where.OR = fullSearchOr;
         }
@@ -869,6 +877,15 @@ export async function getAssets(params: {
       where.kit = { isNot: null };
     }
 
+    /**
+     * Runs the paginated asset query and its total count for a given `where`
+     * clause. Extracted so the ID-shaped-search fallback can re-run the same
+     * query shape with a different `where.OR` without duplicating the include
+     * and ordering config.
+     *
+     * @param assetWhere - The Prisma where clause to fetch and count against
+     * @returns A tuple of `[assets, totalAssets]`
+     */
     const fetchAssetsForWhere = (assetWhere: Prisma.AssetWhereInput) =>
       Promise.all([
         db.asset.findMany({
@@ -893,9 +910,15 @@ export async function getAssets(params: {
     // Fallback: an ID-shaped search ran the narrow clause but matched no
     // assets. The term may be embedded in a title, description, or custom
     // field rather than being a real identifier, so re-run with the full
-    // search clause before giving up.
+    // search clause before giving up. Only the narrow search entries are
+    // swapped for `fullSearchOr`; any filter clauses appended to `where.OR`
+    // afterwards (uncategorized / untagged / without-location / team-member)
+    // are kept so the fallback honours the same filters as the first query.
     if (shouldFallbackToFullSearch && totalAssets === 0 && fullSearchOr) {
-      where.OR = fullSearchOr;
+      const appendedFilterOr = Array.isArray(where.OR)
+        ? where.OR.slice(narrowSearchOrCount)
+        : [];
+      where.OR = [...fullSearchOr, ...appendedFilterOr];
       [assets, totalAssets] = await fetchAssetsForWhere(where);
     }
 

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -500,15 +500,21 @@ const unavailableBookingStatuses = [
  *   - canonical sequential ID ("SAM-0001") — letter prefix + dash + 4+
  *     digits, matching the format produced by getNextSequentialId
  *
- * Used by getAssets to route ID-shaped queries down a narrower OR clause
- * (sequentialId / barcodes.value / qrCodes.id) instead of the full
+ * Used by getAssets to run ID-shaped queries against a narrower OR clause
+ * (sequentialId / barcodes.value / qrCodes.id) first, instead of the full
  * 10-branch chain. The narrower clause skips the slow paths — custodian
- * name traversal and the unindexed customFields JSON ILIKE — while
- * still covering every place an ID-shaped value can legitimately live.
+ * name traversal and the unindexed customFields JSON ILIKE — while still
+ * covering every place an ID-shaped value is *most likely* to live.
  *
- * Loose terms like "lab-12" or "AS1000" fall through to the full search
- * because they don't match canonical sequentialId format and could be
- * substrings of asset titles, custom fields, etc.
+ * Because a bare number can equally be a real barcode OR a value embedded
+ * in a title / description / custom field (indistinguishable by shape),
+ * getAssets falls back to the full search when this narrow clause returns
+ * zero rows — so nothing is ever silently missed. See the fallback re-query
+ * in {@link getAssets}.
+ *
+ * Loose terms like "lab-12" or "AS1000" don't match here and go straight to
+ * the full search, since they're more likely substrings of titles, custom
+ * fields, etc.
  */
 function looksLikeAssetId(term: string): boolean {
   return /^\d+$/.test(term) || /^[a-z]+-\d{4,}$/i.test(term);
@@ -573,6 +579,12 @@ export async function getAssets(params: {
 
     const where: Prisma.AssetWhereInput = { organizationId };
 
+    // When an ID-shaped search uses the narrow fast path but returns nothing,
+    // we re-run with the full clause held here — the number may be embedded in
+    // a title, description, or custom field rather than being a real ID.
+    let shouldFallbackToFullSearch = false;
+    let fullSearchOr: Prisma.AssetWhereInput["OR"] | undefined;
+
     if (availableToBookOnly) {
       where.availableToBook = true;
     }
@@ -585,31 +597,15 @@ export async function getAssets(params: {
         .map((term) => term.trim())
         .filter(Boolean);
 
-      // Fast path: when every term looks like an asset identifier — either
-      // bare digits ("21035", a UPC barcode) or canonical sequentialId
-      // ("SAM-0001") — narrow the OR clause to the three columns where an
-      // ID-shaped value can legitimately live: sequentialId, barcode value,
-      // and QR id. All three are covered by trigram GIN indexes added in
-      // migration 20260525110348, so the planner stays on indexed scans.
-      // Skipping title/description/category/location/tag/custodian/customFields
-      // is intentional — they can still match via the full path below for
-      // non-ID-shaped terms.
-      if (searchTerms.length > 0 && searchTerms.every(looksLikeAssetId)) {
-        where.OR = searchTerms.flatMap((term) => [
-          { sequentialId: { contains: term, mode: "insensitive" } },
-          {
-            barcodes: {
-              some: { value: { contains: term, mode: "insensitive" } },
-            },
-          },
-          {
-            qrCodes: {
-              some: { id: { contains: term, mode: "insensitive" } },
-            },
-          },
-        ]);
-      } else {
-        where.OR = searchTerms.map((term) => ({
+      if (searchTerms.length > 0) {
+        // The full multi-column clause: matches a term anywhere it can
+        // legitimately live — title, sequentialId, description, category,
+        // location, tags, custodian names, QR/barcode, and custom fields. It
+        // is the slow path (custodian relation traversal + an unindexed
+        // customFields JSON ILIKE), so for ID-shaped searches we run the
+        // narrow clause first and only fall back to this when it finds
+        // nothing (see the fallback re-query further down).
+        fullSearchOr = searchTerms.map((term) => ({
           OR: [
             // Search in asset fields
             { title: { contains: term, mode: "insensitive" } },
@@ -673,6 +669,38 @@ export async function getAssets(params: {
             },
           ],
         }));
+
+        // Fast path: when every term looks like an asset identifier — either
+        // bare digits ("21035", a UPC barcode) or canonical sequentialId
+        // ("SAM-0001") — narrow the OR clause to the three columns where an
+        // ID-shaped value can legitimately live: sequentialId, barcode value,
+        // and QR id. All three are covered by trigram GIN indexes added in
+        // migration 20260525110348, so the planner stays on indexed scans and
+        // a real ID lookup (the common case) returns immediately.
+        //
+        // A bare number can ALSO be embedded in a title, description, or
+        // custom field (e.g. "Armchair (Old SKU: 103468)"), and the shape
+        // alone cannot tell those apart from a real barcode. So we flag the
+        // query for fallback: if this narrow clause returns zero rows,
+        // getAssets re-runs with `fullSearchOr` below.
+        if (searchTerms.every(looksLikeAssetId)) {
+          shouldFallbackToFullSearch = true;
+          where.OR = searchTerms.flatMap((term) => [
+            { sequentialId: { contains: term, mode: "insensitive" } },
+            {
+              barcodes: {
+                some: { value: { contains: term, mode: "insensitive" } },
+              },
+            },
+            {
+              qrCodes: {
+                some: { id: { contains: term, mode: "insensitive" } },
+              },
+            },
+          ]);
+        } else {
+          where.OR = fullSearchOr;
+        }
       }
     }
 
@@ -841,23 +869,35 @@ export async function getAssets(params: {
       where.kit = { isNot: null };
     }
 
-    const [assets, totalAssets] = await Promise.all([
-      db.asset.findMany({
-        skip,
-        take,
-        where,
-        include: {
-          ...assetIndexFields({
-            bookingFrom,
-            bookingTo,
-            unavailableBookingStatuses,
-          }),
-          ...extraInclude,
-        },
-        orderBy: { [orderBy]: orderDirection },
-      }),
-      db.asset.count({ where }),
-    ]);
+    const fetchAssetsForWhere = (assetWhere: Prisma.AssetWhereInput) =>
+      Promise.all([
+        db.asset.findMany({
+          skip,
+          take,
+          where: assetWhere,
+          include: {
+            ...assetIndexFields({
+              bookingFrom,
+              bookingTo,
+              unavailableBookingStatuses,
+            }),
+            ...extraInclude,
+          },
+          orderBy: { [orderBy]: orderDirection },
+        }),
+        db.asset.count({ where: assetWhere }),
+      ]);
+
+    let [assets, totalAssets] = await fetchAssetsForWhere(where);
+
+    // Fallback: an ID-shaped search ran the narrow clause but matched no
+    // assets. The term may be embedded in a title, description, or custom
+    // field rather than being a real identifier, so re-run with the full
+    // search clause before giving up.
+    if (shouldFallbackToFullSearch && totalAssets === 0 && fullSearchOr) {
+      where.OR = fullSearchOr;
+      [assets, totalAssets] = await fetchAssetsForWhere(where);
+    }
 
     return { assets, totalAssets };
   } catch (cause) {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -579,15 +579,16 @@ export async function getAssets(params: {
 
     const where: Prisma.AssetWhereInput = { organizationId };
 
-    // When an ID-shaped search uses the narrow fast path but returns nothing,
-    // we re-run with the full clause held here — the number may be embedded in
-    // a title, description, or custom field rather than being a real ID.
+    // Lazily builds the full multi-column search clause. Held as a builder
+    // (not a prebuilt value) so a successful narrow ID lookup never pays to
+    // construct the 10-branch clause it won't use; it is only invoked by the
+    // non-ID path or by the fallback re-query when the narrow query is empty.
     let shouldFallbackToFullSearch = false;
-    let fullSearchOr: Prisma.AssetWhereInput[] | undefined;
+    let buildFullSearchOr: (() => Prisma.AssetWhereInput[]) | undefined;
     // Number of OR entries the narrow search contributed. Later filters
     // (uncategorized / untagged / without-location / team-member) also append
     // to `where.OR`, so the fallback re-query replaces only these first
-    // entries with `fullSearchOr` and preserves the appended filter clauses.
+    // entries with the full clause and preserves the appended filter clauses.
     let narrowSearchOrCount = 0;
 
     if (availableToBookOnly) {
@@ -603,77 +604,86 @@ export async function getAssets(params: {
         .filter(Boolean);
 
       if (searchTerms.length > 0) {
-        // The full multi-column clause: matches a term anywhere it can
-        // legitimately live — title, sequentialId, description, category,
+        // Builder for the full multi-column clause: matches a term anywhere it
+        // can legitimately live — title, sequentialId, description, category,
         // location, tags, custodian names, QR/barcode, and custom fields. It
         // is the slow path (custodian relation traversal + an unindexed
         // customFields JSON ILIKE), so for ID-shaped searches we run the
-        // narrow clause first and only fall back to this when it finds
-        // nothing (see the fallback re-query further down).
-        fullSearchOr = searchTerms.map((term) => ({
-          OR: [
-            // Search in asset fields
-            { title: { contains: term, mode: "insensitive" } },
-            // Search in asset sequential id
-            { sequentialId: { contains: term, mode: "insensitive" } },
-            // Search in asset description
-            { description: { contains: term, mode: "insensitive" } },
-            // Search in related category
-            { category: { name: { contains: term, mode: "insensitive" } } },
-            // Search in related location
-            { location: { name: { contains: term, mode: "insensitive" } } },
-            // Search in related tags
-            {
-              tags: { some: { name: { contains: term, mode: "insensitive" } } },
-            },
-            // Search in custodian names
-            {
-              custody: {
-                custodian: {
-                  OR: [
-                    { name: { contains: term, mode: "insensitive" } },
-                    {
-                      user: {
-                        OR: [
-                          {
-                            firstName: { contains: term, mode: "insensitive" },
-                          },
-                          { lastName: { contains: term, mode: "insensitive" } },
-                        ],
+        // narrow clause first and only build/use this when it finds nothing
+        // (see the fallback re-query further down). Defined as a closure so the
+        // clause is constructed only when actually needed.
+        buildFullSearchOr = () =>
+          searchTerms.map((term) => ({
+            OR: [
+              // Search in asset fields
+              { title: { contains: term, mode: "insensitive" } },
+              // Search in asset sequential id
+              { sequentialId: { contains: term, mode: "insensitive" } },
+              // Search in asset description
+              { description: { contains: term, mode: "insensitive" } },
+              // Search in related category
+              { category: { name: { contains: term, mode: "insensitive" } } },
+              // Search in related location
+              { location: { name: { contains: term, mode: "insensitive" } } },
+              // Search in related tags
+              {
+                tags: {
+                  some: { name: { contains: term, mode: "insensitive" } },
+                },
+              },
+              // Search in custodian names
+              {
+                custody: {
+                  custodian: {
+                    OR: [
+                      { name: { contains: term, mode: "insensitive" } },
+                      {
+                        user: {
+                          OR: [
+                            {
+                              firstName: {
+                                contains: term,
+                                mode: "insensitive",
+                              },
+                            },
+                            {
+                              lastName: { contains: term, mode: "insensitive" },
+                            },
+                          ],
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
               },
-            },
-            // Search qr code id
-            {
-              qrCodes: {
-                some: { id: { contains: term, mode: "insensitive" } },
-              },
-            },
-            // Search barcode values
-            {
-              barcodes: {
-                some: { value: { contains: term, mode: "insensitive" } },
-              },
-            },
-            // Search in custom fields
-            {
-              customFields: {
-                some: {
-                  OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
-                    value: {
-                      path: [jsonPath],
-                      string_contains: term,
-                      mode: "insensitive",
-                    },
-                  })),
+              // Search qr code id
+              {
+                qrCodes: {
+                  some: { id: { contains: term, mode: "insensitive" } },
                 },
               },
-            },
-          ],
-        }));
+              // Search barcode values
+              {
+                barcodes: {
+                  some: { value: { contains: term, mode: "insensitive" } },
+                },
+              },
+              // Search in custom fields
+              {
+                customFields: {
+                  some: {
+                    OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
+                      value: {
+                        path: [jsonPath],
+                        string_contains: term,
+                        mode: "insensitive",
+                      },
+                    })),
+                  },
+                },
+              },
+            ],
+          }));
 
         // Fast path: when every term looks like an asset identifier — either
         // bare digits ("21035", a UPC barcode) or canonical sequentialId
@@ -687,7 +697,7 @@ export async function getAssets(params: {
         // custom field (e.g. "Armchair (Old SKU: 103468)"), and the shape
         // alone cannot tell those apart from a real barcode. So we flag the
         // query for fallback: if this narrow clause returns zero rows,
-        // getAssets re-runs with `fullSearchOr` below.
+        // getAssets builds and re-runs with the full clause below.
         if (searchTerms.every(looksLikeAssetId)) {
           shouldFallbackToFullSearch = true;
           where.OR = searchTerms.flatMap((term) => [
@@ -707,7 +717,8 @@ export async function getAssets(params: {
           // swap them out without disturbing filter clauses appended later.
           narrowSearchOrCount = where.OR.length;
         } else {
-          where.OR = fullSearchOr;
+          // Not an ID-shaped search — go straight to the full clause.
+          where.OR = buildFullSearchOr();
         }
       }
     }
@@ -911,14 +922,14 @@ export async function getAssets(params: {
     // assets. The term may be embedded in a title, description, or custom
     // field rather than being a real identifier, so re-run with the full
     // search clause before giving up. Only the narrow search entries are
-    // swapped for `fullSearchOr`; any filter clauses appended to `where.OR`
+    // swapped for the full clause; any filter clauses appended to `where.OR`
     // afterwards (uncategorized / untagged / without-location / team-member)
     // are kept so the fallback honours the same filters as the first query.
-    if (shouldFallbackToFullSearch && totalAssets === 0 && fullSearchOr) {
+    if (shouldFallbackToFullSearch && totalAssets === 0 && buildFullSearchOr) {
       const appendedFilterOr = Array.isArray(where.OR)
         ? where.OR.slice(narrowSearchOrCount)
         : [];
-      where.OR = [...fullSearchOr, ...appendedFilterOr];
+      where.OR = [...buildFullSearchOr(), ...appendedFilterOr];
       [assets, totalAssets] = await fetchAssetsForWhere(where);
     }
 


### PR DESCRIPTION
Numeric/SAM-ID searches run a narrow indexed query (sequentialId, barcode,
QR id) first for speed. When that clause returns no rows the term may instead
be embedded in a title, description, or custom field (e.g. an asset named
"...(Old SKU: 103468)"), so re-run once with the full search clause before
giving up. The fast path stays a single query for real ID lookups; the extra
query is only paid when the narrow clause already matched nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset search: queries that resemble an ID now run a fast indexed search first and automatically expand to a full search if no results are found, while preserving any additional filters.
  * Booking statistics: terminology updated from “units” to “items” and the tooltip message changed accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->