### PR TITLE
fix(mobile): shape kit branch in QR resolver so kit-linked QR scans don't crash companion

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/qr.$qrId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/qr.$qrId.ts
@@ -7,6 +7,7 @@ import {
   MOBILE_ASSET_SELECT,
   MOBILE_KIT_SELECT,
   shapeMobileAssetResponse,
+  shapeMobileKitResponse,
 } from "~/modules/api/mobile-auth.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
@@ -148,7 +149,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         // Flatten pivot relations (assetKits/assetLocations/custody) into the
         // legacy flat shape (kit/kitId/location/custody) the companion expects.
         asset: asset ? shapeMobileAssetResponse(asset) : null,
-        kit,
+        kit: shapeMobileKitResponse(kit),
       },
     });
   } catch (cause) {


### PR DESCRIPTION
## Problem

`api+/mobile+/qr.$qrId.ts` flattens the **asset** branch via `shapeMobileAssetResponse`, but returns the **kit** branch unshaped (`kit,`).

After the `AssetKit` pivot migration in #2337, `MOBILE_KIT_SELECT` emits `_count.assetKits` + `assetKits[]` instead of the legacy `_count.assets` + `assets[]`. The companion app's `ScannedKit` contract (`apps/companion/lib/api/types.ts`) and scanner read `kit._count.assets` and `kit.assets.some(...)` (`apps/companion/app/(tabs)/scanner.tsx:677-681,709-710,755-756`). So on a **kit-linked QR scan**, `kit.assets` is `undefined` and `kit.assets.some(...)` throws `TypeError: Cannot read property 'some' of undefined`, crashing the scan handler (both the batch-add and check-in paths).

Reachable on the current app for any kit that has a QR code. It is server-side only, so this fix does not require an App Store release.

## Fix

Pass the kit through `shapeMobileKitResponse` (null-safe), mirroring the sibling `barcode.$value.ts` which already does exactly this. One import + one call.

```diff
   MOBILE_KIT_SELECT,
   shapeMobileAssetResponse,
+  shapeMobileKitResponse,
 } from "~/modules/api/mobile-auth.server";
```
```diff
       asset: asset ? shapeMobileAssetResponse(asset) : null,
-      kit,
+      kit: shapeMobileKitResponse(kit),
     },
```

## Verification

- Mirrors `barcode.$value.ts`, which is already on `main` and green.
- `shapeMobileKitResponse` accepts `{ ... } | null` and returns `null` when `kit === null`, so the asset-linked branch (`kit: null`) is unaffected.
- Confirmed at source against `main`; not yet reproduced on-device (no quantities-schema DB available locally). CI typecheck/lint/tests gate this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile QR responses now return a companion-compatible kit format, improving consistency for clients that consume this endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->