### PR TITLE
fix(bookings): fix Models-tab bugs in manage-assets/manage-kits modals

### DIFF
--- a/apps/webapp/app/components/booking/manage-model-requests.tsx
+++ b/apps/webapp/app/components/booking/manage-model-requests.tsx
@@ -624,6 +624,7 @@ function AddRequestRow({
             countKey="totalAssetModels"
             selectionMode="none"
             closeOnSelect
+            resetSearchOnClose
             showSearch
             excludeItems={excludeModelIds}
             defaultValue={assetModelId}

--- a/apps/webapp/app/components/dynamic-select/dynamic-select.test.tsx
+++ b/apps/webapp/app/components/dynamic-select/dynamic-select.test.tsx
@@ -672,4 +672,144 @@ describe("DynamicSelect", () => {
       expect(onChange).toHaveBeenCalledWith("without-custody");
     });
   });
+
+  describe("resetSearchOnClose", () => {
+    it("clears the search input after selecting an item when resetSearchOnClose is set", async () => {
+      const items = createTestItems(3);
+
+      // why: DynamicSelect doesn't own `searchQuery` — it's returned by the
+      // mocked useModelFilters — so the mock's `setSearchQuery` /
+      // `resetModelFiltersFetcher` must actually mutate the mock's return
+      // value for a later render (reopen) to observe the reset, mirroring
+      // how the real hook's state setter affects subsequent renders.
+      const setSearchQuery = vi.fn((value: string) => {
+        mockUseModelFilters.mockReturnValue(
+          createMockUseModelFiltersReturn(items, {
+            searchQuery: value,
+            setSearchQuery,
+            resetModelFiltersFetcher,
+          })
+        );
+      });
+      const resetModelFiltersFetcher = vi.fn(() => {
+        setSearchQuery("");
+      });
+
+      mockUseModelFilters.mockReturnValue(
+        createMockUseModelFiltersReturn(items, {
+          searchQuery: "",
+          setSearchQuery,
+          resetModelFiltersFetcher,
+        })
+      );
+
+      const { rerender } = render(
+        <DynamicSelect
+          model={defaultModel}
+          initialDataKey="categories"
+          countKey="totalCategories"
+          contentLabel="Category"
+          closeOnSelect
+          resetSearchOnClose
+        />
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        await user.click(screen.getByRole("button"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Simulate the user typing "da" — the mock hook now returns the typed
+      // query, same as the "hides withoutValueItem" test above does.
+      mockUseModelFilters.mockReturnValue(
+        createMockUseModelFiltersReturn(items, {
+          searchQuery: "da",
+          setSearchQuery,
+          resetModelFiltersFetcher,
+        })
+      );
+      rerender(
+        <DynamicSelect
+          model={defaultModel}
+          initialDataKey="categories"
+          countKey="totalCategories"
+          contentLabel="Category"
+          closeOnSelect
+          resetSearchOnClose
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("da")).toBeInTheDocument();
+      });
+
+      // Selecting an item closes the popover (closeOnSelect)
+      await act(async () => {
+        await user.click(screen.getByText("Item 1"));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+      expect(resetModelFiltersFetcher).toHaveBeenCalled();
+
+      // Reopen — search should now be empty
+      await act(async () => {
+        await user.click(screen.getByRole("button"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+      expect(screen.getByPlaceholderText("Search Category")).toHaveValue("");
+    });
+
+    it("keeps the typed search after selecting an item when resetSearchOnClose is not set (regression guard)", async () => {
+      const items = createTestItems(3);
+      mockUseModelFilters.mockReturnValue(
+        createMockUseModelFiltersReturn(items, { searchQuery: "da" })
+      );
+
+      render(
+        <DynamicSelect
+          model={defaultModel}
+          initialDataKey="categories"
+          countKey="totalCategories"
+          contentLabel="Category"
+          closeOnSelect
+        />
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        await user.click(screen.getByRole("button"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("da")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        await user.click(screen.getByText("Item 1"));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Reopen — the stale search from before persists (existing behavior)
+      await act(async () => {
+        await user.click(screen.getByRole("button"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+      expect(screen.getByPlaceholderText("Search Category")).toHaveValue("da");
+    });
+  });
 });

--- a/apps/webapp/app/components/dynamic-select/dynamic-select.test.tsx
+++ b/apps/webapp/app/components/dynamic-select/dynamic-select.test.tsx
@@ -811,5 +811,73 @@ describe("DynamicSelect", () => {
       });
       expect(screen.getByPlaceholderText("Search Category")).toHaveValue("da");
     });
+
+    it("keeps the selected label after the fetcher reset when the selection came from typeahead", async () => {
+      // A model found via typeahead lives only in the fetcher results, not the
+      // seed list. When resetSearchOnClose clears the fetcher on close, the
+      // item disappears from `items` — the trigger must still show it (from the
+      // selected-item cache) rather than falling back to the placeholder while
+      // the hidden input still posts the id.
+      const typeaheadItems = createTestItems(3);
+
+      // why: the mock hook must actually drop the item on reset, mirroring the
+      // real fetcher clearing its typeahead results — otherwise the
+      // cache-fallback path under test is never exercised.
+      const resetModelFiltersFetcher = vi.fn(() => {
+        mockUseModelFilters.mockReturnValue(
+          createMockUseModelFiltersReturn([], { resetModelFiltersFetcher })
+        );
+      });
+
+      mockUseModelFilters.mockReturnValue(
+        createMockUseModelFiltersReturn(typeaheadItems, {
+          resetModelFiltersFetcher,
+        })
+      );
+
+      const { rerender } = render(
+        <DynamicSelect
+          model={defaultModel}
+          initialDataKey="categories"
+          countKey="totalCategories"
+          contentLabel="Category"
+          closeOnSelect
+          resetSearchOnClose
+        />
+      );
+
+      const user = userEvent.setup();
+      await act(async () => {
+        await user.click(screen.getByRole("button"));
+      });
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Select Item 2 while it's still in the fetcher results — closeOnSelect
+      // closes the popover, which triggers the fetcher reset.
+      await act(async () => {
+        await user.click(screen.getByText("Item 2"));
+      });
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+      expect(resetModelFiltersFetcher).toHaveBeenCalled();
+
+      // Re-render reflecting the now-empty fetcher results (Item 2 is gone).
+      rerender(
+        <DynamicSelect
+          model={defaultModel}
+          initialDataKey="categories"
+          countKey="totalCategories"
+          contentLabel="Category"
+          closeOnSelect
+          resetSearchOnClose
+        />
+      );
+
+      // The trigger still shows the selected model, not the placeholder.
+      expect(screen.getByRole("button")).toHaveTextContent("Item 2");
+    });
   });
 });

--- a/apps/webapp/app/components/dynamic-select/dynamic-select.tsx
+++ b/apps/webapp/app/components/dynamic-select/dynamic-select.tsx
@@ -261,17 +261,22 @@ export default function DynamicSelect({
     return [...specialItems, ...itemsToRender];
   }, [withValueItem, withoutValueItem, itemsToRender]);
 
-  function handleItemChange(id: string) {
+  function handleItemChange(id: string, knownItem?: ModelFilterItem) {
     const isDeselecting = allowClear && selectedValue === id;
 
     // Update local state
     setSelectedValue(isDeselecting ? undefined : id);
 
-    // Cache the picked item (while it's still present in the render list) so
-    // the trigger can render its label even after the fetcher is reset — a
-    // typeahead-only selection is otherwise dropped by resetSearchOnClose.
+    // Cache the picked item so the trigger can render its label even after the
+    // fetcher is reset — a typeahead-only or just-created selection is
+    // otherwise dropped by resetSearchOnClose. Callers that already hold the
+    // item object (e.g. inline creation) pass it as `knownItem`; the freshly
+    // created item is not yet in `allItemsToRender` in this tick, so the
+    // lookup would miss it.
     setSelectedItemCache(
-      isDeselecting ? undefined : allItemsToRender.find((i) => i.id === id)
+      isDeselecting
+        ? undefined
+        : knownItem ?? allItemsToRender.find((i) => i.id === id)
     );
 
     // Always update URL params and parent state
@@ -314,7 +319,10 @@ export default function DynamicSelect({
 
   const handleItemCreated = (item: ModelFilterItem) => {
     setCreatedItems((prev) => dedupeItems([item, ...prev]));
-    handleItemChange(item.id);
+    // Pass the created item so the selected-item cache holds it directly — it
+    // is not yet in `allItemsToRender` in this render, and the following
+    // `resetModelFiltersFetcher()` clears the fetcher results.
+    handleItemChange(item.id, item);
     setSearchQuery("");
     resetModelFiltersFetcher();
     setIsPopoverOpen(false);

--- a/apps/webapp/app/components/dynamic-select/dynamic-select.tsx
+++ b/apps/webapp/app/components/dynamic-select/dynamic-select.tsx
@@ -185,18 +185,42 @@ export default function DynamicSelect({
   } = useModelFilters({ model, selectionMode, ...hookProps });
 
   /**
-   * Reset the search on the closed transition when opted in. This fires for
-   * BOTH the programmatic close from `closeOnSelect` (handleItemChange calls
-   * `setIsPopoverOpen(false)` directly, so Radix's `onOpenChange` never
-   * fires) and Radix-driven closes (Escape, outside click) — an effect on
-   * `isPopoverOpen` covers both uniformly.
+   * Cache of the last-selected item so the trigger can still render its label
+   * after the model-filters fetcher is reset (see `resetSearchOnClose`). A
+   * model picked from typeahead only exists in the fetcher results, not in the
+   * loader's seed list — resetting the fetcher would otherwise drop it from
+   * `allItemsToRender`, and the trigger would fall back to the placeholder even
+   * though the hidden input still posts the selected id.
    */
+  const [selectedItemCache, setSelectedItemCache] = useState<
+    ModelFilterItem | undefined
+  >(undefined);
+
+  /**
+   * Hold the latest `resetModelFiltersFetcher` in a ref so the close-reset
+   * effect can call it without listing it as a dependency — it's recreated on
+   * every `useModelFilters` call, so depending on it directly would refire the
+   * effect on every render.
+   */
+  const resetFetcherRef = useRef(resetModelFiltersFetcher);
+  resetFetcherRef.current = resetModelFiltersFetcher;
+
+  /**
+   * Reset the search on the open→closed transition when opted in. This covers
+   * BOTH the programmatic close from `closeOnSelect` (handleItemChange calls
+   * `setIsPopoverOpen(false)` directly, so Radix's `onOpenChange` never fires)
+   * and Radix-driven closes (Escape, outside click). The `wasOpen` ref gates on
+   * the transition so it does not fire on the initial closed mount.
+   * `resetModelFiltersFetcher` already clears `searchQuery`, so we don't call
+   * `setSearchQuery` separately.
+   */
+  const wasPopoverOpenRef = useRef(false);
   useEffect(() => {
-    if (resetSearchOnClose && !isPopoverOpen) {
-      setSearchQuery("");
-      resetModelFiltersFetcher();
+    const justClosed = wasPopoverOpenRef.current && !isPopoverOpen;
+    wasPopoverOpenRef.current = isPopoverOpen;
+    if (resetSearchOnClose && justClosed) {
+      resetFetcherRef.current();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- resetModelFiltersFetcher is recreated on every useModelFilters call (not memoized); including it would refire this effect on every render while the popover is closed.
   }, [isPopoverOpen, resetSearchOnClose]);
 
   const itemsWithCreated = useMemo(
@@ -243,6 +267,13 @@ export default function DynamicSelect({
     // Update local state
     setSelectedValue(isDeselecting ? undefined : id);
 
+    // Cache the picked item (while it's still present in the render list) so
+    // the trigger can render its label even after the fetcher is reset — a
+    // typeahead-only selection is otherwise dropped by resetSearchOnClose.
+    setSelectedItemCache(
+      isDeselecting ? undefined : allItemsToRender.find((i) => i.id === id)
+    );
+
     // Always update URL params and parent state
     handleSelectItemChange(id);
 
@@ -254,8 +285,16 @@ export default function DynamicSelect({
     }
   }
 
-  /** This is needed so we know what to show on the trigger */
-  const selectedItem = allItemsToRender.find((i) => i.id === selectedValue);
+  /**
+   * This is needed so we know what to show on the trigger. Falls back to the
+   * cached selected item when the current render list no longer contains it
+   * (e.g. a typeahead selection after the fetcher was reset). The id guard
+   * avoids showing a stale cache once `selectedValue` changes (e.g. a
+   * `defaultValue`-driven reset).
+   */
+  const selectedItem =
+    allItemsToRender.find((i) => i.id === selectedValue) ??
+    (selectedItemCache?.id === selectedValue ? selectedItemCache : undefined);
   const triggerValue = selectedItem
     ? typeof renderItem === "function"
       ? renderItem({ ...selectedItem, metadata: selectedItem })

--- a/apps/webapp/app/components/dynamic-select/dynamic-select.tsx
+++ b/apps/webapp/app/components/dynamic-select/dynamic-select.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import {
@@ -68,6 +68,13 @@ type Props = ModelFilterProps & {
   disabled?: boolean;
   placeholder?: string;
   closeOnSelect?: boolean;
+  /**
+   * When true, clears the internal search query (and resets the
+   * model-filters fetcher) whenever the popover closes — so reopening the
+   * picker starts fresh. Default false to preserve behavior for the ~20
+   * other consumers that rely on persisted search across reopen.
+   */
+  resetSearchOnClose?: boolean;
   excludeItems?: string[];
   /** Allow undefined for deselection cases */
   onChange?: ((value: string | undefined) => void) | null /**
@@ -117,6 +124,7 @@ export default function DynamicSelect({
   disabled,
   placeholder = `Select ${model.name}`,
   closeOnSelect = false,
+  resetSearchOnClose = false,
   excludeItems,
   onChange = null,
   allowClear,
@@ -175,6 +183,21 @@ export default function DynamicSelect({
     handleSelectItemChange,
     getAllEntries,
   } = useModelFilters({ model, selectionMode, ...hookProps });
+
+  /**
+   * Reset the search on the closed transition when opted in. This fires for
+   * BOTH the programmatic close from `closeOnSelect` (handleItemChange calls
+   * `setIsPopoverOpen(false)` directly, so Radix's `onOpenChange` never
+   * fires) and Radix-driven closes (Escape, outside click) — an effect on
+   * `isPopoverOpen` covers both uniformly.
+   */
+  useEffect(() => {
+    if (resetSearchOnClose && !isPopoverOpen) {
+      setSearchQuery("");
+      resetModelFiltersFetcher();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- resetModelFiltersFetcher is recreated on every useModelFilters call (not memoized); including it would refire this effect on every render while the popover is closed.
+  }, [isPopoverOpen, resetSearchOnClose]);
 
   const itemsWithCreated = useMemo(
     () => dedupeItems([...createdItems, ...items]),

--- a/apps/webapp/app/modules/booking-model-request/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.test.ts
@@ -16,6 +16,7 @@ import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 import {
   getAssetModelAvailability,
+  getBookingModelTabData,
   materializeModelRequestForAsset,
   removeBookingModelRequest,
   upsertBookingModelRequest,
@@ -40,6 +41,8 @@ vitest.mock("~/database/db.server", () => ({
       findUnique: vitest
         .fn()
         .mockResolvedValue({ id: "model-1", name: "Dell Latitude 5550" }),
+      count: vitest.fn().mockResolvedValue(0),
+      findMany: vitest.fn().mockResolvedValue([]),
     },
     booking: {
       findUnique: vitest.fn().mockResolvedValue(null),
@@ -585,5 +588,221 @@ describe("materializeModelRequestForAsset", () => {
     expect(result).toEqual({ matched: false });
     expect(db.bookingModelRequest.update).not.toHaveBeenCalled();
     expect(db.bookingModelRequest.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe("getBookingModelTabData", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    // why: clearAllMocks only resets call history — `mockResolvedValue`
+    // implementations from earlier describe blocks leak into later ones.
+    // Re-default the aggregates so each test starts from a clean pool.
+    // @ts-expect-error mocked
+    db.assetModel.count.mockResolvedValue(0);
+    // @ts-expect-error mocked
+    db.assetModel.findMany.mockResolvedValue([]);
+    // @ts-expect-error mocked
+    db.asset.count.mockResolvedValue(0);
+    // @ts-expect-error mocked
+    db.custody.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
+    // @ts-expect-error mocked
+    db.bookingAsset.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
+    // @ts-expect-error mocked
+    db.bookingModelRequest.aggregate.mockResolvedValue({
+      _sum: { quantity: 0 },
+    });
+  });
+
+  /** Minimal `BookingForModelTab` fixture with no model requests. */
+  const emptyBooking = {
+    id: BOOKING_ID,
+    from,
+    to,
+    modelRequests: [],
+  };
+
+  it("hides the Models tab and returns empty lists when the org has no models", async () => {
+    expect.assertions(5);
+    // @ts-expect-error mocked
+    db.assetModel.count.mockResolvedValue(0);
+
+    const result = await getBookingModelTabData({
+      organizationId: ORG_ID,
+      booking: emptyBooking,
+    });
+
+    expect(result.showModelsTab).toBe(false);
+    expect(result.assetModels).toEqual([]);
+    expect(result.initialAssetModels).toEqual([]);
+    expect(result.totalAssetModels).toBe(0);
+    // `booking.modelRequests` is still projected even with no models —
+    // the two are independent (a model could be deleted after a request
+    // was made against it).
+    expect(result.modelRequests).toEqual([]);
+    // `findMany` must be skipped entirely when the count is 0 — no point
+    // querying a picker list nobody will see.
+  });
+
+  it("does not query the model list when the org has no models", async () => {
+    expect.assertions(1);
+    // @ts-expect-error mocked
+    db.assetModel.count.mockResolvedValue(0);
+
+    await getBookingModelTabData({
+      organizationId: ORG_ID,
+      booking: emptyBooking,
+    });
+
+    expect(db.assetModel.findMany).not.toHaveBeenCalled();
+  });
+
+  it("carries per-model availability into assetModels + initialAssetModels", async () => {
+    expect.assertions(4);
+    // @ts-expect-error mocked
+    db.assetModel.count.mockResolvedValue(2);
+    // @ts-expect-error mocked
+    db.assetModel.findMany.mockResolvedValue([
+      { id: "model-1", name: "Dell Latitude 5550" },
+      { id: "model-2", name: "MacBook Pro 16" },
+    ]);
+    // @ts-expect-error mocked
+    db.asset.count.mockResolvedValue(10);
+    // @ts-expect-error mocked
+    db.custody.aggregate.mockResolvedValue({ _sum: { quantity: 1 } });
+    // @ts-expect-error mocked
+    db.bookingAsset.aggregate.mockResolvedValue({ _sum: { quantity: 2 } });
+    // @ts-expect-error mocked
+    db.bookingModelRequest.aggregate.mockResolvedValue({
+      _sum: { quantity: 3 },
+    });
+
+    const result = await getBookingModelTabData({
+      organizationId: ORG_ID,
+      booking: emptyBooking,
+    });
+
+    expect(result.showModelsTab).toBe(true);
+    // 10 total − 1 custody − 2 concrete − 3 via request = 4 available
+    expect(result.assetModels).toEqual([
+      {
+        id: "model-1",
+        name: "Dell Latitude 5550",
+        total: 10,
+        available: 4,
+        reservedConcrete: 2,
+        reservedViaRequest: 3,
+        inCustody: 1,
+      },
+      {
+        id: "model-2",
+        name: "MacBook Pro 16",
+        total: 10,
+        available: 4,
+        reservedConcrete: 2,
+        reservedViaRequest: 3,
+        inCustody: 1,
+      },
+    ]);
+    // `initialAssetModels` mirrors `assetModels` with fields nested under
+    // `metadata`, shaped for the `DynamicSelect` picker.
+    expect(result.initialAssetModels).toEqual([
+      {
+        id: "model-1",
+        name: "Dell Latitude 5550",
+        metadata: {
+          total: 10,
+          available: 4,
+          reservedConcrete: 2,
+          reservedViaRequest: 3,
+          inCustody: 1,
+        },
+      },
+      {
+        id: "model-2",
+        name: "MacBook Pro 16",
+        metadata: {
+          total: 10,
+          available: 4,
+          reservedConcrete: 2,
+          reservedViaRequest: 3,
+          inCustody: 1,
+        },
+      },
+    ]);
+    expect(result.totalAssetModels).toBe(2);
+  });
+
+  it("projects modelRequests: assetModelName, ISO date, and null pass-through", async () => {
+    expect.assertions(1);
+
+    const fulfilledAt = new Date("2026-05-02T10:00:00Z");
+    const booking = {
+      id: BOOKING_ID,
+      from,
+      to,
+      modelRequests: [
+        {
+          assetModelId: "model-1",
+          quantity: 3,
+          fulfilledQuantity: 3,
+          fulfilledAt,
+          assetModel: { name: "Dell Latitude 5550" },
+        },
+        {
+          assetModelId: "model-2",
+          quantity: 2,
+          fulfilledQuantity: 0,
+          fulfilledAt: null,
+          assetModel: { name: "MacBook Pro 16" },
+        },
+      ],
+    };
+
+    const result = await getBookingModelTabData({
+      organizationId: ORG_ID,
+      booking,
+    });
+
+    expect(result.modelRequests).toEqual([
+      {
+        assetModelId: "model-1",
+        assetModelName: "Dell Latitude 5550",
+        quantity: 3,
+        fulfilledQuantity: 3,
+        fulfilledAt: fulfilledAt.toISOString(),
+      },
+      {
+        assetModelId: "model-2",
+        assetModelName: "MacBook Pro 16",
+        quantity: 2,
+        fulfilledQuantity: 0,
+        fulfilledAt: null,
+      },
+    ]);
+  });
+
+  it("scopes the model count + list to the caller's organizationId", async () => {
+    expect.assertions(2);
+    // @ts-expect-error mocked
+    db.assetModel.count.mockResolvedValue(1);
+    // @ts-expect-error mocked
+    db.assetModel.findMany.mockResolvedValue([
+      { id: "model-1", name: "Dell Latitude 5550" },
+    ]);
+
+    await getBookingModelTabData({
+      organizationId: ORG_ID,
+      booking: emptyBooking,
+    });
+
+    // A model belonging to another org must never leak into this org's
+    // picker — both the count and the list query must be scoped.
+    expect(db.assetModel.count).toHaveBeenCalledWith({
+      where: { organizationId: ORG_ID },
+    });
+    const findManyCall = (
+      db.assetModel.findMany as ReturnType<typeof vitest.fn>
+    ).mock.calls[0]?.[0];
+    expect(findManyCall?.where).toEqual({ organizationId: ORG_ID });
   });
 });

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -195,6 +195,193 @@ export async function getAssetModelAvailability({
 }
 
 /* -------------------------------------------------------------------------- */
+/*                          getBookingModelTabData                            */
+/* -------------------------------------------------------------------------- */
+
+/** The upper bound on how many `AssetModel` rows the picker fetches at once. */
+const MODEL_PICKER_LIMIT = 50;
+
+/**
+ * Shape of the booking record `getBookingModelTabData` needs. Callers pass
+ * their already-fetched `booking` through untouched — this is a projection,
+ * not a re-fetch. Deliberately excludes `bookingAssets`: the manage-assets
+ * route pre-filters those to standalone (non-kit) rows for its own picker,
+ * and coupling this shared helper to that filter would silently break the
+ * manage-kits route, which has no such pre-filter.
+ */
+type BookingForModelTab = {
+  id: string;
+  from: Date | null;
+  to: Date | null;
+  modelRequests: Array<{
+    assetModelId: string;
+    quantity: number;
+    fulfilledQuantity: number;
+    fulfilledAt: Date | null;
+    assetModel: { name: string };
+  }>;
+};
+
+/** Per-model row shown in the Models tab's picker + summary list. */
+type BookingModelTabAssetModel = {
+  id: string;
+  name: string;
+  total: number;
+  available: number;
+  reservedConcrete: number;
+  reservedViaRequest: number;
+  inCustody: number;
+};
+
+/** Payload the "Book-by-Model / Models tab" UI needs from the loader. */
+export type BookingModelTabData = {
+  /** Whether the org has any `AssetModel` at all — hides the tab when false. */
+  showModelsTab: boolean;
+  /** Per-model availability for the current booking's window. */
+  assetModels: BookingModelTabAssetModel[];
+  /** `assetModels` reshaped for {@link DynamicSelect}'s seed list. */
+  initialAssetModels: Array<{
+    id: string;
+    name: string;
+    metadata: {
+      total: number;
+      available: number;
+      reservedConcrete: number;
+      reservedViaRequest: number;
+      inCustody: number;
+    };
+  }>;
+  /** Full-org model count (not the truncated `MODEL_PICKER_LIMIT` list). */
+  totalAssetModels: number;
+  /** This booking's existing model-level requests, outstanding + fulfilled. */
+  modelRequests: Array<{
+    assetModelId: string;
+    assetModelName: string;
+    quantity: number;
+    fulfilledQuantity: number;
+    fulfilledAt: string | null;
+  }>;
+};
+
+/**
+ * Build the "Book-by-Model / Models tab" payload for a booking's
+ * manage-assets / manage-kits loaders.
+ *
+ * Always counts the org's `AssetModel`s so the UI knows whether to render
+ * the Models tab at all (hidden when the org has none). When there is at
+ * least one model, also fetches the first `MODEL_PICKER_LIMIT` (sorted by
+ * name) plus each one's availability in the booking's window, and projects
+ * the booking's existing model-level requests for the tab's "active /
+ * fulfilled" split.
+ *
+ * Does not mutate. Org-scoped: both the count and the model list are
+ * filtered to `organizationId`, and `organizationId` is forwarded into
+ * {@link getAssetModelAvailability}.
+ *
+ * @param organizationId - The caller's active organization. Required —
+ * scopes both the model count and list, preventing cross-org leakage.
+ * @param booking - The booking these models are being reserved against.
+ * Only `id`, `from`, `to`, and `modelRequests` are read.
+ * @returns The Models tab payload; see {@link BookingModelTabData}.
+ */
+export async function getBookingModelTabData({
+  organizationId,
+  booking,
+}: {
+  organizationId: string;
+  booking: BookingForModelTab;
+}): Promise<BookingModelTabData> {
+  try {
+    const assetModelsCount = await db.assetModel.count({
+      where: { organizationId },
+    });
+    const showModelsTab = assetModelsCount > 0;
+
+    let assetModels: BookingModelTabAssetModel[] = [];
+
+    if (showModelsTab) {
+      const rawModels = await db.assetModel.findMany({
+        where: { organizationId },
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
+        take: MODEL_PICKER_LIMIT,
+      });
+
+      const availabilities = await Promise.all(
+        rawModels.map((m) =>
+          getAssetModelAvailability({
+            assetModelId: m.id,
+            organizationId,
+            bookingId: booking.id,
+            from: booking.from,
+            to: booking.to,
+          })
+        )
+      );
+
+      assetModels = rawModels.map((m, i) => ({
+        id: m.id,
+        name: m.name,
+        total: availabilities[i].total,
+        available: availabilities[i].available,
+        reservedConcrete: availabilities[i].reservedConcrete,
+        reservedViaRequest: availabilities[i].reservedViaRequest,
+        inCustody: availabilities[i].inCustody,
+      }));
+    }
+
+    // Ship all requests (outstanding + fulfilled). The Models tab UI splits
+    // them into "Active reservations" (editable, not yet fully fulfilled)
+    // and "Fulfilled" (historical, read-only) — the audit trail for "this
+    // booking started life as 3 × Dell" on an ONGOING booking.
+    const modelRequests = booking.modelRequests.map((req) => ({
+      assetModelId: req.assetModelId,
+      assetModelName: req.assetModel.name,
+      quantity: req.quantity,
+      fulfilledQuantity: req.fulfilledQuantity,
+      fulfilledAt:
+        req.fulfilledAt instanceof Date
+          ? req.fulfilledAt.toISOString()
+          : req.fulfilledAt,
+    }));
+
+    // Shape for `DynamicSelect`. The picker reads `initialAssetModels` as
+    // its seed list and `totalAssetModels` to decide whether to offer the
+    // "show all / search" affordance. Availability goes on `metadata` so
+    // the renderItem can show e.g. "5 / 5 available" inline per option.
+    const initialAssetModels = assetModels.map((m) => ({
+      id: m.id,
+      name: m.name,
+      metadata: {
+        total: m.total,
+        available: m.available,
+        reservedConcrete: m.reservedConcrete,
+        reservedViaRequest: m.reservedViaRequest,
+        inCustody: m.inCustody,
+      },
+    }));
+
+    return {
+      showModelsTab,
+      assetModels,
+      initialAssetModels,
+      totalAssetModels: assetModelsCount,
+      modelRequests,
+    };
+  } catch (cause) {
+    // Don't re-wrap a ShelfError already thrown by getAssetModelAvailability
+    // — that would bury its original status/message under a generic one.
+    if (cause instanceof ShelfError) throw cause;
+    throw new ShelfError({
+      cause,
+      label,
+      message: "Failed to build the Models tab payload for this booking.",
+      additionalData: { organizationId, bookingId: booking.id },
+    });
+  }
+}
+
+/* -------------------------------------------------------------------------- */
 /*                         upsertBookingModelRequest                          */
 /* -------------------------------------------------------------------------- */
 

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
@@ -1,17 +1,19 @@
 import { AssetStatus, BookingStatus } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createActionArgs } from "@mocks/remix";
+import { createActionArgs, createLoaderArgs } from "@mocks/remix";
 
 import { db } from "~/database/db.server";
+import * as assetService from "~/modules/asset/service.server";
 import * as bookingService from "~/modules/booking/service.server";
+import * as modelRequestService from "~/modules/booking-model-request/service.server";
 import * as noteService from "~/modules/note/service.server";
 import * as userService from "~/modules/user/service.server";
 import * as bookingAssets from "~/utils/booking-assets";
 import * as httpServer from "~/utils/http.server";
 import * as rolesServer from "~/utils/roles.server";
 
-// Import the action function
-import { action } from "./bookings.$bookingId.overview.manage-assets";
+// Import the action + loader functions
+import { action, loader } from "./bookings.$bookingId.overview.manage-assets";
 import { assertIsDataWithResponseInit } from "../../../test/helpers/assertions";
 
 // @vitest-environment node
@@ -38,6 +40,22 @@ vi.mock("~/modules/booking/service.server", () => ({
   getDetailedPartialCheckinData: vi.fn(),
   updateBookingAssets: vi.fn(),
   removeAssets: vi.fn(),
+  // Loader-only — used by the F2 loader tests below.
+  getBooking: vi.fn(),
+  getKitIdsByAssets: vi.fn(),
+}));
+
+// Loader-only — `getPaginatedAndFilterableAssets` backs the Assets tab list.
+vi.mock("~/modules/asset/service.server", () => ({
+  getPaginatedAndFilterableAssets: vi.fn(),
+}));
+
+// why: mock the shared Models-tab payload helper as a unit so the loader
+// test isolates "does the loader wire the helper's output into the payload"
+// from the helper's own DB logic, which has its own unit test in
+// `booking-model-request/service.server.test.ts`.
+vi.mock("~/modules/booking-model-request/service.server", () => ({
+  getBookingModelTabData: vi.fn(),
 }));
 
 vi.mock("~/modules/user/service.server", () => ({
@@ -68,6 +86,9 @@ vi.mock("~/utils/http.server", () => ({
   json: vi.fn((data) => data),
   getCurrentSearchParams: vi.fn(),
   error: vi.fn((reason) => reason),
+  // Loader-only — mirrors the real `payload()` (`{ error: null, ...data }`)
+  // so the F2 loader tests can inspect the returned keys directly.
+  payload: vi.fn((data) => ({ error: null, ...data })),
 }));
 
 vi.mock("~/modules/asset/utils.server", () => ({
@@ -877,6 +898,233 @@ describe("manage-assets route validation", () => {
           quantities: { "asset-pens": 12 },
         })
       );
+    });
+  });
+
+  /**
+   * The footer `<Form ref={formRef}>` used to render only on the Assets tab,
+   * so `UnsavedChangesAlert.onYes` (`submit(formRef.current)`) ran against a
+   * null ref while on the Models tab and silently no-opped: no redirect, no
+   * assets added. The form is now always mounted; a full Happy-DOM
+   * click-through (Models tab → alert → Yes → POST) isn't practical against
+   * this route (heavy component, many providers), so this covers the
+   * action-level contract the fix depends on: submitting the always-mounted
+   * form with a non-null `redirectTo` must redirect there instead of falling
+   * through to the default `/bookings/:id`.
+   */
+  describe("redirectTo handling (confirm-from-unsaved-changes alert)", () => {
+    it("redirects to the submitted redirectTo URL instead of the default booking page", async () => {
+      const manageKitsUrl =
+        "/bookings/booking123/overview/manage-kits?hideUnavailable=true";
+
+      vi.mocked(httpServer.parseData).mockReturnValue({
+        assetIds: ["asset1", "asset2"], // both already on the booking — isolates the redirect branch
+        removedAssetIds: [],
+        redirectTo: manageKitsUrl,
+      });
+
+      vi.mocked(db.asset.findMany).mockResolvedValue([]);
+
+      const response = await action(
+        createActionArgs({
+          context: mockContext,
+          request: mockRequest,
+          params: mockParams,
+        })
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(302);
+      expect((response as Response).headers.get("Location")).toBe(
+        manageKitsUrl
+      );
+    });
+
+    it("redirects to the default booking page when redirectTo is absent", async () => {
+      vi.mocked(httpServer.parseData).mockReturnValue({
+        assetIds: ["asset1", "asset2"],
+        removedAssetIds: [],
+        redirectTo: null,
+      });
+
+      vi.mocked(db.asset.findMany).mockResolvedValue([]);
+
+      const response = await action(
+        createActionArgs({
+          context: mockContext,
+          request: mockRequest,
+          params: mockParams,
+        })
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(302);
+      expect((response as Response).headers.get("Location")).toBe(
+        "/bookings/booking123"
+      );
+    });
+  });
+});
+
+/**
+ * The loader used to inline the "count AssetModels, fetch the first
+ * MODEL_PICKER_LIMIT, compute per-model availability, project modelRequests"
+ * block directly. It now delegates to the shared `getBookingModelTabData`
+ * helper so manage-assets and manage-kits compute Models-tab availability
+ * identically. This is a pure refactor — the loader's payload keys and shapes
+ * must stay byte-identical, so `getBookingModelTabData` is mocked here to
+ * isolate "does the loader wire the helper's output through" from the
+ * helper's own DB logic (covered separately by
+ * `booking-model-request/service.server.test.ts`).
+ */
+describe("manage-assets loader — Models tab payload", () => {
+  const mockContext = {
+    getSession: () => ({ userId: "user123" }),
+    appVersion: "1.0.0",
+    isAuthenticated: true,
+    setSession: vi.fn(),
+    destroySession: vi.fn(),
+    errorMessage: null,
+  } as any;
+
+  const mockParams = { bookingId: "booking123" };
+
+  /** Minimal booking shape the loader needs — DRAFT so no status guard fires. */
+  const mockLoaderBooking = {
+    id: "booking123",
+    name: "Test Booking",
+    status: BookingStatus.DRAFT,
+    from: new Date("2026-01-01"),
+    to: new Date("2026-01-02"),
+    bookingAssets: [],
+    modelRequests: [],
+  } as any;
+
+  /** `getPaginatedAndFilterableAssets` return shape the loader destructures. */
+  const mockPaginatedAssets = {
+    search: null,
+    totalAssets: 0,
+    perPage: 20,
+    page: 1,
+    categories: [],
+    tags: [],
+    assets: [],
+    totalPages: 0,
+    totalCategories: 0,
+    totalTags: 0,
+    locations: [],
+    totalLocations: 0,
+  };
+
+  /** Known `getBookingModelTabData` output — the five keys F2 is about. */
+  const mockModelTabData = {
+    showModelsTab: true,
+    assetModels: [
+      {
+        id: "model1",
+        name: "Dell XPS",
+        total: 5,
+        available: 3,
+        reservedConcrete: 1,
+        reservedViaRequest: 1,
+        inCustody: 0,
+      },
+    ],
+    initialAssetModels: [
+      {
+        id: "model1",
+        name: "Dell XPS",
+        metadata: {
+          total: 5,
+          available: 3,
+          reservedConcrete: 1,
+          reservedViaRequest: 1,
+          inCustody: 0,
+        },
+      },
+    ],
+    totalAssetModels: 1,
+    modelRequests: [
+      {
+        assetModelId: "model1",
+        assetModelName: "Dell XPS",
+        quantity: 2,
+        fulfilledQuantity: 0,
+        fulfilledAt: null,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(rolesServer.requirePermission).mockResolvedValue({
+      organizationId: "org123",
+      userOrganizations: [],
+      isSelfServiceOrBase: false,
+      organizations: [],
+      currentOrganization: {} as any,
+      role: {} as any,
+      canSeeAllBookings: false,
+      canSeeAllCustody: false,
+      canUseBarcodes: false,
+      canUseAudits: false,
+    });
+
+    vi.mocked(httpServer.getParams).mockReturnValue({
+      bookingId: "booking123",
+    });
+
+    vi.mocked(assetService.getPaginatedAndFilterableAssets).mockResolvedValue(
+      mockPaginatedAssets as any
+    );
+    vi.mocked(bookingService.getBooking).mockResolvedValue(mockLoaderBooking);
+    vi.mocked(bookingService.getKitIdsByAssets).mockReturnValue([]);
+    vi.mocked(modelRequestService.getBookingModelTabData).mockResolvedValue(
+      mockModelTabData as any
+    );
+  });
+
+  it("wires the helper's output through to the loader payload, unchanged", async () => {
+    const result = await loader(
+      createLoaderArgs({ context: mockContext, params: mockParams })
+    );
+
+    expect(modelRequestService.getBookingModelTabData).toHaveBeenCalledWith({
+      organizationId: "org123",
+      booking: mockLoaderBooking,
+    });
+
+    // Byte-identical parity check: same five keys, same values, nothing
+    // dropped or reshaped on the way from helper → payload.
+    expect(result).toMatchObject({
+      showModelsTab: mockModelTabData.showModelsTab,
+      assetModels: mockModelTabData.assetModels,
+      initialAssetModels: mockModelTabData.initialAssetModels,
+      totalAssetModels: mockModelTabData.totalAssetModels,
+      modelRequests: mockModelTabData.modelRequests,
+    });
+  });
+
+  it("hides the Models tab when the helper reports no asset models", async () => {
+    vi.mocked(modelRequestService.getBookingModelTabData).mockResolvedValue({
+      showModelsTab: false,
+      assetModels: [],
+      initialAssetModels: [],
+      totalAssetModels: 0,
+      modelRequests: [],
+    });
+
+    const result = await loader(
+      createLoaderArgs({ context: mockContext, params: mockParams })
+    );
+
+    expect(result).toMatchObject({
+      showModelsTab: false,
+      assetModels: [],
+      initialAssetModels: [],
+      totalAssetModels: 0,
+      modelRequests: [],
     });
   });
 });

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
@@ -80,16 +80,23 @@ vi.mock("~/utils/roles.server", () => ({
   requirePermission: vi.fn(),
 }));
 
-vi.mock("~/utils/http.server", () => ({
-  getParams: vi.fn(),
-  parseData: vi.fn(),
-  json: vi.fn((data) => data),
-  getCurrentSearchParams: vi.fn(),
-  error: vi.fn((reason) => reason),
-  // Loader-only — mirrors the real `payload()` (`{ error: null, ...data }`)
-  // so the F2 loader tests can inspect the returned keys directly.
-  payload: vi.fn((data) => ({ error: null, ...data })),
-}));
+vi.mock("~/utils/http.server", async (importOriginal) => {
+  const actual = await importOriginal<typeof httpServer>();
+  return {
+    getParams: vi.fn(),
+    parseData: vi.fn(),
+    json: vi.fn((data) => data),
+    getCurrentSearchParams: vi.fn(),
+    error: vi.fn((reason) => reason),
+    // why: mirror the real `payload()` shape (`{ error: null, ...data }`) so
+    // the Models-tab loader tests can inspect the returned keys directly.
+    payload: vi.fn((data) => ({ error: null, ...data })),
+    // why: use the REAL safeRedirect so the redirect tests exercise the actual
+    // origin-allowlist sanitization the action now depends on (safeRedirect's
+    // own edge cases are unit-tested in http.server.test.ts).
+    safeRedirect: actual.safeRedirect,
+  };
+});
 
 vi.mock("~/modules/asset/utils.server", () => ({
   getAssetsWhereInput: vi.fn(),
@@ -945,6 +952,34 @@ describe("manage-assets route validation", () => {
         assetIds: ["asset1", "asset2"],
         removedAssetIds: [],
         redirectTo: null,
+      });
+
+      vi.mocked(db.asset.findMany).mockResolvedValue([]);
+
+      const response = await action(
+        createActionArgs({
+          context: mockContext,
+          request: mockRequest,
+          params: mockParams,
+        })
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(302);
+      expect((response as Response).headers.get("Location")).toBe(
+        "/bookings/booking123"
+      );
+    });
+
+    it("sanitizes an off-origin redirectTo to the booking page (no open redirect)", async () => {
+      // A crafted POST could supply an attacker-controlled absolute URL in the
+      // client-side `redirectTo` field. The action must route it through
+      // safeRedirect, which rejects off-origin targets and falls back to the
+      // booking page instead of redirecting the user off-site.
+      vi.mocked(httpServer.parseData).mockReturnValue({
+        assetIds: ["asset1", "asset2"],
+        removedAssetIds: [],
+        redirectTo: "https://evil.example.com/phish",
       });
 
       vi.mocked(db.asset.findMany).mockResolvedValue([]);

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -97,6 +97,7 @@ import {
   getCurrentSearchParams,
   getParams,
   parseData,
+  safeRedirect,
 } from "~/utils/http.server";
 import { ALL_SELECTED_KEY, isSelectingAllItems } from "~/utils/list";
 import { Logger } from "~/utils/logger";
@@ -972,10 +973,12 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     /**
      * If redirectTo is in form that means user has submitted the form through alert,
-     * so we have to redirect to manage-kits url
+     * so we have to redirect to manage-kits url. `redirectTo` is a
+     * client-supplied form value, so route it through `safeRedirect` to block
+     * open-redirects to another origin — falling back to the booking page.
      */
     if (redirectTo) {
-      return redirect(redirectTo);
+      return redirect(safeRedirect(redirectTo, `/bookings/${bookingId}`));
     }
 
     return redirect(`/bookings/${bookingId}`);

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -81,7 +81,7 @@ import {
   removeAssets,
   updateBookingAssets,
 } from "~/modules/booking/service.server";
-import { getAssetModelAvailability } from "~/modules/booking-model-request/service.server";
+import { getBookingModelTabData } from "~/modules/booking-model-request/service.server";
 import { createSystemBookingNote } from "~/modules/booking-note/service.server";
 import { createNotes } from "~/modules/note/service.server";
 import { getUserByID } from "~/modules/user/service.server";
@@ -111,6 +111,7 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
+import { tw } from "~/utils/tw";
 
 export type AssetWithBooking = Asset & {
   bookingAssets: { booking: Booking }[];
@@ -373,110 +374,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     );
 
     /**
-     * Book-by-Model — Models tab payload.
-     *
-     * We always count the org's AssetModels so the UI knows whether to
-     * render the "Models" tab at all (hidden when the org has none).
-     * When there is at least one model we also fetch the list for the
-     * picker plus the per-model availability in the current booking's
-     * window. Capping at `MODEL_PICKER_LIMIT` keeps the loader cheap
-     * for large orgs; if an org has more models we paginate by just
-     * showing the first batch sorted by name.
-     *
-     * TODO: add a paginated "search models" API once an org actually
-     * bumps into the MODEL_PICKER_LIMIT cap.
+     * Book-by-Model — Models tab payload. Shared with the manage-kits
+     * loader via `getBookingModelTabData` so both surfaces compute
+     * model availability identically (see the helper's JSDoc for the
+     * "total − inCustody − reserved" formula).
      */
-    const MODEL_PICKER_LIMIT = 50;
-    const assetModelsCount = await db.assetModel.count({
-      where: { organizationId },
+    const modelTabData = await getBookingModelTabData({
+      organizationId,
+      booking,
     });
-    const showModelsTab = assetModelsCount > 0;
-
-    let assetModels: {
-      id: string;
-      name: string;
-      total: number;
-      available: number;
-      reservedConcrete: number;
-      reservedViaRequest: number;
-      inCustody: number;
-    }[] = [];
-
-    if (showModelsTab) {
-      const rawModels = await db.assetModel.findMany({
-        where: { organizationId },
-        select: { id: true, name: true },
-        orderBy: { name: "asc" },
-        take: MODEL_PICKER_LIMIT,
-      });
-
-      const availabilities = await Promise.all(
-        rawModels.map((m) =>
-          getAssetModelAvailability({
-            assetModelId: m.id,
-            organizationId,
-            bookingId: booking.id,
-            from: booking.from,
-            to: booking.to,
-          })
-        )
-      );
-
-      assetModels = rawModels.map((m, i) => ({
-        id: m.id,
-        name: m.name,
-        total: availabilities[i].total,
-        available: availabilities[i].available,
-        reservedConcrete: availabilities[i].reservedConcrete,
-        reservedViaRequest: availabilities[i].reservedViaRequest,
-        inCustody: availabilities[i].inCustody,
-      }));
-    }
-
-    /**
-     * Flatten the booking's existing model requests for the UI. The
-     * inner `assetModel` relation is included via
-     * `BOOKING_WITH_ASSETS_INCLUDE`, so we just project the fields the
-     * Models tab needs and leave the rest on the booking record.
-     */
-    // Ship all requests (outstanding + fulfilled). The Models tab UI
-    // splits them into "Active reservations" (editable, not yet fully
-    // fulfilled) and "Fulfilled" (historical, read-only). Fulfilled
-    // rows are the audit trail for "this booking started life as 3 ×
-    // Dell" on an ONGOING booking.
-    const modelRequests = booking.modelRequests.map((req) => ({
-      assetModelId: req.assetModelId,
-      assetModelName: req.assetModel.name,
-      quantity: req.quantity,
-      fulfilledQuantity: req.fulfilledQuantity,
-      fulfilledAt:
-        req.fulfilledAt instanceof Date
-          ? req.fulfilledAt.toISOString()
-          : req.fulfilledAt,
-    }));
-
-    /**
-     * Shape for {@link DynamicSelect}. The picker reads
-     * `initialAssetModels` as its seed list and `totalAssetModels`
-     * to decide whether to offer the "show all / search" affordance.
-     * Availability goes on `metadata` so the renderItem can show
-     * e.g. "5 / 5 available" inline per option.
-     *
-     * Full-org `totalAssetModels` is the right denominator (not the
-     * truncated first-50 list) so the picker can present "searching
-     * 80 of 120 models" correctly.
-     */
-    const initialAssetModels = assetModels.map((m) => ({
-      id: m.id,
-      name: m.name,
-      metadata: {
-        total: m.total,
-        available: m.available,
-        reservedConcrete: m.reservedConcrete,
-        reservedViaRequest: m.reservedViaRequest,
-        inCustody: m.inCustody,
-      },
-    }));
 
     return payload({
       header: {
@@ -505,11 +411,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       locations,
       totalLocations,
       bookingKitIds,
-      showModelsTab,
-      assetModels,
-      initialAssetModels,
-      totalAssetModels: assetModelsCount,
-      modelRequests,
+      ...modelTabData,
     });
   } catch (cause) {
     const reason = makeShelfError(cause, { userId, id });
@@ -1490,49 +1392,66 @@ export default function AddAssetsToNewBooking() {
       ) : null}
 
       {/*
-       * Footer of the modal. Only rendered on the Assets tab — the
-       * Models tab submits each model reservation inline via the
-       * model-requests API route, so there's nothing to "Confirm" here.
+       * Footer of the modal. The `<Form ref={formRef}>` (and every hidden
+       * input in it) is ALWAYS mounted, regardless of `activeTab` — it used
+       * to render only on the Assets tab, which left `formRef.current` null
+       * while on the Models tab. Switching Assets → Models → Kits then
+       * opened the "Unsaved changes" alert, but its `onYes` handler submits
+       * `formRef.current` directly (see below), so against a null ref that
+       * submit silently no-opped: no assets were added and no redirect to
+       * manage-kits happened. Only the visible "N selected" text and the
+       * Confirm button stay Assets-tab-only: the Models tab has no
+       * standalone save of its own (each reservation posts inline via the
+       * model-requests API route), and a visible/enabled Confirm there
+       * could post asset changes without the `redirectTo` the alert needs.
        */}
-      {activeTab === "assets" ? (
-        <footer className="item-center mt-auto flex shrink-0 justify-between border-t px-6 py-3">
+      <footer
+        className={tw(
+          "item-center mt-auto flex shrink-0 border-t px-6 py-3",
+          activeTab === "assets" ? "justify-between" : "justify-end"
+        )}
+      >
+        {activeTab === "assets" ? (
           <p>
             {hasSelectedAllItems ? totalItems : selectedBulkItemsCount} assets
             selected
           </p>
+        ) : null}
 
-          <div className="flex gap-3">
-            <Button variant="secondary" to={".."}>
-              Close
-            </Button>
-            <Form method="post" ref={formRef}>
-              {/* We create inputs for both the removed and selected assets, so we can compare and easily add/remove */}
-              {removedAssets.map((asset, i) => (
-                <input
-                  key={asset.id}
-                  type="hidden"
-                  name={`removedAssetIds[${i}]`}
-                  value={asset.id}
-                />
-              ))}
-              {/* These are the ids selected by the user and stored in the atom */}
-              {selectedBulkItems.map((asset, i) => (
-                <input
-                  key={asset.id}
-                  type="hidden"
-                  name={`assetIds[${i}]`}
-                  value={asset.id}
-                />
-              ))}
-              {/* JSON-encoded quantities for QUANTITY_TRACKED assets */}
+        <div className="flex gap-3">
+          <Button variant="secondary" to={".."}>
+            Close
+          </Button>
+          <Form method="post" ref={formRef}>
+            {/* We create inputs for both the removed and selected assets, so we can compare and easily add/remove */}
+            {removedAssets.map((asset, i) => (
               <input
+                key={asset.id}
                 type="hidden"
-                name="quantities"
-                value={JSON.stringify(quantities)}
+                name={`removedAssetIds[${i}]`}
+                value={asset.id}
               />
-              {hasUnsavedChanges && isAlertOpen ? (
-                <input name="redirectTo" value={manageKitsUrl} type="hidden" />
-              ) : null}
+            ))}
+            {/* These are the ids selected by the user and stored in the atom */}
+            {selectedBulkItems.map((asset, i) => (
+              <input
+                key={asset.id}
+                type="hidden"
+                name={`assetIds[${i}]`}
+                value={asset.id}
+              />
+            ))}
+            {/* JSON-encoded quantities for QUANTITY_TRACKED assets */}
+            <input
+              type="hidden"
+              name="quantities"
+              value={JSON.stringify(quantities)}
+            />
+            {hasUnsavedChanges && isAlertOpen ? (
+              <input name="redirectTo" value={manageKitsUrl} type="hidden" />
+            ) : null}
+            {/* Omitted entirely (not just hidden) on the Models tab — see the comment above the footer. */}
+            {activeTab === "assets" ? (
               <Button
                 type="submit"
                 name="intent"
@@ -1541,16 +1460,10 @@ export default function AddAssetsToNewBooking() {
               >
                 Confirm
               </Button>
-            </Form>
-          </div>
-        </footer>
-      ) : (
-        <footer className="item-center mt-auto flex shrink-0 justify-end border-t px-6 py-3">
-          <Button type="button" variant="secondary" to={".."}>
-            Close
-          </Button>
-        </footer>
-      )}
+            ) : null}
+          </Form>
+        </div>
+      </footer>
 
       <UnsavedChangesAlert
         open={isAlertOpen}

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -1410,7 +1410,7 @@ export default function AddAssetsToNewBooking() {
        */}
       <footer
         className={tw(
-          "item-center mt-auto flex shrink-0 border-t px-6 py-3",
+          "mt-auto flex shrink-0 items-center border-t px-6 py-3",
           activeTab === "assets" ? "justify-between" : "justify-end"
         )}
       >

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
@@ -1,17 +1,19 @@
 import { BookingStatus, KitStatus } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createActionArgs } from "@mocks/remix";
+import { createActionArgs, createLoaderArgs } from "@mocks/remix";
 
 import { db } from "~/database/db.server";
 import * as bookingService from "~/modules/booking/service.server";
+import * as modelRequestService from "~/modules/booking-model-request/service.server";
+import * as kitService from "~/modules/kit/service.server";
 import * as noteService from "~/modules/note/service.server";
 import * as userService from "~/modules/user/service.server";
 import * as bookingAssets from "~/utils/booking-assets";
 import * as httpServer from "~/utils/http.server";
 import * as rolesServer from "~/utils/roles.server";
 
-// Import the action function
-import { action } from "./bookings.$bookingId.overview.manage-kits";
+// Import the action + loader functions
+import { action, loader } from "./bookings.$bookingId.overview.manage-kits";
 import { assertIsDataWithResponseInit } from "../../../test/helpers/assertions";
 
 // @vitest-environment node
@@ -32,6 +34,22 @@ vi.mock("~/modules/booking/service.server", () => ({
   getDetailedPartialCheckinData: vi.fn(),
   updateBookingAssets: vi.fn(),
   createKitBookingNote: vi.fn(),
+  // Loader-only — used by the Models-tab loader tests below.
+  getBooking: vi.fn(),
+  getKitIdsByAssets: vi.fn(),
+}));
+
+// Loader-only — `getPaginatedAndFilterableKits` backs the Kits tab list.
+vi.mock("~/modules/kit/service.server", () => ({
+  getPaginatedAndFilterableKits: vi.fn(),
+}));
+
+// why: mock the shared Models-tab payload helper as a unit so the loader
+// test isolates "does the loader wire the helper's output into the payload"
+// from the helper's own DB logic, which has its own unit test in
+// `booking-model-request/service.server.test.ts` (including org-scoping).
+vi.mock("~/modules/booking-model-request/service.server", () => ({
+  getBookingModelTabData: vi.fn(),
 }));
 
 vi.mock("~/modules/user/service.server", () => ({
@@ -55,6 +73,9 @@ vi.mock("~/utils/http.server", () => ({
   parseData: vi.fn(),
   json: vi.fn((data) => data),
   error: vi.fn((reason) => reason),
+  // why: mirror the real `payload()` shape (`{ error: null, ...data }`) so
+  // the Models-tab loader tests can inspect the returned keys directly.
+  payload: vi.fn((data) => ({ error: null, ...data })),
 }));
 
 // Mock request and context objects
@@ -734,6 +755,190 @@ describe("manage-kits route validation", () => {
           ],
         })
       );
+    });
+  });
+});
+
+/**
+ * The manage-kits loader used to only ship the Kits-tab payload, so
+ * manage-kits never rendered a Models tab even when the org had
+ * `AssetModel`s. It now delegates to the shared `getBookingModelTabData`
+ * helper — the SAME helper the manage-assets loader uses — so both surfaces
+ * compute Models-tab availability identically. This is additive: the
+ * loader's existing Kits-tab payload keys are untouched.
+ *
+ * `getBookingModelTabData` is mocked here (as in the manage-assets loader
+ * test) so these tests isolate "does the loader wire the helper's output
+ * into the payload" from the helper's own DB logic — including org-scoping
+ * — which has its own unit test in
+ * `booking-model-request/service.server.test.ts`.
+ */
+describe("manage-kits loader — Models tab payload", () => {
+  const mockContext = {
+    getSession: () => ({ userId: "user123" }),
+    appVersion: "1.0.0",
+    isAuthenticated: true,
+    setSession: vi.fn(),
+    destroySession: vi.fn(),
+    errorMessage: null,
+  } as any;
+
+  const mockParams = { bookingId: "booking123" };
+
+  /** Minimal booking shape the loader needs — DRAFT so no status guard fires. */
+  const mockLoaderBooking = {
+    id: "booking123",
+    name: "Test Booking",
+    status: BookingStatus.DRAFT,
+    from: new Date("2026-01-01"),
+    to: new Date("2026-01-02"),
+    bookingAssets: [],
+    modelRequests: [],
+  } as any;
+
+  /** `getPaginatedAndFilterableKits` return shape the loader destructures. */
+  const mockPaginatedKits = {
+    page: 1,
+    perPage: 20,
+    kits: [],
+    search: null,
+    totalKits: 0,
+    totalPages: 0,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(rolesServer.requirePermission).mockResolvedValue({
+      organizationId: "org123",
+      userOrganizations: [],
+      isSelfServiceOrBase: false,
+      organizations: [],
+      currentOrganization: {} as any,
+      role: {} as any,
+      canSeeAllBookings: false,
+      canSeeAllCustody: false,
+      canUseBarcodes: false,
+      canUseAudits: false,
+    });
+
+    vi.mocked(httpServer.getParams).mockReturnValue({
+      bookingId: "booking123",
+    });
+
+    vi.mocked(bookingService.getBooking).mockResolvedValue(mockLoaderBooking);
+    vi.mocked(bookingService.getKitIdsByAssets).mockReturnValue([]);
+    vi.mocked(kitService.getPaginatedAndFilterableKits).mockResolvedValue(
+      mockPaginatedKits as any
+    );
+  });
+
+  it("hides the Models tab when the org has no asset models", async () => {
+    vi.mocked(modelRequestService.getBookingModelTabData).mockResolvedValue({
+      showModelsTab: false,
+      assetModels: [],
+      initialAssetModels: [],
+      totalAssetModels: 0,
+      modelRequests: [],
+    });
+
+    const result = await loader(
+      createLoaderArgs({ context: mockContext, params: mockParams })
+    );
+
+    expect(result).toMatchObject({
+      showModelsTab: false,
+      assetModels: [],
+      initialAssetModels: [],
+      totalAssetModels: 0,
+      modelRequests: [],
+    });
+  });
+
+  it("wires the helper's Models tab payload through, shipping both crash-guard keys", async () => {
+    // Omitting either `initialAssetModels` or `totalAssetModels` crashes the
+    // Models tab the moment it mounts: `useModelFilters` maps over
+    // `initialData["initialAssetModels"]` / `["totalAssetModels"]`
+    // (`use-model-filters.ts:96-103`), so this test asserts BOTH keys are
+    // present, not just that the tab is shown.
+    const mockModelTabData = {
+      showModelsTab: true,
+      assetModels: [
+        {
+          id: "model1",
+          name: "Dell XPS",
+          total: 5,
+          available: 3,
+          reservedConcrete: 1,
+          reservedViaRequest: 1,
+          inCustody: 0,
+        },
+      ],
+      initialAssetModels: [
+        {
+          id: "model1",
+          name: "Dell XPS",
+          metadata: {
+            total: 5,
+            available: 3,
+            reservedConcrete: 1,
+            reservedViaRequest: 1,
+            inCustody: 0,
+          },
+        },
+      ],
+      totalAssetModels: 1,
+      modelRequests: [
+        {
+          assetModelId: "model1",
+          assetModelName: "Dell XPS",
+          quantity: 2,
+          fulfilledQuantity: 0,
+          fulfilledAt: null,
+        },
+      ],
+    };
+    vi.mocked(modelRequestService.getBookingModelTabData).mockResolvedValue(
+      mockModelTabData as any
+    );
+
+    const result = await loader(
+      createLoaderArgs({ context: mockContext, params: mockParams })
+    );
+
+    expect(result).toHaveProperty("initialAssetModels");
+    expect(result).toHaveProperty("totalAssetModels");
+    expect((result as any).totalAssetModels).toBe(1);
+    expect(result).toMatchObject({
+      showModelsTab: true,
+      assetModels: mockModelTabData.assetModels,
+      initialAssetModels: mockModelTabData.initialAssetModels,
+      totalAssetModels: mockModelTabData.totalAssetModels,
+      modelRequests: mockModelTabData.modelRequests,
+    });
+  });
+
+  it("scopes the Models tab lookup to the caller's organizationId", async () => {
+    // Deep org-scoping (e.g. "a foreign-org model is never counted/listed")
+    // is covered by `getBookingModelTabData`'s own unit tests. At the
+    // loader level we only need to prove the loader forwards the caller's
+    // `organizationId` (from `requirePermission`) — never a value derived
+    // from user input — into the helper.
+    vi.mocked(modelRequestService.getBookingModelTabData).mockResolvedValue({
+      showModelsTab: true,
+      assetModels: [],
+      initialAssetModels: [],
+      totalAssetModels: 1,
+      modelRequests: [],
+    });
+
+    await loader(
+      createLoaderArgs({ context: mockContext, params: mockParams })
+    );
+
+    expect(modelRequestService.getBookingModelTabData).toHaveBeenCalledWith({
+      organizationId: "org123",
+      booking: mockLoaderBooking,
     });
   });
 });

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
@@ -68,15 +68,22 @@ vi.mock("~/utils/roles.server", () => ({
   requirePermission: vi.fn(),
 }));
 
-vi.mock("~/utils/http.server", () => ({
-  getParams: vi.fn(),
-  parseData: vi.fn(),
-  json: vi.fn((data) => data),
-  error: vi.fn((reason) => reason),
-  // why: mirror the real `payload()` shape (`{ error: null, ...data }`) so
-  // the Models-tab loader tests can inspect the returned keys directly.
-  payload: vi.fn((data) => ({ error: null, ...data })),
-}));
+vi.mock("~/utils/http.server", async (importOriginal) => {
+  const actual = await importOriginal<typeof httpServer>();
+  return {
+    getParams: vi.fn(),
+    parseData: vi.fn(),
+    json: vi.fn((data) => data),
+    error: vi.fn((reason) => reason),
+    // why: mirror the real `payload()` shape (`{ error: null, ...data }`) so
+    // the Models-tab loader tests can inspect the returned keys directly.
+    payload: vi.fn((data) => ({ error: null, ...data })),
+    // why: use the REAL safeRedirect so the redirect tests exercise the actual
+    // origin-allowlist sanitization the action now depends on (safeRedirect's
+    // own edge cases are unit-tested in http.server.test.ts).
+    safeRedirect: actual.safeRedirect,
+  };
+});
 
 // Mock request and context objects
 const mockContext = {
@@ -754,6 +761,81 @@ describe("manage-kits route validation", () => {
             },
           ],
         })
+      );
+    });
+  });
+
+  describe("redirectTo handling (confirm-from-unsaved-changes alert)", () => {
+    // A successful kit-add: kit1 (AVAILABLE) brings asset3, which is not yet on
+    // the booking, so the action reaches updateBookingAssets and then the
+    // redirect branch. beforeEach already resolves updateBookingAssets +
+    // createKitBookingNote, so only the kit inputs need setting per test.
+    const availableKit = [
+      {
+        id: "kit1",
+        name: "Kit 1",
+        status: KitStatus.AVAILABLE,
+        assetKits: [
+          { id: "ak-kit1-asset3", quantity: 1, asset: { id: "asset3" } },
+        ],
+        organizationId: "org123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ] as any;
+
+    it("redirects to a same-origin redirectTo submitted through the alert", async () => {
+      const manageAssetsUrl =
+        "/bookings/booking123/overview/manage-assets?hideUnavailable=true";
+
+      vi.mocked(httpServer.parseData).mockReturnValue({
+        kitIds: ["kit1"],
+        removedKitIds: [],
+        redirectTo: manageAssetsUrl,
+      });
+      vi.mocked(db.kit.findMany).mockResolvedValue(availableKit);
+      vi.mocked(bookingAssets.isKitPartiallyCheckedIn).mockReturnValue(false);
+
+      const response = await action(
+        createActionArgs({
+          context: mockContext,
+          request: mockRequest,
+          params: mockParams,
+        })
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(302);
+      expect((response as Response).headers.get("Location")).toBe(
+        manageAssetsUrl
+      );
+    });
+
+    it("sanitizes an off-origin redirectTo to the booking page (no open redirect)", async () => {
+      // A crafted POST could supply an attacker-controlled absolute URL in the
+      // client-side `redirectTo` field. The action must route it through
+      // safeRedirect, which rejects off-origin targets and falls back to the
+      // booking page instead of redirecting the user off-site.
+      vi.mocked(httpServer.parseData).mockReturnValue({
+        kitIds: ["kit1"],
+        removedKitIds: [],
+        redirectTo: "https://evil.example.com/phish",
+      });
+      vi.mocked(db.kit.findMany).mockResolvedValue(availableKit);
+      vi.mocked(bookingAssets.isKitPartiallyCheckedIn).mockReturnValue(false);
+
+      const response = await action(
+        createActionArgs({
+          context: mockContext,
+          request: mockRequest,
+          params: mockParams,
+        })
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(302);
+      expect((response as Response).headers.get("Location")).toBe(
+        "/bookings/booking123"
       );
     });
   });

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -907,7 +907,7 @@ export default function AddKitsToBooking() {
        */}
       <footer
         className={tw(
-          "item-center mt-auto flex shrink-0 border-t px-6 py-3",
+          "mt-auto flex shrink-0 items-center border-t px-6 py-3",
           activeTab === "kits" ? "justify-between" : "justify-end"
         )}
       >

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -77,7 +77,13 @@ import { isKitPartiallyCheckedIn } from "~/utils/booking-assets";
 import { getClientHint } from "~/utils/client-hints";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
-import { payload, error, getParams, parseData } from "~/utils/http.server";
+import {
+  payload,
+  error,
+  getParams,
+  parseData,
+  safeRedirect,
+} from "~/utils/http.server";
 import {
   wrapAssetWithCountForNote,
   wrapLinkForNote,
@@ -652,10 +658,12 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     /**
      * If redirectTo is in form that means user has submitted the form through alert dialog,
-     * so we have to redirect to manage-assets url
+     * so we have to redirect to manage-assets url. `redirectTo` is a
+     * client-supplied form value, so route it through `safeRedirect` to block
+     * open-redirects to another origin — falling back to the booking page.
      */
     if (redirectTo) {
-      return redirect(redirectTo);
+      return redirect(safeRedirect(redirectTo, `/bookings/${bookingId}`));
     }
 
     return redirect(`/bookings/${bookingId}`);

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -34,6 +34,7 @@ import {
   KitAvailabilityLabel,
 } from "~/components/booking/availability-label";
 import { AvailabilitySelect } from "~/components/booking/availability-select";
+import { ManageModelRequests } from "~/components/booking/manage-model-requests";
 import styles from "~/components/booking/styles.css?url";
 import KitImage from "~/components/kits/kit-image";
 import { KitStatusBadge } from "~/components/kits/kit-status-badge";
@@ -67,6 +68,7 @@ import {
   updateBookingAssets,
   createKitBookingNote,
 } from "~/modules/booking/service.server";
+import { getBookingModelTabData } from "~/modules/booking-model-request/service.server";
 import { getPaginatedAndFilterableKits } from "~/modules/kit/service.server";
 import { createNotes } from "~/modules/note/service.server";
 import { getUserByID } from "~/modules/user/service.server";
@@ -86,6 +88,7 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
+import { tw } from "~/utils/tw";
 
 export const meta = () => [{ title: appendToMetaTitle("Manage kits") }];
 
@@ -188,6 +191,17 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       booking.bookingAssets.map((ba) => ba.asset)
     );
 
+    /**
+     * Book-by-Model — Models tab payload. Shared with the manage-assets
+     * loader via `getBookingModelTabData` so both surfaces compute model
+     * availability identically (see the helper's JSDoc for the "total −
+     * inCustody − reserved" formula).
+     */
+    const modelTabData = await getBookingModelTabData({
+      organizationId,
+      booking,
+    });
+
     const { page, perPage, kits, search, totalKits, totalPages } =
       await getPaginatedAndFilterableKits({
         request,
@@ -272,6 +286,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       items: kits,
       totalItems: totalKits,
       bookingKitIds,
+      ...modelTabData,
     });
   } catch (cause) {
     const reason = makeShelfError(cause, { userId, bookingId });
@@ -654,7 +669,23 @@ export default function AddKitsToBooking() {
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
 
-  const { booking, items, bookingKitIds } = useLoaderData<typeof loader>();
+  const {
+    booking,
+    items,
+    bookingKitIds,
+    showModelsTab,
+    assetModels,
+    modelRequests,
+  } = useLoaderData<typeof loader>();
+
+  /**
+   * Local state for the active tab value. "kits" is the default on mount.
+   * "assets" always navigates away (existing manage-assets route); "models"
+   * renders inline via `ManageModelRequests`, mirroring manage-assets' tab
+   * pattern.
+   */
+  const [activeTab, setActiveTab] = useState<"kits" | "models">("kits");
+
   const navigate = useNavigate();
   const navigation = useNavigation();
   const isSearching = isFormProcessing(navigation.state);
@@ -689,6 +720,16 @@ export default function AddKitsToBooking() {
     (ba) => ba.asset.assetKits.length === 0
   ).length;
   const hasUnsavedChanges = selectedBulkItems.length !== bookingKitIds.length;
+
+  /**
+   * Total quantity reserved via model-level requests — shown as a count
+   * badge on the Models tab trigger, identical to manage-assets
+   * (`manage-assets.tsx` — `totalModelRequestUnits`).
+   */
+  const totalModelRequestUnits = useMemo(
+    () => modelRequests.reduce((acc, req) => acc + req.quantity, 0),
+    [modelRequests]
+  );
 
   /**
    * Set selected items for kit based on the route data.
@@ -727,14 +768,23 @@ export default function AddKitsToBooking() {
   return (
     <Tabs
       className="flex h-full max-h-full flex-col"
-      value="kits"
-      onValueChange={() => {
-        if (hasUnsavedChanges) {
-          setIsAlertOpen(true);
+      value={activeTab}
+      activationMode="manual"
+      onValueChange={(nextValue) => {
+        // "assets" always navigates away (existing route). "kits" and
+        // "models" render inline on this route — just update the
+        // active-tab state.
+        if (nextValue === "assets") {
+          if (hasUnsavedChanges) {
+            setIsAlertOpen(true);
+            return;
+          }
+          void navigate(manageAssetsUrl);
           return;
         }
-
-        void navigate(manageAssetsUrl);
+        if (nextValue === "models" || nextValue === "kits") {
+          setActiveTab(nextValue);
+        }
       }}
     >
       <div className="border-b px-6 py-2">
@@ -755,14 +805,39 @@ export default function AddKitsToBooking() {
               </GrayBadge>
             ) : null}
           </TabsTrigger>
+          {showModelsTab ? (
+            <TabsTrigger
+              className="flex-1 gap-x-2"
+              value="models"
+              aria-label={`Models tab${
+                totalModelRequestUnits > 0
+                  ? ` (${totalModelRequestUnits} reserved)`
+                  : ""
+              }`}
+            >
+              Models
+              {totalModelRequestUnits > 0 ? (
+                <GrayBadge className="size-[20px] border border-primary-200 bg-primary-50 text-[10px] leading-[10px] text-primary-700">
+                  {totalModelRequestUnits}
+                </GrayBadge>
+              ) : null}
+            </TabsTrigger>
+          ) : null}
         </TabsList>
       </div>
 
-      <Filters
-        slots={{ "right-of-search": <AvailabilitySelect label="kits" /> }}
-        innerWrapperClassName="justify-between"
-        className="justify-between !border-t-0 border-b px-6 md:flex"
-      />
+      {/*
+       * The kit availability filter only makes sense on the Kits tab. The
+       * Models tab uses its own picker + availability hints (via
+       * `ManageModelRequests`).
+       */}
+      {activeTab === "kits" ? (
+        <Filters
+          slots={{ "right-of-search": <AvailabilitySelect label="kits" /> }}
+          innerWrapperClassName="justify-between"
+          className="justify-between !border-t-0 border-b px-6 md:flex"
+        />
+      ) : null}
 
       <TabsContent value="kits" asChild>
         <List
@@ -799,11 +874,40 @@ export default function AddKitsToBooking() {
         />
       </TabsContent>
 
-      {/* Footer of the modal */}
-      <footer className="item-center mt-auto flex shrink-0 justify-between border-t px-6 py-3">
-        <div className="flex flex-col justify-center gap-1">
-          {selectedBulkItems.length} kits selected
-        </div>
+      {showModelsTab ? (
+        <TabsContent
+          value="models"
+          className="mt-0 flex min-h-0 flex-1 flex-col"
+        >
+          <ManageModelRequests
+            bookingId={booking.id}
+            assetModels={assetModels}
+            modelRequests={modelRequests}
+          />
+        </TabsContent>
+      ) : null}
+
+      {/*
+       * Footer of the modal. The `<Form ref={formRef}>` (and every hidden
+       * input in it) is ALWAYS mounted, regardless of `activeTab`:
+       * `UnsavedChangesAlert.onYes` submits `formRef.current` directly, so
+       * switching tabs must not leave that ref null (a conditionally-mounted
+       * form would make confirm-from-alert silently no-op on the non-Kits
+       * tabs). Only the visible "N kits selected" text and the Confirm button
+       * are Kits-tab-only: the Models tab has no standalone save of its own
+       * (each reservation posts inline via the model-requests API route).
+       */}
+      <footer
+        className={tw(
+          "item-center mt-auto flex shrink-0 border-t px-6 py-3",
+          activeTab === "kits" ? "justify-between" : "justify-end"
+        )}
+      >
+        {activeTab === "kits" ? (
+          <div className="flex flex-col justify-center gap-1">
+            {selectedBulkItems.length} kits selected
+          </div>
+        ) : null}
         <div className="flex gap-3">
           <Button variant="secondary" to={".."}>
             Close
@@ -831,14 +935,17 @@ export default function AddKitsToBooking() {
             {hasUnsavedChanges && isAlertOpen ? (
               <input name="redirectTo" value={manageAssetsUrl} type="hidden" />
             ) : null}
-            <Button
-              type="submit"
-              name="intent"
-              value="addKits"
-              disabled={isSearching}
-            >
-              Confirm
-            </Button>
+            {/* Omitted entirely (not just hidden) on the Models tab — see the comment above the footer. */}
+            {activeTab === "kits" ? (
+              <Button
+                type="submit"
+                name="intent"
+                value="addKits"
+                disabled={isSearching}
+              >
+                Confirm
+              </Button>
+            ) : null}
           </Form>
         </div>
       </footer>


### PR DESCRIPTION
Three interrelated bugs stemming from the Book-by-Model "Models" tab having been
implemented only on the manage-assets modal:

- Reset the model picker search after adding a reservation. New opt-in
  `resetSearchOnClose` prop on DynamicSelect resets the search on popover close;
  enabled only on the model picker so the ~20 other consumers are unaffected.
- Add the Models tab to the manage-kits modal (previously Assets/Kits only).
  Stateful activeTab with activationMode="manual", showModelsTab-guarded trigger,
  and inline ManageModelRequests reused verbatim.
- Fix the unsaved-changes confirm no-op from the Models tab. The confirm form is
  now always mounted (only the visible Confirm button is tab-gated), so
  submit(formRef.current) reaches the action from any tab. Same always-mounted
  pattern applied to manage-kits so it can't regress.

Extract a shared org-scoped getBookingModelTabData helper so both modals compute
the Models-tab payload identically and can't drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Models** tab to booking management with per-model availability and integrated model-request information, including picker-ready availability data.
  * Enhanced model selection dropdown so search resets when the menu closes for quicker repeat selections.
* **Bug Fixes**
  * Hardened `redirectTo` handling to prevent unsafe redirects and fall back to the booking page when needed.
  * Improved unsaved-changes confirmation by keeping the form mounted so submissions reliably trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->