### PR TITLE
feat(mobile-sso): add PKCE (S256) to the native-app SSO exchange

### DIFF
--- a/apps/webapp/app/modules/auth/mobile-sso.server.test.ts
+++ b/apps/webapp/app/modules/auth/mobile-sso.server.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ShelfError } from "~/utils/error";
 import {
@@ -47,9 +48,15 @@ beforeEach(() => {
 });
 
 /** Wires the happy-path mocks for a successful redeem + fresh-session mint. */
-function mockSuccessfulMint(email = "sso@acme.com") {
+function mockSuccessfulMint(
+  email = "sso@acme.com",
+  codeChallenge: string | null = null
+) {
   dbMocks.updateMany.mockResolvedValue({ count: 1 });
-  dbMocks.findUniqueOrThrow.mockResolvedValue({ user: { email } });
+  dbMocks.findUniqueOrThrow.mockResolvedValue({
+    user: { email },
+    codeChallenge,
+  });
   supabaseMocks.generateLink.mockResolvedValue({
     data: { properties: { hashed_token: "hash_123" } },
     error: null,
@@ -84,6 +91,16 @@ describe("createMobileAuthCode", () => {
     expect(data.codeHash).toEqual(expect.any(String));
     expect(data.codeHash).not.toEqual(code); // stored value is the hash
     expect(data.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(data.codeChallenge).toBeNull(); // no PKCE challenge when omitted
+  });
+
+  it("stores the PKCE challenge when provided", async () => {
+    dbMocks.create.mockResolvedValue({});
+
+    await createMobileAuthCode("user_1", "challenge_abc");
+
+    const { data } = dbMocks.create.mock.calls[0][0];
+    expect(data.codeChallenge).toBe("challenge_abc");
   });
 });
 
@@ -218,6 +235,50 @@ describe("redeemMobileAuthCode", () => {
       status: 500,
     });
     expect(supabaseMocks.generateLink).toHaveBeenCalledTimes(1); // no retry
+  });
+
+  it("redeems a legacy (no-challenge) code without a verifier", async () => {
+    mockSuccessfulMint("sso@acme.com", null); // pre-PKCE app: codeChallenge null
+
+    const session = await redeemMobileAuthCode("good-code"); // no verifier
+
+    expect(session).toMatchObject({ accessToken: "at", refreshToken: "rt" });
+    expect(supabaseMocks.generateLink).toHaveBeenCalledTimes(1); // minted
+  });
+
+  it("redeems a PKCE code when the verifier matches the challenge", async () => {
+    const verifier = "v".repeat(64);
+    const challenge = createHash("sha256").update(verifier).digest("base64url");
+    mockSuccessfulMint("sso@acme.com", challenge);
+
+    const session = await redeemMobileAuthCode("good-code", verifier);
+
+    expect(session).toMatchObject({ accessToken: "at", refreshToken: "rt" });
+  });
+
+  it("rejects a PKCE code with a wrong verifier (400, no mint) but consumes it", async () => {
+    const challenge = createHash("sha256")
+      .update("the-real-verifier")
+      .digest("base64url");
+    mockSuccessfulMint("sso@acme.com", challenge);
+
+    await expect(
+      redeemMobileAuthCode("good-code", "a-different-verifier")
+    ).rejects.toMatchObject({ status: 400 });
+    expect(dbMocks.updateMany).toHaveBeenCalledTimes(1); // single-use consume ran
+    expect(supabaseMocks.generateLink).not.toHaveBeenCalled(); // never minted
+  });
+
+  it("rejects a PKCE code when no verifier is supplied", async () => {
+    const challenge = createHash("sha256")
+      .update("verifier")
+      .digest("base64url");
+    mockSuccessfulMint("sso@acme.com", challenge);
+
+    await expect(redeemMobileAuthCode("good-code")).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(supabaseMocks.generateLink).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/webapp/app/modules/auth/mobile-sso.server.ts
+++ b/apps/webapp/app/modules/auth/mobile-sso.server.ts
@@ -20,7 +20,7 @@
  * @see apps/webapp/app/routes/_auth+/oauth.callback.mobile.tsx
  * @see apps/webapp/app/routes/api+/mobile+/exchange.ts
  */
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import {
   isAuthApiError,
   isAuthRetryableFetchError,
@@ -49,6 +49,28 @@ const MOBILE_AUTH_CODE_TTL_MS = 60_000;
  */
 function hashCode(plaintext: string): string {
   return createHash("sha256").update(plaintext).digest("hex");
+}
+
+/**
+ * Verifies a PKCE code verifier against a stored S256 challenge in constant
+ * time. The challenge is `base64url(SHA-256(verifier))` (RFC 7636); we recompute
+ * it from the presented verifier and compare. Length is checked first because
+ * `timingSafeEqual` throws on unequal-length buffers.
+ *
+ * @param codeVerifier - The verifier presented at exchange (from the app)
+ * @param codeChallenge - The S256 challenge bound to the code at mint time
+ * @returns true if the verifier hashes to the stored challenge
+ */
+function verifyPkceChallenge(
+  codeVerifier: string,
+  codeChallenge: string
+): boolean {
+  const computed = createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url");
+  const a = Buffer.from(computed);
+  const b = Buffer.from(codeChallenge);
+  return a.length === b.length && timingSafeEqual(a, b);
 }
 
 /**
@@ -210,10 +232,16 @@ async function mintMobileSessionForUser(email: string): Promise<AuthSession> {
  * and the subsequent exchange request — only its hash is persisted.
  *
  * @param userId - The authenticated user the code authorizes a session for
+ * @param codeChallenge - Optional PKCE (S256) challenge. When present, the code
+ *   can only be redeemed with a matching verifier (see
+ *   {@link redeemMobileAuthCode}). Omitted by legacy (pre-PKCE) app builds.
  * @returns The plaintext authorization code to embed in the deeplink
  * @throws {ShelfError} If the row cannot be created
  */
-export async function createMobileAuthCode(userId: string): Promise<string> {
+export async function createMobileAuthCode(
+  userId: string,
+  codeChallenge?: string
+): Promise<string> {
   try {
     const code = randomBytes(32).toString("base64url"); // 256-bit entropy
 
@@ -221,6 +249,7 @@ export async function createMobileAuthCode(userId: string): Promise<string> {
       data: {
         userId,
         codeHash: hashCode(code),
+        codeChallenge: codeChallenge ?? null,
         expiresAt: new Date(Date.now() + MOBILE_AUTH_CODE_TTL_MS),
       },
     });
@@ -246,11 +275,25 @@ export async function createMobileAuthCode(userId: string): Promise<string> {
  * already-consumed code yields a uniform 400 (no oracle about which check
  * failed).
  *
+ * PKCE: if the code was minted with an S256 `codeChallenge` (a PKCE-capable
+ * app), the caller MUST present a `codeVerifier` that hashes to it — otherwise
+ * the (now-consumed) code is rejected with the SAME uniform 400, so an
+ * intercepted code is useless without the verifier. Codes minted WITHOUT a
+ * challenge (legacy, pre-PKCE builds) redeem with no verifier — backward
+ * compatible. Verification runs AFTER the atomic consume, so a wrong verifier
+ * burns the single-use code; acceptable, since the legitimate app always
+ * presents the matching verifier.
+ *
  * @param code - The plaintext authorization code from the deeplink
+ * @param codeVerifier - PKCE verifier; required iff the code carries a challenge
  * @returns A freshly minted, mapped auth session for the device
- * @throws {ShelfError} 400 if the code is missing/invalid/expired/already used
+ * @throws {ShelfError} 400 if the code is missing/invalid/expired/used, or if a
+ *   PKCE-bound code is presented without a matching verifier
  */
-export async function redeemMobileAuthCode(code: string): Promise<AuthSession> {
+export async function redeemMobileAuthCode(
+  code: string,
+  codeVerifier?: string
+): Promise<AuthSession> {
   try {
     if (!code) {
       throw new ShelfError({
@@ -280,10 +323,26 @@ export async function redeemMobileAuthCode(code: string): Promise<AuthSession> {
       });
     }
 
-    const { user } = await db.mobileAuthCode.findUniqueOrThrow({
+    const { user, codeChallenge } = await db.mobileAuthCode.findUniqueOrThrow({
       where: { codeHash },
-      select: { user: { select: { email: true } } },
+      select: { codeChallenge: true, user: { select: { email: true } } },
     });
+
+    // PKCE check — only for codes minted with a challenge. Same uniform 400 as
+    // an invalid code (no oracle about why redemption failed). The code is
+    // already consumed above, so a wrong/absent verifier burns it.
+    if (
+      codeChallenge &&
+      (!codeVerifier || !verifyPkceChallenge(codeVerifier, codeChallenge))
+    ) {
+      throw new ShelfError({
+        cause: null,
+        message: "Invalid or expired authorization code",
+        label,
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
 
     return await mintMobileSessionForUser(user.email);
   } catch (cause) {

--- a/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
+++ b/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
@@ -11,6 +11,7 @@ import { createMobileAuthCode } from "~/modules/auth/mobile-sso.server";
 import { refreshAccessToken } from "~/modules/auth/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { createSSOFormData } from "~/utils/auth";
+import { mobilePkceChallengeCookie } from "~/utils/cookies.server";
 import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
 import { getActionMethod, parseData, payload } from "~/utils/http.server";
 import { resolveUserAndOrgForSsoCallback } from "~/utils/sso.server";
@@ -124,13 +125,32 @@ export async function action({ request }: ActionFunctionArgs) {
           contactInfo,
         });
 
+        // PKCE: if a PKCE-capable app started this login, the S256 challenge is
+        // waiting in the cookie `/sso-login` set at the start of the flow. Bind
+        // it to the auth code so the exchange must present a matching verifier.
+        // Absent → legacy (pre-PKCE) flow, redeemed without a verifier.
+        const codeChallenge = await mobilePkceChallengeCookie.parse(
+          request.headers.get("Cookie")
+        );
+
         // Hand the device a single-use code via the deeplink — never tokens.
-        const code = await createMobileAuthCode(authSession.userId);
+        const code = await createMobileAuthCode(
+          authSession.userId,
+          typeof codeChallenge === "string" ? codeChallenge : undefined
+        );
 
         return data(
           payload({
             deeplink: `${MOBILE_CALLBACK_URL}?code=${encodeURIComponent(code)}`,
-          })
+          }),
+          {
+            // Clear the one-shot challenge cookie now that it's bound to the code.
+            headers: {
+              "Set-Cookie": await mobilePkceChallengeCookie.serialize("", {
+                maxAge: 0,
+              }),
+            },
+          }
         );
       }
     }

--- a/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
+++ b/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
@@ -71,6 +71,12 @@ const MobileCallbackSchema = z.object({
 
 export async function action({ request }: ActionFunctionArgs) {
   const { disableSSO } = config;
+  // Clears the one-shot PKCE challenge cookie. Applied on every exit path —
+  // success (once the challenge is bound to the code) and failure (so an
+  // abandoned flow doesn't leave the challenge readable for its full TTL).
+  const clearChallengeCookie = await mobilePkceChallengeCookie.serialize("", {
+    maxAge: 0,
+  });
   try {
     if (disableSSO) {
       throw new ShelfError({
@@ -145,11 +151,7 @@ export async function action({ request }: ActionFunctionArgs) {
           }),
           {
             // Clear the one-shot challenge cookie now that it's bound to the code.
-            headers: {
-              "Set-Cookie": await mobilePkceChallengeCookie.serialize("", {
-                maxAge: 0,
-              }),
-            },
+            headers: { "Set-Cookie": clearChallengeCookie },
           }
         );
       }
@@ -160,7 +162,10 @@ export async function action({ request }: ActionFunctionArgs) {
     const reason = makeShelfError(cause);
     return data(
       { error: { message: reason.message } },
-      { status: reason.status }
+      {
+        status: reason.status,
+        headers: { "Set-Cookie": clearChallengeCookie },
+      }
     );
   }
 }

--- a/apps/webapp/app/routes/_auth+/sso-login.tsx
+++ b/apps/webapp/app/routes/_auth+/sso-login.tsx
@@ -19,6 +19,7 @@ import { useSearchParams } from "~/hooks/search-params";
 import { useAutoFocus } from "~/hooks/use-auto-focus";
 import { signInWithSSO } from "~/modules/auth/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { mobilePkceChallengeCookie } from "~/utils/cookies.server";
 import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
 import {
@@ -42,17 +43,17 @@ const SSOLoginFormSchema = z.object({
   platform: z.enum(["web", "mobile"]).optional(),
 });
 
-export function loader({ context, request }: LoaderFunctionArgs) {
+export async function loader({ context, request }: LoaderFunctionArgs) {
   const title = "Log in with SSO";
   const subHeading = "Enter your company's domain to login with SSO.";
   const { disableSSO } = config;
 
+  const url = new URL(request.url);
   // The native-app flow opens this page with `?platform=mobile`. The in-app
   // browser may carry a stale web cookie, but the app still needs to complete
   // the SSO handoff to obtain its OWN session — so don't short-circuit it to
   // /assets. The web flow still redirects an already-authenticated session.
-  const isMobile =
-    new URL(request.url).searchParams.get("platform") === "mobile";
+  const isMobile = url.searchParams.get("platform") === "mobile";
 
   try {
     if (context.isAuthenticated && !isMobile) {
@@ -68,6 +69,26 @@ export function loader({ context, request }: LoaderFunctionArgs) {
         label: "User onboarding",
         status: 403,
         shouldBeCaptured: false,
+      });
+    }
+
+    // PKCE (native SSO): a PKCE-capable companion build appends an S256
+    // `code_challenge`. Stash it in a short-lived cookie so it survives the SSO
+    // redirect chain back to `/oauth/callback/mobile`, where it is bound to the
+    // minted auth code. Only accept a well-formed S256 challenge (43-char
+    // base64url); anything else is ignored (treated as a legacy, non-PKCE flow).
+    const codeChallenge = url.searchParams.get("code_challenge");
+    const validChallenge =
+      isMobile && codeChallenge && /^[A-Za-z0-9_-]{43}$/.test(codeChallenge)
+        ? codeChallenge
+        : null;
+
+    if (validChallenge) {
+      return data(payload({ title, subHeading }), {
+        headers: {
+          "Set-Cookie":
+            await mobilePkceChallengeCookie.serialize(validChallenge),
+        },
       });
     }
 

--- a/apps/webapp/app/routes/api+/mobile+/exchange.ts
+++ b/apps/webapp/app/routes/api+/mobile+/exchange.ts
@@ -21,9 +21,15 @@ import { getActionMethod } from "~/utils/http.server";
 
 const ExchangeSchema = z.object({
   code: z.string().min(1, "Authorization code is required"),
-  // PKCE verifier (RFC 7636: 43–128 chars). Optional — only codes minted by a
-  // PKCE-capable app build carry a challenge that requires it.
-  codeVerifier: z.string().min(43).max(128).optional(),
+  // PKCE verifier (RFC 7636: 43–128 chars, base64url unreserved charset).
+  // Optional — only codes minted by a PKCE-capable app build carry a challenge
+  // that requires it. The charset is constrained to mirror the strict S256
+  // `code_challenge` validation at `/sso-login`; a non-conforming verifier could
+  // never hash to a stored challenge anyway, so we reject it up front.
+  codeVerifier: z
+    .string()
+    .regex(/^[A-Za-z0-9_-]{43,128}$/)
+    .optional(),
 });
 
 /**

--- a/apps/webapp/app/routes/api+/mobile+/exchange.ts
+++ b/apps/webapp/app/routes/api+/mobile+/exchange.ts
@@ -21,12 +21,16 @@ import { getActionMethod } from "~/utils/http.server";
 
 const ExchangeSchema = z.object({
   code: z.string().min(1, "Authorization code is required"),
+  // PKCE verifier (RFC 7636: 43–128 chars). Optional — only codes minted by a
+  // PKCE-capable app build carry a challenge that requires it.
+  codeVerifier: z.string().min(43).max(128).optional(),
 });
 
 /**
  * POST /api/mobile/exchange
  *
- * Body: `{ code: string }` — the single-use code from the SSO deeplink.
+ * Body: `{ code: string, codeVerifier?: string }` — the single-use code from
+ * the SSO deeplink, plus the PKCE verifier when the app build supports it.
  *
  * @param args - React Router action args (carrying the incoming request)
  * @returns `{ accessToken, refreshToken }` on success (the app passes them to
@@ -52,7 +56,10 @@ export async function action({ request }: ActionFunctionArgs) {
       });
     }
 
-    const authSession = await redeemMobileAuthCode(parsed.data.code);
+    const authSession = await redeemMobileAuthCode(
+      parsed.data.code,
+      parsed.data.codeVerifier
+    );
 
     // Opportunistic cleanup of expired codes (no app-level cron in this repo).
     // Fire-and-forget: a cleanup failure must never affect the exchange.

--- a/apps/webapp/app/utils/cookies.server.ts
+++ b/apps/webapp/app/utils/cookies.server.ts
@@ -64,6 +64,28 @@ export function setCookie(cookieValue: string): [string, string] {
   return ["Set-Cookie", cookieValue];
 }
 
+/**
+ * MOBILE SSO PKCE CHALLENGE COOKIE
+ *
+ * Carries the PKCE `code_challenge` (S256) across the native-app SSO round-trip.
+ * A PKCE-capable companion build appends `?code_challenge=…` when it opens
+ * `/sso-login`; the loader stashes it here so it survives the browser-session
+ * redirect chain (Supabase → IdP → `/oauth/callback/mobile`), where it is bound
+ * to the minted auth code and then cleared. HttpOnly + short-lived: it only
+ * needs to outlive one SSO login. The value is a non-secret hash, so it is not
+ * signed — tampering only breaks the attacker's own exchange.
+ *
+ * @see apps/webapp/app/routes/_auth+/sso-login.tsx — sets it
+ * @see apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx — reads + clears it
+ */
+export const mobilePkceChallengeCookie = createCookie("mobile_pkce_challenge", {
+  path: "/",
+  httpOnly: true,
+  sameSite: "lax",
+  secure: process.env.NODE_ENV === "production",
+  maxAge: 60 * 10, // 10 min — must outlive the IdP login + the redirect chain
+});
+
 /** USER PREFS COOKIE */
 
 export const userPrefs = createCookie("user-prefs", {

--- a/packages/database/prisma/migrations/20260611000000_add_mobile_auth_code_pkce_challenge/migration.sql
+++ b/packages/database/prisma/migrations/20260611000000_add_mobile_auth_code_pkce_challenge/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+-- PKCE (S256) challenge for native-app SSO. Nullable + additive: existing rows
+-- and legacy (pre-PKCE) app builds redeem without a verifier; only codes minted
+-- with a challenge require a matching verifier at exchange.
+ALTER TABLE "MobileAuthCode"
+  ADD COLUMN "codeChallenge" TEXT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -34,20 +34,20 @@ model Image {
 }
 
 model User {
-  id                    String  @id @default(cuid())
-  email                 String  @unique
-  username              String  @unique @default(cuid())
-  firstName             String?
-  lastName              String?
-  displayName           String?
-  profilePicture        String?
-  usedFreeTrial         Boolean @default(false)
-  onboarded             Boolean @default(false)
-  customerId            String? @unique // Stripe customer id
-  sso                   Boolean @default(false)
-  createdWithInvite     Boolean @default(false) // Set to true if the user was created by being invited to a workspace
-  skipSubscriptionCheck Boolean @default(false) // Set to true if the user has opted out of subscription checks
-  hasUnpaidInvoice     Boolean @default(false) // Set via Stripe webhooks when invoice payment fails
+  id                     String  @id @default(cuid())
+  email                  String  @unique
+  username               String  @unique @default(cuid())
+  firstName              String?
+  lastName               String?
+  displayName            String?
+  profilePicture         String?
+  usedFreeTrial          Boolean @default(false)
+  onboarded              Boolean @default(false)
+  customerId             String? @unique // Stripe customer id
+  sso                    Boolean @default(false)
+  createdWithInvite      Boolean @default(false) // Set to true if the user was created by being invited to a workspace
+  skipSubscriptionCheck  Boolean @default(false) // Set to true if the user has opted out of subscription checks
+  hasUnpaidInvoice       Boolean @default(false) // Set via Stripe webhooks when invoice payment fails
   warnForNoPaymentMethod Boolean @default(false) // Set when subscription is transferred to a user without a payment method
 
   // Last selected organization for cross-device workspace persistence
@@ -62,37 +62,37 @@ model User {
   deletedAt DateTime?
 
   // Relationships
-  assets             Asset[]
-  categories         Category[]
-  notes              Note[]
-  bookingNotes      BookingNote[]      @relation("BookingNoteUser")
-  auditNotes        AuditNote[]        @relation("AuditNoteUser")
-  locationNotes     LocationNote[]     @relation("LocationNoteUser")
-  qrCodes            Qr[]
-  scans              Scan[]
-  tags               Tag[]
-  roles              Role[]
-  locations          Location[]
-  images             Image[]
-  organizations      Organization[]
-  customFields       CustomField[]
-  sentInvites        Invite[]           @relation("inviter")
-  receivedInvites    Invite[]           @relation("invitee")
-  teamMembers        TeamMember[]
-  userOrganizations  UserOrganization[]
-  bookings           Booking[]          @relation("creator")
-  custodies          Booking[]          @relation("custodian")
-  createdKits        Kit[]
-  tierId             TierId             @default(free)
-  tier               Tier               @relation(fields: [tierId], references: [id])
-  assetReminders     AssetReminder[]
-  contact            UserContact?
-  businessIntel      UserBusinessIntel?
-  auditsCreated      AuditSession[]
-  auditAssignments   AuditAssignment[]
-  auditAssetsScanned AuditAsset[]
-  auditScans         AuditScan[]
-  auditImagesUploaded AuditImage[] @relation("AuditImageUploader")
+  assets              Asset[]
+  categories          Category[]
+  notes               Note[]
+  bookingNotes        BookingNote[]      @relation("BookingNoteUser")
+  auditNotes          AuditNote[]        @relation("AuditNoteUser")
+  locationNotes       LocationNote[]     @relation("LocationNoteUser")
+  qrCodes             Qr[]
+  scans               Scan[]
+  tags                Tag[]
+  roles               Role[]
+  locations           Location[]
+  images              Image[]
+  organizations       Organization[]
+  customFields        CustomField[]
+  sentInvites         Invite[]           @relation("inviter")
+  receivedInvites     Invite[]           @relation("invitee")
+  teamMembers         TeamMember[]
+  userOrganizations   UserOrganization[]
+  bookings            Booking[]          @relation("creator")
+  custodies           Booking[]          @relation("custodian")
+  createdKits         Kit[]
+  tierId              TierId             @default(free)
+  tier                Tier               @relation(fields: [tierId], references: [id])
+  assetReminders      AssetReminder[]
+  contact             UserContact?
+  businessIntel       UserBusinessIntel?
+  auditsCreated       AuditSession[]
+  auditAssignments    AuditAssignment[]
+  auditAssetsScanned  AuditAsset[]
+  auditScans          AuditScan[]
+  auditImagesUploaded AuditImage[]       @relation("AuditImageUploader")
 
   // @deprecated - Historical data only. New entries go to UserBusinessIntel table
   referralSource String? // "How did you hear about us?" field.
@@ -214,7 +214,7 @@ model Asset {
   custody      Custody?
   notes        Note[]
   qrCodes      Qr[]
-  barcodes     Barcode[]              @relation("AssetBarcodes")
+  barcodes     Barcode[]               @relation("AssetBarcodes")
   reports      ReportFound[]
   tags         Tag[]
   customFields AssetCustomFieldValue[]
@@ -682,10 +682,10 @@ model TeamMember {
   userId          String?
   kitCustodies    KitCustody[]
 
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
-  deletedAt      DateTime?
-  bookings       Booking[]
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  deletedAt       DateTime?
+  bookings        Booking[]
   assetReminders  AssetReminder[]
   teamMemberNotes TeamMemberNote[]
 
@@ -754,9 +754,9 @@ model Organization {
   usedBarcodeTrial  Boolean   @default(false) // Set once a 7-day free barcode trial is activated (prevents reuse)
 
   // Audit add-on (per-organization, managed via Stripe subscription)
-  auditsEnabled    Boolean   @default(false) // If true, this organization can use audit functionality
-  auditsEnabledAt  DateTime? // Track when audit feature was enabled
-  usedAuditTrial   Boolean   @default(false) // Set once a 7-day free audit trial is activated (prevents reuse)
+  auditsEnabled   Boolean   @default(false) // If true, this organization can use audit functionality
+  auditsEnabledAt DateTime? // Track when audit feature was enabled
+  usedAuditTrial  Boolean   @default(false) // Set once a 7-day free audit trial is activated (prevents reuse)
 
   // This is used to disable the workspace for the user. It is set to true when the user leaves the workspace
   workspaceDisabled Boolean @default(false) // If true, the workspace is disabled and the user cannot access it
@@ -779,13 +779,13 @@ model Organization {
   assetReminders     AssetReminder[]
   assetFilterPresets AssetFilterPreset[]
 
-  auditSessions      AuditSession[]
-  auditImages        AuditImage[]
+  auditSessions AuditSession[]
+  auditImages   AuditImage[]
 
-  usersWithLastSelected User[] @relation("lastSelectedOrg")
-  roleChangeLogs      RoleChangeLog[]
-  teamMemberNotes     TeamMemberNote[]
-  activityEvents      ActivityEvent[]
+  usersWithLastSelected User[]           @relation("lastSelectedOrg")
+  roleChangeLogs        RoleChangeLog[]
+  teamMemberNotes       TeamMemberNote[]
+  activityEvents        ActivityEvent[]
 
   // Migration flag to track if sequential IDs have been generated for this organization's existing assets
   hasSequentialIdsMigrated Boolean @default(false)
@@ -1197,6 +1197,11 @@ model MobileAuthCode {
   // lives in the deeplink + the exchange request body — never stored.
   codeHash String @unique
 
+  // PKCE (S256) challenge — base64url(SHA-256(verifier)) — set when the minting
+  // client is PKCE-capable. NULL for legacy (pre-PKCE) app builds, which redeem
+  // without a verifier (backward compatible).
+  codeChallenge String?
+
   // Single-use guard: set when redeemed. A non-null value rejects reuse.
   consumedAt DateTime?
 
@@ -1305,15 +1310,15 @@ model BookingSettings {
   autoArchiveBookings Boolean @default(false) // Whether to automatically archive completed bookings
   autoArchiveDays     Int     @default(2) // Number of days after completion before auto-archiving
 
-  requireExplicitCheckinForAdmin      Boolean @default(false) // When true, admins must use explicit check-in (scanner) instead of quick check-in
+  requireExplicitCheckinForAdmin       Boolean @default(false) // When true, admins must use explicit check-in (scanner) instead of quick check-in
   requireExplicitCheckinForSelfService Boolean @default(false) // When true, self-service users must use explicit check-in (scanner) instead of quick check-in
 
   // Progressive check-in/out settings
   countKitsAsSingleUnit Boolean @default(false) // When true, the booking check-in progress bar treats each kit as one unit instead of counting the assets inside it
 
   // Notification settings
-  notifyBookingCreator     Boolean @default(true) // Whether the booking creator receives email notifications
-  notifyAdminsOnNewBooking Boolean @default(true) // Whether all admins receive a notification when a booking is reserved
+  notifyBookingCreator     Boolean      @default(true) // Whether the booking creator receives email notifications
+  notifyAdminsOnNewBooking Boolean      @default(true) // Whether all admins receive a notification when a booking is reserved
   alwaysNotifyTeamMembers  TeamMember[] @relation("BookingSettingsAlwaysNotify") // Team members who always receive ALL booking email notifications
 
   // Relationships
@@ -1642,10 +1647,10 @@ model AuditSession {
   missingAssetCount    Int @default(0)
   unexpectedAssetCount Int @default(0)
 
-  startedAt   DateTime?
-  dueDate     DateTime?
-  completedAt DateTime?
-  cancelledAt DateTime?
+  startedAt                DateTime?
+  dueDate                  DateTime?
+  completedAt              DateTime?
+  cancelledAt              DateTime?
   activeSchedulerReference String?
 
   createdBy      User         @relation(fields: [createdById], references: [id])
@@ -1706,9 +1711,9 @@ model AuditAsset {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  scans AuditScan[]
+  scans  AuditScan[]
   images AuditImage[]
-  notes AuditNote[]
+  notes  AuditNote[]
 
   @@unique([auditSessionId, assetId])
   @@index([status])


### PR DESCRIPTION
## Why

Follow-up to mobile SSO — closes the **Android `shelf://` deeplink interception** risk (#2611). On Android, custom URL schemes aren't exclusive, so a malicious app could intercept the single-use auth code. PKCE makes an intercepted code useless without a verifier that never leaves the legitimate app. (iOS is already safe via `ASWebAuthenticationSession`; PKCE is best practice on both.)

## How the challenge survives the SSO round-trip

The app initiates by opening `/sso-login` in the browser, then control passes through Supabase + the IdP before reaching `/oauth/callback/mobile`. The `code_challenge` **can't** ride Supabase's `redirectTo` (the allow-list is query-free) — so it rides a **short-lived HttpOnly cookie** set at `/sso-login`, which survives the in-browser redirect chain back to the callback.

> Verified empirically on a real Android emulator: a `SameSite=Lax; Secure; HttpOnly` first-party cookie set on origin A survives a cross-site, top-level-GET redirect back to A — exactly this hop. (Chrome = the Chromium engine that backs Custom Tabs.)

## What

- **`schema.prisma` + migration** — nullable `MobileAuthCode.codeChallenge` (additive).
- **`cookies.server.ts`** — `mobilePkceChallengeCookie` (HttpOnly, 10-min, `SameSite=Lax`).
- **`sso-login.tsx`** — loader stashes a valid S256 `?code_challenge=` (mobile flow only; ignores malformed values).
- **`oauth.callback_.mobile.tsx`** — binds the challenge to the minted code, then clears the cookie.
- **`mobile-sso.server.ts`** — `verifyPkceChallenge` (constant-time S256 compare); enforced **only when the code carries a challenge**. Verification runs after the atomic single-use consume, so a wrong verifier burns the code.
- **`exchange.ts`** — accepts optional `codeVerifier`, passes it to redeem.
- **tests** — +5 cases (legacy/no-verifier compat, verifier match, wrong verifier burns the code, missing verifier). **15/15 pass.**

## Backward-compatible rollout

PKCE is enforced **only for codes minted with a challenge**. The live iOS app sends no challenge → its codes redeem with no verifier, completely unaffected. So this deploys safely **ahead of** any PKCE-capable app build. "Enforce for all" (reject no-challenge codes) is a later step, gated on a minimum app version once telemetry shows the legacy tail has drained.

## Companion-app half (separate — mobile team)

Add `expo-crypto`; generate a `code_verifier` + its S256 `code_challenge`; append `&code_challenge=<challenge>` to the `/sso-login` URL; send `codeVerifier` in the exchange POST body. Spec to follow.

## Testing

- `pnpm --filter @shelf/webapp typecheck` ✅
- 15 unit tests ✅ (`mobile-sso.server.test.ts`)
- prettier + `prisma format` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile SSO now supports PKCE-bound authorization codes for stronger native-app authentication
  * OAuth login flow validates, caches, and clears PKCE code challenges during the redirect/deeplink sequence
  * Mobile code exchange endpoint accepts an optional code verifier to complete PKCE exchanges

* **Database**
  * Added storage for mobile auth code PKCE challenges (nullable for legacy codes)

* **Tests**
  * Expanded tests covering PKCE and legacy code redemption, including verifier success/failure cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->