### PR TITLE
fix(booking): name partial-kit assets in partial check-out/in activity-log notes

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -347,8 +347,9 @@ describe("partialCheckoutBooking", () => {
       db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
     ).mockResolvedValue(kitBooking);
 
-    // The in-tx kit-info read returns the scanned asset WITH its kit attached
-    // (and AVAILABLE / no conflicts so validation passes).
+    // why: the in-tx kit-info read must return the scanned asset WITH its kit
+    // attached (and AVAILABLE / no conflicts) so the note-builder sees a
+    // kit-member asset whose kit isn't fully checked out.
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
       (args?: any) => {
         const ids = args?.where?.id?.in;

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -3,6 +3,7 @@ import { CheckoutIntentEnum } from "~/components/booking/checkout-dialog";
 
 import { db } from "~/database/db.server";
 import * as activityEventService from "~/modules/activity-event/service.server";
+import { createSystemBookingNote } from "~/modules/booking-note/service.server";
 import { ShelfError } from "~/utils/error";
 import {
   getRemainingCheckoutAssetIds,
@@ -323,6 +324,66 @@ describe("partialCheckoutBooking", () => {
         }),
       ],
       expect.anything()
+    );
+  });
+
+  it("names an individual kit asset in the activity-log note when only part of its kit is checked out", async () => {
+    expect.assertions(2);
+
+    // Booking holds a 2-asset kit (kit-1). Checking out only ONE of its assets
+    // means the kit is NOT a complete-kit line, so the note must still name the
+    // individual asset. Regression: this previously rendered an empty
+    // "performed a partial check-out: ." because a kit-member asset whose kit
+    // wasn't fully checked out fell through both the kit and standalone buckets.
+    const kitBooking = {
+      ...reservedBooking,
+      _count: { assets: 2 },
+      assets: [
+        { id: "asset-k1", kitId: "kit-1", status: AssetStatus.AVAILABLE },
+        { id: "asset-k2", kitId: "kit-1", status: AssetStatus.AVAILABLE },
+      ],
+    };
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue(kitBooking);
+
+    // The in-tx kit-info read returns the scanned asset WITH its kit attached
+    // (and AVAILABLE / no conflicts so validation passes).
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+      (args?: any) => {
+        const ids = args?.where?.id?.in;
+        return Promise.resolve(
+          Array.isArray(ids)
+            ? ids.map((id: string) => ({
+                id,
+                title: `Asset ${id}`,
+                status: AssetStatus.AVAILABLE,
+                bookings: [],
+                kit: { id: "kit-1", name: "Camera Kit" },
+              }))
+            : []
+        );
+      }
+    );
+
+    await partialCheckoutBooking({
+      ...baseParams,
+      assetIds: ["asset-k1"],
+    });
+
+    // The individual asset is named (linked) in the note...
+    expect(createSystemBookingNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("/assets/asset-k1"),
+      }),
+      expect.anything()
+    );
+    // ...and the note is never the empty "partial check-out: ." form.
+    const contents = (
+      createSystemBookingNote as ReturnType<typeof vitest.fn>
+    ).mock.calls.map((call) => call[0].content as string);
+    expect(contents.every((c) => !/partial check-out:\s*\./.test(c))).toBe(
+      true
     );
   });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2376,7 +2376,12 @@ export async function partialCheckinBooking({
         ) {
           completeKits.push({ id: asset.kit.id, name: asset.kit.name });
           processedKitIds.add(asset.kit.id);
-        } else if (!asset.kit) {
+        } else if (!asset.kit || !completeKitIds.includes(asset.kit.id)) {
+          // Asset belongs to a kit that is only partially being checked
+          // in/out: the kit isn't a complete-kit line, so name the individual
+          // asset (the same way standalone assets are shown) instead of
+          // dropping it. Without this, a batch made up entirely of such
+          // assets produced an empty note (e.g. "partial check-out: .").
           standaloneAssets.push({ id: asset.id, title: asset.title });
         }
       }
@@ -2917,7 +2922,12 @@ export async function partialCheckoutBooking({
         ) {
           completeKits.push({ id: asset.kit.id, name: asset.kit.name });
           processedKitIds.add(asset.kit.id);
-        } else if (!asset.kit) {
+        } else if (!asset.kit || !completeKitIds.includes(asset.kit.id)) {
+          // Asset belongs to a kit that is only partially being checked
+          // in/out: the kit isn't a complete-kit line, so name the individual
+          // asset (the same way standalone assets are shown) instead of
+          // dropping it. Without this, a batch made up entirely of such
+          // assets produced an empty note (e.g. "partial check-out: .").
           standaloneAssets.push({ id: asset.id, title: asset.title });
         }
       }


### PR DESCRIPTION
## Problem

A **partial check-out** (or check-in) that processes only **some assets of a kit** — without taking the whole kit — produced a malformed activity-log entry with no item names:

> John Doe performed a partial check-out: .

## Root cause

`partialCheckoutBooking` / `partialCheckinBooking` build the note by sorting the processed assets into two buckets:

1. **Complete kits** — every asset of the kit is in this batch → render the kit name.
2. **Standalone assets** — assets with no kit → render the asset name.

An asset that **belongs to a kit but whose kit isn't fully processed** matched neither bucket and was silently dropped. When a batch contained only such assets, `itemsDescription` was empty → `"performed a partial check-out: ."`.

This is reachable on both web and mobile: the web partial-checkout drawer explicitly allows checking out individual kit assets, and both the web action (`checkoutAssets`) and the mobile endpoint (`/api/mobile/bookings/partial-checkout`) call the same shared service.

## Fix

Name the individual asset (exactly how standalone assets already render — a title link, no new format) when its kit isn't a complete-kit line:

```diff
-        } else if (!asset.kit) {
+        } else if (!asset.kit || !completeKitIds.includes(asset.kit.id)) {
```

Applied to both `partialCheckoutBooking` and `partialCheckinBooking`. `checkinBooking`'s completion note is intentionally unchanged — it keys on kit **membership** (`kitIds`), not completeness, so it already names the kit rather than dropping the asset.

## Test

Added a regression test to `service.server.partial-checkout.test.ts`: checking out one asset of a two-asset kit asserts the note names that asset and is never the empty `"partial check-out: ."` form. Verified it **fails without the fix**.

`pnpm --filter @shelf/webapp validate` green (2443 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed booking note generation for partial kit check-outs and check-ins. When only some kit assets are processed, the system now correctly includes each individual asset’s name in the resulting booking note instead of omitting them or rendering empty entries.
* **Tests**
  * Added a regression test to verify kit-member behavior for partial check-outs, ensuring the generated note contains the expected asset link/name and no longer matches the prior empty rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->