### PR TITLE
fix(bookings): kit duplication, quick-checkout QT progress, and asset search

### DIFF
--- a/.claude/rules/kit-members-via-kit-slices.md
+++ b/.claude/rules/kit-members-via-kit-slices.md
@@ -1,0 +1,58 @@
+---
+description: Route kit members into a booking through kitSlices, never the standalone assetIds bucket
+globs: apps/webapp/app/routes/_layout+/*booking*,apps/webapp/app/routes/_layout+/kits.*,apps/webapp/app/modules/booking/service.server.ts
+---
+
+# Kit Members Go Through `kitSlices`, Not `assetIds`
+
+Post-pivot, `BookingAsset.assetKitId` discriminates a slice: `NULL` =
+standalone (free pool), non-null = kit-driven (FK → `AssetKit.id`). The two
+**partial** unique indexes let one standalone row coexist with N kit rows for
+the same `(booking, asset)` — by design for QT free-pool + kit bookings.
+
+`createBooking` / `updateBookingAssets` create a standalone row for **every**
+`assetIds` entry and a kit row for **every** `kitSlices` entry — they do NOT
+cross-check the buckets. So when adding a kit, routing its member asset ids
+through `assetIds` is always wrong, in one of two ways:
+
+- Pass members in **both** `assetIds` AND `kitSlices` → **duplicate** rows
+  (member shows twice; inflates every count/progress/value total). This was the
+  v1 `manage-kits` bug — pre-pivot the old single unique masked it.
+- Pass members in `assetIds` **only** (no `kitSlices`) → **kit grouping lost**
+  (members render as loose rows, kit unrecognized).
+
+**Rule:** resolve memberships with `buildKitSlicesForBooking({ kitIds,
+organizationId, existingAssetKitIds })` and pass `assetIds: []` (kit-only add)
+or `assetIds: <genuinely-standalone-only>` (mixed). Reference-correct flows:
+`manage-kits` and `scan-assets` (which subtracts kit-slice asset ids from the
+standalone bucket: `assetIds.filter(id => !kitSliceAssetIds.has(id))`).
+
+```ts
+// ❌ Bad — members in the standalone bucket (duplicates, or lost grouping)
+await updateBookingAssets({
+  id,
+  organizationId,
+  assetIds: kitMemberIds,
+  kitSlices,
+});
+
+// ✅ Good — members only as kit-driven slices
+const kitSlices = await buildKitSlicesForBooking({
+  kitIds,
+  organizationId,
+  existingAssetKitIds,
+});
+await updateBookingAssets({
+  id,
+  organizationId,
+  assetIds: [],
+  kitSlices,
+  kitIds,
+  userId,
+});
+```
+
+When you touch one kit→booking flow, grep the siblings (`manage-kits`,
+`kits.$kitId.assets.add-to-existing-booking`, `kits.$kitId.assets.create-new-booking`
+→ `createBooking`, `scan-assets`) — this bug travels in packs. See
+[[quantity-semantics-per-surface]].

--- a/.claude/rules/kit-members-via-kit-slices.md
+++ b/.claude/rules/kit-members-via-kit-slices.md
@@ -11,9 +11,15 @@ standalone (free pool), non-null = kit-driven (FK → `AssetKit.id`). The two
 the same `(booking, asset)` — by design for QT free-pool + kit bookings.
 
 `createBooking` / `updateBookingAssets` create a standalone row for **every**
-`assetIds` entry and a kit row for **every** `kitSlices` entry — they do NOT
-cross-check the buckets. So when adding a kit, routing its member asset ids
-through `assetIds` is always wrong, in one of two ways:
+`assetIds` entry and a kit row for **every** `kitSlices` entry. Both have a
+**safety net for `AssetType.INDIVIDUAL` only**: `updateBookingAssets` drops an
+INDIVIDUAL asset from the standalone insert when it also appears in `kitSlices`
+in the same call (and skips a kit slice when that INDIVIDUAL asset is already a
+standalone row on the booking); `createBooking` applies the same same-call
+filter. `QUANTITY_TRACKED` is deliberately **not** covered (a free-pool slice may
+legitimately coexist with kit slices), so do not rely on the net — route kit
+members correctly. Routing member asset ids through `assetIds` is wrong in one
+of two ways:
 
 - Pass members in **both** `assetIds` AND `kitSlices` → **duplicate** rows
   (member shows twice; inflates every count/progress/value total). This was the

--- a/apps/webapp/app/components/booking/booking-statistics.tsx
+++ b/apps/webapp/app/components/booking/booking-statistics.tsx
@@ -50,11 +50,10 @@ export function BookingStatistics({
           <span className="text-right font-medium">{duration}</span>
         </div>
 
-        <Separator />
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-500">Assets</span>
-          <span className="text-right font-medium">{assetsCount}</span>
-        </div>
+        {/* Check-out/check-in progress sits directly under Booking duration so
+            the three composition counts (Assets / Kits / Total assets) stay
+            grouped together below it. Conditionally rendered — only once the
+            booking has partial checkout/check-in activity. */}
         {lifecycleProgress &&
           lifecycleProgress.totalUnits > 0 &&
           (lifecycleProgress.hasPartialCheckouts ||
@@ -64,6 +63,11 @@ export function BookingStatistics({
               <BookingLifecycleProgressBar progress={lifecycleProgress} />
             </>
           )}
+        <Separator />
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-500">Assets</span>
+          <span className="text-right font-medium">{assetsCount}</span>
+        </div>
         <Separator />
         <div className="flex items-center justify-between">
           <span className="text-sm text-gray-500">Kits</span>

--- a/apps/webapp/app/components/booking/forms/new-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/new-booking-form.tsx
@@ -31,6 +31,14 @@ type NewBookingFormData = {
   booking: {
     custodianRef?: string; // This is a stringified value for custodianRef. It can be either a team member id or a user id
     assetIds?: string[] | null;
+    /**
+     * Optional originating kit id. Present only when the booking is being
+     * created FROM a kit (kit detail → "Create new booking"). Submitted as a
+     * hidden `kitId` input so the action resolves the kit's memberships into
+     * kit-driven slices, keeping the kit grouped in the new booking instead of
+     * its members landing as loose standalone rows.
+     */
+    kitId?: string;
   };
 
   /**
@@ -42,7 +50,7 @@ type NewBookingFormData = {
 
 export function NewBookingForm({ booking, action }: NewBookingFormData) {
   const fetcher = useFetcher<NewBookingActionReturnType>();
-  const { custodianRef, assetIds } = booking;
+  const { custodianRef, assetIds, kitId } = booking;
 
   const { teamMembers, teamMembersForForm, userId, currentOrganization, tags } =
     useLoaderData<NewBookingLoaderReturnType>();
@@ -204,6 +212,9 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
               value={item}
             />
           ))}
+          {/* Submitted only when creating a booking FROM a kit, so the action
+              can resolve the kit's memberships into kit-driven slices. */}
+          {kitId ? <input type="hidden" name="kitId" value={kitId} /> : null}
           <div className={tw("actions-wrapper flex flex-col gap-2")}>
             {!assetIds ? (
               <Button

--- a/apps/webapp/app/modules/api/mobile-code-resolve.server.ts
+++ b/apps/webapp/app/modules/api/mobile-code-resolve.server.ts
@@ -134,7 +134,10 @@ export async function resolveMobileScannedCode({
 
   const membership = await db.userOrganization.findUnique({
     where: {
-      userId_organizationId: { userId: user.id, organizationId: qr.organizationId },
+      userId_organizationId: {
+        userId: user.id,
+        organizationId: qr.organizationId,
+      },
     },
     select: { id: true },
   });

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -2592,7 +2592,12 @@ describe("getAssets search fallback", () => {
     orderDirection: "desc" as const,
   };
 
-  /** The title branch only exists in the full search clause, never the narrow one. */
+  /**
+   * Title contains-clause used to assert the full (post-fallback) search clause
+   * surfaces title matches. Note: title now ALSO appears in the narrow fast-path
+   * clause (see the first test below) so bare-numeric substrings embedded in a
+   * title are matched without needing the zero-row fallback.
+   */
   const titleClause = {
     title: { contains: "103468", mode: "insensitive" },
   };
@@ -2611,12 +2616,47 @@ describe("getAssets search fallback", () => {
 
     expect(findManyMock).toHaveBeenCalledTimes(1);
     const where = (findManyMock.mock.calls[0][0] as any).where;
-    // Narrow clause: sequentialId / barcode / qr only — no title branch.
-    expect(JSON.stringify(where.OR)).not.toContain("title");
+    // Narrow clause covers the indexed ID columns: sequentialId / barcode / qr.
     expect(where.OR).toContainEqual({
       sequentialId: { contains: "103468", mode: "insensitive" },
     });
+    expect(where.OR).toContainEqual({
+      barcodes: {
+        some: { value: { contains: "103468", mode: "insensitive" } },
+      },
+    });
+    expect(where.OR).toContainEqual({
+      qrCodes: { some: { id: { contains: "103468", mode: "insensitive" } } },
+    });
+    // ...and ALSO title + description (both trigram-indexed), so a bare-numeric
+    // substring embedded in a title is matched directly in the fast path
+    // instead of relying on the zero-row fallback.
+    expect(where.OR).toContainEqual({
+      title: { contains: "103468", mode: "insensitive" },
+    });
+    expect(where.OR).toContainEqual({
+      description: { contains: "103468", mode: "insensitive" },
+    });
     expect(result).toEqual({ assets: [{ id: "a1" }], totalAssets: 1 });
+  });
+
+  it("matches a title-embedded number in the fast path without falling back", async () => {
+    // why: regression guard for the dropped "451" → "KCI-451 Kids Resources Box"
+    // match. "451" is ID-shaped (bare digits) so it takes the narrow path, but
+    // the number lives only inside the title. The narrow clause must carry a
+    // `title` contains-clause so the row surfaces on the FIRST query — otherwise
+    // an unrelated ID-column match returns rows, suppresses the zero-row
+    // fallback, and the title-only asset is silently dropped.
+    findManyMock.mockResolvedValueOnce([{ id: "kci-451" }] as never);
+    countMock.mockResolvedValueOnce(1 as never);
+
+    await getAssets({ ...baseParams, search: "451" });
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const where = (findManyMock.mock.calls[0][0] as any).where;
+    expect(where.OR).toContainEqual({
+      title: { contains: "451", mode: "insensitive" },
+    });
   });
 
   it("falls back to the full search when the narrow clause matches nothing", async () => {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -738,17 +738,24 @@ export async function getAssets(params: {
 
         // Fast path: when every term looks like an asset identifier — either
         // bare digits ("21035", a UPC barcode) or canonical sequentialId
-        // ("SAM-0001") — narrow the OR clause to the three columns where an
+        // ("SAM-0001") — narrow the OR clause to the columns where an
         // ID-shaped value can legitimately live: sequentialId, barcode value,
-        // and QR id. All three are covered by trigram GIN indexes added in
-        // migration 20260525110348, so the planner stays on indexed scans and
-        // a real ID lookup (the common case) returns immediately.
+        // QR id, plus title and description. The ID columns are covered by
+        // trigram GIN indexes added in migration 20260525110348, and
+        // title/description are covered by the composite trigram GIN index
+        // Asset_title_description_idx — so the planner stays on indexed scans
+        // and a real ID lookup (the common case) returns immediately.
         //
-        // A bare number can ALSO be embedded in a title, description, or
-        // custom field (e.g. "Armchair (Old SKU: 103468)"), and the shape
-        // alone cannot tell those apart from a real barcode. So we flag the
-        // query for fallback: if this narrow clause returns zero rows,
-        // getAssets builds and re-runs with the full clause below.
+        // title + description are included here (not deferred to the fallback)
+        // because a bare-numeric term often lives ONLY inside a title — e.g.
+        // searching "451" must match "KCI-451 Kids Resources Box". Without
+        // these branches the narrow query can still return rows (some OTHER
+        // asset matches "451" in an ID column), which suppresses the
+        // zero-row fallback and silently drops the title-only match.
+        //
+        // The fallback flag stays set so the remaining slow-path columns
+        // (custodian names, category/location/tags, custom-field JSON ILIKE)
+        // are still covered when this clause returns zero rows.
         if (searchTerms.every(looksLikeAssetId)) {
           shouldFallbackToFullSearch = true;
           where.OR = searchTerms.flatMap((term) => [
@@ -763,6 +770,11 @@ export async function getAssets(params: {
                 some: { id: { contains: term, mode: "insensitive" } },
               },
             },
+            // Trigram-indexed (Asset_title_description_idx) — matches a
+            // bare-numeric substring embedded in a title/description directly
+            // in the fast path, without relying on the zero-row fallback.
+            { title: { contains: term, mode: "insensitive" } },
+            { description: { contains: term, mode: "insensitive" } },
           ]);
           // Remember how many entries belong to the search so the fallback can
           // swap them out without disturbing filter clauses appended later.

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -470,6 +470,36 @@ describe("createBooking", () => {
     expect(result).toEqual(mockBookingData);
   });
 
+  it("drops an INDIVIDUAL asset from the standalone bucket when it is also a kit slice", async () => {
+    // Defense-in-depth: an INDIVIDUAL asset present in BOTH `assetIds` and
+    // `kitSlices` is one physical unit and must be written ONCE (the kit-driven
+    // row), never twice. QUANTITY_TRACKED would be kept in both buckets.
+    expect.assertions(1);
+    //@ts-expect-error missing vitest type
+    db.booking.create.mockResolvedValue(mockBookingData);
+    // why: the overlap guard looks up types for the overlapping id; mark it
+    // INDIVIDUAL so it is dropped from the standalone insert.
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "asset-1", type: "INDIVIDUAL" },
+    ]);
+
+    await createBooking({
+      ...mockCreateBookingParams,
+      assetIds: ["asset-1"],
+      kitSlices: [{ assetId: "asset-1", assetKitId: "ak-1", quantity: 1 }],
+    });
+
+    expect(db.booking.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          bookingAssets: {
+            create: [{ assetId: "asset-1", quantity: 1, assetKitId: "ak-1" }],
+          },
+        }),
+      })
+    );
+  });
+
   it("should create a booking without custodian when custodianUserId is null", async () => {
     expect.assertions(1);
     const paramsWithoutCustodian = {
@@ -1903,6 +1933,45 @@ describe("updateBookingAssets", () => {
         arg.filter((v) => v === "asset-shared").length === 2
     );
     expect(sharedAssetIdArray).toBeDefined();
+  });
+
+  it("skips a kit slice for an INDIVIDUAL asset already standalone on the booking", async () => {
+    // Adding a kit whose INDIVIDUAL member is already a standalone row must NOT
+    // insert a second (kit-driven) row for that one physical unit. QT is exempt.
+    expect.assertions(2);
+    const mockBooking = {
+      id: "booking-1",
+      name: "Test Booking",
+      status: BookingStatus.DRAFT,
+    };
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
+    // why: validAssets lookup must report the member as INDIVIDUAL for the skip.
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "asset-1", type: "INDIVIDUAL" },
+    ]);
+    // why: the asset already exists on the booking as a standalone row.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([{ assetId: "asset-1" }]);
+
+    await updateBookingAssets({
+      id: "booking-1",
+      organizationId: "org-1",
+      assetIds: [],
+      kitIds: ["kit-1"],
+      kitSlices: [{ assetId: "asset-1", assetKitId: "ak-1", quantity: 1 }],
+    });
+
+    // The kit-driven raw INSERT must NOT run for the skipped slice — no
+    // $executeRaw call should carry the AssetKit id.
+    const kitInsertCall = (
+      db.$executeRaw as unknown as ReturnType<typeof vitest.fn>
+    ).mock.calls.find((call: unknown[]) =>
+      call.some((arg) => Array.isArray(arg) && arg.includes("ak-1"))
+    );
+    expect(kitInsertCall).toBeUndefined();
+    expect(db.booking.findUniqueOrThrow).toHaveBeenCalled();
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -500,6 +500,28 @@ describe("createBooking", () => {
     );
   });
 
+  it("dedupes duplicate standalone assetIds into a single BookingAsset row", async () => {
+    // API/mobile payloads aren't uniqueness-checked; a repeated id must not
+    // create two standalone rows (partial-unique violation) or double its
+    // event qty meta.
+    expect.assertions(1);
+    //@ts-expect-error missing vitest type
+    db.booking.create.mockResolvedValue(mockBookingData);
+
+    await createBooking({
+      ...mockCreateBookingParams,
+      assetIds: ["asset-1", "asset-1"],
+    });
+
+    expect(db.booking.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          bookingAssets: { create: [{ assetId: "asset-1" }] },
+        }),
+      })
+    );
+  });
+
   it("should create a booking without custodian when custodianUserId is null", async () => {
     expect.assertions(1);
     const paramsWithoutCustodian = {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -27,6 +27,7 @@ import {
   getKitIdsByAssets,
   updateBasicBooking,
   updateBookingAssets,
+  buildKitSlicesForBooking,
   reserveBooking,
   checkoutBooking,
   fulfilModelRequestsAndCheckout,
@@ -1902,6 +1903,95 @@ describe("updateBookingAssets", () => {
         arg.filter((v) => v === "asset-shared").length === 2
     );
     expect(sharedAssetIdArray).toBeDefined();
+  });
+});
+
+describe("buildKitSlicesForBooking", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("maps each AssetKit membership row to a kit-driven slice spec", async () => {
+    expect.assertions(2);
+
+    // why: buildKitSlicesForBooking reads kit membership rows via
+    // db.assetKit.findMany — stub the rows so we can assert the mapping
+    // without a real DB. The default mock only echoes `{ id }`, so this
+    // override supplies the assetId/quantity the mapping needs.
+    (db.assetKit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "ak-1", assetId: "asset-1", quantity: 1 },
+      { id: "ak-2", assetId: "asset-2", quantity: 4 },
+    ]);
+
+    const slices = await buildKitSlicesForBooking({
+      kitIds: ["kit-1"],
+      organizationId: "org-1",
+    });
+
+    expect(slices).toEqual([
+      { assetId: "asset-1", assetKitId: "ak-1", quantity: 1 },
+      { assetId: "asset-2", assetKitId: "ak-2", quantity: 4 },
+    ]);
+    // The same asset across multiple kits stays distinct per AssetKit id —
+    // mapping is 1:1 with membership rows, never deduped by assetId.
+    expect(slices).toHaveLength(2);
+  });
+
+  it("excludes memberships already represented on the booking", async () => {
+    expect.assertions(1);
+
+    // why: stub three membership rows; `existingAssetKitIds` should filter
+    // out the ones already on the booking so re-adding a kit is idempotent.
+    (db.assetKit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "ak-1", assetId: "asset-1", quantity: 1 },
+      { id: "ak-2", assetId: "asset-2", quantity: 2 },
+      { id: "ak-3", assetId: "asset-3", quantity: 3 },
+    ]);
+
+    const slices = await buildKitSlicesForBooking({
+      kitIds: ["kit-1"],
+      organizationId: "org-1",
+      existingAssetKitIds: new Set(["ak-2"]),
+    });
+
+    expect(slices).toEqual([
+      { assetId: "asset-1", assetKitId: "ak-1", quantity: 1 },
+      { assetId: "asset-3", assetKitId: "ak-3", quantity: 3 },
+    ]);
+  });
+
+  it("org-scopes the AssetKit lookup (cross-org IDOR guard)", async () => {
+    expect.assertions(1);
+
+    // why: capture the where-clause the helper passes so we can prove it is
+    // scoped by organizationId — the only thing stopping a foreign-org kit id
+    // from leaking another org's membership into the caller's booking.
+    (db.assetKit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      []
+    );
+
+    await buildKitSlicesForBooking({
+      kitIds: ["kit-1", "kit-2"],
+      organizationId: "org-1",
+    });
+
+    expect(db.assetKit.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { kitId: { in: ["kit-1", "kit-2"] }, organizationId: "org-1" },
+      })
+    );
+  });
+
+  it("short-circuits to an empty list without querying when no kitIds", async () => {
+    expect.assertions(2);
+
+    const slices = await buildKitSlicesForBooking({
+      kitIds: [],
+      organizationId: "org-1",
+    });
+
+    expect(slices).toEqual([]);
+    expect(db.assetKit.findMany).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -637,6 +637,13 @@ export async function createBooking({
     // step (create payload, org validation, events) reads the same list.
     const slices = kitSlices ?? [];
 
+    // Dedupe the standalone ids up front. `BookingFormSchema` doesn't enforce
+    // uniqueness and API / mobile payloads can repeat an id, which would
+    // otherwise create duplicate standalone rows (violating the
+    // `(bookingId, assetId) WHERE assetKitId IS NULL` partial unique) and
+    // over-count the per-asset event qty meta below. Mirrors updateBookingAssets.
+    const dedupedAssetIds = [...new Set(assetIds)];
+
     // Defensive INDIVIDUAL-overlap guard (mirror of updateBookingAssets): an
     // INDIVIDUAL asset is one physical unit, so it must never be written as BOTH
     // a standalone row AND a kit-driven row — that books it twice. When the same
@@ -647,7 +654,7 @@ export async function createBooking({
     // free-pool standalone slice may legitimately coexist with kit slices), so
     // we only pay for a type lookup when there is an actual overlap.
     const kitSliceAssetIds = new Set(slices.map((s) => s.assetId));
-    const overlapAssetIds = [...new Set(assetIds)].filter((id) =>
+    const overlapAssetIds = dedupedAssetIds.filter((id) =>
       kitSliceAssetIds.has(id)
     );
     let individualOverlapAssetIds = new Set<string>();
@@ -665,7 +672,7 @@ export async function createBooking({
           .map((a) => a.id)
       );
     }
-    const standaloneCreateAssetIds = assetIds.filter(
+    const standaloneCreateAssetIds = dedupedAssetIds.filter(
       (id) => !individualOverlapAssetIds.has(id)
     );
 
@@ -716,9 +723,9 @@ export async function createBooking({
       // organization — otherwise an attacker in Org A could supply Org B's
       // IDs and link foreign-org entities into their own booking. Validation
       // runs with the active `tx` so it commits atomically with the create.
-      if (assetIds.length > 0) {
+      if (dedupedAssetIds.length > 0) {
         await assertAssetsBelongToOrg(
-          { assetIds, organizationId: booking.organizationId },
+          { assetIds: dedupedAssetIds, organizationId: booking.organizationId },
           tx
         );
       }
@@ -804,7 +811,7 @@ export async function createBooking({
       // so the event meta carries `quantity` for QUANTITY_TRACKED assets
       // (no-op for INDIVIDUAL).
       const eventAssetIds = [
-        ...new Set([...assetIds, ...slices.map((s) => s.assetId)]),
+        ...new Set([...dedupedAssetIds, ...slices.map((s) => s.assetId)]),
       ];
       if (eventAssetIds.length > 0) {
         const assetTypes = await tx.asset.findMany({
@@ -822,7 +829,7 @@ export async function createBooking({
         // slice's own quantity. Mirrors `updateBookingAssets` so the same
         // asset added both standalone and via N kits reports the true count.
         const addedQtyByAssetId = new Map<string, number>();
-        for (const sid of assetIds) {
+        for (const sid of dedupedAssetIds) {
           addedQtyByAssetId.set(sid, (addedQtyByAssetId.get(sid) ?? 0) + 1);
         }
         for (const slice of slices) {

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -563,6 +563,7 @@ async function updateBookingKitStates({
 export async function createBooking({
   booking,
   assetIds,
+  kitSlices,
   hints,
 }: {
   /**
@@ -580,9 +581,29 @@ export async function createBooking({
   > & { custodianTeamMemberId: string; tags: { id: string }[] };
 
   /**
-   * Asset IDs that are connected to the booking
+   * Standalone asset IDs that are connected to the booking (no kit
+   * attribution — these become `BookingAsset` rows with `assetKitId` NULL).
+   *
+   * This can happen when:
+   * - Booking is created from assets bulk actions
+   * - Booking is created from the asset page
    */
   assetIds: Asset["id"][];
+
+  /**
+   * Optional kit-driven slice specs — one element per `AssetKit` membership
+   * to attach at creation. Each becomes a `BookingAsset` row carrying a
+   * non-null `assetKitId` (the kit-source discriminator). Supplying these
+   * lets a booking be created directly from a kit selection (e.g. "create
+   * booking from kit"). Build them with {@link buildKitSlicesForBooking} so
+   * the resolution stays org-scoped and consistent with the kit-add route.
+   *
+   * Carrying a LIST (not a 1:1 assetId → assetKitId map) is what lets the
+   * same quantity-tracked asset belonging to multiple kits produce multiple
+   * distinct kit-driven rows (the kit partial unique is on
+   * `(bookingId, assetKitId)`).
+   */
+  kitSlices?: Array<{ assetId: string; assetKitId: string; quantity: number }>;
 
   /**
    * Hints are used for setting the timezone of the booking
@@ -612,16 +633,35 @@ export async function createBooking({
       },
     };
 
+    // Normalize the optional kit-driven slices once so every downstream
+    // step (create payload, org validation, events) reads the same list.
+    const slices = kitSlices ?? [];
+
     /**
-     * If assetsIds are passed, we directly connect them.
-     * This can happen when:
-     * - Booking is created from assets bulk actions
-     * - Booking is created from asset page
-     * */
-    if (assetIds.length > 0) {
-      dataToCreate.bookingAssets = {
-        create: assetIds.map((id) => ({ assetId: id })),
-      };
+     * Build the `BookingAsset` rows to create:
+     * - Standalone rows (`{ assetId }`) keep the historical shape exactly —
+     *   `quantity` defaults to 1 and `assetKitId` stays NULL via the schema
+     *   default, so the no-kit path is unchanged byte-for-byte.
+     * - Kit-driven rows carry a non-null `assetKitId` (a plain scalar column,
+     *   settable directly in a nested create — mirrors `duplicateBooking`) so
+     *   the same asset can be both standalone AND a kit member without
+     *   tripping the `(bookingId, assetId) WHERE assetKitId IS NULL` partial
+     *   unique.
+     */
+    const bookingAssetRows = [
+      ...assetIds.map((id) => ({ assetId: id })),
+      ...slices.map((s) => ({
+        assetId: s.assetId,
+        quantity: s.quantity,
+        assetKitId: s.assetKitId,
+      })),
+    ];
+
+    // Only set the nested create when there's at least one row — this covers
+    // standalone-only, kit-only, and mixed inputs (and avoids an empty
+    // `create: []` when neither is supplied).
+    if (bookingAssetRows.length > 0) {
+      dataToCreate.bookingAssets = { create: bookingAssetRows };
     }
 
     if (booking.custodianUserId) {
@@ -647,6 +687,29 @@ export async function createBooking({
       if (assetIds.length > 0) {
         await assertAssetsBelongToOrg(
           { assetIds, organizationId: booking.organizationId },
+          tx
+        );
+      }
+
+      // SECURITY (cross-org IDOR): kit-slice asset ids and their source
+      // `AssetKit` ids also originate from request/form input and are written
+      // straight onto `BookingAsset` rows. Prove both belong to the booking's
+      // org before the create — otherwise an attacker could attach Org B's
+      // assets/kit memberships to their own booking. Runs with the active `tx`
+      // so it commits atomically with the create.
+      if (slices.length > 0) {
+        await assertAssetsBelongToOrg(
+          {
+            assetIds: slices.map((s) => s.assetId),
+            organizationId: booking.organizationId,
+          },
+          tx
+        );
+        await assertAssetKitsBelongToOrg(
+          {
+            assetKitIds: slices.map((s) => s.assetKitId),
+            organizationId: booking.organizationId,
+          },
           tx
         );
       }
@@ -695,28 +758,50 @@ export async function createBooking({
           entityType: "BOOKING",
           entityId: created.id,
           bookingId: created.id,
-          meta: { assetCount: assetIds.length },
+          // Count the rows actually created (standalone + kit-driven). For the
+          // no-kit path this equals `assetIds.length` (unchanged); mirrors
+          // `duplicateBooking`, which counts its create payload.
+          meta: { assetCount: bookingAssetRows.length },
         },
         tx
       );
 
-      // One BOOKING_ASSETS_ADDED event per asset attached at creation.
-      // Look up `type`/`unitOfMeasure` so the event meta carries
-      // `quantity` for QUANTITY_TRACKED assets (no-op for INDIVIDUAL).
-      // BookingAsset.quantity is the schema default (1) on this path —
-      // `createBooking` accepts no per-asset quantity input.
-      if (assetIds.length > 0) {
+      // One BOOKING_ASSETS_ADDED event per asset attached at creation —
+      // standalone ids PLUS kit-member asset ids, deduped (an asset can be
+      // both a standalone row and a kit member). Look up `type`/`unitOfMeasure`
+      // so the event meta carries `quantity` for QUANTITY_TRACKED assets
+      // (no-op for INDIVIDUAL).
+      const eventAssetIds = [
+        ...new Set([...assetIds, ...slices.map((s) => s.assetId)]),
+      ];
+      if (eventAssetIds.length > 0) {
         const assetTypes = await tx.asset.findMany({
           where: {
-            id: { in: assetIds },
+            id: { in: eventAssetIds },
             organizationId: booking.organizationId,
           },
           select: { id: true, type: true, unitOfMeasure: true },
         });
         const assetTypeById = new Map(assetTypes.map((a) => [a.id, a]));
 
+        // Sum the booked quantity per asset across every row this create is
+        // responsible for: each standalone row contributes 1 (schema default —
+        // `createBooking` takes no per-asset quantity input) plus each kit
+        // slice's own quantity. Mirrors `updateBookingAssets` so the same
+        // asset added both standalone and via N kits reports the true count.
+        const addedQtyByAssetId = new Map<string, number>();
+        for (const sid of assetIds) {
+          addedQtyByAssetId.set(sid, (addedQtyByAssetId.get(sid) ?? 0) + 1);
+        }
+        for (const slice of slices) {
+          addedQtyByAssetId.set(
+            slice.assetId,
+            (addedQtyByAssetId.get(slice.assetId) ?? 0) + slice.quantity
+          );
+        }
+
         await recordEvents(
-          assetIds.map((assetId) => {
+          eventAssetIds.map((assetId) => {
             const asset = assetTypeById.get(assetId);
             return {
               organizationId: booking.organizationId,
@@ -726,8 +811,9 @@ export async function createBooking({
               entityId: created.id,
               bookingId: created.id,
               assetId,
-              // Default BookingAsset.quantity on create = 1 (schema default).
-              meta: asset ? assetQtyMeta(asset, 1) : {},
+              meta: asset
+                ? assetQtyMeta(asset, addedQtyByAssetId.get(assetId))
+                : {},
             };
           }),
           tx
@@ -6553,6 +6639,75 @@ export async function partialCheckoutBooking({
   }
 }
 
+/**
+ * Resolves a set of kits into the kit-driven `BookingAsset` slice specs needed
+ * to add those kits to a booking.
+ *
+ * Each `AssetKit` membership row becomes one slice in the shape the booking
+ * write paths expect (`{ assetId, assetKitId, quantity }`). A kit with N member
+ * assets yields N slices; the SAME asset belonging to MULTIPLE kits yields
+ * MULTIPLE slices (one per `AssetKit.id`). That one-slice-per-membership shape
+ * is exactly what lets a single quantity-tracked asset produce multiple
+ * distinct kit-driven rows — the kit partial unique is on
+ * `(bookingId, assetKitId)`, not `(bookingId, assetId)`.
+ *
+ * Centralizes the resolution previously inlined in the `manage-kits` route
+ * action so `createBooking`, the kit-add route, and any future kit→booking flow
+ * build slices the exact same, org-scoped way (per the repo's
+ * code-abstraction rule).
+ *
+ * SECURITY (cross-org IDOR): `kitIds` originate from request/form input, so the
+ * lookup is scoped by `organizationId`. `AssetKit` carries its own
+ * `organizationId` column, so this is the authoritative org guard — a
+ * foreign-org kit id simply resolves to no rows rather than leaking another
+ * org's kit membership into the caller's booking.
+ *
+ * @param params.kitIds - Kit IDs whose members should become booking slices
+ * @param params.organizationId - The caller's (validated) organization ID
+ * @param params.existingAssetKitIds - Optional set of `AssetKit.id`s already
+ *   represented on the target booking; matching memberships are skipped so
+ *   re-adding a kit that's already (partly) present is idempotent per slice.
+ * @returns One slice spec per newly-added `AssetKit` membership
+ * @throws {ShelfError} If the database lookup fails
+ */
+export async function buildKitSlicesForBooking({
+  kitIds,
+  organizationId,
+  existingAssetKitIds,
+}: {
+  kitIds: string[];
+  organizationId: string;
+  existingAssetKitIds?: Set<string>;
+}): Promise<Array<{ assetId: string; assetKitId: string; quantity: number }>> {
+  // Nothing to resolve — short-circuit so callers can pass an empty list freely.
+  if (kitIds.length === 0) return [];
+
+  try {
+    const assetKits = await db.assetKit.findMany({
+      where: { kitId: { in: kitIds }, organizationId },
+      select: { id: true, assetId: true, quantity: true },
+    });
+
+    // One slice per AssetKit membership, skipping memberships already on the
+    // booking so re-adding a kit doesn't duplicate its slices.
+    return assetKits
+      .filter((ak) => !existingAssetKitIds?.has(ak.id))
+      .map((ak) => ({
+        assetId: ak.assetId,
+        assetKitId: ak.id,
+        quantity: ak.quantity,
+      }));
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message:
+        "Something went wrong while resolving kit contents for the booking.",
+      additionalData: { kitIds, organizationId },
+      label,
+    });
+  }
+}
+
 export async function updateBookingAssets({
   id,
   organizationId,
@@ -6611,10 +6766,13 @@ export async function updateBookingAssets({
       ];
 
       // Validate that all asset IDs exist before inserting into the join table
-      // to prevent FK violations when assets are deleted between UI load and submission
+      // to prevent FK violations when assets are deleted between UI load and
+      // submission. `type` is selected so we can enforce the standalone/
+      // kit-driven invariant below (INDIVIDUAL assets can't legitimately be
+      // both in the same booking).
       const validAssets = await tx.asset.findMany({
         where: { id: { in: uniqueAssetIds }, organizationId },
-        select: { id: true },
+        select: { id: true, type: true },
       });
       const validAssetIds = validAssets.map((a) => a.id);
 
@@ -6650,10 +6808,35 @@ export async function updateBookingAssets({
         tx
       );
 
+      // INVARIANT: an INDIVIDUAL asset is a single physical unit, so it can
+      // never legitimately be BOTH a standalone row AND a kit-driven row in
+      // the same booking — that would book the one unit twice. Defensive
+      // guard for callers that wrongly route a kit member through the
+      // standalone bucket too: when the SAME INDIVIDUAL asset appears in both
+      // `assetIds` and `kitSlices` in this call, drop it from the standalone
+      // insert and let the kit-driven row own it.
+      //
+      // QUANTITY_TRACKED assets are deliberately EXEMPT: N units booked
+      // standalone PLUS M units via a kit are two legitimate, distinct rows,
+      // so we must NOT touch them here.
+      const kitSliceAssetIds = new Set(slices.map((s) => s.assetId));
+      const individualKitOverlapAssetIds = new Set(
+        validAssets
+          .filter(
+            (a) => a.type === AssetType.INDIVIDUAL && kitSliceAssetIds.has(a.id)
+          )
+          .map((a) => a.id)
+      );
+
       // Standalone rows go through an upsert keyed on the
       // (bookingId, assetId) partial unique. Dedupe the standalone ids
-      // since the upsert can't accept duplicate keys in one statement.
-      const standaloneAssetIds = [...new Set(assetIds)];
+      // since the upsert can't accept duplicate keys in one statement, and
+      // exclude any INDIVIDUAL asset that is also a kit slice (see invariant
+      // above). `standaloneAssetIds` and `standaloneQuantities` stay
+      // index-aligned because both derive from the same filtered array.
+      const standaloneAssetIds = [...new Set(assetIds)].filter(
+        (assetId) => !individualKitOverlapAssetIds.has(assetId)
+      );
       const standaloneQuantities = standaloneAssetIds.map(
         (assetId) => quantities?.[assetId] ?? 1
       );

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -637,19 +637,51 @@ export async function createBooking({
     // step (create payload, org validation, events) reads the same list.
     const slices = kitSlices ?? [];
 
+    // Defensive INDIVIDUAL-overlap guard (mirror of updateBookingAssets): an
+    // INDIVIDUAL asset is one physical unit, so it must never be written as BOTH
+    // a standalone row AND a kit-driven row — that books it twice. When the same
+    // INDIVIDUAL asset appears in both `assetIds` and `kitSlices`, drop it from
+    // the standalone bucket and let the kit slice own it. The only current
+    // caller (`bookings.new`) already subtracts kit members, so this just
+    // hardens the service against future callers. QUANTITY_TRACKED is exempt (a
+    // free-pool standalone slice may legitimately coexist with kit slices), so
+    // we only pay for a type lookup when there is an actual overlap.
+    const kitSliceAssetIds = new Set(slices.map((s) => s.assetId));
+    const overlapAssetIds = [...new Set(assetIds)].filter((id) =>
+      kitSliceAssetIds.has(id)
+    );
+    let individualOverlapAssetIds = new Set<string>();
+    if (overlapAssetIds.length > 0) {
+      const overlapTypes = await db.asset.findMany({
+        where: {
+          id: { in: overlapAssetIds },
+          organizationId: booking.organizationId,
+        },
+        select: { id: true, type: true },
+      });
+      individualOverlapAssetIds = new Set(
+        overlapTypes
+          .filter((a) => a.type === AssetType.INDIVIDUAL)
+          .map((a) => a.id)
+      );
+    }
+    const standaloneCreateAssetIds = assetIds.filter(
+      (id) => !individualOverlapAssetIds.has(id)
+    );
+
     /**
      * Build the `BookingAsset` rows to create:
      * - Standalone rows (`{ assetId }`) keep the historical shape exactly —
      *   `quantity` defaults to 1 and `assetKitId` stays NULL via the schema
      *   default, so the no-kit path is unchanged byte-for-byte.
      * - Kit-driven rows carry a non-null `assetKitId` (a plain scalar column,
-     *   settable directly in a nested create — mirrors `duplicateBooking`) so
-     *   the same asset can be both standalone AND a kit member without
-     *   tripping the `(bookingId, assetId) WHERE assetKitId IS NULL` partial
-     *   unique.
+     *   settable directly in a nested create — mirrors `duplicateBooking`). A
+     *   QUANTITY_TRACKED asset may be both standalone AND a kit member (two
+     *   distinct rows under the two partial uniques); INDIVIDUAL overlaps were
+     *   already removed from the standalone bucket above.
      */
     const bookingAssetRows = [
-      ...assetIds.map((id) => ({ assetId: id })),
+      ...standaloneCreateAssetIds.map((id) => ({ assetId: id })),
       ...slices.map((s) => ({
         assetId: s.assetId,
         quantity: s.quantity,
@@ -6820,12 +6852,41 @@ export async function updateBookingAssets({
       // standalone PLUS M units via a kit are two legitimate, distinct rows,
       // so we must NOT touch them here.
       const kitSliceAssetIds = new Set(slices.map((s) => s.assetId));
-      const individualKitOverlapAssetIds = new Set(
-        validAssets
-          .filter(
-            (a) => a.type === AssetType.INDIVIDUAL && kitSliceAssetIds.has(a.id)
+      const individualKitSliceAssetIds = [...kitSliceAssetIds].filter(
+        (assetId) =>
+          validAssets.some(
+            (a) => a.id === assetId && a.type === AssetType.INDIVIDUAL
           )
-          .map((a) => a.id)
+      );
+      const individualKitOverlapAssetIds = new Set(
+        individualKitSliceAssetIds.filter((assetId) =>
+          assetIds.includes(assetId)
+        )
+      );
+
+      // FINDING: an INDIVIDUAL kit member ALREADY on the booking as a standalone
+      // row would be booked twice if we also inserted its kit-driven row (the
+      // two partial uniques don't collide). The same-call guard above only
+      // covers overlap WITHIN this call; here we check rows already persisted and
+      // SKIP the kit slice for any INDIVIDUAL asset that already has a standalone
+      // row — the existing row already books that single physical unit. (QT is
+      // exempt: a free-pool standalone slice legitimately coexists with kits.)
+      const existingStandaloneIndividualAssetIds = new Set<string>(
+        individualKitSliceAssetIds.length > 0
+          ? (
+              await tx.bookingAsset.findMany({
+                where: {
+                  bookingId: id,
+                  assetKitId: null,
+                  assetId: { in: individualKitSliceAssetIds },
+                },
+                select: { assetId: true },
+              })
+            ).map((row) => row.assetId)
+          : []
+      );
+      const effectiveSlices = slices.filter(
+        (s) => !existingStandaloneIndividualAssetIds.has(s.assetId)
       );
 
       // Standalone rows go through an upsert keyed on the
@@ -6846,10 +6907,11 @@ export async function updateBookingAssets({
       // DO NOTHING because adding the same kit twice should be a no-op,
       // not an upsert (the picker filters already-added kits out
       // client-side anyway). One row per kit slice, so an asset in two
-      // kits yields two rows with distinct assetKitId.
-      const kitAssetIds = slices.map((s) => s.assetId);
-      const kitQuantities = slices.map((s) => s.quantity);
-      const kitAssetKitIds = slices.map((s) => s.assetKitId);
+      // kits yields two rows with distinct assetKitId. Uses `effectiveSlices`
+      // so an INDIVIDUAL already-standalone member is skipped (see above).
+      const kitAssetIds = effectiveSlices.map((s) => s.assetId);
+      const kitQuantities = effectiveSlices.map((s) => s.quantity);
+      const kitAssetKitIds = effectiveSlices.map((s) => s.assetKitId);
 
       // The complete set of assets touched by this call — standalone +
       // kit-driven, deduped. Everything after the insert (status flip,

--- a/apps/webapp/app/modules/booking/utils.server.test.ts
+++ b/apps/webapp/app/modules/booking/utils.server.test.ts
@@ -505,6 +505,22 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     expect(p.returnedCount).toBe(0);
   });
 
+  it("qty asset CHECKED_OUT globally but this booking has progressive records → stays Booked", () => {
+    // Global CHECKED_OUT status can come from a DIFFERENT overlapping booking
+    // for a shared QT asset. Because THIS booking has progressive records
+    // (checkedOutAssetIds non-empty), the all-at-once fallback must NOT fire —
+    // trust the per-row counter, so this un-scanned row stays Booked.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [QT("gloves", 100, 0, 0, null, AssetStatus.CHECKED_OUT)],
+      checkedInAssetIds: [],
+      checkedOutAssetIds: ["some-other-asset"],
+      bookingStatus: BookingStatus.ONGOING,
+    });
+    expect(p.totalUnits).toBe(1);
+    expect(p.bookedCount).toBe(1);
+    expect(p.checkedOutCount).toBe(0);
+  });
+
   it("qty asset with partial checkout AND partial returns — still Partial (one asset, one bucket)", () => {
     // C=5, D=2, B=50. D >= B? no. C >= B? no. 0 < C < B → Partial.
     // The row collapses to a single bucket — the asset is mid-flight.
@@ -588,6 +604,24 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     expect(p.totalUnits).toBe(1);
     expect(p.returnedCount).toBe(1);
     expect(p.bookedCount).toBe(0);
+  });
+
+  it("COMPLETE multi-slice QT — never-checked-out slice stays Booked when records exist", () => {
+    // checkedOutAssetIds is asset-level; with progressive records present a
+    // checked-out slice must NOT drag a sibling never-checked-out slice into
+    // Returned. Each slice uses its own C.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        QT("gloves", 50, 50, 0, "K1"), // slice checked out
+        QT("gloves", 30, 0, 0, null), // sibling slice never checked out
+      ],
+      checkedInAssetIds: [],
+      checkedOutAssetIds: ["gloves"],
+      bookingStatus: BookingStatus.COMPLETE,
+    });
+    expect(p.totalUnits).toBe(2);
+    expect(p.returnedCount).toBe(1); // the checked-out slice
+    expect(p.bookedCount).toBe(1); // the never-checked-out slice
   });
 
   it("qty asset with two slices (kit-driven + standalone) — each slice is its own asset count", () => {

--- a/apps/webapp/app/modules/booking/utils.server.test.ts
+++ b/apps/webapp/app/modules/booking/utils.server.test.ts
@@ -487,6 +487,24 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     expect(p.hasPartialCheckins).toBe(false);
   });
 
+  it("qty asset quick-checked-out — CHECKED_OUT status with no progressive records → CheckedOut", () => {
+    // A quick / all-at-once checkout sets the asset status to CHECKED_OUT but
+    // writes NO PartialBookingCheckout rows, so `checkedOutQuantity` stays 0.
+    // The bucketer must trust the live CHECKED_OUT status as "all booked units
+    // out" (mirrors individualBucketOf) — otherwise the row reads as Booked.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [QT("gloves", 100, 0, 0, null, AssetStatus.CHECKED_OUT)],
+      checkedInAssetIds: [],
+      checkedOutAssetIds: [],
+      bookingStatus: BookingStatus.ONGOING,
+    });
+    expect(p.totalUnits).toBe(1);
+    expect(p.bookedCount).toBe(0);
+    expect(p.partialCount).toBe(0);
+    expect(p.checkedOutCount).toBe(1);
+    expect(p.returnedCount).toBe(0);
+  });
+
   it("qty asset with partial checkout AND partial returns — still Partial (one asset, one bucket)", () => {
     // C=5, D=2, B=50. D >= B? no. C >= B? no. 0 < C < B → Partial.
     // The row collapses to a single bucket — the asset is mid-flight.
@@ -556,6 +574,22 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     expect(p.checkinProgressPercentage).toBe(100);
   });
 
+  it("COMPLETE booking with a quick-checked-out QT row (no records) → Returned", () => {
+    // A quick checkout leaves no PartialBookingCheckout rows, so an empty
+    // checkedOutAssetIds means everything was checked out. The QT row (C=0)
+    // must still collapse to Returned at COMPLETE, mirroring INDIVIDUAL rows
+    // (which use `wasCheckedOut`). Before the fix it read as Booked.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [QT("gloves", 100, 0, 0)],
+      checkedInAssetIds: ["gloves"],
+      checkedOutAssetIds: [],
+      bookingStatus: BookingStatus.COMPLETE,
+    });
+    expect(p.totalUnits).toBe(1);
+    expect(p.returnedCount).toBe(1);
+    expect(p.bookedCount).toBe(0);
+  });
+
   it("qty asset with two slices (kit-driven + standalone) — each slice is its own asset count", () => {
     // Slice 1: QT in K1, 0 < C(2) < B(5) → Partial.
     // Slice 2: QT standalone, C=0, D=0 → Booked.
@@ -613,6 +647,46 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     expect(p.checkedOutCount).toBe(0);
     expect(p.returnedCount).toBe(0);
     expect(p.countMode).toBe("units");
+  });
+
+  it("unit mode: kit with a quick-checked-out QT member + checked-out individuals → kit Fully out", () => {
+    // Reproduces the booking-overview bug: a kit whose QT member was quick
+    // checked out (status CHECKED_OUT, checkedOutQuantity 0) alongside fully
+    // checked-out INDIVIDUAL members must collapse to ONE Fully-out unit. Before
+    // the fix the QT member read as Booked, so the kit's members disagreed and
+    // the kit fell through to Booked (the "1 item not checked out" symptom).
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        QT("gloves", 100, 0, 0, "KIT", AssetStatus.CHECKED_OUT),
+        {
+          id: "individual-asset",
+          kitId: "KIT",
+          status: AssetStatus.CHECKED_OUT,
+          assetType: AssetType.INDIVIDUAL,
+        },
+        {
+          id: "saradomin",
+          kitId: "KIT",
+          status: AssetStatus.CHECKED_OUT,
+          assetType: AssetType.INDIVIDUAL,
+        },
+        {
+          id: "standalone",
+          kitId: null,
+          status: AssetStatus.CHECKED_OUT,
+          assetType: AssetType.INDIVIDUAL,
+        },
+      ],
+      checkedInAssetIds: [],
+      checkedOutAssetIds: [],
+      bookingStatus: BookingStatus.ONGOING,
+      countKitsAsSingleUnit: true,
+    });
+    expect(p.totalUnits).toBe(2); // 1 kit unit + 1 standalone
+    expect(p.checkedOutCount).toBe(2); // kit fully out + standalone
+    expect(p.bookedCount).toBe(0);
+    expect(p.partialCount).toBe(0);
+    expect(p.returnedCount).toBe(0);
   });
 
   it("unit mode with an INDIVIDUAL-only kit — kit-as-1-unit collapse still applies (regression guard)", () => {

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -409,30 +409,35 @@ export function calculateBookingLifecycleProgress({
    *
    * QUICK-CHECKOUT CAVEAT: `checkedOutQuantity` (C) is sourced ONLY from
    * `PartialBookingCheckout` rows (progressive checkout). A quick / all-at-once
-   * checkout writes NO such rows yet sets the asset `status` to CHECKED_OUT, so
-   * C stays 0 even though every booked unit is physically out. Relying on C
-   * alone would mis-bucket such a row as Booked. We therefore also consult the
-   * asset status (live branch) and `wasCheckedOut` (final branch), exactly like
-   * {@link individualBucketOf} — a CHECKED_OUT QT row is fully out; a final-state
-   * QT row that was ever checked out is Returned.
+   * checkout writes NO such rows, so C stays 0 even though every booked unit is
+   * physically out. Relying on C alone would mis-bucket such a row as Booked.
+   * The reliable "all-at-once happened" signal is `checkedOutAssetIds` being
+   * EMPTY (its only source is those same records) — a PER-BOOKING signal. We do
+   * NOT use the asset's global `status`: a QUANTITY_TRACKED asset shared across
+   * overlapping bookings can read CHECKED_OUT because of a DIFFERENT booking
+   * (conflict detection only bars INDIVIDUAL assets from overlapping). We also
+   * do NOT use asset-level `wasCheckedOut` for the per-row math — it would
+   * over-mark a never-scanned slice of a multi-slice QT asset once ANY sibling
+   * slice was checked out.
    */
+  const wasAllAtOnceCheckout = checkedOutAssetIds.length === 0;
   const qtyBucketOf = (a: LifecycleAsset): Bucket => {
     const B = Math.max(0, a.bookedQuantity ?? 0);
     let C = Math.max(0, a.checkedOutQuantity ?? 0);
     const D = Math.max(0, a.dispositionedQuantity ?? 0);
-    // Quick checkout: a live CHECKED_OUT status (attributable to THIS booking —
-    // pre-checkout states are forced to Booked before this runs) means all
-    // booked units are out, even with no progressive records. Only ever raises
-    // C toward B, so progressive partial counts (status AVAILABLE) are untouched.
-    if (!isFinal && a.status === AssetStatus.CHECKED_OUT && D === 0 && C < B) {
+    // Quick checkout: an all-at-once checkout of THIS booking (no progressive
+    // records ⇒ empty checkedOutAssetIds) put every booked unit out. Only ever
+    // raises C toward B, so progressive partial counts are untouched. When
+    // records DO exist we trust the per-row counter.
+    if (!isFinal && wasAllAtOnceCheckout && D === 0 && C < B) {
       C = B;
     }
     if (isFinal) {
       // Any units ever checked out → Returned; otherwise still Booked. A pure
-      // quick checkout leaves no records (C=0), so honor `wasCheckedOut` too
-      // (empty checkedOutAssetIds ⇒ everything was checked out), mirroring the
-      // INDIVIDUAL final branch.
-      return C > 0 || wasCheckedOut(a.id) ? "returned" : "booked";
+      // all-at-once checkout leaves no records (C=0), so treat every row as
+      // Returned. When records exist, use the per-row C so a never-checked-out
+      // slice of a multi-slice QT asset correctly stays Booked.
+      return C > 0 || wasAllAtOnceCheckout ? "returned" : "booked";
     }
     if (B > 0 && D >= B) return "returned";
     if (B > 0 && C >= B && D < B) return "checkedOut";

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -406,14 +406,33 @@ export function calculateBookingLifecycleProgress({
    * At COMPLETE/ARCHIVED, rows where any units were ever checked out collapse
    * to Returned; rows that were never out stay Booked. Partial and CheckedOut
    * are unreachable in the final branch by construction.
+   *
+   * QUICK-CHECKOUT CAVEAT: `checkedOutQuantity` (C) is sourced ONLY from
+   * `PartialBookingCheckout` rows (progressive checkout). A quick / all-at-once
+   * checkout writes NO such rows yet sets the asset `status` to CHECKED_OUT, so
+   * C stays 0 even though every booked unit is physically out. Relying on C
+   * alone would mis-bucket such a row as Booked. We therefore also consult the
+   * asset status (live branch) and `wasCheckedOut` (final branch), exactly like
+   * {@link individualBucketOf} — a CHECKED_OUT QT row is fully out; a final-state
+   * QT row that was ever checked out is Returned.
    */
   const qtyBucketOf = (a: LifecycleAsset): Bucket => {
     const B = Math.max(0, a.bookedQuantity ?? 0);
-    const C = Math.max(0, a.checkedOutQuantity ?? 0);
+    let C = Math.max(0, a.checkedOutQuantity ?? 0);
     const D = Math.max(0, a.dispositionedQuantity ?? 0);
+    // Quick checkout: a live CHECKED_OUT status (attributable to THIS booking —
+    // pre-checkout states are forced to Booked before this runs) means all
+    // booked units are out, even with no progressive records. Only ever raises
+    // C toward B, so progressive partial counts (status AVAILABLE) are untouched.
+    if (!isFinal && a.status === AssetStatus.CHECKED_OUT && D === 0 && C < B) {
+      C = B;
+    }
     if (isFinal) {
-      // Any units ever checked out → Returned; otherwise still Booked.
-      return C > 0 ? "returned" : "booked";
+      // Any units ever checked out → Returned; otherwise still Booked. A pure
+      // quick checkout leaves no records (C=0), so honor `wasCheckedOut` too
+      // (empty checkedOutAssetIds ⇒ everything was checked out), mirroring the
+      // INDIVIDUAL final branch.
+      return C > 0 || wasCheckedOut(a.id) ? "returned" : "booked";
     }
     if (B > 0 && D >= B) return "returned";
     if (B > 0 && C >= B && D < B) return "checkedOut";

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
@@ -306,12 +306,13 @@ describe("manage-kits route validation", () => {
         })
       );
 
-      // The route derives `assetIds` from the newly-added kit slices —
-      // the shared asset's id is forwarded once (deduped) so the
-      // service-side asset-status flip downstream sees it.
+      // A pure kit-add passes `assetIds: []` — the kit members travel ONLY
+      // through `kitSlices`. Forwarding them as `assetIds` too would create
+      // duplicate standalone rows (the "kit assets show twice" bug). The
+      // service derives the asset-status flip + events from the kit slices.
       expect(bookingService.updateBookingAssets).toHaveBeenCalledWith(
         expect.objectContaining({
-          assetIds: ["asset-shared"],
+          assetIds: [],
           kitSlices: [
             {
               assetId: "asset-shared",
@@ -715,12 +716,14 @@ describe("manage-kits route validation", () => {
       );
 
       // updateBookingAssets must be called exactly once with ONLY kit1
-      // (not kit2). The route derives `assetIds` from the newly-added kit
-      // slices so the service-side asset-status flip sees them.
+      // (not kit2). A pure kit-add passes `assetIds: []`; the member id
+      // (asset3) travels via `kitSlices`, and the service derives the
+      // status flip + events from those slices. Passing it as `assetIds`
+      // too would create a duplicate standalone row.
       expect(bookingService.updateBookingAssets).toHaveBeenCalledTimes(1);
       expect(bookingService.updateBookingAssets).toHaveBeenCalledWith(
         expect.objectContaining({
-          assetIds: ["asset3"],
+          assetIds: [],
           kitIds: ["kit1"], // ONLY the newly-added kit, not the pre-existing available kit2
           kitSlices: [
             {

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -503,18 +503,29 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     /** We only update the booking if there are NEW assets to add */
     if (newAssetIds.length > 0) {
       /**
-       * We extend main's "only new asset ids" guard with our slice-aware
-       * payload: `assetIds` carries the genuinely-new standalone-style
-       * asset ids (for FK validation + addedAssetIds reporting), while
-       * `kitSlices` carries the per-AssetKit rows that drive kit-driven
-       * inserts and per-row quantities for QUANTITY_TRACKED. `kitSlices`
-       * is already filtered against `existingAssetKitIds`, so it only
-       * contains genuinely new kit-driven rows.
+       * A pure kit-add has NO genuine standalone assets — every member
+       * already travels through `kitSlices` (one per-AssetKit row that
+       * drives the kit-driven insert and carries per-row quantities for
+       * QUANTITY_TRACKED). So we pass `assetIds: []` here.
+       *
+       * Passing the slice asset ids as `assetIds` too would create a
+       * DUPLICATE standalone `BookingAsset` row (assetKitId NULL) for
+       * every member, on top of the kit-driven row — that was the "kit
+       * assets show twice" bug that inflated all booking counts/progress.
+       *
+       * `updateBookingAssets` still validates and reports correctly with
+       * an empty `assetIds`: FK validation unions `assetIds` with the
+       * slice asset ids, and `addedAssetIds` derives from the kit asset
+       * ids, so the ONGOING/OVERDUE status flip and per-asset
+       * `BOOKING_ASSETS_ADDED` events still fire. `scan-assets.tsx` uses
+       * the same standalone-vs-kit-slice separation.
        */
       const b = await updateBookingAssets({
         id: bookingId,
         organizationId,
-        assetIds: newAssetIds, // Only the newly added assets from kits
+        // Pure kit-add: members are created ONLY as kit-driven rows via
+        // `kitSlices`; no standalone rows — see comment above.
+        assetIds: [],
         kitIds: newlyAddedKitIds, // Only kits being added — see comment above
         userId,
         kitSlices,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -795,9 +795,31 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
      * from "fully out" for QT assets that span multiple slices (kit +
      * standalone, or several kit slices).
      */
+    // Legacy / all-at-once checkout fallback. A quick checkout flips the asset
+    // status to CHECKED_OUT but writes NO `PartialBookingCheckout` rows, so the
+    // progressive `checkedOutByBookingAsset` counters are all 0 even though every
+    // booked unit is physically out. An ONGOING/OVERDUE booking with ZERO
+    // checkout sessions can ONLY have reached that state via the all-at-once flow
+    // (the progressive flow always writes a session row per batch), so treat every
+    // booked unit as out → remaining 0. Without this the inline math reports
+    // `booked − 0 = booked` and wrongly offers a fully-out QT asset for more
+    // checkout in the bulk-checkout dialog + scanner drawer.
+    //
+    // KEEP IN SYNC with the canonical `computeBookingAssetRemainingToCheckOut`
+    // (modules/booking/service.server.ts), which the checkout-assets route uses;
+    // this loader mirrors that logic in-memory to avoid an extra query per asset.
+    const isLegacyAllAtOnceCheckout =
+      checkoutSessions.length === 0 &&
+      (booking.status === BookingStatus.ONGOING ||
+        booking.status === BookingStatus.OVERDUE);
+
     const remainingToCheckOutByAsset: Record<string, number> = {};
     for (const [assetId, rows] of bookingAssetRowsByAsset) {
       const totalBooked = rows.reduce((sum, row) => sum + row.quantity, 0);
+      if (isLegacyAllAtOnceCheckout && totalBooked > 0) {
+        remainingToCheckOutByAsset[assetId] = 0;
+        continue;
+      }
       let totalCheckedOut = 0;
       for (const row of rows) {
         totalCheckedOut += checkedOutByBookingAsset.get(row.id) ?? 0;

--- a/apps/webapp/app/routes/_layout+/bookings.new.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.new.tsx
@@ -277,6 +277,22 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     if (kitIds.length > 0) {
       kitSlices = await buildKitSlicesForBooking({ kitIds, organizationId });
+      // Fail fast when a kit-originated submission resolves to no slices (stale
+      // page, deleted/emptied kit, or tampered input). The form pre-filled
+      // `assetIds` with the kit's members, so silently falling through would
+      // write them as loose standalone rows (assetKitId NULL) — breaking the
+      // kit-slice invariant and re-opening the duplicate/count bugs this fixes.
+      if (kitSlices.length === 0) {
+        throw new ShelfError({
+          cause: null,
+          title: "Kit not found",
+          message:
+            "The selected kit could not be resolved. Please reload and try again.",
+          label: "Booking",
+          status: 409,
+          shouldBeCaptured: false,
+        });
+      }
       const kitMemberIds = new Set(kitSlices.map((s) => s.assetId));
       // Subtract kit members so a kit member is never written as BOTH a kit
       // slice and a standalone row (which would duplicate it on the booking).

--- a/apps/webapp/app/routes/_layout+/bookings.new.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.new.tsx
@@ -17,6 +17,7 @@ import { hasGetAllValue } from "~/hooks/use-model-filters";
 import { useUserData } from "~/hooks/use-user-data";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import {
+  buildKitSlicesForBooking,
   createBooking,
   updateBookingNotificationRecipients,
 } from "~/modules/booking/service.server";
@@ -110,6 +111,12 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         // For consistency, also provide teamMembersForForm
         teamMembersForForm: teamMembersData.teamMembers,
         assetIds: assetIds.length ? assetIds : undefined,
+        // Plain /bookings/new has no originating kit. The kit-create route
+        // (kits.$kitId.assets.create-new-booking) reuses this default export
+        // but overrides the loader, supplying a real kitId. Typing it here as
+        // string | undefined lets the shared component read kitId for both
+        // routes without a separate loader type.
+        kitId: undefined as string | undefined,
         ...tagsData,
         ...notifyData,
       }),
@@ -241,6 +248,43 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     const tags = buildTagsSet(commaSeparatedTags).set;
 
+    /**
+     * Kit ids submitted by the form when the booking is created FROM a kit
+     * (kit detail → "Create new booking"). Read straight from the form rather
+     * than via {@link BookingFormSchema} — the schema doesn't model `kitId`,
+     * and we only need the raw ids to resolve kit memberships into slices.
+     *
+     * SECURITY (cross-org IDOR): these ids are user-supplied. We do NOT trust
+     * them — `buildKitSlicesForBooking` resolves memberships scoped to
+     * `organizationId`, and `createBooking` additionally re-validates every
+     * slice's asset id and `AssetKit` id against the org before writing. So no
+     * extra guard is needed here.
+     */
+    const kitIds = formData.getAll("kitId").map(String).filter(Boolean);
+
+    // Resolve kit memberships into kit-driven slices and split the form's
+    // asset ids into the two buckets `createBooking` expects:
+    // - kit members → `kitSlices` (kit-grouped `BookingAsset` rows)
+    // - everything else → `standaloneAssetIds` (loose rows, `assetKitId` NULL)
+    // When no kit is involved, `standaloneAssetIds` is just the form's
+    // `assetIds` and `kitSlices` stays empty (behavior unchanged).
+    let kitSlices: Array<{
+      assetId: string;
+      assetKitId: string;
+      quantity: number;
+    }> = [];
+    let standaloneAssetIds = assetIds?.length ? assetIds : [];
+
+    if (kitIds.length > 0) {
+      kitSlices = await buildKitSlicesForBooking({ kitIds, organizationId });
+      const kitMemberIds = new Set(kitSlices.map((s) => s.assetId));
+      // Subtract kit members so a kit member is never written as BOTH a kit
+      // slice and a standalone row (which would duplicate it on the booking).
+      standaloneAssetIds = standaloneAssetIds.filter(
+        (id) => !kitMemberIds.has(id)
+      );
+    }
+
     const booking = await createBooking({
       booking: {
         from,
@@ -253,7 +297,10 @@ export async function action({ context, request }: ActionFunctionArgs) {
         creatorId: authSession.userId,
         tags,
       },
-      assetIds: assetIds?.length ? assetIds : [],
+      assetIds: standaloneAssetIds,
+      // Only pass slices when a kit was involved; the no-kit path stays
+      // exactly as before.
+      kitSlices: kitIds.length > 0 ? kitSlices : undefined,
       hints: getClientHint(request),
     });
 
@@ -284,23 +331,31 @@ export async function action({ context, request }: ActionFunctionArgs) {
       senderId: authSession.userId,
     });
 
-    const hasAssetIds = Boolean(assetIds);
+    // The booking has assets if EITHER bucket is non-empty. A kit-only
+    // creation (no standalone ids, but kit slices) still "has assets" and must
+    // land on the overview — not the empty-booking manage-assets flow.
+    const bookingHasAssets =
+      standaloneAssetIds.length > 0 || kitSlices.length > 0;
 
     if (intent === "scan") {
       return redirect(`/bookings/${booking.id}/overview/scan-assets`);
     }
 
-    if (hasAssetIds) {
+    if (bookingHasAssets) {
       /**
-       * If the booking was created from a single QUANTITY_TRACKED asset
-       * (e.g. via the asset page's "Create new booking" dropdown), append
-       * an ?adjustQty=<assetId> search param so the overview route can
+       * If the booking was created from a single STANDALONE QUANTITY_TRACKED
+       * asset (e.g. via the asset page's "Create new booking" dropdown),
+       * append an ?adjustQty=<assetId> search param so the overview route can
        * auto-open the quantity adjust dialog. This avoids the user being
        * silently stuck with quantity=1 when they meant to book more.
+       *
+       * Gated on `standaloneAssetIds` (not kit members): a kit-only booking
+       * has zero standalone ids, so it never triggers this single-asset
+       * shortcut and just lands on the overview.
        */
       let redirectUrl = `/bookings/${booking.id}/overview`;
-      if (assetIds && assetIds.length === 1) {
-        const [singleAssetId] = assetIds;
+      if (standaloneAssetIds.length === 1) {
+        const [singleAssetId] = standaloneAssetIds;
         const addedAsset = await db.asset.findFirst({
           where: { id: singleAssetId, organizationId },
           select: { id: true, type: true },
@@ -335,8 +390,14 @@ export const handle = {
 };
 
 export default function NewBooking() {
-  const { header, isSelfServiceOrBase, teamMembers, assetIds, showModal } =
-    useLoaderData<typeof loader>();
+  const {
+    header,
+    isSelfServiceOrBase,
+    teamMembers,
+    assetIds,
+    kitId,
+    showModal,
+  } = useLoaderData<typeof loader>();
   const user = useUserData();
   const dynamicTitle = useAtomValue(dynamicTitleAtom);
 
@@ -362,6 +423,9 @@ export default function NewBooking() {
           booking={{
             assetIds,
             custodianRef,
+            // Undefined on plain /bookings/new; set by the kit-create route so
+            // the kit grouping is preserved in the new booking.
+            kitId,
           }}
         />
       </div>

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -15,11 +15,11 @@ import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
 
 import {
+  buildKitSlicesForBooking,
   getExistingBookingDetails,
   loadBookingsData,
   updateBookingAssets,
 } from "~/modules/booking/service.server";
-import { getAvailableKitAssetForBooking } from "~/modules/kit/service.server";
 import { createNotes } from "~/modules/note/service.server";
 import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
 import { getUserByID } from "~/modules/user/service.server";
@@ -37,7 +37,6 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
-import { intersected } from "~/utils/utils";
 
 export const meta = () => [{ title: appendToMetaTitle("Add kit to booking") }];
 
@@ -90,60 +89,18 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
 }
 
 /**
- * Resolves the assets for the selected kits and the target booking.
+ * Adds the currently-viewed kit (or kits, via the hidden `kitIds[]` inputs) to
+ * an existing DRAFT/RESERVED booking.
  *
- * `organizationId` is threaded into `getAvailableKitAssetForBooking` so kit
- * assets cannot be resolved across tenants (cross-org IDOR guard).
+ * Kit members are added as **kit-driven** `BookingAsset` rows (each carrying the
+ * originating `AssetKit.id` on `assetKitId`) — NOT as standalone rows. The
+ * booking overview groups rows by `assetKitId`, so writing members through the
+ * standalone `assetIds` bucket (the previous bug) produced loose rows with a
+ * NULL `assetKitId` and silently dropped the kit grouping. Slice resolution is
+ * delegated to the shared `buildKitSlicesForBooking` helper so this flow,
+ * `createBooking`, and the manage-kits route all build slices the same,
+ * org-scoped way.
  */
-const processBooking = async (
-  bookingId: string,
-  kitIds: string[] | undefined,
-  organizationId: string
-) => {
-  try {
-    let finalAssetIds: string[] = [];
-    let booking;
-    if (kitIds && kitIds.length > 0) {
-      const promises = [
-        getAvailableKitAssetForBooking(kitIds, organizationId),
-        getExistingBookingDetails(bookingId, organizationId),
-      ];
-
-      const [assets, bookingDetails] = await Promise.all(promises);
-      finalAssetIds = assets as string[];
-      booking = bookingDetails;
-    } else {
-      throw new ShelfError({
-        cause: null,
-        message: "Invalid operation.",
-        label: "Booking",
-      });
-    }
-
-    if (finalAssetIds.length === 0) {
-      throw new ShelfError({
-        cause: null,
-        message: "No assets available.",
-        status: 400,
-        label: "Booking",
-        shouldBeCaptured: false,
-      });
-    }
-
-    return {
-      finalAssetIds,
-      bookingInfo: booking,
-    };
-  } catch (cause: any) {
-    throw new ShelfError({
-      cause: cause,
-      message:
-        cause?.message || "Something went wrong while processing the booking.",
-      label: "Booking",
-    });
-  }
-};
-
 export async function action({ context, request, params }: ActionFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
@@ -162,30 +119,51 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       shouldBeCaptured: false,
     });
 
-    if (!kitIds?.length && !bookingId?.length) {
+    if (!kitIds || kitIds.length === 0) {
       throw new ShelfError({
         cause: null,
-        message: `No kitIds found or booking not found.`,
+        message: `No kits found to add to the booking.`,
         status: 400,
         label: "Booking",
         shouldBeCaptured: false,
       });
     }
 
-    const { finalAssetIds, bookingInfo } = await processBooking(
+    // Validate the target booking: confirms it exists in the caller's org and
+    // is still DRAFT/RESERVED (the only states that accept new items). Also
+    // returns the existing BookingAsset rows so we can skip kit slices that are
+    // already present. `updateBookingAssets` re-checks existence but NOT
+    // status, so this guard is what blocks adding to a non-editable booking.
+    const bookingInfo = await getExistingBookingDetails(
       bookingId,
-      kitIds,
       organizationId
     );
 
-    const bookingAssetIds = (
-      "bookingAssets" in bookingInfo ? bookingInfo.bookingAssets : []
-    ).map((ba) => ba.asset.id);
+    // AssetKit ids already represented on this booking. We dedupe by AssetKit
+    // membership (NOT by asset id): a QUANTITY_TRACKED asset can sit on the
+    // booking both standalone AND kit-driven at once, so a standalone row must
+    // not block re-adding the kit-driven slice. `assetKitId` is non-null only
+    // on kit-driven rows.
+    const existingAssetKitIds = new Set(
+      bookingInfo.bookingAssets
+        .map((ba) => ba.assetKitId)
+        .filter((id): id is string => id != null)
+    );
 
-    if (
-      bookingAssetIds.length > 0 &&
-      intersected(bookingAssetIds, finalAssetIds)
-    ) {
+    // Resolve the kit memberships into kit-driven slice specs (org-scoped),
+    // skipping any AssetKit already on the booking. Routing members through
+    // `kitSlices` rather than the standalone `assetIds` bucket is what keeps the
+    // kit recognizable in the booking overview (which groups by `assetKitId`).
+    const kitSlices = await buildKitSlicesForBooking({
+      kitIds,
+      organizationId,
+      existingAssetKitIds,
+    });
+
+    // Empty slices means every membership of the selected kit(s) is already on
+    // the booking — nothing new to add. Surface the same friendly message as
+    // before so the user picks a different booking.
+    if (kitSlices.length === 0) {
       throw new ShelfError({
         cause: null,
         message: `The booking you have selected already contains the kit you are trying to add. Please select a different booking.`,
@@ -193,6 +171,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         shouldBeCaptured: false,
       });
     }
+
     const user = await getUserByID(authSession.userId, {
       select: {
         id: true,
@@ -202,12 +181,24 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       } satisfies Prisma.UserSelect,
     });
 
+    // Add the kit(s) as kit-driven rows only: `assetIds: []` prevents duplicate
+    // standalone rows for the members, `kitSlices` carries the per-membership
+    // rows, and `kitIds` lets the ONGOING/OVERDUE status flip cascade to the
+    // kit(s) themselves.
     const booking = await updateBookingAssets({
       id: bookingId,
       organizationId,
-      assetIds: finalAssetIds,
+      assetIds: [],
+      kitSlices,
+      kitIds,
       userId,
     });
+
+    // Distinct member assets just added — used to attribute the per-asset
+    // "added to booking" note below.
+    const addedAssetIds = Array.from(
+      new Set(kitSlices.map((slice) => slice.assetId))
+    );
 
     const actor = wrapUserLinkForNote({
       id: authSession.userId,
@@ -222,7 +213,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       content: `${actor} added asset to ${bookingLink}.`,
       type: "UPDATE",
       userId: authSession.userId,
-      assetIds: finalAssetIds,
+      assetIds: addedAssetIds,
       organizationId,
     });
 

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.create-new-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.create-new-booking.tsx
@@ -109,7 +109,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       ...teamMembersData,
       // For consistency, also provide teamMembersForForm
       teamMembersForForm: teamMembersData.teamMembers,
+      // Kit member asset ids — still surfaced so the form can render them as
+      // hidden `assetIds[]` inputs (used for display/count). The shared
+      // `bookings.new` action moves these member ids into kit-driven slices so
+      // they become kit-grouped `BookingAsset` rows, not loose standalone rows.
       assetIds: kit.assetKits.map((ak) => ak.asset.id),
+      // The originating kit id. Submitted as a hidden `kitId` input so the
+      // action can resolve the kit's memberships into kit slices, preserving
+      // the kit grouping in the new booking.
+      kitId,
       ...tagsData,
     });
   } catch (cause) {


### PR DESCRIPTION
## Summary

Fixes a cluster of quantity/kit bugs on the booking overview reported after the
feat-quantities release, plus an asset-search bug.

The `BookingAsset` pivot migration replaced the single `@@unique([bookingId, assetId])`
with two **partial** unique indexes (standalone vs kit-driven slices). That unmasked a
latent bug in every kit→booking flow: they routed kit members through the standalone
`assetIds` param, which materializes standalone `BookingAsset` rows. Pre-pivot the single
unique silently deduped them; post-pivot they survive.

## Reported bugs

| # | Symptom | Cause | Fix |
|---|---|---|---|
| 1 | Kit members show twice (under the kit **and** as loose rows) | `manage-kits` passed members as **both** `assetIds` and `kitSlices` → duplicate standalone + kit rows | Pass `assetIds: []`; members travel only via `kitSlices` |
| 2 | Progress bar total ignores "Count each kit as a single unit" | Downstream of #1 (duplicate standalone rows inflate the unit count) | Resolved by fixing #1 |
| 3 | "Assets" / "Total assets" counts inflated | Downstream of #1 | Resolved by fixing #1 |
| 4 | Search `451` doesn't match `KCI-451 Kids Resources Box` | ID-search fast path searched only id columns, deferring title to a zero-row fallback that gets suppressed when any other asset matches in an id column | Add `title`/`description` (trigram-indexed) to the narrow clause |

## Also fixed (same regression, found during the sweep)

- **Sibling kit-add flows** — the kit page's "Add to existing booking" and "Create new
  booking" routed members through the standalone bucket too, **losing kit grouping**. Both
  now build kit slices via a shared `buildKitSlicesForBooking` helper; `createBooking`
  learned to accept kit slices.
- **Quick-checkout QT progress** — an all-at-once checkout writes no `PartialBookingCheckout`
  rows, so the lifecycle bar's QT bucketer (which read only that counter) showed
  quick-checked-out QT assets as "Booked", collapsing a fully-out kit to "Booked". It now
  trusts a live `CHECKED_OUT` status (and `wasCheckedOut` at COMPLETE/ARCHIVED), mirroring
  INDIVIDUAL assets. The overview loader's remaining-to-checkout got the matching
  legacy-ONGOING fallback (it had drifted from the canonical service helper), so a
  quick-checked-out QT asset is no longer offered for more checkout.
- **Defense-in-depth** — `updateBookingAssets` now drops any INDIVIDUAL asset present in
  both buckets in one call (QT may legitimately be both), so the bug class can't be
  reintroduced by a future caller.
- **Stats layout** — Assets / Kits / Total assets are grouped together, with the progress
  bar above them.
- **Guardrail** — `.claude/rules/kit-members-via-kit-slices.md`.

## Testing

- `pnpm webapp:validate` green (216 files, 2957 tests).
- New/updated tests: 3 lifecycle quick-checkout cases, `buildKitSlicesForBooking`, search
  narrow-clause, and corrected manage-kits assertions.
- Verified against a live local DB: the affected booking now holds exactly 3 kit slices +
  3 genuine standalone rows (no duplicates); progress reads 4/4 in unit mode.

## Follow-up (not in this PR)

Existing bookings already polluted with duplicate standalone rows need a data cleanup (the
code only prevents new ones). The cleanup will be an **INDIVIDUAL-only** `BookingAsset`
delete migration — QT standalone+kit overlaps can be legitimate (free-pool units booked
alongside kit units) and are deliberately excluded. Pending a production-scale check via
the diagnostic SQL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking creation and kit actions now preserve kit groupings by creating kit-driven booking assets when initiated from a kit.
  * The new-booking flow now carries kit context through the form to maintain correct grouping through to the overview.

* **Bug Fixes**
  * Prevented duplicate booking entries and corrected counts/progress when the same individual asset is supplied both directly and via a kit.
  * Fixed booking lifecycle progress placement and improved quantity-tracked handling for quick-checkout and legacy all-at-once scenarios.
  * Asset search for numeric terms now matches title/description without requiring full-search fallback.

* **Documentation**
  * Updated guidance for kit-driven booking routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->