### PR TITLE
fix(kits): use bookingAssets pivot in availability view loader

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
@@ -46,7 +46,16 @@ export function useKitAvailabilityData(items: Items) {
       kit.assetKits.forEach((ak) => {
         const asset = ak.asset;
         if ("bookingAssets" in asset && asset.bookingAssets) {
-          (asset.bookingAssets as Array<{ booking: Booking }>).forEach((ba) => {
+          // Cast through `unknown` because the kits._index loader passes
+          // its `extraInclude` shape through a `<T extends Prisma.KitInclude>`
+          // generic that doesn't propagate the deep `bookingAssets.select.booking`
+          // selection back to consumers — TS sees the default BookingAsset scalar
+          // shape (id, quantity, assetId, assetKitId, bookingId) which doesn't
+          // overlap with the asserted `{ booking: Booking }[]`. Runtime shape is
+          // correct: loader at kits._index.tsx selects `bookingAssets.booking`.
+          (
+            asset.bookingAssets as unknown as Array<{ booking: Booking }>
+          ).forEach((ba) => {
             const booking = ba.booking;
             const key = `${booking.id}-${kit.id}`;
             if (!allBookings.has(key)) {

--- a/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
@@ -48,20 +48,33 @@ export function useKitAvailabilityData(items: Items) {
         if ("bookingAssets" in asset && asset.bookingAssets) {
           // Cast through `unknown` because the kits._index loader passes
           // its `extraInclude` shape through a `<T extends Prisma.KitInclude>`
-          // generic that doesn't propagate the deep `bookingAssets.select.booking`
-          // selection back to consumers — TS sees the default BookingAsset scalar
-          // shape (id, quantity, assetId, assetKitId, bookingId) which doesn't
-          // overlap with the asserted `{ booking: Booking }[]`. Runtime shape is
-          // correct: loader at kits._index.tsx selects `bookingAssets.booking`.
+          // generic that doesn't propagate the deep
+          // `bookingAssets.select.{assetKitId, booking}` selection back to
+          // consumers — TS sees the default BookingAsset scalar shape
+          // which doesn't overlap with the asserted projection. Runtime
+          // shape is correct: loader at kits._index.tsx selects
+          // assetKitId + booking.
           (
-            asset.bookingAssets as unknown as Array<{ booking: Booking }>
-          ).forEach((ba) => {
-            const booking = ba.booking;
-            const key = `${booking.id}-${kit.id}`;
-            if (!allBookings.has(key)) {
-              allBookings.set(key, { ...booking, kitId: kit.id });
-            }
-          });
+            asset.bookingAssets as unknown as Array<{
+              assetKitId: string | null;
+              booking: Booking;
+            }>
+          )
+            // Per-kit-slice filter (Codex review #2676 P2): a QT asset
+            // shared between Kit A and Kit B has one BookingAsset row per
+            // kit slice, each tagged with its own assetKitId. Only emit
+            // the slice belonging to THIS outer kit-iteration (ak.id),
+            // so Kit B's calendar doesn't render bookings that actually
+            // reserved Kit A's slice. Standalone slices (assetKitId =
+            // null) are intentionally dropped — they're not kit-specific.
+            .filter((ba) => ba.assetKitId === ak.id)
+            .forEach((ba) => {
+              const booking = ba.booking;
+              const key = `${booking.id}-${kit.id}`;
+              if (!allBookings.has(key)) {
+                allBookings.set(key, { ...booking, kitId: kit.id });
+              }
+            });
         }
       });
     });

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -117,20 +117,34 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                   id: true,
                   availableToBook: true,
                   status: true,
+                  // Post-Phase-3a: bookings reach assets through the
+                  // BookingAsset pivot (Asset.bookings was removed).
+                  // useKitAvailabilityData already reads
+                  // asset.bookingAssets[].booking — see
+                  // components/assets/assets-index/use-kit-availability-data.ts.
+                  // The pre-pivot `bookings: { ... }` select here threw a
+                  // PrismaClientValidationError on every kit search with
+                  // ?view=availability (Sentry SHELF-WEBAPP-1P1).
                   ...(view === "availability" && {
-                    bookings: {
+                    bookingAssets: {
                       where: {
-                        status: { in: ["RESERVED", "ONGOING", "OVERDUE"] },
+                        booking: {
+                          status: { in: ["RESERVED", "ONGOING", "OVERDUE"] },
+                        },
                       },
                       select: {
-                        id: true,
-                        name: true,
-                        status: true,
-                        from: true,
-                        to: true,
-                        description: true,
-                        custodianTeamMember: true,
-                        custodianUser: true,
+                        booking: {
+                          select: {
+                            id: true,
+                            name: true,
+                            status: true,
+                            from: true,
+                            to: true,
+                            description: true,
+                            custodianTeamMember: true,
+                            custodianUser: true,
+                          },
+                        },
                       },
                     },
                   }),

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -112,6 +112,13 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
           qrCodes: { select: { id: true } },
           assetKits: {
             select: {
+              // AssetKit.id surfaces the kit-slice discriminator. The
+              // consumer filters `bookingAssets[].assetKitId === ak.id`
+              // so a QT asset shared between Kit A and Kit B only emits
+              // each booking on its own kit's calendar — without this,
+              // every kit containing the pooled asset would show every
+              // booking of it (Codex review #2676 P2).
+              id: true,
               asset: {
                 select: {
                   id: true,
@@ -119,7 +126,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                   status: true,
                   // Post-Phase-3a: bookings reach assets through the
                   // BookingAsset pivot (Asset.bookings was removed).
-                  // useKitAvailabilityData already reads
+                  // useKitAvailabilityData reads
                   // asset.bookingAssets[].booking — see
                   // components/assets/assets-index/use-kit-availability-data.ts.
                   // The pre-pivot `bookings: { ... }` select here threw a
@@ -133,6 +140,11 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                         },
                       },
                       select: {
+                        // Discriminator for per-kit attribution in the
+                        // consumer. NULL = standalone slice (not bound
+                        // to a kit) — those are filtered out so they
+                        // don't pollute any kit's availability calendar.
+                        assetKitId: true,
                         booking: {
                           select: {
                             id: true,
@@ -141,6 +153,14 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                             from: true,
                             to: true,
                             description: true,
+                            // FK columns the consumer reads directly
+                            // (bookingWithRelations.kitId at line 87,
+                            // .custodianUserId at line 117 of the
+                            // useKitAvailabilityData hook). Without
+                            // these, both fields were undefined at
+                            // runtime — CodeRabbit review #2676.
+                            kitId: true,
+                            custodianUserId: true,
                             custodianTeamMember: true,
                             custodianUser: true,
                           },


### PR DESCRIPTION
Sentry SHELF-WEBAPP-1P1: GET /kits.data threw
PrismaClientValidationError "Unknown field `bookings` for select statement on model `Asset`" every time a user opened the kits index with ?view=availability — 4 events from 1 user in the first hour; the route was effectively broken for everyone on the availability view.

Root cause: the loader's extraInclude at kits._index.tsx:121 selected `asset.bookings` (the legacy direct M2M relation). Phase 3a replaced it with the BookingAsset pivot — `Asset.bookings` no longer exists, Prisma rejects the query.

Fix:
- kits._index.tsx: rewrite the select from bookings: { where: { status: { in: [...] } }, select: {...} } to bookingAssets: { where: { booking: { status: { in: [...] } } }, select: { booking: { select: {...} } } } Inline comment cites the Sentry issue + the pivot rationale.

- use-kit-availability-data.ts:49: the consumer was already pivot-aware (reads `asset.bookingAssets[].booking`). The existing `as Array<{ booking: Booking }>` cast now fails typecheck because TS sees `asset.bookingAssets` as the default BookingAsset scalar shape — the loader's `<T extends Prisma.KitInclude>` generic doesn't propagate the deep `bookingAssets.booking` selection back to consumers. Cast through `unknown` with an inline comment explaining the inference gap. Runtime shape is correct (loader selects booking).

Fixes SHELF-WEBAPP-1P1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kit availability loading by aligning it with the most up-to-date booking relationships, keeping availability views accurate.
  * Refined how booking events are assembled for the availability timeline so it reflects the correct booking status and timing without relying on older data paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->