### PR TITLE
feat(companion): kit detail parity + booking list and check-out improvements

### DIFF
--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -1,4 +1,4 @@
-import { useState, memo } from "react";
+import { useState } from "react";
 import {
   View,
   Text,
@@ -24,6 +24,7 @@ import {
   borderRadius,
   formatStatus,
   formatDate,
+  formatCurrency,
 } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -34,6 +35,7 @@ import { AssetHeader } from "@/components/asset-detail/asset-header";
 import { QuickActions } from "@/components/asset-detail/quick-actions";
 import { NotesSection } from "@/components/asset-detail/notes-section";
 import { CustomFieldsSection } from "@/components/asset-detail/custom-fields-section";
+import { InfoRow } from "@/components/shared/info-row";
 import { useAssetData } from "@/hooks/use-asset-data";
 import { useCustodyActions } from "@/hooks/use-custody-actions";
 import { useImageUpload } from "@/hooks/use-image-upload";
@@ -193,19 +195,6 @@ export default function AssetDetailScreen() {
       Alert.alert("Deleted", `"${asset.title}" has been deleted.`, [
         { text: "OK", onPress: () => router.back() },
       ]);
-    }
-  };
-
-  // ── Helpers ─────────────────────────────────────────
-
-  const formatCurrency = (value: number, currency: string) => {
-    try {
-      return new Intl.NumberFormat(undefined, {
-        style: "currency",
-        currency,
-      }).format(value);
-    } catch {
-      return `${currency} ${value.toFixed(2)}`;
     }
   };
 
@@ -552,59 +541,6 @@ export default function AssetDetailScreen() {
   );
 }
 
-// ── Sub-components ─────────────────────────────────────
-
-const InfoRow = memo(function InfoRow({
-  icon,
-  label,
-  value,
-  onPress,
-  accessibilityLabel,
-}: {
-  icon: string;
-  label: string;
-  value: string;
-  /** When set, the row becomes tappable and shows a chevron affordance. */
-  onPress?: () => void;
-  /** A11y label for the tappable row (defaults to the value text). */
-  accessibilityLabel?: string;
-}) {
-  const { colors } = useTheme();
-  const styles = useStyles();
-
-  const content = (
-    <>
-      <View style={styles.infoLabel}>
-        <Ionicons name={icon as any} size={16} color={colors.muted} />
-        <Text style={styles.infoLabelText}>{label}</Text>
-      </View>
-      {/* why: selectable text claims touches — only enable it on static rows */}
-      <Text style={styles.infoValue} numberOfLines={2} selectable={!onPress}>
-        {value}
-      </Text>
-      {onPress && (
-        <Ionicons name="chevron-forward" size={16} color={colors.mutedLight} />
-      )}
-    </>
-  );
-
-  if (onPress) {
-    return (
-      <TouchableOpacity
-        style={styles.infoRow}
-        onPress={onPress}
-        activeOpacity={0.6}
-        accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel ?? value}
-      >
-        {content}
-      </TouchableOpacity>
-    );
-  }
-
-  return <View style={styles.infoRow}>{content}</View>;
-});
-
 // ── Styles ─────────────────────────────────────────────
 
 const useStyles = createStyles((colors, shadows) => ({
@@ -705,24 +641,6 @@ const useStyles = createStyles((colors, shadows) => ({
     borderColor: colors.border,
     overflow: "hidden",
     ...shadows.sm,
-  },
-  infoRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingHorizontal: 14,
-    paddingVertical: spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-  },
-  infoLabel: { flexDirection: "row", alignItems: "center", gap: spacing.sm },
-  infoLabelText: { fontSize: fontSize.base, color: colors.muted },
-  infoValue: {
-    fontSize: fontSize.base,
-    fontWeight: "600",
-    color: colors.foreground,
-    maxWidth: "55%",
-    textAlign: "right",
   },
 
   // Section containers (tags, QR)

--- a/apps/companion/app/(tabs)/assets/kits/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/kits/[id].tsx
@@ -1,12 +1,15 @@
 /**
- * Kit detail screen — image, status, custodian, description, and the
- * contained assets (each row navigates to the asset detail screen).
+ * Kit detail screen — full-bleed hero image, title + status, a details card
+ * (category, location, custodian, total value, dates), the kit's QR code, and
+ * the contained assets (each row navigates to the asset detail screen).
  *
- * Read-and-browse v1: kit mutations (custody, location) happen through the
- * scanner's batch modes, which accept kit scans; create/edit stays web-first.
+ * Harmonised with the asset detail screen: shared `InfoRow`, matching hero +
+ * title + status layout, and the same section/card styling. Custody/location
+ * mutations still run through the scanner's batch modes for now; create/edit
+ * stays web-first.
  *
- * @see {@link file://../assets/[id].tsx} the asset twin of this screen
- * @see {@link file://../../../lib/api/kits.ts} data source
+ * @see {@link file://../[id].tsx} the asset twin of this screen
+ * @see {@link file://../../../../lib/api/kits.ts} data source
  */
 import { useState, useCallback, useEffect } from "react";
 import {
@@ -16,6 +19,9 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   RefreshControl,
+  Modal,
+  Platform,
+  Dimensions,
 } from "react-native";
 import { useLocalSearchParams, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -24,14 +30,40 @@ import { api } from "@/lib/api";
 import type { KitDetail } from "@/lib/api/types";
 import { useOrg } from "@/lib/org-context";
 import { pushIntoTab } from "@/lib/navigation";
-import { fontSize, spacing, borderRadius, formatStatus } from "@/lib/constants";
+import {
+  fontSize,
+  spacing,
+  borderRadius,
+  formatStatus,
+  formatDate,
+  formatCurrency,
+} from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
+import { InfoRow } from "@/components/shared/info-row";
+import { KitActions } from "@/components/kit-detail/kit-actions";
+import { TeamMemberPicker } from "@/components/team-member-picker";
+import { LocationPicker } from "@/components/location-picker";
+import { useKitActions } from "@/hooks/use-kit-actions";
+import { userHasPermission } from "@/lib/permissions";
+
+// Lazy-loaded: ~50KB library only needed when viewing the kit's QR code.
+let QRCode: typeof import("react-native-qrcode-svg").default | null = null;
+try {
+  // why: dynamic require keeps react-native-qrcode-svg out of the initial JS
+  // bundle for screens that don't render a QR code.
+  QRCode =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("react-native-qrcode-svg").default ??
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("react-native-qrcode-svg");
+} catch {
+  QRCode = null;
+}
 
 /**
- * Kit detail screen. Shows a kit's header (name, image, status, code), its
- * asset list, and per-asset status, resolved from the `id` route param scoped
- * to the current workspace. Reached from the kits list or a scanned kit code.
+ * Kit detail screen, resolved from the `id` route param scoped to the current
+ * workspace. Reached from the kits list or a scanned kit code.
  *
  * @returns The kit detail screen element.
  */
@@ -41,10 +73,26 @@ export default function KitDetailScreen() {
   const { colors, statusBadge } = useTheme();
   const styles = useStyles();
 
+  // Role-aware UI — the server re-enforces these on every API call.
+  const roles = currentOrg?.roles;
+  const canCustody = userHasPermission({
+    roles,
+    entity: "kit",
+    action: "custody",
+  });
+  const canUpdate = userHasPermission({
+    roles,
+    entity: "kit",
+    action: "update",
+  });
+
   const [kit, setKit] = useState<KitDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showImageZoom, setShowImageZoom] = useState(false);
+  const [showCustodyPicker, setShowCustodyPicker] = useState(false);
+  const [showLocationPicker, setShowLocationPicker] = useState(false);
 
   const fetchKit = useCallback(
     async (mode: "initial" | "refresh" = "initial") => {
@@ -68,6 +116,17 @@ export default function KitDetailScreen() {
   useEffect(() => {
     fetchKit("initial");
   }, [fetchKit]);
+
+  const {
+    isActionLoading,
+    handleAssignCustody,
+    handleReleaseCustody,
+    handleUpdateLocation,
+  } = useKitActions({
+    kit,
+    currentOrg,
+    fetchKit: () => fetchKit("refresh"),
+  });
 
   const custodianName = kit?.custody
     ? kit.custody.custodian.user
@@ -114,7 +173,7 @@ export default function KitDetailScreen() {
         </View>
       ) : (
         <ScrollView
-          contentContainerStyle={styles.scrollContent}
+          contentContainerStyle={styles.content}
           refreshControl={
             <RefreshControl
               refreshing={isRefreshing}
@@ -123,143 +182,289 @@ export default function KitDetailScreen() {
             />
           }
         >
-          {/* Header card */}
-          <View style={styles.card}>
-            <View style={styles.headerRow}>
-              {kit.image ? (
-                <Image
-                  source={{ uri: kit.image }}
-                  style={styles.kitImage}
-                  contentFit="cover"
+          {/* ── Hero image ─────────────────────────────── */}
+          {kit.image ? (
+            <TouchableOpacity
+              onPress={() => setShowImageZoom(true)}
+              activeOpacity={0.9}
+              accessibilityLabel="View full-size image"
+              accessibilityRole="button"
+            >
+              <Image
+                source={{ uri: kit.image }}
+                style={styles.heroImage}
+                contentFit="cover"
+                accessibilityLabel={`Photo of ${kit.name}`}
+              />
+            </TouchableOpacity>
+          ) : (
+            <View
+              style={[styles.heroImage, styles.heroPlaceholder]}
+              accessible={true}
+              accessibilityRole="image"
+              accessibilityLabel={`No image for ${kit.name}`}
+            >
+              <Ionicons name="albums-outline" size={64} color={colors.border} />
+            </View>
+          )}
+
+          {/* ── Title + Status ─────────────────────────── */}
+          <View style={styles.titleSection}>
+            <Text style={styles.title}>{kit.name}</Text>
+            {badge ? (
+              <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
+                <View
+                  style={[styles.statusDot, { backgroundColor: badge.text }]}
                 />
-              ) : (
-                <View style={[styles.kitImage, styles.kitImagePlaceholder]}>
-                  <Ionicons
-                    name="albums-outline"
-                    size={28}
-                    color={colors.muted}
+                <Text style={[styles.statusText, { color: badge.text }]}>
+                  {formatStatus(kit.status)}
+                </Text>
+              </View>
+            ) : null}
+          </View>
+
+          {kit.description ? (
+            <Text style={styles.description}>{kit.description}</Text>
+          ) : null}
+
+          {/* ── Actions — custody + location ───────────── */}
+          <KitActions
+            kit={kit}
+            onAssignCustody={() => setShowCustodyPicker(true)}
+            onReleaseCustody={handleReleaseCustody}
+            onLocationPress={() => setShowLocationPicker(true)}
+            isActionLoading={isActionLoading}
+            canCustody={canCustody}
+            canUpdate={canUpdate}
+          />
+
+          {/* ── Details ────────────────────────────────── */}
+          <View style={styles.infoSection}>
+            {kit.category ? (
+              <InfoRow
+                icon="pricetag-outline"
+                label="Category"
+                value={kit.category.name}
+              />
+            ) : null}
+            {kit.location ? (
+              <InfoRow
+                icon="location-outline"
+                label="Location"
+                value={kit.location.name}
+              />
+            ) : null}
+            {custodianName ? (
+              <InfoRow
+                icon="person-outline"
+                label="In Custody Of"
+                value={custodianName}
+              />
+            ) : null}
+            {kit.custody?.custodian.user?.email ? (
+              <InfoRow
+                icon="mail-outline"
+                label="Custodian Email"
+                value={kit.custody.custodian.user.email}
+              />
+            ) : null}
+            {kit.custody ? (
+              <InfoRow
+                icon="time-outline"
+                label="Custody Since"
+                value={formatDate(kit.custody.createdAt)}
+              />
+            ) : null}
+            {kit.totalValue > 0 ? (
+              <InfoRow
+                icon="cash-outline"
+                label="Total Value"
+                value={formatCurrency(
+                  kit.totalValue,
+                  kit.organization.currency
+                )}
+              />
+            ) : null}
+            <InfoRow
+              icon="cube-outline"
+              label="Assets"
+              value={String(kit.assets.length)}
+            />
+            <InfoRow
+              icon="calendar-outline"
+              label="Created"
+              value={formatDate(kit.createdAt)}
+            />
+            <InfoRow
+              icon="refresh-outline"
+              label="Updated"
+              value={formatDate(kit.updatedAt)}
+            />
+          </View>
+
+          {/* ── QR Code ────────────────────────────────── */}
+          {kit.qrCodes.length > 0 ? (
+            <View style={styles.sectionContainer}>
+              <Text style={styles.sectionTitle}>QR Code</Text>
+              <View style={styles.qrCard}>
+                {QRCode ? (
+                  <QRCode
+                    value={`${
+                      process.env.EXPO_PUBLIC_QR_BASE_URL ||
+                      "https://app.shelf.nu"
+                    }/qr/${kit.qrCodes[0].id}`}
+                    size={160}
+                    backgroundColor={colors.white}
+                    color={colors.foreground}
                   />
-                </View>
-              )}
-              <View style={styles.headerInfo}>
-                <Text style={styles.kitName}>{kit.name}</Text>
-                {badge && (
-                  <View
-                    style={[styles.statusBadge, { backgroundColor: badge.bg }]}
-                  >
-                    <View
-                      style={[
-                        styles.statusDot,
-                        { backgroundColor: badge.text },
-                      ]}
+                ) : (
+                  <View style={styles.qrPlaceholder}>
+                    <Ionicons
+                      name="qr-code-outline"
+                      size={64}
+                      color={colors.muted}
                     />
-                    <Text style={[styles.statusText, { color: badge.text }]}>
-                      {formatStatus(kit.status)}
-                    </Text>
                   </View>
                 )}
+                <Text style={styles.qrIdText} selectable numberOfLines={1}>
+                  {kit.qrCodes[0].id}
+                </Text>
               </View>
             </View>
+          ) : null}
 
-            {kit.description ? (
-              <Text style={styles.description}>{kit.description}</Text>
-            ) : null}
-
-            {custodianName ? (
-              <View style={styles.infoRow}>
-                <Ionicons
-                  name="person-outline"
-                  size={15}
-                  color={colors.muted}
-                />
-                <Text style={styles.infoLabel}>Custodian</Text>
-                <Text style={styles.infoValue}>{custodianName}</Text>
-              </View>
-            ) : null}
-
-            <View style={styles.infoRow}>
-              <Ionicons name="cube-outline" size={15} color={colors.muted} />
-              <Text style={styles.infoLabel}>Assets</Text>
-              <Text style={styles.infoValue}>{kit.assets.length}</Text>
-            </View>
-          </View>
-
-          {/* Hint: mutations happen via the scanner */}
-          <View style={styles.hintRow}>
-            <Ionicons
-              name="information-circle-outline"
-              size={15}
-              color={colors.muted}
-            />
-            <Text style={styles.hintText}>
-              Assign or release this kit by scanning it in the Scan tab.
+          {/* ── Assets ─────────────────────────────────── */}
+          <View style={styles.sectionContainer}>
+            <Text style={styles.sectionTitle}>
+              Assets ({kit.assets.length})
             </Text>
+            {kit.assets.length === 0 ? (
+              <Text style={styles.stateText}>This kit has no assets yet.</Text>
+            ) : (
+              <View style={styles.assetList}>
+                {kit.assets.map((asset) => {
+                  const assetBadge = statusBadge[asset.status] ?? {
+                    bg: colors.backgroundTertiary,
+                    text: colors.muted,
+                  };
+                  return (
+                    <TouchableOpacity
+                      key={asset.id}
+                      style={styles.assetRow}
+                      onPress={() =>
+                        pushIntoTab(
+                          "/(tabs)/assets",
+                          `/(tabs)/assets/${asset.id}`
+                        )
+                      }
+                      activeOpacity={0.7}
+                      accessibilityLabel={`View asset ${asset.title}`}
+                      accessibilityRole="button"
+                    >
+                      {asset.thumbnailImage || asset.mainImage ? (
+                        <Image
+                          source={{
+                            uri: asset.thumbnailImage || asset.mainImage!,
+                          }}
+                          style={styles.assetImage}
+                          contentFit="cover"
+                        />
+                      ) : (
+                        <View
+                          style={[
+                            styles.assetImage,
+                            styles.assetImagePlaceholder,
+                          ]}
+                        >
+                          <Ionicons
+                            name="cube-outline"
+                            size={16}
+                            color={colors.muted}
+                          />
+                        </View>
+                      )}
+                      <View style={styles.assetInfo}>
+                        <Text style={styles.assetTitle} numberOfLines={1}>
+                          {asset.title}
+                        </Text>
+                        <Text style={styles.assetMeta} numberOfLines={1}>
+                          {asset.category?.name || "Uncategorized"}
+                        </Text>
+                      </View>
+                      <View
+                        style={[
+                          styles.statusBadge,
+                          { backgroundColor: assetBadge.bg },
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.statusText,
+                            { color: assetBadge.text },
+                          ]}
+                        >
+                          {formatStatus(asset.status)}
+                        </Text>
+                      </View>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            )}
           </View>
-
-          {/* Assets section */}
-          <Text style={styles.sectionTitle}>Assets ({kit.assets.length})</Text>
-          {kit.assets.length === 0 ? (
-            <Text style={styles.stateText}>This kit has no assets yet.</Text>
-          ) : (
-            kit.assets.map((asset) => {
-              const assetBadge = statusBadge[asset.status] ?? {
-                bg: colors.backgroundTertiary,
-                text: colors.muted,
-              };
-              return (
-                <TouchableOpacity
-                  key={asset.id}
-                  style={styles.assetRow}
-                  onPress={() =>
-                    pushIntoTab("/(tabs)/assets", `/(tabs)/assets/${asset.id}`)
-                  }
-                  activeOpacity={0.7}
-                  accessibilityLabel={`View asset ${asset.title}`}
-                  accessibilityRole="button"
-                >
-                  {asset.thumbnailImage || asset.mainImage ? (
-                    <Image
-                      source={{ uri: asset.thumbnailImage || asset.mainImage! }}
-                      style={styles.assetImage}
-                      contentFit="cover"
-                    />
-                  ) : (
-                    <View
-                      style={[styles.assetImage, styles.kitImagePlaceholder]}
-                    >
-                      <Ionicons
-                        name="cube-outline"
-                        size={16}
-                        color={colors.muted}
-                      />
-                    </View>
-                  )}
-                  <View style={styles.headerInfo}>
-                    <Text style={styles.assetTitle} numberOfLines={1}>
-                      {asset.title}
-                    </Text>
-                    <Text style={styles.assetMeta} numberOfLines={1}>
-                      {asset.category?.name || "Uncategorized"}
-                    </Text>
-                  </View>
-                  <View
-                    style={[
-                      styles.statusBadge,
-                      { backgroundColor: assetBadge.bg },
-                    ]}
-                  >
-                    <Text
-                      style={[styles.statusText, { color: assetBadge.text }]}
-                    >
-                      {formatStatus(asset.status)}
-                    </Text>
-                  </View>
-                </TouchableOpacity>
-              );
-            })
-          )}
         </ScrollView>
       )}
+
+      {/* ── Image zoom modal ─────────────────────────────── */}
+      {kit?.image ? (
+        <Modal
+          visible={showImageZoom}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setShowImageZoom(false)}
+        >
+          <View style={styles.zoomOverlay} accessibilityViewIsModal={true}>
+            <TouchableOpacity
+              style={styles.zoomCloseBtn}
+              onPress={() => setShowImageZoom(false)}
+              accessibilityLabel="Close image viewer"
+              accessibilityRole="button"
+            >
+              <Ionicons name="close" size={28} color="#fff" />
+            </TouchableOpacity>
+            <Image
+              source={{ uri: kit.image }}
+              style={styles.zoomImage}
+              contentFit="contain"
+            />
+          </View>
+        </Modal>
+      ) : null}
+
+      {/* ── Custody + Location pickers ───────────────────── */}
+      {currentOrg ? (
+        <>
+          <TeamMemberPicker
+            visible={showCustodyPicker}
+            orgId={currentOrg.id}
+            onSelect={(member) => {
+              setShowCustodyPicker(false);
+              handleAssignCustody(member);
+            }}
+            onClose={() => setShowCustodyPicker(false)}
+          />
+          <LocationPicker
+            visible={showLocationPicker}
+            orgId={currentOrg.id}
+            currentLocationId={kit?.location?.id}
+            onSelect={(location) => {
+              setShowLocationPicker(false);
+              handleUpdateLocation(location);
+            }}
+            onClose={() => setShowLocationPicker(false)}
+          />
+        </>
+      ) : null}
     </View>
   );
 }
@@ -267,83 +472,88 @@ export default function KitDetailScreen() {
 const useStyles = createStyles((colors, shadows) => ({
   container: {
     flex: 1,
-    backgroundColor: colors.background,
+    backgroundColor: colors.backgroundSecondary,
   },
-  scrollContent: {
-    padding: spacing.lg,
-    gap: spacing.sm,
+  content: { paddingBottom: 40 },
+  heroImage: {
+    width: "100%",
+    height: 220,
+    backgroundColor: colors.backgroundTertiary,
   },
-  card: {
+  heroPlaceholder: { justifyContent: "center", alignItems: "center" },
+  titleSection: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    gap: spacing.md,
+  },
+  title: {
+    fontSize: fontSize.xxxl,
+    fontWeight: "700",
+    color: colors.foreground,
+    flex: 1,
+  },
+  statusBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: borderRadius.pill,
+    gap: 4,
+  },
+  statusDot: { width: 6, height: 6, borderRadius: 3 },
+  statusText: { fontSize: fontSize.xs, fontWeight: "500" },
+  description: {
+    fontSize: fontSize.lg,
+    color: colors.foregroundSecondary,
+    lineHeight: 22,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+  },
+  infoSection: {
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.xl,
     backgroundColor: colors.white,
-    borderRadius: borderRadius.lg,
-    padding: spacing.lg,
+    borderRadius: borderRadius.xl,
+    borderWidth: 1,
+    borderColor: colors.border,
+    overflow: "hidden",
+    ...shadows.sm,
+  },
+  sectionContainer: { paddingHorizontal: spacing.lg, marginTop: spacing.xl },
+  sectionTitle: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.muted,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: spacing.sm,
+  },
+  qrCard: {
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.xl,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: "center",
+    paddingVertical: spacing.xl,
+    paddingHorizontal: spacing.lg,
     gap: spacing.md,
     ...shadows.sm,
   },
-  headerRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.md,
-  },
-  kitImage: {
-    width: 64,
-    height: 64,
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.backgroundTertiary,
-  },
-  kitImagePlaceholder: {
+  qrPlaceholder: {
+    width: 160,
+    height: 160,
     justifyContent: "center",
     alignItems: "center",
   },
-  headerInfo: {
-    flex: 1,
-    gap: 6,
+  qrIdText: {
+    fontSize: fontSize.xs,
+    color: colors.mutedLight,
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
   },
-  kitName: {
-    fontSize: fontSize.xxl,
-    fontWeight: "700",
-    color: colors.foreground,
-  },
-  description: {
-    fontSize: fontSize.base,
-    color: colors.muted,
-    lineHeight: 20,
-  },
-  infoRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.sm,
-  },
-  infoLabel: {
-    fontSize: fontSize.base,
-    color: colors.muted,
-    width: 80,
-  },
-  infoValue: {
-    flex: 1,
-    fontSize: fontSize.base,
-    color: colors.foreground,
-    fontWeight: "500",
-  },
-  hintRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.sm,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-  },
-  hintText: {
-    flex: 1,
-    fontSize: fontSize.sm,
-    color: colors.muted,
-  },
-  sectionTitle: {
-    fontSize: fontSize.lg,
-    fontWeight: "700",
-    color: colors.foreground,
-    marginTop: spacing.md,
-    marginBottom: spacing.xs,
-  },
+  assetList: { gap: spacing.sm },
   assetRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -351,6 +561,8 @@ const useStyles = createStyles((colors, shadows) => ({
     borderRadius: borderRadius.lg,
     padding: spacing.md,
     gap: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border,
     ...shadows.sm,
   },
   assetImage: {
@@ -359,6 +571,8 @@ const useStyles = createStyles((colors, shadows) => ({
     borderRadius: borderRadius.md,
     backgroundColor: colors.backgroundTertiary,
   },
+  assetImagePlaceholder: { justifyContent: "center", alignItems: "center" },
+  assetInfo: { flex: 1, gap: 4 },
   assetTitle: {
     fontSize: fontSize.base,
     fontWeight: "600",
@@ -368,22 +582,27 @@ const useStyles = createStyles((colors, shadows) => ({
     fontSize: fontSize.sm,
     color: colors.muted,
   },
-  statusBadge: {
-    flexDirection: "row",
+  zoomOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.95)",
+    justifyContent: "center",
     alignItems: "center",
-    gap: 5,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: 4,
-    borderRadius: borderRadius.pill,
   },
-  statusDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
+  zoomCloseBtn: {
+    position: "absolute",
+    top: Platform.OS === "ios" ? 60 : 40,
+    right: 20,
+    zIndex: 10,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: "rgba(255,255,255,0.2)",
+    justifyContent: "center",
+    alignItems: "center",
   },
-  statusText: {
-    fontSize: fontSize.xs,
-    fontWeight: "600",
+  zoomImage: {
+    width: Dimensions.get("window").width,
+    height: Dimensions.get("window").height * 0.7,
   },
   centered: {
     flex: 1,

--- a/apps/companion/app/(tabs)/assets/kits/index.tsx
+++ b/apps/companion/app/(tabs)/assets/kits/index.tsx
@@ -31,13 +31,15 @@ import { InventorySegment } from "@/components/kits/inventory-segment";
 
 const PAGE_SIZE = 20;
 
-/** Status filter pills shown above the list. */
-const FILTERS = [
-  { key: "", label: "All" },
-  { key: "AVAILABLE", label: "Available" },
-  { key: "IN_CUSTODY", label: "In Custody" },
-  { key: "CHECKED_OUT", label: "Checked Out" },
-] as const;
+/** Filter pills — status filters plus the special "My Custody" filter. */
+type KitFilter = { label: string; status: string; myCustody?: boolean };
+const FILTERS: KitFilter[] = [
+  { label: "All", status: "" },
+  { label: "My Custody", status: "", myCustody: true },
+  { label: "Available", status: "AVAILABLE" },
+  { label: "In Custody", status: "IN_CUSTODY" },
+  { label: "Checked Out", status: "CHECKED_OUT" },
+];
 
 const kitKeyExtractor = (item: KitListItem) => item.id;
 
@@ -61,7 +63,7 @@ export default function KitsListScreen() {
   const [error, setError] = useState<string | null>(null);
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [activeFilter, setActiveFilter] = useState(0);
   const nextPageRef = useRef(2);
   const hasMoreRef = useRef(true);
   // Re-entrancy guard for pagination. A ref (not the isLoadingMore state) so
@@ -88,9 +90,11 @@ export default function KitsListScreen() {
       setError(null);
 
       const page = mode === "more" ? nextPageRef.current : 1;
+      const filter = FILTERS[activeFilter];
       const { data, error: fetchErr } = await api.kits(currentOrg.id, {
         search: debouncedSearch || undefined,
-        status: statusFilter || undefined,
+        status: filter.status || undefined,
+        myCustody: filter.myCustody || undefined,
         page,
         perPage: PAGE_SIZE,
       });
@@ -110,7 +114,7 @@ export default function KitsListScreen() {
       setIsLoadingMore(false);
       isLoadingMoreRef.current = false;
     },
-    [currentOrg, debouncedSearch, statusFilter]
+    [currentOrg, debouncedSearch, activeFilter]
   );
 
   // Initial load + reload on search/filter change
@@ -147,10 +151,25 @@ export default function KitsListScreen() {
             <Text style={styles.rowTitle} numberOfLines={1}>
               {item.name}
             </Text>
-            <Text style={styles.rowMeta} numberOfLines={1}>
-              {item._count.assets} asset{item._count.assets === 1 ? "" : "s"}
-              {item.custody ? ` • ${item.custody.custodian.name}` : ""}
-            </Text>
+            <View style={styles.rowMeta}>
+              <Text style={styles.rowCount} numberOfLines={1}>
+                {item._count.assets} asset
+                {item._count.assets === 1 ? "" : "s"}
+                {item.category ? ` • ${item.category.name}` : ""}
+              </Text>
+              {item.location ? (
+                <View style={styles.locationRow}>
+                  <Ionicons
+                    name="location-outline"
+                    size={11}
+                    color={colors.mutedLight}
+                  />
+                  <Text style={styles.rowLocation} numberOfLines={1}>
+                    {item.location.name}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
           </View>
           <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
             <View style={[styles.statusDot, { backgroundColor: badge.text }]} />
@@ -199,21 +218,21 @@ export default function KitsListScreen() {
         style={styles.filterRow}
         contentContainerStyle={styles.filterRowContent}
       >
-        {FILTERS.map((f) => (
+        {FILTERS.map((f, i) => (
           <TouchableOpacity
-            key={f.key}
+            key={f.label}
             style={[
               styles.filterPill,
-              statusFilter === f.key && styles.filterPillActive,
+              activeFilter === i && styles.filterPillActive,
             ]}
-            onPress={() => setStatusFilter(f.key)}
+            onPress={() => setActiveFilter(i)}
             accessibilityLabel={`Filter: ${f.label}`}
             accessibilityRole="button"
           >
             <Text
               style={[
                 styles.filterPillText,
-                statusFilter === f.key && styles.filterPillTextActive,
+                activeFilter === i && styles.filterPillTextActive,
               ]}
             >
               {f.label}
@@ -250,8 +269,12 @@ export default function KitsListScreen() {
           <Text style={styles.stateText}>
             {debouncedSearch
               ? "No kits match your search"
-              : statusFilter
-              ? `No ${formatStatus(statusFilter).toLowerCase()} kits`
+              : FILTERS[activeFilter].myCustody
+              ? "No kits in your custody"
+              : FILTERS[activeFilter].status
+              ? `No ${formatStatus(
+                  FILTERS[activeFilter].status
+                ).toLowerCase()} kits`
               : "No kits yet. Create kits in the web app to group assets."}
           </Text>
         </View>
@@ -375,8 +398,20 @@ const useStyles = createStyles((colors, shadows) => ({
     color: colors.foreground,
   },
   rowMeta: {
+    gap: 2,
+  },
+  rowCount: {
     fontSize: fontSize.sm,
     color: colors.muted,
+  },
+  locationRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 2,
+  },
+  rowLocation: {
+    fontSize: fontSize.xs,
+    color: colors.mutedLight,
   },
   statusBadge: {
     flexDirection: "row",

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -52,11 +52,17 @@ export default function BookingDetailScreen() {
   const [isActioning, setIsActioning] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // For partial check-in: selected assets
+  // For progressive check-in/check-out: selected assets
   const [selectedAssetIds, setSelectedAssetIds] = useState<Set<string>>(
     new Set()
   );
-  const [isSelectMode, setIsSelectMode] = useState(false);
+  // Selection mode picks a subset of assets to act on. "checkin" selects
+  // checked-out assets to return; "checkout" selects not-yet-out assets to take.
+  // null = not selecting.
+  const [selectMode, setSelectMode] = useState<"checkin" | "checkout" | null>(
+    null
+  );
+  const isSelectMode = selectMode !== null;
 
   const lastFetchedAt = useRef(0);
 
@@ -204,7 +210,52 @@ export default function BookingDetailScreen() {
                 text: "OK",
                 onPress: () => {
                   setSelectedAssetIds(new Set());
-                  setIsSelectMode(false);
+                  setSelectMode(null);
+                  fetchBooking();
+                },
+              },
+            ]);
+          },
+        },
+      ]
+    );
+  };
+
+  const handlePartialCheckout = () => {
+    if (!booking || !currentOrg || selectedAssetIds.size === 0) return;
+    const count = selectedAssetIds.size;
+    Alert.alert(
+      "Check Out Selected",
+      `Check out ${count} selected ${count === 1 ? "asset" : "assets"}?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Check Out",
+          onPress: async () => {
+            setIsActioning(true);
+            const { data, error: err } = await api.partialCheckoutBooking(
+              currentOrg.id,
+              booking.id,
+              Array.from(selectedAssetIds),
+              getTimeZone()
+            );
+            setIsActioning(false);
+            if (err) {
+              Alert.alert("Error", err);
+              return;
+            }
+            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            const msg = data?.isComplete
+              ? `All assets are now checked out for "${booking.name}".`
+              : `${data?.checkedOutCount ?? count} checked out, ${
+                  data?.remainingCount ?? "some"
+                } still reserved.`;
+            Alert.alert("Checked Out", msg, [
+              {
+                text: "OK",
+                onPress: () => {
+                  setSelectedAssetIds(new Set());
+                  setSelectMode(null);
                   fetchBooking();
                 },
               },
@@ -233,7 +284,14 @@ export default function BookingDetailScreen() {
       const isCheckedIn = checkedInAssetIds.includes(item.id);
       const isCheckedOut = item.status === "CHECKED_OUT";
       const isSelected = selectedAssetIds.has(item.id);
-      const selectable = isSelectMode && isCheckedOut && !isCheckedIn;
+      // What's selectable depends on the mode: returning checked-out assets
+      // (check-in) vs. taking not-yet-out assets (check-out).
+      const selectable =
+        selectMode === "checkin"
+          ? isCheckedOut && !isCheckedIn
+          : selectMode === "checkout"
+          ? !isCheckedOut
+          : false;
 
       return (
         <TouchableOpacity
@@ -257,7 +315,7 @@ export default function BookingDetailScreen() {
           }`}
           accessibilityRole="button"
         >
-          {isSelectMode && isCheckedOut && !isCheckedIn && (
+          {selectable && (
             <View
               style={[styles.checkbox, isSelected && styles.checkboxChecked]}
             >
@@ -321,7 +379,7 @@ export default function BookingDetailScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       checkedInAssetIds,
-      isSelectMode,
+      selectMode,
       selectedAssetIds,
       router,
       colors,
@@ -362,6 +420,23 @@ export default function BookingDetailScreen() {
       .filter(Boolean)
       .join(" ") ||
     null;
+
+  // Lifecycle counts for the progress bar: assets move reserved → out → returned.
+  // checkedOutCount counts assets still flagged CHECKED_OUT (incl. ones already
+  // returned this session); checkedInAssetIds are the ones returned.
+  const checkedInCount = checkedInAssetIds.length;
+  const onJobCount = Math.max(0, booking.checkedOutCount - checkedInCount);
+  const reservedCount = Math.max(
+    0,
+    booking.assetCount - booking.checkedOutCount
+  );
+  // Only show the bar once there's check-out activity — otherwise it's a flat,
+  // single-colour bar that adds noise to a freshly-reserved booking.
+  const showProgress =
+    booking.assetCount > 0 &&
+    (booking.checkedOutCount > 0 ||
+      checkedInCount > 0 ||
+      ["ONGOING", "OVERDUE", "COMPLETE"].includes(booking.status));
 
   return (
     <View style={styles.container}>
@@ -462,6 +537,80 @@ export default function BookingDetailScreen() {
               </View>
             </View>
 
+            {/* Lifecycle progress: reserved → out → returned (single bar) */}
+            {showProgress && (
+              <View style={styles.progressCard}>
+                <View style={styles.progressLabelRow}>
+                  <Text style={styles.progressTitle}>Check-out progress</Text>
+                  <Text style={styles.progressCount}>
+                    {checkedInCount}/{booking.assetCount} returned
+                  </Text>
+                </View>
+                <View
+                  style={styles.progressBar}
+                  accessibilityLabel={`${reservedCount} reserved, ${onJobCount} checked out, ${checkedInCount} returned`}
+                >
+                  {reservedCount > 0 && (
+                    <View
+                      style={{
+                        flex: reservedCount,
+                        backgroundColor: colors.backgroundTertiary,
+                      }}
+                    />
+                  )}
+                  {onJobCount > 0 && (
+                    <View
+                      style={{
+                        flex: onJobCount,
+                        backgroundColor: colors.primary,
+                      }}
+                    />
+                  )}
+                  {checkedInCount > 0 && (
+                    <View
+                      style={{
+                        flex: checkedInCount,
+                        backgroundColor: colors.success,
+                      }}
+                    />
+                  )}
+                </View>
+                <View style={styles.progressLegend}>
+                  <View style={styles.legendItem}>
+                    <View
+                      style={[
+                        styles.legendDot,
+                        { backgroundColor: colors.backgroundTertiary },
+                      ]}
+                    />
+                    <Text style={styles.legendText}>
+                      {reservedCount} reserved
+                    </Text>
+                  </View>
+                  <View style={styles.legendItem}>
+                    <View
+                      style={[
+                        styles.legendDot,
+                        { backgroundColor: colors.primary },
+                      ]}
+                    />
+                    <Text style={styles.legendText}>{onJobCount} out</Text>
+                  </View>
+                  <View style={styles.legendItem}>
+                    <View
+                      style={[
+                        styles.legendDot,
+                        { backgroundColor: colors.success },
+                      ]}
+                    />
+                    <Text style={styles.legendText}>
+                      {checkedInCount} returned
+                    </Text>
+                  </View>
+                </View>
+              </View>
+            )}
+
             {/* Action buttons */}
             {booking &&
               !["COMPLETE", "ARCHIVED", "CANCELLED"].includes(booking.status) &&
@@ -492,21 +641,65 @@ export default function BookingDetailScreen() {
               )}
 
             {canCheckout && (
-              <TouchableOpacity
-                style={styles.actionButton}
-                onPress={handleCheckout}
-                accessibilityLabel="Check out all assets in this booking"
-                accessibilityRole="button"
-              >
-                <Ionicons
-                  name="log-out-outline"
-                  size={18}
-                  color={colors.primaryForeground}
-                />
-                <Text style={styles.actionButtonText}>
-                  Check Out All Assets
-                </Text>
-              </TouchableOpacity>
+              <View style={styles.checkinActions}>
+                <TouchableOpacity
+                  style={styles.actionButton}
+                  onPress={handleCheckout}
+                  accessibilityLabel="Check out all assets in this booking"
+                  accessibilityRole="button"
+                >
+                  <Ionicons
+                    name="log-out-outline"
+                    size={18}
+                    color={colors.primaryForeground}
+                  />
+                  <Text style={styles.actionButtonText}>
+                    Check Out All Assets
+                  </Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity
+                  style={[
+                    styles.actionButtonOutline,
+                    selectMode === "checkout" &&
+                      styles.actionButtonOutlineActive,
+                  ]}
+                  onPress={() => {
+                    setSelectMode(
+                      selectMode === "checkout" ? null : "checkout"
+                    );
+                    setSelectedAssetIds(new Set());
+                  }}
+                  accessibilityLabel={
+                    selectMode === "checkout"
+                      ? "Cancel selection"
+                      : "Select assets to check out"
+                  }
+                  accessibilityRole="button"
+                >
+                  <Ionicons
+                    name={
+                      selectMode === "checkout" ? "close" : "checkbox-outline"
+                    }
+                    size={18}
+                    color={
+                      selectMode === "checkout"
+                        ? colors.error
+                        : colors.buttonSecondaryText
+                    }
+                  />
+                  <Text
+                    style={[
+                      styles.actionButtonOutlineText,
+                      selectMode === "checkout" && { color: colors.error },
+                    ]}
+                  >
+                    {selectMode === "checkout"
+                      ? "Cancel"
+                      : "Select to Check Out"}
+                  </Text>
+                </TouchableOpacity>
+              </View>
             )}
 
             {canCheckin && (
@@ -550,33 +743,38 @@ export default function BookingDetailScreen() {
                 <TouchableOpacity
                   style={[
                     styles.actionButtonOutline,
-                    isSelectMode && styles.actionButtonOutlineActive,
+                    selectMode === "checkin" &&
+                      styles.actionButtonOutlineActive,
                   ]}
                   onPress={() => {
-                    setIsSelectMode(!isSelectMode);
+                    setSelectMode(selectMode === "checkin" ? null : "checkin");
                     setSelectedAssetIds(new Set());
                   }}
                   accessibilityLabel={
-                    isSelectMode
+                    selectMode === "checkin"
                       ? "Cancel selection"
                       : "Select assets to check in"
                   }
                   accessibilityRole="button"
                 >
                   <Ionicons
-                    name={isSelectMode ? "close" : "checkbox-outline"}
+                    name={
+                      selectMode === "checkin" ? "close" : "checkbox-outline"
+                    }
                     size={18}
                     color={
-                      isSelectMode ? colors.error : colors.buttonSecondaryText
+                      selectMode === "checkin"
+                        ? colors.error
+                        : colors.buttonSecondaryText
                     }
                   />
                   <Text
                     style={[
                       styles.actionButtonOutlineText,
-                      isSelectMode && { color: colors.error },
+                      selectMode === "checkin" && { color: colors.error },
                     ]}
                   >
-                    {isSelectMode ? "Cancel" : "Select to Check In"}
+                    {selectMode === "checkin" ? "Cancel" : "Select to Check In"}
                   </Text>
                 </TouchableOpacity>
               </View>
@@ -590,22 +788,31 @@ export default function BookingDetailScreen() {
         }
       />
 
-      {/* Floating partial check-in button */}
+      {/* Floating progressive check-in / check-out button */}
       {isSelectMode && selectedAssetIds.size > 0 && (
         <View style={styles.floatingAction}>
           <TouchableOpacity
             style={styles.floatingButton}
-            onPress={handlePartialCheckin}
-            accessibilityLabel={`Check in ${selectedAssetIds.size} selected assets`}
+            onPress={
+              selectMode === "checkout"
+                ? handlePartialCheckout
+                : handlePartialCheckin
+            }
+            accessibilityLabel={`${
+              selectMode === "checkout" ? "Check out" : "Check in"
+            } ${selectedAssetIds.size} selected assets`}
             accessibilityRole="button"
           >
             <Ionicons
-              name="log-in-outline"
+              name={
+                selectMode === "checkout" ? "log-out-outline" : "log-in-outline"
+              }
               size={20}
               color={colors.primaryForeground}
             />
             <Text style={styles.floatingButtonText}>
-              Check In {selectedAssetIds.size}{" "}
+              {selectMode === "checkout" ? "Check Out" : "Check In"}{" "}
+              {selectedAssetIds.size}{" "}
               {selectedAssetIds.size === 1 ? "Asset" : "Assets"}
             </Text>
           </TouchableOpacity>
@@ -655,6 +862,56 @@ const useStyles = createStyles((colors, shadows) => ({
     borderWidth: 1,
     borderColor: colors.border,
     gap: spacing.md,
+  },
+
+  // Lifecycle progress bar
+  progressCard: {
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    gap: spacing.sm,
+  },
+  progressLabelRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  progressTitle: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  progressCount: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
+  },
+  progressBar: {
+    flexDirection: "row",
+    height: 8,
+    borderRadius: 4,
+    overflow: "hidden",
+    backgroundColor: colors.backgroundTertiary,
+  },
+  progressLegend: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.md,
+  },
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+  },
+  legendDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  legendText: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
   },
   infoHeader: {
     flexDirection: "row",

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -285,12 +285,14 @@ export default function BookingDetailScreen() {
       const isCheckedOut = item.status === "CHECKED_OUT";
       const isSelected = selectedAssetIds.has(item.id);
       // What's selectable depends on the mode: returning checked-out assets
-      // (check-in) vs. taking not-yet-out assets (check-out).
+      // (check-in) vs. taking never-checked-out assets (check-out). A returned
+      // asset is back to AVAILABLE, so `!isCheckedOut` alone would re-offer it
+      // for check-out — exclude the already-returned ones with `!isCheckedIn`.
       const selectable =
         selectMode === "checkin"
           ? isCheckedOut && !isCheckedIn
           : selectMode === "checkout"
-          ? !isCheckedOut
+          ? !isCheckedOut && !isCheckedIn
           : false;
 
       return (
@@ -421,15 +423,17 @@ export default function BookingDetailScreen() {
       .join(" ") ||
     null;
 
-  // Lifecycle counts for the progress bar: assets move reserved → out → returned.
-  // checkedOutCount counts assets still flagged CHECKED_OUT (incl. ones already
-  // returned this session); checkedInAssetIds are the ones returned.
-  const checkedInCount = checkedInAssetIds.length;
-  const onJobCount = Math.max(0, booking.checkedOutCount - checkedInCount);
+  // Lifecycle counts for the progress bar: every asset is in exactly one of three
+  // states. `checkedOutCount` (status === CHECKED_OUT) already EXCLUDES returned
+  // assets — partial check-in flips them back to AVAILABLE — so it IS the live
+  // "on job" count, and returns are subtracted from the reserved bucket (not from
+  // checkedOutCount again, which would double-count them).
+  const checkedInCount = checkedInAssetIds.length; // returned
+  const onJobCount = booking.checkedOutCount; // still out
   const reservedCount = Math.max(
     0,
-    booking.assetCount - booking.checkedOutCount
-  );
+    booking.assetCount - onJobCount - checkedInCount
+  ); // never checked out
   // Only show the bar once there's check-out activity — otherwise it's a flat,
   // single-colour bar that adds noise to a freshly-reserved booking.
   const showProgress =
@@ -437,6 +441,16 @@ export default function BookingDetailScreen() {
     (booking.checkedOutCount > 0 ||
       checkedInCount > 0 ||
       ["ONGOING", "OVERDUE", "COMPLETE"].includes(booking.status));
+
+  // Progressive check-out stays available while the booking is active AND still
+  // holds never-checked-out assets. The server (`partialCheckoutBooking`) accepts
+  // RESERVED/ONGOING/OVERDUE, but the loader's `canCheckout` is RESERVED-only (it
+  // gates the full "Check Out All" button), so we derive our own flag for the
+  // partial path — otherwise "Select to Check Out" disappears the moment the
+  // first batch flips the booking to ONGOING.
+  const canPartialCheckout =
+    reservedCount > 0 &&
+    ["RESERVED", "ONGOING", "OVERDUE"].includes(booking.status);
 
   return (
     <View style={styles.container}>
@@ -640,66 +654,66 @@ export default function BookingDetailScreen() {
                 </TouchableOpacity>
               )}
 
+            {/* Full check-out is RESERVED-only (web parity); the loader's
+                canCheckout reflects that. */}
             {canCheckout && (
-              <View style={styles.checkinActions}>
-                <TouchableOpacity
-                  style={styles.actionButton}
-                  onPress={handleCheckout}
-                  accessibilityLabel="Check out all assets in this booking"
-                  accessibilityRole="button"
-                >
-                  <Ionicons
-                    name="log-out-outline"
-                    size={18}
-                    color={colors.primaryForeground}
-                  />
-                  <Text style={styles.actionButtonText}>
-                    Check Out All Assets
-                  </Text>
-                </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.actionButton}
+                onPress={handleCheckout}
+                accessibilityLabel="Check out all assets in this booking"
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name="log-out-outline"
+                  size={18}
+                  color={colors.primaryForeground}
+                />
+                <Text style={styles.actionButtonText}>
+                  Check Out All Assets
+                </Text>
+              </TouchableOpacity>
+            )}
 
-                <TouchableOpacity
-                  style={[
-                    styles.actionButtonOutline,
-                    selectMode === "checkout" &&
-                      styles.actionButtonOutlineActive,
-                  ]}
-                  onPress={() => {
-                    setSelectMode(
-                      selectMode === "checkout" ? null : "checkout"
-                    );
-                    setSelectedAssetIds(new Set());
-                  }}
-                  accessibilityLabel={
-                    selectMode === "checkout"
-                      ? "Cancel selection"
-                      : "Select assets to check out"
+            {/* Progressive check-out persists while reserved assets remain, even
+                after the booking has gone ONGOING (canPartialCheckout, not
+                canCheckout) so the user can keep taking the rest. */}
+            {canPartialCheckout && (
+              <TouchableOpacity
+                style={[
+                  styles.actionButtonOutline,
+                  selectMode === "checkout" && styles.actionButtonOutlineActive,
+                ]}
+                onPress={() => {
+                  setSelectMode(selectMode === "checkout" ? null : "checkout");
+                  setSelectedAssetIds(new Set());
+                }}
+                accessibilityLabel={
+                  selectMode === "checkout"
+                    ? "Cancel selection"
+                    : "Select assets to check out"
+                }
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name={
+                    selectMode === "checkout" ? "close" : "checkbox-outline"
                   }
-                  accessibilityRole="button"
+                  size={18}
+                  color={
+                    selectMode === "checkout"
+                      ? colors.error
+                      : colors.buttonSecondaryText
+                  }
+                />
+                <Text
+                  style={[
+                    styles.actionButtonOutlineText,
+                    selectMode === "checkout" && { color: colors.error },
+                  ]}
                 >
-                  <Ionicons
-                    name={
-                      selectMode === "checkout" ? "close" : "checkbox-outline"
-                    }
-                    size={18}
-                    color={
-                      selectMode === "checkout"
-                        ? colors.error
-                        : colors.buttonSecondaryText
-                    }
-                  />
-                  <Text
-                    style={[
-                      styles.actionButtonOutlineText,
-                      selectMode === "checkout" && { color: colors.error },
-                    ]}
-                  >
-                    {selectMode === "checkout"
-                      ? "Cancel"
-                      : "Select to Check Out"}
-                  </Text>
-                </TouchableOpacity>
-              </View>
+                  {selectMode === "checkout" ? "Cancel" : "Select to Check Out"}
+                </Text>
+              </TouchableOpacity>
             )}
 
             {canCheckin && (

--- a/apps/companion/app/(tabs)/bookings/index.tsx
+++ b/apps/companion/app/(tabs)/bookings/index.tsx
@@ -2,11 +2,16 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import {
   View,
   Text,
+  TextInput,
+  ScrollView,
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
   RefreshControl,
   Animated,
+  Platform,
+  ActionSheetIOS,
+  Alert,
 } from "react-native";
 import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
@@ -20,6 +25,7 @@ import {
   borderRadius,
   formatStatus,
   formatDateTime,
+  bookingCountdown,
   hitSlop,
 } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
@@ -32,16 +38,42 @@ import { announce } from "@/lib/a11y";
 const PAGE_SIZE = 20;
 const bookingKeyExtractor = (item: BookingListItem) => item.id;
 
-/** Which status filters to show as pills */
+/**
+ * Status filter pills. The mobile list route already accepts any
+ * comma-separated subset of statuses, so we expose the field-critical
+ * individual statuses (Reserved = upcoming, Ongoing = in progress, Overdue =
+ * needs attention) alongside the grouped Active/Completed/All — letting a tech
+ * isolate exactly what they care about on a job.
+ */
 const STATUS_FILTERS: { label: string; value: string }[] = [
   // DRAFT counts as active: a booking being built (e.g. scan-to-add) must
   // not vanish from the default view the moment the user leaves it.
   { label: "Active", value: "DRAFT,RESERVED,ONGOING,OVERDUE" },
+  { label: "Reserved", value: "RESERVED" },
+  { label: "Ongoing", value: "ONGOING" },
+  { label: "Overdue", value: "OVERDUE" },
   { label: "Completed", value: "COMPLETE" },
   {
     label: "All",
     value: "DRAFT,RESERVED,ONGOING,OVERDUE,COMPLETE,ARCHIVED,CANCELLED",
   },
+];
+
+/**
+ * Sort options surfaced in the sort menu. Each maps to the list route's
+ * allowlisted `sortBy`/`sortOrder` params (default = the first entry, which
+ * matches the route's own default of `from asc`). Directions are chosen to be
+ * the useful one per column (soonest dates first, names A–Z, newest created).
+ */
+const SORT_OPTIONS: {
+  label: string;
+  sortBy: string;
+  sortOrder: "asc" | "desc";
+}[] = [
+  { label: "Start date (earliest)", sortBy: "from", sortOrder: "asc" },
+  { label: "Due date (soonest)", sortBy: "to", sortOrder: "asc" },
+  { label: "Name (A–Z)", sortBy: "name", sortOrder: "asc" },
+  { label: "Recently created", sortBy: "createdAt", sortOrder: "desc" },
 ];
 
 export default function BookingsListScreen() {
@@ -68,6 +100,9 @@ function BookingsListContent() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState(0);
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [sortIndex, setSortIndex] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const nextPage = useRef(1);
   const listRef = useRef<FlatList>(null);
@@ -93,6 +128,9 @@ function BookingsListContent() {
       if (!currentOrg) return;
       const { data, error: fetchErr } = await api.bookings(currentOrg.id, {
         status: STATUS_FILTERS[activeFilter].value,
+        search: debouncedSearch || undefined,
+        sortBy: SORT_OPTIONS[sortIndex].sortBy,
+        sortOrder: SORT_OPTIONS[sortIndex].sortOrder,
         page: pageNum,
         perPage: PAGE_SIZE,
       });
@@ -108,7 +146,7 @@ function BookingsListContent() {
       if (reset) setBookings(data.bookings);
       else setBookings((prev) => [...prev, ...data.bookings]);
     },
-    [currentOrg, activeFilter]
+    [currentOrg, activeFilter, debouncedSearch, sortIndex]
   );
 
   // Refresh on tab focus — skip if data is fresh (< 60s old)
@@ -124,14 +162,20 @@ function BookingsListContent() {
     nextPage.current = 1;
   }, [currentOrg?.id]);
 
-  // Re-fetch immediately when filter changes
+  // Debounce the search box (mirrors the assets/kits list debounce).
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(searchInput.trim()), 400);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
+  // Re-fetch immediately when the filter, search, or sort changes
   useEffect(() => {
     if (!currentOrg || !hasFetchedBookings.current) return;
     nextPage.current = 1;
     fetchBookings(1, true).finally(() => {
       lastFetchedAt.current = Date.now();
     });
-  }, [activeFilter]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeFilter, debouncedSearch, sortIndex]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useFocusEffect(
     useCallback(() => {
@@ -182,6 +226,33 @@ function BookingsListContent() {
     setIsLoadingMore(false);
   };
 
+  // Cross-platform sort picker: native action sheet on iOS, Alert on Android
+  // (mirrors the image-source picker pattern in assets/new.tsx).
+  const openSortMenu = () => {
+    Haptics.selectionAsync();
+    const labels = SORT_OPTIONS.map((o) => o.label);
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: "Sort bookings",
+          options: ["Cancel", ...labels],
+          cancelButtonIndex: 0,
+        },
+        (i) => {
+          if (i > 0) setSortIndex(i - 1);
+        }
+      );
+    } else {
+      Alert.alert("Sort bookings", undefined, [
+        { text: "Cancel", style: "cancel" },
+        ...SORT_OPTIONS.map((o, i) => ({
+          text: o.label,
+          onPress: () => setSortIndex(i),
+        })),
+      ]);
+    }
+  };
+
   const renderBooking = useCallback(
     ({ item }: { item: BookingListItem }) => {
       const badge = bookingStatusBadge[item.status] ?? {
@@ -191,6 +262,7 @@ function BookingsListContent() {
 
       const isUrgent = item.status === "OVERDUE";
       const isActive = item.status === "ONGOING" || item.status === "RESERVED";
+      const countdown = bookingCountdown(item.from, item.to, item.status);
 
       return (
         <TouchableOpacity
@@ -229,6 +301,24 @@ function BookingsListContent() {
                 {formatDateTime(item.from)} → {formatDateTime(item.to)}
               </Text>
             </View>
+
+            {countdown && (
+              <View style={styles.metaRow}>
+                <Ionicons
+                  name={countdown.urgent ? "alert-circle" : "time-outline"}
+                  size={13}
+                  color={countdown.urgent ? colors.error : colors.mutedLight}
+                />
+                <Text
+                  style={[
+                    styles.metaText,
+                    countdown.urgent && styles.metaTextUrgent,
+                  ]}
+                >
+                  {countdown.text}
+                </Text>
+              </View>
+            )}
 
             <View style={styles.metaRow}>
               <Ionicons
@@ -319,8 +409,54 @@ function BookingsListContent() {
 
   return (
     <View style={styles.container}>
-      {/* Status filter pills */}
-      <View style={styles.filterRow} accessibilityRole="tablist">
+      {/* Keyword search + sort */}
+      <View style={styles.searchRow}>
+        <View style={styles.searchContainer}>
+          <Ionicons name="search" size={18} color={colors.mutedLight} />
+          <TextInput
+            style={styles.searchInput}
+            value={searchInput}
+            onChangeText={setSearchInput}
+            placeholder="Search bookings..."
+            placeholderTextColor={colors.mutedLight}
+            autoCorrect={false}
+            autoCapitalize="none"
+            returnKeyType="search"
+            accessibilityLabel="Search bookings"
+          />
+          {searchInput.length > 0 ? (
+            <TouchableOpacity
+              onPress={() => setSearchInput("")}
+              hitSlop={hitSlop.sm}
+              accessibilityLabel="Clear search"
+              accessibilityRole="button"
+            >
+              <Ionicons
+                name="close-circle"
+                size={18}
+                color={colors.mutedLight}
+              />
+            </TouchableOpacity>
+          ) : null}
+        </View>
+        <TouchableOpacity
+          style={styles.sortButton}
+          onPress={openSortMenu}
+          accessibilityLabel="Sort bookings"
+          accessibilityRole="button"
+        >
+          <Ionicons name="swap-vertical" size={20} color={colors.muted} />
+        </TouchableOpacity>
+      </View>
+
+      {/* Status filter pills — scrollable: more statuses than fit one row */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.filterScroll}
+        contentContainerStyle={styles.filterRow}
+        accessibilityRole="tablist"
+      >
         {STATUS_FILTERS.map((f, i) => (
           <TouchableOpacity
             key={f.value}
@@ -347,7 +483,7 @@ function BookingsListContent() {
             </Text>
           </TouchableOpacity>
         ))}
-      </View>
+      </ScrollView>
 
       {/* Swipeable content area — swipe left/right to cycle filter pills */}
       <View style={styles.flexFill} {...swipePanHandlers}>
@@ -445,7 +581,47 @@ const useStyles = createStyles((colors) => ({
     gap: spacing.md,
   },
 
+  // Keyword search box + sort button
+  searchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.md,
+  },
+  searchContainer: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingHorizontal: 14,
+    height: 44,
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: fontSize.md,
+    color: colors.foreground,
+    padding: 0,
+  },
+  sortButton: {
+    width: 44,
+    height: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: borderRadius.lg,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+
   // Filter pills
+  filterScroll: {
+    flexGrow: 0,
+  },
   filterRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -540,6 +716,10 @@ const useStyles = createStyles((colors) => ({
   metaText: {
     fontSize: fontSize.sm,
     color: colors.muted,
+  },
+  metaTextUrgent: {
+    color: colors.error,
+    fontWeight: "600",
   },
 
   // Action hint

--- a/apps/companion/components/kit-detail/kit-actions.tsx
+++ b/apps/companion/components/kit-detail/kit-actions.tsx
@@ -1,0 +1,203 @@
+/**
+ * KitActions — the kit detail screen's action row: a primary custody button
+ * (Assign when available / Release when in custody) and a secondary
+ * Move-location button. Mirrors the asset `QuickActions` component, scoped to
+ * the actions a kit supports today via the existing `kits.bulk-actions`
+ * endpoint (custody + location). Edit/delete stay web-first for now.
+ *
+ * @see {@link file://../asset-detail/quick-actions.tsx} the asset twin
+ * @see {@link file://../../hooks/use-kit-actions.ts} the action handlers
+ */
+import { memo } from "react";
+import { View, Text, TouchableOpacity, ActivityIndicator } from "react-native";
+import * as Haptics from "expo-haptics";
+import { Ionicons } from "@expo/vector-icons";
+import type { KitDetail } from "@/lib/api/types";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+
+interface KitActionsProps {
+  kit: KitDetail;
+  onAssignCustody: () => void;
+  onReleaseCustody: () => void;
+  onLocationPress: () => void;
+  isActionLoading: boolean;
+  /** Role can change custody (assign/release). Server-enforced; hides the button. */
+  canCustody: boolean;
+  /** Role can update the kit (location). Server-enforced; hides the button. */
+  canUpdate: boolean;
+}
+
+/**
+ * Renders the kit's primary custody action + secondary location action,
+ * gated by the caller's permissions (the server re-enforces both).
+ *
+ * @param props - The kit, action callbacks, loading flag, and permission flags.
+ * @returns The action row, a loading row while an action is in flight, or
+ *   `null` when the role can perform no actions.
+ */
+export const KitActions = memo(function KitActions({
+  kit,
+  onAssignCustody,
+  onReleaseCustody,
+  onLocationPress,
+  isActionLoading,
+  canCustody,
+  canUpdate,
+}: KitActionsProps) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+
+  const hasCustody = !!kit.custody;
+  const isAvailable = kit.status === "AVAILABLE";
+  const showPrimary = canCustody && (hasCustody || isAvailable);
+  const showSecondary = canUpdate;
+
+  if (isActionLoading) {
+    return (
+      <View style={styles.actionsSection}>
+        <View style={styles.actionLoading}>
+          <ActivityIndicator size="small" color={colors.muted} />
+          <Text style={styles.actionLoadingText}>Updating...</Text>
+        </View>
+      </View>
+    );
+  }
+
+  // No permitted actions for this role — render nothing rather than buttons
+  // that would 403 server-side.
+  if (!showPrimary && !showSecondary) return null;
+
+  return (
+    <View style={styles.actionsSection}>
+      {/* Primary action — custody assign/release */}
+      {showPrimary &&
+        (hasCustody ? (
+          <TouchableOpacity
+            style={styles.primaryActionGreen}
+            onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+              onReleaseCustody();
+            }}
+            activeOpacity={0.7}
+            accessibilityLabel="Release custody of kit"
+            accessibilityRole="button"
+          >
+            <Ionicons
+              name="person-remove-outline"
+              size={20}
+              color={colors.primaryForeground}
+            />
+            <Text style={styles.primaryActionText}>Release Custody</Text>
+          </TouchableOpacity>
+        ) : isAvailable ? (
+          <TouchableOpacity
+            style={styles.primaryActionBlack}
+            onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+              onAssignCustody();
+            }}
+            activeOpacity={0.7}
+            accessibilityLabel="Assign custody of kit"
+            accessibilityRole="button"
+          >
+            <Ionicons
+              name="person-add-outline"
+              size={20}
+              color={colors.primaryForeground}
+            />
+            <Text style={styles.primaryActionText}>Assign Custody</Text>
+          </TouchableOpacity>
+        ) : null)}
+
+      {/* Secondary action — location */}
+      {showSecondary && (
+        <View style={styles.secondaryActionsRow}>
+          <TouchableOpacity
+            style={styles.secondaryAction}
+            onPress={onLocationPress}
+            activeOpacity={0.7}
+            accessibilityLabel="Update kit location"
+            accessibilityRole="button"
+          >
+            <Ionicons
+              name="location-outline"
+              size={18}
+              color={colors.foreground}
+            />
+            <Text style={styles.secondaryActionText}>
+              {kit.location ? "Move" : "Location"}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+});
+
+const useStyles = createStyles((colors, shadows) => ({
+  actionsSection: {
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.xl,
+    gap: spacing.sm,
+  },
+  primaryActionBlack: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  primaryActionGreen: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.available,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  primaryActionText: {
+    color: colors.primaryForeground,
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+  },
+  secondaryActionsRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+  },
+  secondaryAction: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    gap: 4,
+  },
+  secondaryActionText: {
+    color: colors.gray700,
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+  },
+  actionLoading: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.backgroundTertiary,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  actionLoadingText: { fontSize: fontSize.base, color: colors.muted },
+}));

--- a/apps/companion/components/shared/info-row.tsx
+++ b/apps/companion/components/shared/info-row.tsx
@@ -1,0 +1,111 @@
+/**
+ * InfoRow — a label/value detail row shared across entity detail screens.
+ *
+ * Renders an icon + label on the left and a value on the right, with an
+ * optional chevron + tap affordance when `onPress` is set. Lifted out of the
+ * asset detail screen so the asset and kit detail screens render identically.
+ *
+ * @see {@link file://../../app/(tabs)/assets/[id].tsx} asset detail consumer
+ * @see {@link file://../../app/(tabs)/assets/kits/[id].tsx} kit detail consumer
+ */
+import { memo } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { fontSize, spacing } from "@/lib/constants";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+
+/**
+ * A single label/value row on a detail screen.
+ *
+ * @param props - Component props.
+ * @param props.icon - Ionicons glyph name shown beside the label.
+ * @param props.label - The field label.
+ * @param props.value - The field value (right-aligned).
+ * @param props.onPress - When set, the row becomes tappable and shows a chevron.
+ * @param props.accessibilityLabel - A11y label for a tappable row (defaults to `value`).
+ * @returns The detail row element.
+ */
+export const InfoRow = memo(function InfoRow({
+  icon,
+  label,
+  value,
+  onPress,
+  accessibilityLabel,
+}: {
+  icon: string;
+  label: string;
+  value: string;
+  /** When set, the row becomes tappable and shows a chevron affordance. */
+  onPress?: () => void;
+  /** A11y label for the tappable row (defaults to the value text). */
+  accessibilityLabel?: string;
+}) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+
+  const content = (
+    <>
+      <View style={styles.infoLabel}>
+        <Ionicons name={icon as any} size={16} color={colors.muted} />
+        <Text style={styles.infoLabelText}>{label}</Text>
+      </View>
+      {/* why: selectable text claims touches — only enable it on static rows */}
+      <Text style={styles.infoValue} numberOfLines={2} selectable={!onPress}>
+        {value}
+      </Text>
+      {onPress && (
+        <Ionicons name="chevron-forward" size={16} color={colors.mutedLight} />
+      )}
+    </>
+  );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity
+        style={styles.infoRow}
+        onPress={onPress}
+        activeOpacity={0.6}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel ?? value}
+      >
+        {content}
+      </TouchableOpacity>
+    );
+  }
+
+  return <View style={styles.infoRow}>{content}</View>;
+});
+
+const useStyles = createStyles((colors) => ({
+  infoRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingHorizontal: 14,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  // Label keeps its intrinsic width (no shrink) so the value column starts at a
+  // consistent point row-to-row.
+  infoLabel: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    flexShrink: 0,
+  },
+  infoLabelText: { fontSize: fontSize.base, color: colors.muted },
+  // flex:1 + right-align makes the value hug the right edge — or sit flush
+  // against the chevron on tappable rows — instead of floating in the middle.
+  // (Previously `justifyContent: space-between` split the leftover space into
+  // two gaps once the chevron was added as a third child, so the value drifted
+  // to the centre on tappable rows like "Kit".)
+  infoValue: {
+    flex: 1,
+    fontSize: fontSize.base,
+    fontWeight: "600",
+    color: colors.foreground,
+    textAlign: "right",
+  },
+}));

--- a/apps/companion/hooks/use-kit-actions.ts
+++ b/apps/companion/hooks/use-kit-actions.ts
@@ -1,0 +1,142 @@
+/**
+ * useKitActions — custody (assign/release) and location actions for the kit
+ * detail screen, run through the existing `kits.bulk-actions` mobile endpoint
+ * (one kit at a time). Mirrors the asset `useCustodyActions` hook + the asset
+ * screen's location action, so kit and asset detail behave identically.
+ *
+ * @see {@link file://./use-custody-actions.ts} the asset twin
+ * @see {@link file://../lib/api/kits.ts} the bulk-action API wrappers
+ */
+import { useState } from "react";
+import { Alert } from "react-native";
+import * as Haptics from "expo-haptics";
+import { api, type TeamMember, type Location } from "@/lib/api";
+import type { KitDetail } from "@/lib/api/types";
+
+interface UseKitActionsParams {
+  kit: KitDetail | null;
+  currentOrg: { id: string } | null;
+  fetchKit: () => Promise<void>;
+}
+
+interface UseKitActionsReturn {
+  isActionLoading: boolean;
+  handleAssignCustody: (member: TeamMember) => void;
+  handleReleaseCustody: () => void;
+  handleUpdateLocation: (location: Location) => void;
+}
+
+/**
+ * Wires the kit detail screen's custody + location actions.
+ *
+ * @param params - The current kit, org, and a refetch callback.
+ * @returns Action handlers + the in-flight loading flag.
+ */
+export function useKitActions({
+  kit,
+  currentOrg,
+  fetchKit,
+}: UseKitActionsParams): UseKitActionsReturn {
+  const [isActionLoading, setIsActionLoading] = useState(false);
+
+  const performAssign = async (custodianId: string) => {
+    if (!currentOrg || !kit) return;
+    setIsActionLoading(true);
+    try {
+      const { error: err } = await api.bulkAssignKitCustody(
+        currentOrg.id,
+        [kit.id],
+        custodianId
+      );
+      if (err) Alert.alert("Error", err);
+      else {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        await fetchKit();
+      }
+    } catch {
+      Alert.alert("Error", "Something went wrong");
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+  const handleAssignCustody = (member: TeamMember) => {
+    const displayName = member.user
+      ? [member.user.firstName, member.user.lastName]
+          .filter(Boolean)
+          .join(" ") || member.name
+      : member.name;
+
+    Alert.alert("Assign Custody", `Assign "${kit?.name}" to ${displayName}?`, [
+      { text: "Cancel", style: "cancel" },
+      { text: "Assign", onPress: () => performAssign(member.id) },
+    ]);
+  };
+
+  const performRelease = async () => {
+    if (!currentOrg || !kit) return;
+    setIsActionLoading(true);
+    try {
+      const { error: err } = await api.bulkReleaseKitCustody(currentOrg.id, [
+        kit.id,
+      ]);
+      if (err) Alert.alert("Error", err);
+      else {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        await fetchKit();
+      }
+    } catch {
+      Alert.alert("Error", "Something went wrong");
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+  const handleReleaseCustody = () => {
+    if (!kit?.custody) return;
+    Alert.alert(
+      "Release Custody",
+      `Release "${kit.name}" from ${kit.custody.custodian.name}?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Release", style: "destructive", onPress: performRelease },
+      ]
+    );
+  };
+
+  const performUpdateLocation = async (locationId: string) => {
+    if (!currentOrg || !kit) return;
+    setIsActionLoading(true);
+    try {
+      const { error: err } = await api.bulkUpdateKitLocation(
+        currentOrg.id,
+        [kit.id],
+        locationId
+      );
+      if (err) Alert.alert("Error", err);
+      else {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        await fetchKit();
+      }
+    } catch {
+      Alert.alert("Error", "Something went wrong");
+    } finally {
+      setIsActionLoading(false);
+    }
+  };
+
+  const handleUpdateLocation = (location: Location) => {
+    if (location.id === kit?.location?.id) return; // same location — no-op
+    Alert.alert("Update Location", `Move "${kit?.name}" to ${location.name}?`, [
+      { text: "Cancel", style: "cancel" },
+      { text: "Move", onPress: () => performUpdateLocation(location.id) },
+    ]);
+  };
+
+  return {
+    isActionLoading,
+    handleAssignCustody,
+    handleReleaseCustody,
+    handleUpdateLocation,
+  };
+}

--- a/apps/companion/lib/api/bookings.ts
+++ b/apps/companion/lib/api/bookings.ts
@@ -4,18 +4,29 @@ import type {
   BookingDetailResponse,
   BookingActionResponse,
   PartialCheckinResponse,
+  PartialCheckoutResponse,
 } from "./types";
 
 export const bookingsApi = {
   /** Get paginated bookings for an organization */
   bookings: (
     orgId: string,
-    params?: { status?: string; page?: number; perPage?: number }
+    params?: {
+      status?: string;
+      page?: number;
+      perPage?: number;
+      search?: string;
+      sortBy?: string;
+      sortOrder?: "asc" | "desc";
+    }
   ) => {
     const searchParams = new URLSearchParams({ orgId });
     if (params?.status) searchParams.set("status", params.status);
     if (params?.page) searchParams.set("page", String(params.page));
     if (params?.perPage) searchParams.set("perPage", String(params.perPage));
+    if (params?.search) searchParams.set("search", params.search);
+    if (params?.sortBy) searchParams.set("sortBy", params.sortBy);
+    if (params?.sortOrder) searchParams.set("sortOrder", params.sortOrder);
     return apiFetch<BookingsResponse>(`/api/mobile/bookings?${searchParams}`);
   },
 
@@ -73,6 +84,26 @@ export const bookingsApi = {
   ) =>
     apiFetch<PartialCheckinResponse>(
       `/api/mobile/bookings/partial-checkin?orgId=${orgId}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ bookingId, assetIds, timeZone }),
+      }
+    ),
+
+  /**
+   * Partial check-out: check out a subset of a booking's assets (progressive
+   * check-out — "take some now"). The first checkout transitions the booking to
+   * ONGOING; the rest stay reserved until checked out. Mirrors
+   * {@link partialCheckinBooking}.
+   */
+  partialCheckoutBooking: (
+    orgId: string,
+    bookingId: string,
+    assetIds: string[],
+    timeZone?: string
+  ) =>
+    apiFetch<PartialCheckoutResponse>(
+      `/api/mobile/bookings/partial-checkout?orgId=${orgId}`,
       {
         method: "POST",
         body: JSON.stringify({ bookingId, assetIds, timeZone }),

--- a/apps/companion/lib/api/kits.ts
+++ b/apps/companion/lib/api/kits.ts
@@ -22,6 +22,8 @@ type KitListParams = {
   page?: number;
   perPage?: number;
   status?: string;
+  /** Only kits in the current user's custody. */
+  myCustody?: boolean;
 };
 
 export const kitsApi = {
@@ -32,6 +34,7 @@ export const kitsApi = {
     if (params.page) qs.set("page", String(params.page));
     if (params.perPage) qs.set("perPage", String(params.perPage));
     if (params.status) qs.set("status", params.status);
+    if (params.myCustody) qs.set("myCustody", "true");
     return apiFetch<KitsResponse>(`/api/mobile/kits?${qs.toString()}`);
   },
 

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -175,6 +175,8 @@ export type KitListItem = {
   image: string | null;
   imageExpiration: string | null;
   _count: { assets: number };
+  category: { id: string; name: string } | null;
+  location: { id: string; name: string } | null;
   custody: { custodian: { id: string; name: string } } | null;
 };
 
@@ -190,6 +192,7 @@ export type KitDetailAsset = {
   id: string;
   title: string;
   status: string;
+  valuation: number | null;
   mainImage: string | null;
   thumbnailImage: string | null;
   category: { id: string; name: string } | null;
@@ -204,6 +207,13 @@ export type KitDetail = {
   image: string | null;
   imageExpiration: string | null;
   createdAt: string;
+  updatedAt: string;
+  category: { id: string; name: string; color: string } | null;
+  location: { id: string; name: string } | null;
+  qrCodes: { id: string }[];
+  organization: { currency: string };
+  /** Sum of the contained assets' valuation (computed server-side). */
+  totalValue: number;
   custody: {
     createdAt: string;
     custodian: {
@@ -380,6 +390,18 @@ export type BookingActionResponse = {
 export type PartialCheckinResponse = {
   success: boolean;
   checkedInCount: number;
+  remainingCount: number;
+  isComplete: boolean;
+  booking: {
+    id: string;
+    name: string;
+    status: BookingStatus;
+  };
+};
+
+export type PartialCheckoutResponse = {
+  success: boolean;
+  checkedOutCount: number;
   remainingCount: number;
   isComplete: boolean;
   booking: {

--- a/apps/companion/lib/constants.ts
+++ b/apps/companion/lib/constants.ts
@@ -118,3 +118,96 @@ export function formatDateTime(dateStr: string) {
     minute: "2-digit",
   });
 }
+
+/**
+ * Compact magnitude for a millisecond span — "30m", "6h", "2d", "3w".
+ * Used by the booking countdown so a field tech reads "Due in 3h" at a glance.
+ *
+ * @param ms - A duration in milliseconds (negative values are clamped to 0).
+ * @returns The largest sensible unit as a short string.
+ */
+export function formatDurationShort(ms: number): string {
+  const mins = Math.max(0, Math.round(ms / 60000));
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  if (days < 14) return `${days}d`;
+  return `${Math.round(days / 7)}w`;
+}
+
+/**
+ * At-a-glance timing for a booking, derived purely from its dates + status.
+ * Returns null for states where a countdown is meaningless (DRAFT being built,
+ * or terminal complete/archived/cancelled). RESERVED bookings already past
+ * their window read "Was due …" (muted) rather than "Overdue", since they were
+ * never checked out — only ONGOING/OVERDUE bookings are truly overdue.
+ *
+ * @param from - Booking start ISO date string.
+ * @param to - Booking end ISO date string.
+ * @param status - Booking status.
+ * @param now - Current epoch ms (injectable for tests; defaults to Date.now()).
+ * @returns `{ text, urgent }` or null.
+ */
+export function bookingCountdown(
+  from: string,
+  to: string,
+  status: string,
+  now: number = Date.now()
+): { text: string; urgent: boolean } | null {
+  if (["DRAFT", "COMPLETE", "ARCHIVED", "CANCELLED"].includes(status)) {
+    return null;
+  }
+  const fromMs = new Date(from).getTime();
+  const toMs = new Date(to).getTime();
+  if (Number.isNaN(fromMs) || Number.isNaN(toMs)) return null;
+
+  if (status === "OVERDUE" || (status === "ONGOING" && now > toMs)) {
+    return {
+      text: `Overdue by ${formatDurationShort(now - toMs)}`,
+      urgent: true,
+    };
+  }
+  if (status === "ONGOING") {
+    return {
+      text: `Due in ${formatDurationShort(toMs - now)}`,
+      urgent: toMs - now < 24 * 60 * 60 * 1000,
+    };
+  }
+  // RESERVED
+  if (now < fromMs) {
+    return {
+      text: `Starts in ${formatDurationShort(fromMs - now)}`,
+      urgent: false,
+    };
+  }
+  if (now > toMs) {
+    return {
+      text: `Was due ${formatDurationShort(now - toMs)} ago`,
+      urgent: false,
+    };
+  }
+  return {
+    text: `Due in ${formatDurationShort(toMs - now)}`,
+    urgent: toMs - now < 24 * 60 * 60 * 1000,
+  };
+}
+
+/**
+ * Formats a numeric amount as currency, falling back to "<CODE> <amount>" when
+ * the runtime can't resolve the currency (e.g. an unknown ISO code).
+ *
+ * @param value - The amount to format.
+ * @param currency - ISO 4217 currency code (e.g. "USD").
+ * @returns The localized currency string.
+ */
+export function formatCurrency(value: number, currency: string) {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+    }).format(value);
+  } catch {
+    return `${currency} ${value.toFixed(2)}`;
+  }
+}

--- a/apps/companion/lib/deep-links.ts
+++ b/apps/companion/lib/deep-links.ts
@@ -8,6 +8,7 @@ import { pushIntoTab } from "./navigation";
  * Supported deep link patterns:
  *
  *   shelf://assets/{id}         → Asset detail
+ *   shelf://kits/{id}           → Kit detail
  *   shelf://bookings/{id}       → Booking detail
  *   shelf://qr/{qrId}           → QR code resolve → asset detail
  *   shelf://scanner             → Open scanner
@@ -19,6 +20,7 @@ import { pushIntoTab } from "./navigation";
 
 type ParsedLink =
   | { type: "asset"; id: string }
+  | { type: "kit"; id: string }
   | { type: "booking"; id: string }
   | { type: "qr"; id: string }
   | { type: "scanner" }
@@ -37,6 +39,8 @@ function parseDeepLink(url: string): ParsedLink {
     switch (resource) {
       case "assets":
         return id ? { type: "asset", id } : { type: "unknown" };
+      case "kits":
+        return id ? { type: "kit", id } : { type: "unknown" };
       case "bookings":
         return id ? { type: "booking", id } : { type: "unknown" };
       case "qr":
@@ -90,6 +94,9 @@ export function useDeepLinkHandler() {
       switch (link.type) {
         case "asset":
           pushIntoTab("/(tabs)/assets", `/(tabs)/assets/${link.id}`);
+          break;
+        case "kit":
+          pushIntoTab("/(tabs)/assets", `/(tabs)/assets/kits/${link.id}`);
           break;
         case "booking":
           pushIntoTab("/(tabs)/bookings", `/(tabs)/bookings/${link.id}`);

--- a/apps/companion/lib/deep-links.ts
+++ b/apps/companion/lib/deep-links.ts
@@ -10,7 +10,7 @@ import { pushIntoTab } from "./navigation";
  *   shelf://assets/{id}         → Asset detail
  *   shelf://kits/{id}           → Kit detail
  *   shelf://bookings/{id}       → Booking detail
- *   shelf://qr/{qrId}           → QR code resolve → asset detail
+ *   shelf://qr/{qrId}           → QR code resolve → asset or kit detail
  *   shelf://scanner             → Open scanner
  *
  * Also handles HTTPS universal links:
@@ -30,7 +30,15 @@ function parseDeepLink(url: string): ParsedLink {
   try {
     const parsed = Linking.parse(url);
     const path = parsed.path ?? "";
-    const segments = path.split("/").filter(Boolean);
+    // Custom app scheme (shelf://kits/abc) vs https universal link
+    // (https://app.shelf.nu/kits/abc): for the custom scheme expo-linking puts
+    // the first segment in `hostname` ("kits") and the rest in `path` ("abc"),
+    // whereas for https the hostname is the domain and the resource lives in the
+    // path. Normalise both to one segment list so native scheme links resolve.
+    const isHttp = parsed.scheme === "http" || parsed.scheme === "https";
+    const segments = (
+      isHttp ? path.split("/") : [parsed.hostname ?? "", ...path.split("/")]
+    ).filter(Boolean);
 
     if (segments.length === 0) return { type: "unknown" };
 
@@ -57,8 +65,8 @@ function parseDeepLink(url: string): ParsedLink {
 }
 
 /**
- * Resolves a QR code ID to an asset and navigates to it.
- * Falls back to scanner tab if the QR doesn't map to an asset.
+ * Resolves a QR code ID to its linked asset or kit and navigates to it.
+ * Falls back to the scanner tab if the QR maps to neither.
  */
 async function resolveQrAndNavigate(
   qrId: string,
@@ -70,10 +78,17 @@ async function resolveQrAndNavigate(
       pushIntoTab("/(tabs)/assets", `/(tabs)/assets/${data.qr.asset.id}`);
       return;
     }
+    // Kit-linked QR: open the kit detail (it lives in the Assets stack). Without
+    // this, scanning a kit's own QR falls through to the scanner instead of the
+    // kit it points at.
+    if (!error && data?.qr?.kitId) {
+      pushIntoTab("/(tabs)/assets", `/(tabs)/assets/kits/${data.qr.kitId}`);
+      return;
+    }
   } catch {
     // Fall through to scanner
   }
-  // If QR doesn't resolve to an asset, open the scanner
+  // If the QR resolves to neither an asset nor a kit, open the scanner
   router.push("/(tabs)/scanner");
 }
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.ts
@@ -25,6 +25,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const url = new URL(request.url);
     const statusParam = url.searchParams.get("status");
+    const search = (url.searchParams.get("search") || "").trim().slice(0, 100);
     const page = Math.max(
       1,
       parseInt(url.searchParams.get("page") || "1", 10) || 1
@@ -33,6 +34,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
       50,
       Math.max(1, parseInt(url.searchParams.get("perPage") || "20", 10) || 20)
     );
+
+    // Sort: allowlisted column + direction (mirrors the web list's sortable
+    // columns). Defaults to the original `from asc` so existing callers are
+    // unaffected. The allowlist prevents arbitrary Prisma orderBy injection.
+    const SORTABLE = ["from", "to", "name", "createdAt"] as const;
+    const sortByParam = url.searchParams.get("sortBy") || "";
+    const sortBy = (SORTABLE as readonly string[]).includes(sortByParam)
+      ? (sortByParam as (typeof SORTABLE)[number])
+      : "from";
+    const sortOrder =
+      url.searchParams.get("sortOrder") === "desc" ? "desc" : "asc";
 
     // Build status filter
     const validStatuses = Object.values(BookingStatus);
@@ -71,6 +83,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
       organizationId,
       status: { in: statusFilter },
       ...(isSelfServiceOrBase && { custodianUserId: user.id }),
+      // Keyword search over booking name + description (the field-tech "find my
+      // booking" case). Web also searches tags/custodian/asset names; name +
+      // description covers the common case without a heavier query.
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: "insensitive" as const } },
+              {
+                description: {
+                  contains: search,
+                  mode: "insensitive" as const,
+                },
+              },
+            ],
+          }
+        : {}),
     };
 
     const [bookings, totalCount] = await Promise.all([
@@ -97,7 +125,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             select: { assets: true },
           },
         },
-        orderBy: [{ from: "asc" }],
+        orderBy: [{ [sortBy]: sortOrder }],
         skip: (page - 1) * perPage,
         take: perPage,
       }),

--- a/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
@@ -1,11 +1,11 @@
 /**
  * Mobile API route — kit detail.
  *
- * Serves full kit detail to the companion app's kit screen (status, custody,
- * description, image, and the contained assets). Org-scoped and gated by the
- * mobile bearer auth + `kit:read` permission, mirroring the web kit-detail
- * loader. Failures are caught and returned as `{ error }` responses, not
- * thrown.
+ * Serves full kit detail to the companion app's kit screen: status, custody,
+ * description, image, category, location, QR code, summed total value, and the
+ * contained assets. Org-scoped and gated by the mobile bearer auth +
+ * `kit:read` permission, mirroring the web kit-detail loader. Failures are
+ * caught and returned as `{ error }` responses, not thrown.
  *
  * @see {@link file://./assets.$assetId.ts} the asset twin of this route
  */
@@ -65,6 +65,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         image: true,
         imageExpiration: true,
         createdAt: true,
+        updatedAt: true,
+        category: { select: { id: true, name: true, color: true } },
+        location: { select: { id: true, name: true } },
+        qrCodes: { select: { id: true } },
+        organization: { select: { currency: true } },
         custody: {
           select: {
             createdAt: true,
@@ -84,6 +89,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             id: true,
             title: true,
             status: true,
+            valuation: true,
             mainImage: true,
             thumbnailImage: true,
             category: { select: { id: true, name: true } },
@@ -101,7 +107,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       );
     }
 
-    return data({ kit });
+    // Total value = sum of the contained assets' valuation (a kit has no own
+    // value field), mirroring the web kit overview's summed valuation.
+    const totalValue = kit.assets.reduce(
+      (sum, asset) => sum + (asset.valuation ?? 0),
+      0
+    );
+
+    return data({ kit: { ...kit, totalValue } });
   } catch (cause) {
     const reason = makeShelfError(cause);
     return data(

--- a/apps/webapp/app/routes/api+/mobile+/kits.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.ts
@@ -12,11 +12,11 @@ import {
 } from "~/utils/permissions/permission.data";
 
 /**
- * GET /api/mobile/kits?orgId=xxx&search=xxx&page=1&perPage=20&status=IN_CUSTODY
+ * GET /api/mobile/kits?orgId=xxx&search=xxx&page=1&perPage=20&status=X&myCustody=true
  *
- * Returns paginated kits for the given organization. Mirrors the mobile
- * assets list route so the companion app's Kits screen can reuse the same
- * list patterns (search, infinite scroll, status filter).
+ * Returns paginated kits for the given organization, each with its category,
+ * location, asset count, and custodian. Mirrors the mobile assets list route
+ * (search, infinite scroll, status filter, and the my-custody filter).
  *
  * @see {@link file://./assets.ts} the asset twin of this route
  */
@@ -48,6 +48,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const skip = (page - 1) * perPage;
 
     const statusFilter = url.searchParams.get("status");
+    const myCustody = url.searchParams.get("myCustody") === "true";
 
     const where: Record<string, unknown> = {
       organizationId,
@@ -55,6 +56,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
         ? { name: { contains: search, mode: "insensitive" as const } }
         : {}),
       ...(statusFilter ? { status: statusFilter } : {}),
+      // Scope to the current user's custody — mirrors the asset list filter.
+      ...(myCustody ? { custody: { custodian: { userId: user.id } } } : {}),
     };
 
     const [kits, totalCount] = await Promise.all([
@@ -67,6 +70,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
           image: true,
           imageExpiration: true,
           _count: { select: { assets: true } },
+          category: { select: { id: true, name: true } },
+          location: { select: { id: true, name: true } },
           custody: {
             select: {
               custodian: { select: { id: true, name: true } },


### PR DESCRIPTION
> **Stacked on #2624** (`feat/companion-scan-to-booking`) — review/merge that first; GitHub will retarget this PR to `main` once it lands.

Brings the companion **kit** screens up to parity with the asset screens, and adds the **booking** improvements that work with the existing mobile API (no new routes required).

## Kits
- Kit detail now mirrors asset detail: hero image + zoom, QR card, full Details rows (category, location, value, custody), and inline **Assign / Release custody** + **Move location** actions via the existing kits bulk-actions endpoint.
- Kit index: **My custody** filter + category/location on each row.
- `shelf://kits/:id` deep link opens the kit detail.
- Widened the kits list and `kits.$kitId` mobile loaders to return the extra fields.

## Bookings
- **List:** individual Reserved / Ongoing / Overdue status filters (scrollable pill row), keyword search, and a sort menu (start/due date, name, recently created).
- **Per-row countdown:** "Due in 5h" / "Overdue by 3d" / "Starts in 2d".
- **Detail:** progressive (partial) **check-out** of a selected subset of assets, and a lifecycle **progress bar** (reserved / out / returned).
- Added `search` + allowlisted `sortBy`/`sortOrder` params to the bookings mobile loader.

## Shared
- Extracted `InfoRow` into a shared component used by both asset and kit detail; the value is right-aligned (flush to the chevron on tappable rows), fixing a misaligned "Kit" row on the asset detail.

## Out of scope
Booking create / edit / reserve aren't included here — they need new mobile API routes, tracked separately.

## Verification
- iOS Simulator (iPhone 17 Pro Max): kit custody/location actions, booking per-status filter, search, sort, partial check-out (RESERVED→ONGOING, asset → checked out), and the progress bar all exercised end-to-end.
- `typecheck` + `eslint` clean for both `@shelf/companion` and `@shelf/webapp`.
- Pre-commit security review passed: the mobile loaders keep `requireOrganizationAccess` + org-scoped queries, and `sortBy` is allowlisted (no arbitrary `orderBy`).
