### PR TITLE
fix(bookings): adding a kit to an ongoing booking no longer checks out other kits

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -1338,10 +1338,48 @@ describe("updateBookingAssets", () => {
       data: { status: AssetStatus.CHECKED_OUT },
     });
     expect(db.kit.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["kit-1", "kit-2"] }, organizationId: "org-1" },
+      where: {
+        id: { in: ["kit-1", "kit-2"] },
+        organizationId: "org-1",
+        assets: { some: { id: { in: ["asset-1", "asset-2"] } } },
+      },
       data: { status: KitStatus.CHECKED_OUT },
     });
     expect(result).toEqual(mockBooking);
+  });
+
+  it("scopes the kit CHECKED_OUT flip to kits containing a newly-added asset, not arbitrary kitIds", async () => {
+    expect.assertions(2);
+
+    const mockBooking = {
+      id: "booking-1",
+      name: "Test Booking",
+      status: BookingStatus.ONGOING,
+    };
+    // @ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
+
+    await updateBookingAssets({
+      ...mockUpdateBookingAssetsParams, // assetIds: ["asset-1","asset-2"], org-1
+      // caller over-supplies kit-2; only kits owning a newly-added asset must flip
+      kitIds: ["kit-1", "kit-2"],
+    });
+
+    // assets still flipped as before (unchanged behavior)
+    expect(db.asset.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["asset-1", "asset-2"] }, organizationId: "org-1" },
+      data: { status: AssetStatus.CHECKED_OUT },
+    });
+
+    // kit flip carries the relation-scope guard tying it to the newly-added assets
+    expect(db.kit.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["kit-1", "kit-2"] },
+        organizationId: "org-1",
+        assets: { some: { id: { in: ["asset-1", "asset-2"] } } },
+      },
+      data: { status: KitStatus.CHECKED_OUT },
+    });
   });
 
   it("should not update kit status when no kitIds provided", async () => {

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -3126,7 +3126,14 @@ export async function updateBookingAssets({
          */
         if (kitIds && kitIds.length > 0) {
           await tx.kit.updateMany({
-            where: { id: { in: kitIds }, organizationId },
+            where: {
+              id: { in: kitIds },
+              organizationId,
+              // Only flip kits that actually received a newly-checked-out asset.
+              // Prevents an over-broad kitIds list from clobbering the status of
+              // still-available kits already on the booking.
+              assets: { some: { id: { in: validAssetIds } } },
+            },
             data: { status: KitStatus.CHECKED_OUT },
           });
         }

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
@@ -192,11 +192,13 @@ describe("manage-assets route validation", () => {
       expect(bookingAssets.isAssetPartiallyCheckedIn).toHaveBeenCalledTimes(2);
       expect(bookingAssets.isAssetPartiallyCheckedIn).toHaveBeenCalledWith(
         mockAssets[0],
-        {}
+        {},
+        "ONGOING"
       );
       expect(bookingAssets.isAssetPartiallyCheckedIn).toHaveBeenCalledWith(
         mockAssets[1],
-        {}
+        {},
+        "ONGOING"
       );
     });
 
@@ -288,7 +290,8 @@ describe("manage-assets route validation", () => {
 
       expect(bookingAssets.isAssetPartiallyCheckedIn).toHaveBeenCalledWith(
         mockAssets[0],
-        mockPartialCheckinDetails
+        mockPartialCheckinDetails,
+        "ONGOING"
       );
     });
 
@@ -543,7 +546,8 @@ describe("manage-assets route validation", () => {
       // Verify helper is called with correct parameters
       expect(bookingAssets.isAssetPartiallyCheckedIn).toHaveBeenCalledWith(
         mockAssets[0],
-        mockPartialCheckinDetails
+        mockPartialCheckinDetails,
+        "ONGOING"
       );
     });
   });
@@ -575,14 +579,16 @@ describe("manage-assets route validation", () => {
         id: "booking123",
         organizationId: "org123",
         assetIds: ["asset3"], // only the new asset
+        userId: "user123",
       });
 
       // Verify note creation for new assets
       expect(noteService.createNotes).toHaveBeenCalledWith({
         content:
-          "**John Doe** added asset to booking **[Test Booking](/bookings/booking123)**.",
+          '{% link to="/settings/team/users/user123" text="John Doe" /%} added asset to {% link to="/bookings/booking123" text="Test Booking" /%}.',
         type: "UPDATE",
         userId: "user123",
+        organizationId: "org123",
         assetIds: ["asset3"], // only the new asset
       });
     });
@@ -611,6 +617,7 @@ describe("manage-assets route validation", () => {
       // Verify removeAssets is called
       expect(bookingService.removeAssets).toHaveBeenCalledWith({
         booking: { id: "booking123", assetIds: ["asset2"] },
+        assets: [], // db.asset.findMany returns [] in this test
         firstName: "John",
         lastName: "Doe",
         userId: "user123",

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
@@ -31,6 +31,7 @@ vi.mock("~/database/db.server", () => ({
 vi.mock("~/modules/booking/service.server", () => ({
   getDetailedPartialCheckinData: vi.fn(),
   updateBookingAssets: vi.fn(),
+  createKitBookingNote: vi.fn(),
 }));
 
 vi.mock("~/modules/user/service.server", () => ({
@@ -136,6 +137,9 @@ describe("manage-kits route validation", () => {
       name: "Test Booking",
       status: BookingStatus.ONGOING,
     });
+    vi.mocked(bookingService.createKitBookingNote).mockResolvedValue(
+      undefined as any
+    );
     vi.mocked(noteService.createNotes).mockResolvedValue({ count: 0 });
   });
 
@@ -188,7 +192,8 @@ describe("manage-kits route validation", () => {
       expect(bookingAssets.isKitPartiallyCheckedIn).toHaveBeenCalledWith(
         mockKits[0],
         {},
-        new Set(["asset1", "asset2"])
+        new Set(["asset1", "asset2"]),
+        "ONGOING"
       );
     });
 
@@ -294,7 +299,8 @@ describe("manage-kits route validation", () => {
       expect(bookingAssets.isKitPartiallyCheckedIn).toHaveBeenCalledWith(
         mockKits[0],
         mockPartialCheckinDetails,
-        new Set(["asset1", "asset2"])
+        new Set(["asset1", "asset2"]),
+        "ONGOING"
       );
     });
 
@@ -473,7 +479,63 @@ describe("manage-kits route validation", () => {
       expect(bookingAssets.isKitPartiallyCheckedIn).toHaveBeenCalledWith(
         mockKits[0],
         mockPartialCheckinDetails,
-        new Set(["asset1", "asset2"]) // existing booking asset IDs
+        new Set(["asset1", "asset2"]), // existing booking asset IDs
+        "ONGOING"
+      );
+    });
+  });
+
+  describe("updateBookingAssets call scope", () => {
+    it("should forward only the newly-added kit id, not the full submitted selection", async () => {
+      // Booking already contains asset1 + asset2 (from mockBooking).
+      // kit2 is pre-existing: all its assets (asset1, asset2) are already in the booking.
+      // kit1 is newly added: it brings asset3 which is not yet in the booking.
+      // Submitting kitIds: ["kit2", "kit1"] should only pass kit1 to updateBookingAssets.
+      const mockKits = [
+        {
+          id: "kit2",
+          name: "Kit 2",
+          status: KitStatus.AVAILABLE, // AVAILABLE so the checked-out guard is not tripped
+          assets: [{ id: "asset1" }, { id: "asset2" }], // all already in booking
+          organizationId: "org123",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: "kit1",
+          name: "Kit 1",
+          status: KitStatus.AVAILABLE, // AVAILABLE so the checked-out guard is not tripped
+          assets: [{ id: "asset3" }], // new asset not yet in the booking
+          organizationId: "org123",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ] as any;
+
+      vi.mocked(httpServer.parseData).mockReturnValue({
+        kitIds: ["kit2", "kit1"],
+        removedKitIds: [],
+        redirectTo: null,
+      });
+
+      vi.mocked(db.kit.findMany).mockResolvedValue(mockKits);
+      vi.mocked(bookingAssets.isKitPartiallyCheckedIn).mockReturnValue(false);
+
+      await action(
+        createActionArgs({
+          context: mockContext,
+          request: mockRequest,
+          params: mockParams,
+        })
+      );
+
+      // updateBookingAssets must be called exactly once with ONLY kit1 (not kit2)
+      expect(bookingService.updateBookingAssets).toHaveBeenCalledTimes(1);
+      expect(bookingService.updateBookingAssets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          assetIds: ["asset3"],
+          kitIds: ["kit1"], // ONLY the newly-added kit, not the pre-existing available kit2
+        })
       );
     });
   });

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -394,17 +394,20 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     /** We only update the booking if there are NEW assets to add */
     if (newAssetIds.length > 0) {
+      // Only the kits actually being added now (those contributing a new asset) —
+      // NOT the full submitted selection. Passing the whole selection would flip
+      // still-available kits already on an ongoing booking to CHECKED_OUT.
+      const newlyAddedKitIds = newlyAddedKits.map((kit) => kit.id);
+
       /** We update the booking with ONLY the new assets to avoid connecting already-connected assets */
       const b = await updateBookingAssets({
         id: bookingId,
         organizationId,
         assetIds: newAssetIds, // Only the newly added assets from kits
-        kitIds, // Pass the kit IDs so kit status can be updated if booking is checked out
+        kitIds: newlyAddedKitIds, // Only kits being added — see comment above
         userId,
       });
 
-      /** We create notes for the newly added kits instead of individual assets */
-      const newlyAddedKitIds = newlyAddedKits.map((kit) => kit.id);
       if (newlyAddedKitIds.length > 0) {
         await createKitBookingNote({
           bookingId: b.id,

--- a/apps/webapp/vitest.config.ts
+++ b/apps/webapp/vitest.config.ts
@@ -12,6 +12,12 @@ export default defineConfig({
     globals: true,
     environment: "happy-dom",
     setupFiles: ["./test/setup-test-env.ts"],
+    // Include both standard test files and .test.server.ts route tests.
+    // The `.server` infix avoids React Router typegen collisions (the typegen
+    // mirrors route filenames under .react-router/types, so a plain
+    // `foo.test.ts` would produce a generated file with the same name that
+    // Vitest would otherwise try to run as a second test file).
+    include: ["**/*.{test,spec}.?(c|m)[jt]s?(x)", "**/*.test.server.[jt]s"],
     includeSource: ["app/**/*.{js,ts}"],
     exclude: [
       "node_modules",


### PR DESCRIPTION
When adding a kit to an ONGOING/OVERDUE booking, updateBookingAssets flipped every kit in the submitted kitIds to CHECKED_OUT, including kits already on the booking that were still available. The asset update was correctly scoped to the newly-added assets, but the kit status update was not.

Scope the kit status update to kits that actually received a newly-checked-out asset (assets.some on validAssetIds), and pass only the newly-added kit ids from the manage-kits action instead of the whole submitted selection. This mirrors the completeKitIds semantics already used by partialCheckoutBooking.

Also include *.test.server.ts in the vitest glob: the manage-kits and manage-assets route test files were never being run, so revive them and refresh their stale assertions to match current code, and add route- and service-level regression tests for the scoped kit flip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed kit status updates to apply only to kits that actually received new assets, preventing unintended status changes from over-broad kit selections.

* **Tests**
  * Expanded test coverage for asset and kit management workflows with improved validation and regression tests.
  * Updated test suite configuration to enhance test file discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->