### PR TITLE
fix(sentry): kit location 23514 + /kits and asset overview TypeErrors

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
@@ -33,12 +33,14 @@ export function useKitAvailabilityData(items: Items) {
         mainImage: item.image,
         thumbnailImage: item.imageExpiration,
         status: item.status,
-        // why: assetKits is typed as always-present from the loader, but at least
-        // one production crash shows a runtime-undefined edge case. Empty array is
-        // a safe stand-in — an empty kit has nothing available to book.
-        availableToBook: (item.assetKits ?? []).some(
-          (ak) => ak.asset.availableToBook
-        ),
+        // why: match the list view's semantic in kits._index.tsx — a kit is
+        // bookable only when ALL slices are bookable (booking reserves the
+        // whole kit). Undefined assetKits is treated as not-bookable since we
+        // can't verify the slices.
+        availableToBook:
+          item.assetKits == null
+            ? false
+            : !item.assetKits.some((ak) => !ak.asset.availableToBook),
       },
     }));
 

--- a/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
@@ -33,7 +33,12 @@ export function useKitAvailabilityData(items: Items) {
         mainImage: item.image,
         thumbnailImage: item.imageExpiration,
         status: item.status,
-        availableToBook: item.assetKits.some((ak) => ak.asset.availableToBook),
+        // why: assetKits is typed as always-present from the loader, but at least
+        // one production crash shows a runtime-undefined edge case. Empty array is
+        // a safe stand-in — an empty kit has nothing available to book.
+        availableToBook: (item.assetKits ?? []).some(
+          (ak) => ak.asset.availableToBook
+        ),
       },
     }));
 
@@ -43,7 +48,7 @@ export function useKitAvailabilityData(items: Items) {
     const allBookings = new Map();
 
     items.forEach((kit) => {
-      kit.assetKits.forEach((ak) => {
+      (kit.assetKits ?? []).forEach((ak) => {
         const asset = ak.asset;
         if ("bookingAssets" in asset && asset.bookingAssets) {
           // Cast through `unknown` because the kits._index loader passes

--- a/apps/webapp/app/components/location/scan-details.tsx
+++ b/apps/webapp/app/components/location/scan-details.tsx
@@ -63,11 +63,13 @@ export function ScanDetails({
             </div>
             <div className="flex justify-between py-2">
               <p>Browser</p>
-              <p>{lastScan.ua.browser.name}</p>
+              {/* why: ua-parser-js can return empty sub-objects for malformed UA */}
+              {/* strings; fall back to "Unknown" instead of crashing the page. */}
+              <p>{lastScan.ua.browser?.name ?? "Unknown"}</p>
             </div>
             <div className="flex justify-between py-2">
               <p>OS</p>
-              <p>{lastScan.ua.os.name}</p>
+              <p>{lastScan.ua.os?.name ?? "Unknown"}</p>
             </div>
             <div className="flex justify-between py-2">
               <p>Scanned By</p>

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -46,6 +46,7 @@ vitest.mock("~/database/db.server", () => ({
       findFirstOrThrow: vitest.fn().mockResolvedValue({}),
       findFirst: vitest.fn().mockResolvedValue(null),
       findMany: vitest.fn().mockResolvedValue([]),
+      findUnique: vitest.fn().mockResolvedValue(null),
       findUniqueOrThrow: vitest.fn().mockResolvedValue({}),
       delete: vitest.fn().mockResolvedValue({}),
       deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
@@ -192,6 +193,14 @@ vitest.mock("~/modules/note/service.server", () => ({
   createKitMoveNote: vitest.fn().mockResolvedValue({}),
 }));
 
+// why: `bulkUpdateKitLocation` writes per-location system notes via
+// `createSystemLocationNote` after the tx commits. Stubbed so tests
+// don't depend on the real note pipeline (which calls into db.note
+// + markdoc helpers and would unmask unrelated mock gaps).
+vitest.mock("~/modules/location-note/service.server", () => ({
+  createSystemLocationNote: vitest.fn().mockResolvedValue({}),
+}));
+
 // why: testing kit service without executing actual activity event recording
 vitest.mock("~/modules/activity-event/service.server", () => ({
   recordEvent: vitest.fn().mockResolvedValue(undefined),
@@ -242,7 +251,9 @@ describe("createKit", () => {
     );
     //@ts-expect-error missing vitest type
     db.location.findFirst.mockImplementation(({ where }) =>
-      where?.id ? Promise.resolve({ id: where.id }) : Promise.resolve(null)
+      where?.id
+        ? Promise.resolve({ id: where.id, name: where.id })
+        : Promise.resolve(null)
     );
   });
 
@@ -445,7 +456,9 @@ describe("updateKit", () => {
     );
     //@ts-expect-error missing vitest type
     db.location.findFirst.mockImplementation(({ where }) =>
-      where?.id ? Promise.resolve({ id: where.id }) : Promise.resolve(null)
+      where?.id
+        ? Promise.resolve({ id: where.id, name: where.id })
+        : Promise.resolve(null)
     );
   });
 
@@ -3203,5 +3216,333 @@ describe("moveAssetKitUnits", () => {
     expect(db.assetLocation.createMany).not.toHaveBeenCalled();
     expect(db.assetLocation.deleteMany).not.toHaveBeenCalled();
     expect(db.assetLocation.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Verifies the kit-location cascade respects the
+ * `enforce_individual_asset_single_location` Postgres trigger
+ * (packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql).
+ *
+ * INDIVIDUAL assets that already hold a manual AssetLocation row
+ * (`assetKitId IS NULL`) must be skipped when re-creating kit-driven
+ * AssetLocation rows: the trigger permits at most one row per
+ * INDIVIDUAL asset, so a blind `createMany` raises 23514.
+ *
+ * QUANTITY_TRACKED assets and INDIVIDUAL assets with no manual row are
+ * cascaded normally.
+ */
+describe("updateKitLocation - manual placement guard", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    // why: `assertLocationBelongsToOrg` calls `db.location.findFirst` —
+    // echo a row back for any id so the guard passes (a stricter
+    // version of the createKit mock above).
+    //@ts-expect-error missing vitest type
+    db.location.findFirst.mockImplementation(({ where }) =>
+      where?.id
+        ? Promise.resolve({ id: where.id, name: where.id })
+        : Promise.resolve(null)
+    );
+  });
+
+  it("control: cascades all QUANTITY_TRACKED assets when no manual rows exist", async () => {
+    expect.assertions(3);
+
+    const kitRow = {
+      id: "kit-1",
+      name: "Kit 1",
+      assetKits: [
+        {
+          quantity: 10,
+          asset: {
+            id: "asset-qty",
+            title: "Batch",
+            type: AssetType.QUANTITY_TRACKED,
+            quantity: 50,
+            unitOfMeasure: "kg",
+            assetLocations: [],
+          },
+        },
+      ],
+    };
+
+    //@ts-expect-error missing vitest type
+    db.kit.findUnique.mockResolvedValue(kitRow);
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-1", assetId: "asset-qty", quantity: 10 },
+    ]);
+    // No INDIVIDUAL manual rows.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([]);
+
+    const { updateKitLocation } = await import("./service.server");
+
+    await updateKitLocation({
+      id: "kit-1",
+      organizationId: "org-1",
+      currentLocationId: null,
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: { assetKit: { kitId: "kit-1" } },
+    });
+    // Manual-row probe ran.
+    expect(db.assetLocation.findMany).toHaveBeenCalledWith({
+      where: {
+        assetId: { in: ["asset-qty"] },
+        assetKitId: null,
+        asset: { type: "INDIVIDUAL" },
+      },
+      select: { assetId: true },
+    });
+    // Cascade row created for the qty-tracked asset.
+    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          assetId: "asset-qty",
+          locationId: "loc-new",
+          organizationId: "org-1",
+          quantity: 10,
+          assetKitId: "ak-1",
+        },
+      ],
+    });
+  });
+
+  it("control: cascades INDIVIDUAL assets when no manual row blocks them", async () => {
+    expect.assertions(2);
+
+    const kitRow = {
+      id: "kit-1",
+      name: "Kit 1",
+      assetKits: [
+        {
+          quantity: 1,
+          asset: {
+            id: "asset-ind",
+            title: "Single",
+            type: AssetType.INDIVIDUAL,
+            quantity: null,
+            unitOfMeasure: null,
+            assetLocations: [],
+          },
+        },
+      ],
+    };
+
+    //@ts-expect-error missing vitest type
+    db.kit.findUnique.mockResolvedValue(kitRow);
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-ind", assetId: "asset-ind", quantity: 1 },
+    ]);
+    // No manual rows — INDIVIDUAL asset is free to take the kit-driven row.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([]);
+
+    const { updateKitLocation } = await import("./service.server");
+
+    await updateKitLocation({
+      id: "kit-1",
+      organizationId: "org-1",
+      currentLocationId: null,
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: { assetKit: { kitId: "kit-1" } },
+    });
+    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          assetId: "asset-ind",
+          locationId: "loc-new",
+          organizationId: "org-1",
+          quantity: 1,
+          assetKitId: "ak-ind",
+        },
+      ],
+    });
+  });
+
+  it("regression: skips INDIVIDUAL asset whose manual AssetLocation row already exists", async () => {
+    expect.assertions(3);
+
+    const kitRow = {
+      id: "kit-1",
+      name: "Kit 1",
+      assetKits: [
+        {
+          quantity: 1,
+          asset: {
+            id: "asset-ind-manual",
+            title: "Manually placed",
+            type: AssetType.INDIVIDUAL,
+            quantity: null,
+            unitOfMeasure: null,
+            assetLocations: [
+              { location: { id: "loc-manual", name: "Manual Loc" } },
+            ],
+          },
+        },
+        {
+          quantity: 5,
+          asset: {
+            id: "asset-qty",
+            title: "Batch",
+            type: AssetType.QUANTITY_TRACKED,
+            quantity: 50,
+            unitOfMeasure: "kg",
+            assetLocations: [],
+          },
+        },
+      ],
+    };
+
+    //@ts-expect-error missing vitest type
+    db.kit.findUnique.mockResolvedValue(kitRow);
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
+      { id: "ak-qty", assetId: "asset-qty", quantity: 5 },
+    ]);
+    // INDIVIDUAL asset has a manual row — must be skipped.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([
+      { assetId: "asset-ind-manual" },
+    ]);
+
+    const { updateKitLocation } = await import("./service.server");
+
+    await updateKitLocation({
+      id: "kit-1",
+      organizationId: "org-1",
+      currentLocationId: null,
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    // Kit-driven rows still cleared.
+    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: { assetKit: { kitId: "kit-1" } },
+    });
+    // createMany payload omits the manually-placed INDIVIDUAL asset.
+    expect(db.assetLocation.createMany).toHaveBeenCalledTimes(1);
+    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          assetId: "asset-qty",
+          locationId: "loc-new",
+          organizationId: "org-1",
+          quantity: 5,
+          assetKitId: "ak-qty",
+        },
+      ],
+    });
+  });
+});
+
+describe("bulkUpdateKitLocation - manual placement guard", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    //@ts-expect-error missing vitest type
+    db.location.findFirst.mockImplementation(({ where }) =>
+      where?.id
+        ? Promise.resolve({ id: where.id, name: where.id })
+        : Promise.resolve(null)
+    );
+  });
+
+  it("regression: skips INDIVIDUAL asset with manual row across multiple kits", async () => {
+    expect.assertions(3);
+
+    // Two kits in the bulk set; the first contains an INDIVIDUAL asset
+    // that already has a manual AssetLocation row.
+    const kitsWithAssetsRows = [
+      {
+        id: "kit-a",
+        name: "Kit A",
+        locationId: null,
+        location: null,
+        assetKits: [
+          {
+            quantity: 1,
+            asset: {
+              id: "asset-ind-manual",
+              title: "Manually placed",
+              type: AssetType.INDIVIDUAL,
+              quantity: null,
+              unitOfMeasure: null,
+              assetLocations: [
+                { location: { id: "loc-manual", name: "Manual Loc" } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "kit-b",
+        name: "Kit B",
+        locationId: null,
+        location: null,
+        assetKits: [
+          {
+            quantity: 3,
+            asset: {
+              id: "asset-qty",
+              title: "Batch",
+              type: AssetType.QUANTITY_TRACKED,
+              quantity: 50,
+              unitOfMeasure: "kg",
+              assetLocations: [],
+            },
+          },
+        ],
+      },
+    ];
+
+    //@ts-expect-error missing vitest type
+    db.kit.findMany.mockResolvedValue(kitsWithAssetsRows);
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
+      { id: "ak-qty", assetId: "asset-qty", quantity: 3 },
+    ]);
+    // Manual row exists for the INDIVIDUAL asset.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([
+      { assetId: "asset-ind-manual" },
+    ]);
+
+    const { bulkUpdateKitLocation } = await import("./service.server");
+
+    await bulkUpdateKitLocation({
+      kitIds: ["kit-a", "kit-b"],
+      organizationId: "org-1",
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: { assetKit: { kitId: { in: ["kit-a", "kit-b"] } } },
+    });
+    expect(db.assetLocation.createMany).toHaveBeenCalledTimes(1);
+    // Skipped asset not in payload; QT asset still cascaded.
+    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          assetId: "asset-qty",
+          locationId: "loc-new",
+          organizationId: "org-1",
+          quantity: 3,
+          assetKitId: "ak-qty",
+        },
+      ],
+    });
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -29,7 +29,7 @@ import {
 } from "./service.server";
 import { recordEvents } from "../activity-event/service.server";
 import { lockAssetForQuantityUpdate } from "../consumption-log/quantity-lock.server";
-import { createNotes } from "../note/service.server";
+import { createNote, createNotes } from "../note/service.server";
 import { getQr } from "../qr/service.server";
 
 // @vitest-environment node
@@ -3267,13 +3267,18 @@ describe("updateKitLocation - manual placement guard", () => {
       ],
     };
 
+    // why: kit fetched at the top of `updateKitLocation` — drives the
+    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
     //@ts-expect-error missing vitest type
     db.kit.findUnique.mockResolvedValue(kitRow);
+    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
+    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
       { id: "ak-1", assetId: "asset-qty", quantity: 10 },
     ]);
-    // No INDIVIDUAL manual rows.
+    // why: manual-row probe — empty here so the control path cascades every
+    // asset (no INDIVIDUAL manual placement blocks the cascade).
     //@ts-expect-error missing vitest type
     db.assetLocation.findMany.mockResolvedValue([]);
 
@@ -3334,13 +3339,18 @@ describe("updateKitLocation - manual placement guard", () => {
       ],
     };
 
+    // why: kit fetched at the top of `updateKitLocation` — drives the
+    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
     //@ts-expect-error missing vitest type
     db.kit.findUnique.mockResolvedValue(kitRow);
+    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
+    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
       { id: "ak-ind", assetId: "asset-ind", quantity: 1 },
     ]);
-    // No manual rows — INDIVIDUAL asset is free to take the kit-driven row.
+    // why: manual-row probe — empty so the INDIVIDUAL asset is free to take
+    // the kit-driven row (no `enforce_individual_asset_single_location` conflict).
     //@ts-expect-error missing vitest type
     db.assetLocation.findMany.mockResolvedValue([]);
 
@@ -3404,14 +3414,19 @@ describe("updateKitLocation - manual placement guard", () => {
       ],
     };
 
+    // why: kit fetched at the top of `updateKitLocation` — drives the
+    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
     //@ts-expect-error missing vitest type
     db.kit.findUnique.mockResolvedValue(kitRow);
+    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
+    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
       { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
       { id: "ak-qty", assetId: "asset-qty", quantity: 5 },
     ]);
-    // INDIVIDUAL asset has a manual row — must be skipped.
+    // why: manual-row probe — populated for the INDIVIDUAL asset so the
+    // guard must skip it (manual placement wins over kit cascade).
     //@ts-expect-error missing vitest type
     db.assetLocation.findMany.mockResolvedValue([
       { assetId: "asset-ind-manual" },
@@ -3445,11 +3460,95 @@ describe("updateKitLocation - manual placement guard", () => {
       ],
     });
   });
+
+  it("regression: skipped INDIVIDUAL asset emits no event and no note", async () => {
+    expect.assertions(4);
+
+    // Same setup as the regression case above — kit-1 contains an INDIVIDUAL
+    // asset (manual row exists) + a QUANTITY_TRACKED asset (no manual row).
+    const kitRow = {
+      id: "kit-1",
+      name: "Kit 1",
+      assetKits: [
+        {
+          quantity: 1,
+          asset: {
+            id: "asset-ind-manual",
+            title: "Manually placed",
+            type: AssetType.INDIVIDUAL,
+            quantity: null,
+            unitOfMeasure: null,
+            assetLocations: [
+              { location: { id: "loc-manual", name: "Manual Loc" } },
+            ],
+          },
+        },
+        {
+          quantity: 5,
+          asset: {
+            id: "asset-qty",
+            title: "Batch",
+            type: AssetType.QUANTITY_TRACKED,
+            quantity: 50,
+            unitOfMeasure: "kg",
+            assetLocations: [],
+          },
+        },
+      ],
+    };
+
+    // why: kit fetched at the top of `updateKitLocation` — drives the
+    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
+    //@ts-expect-error missing vitest type
+    db.kit.findUnique.mockResolvedValue(kitRow);
+    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
+    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
+      { id: "ak-qty", assetId: "asset-qty", quantity: 5 },
+    ]);
+    // why: manual-row probe — populated for the INDIVIDUAL asset so the
+    // guard must skip it from both the cascade AND the audit trail.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([
+      { assetId: "asset-ind-manual" },
+    ]);
+
+    const { updateKitLocation } = await import("./service.server");
+
+    await updateKitLocation({
+      id: "kit-1",
+      organizationId: "org-1",
+      currentLocationId: null,
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    // Event fires for the cascaded QT asset only — the skipped INDIVIDUAL
+    // asset must not appear (audit trail matches persisted state).
+    expect(recordEvents).toHaveBeenCalledTimes(1);
+    const eventsArg = (recordEvents as ReturnType<typeof vitest.fn>).mock
+      .calls[0][0];
+    expect(eventsArg.map((e: { assetId: string }) => e.assetId)).toEqual([
+      "asset-qty",
+    ]);
+    // Note fires for the cascaded QT asset only.
+    const noteCalls = (createNote as ReturnType<typeof vitest.fn>).mock.calls;
+    const noteAssetIds = noteCalls.map(
+      (c) => (c[0] as { assetId: string }).assetId
+    );
+    expect(noteAssetIds).toEqual(["asset-qty"]);
+    expect(noteAssetIds).not.toContain("asset-ind-manual");
+  });
 });
 
 describe("bulkUpdateKitLocation - manual placement guard", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+    // why: `assertLocationBelongsToOrg` calls `db.location.findFirst` —
+    // echo a row back for any id so the guard passes (mirrors the
+    // setup in the `updateKitLocation` describe above).
     //@ts-expect-error missing vitest type
     db.location.findFirst.mockImplementation(({ where }) =>
       where?.id
@@ -3506,14 +3605,21 @@ describe("bulkUpdateKitLocation - manual placement guard", () => {
       },
     ];
 
+    // why: kits fetched at the top of `bulkUpdateKitLocation` — drives
+    // the in-memory `kitsWithAssets`/`allAssets` lists that the cascade +
+    // audit-trail iterate.
     //@ts-expect-error missing vitest type
     db.kit.findMany.mockResolvedValue(kitsWithAssetsRows);
+    // why: post-deleteMany re-read of the bulk set's AssetKit rows; the
+    // resulting ids/quantities are what the cascade writes into
+    // `assetLocation.createMany`.
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
       { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
       { id: "ak-qty", assetId: "asset-qty", quantity: 3 },
     ]);
-    // Manual row exists for the INDIVIDUAL asset.
+    // why: manual-row probe — populated for the INDIVIDUAL asset so the
+    // guard must skip it from both the cascade AND the audit trail.
     //@ts-expect-error missing vitest type
     db.assetLocation.findMany.mockResolvedValue([
       { assetId: "asset-ind-manual" },
@@ -3544,5 +3650,92 @@ describe("bulkUpdateKitLocation - manual placement guard", () => {
         },
       ],
     });
+  });
+
+  it("regression: bulk path emits no event for skipped INDIVIDUAL", async () => {
+    expect.assertions(2);
+
+    // Same setup as the bulk regression case above — kit-a holds an
+    // INDIVIDUAL asset with a manual row, kit-b holds a QT asset.
+    const kitsWithAssetsRows = [
+      {
+        id: "kit-a",
+        name: "Kit A",
+        locationId: null,
+        location: null,
+        assetKits: [
+          {
+            quantity: 1,
+            asset: {
+              id: "asset-ind-manual",
+              title: "Manually placed",
+              type: AssetType.INDIVIDUAL,
+              quantity: null,
+              unitOfMeasure: null,
+              assetLocations: [
+                { location: { id: "loc-manual", name: "Manual Loc" } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        id: "kit-b",
+        name: "Kit B",
+        locationId: null,
+        location: null,
+        assetKits: [
+          {
+            quantity: 3,
+            asset: {
+              id: "asset-qty",
+              title: "Batch",
+              type: AssetType.QUANTITY_TRACKED,
+              quantity: 50,
+              unitOfMeasure: "kg",
+              assetLocations: [],
+            },
+          },
+        ],
+      },
+    ];
+
+    // why: kits fetched at the top of `bulkUpdateKitLocation` — drives
+    // the in-memory `kitsWithAssets`/`allAssets` lists that the cascade +
+    // audit-trail iterate.
+    //@ts-expect-error missing vitest type
+    db.kit.findMany.mockResolvedValue(kitsWithAssetsRows);
+    // why: post-deleteMany re-read of the bulk set's AssetKit rows; the
+    // resulting ids/quantities are what the cascade writes into
+    // `assetLocation.createMany`.
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
+      { id: "ak-qty", assetId: "asset-qty", quantity: 3 },
+    ]);
+    // why: manual-row probe — populated for the INDIVIDUAL asset so the
+    // guard must skip it from both the cascade AND the audit trail.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([
+      { assetId: "asset-ind-manual" },
+    ]);
+
+    const { bulkUpdateKitLocation } = await import("./service.server");
+
+    await bulkUpdateKitLocation({
+      kitIds: ["kit-a", "kit-b"],
+      organizationId: "org-1",
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    // Event fires for the cascaded QT asset only — the skipped INDIVIDUAL
+    // asset must not appear (audit trail matches persisted state).
+    expect(recordEvents).toHaveBeenCalledTimes(1);
+    const eventsArg = (recordEvents as ReturnType<typeof vitest.fn>).mock
+      .calls[0][0];
+    expect(eventsArg.map((e: { assetId: string }) => e.assetId)).toEqual([
+      "asset-qty",
+    ]);
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -3021,16 +3021,37 @@ export async function updateKitLocation({
             where: { kitId: id },
             select: { id: true, assetId: true, quantity: true },
           });
-          if (assetKitsForKit.length > 0) {
-            await tx.assetLocation.createMany({
-              data: assetKitsForKit.map((ak) => ({
-                assetId: ak.assetId,
-                locationId: newLocationId,
-                organizationId,
-                quantity: ak.quantity,
-                assetKitId: ak.id,
-              })),
-            });
+          // Skip INDIVIDUAL assets that already hold a manual
+          // AssetLocation row (`assetKitId IS NULL`). The
+          // `enforce_individual_asset_single_location` trigger
+          // (packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql)
+          // permits at most one AssetLocation row per INDIVIDUAL asset:
+          // manual placements override kit-driven cascades for
+          // INDIVIDUAL assets — they can hold at most one
+          // AssetLocation row.
+          const manualAssetIds = new Set(
+            (
+              await tx.assetLocation.findMany({
+                where: {
+                  assetId: { in: assetKitsForKit.map((ak) => ak.assetId) },
+                  assetKitId: null,
+                  asset: { type: "INDIVIDUAL" },
+                },
+                select: { assetId: true },
+              })
+            ).map((r) => r.assetId)
+          );
+          const dataToCreate = assetKitsForKit
+            .filter((ak) => !manualAssetIds.has(ak.assetId))
+            .map((ak) => ({
+              assetId: ak.assetId,
+              locationId: newLocationId,
+              organizationId,
+              quantity: ak.quantity,
+              assetKitId: ak.id,
+            }));
+          if (dataToCreate.length > 0) {
+            await tx.assetLocation.createMany({ data: dataToCreate });
           }
         }
 
@@ -3334,16 +3355,37 @@ export async function bulkUpdateKitLocation({
             where: { kitId: { in: actualKitIds } },
             select: { id: true, assetId: true, quantity: true },
           });
-          if (assetKitsForKits.length > 0) {
-            await tx.assetLocation.createMany({
-              data: assetKitsForKits.map((ak) => ({
-                assetId: ak.assetId,
-                locationId: newLocationId,
-                organizationId,
-                quantity: ak.quantity,
-                assetKitId: ak.id,
-              })),
-            });
+          // Skip INDIVIDUAL assets that already hold a manual
+          // AssetLocation row (`assetKitId IS NULL`). The
+          // `enforce_individual_asset_single_location` trigger
+          // (packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql)
+          // permits at most one AssetLocation row per INDIVIDUAL asset:
+          // manual placements override kit-driven cascades for
+          // INDIVIDUAL assets — they can hold at most one
+          // AssetLocation row.
+          const manualAssetIds = new Set(
+            (
+              await tx.assetLocation.findMany({
+                where: {
+                  assetId: { in: assetKitsForKits.map((ak) => ak.assetId) },
+                  assetKitId: null,
+                  asset: { type: "INDIVIDUAL" },
+                },
+                select: { assetId: true },
+              })
+            ).map((r) => r.assetId)
+          );
+          const dataToCreate = assetKitsForKits
+            .filter((ak) => !manualAssetIds.has(ak.assetId))
+            .map((ak) => ({
+              assetId: ak.assetId,
+              locationId: newLocationId,
+              organizationId,
+              quantity: ak.quantity,
+              assetKitId: ak.id,
+            }));
+          if (dataToCreate.length > 0) {
+            await tx.assetLocation.createMany({ data: dataToCreate });
           }
         }
 

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -2987,6 +2987,11 @@ export async function updateKitLocation({
         (asset) => (getPrimaryLocation(asset)?.id ?? null) !== newLocationId
       );
 
+      // Lifted out of the tx so the post-tx note loop can also use it
+      // (without re-running the manual-row probe). Populated inside the tx
+      // once the filtered `dataToCreate` is built.
+      let cascadedAssetIds = new Set<string>();
+
       // Connect kit to the new location AND cascade per-asset placement via
       // the AssetLocation pivot, atomically with the per-asset
       // ASSET_LOCATION_CHANGED events. The DEFERRED
@@ -3050,14 +3055,25 @@ export async function updateKitLocation({
               quantity: ak.quantity,
               assetKitId: ak.id,
             }));
+          // Track which assets actually got a kit-driven row so the
+          // audit-trail (events + per-asset notes) matches the persisted
+          // state — skipped manual-placement assets must not appear.
+          cascadedAssetIds = new Set(dataToCreate.map((row) => row.assetId));
           if (dataToCreate.length > 0) {
             await tx.assetLocation.createMany({ data: dataToCreate });
           }
         }
 
-        if (userId && assetsWithLocationChange.length > 0) {
+        // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
+        // row) don't actually move with the kit — exclude them from the
+        // activity event so the audit trail matches the persisted state.
+        const cascadedAssetsForEvents = assetsWithLocationChange.filter(
+          (asset) => cascadedAssetIds.has(asset.id)
+        );
+
+        if (userId && cascadedAssetsForEvents.length > 0) {
           await recordEvents(
-            assetsWithLocationChange.map((asset) => ({
+            cascadedAssetsForEvents.map((asset) => ({
               organizationId,
               actorUserId: userId,
               action: "ASSET_LOCATION_CHANGED" as const,
@@ -3079,7 +3095,13 @@ export async function updateKitLocation({
       });
 
       // Add notes to assets about location update via parent kit
-      if (userId && assetIds.length > 0) {
+      // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
+      // row) don't actually move with the kit — exclude them from the
+      // per-asset note so the audit trail matches the persisted state.
+      const cascadedAssetsForNotes = kit.assets.filter((asset) =>
+        cascadedAssetIds.has(asset.id)
+      );
+      if (userId && cascadedAssetsForNotes.length > 0) {
         const user = await getUserByID(userId, {
           select: {
             id: true,
@@ -3095,7 +3117,7 @@ export async function updateKitLocation({
 
         // Create individual notes for each asset
         await Promise.all(
-          kit.assets.map((asset) =>
+          cascadedAssetsForNotes.map((asset) =>
             createNote({
               content: getKitLocationUpdateNoteContent({
                 currentLocation: getPrimaryLocation(asset), // Use the asset's current location
@@ -3322,6 +3344,11 @@ export async function bulkUpdateKitLocation({
         (asset) => (getPrimaryLocation(asset)?.id ?? null) !== newLocationId
       );
 
+      // Lifted out of the tx so the post-tx per-asset note loop can also use it
+      // (without re-running the manual-row probe). Populated inside the tx
+      // once the filtered `dataToCreate` is built.
+      let cascadedAssetIds = new Set<string>();
+
       // Connect kits to the new location AND cascade per-asset placement via
       // the AssetLocation pivot, atomically with the per-asset
       // ASSET_LOCATION_CHANGED events. The DEFERRED
@@ -3384,14 +3411,25 @@ export async function bulkUpdateKitLocation({
               quantity: ak.quantity,
               assetKitId: ak.id,
             }));
+          // Track which assets actually got a kit-driven row so the
+          // audit-trail (events + per-asset notes) matches the persisted
+          // state — skipped manual-placement assets must not appear.
+          cascadedAssetIds = new Set(dataToCreate.map((row) => row.assetId));
           if (dataToCreate.length > 0) {
             await tx.assetLocation.createMany({ data: dataToCreate });
           }
         }
 
-        if (assetsWithLocationChange.length > 0) {
+        // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
+        // row) don't actually move with the kit — exclude them from the
+        // activity event so the audit trail matches the persisted state.
+        const cascadedAssetsForEvents = assetsWithLocationChange.filter(
+          (asset) => cascadedAssetIds.has(asset.id)
+        );
+
+        if (cascadedAssetsForEvents.length > 0) {
           await recordEvents(
-            assetsWithLocationChange.map((asset) => ({
+            cascadedAssetsForEvents.map((asset) => ({
               organizationId,
               actorUserId: userId,
               action: "ASSET_LOCATION_CHANGED" as const,
@@ -3413,7 +3451,15 @@ export async function bulkUpdateKitLocation({
       });
 
       // Create notes for affected assets
-      if (allAssets.length > 0) {
+      // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
+      // row) don't actually move with the kit — exclude them from the
+      // per-asset note so the audit trail matches the persisted state.
+      // (Kit-level system notes below are emitted per-kit and remain
+      // unfiltered — they describe the kit-level movement, not asset rows.)
+      const cascadedAssetsForNotes = allAssets.filter((asset) =>
+        cascadedAssetIds.has(asset.id)
+      );
+      if (cascadedAssetsForNotes.length > 0) {
         const user = await getUserByID(userId, {
           select: {
             id: true,
@@ -3429,7 +3475,7 @@ export async function bulkUpdateKitLocation({
 
         // Create individual notes for each asset
         await Promise.all(
-          allAssets.map((asset) =>
+          cascadedAssetsForNotes.map((asset) =>
             createNote({
               content: getKitLocationUpdateNoteContent({
                 currentLocation: getPrimaryLocation(asset),

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -488,7 +488,9 @@ function ListContent({
                 <KitStatusBadge
                   status={item.status}
                   availableToBook={
-                    !item.assetKits.some((ak) => !ak.asset.availableToBook)
+                    !(item.assetKits ?? []).some(
+                      (ak) => !ak.asset.availableToBook
+                    )
                   }
                 />
                 {displayCode ? <AssetCodeBadge {...displayCode} /> : null}

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -487,10 +487,13 @@ function ListContent({
               <div className="flex flex-wrap items-center gap-2">
                 <KitStatusBadge
                   status={item.status}
+                  // why: undefined assetKits ≠ empty kit — we don't know what's in it,
+                  // so default to not-available (matches the calendar view's semantic
+                  // in use-kit-availability-data.ts).
                   availableToBook={
-                    !(item.assetKits ?? []).some(
-                      (ak) => !ak.asset.availableToBook
-                    )
+                    item.assetKits == null
+                      ? false
+                      : !item.assetKits.some((ak) => !ak.asset.availableToBook)
                   }
                 />
                 {displayCode ? <AssetCodeBadge {...displayCode} /> : null}

--- a/apps/webapp/app/utils/user.ts
+++ b/apps/webapp/app/utils/user.ts
@@ -28,12 +28,15 @@ export function resolveUserDisplayName(
  *  Null-safe — returns "" when teamMember is null/undefined.
  */
 export const resolveTeamMemberName = (
-  teamMember: {
-    name: string;
-    user?: Partial<
-      Pick<User, "displayName" | "firstName" | "lastName" | "email">
-    > | null;
-  },
+  teamMember:
+    | {
+        name: string;
+        user?: Partial<
+          Pick<User, "displayName" | "firstName" | "lastName" | "email">
+        > | null;
+      }
+    | null
+    | undefined,
   includeEmail?: boolean
 ): string => {
   if (!teamMember) return "";

--- a/apps/webapp/app/utils/user.ts
+++ b/apps/webapp/app/utils/user.ts
@@ -24,7 +24,9 @@ export function resolveUserDisplayName(
   return `${first} ${last}`.trim();
 }
 
-/** Resolves the team member name and includes an email if needed */
+/** Resolves the team member name and includes an email if needed.
+ *  Null-safe — returns "" when teamMember is null/undefined.
+ */
 export const resolveTeamMemberName = (
   teamMember: {
     name: string;
@@ -34,6 +36,7 @@ export const resolveTeamMemberName = (
   },
   includeEmail?: boolean
 ): string => {
+  if (!teamMember) return "";
   const displayName = teamMember?.user
     ? resolveUserDisplayName(teamMember.user)
     : "";


### PR DESCRIPTION
## Summary

Triage of three Sentry issues from the 2026-06-30 sweep on shelf-webapp.

- **SHELF-WEBAPP-1P4** — `updateKitLocation` raised Postgres 23514 when an INDIVIDUAL asset in the kit already held a manual `AssetLocation` row (`assetKitId IS NULL`). The `enforce_individual_asset_single_location` trigger rejects the kit-driven INSERT because INDIVIDUAL assets must hold at most one `AssetLocation` row. Fix: query the manual rows for the kit's INDIVIDUAL assets and exclude them from the `createMany` payload — manual placements override kit-driven cascades. Same correction applied to `bulkUpdateKitLocation` (verified to have the identical antipattern). Regression tests added for both.
- **SHELF-WEBAPP-1P2** — TypeError on `/kits` (`Cannot read properties of undefined (reading 'some')`) in a `useMemo` → `Array.map` → `.some(...)` chain. `assetKits` is typed as always-present by the loader, but at least one production crash shows a runtime-undefined edge case. Defensive `(?? [])` guards on three call sites. The deeper *why is `assetKits` undefined?* is a follow-up.
- **SHELF-WEBAPP-1P3** — TypeError on `/assets/:id/overview` (`undefined is not an object (evaluating 's.name')`). `ua-parser-js` can return empty sub-objects for malformed UA strings — `scan-details` now optional-chains `ua.browser?.name` and `ua.os?.name` with an `"Unknown"` fallback. Also makes `resolveTeamMemberName` null-safe (early return `""` for undefined input) as defense-in-depth.

Two paired transient-DB issues from the same sweep (1P5 + 1P6) were resolved directly in Sentry as a one-second Supabase pooler blip — no code change needed.

## Test plan

- [x] \`pnpm webapp:validate\` green (2953 tests + 1 skipped; lint, prettier, typecheck, security-review all pass)
- [x] New regression tests cover both \`updateKitLocation\` and \`bulkUpdateKitLocation\` manual-placement paths
- [ ] Manual SQL probe on staging to find a kit with the bug class, then UI-move it
- [ ] Confirm Sentry quiet on \`firstSeen:-24h\` for 1P4 / 1P2 / 1P3 post-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in kit availability/booking calculations when asset-kit data is missing, including kit status display.
  * Made scan details more defensive by showing “Unknown” for missing or malformed browser/OS data.
  * Preserved user-manual placements for individual assets during kit location updates; stopped emitting activities and system notes for intentionally skipped assets.
  * Made team member name rendering null-safe when member data is missing.
* **Tests**
  * Added/expanded regression coverage for kit location cascade behavior and the manual-placement skip guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->