### PR TITLE
feat(bookings): improve item sorting and fix per-slice QT checkout status

### DIFF
--- a/apps/webapp/app/components/booking/booking-assets-filters.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-filters.tsx
@@ -38,6 +38,19 @@ export function BookingAssetsFilters() {
             sortingOptions={BOOKING_ASSET_SORTING_OPTIONS}
             defaultSortingBy="status"
             defaultSortingDirection="desc"
+            hint={
+              <div className="text-xs">
+                <p>
+                  <strong>Status</strong> keeps items still to check out on top
+                  and moves checked-out items to the bottom, so you can focus on
+                  what's left.
+                </p>
+                <p className="mt-1">
+                  <strong>Item type</strong> groups kits first, then individual
+                  assets.
+                </p>
+              </div>
+            }
           />
         ),
       }}

--- a/apps/webapp/app/components/booking/list-asset-content.test.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.test.tsx
@@ -127,15 +127,27 @@ vi.mock("~/hooks/use-current-organization", () => ({
   }),
 }));
 
-// why: controlling asset status logic to test returned badge vs status badge behavior
-vi.mock("~/utils/booking-assets", () => ({
-  getBookingContextAssetStatus: (
-    ...args: Parameters<typeof getBookingContextAssetStatusMock>
-  ) => getBookingContextAssetStatusMock(...args),
-  isAssetPartiallyCheckedIn: (
-    ...args: Parameters<typeof isAssetPartiallyCheckedInMock>
-  ) => isAssetPartiallyCheckedInMock(...args),
-}));
+// why: controlling asset status logic to test returned badge vs status badge
+// behavior. Only the two status resolvers are stubbed; the rest of the module
+// (notably the pure per-slice `isBookingRowQtyFullyCheckedOut`) uses the REAL
+// implementation via importActual so the per-slice checkout badge is exercised
+// for real, not mocked away. (The `import type` of service.server in the real
+// module is erased at runtime, so no server code is pulled in.)
+vi.mock("~/utils/booking-assets", async () => {
+  const actual = (await vi.importActual("~/utils/booking-assets")) as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...actual,
+    getBookingContextAssetStatus: (
+      ...args: Parameters<typeof getBookingContextAssetStatusMock>
+    ) => getBookingContextAssetStatusMock(...args),
+    isAssetPartiallyCheckedIn: (
+      ...args: Parameters<typeof isAssetPartiallyCheckedInMock>
+    ) => isAssetPartiallyCheckedInMock(...args),
+  };
+});
 
 describe("ListAssetContent", () => {
   const basePartialDetails = {} as PartialCheckinDetailsType;
@@ -613,6 +625,105 @@ describe("ListAssetContent", () => {
       );
 
       expect(screen.queryByText(/insufficient stock/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // Per-slice QT checkout status. A QUANTITY_TRACKED asset can have multiple
+  // BookingAsset slices on one booking (e.g. a kit-driven slice + a standalone
+  // free-pool slice). Each row's badge must reflect THIS slice's own checkout
+  // progress (`checkedOutQuantity` vs `bookedQuantity`), NOT the global
+  // `Asset.status` — which only flips to CHECKED_OUT when EVERY slice is fully
+  // out, so a single fully-checked-out slice would otherwise wrongly read
+  // "Available". Mirrors the existing per-row check-IN completion handling.
+  describe("QT per-slice checkout status", () => {
+    const qtKitSliceRow = {
+      ...baseAsset,
+      id: "asset-qt-pencils",
+      type: "QUANTITY_TRACKED",
+      // Global status stays AVAILABLE: the parallel standalone slice is still
+      // booked, so the asset-wide flip never fires. Mocked resolver returns
+      // AVAILABLE (default) to model exactly that.
+      status: "AVAILABLE",
+      bookingAssetId: "ba-kit-slice",
+      bookedQuantity: 22,
+      dispositionedQuantity: 0,
+    } as unknown as AssetWithBooking;
+
+    it("shows CHECKED_OUT for a slice whose own units are all checked out, even though the global asset status is AVAILABLE", () => {
+      mockUseLoaderData.mockReturnValue({
+        booking: {
+          id: "booking-ongoing-qt",
+          status: "ONGOING",
+          bookingAssets: [{ assetId: qtKitSliceRow.id }],
+          custodianUser: null,
+        },
+      });
+
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <ListAssetContent
+                item={
+                  {
+                    ...qtKitSliceRow,
+                    // This slice's 22 booked units are all checked out; nothing
+                    // returned yet.
+                    checkedOutQuantity: 22,
+                  } as unknown as AssetWithBooking
+                }
+                partialCheckinDetails={basePartialDetails}
+                shouldShowCheckinColumns={false}
+                partialCheckoutDetails={{}}
+                shouldShowCheckoutColumns={false}
+              />
+            </tr>
+          </tbody>
+        </table>
+      );
+
+      expect(assetStatusBadgeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "CHECKED_OUT" })
+      );
+    });
+
+    it("still shows the pending-return badge (not CHECKED_OUT) when only SOME of the slice's units are checked out", () => {
+      mockUseLoaderData.mockReturnValue({
+        booking: {
+          id: "booking-ongoing-qt-partial",
+          status: "ONGOING",
+          bookingAssets: [{ assetId: qtKitSliceRow.id }],
+          custodianUser: null,
+        },
+      });
+
+      render(
+        <table>
+          <tbody>
+            <tr>
+              <ListAssetContent
+                item={
+                  {
+                    ...qtKitSliceRow,
+                    // 10 of 22 out → partial, must NOT read as fully CHECKED_OUT.
+                    checkedOutQuantity: 10,
+                  } as unknown as AssetWithBooking
+                }
+                partialCheckinDetails={basePartialDetails}
+                shouldShowCheckinColumns={false}
+                partialCheckoutDetails={{}}
+                shouldShowCheckoutColumns={false}
+              />
+            </tr>
+          </tbody>
+        </table>
+      );
+
+      expect(assetStatusBadgeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN",
+        })
+      );
     });
   });
 });

--- a/apps/webapp/app/components/booking/list-asset-content.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.tsx
@@ -17,6 +17,7 @@ import type { AssetWithBooking } from "~/routes/_layout+/bookings.$bookingId.ove
 import {
   getBookingContextAssetStatus,
   isAssetPartiallyCheckedIn,
+  isBookingRowQtyFullyCheckedOut,
 } from "~/utils/booking-assets";
 import { tw } from "~/utils/tw";
 import { resolveUserDisplayName } from "~/utils/user";
@@ -256,14 +257,25 @@ export default function ListAssetContent({
     qtyBooked > 0 &&
     qtyCheckedOut > 0 &&
     // Upper guard: ONLY fires when SOME but not all booked units are out.
-    // When `qtyCheckedOut === qtyBooked` and nothing has been returned, the
-    // service-side post-batch flip sets `asset.status = CHECKED_OUT`, so the
-    // row falls through to `baseContextStatus` which renders the standard
-    // violet "Checked out" badge. Without this guard, the amber pending-
-    // return badge would shadow the fully-out state.
+    // The fully-out case (`qtyCheckedOut >= qtyBooked`) is handled by
+    // `isQtyFullyCheckedOut` below → CHECKED_OUT. Without this guard, the
+    // amber pending-return badge would shadow the fully-out state.
     qtyCheckedOut < qtyBooked &&
     qtyDispositioned === 0 &&
     isActiveBooking;
+  /**
+   * This row's own units are ALL progressively checked OUT with NO disposition
+   * yet → the slice is fully out and should read as the standard violet
+   * "Checked out". Resolved per-row (per `bookingAssetId`) via the SHARED
+   * helper so this badge and the status-sort's `isCheckedOut` predicate
+   * (`shape-booking-assets.ts`) use identical logic and can never disagree —
+   * the divergence that let a fully-checked-out kit slice read "Available"
+   * while its kit still sat at the top of a status sort.
+   */
+  const isQtyFullyCheckedOut = isBookingRowQtyFullyCheckedOut(
+    item,
+    booking.status
+  );
 
   /**
    * Workspace-availability lookup for this row's asset. `undefined` when
@@ -322,11 +334,16 @@ export default function ListAssetContent({
    *     as in-progress on the check-IN side.
    *  2. Qty partly reconciled (some disposition, more outstanding) →
    *     `PARTIALLY_CHECKED_OUT_QTY` (violet, "returns underway").
-   *  3. Qty progressively checked OUT with NO returns yet →
-   *     `PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN` (amber, "action
-   *     required") — the out-side equivalent of (2). Only reached when
-   *     `qtyDispositioned === 0`, so it can never shadow (1)/(2).
-   *  4. The base status from `getBookingContextAssetStatus`, which
+   *  3. Qty progressively checked OUT with NO returns yet, but only SOME
+   *     units out → `PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN` (amber,
+   *     "action required") — the out-side equivalent of (2). Only reached
+   *     when `qtyDispositioned === 0`, so it can never shadow (1)/(2).
+   *  4. This slice's units ALL checked out, none returned →
+   *     `CHECKED_OUT` (violet, "Checked out"). Resolved per-row so a
+   *     fully-out kit slice reads correctly even when the global
+   *     `Asset.status` hasn't flipped (a parallel standalone slice is
+   *     still booked). Only reached when `qtyDispositioned === 0`.
+   *  5. The base status from `getBookingContextAssetStatus`, which
    *     already reflects INDIVIDUAL asset progressive-checkout state
    *     via the `partialCheckinDetails` map. `wasCheckedOut` (from
    *     main) is consumed separately by the `ReturnedBadge` branch on
@@ -338,6 +355,8 @@ export default function ListAssetContent({
     ? "PARTIALLY_CHECKED_OUT_QTY"
     : isQtyPartiallyCheckedOut
     ? "PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN"
+    : isQtyFullyCheckedOut
+    ? AssetStatus.CHECKED_OUT
     : baseContextStatus;
 
   const isPartiallyCheckedIn =

--- a/apps/webapp/app/components/booking/list-asset-content.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.tsx
@@ -15,9 +15,8 @@ import type {
 import type { BookingWithCustodians } from "~/modules/booking/types";
 import type { AssetWithBooking } from "~/routes/_layout+/bookings.$bookingId.overview.manage-assets";
 import {
-  getBookingContextAssetStatus,
   isAssetPartiallyCheckedIn,
-  isBookingRowQtyFullyCheckedOut,
+  resolveBookingRowQtyState,
 } from "~/utils/booking-assets";
 import { tw } from "~/utils/tw";
 import { resolveUserDisplayName } from "~/utils/user";
@@ -159,13 +158,6 @@ export default function ListAssetContent({
     isBaseOrSelfService,
   ]);
 
-  // Use centralized status resolver for consistency
-  const baseContextStatus = getBookingContextAssetStatus(
-    item,
-    partialCheckinDetails,
-    booking.status
-  );
-
   /**
    * Qty-tracked partial dispositioning.
    *
@@ -211,71 +203,17 @@ export default function ListAssetContent({
     damaged: 0,
   };
   /**
-   * Per-row attribution for qty-tracked rows. With multi-row slices, an asset
-   * can have its kit-driven slice fully reconciled while a parallel standalone
-   * slice is still partly out. The badge needs the state of THIS row, not the
-   * asset's global rollup.
-   *
-   *  - Fully reconciled for this row → PARTIALLY_CHECKED_IN ("Already
-   *    checked in", blue) — same label as the INDIVIDUAL fully-checked-
-   *    in case.
-   *  - Partly reconciled for this row → PARTIALLY_CHECKED_OUT_QTY
-   *    ("Partially checked out", violet) — emphasises the outstanding
-   *    portion rather than the returned portion.
-   */
-  const isActiveBooking =
-    booking.status === "ONGOING" || booking.status === "OVERDUE";
-  const isQtyFullyCheckedIn =
-    isQuantityTracked(item) &&
-    qtyBooked > 0 &&
-    qtyDispositioned >= qtyBooked &&
-    isActiveBooking;
-  const isQtyPartiallyCheckedIn =
-    isQuantityTracked(item) &&
-    qtyBooked > 0 &&
-    qtyDispositioned > 0 &&
-    qtyRemaining > 0 &&
-    isActiveBooking;
-  /**
-   * Pending-return signal: this row has had SOME units progressively
-   * checked OUT via `PartialBookingCheckout` (`qtyCheckedOut > 0`) but
-   * NO disposition has been recorded yet (`qtyDispositioned === 0`) —
-   * i.e. nothing has been returned / consumed / lost / damaged.
-   *
-   * Distinct from `isQtyPartiallyCheckedIn`, which requires
-   * `qtyDispositioned > 0` (returns are underway). Mutually exclusive
-   * with the check-IN flags because they both require disposition to
-   * have started — so the 3-way ternary below resolves cleanly:
-   * fully-in → partial-in → pending-return → base.
-   *
-   * Resolved per-row (per `bookingAssetId`) like its check-IN
-   * counterparts, so a kit-driven slice and a standalone slice of the
-   * same asset are evaluated independently.
-   */
-  const isQtyPartiallyCheckedOut =
-    isQuantityTracked(item) &&
-    qtyBooked > 0 &&
-    qtyCheckedOut > 0 &&
-    // Upper guard: ONLY fires when SOME but not all booked units are out.
-    // The fully-out case (`qtyCheckedOut >= qtyBooked`) is handled by
-    // `isQtyFullyCheckedOut` below → CHECKED_OUT. Without this guard, the
-    // amber pending-return badge would shadow the fully-out state.
-    qtyCheckedOut < qtyBooked &&
-    qtyDispositioned === 0 &&
-    isActiveBooking;
-  /**
-   * This row's own units are ALL progressively checked OUT with NO disposition
-   * yet → the slice is fully out and should read as the standard violet
-   * "Checked out". Resolved per-row (per `bookingAssetId`) via the SHARED
-   * helper so this badge and the status-sort's `isCheckedOut` predicate
+   * Per-row (per-`bookingAssetId`) status resolution. With multi-row slices an
+   * asset can have its kit-driven slice fully reconciled while a parallel
+   * standalone slice is still partly out, so the badge needs the state of THIS
+   * row, not the asset's global rollup. Resolved via the SHARED
+   * `resolveBookingRowQtyState` so this badge and the status-sort predicate
    * (`shape-booking-assets.ts`) use identical logic and can never disagree —
-   * the divergence that let a fully-checked-out kit slice read "Available"
-   * while its kit still sat at the top of a status sort.
+   * `contextStatus` is exactly the bucket the status sort reads. The
+   * destructured QT flags feed `isPartiallyCheckedIn` below.
    */
-  const isQtyFullyCheckedOut = isBookingRowQtyFullyCheckedOut(
-    item,
-    booking.status
-  );
+  const { contextStatus, isQtyFullyCheckedIn, isQtyPartiallyCheckedIn } =
+    resolveBookingRowQtyState(item, partialCheckinDetails, booking.status);
 
   /**
    * Workspace-availability lookup for this row's asset. `undefined` when
@@ -325,39 +263,6 @@ export default function ListAssetContent({
   const hasProgressiveCheckout = Object.keys(partialCheckoutDetails).length > 0;
   const wasCheckedOut =
     !hasProgressiveCheckout || Boolean(partialCheckoutDetails[item.id]);
-
-  /**
-   * Final status resolution priority (most specific signal wins):
-   *  1. Qty fully reconciled for this row → `PARTIALLY_CHECKED_IN`
-   *     (blue, "already checked in"). Disposition signals win — once
-   *     anything has been returned/consumed/lost/damaged the row reads
-   *     as in-progress on the check-IN side.
-   *  2. Qty partly reconciled (some disposition, more outstanding) →
-   *     `PARTIALLY_CHECKED_OUT_QTY` (violet, "returns underway").
-   *  3. Qty progressively checked OUT with NO returns yet, but only SOME
-   *     units out → `PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN` (amber,
-   *     "action required") — the out-side equivalent of (2). Only reached
-   *     when `qtyDispositioned === 0`, so it can never shadow (1)/(2).
-   *  4. This slice's units ALL checked out, none returned →
-   *     `CHECKED_OUT` (violet, "Checked out"). Resolved per-row so a
-   *     fully-out kit slice reads correctly even when the global
-   *     `Asset.status` hasn't flipped (a parallel standalone slice is
-   *     still booked). Only reached when `qtyDispositioned === 0`.
-   *  5. The base status from `getBookingContextAssetStatus`, which
-   *     already reflects INDIVIDUAL asset progressive-checkout state
-   *     via the `partialCheckinDetails` map. `wasCheckedOut` (from
-   *     main) is consumed separately by the `ReturnedBadge` branch on
-   *     finished bookings.
-   */
-  const contextStatus = isQtyFullyCheckedIn
-    ? "PARTIALLY_CHECKED_IN"
-    : isQtyPartiallyCheckedIn
-    ? "PARTIALLY_CHECKED_OUT_QTY"
-    : isQtyPartiallyCheckedOut
-    ? "PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN"
-    : isQtyFullyCheckedOut
-    ? AssetStatus.CHECKED_OUT
-    : baseContextStatus;
 
   const isPartiallyCheckedIn =
     isQtyFullyCheckedIn ||

--- a/apps/webapp/app/components/list/filters/sort-by.test.tsx
+++ b/apps/webapp/app/components/list/filters/sort-by.test.tsx
@@ -42,6 +42,21 @@ vi.mock("@radix-ui/react-popover", () => ({
   ),
 }));
 
+// why: Radix Tooltip doesn't render content in JSDOM; render it inline so the
+// hint text is queryable.
+vi.mock("~/components/shared/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
 describe("SortBy", () => {
   const defaultProps = {
     sortingOptions: {
@@ -276,6 +291,20 @@ describe("SortBy", () => {
       expect(
         screen.getByRole("button", { name: /sorted by/i })
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("hint tooltip", () => {
+    it("renders the hint content when a hint is provided", () => {
+      render(
+        <SortBy {...defaultProps} hint={<span>How sorting works</span>} />
+      );
+      expect(screen.getByText("How sorting works")).toBeInTheDocument();
+    });
+
+    it("does not render hint content when no hint is provided", () => {
+      render(<SortBy {...defaultProps} />);
+      expect(screen.queryByText("How sorting works")).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/webapp/app/components/list/filters/sort-by.tsx
+++ b/apps/webapp/app/components/list/filters/sort-by.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { CaretSortIcon } from "@radix-ui/react-icons";
 import {
   Popover,
@@ -7,6 +8,7 @@ import {
 } from "@radix-ui/react-popover";
 import { useNavigation } from "react-router";
 
+import { InfoTooltip } from "~/components/shared/info-tooltip";
 import { useSearchParams } from "~/hooks/search-params";
 
 import { isFormProcessing } from "~/utils/form";
@@ -21,6 +23,8 @@ type SortByProps<T extends TSort> = {
   defaultSortingBy: keyof T;
   defaultSortingDirection?: SortingDirection;
   className?: string;
+  /** Optional help content shown as an info tooltip beside "Sort by:". */
+  hint?: ReactNode;
 };
 
 export function SortBy<T extends Record<string, string>>({
@@ -28,6 +32,7 @@ export function SortBy<T extends Record<string, string>>({
   sortingOptions,
   defaultSortingBy,
   defaultSortingDirection = "desc",
+  hint,
 }: SortByProps<T>) {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawOrderBy = searchParams.get("orderBy") || String(defaultSortingBy);
@@ -85,8 +90,17 @@ export function SortBy<T extends Record<string, string>>({
           className="z-[100]  flex flex-col gap-3 overflow-y-auto rounded-md border border-gray-300 bg-white p-4"
           onOpenAutoFocus={(event) => event.preventDefault()}
         >
-          <div>
+          <div className="flex items-center gap-1.5">
             <h5>Sort by:</h5>
+            {hint ? (
+              <InfoTooltip
+                content={hint}
+                iconClassName="size-4"
+                // Raise above this popover's `z-[100]` so the tooltip isn't
+                // hidden behind the sort panel it opens from.
+                contentClassName="z-[110]"
+              />
+            ) : null}
           </div>
 
           <div className="flex flex-col gap-2">

--- a/apps/webapp/app/components/shared/info-tooltip.tsx
+++ b/apps/webapp/app/components/shared/info-tooltip.tsx
@@ -12,10 +12,18 @@ export const InfoTooltip = ({
   icon,
   iconClassName,
   content,
+  contentClassName,
 }: {
   icon?: ReactNode;
   iconClassName?: string;
   content: ReactNode;
+  /**
+   * Extra classes for the tooltip content wrapper. Use this to raise the
+   * z-index when the tooltip lives inside another portalled overlay (e.g. a
+   * Popover with `z-[100]`), whose stacking context would otherwise hide the
+   * default `z-50` tooltip behind it.
+   */
+  contentClassName?: string;
 }) => (
   <TooltipProvider delayDuration={100}>
     <Tooltip>
@@ -24,7 +32,7 @@ export const InfoTooltip = ({
           {icon ? icon : <Info className={tw("size-5", iconClassName)} />}
         </i>
       </TooltipTrigger>
-      <TooltipContent side="bottom">
+      <TooltipContent side="bottom" className={contentClassName}>
         <div className="max-w-[260px] rounded text-left sm:max-w-[320px]">
           {content}
         </div>

--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -206,11 +206,10 @@ export const BOOKING_WITH_ASSETS_INCLUDE = {
       },
     },
     // Base fetch order. The rendered order is computed in-memory by the
-    // consuming route (sortBookingAssets / groupAndSortAssetsByKit); this DB
-    // order only acts as the stable tiebreaker fed into those sorts. Kept
-    // identical to the historical default (CHECKED_OUT first, then creation
-    // order) so the in-memory sorts receive the exact same input as before —
-    // preserving the booking page's default ordering 1:1.
+    // consuming route (groupAndSortAssetsByKit); this DB order only acts as
+    // the stable tiebreaker fed into that sort. Kept identical to the
+    // historical default (CHECKED_OUT first, then creation order) so the
+    // in-memory sort receives the exact same input as before.
     orderBy: [
       { asset: { status: "desc" } }, // CHECKED_OUT (desc) comes before AVAILABLE (asc)
       { asset: { createdAt: "asc" } }, // Then by creation order as fallback
@@ -260,6 +259,7 @@ export const BOOKING_ASSET_SORTING_OPTIONS = {
   title: "Name",
   category: "Category",
   location: "Location",
+  type: "Item type",
 } as const;
 
 export type BookingAssetSortingOption =

--- a/apps/webapp/app/modules/booking/helpers.test.ts
+++ b/apps/webapp/app/modules/booking/helpers.test.ts
@@ -36,269 +36,204 @@ const createAsset = (
 
 describe("groupAndSortAssetsByKit", () => {
   describe("grouping behavior", () => {
-    it("groups assets by kit and places kits before individual assets", () => {
-      const assets = [
-        createAsset("1", "Individual Asset", "AVAILABLE"),
-        createAsset("2", "Kit Asset 1", "AVAILABLE", "kit-1", "Kit A"),
-        createAsset("3", "Kit Asset 2", "AVAILABLE", "kit-1", "Kit A"),
-      ];
-
-      const result = groupAndSortAssetsByKit(assets, "title", "asc");
-
-      // Kit assets should come first, then individual assets
-      expect(result[0].kitId).toBe("kit-1");
-      expect(result[1].kitId).toBe("kit-1");
-      expect(result[2].kitId).toBeNull();
-    });
-
-    it("keeps assets from the same kit together", () => {
+    it("keeps assets from the same kit contiguous", () => {
       const assets = [
         createAsset("1", "Asset A", "AVAILABLE", "kit-1", "Kit 1"),
         createAsset("2", "Asset B", "AVAILABLE", "kit-2", "Kit 2"),
         createAsset("3", "Asset C", "AVAILABLE", "kit-1", "Kit 1"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "title", "asc");
-
-      // Find positions of kit-1 assets
-      const kit1Positions = result
+      const kit1 = result
         .map((a, i) => (a.kitId === "kit-1" ? i : -1))
         .filter((i) => i !== -1);
-
-      // They should be adjacent
-      expect(kit1Positions[1] - kit1Positions[0]).toBe(1);
+      expect(kit1[1] - kit1[0]).toBe(1);
     });
   });
 
-  describe("sorting by title", () => {
-    it("sorts kits by kit name ascending", () => {
+  describe("sorting by title (flat interleave of kits and assets)", () => {
+    it("orders kit units and standalone assets together by name", () => {
       const assets = [
-        createAsset("1", "Asset", "AVAILABLE", "kit-b", "Kit B"),
-        createAsset("2", "Asset", "AVAILABLE", "kit-a", "Kit A"),
+        createAsset("z", "Zebra", "AVAILABLE"),
+        createAsset("k", "member", "AVAILABLE", "kit-1", "Alpha Kit"),
+        createAsset("c", "Camera", "AVAILABLE"),
+        createAsset("d", "member", "AVAILABLE", "kit-2", "Delta Kit"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "title", "asc");
-
-      expect(result[0].kit?.name).toBe("Kit A");
-      expect(result[1].kit?.name).toBe("Kit B");
+      // Alpha Kit(k) < Camera(c) < Delta Kit(d) < Zebra(z)
+      expect(result.map((a) => a.id)).toEqual(["k", "c", "d", "z"]);
     });
 
-    it("sorts kits by kit name descending", () => {
+    it("reverses order when descending", () => {
       const assets = [
-        createAsset("1", "Asset", "AVAILABLE", "kit-a", "Kit A"),
-        createAsset("2", "Asset", "AVAILABLE", "kit-b", "Kit B"),
+        createAsset("a", "Apple", "AVAILABLE"),
+        createAsset("b", "member", "AVAILABLE", "kit-1", "Mango Kit"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "title", "desc");
-
-      expect(result[0].kit?.name).toBe("Kit B");
-      expect(result[1].kit?.name).toBe("Kit A");
-    });
-
-    it("sorts assets within kits by title", () => {
-      const assets = [
-        createAsset("1", "Zebra", "AVAILABLE", "kit-1", "Kit"),
-        createAsset("2", "Apple", "AVAILABLE", "kit-1", "Kit"),
-      ];
-
-      const result = groupAndSortAssetsByKit(assets, "title", "asc");
-
-      expect(result[0].title).toBe("Apple");
-      expect(result[1].title).toBe("Zebra");
-    });
-
-    it("sorts individual assets by title", () => {
-      const assets = [
-        createAsset("1", "Zebra", "AVAILABLE"),
-        createAsset("2", "Apple", "AVAILABLE"),
-      ];
-
-      const result = groupAndSortAssetsByKit(assets, "title", "asc");
-
-      expect(result[0].title).toBe("Apple");
-      expect(result[1].title).toBe("Zebra");
+      expect(result.map((a) => a.id)).toEqual(["b", "a"]); // Mango Kit > Apple
     });
   });
 
-  describe("sorting by status", () => {
-    it("sorts kits by most urgent status (CHECKED_OUT first when desc)", () => {
+  describe("sorting by status (checked-out sinks to the bottom)", () => {
+    it("puts checked-out standalone assets last, actionable first (desc)", () => {
       const assets = [
-        createAsset("1", "Asset", "AVAILABLE", "kit-a", "Kit A"),
-        createAsset("2", "Asset", "CHECKED_OUT", "kit-b", "Kit B"),
+        createAsset("out", "A", "CHECKED_OUT"),
+        createAsset("avail", "B", "AVAILABLE"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "status", "desc");
-
-      // Kit B has CHECKED_OUT which is more urgent
-      expect(result[0].kit?.name).toBe("Kit B");
-      expect(result[1].kit?.name).toBe("Kit A");
+      expect(result.map((a) => a.id)).toEqual(["avail", "out"]);
     });
 
-    it("sorts assets within kits by status", () => {
+    it("uses alphabetical name as the secondary sort within a bucket", () => {
       const assets = [
-        createAsset("1", "Asset A", "AVAILABLE", "kit-1", "Kit"),
-        createAsset("2", "Asset B", "CHECKED_OUT", "kit-1", "Kit"),
+        createAsset("b", "Bravo", "AVAILABLE"),
+        createAsset("a", "Alpha", "AVAILABLE"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "status", "desc");
-
-      expect(result[0].status).toBe("CHECKED_OUT");
-      expect(result[1].status).toBe("AVAILABLE");
+      expect(result.map((a) => a.id)).toEqual(["a", "b"]);
     });
 
-    it("uses title as secondary sort for same status", () => {
+    it("keeps a kit on top while ANY member is not checked out", () => {
       const assets = [
-        createAsset("1", "Zebra", "AVAILABLE"),
-        createAsset("2", "Apple", "AVAILABLE"),
+        createAsset("s", "Solo", "CHECKED_OUT"),
+        createAsset("m1", "M1", "CHECKED_OUT", "kit-1", "Kit"),
+        createAsset("m2", "M2", "AVAILABLE", "kit-1", "Kit"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "status", "desc");
+      // Kit is partially out => actionable => its members precede the
+      // fully-checked-out standalone asset. Members ordered avail-first.
+      expect(result.map((a) => a.id)).toEqual(["m2", "m1", "s"]);
+    });
 
-      expect(result[0].title).toBe("Apple");
-      expect(result[1].title).toBe("Zebra");
+    it("sinks a kit to the bottom only when ALL members are checked out", () => {
+      const assets = [
+        createAsset("avail", "Zzz", "AVAILABLE"),
+        createAsset("m1", "M1", "CHECKED_OUT", "kit-1", "Kit"),
+        createAsset("m2", "M2", "CHECKED_OUT", "kit-1", "Kit"),
+      ];
+      const result = groupAndSortAssetsByKit(assets, "status", "desc");
+      expect(result.map((a) => a.id)).toEqual(["avail", "m1", "m2"]);
+    });
+
+    it("swaps the buckets when ascending (checked-out first)", () => {
+      const assets = [
+        createAsset("avail", "A", "AVAILABLE"),
+        createAsset("out", "B", "CHECKED_OUT"),
+      ];
+      const result = groupAndSortAssetsByKit(assets, "status", "asc");
+      expect(result.map((a) => a.id)).toEqual(["out", "avail"]);
+    });
+
+    it("respects a custom isCheckedOut predicate", () => {
+      const assets = [
+        createAsset("x", "X", "AVAILABLE"),
+        createAsset("y", "Y", "AVAILABLE"),
+      ];
+      // Treat "x" as checked out even though its raw status is AVAILABLE.
+      const result = groupAndSortAssetsByKit(assets, "status", "desc", {
+        isCheckedOut: (a) => a.id === "x",
+      });
+      expect(result.map((a) => a.id)).toEqual(["y", "x"]);
     });
   });
 
-  describe("sorting by category", () => {
-    it("sorts kits by first asset's category", () => {
+  describe("sorting by item type", () => {
+    it("groups kits first then assets (desc)", () => {
       const assets = [
-        createAsset("1", "Asset", "AVAILABLE", "kit-a", "Kit A", "Zebra Cat"),
-        createAsset("2", "Asset", "AVAILABLE", "kit-b", "Kit B", "Apple Cat"),
+        createAsset("solo", "Solo", "AVAILABLE"),
+        createAsset("m", "member", "AVAILABLE", "kit-1", "Kit A"),
       ];
-
-      const result = groupAndSortAssetsByKit(assets, "category", "asc");
-
-      expect(result[0].kit?.name).toBe("Kit B"); // Apple Cat comes first
-      expect(result[1].kit?.name).toBe("Kit A");
+      const result = groupAndSortAssetsByKit(assets, "type", "desc");
+      expect(result.map((a) => a.id)).toEqual(["m", "solo"]);
     });
 
-    it("sorts individual assets by category", () => {
+    it("groups assets first then kits (asc)", () => {
       const assets = [
-        createAsset("1", "Asset A", "AVAILABLE", null, null, "Zebra"),
-        createAsset("2", "Asset B", "AVAILABLE", null, null, "Apple"),
+        createAsset("m", "member", "AVAILABLE", "kit-1", "Kit A"),
+        createAsset("solo", "Solo", "AVAILABLE"),
       ];
-
-      const result = groupAndSortAssetsByKit(assets, "category", "asc");
-
-      expect(result[0].category?.name).toBe("Apple");
-      expect(result[1].category?.name).toBe("Zebra");
+      const result = groupAndSortAssetsByKit(assets, "type", "asc");
+      expect(result.map((a) => a.id)).toEqual(["solo", "m"]);
     });
 
-    it("handles null categories (sorts to end)", () => {
+    it("orders multiple kits and assets alphabetically within their bucket", () => {
       const assets = [
-        createAsset("1", "Asset A", "AVAILABLE", null, null, null),
-        createAsset("2", "Asset B", "AVAILABLE", null, null, "Apple"),
+        createAsset("z", "Zebra", "AVAILABLE"),
+        createAsset("a", "Apple", "AVAILABLE"),
+        createAsset("kb", "member", "AVAILABLE", "kit-b", "Beta Kit"),
+        createAsset("ka", "member", "AVAILABLE", "kit-a", "Alpha Kit"),
       ];
+      const result = groupAndSortAssetsByKit(assets, "type", "desc");
+      // Kits first (Alpha, Beta), then assets (Apple, Zebra).
+      expect(result.map((a) => a.id)).toEqual(["ka", "kb", "a", "z"]);
+    });
+  });
 
+  describe("sorting by category (flat, nulls last)", () => {
+    it("interleaves kits and assets by category, nulls last", () => {
+      const assets = [
+        createAsset("n", "NoCat", "AVAILABLE"),
+        createAsset("m", "member", "AVAILABLE", "kit-1", "Kit", "Beta"),
+        createAsset("a", "AlphaCat", "AVAILABLE", null, null, "Alpha"),
+      ];
       const result = groupAndSortAssetsByKit(assets, "category", "asc");
+      // Alpha(a) < Beta(kit member m) < null(n)
+      expect(result.map((a) => a.id)).toEqual(["a", "m", "n"]);
+    });
+  });
 
-      expect(result[0].category?.name).toBe("Apple");
-      expect(result[1].category).toBeNull();
+  describe("sorting by location (flat, nulls last)", () => {
+    it("interleaves kits and assets by location, nulls last", () => {
+      const assets = [
+        createAsset("n", "NoLoc", "AVAILABLE"),
+        createAsset(
+          "m",
+          "member",
+          "AVAILABLE",
+          "kit-1",
+          "Kit",
+          null,
+          null,
+          "Warehouse B"
+        ),
+        createAsset("a", "AtA", "AVAILABLE", null, null, null, "Warehouse A"),
+      ];
+      const result = groupAndSortAssetsByKit(assets, "location", "asc");
+      // Warehouse A(a) < Warehouse B(kit member m) < null(n)
+      expect(result.map((a) => a.id)).toEqual(["a", "m", "n"]);
     });
   });
 
   describe("edge cases", () => {
-    it("handles empty array", () => {
-      const result = groupAndSortAssetsByKit([], "title", "asc");
-      expect(result).toEqual([]);
+    it("handles an empty array", () => {
+      expect(groupAndSortAssetsByKit([], "title", "asc")).toEqual([]);
     });
 
-    it("handles array with only individual assets", () => {
+    it("handles only individual assets", () => {
       const assets = [
-        createAsset("1", "Asset B", "AVAILABLE"),
-        createAsset("2", "Asset A", "AVAILABLE"),
+        createAsset("b", "Banana", "AVAILABLE"),
+        createAsset("a", "Apple", "AVAILABLE"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "title", "asc");
-
-      expect(result).toHaveLength(2);
-      expect(result[0].title).toBe("Asset A");
-      expect(result[1].title).toBe("Asset B");
+      expect(result.map((a) => a.id)).toEqual(["a", "b"]);
     });
 
-    it("handles array with only kit assets", () => {
+    it("handles only kit assets", () => {
       const assets = [
-        createAsset("1", "Asset B", "AVAILABLE", "kit-1", "Kit"),
-        createAsset("2", "Asset A", "AVAILABLE", "kit-1", "Kit"),
+        createAsset("2", "member", "AVAILABLE", "kit-b", "Beta Kit"),
+        createAsset("1", "member", "AVAILABLE", "kit-a", "Alpha Kit"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "title", "asc");
-
-      expect(result).toHaveLength(2);
-      expect(result[0].title).toBe("Asset A");
-      expect(result[1].title).toBe("Asset B");
+      expect(result.map((a) => a.kitId)).toEqual(["kit-a", "kit-b"]);
     });
 
-    it("uses default values when orderBy is unknown", () => {
+    it("falls back to status ordering for an unknown orderBy", () => {
       const assets = [
-        createAsset("1", "Asset", "AVAILABLE"),
-        createAsset("2", "Asset", "CHECKED_OUT"),
+        createAsset("out", "A", "CHECKED_OUT"),
+        createAsset("avail", "B", "AVAILABLE"),
       ];
-
       const result = groupAndSortAssetsByKit(assets, "unknown", "desc");
-
-      // Falls back to status sorting
-      expect(result[0].status).toBe("CHECKED_OUT");
-      expect(result[1].status).toBe("AVAILABLE");
+      expect(result.map((a) => a.id)).toEqual(["avail", "out"]);
     });
-  });
-});
-
-describe("groupAndSortAssetsByKit — location", () => {
-  it("sorts individual assets by location name ascending", () => {
-    const assets = [
-      createAsset("1", "A", "AVAILABLE", null, null, null, "Warehouse B"),
-      createAsset("2", "B", "AVAILABLE", null, null, null, "Warehouse A"),
-    ];
-
-    const result = groupAndSortAssetsByKit(assets, "location", "asc");
-
-    expect(result[0].location?.name).toBe("Warehouse A");
-    expect(result[1].location?.name).toBe("Warehouse B");
-  });
-
-  it("places assets with no location at the end regardless of direction", () => {
-    const assets = [
-      createAsset("1", "NoLoc", "AVAILABLE"),
-      createAsset("2", "HasLoc", "AVAILABLE", null, null, null, "Shelf 1"),
-    ];
-
-    const ascResult = groupAndSortAssetsByKit(assets, "location", "asc");
-    expect(ascResult[0].location?.name).toBe("Shelf 1");
-    expect(ascResult[1].location).toBeNull();
-
-    const descResult = groupAndSortAssetsByKit(assets, "location", "desc");
-    expect(descResult[1].location).toBeNull();
-  });
-
-  it("sorts kit groups by the kit's own location", () => {
-    const assets = [
-      createAsset(
-        "1",
-        "A",
-        "AVAILABLE",
-        "kit-z",
-        "Kit Z",
-        null,
-        null,
-        "Zone Z"
-      ),
-      createAsset(
-        "2",
-        "B",
-        "AVAILABLE",
-        "kit-a",
-        "Kit A",
-        null,
-        null,
-        "Zone A"
-      ),
-    ];
-
-    const result = groupAndSortAssetsByKit(assets, "location", "asc");
-
-    expect(result[0].kit?.name).toBe("Kit A");
-    expect(result[1].kit?.name).toBe("Kit Z");
   });
 });
 

--- a/apps/webapp/app/modules/booking/helpers.ts
+++ b/apps/webapp/app/modules/booking/helpers.ts
@@ -54,24 +54,28 @@ function compareSortDescriptors(
   orderDirection: "asc" | "desc"
 ): number {
   const dirMul = orderDirection === "asc" ? 1 : -1;
-  const byName = () => a.name.localeCompare(b.name);
+  // Case-insensitive comparator so the A→Z tiebreak matches the documented
+  // contract regardless of runtime/locale default sensitivity.
+  const compareText = (left: string, right: string) =>
+    left.localeCompare(right, undefined, { sensitivity: "base" });
+  const byName = () => compareText(a.name, b.name);
 
   switch (orderBy) {
     case "title":
-      return dirMul * a.name.localeCompare(b.name);
+      return dirMul * compareText(a.name, b.name);
 
     case "category": {
       if (!a.category && b.category) return 1;
       if (a.category && !b.category) return -1;
       if (!a.category && !b.category) return byName();
-      return dirMul * a.category!.localeCompare(b.category!) || byName();
+      return dirMul * compareText(a.category!, b.category!) || byName();
     }
 
     case "location": {
       if (!a.location && b.location) return 1;
       if (a.location && !b.location) return -1;
       if (!a.location && !b.location) return byName();
-      return dirMul * a.location!.localeCompare(b.location!) || byName();
+      return dirMul * compareText(a.location!, b.location!) || byName();
     }
 
     case "type": {

--- a/apps/webapp/app/modules/booking/helpers.ts
+++ b/apps/webapp/app/modules/booking/helpers.ts
@@ -14,168 +14,189 @@ type AssetWithKit = {
 };
 
 /**
- * Groups assets by kit and sorts both kits and assets within them.
- * Returns: sorted kit assets (grouped) followed by sorted individual assets.
+ * Options controlling {@link groupAndSortAssetsByKit}.
+ */
+export type GroupAndSortOptions<T> = {
+  /**
+   * Predicate deciding whether an asset counts as "checked out" for the Status
+   * sort's bottom bucket. Defaults to a raw `status === "CHECKED_OUT"` check
+   * (used by the PDF export). The booking overview injects a booking-context
+   * aware predicate so QT DRAFT/RESERVED rows and partially-checked-in assets
+   * stay in the actionable (top) bucket.
+   */
+  isCheckedOut?: (asset: T) => boolean;
+};
+
+/** Normalized sort key for a single sortable unit (a kit or a standalone asset). */
+type SortDescriptor = {
+  name: string;
+  category: string | null;
+  location: string | null;
+  checkedOut: boolean;
+  isKit: boolean;
+};
+
+/**
+ * Compares two sort descriptors for the given field/direction.
  *
- * @param assets - Array of assets with kit information
- * @param orderBy - Field to sort by (status, title, category, location)
- * @param orderDirection - Sort direction (asc or desc)
- * @returns Sorted array with kit assets grouped together
+ * Rules shared by kit-units and asset-units:
+ * - `category`/`location` nulls always sort last, regardless of direction.
+ * - Every field falls back to a case-insensitive A→Z name tiebreak, so ordering
+ *   is deterministic and stable.
+ * - `status`: not-checked-out (top) vs checked-out (bottom); `desc` keeps
+ *   actionable items on top, `asc` swaps the buckets.
+ * - `type`: kits (top) vs assets (bottom); `desc` keeps kits first, `asc` swaps.
+ */
+function compareSortDescriptors(
+  a: SortDescriptor,
+  b: SortDescriptor,
+  orderBy: string,
+  orderDirection: "asc" | "desc"
+): number {
+  const dirMul = orderDirection === "asc" ? 1 : -1;
+  const byName = () => a.name.localeCompare(b.name);
+
+  switch (orderBy) {
+    case "title":
+      return dirMul * a.name.localeCompare(b.name);
+
+    case "category": {
+      if (!a.category && b.category) return 1;
+      if (a.category && !b.category) return -1;
+      if (!a.category && !b.category) return byName();
+      return dirMul * a.category!.localeCompare(b.category!) || byName();
+    }
+
+    case "location": {
+      if (!a.location && b.location) return 1;
+      if (a.location && !b.location) return -1;
+      if (!a.location && !b.location) return byName();
+      return dirMul * a.location!.localeCompare(b.location!) || byName();
+    }
+
+    case "type": {
+      // Kits (0) before assets (1) when desc; reversed when asc.
+      const bucketA = a.isKit ? 0 : 1;
+      const bucketB = b.isKit ? 0 : 1;
+      const typeMul = orderDirection === "desc" ? 1 : -1;
+      return typeMul * (bucketA - bucketB) || byName();
+    }
+
+    case "status":
+    default: {
+      // Not-checked-out (0) on top, checked-out (1) at the bottom when desc;
+      // reversed when asc. Secondary A→Z by name.
+      const bucketA = a.checkedOut ? 1 : 0;
+      const bucketB = b.checkedOut ? 1 : 0;
+      const statusMul = orderDirection === "desc" ? 1 : -1;
+      return statusMul * (bucketA - bucketB) || byName();
+    }
+  }
+}
+
+/**
+ * Orders a booking's assets for display, treating each kit as a single sortable
+ * unit that competes with standalone assets by the chosen field. Kits stay
+ * visually grouped (their members are emitted contiguously), but they are no
+ * longer force-pinned above standalone assets — except for the `type` sort,
+ * which explicitly groups kits first then assets.
+ *
+ * Preserves the flat-in / flat-out contract: callers pass a flat asset array
+ * and receive a flat array in which each kit's members are adjacent at the
+ * kit's sorted position. `shapeBookingAssets` and the PDF export both rely on
+ * this.
+ *
+ * @param assets - Flat array of enriched booking assets (kit members included).
+ * @param orderBy - Sort field: `status` | `title` | `category` | `location` | `type`.
+ * @param orderDirection - `asc` or `desc`.
+ * @param options - See {@link GroupAndSortOptions}; `isCheckedOut` customizes
+ *   the Status sort's checked-out determination.
+ * @returns The flat, ordered asset array with kit members kept contiguous.
  */
 export function groupAndSortAssetsByKit<T extends AssetWithKit>(
   assets: T[],
   orderBy: string = "status",
-  orderDirection: "asc" | "desc" = "desc"
+  orderDirection: "asc" | "desc" = "desc",
+  options: GroupAndSortOptions<T> = {}
 ): T[] {
-  // Separate kit assets from individual assets
-  const kitAssets: T[] = [];
+  const isCheckedOut =
+    options.isCheckedOut ?? ((asset: T) => asset.status === "CHECKED_OUT");
+
+  // Partition into kit groups (preserving first-seen order) and standalones.
+  const kitOrder: string[] = [];
+  const kitGroups = new Map<string, T[]>();
   const individualAssets: T[] = [];
 
   for (const asset of assets) {
     if (asset.kitId && asset.kit) {
-      kitAssets.push(asset);
+      if (!kitGroups.has(asset.kitId)) {
+        kitGroups.set(asset.kitId, []);
+        kitOrder.push(asset.kitId);
+      }
+      kitGroups.get(asset.kitId)!.push(asset);
     } else {
       individualAssets.push(asset);
     }
   }
 
-  // Group kit assets by kitId
-  const kitGroups = new Map<
-    string,
-    { kitName: string; kitLocationName: string | null; assets: T[] }
-  >();
-  for (const asset of kitAssets) {
-    const kitId = asset.kitId!;
-    if (!kitGroups.has(kitId)) {
-      kitGroups.set(kitId, {
-        kitName: asset.kit!.name,
-        kitLocationName: asset.kit!.location?.name ?? null,
-        assets: [],
-      });
-    }
-    kitGroups.get(kitId)!.assets.push(asset);
+  // Descriptor for a standalone asset (also used to order members inside a kit).
+  const assetDescriptor = (asset: T): SortDescriptor => ({
+    name: asset.title,
+    category: asset.category?.name ?? null,
+    location: asset.location?.name ?? null,
+    checkedOut: isCheckedOut(asset),
+    isKit: false,
+  });
+
+  const compareAssets = (a: T, b: T) =>
+    compareSortDescriptors(
+      assetDescriptor(a),
+      assetDescriptor(b),
+      orderBy,
+      orderDirection
+    );
+
+  // Sort members within each kit so they render in the chosen order and the
+  // first member is a valid representative for the kit's category value.
+  for (const members of kitGroups.values()) {
+    members.sort(compareAssets);
   }
 
-  // Sort function based on orderBy
-  const compareAssets = (a: T, b: T): number => {
-    const multiplier = orderDirection === "asc" ? 1 : -1;
+  // Build the sortable units: one per kit, one per standalone asset.
+  type Unit = { descriptor: SortDescriptor; members: T[] };
+  const units: Unit[] = [];
 
-    switch (orderBy) {
-      case "title":
-        return multiplier * a.title.localeCompare(b.title);
-      case "category": {
-        const catA = a.category?.name;
-        const catB = b.category?.name;
-        // Null categories go to the end regardless of direction
-        if (!catA && catB) return 1;
-        if (catA && !catB) return -1;
-        if (!catA && !catB) return a.title.localeCompare(b.title);
-        // At this point both catA and catB are defined (handled above)
-        return multiplier * catA!.localeCompare(catB!);
-      }
-      case "location": {
-        const locA = a.location?.name;
-        const locB = b.location?.name;
-        // Null locations go to the end regardless of direction
-        if (!locA && locB) return 1;
-        if (locA && !locB) return -1;
-        if (!locA && !locB) return a.title.localeCompare(b.title);
-        return multiplier * locA!.localeCompare(locB!);
-      }
-      case "status":
-      default: {
-        // For status, CHECKED_OUT should come before AVAILABLE when desc
-        // Priority: CHECKED_OUT=1 (urgent), AVAILABLE=3 (least urgent)
-        const statusOrder: Record<string, number> = {
-          CHECKED_OUT: 1,
-          IN_CUSTODY: 2,
-          AVAILABLE: 3,
-        };
-        const statusA = statusOrder[a.status] || 99;
-        const statusB = statusOrder[b.status] || 99;
-        // For "desc", lower priority number comes first (CHECKED_OUT before AVAILABLE)
-        // For "asc", higher priority number comes first (AVAILABLE before CHECKED_OUT)
-        const statusMultiplier = orderDirection === "desc" ? 1 : -1;
-        const statusDiff = statusMultiplier * (statusA - statusB);
-        // Secondary sort by title for consistency
-        return statusDiff !== 0 ? statusDiff : a.title.localeCompare(b.title);
-      }
-    }
-  };
-
-  // First, sort assets within each kit group
-  for (const [, group] of kitGroups) {
-    group.assets.sort(compareAssets);
+  for (const kitId of kitOrder) {
+    const members = kitGroups.get(kitId)!;
+    const first = members[0];
+    units.push({
+      members,
+      descriptor: {
+        name: first.kit!.name,
+        // Representative category = first (already field-sorted) member's.
+        category: first.category?.name ?? null,
+        // Kit's own location, falling back to the first member's location.
+        location: first.kit!.location?.name ?? first.location?.name ?? null,
+        // A kit sinks to the checked-out bucket only when ALL members are out.
+        checkedOut: members.every((m) => isCheckedOut(m)),
+        isKit: true,
+      },
+    });
   }
 
-  // Sort individual assets
-  individualAssets.sort(compareAssets);
+  for (const asset of individualAssets) {
+    units.push({ members: [asset], descriptor: assetDescriptor(asset) });
+  }
 
-  // Now sort kit groups by the sort criteria
-  // (after sorting assets within, so we can use the first sorted asset for comparison)
-  const sortedKitGroups = Array.from(kitGroups.entries()).sort(
-    ([, groupA], [, groupB]) => {
-      const multiplier = orderDirection === "asc" ? 1 : -1;
-
-      switch (orderBy) {
-        case "title":
-          // Sort kits by kit name when sorting by name
-          return multiplier * groupA.kitName.localeCompare(groupB.kitName);
-        case "category": {
-          // Sort kits by first asset's category (after assets are sorted)
-          const catA = groupA.assets[0]?.category?.name;
-          const catB = groupB.assets[0]?.category?.name;
-          // Null categories go to the end regardless of direction
-          if (!catA && catB) return 1;
-          if (catA && !catB) return -1;
-          if (!catA && !catB)
-            return groupA.kitName.localeCompare(groupB.kitName);
-          // At this point both catA and catB are defined (handled above)
-          return multiplier * catA!.localeCompare(catB!);
-        }
-        case "location": {
-          const locA = groupA.kitLocationName;
-          const locB = groupB.kitLocationName;
-          // Null locations go to the end regardless of direction
-          if (!locA && locB) return 1;
-          if (locA && !locB) return -1;
-          if (!locA && !locB)
-            return groupA.kitName.localeCompare(groupB.kitName);
-          return multiplier * locA!.localeCompare(locB!);
-        }
-        case "status":
-        default: {
-          // Sort kits by "most urgent" status in the kit
-          const getKitPriority = (assets: T[]) => {
-            const statusOrder: Record<string, number> = {
-              CHECKED_OUT: 1,
-              IN_CUSTODY: 2,
-              AVAILABLE: 3,
-            };
-            if (assets.length === 0) return 99;
-            return Math.min(...assets.map((a) => statusOrder[a.status] || 99));
-          };
-          const priorityA = getKitPriority(groupA.assets);
-          const priorityB = getKitPriority(groupB.assets);
-          // For "desc", lower priority number comes first (CHECKED_OUT before AVAILABLE)
-          // For "asc", higher priority number comes first (AVAILABLE before CHECKED_OUT)
-          const statusMultiplier = orderDirection === "desc" ? 1 : -1;
-          const priorityDiff = statusMultiplier * (priorityA - priorityB);
-          return priorityDiff !== 0
-            ? priorityDiff
-            : groupA.kitName.localeCompare(groupB.kitName);
-        }
-      }
-    }
+  // Sort the units, then flatten — each kit's members stay contiguous.
+  units.sort((a, b) =>
+    compareSortDescriptors(a.descriptor, b.descriptor, orderBy, orderDirection)
   );
 
-  // Flatten: all kit assets (grouped) + individual assets
   const result: T[] = [];
-  for (const [, group] of sortedKitGroups) {
-    result.push(...group.assets);
+  for (const unit of units) {
+    result.push(...unit.members);
   }
-  result.push(...individualAssets);
-
   return result;
 }
 

--- a/apps/webapp/app/modules/booking/shape-booking-assets.test.ts
+++ b/apps/webapp/app/modules/booking/shape-booking-assets.test.ts
@@ -23,7 +23,7 @@ const baseParams = {
   orderDirection: "desc" as const,
   page: 1,
   perPage: 20,
-  partialCheckinDetails: {} as any,
+  partialCheckinDetails: {},
   bookingStatus: "ONGOING",
 };
 

--- a/apps/webapp/app/modules/booking/shape-booking-assets.test.ts
+++ b/apps/webapp/app/modules/booking/shape-booking-assets.test.ts
@@ -24,10 +24,11 @@ const baseParams = {
   page: 1,
   perPage: 20,
   partialCheckinDetails: {} as any,
+  bookingStatus: "ONGOING",
 };
 
 describe("shapeBookingAssets", () => {
-  it("returns all items when no search, with status-desc default order (CHECKED_OUT first)", () => {
+  it("returns all items with status-desc default order (checked-out last)", () => {
     const rawAssets = [
       asset({ id: "available", status: "AVAILABLE", title: "B" }),
       asset({ id: "checkedout", status: "CHECKED_OUT", title: "A" }),
@@ -37,8 +38,25 @@ describe("shapeBookingAssets", () => {
       rawAssets,
     });
     expect(totalPaginationItems).toBe(2);
-    // CHECKED_OUT must come before AVAILABLE
-    expect(items.map((i) => i.id)).toEqual(["checkedout", "available"]);
+    // Actionable (AVAILABLE) on top; CHECKED_OUT sinks to the bottom.
+    expect(items.map((i) => i.id)).toEqual(["available", "checkedout"]);
+  });
+
+  it("treats partially-checked-in assets as actionable, not checked out", () => {
+    const rawAssets = [
+      asset({ id: "fully-out", status: "CHECKED_OUT", title: "A" }),
+      asset({ id: "partial", status: "CHECKED_OUT", title: "B" }),
+    ];
+    const { items } = shapeBookingAssets({
+      ...baseParams,
+      rawAssets,
+      // A partial check-in entry flips the context status to
+      // PARTIALLY_CHECKED_IN for an ONGOING booking -> top bucket.
+      partialCheckinDetails: {
+        partial: { checkinDate: "2026-01-01T00:00:00.000Z" },
+      } as any,
+    });
+    expect(items.map((i) => i.id)).toEqual(["partial", "fully-out"]);
   });
 
   it("filters by search (and counts reflect the filtered set)", () => {
@@ -97,6 +115,40 @@ describe("shapeBookingAssets", () => {
     });
     expect(totalPages).toBe(2);
     expect(items.map((i) => i.id)).toEqual(["a2"]);
+  });
+
+  it("sinks a kit whose QT member is fully checked out per-slice, even when the member's global status is AVAILABLE", () => {
+    // Regression: a QUANTITY_TRACKED asset with a kit slice + a standalone
+    // slice (44 booked) never flips its GLOBAL status to CHECKED_OUT when only
+    // the kit's 22 are out. The sort must still sink the kit using the row's
+    // OWN per-slice checkout (checkedOutQuantity >= bookedQuantity), matching
+    // what the row badge shows — otherwise a fully-checked-out kit stays on top.
+    const rawAssets = [
+      asset({ id: "zebra", title: "Zebra", status: "AVAILABLE" }),
+      asset({
+        id: "pencils",
+        title: "Pencils",
+        status: "AVAILABLE", // global stays AVAILABLE (multi-slice never flips)
+        type: "QUANTITY_TRACKED",
+        kitId: "kit-1",
+        kit: { name: "Alpha Kit" },
+        bookedQuantity: 22,
+        checkedOutQuantity: 22,
+        dispositionedQuantity: 0,
+      }),
+    ];
+    const rawKits = [{ id: "kit-1", name: "Alpha Kit" }];
+    const { items } = shapeBookingAssets({
+      ...baseParams,
+      rawAssets,
+      rawKits,
+      orderBy: "status",
+      orderDirection: "desc",
+      bookingStatus: "ONGOING",
+    });
+    // "Alpha Kit" sorts before "Zebra" alphabetically, so WITHOUT the per-slice
+    // fix the kit would wrongly lead. With it, the fully-checked-out kit sinks.
+    expect(items.map((i) => i.id)).toEqual(["zebra", "kit-1"]);
   });
 
   it("sorts by title when orderBy=title", () => {

--- a/apps/webapp/app/modules/booking/shape-booking-assets.test.ts
+++ b/apps/webapp/app/modules/booking/shape-booking-assets.test.ts
@@ -59,6 +59,35 @@ describe("shapeBookingAssets", () => {
     expect(items.map((i) => i.id)).toEqual(["partial", "fully-out"]);
   });
 
+  it("keeps a QT row with a partial return underway on top, even when its global status is CHECKED_OUT", () => {
+    // A QT asset can be globally CHECKED_OUT (e.g. units out in another active
+    // booking) while THIS booking has a return underway. The badge shows the
+    // actionable partial state, so the status sort must NOT sink it with the
+    // fully-checked-out rows — the shared resolver keeps sort and badge aligned.
+    const rawAssets = [
+      asset({
+        id: "partial",
+        title: "Partial",
+        status: "CHECKED_OUT", // global (checked out elsewhere)
+        type: "QUANTITY_TRACKED",
+        bookedQuantity: 22,
+        checkedOutQuantity: 22,
+        dispositionedQuantity: 5, // returns underway -> still actionable
+      }),
+      asset({ id: "done", title: "Done", status: "CHECKED_OUT" }), // fully out
+    ];
+    const { items } = shapeBookingAssets({
+      ...baseParams,
+      rawAssets,
+      orderBy: "status",
+      orderDirection: "desc",
+      bookingStatus: "ONGOING",
+    });
+    // Without the shared resolver the QT row would sink via its global
+    // CHECKED_OUT status; with it, only the fully-checked-out "done" sinks.
+    expect(items.map((i) => i.id)).toEqual(["partial", "done"]);
+  });
+
   it("filters by search (and counts reflect the filtered set)", () => {
     const rawAssets = [
       asset({ id: "a1", title: "MacBook" }),

--- a/apps/webapp/app/modules/booking/shape-booking-assets.ts
+++ b/apps/webapp/app/modules/booking/shape-booking-assets.ts
@@ -14,10 +14,7 @@
  */
 import { AssetStatus } from "@prisma/client";
 import type { PartialCheckinDetailsType } from "~/modules/booking/service.server";
-import {
-  resolveBookingRowQtyState,
-  type AssetWithStatus,
-} from "~/utils/booking-assets";
+import { resolveBookingRowQtyState } from "~/utils/booking-assets";
 import { filterBookingAssets, groupAndSortAssetsByKit } from "./helpers";
 
 /** A rendered pagination row: a grouped kit (with its assets) or a lone asset. */
@@ -95,13 +92,8 @@ export function shapeBookingAssets<
     orderDirection,
     {
       isCheckedOut: (asset) =>
-        // Cast to the permissive AssetWithStatus (open `any` index) so the
-        // loosely-typed enriched row is accepted.
-        resolveBookingRowQtyState(
-          asset as AssetWithStatus,
-          partialCheckinDetails,
-          bookingStatus
-        ).contextStatus === AssetStatus.CHECKED_OUT,
+        resolveBookingRowQtyState(asset, partialCheckinDetails, bookingStatus)
+          .contextStatus === AssetStatus.CHECKED_OUT,
     }
   );
 

--- a/apps/webapp/app/modules/booking/shape-booking-assets.ts
+++ b/apps/webapp/app/modules/booking/shape-booking-assets.ts
@@ -9,13 +9,13 @@
  * are strings after the network / hydration); it never constructs Dates itself.
  *
  * @see {@link file://./helpers.ts} filterBookingAssets / groupAndSortAssetsByKit
- * @see {@link file://../../utils/booking-assets.ts} isAssetCheckedOutInBooking
+ * @see {@link file://../../utils/booking-assets.ts} resolveBookingRowQtyState
  * @see docs/superpowers/specs/2026-06-01-booking-asset-search-in-memory-design.md
  */
+import { AssetStatus } from "@prisma/client";
 import type { PartialCheckinDetailsType } from "~/modules/booking/service.server";
 import {
-  isAssetCheckedOutInBooking,
-  isBookingRowQtyFullyCheckedOut,
+  resolveBookingRowQtyState,
   type AssetWithStatus,
 } from "~/utils/booking-assets";
 import { filterBookingAssets, groupAndSortAssetsByKit } from "./helpers";
@@ -82,32 +82,26 @@ export function shapeBookingAssets<
   // 1. Search-filter (with kit re-expansion).
   const filtered = filterBookingAssets(rawAssets, search);
 
-  // 2. Group by kit + sort. Status ordering is booking-context aware: an asset
-  //    counts as "checked out" (bottom bucket) when its per-booking status
-  //    resolves to CHECKED_OUT, OR when THIS row's own units are fully checked
-  //    out per-slice. The per-slice arm is essential for QUANTITY_TRACKED
-  //    assets that span a kit slice + a standalone slice: the GLOBAL status
-  //    never flips until every slice is out, so without it a fully-checked-out
-  //    kit slice would wrongly stay on top (and its kit wouldn't sink). This
-  //    keeps the sort position in lock-step with the row badge, and still
-  //    leaves QT DRAFT/RESERVED rows + partially-checked-in assets on top.
+  // 2. Group by kit + sort. A row counts as "checked out" (bottom bucket) when
+  //    its RESOLVED badge status is CHECKED_OUT — computed by the SAME shared
+  //    resolver the row badge uses, so the badge a user sees and the bucket the
+  //    row sorts into can never disagree. This covers per-slice QT correctly:
+  //    a fully-checked-out kit slice sinks even though the multi-slice asset's
+  //    GLOBAL status hasn't flipped, while a QT row with a partial return
+  //    underway (or DRAFT/RESERVED) stays on top as its actionable state.
   const sortedAssets = groupAndSortAssetsByKit(
     filtered,
     orderBy,
     orderDirection,
     {
-      isCheckedOut: (asset) => {
-        // Cast once to the permissive AssetWithStatus (open `any` index) so both
-        // predicate arms accept the loosely-typed enriched row.
-        const row = asset as AssetWithStatus;
-        return (
-          isAssetCheckedOutInBooking(
-            row,
-            partialCheckinDetails,
-            bookingStatus
-          ) || isBookingRowQtyFullyCheckedOut(row, bookingStatus)
-        );
-      },
+      isCheckedOut: (asset) =>
+        // Cast to the permissive AssetWithStatus (open `any` index) so the
+        // loosely-typed enriched row is accepted.
+        resolveBookingRowQtyState(
+          asset as AssetWithStatus,
+          partialCheckinDetails,
+          bookingStatus
+        ).contextStatus === AssetStatus.CHECKED_OUT,
     }
   );
 

--- a/apps/webapp/app/modules/booking/shape-booking-assets.ts
+++ b/apps/webapp/app/modules/booking/shape-booking-assets.ts
@@ -9,11 +9,15 @@
  * are strings after the network / hydration); it never constructs Dates itself.
  *
  * @see {@link file://./helpers.ts} filterBookingAssets / groupAndSortAssetsByKit
- * @see {@link file://../../utils/booking-assets.ts} sortBookingAssets
+ * @see {@link file://../../utils/booking-assets.ts} isAssetCheckedOutInBooking
  * @see docs/superpowers/specs/2026-06-01-booking-asset-search-in-memory-design.md
  */
 import type { PartialCheckinDetailsType } from "~/modules/booking/service.server";
-import { sortBookingAssets } from "~/utils/booking-assets";
+import {
+  isAssetCheckedOutInBooking,
+  isBookingRowQtyFullyCheckedOut,
+  type AssetWithStatus,
+} from "~/utils/booking-assets";
 import { filterBookingAssets, groupAndSortAssetsByKit } from "./helpers";
 
 /** A rendered pagination row: a grouped kit (with its assets) or a lone asset. */
@@ -39,6 +43,8 @@ export interface ShapeBookingAssetsParams<TAsset, TKit> {
   page: number;
   perPage: number;
   partialCheckinDetails: PartialCheckinDetailsType;
+  /** Parent booking status — drives booking-context checked-out resolution. */
+  bookingStatus: string;
 }
 
 /** Output of {@link shapeBookingAssets} — the view fields the route returns. */
@@ -68,6 +74,7 @@ export function shapeBookingAssets<
   page,
   perPage,
   partialCheckinDetails,
+  bookingStatus,
 }: ShapeBookingAssetsParams<TAsset, TKit>): ShapeBookingAssetsResult<
   TAsset,
   TKit
@@ -75,18 +82,33 @@ export function shapeBookingAssets<
   // 1. Search-filter (with kit re-expansion).
   const filtered = filterBookingAssets(rawAssets, search);
 
-  // 2. Status sort needs partial check-in date ordering; other fields are
-  //    handled entirely by groupAndSortAssetsByKit.
-  const isStatusSort = !orderBy || orderBy === "status";
-  const listAssets = isStatusSort
-    ? sortBookingAssets(filtered, partialCheckinDetails)
-    : filtered;
-
-  // 3. Group by kit + apply the sort to assets and kit groups.
+  // 2. Group by kit + sort. Status ordering is booking-context aware: an asset
+  //    counts as "checked out" (bottom bucket) when its per-booking status
+  //    resolves to CHECKED_OUT, OR when THIS row's own units are fully checked
+  //    out per-slice. The per-slice arm is essential for QUANTITY_TRACKED
+  //    assets that span a kit slice + a standalone slice: the GLOBAL status
+  //    never flips until every slice is out, so without it a fully-checked-out
+  //    kit slice would wrongly stay on top (and its kit wouldn't sink). This
+  //    keeps the sort position in lock-step with the row badge, and still
+  //    leaves QT DRAFT/RESERVED rows + partially-checked-in assets on top.
   const sortedAssets = groupAndSortAssetsByKit(
-    listAssets,
+    filtered,
     orderBy,
-    orderDirection
+    orderDirection,
+    {
+      isCheckedOut: (asset) => {
+        // Cast once to the permissive AssetWithStatus (open `any` index) so both
+        // predicate arms accept the loosely-typed enriched row.
+        const row = asset as AssetWithStatus;
+        return (
+          isAssetCheckedOutInBooking(
+            row,
+            partialCheckinDetails,
+            bookingStatus
+          ) || isBookingRowQtyFullyCheckedOut(row, bookingStatus)
+        );
+      },
+    }
   );
 
   // 4. Build pagination items (kits grouped, individual assets separate).

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -777,13 +777,17 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     }
 
     /**
-     * Attach the per-slice checkout / disposition counters onto each view row
+     * Attach the per-slice checkout / disposition data onto each view row
      * BEFORE sorting, so the status sort can decide "checked out" per-slice.
      * A QUANTITY_TRACKED asset that spans a kit slice + a standalone slice
      * never flips its GLOBAL `Asset.status` until every slice is out, so a
      * fully-checked-out kit slice can only be recognised from these per-row
      * counters. Carried on `rawAssets` in the loader payload too, so the
-     * clientLoader re-sort stays per-slice aware. Keyed by `bookingAssetId`.
+     * clientLoader re-sort keeps them on cache-hit reshapes (which return
+     * `view.items` straight from `rawAssets`, bypassing `enrichedItems`).
+     * `dispositionBreakdown` is included alongside the counters so the QT
+     * return tooltip survives client-side search/sort/pagination. Keyed by
+     * `bookingAssetId`.
      */
     const enrichedAssetsForSort = enrichedAssetsForView.map((asset) => {
       const bookingAssetId = (asset as { bookingAssetId?: string })
@@ -796,6 +800,9 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         dispositionedQuantity: bookingAssetId
           ? dispositionedByBookingAsset.get(bookingAssetId) ?? 0
           : 0,
+        dispositionBreakdown:
+          (bookingAssetId && breakdownByBookingAsset.get(bookingAssetId)) ||
+          emptyBreakdown(),
       };
     });
 

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -572,19 +572,12 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       };
     });
 
-    // Delegate filter → sort → group-by-kit → paginate to the shared pure
-    // shapeBookingAssets helper. The same function runs in clientLoader for
-    // subsequent navigations (no server round-trip).
-    const view = shapeBookingAssets({
-      rawAssets: enrichedAssetsForView,
-      rawKits,
-      search,
-      orderBy,
-      orderDirection,
-      page,
-      perPage,
-      partialCheckinDetails,
-    });
+    // NOTE: the filter → sort → group-by-kit → paginate step
+    // (`shapeBookingAssets`) is deferred to AFTER the per-slice checkout /
+    // disposition maps are computed below, so the status sort can decide
+    // "checked out" per-slice (a fully-checked-out kit slice must sink even
+    // when the multi-slice QT asset's GLOBAL status hasn't flipped). See the
+    // `enrichedAssetsForSort` construction further down.
 
     /**
      * Sum already-dispositioned units per qty-tracked asset for this
@@ -782,6 +775,44 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         checkedOutByBookingAsset.set(bookingAssetId, qty);
       }
     }
+
+    /**
+     * Attach the per-slice checkout / disposition counters onto each view row
+     * BEFORE sorting, so the status sort can decide "checked out" per-slice.
+     * A QUANTITY_TRACKED asset that spans a kit slice + a standalone slice
+     * never flips its GLOBAL `Asset.status` until every slice is out, so a
+     * fully-checked-out kit slice can only be recognised from these per-row
+     * counters. Carried on `rawAssets` in the loader payload too, so the
+     * clientLoader re-sort stays per-slice aware. Keyed by `bookingAssetId`.
+     */
+    const enrichedAssetsForSort = enrichedAssetsForView.map((asset) => {
+      const bookingAssetId = (asset as { bookingAssetId?: string })
+        .bookingAssetId;
+      return {
+        ...asset,
+        checkedOutQuantity: bookingAssetId
+          ? checkedOutByBookingAsset.get(bookingAssetId) ?? 0
+          : 0,
+        dispositionedQuantity: bookingAssetId
+          ? dispositionedByBookingAsset.get(bookingAssetId) ?? 0
+          : 0,
+      };
+    });
+
+    // Delegate filter → sort → group-by-kit → paginate to the shared pure
+    // shapeBookingAssets helper. The same function runs in clientLoader for
+    // subsequent navigations (no server round-trip).
+    const view = shapeBookingAssets({
+      rawAssets: enrichedAssetsForSort,
+      rawKits,
+      search,
+      orderBy,
+      orderDirection,
+      page,
+      perPage,
+      partialCheckinDetails,
+      bookingStatus: booking.status,
+    });
 
     /**
      * Per-asset remaining-to-checkout: folds the per-slice checked-out
@@ -1123,7 +1154,10 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         // BookingAsset-slice projection (one entry per slice, with singular
         // `kitId`/`kit`/`location`) — exactly what `shapeBookingAssets`
         // expects from main's perf rewrite, adapted to our pivot model.
-        rawAssets: enrichedAssetsForView,
+        // Uses the `enrichedAssetsForSort` variant (carries per-slice
+        // `checkedOutQuantity`/`dispositionedQuantity`) so the clientLoader's
+        // re-sort stays per-slice aware, matching the server first paint.
+        rawAssets: enrichedAssetsForSort,
         rawKits,
         // Current search string so the search input pre-fills on first paint /
         // hard refresh (SearchForm reads `search` from loader data).
@@ -1185,6 +1219,7 @@ export async function clientLoader({
       page: paramsValues.page,
       perPage: serverData.perPage,
       partialCheckinDetails: serverData.partialCheckinDetails,
+      bookingStatus: serverData.booking.status,
     });
     return {
       ...serverData,

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -556,3 +556,95 @@ export function isBookingRowQtyFullyCheckedOut(
     isActiveBooking
   );
 }
+
+/** Resolved booking-row status plus the intermediate QT flags. */
+export type BookingRowQtyState = {
+  /** The badge status for this row (what `AssetStatusBadge` renders). */
+  contextStatus: ExtendedAssetStatus;
+  /** QT row fully reconciled (disposition ≥ booked) on an active booking. */
+  isQtyFullyCheckedIn: boolean;
+  /** QT row partly reconciled (some disposition, units still outstanding). */
+  isQtyPartiallyCheckedIn: boolean;
+  /** QT row with some (not all) units out and nothing returned yet. */
+  isQtyPartiallyCheckedOut: boolean;
+  /** QT row with ALL of its own units out and nothing returned yet. */
+  isQtyFullyCheckedOut: boolean;
+};
+
+/**
+ * Resolve one booking row's (slice's) badge status and the intermediate QT
+ * flags. SINGLE source of truth shared by the row badge
+ * (`list-asset-content.tsx`) and the status-sort predicate
+ * (`shape-booking-assets.ts`) so the status a user sees on a row and the
+ * bucket that row sorts into can never disagree.
+ *
+ * Priority (most specific signal wins):
+ *  1. QT fully reconciled for this row → `PARTIALLY_CHECKED_IN`.
+ *  2. QT partly reconciled (returns underway) → `PARTIALLY_CHECKED_OUT_QTY`.
+ *  3. QT some units out, none returned yet → `..._QTY_PENDING_RETURN`.
+ *  4. QT all of THIS slice's units out, none returned → `CHECKED_OUT`.
+ *  5. Otherwise the global booking-context status
+ *     ({@link getBookingContextAssetStatus}) — covers INDIVIDUAL assets and QT
+ *     rows with no per-row activity (e.g. checked out via another booking).
+ *
+ * The per-row (per-`bookingAssetId`) quantity arms gate BEFORE the global
+ * fallback, so a QT row with a partial return underway reads as its actionable
+ * partial state and is NOT mis-bucketed as fully checked out just because the
+ * asset's global status is `CHECKED_OUT` in a different active booking.
+ *
+ * @param row - The enriched row (id/status/type + per-row qty counters).
+ * @param partialCheckinDetails - Per-booking partial check-in records by id.
+ * @param bookingStatus - The parent booking's status.
+ * @returns The resolved badge status and the QT flags used to derive it.
+ */
+export function resolveBookingRowQtyState(
+  row: AssetWithStatus,
+  partialCheckinDetails: PartialCheckinDetailsType,
+  bookingStatus: string
+): BookingRowQtyState {
+  const qtyBooked = toCount(row.bookedQuantity);
+  const qtyCheckedOut = toCount(row.checkedOutQuantity);
+  const qtyDispositioned = toCount(row.dispositionedQuantity);
+  const qtyRemaining = Math.max(0, qtyBooked - qtyDispositioned);
+  const isActiveBooking =
+    bookingStatus === "ONGOING" || bookingStatus === "OVERDUE";
+  const isQt = row.type === "QUANTITY_TRACKED";
+
+  const isQtyFullyCheckedIn =
+    isQt && qtyBooked > 0 && qtyDispositioned >= qtyBooked && isActiveBooking;
+  const isQtyPartiallyCheckedIn =
+    isQt &&
+    qtyBooked > 0 &&
+    qtyDispositioned > 0 &&
+    qtyRemaining > 0 &&
+    isActiveBooking;
+  const isQtyPartiallyCheckedOut =
+    isQt &&
+    qtyBooked > 0 &&
+    qtyCheckedOut > 0 &&
+    qtyCheckedOut < qtyBooked &&
+    qtyDispositioned === 0 &&
+    isActiveBooking;
+  const isQtyFullyCheckedOut = isBookingRowQtyFullyCheckedOut(
+    row,
+    bookingStatus
+  );
+
+  const contextStatus: ExtendedAssetStatus = isQtyFullyCheckedIn
+    ? "PARTIALLY_CHECKED_IN"
+    : isQtyPartiallyCheckedIn
+    ? "PARTIALLY_CHECKED_OUT_QTY"
+    : isQtyPartiallyCheckedOut
+    ? "PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN"
+    : isQtyFullyCheckedOut
+    ? AssetStatus.CHECKED_OUT
+    : getBookingContextAssetStatus(row, partialCheckinDetails, bookingStatus);
+
+  return {
+    contextStatus,
+    isQtyFullyCheckedIn,
+    isQtyPartiallyCheckedIn,
+    isQtyPartiallyCheckedOut,
+    isQtyFullyCheckedOut,
+  };
+}

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -498,44 +498,61 @@ export function isKitPartiallyCheckedIn(
 }
 
 /**
- * Sorts booking assets by priority:
- * 1. CHECKED_OUT assets (need to be checked in)
- * 2. PARTIALLY_CHECKED_IN assets (already checked in, ordered by most recent)
- * 3. AVAILABLE assets
+ * Minimal per-row shape needed to decide whether a booking's row (one
+ * `BookingAsset` slice) is fully checked out on its own. `bookedQuantity` /
+ * `checkedOutQuantity` / `dispositionedQuantity` are the per-slice counters the
+ * overview loader attaches (keyed by `bookingAssetId`), so a kit-driven slice
+ * and a standalone slice of the same asset are evaluated independently. Fields
+ * are typed `unknown` so the loosely-typed enriched rows (which carry open
+ * index signatures) pass without casts; they are narrowed inside the helper.
  */
-export function sortBookingAssets<T extends AssetWithStatus>(
-  assets: T[],
-  partialCheckinDetails: PartialCheckinDetailsType
-): T[] {
-  return assets.sort((a, b) => {
-    // Check if assets have partial check-in dates
-    const aPartialCheckin = partialCheckinDetails[a.id];
-    const bPartialCheckin = partialCheckinDetails[b.id];
+export type QtyCheckoutRow = {
+  type?: unknown;
+  bookedQuantity?: unknown;
+  checkedOutQuantity?: unknown;
+  dispositionedQuantity?: unknown;
+  // Open index so richer enriched rows (which carry their own index
+  // signatures) are accepted directly, without a weak-type mismatch.
+  [key: string]: unknown;
+};
 
-    // Priority order: CHECKED_OUT first, then PARTIALLY_CHECKED_IN, then AVAILABLE
-    const getStatusPriority = (asset: T, hasPartialCheckin: boolean) => {
-      if (asset.status === "CHECKED_OUT" && !hasPartialCheckin) return 1; // CHECKED_OUT
-      if (hasPartialCheckin) return 2; // PARTIALLY_CHECKED_IN
-      return 3; // AVAILABLE
-    };
+/** Coerce an unknown per-row counter to a finite number (0 when absent/NaN). */
+function toCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
 
-    const aPriority = getStatusPriority(a, !!aPartialCheckin);
-    const bPriority = getStatusPriority(b, !!bPartialCheckin);
-
-    // Sort by priority first
-    if (aPriority !== bPriority) {
-      return aPriority - bPriority;
-    }
-
-    // Within same priority, sort partial check-ins by most recent first
-    if (aPartialCheckin && bPartialCheckin) {
-      return (
-        new Date(bPartialCheckin.checkinDate).getTime() -
-        new Date(aPartialCheckin.checkinDate).getTime()
-      );
-    }
-
-    // Finally, sort by asset ID as fallback for consistency
-    return a.id.localeCompare(b.id);
-  });
+/**
+ * Whether THIS row's own units are ALL progressively checked out with nothing
+ * returned yet — i.e. the slice is fully out and should read as CHECKED_OUT.
+ *
+ * QUANTITY_TRACKED only: a QT asset can legitimately span multiple
+ * `BookingAsset` slices (a kit-driven slice + a standalone free-pool slice),
+ * so its GLOBAL `Asset.status` only flips to CHECKED_OUT once EVERY slice is
+ * out (`bookedTotal` sums across slices). A single fully-checked-out slice
+ * therefore can't be detected from the global status — it must be read from
+ * the per-slice counters. Shared by the row badge in `list-asset-content.tsx`
+ * and the status-sort's `isCheckedOut` predicate in
+ * {@link file://../modules/booking/shape-booking-assets.ts} so the badge and
+ * the sort position always agree.
+ *
+ * @param row - The per-slice row (type + per-row qty counters).
+ * @param bookingStatus - Parent booking status; only ONGOING/OVERDUE are active.
+ * @returns `true` when the slice is fully checked out with no disposition yet.
+ */
+export function isBookingRowQtyFullyCheckedOut(
+  row: QtyCheckoutRow,
+  bookingStatus: string
+): boolean {
+  const qtyBooked = toCount(row.bookedQuantity);
+  const qtyCheckedOut = toCount(row.checkedOutQuantity);
+  const qtyDispositioned = toCount(row.dispositionedQuantity);
+  const isActiveBooking =
+    bookingStatus === "ONGOING" || bookingStatus === "OVERDUE";
+  return (
+    row.type === "QUANTITY_TRACKED" &&
+    qtyBooked > 0 &&
+    qtyCheckedOut >= qtyBooked &&
+    qtyDispositioned === 0 &&
+    isActiveBooking
+  );
 }

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -502,18 +502,19 @@ export function isKitPartiallyCheckedIn(
  * `BookingAsset` slice) is fully checked out on its own. `bookedQuantity` /
  * `checkedOutQuantity` / `dispositionedQuantity` are the per-slice counters the
  * overview loader attaches (keyed by `bookingAssetId`), so a kit-driven slice
- * and a standalone slice of the same asset are evaluated independently. Fields
- * are typed `unknown` so the loosely-typed enriched rows (which carry open
- * index signatures) pass without casts; they are narrowed inside the helper.
+ * and a standalone slice of the same asset are evaluated independently.
+ *
+ * Fields are typed `unknown` (narrowed inside the helpers) rather than `number`
+ * so the loosely-typed enriched rows the callers hold pass without casts. No
+ * index signature — callers with extra fields still structurally match these
+ * optional fields, and keeping it index-free avoids leaking an `any`/`unknown`
+ * open index into the resolver's public signature.
  */
 export type QtyCheckoutRow = {
   type?: unknown;
   bookedQuantity?: unknown;
   checkedOutQuantity?: unknown;
   dispositionedQuantity?: unknown;
-  // Open index so richer enriched rows (which carry their own index
-  // signatures) are accepted directly, without a weak-type mismatch.
-  [key: string]: unknown;
 };
 
 /** Coerce an unknown per-row counter to a finite number (0 when absent/NaN). */
@@ -557,6 +558,17 @@ export function isBookingRowQtyFullyCheckedOut(
   );
 }
 
+/**
+ * Input row for {@link resolveBookingRowQtyState}: the identity/status fields
+ * {@link getBookingContextAssetStatus} needs plus the per-slice qty counters.
+ * Index-signature-free and `any`-free, so callers pass their enriched rows
+ * (which structurally satisfy these fields) without an `any`-indexed cast.
+ */
+export type BookingRowStatusInput = {
+  id: string;
+  status: string;
+} & QtyCheckoutRow;
+
 /** Resolved booking-row status plus the intermediate QT flags. */
 export type BookingRowQtyState = {
   /** The badge status for this row (what `AssetStatusBadge` renders). */
@@ -598,7 +610,7 @@ export type BookingRowQtyState = {
  * @returns The resolved badge status and the QT flags used to derive it.
  */
 export function resolveBookingRowQtyState(
-  row: AssetWithStatus,
+  row: BookingRowStatusInput,
   partialCheckinDetails: PartialCheckinDetailsType,
   bookingStatus: string
 ): BookingRowQtyState {


### PR DESCRIPTION
Sorting on the booking overview:
- Interleave kits and standalone assets by the chosen field instead of always pinning kits on top; kits stay visually grouped with members contiguous.
- Redefine Status sort so fully-checked-out items sink to the bottom, keeping actionable items on top during progressive checkout (booking-context aware).
- Add an "Item type" sort option that groups kits first, then assets.
- Add a sort tooltip explaining Status and Item type, and fix the tooltip z-index so it renders above the sort popover.

Per-slice quantity-tracked checkout status:
- A QUANTITY_TRACKED asset booked both in a kit and standalone has two slices; its global status never flips until every slice is out. Resolve the row badge and the status sort per-slice through a shared isBookingRowQtyFullyCheckedOut helper, so a fully-checked-out kit slice reads "Checked out" and its kit sinks.
- Reorder the overview loader so per-slice checkout counters are computed before the sort and carried on rawAssets for the client-side re-sort.

Known follow-up (tracked for after the sorting release): the bulk-checkout dialog cannot render a standalone-only selection of a multi-slice QT asset because the selection dedups by asset id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Item type” option to booking asset list sorting.
  * Sort controls now include an optional info hint explaining “Status” and “Item type” sorting behavior.
* **Bug Fixes**
  * Corrected sorting and status badges for quantity-tracked rows using per-slice checkout progress (fully vs partially checked out).
  * Fixed partially checked-in / in-progress items so they appear in the correct status buckets.
  * Improved kit grouping and status “bucket” behavior, keeping kit members together with more consistent sorting.
* **Tests**
  * Expanded coverage for the new sorting/sorting hint behavior and per-slice status logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->