### PR TITLE
fix(custom-fields): reject non-ISO date imports instead of silently corrupting valueDate

### DIFF
--- a/apps/webapp/app/utils/custom-fields.test.ts
+++ b/apps/webapp/app/utils/custom-fields.test.ts
@@ -1,0 +1,68 @@
+import type { CustomField } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import { buildCustomFieldValue } from "./custom-fields";
+
+/**
+ * Tests for DATE custom-field coercion in {@link buildCustomFieldValue}.
+ *
+ * Regression guard for the silent import-corruption bug: non-ISO date input
+ * (notably dash-separated "03-04-2026") used to be positionally split and
+ * stored as a wildly wrong date (~1908) with no error, because the resulting
+ * JS Date was technically valid. Import dates are an ISO YYYY-MM-DD contract;
+ * anything else must fail loudly rather than corrupt the queryable valueDate.
+ */
+describe("buildCustomFieldValue — DATE", () => {
+  const dateField = {
+    id: "cf_date",
+    name: "Purchase date",
+    type: "DATE",
+  } as unknown as CustomField;
+
+  it("accepts a valid ISO YYYY-MM-DD date and stores UTC-midnight valueDate", () => {
+    const result = buildCustomFieldValue({ raw: "2026-04-03" }, dateField);
+
+    expect(result).toEqual({
+      raw: "2026-04-03",
+      valueDate: "2026-04-03T00:00:00.000Z",
+    });
+  });
+
+  it("rejects dash-separated non-ISO input instead of silently storing a wrong year", () => {
+    // why: the original bug — "03-04-2026" → [3,4,2026] → Date.UTC(3,3,2026) ≈ 1908.
+    expect(() =>
+      buildCustomFieldValue({ raw: "03-04-2026" }, dateField)
+    ).toThrowError(/YYYY-MM-DD/);
+  });
+
+  it("rejects slash-separated input", () => {
+    expect(() =>
+      buildCustomFieldValue({ raw: "03/04/2026" }, dateField)
+    ).toThrowError(/YYYY-MM-DD/);
+  });
+
+  it("rejects an impossible calendar date that JS Date would otherwise roll over", () => {
+    // 2026-02-31 would normalize to 2026-03-03 without the round-trip check.
+    expect(() =>
+      buildCustomFieldValue({ raw: "2026-02-31" }, dateField)
+    ).toThrowError(/real calendar date/);
+  });
+
+  it("rejects a 13th month", () => {
+    expect(() =>
+      buildCustomFieldValue({ raw: "2026-13-01" }, dateField)
+    ).toThrowError();
+  });
+
+  it("returns undefined for an empty value (unchanged skip behavior)", () => {
+    expect(buildCustomFieldValue({ raw: "" }, dateField)).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    const result = buildCustomFieldValue({ raw: "  2026-04-03  " }, dateField);
+
+    expect(result).toEqual({
+      raw: "2026-04-03",
+      valueDate: "2026-04-03T00:00:00.000Z",
+    });
+  });
+});

--- a/apps/webapp/app/utils/custom-fields.ts
+++ b/apps/webapp/app/utils/custom-fields.ts
@@ -366,14 +366,52 @@ export const buildCustomFieldValue = (
         return { raw, valueBoolean: finalValue };
       }
       case "DATE": {
-        // Store raw date as entered by user
+        // Store raw date as entered by user.
         // But format valueDate as ISO string with UTC midnight to satisfy DB constraint
-        // while ensuring the date remains the same in all timezones
-        const dateOnly = raw as string; // YYYY-MM-DD
-        const [year, month, day] = dateOnly.split("-").map(Number);
+        // while ensuring the date remains the same in all timezones.
+        const dateOnly = (raw as string).trim(); // expected: YYYY-MM-DD
 
-        // Create date at UTC midnight to preserve the date across all timezones
+        // why: without a strict format guard, the positional split below silently
+        // mis-parses non-ISO input. e.g. "03-04-2026" → split → [3, 4, 2026] →
+        // Date.UTC(3, 3, 2026) rolls over to ~Oct 1908 — a VALID Date, so it is
+        // stored with no error while the UI keeps showing the raw string, poisoning
+        // the queryable valueDate (sort/filter/reports/reminders) invisibly.
+        // This mirrors the strict guard already used on the bulk-update import path
+        // (see compareCustomField's DATE case in ~/utils/import-update-diff).
+        const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateOnly);
+        if (!match) {
+          throw new ShelfError({
+            cause: null,
+            title: "Invalid date format",
+            message: `Custom field '${def.name}' expects dates in YYYY-MM-DD format. The value we found is: '${dateOnly}'.`,
+            label: "Custom fields",
+            shouldBeCaptured: false,
+          });
+        }
+
+        const year = Number(match[1]);
+        const month = Number(match[2]);
+        const day = Number(match[3]);
+
+        // Create date at UTC midnight to preserve the date across all timezones.
         const utcDate = new Date(Date.UTC(year, month - 1, day));
+
+        // why: new Date normalizes overflow (e.g. 2026-02-31 → 2026-03-03), so we
+        // must confirm the components round-trip — otherwise impossible calendar
+        // dates would be silently stored as a different (shifted) date.
+        if (
+          utcDate.getUTCFullYear() !== year ||
+          utcDate.getUTCMonth() !== month - 1 ||
+          utcDate.getUTCDate() !== day
+        ) {
+          throw new ShelfError({
+            cause: null,
+            title: "Invalid date",
+            message: `Custom field '${def.name}' received '${dateOnly}', which is not a real calendar date. Use the format YYYY-MM-DD.`,
+            label: "Custom fields",
+            shouldBeCaptured: false,
+          });
+        }
 
         return {
           raw: dateOnly,


### PR DESCRIPTION
## Problem

DATE custom-field **import** coerced each raw cell with a positional
`split("-")` and **no format guard**. Because the result was often a
technically-valid `Date`, non-ISO input was stored silently rather than
rejected:

| Input | Old behaviour |
| --- | --- |
| `2026-04-03` (ISO) | ✅ stored correctly |
| `03-04-2026` (dash, day-first) | ⚠️ **silently stored as ~`1908-10-16`** |
| `03/04/2026` (slash) | ❌ threw (loud) |
| `2026-02-31` (impossible) | ⚠️ silently rolled over to `2026-03-03` |

The dangerous case is the dash-separated one: `"03-04-2026".split("-")` →
`[3, 4, 2026]` → `Date.UTC(3, 3, 2026)` overflows to ~Oct 1908, a valid Date, so
it was written to the queryable `valueDate` with **no error**. The UI keeps
showing the original raw string, so the corruption is invisible while it poisons
sorting, advanced-index filters, reports, and reminders.

## Fix

Add a strict `YYYY-MM-DD` regex guard plus a calendar round-trip check on the
import/create path in `buildCustomFieldValue` — mirroring the guard already
present on the bulk-update import path (`compareCustomField`'s DATE case). Non-ISO
input and impossible calendar dates now **fail loudly** with a clear message
instead of corrupting data. The ISO contract is unchanged.

## Tests

New `custom-fields.test.ts`: ISO accepted; dash/slash rejected; calendar
overflow (`2026-02-31`, 13th month) rejected; empty value still skipped;
surrounding whitespace trimmed.

## Verification

- `pnpm webapp:test -- --run custom-fields` → 26/26 pass
- `pnpm --filter @shelf/webapp typecheck` → clean
- ESLint on changed files → clean

No schema or behaviour change for valid ISO input; this only tightens rejection
of malformed input on the import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced date validation for custom date fields to enforce strict ISO format (YYYY-MM-DD) with improved error handling for invalid dates and formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->