### PR TITLE
Security: Unsafe redirect constructed from request URL in splat route

### DIFF
--- a/apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx
@@ -7,13 +7,16 @@ import { getParams } from "~/utils/http.server";
  * This is mostly made for handling users cmd+click on asset or booking in user page
  */
 export const loader = ({ request, params }: LoaderFunctionArgs) => {
-  const { userId: selectedUserId } = getParams(
+  const { "*": splat } = getParams(
     params,
-    z.object({ userId: z.string() })
+    z.object({ userId: z.string(), "*": z.string() })
   );
+  const url = new URL(request.url);
+  const redirectTo = `/${splat}${url.search}${url.hash}`;
 
-  /** Split the url based on the user id */
-  const extraParts = request.url.split(selectedUserId);
+  if (!redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+    throw new Response("Invalid redirect", { status: 400 });
+  }
 
-  return redirect(extraParts[extraParts.length - 1]);
+  return redirect(redirectTo);
 };

--- a/apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx
@@ -1,19 +1,19 @@
 import { redirect, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
-import { getParams } from "~/utils/http.server";
+import { getParams, safeRedirect } from "~/utils/http.server";
 
 /**
  * Splat route to handle requests with data after userId in the url.
  * This is mostly made for handling users cmd+click on asset or booking in user page.
  *
- * Extracts the splat segment from the request URL and redirects to the
- * reconstructed local path, preserving the query string and hash. Only
- * same-origin relative paths are allowed; protocol-relative (`//`) or otherwise
- * non-local targets are rejected to prevent open redirects.
+ * Reconstructs the target from the splat segment (preserving query string and
+ * hash) and routes it through `safeRedirect`, the canonical guard that resolves
+ * the destination and falls back to "/" for anything that is not same-origin —
+ * closing open-redirect vectors like `//host`, `/\host` and `%5C`-decoded
+ * backslashes.
  *
  * @param args - Loader arguments containing the incoming `request` and route `params`.
- * @returns A redirect `Response` pointing to the validated relative path.
- * @throws {Response} 400 response when the resolved redirect target is not a safe local path.
+ * @returns A redirect `Response` to the validated same-origin path.
  */
 export const loader = ({ request, params }: LoaderFunctionArgs) => {
   const { "*": splat } = getParams(
@@ -21,11 +21,6 @@ export const loader = ({ request, params }: LoaderFunctionArgs) => {
     z.object({ userId: z.string(), "*": z.string() })
   );
   const url = new URL(request.url);
-  const redirectTo = `/${splat}${url.search}${url.hash}`;
 
-  if (!redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
-    throw new Response("Invalid redirect", { status: 400 });
-  }
-
-  return redirect(redirectTo);
+  return redirect(safeRedirect(`/${splat}${url.search}${url.hash}`));
 };

--- a/apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx
@@ -3,8 +3,17 @@ import { z } from "zod";
 import { getParams } from "~/utils/http.server";
 
 /**
- * Splat route to handle requests with data after userId in the url
- * This is mostly made for handling users cmd+click on asset or booking in user page
+ * Splat route to handle requests with data after userId in the url.
+ * This is mostly made for handling users cmd+click on asset or booking in user page.
+ *
+ * Extracts the splat segment from the request URL and redirects to the
+ * reconstructed local path, preserving the query string and hash. Only
+ * same-origin relative paths are allowed; protocol-relative (`//`) or otherwise
+ * non-local targets are rejected to prevent open redirects.
+ *
+ * @param args - Loader arguments containing the incoming `request` and route `params`.
+ * @returns A redirect `Response` pointing to the validated relative path.
+ * @throws {Response} 400 response when the resolved redirect target is not a safe local path.
  */
 export const loader = ({ request, params }: LoaderFunctionArgs) => {
   const { "*": splat } = getParams(

--- a/apps/webapp/app/utils/http.server.test.ts
+++ b/apps/webapp/app/utils/http.server.test.ts
@@ -161,6 +161,18 @@ describe(safeRedirect.name, () => {
   it("should return destination path", () => {
     expect(safeRedirect("/items")).toBe("/items");
   });
+
+  it("should block open-redirect bypasses that prefix checks miss", () => {
+    // Protocol-relative and backslash variants all resolve off-origin;
+    // browsers treat "\" like "/" in http(s) URLs.
+    expect(safeRedirect("//evil.com")).toBe("/");
+    expect(safeRedirect("/\\evil.com")).toBe("/"); // "/\evil.com"
+    expect(safeRedirect("/\\\\evil.com")).toBe("/"); // "/\\evil.com"
+    // "%5C" reaches a route loader already decoded to "\" via route params.
+    expect(safeRedirect(`/${decodeURIComponent("%5C")}evil.com`)).toBe("/");
+    // Internal Remix routes remain blocked.
+    expect(safeRedirect("/__manifest")).toBe("/");
+  });
 });
 
 describe(payload.name, () => {

--- a/apps/webapp/app/utils/http.server.test.ts
+++ b/apps/webapp/app/utils/http.server.test.ts
@@ -172,6 +172,10 @@ describe(safeRedirect.name, () => {
     expect(safeRedirect(`/${decodeURIComponent("%5C")}evil.com`)).toBe("/");
     // Internal Remix routes remain blocked.
     expect(safeRedirect("/__manifest")).toBe("/");
+    // Absolute allow-list is matched by origin, not prefix: a host that merely
+    // begins with SERVER_URL, or hides it in userinfo, must not pass.
+    expect(safeRedirect("https://app.shelf.nu.evil.com/phish")).toBe("/");
+    expect(safeRedirect("https://app.shelf.nu@evil.com/phish")).toBe("/");
   });
 });
 

--- a/apps/webapp/app/utils/http.server.ts
+++ b/apps/webapp/app/utils/http.server.ts
@@ -235,23 +235,35 @@ export function safeRedirect(
   to: FormDataEntryValue | string | null | undefined,
   defaultRedirect = "/"
 ) {
-  /** List of domains we allow to redirect to
-   */
+  /** Absolute domains we explicitly allow to redirect to (e.g. URL shortener). */
   const safeList = [SERVER_URL, `https://${URL_SHORTENER}`];
 
-  if (!to || typeof to !== "string" || to.startsWith("//")) {
+  if (!to || typeof to !== "string") {
     return defaultRedirect;
   }
 
-  // Block internal Remix routes (manifest, etc.) from being used as redirects
-  // These are framework-internal URLs created by lazy route discovery
-  if (to.startsWith("/__")) {
+  // Allowed absolute domains pass through unchanged.
+  if (safeList.some((safeUrl) => to.startsWith(safeUrl))) {
+    return to;
+  }
+
+  // Otherwise the target must be a local absolute path. Reject non-paths and
+  // internal Remix routes (manifest, etc.) created by lazy route discovery.
+  if (!to.startsWith("/") || to.startsWith("/__")) {
     return defaultRedirect;
   }
 
-  // Check if the URL starts with any of the safe domains
-  const isSafeDomain = safeList.some((safeUrl) => to.startsWith(safeUrl));
-  if (!to.startsWith("/") && !isSafeDomain) {
+  // Final defense: resolve against our own origin and confirm it stays
+  // same-origin. A prefix check (e.g. `startsWith("//")`) misses "//host",
+  // "/\host" and "/\\host": browsers treat "\" like "/" in http(s) URLs, and a
+  // "\" reaches here decoded from "%5C" via route params. All of these resolve
+  // off-origin, so origin comparison closes the open redirect that prefix
+  // matching leaves open.
+  try {
+    if (new URL(to, SERVER_URL).origin !== new URL(SERVER_URL).origin) {
+      return defaultRedirect;
+    }
+  } catch {
     return defaultRedirect;
   }
 

--- a/apps/webapp/app/utils/http.server.ts
+++ b/apps/webapp/app/utils/http.server.ts
@@ -235,30 +235,39 @@ export function safeRedirect(
   to: FormDataEntryValue | string | null | undefined,
   defaultRedirect = "/"
 ) {
-  /** Absolute domains we explicitly allow to redirect to (e.g. URL shortener). */
-  const safeList = [SERVER_URL, `https://${URL_SHORTENER}`];
-
   if (!to || typeof to !== "string") {
     return defaultRedirect;
   }
 
-  // Allowed absolute domains pass through unchanged.
-  if (safeList.some((safeUrl) => to.startsWith(safeUrl))) {
-    return to;
-  }
-
-  // Otherwise the target must be a local absolute path. Reject non-paths and
-  // internal Remix routes (manifest, etc.) created by lazy route discovery.
-  if (!to.startsWith("/") || to.startsWith("/__")) {
+  // Block internal Remix routes (manifest, etc.) created by lazy route discovery.
+  if (to.startsWith("/__")) {
     return defaultRedirect;
   }
 
-  // Final defense: resolve against our own origin and confirm it stays
-  // same-origin. A prefix check (e.g. `startsWith("//")`) misses "//host",
+  // Absolute URL? Validate the allow-list by ORIGIN, never by prefix.
+  // `SERVER_URL` has its trailing slash stripped, so a prefix check matches any
+  // host that merely begins with it — e.g. "https://app.shelf.nu.evil.com" or
+  // the "https://app.shelf.nu@evil.com" userinfo trick — which resolve
+  // off-origin. `new URL(to)` throws for relative inputs, which fall through.
+  try {
+    const absolute = new URL(to);
+    const allowed = new Set([new URL(SERVER_URL).origin]);
+    if (URL_SHORTENER) {
+      allowed.add(new URL(`https://${URL_SHORTENER}`).origin);
+    }
+    return allowed.has(absolute.origin) ? to : defaultRedirect;
+  } catch {
+    // Not an absolute URL — fall through to local-path handling.
+  }
+
+  if (!to.startsWith("/")) {
+    return defaultRedirect;
+  }
+
+  // Final defense: resolve the local path against our own origin and confirm it
+  // stays same-origin. A prefix check (e.g. `startsWith("//")`) misses "//host",
   // "/\host" and "/\\host": browsers treat "\" like "/" in http(s) URLs, and a
-  // "\" reaches here decoded from "%5C" via route params. All of these resolve
-  // off-origin, so origin comparison closes the open redirect that prefix
-  // matching leaves open.
+  // "\" reaches here decoded from "%5C" via route params — all resolve off-origin.
   try {
     if (new URL(to, SERVER_URL).origin !== new URL(SERVER_URL).origin) {
       return defaultRedirect;


### PR DESCRIPTION
## Summary

Security: Unsafe redirect constructed from request URL in splat route

## Problem

**Severity**: `Medium` | **File**: `apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx:L10`

The loader splits `request.url` on a user-controlled `selectedUserId` and redirects to the trailing portion without validating that the result is a safe local path. A crafted URL could cause an open redirect or redirect to an unexpected route if the extracted suffix begins with `//` or contains a scheme-like value.

## Solution

Parse the URL and only redirect to a validated relative pathname/search/hash component. Reject any target that is not a local path, and avoid deriving redirect targets by string splitting on untrusted input.

## Changes

- `apps/webapp/app/routes/_layout+/settings.team.users.$userId.$.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened redirect validation to block unsafe, malformed, and protocol-relative targets so users aren’t redirected off-site.
* **Refactor**
  * Unified redirect handling to preserve query and hash fragments and enforce same-origin rules for reconstructed wildcard paths.
* **Tests**
  * Added open-redirect edge-case tests covering backslash, encoded, protocol-relative, and internal-route attempts.
* **Documentation**
  * Expanded guidance on wildcard path reconstruction and safe redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->