### PR TITLE
fix(assets): guard empty id set in advanced filter SQL builder

### DIFF
--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -473,6 +473,40 @@ describe("generateWhereClause - special filter values", () => {
       expect(sql).toContain('"locationId" IS NULL');
       expect(sql).toContain("Location");
     });
+
+    // why: regression test for SHELF-WEBAPP-1MY — a `withinHierarchy` location
+    // filter pointing at a deleted/stale location expands to a `containsAny`
+    // filter with an empty array of descendant ids. The builder must not call
+    // `Prisma.join([])` (which throws) and should match no assets instead of
+    // crashing the entire /assets index with a 500.
+    it("handles containsAny with an empty array (expanded withinHierarchy to no descendants)", () => {
+      const filter: Filter = {
+        name: "location",
+        type: "enum",
+        operator: "containsAny",
+        value: [],
+      };
+
+      expect(() => generateWhereClause(orgId, null, [filter])).not.toThrow();
+
+      const sql = getSqlString(generateWhereClause(orgId, null, [filter]));
+      // An empty location set matches no assets.
+      expect(sql).toContain("1=0");
+    });
+
+    it("handles containsAny with an empty string (no location ids) without throwing", () => {
+      const filter: Filter = {
+        name: "location",
+        type: "enum",
+        operator: "containsAny",
+        value: "",
+      };
+
+      expect(() => generateWhereClause(orgId, null, [filter])).not.toThrow();
+
+      const sql = getSqlString(generateWhereClause(orgId, null, [filter]));
+      expect(sql).toContain("1=0");
+    });
   });
 
   describe("kit filter with special values", () => {
@@ -563,6 +597,37 @@ describe("generateWhereClause - special filter values", () => {
       expect(sql).toContain('"kitId" IS NULL');
       expect(sql).toContain("Kit");
     });
+  });
+
+  // why: regression coverage for SHELF-WEBAPP-1MY and its sibling branches. A
+  // `containsAny` filter whose id list resolves to empty (e.g. a stale
+  // `withinHierarchy` expansion, or an empty submitted value) must never call
+  // `Prisma.join([])` (which throws and 500s the /assets index). Every such
+  // branch should instead emit a no-match clause (`1=0`).
+  describe("containsAny with an empty id set is non-fatal (matches nothing)", () => {
+    const cases: { name: Filter["name"] }[] = [
+      { name: "location" },
+      { name: "category" },
+      { name: "kit" },
+      { name: "custody" },
+      { name: "upcomingBookings" },
+    ];
+
+    for (const { name } of cases) {
+      it(`handles empty containsAny for "${name}" without throwing`, () => {
+        const filter = {
+          name,
+          type: "enum",
+          operator: "containsAny",
+          value: [] as string[],
+        } as Filter;
+
+        expect(() => generateWhereClause(orgId, null, [filter])).not.toThrow();
+        expect(
+          getSqlString(generateWhereClause(orgId, null, [filter]))
+        ).toContain("1=0");
+      });
+    }
   });
 });
 

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -542,6 +542,13 @@ function addEnumFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
           )`;
         }
 
+        // An empty category set matches no assets. Guard before
+        // `Prisma.join([])` (which throws) — same crash class as
+        // SHELF-WEBAPP-1MY on the location branch.
+        if (values.length === 0) {
+          return Prisma.sql`${whereClause} AND 1=0`;
+        }
+
         const categoryIdsArray = Prisma.join(
           values.map((id) => Prisma.sql`${id}`),
           ", "
@@ -628,6 +635,15 @@ function addEnumFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
               WHERE id = a."locationId" AND id = ANY(ARRAY[${locationIdsArray}]::text[])
             )
           )`;
+        }
+
+        // An empty location set matches no assets. This happens when a
+        // `withinHierarchy` filter is expanded against a deleted/stale location
+        // whose descendant lookup returns no ids (SHELF-WEBAPP-1MY). Guard here
+        // so we never call `Prisma.join([])`, which throws and 500s the whole
+        // /assets index.
+        if (values.length === 0) {
+          return Prisma.sql`${whereClause} AND 1=0`;
         }
 
         const locationIdsArray = Prisma.join(
@@ -721,6 +737,12 @@ function addEnumFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
               WHERE id = a."kitId" AND id = ANY(ARRAY[${kitIdsArray}]::text[])
             )
           )`;
+        }
+
+        // An empty kit set matches no assets. Guard before `Prisma.join([])`
+        // (which throws) — same crash class as SHELF-WEBAPP-1MY.
+        if (values.length === 0) {
+          return Prisma.sql`${whereClause} AND 1=0`;
         }
 
         const kitIdsArray = Prisma.join(
@@ -1045,6 +1067,12 @@ function addCustodyFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
         )`;
       }
 
+      // An empty custodian set matches no assets. Guard before
+      // `Prisma.join([])` (which throws) — same crash class as SHELF-WEBAPP-1MY.
+      if (values.length === 0) {
+        return Prisma.sql`${whereClause} AND 1=0`;
+      }
+
       const custodianIdsArray = Prisma.join(
         values.map((id) => Prisma.sql`${id}`),
         ", "
@@ -1164,6 +1192,12 @@ function addUpcomingBookingsFilter(
             AND bk.status IN ('RESERVED', 'ONGOING', 'OVERDUE')
           )
         )`;
+      }
+
+      // An empty booking set matches no assets. Guard before `Prisma.join([])`
+      // (which throws) — same crash class as SHELF-WEBAPP-1MY.
+      if (values.length === 0) {
+        return Prisma.sql`${whereClause} AND 1=0`;
       }
 
       const bookingIdsArray = Prisma.join(


### PR DESCRIPTION
A "location is in (incl. sub-locations)" advanced filter pointing at a deleted/stale location expands to a containsAny filter with an empty descendant-id array. The SQL builder then called Prisma.join([]), which throws "Expected join([]) to be called with an array of multiple elements" and 500s the entire /assets index on every load (SHELF-WEBAPP-1MY: 34 events, escalating, 1 user).

Guard values.length === 0 before each fall-through Prisma.join(values) in addEnumFilter/addCustodyFilter/addUpcomingBookingsFilter, emitting `AND 1=0` so an empty id set correctly matches no assets. Fixes the location branch (the production crash) plus the identical latent crash class in the category, kit, custody, and booking branches.

Adds regression tests covering the empty containsAny set for all five entity branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an application crash that occurred when using category, location, kit, custodian, and booking filters with certain search conditions that result in empty value sets. The app now gracefully returns no results instead of throwing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->