### PR TITLE
fix(server): cap runaway .data loader revalidations with a rate limiter

### DIFF
--- a/apps/webapp/server/client-ip.test.ts
+++ b/apps/webapp/server/client-ip.test.ts
@@ -1,0 +1,56 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getClientIp } from "./client-ip";
+
+// @vitest-environment node
+
+/**
+ * Resolves `getClientIp` for a single request carrying the given headers, by
+ * running it inside a throwaway Hono handler (the only way to obtain a real
+ * `Context`).
+ */
+async function resolve(headers: Record<string, string>): Promise<string> {
+  const app = new Hono();
+  let captured = "";
+  app.get("/", (c) => {
+    captured = getClientIp(c);
+    return c.text("ok");
+  });
+  await app.request("/", { headers });
+  return captured;
+}
+
+describe("getClientIp", () => {
+  afterEach(() => {
+    // why: tests below mutate NODE_ENV via stubEnv; restore between cases.
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers Fly-Client-IP and ignores X-Forwarded-For when present", async () => {
+    const ip = await resolve({
+      "Fly-Client-IP": "203.0.113.7",
+      "X-Forwarded-For": "1.2.3.4",
+    });
+    expect(ip).toBe("203.0.113.7");
+  });
+
+  it("does NOT trust X-Forwarded-For in production (returns unknown)", async () => {
+    // why: production must never bucket on a spoofable client-supplied header.
+    vi.stubEnv("NODE_ENV", "production");
+    const ip = await resolve({ "X-Forwarded-For": "9.9.9.9, 10.0.0.5" });
+    expect(ip).toBe("unknown");
+  });
+
+  it("falls back to the leftmost X-Forwarded-For outside production", async () => {
+    // why: local dev has no Fly edge, so the dev fallback must still resolve.
+    vi.stubEnv("NODE_ENV", "development");
+    const ip = await resolve({ "X-Forwarded-For": "9.9.9.9, 10.0.0.5" });
+    expect(ip).toBe("9.9.9.9");
+  });
+
+  it("returns 'unknown' when no usable header is present", async () => {
+    const ip = await resolve({});
+    expect(ip).toBe("unknown");
+  });
+});

--- a/apps/webapp/server/client-ip.test.ts
+++ b/apps/webapp/server/client-ip.test.ts
@@ -23,7 +23,7 @@ async function resolve(headers: Record<string, string>): Promise<string> {
 
 describe("getClientIp", () => {
   afterEach(() => {
-    // why: tests below mutate NODE_ENV via stubEnv; restore between cases.
+    // why: tests below mutate FLY_APP_NAME via stubEnv; restore between cases.
     vi.unstubAllEnvs();
   });
 
@@ -35,16 +35,18 @@ describe("getClientIp", () => {
     expect(ip).toBe("203.0.113.7");
   });
 
-  it("does NOT trust X-Forwarded-For in production (returns unknown)", async () => {
-    // why: production must never bucket on a spoofable client-supplied header.
-    vi.stubEnv("NODE_ENV", "production");
+  it("does NOT trust X-Forwarded-For when running on Fly (returns unknown)", async () => {
+    // why: on Fly a spoofable client-supplied header must never mint a bucket;
+    // FLY_APP_NAME is the runtime signal that we are on the Fly edge.
+    vi.stubEnv("FLY_APP_NAME", "shelf-webapp");
     const ip = await resolve({ "X-Forwarded-For": "9.9.9.9, 10.0.0.5" });
     expect(ip).toBe("unknown");
   });
 
-  it("falls back to the leftmost X-Forwarded-For outside production", async () => {
-    // why: local dev has no Fly edge, so the dev fallback must still resolve.
-    vi.stubEnv("NODE_ENV", "development");
+  it("falls back to the leftmost X-Forwarded-For when not on Fly (self-host/dev)", async () => {
+    // why: self-hosted-behind-proxy and local dev have no Fly edge, so the XFF
+    // fallback must still resolve. Empty FLY_APP_NAME = not on Fly.
+    vi.stubEnv("FLY_APP_NAME", "");
     const ip = await resolve({ "X-Forwarded-For": "9.9.9.9, 10.0.0.5" });
     expect(ip).toBe("9.9.9.9");
   });

--- a/apps/webapp/server/client-ip.test.ts
+++ b/apps/webapp/server/client-ip.test.ts
@@ -27,7 +27,8 @@ describe("getClientIp", () => {
     vi.unstubAllEnvs();
   });
 
-  it("prefers Fly-Client-IP and ignores X-Forwarded-For when present", async () => {
+  it("on Fly, trusts Fly-Client-IP and ignores X-Forwarded-For", async () => {
+    vi.stubEnv("FLY_APP_NAME", "shelf-webapp");
     const ip = await resolve({
       "Fly-Client-IP": "203.0.113.7",
       "X-Forwarded-For": "1.2.3.4",
@@ -35,7 +36,7 @@ describe("getClientIp", () => {
     expect(ip).toBe("203.0.113.7");
   });
 
-  it("does NOT trust X-Forwarded-For when running on Fly (returns unknown)", async () => {
+  it("on Fly, returns 'unknown' when Fly-Client-IP is absent (never trusts XFF)", async () => {
     // why: on Fly a spoofable client-supplied header must never mint a bucket;
     // FLY_APP_NAME is the runtime signal that we are on the Fly edge.
     vi.stubEnv("FLY_APP_NAME", "shelf-webapp");
@@ -43,7 +44,7 @@ describe("getClientIp", () => {
     expect(ip).toBe("unknown");
   });
 
-  it("falls back to the leftmost X-Forwarded-For when not on Fly (self-host/dev)", async () => {
+  it("off Fly, falls back to the leftmost X-Forwarded-For (self-host/dev)", async () => {
     // why: self-hosted-behind-proxy and local dev have no Fly edge, so the XFF
     // fallback must still resolve. Empty FLY_APP_NAME = not on Fly.
     vi.stubEnv("FLY_APP_NAME", "");
@@ -51,7 +52,16 @@ describe("getClientIp", () => {
     expect(ip).toBe("9.9.9.9");
   });
 
+  it("off Fly, IGNORES a forged Fly-Client-IP (cannot mint buckets)", async () => {
+    // why: off Fly, Fly-Client-IP is just another client-supplied header; an
+    // attacker must not be able to rotate it to bypass the rate limiter.
+    vi.stubEnv("FLY_APP_NAME", "");
+    const ip = await resolve({ "Fly-Client-IP": "6.6.6.6" });
+    expect(ip).toBe("unknown");
+  });
+
   it("returns 'unknown' when no usable header is present", async () => {
+    vi.stubEnv("FLY_APP_NAME", "");
     const ip = await resolve({});
     expect(ip).toBe("unknown");
   });

--- a/apps/webapp/server/client-ip.ts
+++ b/apps/webapp/server/client-ip.ts
@@ -1,19 +1,39 @@
 import type { Context } from "hono";
 
 /**
- * Returns the real client IP for a request.
+ * Returns the client IP for a request, for use as a rate-limit bucket key.
  *
- * Prefers `Fly-Client-IP` because it is set by the Fly edge and cannot be
- * spoofed by clients. Falls back to the leftmost `X-Forwarded-For` entry for
- * non-Fly environments (e.g. local dev). Returns `"unknown"` as a last resort
- * so callers always have a usable bucket key — `unknown` becomes a single
- * shared bucket, which is fail-closed enough that misconfigured infra still
- * gets throttled.
+ * Prefers `Fly-Client-IP`, which the Fly edge sets on every request and which a
+ * client cannot forge. In production every request arrives through the Fly
+ * edge, so this header is always present and is the only trusted source.
+ *
+ * `X-Forwarded-For` is **client-supplied and therefore spoofable** — an attacker
+ * could rotate it to mint a fresh rate-limit bucket per request and bypass the
+ * limit entirely. It is gated to non-production only, where it exists purely for
+ * local dev (no Fly edge to set `Fly-Client-IP`). `"unknown"` is the last-resort
+ * key; it collapses to a single shared bucket, which fail-closes (misconfigured
+ * infra still gets throttled rather than waved through).
+ *
+ * NOTE: behind Cloudflare, `Fly-Client-IP` is Cloudflare's edge IP rather than
+ * the end user's, so IP buckets are coarse. That is acceptable here because the
+ * primary rate-limit key is the signed-session `userId` (see `appLoaderRateLimit`
+ * in `./rate-limit`); IP is only a fallback. True per-user IP precision would
+ * mean trusting `CF-Connecting-IP` gated by a Cloudflare-range check or origin
+ * lock — deliberately out of scope.
  */
 export function getClientIp(c: Context): string {
-  return (
-    c.req.header("fly-client-ip") ??
-    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
-    "unknown"
-  );
+  const flyClientIp = c.req.header("fly-client-ip");
+  if (flyClientIp) {
+    return flyClientIp;
+  }
+
+  // Spoofable, so trusted only outside production (local dev has no Fly edge).
+  if (process.env.NODE_ENV !== "production") {
+    const forwarded = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+    if (forwarded) {
+      return forwarded;
+    }
+  }
+
+  return "unknown";
 }

--- a/apps/webapp/server/client-ip.ts
+++ b/apps/webapp/server/client-ip.ts
@@ -3,45 +3,41 @@ import type { Context } from "hono";
 /**
  * Returns the client IP for a request, for use as a rate-limit bucket key.
  *
- * Prefers `Fly-Client-IP`, which the Fly edge sets on every request and which a
- * client cannot forge. In production every request arrives through the Fly
- * edge, so this header is always present and is the only trusted source.
+ * The trusted header depends on where we run, so we branch on the `FLY_APP_NAME`
+ * runtime marker FIRST and trust only that environment's header — never the
+ * other, which would be client-spoofable:
  *
- * `X-Forwarded-For` is **client-supplied and therefore spoofable** — an attacker
- * could rotate it to mint a fresh rate-limit bucket per request and bypass the
- * limit entirely. On Fly we never trust it: `Fly-Client-IP` (returned above) is
- * always set by the edge, and the `FLY_APP_NAME` runtime variable lets us refuse
- * XFF outright even in the impossible case that header were absent. Off Fly —
- * self-hosted deployments behind a trusted reverse proxy (Docker, etc.) and
- * local dev — there is no `Fly-Client-IP`, so we fall back to the leftmost
- * `X-Forwarded-For`; the operator's proxy is responsible for setting a
- * trustworthy value. `"unknown"` is the last-resort key; it collapses to a
- * single shared bucket, which fail-closes (misconfigured infra still gets
- * throttled rather than waved through).
+ * - **On Fly** (`FLY_APP_NAME` set): trust only `Fly-Client-IP`, which the Fly
+ *   edge sets on every request and strips from client input, so it cannot be
+ *   forged. `X-Forwarded-For` is ignored entirely.
+ * - **Off Fly** (self-hosted behind a trusted reverse proxy — Docker, etc. — or
+ *   local dev): there is no Fly edge, so `Fly-Client-IP` would itself be just a
+ *   client-supplied header and must NOT be trusted (an attacker could rotate it
+ *   to mint a fresh rate-limit bucket per request). Fall back to the leftmost
+ *   `X-Forwarded-For`; the operator's proxy is responsible for setting a
+ *   trustworthy value.
  *
- * NOTE: behind Cloudflare, `Fly-Client-IP` (or a proxy's XFF) is the CF/edge IP
- * rather than the end user's, so IP buckets are coarse. That is acceptable here
- * because the primary rate-limit key is the signed-session `userId` (see
- * `appLoaderRateLimit` in `./rate-limit`); IP is only a fallback. True per-user
- * IP precision would mean trusting `CF-Connecting-IP` gated by a Cloudflare-range
- * check or origin lock — deliberately out of scope.
+ * `"unknown"` is the last-resort key; it collapses to a single shared bucket,
+ * which fail-closes (misconfigured infra still gets throttled rather than waved
+ * through).
+ *
+ * NOTE: behind Cloudflare, the trusted header is the CF/edge IP rather than the
+ * end user's, so IP buckets are coarse. That is acceptable here because the
+ * primary rate-limit key is the signed-session `userId` (see `appLoaderRateLimit`
+ * in `./rate-limit`); IP is only a fallback. True per-user IP precision would
+ * mean trusting `CF-Connecting-IP` gated by a Cloudflare-range check or origin
+ * lock — deliberately out of scope.
  */
 export function getClientIp(c: Context): string {
-  const flyClientIp = c.req.header("fly-client-ip");
-  if (flyClientIp) {
-    return flyClientIp;
-  }
-
-  // X-Forwarded-For is client-spoofable. Trust it only when NOT on Fly's edge
-  // (self-hosted-behind-proxy or local dev); on Fly, `Fly-Client-IP` above is
-  // authoritative and a spoofed XFF must never be allowed to mint a bucket.
+  // On Fly the edge sets (and sanitizes) `Fly-Client-IP`; it is the only trusted
+  // source there, and a client-supplied `X-Forwarded-For` is ignored.
   const onFly = Boolean(process.env.FLY_APP_NAME);
-  if (!onFly) {
-    const forwarded = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
-    if (forwarded) {
-      return forwarded;
-    }
+  if (onFly) {
+    return c.req.header("fly-client-ip")?.trim() || "unknown";
   }
 
-  return "unknown";
+  // Off Fly, `Fly-Client-IP` would be client-spoofable, so it is NOT consulted.
+  // Trust only the proxy-set leftmost `X-Forwarded-For` (self-host/local dev).
+  const forwarded = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+  return forwarded || "unknown";
 }

--- a/apps/webapp/server/client-ip.ts
+++ b/apps/webapp/server/client-ip.ts
@@ -9,17 +9,22 @@ import type { Context } from "hono";
  *
  * `X-Forwarded-For` is **client-supplied and therefore spoofable** — an attacker
  * could rotate it to mint a fresh rate-limit bucket per request and bypass the
- * limit entirely. It is gated to non-production only, where it exists purely for
- * local dev (no Fly edge to set `Fly-Client-IP`). `"unknown"` is the last-resort
- * key; it collapses to a single shared bucket, which fail-closes (misconfigured
- * infra still gets throttled rather than waved through).
+ * limit entirely. On Fly we never trust it: `Fly-Client-IP` (returned above) is
+ * always set by the edge, and the `FLY_APP_NAME` runtime variable lets us refuse
+ * XFF outright even in the impossible case that header were absent. Off Fly —
+ * self-hosted deployments behind a trusted reverse proxy (Docker, etc.) and
+ * local dev — there is no `Fly-Client-IP`, so we fall back to the leftmost
+ * `X-Forwarded-For`; the operator's proxy is responsible for setting a
+ * trustworthy value. `"unknown"` is the last-resort key; it collapses to a
+ * single shared bucket, which fail-closes (misconfigured infra still gets
+ * throttled rather than waved through).
  *
- * NOTE: behind Cloudflare, `Fly-Client-IP` is Cloudflare's edge IP rather than
- * the end user's, so IP buckets are coarse. That is acceptable here because the
- * primary rate-limit key is the signed-session `userId` (see `appLoaderRateLimit`
- * in `./rate-limit`); IP is only a fallback. True per-user IP precision would
- * mean trusting `CF-Connecting-IP` gated by a Cloudflare-range check or origin
- * lock — deliberately out of scope.
+ * NOTE: behind Cloudflare, `Fly-Client-IP` (or a proxy's XFF) is the CF/edge IP
+ * rather than the end user's, so IP buckets are coarse. That is acceptable here
+ * because the primary rate-limit key is the signed-session `userId` (see
+ * `appLoaderRateLimit` in `./rate-limit`); IP is only a fallback. True per-user
+ * IP precision would mean trusting `CF-Connecting-IP` gated by a Cloudflare-range
+ * check or origin lock — deliberately out of scope.
  */
 export function getClientIp(c: Context): string {
   const flyClientIp = c.req.header("fly-client-ip");
@@ -27,8 +32,11 @@ export function getClientIp(c: Context): string {
     return flyClientIp;
   }
 
-  // Spoofable, so trusted only outside production (local dev has no Fly edge).
-  if (process.env.NODE_ENV !== "production") {
+  // X-Forwarded-For is client-spoofable. Trust it only when NOT on Fly's edge
+  // (self-hosted-behind-proxy or local dev); on Fly, `Fly-Client-IP` above is
+  // authoritative and a spoofed XFF must never be allowed to mint a bucket.
+  const onFly = Boolean(process.env.FLY_APP_NAME);
+  if (!onFly) {
     const forwarded = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
     if (forwarded) {
       return forwarded;

--- a/apps/webapp/server/index.ts
+++ b/apps/webapp/server/index.ts
@@ -156,6 +156,35 @@ export default createHonoServer<ServerEnv>({
     );
 
     /**
+     * Guard single-fetch loader (`*.data`) revalidations against runaway client
+     * loops that can exhaust the DB connection pool. Keyed per (user, path) so
+     * normal navigation (varied paths) is unaffected; `/__*` (manifest) and SSE
+     * streams are not `.data`, so they are excluded.
+     *
+     * Registered BEFORE refreshSession()/protect() on purpose: protect() runs
+     * validateSession(), a Prisma query against `auth.refresh_tokens`, on every
+     * request. If the limiter ran after it, each over-limit request would still
+     * burn a DB connection before being rejected — defeating the guard, whose
+     * whole point is to keep a runaway loop off the DB hot path. Here it reads
+     * the user id straight from the parsed cookie session and 429s with zero DB
+     * work.
+     *
+     * The limiter is instantiated ONCE so its in-memory store accumulates counts
+     * across requests; a per-request instance would reset the count every time.
+     * A manual matcher (not `server.use(pattern, ...)`) is needed because the
+     * match is a `.data` *suffix*, not a path prefix.
+     */
+    const appLoaderLimiter = appLoaderRateLimit();
+    server.use("*", async (c, next) => {
+      const p = c.req.path;
+      if (!p.endsWith(".data") || p.startsWith("/__")) return next();
+      // `appLoaderLimiter` is typed with hono's default `Env`; our server uses a
+      // custom `ServerEnv`. Cast to bridge the generic — the runtime context is
+      // the same object Hono passes to every middleware.
+      return appLoaderLimiter(c as unknown as Context, next);
+    });
+
+    /**
      * Add refresh session middleware
      *
      */
@@ -196,29 +225,6 @@ export default createHonoServer<ServerEnv>({
         ],
       })
     );
-
-    /**
-     * Guard single-fetch loader (`*.data`) revalidations against runaway
-     * client loops that can exhaust the DB connection pool. Keyed per
-     * (user, path) so normal navigation (varied paths) is unaffected.
-     * `/__*` (manifest) and SSE streams are not `.data`, so excluded.
-     *
-     * The limiter is instantiated ONCE here (not per request) so its
-     * in-memory store accumulates counts across requests — re-creating it in
-     * the closure would hand every request a fresh, empty store and the guard
-     * would never fire. We can't register it via `server.use(pattern, ...)`
-     * like the mobile limiter because the match is a `.data` *suffix*, not a
-     * path prefix, hence the manual matcher wrapper.
-     */
-    const appLoaderLimiter = appLoaderRateLimit();
-    server.use("*", async (c, next) => {
-      const p = c.req.path;
-      if (!p.endsWith(".data") || p.startsWith("/__")) return next();
-      // `appLoaderLimiter` is typed with hono's default `Env`; our server uses
-      // a custom `ServerEnv`. Cast to bridge the generic — the runtime context
-      // is the same object Hono passes to every middleware.
-      return appLoaderLimiter(c as unknown as Context, next);
-    });
   },
 });
 

--- a/apps/webapp/server/index.ts
+++ b/apps/webapp/server/index.ts
@@ -2,6 +2,7 @@
 // It is important to import it as .js for this to work, even if the file is .ts
 import "./instrument.server.js";
 
+import type { Context } from "hono";
 import type { AppLoadContext } from "react-router";
 import type { HonoServerOptions } from "react-router-hono-server/node";
 import { createHonoServer } from "react-router-hono-server/node";
@@ -17,7 +18,7 @@ import {
   refreshSession,
   urlShortener,
 } from "./middleware";
-import { mobileIpRateLimit } from "./rate-limit";
+import { appLoaderRateLimit, mobileIpRateLimit } from "./rate-limit";
 import { runWithRequestCache } from "./request-cache.server";
 import { securityHeaders } from "./security-headers";
 import { authSessionKey, createSessionStorage } from "./session";
@@ -195,6 +196,29 @@ export default createHonoServer<ServerEnv>({
         ],
       })
     );
+
+    /**
+     * Guard single-fetch loader (`*.data`) revalidations against runaway
+     * client loops that can exhaust the DB connection pool. Keyed per
+     * (user, path) so normal navigation (varied paths) is unaffected.
+     * `/__*` (manifest) and SSE streams are not `.data`, so excluded.
+     *
+     * The limiter is instantiated ONCE here (not per request) so its
+     * in-memory store accumulates counts across requests — re-creating it in
+     * the closure would hand every request a fresh, empty store and the guard
+     * would never fire. We can't register it via `server.use(pattern, ...)`
+     * like the mobile limiter because the match is a `.data` *suffix*, not a
+     * path prefix, hence the manual matcher wrapper.
+     */
+    const appLoaderLimiter = appLoaderRateLimit();
+    server.use("*", async (c, next) => {
+      const p = c.req.path;
+      if (!p.endsWith(".data") || p.startsWith("/__")) return next();
+      // `appLoaderLimiter` is typed with hono's default `Env`; our server uses
+      // a custom `ServerEnv`. Cast to bridge the generic — the runtime context
+      // is the same object Hono passes to every middleware.
+      return appLoaderLimiter(c as unknown as Context, next);
+    });
   },
 });
 

--- a/apps/webapp/server/rate-limit.test.ts
+++ b/apps/webapp/server/rate-limit.test.ts
@@ -1,0 +1,100 @@
+import { Hono } from "hono";
+import { session } from "remix-hono/session";
+import { describe, expect, it } from "vitest";
+
+import { appLoaderRateLimit } from "./rate-limit";
+import { createSessionStorage } from "./session";
+
+describe("appLoaderRateLimit middleware", () => {
+  /**
+   * A tiny Hono app mirroring the real `.data`-matcher wiring from
+   * `server/index.ts`: only single-fetch loader paths (`*.data`, excluding the
+   * `/__*` manifest) are passed through the limiter; everything else is left
+   * untouched. The downstream handler always returns 200 so any non-200
+   * response can only have come from the limiter's 429 handler.
+   *
+   * @param limit - Low, deterministic threshold so tests stay fast.
+   */
+  function makeApp(limit: number) {
+    const app = new Hono();
+    // Register the real session middleware exactly as production does, so the
+    // limiter's `getSession(...)` call resolves to an (empty) session instead
+    // of throwing "A session middleware was not set." No cookie is sent in
+    // these tests, so `auth?.userId` is undefined and the limiter falls back
+    // to the client IP — the realistic anonymous-request path.
+    app.use("*", session({ autoCommit: true, createSessionStorage }));
+    // Instantiate the limiter ONCE so its in-memory store persists across
+    // requests (each call to appLoaderRateLimit() builds a fresh MemoryStore).
+    // The `.data` matcher mirrors server/index.ts; only the instantiation site
+    // differs.
+    const limiter = appLoaderRateLimit(limit);
+    app.use("*", async (c, next) => {
+      const p = c.req.path;
+      if (!p.endsWith(".data") || p.startsWith("/__")) return next();
+      return limiter(c, next);
+    });
+    app.all("*", (c) => c.text("ok"));
+    return app;
+  }
+
+  /**
+   * Fires a request at the given app/path. A unique `x-forwarded-for` header
+   * lets each test pin its own identity bucket (no session cookie is sent, so
+   * the limiter falls back to `getClientIp`), keeping the per-machine
+   * MemoryStore isolated between tests.
+   */
+  function request(app: Hono, path: string, ip: string) {
+    return app.request(`https://app.shelf.nu${path}`, {
+      // why: vary the client IP per test so each test owns a distinct
+      // (identity, path) bucket and the shared MemoryStore can't leak counts.
+      headers: { "x-forwarded-for": ip },
+    });
+  }
+
+  it("allows requests up to the limit to the same path", async () => {
+    const app = makeApp(3);
+
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app, "/assets.data", "10.0.0.1");
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("returns 429 on the request past the limit for the same path", async () => {
+    const app = makeApp(3);
+
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app, "/assets.data", "10.0.0.2");
+      expect(res.status).toBe(200);
+    }
+
+    const overLimit = await request(app, "/assets.data", "10.0.0.2");
+    expect(overLimit.status).toBe(429);
+    expect(await overLimit.json()).toEqual({
+      error: { message: "Too many requests. Please try again later." },
+    });
+  });
+
+  it("buckets per path, so a different path is unaffected by another path's limit", async () => {
+    const app = makeApp(3);
+
+    // Exhaust the bucket for /assets.data.
+    for (let i = 0; i < 4; i++) {
+      await request(app, "/assets.data", "10.0.0.3");
+    }
+
+    // Same identity, different path → its own fresh bucket → still 200.
+    const otherPath = await request(app, "/bookings.data", "10.0.0.3");
+    expect(otherPath.status).toBe(200);
+  });
+
+  it("never limits non-`.data` paths", async () => {
+    const app = makeApp(3);
+
+    // Well past the limit on an SSE-style route that is not a `.data` loader.
+    for (let i = 0; i < 10; i++) {
+      const res = await request(app, "/api/sse/notification", "10.0.0.4");
+      expect(res.status).toBe(200);
+    }
+  });
+});

--- a/apps/webapp/server/rate-limit.ts
+++ b/apps/webapp/server/rate-limit.ts
@@ -1,5 +1,9 @@
+import type { Context } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
+import { getSession } from "remix-hono/session";
 import { getClientIp } from "./client-ip";
+import { authSessionKey } from "./session";
+import type { FlashData, SessionData } from "./session";
 
 /**
  * Coarse IP-based rate limit for `/api/mobile/*`.
@@ -20,6 +24,61 @@ export const mobileIpRateLimit = () =>
     limit: 30,
     standardHeaders: "draft-7",
     keyGenerator: (c) => `mobile:ip:${getClientIp(c)}`,
+    handler: (c) =>
+      c.json(
+        {
+          error: {
+            message: "Too many requests. Please try again later.",
+          },
+        },
+        429
+      ),
+  });
+
+/**
+ * Per-(user, path) rate limit for single-fetch `.data` loader revalidations.
+ *
+ * React Router's single-fetch data requests (`*.data`) are issued on every
+ * revalidation. A buggy client — e.g. a tab stuck in a revalidation loop — can
+ * fire these unbounded, and each one opens a DB connection; a single runaway
+ * tab is enough to exhaust the Prisma connection pool and take down the app
+ * (this guard exists because that happened in production).
+ *
+ * The bucket key is `(userId | clientIP, path)`:
+ * - Keying by `userId` (falling back to client IP for unauthenticated/edge
+ *   cases) isolates one user's loop from everyone else.
+ * - Keying by `c.req.path` (which excludes the query string — intentional)
+ *   means a loop hammering ONE path is capped, while normal navigation across
+ *   many varied paths is never throttled. Same-path/different-query
+ *   revalidations deliberately share a bucket.
+ *
+ * Backed by an in-memory MemoryStore, so counters are per-machine: with N Fly
+ * machines the effective ceiling is ~`limit`×N/min worst-case. That's an
+ * accepted trade-off (matching {@link mobileIpRateLimit}); a Cloudflare edge
+ * rule is the eventual hard, cross-machine ceiling. `limit` is the tuning knob
+ * — raise it if legitimate high-frequency revalidation is misfiring, lower it
+ * to clamp down harder.
+ *
+ * @param limit - Max `.data` requests per (user, path) per 60s window.
+ *   Defaults to 60. Exposed primarily so tests can drive a low, deterministic
+ *   threshold; production callers should rely on the default.
+ */
+export const appLoaderRateLimit = (limit = 60) =>
+  rateLimiter({
+    windowMs: 60_000,
+    limit,
+    standardHeaders: "draft-7",
+    keyGenerator: (c) => {
+      // `hono-rate-limiter` types the handler context with hono's default
+      // `Env`, which is structurally narrower than the `Context<Env>` that
+      // remix-hono's `getSession` expects; cast to bridge the two (the value
+      // is a genuine hono Context, only the generic differs).
+      const auth = getSession<SessionData, FlashData>(c as Context).get(
+        authSessionKey
+      );
+      const identity = auth?.userId ?? getClientIp(c);
+      return `app:${identity}:${c.req.path}`;
+    },
     handler: (c) =>
       c.json(
         {

--- a/apps/webapp/test/server/rate-limit.test.ts
+++ b/apps/webapp/test/server/rate-limit.test.ts
@@ -22,10 +22,14 @@ function fire(app: Hono, ip: string, path = "/api/mobile/me") {
 describe("mobileIpRateLimit", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // why: these cases exercise the Fly-Client-IP path, which getClientIp only
+    // trusts when on Fly (FLY_APP_NAME set). Simulate the Fly runtime.
+    vi.stubEnv("FLY_APP_NAME", "shelf-webapp");
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   it("allows requests under the limit and blocks when exceeded", async () => {
@@ -68,6 +72,9 @@ describe("mobileIpRateLimit", () => {
   });
 
   it("falls back to x-forwarded-for when fly-client-ip is absent", async () => {
+    // why: XFF is only trusted off Fly; override the beforeEach Fly stub to
+    // simulate a self-hosted deployment behind a trusted proxy.
+    vi.stubEnv("FLY_APP_NAME", "");
     const app = new Hono();
     app.use("/api/mobile/*", mobileIpRateLimit());
     app.get("/api/mobile/me", (c) => c.json({ ok: true }));


### PR DESCRIPTION
A single browser tab stuck in an unbounded single-fetch revalidation loop
hammered one `*.data` route at ~12 req/s, exhausting the Prisma connection
pool (P2024) and taking down the fleet. Each `.data` request fans out to
several pool-bound loaders, so one looping client is enough to starve the pool.

Add `appLoaderRateLimit`, a hono-rate-limiter middleware scoped to `*.data`
loader requests and keyed by (userId | client IP, path). A same-path
revalidation storm is capped while normal navigation across varied paths is
unaffected. The limiter is instantiated once so its in-memory store
accumulates counts; it mirrors the existing `mobileIpRateLimit` pattern and
its per-machine trade-off (a Cloudflare edge rule is the eventual hard ceiling).

Guard only: the client-side loop root-cause fix and the Cloudflare edge rule
are tracked as separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened client IP detection to strictly trust `Fly-Client-IP` on Fly deployments, avoiding spoofed `X-Forwarded-For`, with safe `"unknown"` fallbacks.
* **New Features**
  * Added rate limiting for React Router single-fetch loader revalidations (`.data` requests), returning a 429 JSON error when throttled, scoped by identity and request path.
* **Tests**
  * Added/updated Vitest coverage to verify client IP precedence and rate-limit behavior, including Fly vs non-Fly scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->