### PR TITLE
fix(assets): bulk QR download reused stale assets after filter change

### DIFF
--- a/apps/webapp/app/components/assets/bulk-download-qr-dialog.test.tsx
+++ b/apps/webapp/app/components/assets/bulk-download-qr-dialog.test.tsx
@@ -1,21 +1,21 @@
 /**
  * Regression tests for {@link BulkDownloadQrDialog}.
  *
- * Guards against a stale-data bug: the dialog is permanently mounted on the
- * asset index (only the `isDialogOpen` prop toggles), so the component — and
- * the response cached inside its `useApiQuery` — survives the user closing it,
- * changing the active filter/selection, and reopening it. A second "Download QR
- * codes" must fetch fresh data for the now-current filters; the original bug
- * reused the first filter's cached response, so the second zip contained the
- * wrong assets until the page was refreshed.
+ * The dialog is permanently mounted on the asset index (only the `isDialogOpen`
+ * prop toggles), so its fetch state survives the user closing it, changing the
+ * active filter/selection, and reopening it. Two distinct bugs are guarded here:
  *
- * Observable, implementation-agnostic signal: each download with different
- * filters issues its own fetch whose URL reflects the then-current params.
- * Buggy code fetches once (cache reuse); fixed code fetches twice with
- * different URLs.
+ * 1. Stale-cache reuse: a second "Download QR codes" after a filter change must
+ *    fetch fresh data for the now-current filters, not reuse the first response.
+ * 2. Superseded slow response: dismissing the loading dialog mid-fetch and
+ *    starting a new download must NOT let the first (slow) response complete and
+ *    zip the previous filter's assets — the newest request always wins.
+ *
+ * Observable, implementation-agnostic signals: each download issues a fetch
+ * whose URL reflects the then-current params, and only the latest request's
+ * assets are ever rasterized into the zip.
  *
  * @see {@link file://./bulk-download-qr-dialog.tsx}
- * @see {@link file://../../hooks/use-api-query.ts}
  */
 
 import { act, render, screen, waitFor } from "@testing-library/react";
@@ -28,12 +28,14 @@ import type { BulkQrDownloadLoaderData } from "~/routes/api+/assets.get-assets-f
 import BulkDownloadQrDialog from "./bulk-download-qr-dialog";
 
 /**
- * Hoisted, mutable holder for the search params the mocked `useSearchParams`
- * returns. Lives in `vi.hoisted` so the (hoisted) `vi.mock` factory can read it
- * safely; tests reassign `hoisted.searchParams` to simulate a filter change.
+ * Hoisted, mutable state read by the (hoisted) `vi.mock` factories:
+ * - `searchParams`: what the mocked `useSearchParams` returns (the active filter)
+ * - `renderedTitles`: titles of every asset actually rasterized into a zip, so a
+ *   test can assert which request's assets were processed.
  */
 const hoisted = vi.hoisted(() => ({
   searchParams: new URLSearchParams(),
+  renderedTitles: [] as string[],
 }));
 
 // why: the dialog imports `useSearchParams` from this cookie/org-context-aware
@@ -57,22 +59,27 @@ vi.mock("html-to-image", () => ({
 }));
 
 // why: avoids rendering <QrLabel> via renderToStaticMarkup (pulls in QR-codec
-// deps irrelevant to this test); a bare element is enough for toBlob's input.
+// deps irrelevant to this test). It also records the title of each asset that
+// reaches rasterization, which is how the race test proves WHICH request's
+// assets were zipped.
 vi.mock("~/utils/component-to-html", () => ({
-  generateHtmlFromComponent: () => document.createElement("div"),
+  generateHtmlFromComponent: (element: { props?: { title?: string } }) => {
+    if (element?.props?.title) hoisted.renderedTitles.push(element.props.title);
+    return document.createElement("div");
+  },
 }));
 
-// why: QrLabel is only ever passed to the (already-stubbed)
-// generateHtmlFromComponent, never rendered here, and its module chain
-// (AddBarcodeDialog -> scan-barcode-tab -> scanner -> lottie-web) touches canvas
-// at import time and crashes under happy-dom. A stub cuts that chain.
+// why: QrLabel is only ever passed to the (mocked) generateHtmlFromComponent,
+// never rendered here, and its module chain (AddBarcodeDialog -> scan-barcode-tab
+// -> scanner -> lottie-web) touches canvas at import time and crashes under
+// happy-dom. A stub cuts that chain.
 vi.mock("~/components/code-preview/code-preview", () => ({
-  QrLabel: () => null,
+  QrLabel: (props: { title?: string }) => props as unknown as null,
 }));
 
-// why: zip generation is irrelevant to the fetch-freshness assertion and its
-// Blob plumbing is unreliable under happy-dom; a no-op archive lets
-// processDownload reach its success state deterministically.
+// why: zip generation is irrelevant to the assertions and its Blob plumbing is
+// unreliable under happy-dom; a no-op archive lets processDownload reach its
+// success state deterministically.
 vi.mock("jszip", () => {
   class FakeZip {
     folder() {
@@ -90,6 +97,19 @@ vi.mock("jszip", () => {
 
 /** Records every URL the dialog requests. */
 const fetchSpy = vi.fn();
+
+/**
+ * Controls how the mocked `fetch` resolves:
+ * - "auto": resolve immediately with a payload matching the URL's assetIds.
+ * - "manual": defer; the test resolves `pending[i]` by hand to control ordering.
+ */
+const fetchControl = {
+  mode: "auto" as "auto" | "manual",
+  pending: [] as Array<{
+    url: string;
+    resolve: (data: BulkQrDownloadLoaderData) => void;
+  }>,
+};
 
 /** Builds a valid loader payload whose assets match the requested ids. */
 function payloadFor(assetIds: string[]): BulkQrDownloadLoaderData {
@@ -111,10 +131,14 @@ function payloadFor(assetIds: string[]): BulkQrDownloadLoaderData {
 }
 
 beforeEach(() => {
+  fetchControl.mode = "auto";
+  fetchControl.pending = [];
+  hoisted.searchParams = new URLSearchParams();
+  hoisted.renderedTitles = [];
+
   // why: install the fetch spy AFTER MSW's interception (mirrors
   // use-api-query.test.ts) so the dialog's request is captured here and never
-  // reaches MSW (which errors on unhandled requests). Each call records its URL
-  // and returns a payload consistent with that URL's assetIds.
+  // reaches MSW (which errors on unhandled requests).
   vi.spyOn(globalThis, "fetch").mockImplementation(((
     input: RequestInfo | URL
   ) => {
@@ -123,6 +147,15 @@ beforeEach(() => {
     const ids = new URL(url, "http://localhost").searchParams.getAll(
       "assetIds"
     );
+    if (fetchControl.mode === "manual") {
+      return new Promise<Response>((resolve) => {
+        fetchControl.pending.push({
+          url,
+          resolve: (data) =>
+            resolve({ json: () => Promise.resolve(data) } as Response),
+        });
+      });
+    }
     return Promise.resolve({
       json: () => Promise.resolve(payloadFor(ids)),
     } as Response);
@@ -132,8 +165,6 @@ beforeEach(() => {
   // why: happy-dom does not implement object URLs; processDownload calls both.
   globalThis.URL.createObjectURL = vi.fn(() => "blob:mock");
   globalThis.URL.revokeObjectURL = vi.fn();
-
-  hoisted.searchParams = new URLSearchParams();
 });
 
 afterEach(() => {
@@ -142,8 +173,8 @@ afterEach(() => {
 
 /**
  * Renders the dialog under a dedicated jotai store (so selection state persists
- * across rerenders) with the dialog kept open for the whole test — the bug only
- * reproduces while component state survives close/reopen.
+ * across rerenders) with the dialog kept open for the whole test — both bugs
+ * only reproduce while component state survives close/reopen.
  */
 function renderDialog() {
   const store = createStore();
@@ -168,8 +199,8 @@ async function setFilterAndSelection(
       selectedBulkItemsAtom,
       assetIds.map((id) => ({ id }) as unknown as ListItemData)
     );
-    // Flush microtask-scheduled effects (useApiQuery / useMemo recompute) so the
-    // dialog observes the new filter + selection before we interact with it.
+    // Flush microtask-scheduled effects (useMemo recompute) so the dialog
+    // observes the new filter + selection before we interact with it.
     await Promise.resolve();
   });
 }
@@ -210,5 +241,50 @@ describe("BulkDownloadQrDialog", () => {
     expect(secondUrl).not.toContain("category=cat-A");
     expect(secondUrl).not.toContain("assetIds=a1");
     expect(secondUrl).not.toEqual(firstUrl);
+  });
+
+  it("ignores a slow superseded response and only zips the latest request's assets", async () => {
+    // Manually control fetch resolution to simulate a slow first request that
+    // resolves AFTER the user dismissed it and started a second download.
+    fetchControl.mode = "manual";
+    const user = userEvent.setup();
+    const { store } = renderDialog();
+
+    /* ---------- Download #1: category A (will resolve LATE) ---------- */
+    await setFilterAndSelection(store, "category=cat-A", ["a1", "a2"]);
+    await user.click(await screen.findByRole("button", { name: "Download" }));
+    await waitFor(() => expect(fetchControl.pending).toHaveLength(1));
+
+    /* ---------- Dismiss the loading dialog mid-flight via the header X ---------- */
+    // The header close button is not gated by the loading state (unlike the body
+    // Close/Download buttons), so it — like Escape/backdrop — can cancel an
+    // in-flight download.
+    await user.click(screen.getByRole("button", { name: /close dialog/i }));
+
+    /* ---------- Download #2: tag A (the current request) ---------- */
+    await setFilterAndSelection(store, "tag=tag-A", ["b9"]);
+    await user.click(await screen.findByRole("button", { name: "Download" }));
+    await waitFor(() => expect(fetchControl.pending).toHaveLength(2));
+
+    /* ---------- The superseded request resolves FIRST, then the current one ---------- */
+    await act(async () => {
+      fetchControl.pending[0].resolve(payloadFor(["a1", "a2"]));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fetchControl.pending[1].resolve(payloadFor(["b9"]));
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/successfully downloaded qr codes/i)
+      ).toBeInTheDocument()
+    );
+
+    // Only the latest request's assets are rasterized; the stale ones never are.
+    expect(hoisted.renderedTitles).toContain("Asset b9");
+    expect(hoisted.renderedTitles).not.toContain("Asset a1");
+    expect(hoisted.renderedTitles).not.toContain("Asset a2");
   });
 });

--- a/apps/webapp/app/components/assets/bulk-download-qr-dialog.test.tsx
+++ b/apps/webapp/app/components/assets/bulk-download-qr-dialog.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Regression tests for {@link BulkDownloadQrDialog}.
+ *
+ * Guards against a stale-data bug: the dialog is permanently mounted on the
+ * asset index (only the `isDialogOpen` prop toggles), so the component — and
+ * the response cached inside its `useApiQuery` — survives the user closing it,
+ * changing the active filter/selection, and reopening it. A second "Download QR
+ * codes" must fetch fresh data for the now-current filters; the original bug
+ * reused the first filter's cached response, so the second zip contained the
+ * wrong assets until the page was refreshed.
+ *
+ * Observable, implementation-agnostic signal: each download with different
+ * filters issues its own fetch whose URL reflects the then-current params.
+ * Buggy code fetches once (cache reuse); fixed code fetches twice with
+ * different URLs.
+ *
+ * @see {@link file://./bulk-download-qr-dialog.tsx}
+ * @see {@link file://../../hooks/use-api-query.ts}
+ */
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider, createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { selectedBulkItemsAtom } from "~/atoms/list";
+import type { ListItemData } from "~/components/list/list-item";
+import type { BulkQrDownloadLoaderData } from "~/routes/api+/assets.get-assets-for-bulk-qr-download";
+import BulkDownloadQrDialog from "./bulk-download-qr-dialog";
+
+/**
+ * Hoisted, mutable holder for the search params the mocked `useSearchParams`
+ * returns. Lives in `vi.hoisted` so the (hoisted) `vi.mock` factory can read it
+ * safely; tests reassign `hoisted.searchParams` to simulate a filter change.
+ */
+const hoisted = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}));
+
+// why: the dialog imports `useSearchParams` from this cookie/org-context-aware
+// wrapper; in a unit test we only need it to surface the current filter params
+// so the dialog folds them into the request URL.
+vi.mock("~/hooks/search-params", () => ({
+  useSearchParams: () => [hoisted.searchParams, vi.fn()] as const,
+}));
+
+// why: replace only `useLoaderData` so the dialog reads a small `totalItems`
+// (keeping the "more than 100" branch off) without running a real route loader.
+vi.mock("react-router", async (importActual) => {
+  const actual = await importActual<Record<string, unknown>>();
+  return { ...actual, useLoaderData: () => ({ totalItems: 5 }) };
+});
+
+// why: happy-dom cannot rasterize a DOM node to an image, so html-to-image's
+// toBlob would throw. Resolve a tiny blob so the download path completes.
+vi.mock("html-to-image", () => ({
+  toBlob: vi.fn(() => Promise.resolve(new Blob(["x"], { type: "image/jpeg" }))),
+}));
+
+// why: avoids rendering <QrLabel> via renderToStaticMarkup (pulls in QR-codec
+// deps irrelevant to this test); a bare element is enough for toBlob's input.
+vi.mock("~/utils/component-to-html", () => ({
+  generateHtmlFromComponent: () => document.createElement("div"),
+}));
+
+// why: QrLabel is only ever passed to the (already-stubbed)
+// generateHtmlFromComponent, never rendered here, and its module chain
+// (AddBarcodeDialog -> scan-barcode-tab -> scanner -> lottie-web) touches canvas
+// at import time and crashes under happy-dom. A stub cuts that chain.
+vi.mock("~/components/code-preview/code-preview", () => ({
+  QrLabel: () => null,
+}));
+
+// why: zip generation is irrelevant to the fetch-freshness assertion and its
+// Blob plumbing is unreliable under happy-dom; a no-op archive lets
+// processDownload reach its success state deterministically.
+vi.mock("jszip", () => {
+  class FakeZip {
+    folder() {
+      return { file: () => undefined };
+    }
+    file() {
+      return undefined;
+    }
+    generateAsync() {
+      return Promise.resolve(new Blob(["zip"]));
+    }
+  }
+  return { default: FakeZip };
+});
+
+/** Records every URL the dialog requests. */
+const fetchSpy = vi.fn();
+
+/** Builds a valid loader payload whose assets match the requested ids. */
+function payloadFor(assetIds: string[]): BulkQrDownloadLoaderData {
+  return {
+    assets: assetIds.map((id) => ({
+      id,
+      title: `Asset ${id}`,
+      sequentialId: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      qr: {
+        id: `qr-${id}`,
+        src: "data:image/png;base64,xxx",
+        size: "medium" as const,
+      },
+    })),
+    qrIdDisplayPreference: "QR_ID",
+    showShelfBranding: true,
+  };
+}
+
+beforeEach(() => {
+  // why: install the fetch spy AFTER MSW's interception (mirrors
+  // use-api-query.test.ts) so the dialog's request is captured here and never
+  // reaches MSW (which errors on unhandled requests). Each call records its URL
+  // and returns a payload consistent with that URL's assetIds.
+  vi.spyOn(globalThis, "fetch").mockImplementation(((
+    input: RequestInfo | URL
+  ) => {
+    const url = String(input);
+    fetchSpy(url);
+    const ids = new URL(url, "http://localhost").searchParams.getAll(
+      "assetIds"
+    );
+    return Promise.resolve({
+      json: () => Promise.resolve(payloadFor(ids)),
+    } as Response);
+  }) as typeof fetch);
+  fetchSpy.mockClear();
+
+  // why: happy-dom does not implement object URLs; processDownload calls both.
+  globalThis.URL.createObjectURL = vi.fn(() => "blob:mock");
+  globalThis.URL.revokeObjectURL = vi.fn();
+
+  hoisted.searchParams = new URLSearchParams();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Renders the dialog under a dedicated jotai store (so selection state persists
+ * across rerenders) with the dialog kept open for the whole test — the bug only
+ * reproduces while component state survives close/reopen.
+ */
+function renderDialog() {
+  const store = createStore();
+  const onClose = vi.fn();
+  const utils = render(
+    <Provider store={store}>
+      <BulkDownloadQrDialog isDialogOpen onClose={onClose} />
+    </Provider>
+  );
+  return { store, onClose, ...utils };
+}
+
+/** Sets the active filter params + selected assets, flushing React effects. */
+async function setFilterAndSelection(
+  store: ReturnType<typeof createStore>,
+  filterQuery: string,
+  assetIds: string[]
+) {
+  hoisted.searchParams = new URLSearchParams(filterQuery);
+  await act(async () => {
+    store.set(
+      selectedBulkItemsAtom,
+      assetIds.map((id) => ({ id }) as unknown as ListItemData)
+    );
+    // Flush microtask-scheduled effects (useApiQuery / useMemo recompute) so the
+    // dialog observes the new filter + selection before we interact with it.
+    await Promise.resolve();
+  });
+}
+
+describe("BulkDownloadQrDialog", () => {
+  it("refetches with the current params on a second download after filters change", async () => {
+    const user = userEvent.setup();
+    const { store } = renderDialog();
+
+    /* ---------- Download #1: category A, assets a1 + a2 ---------- */
+    await setFilterAndSelection(store, "category=cat-A", ["a1", "a2"]);
+
+    await user.click(await screen.findByRole("button", { name: "Download" }));
+    await screen.findByText(/successfully downloaded qr codes/i);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const firstUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(firstUrl).toContain("category=cat-A");
+    expect(firstUrl).toContain("assetIds=a1");
+    expect(firstUrl).toContain("assetIds=a2");
+
+    /* ---------- Close to re-show the Download button (state persists) ---------- */
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    /* ---------- Change filter to tag A, assets b9 ---------- */
+    await setFilterAndSelection(store, "tag=tag-A", ["b9"]);
+
+    /* ---------- Download #2 ---------- */
+    await user.click(await screen.findByRole("button", { name: "Download" }));
+
+    // Fixed code issues a fresh fetch for the new params; the original bug
+    // reused the cached response and never fetched again.
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+
+    const secondUrl = fetchSpy.mock.calls[1][0] as string;
+    expect(secondUrl).toContain("tag=tag-A");
+    expect(secondUrl).toContain("assetIds=b9");
+    expect(secondUrl).not.toContain("category=cat-A");
+    expect(secondUrl).not.toContain("assetIds=a1");
+    expect(secondUrl).not.toEqual(firstUrl);
+  });
+});

--- a/apps/webapp/app/components/assets/bulk-download-qr-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-download-qr-dialog.tsx
@@ -6,7 +6,6 @@ import { DownloadIcon } from "lucide-react";
 import { useLoaderData } from "react-router";
 import { selectedBulkItemsAtom } from "~/atoms/list";
 import { useSearchParams } from "~/hooks/search-params";
-import useApiQuery from "~/hooks/use-api-query";
 import type { BulkQrDownloadLoaderData } from "~/routes/api+/assets.get-assets-for-bulk-qr-download";
 import { generateHtmlFromComponent } from "~/utils/component-to-html";
 import { isSelectingAllItems } from "~/utils/list";
@@ -39,19 +38,26 @@ export default function BulkDownloadQrDialog({
   const [downloadState, setDownloadState] = useState<DownloadState>({
     status: "idle",
   });
-  const [shouldFetchAssets, setShouldFetchAssets] = useState(false);
   const [searchParams] = useSearchParams();
 
   /**
-   * Tracks whether a download the user explicitly requested is still pending.
+   * Monotonically increasing id of the most recent download request.
    *
    * The dialog stays mounted while the user filters/re-selects behind it (only
-   * `isDialogOpen` toggles), so the fetched response must never be reused across
-   * requests. This ref lets the (stable) success/error callbacks ignore a
-   * resolution whose request was cancelled — e.g. the dialog was closed while
-   * the fetch was in flight — instead of triggering a stale download.
+   * `isDialogOpen` toggles), and a download can be dismissed (header X, Escape,
+   * backdrop) while its fetch is still in flight. A single boolean can't tell
+   * which request a late response belongs to once a newer request has started,
+   * so every click (and every close) bumps this token; a resolution is only
+   * acted on while its captured id still matches the latest one.
    */
-  const isDownloadPendingRef = useRef(false);
+  const requestIdRef = useRef(0);
+
+  /**
+   * AbortController for the in-flight request, so starting a new download (or
+   * closing the dialog) aborts the previous fetch instead of leaving it to
+   * resolve and zip stale assets.
+   */
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const selectedAssets = useAtomValue(selectedBulkItemsAtom);
   const allAssetsSelected = isSelectingAllItems(selectedAssets);
@@ -63,11 +69,12 @@ export default function BulkDownloadQrDialog({
     selectedAssets.length === 0 || downloadState.status === "loading";
 
   function handleClose() {
-    // Cancel any in-flight request so a late resolution cannot trigger a
-    // download after the dialog has been closed.
-    isDownloadPendingRef.current = false;
+    // Supersede and abort any in-flight request so a late resolution cannot
+    // trigger a download after the dialog has been dismissed.
+    requestIdRef.current += 1;
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
     setDownloadState({ status: "idle" });
-    setShouldFetchAssets(false);
     onClose();
   }
 
@@ -91,9 +98,11 @@ export default function BulkDownloadQrDialog({
    * the user just made — not a response cached from a previous filter/selection.
    *
    * @param data - Asset + QR payload for the current selection/filters
+   * @param requestId - Token of the request that produced `data`; the browser
+   * download is skipped if a newer request has since superseded this one.
    */
   const processDownload = useCallback(
-    async (data: BulkQrDownloadLoaderData) => {
+    async (data: BulkQrDownloadLoaderData, requestId: number) => {
       try {
         const { assets, qrIdDisplayPreference, showShelfBranding } = data;
 
@@ -162,6 +171,11 @@ export default function BulkDownloadQrDialog({
         });
 
         const zipBlob = await zip.generateAsync({ type: "blob" });
+
+        // A newer request may have superseded this one while we were
+        // rasterizing; if so, drop this download silently.
+        if (requestId !== requestIdRef.current) return;
+
         const downloadLink = document.createElement("a");
 
         downloadLink.href = URL.createObjectURL(zipBlob);
@@ -175,68 +189,66 @@ export default function BulkDownloadQrDialog({
 
         setDownloadState({ status: "success" });
       } catch (error) {
+        // A superseded request must not clobber the UI with its own error.
+        if (requestId !== requestIdRef.current) return;
         setDownloadState({
           status: "error",
           error:
             error instanceof Error ? error.message : "Something went wrong.",
         });
-      } finally {
-        // Re-arm the fetch gate so the NEXT Download click triggers a fresh
-        // fetch (useApiQuery refires on the enabled false->true edge).
-        setShouldFetchAssets(false);
       }
     },
     []
   );
 
   /**
-   * Stable success handler for the assets query. Drives the download with the
-   * freshly fetched payload, ignoring a resolution whose request was cancelled
-   * (e.g. the dialog was closed while the fetch was in flight).
+   * Starts a download for the CURRENT selection/filters.
+   *
+   * Each click supersedes any in-flight request (bumping the token and aborting
+   * the previous fetch) and fetches fresh data directly, so a slower earlier
+   * response can never be processed in place of this one. We fetch imperatively
+   * here — rather than via `useApiQuery` — precisely because this flow needs
+   * per-request cancellation that a shared, cache-retaining query hook can't
+   * provide.
    */
-  const handleQuerySuccess = useCallback(
-    (data: BulkQrDownloadLoaderData) => {
-      if (!isDownloadPendingRef.current) return;
-      isDownloadPendingRef.current = false;
-      void processDownload(data);
-    },
-    [processDownload]
-  );
-
-  /** Stable error handler for the assets query. */
-  const handleQueryError = useCallback((message: string) => {
-    if (!isDownloadPendingRef.current) return;
-    isDownloadPendingRef.current = false;
-    setShouldFetchAssets(false);
-    setDownloadState({ status: "error", error: message });
-  }, []);
-
-  /**
-   * Fetches assets for the CURRENT request. `enabled` is true only while a
-   * download is pending and is re-armed on every click, so each download fetches
-   * fresh data for the live selection/filters instead of reusing a cached
-   * response. The download is driven by `onSuccess` (not the cached `data`) so a
-   * stale response can never be acted on.
-   */
-  useApiQuery<BulkQrDownloadLoaderData>({
-    api: "/api/assets/get-assets-for-bulk-qr-download",
-    searchParams: apiSearchParams,
-    enabled: shouldFetchAssets && !isSelectingMoreThan100,
-    onSuccess: handleQuerySuccess,
-    onError: handleQueryError,
-  });
-
-  function handleBulkDownloadQr() {
-    if (isSelectingMoreThan100) {
+  async function handleBulkDownloadQr() {
+    if (isSelectingMoreThan100 || !apiSearchParams) {
       return;
     }
 
-    // Mark a fresh request and (re)arm the fetch. shouldFetchAssets is always
-    // false here (it is reset after each download/close), so this false->true
-    // edge is what makes useApiQuery fetch the CURRENT selection/filters.
-    isDownloadPendingRef.current = true;
+    // Supersede any in-flight request before starting a fresh one.
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     setDownloadState({ status: "loading" });
-    setShouldFetchAssets(true);
+
+    try {
+      const response = await fetch(
+        `/api/assets/get-assets-for-bulk-qr-download?${apiSearchParams.toString()}`,
+        { signal: controller.signal }
+      );
+      const data = (await response.json()) as BulkQrDownloadLoaderData;
+
+      // Ignore the response if a newer request superseded this one in flight.
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
+      await processDownload(data, requestId);
+    } catch (error) {
+      // Aborted/superseded requests resolve here too; only the latest one may
+      // surface an error.
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setDownloadState({
+        status: "error",
+        error: error instanceof Error ? error.message : "Something went wrong.",
+      });
+    }
   }
 
   return (
@@ -303,7 +315,7 @@ export default function BulkDownloadQrDialog({
                   <Button
                     type="button"
                     className="flex-1"
-                    onClick={handleBulkDownloadQr}
+                    onClick={() => void handleBulkDownloadQr()}
                     disabled={disabled || isSelectingMoreThan100}
                   >
                     Download

--- a/apps/webapp/app/components/assets/bulk-download-qr-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-download-qr-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import { toBlob } from "html-to-image";
 import { useAtomValue } from "jotai";
 import JSZip from "jszip";
@@ -42,6 +42,17 @@ export default function BulkDownloadQrDialog({
   const [shouldFetchAssets, setShouldFetchAssets] = useState(false);
   const [searchParams] = useSearchParams();
 
+  /**
+   * Tracks whether a download the user explicitly requested is still pending.
+   *
+   * The dialog stays mounted while the user filters/re-selects behind it (only
+   * `isDialogOpen` toggles), so the fetched response must never be reused across
+   * requests. This ref lets the (stable) success/error callbacks ignore a
+   * resolution whose request was cancelled — e.g. the dialog was closed while
+   * the fetch was in flight — instead of triggering a stale download.
+   */
+  const isDownloadPendingRef = useRef(false);
+
   const selectedAssets = useAtomValue(selectedBulkItemsAtom);
   const allAssetsSelected = isSelectingAllItems(selectedAssets);
 
@@ -52,6 +63,9 @@ export default function BulkDownloadQrDialog({
     selectedAssets.length === 0 || downloadState.status === "loading";
 
   function handleClose() {
+    // Cancel any in-flight request so a late resolution cannot trigger a
+    // download after the dialog has been closed.
+    isDownloadPendingRef.current = false;
     setDownloadState({ status: "idle" });
     setShouldFetchAssets(false);
     onClose();
@@ -68,129 +82,161 @@ export default function BulkDownloadQrDialog({
     return query;
   }, [selectedAssets, searchParams]);
 
-  // Use useApiQuery to fetch assets data
-  const { data: apiResponse } = useApiQuery<BulkQrDownloadLoaderData>({
+  /**
+   * Builds the QR zip from the assets returned for THIS request and triggers the
+   * browser download.
+   *
+   * The freshly fetched payload is passed in as an argument and never read from
+   * the query cache, so the zip always contains the assets matching the request
+   * the user just made — not a response cached from a previous filter/selection.
+   *
+   * @param data - Asset + QR payload for the current selection/filters
+   */
+  const processDownload = useCallback(
+    async (data: BulkQrDownloadLoaderData) => {
+      try {
+        const { assets, qrIdDisplayPreference, showShelfBranding } = data;
+
+        const zip = new JSZip();
+        const qrFolder = zip.folder("qr-codes");
+
+        /* Converting our React component to html so that we can later convert it into an image */
+        const qrNodes = assets.map((asset) =>
+          generateHtmlFromComponent(
+            <QrLabel
+              data={{ qr: asset.qr }}
+              title={asset.title}
+              qrIdDisplayPreference={qrIdDisplayPreference}
+              sequentialId={asset.sequentialId}
+              showShelfBranding={showShelfBranding}
+            />
+          )
+        );
+
+        const toBlobOptions = {
+          width: 300,
+          height: 300,
+          backgroundColor: "white",
+          style: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            textAlign: "center",
+          },
+        };
+
+        /**
+         * We are converting first qr to image separately because toBlob will cache the font
+         * and will not make further network requests for other qr codes.
+         */
+        const firstQrImage = await toBlob(qrNodes[0], toBlobOptions);
+
+        /* Converting all qr nodes into images */
+        const qrImages = await Promise.all(
+          qrNodes.slice(1).map((qrNode) => toBlob(qrNode, toBlobOptions))
+        );
+
+        /* Appending qr code image to zip file */
+        [firstQrImage, ...qrImages].forEach((qrImage, index) => {
+          const asset = assets[index];
+
+          // Generate filename based on preference
+          let filename: string;
+          if (qrIdDisplayPreference === "SAM_ID" && asset.sequentialId) {
+            filename = `${asset.sequentialId}_${sanitizeFilename(
+              asset.title
+            )}_${asset.qr.id}.jpg`;
+          } else {
+            filename = `${sanitizeFilename(asset.title)}_${asset.qr.id}.jpg`;
+          }
+
+          if (!qrImage) {
+            return;
+          }
+
+          if (qrFolder) {
+            qrFolder.file(filename, qrImage);
+          } else {
+            zip.file(filename, qrImage);
+          }
+        });
+
+        const zipBlob = await zip.generateAsync({ type: "blob" });
+        const downloadLink = document.createElement("a");
+
+        downloadLink.href = URL.createObjectURL(zipBlob);
+        downloadLink.download = `qr-codes-${new Date().getTime()}.zip`;
+
+        downloadLink.click();
+
+        setTimeout(() => {
+          URL.revokeObjectURL(downloadLink.href);
+        }, 4e4);
+
+        setDownloadState({ status: "success" });
+      } catch (error) {
+        setDownloadState({
+          status: "error",
+          error:
+            error instanceof Error ? error.message : "Something went wrong.",
+        });
+      } finally {
+        // Re-arm the fetch gate so the NEXT Download click triggers a fresh
+        // fetch (useApiQuery refires on the enabled false->true edge).
+        setShouldFetchAssets(false);
+      }
+    },
+    []
+  );
+
+  /**
+   * Stable success handler for the assets query. Drives the download with the
+   * freshly fetched payload, ignoring a resolution whose request was cancelled
+   * (e.g. the dialog was closed while the fetch was in flight).
+   */
+  const handleQuerySuccess = useCallback(
+    (data: BulkQrDownloadLoaderData) => {
+      if (!isDownloadPendingRef.current) return;
+      isDownloadPendingRef.current = false;
+      void processDownload(data);
+    },
+    [processDownload]
+  );
+
+  /** Stable error handler for the assets query. */
+  const handleQueryError = useCallback((message: string) => {
+    if (!isDownloadPendingRef.current) return;
+    isDownloadPendingRef.current = false;
+    setShouldFetchAssets(false);
+    setDownloadState({ status: "error", error: message });
+  }, []);
+
+  /**
+   * Fetches assets for the CURRENT request. `enabled` is true only while a
+   * download is pending and is re-armed on every click, so each download fetches
+   * fresh data for the live selection/filters instead of reusing a cached
+   * response. The download is driven by `onSuccess` (not the cached `data`) so a
+   * stale response can never be acted on.
+   */
+  useApiQuery<BulkQrDownloadLoaderData>({
     api: "/api/assets/get-assets-for-bulk-qr-download",
     searchParams: apiSearchParams,
     enabled: shouldFetchAssets && !isSelectingMoreThan100,
+    onSuccess: handleQuerySuccess,
+    onError: handleQueryError,
   });
-
-  const processDownload = useCallback(async () => {
-    if (!apiResponse) return;
-
-    try {
-      const { assets, qrIdDisplayPreference, showShelfBranding } = apiResponse;
-
-      const zip = new JSZip();
-      const qrFolder = zip.folder("qr-codes");
-
-      /* Converting our React component to html so that we can later convert it into an image */
-      const qrNodes = assets.map((asset) =>
-        generateHtmlFromComponent(
-          <QrLabel
-            data={{ qr: asset.qr }}
-            title={asset.title}
-            qrIdDisplayPreference={qrIdDisplayPreference}
-            sequentialId={asset.sequentialId}
-            showShelfBranding={showShelfBranding}
-          />
-        )
-      );
-
-      const toBlobOptions = {
-        width: 300,
-        height: 300,
-        backgroundColor: "white",
-        style: {
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          textAlign: "center",
-        },
-      };
-
-      /**
-       * We are converting first qr to image separately because toBlob will cache the font
-       * and will not make further network requests for other qr codes.
-       */
-      const firstQrImage = await toBlob(qrNodes[0], toBlobOptions);
-
-      /* Converting all qr nodes into images */
-      const qrImages = await Promise.all(
-        qrNodes.slice(1).map((qrNode) => toBlob(qrNode, toBlobOptions))
-      );
-
-      /* Appending qr code image to zip file */
-      [firstQrImage, ...qrImages].forEach((qrImage, index) => {
-        const asset = assets[index];
-
-        // Generate filename based on preference
-        let filename: string;
-        if (qrIdDisplayPreference === "SAM_ID" && asset.sequentialId) {
-          filename = `${asset.sequentialId}_${sanitizeFilename(asset.title)}_${
-            asset.qr.id
-          }.jpg`;
-        } else {
-          filename = `${sanitizeFilename(asset.title)}_${asset.qr.id}.jpg`;
-        }
-
-        if (!qrImage) {
-          return;
-        }
-
-        if (qrFolder) {
-          qrFolder.file(filename, qrImage);
-        } else {
-          zip.file(filename, qrImage);
-        }
-      });
-
-      const zipBlob = await zip.generateAsync({ type: "blob" });
-      const downloadLink = document.createElement("a");
-
-      downloadLink.href = URL.createObjectURL(zipBlob);
-      downloadLink.download = `qr-codes-${new Date().getTime()}.zip`;
-
-      downloadLink.click();
-
-      setTimeout(() => {
-        URL.revokeObjectURL(downloadLink.href);
-      }, 4e4);
-
-      setDownloadState({ status: "success" });
-    } catch (error) {
-      setDownloadState({
-        status: "error",
-        error: error instanceof Error ? error.message : "Something went wrong.",
-      });
-    }
-  }, [apiResponse]);
-
-  // Trigger download when API response is ready
-  useEffect(() => {
-    if (
-      shouldFetchAssets &&
-      apiResponse &&
-      downloadState.status === "loading"
-    ) {
-      void processDownload();
-    }
-  }, [shouldFetchAssets, apiResponse, downloadState.status, processDownload]);
 
   function handleBulkDownloadQr() {
     if (isSelectingMoreThan100) {
       return;
     }
 
-    // Set loading state immediately
+    // Mark a fresh request and (re)arm the fetch. shouldFetchAssets is always
+    // false here (it is reset after each download/close), so this false->true
+    // edge is what makes useApiQuery fetch the CURRENT selection/filters.
+    isDownloadPendingRef.current = true;
     setDownloadState({ status: "loading" });
-
-    // Trigger the API call if not already done
-    if (!apiResponse) {
-      setShouldFetchAssets(true);
-    } else {
-      void processDownload();
-    }
+    setShouldFetchAssets(true);
   }
 
   return (


### PR DESCRIPTION
The bulk "Download QR codes" dialog is permanently mounted (only the isDialogOpen prop toggles), so useApiQuery's cached response survived close/reopen. After changing the filter and downloading again, the handler reused that stale cache instead of refetching for the current selection, producing a zip with the previous filter's assets until a page refresh.

Drive the download from useApiQuery's onSuccess with the freshly fetched payload (never the cached data), gate the fetch on a per-click shouldFetchAssets edge so each download refetches the current selection/filters, and add an isDownloadPendingRef guard so a request cancelled mid-flight (e.g. closing the dialog) cannot trigger a stale download.

Add a regression test covering two consecutive downloads across a filter change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk download dialog to use current filters and parameters when reopened, preventing stale cached responses from being reused after the dialog closes or filters change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->