### PR TITLE
feat(bulk-actions): clear selection after a successful bulk action

### DIFF
--- a/.claude/rules/bulk-action-clear-selection.md
+++ b/.claude/rules/bulk-action-clear-selection.md
@@ -1,0 +1,32 @@
+---
+description: Bulk actions on index/list pages must clear the multi-select on success via the shared chokepoint, not bespoke per-dialog logic.
+globs: apps/webapp/app/components/**/bulk-*.tsx, apps/webapp/app/components/bulk-update-dialog/*.tsx
+---
+
+# Clear Bulk Selection On Success
+
+After a bulk action succeeds, the multi-select (`selectedBulkItemsAtom`) must be
+**cleared** so users don't have to "unselect all" before the next batch. This is
+centralized in `BulkUpdateDialogContent` (`~/components/bulk-update-dialog/bulk-update-dialog.tsx`):
+its `handleBulkActionSuccess` clears the selection on success for **all** dialog
+types. The ~37 bulk dialogs that route through it get this for free — do **not**
+re-implement clearing in a feature dialog.
+
+Opt out only when a dialog stays open showing an **in-dialog success panel** that
+re-uses the selection (e.g. add-to-existing-booking "Add more"): pass
+`keepSelectionOnSuccess`. Pair it with `skipCloseOnSuccess` (the two are
+independent: one keeps the selection, the other keeps the dialog open).
+
+**Deliberately excluded:** read-only exports / QR downloads keep the selection
+(no mutation). The booking-detail check-in/out dialogs clear via their own
+`clearSelectedBulkItemsAtom` effect (they bypass the chokepoint). The `manage-*`
+routes own their selection lifecycle (cleared via redirect + `AtomsResetHandler`).
+
+```tsx
+// ❌ Bad — bespoke clearing in a feature dialog that already routes through the chokepoint
+useEffect(() => { if (fetcher.data?.success) setSelectedItems([]); }, [fetcher.data]);
+
+// ✅ Good — let the shared dialog clear it; opt out only for success-panel reuse
+<BulkUpdateDialogContent type="location" arrayFieldId="assetIds" />
+<BulkUpdateDialogContent type="booking-exist" skipCloseOnSuccess keepSelectionOnSuccess />
+```

--- a/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
@@ -60,6 +60,9 @@ export default function AddAssetsToExistingBookingDialog() {
       actionUrl="/api/assets/add-to-booking"
       className="lg:w-[600px]"
       skipCloseOnSuccess
+      // why: the success panel's "Add more" button re-uses the same selection to
+      // add the assets to another booking, so the selection must survive success.
+      keepSelectionOnSuccess
     >
       {({
         disabled,

--- a/apps/webapp/app/components/assets/bulk-add-to-audit-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-add-to-audit-dialog.tsx
@@ -68,6 +68,9 @@ export default function BulkAddToAuditDialog() {
       actionUrl="/api/audits/add-assets"
       arrayFieldId="assetIds"
       skipCloseOnSuccess={true}
+      // why: this dialog stays open showing a success panel; keeping the selection
+      // avoids a stale "(0)" count in the title and matches add-to-existing-booking.
+      keepSelectionOnSuccess={true}
     >
       {({ fetcherError, fetcherData, disabled, handleCloseDialog }) => {
         const isSuccess = fetcherData?.success;

--- a/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.test.tsx
+++ b/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Behaviour tests for {@link BulkUpdateDialogContent}'s post-success selection
+ * handling.
+ *
+ * `BulkUpdateDialogContent` is the chokepoint ~37 bulk-action dialogs route
+ * through. The contract under test: on a successful mutation it clears the
+ * shared bulk selection (`selectedBulkItemsAtom`) by default — so the user does
+ * not have to manually "unselect all" before the next batch — and closes the
+ * dialog (`bulkDialogAtom[type]` -> false). Two opt-outs are independent:
+ *   - `keepSelectionOnSuccess` retains the selection (for in-dialog success
+ *     panels that re-use it).
+ *   - `skipCloseOnSuccess` keeps the dialog open.
+ * On a fetcher error neither clearing nor closing happens.
+ *
+ * Tests assert on observable atom state (the real atoms, never mocked), driven
+ * by a controllable fake fetcher.
+ *
+ * @see {@link file://./bulk-update-dialog.tsx}
+ */
+
+import type { PropsWithChildren } from "react";
+import { act, render } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bulkDialogAtom } from "~/atoms/bulk-update-dialog";
+import { selectedBulkItemsAtom } from "~/atoms/list";
+import type { ListItemData } from "~/components/list/list-item";
+import type { BulkDialogType } from "./bulk-update-dialog";
+import { BulkUpdateDialogContent } from "./bulk-update-dialog";
+
+/**
+ * Hoisted, mutable fetcher state read by the (hoisted) `vi.mock` factory.
+ * `data` is what the fake fetcher exposes; mutating it + rerendering simulates a
+ * server response landing.
+ */
+const hoisted = vi.hoisted(() => ({
+  fetcherData: undefined as Record<string, unknown> | undefined,
+}));
+
+// why: drive the dialog's success/error effect deterministically without a real
+// Remix route + network. The fake fetcher exposes controllable `.data` (from
+// hoisted state) and a plain `<form>` for `.Form`, so no router context is
+// needed and `isFormProcessing("idle")` keeps `disabled` false.
+vi.mock("~/hooks/use-fetcher-with-reset", () => ({
+  default: () => ({
+    state: "idle" as const,
+    data: hoisted.fetcherData,
+    reset: vi.fn(),
+    Form: ({
+      children,
+      ...props
+    }: PropsWithChildren<Record<string, unknown>>) => (
+      <form {...props}>{children}</form>
+    ),
+  }),
+}));
+
+// why: the dialog reads `useSearchParams` from this org/cookie-aware wrapper
+// only to fold the current params into a hidden input; an empty params object
+// is all the assertions need.
+vi.mock("~/hooks/search-params", () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()] as const,
+}));
+
+beforeEach(() => {
+  hoisted.fetcherData = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/** A handful of selected rows to seed the selection atom with. */
+const SELECTION = [
+  { id: "a1" },
+  { id: "a2" },
+  { id: "a3" },
+] as unknown as ListItemData[];
+
+/**
+ * Renders the dialog for a given `type` under a dedicated jotai store, then
+ * seeds the dialog-open + selection atoms. Seeding happens AFTER the first
+ * render (inside `act`) on purpose: both atoms reset themselves via `onMount`
+ * when first subscribed, so seeding before render would be clobbered. Returns
+ * the store so tests can read the resulting atom state.
+ */
+async function renderDialog(
+  type: BulkDialogType,
+  props: {
+    keepSelectionOnSuccess?: boolean;
+    skipCloseOnSuccess?: boolean;
+  } = {}
+) {
+  const store = createStore();
+
+  const utils = render(
+    <Provider store={store}>
+      <BulkUpdateDialogContent type={type} arrayFieldId="assetIds" {...props}>
+        <button type="submit">Confirm</button>
+      </BulkUpdateDialogContent>
+    </Provider>
+  );
+
+  // Seed the dialog open for this type and a non-empty selection now that the
+  // atoms have mounted (and their reset-on-mount has already run).
+  await act(async () => {
+    store.set(bulkDialogAtom, (prev) => ({ ...prev, [type]: true }));
+    store.set(selectedBulkItemsAtom, SELECTION);
+    await Promise.resolve();
+  });
+
+  return { store, ...utils };
+}
+
+/** Flips the fake fetcher to a response and flushes the success/error effect. */
+async function resolveFetcher(
+  utils: Awaited<ReturnType<typeof renderDialog>>,
+  data: Record<string, unknown>
+) {
+  hoisted.fetcherData = data;
+  await act(async () => {
+    utils.rerender(
+      <Provider store={utils.store}>
+        <BulkUpdateDialogContent
+          type={lastType}
+          arrayFieldId="assetIds"
+          {...lastProps}
+        >
+          <button type="submit">Confirm</button>
+        </BulkUpdateDialogContent>
+      </Provider>
+    );
+    await Promise.resolve();
+  });
+}
+
+// Remember the last render config so `resolveFetcher` can rerender identically.
+let lastType: BulkDialogType;
+let lastProps: {
+  keepSelectionOnSuccess?: boolean;
+  skipCloseOnSuccess?: boolean;
+};
+
+/** Wraps `renderDialog` capturing config for the rerender helper. */
+function open(
+  type: BulkDialogType,
+  props: { keepSelectionOnSuccess?: boolean; skipCloseOnSuccess?: boolean } = {}
+) {
+  lastType = type;
+  lastProps = props;
+  return renderDialog(type, props);
+}
+
+describe("BulkUpdateDialogContent — post-success selection handling", () => {
+  it("clears the selection and closes the dialog on success (non-destructive type)", async () => {
+    const utils = await open("location");
+
+    expect(utils.store.get(selectedBulkItemsAtom)).toHaveLength(3);
+
+    await resolveFetcher(utils, { success: true });
+
+    // Selection emptied + dialog closed.
+    expect(utils.store.get(selectedBulkItemsAtom)).toEqual([]);
+    expect(utils.store.get(bulkDialogAtom).location).toBe(false);
+  });
+
+  it.each(["trash", "archive", "cancel", "delete-audit"] as const)(
+    "still clears the selection on success for destructive type %s",
+    async (type) => {
+      const utils = await open(type);
+
+      await resolveFetcher(utils, { success: true });
+
+      expect(utils.store.get(selectedBulkItemsAtom)).toEqual([]);
+      expect(utils.store.get(bulkDialogAtom)[type]).toBe(false);
+    }
+  );
+
+  it("retains the selection on success when keepSelectionOnSuccess is set", async () => {
+    const utils = await open("booking-exist", { keepSelectionOnSuccess: true });
+
+    await resolveFetcher(utils, { success: true });
+
+    // Selection is untouched (re-used by the in-dialog success panel).
+    expect(utils.store.get(selectedBulkItemsAtom)).toEqual(SELECTION);
+  });
+
+  it("clears the selection but keeps the dialog open when only skipCloseOnSuccess is set", async () => {
+    // Synthetic prop combo to isolate the orthogonality contract: the real
+    // add-to-audit call site pairs skipCloseOnSuccess with keepSelectionOnSuccess.
+    // Here we omit keepSelectionOnSuccess to prove the two opt-outs are independent.
+    const utils = await open("add-to-audit", { skipCloseOnSuccess: true });
+
+    await resolveFetcher(utils, { success: true });
+
+    // Orthogonal opt-outs: selection cleared, dialog stays open.
+    expect(utils.store.get(selectedBulkItemsAtom)).toEqual([]);
+    expect(utils.store.get(bulkDialogAtom)["add-to-audit"]).toBe(true);
+  });
+
+  it("does not clear the selection or close the dialog on a fetcher error", async () => {
+    const utils = await open("location");
+
+    await resolveFetcher(utils, { error: { message: "Boom" } });
+
+    expect(utils.store.get(selectedBulkItemsAtom)).toEqual(SELECTION);
+    expect(utils.store.get(bulkDialogAtom).location).toBe(true);
+  });
+});

--- a/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
+++ b/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useCallback, useEffect } from "react";
 import type { ElementRef, ReactNode } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
-import { useLoaderData } from "react-router";
 
 import {
   bulkDialogAtom,
@@ -18,7 +17,6 @@ import { isFormProcessing } from "~/utils/form";
 import { tw } from "~/utils/tw";
 import Icon from "../icons/icon";
 import { Dialog, DialogPortal } from "../layout/dialog";
-import type { ListItemData } from "../list/list-item";
 import { Button } from "../shared/button";
 import {
   HoverCard,
@@ -214,6 +212,15 @@ type BulkUpdateDialogContentProps = CommonBulkDialogProps & {
   skipCloseOnSuccess?: boolean;
 
   /**
+   * When `true`, a successful mutation will NOT clear the bulk selection.
+   * Use only for flows that re-use the selection in an in-dialog success panel
+   * (e.g. the "Add more" path on add-to-existing-booking). Defaults to `false`
+   * so every bulk action clears the selection on success — the consistent
+   * behaviour across all index/list bulk actions.
+   */
+  keepSelectionOnSuccess?: boolean;
+
+  /**
    * Additional className to form
    */
   formClassName?: string;
@@ -234,12 +241,11 @@ const BulkUpdateDialogContent = forwardRef<
     actionUrl,
     arrayFieldId,
     skipCloseOnSuccess = false,
+    keepSelectionOnSuccess = false,
     formClassName = "",
   },
   ref
 ) {
-  const { items } = useLoaderData<{ items: ListItemData[] }>();
-
   const fetcher = useFetcherWithReset<any>();
   const disabled = isFormProcessing(fetcher.state);
 
@@ -261,42 +267,31 @@ const BulkUpdateDialogContent = forwardRef<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [closeBulkDialog, type]);
 
+  /**
+   * Runs once a bulk action succeeds. Clears the selection by default so the
+   * user does not have to manually "unselect all" before the next batch — the
+   * central behaviour that makes every index's bulk actions consistent.
+   *
+   * Opt out with `keepSelectionOnSuccess` for the rare flow that re-uses the
+   * selection in an in-dialog success panel (the dialog stays open via
+   * `skipCloseOnSuccess`).
+   */
   const handleBulkActionSuccess = useCallback(() => {
-    if (
-      type === "trash" ||
-      type === "archive" ||
-      type === "cancel" ||
-      type === "delete-audit"
-    ) {
+    if (!keepSelectionOnSuccess) {
       setSelectedItems([]);
-
-      if (!skipCloseOnSuccess) {
-        handleCloseDialog();
-      }
-
-      onSuccess && onSuccess();
-      return;
     }
-
-    /**
-     * On successful bulk action, the data becomes old as we are storing the whole object now.
-     * So we have to update the selectedItems data to new one
-     *  */
-    setSelectedItems((prev) =>
-      items.filter((item) => prev.some((i) => i.id === item.id))
-    );
 
     if (!skipCloseOnSuccess) {
       handleCloseDialog();
     }
+
     onSuccess && onSuccess();
   }, [
-    type,
+    keepSelectionOnSuccess,
     setSelectedItems,
     skipCloseOnSuccess,
     onSuccess,
     handleCloseDialog,
-    items,
   ]);
 
   useEffect(


### PR DESCRIPTION
After selecting rows and running a bulk action, the multi-select lingered on every index except where it had been special-cased — confusing UX that forced users to "unselect all" before the next batch.

Centralize the behaviour in BulkUpdateDialogContent: handleBulkActionSuccess now clears selectedBulkItemsAtom on success for all dialog types, not just the destructive ones, and drops the stale-data refresh branch (with its now-unused useLoaderData/items plumbing). This fixes ~37 bulk-action dialogs across assets, kits, bookings, locations, audits, tags, categories, custom fields and team members in one place.

Add a keepSelectionOnSuccess opt-out for the two dialogs that stay open with an in-dialog success panel (add-to-existing-booking's "Add more" reuse and add-to-audit), keeping their selection and avoiding a stale "(0)" title count.

Read-only exports/QR downloads, the booking-detail check-in/out dialogs and the manage-* routes are intentionally left as-is.

Add behaviour tests for the chokepoint and a .claude rule documenting the pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established rules for consistent selection handling across bulk operations.

* **Bug Fixes**
  * Standardized selection clearing behavior after bulk actions.
  * Fixed selection preservation in multi-step workflows (e.g., "add more" operations).

* **Tests**
  * Added test coverage for bulk dialog selection and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->