### PR TITLE
fix(bookings): scope lifecycle progress bar to live-checkout states

### DIFF
--- a/apps/webapp/app/components/booking/bulk-partial-checkin-dialog.tsx
+++ b/apps/webapp/app/components/booking/bulk-partial-checkin-dialog.tsx
@@ -184,7 +184,8 @@ export default function BulkPartialCheckinDialog({
           {skippedCount > 0 && (
             <p className="mb-3 rounded border border-warning-200 bg-warning-50 p-2 text-xs text-warning-800">
               {skippedCount} selected item{skippedCount === 1 ? "" : "s"}{" "}
-              {skippedCount === 1 ? "is" : "are"} not eligible for check-in and will be skipped.
+              {skippedCount === 1 ? "is" : "are"} not eligible for check-in and
+              will be skipped.
             </p>
           )}
 

--- a/apps/webapp/app/modules/booking/utils.server.test.ts
+++ b/apps/webapp/app/modules/booking/utils.server.test.ts
@@ -219,6 +219,67 @@ describe("calculateBookingLifecycleProgress (asset mode)", () => {
     expect(p.checkinProgressPercentage).toBe(100);
   });
 
+  it("DRAFT ignores global CHECKED_OUT status — everything Booked, no progress", () => {
+    // Regression: duplicating an ongoing booking creates a DRAFT booking that
+    // connects the SAME assets, which are still physically CHECKED_OUT in the
+    // original booking. A DRAFT has never been checked out *in this booking*, so
+    // the global asset status must not bleed into its lifecycle bar.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        A("a", AssetStatus.CHECKED_OUT),
+        A("b", AssetStatus.CHECKED_OUT),
+        A("c", AssetStatus.AVAILABLE),
+      ],
+      checkedInAssetIds: [],
+      bookingStatus: BookingStatus.DRAFT,
+    });
+    expect(p.totalUnits).toBe(3);
+    expect(p.bookedCount).toBe(3);
+    expect(p.checkedOutCount).toBe(0);
+    expect(p.returnedCount).toBe(0);
+    expect(p.checkoutProgressCount).toBe(0);
+    expect(p.checkoutProgressPercentage).toBe(0);
+    expect(p.hasPartialCheckouts).toBe(false);
+    expect(p.hasPartialCheckins).toBe(false);
+  });
+
+  it("RESERVED ignores global CHECKED_OUT status — everything Booked, no progress", () => {
+    // A RESERVED booking has never had any of its own assets checked out:
+    // progressive checkout's first scan flips RESERVED → ONGOING. So a
+    // CHECKED_OUT status here belongs to a different booking (e.g. the asset is
+    // reserved for a future window while physically out elsewhere now) and must
+    // not register as this booking's checkout progress.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        A("a", AssetStatus.CHECKED_OUT),
+        A("b", AssetStatus.AVAILABLE),
+      ],
+      checkedInAssetIds: [],
+      bookingStatus: BookingStatus.RESERVED,
+    });
+    expect(p.bookedCount).toBe(2);
+    expect(p.checkedOutCount).toBe(0);
+    expect(p.returnedCount).toBe(0);
+    expect(p.hasPartialCheckouts).toBe(false);
+  });
+
+  it("CANCELLED ignores global CHECKED_OUT status — everything Booked, no progress", () => {
+    // A cancelled booking has released its assets; any CHECKED_OUT status comes
+    // from a different (live) booking and must not show as this booking's progress.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        A("a", AssetStatus.CHECKED_OUT),
+        A("b", AssetStatus.AVAILABLE),
+      ],
+      checkedInAssetIds: [],
+      bookingStatus: BookingStatus.CANCELLED,
+    });
+    expect(p.bookedCount).toBe(2);
+    expect(p.checkedOutCount).toBe(0);
+    expect(p.returnedCount).toBe(0);
+    expect(p.hasPartialCheckouts).toBe(false);
+  });
+
   it("COMPLETE with a checked-out subset marks only that subset returned, the rest booked", () => {
     // Progressive checkout: 4 assets, only 2 were ever checked out. At COMPLETE,
     // the 2 never-checked-out assets must stay Booked (not forced to Returned),

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -255,6 +255,13 @@ export type BookingLifecycleProgress = {
  * exist when progressive checkout was used — stay in the Booked bucket.
  * Percentages reflect that split rather than being forced to 100%.
  *
+ * For pre-checkout bookings (DRAFT/RESERVED/CANCELLED) no checkout has happened
+ * in THIS booking — only ONGOING/OVERDUE own a live checkout — so every unit is
+ * forced into the Booked bucket. This prevents the global asset `status` (which
+ * may be CHECKED_OUT because the asset is out in a DIFFERENT booking — e.g.
+ * after duplicating an ongoing booking, or reserving an asset that's checked out
+ * elsewhere for a future window) from leaking into this booking's progress bar.
+ *
  * @returns bucket counts, checkout/check-in counts + percentages, and flags.
  */
 export function calculateBookingLifecycleProgress({
@@ -282,6 +289,22 @@ export function calculateBookingLifecycleProgress({
   const isFinal =
     bookingStatus === BookingStatus.COMPLETE ||
     bookingStatus === BookingStatus.ARCHIVED;
+  // Only ONGOING/OVERDUE bookings own a live checkout, so only there is an
+  // asset's global `status === CHECKED_OUT` attributable to THIS booking
+  // (conflict detection guarantees an asset can't be live-checked-out in two
+  // overlapping bookings). Every pre-checkout state — DRAFT, RESERVED, CANCELLED
+  // — has never had any of its own assets checked out: progressive checkout's
+  // first scan already flips RESERVED → ONGOING, and a cancelled booking has
+  // released its assets. Their assets may still read CHECKED_OUT because they're
+  // physically out in a DIFFERENT booking (e.g. after duplicating an ongoing
+  // booking into a fresh DRAFT, or reserving an asset for a future window while
+  // it's checked out elsewhere now). Force every unit to Booked so cross-booking
+  // status never leaks into this booking's progress bar. (COMPLETE/ARCHIVED is
+  // handled separately below via `checkedOutAssetIds`, not live status.)
+  const isPreCheckout =
+    bookingStatus === BookingStatus.DRAFT ||
+    bookingStatus === BookingStatus.RESERVED ||
+    bookingStatus === BookingStatus.CANCELLED;
 
   // An asset "was actually checked out" iff it has a checkout record. When no
   // records exist at all (empty array), every asset was checked out.
@@ -310,7 +333,13 @@ export function calculateBookingLifecycleProgress({
       ? "returned"
       : "booked";
 
-  const resolveBucket = isFinal ? finalBucketOf : bucketOf;
+  // Pre-checkout bookings (DRAFT/CANCELLED): force every unit to Booked,
+  // ignoring the global asset status that may belong to another booking.
+  const resolveBucket = isPreCheckout
+    ? (): "booked" => "booked"
+    : isFinal
+    ? finalBucketOf
+    : bucketOf;
 
   let booked = 0;
   let checkedOut = 0;


### PR DESCRIPTION
The booking progress bar bucketed assets by the global `asset.status === CHECKED_OUT`, which reflects checkout in ANY booking rather than the one being viewed. Duplicating an ongoing booking connects the same (still physically checked-out) assets to a fresh DRAFT, so the draft's bar wrongly showed checkout progress. The same leak hit RESERVED bookings that include an asset checked out elsewhere for a non-overlapping window.

Gate the live-status bucketing in `calculateBookingLifecycleProgress` to the only states that own a live checkout: ONGOING/OVERDUE. Pre-checkout states (DRAFT, RESERVED, CANCELLED) now force every unit into the Booked bucket, so cross-booking status never leaks in. COMPLETE/ARCHIVED keep their existing `checkedOutAssetIds` branch. Progressive-checkout records can't be the signal here because an all-at-once checkout leaves none.

Add DRAFT/RESERVED/CANCELLED regression tests. Also includes an incidental Prettier line-wrap in bulk-partial-checkin-dialog.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed booking progress calculations so draft, reserved, and cancelled bookings no longer show checked-out assets from elsewhere.
  * Kept pre-checkout items consistently counted as booked, with checkout progress and partial check-in states shown correctly.
  * Improved the warning message layout in the bulk partial check-in dialog for clearer readability.

* **Tests**
  * Added regression coverage for booking progress in draft, reserved, and cancelled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->