### PR TITLE
feat(asset): qty-aware value display across UI, aggregates, exports & mobile

### DIFF
--- a/.claude/rules/quantity-semantics-per-surface.md
+++ b/.claude/rules/quantity-semantics-per-surface.md
@@ -1,0 +1,48 @@
+# Quantity Semantics Per Surface
+
+Shelf has FOUR different `quantity` fields across the schema, each
+meaning something different. Reaching for `getAssetTotalValue(asset)`
+on every surface looks ergonomic but silently substitutes the WRONG
+multiplier — every booking, kit, custody, and value-at-risk total in
+the codebase had this bug at v1.0 of the QT-aware-display work.
+
+| Surface           | Right multiplier               | Field on row            |
+| ----------------- | ------------------------------ | ----------------------- |
+| Inventory / dash  | workspace stock                | `Asset.quantity`        |
+| Booking total/PDF | booked units                   | `BookingAsset.quantity` |
+| Kit overview      | units in this kit              | `AssetKit.quantity`     |
+| Custody snapshot  | units held by this custodian   | `Custody.quantity`      |
+| Overdue at-risk   | booked units (still out)       | `BookingAsset.quantity` |
+| Idle assets       | workspace stock (sitting idle) | `Asset.quantity`        |
+
+Before reaching for `getAssetTotalValue`, **state in a comment what the
+row represents and which quantity it should multiply by**. If it's
+anything other than workspace stock, do NOT use the helper — inline the
+multiplication with the right field, named explicitly. The helper is
+reserved for surfaces where `Asset.quantity` IS the multiplier.
+
+```typescript
+// ❌ Bad — `ba.asset.quantity` is workspace stock (e.g. 100), but
+// the booking only reserved `ba.quantity` (e.g. 5). Total reports
+// 100× the unit price; multi-slice assets double-count.
+const total = bookingAssets.reduce(
+  (sum, ba) => sum + getAssetTotalValue(ba.asset),
+  0
+);
+
+// ✅ Good — explicit booked-units multiplier; comment names the surface
+// Each row = one BookingAsset slice. Multiplier = ba.quantity (booked).
+const total = bookingAssets.reduce(
+  (sum, ba) => sum + (ba.asset.valuation ?? 0) * ba.quantity,
+  0
+);
+```
+
+When you fix one occurrence, **grep sibling aggregates of the same
+entity** — this bug travels in packs (per [[bulk-event-parity]] / IDOR
+fix patterns: review never finds them all, sweeps do).
+
+The Prisma `select` clause must match: surfacing the wrong quantity in
+the loader → wrong total in the reducer is the easier mistake to make.
+Select the field whose name matches the multiplier the surface needs;
+don't select `asset.quantity` "just in case" if the row is custody.

--- a/.claude/rules/raw-sql-respects-prisma-map.md
+++ b/.claude/rules/raw-sql-respects-prisma-map.md
@@ -1,0 +1,37 @@
+Prisma's `@map` decouples the schema field name from the actual DB column.
+`Asset.valuation` is `@map("value")`, so `value` is what Postgres knows.
+**Typecheck cannot validate raw SQL** — `Prisma.sql\`...\``is just a string
+to TS, and the`<{...}[]>` return type is a user-supplied cast, not a
+contract. The first signal of a wrong column name is a 500 in production
+(`column "valuation" does not exist`).
+
+When you write `$queryRaw` / `Prisma.sql` against any model:
+
+1. Open `packages/database/prisma/schema.prisma` and grep every referenced
+   field for `@map(`. Use the mapped column name in SQL, not the Prisma
+   field name. Currently known traps on `Asset`: `valuation → value`.
+2. Drop any `::bigint` cast on `SUM(float × int)` — Postgres returns
+   `double precision` and the cast silently truncates fractional values.
+3. Wrap nullable columns in `COALESCE(col, default)` so a missing value
+   doesn't poison the whole aggregate to `NULL`.
+4. **Add a hitting-real-DB integration test** for any new raw query, or at
+   minimum a unit test asserting the SQL string contains the mapped column
+   name (cheap regression guard against future refactors).
+
+```typescript
+// ❌ Bad — uses Prisma field name; crashes at runtime
+db.$queryRaw<{ total: bigint }[]>(Prisma.sql`
+  SELECT COALESCE(SUM(valuation * quantity), 0)::bigint AS total
+  FROM "Asset" WHERE "organizationId" = ${orgId}
+`);
+
+// ✅ Good — uses @map column; null-safe; preserves fractional totals
+db.$queryRaw<{ total: number | null }[]>(Prisma.sql`
+  SELECT COALESCE(SUM(COALESCE(value, 0) * COALESCE(quantity, 1)), 0) AS total
+  FROM "Asset" WHERE "organizationId" = ${orgId}
+`);
+```
+
+When the aggregate is expressible in Prisma's typed API (`groupBy`,
+`findMany` + JS reduce), prefer that — you get the schema-awareness back
+and trade only a small amount of round-trip weight.

--- a/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
+++ b/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
@@ -48,6 +48,7 @@ import type {
 } from "~/modules/asset-index-settings/helpers";
 import { formatCustodyList } from "~/modules/custody/utils";
 import { type AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
+import { formatAssetValueWithBreakdown } from "~/utils/asset-value";
 import { getStatusClasses, isOneDayEvent } from "~/utils/calendar";
 import { formatCurrency } from "~/utils/currency";
 import { getCustomFieldDisplayValue } from "~/utils/custom-fields";
@@ -232,16 +233,36 @@ export function AdvancedIndexColumn({
       return <DescriptionColumn value={item.description ?? ""} />;
 
     case "valuation": {
-      const value = item?.valuation
-        ? formatCurrency({
-            value: item.valuation,
-            locale,
-            currency: currentOrganization.currency,
-          })
-        : null;
+      // Quantity-aware: render TOTAL (valuation × quantity) on top, with a
+      // small "<unit price> × N <unit>" subtext for QT assets whose total
+      // differs from the per-unit price. INDIVIDUAL assets and QT with
+      // quantity ≤ 1 collapse to a single line — visually unchanged from
+      // the legacy behaviour. See {@link formatAssetValueWithBreakdown}.
+      if (item?.valuation == null) {
+        return (
+          <Td className="w-full max-w-none whitespace-nowrap">
+            <EmptyTableValue />
+          </Td>
+        );
+      }
+
+      const breakdown = formatAssetValueWithBreakdown(item, {
+        currency: currentOrganization.currency,
+        locale,
+      });
+
       return (
         <Td className="w-full max-w-none whitespace-nowrap">
-          {value ? value : <EmptyTableValue />}
+          {breakdown.unit && breakdown.suffix ? (
+            <div className="flex flex-col leading-tight">
+              <span className="tabular-nums">{breakdown.total}</span>
+              <span className="text-xs tabular-nums text-gray-500">
+                {breakdown.unit} {breakdown.suffix}
+              </span>
+            </div>
+          ) : (
+            <span className="tabular-nums">{breakdown.total}</span>
+          )}
         </Td>
       );
     }

--- a/apps/webapp/app/components/reports/asset-inventory-content.tsx
+++ b/apps/webapp/app/components/reports/asset-inventory-content.tsx
@@ -113,9 +113,10 @@ const ASSET_INVENTORY_COLUMNS: ColumnDef<AssetInventoryRow>[] = [
   {
     accessorKey: "valuation",
     header: "Value",
-    cell: ({ row }) => (
-      <CurrencyCell value={row.original.valuation} treatZeroAsEmpty />
-    ),
+    // Asset-aware: shows TOTAL (valuation × quantity) for QT assets, with
+    // a "<unit price> × N <unit>" subtext. INDIVIDUAL assets render the
+    // single-line value as before. See {@link CurrencyCell}.
+    cell: ({ row }) => <CurrencyCell asset={row.original} treatZeroAsEmpty />,
   },
   {
     accessorKey: "createdAt",

--- a/apps/webapp/app/components/reports/asset-utilization-content.tsx
+++ b/apps/webapp/app/components/reports/asset-utilization-content.tsx
@@ -87,9 +87,9 @@ const ASSET_UTILIZATION_COLUMNS: ColumnDef<AssetUtilizationRow>[] = [
   {
     accessorKey: "valuation",
     header: "Value",
-    cell: ({ row }) => (
-      <CurrencyCell value={row.original.valuation} treatZeroAsEmpty />
-    ),
+    // Asset-aware: shows TOTAL (valuation × quantity) for QT assets, with
+    // a "<unit price> × N <unit>" subtext. See {@link CurrencyCell}.
+    cell: ({ row }) => <CurrencyCell asset={row.original} treatZeroAsEmpty />,
   },
 ];
 

--- a/apps/webapp/app/components/reports/custody-snapshot-content.tsx
+++ b/apps/webapp/app/components/reports/custody-snapshot-content.tsx
@@ -135,8 +135,10 @@ export function CustodySnapshotContent({
       {
         accessorKey: "valuation",
         header: "Value",
+        // Asset-aware: shows TOTAL (valuation × quantity) for QT assets,
+        // with a "<unit price> × N <unit>" subtext. See {@link CurrencyCell}.
         cell: ({ row }) => (
-          <CurrencyCell value={row.original.valuation} treatZeroAsEmpty />
+          <CurrencyCell asset={row.original} treatZeroAsEmpty />
         ),
       },
     ],

--- a/apps/webapp/app/components/reports/idle-assets-content.tsx
+++ b/apps/webapp/app/components/reports/idle-assets-content.tsx
@@ -94,8 +94,10 @@ const IDLE_ASSETS_COLUMNS: ColumnDef<IdleAssetRow>[] = [
   {
     accessorKey: "valuation",
     header: "Value",
-    // A real $0 valuation renders as "$0" (or workspace equivalent), not "—".
-    cell: ({ row }) => <CurrencyCell value={row.original.valuation} />,
+    // Asset-aware: shows TOTAL (valuation × quantity) for QT assets, with
+    // a "<unit price> × N <unit>" subtext. A real $0 valuation renders as
+    // "$0" (or workspace equivalent), not "—". See {@link CurrencyCell}.
+    cell: ({ row }) => <CurrencyCell asset={row.original} />,
   },
 ];
 

--- a/apps/webapp/app/components/reports/report-table.tsx
+++ b/apps/webapp/app/components/reports/report-table.tsx
@@ -32,6 +32,7 @@ import { DateS } from "~/components/shared/date";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import {
   formatAssetValueWithBreakdown,
+  getAssetTotalValue,
   type AssetForValue,
 } from "~/utils/asset-value";
 import { useHints } from "~/utils/client-hints";
@@ -417,11 +418,13 @@ export function CurrencyCell({
 
   // Asset-aware path: compute the breakdown from the asset itself. Empty
   // when the per-unit price is missing — same "no value set" UX as below.
+  // `treatZeroAsEmpty` keys off the TOTAL (valuation × quantity), not the
+  // per-unit price: a QT asset with `valuation: 1, quantity: 0` displays
+  // "$0", which should collapse to the empty fallback, while a row with
+  // `valuation: 0, quantity: 100` (free items, real stock) already does.
   if (asset) {
-    if (
-      asset.valuation == null ||
-      (treatZeroAsEmpty && asset.valuation === 0)
-    ) {
+    const total = getAssetTotalValue(asset);
+    if (asset.valuation == null || (treatZeroAsEmpty && total === 0)) {
       return <span className="text-gray-400">{emptyFallback}</span>;
     }
 

--- a/apps/webapp/app/components/reports/report-table.tsx
+++ b/apps/webapp/app/components/reports/report-table.tsx
@@ -30,6 +30,10 @@ import { AssetImage } from "~/components/assets/asset-image";
 import KitImage from "~/components/kits/kit-image";
 import { DateS } from "~/components/shared/date";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
+import {
+  formatAssetValueWithBreakdown,
+  type AssetForValue,
+} from "~/utils/asset-value";
 import { useHints } from "~/utils/client-hints";
 import { formatCurrency } from "~/utils/currency";
 import { tw } from "~/utils/tw";
@@ -367,16 +371,41 @@ export function NumberCell({
  * `0` renders as a real "$0" (or workspace equivalent), not the empty
  * fallback — pass `treatZeroAsEmpty` if the caller prefers the dash for zero.
  *
- * @example
+ * When the caller passes an `asset` (with `type`, `quantity`, `valuation`,
+ * and optionally `unitOfMeasure`), the cell switches to the quantity-aware
+ * two-line layout: the TOTAL value (valuation × quantity) renders on top,
+ * with a small "<unit price> × N <unit>" subtext underneath. Used for
+ * QUANTITY_TRACKED assets whose per-unit valuation does not match the total
+ * worth carried by the row. INDIVIDUAL assets (or QT assets with quantity
+ * ≤ 1) collapse back to the single-line layout — visually identical to the
+ * pre-Wave-B behaviour.
+ *
+ * @example Plain value (legacy callers)
  * { accessorKey: "valuation", cell: ({ row }) => <CurrencyCell value={row.original.valuation} /> }
+ *
+ * @example Asset-aware (QT-friendly) — preferred for asset rows
+ * { accessorKey: "valuation", cell: ({ row }) => <CurrencyCell asset={row.original} /> }
  */
 export function CurrencyCell({
   value,
+  asset,
   emptyFallback = "—",
   treatZeroAsEmpty = false,
 }: {
-  /** Numeric value to format. `null`/`undefined` render the empty fallback. */
-  value: number | null | undefined;
+  /**
+   * Numeric value to format when `asset` is not provided. `null`/`undefined`
+   * renders the empty fallback. Ignored when `asset` is set — the breakdown
+   * is computed from `asset.valuation × asset.quantity` instead.
+   */
+  value?: number | null | undefined;
+  /**
+   * Optional asset shape for quantity-aware rendering. When set, the cell
+   * displays the TOTAL value on top with a "<unit> × N <unit>" subtext for
+   * QT assets whose total differs from the per-unit price. The breakdown
+   * collapses to a single line for INDIVIDUAL assets and QT assets with
+   * quantity ≤ 1 or `valuation: null`.
+   */
+  asset?: AssetForValue;
   /** Fallback text when value is missing. Defaults to em-dash. */
   emptyFallback?: string;
   /** When true, `0` renders as the empty fallback instead of "$0". */
@@ -384,7 +413,41 @@ export function CurrencyCell({
 }) {
   const currentOrganization = useCurrentOrganization();
   const { locale } = useHints();
+  const currency = currentOrganization?.currency ?? "USD";
 
+  // Asset-aware path: compute the breakdown from the asset itself. Empty
+  // when the per-unit price is missing — same "no value set" UX as below.
+  if (asset) {
+    if (
+      asset.valuation == null ||
+      (treatZeroAsEmpty && asset.valuation === 0)
+    ) {
+      return <span className="text-gray-400">{emptyFallback}</span>;
+    }
+
+    const breakdown = formatAssetValueWithBreakdown(asset, {
+      currency,
+      locale,
+    });
+
+    // No breakdown to surface (INDIVIDUAL or QT-with-qty-≤-1): single line,
+    // visually identical to the legacy `value` path so unrelated rows don't
+    // suddenly get extra vertical space.
+    if (breakdown.unit == null || breakdown.suffix == null) {
+      return <span className="tabular-nums">{breakdown.total}</span>;
+    }
+
+    return (
+      <div className="flex flex-col leading-tight">
+        <span className="tabular-nums">{breakdown.total}</span>
+        <span className="text-xs tabular-nums text-gray-500">
+          {breakdown.unit} {breakdown.suffix}
+        </span>
+      </div>
+    );
+  }
+
+  // Legacy plain-number path: no asset, just format the scalar value.
   if (value == null || (treatZeroAsEmpty && value === 0)) {
     return <span className="text-gray-400">{emptyFallback}</span>;
   }
@@ -393,7 +456,7 @@ export function CurrencyCell({
     <span className="tabular-nums">
       {formatCurrency({
         value,
-        currency: currentOrganization?.currency ?? "USD",
+        currency,
         locale,
       })}
     </span>

--- a/apps/webapp/app/modules/asset-index-settings/helpers.ts
+++ b/apps/webapp/app/modules/asset-index-settings/helpers.ts
@@ -48,10 +48,19 @@ export type FixedField = (typeof fixedFields)[number];
 type CustomFieldColumnKey = `cf_${string}`;
 
 // Define a new type that includes both FixedField, BarcodeField and the additional key "name"
+//
+// `total_value` is **export-only** — emitted as a synthetic column in the
+// CSV export (`buildCsvExportDataFromAssets`) so users get a round-trip-safe
+// per-unit `valuation` AND the qty-aware total side by side. It's
+// intentionally NOT in `fixedFields` / `defaultFields` / the column-picker
+// schema (`generateColumnsSchema`), so it never appears in user column
+// settings or the UI's "manage columns" picker. Including it here keeps
+// the type system honest when the export caller injects it.
 export type ColumnLabelKey =
   | FixedField
   | BarcodeField
   | "name"
+  | "total_value"
   | CustomFieldColumnKey;
 
 export const columnsLabelsMap: { [key in ColumnLabelKey]: string } = {
@@ -62,6 +71,8 @@ export const columnsLabelsMap: { [key in ColumnLabelKey]: string } = {
   status: "Status",
   description: "Description",
   valuation: "Value",
+  // Export-only synthetic column (see `ColumnLabelKey` comment above).
+  total_value: "Total value",
   availableToBook: "Available to book",
   createdAt: "Created at",
   updatedAt: "Updated at",

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1583,6 +1583,16 @@ export function parseSortingOptions(sortBy: string[]): {
         orderByParts.push(
           getNormalizedSortExpression(`"${columnName}"`, field.direction)
         );
+      } else if (field.name === "valuation") {
+        // Quantity-aware: sort by TOTAL value (per-unit × quantity), matching
+        // what the "Value" cell displays. INDIVIDUAL assets are quantity=1 so
+        // this is identical to sorting on `assetValue` for them; QT assets
+        // are now ordered by total worth (the number users actually compare),
+        // not per-unit price. `assetValue` and `assetQuantity` are aliases on
+        // the outer SELECT — safe to multiply without quoting concerns.
+        orderByParts.push(
+          `("assetValue" * "assetQuantity") ${field.direction}`
+        );
       } else {
         // Use regular sorting for non-text columns
         orderByParts.push(`"${columnName}" ${field.direction}`);

--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -126,6 +126,10 @@ export const BOOKING_WITH_ASSETS_INCLUDE = {
           availableToBook: true,
           status: true,
           valuation: true,
+          // `quantity` is needed by `calculateTotalValueOfAssets` (booking
+          // overview total + PDF total) so QT assets contribute
+          // valuation × quantity instead of just per-unit.
+          quantity: true,
           // Asset-code resolution fields — see `app/modules/barcode/display.ts`
           // for the canonical select shape. Tight `take: 1` + narrow `select`
           // keeps query weight minimal even with hundreds of booking assets.

--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -126,9 +126,11 @@ export const BOOKING_WITH_ASSETS_INCLUDE = {
           availableToBook: true,
           status: true,
           valuation: true,
-          // `quantity` is needed by `calculateTotalValueOfAssets` (booking
-          // overview total + PDF total) so QT assets contribute
-          // valuation × quantity instead of just per-unit.
+          // `Asset.quantity` is the workspace stock pool — surfaced for QT
+          // availability/headroom math, NOT for booking-value totals.
+          // The booking total uses `BookingAsset.quantity` (booked units)
+          // — see `calculateTotalValueOfAssets`. Using `asset.quantity`
+          // there would value a 5-of-100 booking at 100 units.
           quantity: true,
           // Asset-code resolution fields — see `app/modules/barcode/display.ts`
           // for the canonical select shape. Tight `take: 1` + narrow `select`

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -250,13 +250,19 @@ export async function fetchAllPdfRelatedData(
       // Keep the total aligned with the exported (search-filtered) rows so a
       // searched PDF doesn't show a subset of assets with a full-booking total.
       totalValue: calculateTotalValueOfAssets({
-        // `sortedAssets` is the deduped + search-filtered + kit-grouped
-        // projection that the PDF renders, so the total stays aligned
-        // with the exported rows. Multi-slice qty-tracked assets are
-        // counted once at the asset level (matching the bookingAssets
-        // grouping above); per-slice valuation expansion would belong
-        // in `calculateTotalValueOfAssets` itself, not here.
-        assets: sortedAssets,
+        // Sum per-slice from the `BookingAsset` pivot, scoped to the
+        // search-visible asset ids. Each slice contributes its own
+        // `ba.quantity` (booked units) × per-unit `valuation`, so a QT
+        // asset stocked at 100 with 5 booked contributes value-for-5,
+        // not value-for-100. Multi-slice (standalone + kit) sums each
+        // slice independently — the deduped `sortedAssets` is the
+        // rendered ROW list, not the value-summation list.
+        assets: booking.bookingAssets
+          .filter((ba) => visibleAssetIds.includes(ba.assetId))
+          .map((ba) => ({
+            valuation: ba.asset.valuation,
+            bookedQuantity: ba.quantity,
+          })),
         currency: organization.currency,
         locale: getClientHint(request).locale,
       }),

--- a/apps/webapp/app/modules/kit/fields.ts
+++ b/apps/webapp/app/modules/kit/fields.ts
@@ -17,9 +17,12 @@ const KIT_OVERVIEW_BARCODES_FIELDS = {
 const KIT_OVERVIEW_BASE_FIELDS = {
   assetKits: {
     select: {
-      // `quantity` is needed by the overview's totalValue reducer so it can
-      // compute valuation × quantity per asset (QT-aware totals).
-      asset: { select: { valuation: true, quantity: true } },
+      // `AssetKit.quantity` = units of this asset *inside this kit* (not
+      // workspace stock). The overview's totalValue reducer multiplies
+      // per-unit valuation × this number, so a QT asset stocked at 100
+      // with 5 of those in this kit contributes value-for-5, not 100.
+      quantity: true,
+      asset: { select: { valuation: true } },
     },
   },
   qrCodes: {

--- a/apps/webapp/app/modules/kit/fields.ts
+++ b/apps/webapp/app/modules/kit/fields.ts
@@ -17,7 +17,9 @@ const KIT_OVERVIEW_BARCODES_FIELDS = {
 const KIT_OVERVIEW_BASE_FIELDS = {
   assetKits: {
     select: {
-      asset: { select: { valuation: true } },
+      // `quantity` is needed by the overview's totalValue reducer so it can
+      // compute valuation × quantity per asset (QT-aware totals).
+      asset: { select: { valuation: true, quantity: true } },
     },
   },
   qrCodes: {

--- a/apps/webapp/app/modules/location/service.server.test.ts
+++ b/apps/webapp/app/modules/location/service.server.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 
 // why: testing location valuation aggregation logic without database
-// dependency. QT-aware totals require SUM(valuation × quantity) which Prisma's
+// dependency. QT-aware totals require SUM(value × quantity) which Prisma's
 // `aggregate({_sum})` cannot express, so the implementation now uses
-// `$queryRaw` — the mock surface mirrors that.
+// `$queryRaw` — the mock surface mirrors that. (Column is `value`, not
+// `valuation`: `Asset.valuation` is `@map("value")` in schema.prisma.)
 vi.mock("~/database/db.server", () => ({
   db: {
     $queryRaw: vi.fn(),
@@ -20,9 +21,11 @@ describe("getLocationTotalValuation", () => {
     queryRawMock.mockReset();
   });
 
-  it("returns the QT-aware total (SUM(valuation × quantity)) for the location", async () => {
-    // bigint is the SQL cast in the implementation; the helper Number()s it.
-    queryRawMock.mockResolvedValue([{ total: BigInt(1234) }]);
+  it("returns the QT-aware total (SUM(value × quantity)) for the location", async () => {
+    // Postgres returns `double precision` for SUM(float * int) — arrives as
+    // a JS number now that the implementation no longer casts to ::bigint
+    // (the cast truncated fractional valuations).
+    queryRawMock.mockResolvedValue([{ total: 1234 }]);
 
     const total = await getLocationTotalValuation({ locationId: "loc-123" });
 
@@ -30,9 +33,18 @@ describe("getLocationTotalValuation", () => {
     expect(total).toBe(1234);
   });
 
+  it("preserves fractional totals (no ::bigint truncation)", async () => {
+    // Prior bigint cast lost the .50; verifies we kept the float through.
+    queryRawMock.mockResolvedValue([{ total: 99.5 }]);
+
+    const total = await getLocationTotalValuation({ locationId: "loc-123" });
+
+    expect(total).toBe(99.5);
+  });
+
   it("returns 0 when no valuation data is available", async () => {
     // COALESCE in the SQL yields 0 for empty/all-null sums.
-    queryRawMock.mockResolvedValue([{ total: BigInt(0) }]);
+    queryRawMock.mockResolvedValue([{ total: 0 }]);
 
     const total = await getLocationTotalValuation({ locationId: "loc-123" });
 

--- a/apps/webapp/app/modules/location/service.server.test.ts
+++ b/apps/webapp/app/modules/location/service.server.test.ts
@@ -1,40 +1,46 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 
-// why: testing location valuation aggregation logic without database dependency
+// why: testing location valuation aggregation logic without database
+// dependency. QT-aware totals require SUM(valuation × quantity) which Prisma's
+// `aggregate({_sum})` cannot express, so the implementation now uses
+// `$queryRaw` — the mock surface mirrors that.
 vi.mock("~/database/db.server", () => ({
   db: {
-    asset: {
-      aggregate: vi.fn(),
-    },
+    $queryRaw: vi.fn(),
   },
 }));
 
 const { db } = await import("~/database/db.server");
 const { getLocationTotalValuation } = await import("./service.server");
 
-const aggregateMock = vi.mocked(db.asset.aggregate);
+const queryRawMock = vi.mocked(db.$queryRaw);
 
 describe("getLocationTotalValuation", () => {
   beforeEach(() => {
-    aggregateMock.mockReset();
+    queryRawMock.mockReset();
   });
 
-  it("returns the aggregated valuation for all assets in a location", async () => {
-    aggregateMock.mockResolvedValue({ _sum: { valuation: 1234.56 } });
+  it("returns the QT-aware total (SUM(valuation × quantity)) for the location", async () => {
+    // bigint is the SQL cast in the implementation; the helper Number()s it.
+    queryRawMock.mockResolvedValue([{ total: BigInt(1234) }]);
 
     const total = await getLocationTotalValuation({ locationId: "loc-123" });
 
-    // Asset placement lives on the AssetLocation pivot, so the aggregation
-    // filters via `assetLocations: { some }` rather than `Asset.locationId`.
-    expect(aggregateMock).toHaveBeenCalledWith({
-      _sum: { valuation: true },
-      where: { assetLocations: { some: { locationId: "loc-123" } } },
-    });
-    expect(total).toBe(1234.56);
+    expect(queryRawMock).toHaveBeenCalledTimes(1);
+    expect(total).toBe(1234);
   });
 
   it("returns 0 when no valuation data is available", async () => {
-    aggregateMock.mockResolvedValue({ _sum: { valuation: null } });
+    // COALESCE in the SQL yields 0 for empty/all-null sums.
+    queryRawMock.mockResolvedValue([{ total: BigInt(0) }]);
+
+    const total = await getLocationTotalValuation({ locationId: "loc-123" });
+
+    expect(total).toBe(0);
+  });
+
+  it("returns 0 when the raw query returns no rows", async () => {
+    queryRawMock.mockResolvedValue([]);
 
     const total = await getLocationTotalValuation({ locationId: "loc-123" });
 

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -1,5 +1,4 @@
 import type {
-  Prisma,
   User,
   Location,
   Organization,
@@ -7,7 +6,7 @@ import type {
   Asset,
   Kit,
 } from "@prisma/client";
-import { AssetType, BookingStatus } from "@prisma/client";
+import { AssetType, BookingStatus, Prisma } from "@prisma/client";
 import invariant from "tiny-invariant";
 import { db } from "~/database/db.server";
 import { getSupabaseAdmin } from "~/integrations/supabase/client";
@@ -680,13 +679,22 @@ export async function getLocationTotalValuation({
 }: {
   locationId: Location["id"];
 }) {
+  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
   // Filter via the `AssetLocation` pivot — there is no `Asset.locationId`.
-  const result = await db.asset.aggregate({
-    _sum: { valuation: true },
-    where: { assetLocations: { some: { locationId } } },
-  });
+  // Prisma's `aggregate({_sum})` cannot express the multiplication, so we drop
+  // to `$queryRaw` and keep the same scope (assets joined to the pivot).
+  const rows = await db.$queryRaw<{ total: bigint }[]>(
+    Prisma.sql`
+      SELECT COALESCE(SUM(a.valuation * a.quantity), 0)::bigint AS total
+      FROM "Asset" a
+      WHERE a.id IN (
+        SELECT al."assetId" FROM "AssetLocation" al
+        WHERE al."locationId" = ${locationId}
+      )
+    `
+  );
 
-  return result._sum.valuation ?? 0;
+  return Number(rows[0]?.total ?? 0);
 }
 
 /**

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -679,13 +679,15 @@ export async function getLocationTotalValuation({
 }: {
   locationId: Location["id"];
 }) {
-  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+  // QT-aware: multiplies value × quantity so qty-tracked assets are not silently underreported.
   // Filter via the `AssetLocation` pivot — there is no `Asset.locationId`.
   // Prisma's `aggregate({_sum})` cannot express the multiplication, so we drop
   // to `$queryRaw` and keep the same scope (assets joined to the pivot).
-  const rows = await db.$queryRaw<{ total: bigint }[]>(
+  // Column is `value` (Asset.valuation is `@map("value")`). COALESCE
+  // mirrors `getAssetTotalValue`. No `::bigint` cast — truncated floats.
+  const rows = await db.$queryRaw<{ total: number | null }[]>(
     Prisma.sql`
-      SELECT COALESCE(SUM(a.valuation * a.quantity), 0)::bigint AS total
+      SELECT COALESCE(SUM(COALESCE(a.value, 0) * COALESCE(a.quantity, 1)), 0) AS total
       FROM "Asset" a
       WHERE a.id IN (
         SELECT al."assetId" FROM "AssetLocation" al

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -16,8 +16,8 @@ import type {
   ActivityAction,
   AssetStatus,
   BookingStatus,
-  Prisma,
 } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 import { db } from "~/database/db.server";
 import {
@@ -26,6 +26,7 @@ import {
   isOnTime,
   resolveCheckInAt,
 } from "~/modules/booking/lateness";
+import { getAssetTotalValue } from "~/utils/asset-value";
 import { ShelfError } from "~/utils/error";
 
 import { resolveCheckInTimes } from "./check-in-time.server";
@@ -1125,7 +1126,9 @@ async function computeOverdueKpis(
       bookingAssets: {
         select: {
           asset: {
-            select: { id: true, valuation: true },
+            // `quantity` is selected so the value-at-risk reducer below can
+            // compute valuation × quantity (QT-aware totals).
+            select: { id: true, valuation: true, quantity: true },
           },
         },
       },
@@ -1163,9 +1166,10 @@ async function computeOverdueKpis(
       0,
       b._count.bookingAssets - checkedInAssetIds.size
     );
+    // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
     totalValueAtRisk += b.bookingAssets
       .filter((ba) => !checkedInAssetIds.has(ba.asset.id))
-      .reduce((assetSum, ba) => assetSum + (ba.asset.valuation || 0), 0);
+      .reduce((assetSum, ba) => assetSum + getAssetTotalValue(ba.asset), 0);
   }
 
   // Also track total for context in hero subtitle
@@ -1409,6 +1413,9 @@ async function fetchIdleAssetRows(
       thumbnailImage: true,
       status: true,
       valuation: true,
+      type: true,
+      quantity: true,
+      unitOfMeasure: true,
       updatedAt: true,
       category: {
         select: {
@@ -1472,6 +1479,9 @@ async function fetchIdleAssetRows(
       daysSinceLastUse,
       status: asset.status,
       valuation: asset.valuation,
+      type: asset.type,
+      quantity: asset.quantity,
+      unitOfMeasure: asset.unitOfMeasure,
     };
   });
 }
@@ -1560,6 +1570,9 @@ async function computeIdleAssetsKpis(
     select: {
       id: true,
       valuation: true,
+      // `quantity` is selected so `totalIdleValue` below can compute
+      // valuation × quantity (QT-aware totals).
+      quantity: true,
       updatedAt: true,
       bookingAssets: {
         where: {
@@ -1585,9 +1598,9 @@ async function computeIdleAssetsKpis(
   const idlePercentage =
     totalAssets > 0 ? Math.round((totalIdle / totalAssets) * 100) : 0;
 
-  // Calculate total value of idle assets
+  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
   const totalIdleValue = trulyIdle.reduce(
-    (sum, asset) => sum + (asset.valuation || 0),
+    (sum, asset) => sum + getAssetTotalValue(asset),
     0
   );
 
@@ -1803,6 +1816,9 @@ async function fetchCustodyRows(
           mainImageExpiration: true,
           thumbnailImage: true,
           valuation: true,
+          type: true,
+          quantity: true,
+          unitOfMeasure: true,
           category: {
             select: { name: true },
           },
@@ -1849,6 +1865,9 @@ async function fetchCustodyRows(
       assignedAt,
       daysInCustody,
       valuation: c.asset.valuation,
+      type: c.asset.type,
+      quantity: c.asset.quantity,
+      unitOfMeasure: c.asset.unitOfMeasure,
     };
   });
 }
@@ -1870,6 +1889,9 @@ async function computeCustodyKpis(
       asset: {
         select: {
           valuation: true,
+          // `quantity` is selected so the totalValue reducer below can
+          // compute valuation × quantity (QT-aware totals).
+          quantity: true,
         },
       },
     },
@@ -1881,9 +1903,9 @@ async function computeCustodyKpis(
   const uniqueCustodians = new Set(custodyRecords.map((c) => c.teamMemberId))
     .size;
 
-  // Calculate total value
+  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
   const totalValue = custodyRecords.reduce(
-    (sum, c) => sum + (c.asset.valuation || 0),
+    (sum, c) => sum + getAssetTotalValue(c.asset),
     0
   );
 
@@ -2835,18 +2857,23 @@ async function computeDistributionByStatus(
 async function computeDistributionKpis(
   organizationId: string
 ): Promise<ReportKpi[]> {
-  const [totalAssets, totalValue, categoryCount, locationCount] =
+  const [totalAssets, totalValueRows, categoryCount, locationCount] =
     await Promise.all([
       db.asset.count({ where: { organizationId } }),
-      db.asset.aggregate({
-        where: { organizationId },
-        _sum: { valuation: true },
-      }),
+      // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+      // Prisma's `aggregate({_sum})` cannot express the multiplication, so we drop to `$queryRaw`.
+      db.$queryRaw<{ total: bigint }[]>(
+        Prisma.sql`
+          SELECT COALESCE(SUM(valuation * quantity), 0)::bigint AS total
+          FROM "Asset"
+          WHERE "organizationId" = ${organizationId}
+        `
+      ),
       db.category.count({ where: { organizationId } }),
       db.location.count({ where: { organizationId } }),
     ]);
 
-  const totalAssetValue = totalValue._sum.valuation || 0;
+  const totalAssetValue = Number(totalValueRows[0]?.total ?? 0);
 
   return [
     {
@@ -2942,7 +2969,13 @@ export async function assetInventoryReport(
     const [rows, totalCount, kpis] = await Promise.all([
       fetchInventoryRows(where, page, pageSize),
       db.asset.count({ where }),
-      computeInventoryKpis(organizationId, where),
+      // Filters are passed through so the KPI helper can mirror them in its
+      // `$queryRaw` valuation sum (Prisma doesn't expose where → SQL).
+      computeInventoryKpis(organizationId, where, {
+        categoryIds,
+        locationIds,
+        statuses: statuses as AssetStatus[] | undefined,
+      }),
     ]);
 
     const computedMs = Math.round(performance.now() - startTime);
@@ -3005,6 +3038,9 @@ async function fetchInventoryRows(
       thumbnailImage: true,
       status: true,
       valuation: true,
+      type: true,
+      quantity: true,
+      unitOfMeasure: true,
       createdAt: true,
       category: { select: { name: true } },
       assetLocations: {
@@ -3042,6 +3078,9 @@ async function fetchInventoryRows(
       ? stripNameSuffix(a.custody[0].custodian.name)
       : null,
     valuation: a.valuation,
+    type: a.type,
+    quantity: a.quantity,
+    unitOfMeasure: a.unitOfMeasure,
     createdAt: a.createdAt,
     qrId: a.qrCodes[0]?.id || null,
   }));
@@ -3049,18 +3088,53 @@ async function fetchInventoryRows(
 
 async function computeInventoryKpis(
   organizationId: string,
-  where: Prisma.AssetWhereInput
+  where: Prisma.AssetWhereInput,
+  filters: {
+    categoryIds?: string[];
+    locationIds?: string[];
+    statuses?: AssetStatus[];
+  }
 ): Promise<ReportKpi[]> {
   // Defense-in-depth: enforce organizationId on every query even though
   // callers' `where` already includes it. Cheap to add, prevents an
   // accidental cross-org leak if the where-builder ever regresses.
   const scopedWhere: Prisma.AssetWhereInput = { ...where, organizationId };
-  const [totalAssets, totalValue, statusCounts] = await Promise.all([
+
+  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+  // Prisma's `aggregate({_sum})` cannot express the multiplication, so we drop
+  // to `$queryRaw` and mirror the same filters (organizationId + the optional
+  // category / location / status filters) the Prisma `where` carries.
+  const filterFragments: Prisma.Sql[] = [
+    Prisma.sql`"organizationId" = ${organizationId}`,
+  ];
+  if (filters.categoryIds && filters.categoryIds.length > 0) {
+    filterFragments.push(
+      Prisma.sql`"categoryId" IN (${Prisma.join(filters.categoryIds)})`
+    );
+  }
+  if (filters.locationIds && filters.locationIds.length > 0) {
+    filterFragments.push(
+      Prisma.sql`id IN (SELECT "assetId" FROM "AssetLocation" WHERE "locationId" IN (${Prisma.join(
+        filters.locationIds
+      )}))`
+    );
+  }
+  if (filters.statuses && filters.statuses.length > 0) {
+    filterFragments.push(
+      Prisma.sql`status::text IN (${Prisma.join(filters.statuses)})`
+    );
+  }
+  const whereSql = Prisma.join(filterFragments, " AND ");
+
+  const [totalAssets, totalValueRows, statusCounts] = await Promise.all([
     db.asset.count({ where: scopedWhere }),
-    db.asset.aggregate({
-      where: scopedWhere,
-      _sum: { valuation: true },
-    }),
+    db.$queryRaw<{ total: bigint }[]>(
+      Prisma.sql`
+        SELECT COALESCE(SUM(valuation * quantity), 0)::bigint AS total
+        FROM "Asset"
+        WHERE ${whereSql}
+      `
+    ),
     db.asset.groupBy({
       by: ["status"],
       where: scopedWhere,
@@ -3072,7 +3146,7 @@ async function computeInventoryKpis(
     statusCounts.find((s) => s.status === "AVAILABLE")?._count.id || 0;
   const inCustodyCount =
     statusCounts.find((s) => s.status === "IN_CUSTODY")?._count.id || 0;
-  const totalAssetValue = totalValue._sum.valuation || 0;
+  const totalAssetValue = Number(totalValueRows[0]?.total ?? 0);
 
   return [
     {
@@ -3436,6 +3510,9 @@ export async function assetUtilizationReport(
         mainImageExpiration: true,
         thumbnailImage: true,
         valuation: true,
+        type: true,
+        quantity: true,
+        unitOfMeasure: true,
         category: { select: { name: true } },
         assetLocations: {
           select: {
@@ -3508,6 +3585,9 @@ export async function assetUtilizationReport(
         utilizationRate,
         bookingCount: bookingIds.size,
         valuation: asset.valuation,
+        type: asset.type,
+        quantity: asset.quantity,
+        unitOfMeasure: asset.unitOfMeasure,
       };
     });
 

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -1125,10 +1125,12 @@ async function computeOverdueKpis(
       to: true,
       bookingAssets: {
         select: {
+          // `BookingAsset.quantity` = booked units. Value-at-risk for an
+          // overdue booking is the value of what hasn't been returned —
+          // `valuation × bookedUnits`, NOT `valuation × workspaceStock`.
+          quantity: true,
           asset: {
-            // `quantity` is selected so the value-at-risk reducer below can
-            // compute valuation × quantity (QT-aware totals).
-            select: { id: true, valuation: true, quantity: true },
+            select: { id: true, valuation: true },
           },
         },
       },
@@ -1166,10 +1168,15 @@ async function computeOverdueKpis(
       0,
       b._count.bookingAssets - checkedInAssetIds.size
     );
-    // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+    // Multiplies per-unit valuation × booked units (BookingAsset.quantity).
+    // Using `asset.quantity` (workspace stock) would value a 5-of-100
+    // booked + overdue row at 100 units of risk. See select above.
     totalValueAtRisk += b.bookingAssets
       .filter((ba) => !checkedInAssetIds.has(ba.asset.id))
-      .reduce((assetSum, ba) => assetSum + getAssetTotalValue(ba.asset), 0);
+      .reduce(
+        (assetSum, ba) => assetSum + (ba.asset.valuation ?? 0) * ba.quantity,
+        0
+      );
   }
 
   // Also track total for context in hero subtitle
@@ -1801,6 +1808,10 @@ async function fetchCustodyRows(
     select: {
       id: true,
       createdAt: true,
+      // `Custody.quantity` = units this custodian actually holds (not
+      // workspace stock). Drives the row's value breakdown — a custodian
+      // holding 5 of a 100-unit pool should see value-for-5, not 100.
+      quantity: true,
       custodian: {
         select: {
           id: true,
@@ -1817,7 +1828,6 @@ async function fetchCustodyRows(
           thumbnailImage: true,
           valuation: true,
           type: true,
-          quantity: true,
           unitOfMeasure: true,
           category: {
             select: { name: true },
@@ -1866,7 +1876,9 @@ async function fetchCustodyRows(
       daysInCustody,
       valuation: c.asset.valuation,
       type: c.asset.type,
-      quantity: c.asset.quantity,
+      // Surfaced as the multiplier for the per-row Value cell — units
+      // in this custody, not asset stock. See select comment above.
+      quantity: c.quantity,
       unitOfMeasure: c.asset.unitOfMeasure,
     };
   });
@@ -1886,12 +1898,13 @@ async function computeCustodyKpis(
     select: {
       createdAt: true,
       teamMemberId: true,
+      // `Custody.quantity` = units held by this custodian. Multiplied
+      // against per-unit valuation below — using `Asset.quantity` (total
+      // stock) would value a 5-of-100 custody at 100 units.
+      quantity: true,
       asset: {
         select: {
           valuation: true,
-          // `quantity` is selected so the totalValue reducer below can
-          // compute valuation × quantity (QT-aware totals).
-          quantity: true,
         },
       },
     },
@@ -1903,9 +1916,9 @@ async function computeCustodyKpis(
   const uniqueCustodians = new Set(custodyRecords.map((c) => c.teamMemberId))
     .size;
 
-  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+  // Multiplies per-unit valuation × custody-held units. See select above.
   const totalValue = custodyRecords.reduce(
-    (sum, c) => sum + getAssetTotalValue(c.asset),
+    (sum, c) => sum + (c.asset.valuation ?? 0) * c.quantity,
     0
   );
 
@@ -2860,11 +2873,14 @@ async function computeDistributionKpis(
   const [totalAssets, totalValueRows, categoryCount, locationCount] =
     await Promise.all([
       db.asset.count({ where: { organizationId } }),
-      // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+      // QT-aware: multiplies value × quantity so qty-tracked assets are not silently underreported.
       // Prisma's `aggregate({_sum})` cannot express the multiplication, so we drop to `$queryRaw`.
-      db.$queryRaw<{ total: bigint }[]>(
+      // Column name is `value` (Asset.valuation is `@map("value")`). COALESCE
+      // mirrors `getAssetTotalValue` (null quantity → 1, null value → 0).
+      // No `::bigint` cast — it truncated fractional Float valuations.
+      db.$queryRaw<{ total: number | null }[]>(
         Prisma.sql`
-          SELECT COALESCE(SUM(valuation * quantity), 0)::bigint AS total
+          SELECT COALESCE(SUM(COALESCE(value, 0) * COALESCE(quantity, 1)), 0) AS total
           FROM "Asset"
           WHERE "organizationId" = ${organizationId}
         `
@@ -3128,9 +3144,11 @@ async function computeInventoryKpis(
 
   const [totalAssets, totalValueRows, statusCounts] = await Promise.all([
     db.asset.count({ where: scopedWhere }),
-    db.$queryRaw<{ total: bigint }[]>(
+    // Column is `value` (Asset.valuation is `@map("value")`). COALESCE
+    // mirrors `getAssetTotalValue`. No `::bigint` cast — truncated floats.
+    db.$queryRaw<{ total: number | null }[]>(
       Prisma.sql`
-        SELECT COALESCE(SUM(valuation * quantity), 0)::bigint AS total
+        SELECT COALESCE(SUM(COALESCE(value, 0) * COALESCE(quantity, 1)), 0) AS total
         FROM "Asset"
         WHERE ${whereSql}
       `

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -353,13 +353,15 @@ export interface CustodySnapshotRow {
   /** Days in custody */
   daysInCustody: number;
   /** Per-unit valuation if set. The displayed "Value" column shows the
-   * TOTAL (valuation × quantity) for QT assets; see {@link CurrencyCell}. */
+   * TOTAL (valuation × quantity-in-custody) for QT; see {@link CurrencyCell}. */
   valuation: number | null;
   /** Asset kind — drives the quantity-aware value breakdown in cells. */
   type: AssetType;
-  /** Total stock count; >1 only for QT assets. Nullable to match
-   * Prisma's `Asset.quantity` shape; consumers treat `null` as 1
-   * (see `getAssetTotalValue` in `~/utils/asset-value`). */
+  /** **Units held in this custody** (`Custody.quantity`), NOT workspace
+   * stock. Drives the per-row Value cell multiplier — a custodian holding
+   * 5 of a 100-unit QT pool reports value-for-5, not 100. Typed as
+   * `number | null` for `CurrencyCell` compatibility; `Custody.quantity`
+   * is non-null at the DB layer (Int @default(1)). */
   quantity: number | null;
   /** Optional unit label (e.g. "boxes") used by the value breakdown. */
   unitOfMeasure: string | null;

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -10,7 +10,7 @@
  * @see {@link file://./helpers.server.ts}
  */
 
-import type { BookingStatus, Currency } from "@prisma/client";
+import type { AssetType, BookingStatus, Currency } from "@prisma/client";
 
 // -----------------------------------------------------------------------------
 // KPI Types
@@ -313,8 +313,17 @@ export interface IdleAssetRow {
   daysSinceLastUse: number;
   /** Current asset status */
   status: string;
-  /** Asset valuation if set */
+  /** Per-unit valuation if set. The displayed "Value" column shows the
+   * TOTAL (valuation × quantity) for QT assets; see {@link CurrencyCell}. */
   valuation: number | null;
+  /** Asset kind — drives the quantity-aware value breakdown in cells. */
+  type: AssetType;
+  /** Total stock count; >1 only for QT assets. Nullable to match
+   * Prisma's `Asset.quantity` shape; consumers treat `null` as 1
+   * (see `getAssetTotalValue` in `~/utils/asset-value`). */
+  quantity: number | null;
+  /** Optional unit label (e.g. "boxes") used by the value breakdown. */
+  unitOfMeasure: string | null;
 }
 
 /** KPI IDs for the Idle Assets report */
@@ -343,8 +352,17 @@ export interface CustodySnapshotRow {
   assignedAt: Date;
   /** Days in custody */
   daysInCustody: number;
-  /** Asset valuation if set */
+  /** Per-unit valuation if set. The displayed "Value" column shows the
+   * TOTAL (valuation × quantity) for QT assets; see {@link CurrencyCell}. */
   valuation: number | null;
+  /** Asset kind — drives the quantity-aware value breakdown in cells. */
+  type: AssetType;
+  /** Total stock count; >1 only for QT assets. Nullable to match
+   * Prisma's `Asset.quantity` shape; consumers treat `null` as 1
+   * (see `getAssetTotalValue` in `~/utils/asset-value`). */
+  quantity: number | null;
+  /** Optional unit label (e.g. "boxes") used by the value breakdown. */
+  unitOfMeasure: string | null;
 }
 
 /** KPI IDs for the Custody Snapshot report */
@@ -465,8 +483,17 @@ export interface AssetInventoryRow {
   location: string | null;
   status: string;
   custodian: string | null;
-  /** Asset valuation if set */
+  /** Per-unit valuation if set. The displayed "Value" column shows the
+   * TOTAL (valuation × quantity) for QT assets; see {@link CurrencyCell}. */
   valuation: number | null;
+  /** Asset kind — drives the quantity-aware value breakdown in cells. */
+  type: AssetType;
+  /** Total stock count; >1 only for QT assets. Nullable to match
+   * Prisma's `Asset.quantity` shape; consumers treat `null` as 1
+   * (see `getAssetTotalValue` in `~/utils/asset-value`). */
+  quantity: number | null;
+  /** Optional unit label (e.g. "boxes") used by the value breakdown. */
+  unitOfMeasure: string | null;
   /** Date asset was created */
   createdAt: Date;
   /** QR code ID if assigned */
@@ -529,8 +556,17 @@ export interface AssetUtilizationRow {
   utilizationRate: number;
   /** Number of bookings in the period */
   bookingCount: number;
-  /** Asset valuation if set */
+  /** Per-unit valuation if set. The displayed "Value" column shows the
+   * TOTAL (valuation × quantity) for QT assets; see {@link CurrencyCell}. */
   valuation: number | null;
+  /** Asset kind — drives the quantity-aware value breakdown in cells. */
+  type: AssetType;
+  /** Total stock count; >1 only for QT assets. Nullable to match
+   * Prisma's `Asset.quantity` shape; consumers treat `null` as 1
+   * (see `getAssetTotalValue` in `~/utils/asset-value`). */
+  quantity: number | null;
+  /** Optional unit label (e.g. "boxes") used by the value breakdown. */
+  unitOfMeasure: string | null;
 }
 
 /** KPI IDs for the Asset Utilization report */

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
@@ -81,6 +81,7 @@ import { getScanByQrId } from "~/modules/scan/service.server";
 import { parseScanData } from "~/modules/scan/utils.server";
 import { getTeamMembersForQuantityCustody } from "~/modules/team-member/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { formatAssetValueWithBreakdown } from "~/utils/asset-value";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getClientHint } from "~/utils/client-hints";
 import { formatCurrency } from "~/utils/currency";
@@ -1220,6 +1221,36 @@ export default function AssetOverview() {
                   />
                 )}
               />
+
+              {/* QT-aware: shows total value (per-unit × quantity) below the
+                  per-unit Value row. Hidden for INDIVIDUAL assets and QT with
+                  qty=1 where it would be redundant. */}
+              {isQuantityTracked(asset) &&
+              asset.valuation != null &&
+              (asset.quantity ?? 1) > 1
+                ? (() => {
+                    const breakdown = formatAssetValueWithBreakdown(asset, {
+                      currency: asset.organization.currency,
+                      locale,
+                    });
+                    return (
+                      <li className="w-full border-b-[1.1px] border-b-gray-100 p-4 last:border-b-0 md:flex">
+                        <span className="w-1/4 text-[14px] font-medium text-gray-900">
+                          Total value
+                        </span>
+                        <div className="mt-1 text-gray-600 md:mt-0 md:w-3/5">
+                          {breakdown.total}
+                          {breakdown.unit && breakdown.suffix ? (
+                            <span className="text-gray-500">
+                              {" "}
+                              ({breakdown.unit} {breakdown.suffix})
+                            </span>
+                          ) : null}
+                        </div>
+                      </li>
+                    );
+                  })()
+                : null}
 
               {asset?.assetModel ? (
                 <li className="w-full border-b-[1.1px] border-b-gray-100 p-4 last:border-b-0 md:flex">

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -1062,7 +1062,14 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         bookingFlags,
         totalKits: view.totalKits,
         totalValue: calculateTotalValueOfAssets({
-          assets: bookingAssets,
+          // Each `bookingAssets` row is built from a `BookingAsset` pivot
+          // and preserves `bookedQuantity` (= `ba.quantity`). The asset's
+          // stock quantity (spread from `...ba.asset`) is intentionally
+          // ignored here — see `calculateTotalValueOfAssets` JSDoc.
+          assets: bookingAssets.map((a) => ({
+            valuation: a.valuation,
+            bookedQuantity: a.bookedQuantity,
+          })),
           currency: currentOrganization.currency,
           locale: getClientHint(request).locale,
         }),

--- a/apps/webapp/app/routes/_layout+/home.tsx
+++ b/apps/webapp/app/routes/_layout+/home.tsx
@@ -1,3 +1,14 @@
+/**
+ * Dashboard (`/` after auth).
+ *
+ * Server-side aggregates the workspace KPIs surfaced on the landing tile
+ * grid: asset count, total inventory value (QT-aware: `value × quantity`
+ * via raw SQL since Prisma's `aggregate({_sum})` can't multiply), assets
+ * by category / status, locations, team members, recent activity, and
+ * onboarding state. Renders the dashboard hero, KPI tiles, the asset-
+ * by-status donut, and the onboarding checklist; tile clicks navigate
+ * into the corresponding index page or report.
+ */
 import { Prisma } from "@prisma/client";
 import type {
   MetaFunction,
@@ -114,9 +125,15 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
             });
           }),
         db
-          .$queryRaw<{ total: bigint }[]>(
+          // `Asset.valuation` is mapped to the DB column `value` (@map),
+          // so raw SQL must reference `value`. `COALESCE(quantity, 1)`
+          // mirrors `getAssetTotalValue` (which treats nullable quantity
+          // as 1, matching the INDIVIDUAL default). No `::bigint` cast —
+          // it truncated fractional Float valuations. SUM on a Float ×
+          // Int returns `double precision`, which arrives as a JS number.
+          .$queryRaw<{ total: number | null }[]>(
             Prisma.sql`
-            SELECT COALESCE(SUM(valuation * quantity), 0)::bigint AS total
+            SELECT COALESCE(SUM(COALESCE(value, 0) * COALESCE(quantity, 1)), 0) AS total
             FROM "Asset"
             WHERE "organizationId" = ${organizationId}
           `

--- a/apps/webapp/app/routes/_layout+/home.tsx
+++ b/apps/webapp/app/routes/_layout+/home.tsx
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import type {
   MetaFunction,
   LoaderFunctionArgs,
@@ -95,20 +96,43 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       cookieResult,
     ] = await Promise.all([
       // 1a. Asset count + total valuation
-      db.asset
-        .aggregate({
-          where: { organizationId },
-          _count: { _all: true },
-          _sum: { valuation: true },
-        })
-        .catch((cause) => {
-          throw new ShelfError({
-            cause,
-            message: "Failed to load asset aggregation",
-            additionalData: { userId, organizationId },
-            label: "Dashboard",
-          });
-        }),
+      // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+      // `aggregate({_sum: { valuation }})` would only sum the per-unit price; QT assets with
+      // quantity > 1 would silently underreport. `$queryRaw` lets us express the multiplication.
+      Promise.all([
+        db.asset
+          .aggregate({
+            where: { organizationId },
+            _count: { _all: true },
+          })
+          .catch((cause) => {
+            throw new ShelfError({
+              cause,
+              message: "Failed to load asset aggregation",
+              additionalData: { userId, organizationId },
+              label: "Dashboard",
+            });
+          }),
+        db
+          .$queryRaw<{ total: bigint }[]>(
+            Prisma.sql`
+            SELECT COALESCE(SUM(valuation * quantity), 0)::bigint AS total
+            FROM "Asset"
+            WHERE "organizationId" = ${organizationId}
+          `
+          )
+          .catch((cause) => {
+            throw new ShelfError({
+              cause,
+              message: "Failed to load asset total valuation",
+              additionalData: { userId, organizationId },
+              label: "Dashboard",
+            });
+          }),
+      ]).then(([countResult, valuationRows]) => ({
+        _count: countResult._count,
+        totalValuation: Number(valuationRows[0]?.total ?? 0),
+      })),
 
       // 1a. Count of assets with known valuation
       db.asset.count({
@@ -296,7 +320,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     ]);
 
     const totalAssets = assetAggregation._count._all;
-    const totalValuation = assetAggregation._sum.valuation ?? 0;
+    const totalValuation = assetAggregation.totalValuation;
 
     const header: HeaderData = {
       title: "Home",

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.overview.tsx
@@ -14,7 +14,6 @@ import When from "~/components/when/when";
 import { getKitOverviewFields } from "~/modules/kit/fields";
 import { getKit } from "~/modules/kit/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
-import { getAssetTotalValue } from "~/utils/asset-value";
 import { getClientHint } from "~/utils/client-hints";
 import { formatCurrency } from "~/utils/currency";
 import { makeShelfError } from "~/utils/error";
@@ -89,9 +88,11 @@ export const handle = {
 export default function KitOverview() {
   const { kit, currentOrganization, locale } = useLoaderData<typeof loader>();
   const { canUseBarcodes } = useBarcodePermissions();
-  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+  // Multiplies per-unit `valuation` by `AssetKit.quantity` — units of
+  // this asset *in this kit*, not workspace stock. A QT asset stocked
+  // at 100 with 5 in this kit contributes `valuation × 5`, not × 100.
   const totalValue = kit.assetKits.reduce(
-    (total, ak) => total + getAssetTotalValue(ak.asset),
+    (total, ak) => total + (ak.asset.valuation ?? 0) * (ak.quantity ?? 1),
     0
   );
 

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.overview.tsx
@@ -14,6 +14,7 @@ import When from "~/components/when/when";
 import { getKitOverviewFields } from "~/modules/kit/fields";
 import { getKit } from "~/modules/kit/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { getAssetTotalValue } from "~/utils/asset-value";
 import { getClientHint } from "~/utils/client-hints";
 import { formatCurrency } from "~/utils/currency";
 import { makeShelfError } from "~/utils/error";
@@ -88,8 +89,9 @@ export const handle = {
 export default function KitOverview() {
   const { kit, currentOrganization, locale } = useLoaderData<typeof loader>();
   const { canUseBarcodes } = useBarcodePermissions();
+  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
   const totalValue = kit.assetKits.reduce(
-    (total, ak) => total + (ak.asset.valuation ?? 0),
+    (total, ak) => total + getAssetTotalValue(ak.asset),
     0
   );
 

--- a/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
@@ -17,6 +17,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { getAssetTotalValue } from "~/utils/asset-value";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
 import {
@@ -96,6 +97,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 title: true,
                 status: true,
                 valuation: true,
+                // QT-aware total value: quantity is needed so the reducer
+                // below can multiply per-unit valuation × quantity for
+                // QUANTITY_TRACKED assets. INDIVIDUAL assets are always
+                // quantity: 1, so the math collapses to the prior behaviour.
+                quantity: true,
                 mainImage: true,
                 thumbnailImage: true,
                 category: { select: { id: true, name: true } },
@@ -134,8 +140,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     // Total value = sum of the contained assets' valuation (a kit has no own
     // value field), mirroring the web kit overview's summed valuation.
+    // QT-aware: multiplies valuation × quantity. Non-breaking — same response
+    // field, more accurate value for kits containing QT assets.
     const totalValue = assets.reduce(
-      (sum, asset) => sum + (asset.valuation ?? 0),
+      (sum, asset) => sum + getAssetTotalValue(asset),
       0
     );
 

--- a/apps/webapp/app/utils/asset-value.test.ts
+++ b/apps/webapp/app/utils/asset-value.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the asset-value helpers.
+ *
+ * These guard the contract that every "total value" surface relies on:
+ * `valuation × quantity` for QT assets, plain `valuation` for INDIVIDUAL
+ * (which always has quantity=1). If the math here drifts from the raw-SQL
+ * `SUM(valuation * quantity)` expressions used in reports/aggregates,
+ * surfaces will silently disagree on the same number.
+ *
+ * @see {@link file://./asset-value.ts}
+ */
+import { AssetType, type Currency } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  formatAssetValueWithBreakdown,
+  getAssetTotalValue,
+} from "./asset-value";
+
+/** Shorthand for a workspace-currency fixture mirroring currency.test.ts. */
+const usd = { currency: "USD" as Currency, locale: "en-US" };
+
+describe("getAssetTotalValue", () => {
+  it("returns the per-unit valuation for INDIVIDUAL assets", () => {
+    // Individual assets are always quantity=1 (DB CHECK); total === valuation.
+    expect(
+      getAssetTotalValue({
+        type: AssetType.INDIVIDUAL,
+        valuation: 2000,
+        quantity: 1,
+      })
+    ).toBe(2000);
+  });
+
+  it("returns valuation × quantity for QT assets with quantity > 1", () => {
+    expect(
+      getAssetTotalValue({
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: 1,
+        quantity: 100,
+      })
+    ).toBe(100);
+  });
+
+  it("returns 0 when valuation is null (no price set means no contribution)", () => {
+    expect(
+      getAssetTotalValue({
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: null,
+        quantity: 100,
+      })
+    ).toBe(0);
+  });
+
+  it("treats null/undefined quantity as 1 so callers omitting it don't explode", () => {
+    expect(
+      getAssetTotalValue({
+        type: AssetType.INDIVIDUAL,
+        valuation: 50,
+        quantity: null,
+      })
+    ).toBe(50);
+    expect(
+      getAssetTotalValue({
+        type: AssetType.INDIVIDUAL,
+        valuation: 50,
+      })
+    ).toBe(50);
+  });
+
+  it("returns 0 when valuation is 0 and quantity > 0 (free × N is still 0)", () => {
+    expect(
+      getAssetTotalValue({
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: 0,
+        quantity: 100,
+      })
+    ).toBe(0);
+  });
+});
+
+describe("formatAssetValueWithBreakdown", () => {
+  it("INDIVIDUAL assets get only total — no redundant '× 1 unit' breakdown", () => {
+    const result = formatAssetValueWithBreakdown(
+      {
+        type: AssetType.INDIVIDUAL,
+        valuation: 2000,
+        quantity: 1,
+      },
+      usd
+    );
+    expect(result.total).toBe("$2,000.00");
+    expect(result.unit).toBeNull();
+    expect(result.suffix).toBeNull();
+  });
+
+  it("QT with quantity > 1 returns total, unit price, and labelled suffix", () => {
+    const result = formatAssetValueWithBreakdown(
+      {
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: 1,
+        quantity: 100,
+        unitOfMeasure: "boxes",
+      },
+      usd
+    );
+    expect(result.total).toBe("$100.00");
+    expect(result.unit).toBe("$1.00");
+    expect(result.suffix).toBe("× 100 boxes");
+  });
+
+  it("QT with quantity > 1 and no unitOfMeasure falls back to '× N units'", () => {
+    const result = formatAssetValueWithBreakdown(
+      {
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: 5,
+        quantity: 20,
+        unitOfMeasure: null,
+      },
+      usd
+    );
+    expect(result.total).toBe("$100.00");
+    expect(result.unit).toBe("$5.00");
+    expect(result.suffix).toBe("× 20 units");
+  });
+
+  it("QT with quantity == 1 omits breakdown (nothing useful to surface)", () => {
+    const result = formatAssetValueWithBreakdown(
+      {
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: 50,
+        quantity: 1,
+        unitOfMeasure: "boxes",
+      },
+      usd
+    );
+    expect(result.total).toBe("$50.00");
+    expect(result.unit).toBeNull();
+    expect(result.suffix).toBeNull();
+  });
+
+  it("QT with null valuation produces zero-formatted total and no breakdown", () => {
+    const result = formatAssetValueWithBreakdown(
+      {
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: null,
+        quantity: 100,
+        unitOfMeasure: "boxes",
+      },
+      usd
+    );
+    expect(result.total).toBe("$0.00");
+    expect(result.unit).toBeNull();
+    expect(result.suffix).toBeNull();
+  });
+
+  it("respects locale + currency formatting (de-DE, EUR)", () => {
+    const result = formatAssetValueWithBreakdown(
+      {
+        type: AssetType.QUANTITY_TRACKED,
+        valuation: 1.5,
+        quantity: 10,
+        unitOfMeasure: "kg",
+      },
+      { currency: "EUR" as Currency, locale: "de-DE" }
+    );
+    // German locale uses comma as decimal separator.
+    expect(result.total).toContain("15,00");
+    expect(result.unit).toContain("1,50");
+    expect(result.suffix).toBe("× 10 kg");
+  });
+});

--- a/apps/webapp/app/utils/asset-value.ts
+++ b/apps/webapp/app/utils/asset-value.ts
@@ -1,0 +1,174 @@
+/**
+ * Asset value helpers — single source of truth for "total value" math.
+ *
+ * `Asset.valuation` is stored **per unit** by schema (one Pen costs €1, even
+ * when the Pens asset row has `quantity: 100`). Pre-Wave-B every asset was
+ * effectively `quantity: 1`, so "valuation" and "total value" were the same
+ * number — no UI ever had to distinguish them. With QUANTITY_TRACKED assets
+ * the two diverge: dashboards / location / kit / booking totals that sum
+ * `valuation` without multiplying by `quantity` silently underreport.
+ *
+ * This module centralises the multiplication in ONE place so:
+ *
+ *   - Every JS surface (cells, tooltips, aggregates over already-loaded
+ *     assets) reaches for {@link getAssetTotalValue}.
+ *   - Raw-SQL aggregates (`SUM(valuation * quantity)` in `$queryRaw`)
+ *     stay numerically consistent with the JS helper. If you change the
+ *     math here, update the SQL fragments in `modules/reports/*` and
+ *     friends to match — they intentionally mirror this expression.
+ *
+ * INDIVIDUAL assets are always `quantity: 1` (DB CHECK), so the helper
+ * collapses to "return valuation" for them — no behaviour change.
+ *
+ * @see {@link file://./asset-quantity.ts} formatUnitCount — produces the
+ *   "× 100 boxes" suffix surfaced alongside the totals.
+ * @see {@link file://./currency.ts} formatCurrency — used to render each
+ *   monetary string in the workspace's currency + locale.
+ * @see {@link file://./../modules/asset/utils.ts} isQuantityTracked — call
+ *   sites still gate UI on this; this helper is type-safe for both kinds.
+ */
+
+import type { AssetType, Currency } from "@prisma/client";
+
+import { formatUnitCount } from "./asset-quantity";
+import { formatCurrency } from "./currency";
+
+/**
+ * Minimal asset shape needed to compute total value.
+ *
+ * - `valuation` is the per-unit price (nullable: assets may have no price set).
+ * - `quantity` is the total stock count (optional; treated as 1 when missing,
+ *   which matches the DB CHECK constraint for INDIVIDUAL assets).
+ * - `type` and `unitOfMeasure` are optional — only needed by the breakdown
+ *   formatter to label the suffix and decide whether to surface it at all.
+ */
+export type AssetForValue = {
+  type?: AssetType | null;
+  valuation: number | null;
+  quantity?: number | null;
+  unitOfMeasure?: string | null;
+};
+
+/**
+ * Returns the TOTAL monetary value of an asset: `valuation × quantity`.
+ *
+ * Designed for both INDIVIDUAL and QUANTITY_TRACKED assets:
+ *
+ *   - INDIVIDUAL → `quantity` is always 1, so result === `valuation ?? 0`.
+ *   - QT with quantity > 1 → result is the multiplied total.
+ *
+ * Edge cases:
+ *
+ *   - `valuation: null` → returns 0 (no price set means no contribution).
+ *   - `quantity: null` / `undefined` → treated as 1 (matches the schema
+ *     default for INDIVIDUAL and avoids exploding when callers project the
+ *     asset without `quantity`). Caller should still include `quantity` in
+ *     the Prisma `select` for QT assets — see CLAUDE.md "Loader audit".
+ *   - `valuation: 0` with `quantity > 0` → returns 0 (free items × N is 0).
+ *
+ * @param asset - The asset (only `valuation` and `quantity` are read here).
+ * @returns The total value as a plain number (caller formats to currency).
+ */
+export function getAssetTotalValue(asset: AssetForValue): number {
+  const unitValue = asset.valuation ?? 0;
+  const quantity = asset.quantity ?? 1;
+  return unitValue * quantity;
+}
+
+/**
+ * Options for the breakdown formatter — workspace currency + UI locale.
+ *
+ * Mirrors `formatCurrency`'s signature so callers can pass the same
+ * `{ currency, locale }` they already build for other monetary fields.
+ */
+export type FormatAssetValueOptions = {
+  currency: Currency;
+  locale: string;
+};
+
+/**
+ * The three pieces of a breakdown display:
+ *
+ *   - `total`  — always populated; the currency-formatted total value
+ *     (e.g. `"€100.00"`).
+ *   - `unit`   — the per-unit price formatted with the same currency, or
+ *     `null` when there's no useful breakdown to surface.
+ *   - `suffix` — the human "× N boxes" string (from {@link formatUnitCount}),
+ *     or `null` when omitted (same condition as `unit`).
+ *
+ * The `unit` / `suffix` pair is `null` when the breakdown would be
+ * redundant or meaningless: INDIVIDUAL assets (qty always 1), QT assets
+ * with `quantity` ≤ 1 or missing, and QT assets with `valuation: null`.
+ */
+export type AssetValueBreakdown = {
+  total: string;
+  unit: string | null;
+  suffix: string | null;
+};
+
+/**
+ * Renders an asset's value as a `{ total, unit, suffix }` breakdown.
+ *
+ * Used by UI surfaces that want to lead with the total (the number users
+ * actually want when comparing inventory worth) while keeping the per-unit
+ * price + count visible as supporting context.
+ *
+ * The breakdown decision matrix:
+ *
+ *   | Asset type   | quantity   | valuation | total          | unit       | suffix         |
+ *   | ------------ | ---------- | --------- | -------------- | ---------- | -------------- |
+ *   | INDIVIDUAL   | any        | any       | formatted      | `null`     | `null`         |
+ *   | QT           | > 1        | non-null  | total formatted| unit price | "× N units"    |
+ *   | QT           | > 1        | null      | "<zero string>"| `null`     | `null`         |
+ *   | QT           | ≤ 1 / null | any       | formatted      | `null`     | `null`         |
+ *
+ * INDIVIDUAL assets get only `total` because qty is always 1 — a "× 1 unit"
+ * suffix is redundant noise. QT assets with `quantity: 1` get the same
+ * treatment for the same reason: there's nothing useful to break down.
+ * QT assets with `valuation: null` show `"€0.00"` and no breakdown — the
+ * caller's UI may choose to render `"-"` instead by checking `total` against
+ * a zero-formatted string, but the helper itself is consistent.
+ *
+ * @param asset - The asset; reads `valuation`, `quantity`, `type`,
+ *   `unitOfMeasure`. Type/unitOfMeasure are only consulted to label the
+ *   suffix — passing them isn't required for INDIVIDUAL assets.
+ * @param options - Workspace currency + locale to format the strings.
+ * @returns The three breakdown pieces; `total` is always set, the other
+ *   two are `null` when no useful breakdown applies.
+ */
+export function formatAssetValueWithBreakdown(
+  asset: AssetForValue,
+  options: FormatAssetValueOptions
+): AssetValueBreakdown {
+  const { currency, locale } = options;
+  const total = getAssetTotalValue(asset);
+  const totalFormatted = formatCurrency({ value: total, currency, locale });
+
+  // QT assets with a real per-unit price and quantity > 1 get the full
+  // breakdown. Everything else collapses to "just the total".
+  const isQt = asset.type === "QUANTITY_TRACKED";
+  const quantity = asset.quantity ?? 1;
+  const hasValuation = asset.valuation != null;
+
+  if (!isQt || quantity <= 1 || !hasValuation) {
+    return { total: totalFormatted, unit: null, suffix: null };
+  }
+
+  // formatUnitCount returns null when not applicable; we've already gated
+  // on type === QUANTITY_TRACKED and quantity > 0, so it should return a
+  // string here, but the `?? null` keeps the type honest.
+  const suffix = formatUnitCount(
+    { type: asset.type as AssetType, unitOfMeasure: asset.unitOfMeasure },
+    quantity
+  );
+
+  return {
+    total: totalFormatted,
+    unit: formatCurrency({
+      value: asset.valuation ?? 0,
+      currency,
+      locale,
+    }),
+    suffix: suffix != null ? `× ${suffix}` : null,
+  };
+}

--- a/apps/webapp/app/utils/bookings.ts
+++ b/apps/webapp/app/utils/bookings.ts
@@ -1,5 +1,6 @@
 import type { Asset, Booking, Currency } from "@prisma/client";
 import { BookingStatus } from "@prisma/client";
+import { getAssetTotalValue } from "./asset-value";
 import { BADGE_COLORS, type BadgeColorScheme } from "./badge-colors";
 import { formatCurrency } from "./currency";
 import { resolveTeamMemberName } from "./user";
@@ -76,11 +77,17 @@ export function calculateTotalValueOfAssets({
   currency,
   locale,
 }: {
-  assets: Pick<Asset, "valuation">[];
+  // `quantity` is required so QT assets contribute valuation × quantity.
+  // INDIVIDUAL assets always have quantity: 1, so behaviour is unchanged for them.
+  assets: Pick<Asset, "valuation" | "quantity">[];
   currency: Currency;
   locale: string;
 }): string {
-  const value = assets.reduce((acc, asset) => acc + (asset.valuation || 0), 0);
+  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+  const value = assets.reduce(
+    (acc, asset) => acc + getAssetTotalValue(asset),
+    0
+  );
   return formatCurrency({
     value: value,
     locale,

--- a/apps/webapp/app/utils/bookings.ts
+++ b/apps/webapp/app/utils/bookings.ts
@@ -1,6 +1,5 @@
-import type { Asset, Booking, Currency } from "@prisma/client";
+import type { Booking, Currency } from "@prisma/client";
 import { BookingStatus } from "@prisma/client";
-import { getAssetTotalValue } from "./asset-value";
 import { BADGE_COLORS, type BadgeColorScheme } from "./badge-colors";
 import { formatCurrency } from "./currency";
 import { resolveTeamMemberName } from "./user";
@@ -37,18 +36,22 @@ export const bookingStatusColorMap: {
 };
 
 /**
- * Calculates the total value of assets in a booking.
- * @param assets - Array of assets with their valuations.
- * @param currency - The currency in which the total value should be formatted.
- * @param locale - The locale for formatting the currency.
- * @returns A formatted string representing the total value of assets.
- * @example
- * const totalValue = calculateTotalValueOfAssets({
- *   assets: [{ valuation: 100 }, { valuation: 200 }],
- *   currency: "USD",
- *   locale: "en-US",
- * });
- * Returns "$300.00"
+ * Calculates the total value of booked items in a booking.
+ *
+ * The multiplier is **`bookedQuantity`** — the units the booking actually
+ * reserved (from `BookingAsset.quantity`), NOT `Asset.quantity` (total
+ * workspace stock). For a QT asset stocked at 100 with 5 booked, the
+ * contribution is `valuation × 5`, not `valuation × 100`. Booking a
+ * single asset across multiple slices (standalone + kit, or two kits)
+ * naturally sums correctly: each slice contributes its own bookedQuantity.
+ *
+ * Callers always project from `booking.bookingAssets`. Do not pass
+ * spread asset rows — they carry stock quantity and would overcharge.
+ *
+ * @param assets - Per-slice projection: `{ valuation, bookedQuantity }`.
+ * @param currency - Workspace currency.
+ * @param locale - UI locale for number formatting.
+ * @returns Formatted total (e.g. `"$300.00"`).
  */
 /** Resolve custodian display name from booking data */
 export function getBookingCustodianName(booking: {
@@ -77,15 +80,26 @@ export function calculateTotalValueOfAssets({
   currency,
   locale,
 }: {
-  // `quantity` is required so QT assets contribute valuation × quantity.
-  // INDIVIDUAL assets always have quantity: 1, so behaviour is unchanged for them.
-  assets: Pick<Asset, "valuation" | "quantity">[];
+  assets: {
+    /** Per-unit price (`Asset.valuation`). May be null when not set. */
+    valuation: number | null;
+    /**
+     * Booked units for this slice (`BookingAsset.quantity`). INDIVIDUAL
+     * assets always have `1`. Defaults to `1` defensively if missing so a
+     * malformed input never explodes; callers should always supply it.
+     */
+    bookedQuantity: number | null;
+  }[];
   currency: Currency;
   locale: string;
 }): string {
-  // QT-aware: multiplies valuation × quantity so qty-tracked assets are not silently underreported.
+  // Multiplies per-unit `valuation` by `bookedQuantity` — the units the
+  // booking actually reserved. Asset stock quantity is irrelevant to a
+  // booking total; using it would overcharge for QT assets where the
+  // booking holds only a slice of the pool. See JSDoc above.
   const value = assets.reduce(
-    (acc, asset) => acc + getAssetTotalValue(asset),
+    (acc, { valuation, bookedQuantity }) =>
+      acc + (valuation ?? 0) * (bookedQuantity ?? 1),
     0
   );
   return formatCurrency({

--- a/apps/webapp/app/utils/csv.server.test.ts
+++ b/apps/webapp/app/utils/csv.server.test.ts
@@ -404,6 +404,47 @@ describe("buildCsvExportDataFromAssets", () => {
       '""',
     ]);
   });
+
+  it("emits per-unit valuation and qty-aware total_value side by side", () => {
+    // QT asset: 100 boxes at €1/each. `valuation` column stays per-unit
+    // (CSV round-trip safe — re-import won't inflate it), while the new
+    // synthetic `total_value` column reports the qty-aware total (€100).
+    const assets = [
+      {
+        id: "asset-pens",
+        title: "Pens",
+        valuation: 1,
+        quantity: 100,
+        type: "QUANTITY_TRACKED",
+        unitOfMeasure: "boxes",
+        tags: [],
+        custody: [],
+        customFields: [],
+      },
+    ];
+
+    const columns = [
+      { name: "name", visible: true, position: 0 },
+      { name: "valuation", visible: true, position: 1 },
+      // Injected by the export caller at MAX_SAFE_INTEGER; here we pin
+      // it to position 2 for a stable assertion.
+      { name: "total_value", visible: true, position: 2 },
+    ];
+
+    const [headers, row] = buildCsvExportDataFromAssets({
+      assets: assets as any,
+      columns: columns as any,
+      currentOrganization: {
+        id: "org-1",
+        barcodesEnabled: false,
+        currency: "USD",
+      },
+      request: baseRequest,
+    });
+
+    expect(headers).toEqual(['"Name"', '"Value"', '"Total value"']);
+    expect(row).toEqual(['"Pens"', '"$1.00"', '"$100.00"']);
+  });
 });
 
 describe("buildCsvExportDataFromBookings", () => {

--- a/apps/webapp/app/utils/csv.server.ts
+++ b/apps/webapp/app/utils/csv.server.ts
@@ -348,6 +348,13 @@ export async function exportAssetsFromIndexToCsv({
     columns: [
       { name: "name", visible: true, position: 0 },
       ...(settings.columns as Column[]),
+      // Synthetic export-only column: emits `valuation × quantity` so QT
+      // inventories report total worth without overwriting the per-unit
+      // `valuation` column (kept lossless for CSV → re-import round-trip).
+      // Always appended at the end so existing user column ordering is
+      // unaffected. Not in `defaultFields` / column-picker schema, so
+      // users can't toggle or reorder it via settings.
+      { name: "total_value", visible: true, position: Number.MAX_SAFE_INTEGER },
     ],
     currentOrganization,
     request,
@@ -404,7 +411,11 @@ export const buildCsvExportDataFromAssets = ({
 
       // If it's not a custom field, it must be a fixed field or 'name'
       if (!column.name.startsWith("cf_")) {
-        const fieldName = column.name as FixedField | BarcodeField | "name";
+        const fieldName = column.name as
+          | FixedField
+          | BarcodeField
+          | "name"
+          | "total_value";
 
         switch (fieldName) {
           case "id":
@@ -455,18 +466,31 @@ export const buildCsvExportDataFromAssets = ({
               : "";
             break;
           case "valuation":
-            // Per the QT-aware design pick: the CSV valuation column now emits
-            // the TOTAL value (per-unit × quantity). Asset.valuation is still
-            // per-unit in the DB. CSV round-trip is lossy for QT assets —
-            // flagged in the plan (and confirmed by CodeRabbit review) as a
-            // follow-up to address with a per-unit column or import-side
-            // handling. `!= null` (not truthy) so `valuation: 0` still emits
-            // "$0.00" instead of an empty cell.
+            // Per-unit price — matches `Asset.valuation` in the DB so CSV
+            // round-trip (export → re-import) is lossless. The qty-aware
+            // total is emitted separately under `total_value` (see below)
+            // so users see both without breaking the import contract.
+            // `!= null` so `valuation: 0` exports as "$0.00" instead of "".
+            value =
+              asset.valuation != null
+                ? formatCurrency({
+                    value: asset.valuation,
+                    locale: "en-US", // Default locale for CSV exports
+                    currency: currentOrganization.currency,
+                  })
+                : "";
+            break;
+          case "total_value":
+            // Synthetic export-only column injected by the caller (see
+            // `exportAssetsToCsv` and the `ColumnLabelKey` doc). Emits
+            // `valuation × quantity` so QT inventories report correctly —
+            // a Pens row stocked at 100 boxes at €1 each shows €100 here
+            // while the `valuation` column above stays at €1 per-unit.
             value =
               asset.valuation != null
                 ? formatCurrency({
                     value: getAssetTotalValue(asset),
-                    locale: "en-US", // Default locale for CSV exports
+                    locale: "en-US",
                     currency: currentOrganization.currency,
                   })
                 : "";

--- a/apps/webapp/app/utils/csv.server.ts
+++ b/apps/webapp/app/utils/csv.server.ts
@@ -458,15 +458,18 @@ export const buildCsvExportDataFromAssets = ({
             // Per the QT-aware design pick: the CSV valuation column now emits
             // the TOTAL value (per-unit × quantity). Asset.valuation is still
             // per-unit in the DB. CSV round-trip is lossy for QT assets —
-            // flagged in the plan as a follow-up to address with a per-unit
-            // column or import-side handling.
-            value = asset.valuation
-              ? formatCurrency({
-                  value: getAssetTotalValue(asset),
-                  locale: "en-US", // Default locale for CSV exports
-                  currency: currentOrganization.currency,
-                })
-              : "";
+            // flagged in the plan (and confirmed by CodeRabbit review) as a
+            // follow-up to address with a per-unit column or import-side
+            // handling. `!= null` (not truthy) so `valuation: 0` still emits
+            // "$0.00" instead of an empty cell.
+            value =
+              asset.valuation != null
+                ? formatCurrency({
+                    value: getAssetTotalValue(asset),
+                    locale: "en-US", // Default locale for CSV exports
+                    currency: currentOrganization.currency,
+                  })
+                : "";
             break;
           case "availableToBook":
             value = asset.availableToBook ? "Yes" : "No";

--- a/apps/webapp/app/utils/csv.server.ts
+++ b/apps/webapp/app/utils/csv.server.ts
@@ -44,6 +44,7 @@ import {
 import type { BookingWithCustodians } from "~/modules/booking/types";
 import { calculatePartialCheckinProgress } from "~/modules/booking/utils.server";
 import { getPrimaryCustody } from "~/modules/custody/utils";
+import { getAssetTotalValue } from "./asset-value";
 import { getBookingAssetCheckinLabel } from "./booking-assets";
 import { checkExhaustiveSwitch } from "./check-exhaustive-switch";
 import { getDateTimeFormat } from "./client-hints";
@@ -454,9 +455,14 @@ export const buildCsvExportDataFromAssets = ({
               : "";
             break;
           case "valuation":
+            // Per the QT-aware design pick: the CSV valuation column now emits
+            // the TOTAL value (per-unit × quantity). Asset.valuation is still
+            // per-unit in the DB. CSV round-trip is lossy for QT assets —
+            // flagged in the plan as a follow-up to address with a per-unit
+            // column or import-side handling.
             value = asset.valuation
               ? formatCurrency({
-                  value: asset.valuation,
+                  value: getAssetTotalValue(asset),
                   locale: "en-US", // Default locale for CSV exports
                   currency: currentOrganization.currency,
                 })


### PR DESCRIPTION
## Summary

`Asset.valuation` is stored per-unit. Pre-Wave-B (qty-tracked assets), every asset was effectively quantity = 1, so per-unit and total were the same number — single column, single aggregate, no design tension. With QT assets (e.g. Pens at €1 × 100 boxes) the two diverge, and an audit found **14 display surfaces silently underreporting** total inventory worth by an arbitrary multiplier.

This PR introduces qty-aware value display across every surface, with the math centralised in a single helper so JS reducers and raw-SQL aggregates can't drift apart.

### What's new

- New helper `getAssetTotalValue(asset)` — `(valuation ?? 0) × (quantity ?? 1)`. Single source of truth.
- New helper `formatAssetValueWithBreakdown(asset, { currency, locale })` — returns `{ total, unit, suffix }` for clean rendering. INDIVIDUAL and QT-qty-1 assets get `unit/suffix: null` so no redundant "× 1 unit" subtext leaks in.

### What's fixed

**5 silent-bug aggregates** (data correctness):
- Dashboard "Inventory value" tile
- Location total value (`getLocationTotalValuation`)
- Kit overview total value
- Booking total assets value (stats card + PDF)
- 5 report KPIs: Asset Distribution, Asset Inventory, Idle Assets, Custody Snapshot, Overdue Items

For each: `SUM(valuation)` → `SUM(valuation × quantity)`. Prisma `_sum` aggregates that can't express multiplication were rewritten as `$queryRaw` with `Prisma.sql` tagged templates. JS reducers swap `asset.valuation` → `getAssetTotalValue(asset)` after widening the relevant Prisma selects to include `quantity`.

**4 display surfaces** (UX):
    - **Asset detail page:** new "Total value" row beneath the existing "Value" row. Shows `€100.00 (€1.00 × 100 boxes)` for QT with qty > 1; hidden for INDIVIDUAL and QT qty = 1 (no useful info to surface).
    - **Advanced asset index "Valuation" column:** cell now shows total, with a small `× N boxes` subtext below for QT. INDIVIDUAL rows render identically to today.
    - **Report tables** (asset-inventory, idle-assets, custody-snapshot, asset-utilization): per-row Value column extended via a shared `<CurrencyCell>` so all 4 reports get the breakdown without per-report duplication.
    - **Advanced-index sort:** the `valuation` sort key now multiplies by quantity. Total is the more useful sort target for inventory comparison.

**Export + mobile:**
    - **CSV export `valuation` column:** now emits total value. ⚠ See follow-up below.
    - **Mobile API kit endpoint:** `totalValue` reducer is now qty-aware. Same response field, more accurate number — non-breaking for the in-App-Store companion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quantity-aware asset valuation is now used for totals, including a consistent total value breakdown for multi-unit assets.
  * Added “Total value” display in relevant asset/kit views and included a new **Total value** field in CSV exports.

* **Bug Fixes**
  * Valuation sorting and report/dashboard summaries now reflect quantity-aware totals (valuation × quantity), with improved handling of missing values and correct `$0` rendering.

* **Tests**
  * Added and updated test coverage to verify quantity-aware total calculations and formatting, including CSV export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->