### PR TITLE
fix(bookings): sync start date on client navigation between bookings

### DIFF
--- a/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
@@ -204,11 +204,26 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
   });
 
   /**
-   * Sync the editable `endDate` state with the `incomingEndDate` prop when it
-   * changes. Using the "store prior prop in ref + update during render" pattern
-   * (the React-recommended replacement for prop-sync effects) satisfies
+   * Sync the editable `startDate` / `endDate` state with the incoming loader
+   * props when they change. React Router reuses this component instance across
+   * a client-side navigation between two bookings (same route, different
+   * param), so `useState` keeps the previously-rendered booking's dates unless
+   * we mirror the new props here. Without the `startDate` sync, the duplicate →
+   * redirect flow showed the SOURCE booking's start date until a full refresh.
+   *
+   * Uses the "store prior prop in ref + update during render" pattern (the
+   * React-recommended replacement for prop-sync effects), which satisfies
    * `no-effect-event-handler` while preserving the original behaviour.
    */
+  const lastIncomingStartDateRef = useRef(incomingStartDate);
+  if (
+    incomingStartDate &&
+    incomingStartDate !== lastIncomingStartDateRef.current
+  ) {
+    lastIncomingStartDateRef.current = incomingStartDate;
+    setStartDate(incomingStartDate);
+  }
+
   const lastIncomingEndDateRef = useRef(incomingEndDate);
   if (incomingEndDate && incomingEndDate !== lastIncomingEndDateRef.current) {
     lastIncomingEndDateRef.current = incomingEndDate;

--- a/apps/webapp/app/components/booking/forms/fields/dates.test.tsx
+++ b/apps/webapp/app/components/booking/forms/fields/dates.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Regression tests for {@link DatesFields} — start/end date input binding.
+ *
+ * Guards the fix for the duplicate → redirect bug: when React Router reuses the
+ * booking edit form instance across a client-side navigation between two
+ * bookings, the parent re-renders `DatesFields` with a new `startDate` prop
+ * WITHOUT remounting. The Start Date input must be CONTROLLED (like End Date)
+ * so it reflects the new value instead of stranding the previously-rendered
+ * booking's start date until a full page refresh.
+ *
+ * @see {@link file://./dates.tsx}
+ * @see {@link file://../edit-booking-form.tsx} (the startDate/endDate re-sync)
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DatesFields } from "./dates";
+
+// why: DatesFields reads workspace booking settings from the _layout route
+// loader via this hook; there's no router in a unit test, so stub it.
+vi.mock("~/hooks/use-booking-settings", () => ({
+  useBookingSettings: () => ({ maxBookingLength: null, bufferStartTime: 0 }),
+}));
+
+/** Minimal props for DatesFields; per-test overrides applied on top. */
+function baseProps() {
+  return {
+    startDateName: "startDate",
+    endDateName: "endDate",
+    setStartDate: vi.fn(),
+    setEndDate: vi.fn(),
+    disabled: false,
+    isNewBooking: false as boolean | undefined,
+    // workingHours=null → WorkingHoursInfo renders nothing (no preview dialog).
+    workingHoursData: {
+      workingHours: null,
+      isLoading: false,
+      error: undefined,
+    },
+  };
+}
+
+function startInput(container: HTMLElement) {
+  return container.querySelector<HTMLInputElement>('input[name="startDate"]');
+}
+function endInput(container: HTMLElement) {
+  return container.querySelector<HTMLInputElement>('input[name="endDate"]');
+}
+
+describe("DatesFields", () => {
+  it("renders the provided start and end dates", () => {
+    const { container } = render(
+      <DatesFields
+        {...baseProps()}
+        startDate="2026-06-23T14:34"
+        endDate="2026-07-01T18:00"
+      />
+    );
+
+    expect(startInput(container)?.value).toBe("2026-06-23T14:34");
+    expect(endInput(container)?.value).toBe("2026-07-01T18:00");
+  });
+
+  it("reflects a new startDate prop on re-render WITHOUT remounting (controlled input)", () => {
+    // This is the regression: an uncontrolled `defaultValue` would keep the
+    // original value ("2026-06-23T14:34") after a prop change, which is exactly
+    // the stale start date users saw after duplicating a booking.
+    const { container, rerender } = render(
+      <DatesFields
+        {...baseProps()}
+        startDate="2026-06-23T14:34"
+        endDate="2026-07-01T18:00"
+      />
+    );
+
+    expect(startInput(container)?.value).toBe("2026-06-23T14:34");
+
+    // Simulate the parent (edit form) re-rendering with the newly-navigated
+    // booking's dates — same component instance, no key/remount here.
+    rerender(
+      <DatesFields
+        {...baseProps()}
+        startDate="2026-07-01T14:43"
+        endDate="2026-07-01T18:00"
+      />
+    );
+
+    expect(startInput(container)?.value).toBe("2026-07-01T14:43");
+    // End date already behaved correctly (controlled) — assert it stays in sync too.
+    expect(endInput(container)?.value).toBe("2026-07-01T18:00");
+  });
+});

--- a/apps/webapp/app/components/booking/forms/fields/dates.tsx
+++ b/apps/webapp/app/components/booking/forms/fields/dates.tsx
@@ -59,7 +59,13 @@ export function DatesFields({
           disabled={workingHoursDisabled}
           error={startDateError}
           className="w-full"
-          defaultValue={startDate}
+          // Controlled (mirrors the End Date input below) so the field stays in
+          // sync with `startDate` state. When the parent re-renders with a new
+          // value on a client-side navigation between bookings (e.g. the
+          // duplicate → redirect flow), an uncontrolled `defaultValue` would
+          // keep showing the previously-rendered booking's start date until a
+          // full page refresh. A controlled `value` reflects the update.
+          value={startDate}
           placeholder="Booking"
           required
           onChange={(event) => {

--- a/apps/webapp/app/components/booking/forms/fields/dates.tsx
+++ b/apps/webapp/app/components/booking/forms/fields/dates.tsx
@@ -31,7 +31,7 @@ export function DatesFields({
   startDateName: string;
   disabled: boolean;
   startDateError?: string;
-  setStartDate?: Dispatch<SetStateAction<string>>;
+  setStartDate: Dispatch<SetStateAction<string>>;
   endDate: string | undefined;
   endDateName: string;
   endDateError?: string;
@@ -70,9 +70,7 @@ export function DatesFields({
           required
           onChange={(event) => {
             // Update start date state to persist user's selection
-            if (setStartDate) {
-              setStartDate(event.target.value);
-            }
+            setStartDate(event.target.value);
 
             /**
              * When user changes the startDate and the new startDate is greater than the endDate


### PR DESCRIPTION
The booking edit form re-syncs endDate from the loader props on a client-side navigation (same route, different bookingId) but had no equivalent for startDate, and the Start Date input was uncontrolled (defaultValue) while End Date was controlled (value). React Router reuses the form instance across such navigations, so useState kept the previously-rendered booking's start date.

After duplicating a booking, the redirect showed the SOURCE booking's start date until a full refresh (end date and duration were already correct, proving the data was stored correctly — the action was never at fault).

Make the Start Date input controlled (mirrors End Date) and add the missing startDate re-sync so both date fields stay in sync on navigation. Adds a regression test that reproduces the stale-start-date behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The booking edit form now synchronizes the start date correctly across client-side navigations, preventing stale values from showing.
  * Date inputs are now properly controlled to reflect updated start/end values during the same session.
* **Tests**
  * Added regression coverage ensuring `DatesFields` renders the correct initial dates and stays synchronized after rerenders without remounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->