### PR TITLE
fix: post-deploy Sentry cleanup — list helper guard + asset edit N+1

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -2295,9 +2295,17 @@ export async function updateAsset({
             : {}),
           ...(customFieldValuesToRemove.length > 0
             ? {
-                deleteMany: customFieldValuesToRemove.map((cf) => ({
-                  customFieldId: cf.id,
-                })),
+                // Collapse N per-field deleteMany filters into ONE `IN`
+                // clause so Prisma issues a single SELECT pre-flight +
+                // single DELETE, not 2N round trips (Sentry N+1
+                // SHELF-WEBAPP-1NZ, 1P0). Prisma's nested `deleteMany`
+                // accepts EITHER a single where OR an array of wheres —
+                // the array form fans out into per-entry queries.
+                deleteMany: {
+                  customFieldId: {
+                    in: customFieldValuesToRemove.map((cf) => cf.id),
+                  },
+                },
               }
             : {}),
         },

--- a/apps/webapp/app/modules/custody/utils.ts
+++ b/apps/webapp/app/modules/custody/utils.ts
@@ -51,7 +51,16 @@ export function hasCustody(
 export function formatCustodyList<T extends Record<string, unknown>>(
   custody: T[] | null | undefined
 ): { primary: T | null; others: T[]; total: number } {
-  if (!custody || custody.length === 0) {
+  // Defensive `Array.isArray` against Sentry-observed crashes
+  // (SHELF-WEBAPP-1NX, 1NY): a truthy non-array object with a `.length`
+  // field bypasses both the `!custody` and `length === 0` guards, then
+  // crashes on `custody.slice(1)` with "r.slice is not a function" —
+  // breaking the asset list + dashboard row through the error boundary.
+  // The TypeScript signature claims `T[] | null | undefined`, but the
+  // runtime value can drift (loader code path returning the pre-Phase-2
+  // 1:1 shape, hydration mismatch, etc.). Treat anything non-array as
+  // empty rather than letting it crash the row.
+  if (!custody || !Array.isArray(custody) || custody.length === 0) {
     return { primary: null, others: [], total: 0 };
   }
   return {


### PR DESCRIPTION
## Summary

Two unrelated regressions caught by Sentry in the hours after the
`feat-quantities` deploy. Both small, both bisectable, both auto-close
their Sentry issues on merge.

### 1. `TypeError: r.slice is not a function` on `/` and `/assets` ([SHELF-WEBAPP-1NX](https://shelf-asset-management.sentry.io/issues/SHELF-WEBAPP-1NX), [SHELF-WEBAPP-1NY](https://shelf-asset-management.sentry.io/issues/SHELF-WEBAPP-1NY))

`formatCustodyList(custody)` in `apps/webapp/app/modules/custody/utils.ts`
guards `!custody || custody.length === 0` but doesn't guard against
non-array inputs. A truthy object with a numeric `.length` property
bypasses both guards, then `custody.slice(1)` crashes because plain
objects don't have a `.slice` method. The error boundary caught it, but
the affected list row didn't render.

TypeScript signature says `T[] | null | undefined`; runtime value drifted
(likely a loader code path returning the pre-Phase-2 1:1 custody shape,
or a hydration mismatch with a stale client bundle). Adding
`!Array.isArray(custody)` to the guard treats anything non-array as
empty rather than crashing. All 5 call sites instantly protected.

### 2. N+1 on `POST /assets/*/edit.data` ([SHELF-WEBAPP-1NZ](https://shelf-asset-management.sentry.io/issues/SHELF-WEBAPP-1NZ), [SHELF-WEBAPP-1P0](https://shelf-asset-management.sentry.io/issues/SHELF-WEBAPP-1P0))

`updateAsset` was passing an array of per-field where clauses to the
nested `customFields.deleteMany`:

\`\`\`ts
deleteMany: customFieldValuesToRemove.map((cf) => ({ customFieldId: cf.id }))
\`\`\`

Prisma's nested \`deleteMany\` accepts EITHER a single where OR an array
of wheres — the array form fans out into one SELECT pre-flight + one
DELETE per entry. With N removed fields, you pay 2N round-trips
(observed at 9 fields → 18 queries). Collapsing to a single
\`{ customFieldId: { in: [ids] } }\` where reduces it to exactly one
SELECT + one DELETE regardless of N.

Same anti-pattern this file already fixed for nested upserts back in
[SHELF-WEBAPP-1KY / 1MF](https://shelf-asset-management.sentry.io) (see
the comment around line 2253). Don't pass arrays to nested Prisma
write operations when you can collapse them.

## Test plan

- [ ] **Issue 1** — load \`/assets\` and \`/\` as a non-admin user with at
      least one asset that has custody assigned. Pre-fix: 50/50 the row
      shows the error boundary state. Post-fix: row renders normally,
      empty-custody case shows "no custodian" cleanly.
- [ ] **Issue 2** — edit an asset that has 3+ custom fields, clear
      values from 2+ of them, save. Watch the Sentry performance tab
      for that transaction: pre-fix you see N pairs of SELECT/DELETE
      spans; post-fix you see one SELECT + one DELETE.
- [ ] Both fixes ship with inline comments citing the Sentry issue IDs
      so future readers know the lineage if the guard or the IN-clause
      ever looks unnecessary in isolation.
- [ ] No tests added (both fixes are defensive against runtime states
      that aren't easily reproducible in unit tests; the inline
      comments document the why).

## Auto-closes

\`Fixes SHELF-WEBAPP-1NX\`, \`Fixes SHELF-WEBAPP-1NY\`,
\`Fixes SHELF-WEBAPP-1NZ\`, \`Fixes SHELF-WEBAPP-1P0\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custody data so invalid or unexpected values no longer cause errors; empty results are now returned safely.
  * Optimized removal of custom-field values during asset updates, reducing unnecessary work and improving update performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->