### PR TITLE
fix(qr): return 400 for QR import validation errors instead of 500

### DIFF
--- a/apps/webapp/app/modules/qr/service.server.test.ts
+++ b/apps/webapp/app/modules/qr/service.server.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vitest, beforeEach } from "vitest";
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+import { parseQrCodesFromImportData } from "./service.server";
+
+// why: parseQrCodesFromImportData reads QR rows from the database to detect
+// invalid imports; mock the client so the tests exercise the validation
+// branches without a real DB.
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    qr: {
+      findMany: vitest.fn().mockResolvedValue([]),
+      updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
+    },
+  },
+}));
+
+const userId = "user-1";
+const organizationId = "org-1";
+
+/**
+ * Runs parseQrCodesFromImportData and returns the thrown ShelfError, failing
+ * the test if it unexpectedly resolves.
+ */
+async function captureThrow(
+  data: Parameters<typeof parseQrCodesFromImportData>[0]["data"]
+) {
+  try {
+    await parseQrCodesFromImportData({ data, userId, organizationId });
+    throw new Error("expected parseQrCodesFromImportData to throw");
+  } catch (err) {
+    expect(err).toBeInstanceOf(ShelfError);
+    return err as ShelfError;
+  }
+}
+
+describe("parseQrCodesFromImportData — import validation errors", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    (db.qr.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([]);
+  });
+
+  it("rejects duplicate QR codes with a 400 and does not capture", async () => {
+    const data = [
+      { key: "a", title: "A", qrId: "qr-1" },
+      { key: "b", title: "B", qrId: "qr-1" },
+    ] as Parameters<typeof parseQrCodesFromImportData>[0]["data"];
+
+    const err = await captureThrow(data);
+
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
+  });
+
+  it("rejects non-existent QR codes with a 400 and does not capture", async () => {
+    // No matching rows returned → the code is treated as non-existent.
+    const data = [{ key: "a", title: "A", qrId: "missing" }] as Parameters<
+      typeof parseQrCodesFromImportData
+    >[0]["data"];
+
+    const err = await captureThrow(data);
+
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
+  });
+
+  it("rejects codes already linked to an asset/kit with a 400 and does not capture", async () => {
+    (db.qr.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "qr-1", assetId: "asset-1", kitId: null, organizationId },
+    ]);
+    const data = [{ key: "a", title: "A", qrId: "qr-1" }] as Parameters<
+      typeof parseQrCodesFromImportData
+    >[0]["data"];
+
+    const err = await captureThrow(data);
+
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
+  });
+
+  it("rejects codes belonging to another organization with a 400 and does not capture", async () => {
+    (db.qr.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "qr-1", assetId: null, kitId: null, organizationId: "other-org" },
+    ]);
+    const data = [{ key: "a", title: "A", qrId: "qr-1" }] as Parameters<
+      typeof parseQrCodesFromImportData
+    >[0]["data"];
+
+    const err = await captureThrow(data);
+
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
+  });
+});

--- a/apps/webapp/app/modules/qr/service.server.ts
+++ b/apps/webapp/app/modules/qr/service.server.ts
@@ -580,6 +580,10 @@ export async function parseQrCodesFromImportData({
           "Some of the QR codes you are trying to import are present more than once in the data. Please make sure each QR code is only present once.",
         additionalData: { duplicateCodes },
         label,
+        // This is a user-input validation failure, not a server fault: return a
+        // 400 and don't capture it to Sentry (see SHELF-WEBAPP-1J0).
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 
@@ -594,6 +598,8 @@ export async function parseQrCodesFromImportData({
         message: "Some of the QR codes you are trying to import do not exist",
         additionalData: { nonExistentCodes },
         label,
+        // User-input validation failure: return a 400 (already not captured).
+        status: 400,
         shouldBeCaptured: false,
       });
     }
@@ -611,6 +617,10 @@ export async function parseQrCodesFromImportData({
           "Some of the QR codes you are trying to import are already linked to an asset or a kit. Please use unlinked or unclaimed codes for your import.",
         additionalData: { linkedCodes },
         label,
+        // User-input validation failure: return a 400 and don't capture it to
+        // Sentry (SHELF-WEBAPP-1J0).
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 
@@ -630,6 +640,10 @@ export async function parseQrCodesFromImportData({
           "Some of the QR codes you are trying to import don't belong to your current organization. You can only import codes that are unclaimed, unlinked or linked to your organization.",
         additionalData: { connectedToOtherOrgs },
         label,
+        // User-input validation failure: return a 400 and don't capture it to
+        // Sentry (SHELF-WEBAPP-1J0).
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 


### PR DESCRIPTION
The four user-input validation failures in parseQrCodesFromImportData (duplicate / non-existent / already-linked / other-org QR codes) threw a ShelfError without a status or shouldBeCaptured flag. ShelfError defaults those to status 500 + shouldBeCaptured true, so user mistakes surfaced as captured 500 errors in Sentry (SHELF-WEBAPP-1J0) instead of quiet 400 client errors.

Set status: 400 + shouldBeCaptured: false on each validation throw. The outer catch wrapper already propagates both fields from a ShelfError cause (status || cause.status, shouldBeCaptured ?? cause.shouldBeCaptured), so the re-thrown error keeps the 400 and stays out of Sentry.

Adds a service test covering all four branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for QR code import validation scenarios, including duplicate codes, non-existent codes, already-linked codes, and cross-organization conflicts.

* **Bug Fixes**
  * Improved error handling for QR code imports with more precise status codes and error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->