### PR TITLE
fix(database): enable RLS on MobileAuthCode and guard against missing RLS

### DIFF
--- a/.claude/agents/shelf-security-reviewer-headless.md
+++ b/.claude/agents/shelf-security-reviewer-headless.md
@@ -125,9 +125,22 @@ Per `CLAUDE.md`: Zod schemas with server-side error display.
 
 ### 7. Supabase RLS
 
-- New Prisma models or tables MUST have a matching RLS policy migration. Flag any new `model` in `schema.prisma` without an RLS policy in the same PR.
-- Webapp uses both Supabase client (RLS-enforcing) and direct Prisma client (RLS-bypassing). Flag direct-Prisma access to per-tenant data where Supabase + RLS would be safer.
-- For migrations: check `USING` and `WITH CHECK` clauses for the `auth.uid()` org-membership pattern.
+**7a. RLS-enablement audit for new tables (MECHANICAL — run on every diff that touches `packages/database/prisma/migrations/`).** This is the regression that shipped on 2026-06-16: a new `MobileAuthCode` table was created without an `ENABLE ROW LEVEL SECURITY` line, leaving it exposed through the Supabase anon/PostgREST surface. Every `public` table in Shelf MUST have RLS enabled — RLS-disabled is the unsafe default. You work from the diff only; a new migration file appears entirely as added (`+`) lines, so everything you need is in the hunk.
+
+Procedure (do this literally, do not eyeball it):
+
+1. In the added lines, find every newly-created table: each `CREATE TABLE [IF NOT EXISTS] "public"."T"` (or unqualified `"T"`). Ignore `CREATE TABLE` text inside SQL comments (`--`).
+2. For each table `T`, scan all added lines across the whole diff for a matching `ALTER TABLE … "T" … ENABLE ROW LEVEL SECURITY;` (the repo writes it lowercase: `alter table "T" ENABLE row level security;`). Match case-insensitively; the enable statement may be in the same migration file or another migration added in the same diff.
+3. Any `CREATE TABLE` with **no** matching enable line is a finding:
+   - **🟠 High / P1** by default.
+   - **🔴 Critical / P0** when the table holds credentials, tokens, auth codes, sessions, PII, or any per-tenant (`organizationId`-scoped) data — the realistic Shelf case. `MobileAuthCode` would have been Critical.
+   - Downgrade only if it is provably a global, non-tenant lookup/enum table AND the migration carries an explicit `-- no RLS: <reason>` comment. Absent that comment, flag it.
+   - Cite the migration file path (and the `CREATE TABLE` line from the hunk). **Fix:** add `ALTER TABLE "T" ENABLE row level security;` to the migration.
+   - This finding makes the diff `security_relevant: true` and sets `risk_level`/`verdict` to match the highest severity above.
+
+**7b. Policies are a separate, weaker requirement.** Shelf's standard for most tables is _RLS enabled with no policies_ (denies the Supabase anon/authenticated roles; the direct Prisma service-role client bypasses RLS for app queries). So a new table **must** have RLS enabled (7a), but a missing `CREATE POLICY` is **not** automatically a finding — only flag it when the table is meant to be read directly by a Supabase client. When policies exist, check `USING` / `WITH CHECK` clauses for the `auth.uid()` org-membership pattern.
+
+**7c. Schema ↔ migration cross-check.** Flag any new `model` in `schema.prisma` whose backing migration in the same diff lacks the RLS enable line. Also flag direct-Prisma access to per-tenant data where Supabase + RLS would be the safer boundary.
 
 ### 8. Session / auth flow
 
@@ -189,10 +202,11 @@ Use the same structure as the interactive reviewer:
 
 ## Checklist coverage
 
-| Area               | Status             | Notes |
-| ------------------ | ------------------ | ----- |
-| Org-scoping / IDOR | ✅ / ⚠️ / ❌ / N/A | …     |
-| …                  | …                  | …     |
+| Area                                  | Status             | Notes |
+| ------------------------------------- | ------------------ | ----- |
+| Org-scoping / IDOR                    | ✅ / ⚠️ / ❌ / N/A | …     |
+| RLS enabled on new tables (migration) | …                  | …     |
+| …                                     | …                  | …     |
 
 ## Skills consulted
 

--- a/.claude/agents/shelf-security-reviewer.md
+++ b/.claude/agents/shelf-security-reviewer.md
@@ -94,9 +94,22 @@ Shelf is multi-tenant. The most common security bug here is cross-organization a
 
 ### 7. Supabase RLS
 
-- New Prisma models or tables MUST have a matching RLS policy migration. Flag any new `model` in `packages/database/prisma/schema.prisma` without an RLS policy in the same PR.
-- The webapp uses both the Supabase client (RLS-enforcing) and the direct Prisma client (RLS-bypassing). Flag direct-Prisma access to per-tenant data in places that should be using Supabase + RLS, especially in routes that proxy unverified user input.
-- Migrations: invoke the `supabase` skill for RLS review; check `USING` and `WITH CHECK` clauses for the `auth.uid()` org-membership pattern Shelf uses.
+**7a. RLS-enablement audit for new tables (MECHANICAL — run this on every diff that touches `packages/database/prisma/migrations/`).** This is the regression that shipped on 2026-06-16: a new `MobileAuthCode` table was created without an `ENABLE ROW LEVEL SECURITY` line, leaving it readable/writable through the Supabase anon/PostgREST surface. Every `public` table in Shelf MUST have RLS enabled — RLS-disabled is the unsafe default.
+
+Procedure (do this literally, do not eyeball it):
+
+1. Enumerate the migration files added in this PR: `git diff --name-only --diff-filter=A main...HEAD -- 'packages/database/prisma/migrations/**/migration.sql'` (substitute the real base branch). Also re-check any existing migration the diff modifies.
+2. For each such file, grep every newly-created table: `grep -ioE 'CREATE TABLE (IF NOT EXISTS )?"?(public"?\.)?"?[A-Za-z0-9_]+"?' <file>`. Ignore `CREATE TABLE` inside comments.
+3. For each table `T` found, confirm the **same PR** contains a matching `ALTER TABLE … "T" … ENABLE ROW LEVEL SECURITY;` (the repo writes it lowercase: `alter table "T" ENABLE row level security;`). Match case-insensitively; the enable statement may live in the same migration or a later one in the same PR.
+4. Any `CREATE TABLE` with **no** matching enable line is a finding:
+   - **🟠 High / P1** by default.
+   - **🔴 Critical / P0** when the table holds credentials, tokens, auth codes, sessions, PII, or any per-tenant (`organizationId`-scoped) data — i.e. the realistic Shelf case. `MobileAuthCode` would have been Critical.
+   - Only downgrade to a nit (or N/A) if it is provably a global, non-tenant lookup/enum table with no sensitive rows, AND there is an explicit `-- no RLS: <reason>` comment in the migration. Absent that comment, flag it.
+   - **Fix** to suggest: add `ALTER TABLE "T" ENABLE row level security;` to the migration (Shelf's convention is RLS-enabled, usually with **no** policies — see 7b).
+
+**7b. Policies are a separate, weaker requirement.** Shelf's standard for most tables is _RLS enabled with no policies_, which denies all access to the Supabase anon/authenticated roles while the direct Prisma client (service role) bypasses RLS for app queries. So a new table **must** have RLS enabled (7a), but the absence of `CREATE POLICY` is **not** automatically a finding — only flag missing policies when the table is intended to be reached directly by a Supabase client (rare; e.g. realtime/storage-backed reads). When policies do exist, invoke the `supabase` skill and check `USING` / `WITH CHECK` clauses for the `auth.uid()` org-membership pattern Shelf uses.
+
+**7c. Schema ↔ migration cross-check.** Flag any new `model` in `packages/database/prisma/schema.prisma` whose backing migration in the same PR is missing the RLS enable line (this is the same defect viewed from the schema side). Also flag direct-Prisma access to per-tenant data in routes that proxy unverified user input where Supabase + RLS would be the safer boundary.
 
 ### 8. Session / auth flow
 
@@ -171,7 +184,8 @@ Produce one markdown report with these sections, in order:
 | requirePermission on mutating routes  | …                  | …     |
 | Zod validation + server-side fallback | …                  | …     |
 | Secrets / env                         | …                  | …     |
-| Supabase RLS                          | …                  | …     |
+| RLS enabled on new tables (migration) | …                  | …     |
+| Supabase RLS policies (if applicable) | …                  | …     |
 | Session / cookie flags                | …                  | …     |
 | Open redirect                         | …                  | …     |
 | File upload validation                | …                  | …     |

--- a/apps/docs/security-review-agent.md
+++ b/apps/docs/security-review-agent.md
@@ -107,8 +107,13 @@ The agent operates against a Shelf-specific checklist baked into
 - **Secrets / env** — no hardcoded credentials; no leaking of
   `SESSION_SECRET`, `SUPABASE_SERVICE_ROLE`, Stripe keys, SMTP creds, etc.
   into client bundles.
-- **Supabase RLS** — new models in `schema.prisma` must ship with an RLS
-  policy migration; direct-Prisma access to per-tenant data is flagged where
+- **Supabase RLS** — every `CREATE TABLE` in a new migration must have a
+  matching `ENABLE ROW LEVEL SECURITY` line in the same PR (a `CREATE TABLE`
+  without it is High, or Critical for credential/token/PII/tenant tables —
+  this is the `MobileAuthCode` regression of 2026-06-16). Policies are a
+  separate, weaker requirement: Shelf's norm is RLS-enabled-with-no-policies,
+  so missing `CREATE POLICY` is only flagged for tables read directly by a
+  Supabase client. Direct-Prisma access to per-tenant data is flagged where
   RLS-enforcing Supabase access would be safer.
 - **Session / cookie flags** — new `Set-Cookie` entries must set
   `httpOnly`, `secure`, and `sameSite` for auth cookies.

--- a/packages/database/prisma/migrations/20260616081650_enable_rls_for_mobile_auth_code/migration.sql
+++ b/packages/database/prisma/migrations/20260616081650_enable_rls_for_mobile_auth_code/migration.sql
@@ -1,0 +1,2 @@
+-- Enable row level security for table "MobileAuthCode"
+ALTER TABLE "MobileAuthCode" ENABLE row level security;


### PR DESCRIPTION
The `MobileAuthCode` table was created (migration 20260608104616) without an `ENABLE ROW LEVEL SECURITY` line, leaving it exposed through the Supabase anon/PostgREST surface. Add a migration that enables RLS on the table.

To prevent recurrence, teach both security-review agents (shelf-security-reviewer and the headless pre-commit variant) a mechanical RLS-enablement audit: for every CREATE TABLE in a new migration, confirm a matching `ENABLE ROW LEVEL SECURITY` exists in the same PR. Missing it is High, or Critical for credential/token/PII/tenant tables. Also clarify that policies are a separate, weaker requirement (Shelf's norm is RLS-enabled-with-no-policies), correcting the prior wording that over-implied CREATE POLICY is always required.

Update `apps/docs/security-review-agent.md` to document the sharpened check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security review agent instructions with comprehensive row-level security audit procedures and verification checklist for database migrations.

* **Chores**
  * Enabled row-level security on database table to strengthen data protection and security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->