### PR TITLE
feat(bookings): keep assets available when added to an ongoing booking

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
@@ -152,7 +152,11 @@ function BookingSelect({
               />
             </div>
 
-            <div className="max-h-[320px] divide-y overflow-y-auto">
+            <div
+              className="max-h-[320px] divide-y overflow-y-auto"
+              role="listbox"
+              aria-label="Existing bookings"
+            >
               {filteredBookings.length === 0 ? (
                 <div className="p-4 text-center text-sm text-gray-500">
                   {isLoading

--- a/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
@@ -1,4 +1,12 @@
+import { useMemo, useRef, useState } from "react";
 import type { Asset, Booking } from "@prisma/client";
+import { ChevronDownIcon } from "@radix-ui/react-icons";
+import {
+  Popover,
+  PopoverContent,
+  PopoverPortal,
+  PopoverTrigger,
+} from "@radix-ui/react-popover";
 import { useAtomValue } from "jotai";
 import { useNavigate } from "react-router";
 import { useZorm } from "react-zorm";
@@ -6,17 +14,15 @@ import { z } from "zod";
 import { bulkDialogAtom } from "~/atoms/bulk-update-dialog";
 import { selectedBulkItemsAtom } from "~/atoms/list";
 import { BulkUpdateDialogContent } from "~/components/bulk-update-dialog/bulk-update-dialog";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/forms/select";
+import Input from "~/components/forms/input";
+import { CheckIcon } from "~/components/icons/library";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
 import When from "~/components/when/when";
 import useApiQuery from "~/hooks/use-api-query";
+import { useAutoFocus } from "~/hooks/use-auto-focus";
+import { handleActivationKeyPress } from "~/utils/keyboard";
+import { tw } from "~/utils/tw";
 
 export const addAssetsToExistingBookingSchema = z.object({
   id: z
@@ -25,6 +31,184 @@ export const addAssetsToExistingBookingSchema = z.object({
   assetsIds: z.string().array().min(1, "Please select at least one asset."),
   addOnlyRestAssets: z.coerce.boolean().optional().nullable(),
 });
+
+/**
+ * Searchable booking picker for the bulk "add to existing booking" dialog.
+ *
+ * Mirrors the look & feel of the shared `DynamicSelect` (searchable popover,
+ * check-marked selection, date range per row) but is fed directly from the
+ * `/api/bookings/get-all` fetch instead of route-loader data — the assets-index
+ * loader does not (and should not, for perf) carry booking data. `get-all`
+ * returns every open booking (`takeAll`), so filtering is done client-side for
+ * instant results.
+ *
+ * @see {@link file://./../../../routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx}
+ *   the singular-asset flow this is styled to match.
+ */
+function BookingSelect({
+  bookings,
+  isLoading,
+  disabled,
+  errorMessage,
+}: {
+  /** All open bookings returned by `/api/bookings/get-all`. */
+  bookings: Booking[];
+  /** Whether the bookings fetch is still in flight. */
+  isLoading: boolean;
+  /** Disable the trigger (e.g. while the form is submitting). */
+  disabled?: boolean;
+  /** Zorm/server validation message for the `id` field. */
+  errorMessage?: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  // Focus the search box when the popover opens (Radix portal mounts a frame
+  // late, which the hook accounts for).
+  const searchInputRef = useAutoFocus<HTMLInputElement>({ when: isOpen });
+
+  const filteredBookings = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return bookings;
+    return bookings.filter((booking) =>
+      booking.name.toLowerCase().includes(query)
+    );
+  }, [bookings, searchQuery]);
+
+  const selectedBooking = bookings.find((booking) => booking.id === selectedId);
+
+  const triggerLabel = selectedBooking
+    ? selectedBooking.name
+    : isLoading
+    ? "Fetching bookings..."
+    : "Select a booking";
+
+  return (
+    <div className="relative z-50 mb-2">
+      {/* Value submitted with the form; matches the `id` schema field. */}
+      <input type="hidden" name="id" value={selectedId ?? ""} />
+
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild disabled={isLoading || disabled}>
+          <button
+            type="button"
+            className={tw(
+              "w-full",
+              (isLoading || disabled) && "cursor-not-allowed opacity-60"
+            )}
+          >
+            <div
+              ref={triggerRef}
+              className="flex w-full items-center justify-between whitespace-nowrap rounded border border-gray-300 px-[14px] py-2 text-sm hover:cursor-pointer"
+            >
+              <span
+                className={tw(
+                  "truncate whitespace-nowrap pr-2",
+                  !selectedBooking && "text-gray-500"
+                )}
+              >
+                {triggerLabel}
+              </span>
+              <ChevronDownIcon />
+            </div>
+          </button>
+        </PopoverTrigger>
+        <PopoverPortal>
+          <PopoverContent
+            className="z-[100] overflow-y-auto rounded-md border border-gray-300 bg-white"
+            style={{ width: triggerRef.current?.clientWidth }}
+            align="center"
+            sideOffset={5}
+          >
+            <div className="flex items-center justify-between p-3">
+              <div className="text-xs font-semibold text-gray-700">
+                Existing bookings
+              </div>
+              <When truthy={Boolean(selectedBooking)}>
+                <Button
+                  type="button"
+                  as="button"
+                  variant="link"
+                  className="whitespace-nowrap text-xs font-normal text-gray-500 hover:text-gray-600"
+                  onClick={() => setSelectedId(undefined)}
+                >
+                  Clear selection
+                </Button>
+              </When>
+            </div>
+
+            <div className="filters-form relative border-y border-y-gray-200 p-3">
+              <Input
+                ref={searchInputRef}
+                type="text"
+                label="Search bookings"
+                placeholder="Search bookings"
+                hideLabel
+                className="text-gray-500"
+                icon="search"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.currentTarget.value)}
+              />
+            </div>
+
+            <div className="max-h-[320px] divide-y overflow-y-auto">
+              {filteredBookings.length === 0 ? (
+                <div className="p-4 text-center text-sm text-gray-500">
+                  {isLoading
+                    ? "Fetching bookings..."
+                    : searchQuery
+                    ? "No bookings found"
+                    : "No open bookings available"}
+                </div>
+              ) : (
+                filteredBookings.map((booking) => (
+                  <div
+                    key={booking.id}
+                    className={tw(
+                      "flex cursor-pointer touch-manipulation select-none items-center justify-between gap-4 px-4 py-3 outline-none hover:bg-gray-100 focus:bg-gray-100",
+                      booking.id === selectedId && "bg-gray-100"
+                    )}
+                    role="option"
+                    aria-selected={booking.id === selectedId}
+                    tabIndex={0}
+                    onClick={() => {
+                      setSelectedId(booking.id);
+                      setIsOpen(false);
+                    }}
+                    onKeyDown={handleActivationKeyPress(() => {
+                      setSelectedId(booking.id);
+                      setIsOpen(false);
+                    })}
+                  >
+                    <div className="flex min-w-0 flex-col items-start gap-1 text-black">
+                      <div className="max-w-[250px] truncate font-medium">
+                        {booking.name}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        <DateS date={booking.from} includeTime /> -{" "}
+                        <DateS date={booking.to} includeTime />
+                      </div>
+                    </div>
+                    <When truthy={booking.id === selectedId}>
+                      <span className="h-auto w-[18px] shrink-0 text-primary">
+                        <CheckIcon />
+                      </span>
+                    </When>
+                  </div>
+                ))
+              )}
+            </div>
+          </PopoverContent>
+        </PopoverPortal>
+      </Popover>
+
+      <When truthy={Boolean(errorMessage)}>
+        <p className="mt-2 text-sm text-error-500">{errorMessage}</p>
+      </When>
+    </div>
+  );
+}
 
 export default function AddAssetsToExistingBookingDialog() {
   const navigate = useNavigate();
@@ -75,56 +259,28 @@ export default function AddAssetsToExistingBookingDialog() {
           {/* Handling the initial state of the dialog */}
           <When truthy={!fetcherData?.success}>
             <div className="max-h-[calc(100vh_-_200px)] overflow-auto">
-              <Select name="id" disabled={isFetchingBookings || disabled}>
-                <SelectTrigger className="mb-4">
-                  <SelectValue
-                    placeholder={
-                      isFetchingBookings
-                        ? "Fetching bookings..."
-                        : bookings.length === 0
-                        ? "No bookings available"
-                        : "Select booking"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent
-                  position="popper"
-                  className="min-w-[var(--radix-select-trigger-width)]"
-                  align="start"
-                >
-                  {bookings.length > 0 ? (
-                    bookings.map((booking) => (
-                      <SelectItem key={booking.id} value={booking.id}>
-                        <div className="flex flex-col items-start gap-1  text-black">
-                          <div className="semi-bold max-w-[250px] truncate">
-                            {booking.name}
-                          </div>
-                          <div className="text-xs text-gray-500">
-                            <DateS date={booking.from} includeTime /> -{" "}
-                            <DateS date={booking.to} includeTime />
-                          </div>
-                        </div>
-                      </SelectItem>
-                    ))
-                  ) : (
-                    <div className="p-2 text-center text-sm text-gray-500">
-                      No bookings available
-                    </div>
-                  )}
-                </SelectContent>
-              </Select>
+              <BookingSelect
+                bookings={bookings}
+                isLoading={isFetchingBookings}
+                disabled={disabled}
+                errorMessage={zo.errors.id()?.message}
+              />
+              <div className="mb-4 mt-2 text-gray-500">
+                <span className="font-medium text-gray-600">Draft</span>,{" "}
+                <span className="font-medium text-gray-600">Reserved</span>,{" "}
+                <span className="font-medium text-gray-600">Ongoing</span> and{" "}
+                <span className="font-medium text-gray-600">Overdue</span>{" "}
+                bookings are shown. Assets added to an ongoing booking stay
+                available until you check them out.
+              </div>
+
               <When truthy={!isFetchingBookings && bookings.length === 0}>
                 <div className="mb-4 rounded-md border border-gray-300 bg-gray-25 p-2">
                   <p className="text-sm text-gray-600">
-                    No draft or reserved bookings found. Create a new booking
-                    first to add assets to it.
+                    No open bookings found. Create a new booking first to add
+                    assets to it.
                   </p>
                 </div>
-              </When>
-              <When truthy={!!zo.errors.id()?.message}>
-                <p className="mb-4 text-sm text-error-500">
-                  {zo.errors.id()?.message}
-                </p>
               </When>
 
               <When truthy={!!fetcherError || !!fetcherErrorAdditionalData}>

--- a/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
@@ -89,7 +89,15 @@ function BookingSelect({
       {/* Value submitted with the form; matches the `id` schema field. */}
       <input type="hidden" name="id" value={selectedId ?? ""} />
 
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <Popover
+        open={isOpen}
+        onOpenChange={(open) => {
+          // `disabled` on an `asChild` PopoverTrigger doesn't reliably block
+          // opening (Radix clones the child), so gate state changes here.
+          if (isLoading || disabled) return;
+          setIsOpen(open);
+        }}
+      >
         <PopoverTrigger asChild disabled={isLoading || disabled}>
           <button
             type="button"

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -41,6 +41,8 @@ import {
   extendBooking,
   removeAssets,
   addScannedAssetsToBooking,
+  processBooking,
+  getExistingBookingDetails,
   getOngoingBookingForAsset,
   bulkArchiveBookings,
   bulkCancelBookings,
@@ -1597,7 +1599,10 @@ describe("updateBookingAssets", () => {
     expect(result).toEqual(mockBooking);
   });
 
-  it("should update asset status to CHECKED_OUT for ONGOING booking", async () => {
+  it("does NOT flip asset status to CHECKED_OUT for ONGOING booking (progressive checkout)", async () => {
+    // Progressive checkout: assets added to an ONGOING booking join it as line
+    // items but stay AVAILABLE until purposefully checked out. Adding must not
+    // flip status as a side-effect.
     expect.assertions(3);
 
     const mockBooking = {
@@ -1617,14 +1622,11 @@ describe("updateBookingAssets", () => {
     const result = await updateBookingAssets(mockUpdateBookingAssetsParams);
 
     expect(db.$executeRaw).toHaveBeenCalled();
-    expect(db.asset.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["asset-1", "asset-2"] }, organizationId: "org-1" },
-      data: { status: AssetStatus.CHECKED_OUT },
-    });
+    expect(db.asset.updateMany).not.toHaveBeenCalled();
     expect(result).toEqual(mockBooking);
   });
 
-  it("should update asset status to CHECKED_OUT for OVERDUE booking", async () => {
+  it("does NOT flip asset status to CHECKED_OUT for OVERDUE booking (progressive checkout)", async () => {
     expect.assertions(3);
 
     const mockBooking = {
@@ -1644,14 +1646,13 @@ describe("updateBookingAssets", () => {
     const result = await updateBookingAssets(mockUpdateBookingAssetsParams);
 
     expect(db.$executeRaw).toHaveBeenCalled();
-    expect(db.asset.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["asset-1", "asset-2"] }, organizationId: "org-1" },
-      data: { status: AssetStatus.CHECKED_OUT },
-    });
+    expect(db.asset.updateMany).not.toHaveBeenCalled();
     expect(result).toEqual(mockBooking);
   });
 
-  it("should update kit status to CHECKED_OUT when kitIds provided for ONGOING booking", async () => {
+  it("does NOT flip kit status to CHECKED_OUT when kitIds provided for ONGOING booking (progressive checkout)", async () => {
+    // Kits added to an active booking stay AVAILABLE too — no status sync at
+    // add time; checkout is a deliberate, separate step.
     expect.assertions(4);
 
     const mockBooking = {
@@ -1670,106 +1671,9 @@ describe("updateBookingAssets", () => {
     const result = await updateBookingAssets(params);
 
     expect(db.$executeRaw).toHaveBeenCalled();
-    expect(db.asset.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["asset-1", "asset-2"] }, organizationId: "org-1" },
-      data: { status: AssetStatus.CHECKED_OUT },
-    });
-    expect(db.kit.updateMany).toHaveBeenCalledWith({
-      where: {
-        id: { in: ["kit-1", "kit-2"] },
-        organizationId: "org-1",
-        assetKits: { some: { assetId: { in: ["asset-1", "asset-2"] } } },
-      },
-      data: { status: KitStatus.CHECKED_OUT },
-    });
+    expect(db.asset.updateMany).not.toHaveBeenCalled();
+    expect(db.kit.updateMany).not.toHaveBeenCalled();
     expect(result).toEqual(mockBooking);
-  });
-
-  it("scopes the kit CHECKED_OUT flip to kits containing a newly-added asset, not arbitrary kitIds", async () => {
-    expect.assertions(2);
-
-    const mockBooking = {
-      id: "booking-1",
-      name: "Test Booking",
-      status: BookingStatus.ONGOING,
-    };
-    // @ts-expect-error missing vitest type
-    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
-
-    await updateBookingAssets({
-      ...mockUpdateBookingAssetsParams, // assetIds: ["asset-1","asset-2"], org-1
-      // caller over-supplies kit-2; only kits owning a newly-added asset must flip
-      kitIds: ["kit-1", "kit-2"],
-    });
-
-    // assets still flipped as before (unchanged behavior)
-    expect(db.asset.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["asset-1", "asset-2"] }, organizationId: "org-1" },
-      data: { status: AssetStatus.CHECKED_OUT },
-    });
-
-    // kit flip carries the relation-scope guard tying it to the newly-added assets
-    expect(db.kit.updateMany).toHaveBeenCalledWith({
-      where: {
-        id: { in: ["kit-1", "kit-2"] },
-        organizationId: "org-1",
-        assetKits: { some: { assetId: { in: ["asset-1", "asset-2"] } } },
-      },
-      data: { status: KitStatus.CHECKED_OUT },
-    });
-  });
-
-  it("should not update kit status when no kitIds provided", async () => {
-    expect.assertions(3);
-
-    const mockBooking = {
-      id: "booking-1",
-      name: "Test Booking",
-      status: BookingStatus.ONGOING,
-    };
-    //@ts-expect-error missing vitest type
-    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
-
-    //@ts-expect-error missing vitest type
-    db.asset.findMany.mockResolvedValue([
-      { id: "asset-1", title: "Asset 1" },
-      { id: "asset-2", title: "Asset 2" },
-    ]);
-
-    await updateBookingAssets(mockUpdateBookingAssetsParams);
-
-    expect(db.$executeRaw).toHaveBeenCalled();
-    expect(db.asset.updateMany).toHaveBeenCalled();
-    expect(db.kit.updateMany).not.toHaveBeenCalled();
-  });
-
-  it("should not update kit status when empty kitIds array provided", async () => {
-    expect.assertions(3);
-
-    const mockBooking = {
-      id: "booking-1",
-      name: "Test Booking",
-      status: BookingStatus.ONGOING,
-    };
-    //@ts-expect-error missing vitest type
-    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
-
-    //@ts-expect-error missing vitest type
-    db.asset.findMany.mockResolvedValue([
-      { id: "asset-1", title: "Asset 1" },
-      { id: "asset-2", title: "Asset 2" },
-    ]);
-
-    const params = {
-      ...mockUpdateBookingAssetsParams,
-      kitIds: [],
-    };
-
-    await updateBookingAssets(params);
-
-    expect(db.$executeRaw).toHaveBeenCalled();
-    expect(db.asset.updateMany).toHaveBeenCalled();
-    expect(db.kit.updateMany).not.toHaveBeenCalled();
   });
 
   it("should not update asset or kit status for RESERVED booking", async () => {
@@ -6884,7 +6788,7 @@ describe("addScannedAssetsToBooking", () => {
     ).rejects.toThrow(/already booked or checked out/i);
 
     // The conflicting asset must never be connected to the booking — the guard
-    // runs before the connect/force-checkout transaction.
+    // runs before the connect transaction.
     expect(db.booking.update).not.toHaveBeenCalled();
   });
 
@@ -6939,6 +6843,122 @@ describe("addScannedAssetsToBooking", () => {
       ]),
       expect.anything()
     );
+  });
+});
+
+describe("getExistingBookingDetails — addable statuses", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it.each([
+    BookingStatus.DRAFT,
+    BookingStatus.RESERVED,
+    BookingStatus.ONGOING,
+    BookingStatus.OVERDUE,
+  ])("allows adding to a %s booking", async (status) => {
+    // Progressive checkout: active (ONGOING/OVERDUE) bookings accept new items
+    // too, not just not-yet-started DRAFT/RESERVED ones.
+    (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      id: "booking-1",
+      status,
+      bookingAssets: [],
+    });
+
+    const result = await getExistingBookingDetails("booking-1", "org-1");
+    expect(result.status).toBe(status);
+  });
+
+  it.each([
+    BookingStatus.COMPLETE,
+    BookingStatus.ARCHIVED,
+    BookingStatus.CANCELLED,
+  ])("rejects adding to a terminal %s booking", async (status) => {
+    (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      id: "booking-1",
+      status,
+      bookingAssets: [],
+    });
+
+    await expect(
+      getExistingBookingDetails("booking-1", "org-1")
+    ).rejects.toThrow(/Draft, Reserved, Ongoing or Overdue/i);
+  });
+});
+
+describe("processBooking — checked-out guard for active bookings", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  /**
+   * Wire the two db.asset.findMany call sites processBooking triggers:
+   *  1. getAvailableAssetsIdsForBooking — no `status` filter; must return
+   *     `{ id, status, assetKits }` rows.
+   *  2. the guard — filters `status: CHECKED_OUT`; returns the offending rows.
+   */
+  function mockAssets(
+    rows: Array<{ id: string; title?: string; status: AssetStatus }>
+  ) {
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+      (args?: any) => {
+        if (args?.where?.status === AssetStatus.CHECKED_OUT) {
+          return Promise.resolve(
+            rows
+              .filter((r) => r.status === AssetStatus.CHECKED_OUT)
+              .map((r) => ({ id: r.id, title: r.title ?? r.id }))
+          );
+        }
+        return Promise.resolve(
+          rows.map((r) => ({ id: r.id, status: r.status, assetKits: [] }))
+        );
+      }
+    );
+  }
+
+  function mockBooking(status: BookingStatus) {
+    (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      id: "booking-1",
+      status,
+      bookingAssets: [],
+    });
+  }
+
+  it("blocks a CHECKED_OUT asset from being added to an ONGOING booking", async () => {
+    mockBooking(BookingStatus.ONGOING);
+    mockAssets([
+      { id: "asset-1", title: "Asset 1", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    await expect(
+      processBooking("booking-1", ["asset-1"], "org-1")
+    ).rejects.toThrow(/already checked out/i);
+  });
+
+  it("allows AVAILABLE assets to be added to an ONGOING booking (they stay available)", async () => {
+    mockBooking(BookingStatus.ONGOING);
+    mockAssets([{ id: "asset-1", status: AssetStatus.AVAILABLE }]);
+
+    const { finalAssetIds } = await processBooking(
+      "booking-1",
+      ["asset-1"],
+      "org-1"
+    );
+    expect(finalAssetIds).toEqual(["asset-1"]);
+  });
+
+  it("does NOT block a CHECKED_OUT asset for a DRAFT booking (guard is active-only)", async () => {
+    mockBooking(BookingStatus.DRAFT);
+    mockAssets([
+      { id: "asset-1", title: "Asset 1", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    const { finalAssetIds } = await processBooking(
+      "booking-1",
+      ["asset-1"],
+      "org-1"
+    );
+    expect(finalAssetIds).toEqual(["asset-1"]);
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -6926,10 +6926,26 @@ describe("processBooking — checked-out guard for active bookings", () => {
     );
   }
 
-  function mockBooking(status: BookingStatus, existingAssetIds: string[] = []) {
+  // Owner auth for the checked-out-guard cases: validateBookingOwnership is a
+  // no-op for OWNER, keeping these focused on the CHECKED_OUT behavior.
+  const OWNER_AUTH = {
+    userId: "user-1",
+    role: OrganizationRoles.OWNER,
+  } as const;
+
+  function mockBooking(
+    status: BookingStatus,
+    existingAssetIds: string[] = [],
+    ownership: {
+      creatorId?: string | null;
+      custodianUserId?: string | null;
+    } = {}
+  ) {
     (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
       id: "booking-1",
       status,
+      creatorId: ownership.creatorId ?? "user-1",
+      custodianUserId: ownership.custodianUserId ?? null,
       bookingAssets: existingAssetIds.map((assetId) => ({
         assetId,
         assetKitId: null,
@@ -6945,8 +6961,37 @@ describe("processBooking — checked-out guard for active bookings", () => {
     ]);
 
     await expect(
-      processBooking("booking-1", ["asset-1"], "org-1")
+      processBooking("booking-1", ["asset-1"], "org-1", OWNER_AUTH)
     ).rejects.toThrow(/already checked out/i);
+  });
+
+  it("blocks a SELF_SERVICE user from adding to a booking they do not own", async () => {
+    // Cross-user IDOR guard: booking:create/update is org-wide for SELF_SERVICE.
+    mockBooking(BookingStatus.RESERVED, [], {
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+    mockAssets([{ id: "asset-1", status: AssetStatus.AVAILABLE }]);
+
+    await expect(
+      processBooking("booking-1", ["asset-1"], "org-1", {
+        userId: "attacker",
+        role: OrganizationRoles.SELF_SERVICE,
+      })
+    ).rejects.toThrow(/not authorized/i);
+  });
+
+  it("allows a SELF_SERVICE user to add to a booking they own", async () => {
+    mockBooking(BookingStatus.RESERVED, [], { creatorId: "owner-user" });
+    mockAssets([{ id: "asset-1", status: AssetStatus.AVAILABLE }]);
+
+    const { finalAssetIds } = await processBooking(
+      "booking-1",
+      ["asset-1"],
+      "org-1",
+      { userId: "owner-user", role: OrganizationRoles.SELF_SERVICE }
+    );
+    expect(finalAssetIds).toEqual(["asset-1"]);
   });
 
   it("allows AVAILABLE assets to be added to an ONGOING booking (they stay available)", async () => {
@@ -6956,7 +7001,8 @@ describe("processBooking — checked-out guard for active bookings", () => {
     const { finalAssetIds } = await processBooking(
       "booking-1",
       ["asset-1"],
-      "org-1"
+      "org-1",
+      OWNER_AUTH
     );
     expect(finalAssetIds).toEqual(["asset-1"]);
   });
@@ -6970,7 +7016,8 @@ describe("processBooking — checked-out guard for active bookings", () => {
     const { finalAssetIds } = await processBooking(
       "booking-1",
       ["asset-1"],
-      "org-1"
+      "org-1",
+      OWNER_AUTH
     );
     expect(finalAssetIds).toEqual(["asset-1"]);
   });
@@ -6987,7 +7034,8 @@ describe("processBooking — checked-out guard for active bookings", () => {
     const { finalAssetIds } = await processBooking(
       "booking-1",
       ["asset-1"],
-      "org-1"
+      "org-1",
+      OWNER_AUTH
     );
     expect(finalAssetIds).toEqual(["asset-1"]);
   });
@@ -7004,7 +7052,8 @@ describe("processBooking — checked-out guard for active bookings", () => {
     const { finalAssetIds } = await processBooking(
       "booking-1",
       ["asset-1", "asset-2"],
-      "org-1"
+      "org-1",
+      OWNER_AUTH
     );
     expect(finalAssetIds).toEqual(["asset-1", "asset-2"]);
   });

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -6902,25 +6902,39 @@ describe("processBooking — checked-out guard for active bookings", () => {
   ) {
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
       (args?: any) => {
+        // Respect the `id: { in }` scope so the guard's narrowed query (which
+        // excludes assets already on the booking) is reflected accurately.
+        const requestedIds: string[] | undefined = args?.where?.id?.in;
+        const inScope = (id: string) =>
+          !requestedIds || requestedIds.includes(id);
+
         if (args?.where?.status === AssetStatus.CHECKED_OUT) {
           return Promise.resolve(
             rows
-              .filter((r) => r.status === AssetStatus.CHECKED_OUT)
+              .filter(
+                (r) => r.status === AssetStatus.CHECKED_OUT && inScope(r.id)
+              )
               .map((r) => ({ id: r.id, title: r.title ?? r.id }))
           );
         }
         return Promise.resolve(
-          rows.map((r) => ({ id: r.id, status: r.status, assetKits: [] }))
+          rows
+            .filter((r) => inScope(r.id))
+            .map((r) => ({ id: r.id, status: r.status, assetKits: [] }))
         );
       }
     );
   }
 
-  function mockBooking(status: BookingStatus) {
+  function mockBooking(status: BookingStatus, existingAssetIds: string[] = []) {
     (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
       id: "booking-1",
       status,
-      bookingAssets: [],
+      bookingAssets: existingAssetIds.map((assetId) => ({
+        assetId,
+        assetKitId: null,
+        asset: { id: assetId, title: assetId },
+      })),
     });
   }
 
@@ -6959,6 +6973,40 @@ describe("processBooking — checked-out guard for active bookings", () => {
       "org-1"
     );
     expect(finalAssetIds).toEqual(["asset-1"]);
+  });
+
+  it("does NOT block an asset already on this ONGOING booking even if it is CHECKED_OUT", async () => {
+    // Regression: an asset checked out via THIS booking's progressive checkout
+    // must not trip the guard when re-submitted — the duplicate / "add only the
+    // rest" flow handles it downstream.
+    mockBooking(BookingStatus.ONGOING, ["asset-1"]);
+    mockAssets([
+      { id: "asset-1", title: "Asset 1", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    const { finalAssetIds } = await processBooking(
+      "booking-1",
+      ["asset-1"],
+      "org-1"
+    );
+    expect(finalAssetIds).toEqual(["asset-1"]);
+  });
+
+  it("guards only NEW checked-out assets, ignoring ones already on this booking", async () => {
+    // asset-1 is already on the (ONGOING) booking and checked out here → skipped.
+    // asset-2 is new and AVAILABLE → allowed. No throw.
+    mockBooking(BookingStatus.ONGOING, ["asset-1"]);
+    mockAssets([
+      { id: "asset-1", title: "Asset 1", status: AssetStatus.CHECKED_OUT },
+      { id: "asset-2", title: "Asset 2", status: AssetStatus.AVAILABLE },
+    ]);
+
+    const { finalAssetIds } = await processBooking(
+      "booking-1",
+      ["asset-1", "asset-2"],
+      "org-1"
+    );
+    expect(finalAssetIds).toEqual(["asset-1", "asset-2"]);
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -10581,7 +10581,7 @@ export async function getExistingBookingDetails(
       throw new ShelfError({
         cause: null,
         message:
-          "Assets can only be added to Draft, Reserved, Ongoing or Overdue bookings.",
+          "Items can only be added to Draft, Reserved, Ongoing or Overdue bookings.",
         status: 400,
         label: "Booking",
         shouldBeCaptured: false,
@@ -10686,23 +10686,38 @@ export async function processBooking(
     }
 
     // Progressive-checkout guard (parity with the manage-assets route): assets
-    // that are physically CHECKED_OUT (on another active booking) cannot be
-    // added to an ONGOING/OVERDUE booking — there is nothing available to
-    // stage. New assets otherwise stay AVAILABLE. This only fires for active
-    // bookings; DRAFT/RESERVED targets still accept checked-out assets (they'll
-    // be available by the time that booking starts).
+    // that are physically CHECKED_OUT on ANOTHER active booking cannot be added
+    // to an ONGOING/OVERDUE booking — there is nothing available to stage. New
+    // assets otherwise stay AVAILABLE. This only fires for active bookings;
+    // DRAFT/RESERVED targets still accept checked-out assets (they'll be
+    // available by the time that booking starts).
+    //
+    // Assets ALREADY on this booking are excluded from the check: their
+    // CHECKED_OUT status can be owned by this same booking (progressive
+    // checkout), and re-submitting them is handled downstream by the
+    // duplicate / "add only the rest" flow — not by this guard.
     if (
       bookingInfo.status === BookingStatus.ONGOING ||
       bookingInfo.status === BookingStatus.OVERDUE
     ) {
-      const checkedOutAssets = await db.asset.findMany({
-        where: {
-          id: { in: finalAssetIds },
-          organizationId,
-          status: AssetStatus.CHECKED_OUT,
-        },
-        select: { id: true, title: true },
-      });
+      const existingAssetIds = new Set(
+        bookingInfo.bookingAssets.map((ba) => ba.assetId)
+      );
+      const newAssetIdsToCheck = finalAssetIds.filter(
+        (id) => !existingAssetIds.has(id)
+      );
+
+      const checkedOutAssets =
+        newAssetIdsToCheck.length > 0
+          ? await db.asset.findMany({
+              where: {
+                id: { in: newAssetIdsToCheck },
+                organizationId,
+                status: AssetStatus.CHECKED_OUT,
+              },
+              select: { id: true, title: true },
+            })
+          : [];
 
       if (checkedOutAssets.length > 0) {
         throw new ShelfError({

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -6959,35 +6959,15 @@ export async function updateBookingAssets({
       ]);
 
       /**
-       *  When adding an asset to a booking, we need to update the status of the asset to CHECKED_OUT if the booking is ONGOING or OVERDUE
+       * Progressive checkout: assets added to an ONGOING/OVERDUE booking are
+       * NOT auto-flipped to CHECKED_OUT. They join the booking as line items
+       * and stay AVAILABLE until purposefully checked out via the
+       * progressive-checkout flow ({@link partialCheckoutBooking}). This keeps
+       * an active booking flexible — you can stage assets onto it without
+       * committing them to the field. See the checked-out guard in the add
+       * routes (manage-assets / manage-kits) which still blocks adding an asset
+       * that is physically checked out on ANOTHER booking.
        */
-      if (
-        b.status === BookingStatus.ONGOING ||
-        b.status === BookingStatus.OVERDUE
-      ) {
-        await tx.asset.updateMany({
-          where: { id: { in: addedAssetIds }, organizationId },
-          data: { status: AssetStatus.CHECKED_OUT },
-        });
-
-        /**
-         * Also update kit status to CHECKED_OUT for any kits that contain these assets
-         */
-        if (kitIds && kitIds.length > 0) {
-          await tx.kit.updateMany({
-            where: {
-              id: { in: kitIds },
-              organizationId,
-              // Only flip kits that actually received a newly-checked-out asset.
-              // Prevents an over-broad kitIds list from clobbering the status of
-              // still-available kits already on the booking. Asset-Kit membership
-              // is via the AssetKit pivot (no direct Kit.assets relation).
-              assetKits: { some: { assetId: { in: validAssetIds } } },
-            },
-            data: { status: KitStatus.CHECKED_OUT },
-          });
-        }
-      }
 
       // Activity events — one BOOKING_ASSETS_ADDED per asset added, inside the tx.
       // Must be atomic with asset addition for audit trail consistency.
@@ -10127,7 +10107,7 @@ async function createNotesForScannedAssetsAndKits({
  * @param tx - Prisma transaction client (must be a real `$transaction` tx)
  * @param args.assetIds - IDs of directly-scanned (standalone) assets to add
  * @param args.kitSlices - Kit-driven slice specs (one per AssetKit membership)
- * @param args.kitIds - Optional kit IDs (only used to propagate kit status sync when booking is active)
+ * @param args.kitIds - Optional kit IDs. Retained on the contract for callers; no longer read here (assets are added AVAILABLE — progressive checkout — so there is no kit status to sync at add time).
  * @param args.bookingId - Booking being modified
  * @param args.organizationId - Organization scope for the booking + assets
  * @param args.userId - User performing the scan (attributed on materialized logs)
@@ -10138,7 +10118,6 @@ async function addScannedAssetsToBookingWithinTx(
   tx: any,
   {
     assetIds,
-    kitIds,
     bookingId,
     organizationId,
     userId,
@@ -10147,7 +10126,12 @@ async function addScannedAssetsToBookingWithinTx(
   }: {
     /** Directly-scanned (standalone) asset IDs — written with `assetKitId = null`. */
     assetIds: Asset["id"][];
-    kitIds: string[];
+    /**
+     * Optional kit IDs. Retained on the contract for callers, but no longer
+     * read here: assets are added AVAILABLE (progressive checkout), so there is
+     * no kit status to sync at add time.
+     */
+    kitIds?: string[];
     bookingId: Booking["id"];
     organizationId: Booking["organizationId"];
     userId: string;
@@ -10437,26 +10421,12 @@ async function addScannedAssetsToBookingWithinTx(
     );
   }
 
-  /** When booking is active, newly added items must be flagged checked out */
-  const isActiveBooking =
-    booking.status === BookingStatus.ONGOING ||
-    booking.status === BookingStatus.OVERDUE;
-
-  if (isActiveBooking) {
-    if (allScannedAssetIds.length > 0) {
-      await tx.asset.updateMany({
-        where: { id: { in: allScannedAssetIds }, organizationId },
-        data: { status: AssetStatus.CHECKED_OUT },
-      });
-    }
-
-    if (kitIds.length > 0) {
-      await tx.kit.updateMany({
-        where: { id: { in: kitIds }, organizationId },
-        data: { status: KitStatus.CHECKED_OUT },
-      });
-    }
-  }
+  /**
+   * Progressive checkout: scanning assets into an ONGOING/OVERDUE booking adds
+   * them as line items but leaves them AVAILABLE — consistent with every other
+   * add surface. They are checked out purposefully via the progressive-checkout
+   * flow ({@link partialCheckoutBooking}), never as a side-effect of scanning.
+   */
 
   return booking;
 }
@@ -10596,10 +10566,22 @@ export async function getExistingBookingDetails(
       });
     }
 
-    if (!["DRAFT", "RESERVED"].includes(booking.status!)) {
+    // Bookings that accept new items: DRAFT/RESERVED (not yet started) plus
+    // ONGOING/OVERDUE (active — progressive checkout). Added items stay
+    // AVAILABLE until purposefully checked out; the CHECKED_OUT guard for
+    // active bookings lives in the callers/processBooking. COMPLETE, ARCHIVED
+    // and CANCELLED bookings are terminal and reject additions.
+    const addableStatuses: BookingStatus[] = [
+      BookingStatus.DRAFT,
+      BookingStatus.RESERVED,
+      BookingStatus.ONGOING,
+      BookingStatus.OVERDUE,
+    ];
+    if (!addableStatuses.includes(booking.status!)) {
       throw new ShelfError({
         cause: null,
-        message: "Booking is not in Draft or Reserved status.",
+        message:
+          "Assets can only be added to Draft, Reserved, Ongoing or Overdue bookings.",
         status: 400,
         label: "Booking",
         shouldBeCaptured: false,
@@ -10703,6 +10685,40 @@ export async function processBooking(
       });
     }
 
+    // Progressive-checkout guard (parity with the manage-assets route): assets
+    // that are physically CHECKED_OUT (on another active booking) cannot be
+    // added to an ONGOING/OVERDUE booking — there is nothing available to
+    // stage. New assets otherwise stay AVAILABLE. This only fires for active
+    // bookings; DRAFT/RESERVED targets still accept checked-out assets (they'll
+    // be available by the time that booking starts).
+    if (
+      bookingInfo.status === BookingStatus.ONGOING ||
+      bookingInfo.status === BookingStatus.OVERDUE
+    ) {
+      const checkedOutAssets = await db.asset.findMany({
+        where: {
+          id: { in: finalAssetIds },
+          organizationId,
+          status: AssetStatus.CHECKED_OUT,
+        },
+        select: { id: true, title: true },
+      });
+
+      if (checkedOutAssets.length > 0) {
+        throw new ShelfError({
+          cause: null,
+          title: "Not allowed. Assets already checked out",
+          message: `The following assets are already checked out and cannot be added to the booking: ${checkedOutAssets
+            .map((asset) => asset.title)
+            .join(", ")}`,
+          additionalData: { checkedOutAssets, bookingId },
+          status: 400,
+          label: "Booking",
+          shouldBeCaptured: false,
+        });
+      }
+    }
+
     return {
       finalAssetIds,
       bookingInfo,
@@ -10744,14 +10760,16 @@ export async function loadBookingsData({
   const { page, search } = getParamsValues(searchParams);
   const perPage = 20;
 
-  // Fetch bookings with filters
+  // Fetch bookings with filters. Includes ONGOING/OVERDUE so assets/kits can be
+  // added to active bookings (they stay AVAILABLE — progressive checkout), not
+  // just to not-yet-started DRAFT/RESERVED ones.
   const { bookings, bookingCount } = await getBookings({
     organizationId,
     page,
     perPage,
     search,
     userId,
-    statuses: ["DRAFT", "RESERVED"],
+    statuses: ["DRAFT", "RESERVED", "ONGOING", "OVERDUE"],
     // Here we just need the bookigns of the current user if they are self service or base, as they can edit only their own bookings
     ...(isSelfServiceOrBase && {
       custodianUserId: userId,

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -10548,6 +10548,10 @@ export async function getExistingBookingDetails(
       select: {
         id: true,
         status: true,
+        // Needed so callers can enforce per-user ownership (SELF_SERVICE/BASE
+        // may only add to bookings they created or are custodian of).
+        creatorId: true,
+        custodianUserId: true,
         bookingAssets: {
           include: {
             asset: { select: { id: true, title: true } },
@@ -10661,19 +10665,38 @@ export async function getAvailableAssetsIdsForBooking(
  * @param organizationId - The caller's validated organization ID. Forwarded to
  *   {@link getAvailableAssetsIdsForBooking} so foreign-org assets cannot be
  *   added to the booking (cross-org IDOR protection).
+ * @param auth - The acting user's id and org role. Used to enforce per-user
+ *   booking ownership: `booking:create/update` is granted org-wide to
+ *   SELF_SERVICE/BASE, so without this a non-owner could add items to another
+ *   user's booking (cross-user IDOR). ADMIN/OWNER are unrestricted.
  * @returns The resolved (org-scoped) asset IDs and the booking details
- * @throws {ShelfError} If no assets are available or the booking lookup fails
+ * @throws {ShelfError} If no assets are available, the booking lookup fails, or
+ *   the caller does not own the booking
  */
 export async function processBooking(
   bookingId: string,
   assetIds: string[],
-  organizationId: string
+  organizationId: string,
+  auth: { userId: string; role: OrganizationRoles }
 ) {
   try {
     const [finalAssetIds, bookingInfo] = await Promise.all([
       getAvailableAssetsIdsForBooking(assetIds, organizationId),
       getExistingBookingDetails(bookingId, organizationId),
     ]);
+
+    // Cross-user IDOR guard: SELF_SERVICE/BASE may only add to bookings they
+    // created or are custodian of. No-op for ADMIN/OWNER. Runs before any
+    // mutation-shaping logic below.
+    validateBookingOwnership({
+      booking: {
+        creatorId: bookingInfo.creatorId,
+        custodianUserId: bookingInfo.custodianUserId,
+      },
+      userId: auth.userId,
+      role: auth.role,
+      action: "add items to",
+    });
 
     if (!finalAssetIds.length) {
       throw new ShelfError({

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -248,12 +248,14 @@ export default function ExistingBooking() {
   const unitLabel = asset?.unitOfMeasure || "units";
   const maxQuantity = assetAvailability?.available ?? undefined;
 
-  function isValidBooking(booking: any) {
+  function isValidBooking(
+    booking: { status?: string | null } | null | undefined
+  ) {
     // DRAFT/RESERVED (not yet started) + ONGOING/OVERDUE (active). Adding to an
     // active booking keeps the asset AVAILABLE until it is purposefully checked
     // out (progressive checkout).
     return (
-      booking &&
+      !!booking?.status &&
       ["RESERVED", "DRAFT", "ONGOING", "OVERDUE"].includes(booking.status)
     );
   }

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -116,7 +116,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   const { userId } = authSession;
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, role } = await requirePermission({
       userId: authSession?.userId,
       request,
       entity: PermissionEntity.booking,
@@ -136,7 +136,8 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const { finalAssetIds, bookingInfo } = await processBooking(
       bookingId,
       assetIds,
-      organizationId
+      organizationId,
+      { userId, role }
     );
 
     /**

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -249,7 +249,13 @@ export default function ExistingBooking() {
   const maxQuantity = assetAvailability?.available ?? undefined;
 
   function isValidBooking(booking: any) {
-    return booking && ["RESERVED", "DRAFT"].includes(booking.status);
+    // DRAFT/RESERVED (not yet started) + ONGOING/OVERDUE (active). Adding to an
+    // active booking keeps the asset AVAILABLE until it is purposefully checked
+    // out (progressive checkout).
+    return (
+      booking &&
+      ["RESERVED", "DRAFT", "ONGOING", "OVERDUE"].includes(booking.status)
+    );
   }
 
   return (
@@ -261,8 +267,9 @@ export default function ExistingBooking() {
         <div className="mb-5">
           <h3>Add to Existing Booking</h3>
           <div>
-            You can only add an asset to bookings that are in Draft or Reserved
-            State.
+            You can add an asset to Draft, Reserved, Ongoing or Overdue
+            bookings. Assets added to an ongoing booking stay available until
+            you check them out.
           </div>
         </div>
         {ids?.map((item, i) => (
@@ -308,8 +315,10 @@ export default function ExistingBooking() {
             }
           />
           <div className="mt-2 text-gray-500">
-            Only <span className="font-medium text-gray-600">Draft</span> and{" "}
-            <span className="font-medium text-gray-600">Reserved</span> bookings
+            <span className="font-medium text-gray-600">Draft</span>,{" "}
+            <span className="font-medium text-gray-600">Reserved</span>,{" "}
+            <span className="font-medium text-gray-600">Ongoing</span> and{" "}
+            <span className="font-medium text-gray-600">Overdue</span> bookings
             are visible
           </div>
         </div>

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -141,23 +141,61 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       organizationId
     );
 
+    // AssetKit ids already represented on this booking. We dedupe by AssetKit
+    // membership (NOT by asset id): a QUANTITY_TRACKED asset can sit on the
+    // booking both standalone AND kit-driven at once, so a standalone row must
+    // not block re-adding the kit-driven slice. `assetKitId` is non-null only
+    // on kit-driven rows.
+    const existingAssetKitIds = new Set(
+      bookingInfo.bookingAssets
+        .map((ba) => ba.assetKitId)
+        .filter((id): id is string => id != null)
+    );
+
     // Progressive-checkout guard (parity with the manage-kits route): a kit that
-    // is physically CHECKED_OUT (out on another active booking) cannot be added
-    // to an ONGOING/OVERDUE booking. Kits added to an active booking otherwise
-    // stay AVAILABLE until purposefully checked out. Only fires for active
-    // targets; DRAFT/RESERVED bookings still accept checked-out kits.
+    // is physically CHECKED_OUT on ANOTHER active booking cannot be added to an
+    // ONGOING/OVERDUE booking. Kits added to an active booking otherwise stay
+    // AVAILABLE until purposefully checked out. Only fires for active targets;
+    // DRAFT/RESERVED bookings still accept checked-out kits.
+    //
+    // Kits already represented on this booking are excluded: their CHECKED_OUT
+    // status can be owned by this same booking, and re-adding only attaches
+    // newly-added members (buildKitSlicesForBooking skips existing memberships).
+    // Mirrors the manage-kits "newly added kits only" guard.
     if (
       bookingInfo.status === BookingStatus.ONGOING ||
       bookingInfo.status === BookingStatus.OVERDUE
     ) {
-      const checkedOutKits = await db.kit.findMany({
-        where: {
-          id: { in: kitIds },
-          organizationId,
-          status: KitStatus.CHECKED_OUT,
-        },
-        select: { id: true, name: true },
-      });
+      // Kit ids that already have at least one membership on this booking.
+      const kitIdsAlreadyOnBooking = new Set(
+        existingAssetKitIds.size > 0
+          ? (
+              await db.assetKit.findMany({
+                where: {
+                  id: { in: [...existingAssetKitIds] },
+                  kitId: { in: kitIds },
+                  organizationId,
+                },
+                select: { kitId: true },
+              })
+            ).map((ak) => ak.kitId)
+          : []
+      );
+      const kitIdsToGuard = kitIds.filter(
+        (id) => !kitIdsAlreadyOnBooking.has(id)
+      );
+
+      const checkedOutKits =
+        kitIdsToGuard.length > 0
+          ? await db.kit.findMany({
+              where: {
+                id: { in: kitIdsToGuard },
+                organizationId,
+                status: KitStatus.CHECKED_OUT,
+              },
+              select: { id: true, name: true },
+            })
+          : [];
 
       if (checkedOutKits.length > 0) {
         throw new ShelfError({
@@ -173,17 +211,6 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
     }
-
-    // AssetKit ids already represented on this booking. We dedupe by AssetKit
-    // membership (NOT by asset id): a QUANTITY_TRACKED asset can sit on the
-    // booking both standalone AND kit-driven at once, so a standalone row must
-    // not block re-adding the kit-driven slice. `assetKitId` is non-null only
-    // on kit-driven rows.
-    const existingAssetKitIds = new Set(
-      bookingInfo.bookingAssets
-        .map((ba) => ba.assetKitId)
-        .filter((id): id is string => id != null)
-    );
 
     // Resolve the kit memberships into kit-driven slice specs (org-scoped),
     // skipping any AssetKit already on the booking. Routing members through
@@ -277,12 +304,14 @@ export default function ExistingBooking() {
   const actionData = useActionData<typeof action>();
   const transition = useNavigation();
   const disabled = isFormProcessing(transition.state);
-  function isValidBooking(booking: any) {
+  function isValidBooking(
+    booking: { status?: string | null } | null | undefined
+  ) {
     // DRAFT/RESERVED (not yet started) + ONGOING/OVERDUE (active). Kits added to
     // an active booking stay AVAILABLE until purposefully checked out
     // (progressive checkout).
     return (
-      booking &&
+      !!booking?.status &&
       ["RESERVED", "DRAFT", "ONGOING", "OVERDUE"].includes(booking.status)
     );
   }

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -26,6 +26,7 @@ import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.
 import { getUserByID } from "~/modules/user/service.server";
 import styles from "~/styles/layout/custom-modal.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { setCookie } from "~/utils/cookies.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -107,7 +108,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   const { userId } = authSession;
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, role } = await requirePermission({
       userId: authSession?.userId,
       request,
       entity: PermissionEntity.booking,
@@ -140,6 +141,20 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       bookingId,
       organizationId
     );
+
+    // Cross-user IDOR guard: `booking:create` is granted org-wide to
+    // SELF_SERVICE/BASE, so without this a non-owner could add kits to another
+    // user's booking. No-op for ADMIN/OWNER. Mirrors the asset flow's guard in
+    // processBooking and the sibling adjust-asset-quantity route.
+    validateBookingOwnership({
+      booking: {
+        creatorId: bookingInfo.creatorId,
+        custodianUserId: bookingInfo.custodianUserId,
+      },
+      userId,
+      role,
+      action: "add kits to",
+    });
 
     // AssetKit ids already represented on this booking. We dedupe by AssetKit
     // membership (NOT by asset id): a QUANTITY_TRACKED asset can sit on the

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -1,4 +1,4 @@
-import type { Prisma } from "@prisma/client";
+import { BookingStatus, KitStatus, type Prisma } from "@prisma/client";
 import { CalendarCheck } from "lucide-react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import {
@@ -13,6 +13,7 @@ import { Form } from "~/components/custom-form";
 import DynamicSelect from "~/components/dynamic-select/dynamic-select";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
+import { db } from "~/database/db.server";
 
 import {
   buildKitSlicesForBooking,
@@ -130,14 +131,48 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     }
 
     // Validate the target booking: confirms it exists in the caller's org and
-    // is still DRAFT/RESERVED (the only states that accept new items). Also
-    // returns the existing BookingAsset rows so we can skip kit slices that are
-    // already present. `updateBookingAssets` re-checks existence but NOT
-    // status, so this guard is what blocks adding to a non-editable booking.
+    // is in an addable state (DRAFT/RESERVED/ONGOING/OVERDUE). Also returns the
+    // existing BookingAsset rows so we can skip kit slices that are already
+    // present. `updateBookingAssets` re-checks existence but NOT status, so this
+    // guard is what blocks adding to a terminal (COMPLETE/ARCHIVED/CANCELLED)
+    // booking.
     const bookingInfo = await getExistingBookingDetails(
       bookingId,
       organizationId
     );
+
+    // Progressive-checkout guard (parity with the manage-kits route): a kit that
+    // is physically CHECKED_OUT (out on another active booking) cannot be added
+    // to an ONGOING/OVERDUE booking. Kits added to an active booking otherwise
+    // stay AVAILABLE until purposefully checked out. Only fires for active
+    // targets; DRAFT/RESERVED bookings still accept checked-out kits.
+    if (
+      bookingInfo.status === BookingStatus.ONGOING ||
+      bookingInfo.status === BookingStatus.OVERDUE
+    ) {
+      const checkedOutKits = await db.kit.findMany({
+        where: {
+          id: { in: kitIds },
+          organizationId,
+          status: KitStatus.CHECKED_OUT,
+        },
+        select: { id: true, name: true },
+      });
+
+      if (checkedOutKits.length > 0) {
+        throw new ShelfError({
+          cause: null,
+          title: "Not allowed. Kits already checked out",
+          message: `The following kits are already checked out and cannot be added to the booking: ${checkedOutKits
+            .map((kit) => kit.name)
+            .join(", ")}`,
+          additionalData: { checkedOutKits, bookingId },
+          status: 400,
+          label: "Booking",
+          shouldBeCaptured: false,
+        });
+      }
+    }
 
     // AssetKit ids already represented on this booking. We dedupe by AssetKit
     // membership (NOT by asset id): a QUANTITY_TRACKED asset can sit on the
@@ -182,9 +217,10 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     });
 
     // Add the kit(s) as kit-driven rows only: `assetIds: []` prevents duplicate
-    // standalone rows for the members, `kitSlices` carries the per-membership
-    // rows, and `kitIds` lets the ONGOING/OVERDUE status flip cascade to the
-    // kit(s) themselves.
+    // standalone rows for the members and `kitSlices` carries the per-membership
+    // rows. Added members stay AVAILABLE (progressive checkout) — no status flip
+    // happens here regardless of booking status. `kitIds` is still forwarded for
+    // note attribution / membership resolution.
     const booking = await updateBookingAssets({
       id: bookingId,
       organizationId,
@@ -242,7 +278,13 @@ export default function ExistingBooking() {
   const transition = useNavigation();
   const disabled = isFormProcessing(transition.state);
   function isValidBooking(booking: any) {
-    return booking && ["RESERVED", "DRAFT"].includes(booking.status);
+    // DRAFT/RESERVED (not yet started) + ONGOING/OVERDUE (active). Kits added to
+    // an active booking stay AVAILABLE until purposefully checked out
+    // (progressive checkout).
+    return (
+      booking &&
+      ["RESERVED", "DRAFT", "ONGOING", "OVERDUE"].includes(booking.status)
+    );
   }
 
   return (
@@ -254,8 +296,9 @@ export default function ExistingBooking() {
         <div className="mb-5">
           <h3>Add to Existing Booking</h3>
           <div>
-            You can only add an asset to bookings that are in Draft or Reserved
-            State.
+            You can add a kit to Draft, Reserved, Ongoing or Overdue bookings.
+            Kits added to an ongoing booking stay available until you check them
+            out.
           </div>
         </div>
         {ids?.map((item, i) => (
@@ -294,8 +337,10 @@ export default function ExistingBooking() {
             }
           />
           <div className="mt-2 text-gray-500">
-            Only <span className="font-medium text-gray-600">Draft</span> and{" "}
-            <span className="font-medium text-gray-600">Reserved</span> bookings
+            <span className="font-medium text-gray-600">Draft</span>,{" "}
+            <span className="font-medium text-gray-600">Reserved</span>,{" "}
+            <span className="font-medium text-gray-600">Ongoing</span> and{" "}
+            <span className="font-medium text-gray-600">Overdue</span> bookings
             are visible
           </div>
         </div>

--- a/apps/webapp/app/routes/api+/assets.add-to-booking.ts
+++ b/apps/webapp/app/routes/api+/assets.add-to-booking.ts
@@ -25,7 +25,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, role } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.booking,
@@ -44,7 +44,8 @@ export async function action({ request, context }: ActionFunctionArgs) {
     let { finalAssetIds, bookingInfo } = await processBooking(
       id,
       assetsIds,
-      organizationId
+      organizationId,
+      { userId, role }
     );
 
     /**

--- a/apps/webapp/app/routes/api+/bookings.get-all.ts
+++ b/apps/webapp/app/routes/api+/bookings.get-all.ts
@@ -27,7 +27,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       page,
       search,
       userId,
-      statuses: ["DRAFT", "RESERVED"],
+      // Include active bookings so the bulk "add to existing booking" dialog can
+      // target ONGOING/OVERDUE bookings too (added assets stay AVAILABLE —
+      // progressive checkout), not just DRAFT/RESERVED ones.
+      statuses: ["DRAFT", "RESERVED", "ONGOING", "OVERDUE"],
       takeAll: true,
       ...(isSelfServiceOrBase && { custodianUserId: userId }),
     });


### PR DESCRIPTION
Progressive checkout makes the old "add = instant checkout" behavior wrong. Assets/kits added to an ONGOING/OVERDUE booking now join it as line items and stay AVAILABLE until purposefully checked out.

- Remove the CHECKED_OUT status flip from updateBookingAssets and addScannedAssetsToBookingWithinTx (covers manage-assets, manage-kits, the asset/kit add-to-existing flows, the bulk add API, and both scanners).
- Allow adding to active bookings from every surface: relax the shared getExistingBookingDetails gate and the loadBookingsData / bookings.get-all status filters to include ONGOING/OVERDUE, and expand the asset-page, kit-page and bulk pickers (filters + copy).
- Keep the "already checked out elsewhere" guard for active bookings and extend it to the newly reachable surfaces (processBooking for assets, kit add-to-existing action for kits).
- Rework the bulk add-to-existing-booking picker into a searchable popover styled like DynamicSelect (client-side search over /api/bookings/get-all), replacing the plain unsearchable select.
- Update and add server-side tests for the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded “Add to Existing Booking” to support adding assets and kits to **Ongoing** and **Overdue** bookings.
  * Upgraded the booking picker with a searchable popover, clear selection controls, and improved loading/empty/error states.
* **Bug Fixes**
  * Items added to Ongoing/Overdue bookings no longer get marked **checked out** immediately; they follow the progressive checkout flow.
  * Added safeguards to prevent adding assets/kits that are already checked out elsewhere to active bookings.
* **Security**
  * Added ownership validation to prevent cross-user booking modifications.
* **Documentation**
  * Updated on-screen status guidance to reflect Draft/Reserved/Ongoing/Overdue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->