### PR TITLE
fix(bookings): guard bookingAssets.some() against undefined

### DIFF
--- a/apps/webapp/app/routes/_layout+/bookings._index.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings._index.tsx
@@ -589,8 +589,17 @@ const ListBookingsContent = ({
     };
   }>;
 }) => {
+  // Defensive `?? []` against a Sentry-observed crash (SHELF-WEBAPP-1NW):
+  // a single client-side render hit `item.bookingAssets` as undefined and
+  // tripped the `.some(...)` call, breaking the row through the error
+  // boundary. The component's prop type declares `bookingAssets` as
+  // required and the loader always selects it, so the undefined was either
+  // a stale-bundle / hydration mismatch in the deploy window or an as-yet
+  // unidentified loader edge case. The empty-array fallback turns a hard
+  // crash into a safe degraded render (the row simply shows "no
+  // unavailable assets" instead of crashing).
   const hasUnavaiableAssets =
-    item.bookingAssets.some(
+    (item.bookingAssets ?? []).some(
       (ba) => !ba.asset.availableToBook || hasCustody(ba.asset.custody)
     ) && !["COMPLETE", "CANCELLED", "ARCHIVED"].includes(item.status);
 

--- a/apps/webapp/app/routes/_layout+/bookings._index.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings._index.tsx
@@ -502,7 +502,7 @@ export default function BookingsIndexPage({
 }
 
 const ListBookingsContent = ({
-  item,
+  item: rawItem,
 }: {
   item: Prisma.BookingGetPayload<{
     include: {
@@ -589,17 +589,26 @@ const ListBookingsContent = ({
     };
   }>;
 }) => {
-  // Defensive `?? []` against a Sentry-observed crash (SHELF-WEBAPP-1NW):
-  // a single client-side render hit `item.bookingAssets` as undefined and
-  // tripped the `.some(...)` call, breaking the row through the error
-  // boundary. The component's prop type declares `bookingAssets` as
-  // required and the loader always selects it, so the undefined was either
-  // a stale-bundle / hydration mismatch in the deploy window or an as-yet
-  // unidentified loader edge case. The empty-array fallback turns a hard
-  // crash into a safe degraded render (the row simply shows "no
-  // unavailable assets" instead of crashing).
+  // Defensive normalisation against a Sentry-observed crash
+  // (SHELF-WEBAPP-1NW): a single client-side render hit
+  // `item.bookingAssets` as undefined and tripped `.some(...)`, breaking
+  // the row through the error boundary. The component's prop type
+  // declares `bookingAssets` as required and the loader always selects
+  // it, so the undefined was either a stale-bundle / hydration mismatch
+  // in the deploy window or an as-yet unidentified loader edge case.
+  //
+  // Normalise once at the top so EVERY downstream reader gets a safe
+  // array — the badge calc below, `<BookingAssetsSidebar />` (which
+  // calls `groupAssets(booking.bookingAssets)` + reads
+  // `booking.bookingAssets.length` in multiple places), and any future
+  // additions. A scoped `?? []` on each reader would be brittle.
+  const item = {
+    ...rawItem,
+    bookingAssets: rawItem.bookingAssets ?? [],
+  };
+
   const hasUnavaiableAssets =
-    (item.bookingAssets ?? []).some(
+    item.bookingAssets.some(
       (ba) => !ba.asset.availableToBook || hasCustody(ba.asset.custody)
     ) && !["COMPLETE", "CANCELLED", "ARCHIVED"].includes(item.status);
 


### PR DESCRIPTION
Sentry issue SHELF-WEBAPP-1NW caught a single client-side TypeError on the /bookings index 35min after the feat-quantities deploy went live:

  TypeError: Cannot read properties of undefined (reading 'some')

ListBookingsContent at app/routes/_layout+/bookings._index.tsx:593 calls `item.bookingAssets.some(...)` to compute the "unavailable assets" badge. The component's prop type (Prisma.BookingGetPayload<{include:{bookingAssets:{...}}}>) declares bookingAssets as required, and the loader (getBookings) always selects it — so the undefined value was likely a stale client bundle hitting the new server during the deploy window, or an as-yet uncaught loader edge case.

Either way, the cost of guarding is one `?? []`. Turns a hard render crash (caught by the error boundary, but visible to the user as a broken row) into a graceful degraded state ("no unavailable assets" badge omitted for that row).

Inline comment cites the Sentry issue ID so future readers can trace the why if the guard ever looks unnecessary in isolation.

Fixes SHELF-WEBAPP-1NW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bookings page crash when booking asset data is missing by ensuring asset lists are always treated as an array.
  * Improved stability of the “unavailable asset” badge logic so it evaluates safely even when related asset data isn’t present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->