### PR TITLE
fix(assets): show NRM custodian in advanced index custody column

### DIFF
--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -661,6 +661,21 @@ describe("assetQueryFragment", () => {
         "WHEN cu.id IS NOT NULL AND a.status = 'CHECKED_OUT'"
       );
     });
+
+    it("falls back to the NRM team-member name for booking custody", () => {
+      // why: when the booking custodian is an NRM (TeamMember with no User),
+      // Postgres CONCAT returns ' ' (a space, non-NULL) for the absent user, so
+      // the old COALESCE(CONCAT(...), btm.name) never reached the NRM name and the
+      // badge rendered blank. The name must be guarded on bu.id with a btm.name
+      // fallback instead.
+      const fragment = assetQueryFragment();
+      const sql = getFragmentSqlString(fragment);
+
+      // The buggy COALESCE(CONCAT(...)) pattern must be gone
+      expect(sql).not.toContain('COALESCE(CONCAT(bu."firstName"');
+      // Booking custody name must fall back to the team-member (NRM) name
+      expect(sql).toContain("ELSE btm.name");
+    });
   });
 
   describe("withCustomFieldDefinitions option", () => {

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1885,13 +1885,13 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
         '[]'::jsonb
       ) AS tags,
       COALESCE(
-        CASE 
+        CASE
           WHEN cu.id IS NOT NULL THEN
             jsonb_build_object(
               'name', tm.name,
               'custodian', jsonb_build_object(
                 'name', tm.name,
-                'user', CASE 
+                'user', CASE
                   WHEN u.id IS NOT NULL THEN
                     jsonb_build_object(
                       'id', u.id,
@@ -1906,9 +1906,23 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
             )
           WHEN b.id IS NOT NULL AND ${ASSET_IS_CHECKED_OUT} THEN
             jsonb_build_object(
-              'name', COALESCE(CONCAT(bu."firstName", ' ', bu."lastName"), btm.name),
+              -- why: when the booking custodian is an NRM (team member with no
+              -- user account), bu.* is NULL. We must NOT CONCAT the user columns
+              -- here: Postgres CONCAT ignores NULLs and returns ' ' (a space),
+              -- which is non-NULL, so a COALESCE(CONCAT(...), btm.name) would
+              -- never fall back to the NRM name and the badge renders blank.
+              -- Guard on bu.id (mirrors the 'user' sub-object branch below).
+              'name', CASE
+                WHEN bu.id IS NOT NULL
+                  THEN CONCAT(bu."firstName", ' ', bu."lastName")
+                ELSE btm.name
+              END,
               'custodian', jsonb_build_object(
-                'name', COALESCE(CONCAT(bu."firstName", ' ', bu."lastName"), btm.name),
+                'name', CASE
+                  WHEN bu.id IS NOT NULL
+                    THEN CONCAT(bu."firstName", ' ', bu."lastName")
+                  ELSE btm.name
+                END,
                 'user', CASE
                   WHEN bu.id IS NOT NULL THEN
                     jsonb_build_object(


### PR DESCRIPTION
The advanced asset index custody column rendered blank for assets checked out in a booking whose custodian is an NRM (a TeamMember with no linked User), while the simple index showed the name correctly.

Root cause is in the raw SQL custody resolution (asset/query.server.ts). The booking-custodian name used:
```
  COALESCE(CONCAT(bu."firstName", ' ', bu."lastName"), btm.name)
```
Postgres CONCAT ignores NULLs and returns ' ' (a single space, non-NULL) when the booking has no custodian user, so the COALESCE never fell back to the team-member (NRM) name and the badge rendered a blank space.

Guard the user concat on bu.id with a btm.name fallback (mirroring the adjacent 'user' sub-object branch), so NRM booking custodians resolve to their name.

Verified against real data: the old expression yielded '' for all assets in an NRM-custodian booking; the fix yields the NRM name. Add a regression test asserting the COALESCE(CONCAT(...)) pattern is gone and the name falls back to btm.name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custodian name display for booking-based custody so it now correctly falls back to the team member name when the booking user is missing.
  * Improved custody details shown in asset results to avoid blank or incorrect names in these cases.
  * Added regression coverage to help prevent this issue from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->