### PR TITLE
fix(bookings): enforce overlap conflict check on scan-add and mobile checkout

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -3547,14 +3547,15 @@ describe("addScannedAssetsToBooking", () => {
     const from = new Date("2026-07-01T09:00:00Z");
     const to = new Date("2026-07-01T17:00:00Z");
 
-    // Target booking's reservation window (drives the overlap query).
+    // why: stub the booking-window lookup that drives the overlap query so the
+    // guard runs without hitting the DB.
     (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
       from,
       to,
     });
-    // The scanned asset is RESERVED by ANOTHER booking whose window overlaps —
-    // createBookingConflictConditions would surface it; hasAssetBookingConflicts
-    // treats an overlapping RESERVED booking as an always-conflict.
+    // why: return one asset RESERVED by another overlapping booking so the real
+    // hasAssetBookingConflicts fires (and assertAssetsBelongToOrg sees it as an
+    // org member) — keeps the test off a real DB.
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
       {
         id: "asset-1",

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -33,6 +33,7 @@ import {
   revertBookingToDraft,
   extendBooking,
   removeAssets,
+  addScannedAssetsToBooking,
   getOngoingBookingForAsset,
   bulkArchiveBookings,
   // Test helper functions
@@ -3534,5 +3535,46 @@ describe("bulkArchiveBookings", () => {
     await expect(
       bulkArchiveBookings({ bookingIds: ["b1"], organizationId: "org-1" })
     ).rejects.toThrow(ShelfError);
+  });
+});
+
+describe("addScannedAssetsToBooking", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("rejects when a scanned asset is reserved for an overlapping booking", async () => {
+    const from = new Date("2026-07-01T09:00:00Z");
+    const to = new Date("2026-07-01T17:00:00Z");
+
+    // Target booking's reservation window (drives the overlap query).
+    (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      from,
+      to,
+    });
+    // The scanned asset is RESERVED by ANOTHER booking whose window overlaps —
+    // createBookingConflictConditions would surface it; hasAssetBookingConflicts
+    // treats an overlapping RESERVED booking as an always-conflict.
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      {
+        id: "asset-1",
+        title: "Conflicting Asset",
+        status: AssetStatus.AVAILABLE,
+        bookings: [{ id: "other-booking", status: BookingStatus.RESERVED }],
+      },
+    ]);
+
+    await expect(
+      addScannedAssetsToBooking({
+        assetIds: ["asset-1"],
+        bookingId: "booking-1",
+        organizationId: "org-1",
+        userId: "user-1",
+      })
+    ).rejects.toThrow(/already booked or checked out/i);
+
+    // The conflicting asset must never be connected to the booking — the guard
+    // runs before the connect/force-checkout transaction.
+    expect(db.booking.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -5620,6 +5620,74 @@ export async function addScannedAssetsToBooking({
 }) {
   try {
     /**
+     * Conflict guard (mirrors the reserve/checkout guards): reject the add when
+     * any scanned asset — including a scanned kit's member assets — is already
+     * RESERVED, or CHECKED OUT, for a *different* booking whose window OVERLAPS
+     * this booking's window. Without this, the scanner can attach (and on an
+     * ONGOING booking immediately force-check-out, bypassing the checkout guard)
+     * an asset that is committed elsewhere, silently double-booking it. The rule
+     * is "reserved/checked-out AND date-overlapping", not "any reservation"; the
+     * booking's stored from/to is the conflict window.
+     */
+    if (assetIds.length > 0 || kitIds.length > 0) {
+      const conflictBooking = await db.booking.findFirst({
+        where: { id: bookingId, organizationId },
+        select: { from: true, to: true },
+      });
+
+      if (conflictBooking?.from && conflictBooking?.to) {
+        const kitAssetIds =
+          kitIds.length > 0
+            ? (
+                await db.asset.findMany({
+                  where: { kitId: { in: kitIds }, organizationId },
+                  select: { id: true },
+                })
+              ).map((a) => a.id)
+            : [];
+        const candidateIds = [...new Set([...assetIds, ...kitAssetIds])];
+
+        const candidates = await db.asset.findMany({
+          where: { id: { in: candidateIds }, organizationId },
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            bookings: createBookingConflictConditions({
+              currentBookingId: bookingId,
+              fromDate: conflictBooking.from,
+              toDate: conflictBooking.to,
+            }),
+          },
+        });
+
+        const conflicted = candidates.filter((asset) =>
+          hasAssetBookingConflicts(asset, bookingId)
+        );
+
+        if (conflicted.length > 0) {
+          const conflictedNames = conflicted
+            .slice(0, 3)
+            .map((asset) => asset.title)
+            .join(", ");
+          const additionalCount =
+            conflicted.length > 3 ? conflicted.length - 3 : 0;
+          const additionalText =
+            additionalCount > 0 ? ` and ${additionalCount} more` : "";
+
+          throw new ShelfError({
+            cause: null,
+            label,
+            title: "Booking conflict",
+            message: `Cannot add to booking. Some assets are already booked or checked out for an overlapping period: ${conflictedNames}${additionalText}. Please remove them and try again.`,
+            status: 400,
+            shouldBeCaptured: false,
+          });
+        }
+      }
+    }
+
+    /**
      * Step 1: Add assets to booking inside a transaction so we can mirror the
      * status-sync behaviour used in manage-assets.
      */

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -5620,78 +5620,88 @@ export async function addScannedAssetsToBooking({
 }) {
   try {
     /**
-     * Conflict guard (mirrors the reserve/checkout guards): reject the add when
-     * any scanned asset — including a scanned kit's member assets — is already
-     * RESERVED, or CHECKED OUT, for a *different* booking whose window OVERLAPS
-     * this booking's window. Without this, the scanner can attach (and on an
-     * ONGOING booking immediately force-check-out, bypassing the checkout guard)
-     * an asset that is committed elsewhere, silently double-booking it. The rule
-     * is "reserved/checked-out AND date-overlapping", not "any reservation"; the
-     * booking's stored from/to is the conflict window.
-     */
-    if (assetIds.length > 0 || kitIds.length > 0) {
-      const conflictBooking = await db.booking.findFirst({
-        where: { id: bookingId, organizationId },
-        select: { from: true, to: true },
-      });
-
-      if (conflictBooking?.from && conflictBooking?.to) {
-        const kitAssetIds =
-          kitIds.length > 0
-            ? (
-                await db.asset.findMany({
-                  where: { kitId: { in: kitIds }, organizationId },
-                  select: { id: true },
-                })
-              ).map((a) => a.id)
-            : [];
-        const candidateIds = [...new Set([...assetIds, ...kitAssetIds])];
-
-        const candidates = await db.asset.findMany({
-          where: { id: { in: candidateIds }, organizationId },
-          select: {
-            id: true,
-            title: true,
-            status: true,
-            bookings: createBookingConflictConditions({
-              currentBookingId: bookingId,
-              fromDate: conflictBooking.from,
-              toDate: conflictBooking.to,
-            }),
-          },
-        });
-
-        const conflicted = candidates.filter((asset) =>
-          hasAssetBookingConflicts(asset, bookingId)
-        );
-
-        if (conflicted.length > 0) {
-          const conflictedNames = conflicted
-            .slice(0, 3)
-            .map((asset) => asset.title)
-            .join(", ");
-          const additionalCount =
-            conflicted.length > 3 ? conflicted.length - 3 : 0;
-          const additionalText =
-            additionalCount > 0 ? ` and ${additionalCount} more` : "";
-
-          throw new ShelfError({
-            cause: null,
-            label,
-            title: "Booking conflict",
-            message: `Cannot add to booking. Some assets are already booked or checked out for an overlapping period: ${conflictedNames}${additionalText}. Please remove them and try again.`,
-            status: 400,
-            shouldBeCaptured: false,
-          });
-        }
-      }
-    }
-
-    /**
-     * Step 1: Add assets to booking inside a transaction so we can mirror the
-     * status-sync behaviour used in manage-assets.
+     * Add the assets inside a transaction so the validation + conflict guard,
+     * the connect, and the active-booking status-sync all commit atomically
+     * (the guard runs against the `tx` snapshot to keep the read-then-connect
+     * tight against concurrent reservations/checkouts).
      */
     const updatedBooking = await db.$transaction(async (tx) => {
+      /**
+       * Conflict + ownership guard (mirrors the reserve/checkout guards), run
+       * INSIDE the write transaction so the read-then-connect is atomic — this
+       * closes the validate→write race and org-scopes the caller-supplied ids
+       * before the raw connect below. Reject the add when any scanned asset
+       * (including a scanned kit's member assets) is already RESERVED, or
+       * CHECKED OUT, for a *different* booking whose window OVERLAPS this
+       * booking's window. The rule is "reserved/checked-out AND
+       * date-overlapping", not "any reservation"; the booking's stored from/to
+       * is the conflict window.
+       */
+      if (assetIds.length > 0 || kitIds.length > 0) {
+        // Org-scope the standalone asset ids before the connect: a foreign /
+        // missing id would otherwise be dropped by the org-scoped candidate
+        // query (so it bypasses the conflict check) yet still get connected.
+        if (assetIds.length > 0) {
+          await assertAssetsBelongToOrg({ assetIds, organizationId }, tx);
+        }
+
+        const conflictBooking = await tx.booking.findFirst({
+          where: { id: bookingId, organizationId },
+          select: { from: true, to: true },
+        });
+
+        if (conflictBooking?.from && conflictBooking?.to) {
+          const kitAssetIds =
+            kitIds.length > 0
+              ? (
+                  await tx.asset.findMany({
+                    where: { kitId: { in: kitIds }, organizationId },
+                    select: { id: true },
+                  })
+                ).map((a) => a.id)
+              : [];
+          const candidateIds = [...new Set([...assetIds, ...kitAssetIds])];
+
+          const candidates = await tx.asset.findMany({
+            where: { id: { in: candidateIds }, organizationId },
+            select: {
+              id: true,
+              title: true,
+              status: true,
+              bookings: createBookingConflictConditions({
+                currentBookingId: bookingId,
+                fromDate: conflictBooking.from,
+                toDate: conflictBooking.to,
+              }),
+            },
+          });
+
+          const conflicted = candidates.filter((asset) =>
+            hasAssetBookingConflicts(asset, bookingId)
+          );
+
+          if (conflicted.length > 0) {
+            const conflictedNames = conflicted
+              .slice(0, 3)
+              .map((asset) => asset.title)
+              .join(", ");
+            const additionalCount =
+              conflicted.length > 3 ? conflicted.length - 3 : 0;
+            const additionalText =
+              additionalCount > 0 ? ` and ${additionalCount} more` : "";
+
+            throw new ShelfError({
+              cause: null,
+              label,
+              title: "Booking conflict",
+              message: `Cannot add to booking. Some assets are already booked or checked out for an overlapping period: ${conflictedNames}${additionalText}. Please remove them and try again.`,
+              status: 400,
+              shouldBeCaptured: false,
+            });
+          }
+        }
+      }
+
       const booking = await tx.booking.update({
         where: { id: bookingId, organizationId },
         data: {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
@@ -1,5 +1,6 @@
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
   requireMobilePermission,
@@ -44,6 +45,24 @@ export async function action({ request }: ActionFunctionArgs) {
       })
       .parse(body);
 
+    // Load the booking's reservation window so checkoutBooking can run its
+    // asset-conflict guard. That guard is gated on `from && to`; without these
+    // dates it is skipped, which on mobile silently checks out (double-books)
+    // an asset already reserved/checked-out for an overlapping window. The web
+    // checkout passes the booking's from/to — mobile must too. Org-scoped, so a
+    // foreign-org id 404s.
+    const existingBooking = await db.booking.findFirst({
+      where: { id: bookingId, organizationId },
+      select: { from: true, to: true },
+    });
+
+    if (!existingBooking) {
+      return data(
+        { error: { message: "Booking not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+
     // Derive hints the standard way: locale from the request's Accept-Language
     // header and timeZone from the CH-time-zone cookie (UTC fallback). Native
     // clients can't set that cookie, so they pass their device timeZone in the
@@ -58,6 +77,11 @@ export async function action({ request }: ActionFunctionArgs) {
       organizationId,
       hints,
       userId: user.id,
+      // Pass the booking's own window: this enables the conflict guard without
+      // adjusting any dates (date adjustment requires intentChoice, which mobile
+      // never sends — so this stays a "without-adjusted-date" checkout).
+      from: existingBooking.from,
+      to: existingBooking.to,
     });
 
     return data({

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
@@ -37,6 +37,12 @@ vi.mock("~/modules/booking/service.server", () => ({
   checkoutBooking: vi.fn(),
 }));
 
+// why: the endpoint now loads the booking's from/to (so checkoutBooking's
+// conflict guard fires) — mock the org-scoped lookup to avoid a DB call.
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
 // why: we need to control error formatting in the catch block
 vi.mock("~/utils/error", () => ({
   makeShelfError: vi.fn(),
@@ -54,6 +60,7 @@ import {
   requireOrganizationAccess,
   requireMobilePermission,
 } from "~/modules/api/mobile-auth.server";
+import { db } from "~/database/db.server";
 import { checkoutBooking } from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
 
@@ -63,6 +70,10 @@ const mockUser = {
   firstName: "Test",
   lastName: "User",
 };
+
+// The booking's stored reservation window, returned by the org-scoped lookup.
+const BOOKING_FROM = new Date("2026-07-01T09:00:00Z");
+const BOOKING_TO = new Date("2026-07-01T17:00:00Z");
 
 function createCheckoutRequest(body: Record<string, unknown>, orgId = "org-1") {
   return new Request(
@@ -89,9 +100,13 @@ describe("POST /api/mobile/bookings/checkout", () => {
 
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    (db.booking.findFirst as any).mockResolvedValue({
+      from: BOOKING_FROM,
+      to: BOOKING_TO,
+    });
   });
 
-  it("should checkout a booking and return booking data", async () => {
+  it("should checkout a booking and pass its window so the conflict guard fires", async () => {
     (checkoutBooking as any).mockResolvedValue({
       id: "booking-1",
       name: "Test Booking",
@@ -110,12 +125,27 @@ describe("POST /api/mobile/bookings/checkout", () => {
       status: "ONGOING",
     });
 
+    // Regression guard: the booking's from/to MUST be forwarded, otherwise
+    // checkoutBooking's `if (from && to)` conflict check is skipped and a
+    // reserved/overlapping asset is silently double-booked.
     expect(checkoutBooking).toHaveBeenCalledWith({
       id: "booking-1",
       organizationId: "org-1",
       hints: { timeZone: "UTC", locale: "en-US" },
       userId: "user-1",
+      from: BOOKING_FROM,
+      to: BOOKING_TO,
     });
+  });
+
+  it("returns 404 when the booking is not in the workspace", async () => {
+    (db.booking.findFirst as any).mockResolvedValue(null);
+
+    const request = createCheckoutRequest({ bookingId: "missing" });
+    const result = await action(createActionArgs({ request }));
+
+    expect((result as unknown as Response).status).toBe(404);
+    expect(checkoutBooking).not.toHaveBeenCalled();
   });
 
   it("should return 403 when user lacks checkout permission", async () => {


### PR DESCRIPTION
## Summary

Fixes two related gaps that let an asset committed to one booking be **silently double-booked** into an overlapping one — surfaced by a customer using the companion app.

## The bugs

**1. All-at-once mobile checkout skipped the conflict guard.**
`checkoutBooking`'s asset-conflict validation is gated on `if (from && to)`, but the mobile `bookings.checkout` endpoint called it **without** the booking's dates — so the guard was dead code, and an asset reserved/checked-out for an overlapping window was checked out under two bookings with no warning. The web checkout passes the booking's `from`/`to`; mobile now does too. (The per-item "partial" checkout was already safe — it passes the dates.)

**2. Scan-to-add had no availability check.**
`addScannedAssetsToBooking` (shared by the web + mobile scanner) attached scanned assets — and, on an ONGOING booking, *immediately force-checked them out* — with no conflict check at all. A reserved/overlapping asset could be scanned straight in. Added a guard that rejects assets reserved or checked out for an **overlapping** window before the connect/checkout, reusing the same `createBookingConflictConditions` + `hasAssetBookingConflicts` used by reserve and checkout.

## The rule

It blocks **"reserved/checked-out AND date-overlapping"**, not "any reservation": an asset reserved for a *non-overlapping* window is still legitimately addable (matching the web availability filter).

## Tests

- `bookings.checkout` forwards the booking's `from`/`to` (regression guard) + 404s a foreign-org id.
- `addScannedAssetsToBooking` rejects a scanned asset reserved for an overlapping booking and never connects it.
- Full `pnpm webapp:validate` green.

## Note

Both fixes are server-side; the companion app already surfaces the returned "Booking conflict" error. The scan-add guard lives in the shared service, so it also closes the same gap on the **web** scanner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scanned assets (including assets from kits) from being added to a booking if they are already reserved or checked out during an overlapping reservation window.
  * Mobile booking checkout now uses the booking’s stored reservation window (`from`/`to`) fetched from the workspace before validating and completing checkout.
  * Improved the mobile checkout response to return a clearer 404 when the booking can’t be found in the current workspace.
* **Tests**
  * Updated/added coverage for conflict handling and the new mobile booking lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->