### PR TITLE
feat: recurring asset reminders (auto-repeat on a cadence)

### DIFF
--- a/apps/webapp/app/components/asset-reminder/actions-dropdown.tsx
+++ b/apps/webapp/app/components/asset-reminder/actions-dropdown.tsx
@@ -10,6 +10,10 @@ import {
   DropdownMenuTrigger,
 } from "~/components/shared/dropdown";
 import type { ASSET_REMINDER_INCLUDE_FIELDS } from "~/modules/asset-reminder/fields";
+import {
+  isRecurringReminder,
+  repeatValueFromRecurrence,
+} from "~/modules/asset-reminder/recurrence";
 import DeleteReminder from "./delete-reminder";
 import SetOrEditReminderDialog from "./set-or-edit-reminder-dialog";
 import When from "../when/when";
@@ -25,7 +29,13 @@ export default function ActionsDropdown({ reminder }: ActionsDropdownProps) {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 
   const now = new Date();
-  const isPending = now < new Date(reminder.alertDateTime);
+  /**
+   * One-shot reminders are immutable once sent. Recurring reminders stay
+   * editable even when the stored date briefly sits in the past (fire-to-
+   * fetch window) or the series ended — editing re-arms the series.
+   */
+  const isPending =
+    now < new Date(reminder.alertDateTime) || isRecurringReminder(reminder);
 
   return (
     <DropdownMenu
@@ -70,6 +80,9 @@ export default function ActionsDropdown({ reminder }: ActionsDropdownProps) {
           message: reminder.message,
           alertDateTime: reminder.alertDateTime,
           teamMembers: reminder.teamMembers.map((tm) => tm.id),
+          repeat: repeatValueFromRecurrence(reminder),
+          endsAt: reminder.recurrenceEndsAt,
+          recurrenceTimezone: reminder.recurrenceTimezone,
         }}
         open={isEditDialogOpen}
         onClose={() => {

--- a/apps/webapp/app/components/asset-reminder/reminder-recurrence-fields.tsx
+++ b/apps/webapp/app/components/asset-reminder/reminder-recurrence-fields.tsx
@@ -1,0 +1,161 @@
+/**
+ * Recurrence controls for the set/edit reminder dialog: the Repeat select
+ * (locked with an upgrade nudge when the workspace tier lacks recurrence)
+ * and the optional "Ends on" date input.
+ *
+ * Extracted from SetOrEditReminderDialog to keep the dialog component lean;
+ * all form state (zorm field names, error fallbacks) is threaded in as props.
+ *
+ * @see {@link file://./set-or-edit-reminder-dialog.tsx}
+ */
+import Input from "~/components/forms/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/forms/select";
+import { Button } from "~/components/shared/button";
+import {
+  REMINDER_REPEAT_PRESETS,
+  type ReminderRepeatValue,
+} from "~/modules/asset-reminder/recurrence";
+
+type ReminderRecurrenceFieldsProps = {
+  /** Whether the workspace tier includes recurring reminders. */
+  canUseRecurringReminders: boolean;
+  /** Form-submission disabled state (useDisabled). */
+  disabled: boolean;
+  /** Controlled Repeat selection. */
+  repeat: ReminderRepeatValue;
+  onRepeatChange: (value: ReminderRepeatValue) => void;
+  /** The stored cadence, round-tripped via hidden inputs when locked. */
+  initialRepeat: ReminderRepeatValue;
+  /** Stored end date (yyyy-MM-dd in the series' own timezone), if any. */
+  endsAtDefault?: string;
+  /** zorm field names. */
+  repeatFieldName: string;
+  endsAtFieldName: string;
+  /** Combined client/server error message for the endsAt field, if any. */
+  endsAtError?: string;
+};
+
+function RepeatOptions() {
+  return (
+    <SelectContent>
+      <SelectItem value="never">Never</SelectItem>
+      {Object.entries(REMINDER_REPEAT_PRESETS).map(([value, preset]) => (
+        <SelectItem key={value} value={value}>
+          {preset.label}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  );
+}
+
+export default function ReminderRecurrenceFields({
+  canUseRecurringReminders,
+  disabled,
+  repeat,
+  onRepeatChange,
+  initialRepeat,
+  endsAtDefault,
+  repeatFieldName,
+  endsAtFieldName,
+  endsAtError,
+}: ReminderRecurrenceFieldsProps) {
+  return (
+    <>
+      <div className="mb-4">
+        <label
+          htmlFor="reminder-repeat-trigger"
+          className={`mb-[6px] block text-sm font-medium ${
+            canUseRecurringReminders ? "text-gray-700" : "text-gray-500"
+          }`}
+        >
+          Repeat
+        </label>
+        {canUseRecurringReminders ? (
+          <Select
+            name={repeatFieldName}
+            value={repeat}
+            onValueChange={(value) =>
+              onRepeatChange(value as ReminderRepeatValue)
+            }
+            disabled={disabled}
+          >
+            <SelectTrigger id="reminder-repeat-trigger">
+              <SelectValue placeholder="Never" />
+            </SelectTrigger>
+            <RepeatOptions />
+          </Select>
+        ) : (
+          <>
+            {/* why hidden inputs: a disabled control submits nothing —
+                carry the STORED cadence through so plain edits by
+                downgraded workspaces neither throw nor strip it */}
+            <input type="hidden" name="repeat" value={initialRepeat} />
+            {endsAtDefault ? (
+              <input type="hidden" name="endsAt" value={endsAtDefault} />
+            ) : null}
+            <Select value={initialRepeat} disabled>
+              <SelectTrigger id="reminder-repeat-trigger">
+                <SelectValue placeholder="Never" />
+              </SelectTrigger>
+              <RepeatOptions />
+            </Select>
+          </>
+        )}
+        {canUseRecurringReminders ? (
+          <p className="mt-1 text-gray-500">
+            Automatically send this reminder again on a schedule.
+          </p>
+        ) : (
+          <>
+            <p className="mt-1 text-gray-500">
+              Recurring reminders are a premium feature.{" "}
+              <Button
+                variant="link"
+                className="inline text-sm"
+                to="/account-details/subscription"
+              >
+                Upgrade your plan
+              </Button>{" "}
+              to send reminders on a schedule.
+            </p>
+            {/* why: the Ends-on input doesn't render in the locked state,
+                but its stored value still round-trips through hidden inputs
+                and can fail validation (e.g. moving the reminder date past
+                the series' end date) — surface that error here or the
+                submit blocks with no visible cause. role="alert" because
+                there is no associated rendered input for screen readers. */}
+            {endsAtError ? (
+              <p role="alert" className="mt-1 text-sm text-error-500">
+                {endsAtError} (this reminder's end date is fixed on your current
+                plan)
+              </p>
+            ) : null}
+          </>
+        )}
+      </div>
+
+      {canUseRecurringReminders && repeat !== "never" ? (
+        <div>
+          <Input
+            defaultValue={endsAtDefault}
+            type="date"
+            name={endsAtFieldName}
+            error={endsAtError}
+            label="Ends on (optional)"
+            disabled={disabled}
+            className="mb-2"
+          />
+          <p className="text-gray-500">
+            Leave empty to repeat until the reminder is deleted.
+          </p>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/webapp/app/components/asset-reminder/reminder-recurrence-fields.tsx
+++ b/apps/webapp/app/components/asset-reminder/reminder-recurrence-fields.tsx
@@ -22,6 +22,7 @@ import {
   type ReminderRepeatValue,
 } from "~/modules/asset-reminder/recurrence";
 
+/** Props for {@link ReminderRecurrenceFields}. */
 type ReminderRecurrenceFieldsProps = {
   /** Whether the workspace tier includes recurring reminders. */
   canUseRecurringReminders: boolean;
@@ -41,6 +42,7 @@ type ReminderRecurrenceFieldsProps = {
   endsAtError?: string;
 };
 
+/** The shared option list (Never + the repeating presets) for both select states. */
 function RepeatOptions() {
   return (
     <SelectContent>
@@ -54,6 +56,15 @@ function RepeatOptions() {
   );
 }
 
+/**
+ * Renders the Repeat select and the optional "Ends on" date input for the
+ * set/edit reminder dialog. When the workspace tier lacks recurring
+ * reminders, the controls render locked with an upgrade nudge and the
+ * stored cadence round-trips via hidden inputs.
+ *
+ * @param props - See {@link ReminderRecurrenceFieldsProps}.
+ * @returns The recurrence form-fields fragment.
+ */
 export default function ReminderRecurrenceFields({
   canUseRecurringReminders,
   disabled,

--- a/apps/webapp/app/components/asset-reminder/reminders-table.tsx
+++ b/apps/webapp/app/components/asset-reminder/reminders-table.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import type { Prisma } from "@prisma/client";
+import { RepeatIcon } from "lucide-react";
 import { useParams } from "react-router";
 import colors from "tailwindcss/colors";
 import type { ASSET_REMINDER_INCLUDE_FIELDS } from "~/modules/asset-reminder/fields";
+import { describeRecurrence } from "~/modules/asset-reminder/recurrence";
 import { List } from "../list";
 import ReminderTeamMembers from "./reminder-team-members";
 import SetOrEditReminderDialog from "./set-or-edit-reminder-dialog";
@@ -110,8 +112,15 @@ function ListContent({
   extraProps: { isAssetReminderPage: boolean };
 }) {
   const now = new Date();
+  /**
+   * For an ACTIVE recurring reminder, alertDateTime is always the next
+   * occurrence (the worker advances it in place), so "Pending" stays
+   * correct; once a series ends the date stays in the past and the badge
+   * flips to "Reminder sent" — same rule as one-shots.
+   */
   const status =
     now < new Date(item.alertDateTime) ? "Pending" : "Reminder sent";
+  const recurrenceLabel = describeRecurrence(item);
 
   return (
     <>
@@ -131,6 +140,12 @@ function ListContent({
       </When>
       <Td>
         <DateS date={item.alertDateTime} includeTime />
+        {recurrenceLabel ? (
+          <span className="mt-0.5 flex items-center gap-1 text-xs text-gray-500">
+            <RepeatIcon className="size-3" aria-hidden="true" />
+            {recurrenceLabel}
+          </span>
+        ) : null}
       </Td>
       <Td>
         <Badge

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.schema.test.ts
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.schema.test.ts
@@ -53,7 +53,7 @@ describe("setReminderSchema", () => {
     ).not.toThrow();
   });
 
-  it("rejects an end date before the reminder date", () => {
+  it("rejects an end date on an earlier CALENDAR DAY than the reminder (client)", () => {
     const result = setReminderSchema.safeParse(
       basePayload({ repeat: "monthly", endsAt: "2099-07-01" })
     );
@@ -61,6 +61,20 @@ describe("setReminderSchema", () => {
     if (!result.success) {
       expect(result.error.issues[0].path).toEqual(["endsAt"]);
     }
+  });
+
+  it("accepts a same-day end date with a LATE-evening reminder time (calendar compare, not instant compare)", () => {
+    // The old instant-based check (endsAt UTC-midnight + 24h vs local
+    // datetime) rejected this shape for users west of UTC.
+    expect(() =>
+      setReminderSchema.parse(
+        basePayload({
+          repeat: "weekly",
+          alertDateTime: "2099-07-15T23:30",
+          endsAt: "2099-07-15",
+        })
+      )
+    ).not.toThrow();
   });
 
   it("rejects a past alertDateTime at PARSE time on the CLIENT schema", () => {
@@ -73,14 +87,20 @@ describe("setReminderSchema", () => {
     }
   });
 
-  it("does NOT run the future check on the SERVER schema (zone-resolved check happens in resolveReminderPayloadDates)", () => {
-    // Server-side, z.coerce.date() reads the raw string in the process zone,
-    // so a future-check here would wrongly reject valid times for users west
-    // of UTC. The authoritative check runs on the resolved instant instead.
-    const result = setReminderServerSchema.safeParse(
-      basePayload({ alertDateTime: "2020-01-01T09:00" })
-    );
-    expect(result.success).toBe(true);
+  it("runs NO date refinements on the SERVER schemas (zone-resolved checks happen in resolveReminderPayloadDates)", () => {
+    // Server-side, z.coerce.date() reads raw strings in the process zone, so
+    // both the future check and the endsAt ordering check would misfire for
+    // users in other zones. Both run on the resolved instants instead.
+    expect(
+      setReminderServerSchema.safeParse(
+        basePayload({ alertDateTime: "2020-01-01T09:00" })
+      ).success
+    ).toBe(true);
+    expect(
+      setReminderServerSchema.safeParse(
+        basePayload({ repeat: "monthly", endsAt: "2099-07-01" })
+      ).success
+    ).toBe(true);
   });
 
   it("ignores endsAt ordering when repeat is never", () => {
@@ -91,7 +111,7 @@ describe("setReminderSchema", () => {
 });
 
 describe("editReminderServerSchema", () => {
-  it("requires the reminder id and keeps the ordering refinement", () => {
+  it("requires the reminder id", () => {
     const parsed = editReminderServerSchema.parse(
       basePayload({ id: "reminder-1", repeat: "yearly" })
     );
@@ -102,11 +122,5 @@ describe("editReminderServerSchema", () => {
       editReminderServerSchema.safeParse(basePayload({ repeat: "yearly" }))
         .success
     ).toBe(false);
-
-    expect(
-      editReminderServerSchema.safeParse(
-        basePayload({ id: "r-1", repeat: "monthly", endsAt: "2099-07-01" })
-      ).success
-    ).toBe(false); // ordering refinement still applies
   });
 });

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.schema.test.ts
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.schema.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+/**
+ * Parse-level tests for the reminder form schemas. These cover the two
+ * multipart-form traps that would otherwise break the flows silently:
+ * an empty optional date input submits "" (not undefined), and a disabled
+ * Repeat select submits nothing at all.
+ */
+import {
+  editReminderSchema,
+  setReminderSchema,
+} from "./set-or-edit-reminder-dialog";
+
+const FUTURE = "2099-07-15T09:00";
+
+function basePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Service the generator",
+    message: "Change oil and filters",
+    alertDateTime: FUTURE,
+    teamMembers: ["tm-1"],
+    ...overrides,
+  };
+}
+
+describe("setReminderSchema", () => {
+  it("defaults repeat to never when the field is absent (disabled/locked select)", () => {
+    const parsed = setReminderSchema.parse(basePayload());
+    expect(parsed.repeat).toBe("never");
+    expect(parsed.endsAt).toBeUndefined();
+  });
+
+  it('treats an empty "Ends on" input ("") as no end date', () => {
+    const parsed = setReminderSchema.parse(
+      basePayload({ repeat: "monthly", endsAt: "" })
+    );
+    expect(parsed.repeat).toBe("monthly");
+    expect(parsed.endsAt).toBeUndefined();
+  });
+
+  it("accepts a recurring payload with an end date after the reminder date", () => {
+    const parsed = setReminderSchema.parse(
+      basePayload({ repeat: "quarterly", endsAt: "2099-12-31" })
+    );
+    expect(parsed.endsAt).toBeInstanceOf(Date);
+  });
+
+  it("accepts a SAME-DAY end date (interpreted as end-of-day server-side)", () => {
+    expect(() =>
+      setReminderSchema.parse(
+        basePayload({ repeat: "weekly", endsAt: "2099-07-15" })
+      )
+    ).not.toThrow();
+  });
+
+  it("rejects an end date before the reminder date", () => {
+    const result = setReminderSchema.safeParse(
+      basePayload({ repeat: "monthly", endsAt: "2099-07-01" })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["endsAt"]);
+    }
+  });
+
+  it("rejects a past alertDateTime at PARSE time (not module-load time)", () => {
+    const result = setReminderSchema.safeParse(
+      basePayload({ alertDateTime: "2020-01-01T09:00" })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(["alertDateTime"]);
+    }
+  });
+
+  it("ignores endsAt ordering when repeat is never", () => {
+    expect(() =>
+      setReminderSchema.parse(basePayload({ endsAt: "2000-01-01" }))
+    ).not.toThrow();
+  });
+});
+
+describe("editReminderSchema", () => {
+  it("requires the reminder id and keeps the shared refinements", () => {
+    const parsed = editReminderSchema.parse(
+      basePayload({ id: "reminder-1", repeat: "yearly" })
+    );
+    expect(parsed.id).toBe("reminder-1");
+    expect(parsed.repeat).toBe("yearly");
+
+    expect(
+      editReminderSchema.safeParse(basePayload({ repeat: "yearly" })).success
+    ).toBe(false);
+  });
+});

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.schema.test.ts
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.schema.test.ts
@@ -6,8 +6,9 @@
  * Repeat select submits nothing at all.
  */
 import {
-  editReminderSchema,
+  editReminderServerSchema,
   setReminderSchema,
+  setReminderServerSchema,
 } from "./set-or-edit-reminder-dialog";
 
 const FUTURE = "2099-07-15T09:00";
@@ -62,7 +63,7 @@ describe("setReminderSchema", () => {
     }
   });
 
-  it("rejects a past alertDateTime at PARSE time (not module-load time)", () => {
+  it("rejects a past alertDateTime at PARSE time on the CLIENT schema", () => {
     const result = setReminderSchema.safeParse(
       basePayload({ alertDateTime: "2020-01-01T09:00" })
     );
@@ -72,6 +73,16 @@ describe("setReminderSchema", () => {
     }
   });
 
+  it("does NOT run the future check on the SERVER schema (zone-resolved check happens in resolveReminderPayloadDates)", () => {
+    // Server-side, z.coerce.date() reads the raw string in the process zone,
+    // so a future-check here would wrongly reject valid times for users west
+    // of UTC. The authoritative check runs on the resolved instant instead.
+    const result = setReminderServerSchema.safeParse(
+      basePayload({ alertDateTime: "2020-01-01T09:00" })
+    );
+    expect(result.success).toBe(true);
+  });
+
   it("ignores endsAt ordering when repeat is never", () => {
     expect(() =>
       setReminderSchema.parse(basePayload({ endsAt: "2000-01-01" }))
@@ -79,16 +90,23 @@ describe("setReminderSchema", () => {
   });
 });
 
-describe("editReminderSchema", () => {
-  it("requires the reminder id and keeps the shared refinements", () => {
-    const parsed = editReminderSchema.parse(
+describe("editReminderServerSchema", () => {
+  it("requires the reminder id and keeps the ordering refinement", () => {
+    const parsed = editReminderServerSchema.parse(
       basePayload({ id: "reminder-1", repeat: "yearly" })
     );
     expect(parsed.id).toBe("reminder-1");
     expect(parsed.repeat).toBe("yearly");
 
     expect(
-      editReminderSchema.safeParse(basePayload({ repeat: "yearly" })).success
+      editReminderServerSchema.safeParse(basePayload({ repeat: "yearly" }))
+        .success
     ).toBe(false);
+
+    expect(
+      editReminderServerSchema.safeParse(
+        basePayload({ id: "r-1", repeat: "monthly", endsAt: "2099-07-01" })
+      ).success
+    ).toBe(false); // ordering refinement still applies
   });
 });

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
@@ -4,20 +4,12 @@ import { Form, useLoaderData, useLocation, useActionData } from "react-router";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import Input from "~/components/forms/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "~/components/forms/select";
 import { Button } from "~/components/shared/button";
 import { Separator } from "~/components/shared/separator";
 import { useSearchParams } from "~/hooks/search-params";
 import { useAutoFocus } from "~/hooks/use-auto-focus";
 import { useDisabled } from "~/hooks/use-disabled";
 import {
-  REMINDER_REPEAT_PRESETS,
   REMINDER_REPEAT_VALUES,
   resolveRecurrenceZone,
   type ReminderRepeatValue,
@@ -25,6 +17,7 @@ import {
 import { dateForDateTimeInputValue } from "~/utils/date-fns";
 import { getValidationErrors } from "~/utils/http";
 import type { DataOrErrorResponse } from "~/utils/http.server";
+import ReminderRecurrenceFields from "./reminder-recurrence-fields";
 import TeamMembersSelector from "./team-members-selector";
 import { Dialog, DialogPortal } from "../layout/dialog";
 
@@ -175,13 +168,21 @@ export default function SetOrEditReminderDialog({
   /**
    * Reset the Repeat selection whenever the dialog (re)opens — useState only
    * seeds once, so without this a changed-then-cancelled cadence would leak
-   * into the next open and could be submitted unintentionally.
+   * into the next open and could be submitted unintentionally. Uses the
+   * adjust-state-during-render pattern (not an effect) so the reset applies
+   * in the same render pass with no stale flash.
    */
-  useEffect(() => {
+  // why: react-doctor flags prop-seeded useState (no-derived-useState), but
+  // this is the React-docs "adjust state during render" pattern — `repeat`
+  // is user-editable state that must RESET on open, not derived state that
+  // could be computed inline. Accepted residual per CLAUDE.md.
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
     if (open) {
       setRepeat(initialRepeat);
     }
-  }, [open, initialRepeat]);
+  }
 
   /** Ref for the first field so we can focus it on open without autoFocus. */
   const nameInputRef = useAutoFocus<HTMLInputElement>({ when: open });
@@ -315,121 +316,19 @@ export default function SetOrEditReminderDialog({
               </p>
             </div>
 
-            <div className="mb-4">
-              <label
-                htmlFor="reminder-repeat-trigger"
-                className={`mb-[6px] block text-sm font-medium ${
-                  canUseRecurringReminders ? "text-gray-700" : "text-gray-500"
-                }`}
-              >
-                Repeat
-              </label>
-              {canUseRecurringReminders ? (
-                <Select
-                  name={zo.fields.repeat()}
-                  value={repeat}
-                  onValueChange={(value) =>
-                    setRepeat(value as ReminderRepeatValue)
-                  }
-                  disabled={disabled}
-                >
-                  <SelectTrigger id="reminder-repeat-trigger">
-                    <SelectValue placeholder="Never" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="never">Never</SelectItem>
-                    {Object.entries(REMINDER_REPEAT_PRESETS).map(
-                      ([value, preset]) => (
-                        <SelectItem key={value} value={value}>
-                          {preset.label}
-                        </SelectItem>
-                      )
-                    )}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <>
-                  {/* why hidden inputs: a disabled control submits nothing —
-                      carry the STORED cadence through so plain edits by
-                      downgraded workspaces neither throw nor strip it */}
-                  <input type="hidden" name="repeat" value={initialRepeat} />
-                  {endsAtDefault ? (
-                    <input type="hidden" name="endsAt" value={endsAtDefault} />
-                  ) : null}
-                  <Select value={initialRepeat} disabled>
-                    <SelectTrigger id="reminder-repeat-trigger">
-                      <SelectValue placeholder="Never" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="never">Never</SelectItem>
-                      {Object.entries(REMINDER_REPEAT_PRESETS).map(
-                        ([value, preset]) => (
-                          <SelectItem key={value} value={value}>
-                            {preset.label}
-                          </SelectItem>
-                        )
-                      )}
-                    </SelectContent>
-                  </Select>
-                </>
-              )}
-              {canUseRecurringReminders ? (
-                <p className="mt-1 text-gray-500">
-                  Automatically send this reminder again on a schedule.
-                </p>
-              ) : (
-                <>
-                  <p className="mt-1 text-gray-500">
-                    Recurring reminders are a premium feature.{" "}
-                    <Button
-                      variant="link"
-                      className="inline text-sm"
-                      to="/account-details/subscription"
-                    >
-                      Upgrade your plan
-                    </Button>{" "}
-                    to send reminders on a schedule.
-                  </p>
-                  {/* why: the Ends-on input doesn't render in the locked
-                      state, but its stored value still round-trips through
-                      hidden inputs and can fail validation (e.g. moving the
-                      reminder date past the series' end date) — surface that
-                      error here or the submit blocks with no visible cause */}
-                  {validationErrors?.endsAt?.message ||
-                  zo.errors.endsAt()?.message ? (
-                    // why role="alert": this error isn't tied to a rendered
-                    // input (the Ends-on field is hidden in the locked state),
-                    // so screen readers need a live-region announcement when
-                    // it appears after a blocked submit
-                    <p role="alert" className="mt-1 text-sm text-error-500">
-                      {validationErrors?.endsAt?.message ||
-                        zo.errors.endsAt()?.message}{" "}
-                      (this reminder's end date is fixed on your current plan)
-                    </p>
-                  ) : null}
-                </>
-              )}
-            </div>
-
-            {canUseRecurringReminders && repeat !== "never" ? (
-              <div>
-                <Input
-                  defaultValue={endsAtDefault}
-                  type="date"
-                  name={zo.fields.endsAt()}
-                  error={
-                    validationErrors?.endsAt?.message ||
-                    zo.errors.endsAt()?.message
-                  }
-                  label="Ends on (optional)"
-                  disabled={disabled}
-                  className="mb-2"
-                />
-                <p className="text-gray-500">
-                  Leave empty to repeat until the reminder is deleted.
-                </p>
-              </div>
-            ) : null}
+            <ReminderRecurrenceFields
+              canUseRecurringReminders={canUseRecurringReminders}
+              disabled={disabled}
+              repeat={repeat}
+              onRepeatChange={setRepeat}
+              initialRepeat={initialRepeat}
+              endsAtDefault={endsAtDefault}
+              repeatFieldName={zo.fields.repeat()}
+              endsAtFieldName={zo.fields.endsAt()}
+              endsAtError={
+                validationErrors?.endsAt?.message || zo.errors.endsAt()?.message
+              }
+            />
           </div>
           <div>
             <Separator className="md:hidden" />

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
@@ -397,7 +397,11 @@ export default function SetOrEditReminderDialog({
                       error here or the submit blocks with no visible cause */}
                   {validationErrors?.endsAt?.message ||
                   zo.errors.endsAt()?.message ? (
-                    <p className="mt-1 text-sm text-error-500">
+                    // why role="alert": this error isn't tied to a rendered
+                    // input (the Ends-on field is hidden in the locked state),
+                    // so screen readers need a live-region announcement when
+                    // it appears after a blocked submit
+                    <p role="alert" className="mt-1 text-sm text-error-500">
                       {validationErrors?.endsAt?.message ||
                         zo.errors.endsAt()?.message}{" "}
                       (this reminder's end date is fixed on your current plan)

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
@@ -1,37 +1,116 @@
-import { useEffect } from "react";
-import { Form, useNavigation, useLocation, useActionData } from "react-router";
+import { useEffect, useState } from "react";
+import { DateTime } from "luxon";
+import { Form, useLoaderData, useLocation, useActionData } from "react-router";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import Input from "~/components/forms/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/forms/select";
 import { Button } from "~/components/shared/button";
 import { Separator } from "~/components/shared/separator";
 import { useSearchParams } from "~/hooks/search-params";
 import { useAutoFocus } from "~/hooks/use-auto-focus";
+import { useDisabled } from "~/hooks/use-disabled";
+import {
+  REMINDER_REPEAT_PRESETS,
+  REMINDER_REPEAT_VALUES,
+  resolveRecurrenceZone,
+  type ReminderRepeatValue,
+} from "~/modules/asset-reminder/recurrence";
 import { dateForDateTimeInputValue } from "~/utils/date-fns";
-import { isFormProcessing } from "~/utils/form";
 import { getValidationErrors } from "~/utils/http";
 import type { DataOrErrorResponse } from "~/utils/http.server";
 import TeamMembersSelector from "./team-members-selector";
 import { Dialog, DialogPortal } from "../layout/dialog";
 
-export const setReminderSchema = z.object({
+const baseReminderSchema = z.object({
   name: z.string().min(1, "Please enter name."),
   message: z.string().min(1, "Please enter message."),
-  alertDateTime: z.coerce
-    .date()
-    .min(new Date(), "Please select a date in the future"),
+  alertDateTime: z.coerce.date(),
   teamMembers: z
     .array(z.string())
     .min(1, "Please select at least one team member"),
+  repeat: z.enum(REMINDER_REPEAT_VALUES).default("never"),
+  // why preprocess: an empty optional date input submits "" through the
+  // multipart form, and z.coerce.date() would turn "" into Invalid Date
+  endsAt: z.preprocess(
+    (value) => (value === "" || value == null ? undefined : value),
+    z.coerce.date().optional()
+  ),
   redirectTo: z.string().optional(),
 });
+
+/**
+ * Runtime refinements shared by the create and edit schemas.
+ * The future-check must run at parse time — the previous
+ * `.min(new Date())` evaluated new Date() once at module load, so on a
+ * long-running process "in the future" silently meant "after boot".
+ */
+function reminderRefinements(
+  data: z.infer<typeof baseReminderSchema>,
+  ctx: z.RefinementCtx
+) {
+  if (data.alertDateTime.getTime() <= Date.now()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["alertDateTime"],
+      message: "Please select a date in the future",
+    });
+  }
+
+  // endsAt is interpreted as end-of-day server-side, so a same-day end
+  // date is valid; only reject dates before the reminder's own day.
+  if (
+    data.repeat !== "never" &&
+    data.endsAt &&
+    data.endsAt.getTime() + 24 * 60 * 60 * 1000 - 1 <
+      data.alertDateTime.getTime()
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["endsAt"],
+      message: "End date must be on or after the reminder date",
+    });
+  }
+}
+
+export const setReminderSchema =
+  baseReminderSchema.superRefine(reminderRefinements);
+
+/** Edit adds the reminder id; consumed by resolveRemindersActions. */
+export const editReminderSchema = baseReminderSchema
+  .extend({ id: z.string() })
+  .superRefine(reminderRefinements);
 
 type SetOrEditReminderDialogProps = {
   open: boolean;
   onClose: () => void;
-  reminder?: z.infer<typeof setReminderSchema> & { id: string };
+  reminder?: Omit<z.infer<typeof setReminderSchema>, "repeat" | "endsAt"> & {
+    id: string;
+    repeat?: ReminderRepeatValue;
+    endsAt?: Date | string | null;
+    recurrenceTimezone?: string | null;
+  };
   action?: string;
 };
+
+/**
+ * Reads the tier capability exposed by every route that renders this dialog
+ * (asset detail, global reminders index, asset reminders tab). Fails CLOSED
+ * (locked UI) if a future surface forgets to expose it — the server asserts
+ * independently either way.
+ */
+function useCanUseRecurringReminders(): boolean {
+  const data = useLoaderData() as
+    | { canUseRecurringReminders?: boolean }
+    | undefined;
+  return data?.canUseRecurringReminders ?? false;
+}
 
 export default function SetOrEditReminderDialog({
   open,
@@ -39,11 +118,11 @@ export default function SetOrEditReminderDialog({
   reminder,
   action,
 }: SetOrEditReminderDialogProps) {
-  const navigation = useNavigation();
-  const disabled = isFormProcessing(navigation.state);
+  const disabled = useDisabled();
 
   const pathname = useLocation().pathname;
   const [searchParams, setSearchParams] = useSearchParams();
+  const canUseRecurringReminders = useCanUseRecurringReminders();
 
   const redirectTo = `${pathname}${
     searchParams.size > 0
@@ -60,6 +139,8 @@ export default function SetOrEditReminderDialog({
   );
 
   const isEdit = !!reminder;
+  const initialRepeat: ReminderRepeatValue = reminder?.repeat ?? "never";
+  const [repeat, setRepeat] = useState<ReminderRepeatValue>(initialRepeat);
 
   /** Ref for the first field so we can focus it on open without autoFocus. */
   const nameInputRef = useAutoFocus<HTMLInputElement>({ when: open });
@@ -77,6 +158,16 @@ export default function SetOrEditReminderDialog({
     },
     [onClose, searchParams, setSearchParams]
   );
+
+  // why: recurrenceEndsAt is stored as end-of-day in the reminder's own
+  // timezone. Render the calendar date back in THAT zone (not UTC via
+  // toISOString) so the date shown matches what was picked and does not drift
+  // +1 day per save for west-of-UTC workspaces.
+  const endsAtDefault = reminder?.endsAt
+    ? DateTime.fromJSDate(new Date(reminder.endsAt))
+        .setZone(resolveRecurrenceZone(reminder.recurrenceTimezone ?? null))
+        .toFormat("yyyy-MM-dd")
+    : undefined;
 
   return (
     <DialogPortal>
@@ -157,7 +248,7 @@ export default function SetOrEditReminderDialog({
               </p>
             </div>
 
-            <div>
+            <div className="mb-4">
               <Input
                 defaultValue={
                   reminder?.alertDateTime
@@ -182,6 +273,103 @@ export default function SetOrEditReminderDialog({
                 We will send the reminder at this date/time.
               </p>
             </div>
+
+            <div className="mb-4">
+              <label
+                htmlFor="reminder-repeat-trigger"
+                className={`mb-[6px] block text-sm font-medium ${
+                  canUseRecurringReminders ? "text-gray-700" : "text-gray-400"
+                }`}
+              >
+                Repeat
+              </label>
+              {canUseRecurringReminders ? (
+                <Select
+                  name={zo.fields.repeat()}
+                  value={repeat}
+                  onValueChange={(value) =>
+                    setRepeat(value as ReminderRepeatValue)
+                  }
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="reminder-repeat-trigger">
+                    <SelectValue placeholder="Never" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="never">Never</SelectItem>
+                    {Object.entries(REMINDER_REPEAT_PRESETS).map(
+                      ([value, preset]) => (
+                        <SelectItem key={value} value={value}>
+                          {preset.label}
+                        </SelectItem>
+                      )
+                    )}
+                  </SelectContent>
+                </Select>
+              ) : (
+                <>
+                  {/* why hidden inputs: a disabled control submits nothing —
+                      carry the STORED cadence through so plain edits by
+                      downgraded workspaces neither throw nor strip it */}
+                  <input type="hidden" name="repeat" value={initialRepeat} />
+                  {endsAtDefault ? (
+                    <input type="hidden" name="endsAt" value={endsAtDefault} />
+                  ) : null}
+                  <Select value={initialRepeat} disabled>
+                    <SelectTrigger id="reminder-repeat-trigger">
+                      <SelectValue placeholder="Never" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="never">Never</SelectItem>
+                      {Object.entries(REMINDER_REPEAT_PRESETS).map(
+                        ([value, preset]) => (
+                          <SelectItem key={value} value={value}>
+                            {preset.label}
+                          </SelectItem>
+                        )
+                      )}
+                    </SelectContent>
+                  </Select>
+                </>
+              )}
+              {canUseRecurringReminders ? (
+                <p className="mt-1 text-gray-500">
+                  Automatically send this reminder again on a schedule.
+                </p>
+              ) : (
+                <p className="mt-1 text-gray-500">
+                  Recurring reminders are a premium feature.{" "}
+                  <Button
+                    variant="link"
+                    className="inline text-sm"
+                    to="/account-details/subscription"
+                  >
+                    Upgrade your plan
+                  </Button>{" "}
+                  to send reminders on a schedule.
+                </p>
+              )}
+            </div>
+
+            {canUseRecurringReminders && repeat !== "never" ? (
+              <div>
+                <Input
+                  defaultValue={endsAtDefault}
+                  type="date"
+                  name={zo.fields.endsAt()}
+                  error={
+                    validationErrors?.endsAt?.message ||
+                    zo.errors.endsAt()?.message
+                  }
+                  label="Ends on (optional)"
+                  disabled={disabled}
+                  className="mb-2"
+                />
+                <p className="text-gray-500">
+                  Leave empty to repeat until the reminder is deleted.
+                </p>
+              </div>
+            ) : null}
           </div>
           <div>
             <Separator className="md:hidden" />

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
@@ -46,21 +46,28 @@ const baseReminderSchema = z.object({
 });
 
 /**
- * endsAt ordering check, shared by client and server schemas. Both dates are
- * parsed the same way within one parse, so relative ordering is zone-safe.
- * endsAt is interpreted as end-of-day server-side, so a same-day end date is
- * valid; only reject dates before the reminder's own day.
+ * CLIENT-ONLY endsAt ordering check, comparing CALENDAR DAYS rather than
+ * instants. The two inputs coerce differently: a type="date" string parses
+ * at UTC midnight while a datetime-local string parses in the browser's
+ * local zone — comparing the raw instants wrongly rejected valid same-day
+ * evening reminders for users west of UTC. The endsAt calendar day is the
+ * UTC date of the coerced value; the reminder's calendar day is its LOCAL
+ * date. The authoritative server check runs on the zone-resolved values in
+ * resolveReminderPayloadDates.
  */
-function endsAtOrderingRefinement(
+function clientEndsAtOrderingRefinement(
   data: z.infer<typeof baseReminderSchema>,
   ctx: z.RefinementCtx
 ) {
-  if (
-    data.repeat !== "never" &&
-    data.endsAt &&
-    data.endsAt.getTime() + 24 * 60 * 60 * 1000 - 1 <
-      data.alertDateTime.getTime()
-  ) {
+  if (data.repeat === "never" || !data.endsAt) return;
+
+  const endsDay = data.endsAt.toISOString().slice(0, 10);
+  const alert = data.alertDateTime;
+  const alertDay = `${alert.getFullYear()}-${String(
+    alert.getMonth() + 1
+  ).padStart(2, "0")}-${String(alert.getDate()).padStart(2, "0")}`;
+
+  if (endsDay < alertDay) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["endsAt"],
@@ -92,24 +99,23 @@ function clientFutureRefinement(
   }
 }
 
-/** Client-side schema (zorm): ordering + zone-correct future check. */
+/** Client-side schema (zorm): calendar-day ordering + zone-correct future check. */
 export const setReminderSchema = baseReminderSchema
-  .superRefine(endsAtOrderingRefinement)
+  .superRefine(clientEndsAtOrderingRefinement)
   .superRefine(clientFutureRefinement);
 
 /**
- * Server-side parse schemas: NO future refinement (the raw string would be
- * coerced in the server's zone, not the user's) — resolveReminderPayloadDates
- * enforces future-ness on the correctly-resolved instant instead.
+ * Server-side parse schemas: NO date refinements — server-side coercion runs
+ * in the process zone, not the user's, so both the future check and the
+ * endsAt ordering check are enforced by resolveReminderPayloadDates on the
+ * client-hint-resolved instants instead.
  */
-export const setReminderServerSchema = baseReminderSchema.superRefine(
-  endsAtOrderingRefinement
-);
+export const setReminderServerSchema = baseReminderSchema;
 
 /** Edit adds the reminder id; consumed by resolveRemindersActions. */
-export const editReminderServerSchema = baseReminderSchema
-  .extend({ id: z.string() })
-  .superRefine(endsAtOrderingRefinement);
+export const editReminderServerSchema = baseReminderSchema.extend({
+  id: z.string(),
+});
 
 type SetOrEditReminderDialogProps = {
   open: boolean;
@@ -313,7 +319,7 @@ export default function SetOrEditReminderDialog({
               <label
                 htmlFor="reminder-repeat-trigger"
                 className={`mb-[6px] block text-sm font-medium ${
-                  canUseRecurringReminders ? "text-gray-700" : "text-gray-400"
+                  canUseRecurringReminders ? "text-gray-700" : "text-gray-500"
                 }`}
               >
                 Repeat
@@ -372,17 +378,32 @@ export default function SetOrEditReminderDialog({
                   Automatically send this reminder again on a schedule.
                 </p>
               ) : (
-                <p className="mt-1 text-gray-500">
-                  Recurring reminders are a premium feature.{" "}
-                  <Button
-                    variant="link"
-                    className="inline text-sm"
-                    to="/account-details/subscription"
-                  >
-                    Upgrade your plan
-                  </Button>{" "}
-                  to send reminders on a schedule.
-                </p>
+                <>
+                  <p className="mt-1 text-gray-500">
+                    Recurring reminders are a premium feature.{" "}
+                    <Button
+                      variant="link"
+                      className="inline text-sm"
+                      to="/account-details/subscription"
+                    >
+                      Upgrade your plan
+                    </Button>{" "}
+                    to send reminders on a schedule.
+                  </p>
+                  {/* why: the Ends-on input doesn't render in the locked
+                      state, but its stored value still round-trips through
+                      hidden inputs and can fail validation (e.g. moving the
+                      reminder date past the series' end date) — surface that
+                      error here or the submit blocks with no visible cause */}
+                  {validationErrors?.endsAt?.message ||
+                  zo.errors.endsAt()?.message ? (
+                    <p className="mt-1 text-sm text-error-500">
+                      {validationErrors?.endsAt?.message ||
+                        zo.errors.endsAt()?.message}{" "}
+                      (this reminder's end date is fixed on your current plan)
+                    </p>
+                  ) : null}
+                </>
               )}
             </div>
 

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
@@ -46,25 +46,15 @@ const baseReminderSchema = z.object({
 });
 
 /**
- * Runtime refinements shared by the create and edit schemas.
- * The future-check must run at parse time — the previous
- * `.min(new Date())` evaluated new Date() once at module load, so on a
- * long-running process "in the future" silently meant "after boot".
+ * endsAt ordering check, shared by client and server schemas. Both dates are
+ * parsed the same way within one parse, so relative ordering is zone-safe.
+ * endsAt is interpreted as end-of-day server-side, so a same-day end date is
+ * valid; only reject dates before the reminder's own day.
  */
-function reminderRefinements(
+function endsAtOrderingRefinement(
   data: z.infer<typeof baseReminderSchema>,
   ctx: z.RefinementCtx
 ) {
-  if (data.alertDateTime.getTime() <= Date.now()) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["alertDateTime"],
-      message: "Please select a date in the future",
-    });
-  }
-
-  // endsAt is interpreted as end-of-day server-side, so a same-day end
-  // date is valid; only reject dates before the reminder's own day.
   if (
     data.repeat !== "never" &&
     data.endsAt &&
@@ -79,13 +69,47 @@ function reminderRefinements(
   }
 }
 
-export const setReminderSchema =
-  baseReminderSchema.superRefine(reminderRefinements);
+/**
+ * CLIENT-ONLY future check. In the browser, z.coerce.date() parses the
+ * datetime-local string in the user's own zone, so comparing against
+ * Date.now() is correct. On the SERVER the same coercion runs in the
+ * process zone (UTC in prod) and would wrongly reject valid future times
+ * for users west of UTC — the authoritative server check happens in
+ * resolveReminderPayloadDates against the client-hint-resolved instant.
+ * (Evaluated at parse time; the previous `.min(new Date())` snapshotted
+ * boot time.)
+ */
+function clientFutureRefinement(
+  data: z.infer<typeof baseReminderSchema>,
+  ctx: z.RefinementCtx
+) {
+  if (data.alertDateTime.getTime() <= Date.now()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["alertDateTime"],
+      message: "Please select a date in the future",
+    });
+  }
+}
+
+/** Client-side schema (zorm): ordering + zone-correct future check. */
+export const setReminderSchema = baseReminderSchema
+  .superRefine(endsAtOrderingRefinement)
+  .superRefine(clientFutureRefinement);
+
+/**
+ * Server-side parse schemas: NO future refinement (the raw string would be
+ * coerced in the server's zone, not the user's) — resolveReminderPayloadDates
+ * enforces future-ness on the correctly-resolved instant instead.
+ */
+export const setReminderServerSchema = baseReminderSchema.superRefine(
+  endsAtOrderingRefinement
+);
 
 /** Edit adds the reminder id; consumed by resolveRemindersActions. */
-export const editReminderSchema = baseReminderSchema
+export const editReminderServerSchema = baseReminderSchema
   .extend({ id: z.string() })
-  .superRefine(reminderRefinements);
+  .superRefine(endsAtOrderingRefinement);
 
 type SetOrEditReminderDialogProps = {
   open: boolean;
@@ -141,6 +165,17 @@ export default function SetOrEditReminderDialog({
   const isEdit = !!reminder;
   const initialRepeat: ReminderRepeatValue = reminder?.repeat ?? "never";
   const [repeat, setRepeat] = useState<ReminderRepeatValue>(initialRepeat);
+
+  /**
+   * Reset the Repeat selection whenever the dialog (re)opens — useState only
+   * seeds once, so without this a changed-then-cancelled cadence would leak
+   * into the next open and could be submitted unintentionally.
+   */
+  useEffect(() => {
+    if (open) {
+      setRepeat(initialRepeat);
+    }
+  }, [open, initialRepeat]);
 
   /** Ref for the first field so we can focus it on open without autoFocus. */
   const nameInputRef = useAutoFocus<HTMLInputElement>({ when: open });

--- a/apps/webapp/app/components/assets/asset-reminder-cards.tsx
+++ b/apps/webapp/app/components/assets/asset-reminder-cards.tsx
@@ -42,6 +42,7 @@ export function AssetReminderCards({
         const remainingTeamMembers =
           reminder.teamMembers.length - slicedTeamMembers.length;
         const isAlreadySent = new Date() > new Date(reminder.alertDateTime);
+        const recurrenceLabel = describeRecurrence(reminder);
 
         return (
           <div key={reminder.id} className="border-b px-4 py-3">
@@ -55,10 +56,10 @@ export function AssetReminderCards({
             <p className="mb-2">
               <DateS date={reminder.alertDateTime} includeTime />
             </p>
-            {describeRecurrence(reminder) ? (
+            {recurrenceLabel ? (
               <p className="mb-2 flex items-center gap-1 text-xs text-gray-500">
                 <RepeatIcon className="size-3" aria-hidden="true" />
-                {describeRecurrence(reminder)}
+                {recurrenceLabel}
               </p>
             ) : null}
 

--- a/apps/webapp/app/components/assets/asset-reminder-cards.tsx
+++ b/apps/webapp/app/components/assets/asset-reminder-cards.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties } from "react";
+import { RepeatIcon } from "lucide-react";
 import { useLoaderData } from "react-router";
+import { describeRecurrence } from "~/modules/asset-reminder/recurrence";
 import { type loader } from "~/routes/_layout+/assets.$assetId.overview";
 import { tw } from "~/utils/tw";
 import ReminderTeamMembers from "../asset-reminder/reminder-team-members";
@@ -53,6 +55,12 @@ export function AssetReminderCards({
             <p className="mb-2">
               <DateS date={reminder.alertDateTime} includeTime />
             </p>
+            {describeRecurrence(reminder) ? (
+              <p className="mb-2 flex items-center gap-1 text-xs text-gray-500">
+                <RepeatIcon className="size-3" aria-hidden="true" />
+                {describeRecurrence(reminder)}
+              </p>
+            ) : null}
 
             <p className="mb-2 text-sm text-gray-600">
               {reminder.message.substring(0, 1000)}

--- a/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
+++ b/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
@@ -9,6 +9,7 @@ import {
   PopoverPortal,
   PopoverContent,
 } from "@radix-ui/react-popover";
+import { RepeatIcon } from "lucide-react";
 import { Link, useLoaderData } from "react-router";
 import { EventCardContent } from "~/components/calendar/event-card";
 import LineBreakText from "~/components/layout/line-break-text";
@@ -46,6 +47,7 @@ import type {
   ColumnLabelKey,
   BarcodeField,
 } from "~/modules/asset-index-settings/helpers";
+import { describeRecurrence } from "~/modules/asset-reminder/recurrence";
 import { formatCustodyList } from "~/modules/custody/utils";
 import { type AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
 import { formatAssetValueWithBreakdown } from "~/utils/asset-value";
@@ -771,18 +773,31 @@ function UpcomingReminderColumn({
     return <Td>No upcoming reminder</Td>;
   }
 
+  const recurrenceLabel = describeRecurrence(upcomingReminder);
+
   return (
     <Td>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button variant="link-gray" to={`/assets/${assetId}/reminders`}>
-            <DateS date={upcomingReminder.alertDateTime} includeTime />
+            <span className="flex items-center gap-1">
+              <DateS date={upcomingReminder.alertDateTime} includeTime />
+              {recurrenceLabel ? (
+                <RepeatIcon
+                  className="size-3 text-gray-400"
+                  aria-label="Recurring reminder"
+                />
+              ) : null}
+            </span>
           </Button>
         </TooltipTrigger>
 
         <TooltipContent className="max-w-[400px]">
           <p className="mb-1 font-bold">{upcomingReminder.name}</p>
           <p>{upcomingReminder.message.substring(0, 1000)}</p>
+          {recurrenceLabel ? (
+            <p className="mt-1 text-gray-500">Repeats: {recurrenceLabel}</p>
+          ) : null}
         </TooltipContent>
       </Tooltip>
     </Td>

--- a/apps/webapp/app/components/home/upcoming-reminders.tsx
+++ b/apps/webapp/app/components/home/upcoming-reminders.tsx
@@ -1,4 +1,6 @@
+import { RepeatIcon } from "lucide-react";
 import { useLoaderData } from "react-router";
+import { isRecurringReminder } from "~/modules/asset-reminder/recurrence";
 import type { loader } from "~/routes/_layout+/home";
 import { ClickableTr } from "../dashboard/clickable-tr";
 import { DashboardEmptyState } from "../dashboard/empty-state";
@@ -57,6 +59,12 @@ export default function UpcomingReminders() {
                         options={{ month: "short", day: "numeric" }}
                         includeTime
                       />
+                      {isRecurringReminder(reminder) ? (
+                        <RepeatIcon
+                          className="ml-1 inline size-3 align-[-1px] text-gray-400"
+                          aria-label="Recurring reminder"
+                        />
+                      ) : null}
                     </span>
                   </div>
                 </Td>

--- a/apps/webapp/app/entry.server.tsx
+++ b/apps/webapp/app/entry.server.tsx
@@ -9,6 +9,7 @@ import { ServerRouter } from "react-router";
 import type { AppLoadContext, EntryContext } from "react-router";
 import { registerEmailWorkers } from "./emails/email.worker.server";
 import { registerAddonTrialWorkers } from "./modules/addon-trial/worker.server";
+import { reconcileRecurringReminders } from "./modules/asset-reminder/chain.server";
 import { regierAssetWorkers } from "./modules/asset-reminder/worker.server";
 import { registerAuditWorkers } from "./modules/audit/worker.server";
 import { registerBookingWorkers } from "./modules/booking/worker.server";
@@ -80,6 +81,31 @@ schedulerService
           );
         }),
     ])
+  )
+  .then(() =>
+    /**
+     * Boot-time safety net for recurring reminders (no cron by design):
+     * re-arms series whose self-rescheduling chain died. Runs after worker
+     * registration so a re-armed overdue job can be picked up immediately.
+     */
+    reconcileRecurringReminders()
+      .then(({ scanned, rearmed }) => {
+        if (scanned > 0) {
+          console.log(
+            `Recurring reminders reconciled: ${rearmed}/${scanned} chains re-armed`
+          );
+        }
+      })
+      .catch((cause) => {
+        Logger.error(
+          new ShelfError({
+            cause,
+            message:
+              "Something went wrong while reconciling recurring reminders.",
+            label: "Scheduler",
+          })
+        );
+      })
   )
   .finally(() => {
     // eslint-disable-next-line no-console

--- a/apps/webapp/app/modules/asset-reminder/chain.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/chain.server.test.ts
@@ -14,6 +14,7 @@ vitest.mock("~/database/db.server", () => ({
     assetReminder: {
       updateMany: vitest.fn().mockResolvedValue({ count: 1 }),
       findMany: vitest.fn().mockResolvedValue([]),
+      findUnique: vitest.fn().mockResolvedValue(null),
     },
     organization: {
       findUnique: vitest.fn().mockResolvedValue({ userId: "owner-1" }),
@@ -72,6 +73,7 @@ function buildReminder(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vitest.clearAllMocks();
   (db.assetReminder.updateMany as any).mockResolvedValue({ count: 1 });
+  (db.assetReminder.findUnique as any).mockResolvedValue(null);
   (db.organization.findUnique as any).mockResolvedValue({ userId: "owner-1" });
   (getUserTierLimit as any).mockResolvedValue({
     canUseRecurringReminders: true,
@@ -88,7 +90,12 @@ describe("advanceRecurringReminder", () => {
       now: NOW,
     });
 
-    expect(result).toEqual({ next: null, advanced: false, paused: false });
+    expect(result).toEqual({
+      next: null,
+      advanced: false,
+      paused: false,
+      ended: false,
+    });
     expect(db.assetReminder.updateMany).not.toHaveBeenCalled();
     expect(scheduleAssetReminder).not.toHaveBeenCalled();
   });
@@ -144,7 +151,12 @@ describe("advanceRecurringReminder", () => {
       now: NOW,
     });
 
-    expect(result).toEqual({ next: null, advanced: false, paused: false });
+    expect(result).toEqual({
+      next: null,
+      advanced: false,
+      paused: false,
+      ended: true,
+    });
     expect(db.assetReminder.updateMany).not.toHaveBeenCalled();
     expect(scheduleAssetReminder).not.toHaveBeenCalled();
   });
@@ -224,6 +236,31 @@ describe("reconcileRecurringReminders", () => {
     expect(scanned).toBe(2);
     expect(rearmed).toBe(1);
     expect(scheduleAssetReminder).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-arms the row's current occurrence when the CAS committed but scheduling failed", async () => {
+    const row = buildReminder({
+      id: "orphan-1",
+      alertDateTime: new Date("2026-07-02T09:00:00.000Z"),
+    });
+    (db.assetReminder.findMany as any).mockResolvedValue([row]);
+    // why: advance CAS commits, then the schedule for the NEXT occurrence
+    // throws; the refetched row now points at that future occurrence
+    (scheduleAssetReminder as any)
+      .mockRejectedValueOnce(new Error("pg-boss hiccup"))
+      .mockResolvedValueOnce(undefined);
+    (db.assetReminder.findUnique as any).mockResolvedValue({
+      alertDateTime: new Date("2026-08-02T09:00:00.000Z"),
+    });
+
+    const { rearmed } = await reconcileRecurringReminders({ now: NOW });
+
+    expect(rearmed).toBe(1);
+    expect(scheduleAssetReminder).toHaveBeenCalledTimes(2);
+    expect((scheduleAssetReminder as any).mock.calls[1][0]).toMatchObject({
+      when: new Date("2026-08-02T09:00:00.000Z"),
+      options: expect.objectContaining({ retryLimit: 3 }),
+    });
   });
 
   it("skips ended-but-not-yet-expired series quietly", async () => {

--- a/apps/webapp/app/modules/asset-reminder/chain.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/chain.server.test.ts
@@ -1,0 +1,247 @@
+// @vitest-environment node
+import { ReminderRecurrenceUnit } from "@prisma/client";
+import { db } from "~/database/db.server";
+import {
+  advanceRecurringReminder,
+  reconcileRecurringReminders,
+  RECONCILE_GRACE_MS,
+} from "./chain.server";
+import { scheduleAssetReminder } from "./scheduler.server";
+
+// why: testing chain logic without a real database
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    assetReminder: {
+      updateMany: vitest.fn().mockResolvedValue({ count: 1 }),
+      findMany: vitest.fn().mockResolvedValue([]),
+    },
+    organization: {
+      findUnique: vitest.fn().mockResolvedValue({ userId: "owner-1" }),
+    },
+  },
+}));
+
+// why: preventing real pg-boss scheduling; recurringReminderJobOptions stays
+// real so option shapes are asserted end-to-end
+vitest.mock("./scheduler.server", async (importOriginal) => {
+  const original = (await importOriginal()) as object;
+  return {
+    ...original,
+    scheduleAssetReminder: vitest.fn().mockResolvedValue(undefined),
+  };
+});
+
+// why: tier resolution hits the database; the capability flag is the input
+// under test
+vitest.mock("../tier/service.server", () => ({
+  getUserTierLimit: vitest.fn().mockResolvedValue({
+    canUseRecurringReminders: true,
+  }),
+}));
+
+// why: subscription helpers read premium config from env at import time
+vitest.mock("~/utils/subscription.server", () => ({
+  canUseRecurringReminders: vitest.fn(
+    (tierLimit: { canUseRecurringReminders: boolean } | null) =>
+      tierLimit?.canUseRecurringReminders ?? false
+  ),
+}));
+
+// why: spying on logging without side effects
+vitest.mock("~/utils/logger", () => ({
+  Logger: { warn: vitest.fn(), info: vitest.fn(), error: vitest.fn() },
+}));
+
+const { getUserTierLimit } = await import("../tier/service.server");
+
+const NOW = new Date("2026-07-02T12:00:00.000Z");
+
+function buildReminder(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "reminder-1",
+    organizationId: "org-1",
+    alertDateTime: new Date("2026-07-02T11:59:00.000Z"),
+    recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+    recurrenceInterval: 1,
+    recurrenceTimezone: "UTC",
+    recurrenceEndsAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vitest.clearAllMocks();
+  (db.assetReminder.updateMany as any).mockResolvedValue({ count: 1 });
+  (db.organization.findUnique as any).mockResolvedValue({ userId: "owner-1" });
+  (getUserTierLimit as any).mockResolvedValue({
+    canUseRecurringReminders: true,
+  });
+});
+
+describe("advanceRecurringReminder", () => {
+  it("is a no-op for one-shot reminders", async () => {
+    const result = await advanceRecurringReminder({
+      reminder: buildReminder({
+        recurrenceUnit: null,
+        recurrenceInterval: null,
+      }) as any,
+      now: NOW,
+    });
+
+    expect(result).toEqual({ next: null, advanced: false, paused: false });
+    expect(db.assetReminder.updateMany).not.toHaveBeenCalled();
+    expect(scheduleAssetReminder).not.toHaveBeenCalled();
+  });
+
+  it("advances the row via CAS and schedules the next job with retry + singleton options", async () => {
+    const result = await advanceRecurringReminder({
+      reminder: buildReminder() as any,
+      now: NOW,
+    });
+
+    const expectedNext = new Date("2026-08-02T11:59:00.000Z");
+    expect(result.advanced).toBe(true);
+    expect(result.next?.toISOString()).toBe(expectedNext.toISOString());
+
+    // CAS: the update is guarded on the OLD alertDateTime
+    expect(db.assetReminder.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "reminder-1",
+        organizationId: "org-1",
+        alertDateTime: new Date("2026-07-02T11:59:00.000Z"),
+      },
+      data: { alertDateTime: expectedNext },
+    });
+
+    expect(scheduleAssetReminder).toHaveBeenCalledWith({
+      data: { reminderId: "reminder-1", eventType: "REMINDER" },
+      when: expectedNext,
+      options: {
+        retryLimit: 3,
+        retryBackoff: true,
+        singletonKey: `asset-reminder-reminder-1-${expectedNext.toISOString()}`,
+      },
+    });
+  });
+
+  it("stops without scheduling when a concurrent actor wins the CAS", async () => {
+    (db.assetReminder.updateMany as any).mockResolvedValue({ count: 0 });
+
+    const result = await advanceRecurringReminder({
+      reminder: buildReminder() as any,
+      now: NOW,
+    });
+
+    expect(result.advanced).toBe(false);
+    expect(scheduleAssetReminder).not.toHaveBeenCalled();
+  });
+
+  it("ends the series when the next occurrence would exceed endsAt", async () => {
+    const result = await advanceRecurringReminder({
+      reminder: buildReminder({
+        recurrenceEndsAt: new Date("2026-07-15T00:00:00.000Z"),
+      }) as any,
+      now: NOW,
+    });
+
+    expect(result).toEqual({ next: null, advanced: false, paused: false });
+    expect(db.assetReminder.updateMany).not.toHaveBeenCalled();
+    expect(scheduleAssetReminder).not.toHaveBeenCalled();
+  });
+
+  it("pauses (no reschedule) when the org tier lost the capability", async () => {
+    (getUserTierLimit as any).mockResolvedValue({
+      canUseRecurringReminders: false,
+    });
+
+    const result = await advanceRecurringReminder({
+      reminder: buildReminder() as any,
+      now: NOW,
+    });
+
+    expect(result.paused).toBe(true);
+    expect(result.advanced).toBe(false);
+    expect(db.assetReminder.updateMany).not.toHaveBeenCalled();
+    expect(scheduleAssetReminder).not.toHaveBeenCalled();
+  });
+
+  it("fails OPEN when the tier lookup errors (never kills a series on a transient)", async () => {
+    (getUserTierLimit as any).mockRejectedValue(new Error("db down"));
+
+    const result = await advanceRecurringReminder({
+      reminder: buildReminder() as any,
+      now: NOW,
+    });
+
+    expect(result.advanced).toBe(true);
+    expect(scheduleAssetReminder).toHaveBeenCalled();
+  });
+
+  it("propagates scheduling failures (caller must retry/reconcile)", async () => {
+    (scheduleAssetReminder as any).mockRejectedValue(new Error("pg-boss down"));
+
+    await expect(
+      advanceRecurringReminder({ reminder: buildReminder() as any, now: NOW })
+    ).rejects.toThrow("pg-boss down");
+  });
+});
+
+describe("reconcileRecurringReminders", () => {
+  it("only claims chains dead for longer than the grace window", async () => {
+    await reconcileRecurringReminders({ now: NOW });
+
+    expect(db.assetReminder.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          recurrenceUnit: { not: null },
+          alertDateTime: {
+            lt: new Date(NOW.getTime() - RECONCILE_GRACE_MS),
+          },
+        }),
+      })
+    );
+  });
+
+  it("re-arms dead chains and isolates per-row failures", async () => {
+    const deadRow = buildReminder({
+      id: "dead-1",
+      alertDateTime: new Date("2026-07-02T09:00:00.000Z"),
+    });
+    const badRow = buildReminder({
+      id: "bad-1",
+      alertDateTime: new Date("2026-07-02T08:00:00.000Z"),
+    });
+    (db.assetReminder.findMany as any).mockResolvedValue([badRow, deadRow]);
+    // why: first row's schedule blows up — the loop must continue to row 2
+    (scheduleAssetReminder as any)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined);
+
+    const { scanned, rearmed } = await reconcileRecurringReminders({
+      now: NOW,
+    });
+
+    expect(scanned).toBe(2);
+    expect(rearmed).toBe(1);
+    expect(scheduleAssetReminder).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips ended-but-not-yet-expired series quietly", async () => {
+    // Monthly series: last occurrence fired, endsAt is still future but the
+    // NEXT occurrence would exceed it -> getNextOccurrence returns null
+    const endedRow = buildReminder({
+      id: "ended-1",
+      alertDateTime: new Date("2026-07-01T09:00:00.000Z"),
+      recurrenceEndsAt: new Date("2026-07-20T00:00:00.000Z"),
+    });
+    (db.assetReminder.findMany as any).mockResolvedValue([endedRow]);
+
+    const { scanned, rearmed } = await reconcileRecurringReminders({
+      now: NOW,
+    });
+
+    expect(scanned).toBe(1);
+    expect(rearmed).toBe(0);
+    expect(scheduleAssetReminder).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/asset-reminder/chain.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/chain.server.ts
@@ -56,6 +56,11 @@ type AdvanceResult = {
   advanced: boolean;
   /** True when the org's tier no longer includes recurrence (series pauses). */
   paused: boolean;
+  /**
+   * True when the series ended naturally (the next occurrence would exceed
+   * recurrenceEndsAt) — lets the worker call out the final fire explicitly.
+   */
+  ended: boolean;
 };
 
 /**
@@ -123,7 +128,7 @@ export async function advanceRecurringReminder({
   now?: Date;
 }): Promise<AdvanceResult> {
   if (!isRecurringReminder(reminder)) {
-    return { next: null, advanced: false, paused: false };
+    return { next: null, advanced: false, paused: false, ended: false };
   }
 
   const next = getNextOccurrence({
@@ -137,11 +142,11 @@ export async function advanceRecurringReminder({
 
   /** Series ended (next occurrence would exceed recurrenceEndsAt). */
   if (!next) {
-    return { next: null, advanced: false, paused: false };
+    return { next: null, advanced: false, paused: false, ended: true };
   }
 
   if (!(await orgCanUseRecurringReminders(reminder.organizationId))) {
-    return { next: null, advanced: false, paused: true };
+    return { next: null, advanced: false, paused: true, ended: false };
   }
 
   /**
@@ -159,7 +164,7 @@ export async function advanceRecurringReminder({
   });
 
   if (count === 0) {
-    return { next: null, advanced: false, paused: false };
+    return { next: null, advanced: false, paused: false, ended: false };
   }
 
   await scheduleAssetReminder({
@@ -171,7 +176,7 @@ export async function advanceRecurringReminder({
     options: recurringReminderJobOptions(reminder.id, next),
   });
 
-  return { next, advanced: true, paused: false };
+  return { next, advanced: true, paused: false, ended: false };
 }
 
 /**
@@ -234,6 +239,46 @@ export async function reconcileRecurringReminders({
           label,
         })
       );
+
+      /**
+       * The CAS may have committed before scheduling failed, leaving the row
+       * pointing at a future occurrence with no queued job — a state this
+       * sweep would no longer match. Best-effort re-arm of the row's CURRENT
+       * occurrence (singletonKey makes it idempotent); if this also fails,
+       * the worker's orphan-recovery branch or the sweep after that
+       * occurrence goes stale (grace period) recovers the series.
+       */
+      try {
+        const current = await db.assetReminder.findUnique({
+          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: system boot sweep, id comes from the org-scoped candidate query above
+          where: { id: reminder.id },
+          select: { alertDateTime: true },
+        });
+        if (current && current.alertDateTime.getTime() > now.getTime()) {
+          await scheduleAssetReminder({
+            data: {
+              reminderId: reminder.id,
+              eventType: ASSETS_EVENT_TYPE_MAP.REMINDER,
+            },
+            when: current.alertDateTime,
+            options: recurringReminderJobOptions(
+              reminder.id,
+              current.alertDateTime
+            ),
+          });
+          rearmed += 1;
+        }
+      } catch (rearmCause) {
+        Logger.error(
+          new ShelfError({
+            cause: rearmCause,
+            message:
+              "Orphan re-arm after failed reconciliation also failed. The series recovers at the next sweep.",
+            additionalData: { reminderId: reminder.id },
+            label,
+          })
+        );
+      }
     }
   }
 

--- a/apps/webapp/app/modules/asset-reminder/chain.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/chain.server.ts
@@ -1,0 +1,241 @@
+/**
+ * Recurring-reminder chain: the advance step shared by the worker and boot
+ * reconciliation.
+ *
+ * Design (no cron — pg-boss runs with noScheduling: true):
+ * - A recurring reminder is ONE AssetReminder row whose alertDateTime is
+ *   advanced in place to the next occurrence each time it fires
+ *   (advance-before-notify, see worker.server.ts).
+ * - Concurrency safety without locks: the row update is a compare-and-swap on
+ *   the old alertDateTime (updateMany where { id, alertDateTime }); a racing
+ *   actor (worker vs boot reconciliation vs a second bluegreen machine) loses
+ *   the CAS and stops. Scheduling itself is deduped by a pg-boss singletonKey
+ *   keyed on (reminderId, occurrence), so even a double-schedule of the same
+ *   next occurrence collapses to one job.
+ * - Chains can still die (handler crash after retries, jobs archived while
+ *   workers are down for >14 days past fire time). reconcileRecurringReminders
+ *   runs at every boot/deploy and re-arms provably-dead chains.
+ *
+ * @see {@link file://./worker.server.ts}
+ * @see {@link file://./recurrence.ts}
+ */
+import type { AssetReminder } from "@prisma/client";
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
+import { canUseRecurringReminders } from "~/utils/subscription.server";
+import { getNextOccurrence, isRecurringReminder } from "./recurrence";
+import {
+  ASSETS_EVENT_TYPE_MAP,
+  recurringReminderJobOptions,
+  scheduleAssetReminder,
+} from "./scheduler.server";
+import { getUserTierLimit } from "../tier/service.server";
+
+const label = "Asset Scheduler";
+
+/**
+ * Grace period before boot reconciliation considers a chain dead. Must be
+ * comfortably larger than the pg-boss poll interval (5 min) plus the retry
+ * backoff horizon, or reconciliation would hijack healthy in-flight fires and
+ * the worker's stale-job guard would then swallow the due notification.
+ */
+export const RECONCILE_GRACE_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Tolerance on the "did this occurrence actually come due" check. Covers
+ * clock skew between the app server (evaluating the guard) and Postgres
+ * (releasing the job).
+ */
+export const ADVANCE_CLOCK_EPSILON_MS = 60 * 1000; // 1 minute
+
+type AdvanceResult = {
+  /** The next occurrence now scheduled, when the advance happened. */
+  next: Date | null;
+  /** False when the series ended, the CAS lost, or the tier paused it. */
+  advanced: boolean;
+  /** True when the org's tier no longer includes recurrence (series pauses). */
+  paused: boolean;
+};
+
+/**
+ * Checks whether the reminder's organization (owner tier) still includes
+ * recurring reminders. Fails OPEN on lookup errors so a transient DB issue
+ * never kills a paying customer's series; an explicit `false` tier flag is
+ * the only thing that pauses it.
+ */
+async function orgCanUseRecurringReminders(
+  organizationId: AssetReminder["organizationId"]
+): Promise<boolean> {
+  try {
+    const organization = await db.organization.findUnique({
+      where: { id: organizationId },
+      select: { userId: true },
+    });
+    if (!organization) return true;
+
+    const tierLimit = await getUserTierLimit(organization.userId);
+    return canUseRecurringReminders(tierLimit);
+  } catch (cause) {
+    Logger.error(
+      new ShelfError({
+        cause,
+        message:
+          "Failed to resolve tier for recurring reminder advance. Failing open.",
+        additionalData: { organizationId },
+        label,
+        shouldBeCaptured: false,
+      })
+    );
+    return true;
+  }
+}
+
+/**
+ * Advances a recurring reminder to its next occurrence and schedules the
+ * next pg-boss job.
+ *
+ * Ordering note: the CAS row-update commits BEFORE sendAfter. If scheduling
+ * then fails, the row points at a next occurrence with no queued job. On the
+ * pg-boss retry the worker sees the already-advanced (future) alertDateTime
+ * and re-arms that occurrence via its orphan-recovery branch; boot
+ * reconciliation is the terminal safety net if the retries are exhausted.
+ * pg-boss writes through its own pool, so sendAfter can never be part of a
+ * Prisma transaction.
+ *
+ * @throws When the CAS succeeded but scheduling failed — callers must treat
+ *         this as critical (retry / reconcile), not swallow it.
+ */
+export async function advanceRecurringReminder({
+  reminder,
+  now = new Date(),
+}: {
+  reminder: Pick<
+    AssetReminder,
+    | "id"
+    | "alertDateTime"
+    | "organizationId"
+    | "recurrenceUnit"
+    | "recurrenceInterval"
+    | "recurrenceTimezone"
+    | "recurrenceEndsAt"
+  >;
+  now?: Date;
+}): Promise<AdvanceResult> {
+  if (!isRecurringReminder(reminder)) {
+    return { next: null, advanced: false, paused: false };
+  }
+
+  const next = getNextOccurrence({
+    base: reminder.alertDateTime,
+    unit: reminder.recurrenceUnit!,
+    interval: reminder.recurrenceInterval!,
+    timezone: reminder.recurrenceTimezone,
+    endsAt: reminder.recurrenceEndsAt,
+    now,
+  });
+
+  /** Series ended (next occurrence would exceed recurrenceEndsAt). */
+  if (!next) {
+    return { next: null, advanced: false, paused: false };
+  }
+
+  if (!(await orgCanUseRecurringReminders(reminder.organizationId))) {
+    return { next: null, advanced: false, paused: true };
+  }
+
+  /**
+   * Compare-and-swap: only the actor that still sees the fired occurrence
+   * gets to advance. A concurrent worker/reconcile/edit that already moved
+   * alertDateTime makes this a no-op.
+   */
+  const { count } = await db.assetReminder.updateMany({
+    where: {
+      id: reminder.id,
+      organizationId: reminder.organizationId,
+      alertDateTime: reminder.alertDateTime,
+    },
+    data: { alertDateTime: next },
+  });
+
+  if (count === 0) {
+    return { next: null, advanced: false, paused: false };
+  }
+
+  await scheduleAssetReminder({
+    data: {
+      reminderId: reminder.id,
+      eventType: ASSETS_EVENT_TYPE_MAP.REMINDER,
+    },
+    when: next,
+    options: recurringReminderJobOptions(reminder.id, next),
+  });
+
+  return { next, advanced: true, paused: false };
+}
+
+/**
+ * Boot-time reconciliation: re-arms recurring series whose chain died
+ * (worker crash after retries, jobs archived during long downtime, crash
+ * between sendAfter and the reference write).
+ *
+ * Runs once per boot from entry.server.tsx — Shelf deploys frequently, so
+ * this is the no-cron sweep. Only claims PROVABLY dead chains: the stored
+ * occurrence must be more than RECONCILE_GRACE_MS in the past, far beyond
+ * the poll + retry horizon of a healthy in-flight fire.
+ *
+ * Each row is fault-isolated: one bad row (e.g. a timezone the zone database
+ * dropped) must never abort resurrection for the remaining tenants.
+ */
+export async function reconcileRecurringReminders({
+  now = new Date(),
+}: { now?: Date } = {}): Promise<{ scanned: number; rearmed: number }> {
+  const deadBefore = new Date(now.getTime() - RECONCILE_GRACE_MS);
+
+  const candidates = await db.assetReminder.findMany({
+    where: {
+      recurrenceUnit: { not: null },
+      alertDateTime: { lt: deadBefore },
+      OR: [{ recurrenceEndsAt: null }, { recurrenceEndsAt: { gt: now } }],
+    },
+    select: {
+      id: true,
+      alertDateTime: true,
+      organizationId: true,
+      recurrenceUnit: true,
+      recurrenceInterval: true,
+      recurrenceTimezone: true,
+      recurrenceEndsAt: true,
+    },
+  });
+
+  let rearmed = 0;
+
+  for (const reminder of candidates) {
+    try {
+      const { advanced } = await advanceRecurringReminder({ reminder, now });
+      if (advanced) {
+        rearmed += 1;
+        Logger.info(
+          `Re-armed dead recurring reminder chain ${reminder.id} (org ${reminder.organizationId}).`
+        );
+      }
+      // advanced === false covers: series actually ended (next beyond
+      // endsAt — quietly skipped every boot until endsAt passes), tier
+      // paused, or a concurrent actor won the CAS. All are no-ops here.
+    } catch (cause) {
+      // why: per-row isolation — reconciliation is the only recovery
+      // mechanism in a no-cron design, so one bad row must not abort the rest
+      Logger.error(
+        new ShelfError({
+          cause,
+          message: "Failed to reconcile recurring reminder. Continuing.",
+          additionalData: { reminderId: reminder.id },
+          label,
+        })
+      );
+    }
+  }
+
+  return { scanned: candidates.length, rearmed };
+}

--- a/apps/webapp/app/modules/asset-reminder/emails.tsx
+++ b/apps/webapp/app/modules/asset-reminder/emails.tsx
@@ -9,14 +9,13 @@ import {
   Row,
   Text,
 } from "@react-email/components";
-import { DateTime } from "luxon";
 import colors from "tailwindcss/colors";
 import { CustomEmailFooter } from "~/emails/components/custom-footer";
 import { LogoForEmail } from "~/emails/logo";
 import { styles } from "~/emails/styles";
 import { SERVER_URL } from "~/utils/env";
 import { resolveUserDisplayName } from "~/utils/user";
-import { describeRecurrence, resolveRecurrenceZone } from "./recurrence";
+import { describeRecurrence, formatOccurrenceInZone } from "./recurrence";
 
 type AssetAlertEmailProps = {
   user: Pick<User, "email" | "firstName" | "lastName" | "displayName">;
@@ -42,12 +41,10 @@ function recurrenceLine(
   const cadence = describeRecurrence(reminder);
   if (!cadence || !nextOccurrence) return null;
 
-  const zone = resolveRecurrenceZone(reminder.recurrenceTimezone);
-  const formatted = DateTime.fromJSDate(nextOccurrence)
-    .setZone(zone)
-    .toFormat("d LLL yyyy, HH:mm");
-
-  return `${cadence} reminder. Next reminder: ${formatted} (${zone}).`;
+  return `${cadence} reminder. Next reminder: ${formatOccurrenceInZone(
+    nextOccurrence,
+    reminder.recurrenceTimezone
+  )}.`;
 }
 
 export function assetAlertEmailText({

--- a/apps/webapp/app/modules/asset-reminder/emails.tsx
+++ b/apps/webapp/app/modules/asset-reminder/emails.tsx
@@ -9,12 +9,14 @@ import {
   Row,
   Text,
 } from "@react-email/components";
+import { DateTime } from "luxon";
 import colors from "tailwindcss/colors";
 import { CustomEmailFooter } from "~/emails/components/custom-footer";
 import { LogoForEmail } from "~/emails/logo";
 import { styles } from "~/emails/styles";
 import { SERVER_URL } from "~/utils/env";
 import { resolveUserDisplayName } from "~/utils/user";
+import { describeRecurrence, resolveRecurrenceZone } from "./recurrence";
 
 type AssetAlertEmailProps = {
   user: Pick<User, "email" | "firstName" | "lastName" | "displayName">;
@@ -23,7 +25,30 @@ type AssetAlertEmailProps = {
   workspaceName: string;
   isOwner?: boolean;
   customEmailFooter?: string | null;
+  /** Next occurrence of a recurring series, when one was scheduled. */
+  nextOccurrence?: Date | null;
 };
+
+/**
+ * "Repeats every 3 months. Next reminder: 15 Oct 2026, 09:00 (Europe/Berlin)."
+ * Rendered in the timezone the series was configured in (the worker has no
+ * request context, so the recipient's own zone is unknown) — the zone label
+ * keeps it unambiguous for recipients elsewhere.
+ */
+function recurrenceLine(
+  reminder: AssetReminder,
+  nextOccurrence?: Date | null
+): string | null {
+  const cadence = describeRecurrence(reminder);
+  if (!cadence || !nextOccurrence) return null;
+
+  const zone = resolveRecurrenceZone(reminder.recurrenceTimezone);
+  const formatted = DateTime.fromJSDate(nextOccurrence)
+    .setZone(zone)
+    .toFormat("d LLL yyyy, HH:mm");
+
+  return `${cadence} reminder. Next reminder: ${formatted} (${zone}).`;
+}
 
 export function assetAlertEmailText({
   user,
@@ -32,6 +57,7 @@ export function assetAlertEmailText({
   workspaceName,
   isOwner,
   customEmailFooter,
+  nextOccurrence,
 }: AssetAlertEmailProps) {
   const userName = resolveUserDisplayName(user);
 
@@ -39,6 +65,8 @@ export function assetAlertEmailText({
     ? `You are receiving this email because the original person was removed from workspace ${workspaceName}.`
     : `This email was sent to ${user.email} because it is part of the Shelf workspace ${workspaceName}.
 If you think you weren't supposed to have received this email please contact the owner of the workspace.`;
+
+  const recurrence = recurrenceLine(reminder, nextOccurrence);
 
   return `Asset reminder notice
 
@@ -51,7 +79,7 @@ ${asset.id}
 Reminder - ${reminder.name}
 
 ${reminder.message}
-
+${recurrence ? `\n${recurrence}\n` : ""}
 ${SERVER_URL}/assets/${asset.id}
 
 ${note}
@@ -79,10 +107,13 @@ function AssetAlertEmailTemplate({
   workspaceName,
   isOwner,
   customEmailFooter,
+  nextOccurrence,
 }: AssetAlertEmailProps) {
   const userName = resolveUserDisplayName(user);
 
   const isEmailExpired = isAssetImageExpired(asset.mainImageExpiration);
+
+  const recurrence = recurrenceLine(reminder, nextOccurrence);
 
   return (
     <Html>
@@ -165,6 +196,14 @@ function AssetAlertEmailTemplate({
           >
             {reminder.message}
           </Text>
+
+          {recurrence ? (
+            <Text
+              style={{ ...styles.p, marginBottom: "32px", textAlign: "left" }}
+            >
+              {recurrence}
+            </Text>
+          ) : null}
 
           <Button
             href={`${SERVER_URL}/assets/${asset.id}`}

--- a/apps/webapp/app/modules/asset-reminder/recurrence.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/recurrence.test.ts
@@ -1,0 +1,235 @@
+// @vitest-environment node
+import { ReminderRecurrenceUnit } from "@prisma/client";
+import {
+  describeRecurrence,
+  getNextOccurrence,
+  isRecurringReminder,
+  repeatValueFromRecurrence,
+  resolveRecurrenceZone,
+} from "./recurrence";
+
+describe("getNextOccurrence", () => {
+  it("advances a daily series by one day", () => {
+    const base = new Date("2026-07-10T09:00:00.000Z");
+    const next = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.DAY,
+      interval: 1,
+      timezone: "UTC",
+      now: new Date("2026-07-10T09:00:01.000Z"),
+    });
+    expect(next?.toISOString()).toBe("2026-07-11T09:00:00.000Z");
+  });
+
+  it("keeps wall-clock time across spring-forward DST (Europe/Berlin)", () => {
+    // 2026-03-28 09:00 CET (+01:00) = 08:00Z; next day is CEST (+02:00)
+    const base = new Date("2026-03-28T08:00:00.000Z");
+    const next = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.DAY,
+      interval: 1,
+      timezone: "Europe/Berlin",
+      now: new Date("2026-03-28T08:00:01.000Z"),
+    });
+    // 09:00 wall-clock in CEST = 07:00Z — the UTC instant shifts, the
+    // local time does not
+    expect(next?.toISOString()).toBe("2026-03-29T07:00:00.000Z");
+  });
+
+  it("keeps wall-clock time across fall-back DST (Europe/Berlin)", () => {
+    // 2026-10-24 09:00 CEST (+02:00) = 07:00Z; 2026-10-25 is CET (+01:00)
+    const base = new Date("2026-10-24T07:00:00.000Z");
+    const next = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.DAY,
+      interval: 1,
+      timezone: "Europe/Berlin",
+      now: new Date("2026-10-24T07:00:01.000Z"),
+    });
+    expect(next?.toISOString()).toBe("2026-10-25T08:00:00.000Z");
+  });
+
+  it("clamps month-end anniversaries (Jan 31 -> Feb 28, then stays on the 28th)", () => {
+    const base = new Date("2026-01-31T10:00:00.000Z");
+    const feb = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.MONTH,
+      interval: 1,
+      timezone: "UTC",
+      now: new Date("2026-01-31T10:00:01.000Z"),
+    });
+    expect(feb?.toISOString()).toBe("2026-02-28T10:00:00.000Z");
+
+    // The advanced date is the new anchor — intended v1 behavior
+    const mar = getNextOccurrence({
+      base: feb!,
+      unit: ReminderRecurrenceUnit.MONTH,
+      interval: 1,
+      timezone: "UTC",
+      now: new Date("2026-02-28T10:00:01.000Z"),
+    });
+    expect(mar?.toISOString()).toBe("2026-03-28T10:00:00.000Z");
+  });
+
+  it("supports multi-unit intervals (every 2 weeks, every 3 months, yearly)", () => {
+    const base = new Date("2026-07-01T08:00:00.000Z");
+    const now = new Date("2026-07-01T08:00:01.000Z");
+
+    expect(
+      getNextOccurrence({
+        base,
+        unit: ReminderRecurrenceUnit.WEEK,
+        interval: 2,
+        timezone: "UTC",
+        now,
+      })?.toISOString()
+    ).toBe("2026-07-15T08:00:00.000Z");
+
+    expect(
+      getNextOccurrence({
+        base,
+        unit: ReminderRecurrenceUnit.MONTH,
+        interval: 3,
+        timezone: "UTC",
+        now,
+      })?.toISOString()
+    ).toBe("2026-10-01T08:00:00.000Z");
+
+    expect(
+      getNextOccurrence({
+        base,
+        unit: ReminderRecurrenceUnit.YEAR,
+        interval: 1,
+        timezone: "UTC",
+        now,
+      })?.toISOString()
+    ).toBe("2027-07-01T08:00:00.000Z");
+  });
+
+  it("skips occurrences missed during downtime (catch-up policy: no burst)", () => {
+    const base = new Date("2026-01-01T09:00:00.000Z");
+    const next = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.DAY,
+      interval: 1,
+      timezone: "UTC",
+      now: new Date("2026-01-10T12:00:00.000Z"),
+    });
+    // Jan 2..10 are skipped; the first occurrence strictly after now wins
+    expect(next?.toISOString()).toBe("2026-01-11T09:00:00.000Z");
+  });
+
+  it("returns a strictly-future occurrence when now lands exactly on one", () => {
+    const base = new Date("2026-07-10T09:00:00.000Z");
+    const next = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.DAY,
+      interval: 1,
+      timezone: "UTC",
+      now: new Date("2026-07-11T09:00:00.000Z"),
+    });
+    expect(next?.toISOString()).toBe("2026-07-12T09:00:00.000Z");
+  });
+
+  it("ends the series when the next occurrence would exceed endsAt", () => {
+    const base = new Date("2026-01-01T09:00:00.000Z");
+    const endsAt = new Date("2026-02-15T23:59:59.999Z");
+
+    const feb = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.MONTH,
+      interval: 1,
+      timezone: "UTC",
+      endsAt,
+      now: new Date("2026-01-01T09:00:01.000Z"),
+    });
+    expect(feb?.toISOString()).toBe("2026-02-01T09:00:00.000Z");
+
+    const march = getNextOccurrence({
+      base: feb!,
+      unit: ReminderRecurrenceUnit.MONTH,
+      interval: 1,
+      timezone: "UTC",
+      endsAt,
+      now: new Date("2026-02-01T09:00:01.000Z"),
+    });
+    expect(march).toBeNull();
+  });
+
+  it("falls back to UTC for an invalid stored timezone instead of failing", () => {
+    const base = new Date("2026-07-10T09:00:00.000Z");
+    const next = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.DAY,
+      interval: 1,
+      timezone: "Not/AZone",
+      now: new Date("2026-07-10T09:00:01.000Z"),
+    });
+    expect(next?.toISOString()).toBe("2026-07-11T09:00:00.000Z");
+  });
+
+  it("clamps interval below 1 to 1 (no infinite/backwards loop)", () => {
+    const base = new Date("2026-07-10T09:00:00.000Z");
+    const next = getNextOccurrence({
+      base,
+      unit: ReminderRecurrenceUnit.DAY,
+      interval: 0,
+      timezone: "UTC",
+      now: new Date("2026-07-10T09:00:01.000Z"),
+    });
+    expect(next?.toISOString()).toBe("2026-07-11T09:00:00.000Z");
+  });
+});
+
+describe("recurrence helpers", () => {
+  it("identifies recurring reminders", () => {
+    expect(
+      isRecurringReminder({ recurrenceUnit: null, recurrenceInterval: null })
+    ).toBe(false);
+    expect(
+      isRecurringReminder({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 3,
+      })
+    ).toBe(true);
+  });
+
+  it("maps stored (unit, interval) back to a dialog preset", () => {
+    expect(
+      repeatValueFromRecurrence({
+        recurrenceUnit: ReminderRecurrenceUnit.WEEK,
+        recurrenceInterval: 2,
+      })
+    ).toBe("biweekly");
+    expect(
+      repeatValueFromRecurrence({
+        recurrenceUnit: null,
+        recurrenceInterval: null,
+      })
+    ).toBe("never");
+  });
+
+  it("describes cadences for the UI and emails", () => {
+    expect(
+      describeRecurrence({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 3,
+      })
+    ).toBe("Every 3 months");
+    expect(
+      describeRecurrence({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 5, // non-preset data falls back to a generated label
+      })
+    ).toBe("Every 5 months");
+    expect(
+      describeRecurrence({ recurrenceUnit: null, recurrenceInterval: null })
+    ).toBeNull();
+  });
+
+  it("validates stored zones", () => {
+    expect(resolveRecurrenceZone("Europe/Berlin")).toBe("Europe/Berlin");
+    expect(resolveRecurrenceZone("Not/AZone")).toBe("UTC");
+    expect(resolveRecurrenceZone(null)).toBe("UTC");
+  });
+});

--- a/apps/webapp/app/modules/asset-reminder/recurrence.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/recurrence.test.ts
@@ -2,8 +2,10 @@
 import { ReminderRecurrenceUnit } from "@prisma/client";
 import {
   describeRecurrence,
+  formatOccurrenceInZone,
   getNextOccurrence,
   isRecurringReminder,
+  rebaseEndOfDayToZone,
   repeatValueFromRecurrence,
   resolveRecurrenceZone,
 } from "./recurrence";
@@ -231,5 +233,37 @@ describe("recurrence helpers", () => {
     expect(resolveRecurrenceZone("Europe/Berlin")).toBe("Europe/Berlin");
     expect(resolveRecurrenceZone("Not/AZone")).toBe("UTC");
     expect(resolveRecurrenceZone(null)).toBe("UTC");
+  });
+
+  it("formats occurrences in the series zone with an explicit label", () => {
+    expect(
+      formatOccurrenceInZone(
+        new Date("2026-10-15T07:00:00.000Z"),
+        "Europe/Berlin"
+      )
+    ).toBe("15 Oct 2026, 09:00 (Europe/Berlin)");
+    expect(
+      formatOccurrenceInZone(new Date("2026-10-15T07:00:00.000Z"), null)
+    ).toBe("15 Oct 2026, 07:00 (UTC)");
+  });
+
+  it("rebases an end-of-day instant to another zone keeping the calendar date", () => {
+    // 2026-07-15 end-of-day in America/New_York (EDT) = 2026-07-16T03:59:59.999Z
+    const nyEndOfDay = new Date("2026-07-16T03:59:59.999Z");
+    const rebased = rebaseEndOfDayToZone(
+      nyEndOfDay,
+      "America/New_York",
+      "Europe/Berlin"
+    );
+    // Same calendar day (July 15), end-of-day in Berlin (CEST) = 21:59:59.999Z
+    expect(rebased.toISOString()).toBe("2026-07-15T21:59:59.999Z");
+
+    // Same-zone rebase is an identity
+    const identity = rebaseEndOfDayToZone(
+      nyEndOfDay,
+      "America/New_York",
+      "America/New_York"
+    );
+    expect(identity.getTime()).toBe(nyEndOfDay.getTime());
   });
 });

--- a/apps/webapp/app/modules/asset-reminder/recurrence.ts
+++ b/apps/webapp/app/modules/asset-reminder/recurrence.ts
@@ -147,9 +147,60 @@ export function describeRecurrence(
  * from the client-hint cookie (validated at write time), but zone databases
  * drift over multi-year series lifetimes, so fall back to UTC instead of
  * propagating an Invalid DateTime into the scheduler.
+ *
+ * @param timezone - The stored IANA zone (or null for legacy/one-shot rows).
+ * @returns A zone luxon accepts; UTC when the input is null or invalid.
  */
 export function resolveRecurrenceZone(timezone: string | null): string {
   return timezone && IANAZone.isValidZone(timezone) ? timezone : "UTC";
+}
+
+/**
+ * Formats an occurrence instant for user-facing text (emails, notes):
+ * "15 Oct 2026, 09:00 (Europe/Berlin)". Rendered in the series' own timezone
+ * with an explicit zone label so recipients in other zones aren't misled.
+ *
+ * @param date - The occurrence instant.
+ * @param timezone - The series' stored timezone (falls back to UTC).
+ * @returns The formatted date string including the zone label.
+ */
+export function formatOccurrenceInZone(
+  date: Date,
+  timezone: string | null
+): string {
+  const zone = resolveRecurrenceZone(timezone);
+  const formatted = DateTime.fromJSDate(date)
+    .setZone(zone)
+    .toFormat("d LLL yyyy, HH:mm");
+  return `${formatted} (${zone})`;
+}
+
+/**
+ * Re-anchors an end-of-day instant from one timezone to another while keeping
+ * the same CALENDAR date. Used when an existing recurring reminder is edited
+ * from a different timezone: the submitted endsAt was parsed as end-of-day in
+ * the editor's zone, but the series keeps its stored zone, so the end date
+ * must be end-of-day in THAT zone or the instant silently shifts (and the
+ * downgraded-tier change-detection would trip on plain edits).
+ *
+ * @param endsAt - The end-of-day instant parsed in `fromZone`.
+ * @param fromZone - The zone the instant was parsed in (editor's zone).
+ * @param toZone - The series' stored zone to re-anchor into.
+ * @returns The end-of-day instant of the same calendar date in `toZone`.
+ */
+export function rebaseEndOfDayToZone(
+  endsAt: Date,
+  fromZone: string | null,
+  toZone: string | null
+): Date {
+  const calendarDay = DateTime.fromJSDate(endsAt)
+    .setZone(resolveRecurrenceZone(fromZone))
+    .toFormat("yyyy-MM-dd");
+  return DateTime.fromFormat(calendarDay, "yyyy-MM-dd", {
+    zone: resolveRecurrenceZone(toZone),
+  })
+    .endOf("day")
+    .toJSDate();
 }
 
 /**

--- a/apps/webapp/app/modules/asset-reminder/recurrence.ts
+++ b/apps/webapp/app/modules/asset-reminder/recurrence.ts
@@ -1,0 +1,214 @@
+/**
+ * Reminder recurrence — presets and next-occurrence math.
+ *
+ * A recurring reminder stores a cadence as (recurrenceUnit, recurrenceInterval)
+ * plus the IANA timezone it was configured in. The worker advances
+ * `alertDateTime` in place each time the reminder fires (see worker.server.ts),
+ * so `alertDateTime` is always the NEXT occurrence of an active series.
+ *
+ * This module is pure (no db, no request context) so it is safe to import from
+ * both server code (worker, reconciliation, actions) and UI components
+ * (dialog preset list, table cadence labels).
+ *
+ * @see {@link file://./worker.server.ts}
+ * @see {@link file://./service.server.ts}
+ * @see {@link file://./../../components/asset-reminder/set-or-edit-reminder-dialog.tsx}
+ */
+import type { AssetReminder } from "@prisma/client";
+import { ReminderRecurrenceUnit } from "@prisma/client";
+import { DateTime, IANAZone } from "luxon";
+
+/** Form values for the dialog's Repeat select. "never" = one-shot. */
+export const REMINDER_REPEAT_VALUES = [
+  "never",
+  "daily",
+  "weekly",
+  "biweekly",
+  "monthly",
+  "quarterly",
+  "semiannually",
+  "yearly",
+] as const;
+
+export type ReminderRepeatValue = (typeof REMINDER_REPEAT_VALUES)[number];
+
+/**
+ * Maps every repeating preset to its stored (unit, interval) pair.
+ * Storage is unit + interval (not the preset string) so future custom
+ * cadences need no migration.
+ */
+export const REMINDER_REPEAT_PRESETS: Record<
+  Exclude<ReminderRepeatValue, "never">,
+  {
+    label: string;
+    unit: ReminderRecurrenceUnit;
+    interval: number;
+  }
+> = {
+  daily: { label: "Daily", unit: ReminderRecurrenceUnit.DAY, interval: 1 },
+  weekly: { label: "Weekly", unit: ReminderRecurrenceUnit.WEEK, interval: 1 },
+  biweekly: {
+    label: "Every 2 weeks",
+    unit: ReminderRecurrenceUnit.WEEK,
+    interval: 2,
+  },
+  monthly: {
+    label: "Monthly",
+    unit: ReminderRecurrenceUnit.MONTH,
+    interval: 1,
+  },
+  quarterly: {
+    label: "Every 3 months",
+    unit: ReminderRecurrenceUnit.MONTH,
+    interval: 3,
+  },
+  semiannually: {
+    label: "Every 6 months",
+    unit: ReminderRecurrenceUnit.MONTH,
+    interval: 6,
+  },
+  yearly: { label: "Yearly", unit: ReminderRecurrenceUnit.YEAR, interval: 1 },
+};
+
+/** The subset of AssetReminder fields recurrence logic operates on. */
+export type ReminderRecurrenceFields = Pick<
+  AssetReminder,
+  | "recurrenceUnit"
+  | "recurrenceInterval"
+  | "recurrenceTimezone"
+  | "recurrenceEndsAt"
+>;
+
+/** A reminder is recurring when it has a cadence configured. */
+export function isRecurringReminder(
+  reminder: Pick<AssetReminder, "recurrenceUnit" | "recurrenceInterval">
+): boolean {
+  return reminder.recurrenceUnit !== null && !!reminder.recurrenceInterval;
+}
+
+/**
+ * Resolves the stored (unit, interval) pair back to the dialog preset value.
+ * All v1 rows are written from presets; the fallback covers hypothetical
+ * hand-written data so the edit dialog never crashes.
+ */
+export function repeatValueFromRecurrence(
+  reminder: Pick<AssetReminder, "recurrenceUnit" | "recurrenceInterval">
+): ReminderRepeatValue {
+  if (!isRecurringReminder(reminder)) return "never";
+
+  const match = Object.entries(REMINDER_REPEAT_PRESETS).find(
+    ([, preset]) =>
+      preset.unit === reminder.recurrenceUnit &&
+      preset.interval === reminder.recurrenceInterval
+  );
+
+  return (match?.[0] as ReminderRepeatValue) ?? "monthly";
+}
+
+/** Luxon duration key for a recurrence unit. */
+const UNIT_TO_LUXON: Record<
+  ReminderRecurrenceUnit,
+  "days" | "weeks" | "months" | "years"
+> = {
+  DAY: "days",
+  WEEK: "weeks",
+  MONTH: "months",
+  YEAR: "years",
+};
+
+/** Human label for a cadence, e.g. "Monthly", "Every 2 weeks". */
+export function describeRecurrence(
+  reminder: Pick<AssetReminder, "recurrenceUnit" | "recurrenceInterval">
+): string | null {
+  if (!isRecurringReminder(reminder)) return null;
+
+  const preset = Object.values(REMINDER_REPEAT_PRESETS).find(
+    (p) =>
+      p.unit === reminder.recurrenceUnit &&
+      p.interval === reminder.recurrenceInterval
+  );
+  if (preset) return preset.label;
+
+  // Fallback for non-preset (unit, interval) data.
+  const interval = reminder.recurrenceInterval ?? 1;
+  const unitWord = {
+    DAY: "day",
+    WEEK: "week",
+    MONTH: "month",
+    YEAR: "year",
+  }[reminder.recurrenceUnit as ReminderRecurrenceUnit];
+  return interval === 1
+    ? `Every ${unitWord}`
+    : `Every ${interval} ${unitWord}s`;
+}
+
+/**
+ * Resolves a stored timezone to a zone luxon accepts. The stored value comes
+ * from the client-hint cookie (validated at write time), but zone databases
+ * drift over multi-year series lifetimes, so fall back to UTC instead of
+ * propagating an Invalid DateTime into the scheduler.
+ */
+export function resolveRecurrenceZone(timezone: string | null): string {
+  return timezone && IANAZone.isValidZone(timezone) ? timezone : "UTC";
+}
+
+/**
+ * Hard cap on catch-up iterations. Unreachable via the preset UI (a daily
+ * series would need ~27 years of downtime); guards a future custom-cadence
+ * UI or bad data from looping the worker/boot forever.
+ */
+const MAX_CATCH_UP_ITERATIONS = 10_000;
+
+/**
+ * Computes the next occurrence of a series strictly after `now`.
+ *
+ * - Wall-clock stable in the stored timezone (a 09:00 reminder stays 09:00
+ *   across DST). Month-end clamps per luxon calendar math: a series anchored
+ *   Jan 31 becomes Feb 28 and stays on the 28th thereafter — intended v1
+ *   behavior (the advanced date is the new anchor).
+ * - Catch-up policy: occurrences missed while the app was down are SKIPPED
+ *   (the late-fired job still notifies once); we never send a burst.
+ *
+ * @param base - The occurrence the series last pointed at (usually the fired
+ *               alertDateTime).
+ * @param now - The reference instant; the result is strictly after it.
+ * @returns The next occurrence, or null when the series has ended (next would
+ *          exceed recurrenceEndsAt).
+ */
+export function getNextOccurrence({
+  base,
+  unit,
+  interval,
+  timezone,
+  endsAt,
+  now = new Date(),
+}: {
+  base: Date;
+  unit: ReminderRecurrenceUnit;
+  interval: number;
+  timezone: string | null;
+  endsAt?: Date | null;
+  now?: Date;
+}): Date | null {
+  const zone = resolveRecurrenceZone(timezone);
+  // Clamp defensively: interval < 1 would loop backwards/forever.
+  const step = Math.max(1, Math.floor(interval));
+  const luxonUnit = UNIT_TO_LUXON[unit];
+
+  let next = DateTime.fromJSDate(base, { zone });
+  if (!next.isValid) {
+    // Invalid base (should be unreachable; alertDateTime is a real instant):
+    // treat the series as ended rather than scheduling garbage.
+    return null;
+  }
+
+  for (let i = 0; i < MAX_CATCH_UP_ITERATIONS; i++) {
+    next = next.plus({ [luxonUnit]: step });
+    if (next.toMillis() > now.getTime()) {
+      if (endsAt && next.toMillis() > endsAt.getTime()) return null;
+      return next.toJSDate();
+    }
+  }
+
+  return null;
+}

--- a/apps/webapp/app/modules/asset-reminder/scheduler.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/scheduler.server.ts
@@ -1,9 +1,11 @@
 import type { AssetReminder } from "@prisma/client";
 import { isBefore } from "date-fns";
+import type PgBoss from "pg-boss";
 import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
 import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import { isRecurringReminder } from "./recurrence";
 
 export const ASSETS_EVENT_TYPE_MAP = {
   REMINDER: "REMINDER",
@@ -18,27 +20,61 @@ export type AssetsSchedulerData = {
 };
 
 /**
- * This function is used to schedule an asset reminder.
+ * pg-boss send options for jobs belonging to a RECURRING reminder.
+ *
+ * - retryLimit/retryBackoff: the worker rethrows failures of the critical
+ *   advance step (see worker.server.ts), so recurring jobs must be sent with
+ *   retries or a transient error kills the chain until the next deploy's
+ *   reconciliation. One-shot jobs keep the historical `{}` (swallowed errors,
+ *   no retries) byte-identical.
+ * - singletonKey: dedupes scheduling of the same occurrence when two actors
+ *   race (worker advance vs boot reconciliation vs edit). pg-boss enforces a
+ *   unique index on (name, singletonKey) for jobs in state < 'completed', so
+ *   the losing sendAfter returns null instead of inserting a duplicate.
+ */
+export function recurringReminderJobOptions(
+  reminderId: AssetReminder["id"],
+  when: Date
+): PgBoss.SendOptions {
+  return {
+    retryLimit: 3,
+    retryBackoff: true,
+    singletonKey: `asset-reminder-${reminderId}-${when.toISOString()}`,
+  };
+}
+
+/**
+ * Schedules the pg-boss job for a reminder occurrence and persists the job
+ * reference on the row.
+ *
+ * When pg-boss dedupes the insert via singletonKey it returns null. We then
+ * persist `activeSchedulerReference = null` EXPLICITLY (instead of skipping
+ * the write like the audit scheduler does): the already-queued job with the
+ * same key IS the correct next-occurrence job, and the worker's stale-job
+ * guard treats a null reference as permissive. Keeping the OLD reference
+ * around would make the guard kill that legitimate job.
  */
 export async function scheduleAssetReminder({
   data,
   when,
+  options = {},
 }: {
   data: AssetsSchedulerData;
   when: Date;
+  options?: PgBoss.SendOptions;
 }) {
   try {
     const reference = await scheduler.sendAfter(
       QueueNames.assetsQueue,
       data,
-      {},
+      options,
       when
     );
 
     await db.assetReminder.update({
-      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: internal scheduler-bookkeeping write (only sets activeSchedulerReference); both callers (createAssetReminder, editAssetReminder) pass an org-proven reminderId
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: internal scheduler-bookkeeping write (only sets activeSchedulerReference); all callers (createAssetReminder, editAssetReminder, worker advance, reconciliation) pass an org-proven or system-generated reminderId
       where: { id: data.reminderId },
-      data: { activeSchedulerReference: reference },
+      data: { activeSchedulerReference: reference ?? null },
     });
   } catch (cause) {
     throw new ShelfError({
@@ -54,13 +90,26 @@ export async function scheduleAssetReminder({
  * This function is used to cancel an asset reminder scheduler.
  */
 export async function cancelAssetReminderScheduler(
-  reminder: Pick<AssetReminder, "alertDateTime" | "activeSchedulerReference">
+  reminder: Pick<
+    AssetReminder,
+    | "alertDateTime"
+    | "activeSchedulerReference"
+    | "recurrenceUnit"
+    | "recurrenceInterval"
+  >
 ) {
   try {
     /**
-     * If the reminder is already triggered, then we don't need to cancel the scheduler.
+     * A one-shot reminder whose alertDateTime passed has already fired, so
+     * there is nothing to cancel. Recurring reminders can hold a QUEUED job
+     * while alertDateTime is briefly in the past (poll latency between fire
+     * time and fetch), so for them we always attempt the cancel — pg-boss
+     * cancel is a no-op on completed/missing jobs.
      */
-    if (isBefore(reminder.alertDateTime, new Date())) {
+    if (
+      !isRecurringReminder(reminder) &&
+      isBefore(reminder.alertDateTime, new Date())
+    ) {
       return;
     }
 

--- a/apps/webapp/app/modules/asset-reminder/service.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/service.server.ts
@@ -5,16 +5,33 @@ import { isLikeShelfError, isNotFoundError, ShelfError } from "~/utils/error";
 import { getCurrentSearchParams } from "~/utils/http.server";
 import { getParamsValues } from "~/utils/list";
 import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
+import { assertAssetsBelongToOrg } from "~/utils/org-validation.server";
 import { ASSET_REMINDER_INCLUDE_FIELDS } from "./fields";
+import { isRecurringReminder } from "./recurrence";
 import {
   ASSETS_EVENT_TYPE_MAP,
   cancelAssetReminderScheduler,
+  recurringReminderJobOptions,
   scheduleAssetReminder,
 } from "./scheduler.server";
 import { createNote } from "../note/service.server";
 import { getUserByID } from "../user/service.server";
 
 const label = "Asset Reminder";
+
+/**
+ * Cadence payload for a recurring reminder. `null` = one-shot.
+ * Callers derive (unit, interval) from the dialog's Repeat preset and capture
+ * the timezone from client hints; the tier gate is enforced by the caller for
+ * create (assertUserCanUseRecurringReminders) and by editAssetReminder for
+ * edit (compare-to-stored, so downgraded orgs can still edit other fields).
+ */
+export type ReminderRecurrenceInput = {
+  unit: NonNullable<AssetReminder["recurrenceUnit"]>;
+  interval: number;
+  timezone: string | null;
+  endsAt: Date | null;
+} | null;
 
 export async function createAssetReminder({
   name,
@@ -24,6 +41,7 @@ export async function createAssetReminder({
   createdById,
   organizationId,
   teamMembers,
+  recurrence = null,
 }: Pick<
   AssetReminder,
   | "name"
@@ -32,9 +50,18 @@ export async function createAssetReminder({
   | "assetId"
   | "createdById"
   | "organizationId"
-> & { teamMembers: TeamMember["id"][] }) {
+> & {
+  teamMembers: TeamMember["id"][];
+  recurrence?: ReminderRecurrenceInput;
+}) {
   try {
-    await validateTeamMembersForReminder(teamMembers, organizationId);
+    await Promise.all([
+      // why: assetId is user-supplied (route param) — prove it belongs to the
+      // caller's org BEFORE creating, per org-scope-user-supplied-ids rule
+      // (the note write below validates too, but only after the row exists)
+      assertAssetsBelongToOrg({ assetIds: [assetId], organizationId }),
+      validateTeamMembersForReminder(teamMembers, organizationId),
+    ]);
 
     const user = await getUserByID(createdById, {
       select: {
@@ -52,6 +79,10 @@ export async function createAssetReminder({
         assetId,
         createdById,
         organizationId,
+        recurrenceUnit: recurrence?.unit ?? null,
+        recurrenceInterval: recurrence?.interval ?? null,
+        recurrenceTimezone: recurrence?.timezone ?? null,
+        recurrenceEndsAt: recurrence?.endsAt ?? null,
         teamMembers: {
           connect: teamMembers.map((id) => ({ id })),
         },
@@ -83,6 +114,11 @@ export async function createAssetReminder({
           eventType: ASSETS_EVENT_TYPE_MAP.REMINDER,
         },
         when: alertDateTime,
+        // why: recurring jobs need retries + singleton dedupe or a transient
+        // failure kills the chain; one-shot jobs keep historical semantics
+        options: recurrence
+          ? recurringReminderJobOptions(assetReminder.id, alertDateTime)
+          : {},
       }),
     ]);
 
@@ -95,6 +131,7 @@ export async function createAssetReminder({
         : "Something went wrong while creating asset reminder.",
       label,
       additionalData: { assetId, organizationId, createdById },
+      shouldBeCaptured: isLikeShelfError(cause) ? cause.shouldBeCaptured : true,
     });
   }
 }
@@ -210,7 +247,9 @@ export async function getPaginatedAndFilterableReminders({
       db.assetReminder.count({ where: finalWhere }),
     ]);
 
-    const totalPages = Math.ceil(totalReminders / perPageParam);
+    // why: divide by the cookie-resolved perPage, not the raw query param —
+    // perPageParam defaults to 0 without a ?per_page, making this Infinity
+    const totalPages = Math.ceil(totalReminders / perPage);
 
     return {
       reminders,
@@ -236,10 +275,22 @@ export async function editAssetReminder({
   alertDateTime,
   organizationId,
   teamMembers,
+  recurrence = null,
+  canUseRecurringReminders,
 }: Pick<
   AssetReminder,
   "id" | "name" | "message" | "alertDateTime" | "organizationId"
-> & { teamMembers: TeamMember["id"][] }) {
+> & {
+  teamMembers: TeamMember["id"][];
+  recurrence?: ReminderRecurrenceInput;
+  /**
+   * Whether the org's tier allows recurring reminders. The gate only fires
+   * when this edit ADDS or CHANGES recurrence relative to the stored row —
+   * downgraded orgs can still edit other fields, turn recurrence off, or
+   * delete the reminder.
+   */
+  canUseRecurringReminders: boolean;
+}) {
   try {
     await validateTeamMembersForReminder(teamMembers, organizationId);
 
@@ -249,7 +300,13 @@ export async function editAssetReminder({
     });
 
     const now = new Date();
-    if (now > reminder.alertDateTime) {
+    /**
+     * One-shot reminders become immutable after they fire (historical
+     * events). A RECURRING reminder stays editable even when its stored
+     * alertDateTime is briefly in the past (fire-to-fetch poll window) or
+     * the series ended — editing re-arms it with a new future date.
+     */
+    if (now > reminder.alertDateTime && !isRecurringReminder(reminder)) {
       throw new ShelfError({
         cause: null,
         message: "Edit is not allowed for this reminder.",
@@ -259,13 +316,37 @@ export async function editAssetReminder({
       });
     }
 
+    if (recurrence && !canUseRecurringReminders) {
+      const recurrenceChanged =
+        reminder.recurrenceUnit !== recurrence.unit ||
+        reminder.recurrenceInterval !== recurrence.interval ||
+        (reminder.recurrenceEndsAt?.getTime() ?? null) !==
+          (recurrence.endsAt?.getTime() ?? null);
+
+      if (!isRecurringReminder(reminder) || recurrenceChanged) {
+        throw new ShelfError({
+          cause: null,
+          title: "Not allowed",
+          message:
+            "Recurring reminders are not available on your workspace's current plan. Please upgrade your subscription to unlock this feature, or set a one-time reminder instead.",
+          label: "Tier",
+          additionalData: { id, organizationId },
+          shouldBeCaptured: false,
+        });
+      }
+    }
+
     const updatedReminder = await db.assetReminder.update({
-      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: reminder.id comes from the org-scoped findFirstOrThrow on lines 247-249 (where id + organizationId)
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: reminder.id comes from the org-scoped findFirstOrThrow above (where id + organizationId)
       where: { id: reminder.id },
       data: {
         name,
         message,
         alertDateTime,
+        recurrenceUnit: recurrence?.unit ?? null,
+        recurrenceInterval: recurrence?.interval ?? null,
+        recurrenceTimezone: recurrence?.timezone ?? null,
+        recurrenceEndsAt: recurrence?.endsAt ?? null,
         teamMembers: {
           set: [], // set empty so that if any team member is removed, the relation is removed
           connect: teamMembers.map((id) => ({ id })), // then connect
@@ -282,6 +363,7 @@ export async function editAssetReminder({
         eventType: ASSETS_EVENT_TYPE_MAP.REMINDER,
       },
       when,
+      options: recurrence ? recurringReminderJobOptions(reminder.id, when) : {},
     });
 
     return updatedReminder;
@@ -388,7 +470,9 @@ export async function getRemindersForOverviewPage({
       },
       take: 2,
       include: ASSET_REMINDER_INCLUDE_FIELDS,
-      orderBy: { alertDateTime: "desc" },
+      // why: asc = the NEXT two upcoming reminders (desc showed the two
+      // furthest-future ones; the home widget already uses asc)
+      orderBy: { alertDateTime: "asc" },
     });
 
     return reminders;

--- a/apps/webapp/app/modules/asset-reminder/service.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/service.server.ts
@@ -258,9 +258,10 @@ export async function getPaginatedAndFilterableReminders({
       db.assetReminder.count({ where: finalWhere }),
     ]);
 
-    // why: divide by the cookie-resolved perPage, not the raw query param —
-    // perPageParam defaults to 0 without a ?per_page, making this Infinity
-    const totalPages = Math.ceil(totalReminders / perPage);
+    // why: divide by `take` — the clamped page size the query actually used
+    // (the raw per_page param defaults to 0 → Infinity, and an out-of-range
+    // cookie perPage wouldn't match the query either)
+    const totalPages = Math.ceil(totalReminders / take);
 
     return {
       reminders,
@@ -370,7 +371,11 @@ export async function editAssetReminder({
         reminder.recurrenceUnit !== effectiveRecurrence.unit ||
         reminder.recurrenceInterval !== effectiveRecurrence.interval ||
         (reminder.recurrenceEndsAt?.getTime() ?? null) !==
-          (effectiveRecurrence.endsAt?.getTime() ?? null);
+          (effectiveRecurrence.endsAt?.getTime() ?? null) ||
+        // why: moving the next fire date re-anchors the whole series — that
+        // is recurring behavior too, so it's gated. Message/recipient edits
+        // round-trip the prefilled date unchanged and still pass.
+        reminder.alertDateTime.getTime() !== alertDateTime.getTime();
 
       if (!isRecurringReminder(reminder) || recurrenceChanged) {
         throw new ShelfError({

--- a/apps/webapp/app/modules/asset-reminder/service.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/service.server.ts
@@ -7,7 +7,7 @@ import { getParamsValues } from "~/utils/list";
 import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import { assertAssetsBelongToOrg } from "~/utils/org-validation.server";
 import { ASSET_REMINDER_INCLUDE_FIELDS } from "./fields";
-import { isRecurringReminder } from "./recurrence";
+import { isRecurringReminder, rebaseEndOfDayToZone } from "./recurrence";
 import {
   ASSETS_EVENT_TYPE_MAP,
   cancelAssetReminderScheduler,
@@ -33,6 +33,17 @@ export type ReminderRecurrenceInput = {
   endsAt: Date | null;
 } | null;
 
+/**
+ * Creates a reminder (optionally recurring) for an asset and schedules its
+ * pg-boss job. Recurring jobs are sent with retry + singleton options so a
+ * transient failure cannot kill the chain.
+ *
+ * @returns The created AssetReminder.
+ * @throws {ShelfError} 400 when the asset or recipients don't belong to the
+ *         caller's organization or recipients are stale; wrapped errors for
+ *         db/scheduler failures. The tier gate for recurrence is asserted by
+ *         the calling action (assertUserCanUseRecurringReminders).
+ */
 export async function createAssetReminder({
   name,
   message,
@@ -268,6 +279,22 @@ export async function getPaginatedAndFilterableReminders({
   }
 }
 
+/**
+ * Edits a reminder, including its recurrence configuration.
+ *
+ * Recurrence timezone semantics: the series' timezone is captured when
+ * recurrence is FIRST enabled and preserved on subsequent edits, even when
+ * the editor is in another timezone. Otherwise a plain edit (message/
+ * recipients) from another zone would silently re-anchor the series'
+ * wall-clock schedule and shift future occurrences across DST boundaries.
+ * The submitted end date's CALENDAR day is re-anchored (end-of-day) into
+ * the stored zone for the same reason.
+ *
+ * @returns The updated AssetReminder.
+ * @throws {ShelfError} 400 stale recipients; not-found for wrong org;
+ *         "Edit is not allowed" for fired one-shots; 403 when the edit adds
+ *         or changes recurrence and the tier lacks the capability.
+ */
 export async function editAssetReminder({
   id,
   name,
@@ -316,12 +343,34 @@ export async function editAssetReminder({
       });
     }
 
-    if (recurrence && !canUseRecurringReminders) {
+    /**
+     * Preserve the series' stored timezone once recurrence exists (see the
+     * function JSDoc), re-anchoring the submitted end date's calendar day
+     * into that zone. Because the timezone is never taken from the request
+     * for an existing series, a downgraded org cannot mutate the schedule
+     * via the zone either.
+     */
+    const effectiveRecurrence =
+      recurrence && isRecurringReminder(reminder)
+        ? {
+            ...recurrence,
+            timezone: reminder.recurrenceTimezone,
+            endsAt: recurrence.endsAt
+              ? rebaseEndOfDayToZone(
+                  recurrence.endsAt,
+                  recurrence.timezone,
+                  reminder.recurrenceTimezone
+                )
+              : null,
+          }
+        : recurrence;
+
+    if (effectiveRecurrence && !canUseRecurringReminders) {
       const recurrenceChanged =
-        reminder.recurrenceUnit !== recurrence.unit ||
-        reminder.recurrenceInterval !== recurrence.interval ||
+        reminder.recurrenceUnit !== effectiveRecurrence.unit ||
+        reminder.recurrenceInterval !== effectiveRecurrence.interval ||
         (reminder.recurrenceEndsAt?.getTime() ?? null) !==
-          (recurrence.endsAt?.getTime() ?? null);
+          (effectiveRecurrence.endsAt?.getTime() ?? null);
 
       if (!isRecurringReminder(reminder) || recurrenceChanged) {
         throw new ShelfError({
@@ -331,6 +380,7 @@ export async function editAssetReminder({
             "Recurring reminders are not available on your workspace's current plan. Please upgrade your subscription to unlock this feature, or set a one-time reminder instead.",
           label: "Tier",
           additionalData: { id, organizationId },
+          status: 403,
           shouldBeCaptured: false,
         });
       }
@@ -343,10 +393,10 @@ export async function editAssetReminder({
         name,
         message,
         alertDateTime,
-        recurrenceUnit: recurrence?.unit ?? null,
-        recurrenceInterval: recurrence?.interval ?? null,
-        recurrenceTimezone: recurrence?.timezone ?? null,
-        recurrenceEndsAt: recurrence?.endsAt ?? null,
+        recurrenceUnit: effectiveRecurrence?.unit ?? null,
+        recurrenceInterval: effectiveRecurrence?.interval ?? null,
+        recurrenceTimezone: effectiveRecurrence?.timezone ?? null,
+        recurrenceEndsAt: effectiveRecurrence?.endsAt ?? null,
         teamMembers: {
           set: [], // set empty so that if any team member is removed, the relation is removed
           connect: teamMembers.map((id) => ({ id })), // then connect
@@ -363,7 +413,9 @@ export async function editAssetReminder({
         eventType: ASSETS_EVENT_TYPE_MAP.REMINDER,
       },
       when,
-      options: recurrence ? recurringReminderJobOptions(reminder.id, when) : {},
+      options: effectiveRecurrence
+        ? recurringReminderJobOptions(reminder.id, when)
+        : {},
     });
 
     return updatedReminder;

--- a/apps/webapp/app/modules/asset-reminder/utils.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/utils.server.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+/**
+ * Round-trip regression for the recurrence end-date timezone handling.
+ *
+ * recurrenceEndsAt is stored as END-OF-DAY in the reminder's own timezone.
+ * The edit dialog must render the calendar date back in THAT zone (not UTC),
+ * otherwise west-of-UTC workspaces see the date +1 day and it drifts on every
+ * save. This test drives the real server parser + the exact formatting the
+ * dialog uses and asserts the stored instant is stable across edit cycles.
+ */
+import { DateTime } from "luxon";
+import { resolveRecurrenceZone } from "./recurrence";
+import { resolveReminderPayloadDates } from "./utils.server";
+
+// why: resolveReminderPayloadDates is pure, but importing utils.server pulls
+// in the service module graph (service.server -> db.server) which would
+// otherwise instantiate a real Prisma connection attempt during import
+vitest.mock("~/database/db.server", () => ({ db: {} }));
+
+function requestWithZone(timeZone: string): Request {
+  return new Request("https://app.shelf.nu/assets/a/reminders", {
+    headers: { Cookie: `CH-time-zone=${timeZone}` },
+  });
+}
+
+function formData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.set(k, v);
+  return fd;
+}
+
+/** Mirrors the dialog's endsAtDefault computation exactly. */
+function dialogEndsAtDefault(endsAt: Date, timezone: string | null): string {
+  return DateTime.fromJSDate(endsAt)
+    .setZone(resolveRecurrenceZone(timezone))
+    .toFormat("yyyy-MM-dd");
+}
+
+describe("resolveReminderPayloadDates end-date round-trip", () => {
+  it("does not drift across edit cycles for a west-of-UTC workspace", () => {
+    const zone = "America/New_York"; // UTC-4/-5
+
+    // STORE: user picks 2026-07-15 as the end date
+    const first = resolveReminderPayloadDates({
+      request: requestWithZone(zone),
+      formData: formData({
+        alertDateTime: "2026-07-10T09:00",
+        endsAt: "2026-07-15",
+      }),
+      repeat: "monthly",
+    });
+    const storedEndsAt = first.recurrence!.endsAt!;
+
+    // DISPLAY: the dialog renders the calendar date back in the stored zone
+    const shownDate = dialogEndsAtDefault(storedEndsAt, zone);
+    expect(shownDate).toBe("2026-07-15"); // NOT 2026-07-16
+
+    // RE-SUBMIT unchanged: the parsed instant must equal the stored one
+    const second = resolveReminderPayloadDates({
+      request: requestWithZone(zone),
+      formData: formData({
+        alertDateTime: "2026-07-10T09:00",
+        endsAt: shownDate,
+      }),
+      repeat: "monthly",
+    });
+    expect(second.recurrence!.endsAt!.getTime()).toBe(storedEndsAt.getTime());
+  });
+
+  it("stores the end date as end-of-day in the workspace zone", () => {
+    const { recurrence } = resolveReminderPayloadDates({
+      request: requestWithZone("America/New_York"),
+      formData: formData({
+        alertDateTime: "2026-07-10T09:00",
+        endsAt: "2026-07-15",
+      }),
+      repeat: "weekly",
+    });
+    // 2026-07-15 23:59:59.999 in New York (EDT, -04:00) = 2026-07-16T03:59:59.999Z
+    expect(recurrence!.endsAt!.toISOString()).toBe("2026-07-16T03:59:59.999Z");
+  });
+
+  it("returns null recurrence for a one-shot (repeat = never)", () => {
+    const { recurrence } = resolveReminderPayloadDates({
+      request: requestWithZone("UTC"),
+      formData: formData({ alertDateTime: "2026-07-10T09:00" }),
+      repeat: "never",
+    });
+    expect(recurrence).toBeNull();
+  });
+
+  it("captures the workspace timezone on the recurrence payload", () => {
+    const { recurrence } = resolveReminderPayloadDates({
+      request: requestWithZone("Europe/Berlin"),
+      formData: formData({ alertDateTime: "2026-07-10T09:00" }),
+      repeat: "quarterly",
+    });
+    expect(recurrence!.timezone).toBe("Europe/Berlin");
+    expect(recurrence!.endsAt).toBeNull();
+  });
+});

--- a/apps/webapp/app/modules/asset-reminder/utils.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/utils.server.test.ts
@@ -40,12 +40,12 @@ describe("resolveReminderPayloadDates end-date round-trip", () => {
   it("does not drift across edit cycles for a west-of-UTC workspace", () => {
     const zone = "America/New_York"; // UTC-4/-5
 
-    // STORE: user picks 2026-07-15 as the end date
+    // STORE: user picks 2099-07-15 as the end date
     const first = resolveReminderPayloadDates({
       request: requestWithZone(zone),
       formData: formData({
-        alertDateTime: "2026-07-10T09:00",
-        endsAt: "2026-07-15",
+        alertDateTime: "2099-07-10T09:00",
+        endsAt: "2099-07-15",
       }),
       repeat: "monthly",
     });
@@ -53,13 +53,13 @@ describe("resolveReminderPayloadDates end-date round-trip", () => {
 
     // DISPLAY: the dialog renders the calendar date back in the stored zone
     const shownDate = dialogEndsAtDefault(storedEndsAt, zone);
-    expect(shownDate).toBe("2026-07-15"); // NOT 2026-07-16
+    expect(shownDate).toBe("2099-07-15"); // NOT 2099-07-16
 
     // RE-SUBMIT unchanged: the parsed instant must equal the stored one
     const second = resolveReminderPayloadDates({
       request: requestWithZone(zone),
       formData: formData({
-        alertDateTime: "2026-07-10T09:00",
+        alertDateTime: "2099-07-10T09:00",
         endsAt: shownDate,
       }),
       repeat: "monthly",
@@ -71,19 +71,37 @@ describe("resolveReminderPayloadDates end-date round-trip", () => {
     const { recurrence } = resolveReminderPayloadDates({
       request: requestWithZone("America/New_York"),
       formData: formData({
-        alertDateTime: "2026-07-10T09:00",
-        endsAt: "2026-07-15",
+        alertDateTime: "2099-07-10T09:00",
+        endsAt: "2099-07-15",
       }),
       repeat: "weekly",
     });
-    // 2026-07-15 23:59:59.999 in New York (EDT, -04:00) = 2026-07-16T03:59:59.999Z
-    expect(recurrence!.endsAt!.toISOString()).toBe("2026-07-16T03:59:59.999Z");
+    // 2099-07-15 23:59:59.999 in New York (EDT, -04:00) = 2099-07-16T03:59:59.999Z
+    expect(recurrence!.endsAt!.toISOString()).toBe("2099-07-16T03:59:59.999Z");
+  });
+
+  it("rejects a past alertDateTime against the RESOLVED instant (field-level 400)", () => {
+    let thrown: any = null;
+    try {
+      resolveReminderPayloadDates({
+        request: requestWithZone("America/New_York"),
+        formData: formData({ alertDateTime: "2020-01-01T09:00" }),
+        repeat: "never",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).not.toBeNull();
+    expect(thrown.status).toBe(400);
+    expect(thrown.additionalData.validationErrors.alertDateTime.message).toBe(
+      "Please select a date in the future"
+    );
   });
 
   it("returns null recurrence for a one-shot (repeat = never)", () => {
     const { recurrence } = resolveReminderPayloadDates({
       request: requestWithZone("UTC"),
-      formData: formData({ alertDateTime: "2026-07-10T09:00" }),
+      formData: formData({ alertDateTime: "2099-07-10T09:00" }),
       repeat: "never",
     });
     expect(recurrence).toBeNull();
@@ -92,7 +110,7 @@ describe("resolveReminderPayloadDates end-date round-trip", () => {
   it("captures the workspace timezone on the recurrence payload", () => {
     const { recurrence } = resolveReminderPayloadDates({
       request: requestWithZone("Europe/Berlin"),
-      formData: formData({ alertDateTime: "2026-07-10T09:00" }),
+      formData: formData({ alertDateTime: "2099-07-10T09:00" }),
       repeat: "quarterly",
     });
     expect(recurrence!.timezone).toBe("Europe/Berlin");

--- a/apps/webapp/app/modules/asset-reminder/utils.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/utils.server.test.ts
@@ -98,6 +98,40 @@ describe("resolveReminderPayloadDates end-date round-trip", () => {
     );
   });
 
+  it("rejects an end date before the reminder on the RESOLVED instants (field-level 400)", () => {
+    let thrown: any = null;
+    try {
+      resolveReminderPayloadDates({
+        request: requestWithZone("America/New_York"),
+        formData: formData({
+          alertDateTime: "2099-07-10T09:00",
+          endsAt: "2099-07-01",
+        }),
+        repeat: "monthly",
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown?.status).toBe(400);
+    expect(thrown?.additionalData.validationErrors.endsAt.message).toBe(
+      "End date must be on or after the reminder date"
+    );
+  });
+
+  it("accepts a same-day end date with a late-evening reminder for west-of-UTC users", () => {
+    // 23:30 New York on July 15 = 03:30Z July 16; end-of-day NY July 15 =
+    // 03:59:59.999Z July 16 — same-day is valid and must not be rejected.
+    const { recurrence } = resolveReminderPayloadDates({
+      request: requestWithZone("America/New_York"),
+      formData: formData({
+        alertDateTime: "2099-07-15T23:30",
+        endsAt: "2099-07-15",
+      }),
+      repeat: "weekly",
+    });
+    expect(recurrence!.endsAt!.toISOString()).toBe("2099-07-16T03:59:59.999Z");
+  });
+
   it("returns null recurrence for a one-shot (repeat = never)", () => {
     const { recurrence } = resolveReminderPayloadDates({
       request: requestWithZone("UTC"),

--- a/apps/webapp/app/modules/asset-reminder/utils.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/utils.server.ts
@@ -2,11 +2,12 @@ import type { AssetReminder, Organization } from "@prisma/client";
 import { DateTime, IANAZone } from "luxon";
 import { redirect } from "react-router";
 import { z } from "zod";
-import { editReminderSchema } from "~/components/asset-reminder/set-or-edit-reminder-dialog";
+import { editReminderServerSchema } from "~/components/asset-reminder/set-or-edit-reminder-dialog";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getHints } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
+import { ShelfError, VALIDATION_ERROR } from "~/utils/error";
 import { payload, parseData, safeRedirect } from "~/utils/http.server";
 import { canUseRecurringReminders } from "~/utils/subscription.server";
 import {
@@ -32,9 +33,17 @@ type OrganizationsForTier = {
  * - The datetime-local string is wall-clock in the USER's zone (client-hint
  *   cookie); we parse it with luxon in a VALIDATED zone (tampered/unknown
  *   cookie values fall back to UTC instead of producing an Invalid Date).
+ * - The "date must be in the future" rule is enforced HERE, against the
+ *   correctly-resolved instant. The zod schemas deliberately skip it
+ *   server-side: z.coerce.date() would read the raw string in the server's
+ *   zone and wrongly reject valid future times for users west of UTC.
  * - The optional endsAt date (no time component) is interpreted as
  *   END-OF-DAY in that same zone so "ends on July 15" includes July 15's
  *   occurrence for users ahead of UTC.
+ *
+ * @throws {ShelfError} 400 with a field-level validation error (matching the
+ *         parseData shape so the form shows it on the input) when the
+ *         resolved alertDateTime is not in the future.
  */
 export function resolveReminderPayloadDates({
   request,
@@ -53,6 +62,22 @@ export function resolveReminderPayloadDates({
     DATE_TIME_FORMAT,
     { zone }
   ).toJSDate();
+
+  if (isNaN(alertDateTime.getTime()) || alertDateTime.getTime() <= Date.now()) {
+    throw new ShelfError({
+      cause: null,
+      title: "Validation error",
+      message: "Please select a date in the future",
+      additionalData: {
+        [VALIDATION_ERROR]: {
+          alertDateTime: { message: "Please select a date in the future" },
+        },
+      },
+      label: "Asset Reminder",
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
 
   if (repeat === "never") {
     return { alertDateTime, recurrence: null };
@@ -104,7 +129,7 @@ export async function resolveRemindersActions({
     case "edit-reminder": {
       const { redirectTo, ...payload } = parseData(
         formData,
-        editReminderSchema,
+        editReminderServerSchema,
         // Expected user-input validation (e.g. "Please select a date in the
         // future") — a 400, not a server error. The create path already opts
         // out; mirror it here (was noise: SHELF-WEBAPP-1ME).

--- a/apps/webapp/app/modules/asset-reminder/utils.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/utils.server.ts
@@ -86,11 +86,36 @@ export function resolveReminderPayloadDates({
   const preset = REMINDER_REPEAT_PRESETS[repeat];
 
   const rawEndsAt = formData.get("endsAt")?.toString();
-  const endsAt = rawEndsAt
+  const parsedEndsAt = rawEndsAt
     ? DateTime.fromFormat(rawEndsAt, "yyyy-MM-dd", { zone })
         .endOf("day")
         .toJSDate()
     : null;
+  const endsAt =
+    parsedEndsAt && !isNaN(parsedEndsAt.getTime()) ? parsedEndsAt : null;
+
+  /**
+   * Authoritative endsAt ordering check on the ZONE-RESOLVED values (both in
+   * the user's zone: endsAt as end-of-day, alertDateTime as the picked
+   * instant). The zod schemas can't do this correctly: type="date" coerces
+   * at UTC midnight while datetime-local coerces in the parser's zone, which
+   * wrongly rejected valid same-day evening reminders west of UTC.
+   */
+  if (endsAt && endsAt.getTime() < alertDateTime.getTime()) {
+    throw new ShelfError({
+      cause: null,
+      title: "Validation error",
+      message: "End date must be on or after the reminder date",
+      additionalData: {
+        [VALIDATION_ERROR]: {
+          endsAt: { message: "End date must be on or after the reminder date" },
+        },
+      },
+      label: "Asset Reminder",
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
 
   return {
     alertDateTime,
@@ -98,7 +123,7 @@ export function resolveReminderPayloadDates({
       unit: preset.unit,
       interval: preset.interval,
       timezone: zone,
-      endsAt: endsAt && !isNaN(endsAt.getTime()) ? endsAt : null,
+      endsAt,
     },
   };
 }

--- a/apps/webapp/app/modules/asset-reminder/utils.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/utils.server.ts
@@ -1,14 +1,82 @@
-import type { AssetReminder } from "@prisma/client";
-import { DateTime } from "luxon";
+import type { AssetReminder, Organization } from "@prisma/client";
+import { DateTime, IANAZone } from "luxon";
 import { redirect } from "react-router";
 import { z } from "zod";
-import { setReminderSchema } from "~/components/asset-reminder/set-or-edit-reminder-dialog";
+import { editReminderSchema } from "~/components/asset-reminder/set-or-edit-reminder-dialog";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getHints } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { payload, parseData, safeRedirect } from "~/utils/http.server";
+import { canUseRecurringReminders } from "~/utils/subscription.server";
+import {
+  REMINDER_REPEAT_PRESETS,
+  type ReminderRepeatValue,
+} from "./recurrence";
+import type { ReminderRecurrenceInput } from "./service.server";
 import { deleteAssetReminder, editAssetReminder } from "./service.server";
+import { getOrganizationTierLimit } from "../tier/service.server";
+
+type OrganizationsForTier = {
+  id: string;
+  type: Organization["type"];
+  name: string;
+  imageId: string | null;
+  userId: string;
+}[];
+
+/**
+ * Resolves the timezone-dependent parts of a reminder form submission:
+ * the alertDateTime instant and the recurrence payload.
+ *
+ * - The datetime-local string is wall-clock in the USER's zone (client-hint
+ *   cookie); we parse it with luxon in a VALIDATED zone (tampered/unknown
+ *   cookie values fall back to UTC instead of producing an Invalid Date).
+ * - The optional endsAt date (no time component) is interpreted as
+ *   END-OF-DAY in that same zone so "ends on July 15" includes July 15's
+ *   occurrence for users ahead of UTC.
+ */
+export function resolveReminderPayloadDates({
+  request,
+  formData,
+  repeat,
+}: {
+  request: Request;
+  formData: FormData;
+  repeat: ReminderRepeatValue;
+}): { alertDateTime: Date; recurrence: ReminderRecurrenceInput } {
+  const hints = getHints(request);
+  const zone = IANAZone.isValidZone(hints.timeZone) ? hints.timeZone : "UTC";
+
+  const alertDateTime = DateTime.fromFormat(
+    formData.get("alertDateTime")!.toString()!,
+    DATE_TIME_FORMAT,
+    { zone }
+  ).toJSDate();
+
+  if (repeat === "never") {
+    return { alertDateTime, recurrence: null };
+  }
+
+  const preset = REMINDER_REPEAT_PRESETS[repeat];
+
+  const rawEndsAt = formData.get("endsAt")?.toString();
+  const endsAt = rawEndsAt
+    ? DateTime.fromFormat(rawEndsAt, "yyyy-MM-dd", { zone })
+        .endOf("day")
+        .toJSDate()
+    : null;
+
+  return {
+    alertDateTime,
+    recurrence: {
+      unit: preset.unit,
+      interval: preset.interval,
+      timezone: zone,
+      endsAt: endsAt && !isNaN(endsAt.getTime()) ? endsAt : null,
+    },
+  };
+}
 
 /**
  * This function handles the editing and deleting of reminders..
@@ -17,10 +85,12 @@ import { deleteAssetReminder, editAssetReminder } from "./service.server";
 export async function resolveRemindersActions({
   request,
   organizationId,
+  organizations,
   userId,
 }: {
   request: Request;
   organizationId: AssetReminder["organizationId"];
+  organizations: OrganizationsForTier;
   userId: AssetReminder["createdById"];
 }) {
   const formData = await request.formData();
@@ -34,20 +104,28 @@ export async function resolveRemindersActions({
     case "edit-reminder": {
       const { redirectTo, ...payload } = parseData(
         formData,
-        setReminderSchema.extend({ id: z.string() }),
+        editReminderSchema,
         // Expected user-input validation (e.g. "Please select a date in the
         // future") — a 400, not a server error. The create path already opts
         // out; mirror it here (was noise: SHELF-WEBAPP-1ME).
         { shouldBeCaptured: false }
       );
 
-      const hints = getHints(request);
+      const { alertDateTime, recurrence } = resolveReminderPayloadDates({
+        request,
+        formData,
+        repeat: payload.repeat,
+      });
 
-      const alertDateTime = DateTime.fromFormat(
-        formData.get("alertDateTime")!.toString()!,
-        DATE_TIME_FORMAT,
-        { zone: hints.timeZone }
-      ).toJSDate();
+      /**
+       * The tier capability is passed to the service, which only enforces it
+       * when this edit ADDS or CHANGES recurrence relative to the stored row
+       * (downgraded workspaces keep editing other fields).
+       */
+      const tierLimit = await getOrganizationTierLimit({
+        organizationId,
+        organizations,
+      });
 
       await editAssetReminder({
         id: payload.id,
@@ -55,6 +133,8 @@ export async function resolveRemindersActions({
         message: payload.message,
         teamMembers: payload.teamMembers,
         alertDateTime,
+        recurrence,
+        canUseRecurringReminders: canUseRecurringReminders(tierLimit),
         organizationId,
       });
 

--- a/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
@@ -1,0 +1,286 @@
+// @vitest-environment node
+import { ReminderRecurrenceUnit } from "@prisma/client";
+import { db } from "~/database/db.server";
+import { sendEmail } from "~/emails/mail.server";
+import { Logger } from "~/utils/logger";
+import { scheduler } from "~/utils/scheduler.server";
+import { advanceRecurringReminder } from "./chain.server";
+import {
+  scheduleAssetReminder,
+  type AssetsSchedulerData,
+} from "./scheduler.server";
+import { regierAssetWorkers, RecurringAdvanceError } from "./worker.server";
+import { createNote } from "../note/service.server";
+
+// why: testing the worker handler without a real database
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    assetReminder: {
+      findFirst: vitest.fn().mockResolvedValue(null),
+    },
+    user: {
+      findFirst: vitest.fn().mockResolvedValue(null),
+    },
+  },
+}));
+
+// why: preventing real pg-boss registration; the handler is extracted from
+// the work() mock
+vitest.mock("~/utils/scheduler.server", () => ({
+  scheduler: {
+    work: vitest.fn(),
+    cancel: vitest.fn(),
+    sendAfter: vitest.fn(),
+  },
+  QueueNames: {
+    assetsQueue: "assets-queue",
+  },
+}));
+
+// why: the advance step is unit-tested in chain.server.test.ts; here we only
+// verify the worker calls it at the right time and handles its outcomes
+vitest.mock("./chain.server", () => ({
+  ADVANCE_CLOCK_EPSILON_MS: 60 * 1000,
+  advanceRecurringReminder: vitest
+    .fn()
+    .mockResolvedValue({ next: null, advanced: false, paused: false }),
+}));
+
+// why: asserting the orphan-recovery branch re-arms the pending occurrence
+// without invoking the full scheduler
+vitest.mock("./scheduler.server", async (importOriginal) => {
+  const original = (await importOriginal()) as object;
+  return {
+    ...original,
+    scheduleAssetReminder: vitest.fn().mockResolvedValue(undefined),
+  };
+});
+
+// why: preventing real email template rendering during tests
+vitest.mock("./emails", () => ({
+  assetAlertEmailHtmlString: vitest.fn().mockResolvedValue("<html></html>"),
+  assetAlertEmailText: vitest.fn().mockReturnValue("text"),
+}));
+
+// why: preventing actual email sending during tests
+vitest.mock("~/emails/mail.server", () => ({
+  sendEmail: vitest.fn(),
+}));
+
+// why: preventing actual note creation during worker tests
+vitest.mock("../note/service.server", () => ({
+  createNote: vitest.fn().mockResolvedValue({}),
+}));
+
+// why: spying on Logger to verify warn/skip behavior without side effects
+vitest.mock("~/utils/logger", () => ({
+  Logger: { warn: vitest.fn(), info: vitest.fn(), error: vitest.fn() },
+}));
+
+type WorkerJob = { id?: string; data: AssetsSchedulerData };
+
+/**
+ * Extracts the internal REMINDER handler by registering the worker and
+ * capturing the callback passed to scheduler.work (same pattern as the
+ * booking worker tests).
+ */
+async function getWorkerHandler(): Promise<(job: WorkerJob) => Promise<void>> {
+  await regierAssetWorkers();
+  const workMock = scheduler.work as ReturnType<typeof vitest.fn>;
+  return workMock.mock.calls[0][1];
+}
+
+function buildReminderRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "reminder-1",
+    name: "Calibrate flow meter",
+    message: "Quarterly calibration",
+    organizationId: "org-1",
+    assetId: "asset-1",
+    createdById: "user-1",
+    alertDateTime: new Date(Date.now() - 60_000),
+    activeSchedulerReference: "job-1",
+    recurrenceUnit: null,
+    recurrenceInterval: null,
+    recurrenceTimezone: null,
+    recurrenceEndsAt: null,
+    teamMembers: [
+      {
+        user: {
+          email: "tech@example.com",
+          firstName: "Tess",
+          lastName: "Tech",
+          displayName: "Tess Tech",
+        },
+      },
+    ],
+    asset: {
+      id: "asset-1",
+      title: "Flow meter",
+      mainImage: null,
+      mainImageExpiration: null,
+    },
+    organization: { name: "Acme", customEmailFooter: null },
+    ...overrides,
+  };
+}
+
+const JOB: WorkerJob = {
+  id: "job-1",
+  data: { reminderId: "reminder-1", eventType: "REMINDER" },
+};
+
+let handler: (job: WorkerJob) => Promise<void>;
+
+beforeAll(async () => {
+  handler = await getWorkerHandler();
+});
+
+beforeEach(() => {
+  vitest.clearAllMocks();
+  (advanceRecurringReminder as any).mockResolvedValue({
+    next: null,
+    advanced: false,
+    paused: false,
+  });
+});
+
+describe("REMINDER worker handler", () => {
+  it("fires a one-shot reminder: emails + note, no advance", async () => {
+    (db.assetReminder.findFirst as any).mockResolvedValue(buildReminderRow());
+
+    await handler(JOB);
+
+    expect(advanceRecurringReminder).not.toHaveBeenCalled();
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(createNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "**System** has sent **Calibrate flow meter** reminder.",
+      })
+    );
+  });
+
+  it("skips silently when the reminder row is gone (deleted asset/reminder)", async () => {
+    (db.assetReminder.findFirst as any).mockResolvedValue(null);
+
+    await handler(JOB);
+
+    expect(Logger.warn).toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(createNote).not.toHaveBeenCalled();
+  });
+
+  it("skips a stale job (row tracks a different live job) without notifying or advancing", async () => {
+    (db.assetReminder.findFirst as any).mockResolvedValue(
+      buildReminderRow({ activeSchedulerReference: "job-NEWER" })
+    );
+
+    await handler(JOB);
+
+    expect(Logger.warn).toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(advanceRecurringReminder).not.toHaveBeenCalled();
+  });
+
+  it("fires permissively when the stored reference is null (unknown state)", async () => {
+    (db.assetReminder.findFirst as any).mockResolvedValue(
+      buildReminderRow({ activeSchedulerReference: null })
+    );
+
+    await handler(JOB);
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("advances a due recurring series BEFORE notifying and mentions the next date in the note", async () => {
+    const next = new Date("2026-08-02T09:00:00.000Z");
+    const callOrder: string[] = [];
+    (advanceRecurringReminder as any).mockImplementation(() => {
+      callOrder.push("advance");
+      return Promise.resolve({ next, advanced: true, paused: false });
+    });
+    (sendEmail as any).mockImplementation(() => {
+      callOrder.push("email");
+    });
+    (db.assetReminder.findFirst as any).mockResolvedValue(
+      buildReminderRow({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 1,
+        recurrenceTimezone: "UTC",
+      })
+    );
+
+    await handler(JOB);
+
+    expect(callOrder[0]).toBe("advance");
+    expect(callOrder).toContain("email");
+    expect(createNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("Next reminder scheduled for"),
+      })
+    );
+  });
+
+  it("re-arms an orphaned occurrence on retry (row advanced but next job never scheduled)", async () => {
+    // The row already points at a future occurrence, and THIS job is still the
+    // row's active reference (self-match) — the sendAfter failed on a prior
+    // attempt. The worker must re-schedule that occurrence, not advance again.
+    const future = new Date(Date.now() + 10 * 60_000);
+    (db.assetReminder.findFirst as any).mockResolvedValue(
+      buildReminderRow({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 1,
+        alertDateTime: future,
+        activeSchedulerReference: "job-1", // == JOB.id (not stale)
+      })
+    );
+
+    await handler(JOB);
+
+    expect(advanceRecurringReminder).not.toHaveBeenCalled();
+    expect(scheduleAssetReminder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        when: future,
+        options: expect.objectContaining({ retryLimit: 3 }),
+      })
+    );
+    // the fired occurrence still notifies (at-least-once)
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("notes the pause when the workspace tier lost recurrence", async () => {
+    (advanceRecurringReminder as any).mockResolvedValue({
+      next: null,
+      advanced: false,
+      paused: true,
+    });
+    (db.assetReminder.findFirst as any).mockResolvedValue(
+      buildReminderRow({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 1,
+      })
+    );
+
+    await handler(JOB);
+
+    expect(createNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("paused"),
+      })
+    );
+  });
+
+  it("rethrows advance failures as RecurringAdvanceError so pg-boss retries (no email sent first)", async () => {
+    (advanceRecurringReminder as any).mockRejectedValue(new Error("boom"));
+    (db.assetReminder.findFirst as any).mockResolvedValue(
+      buildReminderRow({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 1,
+      })
+    );
+
+    await expect(handler(JOB)).rejects.toBeInstanceOf(RecurringAdvanceError);
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(createNote).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
@@ -43,7 +43,12 @@ vitest.mock("./chain.server", () => ({
   ADVANCE_CLOCK_EPSILON_MS: 60 * 1000,
   advanceRecurringReminder: vitest
     .fn()
-    .mockResolvedValue({ next: null, advanced: false, paused: false }),
+    .mockResolvedValue({
+      next: null,
+      advanced: false,
+      paused: false,
+      ended: false,
+    }),
 }));
 
 // why: asserting the orphan-recovery branch re-arms the pending occurrence
@@ -142,6 +147,7 @@ beforeEach(() => {
     next: null,
     advanced: false,
     paused: false,
+    ended: false,
   });
 });
 
@@ -197,7 +203,12 @@ describe("REMINDER worker handler", () => {
     const callOrder: string[] = [];
     (advanceRecurringReminder as any).mockImplementation(() => {
       callOrder.push("advance");
-      return Promise.resolve({ next, advanced: true, paused: false });
+      return Promise.resolve({
+        next,
+        advanced: true,
+        paused: false,
+        ended: false,
+      });
     });
     (sendEmail as any).mockImplementation(() => {
       callOrder.push("email");
@@ -248,11 +259,35 @@ describe("REMINDER worker handler", () => {
     expect(sendEmail).toHaveBeenCalledTimes(1);
   });
 
+  it("notes the final occurrence when the series ends (end date reached)", async () => {
+    (advanceRecurringReminder as any).mockResolvedValue({
+      next: null,
+      advanced: false,
+      paused: false,
+      ended: true,
+    });
+    (db.assetReminder.findFirst as any).mockResolvedValue(
+      buildReminderRow({
+        recurrenceUnit: ReminderRecurrenceUnit.MONTH,
+        recurrenceInterval: 1,
+      })
+    );
+
+    await handler(JOB);
+
+    expect(createNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("last occurrence"),
+      })
+    );
+  });
+
   it("notes the pause when the workspace tier lost recurrence", async () => {
     (advanceRecurringReminder as any).mockResolvedValue({
       next: null,
       advanced: false,
       paused: true,
+      ended: false,
     });
     (db.assetReminder.findFirst as any).mockResolvedValue(
       buildReminderRow({

--- a/apps/webapp/app/modules/asset-reminder/worker.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/worker.server.ts
@@ -1,5 +1,4 @@
 import type { Prisma, User } from "@prisma/client";
-import { DateTime } from "luxon";
 import type PgBoss from "pg-boss";
 import { db } from "~/database/db.server";
 import { sendEmail } from "~/emails/mail.server";
@@ -11,7 +10,7 @@ import {
   advanceRecurringReminder,
 } from "./chain.server";
 import { assetAlertEmailHtmlString, assetAlertEmailText } from "./emails";
-import { isRecurringReminder, resolveRecurrenceZone } from "./recurrence";
+import { formatOccurrenceInZone, isRecurringReminder } from "./recurrence";
 import {
   ASSETS_EVENT_TYPE_MAP,
   recurringReminderJobOptions,
@@ -127,6 +126,7 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
     const now = new Date();
     let nextOccurrence: Date | null = null;
     let seriesPaused = false;
+    let seriesEnded = false;
 
     if (isRecurringReminder(reminder)) {
       const dueNow =
@@ -136,12 +136,13 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
       try {
         if (dueNow) {
           // Normal fire: advance the row and schedule the next occurrence.
-          const { next, paused } = await advanceRecurringReminder({
+          const { next, paused, ended } = await advanceRecurringReminder({
             reminder,
             now,
           });
           nextOccurrence = next;
           seriesPaused = paused;
+          seriesEnded = ended;
         } else {
           // The row already points at a FUTURE occurrence while this job is
           // firing. The stale-job guard above proved this job is still the
@@ -220,11 +221,12 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
      */
     let noteContent = `**System** has sent **${reminder.name.trim()}** reminder.`;
     if (nextOccurrence) {
-      const zone = resolveRecurrenceZone(reminder.recurrenceTimezone);
-      const formattedNext = DateTime.fromJSDate(nextOccurrence)
-        .setZone(zone)
-        .toFormat("d LLL yyyy, HH:mm");
-      noteContent += ` Next reminder scheduled for ${formattedNext} (${zone}).`;
+      noteContent += ` Next reminder scheduled for ${formatOccurrenceInZone(
+        nextOccurrence,
+        reminder.recurrenceTimezone
+      )}.`;
+    } else if (seriesEnded) {
+      noteContent += ` This was the last occurrence of this recurring reminder (end date reached).`;
     } else if (seriesPaused) {
       noteContent += ` This recurring reminder was paused because the workspace plan no longer includes recurring reminders.`;
     }

--- a/apps/webapp/app/modules/asset-reminder/worker.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/worker.server.ts
@@ -1,13 +1,39 @@
 import type { Prisma, User } from "@prisma/client";
+import { DateTime } from "luxon";
 import type PgBoss from "pg-boss";
 import { db } from "~/database/db.server";
 import { sendEmail } from "~/emails/mail.server";
 import { ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
 import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import {
+  ADVANCE_CLOCK_EPSILON_MS,
+  advanceRecurringReminder,
+} from "./chain.server";
 import { assetAlertEmailHtmlString, assetAlertEmailText } from "./emails";
+import { isRecurringReminder, resolveRecurrenceZone } from "./recurrence";
+import {
+  ASSETS_EVENT_TYPE_MAP,
+  recurringReminderJobOptions,
+  scheduleAssetReminder,
+} from "./scheduler.server";
 import type { AssetsEventType, AssetsSchedulerData } from "./scheduler.server";
 import { createNote } from "../note/service.server";
+
+/**
+ * Marks a failure of the recurring-reminder advance step. The worker wrapper
+ * RETHROWS these (recurring jobs are sent with retryLimit 3, so pg-boss
+ * retries the job) while keeping the historical swallow-and-log behavior for
+ * everything else. Ordering guarantees retries cannot double-email: the
+ * advance step runs BEFORE any notification is sent.
+ */
+export class RecurringAdvanceError extends Error {
+  constructor(cause: unknown, reminderId: string) {
+    super(`Failed to advance recurring reminder ${reminderId}`);
+    this.name = "RecurringAdvanceError";
+    this.cause = cause;
+  }
+}
 
 const ASSET_REMINDER_INCLUDES_FOR_EMAIL = {
   teamMembers: {
@@ -64,6 +90,85 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
       return;
     }
 
+    /**
+     * Stale-job guard: when the row tracks a DIFFERENT live job than the one
+     * firing, this job was superseded (an edit whose cancel silently failed,
+     * or a reconciliation re-arm) — firing it would double-notify or corrupt
+     * the chain. A null reference is permissive (unknown state: fire).
+     */
+    if (
+      reminder.activeSchedulerReference &&
+      job.id &&
+      reminder.activeSchedulerReference !== job.id
+    ) {
+      Logger.warn(
+        new ShelfError({
+          cause: null,
+          message:
+            "Skipping stale asset reminder job (superseded by a newer schedule).",
+          additionalData: {
+            ...job.data,
+            jobId: job.id,
+            activeSchedulerReference: reminder.activeSchedulerReference,
+          },
+          label: "Asset Scheduler",
+          shouldBeCaptured: false,
+        })
+      );
+      return;
+    }
+
+    /**
+     * Recurring series: advance the row to the next occurrence and schedule
+     * the next job BEFORE notifying. If this critical step fails the error
+     * escapes the wrapper as RecurringAdvanceError so pg-boss retries the
+     * job — no email has gone out yet, so a retry cannot double-send.
+     */
+    const now = new Date();
+    let nextOccurrence: Date | null = null;
+    let seriesPaused = false;
+
+    if (isRecurringReminder(reminder)) {
+      const dueNow =
+        reminder.alertDateTime.getTime() <=
+        now.getTime() + ADVANCE_CLOCK_EPSILON_MS;
+
+      try {
+        if (dueNow) {
+          // Normal fire: advance the row and schedule the next occurrence.
+          const { next, paused } = await advanceRecurringReminder({
+            reminder,
+            now,
+          });
+          nextOccurrence = next;
+          seriesPaused = paused;
+        } else {
+          // The row already points at a FUTURE occurrence while this job is
+          // firing. The stale-job guard above proved this job is still the
+          // row's active job (or the reference is null), so we are NOT looking
+          // at a concurrent edit — the advance committed on a prior attempt
+          // but scheduling the next job did not durably succeed (transient
+          // sendAfter failure). Re-arm it idempotently (the singletonKey
+          // dedupes if the job already exists) so the series is not orphaned
+          // until boot reconciliation.
+          await scheduleAssetReminder({
+            data: {
+              reminderId: reminder.id,
+              eventType: ASSETS_EVENT_TYPE_MAP.REMINDER,
+            },
+            when: reminder.alertDateTime,
+            options: recurringReminderJobOptions(
+              reminder.id,
+              reminder.alertDateTime
+            ),
+          });
+          nextOccurrence = reminder.alertDateTime;
+        }
+      } catch (cause) {
+        throw new RecurringAdvanceError(cause, reminder.id);
+      }
+    }
+
     const usersToSendEmail = reminder.teamMembers
       .filter((tm) => !!tm.user)
       .map((teamMember) => teamMember.user! as UserToEmail);
@@ -109,6 +214,21 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
       });
     }
 
+    /**
+     * Note text reflects the chain state so users can see why a series
+     * continues, ended, or stopped, straight from the asset activity.
+     */
+    let noteContent = `**System** has sent **${reminder.name.trim()}** reminder.`;
+    if (nextOccurrence) {
+      const zone = resolveRecurrenceZone(reminder.recurrenceTimezone);
+      const formattedNext = DateTime.fromJSDate(nextOccurrence)
+        .setZone(zone)
+        .toFormat("d LLL yyyy, HH:mm");
+      noteContent += ` Next reminder scheduled for ${formattedNext} (${zone}).`;
+    } else if (seriesPaused) {
+      noteContent += ` This recurring reminder was paused because the workspace plan no longer includes recurring reminders.`;
+    }
+
     /** Sending alert mails to all associated users. */
     await Promise.all([
       ...usersToSendEmail.map(async (user) => {
@@ -119,6 +239,7 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
           workspaceName: reminder.organization.name,
           isOwner: user.isOwner,
           customEmailFooter: reminder.organization.customEmailFooter,
+          nextOccurrence,
         });
 
         sendEmail({
@@ -131,6 +252,7 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
             workspaceName: reminder.organization.name,
             isOwner: user.isOwner,
             customEmailFooter: reminder.organization.customEmailFooter,
+            nextOccurrence,
           }),
           html,
         });
@@ -143,7 +265,7 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
         organizationId: reminder.organizationId,
         userId: reminder.createdById,
         type: "UPDATE",
-        content: `**System** has sent **${reminder.name.trim()}** reminder.`,
+        content: noteContent,
       }),
     ]);
   },
@@ -170,6 +292,16 @@ export async function regierAssetWorkers() {
             label: "Asset Scheduler",
           })
         );
+
+        /**
+         * Recurring-chain advance failures must reach pg-boss so the job is
+         * retried (recurring jobs are sent with retryLimit 3). Everything
+         * else keeps the historical swallow-and-log (at-most-once) behavior
+         * so one-shot reminder semantics are unchanged.
+         */
+        if (cause instanceof RecurringAdvanceError) {
+          throw cause;
+        }
       }
     }
   );

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -2074,7 +2074,9 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
           'id', ar.id,
           'name', ar.name,
           'message', ar.message,
-          'alertDateTime', ar."alertDateTime"
+          'alertDateTime', ar."alertDateTime",
+          'recurrenceUnit', ar."recurrenceUnit",
+          'recurrenceInterval', ar."recurrenceInterval"
         )
         FROM public."AssetReminder" ar
         WHERE 

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3014,7 +3014,15 @@ export async function deleteAsset({
         where: { id, organizationId },
         select: {
           reminders: {
-            select: { alertDateTime: true, activeSchedulerReference: true },
+            select: {
+              alertDateTime: true,
+              activeSchedulerReference: true,
+              // why: cancelAssetReminderScheduler skips its already-fired
+              // early-return for recurring rows (they can hold a queued job
+              // while alertDateTime is briefly past)
+              recurrenceUnit: true,
+              recurrenceInterval: true,
+            },
           },
         },
       });

--- a/apps/webapp/app/modules/asset/types.ts
+++ b/apps/webapp/app/modules/asset/types.ts
@@ -247,7 +247,12 @@ export type AdvancedIndexAsset = Pick<
   })[];
   upcomingReminder?: Pick<
     AssetReminder,
-    "id" | "alertDateTime" | "name" | "message"
+    | "id"
+    | "alertDateTime"
+    | "name"
+    | "message"
+    | "recurrenceUnit"
+    | "recurrenceInterval"
   >;
   bookings?: Array<AdvancedAssetBooking>;
   barcodes?: Array<Pick<Barcode, "id" | "type" | "value">>;

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.reminders.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.reminders.tsx
@@ -5,6 +5,7 @@ import RemindersTable from "~/components/asset-reminder/reminders-table";
 import type { HeaderData } from "~/components/layout/header/types";
 import { getPaginatedAndFilterableReminders } from "~/modules/asset-reminder/service.server";
 import { resolveRemindersActions } from "~/modules/asset-reminder/utils.server";
+import { getOrganizationTierLimit } from "~/modules/tier/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError } from "~/utils/error";
 import { payload, error, getParams } from "~/utils/http.server";
@@ -13,6 +14,7 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
+import { canUseRecurringReminders } from "~/utils/subscription.server";
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => [
   { title: data ? appendToMetaTitle(data.header.title) : "" },
@@ -27,19 +29,24 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   });
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, organizations } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.assetReminders,
       action: PermissionAction.read,
     });
 
-    const { reminders, totalReminders, page, perPage, totalPages, search } =
-      await getPaginatedAndFilterableReminders({
+    const [
+      { reminders, totalReminders, page, perPage, totalPages, search },
+      tierLimit,
+    ] = await Promise.all([
+      getPaginatedAndFilterableReminders({
         organizationId,
         request,
         where: { assetId },
-      });
+      }),
+      getOrganizationTierLimit({ organizationId, organizations }),
+    ]);
 
     const header: HeaderData = { title: "Reminders" };
     const modelName = {
@@ -56,6 +63,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       perPage,
       totalPages,
       search,
+      canUseRecurringReminders: canUseRecurringReminders(tierLimit),
     });
   } catch (cause) {
     const reason = makeShelfError(cause, { userId, assetId });
@@ -68,7 +76,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
   const userId = authSession.userId;
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, organizations } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.asset,
@@ -78,6 +86,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
     return await resolveRemindersActions({
       request,
       organizationId,
+      organizations,
       userId,
     });
   } catch (cause) {

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
@@ -7,7 +7,7 @@ import type {
 } from "react-router";
 import { redirect, data, useLoaderData, Outlet } from "react-router";
 import { z } from "zod";
-import { setReminderSchema } from "~/components/asset-reminder/set-or-edit-reminder-dialog";
+import { setReminderServerSchema } from "~/components/asset-reminder/set-or-edit-reminder-dialog";
 import ActionsDropdown from "~/components/assets/actions-dropdown";
 import { AssetImage } from "~/components/assets/asset-image/component";
 import { AssetStatusBadge } from "~/components/assets/asset-status-badge";
@@ -362,7 +362,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           repeat,
           endsAt: _endsAt,
           ...payload
-        } = parseData(formData, setReminderSchema, {
+        } = parseData(formData, setReminderServerSchema, {
           shouldBeCaptured: false,
         });
 

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
@@ -1,5 +1,4 @@
 import { BarcodeType, OrganizationRoles } from "@prisma/client";
-import { DateTime } from "luxon";
 import type {
   ActionFunctionArgs,
   LinksFunction,
@@ -28,6 +27,7 @@ import {
 } from "~/modules/asset/service.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import { createAssetReminder } from "~/modules/asset-reminder/service.server";
+import { resolveReminderPayloadDates } from "~/modules/asset-reminder/utils.server";
 import { createBarcode } from "~/modules/barcode/service.server";
 import {
   validateBarcodeValue,
@@ -35,12 +35,11 @@ import {
 } from "~/modules/barcode/validation";
 import { computeBookingAssetRemainingToCheckOut } from "~/modules/booking/service.server";
 import { getTeamMembersForQuantityCustody } from "~/modules/team-member/service.server";
+import { getOrganizationTierLimit } from "~/modules/tier/service.server";
 import assetCss from "~/styles/asset.css?url";
 
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
-import { getHints } from "~/utils/client-hints";
-import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -56,6 +55,10 @@ import {
 } from "~/utils/permissions/permission.data";
 import { userHasPermission } from "~/utils/permissions/permission.validator.client";
 import { requirePermission } from "~/utils/roles.server";
+import {
+  assertUserCanUseRecurringReminders,
+  canUseRecurringReminders,
+} from "~/utils/subscription.server";
 import { tw } from "~/utils/tw";
 
 export const AvailabilityForBookingFormSchema = z.object({
@@ -96,14 +99,13 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   });
 
   try {
-    const { organizationId, userOrganizations, role } = await requirePermission(
-      {
+    const { organizationId, userOrganizations, organizations, role } =
+      await requirePermission({
         userId,
         request,
         entity: PermissionEntity.asset,
         action: PermissionAction.read,
-      }
-    );
+      });
 
     const asset = await getAsset({
       id,
@@ -248,11 +250,18 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       title: asset.title,
     };
 
+    /** Drives the Repeat control in the set-reminder dialog. */
+    const tierLimit = await getOrganizationTierLimit({
+      organizationId,
+      organizations,
+    });
+
     return payload({
       asset: assetWithEffectiveBookingAssets,
       header,
       teamMembers,
       totalTeamMembers,
+      canUseRecurringReminders: canUseRecurringReminders(tierLimit),
     });
   } catch (cause) {
     const reason = makeShelfError(cause);
@@ -289,7 +298,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       "add-barcode": PermissionAction.update,
     };
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, organizations } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.asset,
@@ -348,25 +357,37 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       }
 
       case "set-reminder": {
-        const { redirectTo, ...payload } = parseData(
-          formData,
-          setReminderSchema,
-          { shouldBeCaptured: false }
-        );
-        const hints = getHints(request);
+        const {
+          redirectTo,
+          repeat,
+          endsAt: _endsAt,
+          ...payload
+        } = parseData(formData, setReminderSchema, {
+          shouldBeCaptured: false,
+        });
 
-        const alertDateTime = DateTime.fromFormat(
-          formData.get("alertDateTime")!.toString()!,
-          DATE_TIME_FORMAT,
-          {
-            zone: hints.timeZone,
-          }
-        ).toJSDate();
+        const { alertDateTime, recurrence } = resolveReminderPayloadDates({
+          request,
+          formData,
+          repeat,
+        });
+
+        /**
+         * One-shot reminders stay free; only an actual recurrence request is
+         * tier-gated (server-side — the disabled UI control is not a gate).
+         */
+        if (recurrence) {
+          await assertUserCanUseRecurringReminders({
+            organizationId,
+            organizations,
+          });
+        }
 
         await createAssetReminder({
           ...payload,
           assetId: id,
           alertDateTime,
+          recurrence,
           organizationId,
           createdById: userId,
         });

--- a/apps/webapp/app/routes/_layout+/reminders._index.tsx
+++ b/apps/webapp/app/routes/_layout+/reminders._index.tsx
@@ -9,6 +9,7 @@ import Header from "~/components/layout/header";
 import type { HeaderData } from "~/components/layout/header/types";
 import { getPaginatedAndFilterableReminders } from "~/modules/asset-reminder/service.server";
 import { resolveRemindersActions } from "~/modules/asset-reminder/utils.server";
+import { getOrganizationTierLimit } from "~/modules/tier/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError } from "~/utils/error";
 import { payload, error } from "~/utils/http.server";
@@ -17,24 +18,30 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
+import { canUseRecurringReminders } from "~/utils/subscription.server";
 
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, organizations } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.assetReminders,
       action: PermissionAction.read,
     });
 
-    const { page, perPage, reminders, totalPages, totalReminders, search } =
-      await getPaginatedAndFilterableReminders({
+    const [
+      { page, perPage, reminders, totalPages, totalReminders, search },
+      tierLimit,
+    ] = await Promise.all([
+      getPaginatedAndFilterableReminders({
         organizationId,
         request,
-      });
+      }),
+      getOrganizationTierLimit({ organizationId, organizations }),
+    ]);
 
     const header: HeaderData = { title: "Reminders" };
     const modelName = {
@@ -56,6 +63,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         text: "Search reminders by reminder name, message, asset name or team member name. Separate your keywords by a comma(,) to search with OR condition. For example: searching 'Laptop, maintenance' will find reminders matching any of these terms.",
       },
       search,
+      canUseRecurringReminders: canUseRecurringReminders(tierLimit),
     });
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
@@ -68,7 +76,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
   const userId = authSession.userId;
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, organizations } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.assetReminders,
@@ -78,6 +86,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
     return await resolveRemindersActions({
       request,
       organizationId,
+      organizations,
       userId,
     });
   } catch (cause) {

--- a/apps/webapp/app/utils/subscription.server.ts
+++ b/apps/webapp/app/utils/subscription.server.ts
@@ -434,7 +434,10 @@ export const canUseRecurringReminders = (
  * Call this only when a mutation actually requests recurrence — creating or
  * editing one-shot reminders must stay free.
  *
- * @throws {ShelfError} 403-style "Not allowed" upgrade nudge.
+ * @param organizationId - The current organization id.
+ * @param organizations - The caller's organizations (from requirePermission);
+ *                        used to resolve the org OWNER whose tier applies.
+ * @throws {ShelfError} 403 "Not allowed" upgrade nudge.
  */
 export async function assertUserCanUseRecurringReminders({
   organizationId,
@@ -462,6 +465,7 @@ export async function assertUserCanUseRecurringReminders({
         "Recurring reminders are not available on your workspace's current plan. Please upgrade your subscription to unlock this feature, or set a one-time reminder instead.",
       additionalData: { organizationId },
       label,
+      status: 403,
       shouldBeCaptured: false,
     });
   }

--- a/apps/webapp/app/utils/subscription.server.ts
+++ b/apps/webapp/app/utils/subscription.server.ts
@@ -410,6 +410,64 @@ export async function assertUserCanInviteUsersToWorkspace({
 }
 /** End Team Features */
 
+/** Recurring Reminders */
+
+/**
+ * Determines whether the current organization's tier allows recurring
+ * (auto-repeating) asset reminders. One-shot reminders are free and are
+ * never gated by this.
+ *
+ * @param tierLimit - The tier limits of the organization OWNER (see
+ *                    getOrganizationTierLimit).
+ * @returns `true` if recurrence can be used or premium features are disabled.
+ */
+export const canUseRecurringReminders = (
+  tierLimit: { canUseRecurringReminders: boolean } | null | undefined
+) => {
+  if (!premiumIsEnabled) return true;
+  if (!tierLimit) return false;
+  return tierLimit.canUseRecurringReminders;
+};
+
+/**
+ * Throws when the organization's tier does not include recurring reminders.
+ * Call this only when a mutation actually requests recurrence — creating or
+ * editing one-shot reminders must stay free.
+ *
+ * @throws {ShelfError} 403-style "Not allowed" upgrade nudge.
+ */
+export async function assertUserCanUseRecurringReminders({
+  organizationId,
+  organizations,
+}: {
+  organizationId: Organization["id"];
+  organizations: {
+    id: string;
+    type: OrganizationType;
+    name: string;
+    imageId: string | null;
+    userId: string;
+  }[];
+}) {
+  const tierLimit = await getOrganizationTierLimit({
+    organizationId,
+    organizations,
+  });
+
+  if (!canUseRecurringReminders(tierLimit)) {
+    throw new ShelfError({
+      cause: null,
+      title: "Not allowed",
+      message:
+        "Recurring reminders are not available on your workspace's current plan. Please upgrade your subscription to unlock this feature, or set a one-time reminder instead.",
+      additionalData: { organizationId },
+      label,
+      shouldBeCaptured: false,
+    });
+  }
+}
+/** End Recurring Reminders */
+
 /** Audit Add-on */
 export const canUseAudits = (org: { auditsEnabled: boolean }) => {
   if (!premiumIsEnabled) return true;

--- a/packages/database/prisma/migrations/20260702120000_add_recurring_reminders/migration.sql
+++ b/packages/database/prisma/migrations/20260702120000_add_recurring_reminders/migration.sql
@@ -1,0 +1,18 @@
+-- Recurring reminders: cadence fields on AssetReminder + tier capability flags.
+-- All AssetReminder columns are nullable; existing rows stay one-shot (null unit/interval).
+
+-- CreateEnum
+CREATE TYPE "ReminderRecurrenceUnit" AS ENUM ('DAY', 'WEEK', 'MONTH', 'YEAR');
+
+-- AlterTable
+ALTER TABLE "AssetReminder" ADD COLUMN     "recurrenceUnit" "ReminderRecurrenceUnit",
+ADD COLUMN     "recurrenceInterval" INTEGER,
+ADD COLUMN     "recurrenceTimezone" TEXT,
+ADD COLUMN     "recurrenceEndsAt" TIMESTAMP(3);
+
+-- AlterTable (mirrors the canImportNRM / canHideShelfBranding precedent pair:
+-- TierLimit defaults false, CustomTierLimit defaults true)
+ALTER TABLE "TierLimit" ADD COLUMN     "canUseRecurringReminders" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "CustomTierLimit" ADD COLUMN     "canUseRecurringReminders" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/database/prisma/migrations/20260702120000_add_recurring_reminders/migration.sql
+++ b/packages/database/prisma/migrations/20260702120000_add_recurring_reminders/migration.sql
@@ -10,6 +10,16 @@ ADD COLUMN     "recurrenceInterval" INTEGER,
 ADD COLUMN     "recurrenceTimezone" TEXT,
 ADD COLUMN     "recurrenceEndsAt" TIMESTAMP(3);
 
+-- Cadence invariant: a reminder is either one-shot (both cadence fields null)
+-- or recurring (both present, positive interval). Guards downstream recurrence
+-- detection (isRecurringReminder) against partial/invalid rows written by any
+-- future path that bypasses the service layer. (Prisma cannot model CHECK
+-- constraints, so this lives in SQL only.)
+ALTER TABLE "AssetReminder" ADD CONSTRAINT "AssetReminder_recurrence_cadence_check" CHECK (
+  ("recurrenceUnit" IS NULL AND "recurrenceInterval" IS NULL)
+  OR ("recurrenceUnit" IS NOT NULL AND "recurrenceInterval" IS NOT NULL AND "recurrenceInterval" > 0)
+);
+
 -- AlterTable (mirrors the canImportNRM / canHideShelfBranding precedent pair:
 -- TierLimit defaults false, CustomTierLimit defaults true)
 ALTER TABLE "TierLimit" ADD COLUMN     "canUseRecurringReminders" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/prisma/migrations/20260702120100_enable_recurring_reminders_for_paid_tiers/migration.sql
+++ b/packages/database/prisma/migrations/20260702120100_enable_recurring_reminders_for_paid_tiers/migration.sql
@@ -1,0 +1,4 @@
+-- Enable canUseRecurringReminders for Plus (tier_1) and Team (tier_2) tiers
+UPDATE "TierLimit"
+SET "canUseRecurringReminders" = true
+WHERE id IN ('tier_1', 'tier_2');

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1054,6 +1054,7 @@ model TierLimit {
   canExportAssets      Boolean  @default(false)
   canImportNRM         Boolean  @default(false)
   canHideShelfBranding Boolean  @default(false)
+  canUseRecurringReminders Boolean @default(false)
   maxCustomFields      Int      @default(0)
   maxOrganizations     Int      @default(1)
   createdAt            DateTime @default(now())
@@ -1069,6 +1070,7 @@ model CustomTierLimit {
   canExportAssets      Boolean  @default(true)
   canImportNRM         Boolean  @default(true)
   canHideShelfBranding Boolean  @default(true)
+  canUseRecurringReminders Boolean @default(true)
   maxCustomFields      Int      @default(1000)
   maxOrganizations     Int      @default(1)
   isEnterprise         Boolean  @default(false) // Set this to true for enterprise users. It is used to control some visuals in the app
@@ -1817,12 +1819,34 @@ model AssetLocation {
   @@index([assetKitId])
 }
 
+// Units for reminder recurrence cadences ("every N <unit>"). Stored as
+// unit + interval (not presets) so future custom cadences need no migration.
+enum ReminderRecurrenceUnit {
+  DAY
+  WEEK
+  MONTH
+  YEAR
+}
+
 model AssetReminder {
   id                       String       @id @default(cuid())
   name                     String
   message                  String
   alertDateTime            DateTime
   activeSchedulerReference String?
+
+  // Recurrence (null unit/interval = one-shot reminder, the default). For an
+  // active recurring reminder, alertDateTime always holds the NEXT occurrence:
+  // the worker advances it in place each time the reminder fires, keeping every
+  // "upcoming" surface and the status/edit/cancel guards correct without forks.
+  recurrenceUnit     ReminderRecurrenceUnit?
+  recurrenceInterval Int?
+  // IANA zone captured from client hints at create/edit so "every month at
+  // 09:00" stays wall-clock-stable across DST. Null = UTC math (legacy rows).
+  recurrenceTimezone String?
+  // Optional series end (inclusive). Null = repeat until deleted.
+  recurrenceEndsAt DateTime?
+
   organization             Organization @relation(fields: [organizationId], references: [id])
   organizationId           String
   asset                    Asset        @relation(fields: [assetId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
Closes #2659. Also addresses the long-standing recurrence asks in #483, #1445 and #2520 (calibration / service-interval workflows that today require manually re-creating a reminder after each fire).

## What

Reminders can now **repeat on a cadence**: daily, weekly, every 2 weeks, monthly, every 3 months, every 6 months, or yearly, with an optional end date. One-time reminders are unchanged and stay available to everyone; recurrence is a paid-tier capability (see Gating).

## Design: one row per series, `alertDateTime` = next occurrence

A recurring reminder is the existing `AssetReminder` row. When it fires, the worker **advances `alertDateTime` in place** to the next occurrence and schedules the next job. This keeps every existing surface correct with no forked logic:

- home "Upcoming reminders" widget and asset-overview card (`gte: now` filters)
- advanced asset-index "Upcoming Reminder" column and its CSV export
- the Pending / Reminder sent status badge
- the edit guard (active series stays editable) and the cancel-on-delete guard

Fire history remains visible as asset notes (one per fire, now including the next scheduled date).

## Scheduling: self-rescheduling chain, no cron

`noScheduling: true` is untouched. Recurrence is a self-rescheduling `sendAfter` chain, the same in-house pattern the audit reminder chain (24h → 4h → 1h → overdue) and the booking checkin → overdue hop already use, hardened with:

- **singletonKey + retryLimit 3** on all recurring jobs (one-shot jobs keep today's exact semantics)
- **compare-and-swap advance** (`updateMany` guarded on the old `alertDateTime`) so concurrent workers/reconciliation/edits can never double-advance (relevant under bluegreen deploys where two machines briefly poll)
- **advance-before-notify ordering**: a retried job can never double-email
- **stale-job guard**: a job superseded by a newer schedule is skipped; this also closes a pre-existing double-fire window when an edit's cancel silently failed
- **orphan recovery on retry**: if the advance committed but scheduling the next job failed transiently, the retry re-arms it
- **boot reconciliation**: at every deploy/boot, series whose chain died (crash, jobs archived during long downtime) are re-armed. 1-hour grace so healthy in-flight fires are never hijacked; per-row fault isolation so one bad row can't block the sweep

pg-boss 9 retention is safe for far-future occurrences: `keepUntil` anchors to `startAfter`, so a job scheduled months out is not reaped (verified in the vendored source).

Timezone: the cadence is wall-clock stable in the IANA zone captured from client hints at create/edit (luxon; DST-correct). Month-end anniversaries clamp (Jan 31 → Feb 28 and the advanced date becomes the new anchor) — intended v1 behavior, covered by tests. Catch-up policy: occurrences missed during downtime are skipped, never bursted.

## Gating

- One-time reminders remain free.
- Recurrence requires the new `canUseRecurringReminders` tier flag (`TierLimit` default false, enabled for `tier_1`/`tier_2`; `CustomTierLimit` default true), following the `canHideShelfBranding` precedent, asserted **server-side** at both mutation entry points.
- Edits only assert when recurrence is being added or changed vs the stored row, so a downgraded workspace can still edit other fields, turn recurrence off, or delete.
- Downgrade behavior: the series **pauses at its next fire** (that occurrence still notifies; nothing further is scheduled; a note explains why). Upgrading + editing re-arms it.
- Self-host (`ENABLE_PREMIUM_FEATURES=false`): everything enabled, per the existing convention.
- Free-tier UI: the Repeat select renders locked with an upgrade link (workspace edit-form precedent); hidden inputs carry the stored cadence so plain edits round-trip safely.

## Migrations

Two migrations mirroring the `canImportNRM` / `canHideShelfBranding` pair: enum + 4 nullable `AssetReminder` columns + both tier-table booleans, then the `UPDATE` enabling paid tiers. Verified on a clean Postgres 16: `prisma migrate deploy` applies cleanly and `migrate status` reports **zero drift**; a live-Prisma script additionally exercised the reconcile query and the CAS advance against the real database.

## Drive-by fixes (each on a line this change already touches)

- `createAssetReminder` now runs `assertAssetsBelongToOrg` before creating (org-scope-user-supplied-ids rule: create paths too)
- reminders pagination `totalPages` divided by the raw `per_page` param → `Infinity` when absent; now uses the cookie-resolved `perPage`
- asset-overview reminders card ordered `desc` (showed the two furthest-future reminders instead of the next two)
- reminder schema's future-check evaluated `new Date()` once at module load; now validated at parse time

## Deliberate non-goals (v1)

- Duplicating an asset does **not** copy its reminders (kept as-is by design)
- No per-occurrence editing (edit = edit the series), no calendar surface, no mobile surface (reminders don't exist on mobile today), no maintenance module (separate scope)
- recordEvent/ActivityAction wiring deferred: no reminder events exist today; matching existing behavior

## Tests

First tests for the asset-reminder module (44 new): recurrence math (DST both directions, month-end clamp, catch-up skip, end-date termination, invalid-zone fallback, interval clamp), chain advance/reconcile (CAS, grace window, per-row isolation, tier pause, fail-open), worker handler (advance-before-notify order, stale-job guard, orphan re-arm, rethrow path, one-shot unchanged), form schema parsing (empty `endsAt`, missing `repeat`, past dates), and the `endsAt` timezone round-trip. `pnpm webapp:validate` green (3073 tests).

## Verification honesty

Statically verified + live-DB-verified as above. **Not click-through-verified in a browser**: the shared dev/QA database cannot take this migration (it is on a diverged schema), so reviewers should expect to exercise the dialog in their own environment. The UI changes follow existing primitives (Radix Select, locked-control precedent, `DateS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recurring asset reminders (daily–yearly) with timezone-aware repeat settings and optional “Ends on”.
  * Recurrence now shows across the experience: lists, cards, upcoming reminders, advanced asset tooltips, and reminder emails (including next occurrence).
* **Bug Fixes**
  * Improved recurring reminders’ delivery and edit behavior, including correct “Pending”/editable status across series state and safer retries.
* **Chores**
  * Added recurring schema, client/server validation, and expanded automated test coverage; enabled recurring reminders for eligible paid tiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->