### PR TITLE
fix(kits): remove invalid kitId select crashing availability view

### DIFF
--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -153,13 +153,20 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                             from: true,
                             to: true,
                             description: true,
-                            // FK columns the consumer reads directly
-                            // (bookingWithRelations.kitId at line 87,
-                            // .custodianUserId at line 117 of the
-                            // useKitAvailabilityData hook). Without
-                            // these, both fields were undefined at
-                            // runtime — CodeRabbit review #2676.
-                            kitId: true,
+                            // FK column the consumer reads directly
+                            // (bookingWithRelations.custodianUserId in the
+                            // useKitAvailabilityData hook). Without it the
+                            // field was undefined at runtime — CodeRabbit
+                            // review #2676.
+                            //
+                            // NOTE: do NOT select `kitId` here — `Booking`
+                            // has no `kitId` scalar (a booking spans kits via
+                            // BookingAsset, not a direct FK). Selecting it
+                            // throws PrismaClientValidationError and 500s the
+                            // whole kits index (Sentry SHELF-WEBAPP-1P1). The
+                            // hook derives the resource id from the kit it's
+                            // iterating (`kitId: kit.id`), so the DB never
+                            // needs to supply it.
                             custodianUserId: true,
                             custodianTeamMember: true,
                             custodianUser: true,


### PR DESCRIPTION
The kits availability view (?view=availability) 500d on every load because the loader selected `kitId: true` inside the nested booking select. Booking has no `kitId` scalar column (a booking spans kits via the BookingAsset pivot, not a direct FK), so Prisma threw PrismaClientValidationError which surfaced as "Something went wrong while fetching kits".

The field was also unused: the useKitAvailabilityData hook derives the resource id from the kit it is iterating (kitId: kit.id), overwriting any value from the DB. Removed the select and documented why it must not return.

Fixes SHELF-WEBAPP-1P1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the kits availability view by fixing booking data selection, preventing an invalid field from being requested.
  * Custodian-related information continues to load correctly, while the availability display now relies on the appropriate derived kit attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->