### PR TITLE
feat(mobile): inline tag creation + universal-link cold-start fix

### DIFF
--- a/.claude/rules/companion-deep-link-allowlist.md
+++ b/.claude/rules/companion-deep-link-allowlist.md
@@ -1,35 +1,50 @@
 ---
-description: Adding a Companion deep-linkable route (Universal Links / App Links) requires updating the allowlist in THREE places that must stay in sync — plus the screen must exist. Never claim the whole domain, and never hand a claimed path back to the OS via Linking.openURL.
+description: Adding a Companion deep-linkable route (Universal Links / App Links) requires updating the allowlist in FOUR places that must stay in sync — plus the screen must exist. Never claim the whole domain, never hand a claimed path back to the OS via Linking.openURL, and every claimed prefix MUST have a +native-intent mapping or cold starts hang on the splash.
 globs:
   [
     "apps/webapp/app/routes/*well-known*",
     "apps/companion/app.json",
     "apps/companion/lib/deep-links.ts",
     "apps/companion/app/**/*.tsx",
+    "apps/companion/app/+native-intent.ts",
   ]
 ---
 
 # Companion Deep-Link Allowlist Consistency
 
 `https://app.shelf.nu/...` links open the Companion app (not the web) only for
-an explicit path allowlist. That allowlist is declared in **three places** and
-they MUST stay in sync. Touch one → check the other two.
+an explicit path allowlist. That allowlist is declared in **four places** and
+they MUST stay in sync. Touch one → check the other three.
 
 | #   | File                                                                  | What to add for a new route (e.g. `/locations`)                                        |
 | --- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | 1   | `apps/webapp/app/routes/[.well-known].apple-app-site-association.tsx` | a `{ "/": "/locations/*" }` entry in `DEEP_LINK_COMPONENTS` (iOS)                      |
 | 2   | `apps/companion/app.json` → `android.intentFilters[].data`            | `{ "scheme": "https", "host": "app.shelf.nu", "pathPrefix": "/locations/" }` (Android) |
-| 3   | `apps/companion/lib/deep-links.ts`                                    | a `case "locations":` in BOTH `parseDeepLink` and `navigateToLink`                     |
+| 3   | `apps/companion/app/+native-intent.ts`                                | a `case "locations":` in `redirectSystemPath` mapping to a REAL native route           |
+| 4   | `apps/companion/lib/deep-links.ts`                                    | a `case "locations":` in `parseDeepLink` + `navigateToLink` (custom-scheme links)      |
+
+**Division of labour:** HTTPS universal links are routed natively by
+expo-router via the `+native-intent.ts` rewrite (#3). The JS hook (#4) only
+navigates custom-scheme links and resolves `/qr/:id` (async API call). Acting
+on other HTTPS links in the JS hook double-navigates.
 
 **Prerequisite:** the destination screen must already exist (e.g.
 `apps/companion/app/(tabs)/locations/[id].tsx`) and be reachable via
 `pushIntoTab` — anchored navigation, or the back button strands the user
 (App Store Guideline 2.1).
 
-**Rollout:** #1 ships with a normal webapp deploy. #2 and #3 live in the native
+**Rollout:** #1 ships with a normal webapp deploy. #2–#4 live in the native
 binary → require a new app build + store submission (no OTA).
 
-## Two hard rules — getting these wrong is a production incident
+## Three hard rules — getting these wrong is a production incident
+
+❌ **Never claim an HTTPS prefix without a `+native-intent` mapping.** The OS
+delivers EVERY nested path under a claimed prefix (the canonical web asset URL
+is `/assets/:id/overview`). Without a rewrite the router lands on an unmatched
+route at cold start and the user hangs on the splash forever (the 1.1.0
+build-25 bug). Deeper-nested paths map to the resource DETAIL screen — that is
+what the tapper wants. `app/+not-found.tsx` redirects any remaining unmatched
+route to the start screen as a last-resort net.
 
 ❌ **Never claim the whole domain / never add an auth path.** Do not use a `/*`
 wildcard and never list `/login`, `/oauth*`, `/sso-login`, `/forgot-password`,
@@ -40,7 +55,8 @@ breaks web login / password reset / invites for everyone with the app.
 ❌ **Never `Linking.openURL` a claimed path.** A web-fallback to a claimed URL
 (e.g. `https://app.shelf.nu/qr/...`) is re-intercepted by Android App Links and
 re-opens the app → infinite loop. Use `openShelfWebUrl()` (`lib/navigation.ts`,
-in-app browser) instead.
+in-app browser) instead — today only the QR not-resolvable fallback needs it.
 
 ✅ Allowlist mirrors a real native screen, is path-scoped (trailing slash so
-index pages aren't claimed), and falls back to the web via `openShelfWebUrl`.
+index pages aren't claimed), has a `+native-intent` mapping for cold starts,
+and web hand-offs go through `openShelfWebUrl`.

--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shelf",
     "slug": "shelf-companion",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "shelf",

--- a/apps/companion/app/(tabs)/assets/edit.tsx
+++ b/apps/companion/app/(tabs)/assets/edit.tsx
@@ -409,6 +409,8 @@ export default function EditAssetScreen() {
             isLoading={form.isTagsLoading}
             isOpen={showTagsPicker}
             onToggle={setShowTagsPicker}
+            canCreate={form.canCreateTag}
+            onCreateTag={form.createTag}
           />
 
           {/* ── Valuation ──────────────────────────────── */}

--- a/apps/companion/app/(tabs)/assets/new.tsx
+++ b/apps/companion/app/(tabs)/assets/new.tsx
@@ -93,6 +93,9 @@ export default function CreateAssetScreen() {
   const [isCategoriesLoading, setIsCategoriesLoading] = useState(false);
   const [isLocationsLoading, setIsLocationsLoading] = useState(false);
   const [isTagsLoading, setIsTagsLoading] = useState(false);
+  // Server-computed from GET /api/mobile/tags: whether the caller may mint
+  // tags inline (admins/owners). Gates the picker's "create tag" row.
+  const [canCreateTag, setCanCreateTag] = useState(false);
 
   // ── Picker visibility ───────────────────────────
   const [showCategoryPicker, setShowCategoryPicker] = useState(false);
@@ -171,6 +174,8 @@ export default function CreateAssetScreen() {
       if (requestId !== latestTagsRequestRef.current) return;
       const nextTags = data?.tags ?? [];
       setTags(nextTags);
+      // Server-computed create capability (false on older servers).
+      setCanCreateTag(data?.canCreate ?? false);
       setSelectedTags((prev) =>
         prev.filter((selected) =>
           nextTags.some((tag) => tag.id === selected.id)
@@ -182,6 +187,26 @@ export default function CreateAssetScreen() {
       }
     }
   }, [currentOrg]);
+
+  // Inline tag creation from the picker (admins/owners; the server enforces
+  // `tag.create`). Adds the new tag to the local list so the dropdown shows it
+  // without a refetch (the API helper already invalidated the cached list).
+  const handleCreateTag = useCallback(
+    async (name: string): Promise<Tag | null> => {
+      if (!currentOrg) return null;
+      const { data, error } = await api.createTag(currentOrg.id, name);
+      if (error || !data?.tag) {
+        Alert.alert("Couldn't create tag", error || "Please try again.");
+        return null;
+      }
+      const tag = data.tag;
+      setTags((prev) =>
+        [...prev, tag].sort((a, b) => a.name.localeCompare(b.name))
+      );
+      return tag;
+    },
+    [currentOrg]
+  );
 
   // ── Load custom fields for the selected category ──
   // Re-runs whenever the chosen category changes (including "no category").
@@ -866,6 +891,8 @@ export default function CreateAssetScreen() {
               setShowLocationPicker(false);
             }
           }}
+          canCreate={canCreateTag}
+          onCreateTag={handleCreateTag}
         />
 
         {/* ── Custom Fields (scoped to selected category) ────────── */}

--- a/apps/companion/app/+native-intent.ts
+++ b/apps/companion/app/+native-intent.ts
@@ -1,0 +1,126 @@
+/**
+ * expo-router native intent hook.
+ *
+ * `redirectSystemPath` runs for every URL the OS delivers to the app
+ * (Universal Links / App Links and custom-scheme links), BEFORE the router
+ * resolves a route — on cold start (`initial: true`) and on warm `url`
+ * events (`initial: false`). Returning a different string rewrites what the
+ * router navigates to.
+ *
+ * IMPORTANT (verified against expo-router 6.0.23 source,
+ * `build/getLinkingConfig.js` + `build/link/linking.js`): in a bare app the
+ * `path` argument is the RAW FULL URL (`https://app.shelf.nu/assets/:id/overview`,
+ * `shelf://assets/:id`), not a path — so this function normalises scheme and
+ * host before matching.
+ *
+ * Why this exists: the OS delivers every nested path under a claimed prefix
+ * (e.g. `/assets/:id/overview` — the canonical web asset URL), but the native
+ * app only has routes for the resource details. Without a rewrite the router
+ * lands on an unmatched route at cold start and the user is stuck behind the
+ * splash screen with no navigation running (the 1.1.0 build-25 hang). Mapping
+ * every claimed prefix to a real native screen here makes cold-start links
+ * deterministic and removes any timing race with the JS deep-link listener.
+ *
+ * Kept in sync with the claimed-path allowlist — see
+ * `.claude/rules/companion-deep-link-allowlist.md`, the iOS AASA route and
+ * `android.intentFilters` in app.json. `/qr/:id` is the one claimed path that
+ * cannot be rewritten synchronously (needs an API resolve to know whether it
+ * is an asset or a kit) — it lands on the start screen and
+ * `useDeepLinkHandler` (lib/deep-links.ts) finishes the job from the original
+ * URL.
+ *
+ * @see {@link file://./../lib/deep-links.ts}
+ */
+
+type RedirectSystemPathArgs = {
+  /**
+   * The URL that opened the app. On native this is the raw full URL
+   * (scheme + host + path + query), despite the parameter name.
+   */
+  path: string;
+  /** True when the URL is the app's launch (cold start) URL. */
+  initial: boolean;
+};
+
+/**
+ * Extracts the resource path segments from a raw incoming URL.
+ *
+ * Handles all three shapes the router hands us:
+ * - `https://app.shelf.nu/assets/:id/overview` → host dropped → ["assets", ":id", "overview"]
+ * - `shelf://assets/:id` → custom scheme: the first component IS the resource → ["assets", ":id"]
+ * - `/assets/:id` (already a path) → ["assets", ":id"]
+ *
+ * @param url - the raw URL or path delivered by the OS
+ * @returns the path segments, without scheme/host/query/hash
+ */
+function extractSegments(url: string): string[] {
+  let rest = url;
+
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):\/\//i.exec(url);
+  if (schemeMatch) {
+    rest = url.slice(schemeMatch[0].length);
+    // For http(s) the first component is the domain — drop it. For custom
+    // schemes (shelf://assets/:id) the first component is the resource
+    // itself (expo-linking puts it in `hostname`) — keep it.
+    const scheme = schemeMatch[1].toLowerCase();
+    if (scheme === "http" || scheme === "https") {
+      rest = rest.slice(rest.indexOf("/") + 1);
+      // Domain-only URL (no path): nothing left to match.
+      if (rest === url.slice(schemeMatch[0].length)) rest = "";
+    }
+  }
+
+  // Strip query/hash; internal routes take no query params.
+  const [pathname = ""] = rest.split(/[?#]/);
+  return pathname.split("/").filter(Boolean);
+}
+
+/**
+ * Rewrites OS-delivered link URLs to navigable in-app routes.
+ *
+ * @param args - the incoming URL and whether it launched the app
+ * @returns the in-app path the router should resolve instead, or the
+ *          original string unchanged when the URL isn't a claimed pattern
+ */
+export function redirectSystemPath({ path }: RedirectSystemPathArgs): string {
+  try {
+    const segments = extractSegments(path);
+    if (segments.length === 0) return "/";
+
+    const [resource, id] = segments;
+
+    switch (resource) {
+      case "assets":
+        // Custom-scheme kit links can arrive as assets/kits/:id (the kit
+        // detail lives inside the assets stack).
+        if (id === "kits") {
+          return segments[2] ? `/assets/kits/${segments[2]}` : "/assets";
+        }
+        // Any deeper web path (/assets/:id/overview, /assets/:id/activity…)
+        // maps to the native asset detail — that is what the tapper wants.
+        return id ? `/assets/${id}` : "/assets";
+      case "kits":
+        return id ? `/assets/kits/${id}` : "/assets";
+      case "bookings":
+        return id ? `/bookings/${id}` : "/bookings";
+      case "audits":
+        return id ? `/audits/${id}` : "/audits";
+      case "qr":
+        // Needs an async API resolve (asset vs kit vs other-org) that a path
+        // rewrite cannot express. Land on the start screen; useDeepLinkHandler
+        // reads the original URL via Linking and navigates once resolved.
+        return "/";
+      case "scanner":
+      case "scan":
+        return "/scanner";
+      default:
+        // Not a claimed prefix (dev-client URLs, custom-scheme extras): leave
+        // the URL unchanged so existing behavior is preserved.
+        // `app/+not-found.tsx` catches anything the router still can't match.
+        return path;
+    }
+  } catch {
+    // Never let a parse error strand the user — fall back to the start screen.
+    return "/";
+  }
+}

--- a/apps/companion/app/+native-intent.ts
+++ b/apps/companion/app/+native-intent.ts
@@ -43,17 +43,21 @@ type RedirectSystemPathArgs = {
 };
 
 /**
- * Extracts the resource path segments from a raw incoming URL.
+ * Extracts the resource path segments and query string from a raw incoming URL.
  *
  * Handles all three shapes the router hands us:
  * - `https://app.shelf.nu/assets/:id/overview` → host dropped → ["assets", ":id", "overview"]
  * - `shelf://assets/:id` → custom scheme: the first component IS the resource → ["assets", ":id"]
  * - `/assets/:id` (already a path) → ["assets", ":id"]
  *
+ * The query string is preserved (hash stripped) because some claimed routes
+ * consume params — e.g. `/assets/new?qrId=...` links a scanned QR to the
+ * asset being created. Dropping it would silently break that flow.
+ *
  * @param url - the raw URL or path delivered by the OS
- * @returns the path segments, without scheme/host/query/hash
+ * @returns the path segments (no scheme/host/query/hash) and the query string
  */
-function extractSegments(url: string): string[] {
+function extractPathParts(url: string): { segments: string[]; query: string } {
   let rest = url;
 
   const schemeMatch = /^([a-z][a-z0-9+.-]*):\/\//i.exec(url);
@@ -64,15 +68,19 @@ function extractSegments(url: string): string[] {
     // itself (expo-linking puts it in `hostname`) — keep it.
     const scheme = schemeMatch[1].toLowerCase();
     if (scheme === "http" || scheme === "https") {
-      rest = rest.slice(rest.indexOf("/") + 1);
+      const slash = rest.indexOf("/");
       // Domain-only URL (no path): nothing left to match.
-      if (rest === url.slice(schemeMatch[0].length)) rest = "";
+      rest = slash === -1 ? "" : rest.slice(slash + 1);
     }
   }
 
-  // Strip query/hash; internal routes take no query params.
-  const [pathname = ""] = rest.split(/[?#]/);
-  return pathname.split("/").filter(Boolean);
+  // Split off the query (kept) and the hash (dropped — never meaningful here).
+  const hashless = rest.split("#")[0] ?? "";
+  const queryStart = hashless.indexOf("?");
+  const pathname = queryStart === -1 ? hashless : hashless.slice(0, queryStart);
+  const query = queryStart === -1 ? "" : hashless.slice(queryStart + 1);
+
+  return { segments: pathname.split("/").filter(Boolean), query };
 }
 
 /**
@@ -84,8 +92,14 @@ function extractSegments(url: string): string[] {
  */
 export function redirectSystemPath({ path }: RedirectSystemPathArgs): string {
   try {
-    const segments = extractSegments(path);
+    const { segments, query } = extractPathParts(path);
     if (segments.length === 0) return "/";
+
+    // Re-attach the original query so param-consuming routes keep working
+    // (e.g. /assets/new?qrId=... reads qrId via useLocalSearchParams to link
+    // the scanned QR to the created asset). Extra params on routes that
+    // ignore them are harmless.
+    const withQuery = (route: string) => (query ? `${route}?${query}` : route);
 
     const [resource, id] = segments;
 
@@ -94,17 +108,20 @@ export function redirectSystemPath({ path }: RedirectSystemPathArgs): string {
         // Custom-scheme kit links can arrive as assets/kits/:id (the kit
         // detail lives inside the assets stack).
         if (id === "kits") {
-          return segments[2] ? `/assets/kits/${segments[2]}` : "/assets";
+          return withQuery(
+            segments[2] ? `/assets/kits/${segments[2]}` : "/assets"
+          );
         }
         // Any deeper web path (/assets/:id/overview, /assets/:id/activity…)
         // maps to the native asset detail — that is what the tapper wants.
-        return id ? `/assets/${id}` : "/assets";
+        // This also covers /assets/new (id = "new" → the create screen).
+        return withQuery(id ? `/assets/${id}` : "/assets");
       case "kits":
-        return id ? `/assets/kits/${id}` : "/assets";
+        return withQuery(id ? `/assets/kits/${id}` : "/assets");
       case "bookings":
-        return id ? `/bookings/${id}` : "/bookings";
+        return withQuery(id ? `/bookings/${id}` : "/bookings");
       case "audits":
-        return id ? `/audits/${id}` : "/audits";
+        return withQuery(id ? `/audits/${id}` : "/audits");
       case "qr":
         // Needs an async API resolve (asset vs kit vs other-org) that a path
         // rewrite cannot express. Land on the start screen; useDeepLinkHandler

--- a/apps/companion/app/+not-found.tsx
+++ b/apps/companion/app/+not-found.tsx
@@ -1,0 +1,12 @@
+import { Redirect } from "expo-router";
+
+/**
+ * Route-level safety net: any path the router cannot match (e.g. an
+ * OS-delivered link shape `app/+native-intent.ts` didn't anticipate)
+ * redirects to the start screen instead of stranding the user on a dead
+ * screen behind the splash — the failure mode of the 1.1.0 build-25
+ * cold-start deep-link hang.
+ */
+export default function NotFoundScreen() {
+  return <Redirect href="/" />;
+}

--- a/apps/companion/components/asset-edit/tag-picker-field.tsx
+++ b/apps/companion/components/asset-edit/tag-picker-field.tsx
@@ -46,7 +46,22 @@ type TagPickerFieldProps = {
   onToggle: (next: boolean) => void;
   /** Placeholder for the in-dropdown search input (shown when >5 tags). */
   searchPlaceholder?: string;
+  /**
+   * Whether the caller may create tags (server-computed `canCreate` from
+   * `GET /api/mobile/tags`). When true and `onCreateTag` is provided, typing
+   * a name with no exact match shows an inline "Create tag" row.
+   */
+  canCreate?: boolean;
+  /**
+   * Creates the tag (parent owns the API call + list refresh) and returns it,
+   * or null when creation failed (parent surfaces the error). On success the
+   * picker selects the new tag and clears the search.
+   */
+  onCreateTag?: (name: string) => Promise<Tag | null>;
 };
+
+/** Server-side minimum tag-name length (web `NewTagFormSchema` parity). */
+const MIN_TAG_NAME_LENGTH = 3;
 
 /**
  * Render the multi-select tag picker. See the file header for the controlled
@@ -63,14 +78,43 @@ export function TagPickerField({
   isOpen,
   onToggle,
   searchPlaceholder = "Search tags...",
+  canCreate = false,
+  onCreateTag,
 }: TagPickerFieldProps) {
   const { colors } = useTheme();
   const styles = useStyles();
   const [search, setSearch] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
 
   const filteredTags = search
     ? tags.filter((t) => t.name.toLowerCase().includes(search.toLowerCase()))
     : tags;
+
+  // Offer inline creation only for a typed name that (a) meets the server's
+  // minimum length and (b) doesn't already exist (case-insensitive) — an
+  // exact match should be selected, not duplicated.
+  const trimmedSearch = search.trim();
+  const showCreateRow =
+    canCreate &&
+    !!onCreateTag &&
+    trimmedSearch.length >= MIN_TAG_NAME_LENGTH &&
+    !tags.some((t) => t.name.toLowerCase() === trimmedSearch.toLowerCase());
+
+  // Create the typed tag, select it, and reset the search so the full list
+  // shows again (with the fresh tag now selected as a chip).
+  const createAndSelect = async () => {
+    if (!onCreateTag || isCreating) return;
+    setIsCreating(true);
+    try {
+      const tag = await onCreateTag(trimmedSearch);
+      if (tag) {
+        onChange([...selectedTags, tag]);
+        setSearch("");
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  };
 
   const removeTag = (id: string) =>
     onChange(selectedTags.filter((t) => t.id !== id));
@@ -136,7 +180,9 @@ export function TagPickerField({
 
       {isOpen && (
         <View style={styles.pickerDropdown}>
-          {tags.length > 5 && (
+          {/* The search box doubles as the new-tag name input for creators,
+              so it must show even when the list is short. */}
+          {(tags.length > 5 || (canCreate && !!onCreateTag)) && (
             <TextInput
               style={styles.pickerSearch}
               value={search}
@@ -145,6 +191,28 @@ export function TagPickerField({
               placeholderTextColor={colors.placeholderText}
               accessibilityLabel={searchPlaceholder}
             />
+          )}
+          {showCreateRow && (
+            <TouchableOpacity
+              style={styles.pickerCreate}
+              onPress={() => void createAndSelect()}
+              disabled={isCreating}
+              accessibilityRole="button"
+              accessibilityLabel={`Create tag ${trimmedSearch}`}
+            >
+              {isCreating ? (
+                <ActivityIndicator size="small" color={colors.primary} />
+              ) : (
+                <Ionicons
+                  name="add-circle-outline"
+                  size={16}
+                  color={colors.primary}
+                />
+              )}
+              <Text style={styles.pickerCreateText}>
+                {`Create tag "${trimmedSearch}"`}
+              </Text>
+            </TouchableOpacity>
           )}
           {isLoading ? (
             <ActivityIndicator
@@ -281,6 +349,21 @@ const useStyles = createStyles((colors, shadows) => ({
     flex: 1,
     fontSize: fontSize.base,
     color: colors.foreground,
+  },
+  pickerCreate: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  pickerCreateText: {
+    flex: 1,
+    fontSize: fontSize.base,
+    color: colors.primary,
+    fontWeight: "500",
   },
   pickerClear: {
     paddingHorizontal: 14,

--- a/apps/companion/components/asset-edit/tag-picker-field.tsx
+++ b/apps/companion/components/asset-edit/tag-picker-field.tsx
@@ -13,7 +13,7 @@
  * @see {@link file://./picker-field.tsx PickerField} — the single-select sibling.
  */
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   View,
   Text,
@@ -86,6 +86,13 @@ export function TagPickerField({
   const [search, setSearch] = useState("");
   const [isCreating, setIsCreating] = useState(false);
 
+  // Mirror of the latest selection. The async create continuation must merge
+  // against this, not the render-time `selectedTags` closure — other tag rows
+  // stay tappable while the create request is in flight, and a stale array
+  // would silently revert any toggle made during that window.
+  const selectedTagsRef = useRef(selectedTags);
+  selectedTagsRef.current = selectedTags;
+
   const filteredTags = search
     ? tags.filter((t) => t.name.toLowerCase().includes(search.toLowerCase()))
     : tags;
@@ -108,7 +115,12 @@ export function TagPickerField({
     try {
       const tag = await onCreateTag(trimmedSearch);
       if (tag) {
-        onChange([...selectedTags, tag]);
+        // Merge against the LATEST selection (ref), and drop any duplicate id
+        // defensively, so toggles made while the request was pending survive.
+        onChange([
+          ...selectedTagsRef.current.filter((t) => t.id !== tag.id),
+          tag,
+        ]);
         setSearch("");
       }
     } finally {

--- a/apps/companion/hooks/use-edit-asset-form.ts
+++ b/apps/companion/hooks/use-edit-asset-form.ts
@@ -22,6 +22,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { Alert } from "react-native";
 import {
   api,
   type AssetDetail,
@@ -146,6 +147,10 @@ export type EditAssetFormState = {
   isCategoriesLoading: boolean;
   isLocationsLoading: boolean;
   isTagsLoading: boolean;
+  /** Server-computed: caller may mint tags inline (admins/owners). */
+  canCreateTag: boolean;
+  /** Create a tag inline; adds it to `tags` and returns it, or null on failure. */
+  createTag: (name: string) => Promise<Tag | null>;
 
   // Submission
   isSubmitting: boolean;
@@ -219,6 +224,9 @@ export function useEditAssetForm(
   const [isCategoriesLoading, setIsCategoriesLoading] = useState(false);
   const [isLocationsLoading, setIsLocationsLoading] = useState(false);
   const [isTagsLoading, setIsTagsLoading] = useState(false);
+  // Server-computed from GET /api/mobile/tags: whether the caller may mint
+  // tags inline (admins/owners). Gates the picker's "create tag" row.
+  const [canCreateTag, setCanCreateTag] = useState(false);
 
   // ── Load existing asset ─────────────────────────
   useEffect(() => {
@@ -302,12 +310,35 @@ export function useEditAssetForm(
       const { data } = await api.tags(orgId);
       if (requestId !== latestTagsRequestRef.current) return;
       if (data?.tags) setTags(data.tags);
+      // Server-computed create capability (gates the picker's inline
+      // "create tag" row; false on older servers that omit the flag).
+      setCanCreateTag(data?.canCreate ?? false);
     } finally {
       if (requestId === latestTagsRequestRef.current) {
         setIsTagsLoading(false);
       }
     }
   }, [orgId]);
+
+  // Inline tag creation from the picker (admins/owners; the server enforces
+  // `tag.create`). Adds the new tag to the local list so the dropdown shows it
+  // without a refetch (the API helper already invalidated the cached list).
+  const createTag = useCallback(
+    async (name: string): Promise<Tag | null> => {
+      if (!orgId) return null;
+      const { data, error } = await api.createTag(orgId, name);
+      if (error || !data?.tag) {
+        Alert.alert("Couldn't create tag", error || "Please try again.");
+        return null;
+      }
+      const tag = data.tag;
+      setTags((prev) =>
+        [...prev, tag].sort((a, b) => a.name.localeCompare(b.name))
+      );
+      return tag;
+    },
+    [orgId]
+  );
 
   useEffect(() => {
     loadCategories();
@@ -422,6 +453,8 @@ export function useEditAssetForm(
     isCategoriesLoading,
     isLocationsLoading,
     isTagsLoading,
+    canCreateTag,
+    createTag,
     isSubmitting,
     setIsSubmitting,
   };

--- a/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
+++ b/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
@@ -360,7 +360,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -392,7 +392,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/companion/ios/Shelf/Info.plist
+++ b/apps/companion/ios/Shelf/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apps/companion/lib/api/asset-mutations.ts
+++ b/apps/companion/lib/api/asset-mutations.ts
@@ -11,10 +11,11 @@
  */
 
 import { apiFetch, apiUpload } from "./client";
-import { cachedApiFetch } from "./cache";
+import { cachedApiFetch, invalidateResponseCache } from "./cache";
 import type {
   CategoriesResponse,
   TagsResponse,
+  CreateTagResponse,
   CreateAssetResponse,
   CustomFieldsResponse,
   CustomFieldValue,
@@ -32,6 +33,27 @@ export const assetMutationsApi = {
   /** Get tags assignable to assets (for the create-asset tag picker) */
   tags: (orgId: string) =>
     cachedApiFetch<TagsResponse>(`/api/mobile/tags?orgId=${orgId}`),
+
+  /**
+   * Create a new tag inline from the tag picker (admins/owners only — the
+   * server enforces `tag.create`; the picker hides the affordance via the
+   * `canCreate` flag on {@link TagsResponse}). Invalidates the cached tag
+   * list on success so the next picker load includes the new tag.
+   *
+   * @param orgId - the active organization
+   * @param name - the tag name (server requires 3+ chars, web parity)
+   */
+  createTag: async (orgId: string, name: string) => {
+    const result = await apiFetch<CreateTagResponse>(
+      `/api/mobile/tags/create?orgId=${orgId}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ name }),
+      }
+    );
+    if (!result.error) invalidateResponseCache("/api/mobile/tags");
+    return result;
+  },
 
   /**
    * Get the active custom field definitions for the org, optionally filtered

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -716,6 +716,18 @@ export type Tag = {
 /** Response payload for `GET /api/mobile/tags` (the asset tag picker source). */
 export type TagsResponse = {
   tags: Tag[];
+  /**
+   * Server-computed: whether the caller may mint a new tag via
+   * `POST /api/mobile/tags/create` (admins/owners). Gates the picker's inline
+   * "create tag" affordance so self-service users never see a control that
+   * would 403. Optional so the app tolerates older servers (treated as false).
+   */
+  canCreate?: boolean;
+};
+
+/** Response payload for `POST /api/mobile/tags/create`. */
+export type CreateTagResponse = {
+  tag: Tag;
 };
 
 export type CreateAssetResponse = {

--- a/apps/companion/lib/deep-links.ts
+++ b/apps/companion/lib/deep-links.ts
@@ -24,9 +24,15 @@ import { openShelfWebUrl, pushIntoTab } from "./navigation";
  *
  * The claimed paths are kept in sync with the iOS AASA `components` list and
  * the Android `intentFilters` path prefixes. Paths outside the claimed prefixes
- * are never delivered to the app and keep opening the web. A claimed prefix that
- * nests deeper than the app can render (e.g. `/assets/:id/edit`) is opened in
- * the in-app web view instead of landing on the wrong native screen.
+ * are never delivered to the app and keep opening the web.
+ *
+ * Division of labour with `app/+native-intent.ts`: HTTPS universal links are
+ * rewritten there to native routes and handled by expo-router itself (a
+ * claimed path that nests deeper than the app renders, e.g.
+ * `/assets/:id/overview`, maps to the resource detail). This hook only
+ * handles (a) custom-scheme links, which have no native path mapping
+ * guarantees, and (b) `/qr/:id` links, which need an async API resolve.
+ * Acting on other HTTPS links here would double-navigate.
  */
 
 type ParsedLink =
@@ -36,10 +42,6 @@ type ParsedLink =
   | { type: "audit"; id: string }
   | { type: "qr"; id: string }
   | { type: "scanner" }
-  // A claimed HTTPS prefix matched but the path nests deeper than the native
-  // app can render (e.g. /assets/:id/edit) — open the original URL in the web
-  // view rather than a wrong native screen.
-  | { type: "web"; url: string }
   | { type: "unknown" };
 
 function parseDeepLink(url: string): ParsedLink {
@@ -58,24 +60,11 @@ function parseDeepLink(url: string): ParsedLink {
 
     if (segments.length === 0) return { type: "unknown" };
 
+    // A path that nests deeper than `resource/id` (e.g. /assets/:id/overview,
+    // the canonical web asset URL) resolves to the resource detail — that is
+    // what the tapper wants, and it matches the +native-intent rewrite so warm
+    // and cold starts behave identically.
     const [resource, id] = segments;
-
-    // Over-claim guard: the OS delivers every nested path under a claimed prefix
-    // (e.g. /assets/:id/edit, /bookings/:id/overview/checkin-assets), but the
-    // native app only renders the resource detail and the OS path patterns can't
-    // be scoped to a single segment. So for an HTTPS link that nests deeper than
-    // `resource/id`, open the original URL in the in-app web view (loop-safe via
-    // openShelfWebUrl, NOT Linking.openURL which App Links would re-intercept)
-    // rather than landing on the wrong native screen.
-    const CLAIMED_HTTPS_PREFIXES = ["qr", "assets", "bookings", "audits"];
-    if (
-      isHttp &&
-      id &&
-      segments.length > 2 &&
-      CLAIMED_HTTPS_PREFIXES.includes(resource)
-    ) {
-      return { type: "web", url };
-    }
 
     switch (resource) {
       case "assets":
@@ -143,8 +132,19 @@ async function resolveQrAndNavigate(qrId: string) {
  */
 export function useDeepLinkHandler() {
   useEffect(() => {
+    /**
+     * True for URLs that expo-router already routes natively via the
+     * `app/+native-intent.ts` rewrite. Acting on those here too would
+     * double-navigate; the exception is `/qr/:id`, which needs an async API
+     * resolve that a path rewrite cannot express.
+     */
+    function isNativelyRouted(url: string, link: ParsedLink) {
+      return /^https?:/i.test(url) && link.type !== "qr";
+    }
+
     function handleUrl(event: { url: string }) {
       const link = parseDeepLink(event.url);
+      if (isNativelyRouted(event.url, link)) return;
       navigateToLink(link);
     }
 
@@ -169,24 +169,20 @@ export function useDeepLinkHandler() {
         case "scanner":
           pushIntoTab("/(tabs)/scanner");
           break;
-        case "web":
-          // Claimed prefix nested deeper than the app renders: open the real
-          // web page in the in-app browser (loop-safe) instead of a wrong
-          // native screen.
-          void openShelfWebUrl(link.url);
-          break;
         case "unknown":
           // Ignore unrecognized links — nothing to navigate to.
           break;
       }
     }
 
-    // Handle the URL that launched the app (cold start)
+    // Handle the URL that launched the app (cold start). HTTPS links are
+    // already routed by expo-router via the +native-intent rewrite — only
+    // custom-scheme links and /qr resolution need JS navigation here.
     Linking.getInitialURL().then((url) => {
       if (url) {
         const link = parseDeepLink(url);
-        // Skip navigation for unrecognized links.
-        if (link.type !== "unknown") {
+        // Skip natively-routed and unrecognized links.
+        if (link.type !== "unknown" && !isNativelyRouted(url, link)) {
           // Small delay to let navigation mount
           setTimeout(() => navigateToLink(link), 500);
         }

--- a/apps/webapp/app/routes/api+/mobile+/tags.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/tags.create.ts
@@ -8,6 +8,7 @@ import {
 import { createTag } from "~/modules/tag/service.server";
 import { makeShelfError } from "~/utils/error";
 import { getRandomColor } from "~/utils/get-random-color";
+import { parseData } from "~/utils/http.server";
 import {
   PermissionAction,
   PermissionEntity,
@@ -52,7 +53,13 @@ export async function action({ request }: ActionFunctionArgs) {
     });
 
     const body = await request.json();
-    const { name } = CreateTagSchema.parse(body);
+    // parseData maps validation failures to a 400 ShelfError (a bare
+    // schema.parse would throw ZodError -> generic 500 + Sentry capture).
+    const { name } = parseData(body, CreateTagSchema, {
+      // Expected user-input validation, not a server fault.
+      shouldBeCaptured: false,
+      additionalData: { userId: user.id, organizationId },
+    });
 
     const tag = await createTag({
       name,

--- a/apps/webapp/app/routes/api+/mobile+/tags.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/tags.create.ts
@@ -1,0 +1,78 @@
+import { data, type ActionFunctionArgs } from "react-router";
+import { z } from "zod";
+import {
+  requireMobileAuth,
+  requireMobilePermission,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { createTag } from "~/modules/tag/service.server";
+import { makeShelfError } from "~/utils/error";
+import { getRandomColor } from "~/utils/get-random-color";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+
+/**
+ * POST /api/mobile/tags/create
+ *
+ * Creates a new tag in the caller's organization so the mobile tag picker can
+ * mint tags inline (admins/owners only — same `tag.create` permission the web
+ * tag settings page enforces). The tag is created all-purpose (`useFor: []`,
+ * usable on assets and bookings) with a server-picked color, mirroring the web
+ * form's defaults.
+ *
+ * Body: `{ name: string }` — min 3 chars, same rule as the web
+ * `NewTagFormSchema`. Duplicate names surface as a 400 via the tag service's
+ * unique-constraint mapping.
+ *
+ * Query: ?orgId=...
+ *
+ * Response: `{ tag: { id, name } }` — the shape the picker consumes.
+ *
+ * @see {@link file://./tags.ts} the picker read (returns `canCreate` for UI gating).
+ * @see {@link file://../../_layout+/tags.new.tsx} the web equivalent this mirrors.
+ */
+
+/** Mirrors the web `NewTagFormSchema.name` rule (min 3 chars). */
+const CreateTagSchema = z.object({
+  name: z.string().trim().min(3, "Name is required"),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  try {
+    const { user } = await requireMobileAuth(request);
+    const organizationId = await requireOrganizationAccess(request, user.id);
+
+    await requireMobilePermission({
+      userId: user.id,
+      organizationId,
+      entity: PermissionEntity.tag,
+      action: PermissionAction.create,
+    });
+
+    const body = await request.json();
+    const { name } = CreateTagSchema.parse(body);
+
+    const tag = await createTag({
+      name,
+      description: null,
+      // The mobile form has no color input; pick one server-side like the web
+      // form's `colorFromServer` default.
+      color: getRandomColor(),
+      userId: user.id,
+      organizationId,
+      // All-purpose (assets AND bookings) — the web form's default when no
+      // "use for" restriction is ticked.
+      useFor: [],
+    });
+
+    return data({ tag: { id: tag.id, name: tag.name } });
+  } catch (cause) {
+    const reason = makeShelfError(cause);
+    return data(
+      { error: { message: reason.message } },
+      { status: reason.status }
+    );
+  }
+}

--- a/apps/webapp/app/routes/api+/mobile+/tags.ts
+++ b/apps/webapp/app/routes/api+/mobile+/tags.ts
@@ -1,10 +1,16 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
 import { getTagsForAssetTagsFilter } from "~/modules/tag/service.server";
 import { makeShelfError } from "~/utils/error";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { hasPermission } from "~/utils/permissions/permission.validator.server";
 
 /**
  * GET /api/mobile/tags
@@ -16,6 +22,10 @@ import { makeShelfError } from "~/utils/error";
  * endpoint, and sits alongside the other top-level asset-form pickers
  * (`/api/mobile/categories`, `/api/mobile/locations`).
  *
+ * Also returns `canCreate` — whether the caller may mint a new tag via
+ * `POST /api/mobile/tags/create` — so the picker can gate its inline
+ * "create tag" affordance server-side instead of guessing roles on-device.
+ *
  * Query: ?orgId=...
  *
  * @see {@link file://./bookings.tags.ts} the booking tag picker (same shape).
@@ -26,10 +36,26 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
 
-    const { tags } = await getTagsForAssetTagsFilter({ organizationId });
+    const [{ tags }, { role }] = await Promise.all([
+      getTagsForAssetTagsFilter({ organizationId }),
+      getMobileUserContext(user.id, organizationId),
+    ]);
+
+    // Server-computed capability flag (same pattern as the booking detail's
+    // `bookingActions`): the picker shows its inline "create tag" affordance
+    // only when the caller could actually create one, so self-service users
+    // never see a control that would 403.
+    const canCreate = await hasPermission({
+      userId: user.id,
+      organizationId,
+      roles: [role],
+      entity: PermissionEntity.tag,
+      action: PermissionAction.create,
+    });
 
     return data({
       tags: tags.map((tag) => ({ id: tag.id, name: tag.name })),
+      canCreate,
     });
   } catch (cause) {
     const reason = makeShelfError(cause);

--- a/apps/webapp/test/routes-tests/api+/mobile.tags.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.tags.create.test.ts
@@ -37,12 +37,17 @@ vi.mock("~/modules/tag/service.server", () => ({
   createTag: vi.fn(),
 }));
 
-// why: error utility — we mock to control error formatting in tests
+// why: error utility — we mock to control error formatting in tests.
+// badRequest must be provided too: parseData (http.server) imports it from
+// this module to build its 400 validation error.
 vi.mock("~/utils/error", () => ({
   makeShelfError: vi.fn((cause: any) => ({
     message: cause?.message || "Unknown error",
     status: cause?.status || 500,
   })),
+  badRequest: vi.fn((message: string, options: any) =>
+    Object.assign(new Error(message), { ...options, status: 400 })
+  ),
   ShelfError: class ShelfError extends Error {
     status: number;
     constructor(opts: any) {
@@ -121,12 +126,13 @@ describe("POST /api/mobile/tags/create", () => {
     expect(createTag).not.toHaveBeenCalled();
   });
 
-  it("rejects names shorter than 3 chars (web NewTagFormSchema parity)", async () => {
+  it("rejects names shorter than 3 chars as a 400 (web NewTagFormSchema parity)", async () => {
     const response = (await action(
       createActionArgs({ request: makeRequest({ name: "ab" }) })
     )) as unknown as Response;
 
-    expect(response.status).toBeGreaterThanOrEqual(400);
+    // parseData maps validation failures to a 400 client error, not a 500.
+    expect(response.status).toBe(400);
     expect(createTag).not.toHaveBeenCalled();
   });
 

--- a/apps/webapp/test/routes-tests/api+/mobile.tags.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.tags.create.test.ts
@@ -1,0 +1,149 @@
+import { action } from "~/routes/api+/mobile+/tags.create";
+import { createActionArgs } from "@mocks/remix";
+
+// @vitest-environment node
+
+// why: mocking Remix's data() function to return Response objects for React Router v7 single fetch
+const createDataMock = vi.hoisted(() => {
+  return () =>
+    vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: {
+          "Content-Type": "application/json",
+          ...(init?.headers || {}),
+        },
+      });
+    });
+});
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    data: createDataMock(),
+  };
+});
+
+// why: external auth — we don't want to hit Supabase in tests
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+  requireMobilePermission: vi.fn(),
+}));
+
+// why: external service — we don't want to hit the real database when creating tags
+vi.mock("~/modules/tag/service.server", () => ({
+  createTag: vi.fn(),
+}));
+
+// why: error utility — we mock to control error formatting in tests
+vi.mock("~/utils/error", () => ({
+  makeShelfError: vi.fn((cause: any) => ({
+    message: cause?.message || "Unknown error",
+    status: cause?.status || 500,
+  })),
+  ShelfError: class ShelfError extends Error {
+    status: number;
+    constructor(opts: any) {
+      super(opts.message);
+      this.status = opts.status || 500;
+    }
+  },
+}));
+
+import {
+  requireMobileAuth,
+  requireMobilePermission,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { createTag } from "~/modules/tag/service.server";
+
+const ORG_ID = "org-1";
+const USER = { id: "user-1" };
+
+function makeRequest(body: unknown) {
+  return new Request(
+    `https://app.test/api/mobile/tags/create?orgId=${ORG_ID}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("POST /api/mobile/tags/create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (requireMobileAuth as any).mockResolvedValue({ user: USER });
+    (requireOrganizationAccess as any).mockResolvedValue(ORG_ID);
+    (requireMobilePermission as any).mockResolvedValue(undefined);
+    (createTag as any).mockResolvedValue({
+      id: "tag-1",
+      name: "Fragile",
+      color: "#175CD3",
+    });
+  });
+
+  it("creates an org-scoped, all-purpose tag and returns its picker shape", async () => {
+    const response = (await action(
+      createActionArgs({ request: makeRequest({ name: "  Fragile  " }) })
+    )) as unknown as Response;
+
+    expect(createTag).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // Zod trims before the service sees it.
+        name: "Fragile",
+        organizationId: ORG_ID,
+        userId: USER.id,
+        // All-purpose default — usable on assets AND bookings (web parity).
+        useFor: [],
+        color: expect.stringMatching(/^#[0-9a-fA-F]{6}$/),
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      tag: { id: "tag-1", name: "Fragile" },
+    });
+  });
+
+  it("enforces the tag.create permission before touching the service", async () => {
+    (requireMobilePermission as any).mockRejectedValue(
+      Object.assign(new Error("Forbidden"), { status: 403 })
+    );
+
+    const response = (await action(
+      createActionArgs({ request: makeRequest({ name: "Fragile" }) })
+    )) as unknown as Response;
+
+    expect(response.status).toBe(403);
+    expect(createTag).not.toHaveBeenCalled();
+  });
+
+  it("rejects names shorter than 3 chars (web NewTagFormSchema parity)", async () => {
+    const response = (await action(
+      createActionArgs({ request: makeRequest({ name: "ab" }) })
+    )) as unknown as Response;
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(createTag).not.toHaveBeenCalled();
+  });
+
+  it("surfaces duplicate-name errors from the service as a client error", async () => {
+    (createTag as any).mockRejectedValue(
+      Object.assign(new Error("Tag with that name already exists"), {
+        status: 400,
+      })
+    );
+
+    const response = (await action(
+      createActionArgs({ request: makeRequest({ name: "Fragile" }) })
+    )) as unknown as Response;
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: { message: "Tag with that name already exists" },
+    });
+  });
+});


### PR DESCRIPTION
## What

Two companion improvements shipping with the 1.1.0 store release, plus the version bump.

### 1. Fix: universal links froze the app on cold start
Found in TestFlight smoke testing (build 25). The canonical web asset URL is `/assets/:id/overview`; no native route matched it, so a link tap that cold-started the app left the router on an unmatched route behind the splash screen forever. The in-app-browser fallback (a 500ms `setTimeout`) silently failed during launch.

Fix, following expo-router's intended mechanism:
- **`app/+native-intent.ts`** rewrites every claimed prefix to a real native route before the router resolves. Nested paths land on the resource **detail** screen (what the tapper wants). Note: on native, expo-router passes the **raw full URL** to `redirectSystemPath` (verified against the 6.0.23 source), so the rewriter normalises scheme + host.
- **`app/+not-found.tsx`** redirect-home safety net so no unmatched route can ever strand a user again.
- `lib/deep-links.ts` now only handles custom-scheme links and async `/qr` resolution; handling other https links in JS would double-navigate.
- The deep-link allowlist rule doc now lists **four** places to keep in sync.

Verified: 19 link shapes asserted through the compiled rewriter (incl. the exact failing link, query strings, custom scheme, dev-client passthrough), plus on-device TestFlight re-test on the next build.

### 2. Feat: create tags from the mobile tag picker
Admins/owners can mint a tag inline while creating/editing an asset:
- New `POST /api/mobile/tags/create`: mobile auth trio + `tag.create` permission, name min 3 chars (`NewTagFormSchema` parity), server-picked color, all-purpose `useFor` (web form default). Duplicates surface as 400 via the tag service's unique-constraint mapping.
- `GET /api/mobile/tags` now returns a server-computed `canCreate` flag (same pattern as the booking detail's `bookingActions`) so the app never guesses roles; self-service users never see the control.
- Picker shows a **Create tag "name"** row when allowed and the typed name has no case-insensitive match; new tag is inserted sorted + selected; cached list invalidated.
- **Graceful rollout:** `canCreate` is optional client-side, so app builds shipped before this deploys simply hide the affordance until the server catches up. No build-order coupling.

### 3. Version bump 1.1.0
All four marketing-version spots (app.json + Info.plist `CFBundleShortVersionString` + `MARKETING_VERSION` ×2). Build numbers remain EAS-managed.

## Testing
- 4 new route tests for the endpoint (permission gate, trim+shape, min-length, duplicate mapping)
- Full webapp suite green: 220 files / 3005 tests
- Companion typecheck + lint clean
- Deep-link rewriter: 19-shape assertion run against the compiled function

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-gated inline “Create tag” support in the asset create/edit tag picker.
  * Added a catch-all not-found route that redirects to the app start screen.
* **Bug Fixes**
  * Improved deep-link handling to reduce double-navigation and align native vs in-app routing, including cold-start and QR flows.
* **Documentation**
  * Updated companion deep-link allowlist guidance to reflect the required native intent mapping and revised routing expectations.
* **Chores**
  * Bumped companion app version to **1.1.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->