### PR TITLE
docs(sso): clarify pre-requisites and relax group mapping to a single group

### DIFF
--- a/apps/docs/sso/index.md
+++ b/apps/docs/sso/index.md
@@ -4,7 +4,7 @@ Shelf offers single sign-on (SSO) as a login option to provide additional accoun
 
 Shelf currently provides SAML SSO for Team and Enterprise plan customers. Please contact Sales to have this enabled for your organization.
 
-## Before you start: pre-requisites [#](#before-you-start-pre-requisites)
+## Before you start: prerequisites [#](#before-you-start-prerequisites)
 
 SSO changes how accounts on your domain are created and managed, so a few things must be in place **before** we activate the connection. Please read these carefully — most setup confusion comes from skipping them.
 

--- a/apps/docs/sso/index.md
+++ b/apps/docs/sso/index.md
@@ -4,6 +4,34 @@ Shelf offers single sign-on (SSO) as a login option to provide additional accoun
 
 Shelf currently provides SAML SSO for Team and Enterprise plan customers. Please contact Sales to have this enabled for your organization.
 
+## Before you start: pre-requisites [#](#before-you-start-pre-requisites)
+
+SSO changes how accounts on your domain are created and managed, so a few things must be in place **before** we activate the connection. Please read these carefully — most setup confusion comes from skipping them.
+
+### 1. You need one non-SSO account to own the workspace [#](#1-non-sso-owner-account)
+
+Shelf SSO requires **one non-SSO user to be the owner of the workspace**. This account's only job is to own the workspace and configure the SSO settings (the group-to-role mapping). It is not used for daily work — owners typically sign in only when doing the initial setup or adjusting the configuration later.
+
+Most customers create a dedicated account for this purpose using an address such as `it@yourdomain.com` or `shelf_admin@yourdomain.com`.
+
+> [!IMPORTANT]
+> This account **must be created before SSO is activated**. Once your domain is configured as an SSO domain, no more non-SSO accounts can be created with that domain. If you don't have this owner account ready beforehand, you will be locked out of administrative changes.
+
+### 2. Decide what happens to any existing workspace [#](#2-existing-workspace)
+
+If you already have a workspace that was used for testing or trials (for example one created with a few standard accounts), decide whether you want to **keep it together with all the assets inside it**, or start fresh. Let your Shelf contact know so the right workspace is connected to SSO.
+
+### 3. Existing standard accounts on the domain must be removed [#](#3-existing-standard-accounts)
+
+Any existing **standard (non-SSO) accounts** that use the SSO domain — for example `jane@yourdomain.com` and `joe@yourdomain.com` — must be removed so that new accounts can be created through SSO login. Once an email is linked to a standard account it cannot log in via SSO, and once the domain is an SSO domain no new standard accounts can be created on it. Share the list of these accounts with your Shelf contact, who will take care of removing them at the right point in the setup.
+
+### 4. Plan your group-to-role mapping [#](#4-plan-group-mapping)
+
+Shelf decides which role a user gets by matching the groups they belong to in your identity provider. You map those groups to Shelf roles (Administrator, Self service, Base) in the workspace settings.
+
+> [!NOTE]
+> You only need to map the **roles you actually use** — a single group mapping is enough for SSO to work. You do not need to create a group for every role. See your provider guide below for whether to use group **names** or group **IDs**.
+
 ## Setup and limitations [#](#setup-and-limitations)
 
 Shelf supports most identity providers that support the SAML 2.0 SSO protocol. We've prepared these guides for commonly used identity providers to help you get started. If you use a different provider, our support stands ready to help you out.

--- a/apps/docs/sso/providers/google-workspace.md
+++ b/apps/docs/sso/providers/google-workspace.md
@@ -65,12 +65,14 @@ In the meantime, you can continue with the next steps that will show you how to 
 
 ## Step 8: Create groups and assign users [#](#step-8-create-groups-and-assign-users)
 
-In order to manage which users get access to which workspace and with what role, Shelf uses groups for the mapping.
-For each workspace you will have to create 3 groups, each one representing a different role in Shelf:
+In order to manage which users get access to which workspace and with what role, Shelf uses groups for the mapping. Shelf has three roles you can map a group to:
 
 - Admin group
 - Self service group
 - Base user group
+
+> [!NOTE]
+> You only need to create a group for the **roles you actually use** — mapping a single group is enough for SSO to work. For example, if everyone on your team should have the same role, one group is all you need. Create additional groups only if you want different users to get different roles.
 
 ### 8.1: Create your groups in Google Workspace [#](#81-create-your-groups-in-google-workspace)
 
@@ -78,10 +80,10 @@ First step is to create the groups in the google workspace. Inside your admin pa
 
 ![step-8.1](../../img/google-workspace-step-8-1.png)
 
-Add a name, email and make sure the group is labeled as security. Optionally fill in the other fields as well. Make sure to create 2 groups for each workspace, one for Admins and one for Self service users.
+Add a name, email and make sure the group is labeled as security. Optionally fill in the other fields as well. Create one group per Shelf role you want to use (you need at least one).
 
-> [!NOTE]
-> Due to how Google Workspaces works, it returns group names instead of IDs when the user tries to login. We recommend using lower cased group names without spaces, to avoid mismatch. This is not required, but can ensure a better integration.
+> [!IMPORTANT]
+> Due to how Google Workspace works, it returns group **names** (not IDs) when a user logs in. This means that in Shelf you will map your groups using their **names**, not an ID. We recommend using lower-cased group names without spaces to avoid any mismatch. This is not required, but ensures a smoother integration.
 
 ### 8.2: Assign members to each group [#](#82-assign-members-to-each-group)
 
@@ -107,12 +109,12 @@ Make sure to add all groups that you want to access Shelf. The **_App attribute_
 
 ## Step 9: Map Google workspace groups inside Shelf [#](#step-9-map-google-workspace-groups-inside-shelf)
 
-Once you have the groups ready, you need to add their names in the workspace settings inside Shelf. If you have multiple workspaces, you will need to map each one.
+Once you have the groups ready, you need to add their **names** in the workspace settings inside Shelf. If you have multiple workspaces, you will need to map each one.
 
-Go the the workspace settings and place the name of the ADMIN, BASE & SELF SERVICE groups.
+Go to the workspace settings and place the **name** of each group next to its matching role (Administrator, Self service, Base). You only need to fill in the roles you use — leave the others blank, but at least one group must be mapped.
 
 > [!IMPORTANT]
-> Those fields are case sensitive. The name should be placed exactly as the group name is in Google workspace.
+> These fields are case sensitive. The name must be entered exactly as the group name appears in Google Workspace.
 
 ![step-9](../../img/google-workspace-step-9.png)
 

--- a/apps/docs/sso/providers/google-workspace.md
+++ b/apps/docs/sso/providers/google-workspace.md
@@ -76,7 +76,7 @@ In order to manage which users get access to which workspace and with what role,
 
 ### 8.1: Create your groups in Google Workspace [#](#81-create-your-groups-in-google-workspace)
 
-First step is to create the groups in the google workspace. Inside your admin panel, navigate to Directory > Groups > Create group
+First step is to create the groups in Google Workspace. Inside your admin panel, navigate to Directory > Groups > Create group
 
 ![step-8.1](../../img/google-workspace-step-8-1.png)
 

--- a/apps/docs/sso/providers/microsoft-entra.md
+++ b/apps/docs/sso/providers/microsoft-entra.md
@@ -165,4 +165,4 @@ Go to the workspace settings and place the **Object ID** of each group next to i
 > [!IMPORTANT]
 > These fields are case sensitive. The Object ID must be entered exactly as it appears in Microsoft Entra.
 
-![step-9](../../img/google-workspace-step-9.png)
+![Shelf workspace SSO group mapping](../../img/google-workspace-step-9.png)

--- a/apps/docs/sso/providers/microsoft-entra.md
+++ b/apps/docs/sso/providers/microsoft-entra.md
@@ -120,12 +120,14 @@ In the meantime, you can continue with the next steps that will show you how to 
 
 ## Step 10: Create groups and assign users [#](#step-10-create-groups-and-assign-users)
 
-In order to manage which users get access to which workspace and with what role, Shelf uses groups for the mapping.
-For each workspace you will have to create 3 groups, each one representing a different role in Shelf:
+In order to manage which users get access to which workspace and with what role, Shelf uses groups for the mapping. Shelf has three roles you can map a group to:
 
 - Admin group
 - Self service group
 - Base user group
+
+> [!NOTE]
+> You only need to create a group for the **roles you actually use** — mapping a single group is enough for SSO to work. Create additional groups only if you want different users to get different roles.
 
 > [!NOTE]
 > A user should not be added to more than 1 group within the application as it may cause undesired behaviour.
@@ -156,11 +158,11 @@ Once confirmed you should end up with a setup similar to this:
 >
 > Keep in mind that the OWNER of the workspace in shelf, cannot be an SSO user. The workspace needs to be created by a normal user. If you are having trouble with this, please feel free to contact your account manager to help it get resolved.
 
-Once you have the groups ready, you need to add their IDs in the workspace settings inside Shelf. If you have multiple workspaces, you will need to map each one.
+Once you have the groups ready, you need to add their **IDs** in the workspace settings inside Shelf. If you have multiple workspaces, you will need to map each one.
 
-Go the the workspace settings and place the id of the ADMIN, BASE & SELF SERVICE groups. You can find the ID by clicking on each group in Entra and copying the _Object ID_
+Go to the workspace settings and place the **Object ID** of each group next to its matching role (Administrator, Self service, Base). You can find the ID by clicking on each group in Entra and copying the _Object ID_. You only need to fill in the roles you use — leave the others blank, but at least one group must be mapped.
 
 > [!IMPORTANT]
-> Those fields are case sensitive. The name should be placed exactly as the group name is in Google workspace.
+> These fields are case sensitive. The Object ID must be entered exactly as it appears in Microsoft Entra.
 
 ![step-9](../../img/google-workspace-step-9.png)

--- a/apps/docs/sso/providers/microsoft-entra.md
+++ b/apps/docs/sso/providers/microsoft-entra.md
@@ -151,7 +151,7 @@ Once confirmed you should end up with a setup similar to this:
 
 ![Step 10.2](../../img/microsoft-entra-step-8-2.png)
 
-## Step 11: Map Microsoft Entra groups inside Shelf [#](#step-9-map-google-workspace-groups-inside-shelf)
+## Step 11: Map Microsoft Entra groups inside Shelf [#](#step-11-map-microsoft-entra-groups-inside-shelf)
 
 > [!NOTE]
 > You can only complete this step, once you have received confirmation from your contact person at Shelf that the setup has been completed.

--- a/apps/webapp/app/components/workspace/edit-form.test.ts
+++ b/apps/webapp/app/components/workspace/edit-form.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the workspace SSO settings form schema.
+ *
+ * These lock in the security-relevant invariant that an SSO-enabled workspace
+ * can never persist an empty group→role mapping: at least one of the three
+ * group identifiers must be provided. The auth-side role resolver
+ * (`getRoleFromGroupId`) treats an all-empty mapping as a hard deny, but the
+ * schema is the first line of defence — it rejects the all-blank submission
+ * server-side (the action parses with this same schema before saving).
+ *
+ * @see {@link file://./edit-form.tsx}
+ * @see {@link file://./../../routes/_layout+/account-details.workspace.$workspaceId.edit.tsx}
+ */
+import { describe, expect, it } from "vitest";
+
+import { EditWorkspaceSSOSettingsFormSchema } from "./edit-form";
+
+describe("EditWorkspaceSSOSettingsFormSchema", () => {
+  describe("when SSO is enabled", () => {
+    const schema = EditWorkspaceSSOSettingsFormSchema(true);
+
+    it("rejects a submission with no group mapped", () => {
+      const result = schema.safeParse({
+        id: "org-1",
+        adminGroupId: "",
+        selfServiceGroupId: "",
+        baseUserGroupId: "",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // The "at least one group" error is surfaced on the Administrator field
+        const issue = result.error.issues.find((i) =>
+          i.path.includes("adminGroupId")
+        );
+        expect(issue?.message).toMatch(/at least one group/i);
+      }
+    });
+
+    it("rejects a submission where every group is whitespace only", () => {
+      const result = schema.safeParse({
+        id: "org-1",
+        adminGroupId: "   ",
+        selfServiceGroupId: "\t",
+        baseUserGroupId: " ",
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a submission with only one group mapped", () => {
+      const result = schema.safeParse({
+        id: "org-1",
+        adminGroupId: "shelf-admins",
+        selfServiceGroupId: "",
+        baseUserGroupId: "",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a submission with all three groups mapped", () => {
+      const result = schema.safeParse({
+        id: "org-1",
+        adminGroupId: "shelf-admins",
+        selfServiceGroupId: "shelf-self-service",
+        baseUserGroupId: "shelf-base",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("when SSO is disabled", () => {
+    const schema = EditWorkspaceSSOSettingsFormSchema(false);
+
+    it("accepts a submission with no group mapped", () => {
+      const result = schema.safeParse({
+        id: "org-1",
+        adminGroupId: "",
+        selfServiceGroupId: "",
+        baseUserGroupId: "",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/apps/webapp/app/components/workspace/edit-form.tsx
+++ b/apps/webapp/app/components/workspace/edit-form.tsx
@@ -549,10 +549,13 @@ const WorkspaceSSOEditForm = ({ className }: Props) => {
             required, the rest can be left blank.
           </p>
           <p className="mt-2">
-            For <b>Google Workspace</b>, enter the group <b>name</b> (Google
-            returns names, not IDs). For <b>Microsoft Entra</b> and <b>Okta</b>,
-            enter the group <b>Object ID</b>. Values are case-sensitive and must
-            match your IdP exactly.
+            Enter the exact value your identity provider sends in the user's{" "}
+            <b>groups</b> claim. <b>Google Workspace</b> returns group{" "}
+            <b>names</b>. <b>Microsoft Entra</b> returns the group{" "}
+            <b>Object ID</b>. <b>Okta</b> and most other providers return the
+            group <b>name</b> (depending on how your groups attribute statement
+            is configured). Values are case-sensitive and must match your IdP
+            exactly.
           </p>
         </div>
 

--- a/apps/webapp/app/components/workspace/edit-form.tsx
+++ b/apps/webapp/app/components/workspace/edit-form.tsx
@@ -15,6 +15,8 @@ import { useDisabled } from "~/hooks/use-disabled";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { loader } from "~/routes/_layout+/account-details.workspace.$workspaceId.edit";
 import { ACCEPT_SUPPORTED_IMAGES } from "~/utils/constants";
+import { getValidationErrors } from "~/utils/http";
+import type { DataOrErrorResponse } from "~/utils/http.server";
 import { tw } from "~/utils/tw";
 import { zodFieldIsRequired } from "~/utils/zod";
 import CurrencySelector from "./currency-selector";
@@ -466,19 +468,48 @@ const WorkspacePermissionsEditForm = ({ className }: Props) => {
   ) : null;
 };
 
+/**
+ * Schema for the workspace SSO settings form.
+ *
+ * Group mappings are intentionally individually optional: a workspace only
+ * needs to map the roles it actually uses. The auth-side role resolver
+ * (`getRoleFromGroupId`) and SSO user provisioning evaluate each mapped group
+ * independently, so a single mapping is enough for SSO to work.
+ *
+ * When SSO is enabled we still require **at least one** group to be mapped —
+ * otherwise the configuration is a no-op that silently grants no access. That
+ * cross-field rule is enforced via `superRefine` and surfaced on the first
+ * (Administrator) field.
+ *
+ * @param sso - Whether SSO is enabled for the workspace. When false, all group
+ *   fields are optional and the "at least one" rule is skipped.
+ */
 export const EditWorkspaceSSOSettingsFormSchema = (sso: boolean = false) =>
-  z.object({
-    id: z.string(),
-    selfServiceGroupId: sso
-      ? z.string().min(1, "Self service group id is required")
-      : z.string().optional(),
-    baseUserGroupId: sso
-      ? z.string().min(1, "Base user group id is required")
-      : z.string().optional(),
-    adminGroupId: sso
-      ? z.string().min(1, "Administrator group id is required")
-      : z.string().optional(),
-  });
+  z
+    .object({
+      id: z.string(),
+      selfServiceGroupId: z.string().optional(),
+      baseUserGroupId: z.string().optional(),
+      adminGroupId: z.string().optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (!sso) return;
+
+      const hasAtLeastOneGroup = [
+        data.adminGroupId,
+        data.selfServiceGroupId,
+        data.baseUserGroupId,
+      ].some((value) => value != null && value.trim().length > 0);
+
+      if (!hasAtLeastOneGroup) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "Map at least one group to a role. Only the roles you use need a group.",
+          path: ["adminGroupId"],
+        });
+      }
+    });
 
 const WorkspaceSSOEditForm = ({ className }: Props) => {
   const { organization } = useLoaderData<typeof loader>();
@@ -487,6 +518,15 @@ const WorkspaceSSOEditForm = ({ className }: Props) => {
   const schema = EditWorkspaceSSOSettingsFormSchema(organization.enabledSso);
   const zo = useZorm("NewQuestionWizardScreen", schema);
   const disabled = useDisabled(fetcher);
+
+  /**
+   * Server-side validation errors, surfaced as a fallback in case client-side
+   * validation is bypassed. The SSO form submits via a fetcher, so we read the
+   * error off `fetcher.data` rather than `useActionData`.
+   */
+  const validationErrors = getValidationErrors<typeof schema>(
+    (fetcher.data as DataOrErrorResponse | undefined)?.error
+  );
 
   return isOwner && organization.enabledSso && organization.ssoDetails ? (
     <fetcher.Form ref={zo.ref} method="post" className="flex flex-col gap-2">
@@ -498,6 +538,23 @@ const WorkspaceSSOEditForm = ({ className }: Props) => {
           </p>
         </div>
         <input type="hidden" value={organization.id} name="id" />
+
+        {/* Group identifiers differ per identity provider, and the field
+            stores whatever the IdP returns in the user's `groups` attribute.
+            Spell out the convention so owners don't paste the wrong value. */}
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-[14px] text-gray-600">
+          <p>
+            Map your identity provider's groups to Shelf roles below. You only
+            need to map the roles you use — <b>at least one</b> mapping is
+            required, the rest can be left blank.
+          </p>
+          <p className="mt-2">
+            For <b>Google Workspace</b>, enter the group <b>name</b> (Google
+            returns names, not IDs). For <b>Microsoft Entra</b> and <b>Okta</b>,
+            enter the group <b>Object ID</b>. Values are case-sensitive and must
+            match your IdP exactly.
+          </p>
+        </div>
 
         <FormRow
           rowLabel={"SSO Domain"}
@@ -518,69 +575,72 @@ const WorkspaceSSOEditForm = ({ className }: Props) => {
         </FormRow>
 
         <FormRow
-          rowLabel={`Administrator role group id`}
+          rowLabel={`Administrator role group`}
           subHeading={
             <div>
-              Place the Id of the group that should be mapped to the{" "}
+              The group identifier that should be mapped to the{" "}
               <b>Administrator</b> role.
             </div>
           }
           className="border-b-0 pb-[10px]"
-          required
         >
           <Input
-            label={"Administrator role group id"}
+            label={"Administrator role group"}
             hideLabel
             className="w-full"
             name={zo.fields.adminGroupId()}
-            error={zo.errors.adminGroupId()?.message}
+            error={
+              validationErrors?.adminGroupId?.message ||
+              zo.errors.adminGroupId()?.message
+            }
             defaultValue={organization.ssoDetails.adminGroupId || undefined}
-            required
           />
         </FormRow>
 
         <FormRow
-          rowLabel={`Self service role group id`}
+          rowLabel={`Self service role group`}
           subHeading={
             <div>
-              Place the Id of the group that should be mapped to the{" "}
+              The group identifier that should be mapped to the{" "}
               <b>Self service</b> role.
             </div>
           }
           className="border-b-0 pb-[10px]"
-          required
         >
           <Input
-            label={"Self service role group id"}
+            label={"Self service role group"}
             hideLabel
             name={zo.fields.selfServiceGroupId()}
-            error={zo.errors.selfServiceGroupId()?.message}
+            error={
+              validationErrors?.selfServiceGroupId?.message ||
+              zo.errors.selfServiceGroupId()?.message
+            }
             defaultValue={
               organization.ssoDetails.selfServiceGroupId || undefined
             }
             className="w-full"
-            required
           />
         </FormRow>
         <FormRow
-          rowLabel={`Base user role group id`}
+          rowLabel={`Base user role group`}
           subHeading={
             <div>
-              Place the Id of the group that should be mapped to the <b>Base</b>{" "}
+              The group identifier that should be mapped to the <b>Base</b>{" "}
               role.
             </div>
           }
           className="border-b-0 pb-[10px]"
-          required
         >
           <Input
-            label={"Base user role group id"}
+            label={"Base user role group"}
             hideLabel
             name={zo.fields.baseUserGroupId()}
-            error={zo.errors.baseUserGroupId()?.message}
+            error={
+              validationErrors?.baseUserGroupId?.message ||
+              zo.errors.baseUserGroupId()?.message
+            }
             defaultValue={organization.ssoDetails.baseUserGroupId || undefined}
             className="w-full"
-            required
           />
         </FormRow>
         <div className="text-right">

--- a/apps/webapp/app/modules/organization/service.server.ts
+++ b/apps/webapp/app/modules/organization/service.server.ts
@@ -271,9 +271,9 @@ export async function updateOrganization({
   userId: User["id"];
   image?: File | null;
   ssoDetails?: {
-    selfServiceGroupId: string;
-    adminGroupId: string;
-    baseUserGroupId: string;
+    selfServiceGroupId: string | null;
+    adminGroupId: string | null;
+    baseUserGroupId: string | null;
   };
   hasSequentialIdsMigrated?: Organization["hasSequentialIdsMigrated"];
   qrIdDisplayPreference?: Organization["qrIdDisplayPreference"];

--- a/apps/webapp/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/account-details.workspace.$workspaceId.edit.tsx
@@ -393,13 +393,24 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         const { selfServiceGroupId, adminGroupId, baseUserGroupId } =
           parsedData;
 
+        /**
+         * Group mappings are optional per-role (only one is required overall),
+         * so normalize blank/whitespace-only inputs to `null`. Storing `null`
+         * instead of an empty string keeps the auth-side role resolver and the
+         * "is this group mapped" checks unambiguous.
+         */
+        const normalizeGroupId = (value: string | undefined) => {
+          const trimmed = value?.trim();
+          return trimmed ? trimmed : null;
+        };
+
         await updateOrganization({
           id,
           userId: authSession.userId,
           ssoDetails: {
-            selfServiceGroupId: selfServiceGroupId as string,
-            adminGroupId: adminGroupId as string,
-            baseUserGroupId: baseUserGroupId as string,
+            selfServiceGroupId: normalizeGroupId(selfServiceGroupId),
+            adminGroupId: normalizeGroupId(adminGroupId),
+            baseUserGroupId: normalizeGroupId(baseUserGroupId),
           },
         });
 


### PR DESCRIPTION
Reduce the recurring confusion around SSO setup, on both the docs and the app.

Docs:
- Add a "Before you start: pre-requisites" section to the SSO overview covering the dedicated non-SSO owner account, the fate of existing workspaces, removal of existing standard accounts on the domain, and planning the group mapping.
- Stop telling customers they must create 3 groups; mapping one group is enough.
- Reinforce that Google Workspace uses group names while Microsoft Entra uses group Object IDs, and fix the Entra guide's copy-paste reference to Google.

App:
- Relax EditWorkspaceSSOSettingsFormSchema so each group is optional, requiring at least one mapping when SSO is enabled (the auth-side resolver already supports partial mappings, so a single group works at login time).
- Relabel the fields from "group id" to "group identifier" and add a note explaining the name-vs-Object-ID convention per provider.
- Normalize blank group inputs to null in the action and widen the updateOrganization ssoDetails type to allow null per field.
- Surface server-side validation errors on the SSO form as a fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an SSO prerequisites checklist to the setup guide.
  * Updated Google Workspace instructions to use role-driven group creation and name-based mapping (with clearer lower-cased, case-sensitive naming guidance).
  * Updated Microsoft Entra instructions to map only the roles in use, using group Object IDs.
* **Bug Fixes**
  * Improved SSO settings validation: when SSO is enabled, at least one role-group mapping is required, with server-side validation errors properly surfaced.
  * Normalized unmapped SSO group fields to a consistent “not set” value when saving.
* **Tests**
  * Added validation tests for enabled vs. disabled SSO behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->