### PR TITLE
fix(mobile-sso): prod hardening — Sentry 5xx capture, migrate-status gate, wider code TTL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,33 +116,3 @@ jobs:
         run: flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app_name.outputs.value }} --dockerfile apps/webapp/Dockerfile
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-      # Migrations apply via fly.toml's `release_command` (`prisma migrate
-      # deploy`) during the deploy above. If that ever exits 0 without applying
-      # (e.g. a schema-path/env hiccup at release time), the deploy still goes
-      # green and a missing table only surfaces later as runtime 500s — which is
-      # how a prod migration once drifted unnoticed. This gate asks the running
-      # production machine whether Prisma considers the schema in sync and fails
-      # loudly otherwise, so drift is caught here rather than by a user. It
-      # reuses FLY_API_TOKEN (no DB credentials in CI) and runs on the machine,
-      # which already carries DATABASE_URL/DIRECT_URL as Fly secrets. It runs
-      # after deploy, so a failure is an alert to investigate — it does not roll
-      # the release back.
-      - name: 🔎 Verify migrations applied (production)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          set -uo pipefail
-          echo "Checking 'prisma migrate status' on production…"
-          OUTPUT=$(flyctl ssh console --app ${{ steps.app_name.outputs.value }} \
-            -C "/bin/sh -lc 'cd /src/apps/webapp && npx prisma migrate status'" 2>&1) || true
-          echo "--- prisma migrate status ---"
-          echo "$OUTPUT"
-          echo "-----------------------------"
-          if echo "$OUTPUT" | grep -q "Database schema is up to date"; then
-            echo "✅ Production database schema is up to date."
-            exit 0
-          fi
-          echo "::error::Prisma reports the production schema is NOT up to date — a migration may have failed to apply during release. Run 'npx prisma migrate status' / 'migrate deploy' against production and investigate before treating this deploy as healthy."
-          exit 1
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,3 +116,33 @@ jobs:
         run: flyctl deploy --remote-only --build-arg COMMIT_SHA=${{ github.sha }} --app ${{ steps.app_name.outputs.value }} --dockerfile apps/webapp/Dockerfile
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      # Migrations apply via fly.toml's `release_command` (`prisma migrate
+      # deploy`) during the deploy above. If that ever exits 0 without applying
+      # (e.g. a schema-path/env hiccup at release time), the deploy still goes
+      # green and a missing table only surfaces later as runtime 500s — which is
+      # how a prod migration once drifted unnoticed. This gate asks the running
+      # production machine whether Prisma considers the schema in sync and fails
+      # loudly otherwise, so drift is caught here rather than by a user. It
+      # reuses FLY_API_TOKEN (no DB credentials in CI) and runs on the machine,
+      # which already carries DATABASE_URL/DIRECT_URL as Fly secrets. It runs
+      # after deploy, so a failure is an alert to investigate — it does not roll
+      # the release back.
+      - name: 🔎 Verify migrations applied (production)
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          set -uo pipefail
+          echo "Checking 'prisma migrate status' on production…"
+          OUTPUT=$(flyctl ssh console --app ${{ steps.app_name.outputs.value }} \
+            -C "/bin/sh -lc 'cd /src/apps/webapp && npx prisma migrate status'" 2>&1) || true
+          echo "--- prisma migrate status ---"
+          echo "$OUTPUT"
+          echo "-----------------------------"
+          if echo "$OUTPUT" | grep -q "Database schema is up to date"; then
+            echo "✅ Production database schema is up to date."
+            exit 0
+          fi
+          echo "::error::Prisma reports the production schema is NOT up to date — a migration may have failed to apply during release. Run 'npx prisma migrate status' / 'migrate deploy' against production and investigate before treating this deploy as healthy."
+          exit 1
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/apps/webapp/app/modules/auth/mobile-sso.server.ts
+++ b/apps/webapp/app/modules/auth/mobile-sso.server.ts
@@ -35,10 +35,15 @@ import { mapAuthSession } from "./mappers.server";
 const label: ErrorLabel = "Auth";
 
 /**
- * Lifetime of a mobile auth code. Deliberately short — it only needs to survive
- * the deeplink round-trip from the web callback back into the app.
+ * Lifetime of a mobile auth code. Short by design — the code is minted in the
+ * web callback *after* SSO/MFA completes, so this window only spans the
+ * `shelf://` deeplink hand-back plus the app's exchange POST, not the
+ * human-paced IdP login. 180s (rather than a tighter 60s) leaves margin if iOS
+ * briefly backgrounds the app during the hand-back or the exchange runs on a
+ * slow network, without meaningfully widening the attack surface of a
+ * single-use, hashed code.
  */
-const MOBILE_AUTH_CODE_TTL_MS = 60_000;
+const MOBILE_AUTH_CODE_TTL_MS = 180_000;
 
 /**
  * SHA-256 hex digest. Auth codes are high-entropy (256-bit) single-use tokens,

--- a/apps/webapp/app/modules/auth/service.server.ts
+++ b/apps/webapp/app/modules/auth/service.server.ts
@@ -536,14 +536,15 @@ export async function refreshAccessToken(
 
     return mapAuthSession(session);
   } catch (cause) {
+    // SECURITY: never put `refreshToken` (a long-lived bearer credential) in
+    // additionalData — if this error is ever captured it would be spread into
+    // the Sentry event's `extra`. `makeSentryContext` also redacts secret-ish
+    // keys as a backstop, but the credential should not be in the error at all.
     throw new ShelfError({
       cause,
       message:
         "Unable to refresh access token. Please try again. If the issue persists, contact support",
       label,
-      additionalData: {
-        refreshToken,
-      },
     });
   }
 }

--- a/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
+++ b/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
@@ -18,6 +18,7 @@ import {
   logException,
   parseData,
   payload,
+  readFormData,
 } from "~/utils/http.server";
 import { resolveUserAndOrgForSsoCallback } from "~/utils/sso.server";
 
@@ -99,6 +100,9 @@ export async function action({ request }: ActionFunctionArgs) {
 
     switch (method) {
       case "POST": {
+        // why: readFormData (not request.formData()) so a malformed body / wrong
+        // Content-Type is downgraded to a non-captured 400, rather than a
+        // TypeError that logException would otherwise surface as a captured 5xx.
         const {
           refreshToken,
           firstName,
@@ -110,7 +114,7 @@ export async function action({ request }: ActionFunctionArgs) {
           stateProvince,
           postalCode,
           country,
-        } = parseData(await request.formData(), MobileCallbackSchema);
+        } = parseData(await readFormData(request), MobileCallbackSchema);
 
         // Don't trust client tokens — re-derive the session from the refresh
         // token server-side (same trust boundary as the web callback).

--- a/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
+++ b/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
@@ -13,6 +13,7 @@ import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { createSSOFormData } from "~/utils/auth";
 import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
 import { getActionMethod, parseData, payload } from "~/utils/http.server";
+import { Logger } from "~/utils/logger";
 import { resolveUserAndOrgForSsoCallback } from "~/utils/sso.server";
 
 /**
@@ -138,6 +139,17 @@ export async function action({ request }: ActionFunctionArgs) {
     throw notAllowedMethod(method);
   } catch (cause) {
     const reason = makeShelfError(cause);
+    // why: the client component renders `result.error` and never re-throws, so
+    // without an explicit log a genuine 5xx (refresh-token exchange, user/org
+    // provisioning, or code mint failing) would never reach Sentry. Capture
+    // server faults as errors; keep a sampled, non-alerting trail of the
+    // expected 4xx (SSO disabled, malformed callback payload) for diagnostics.
+    // A missing status defaults to 500 (server fault).
+    if ((reason.status ?? 500) >= 500) {
+      Logger.error(reason);
+    } else {
+      Logger.handledClientError(reason);
+    }
     return data(
       { error: { message: reason.message } },
       { status: reason.status }

--- a/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
+++ b/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
@@ -13,8 +13,12 @@ import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { createSSOFormData } from "~/utils/auth";
 import { mobilePkceChallengeCookie } from "~/utils/cookies.server";
 import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
-import { getActionMethod, parseData, payload } from "~/utils/http.server";
-import { Logger } from "~/utils/logger";
+import {
+  getActionMethod,
+  logException,
+  parseData,
+  payload,
+} from "~/utils/http.server";
 import { resolveUserAndOrgForSsoCallback } from "~/utils/sso.server";
 
 /**
@@ -161,17 +165,11 @@ export async function action({ request }: ActionFunctionArgs) {
     throw notAllowedMethod(method);
   } catch (cause) {
     const reason = makeShelfError(cause);
-    // why: the client component renders `result.error` and never re-throws, so
-    // without an explicit log a genuine 5xx (refresh-token exchange, user/org
-    // provisioning, or code mint failing) would never reach Sentry. Capture
-    // server faults as errors; keep a sampled, non-alerting trail of the
-    // expected 4xx (SSO disabled, malformed callback payload) for diagnostics.
-    // A missing status defaults to 500 (server fault).
-    if ((reason.status ?? 500) >= 500) {
-      Logger.error(reason);
-    } else {
-      Logger.handledClientError(reason);
-    }
+    // why: the client renders `result.error` and never re-throws, so without an
+    // explicit log a genuine 5xx (refresh-token exchange, user/org provisioning,
+    // or code mint failing) would never reach Sentry. `logException` mirrors
+    // `error()`'s logging (5xx → Sentry, handled 4xx → trail, aborts skipped).
+    logException(reason);
     return data(
       { error: { message: reason.message } },
       {

--- a/apps/webapp/app/routes/api+/mobile+/exchange.ts
+++ b/apps/webapp/app/routes/api+/mobile+/exchange.ts
@@ -18,6 +18,7 @@ import {
 } from "~/modules/auth/mobile-sso.server";
 import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
 import { getActionMethod } from "~/utils/http.server";
+import { Logger } from "~/utils/logger";
 
 const ExchangeSchema = z.object({
   code: z.string().min(1, "Authorization code is required"),
@@ -64,6 +65,18 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   } catch (cause) {
     const reason = makeShelfError(cause);
+    // why: this resource route returns failures as JSON (the companion app
+    // parses `{ error }`) and never re-throws, so without an explicit log a
+    // genuine 5xx (Supabase mint outage, broken auth contract, DB/migration
+    // fault) would never reach Sentry — exactly how a prod migration-drift 500
+    // once went unnoticed. Capture server faults as errors; keep a sampled,
+    // non-alerting trail of the expected 4xx (expired / invalid / already-used
+    // code) for diagnostics. A missing status defaults to 500 (server fault).
+    if ((reason.status ?? 500) >= 500) {
+      Logger.error(reason);
+    } else {
+      Logger.handledClientError(reason);
+    }
     return data(
       { error: { message: reason.message } },
       { status: reason.status }

--- a/apps/webapp/app/routes/api+/mobile+/exchange.ts
+++ b/apps/webapp/app/routes/api+/mobile+/exchange.ts
@@ -17,8 +17,7 @@ import {
   redeemMobileAuthCode,
 } from "~/modules/auth/mobile-sso.server";
 import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
-import { getActionMethod } from "~/utils/http.server";
-import { Logger } from "~/utils/logger";
+import { getActionMethod, logException } from "~/utils/http.server";
 
 const ExchangeSchema = z.object({
   code: z.string().min(1, "Authorization code is required"),
@@ -80,16 +79,12 @@ export async function action({ request }: ActionFunctionArgs) {
     const reason = makeShelfError(cause);
     // why: this resource route returns failures as JSON (the companion app
     // parses `{ error }`) and never re-throws, so without an explicit log a
-    // genuine 5xx (Supabase mint outage, broken auth contract, DB/migration
-    // fault) would never reach Sentry — exactly how a prod migration-drift 500
-    // once went unnoticed. Capture server faults as errors; keep a sampled,
-    // non-alerting trail of the expected 4xx (expired / invalid / already-used
-    // code) for diagnostics. A missing status defaults to 500 (server fault).
-    if ((reason.status ?? 500) >= 500) {
-      Logger.error(reason);
-    } else {
-      Logger.handledClientError(reason);
-    }
+    // genuine 5xx (Supabase mint outage, broken auth contract, DB fault) would
+    // never reach Sentry. `logException` mirrors `error()`'s logging (5xx →
+    // Sentry, handled 4xx → low-severity trail, client aborts skipped). NOTE:
+    // every route under `api+/mobile+/` swallows 5xx this same way and none log
+    // yet — `logException` is the shared fix to finish that off route by route.
+    logException(reason);
     return data(
       { error: { message: reason.message } },
       { status: reason.status }

--- a/apps/webapp/app/utils/http.server.ts
+++ b/apps/webapp/app/utils/http.server.ts
@@ -297,6 +297,28 @@ export type DataResponse<T extends ResponsePayload = ResponsePayload> =
   ReturnType<typeof payload<T>>;
 
 /**
+ * Log a caught server error for observability WITHOUT building a response.
+ *
+ * The logging half of {@link error}, for resource/API routes that catch a
+ * `ShelfError` and return their own JSON shape (so they can't use `error()`,
+ * which also fires a user notification and returns a richer payload). Mirrors
+ * `error()`'s logging exactly: 5xx (and uncaught) reach Sentry via
+ * `Logger.error`; handled 4xx land on the low-severity log trail via
+ * `Logger.handledClientError` (and are dropped from the Sentry error pipeline
+ * by `handleBeforeSendError`); client disconnects (status 499, "Request
+ * aborted") are intentionally skipped from both.
+ *
+ * @param cause - The normalized `ShelfError` to log
+ */
+export function logException(cause: ShelfError) {
+  if (cause.label === "Request aborted") {
+    return;
+  }
+  Logger.error(cause);
+  Logger.handledClientError(cause);
+}
+
+/**
  * Create an error response payload.
  *
  * Normalize the error to return to help type inference.

--- a/apps/webapp/app/utils/http.server.ts
+++ b/apps/webapp/app/utils/http.server.ts
@@ -327,17 +327,13 @@ export function logException(cause: ShelfError) {
  * @returns The normalized error with `error` key set to the error
  */
 export function error(cause: ShelfError, shouldSendNotification = true) {
-  if (cause.label !== "Request aborted") {
-    Logger.error(cause);
-
-    // Handled client errors (4xx) are dropped from the Sentry error pipeline
-    // (see handleBeforeSendError); record them as a low-severity log trail
-    // instead so we keep visibility without burning the error quota. No-op for
-    // non-4xx errors. Kept inside the abort guard so client disconnects
-    // (status 499 "Request aborted") aren't reintroduced as log noise — they're
-    // intentionally suppressed from both Logger.error and beforeSend.
-    Logger.handledClientError(cause);
-  }
+  // Single source of truth for "how we log a caught ShelfError": 5xx (and
+  // uncaught) reach Sentry via Logger.error; handled 4xx land on the
+  // low-severity log trail via Logger.handledClientError (dropped from the
+  // Sentry error pipeline by handleBeforeSendError); client disconnects
+  // (status 499 "Request aborted") are skipped from both. error() layers the
+  // notification + richer response payload on top of this.
+  logException(cause);
 
   if (
     cause.label !== "Request aborted" &&

--- a/apps/webapp/server/instrument.server.ts
+++ b/apps/webapp/server/instrument.server.ts
@@ -160,24 +160,52 @@ function handleBeforeSendError<E extends Event>(event: E, hint: EventHint) {
  * guarantees a stray one can't be spread into the captured event's `extra`.
  */
 const SENSITIVE_KEY_PATTERN =
-  /token|password|secret|verifier|cookie|authorization|api[-_]?key/i;
+  /token|password|secret|verifier|cookie|authorization|credential|jwt|api[-_]?key/i;
 
 /**
- * Shallow-redact values under sensitive keys before they are spread into a
- * Sentry event's `extra`. Non-object input yields an empty object.
+ * Recursively redact values under sensitive keys. Walks nested objects and
+ * arrays (cycle-safe via `seen`) so a secret tucked under a non-sensitive key
+ * (e.g. `{ session: { refreshToken } }`) is scrubbed too — not just top-level
+ * keys.
+ *
+ * @param value - The value to walk
+ * @param seen - Visited objects, to break reference cycles
+ * @returns The value with secret-keyed entries replaced by `"[redacted]"`
+ */
+function redactValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[circular]";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((v) => redactValue(v, seen));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = SENSITIVE_KEY_PATTERN.test(key)
+      ? "[redacted]"
+      : redactValue(val, seen);
+  }
+  return out;
+}
+
+/**
+ * Redact a ShelfError's `additionalData` for safe inclusion in a Sentry event's
+ * `extra`. Non-object input yields an empty object so the result is spreadable.
+ * Defense-in-depth: callers must still avoid putting secrets in `additionalData`
+ * at all — this guarantees a stray one (at any depth) can't reach Sentry.
  *
  * @param data - A ShelfError's `additionalData`
- * @returns A copy with secret-ish values replaced by `"[redacted]"`
+ * @returns A deep copy with secret-keyed values replaced by `"[redacted]"`
  */
 function redactSecrets(data: unknown): Record<string, unknown> {
   if (!data || typeof data !== "object") {
     return {};
   }
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
-    out[key] = SENSITIVE_KEY_PATTERN.test(key) ? "[redacted]" : value;
-  }
-  return out;
+  return redactValue(data, new WeakSet<object>()) as Record<string, unknown>;
 }
 
 /**

--- a/apps/webapp/server/instrument.server.ts
+++ b/apps/webapp/server/instrument.server.ts
@@ -154,6 +154,33 @@ function handleBeforeSendError<E extends Event>(event: E, hint: EventHint) {
 }
 
 /**
+ * Keys whose values are credentials/secrets and must NEVER reach Sentry, even
+ * if one slips into a ShelfError's `additionalData`. Defense-in-depth: callers
+ * shouldn't put secrets in `additionalData` in the first place, but this
+ * guarantees a stray one can't be spread into the captured event's `extra`.
+ */
+const SENSITIVE_KEY_PATTERN =
+  /token|password|secret|verifier|cookie|authorization|api[-_]?key/i;
+
+/**
+ * Shallow-redact values under sensitive keys before they are spread into a
+ * Sentry event's `extra`. Non-object input yields an empty object.
+ *
+ * @param data - A ShelfError's `additionalData`
+ * @returns A copy with secret-ish values replaced by `"[redacted]"`
+ */
+function redactSecrets(data: unknown): Record<string, unknown> {
+  if (!data || typeof data !== "object") {
+    return {};
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+    out[key] = SENSITIVE_KEY_PATTERN.test(key) ? "[redacted]" : value;
+  }
+  return out;
+}
+
+/**
  * Build a Sentry overlay (user / tags / extras) from a ShelfError.
  *
  * Returns `undefined` for anything that isn't a ShelfError so the caller
@@ -176,7 +203,7 @@ function makeSentryContext(exception: unknown) {
       shelf_trace_id: exception.traceId || "Unknown",
     },
     extra: {
-      ...(exception.additionalData || {}),
+      ...redactSecrets(exception.additionalData),
       traceId: exception.traceId,
       message: exception.message,
       cause: {

--- a/apps/webapp/server/instrument.server.ts
+++ b/apps/webapp/server/instrument.server.ts
@@ -236,7 +236,12 @@ function makeSentryContext(exception: unknown) {
       message: exception.message,
       cause: {
         message: (exception.cause as Error | null)?.message,
-        raw: JSON.stringify(exception.cause),
+        // Redact the raw cause chain too; otherwise it bypasses redactSecrets
+        // and the "no secret can reach Sentry (at any depth)" guarantee would
+        // not actually hold.
+        raw: JSON.stringify(
+          redactValue(exception.cause, new WeakSet<object>())
+        ),
       },
     },
   };


### PR DESCRIPTION
## Why

Follow-up hardening for mobile SSO (merged in #2607), making the prod rollout safe to pilot. Three gaps:

1. **The mobile SSO server flow was ~invisible to Sentry.** Both `exchange.ts` and `oauth.callback_.mobile.tsx` catch every error and `return data({ error })` without re-throwing or logging. Since `Sentry.captureException` only fires via `Logger.error` (or an uncaught throw), even genuine 5xx — a Supabase mint outage, a broken auth contract, a DB/migration fault — never reached Sentry. Confirmed empirically: the prod migration-drift 500 (missing `MobileAuthCode` table) paged no one and was only found by manual probing.

2. **A migration can silently fail to apply on deploy.** `fly.toml`'s `release_command = prisma migrate deploy` applies migrations during deploy, but if it ever exits `0` without applying, the deploy still goes green and the missing table only surfaces later as runtime 500s.

3. **The single-use code TTL was tight for edge cases.** The code is minted in the web callback *after* SSO/MFA, so 60s only had to cover the `shelf://` hand-back + the exchange POST — but iOS briefly backgrounding the app during hand-back, or a slow-network exchange, could still expire it.

## What

- **`exchange.ts` / `oauth.callback_.mobile.tsx`** — in the `catch`, log `status >= 500` via `Logger.error` (→ Sentry) and keep a sampled, non-alerting trail of the expected 4xx (expired / invalid / replayed code, SSO disabled, malformed payload) via `Logger.handledClientError`. Success path unchanged.
- **`deploy.yml`** — after the production deploy, run `prisma migrate status` on the running machine over `flyctl ssh console` and fail the workflow loudly if the schema isn't in sync. So a `release_command` that exits `0` without applying a migration is caught here, not by a user.
- **`mobile-sso.server.ts`** — widen the single-use code TTL `60s → 180s`. No security impact (single-use, hashed); just margin for the deeplink hand-back / slow exchange. The comment is corrected to note the code is minted *after* SSO/MFA, so this window never spanned the human-paced login.

## Why this is low-risk

- Additive observability + a wider (still short, single-use) code window — success path and response shapes unchanged.
- The CI gate **reuses the existing `FLY_API_TOKEN`** and runs **on the prod machine**, which already carries `DATABASE_URL`/`DIRECT_URL` as Fly secrets — no new secrets, no DB creds in CI.
- The gate is **post-deploy**: a failure is an alert to investigate, never a rollback or outage.

## Testing

- Pre-commit hook green: typecheck ✅, eslint ✅, prettier ✅, commitlint ✅
- TTL change: no test pins the value (tests assert `expiresAt > now`); behavior unchanged beyond the wider window.
- `deploy.yml` validated as YAML; new step parses as `🔎 Verify migrations applied (production)`.

## One thing to confirm on the first prod run

The exact `flyctl ssh console -C "/bin/sh -lc 'cd /src/apps/webapp && npx prisma migrate status'"` invocation can't be exercised from CI here. Please eyeball the step's output on the first `main` deploy — it greps for `Database schema is up to date`. If `flyctl ssh` / `npx prisma` resolves differently on the machine, the command is easy to adjust (the grep + fail-safe logic is already defensive).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended mobile authentication code validity from 60 seconds to 3 minutes.

* **Bug Fixes**
  * Improved observability for mobile OAuth callback and SSO token exchange by explicitly logging handled exceptions.
  * Added security-focused error handling to avoid exposing sensitive refresh-token data in logs/telemetry.
  * Enhanced monitoring by redacting sensitive fields in tracking “extra” details, including safe handling of nested/circular data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->