### PR TITLE
chore(companion): 1.0.3 release config — version bump + Android auto-submit

### DIFF
--- a/apps/companion/.gitignore
+++ b/apps/companion/.gitignore
@@ -32,3 +32,5 @@ web-build/
 
 expo-env.d.ts
 # @end expo-cli
+# Android Play service account key (secret — never commit)
+google-service-account*.json

--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shelf",
     "slug": "shelf-companion",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "shelf",

--- a/apps/companion/eas.json
+++ b/apps/companion/eas.json
@@ -30,6 +30,11 @@
         "appleId": "cv@shelf.nu",
         "ascAppId": "6765639874",
         "appleTeamId": "27Q4MHFB8K"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./google-service-account.json",
+        "track": "production",
+        "releaseStatus": "draft"
       }
     }
   }

--- a/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
+++ b/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
@@ -360,7 +360,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -392,7 +392,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/companion/ios/Shelf/Info.plist
+++ b/apps/companion/ios/Shelf/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
## What

Release config for the companion app **1.0.3** (kit support + booking improvements).

- **Version 1.0.2 → 1.0.3** across every iOS spot the bare build reads: `app.json`, `ios/Shelf/Info.plist` (`CFBundleShortVersionString`), and the Xcode project's `MARKETING_VERSION` (×2). Build numbers stay EAS-managed via `appVersionSource: "remote"`.
- **Android auto-submit** — add `submit.production.android` to `eas.json` (service-account key path, `production` track, `draft` release status) so `eas submit --platform android` is a one-command release, matching the existing iOS submit config.
- **Gitignore** the Play service-account key (`google-service-account*.json`). It is a secret and must never be committed — provision it locally or via EAS credentials.

## Why

Keeps `main` aligned with the 1.0.3 release config so a fresh clone has both the Android submit setup and the correct marketing-version baseline.

## Notes

- Config only — no app/runtime code changes.
- The iOS marketing version lives in 3 files for the bare build; all three are bumped here. A future cleanup could collapse them to a single source of truth (managed prebuild, or `$(MARKETING_VERSION)` in `Info.plist`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped app version to 1.0.3 across iOS and Android
  * Configured Android production deployment settings

* **Security**
  * Added protection for sensitive credential files in version control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->