### PR TITLE
fix(assets): show bookings in advanced-mode availability view

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Availability-calendar data hook tests
+ *
+ * Regression coverage for the assets-index availability view. The view is fed
+ * by two different loaders with two different booking shapes:
+ *   - Simple mode (`data.server.ts`) includes the `BookingAsset` pivot
+ *     relation → `asset.bookingAssets: { booking }[]`.
+ *   - Advanced mode (`query.server.ts` raw SQL) aggregates the pivot into a
+ *     flat `asset.bookings: AdvancedAssetBooking[]`.
+ *
+ * The quantities pivot updated the hook + simple loader to the `bookingAssets`
+ * shape but left advanced mode on `bookings`, so advanced-mode availability
+ * rendered the asset rows but produced zero booking events. These tests lock in
+ * that BOTH shapes yield events.
+ *
+ * @see {@link file://./use-asset-availability-data.ts}
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AdvancedAssetBooking } from "~/modules/asset/types";
+import { useAssetAvailabilityData } from "./use-asset-availability-data";
+
+// why: useUserRoleHelper resolves roles via Remix loader data; tests do not
+// run inside a route, so stub it to a single-role admin set.
+vi.mock("~/hooks/user-user-role-helper", () => ({
+  useUserRoleHelper: () => ({ roles: ["ADMIN"] }),
+}));
+
+// why: useCurrentOrganization reads Remix root loader data unavailable in the
+// test; a plain object is enough — the permission helper is stubbed below.
+vi.mock("~/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({ id: "org-1" }),
+}));
+
+// why: useHints reads client hints from a Remix context; pin the timezone so
+// date conversion is deterministic.
+vi.mock("~/utils/client-hints", () => ({
+  useHints: () => ({ timeZone: "UTC" }),
+}));
+
+// why: custody-view gating is orthogonal to this hook's shape-normalization;
+// force it off so event titles stay the plain booking name.
+vi.mock(
+  "~/utils/permissions/custody-and-bookings-permissions.validator.client",
+  () => ({
+    userHasCustodyViewPermission: () => false,
+  })
+);
+
+/** Builds a minimal AdvancedAssetBooking with sane defaults. */
+function makeBooking(
+  overrides: Partial<AdvancedAssetBooking> = {}
+): AdvancedAssetBooking {
+  return {
+    id: "booking-1",
+    name: "Test Booking",
+    status: "RESERVED",
+    description: null,
+    from: "2026-07-10T09:00:00.000Z",
+    to: "2026-07-11T09:00:00.000Z",
+    tags: [],
+    ...overrides,
+  };
+}
+
+/** Casts loosely-typed test items to the hook's expected input type. */
+type Items = Parameters<typeof useAssetAvailabilityData>[0];
+
+describe("useAssetAvailabilityData", () => {
+  it("produces events for advanced-mode assets (flat `bookings` shape)", () => {
+    const booking = makeBooking({
+      id: "booking-adv",
+      name: "Advanced Booking",
+    });
+    const items = [
+      { id: "asset-adv", title: "Advanced Asset", bookings: [booking] },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0]).toMatchObject({
+      title: "Advanced Booking",
+      resourceId: "asset-adv",
+    });
+    expect(result.current.events[0].extendedProps).toMatchObject({
+      id: "booking-adv",
+      url: "/bookings/booking-adv",
+    });
+  });
+
+  it("produces events for simple-mode assets (`bookingAssets` pivot shape)", () => {
+    const booking = makeBooking({ id: "booking-sim", name: "Simple Booking" });
+    const items = [
+      {
+        id: "asset-sim",
+        title: "Simple Asset",
+        bookingAssets: [{ booking }],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0]).toMatchObject({
+      title: "Simple Booking",
+      resourceId: "asset-sim",
+    });
+  });
+
+  it("emits no events for assets carrying neither booking shape", () => {
+    const items = [
+      { id: "asset-none", title: "No Bookings Asset" },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(0);
+    // The asset row (resource) still renders even without bookings.
+    expect(result.current.resources).toHaveLength(1);
+  });
+});

--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
@@ -64,79 +64,86 @@ export function useAssetAvailabilityData(items: Items) {
 
     const events = safeItems
       .map((asset) => {
-        if (!("bookingAssets" in asset) || !asset.bookingAssets) {
-          return [];
-        }
+        // The availability calendar is fed by two loaders with two booking
+        // shapes: simple mode (`data.server.ts`) includes the `BookingAsset`
+        // pivot relation → `asset.bookingAssets: { booking }[]`, while advanced
+        // mode (`query.server.ts` raw SQL) aggregates the pivot into a flat
+        // `asset.bookings: AdvancedAssetBooking[]`. Normalize both to a flat
+        // booking list so events render in either mode — otherwise advanced
+        // mode renders the asset rows but no bookings on the timeline.
+        const bookings: AdvancedAssetBooking[] =
+          "bookingAssets" in asset && asset.bookingAssets
+            ? (
+                asset.bookingAssets as unknown as {
+                  booking: AdvancedAssetBooking;
+                }[]
+              ).map((ba) => ba.booking)
+            : "bookings" in asset && asset.bookings
+            ? (asset.bookings as unknown as AdvancedAssetBooking[])
+            : [];
 
-        return [
-          ...(
-            asset.bookingAssets as unknown as {
-              booking: AdvancedAssetBooking;
-            }[]
-          ).map((ba) => {
-            const booking = ba.booking;
-            const custodianName = booking?.custodianUser
-              ? resolveUserDisplayName(booking.custodianUser)
-              : booking.custodianTeamMember?.name;
+        return bookings.map((booking) => {
+          const custodianName = booking?.custodianUser
+            ? resolveUserDisplayName(booking.custodianUser)
+            : booking.custodianTeamMember?.name;
 
-            let title = booking.name;
-            if (canSeeAllCustody) {
-              title += ` | ${custodianName}`;
-            }
+          let title = booking.name;
+          if (canSeeAllCustody) {
+            title += ` | ${custodianName}`;
+          }
 
-            return {
-              title,
-              resourceId: asset.id,
-              start: toIsoDateTimeToUserTimezone(booking.from, timeZone),
-              end: toIsoDateTimeToUserTimezone(booking.to, timeZone),
-              classNames: [
-                `bookingId-${booking.id}`,
-                ...getStatusClasses(
-                  booking.status,
-                  isOneDayEvent(new Date(booking.from), new Date(booking.to)),
-                  "px-1"
-                ),
-              ],
-              extendedProps: {
-                url: `/bookings/${booking.id}`,
-                id: booking.id,
-                name: booking.name,
-                status: booking.status,
-                title: booking.name,
-                description: booking.description,
-                start: booking.from,
-                end: booking.to,
-                custodian: {
-                  name: custodianName,
-                  user: booking.custodianUser
-                    ? {
-                        id: booking.custodianUser?.id,
-                        firstName: booking.custodianUser?.firstName,
-                        lastName: booking.custodianUser?.lastName,
-                        profilePicture: booking.custodianUser?.profilePicture,
-                      }
-                    : undefined,
-                },
-                creator: booking.creator
+          return {
+            title,
+            resourceId: asset.id,
+            start: toIsoDateTimeToUserTimezone(booking.from, timeZone),
+            end: toIsoDateTimeToUserTimezone(booking.to, timeZone),
+            classNames: [
+              `bookingId-${booking.id}`,
+              ...getStatusClasses(
+                booking.status,
+                isOneDayEvent(new Date(booking.from), new Date(booking.to)),
+                "px-1"
+              ),
+            ],
+            extendedProps: {
+              url: `/bookings/${booking.id}`,
+              id: booking.id,
+              name: booking.name,
+              status: booking.status,
+              title: booking.name,
+              description: booking.description,
+              start: booking.from,
+              end: booking.to,
+              custodian: {
+                name: custodianName,
+                user: booking.custodianUser
                   ? {
-                      name: booking.creator
-                        ? resolveUserDisplayName(booking.creator)
-                        : "Unknown",
-                      user: booking.creator
-                        ? {
-                            id: booking.creator.id,
-                            firstName: booking.creator.firstName,
-                            lastName: booking.creator.lastName,
-                            profilePicture: booking.creator.profilePicture,
-                          }
-                        : null,
+                      id: booking.custodianUser?.id,
+                      firstName: booking.custodianUser?.firstName,
+                      lastName: booking.custodianUser?.lastName,
+                      profilePicture: booking.custodianUser?.profilePicture,
                     }
                   : undefined,
-                tags: booking.tags,
               },
-            };
-          }),
-        ];
+              creator: booking.creator
+                ? {
+                    name: booking.creator
+                      ? resolveUserDisplayName(booking.creator)
+                      : "Unknown",
+                    user: booking.creator
+                      ? {
+                          id: booking.creator.id,
+                          firstName: booking.creator.firstName,
+                          lastName: booking.creator.lastName,
+                          profilePicture: booking.creator.profilePicture,
+                        }
+                      : null,
+                  }
+                : undefined,
+              tags: booking.tags,
+            },
+          };
+        });
       })
       .flat();
 


### PR DESCRIPTION
The quantities pivot (BookingAsset) migrated the availability calendar hook and the simple-mode loader to read `asset.bookingAssets[].booking`, but advanced index mode still exposes a flat `asset.bookings[]` array from the raw SQL aggregation. The hook's `"bookingAssets" in asset` guard was false for advanced-mode assets, so no booking events were produced and the timeline rendered asset rows with no bookings.

Normalize both loader shapes to a flat booking list in the hook so events render in either index mode. Add regression tests covering both shapes plus the no-bookings case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asset availability now shows bookings from both advanced and standard booking data formats.

* **Bug Fixes**
  * Fixed cases where bookings could disappear from the availability timeline when only one data shape was present.
  * Assets without booking details still display correctly in the resource list.

* **Tests**
  * Added regression coverage for booking event rendering across both booking formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->