### PR TITLE
refactor(bookings): extract shared kit add-to-booking checked-out guard

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -43,6 +43,7 @@ import {
   addScannedAssetsToBooking,
   processBooking,
   getExistingBookingDetails,
+  assertKitsAddableToActiveBooking,
   getOngoingBookingForAsset,
   bulkArchiveBookings,
   bulkCancelBookings,
@@ -7056,6 +7057,92 @@ describe("processBooking — checked-out guard for active bookings", () => {
       OWNER_AUTH
     );
     expect(finalAssetIds).toEqual(["asset-1", "asset-2"]);
+  });
+});
+
+describe("assertKitsAddableToActiveBooking", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  /** Kits already on the booking, resolved from existingAssetKitIds. */
+  function mockKitsAlreadyOnBooking(kitIds: string[]) {
+    (db.assetKit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      kitIds.map((kitId) => ({ kitId }))
+    );
+  }
+
+  /** Kits returned by the CHECKED_OUT query. */
+  function mockCheckedOutKits(kits: Array<{ id: string; name: string }>) {
+    (db.kit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue(kits);
+  }
+
+  it.each([BookingStatus.DRAFT, BookingStatus.RESERVED])(
+    "is a no-op for a %s booking (no queries, no throw)",
+    async (bookingStatus) => {
+      await assertKitsAddableToActiveBooking({
+        kitIds: ["kit-1"],
+        existingAssetKitIds: new Set(["ak-1"]),
+        bookingStatus,
+        bookingId: "booking-1",
+        organizationId: "org-1",
+      });
+
+      expect(db.assetKit.findMany).not.toHaveBeenCalled();
+      expect(db.kit.findMany).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([BookingStatus.ONGOING, BookingStatus.OVERDUE])(
+    "throws for a kit checked out elsewhere when target is %s",
+    async (bookingStatus) => {
+      mockKitsAlreadyOnBooking([]); // nothing already on booking
+      mockCheckedOutKits([{ id: "kit-1", name: "Kit 1" }]);
+
+      await expect(
+        assertKitsAddableToActiveBooking({
+          kitIds: ["kit-1"],
+          existingAssetKitIds: new Set(["ak-1"]),
+          bookingStatus,
+          bookingId: "booking-1",
+          organizationId: "org-1",
+        })
+      ).rejects.toThrow(/already checked out/i);
+    }
+  );
+
+  it("does NOT throw for a checked-out kit that is already on this booking", async () => {
+    // kit-1 already has a membership on the booking → excluded from the guard,
+    // so its CHECKED_OUT status (owned by this booking) is ignored.
+    mockKitsAlreadyOnBooking(["kit-1"]);
+
+    await assertKitsAddableToActiveBooking({
+      kitIds: ["kit-1"],
+      existingAssetKitIds: new Set(["ak-1"]),
+      bookingStatus: BookingStatus.ONGOING,
+      bookingId: "booking-1",
+      organizationId: "org-1",
+    });
+
+    // Short-circuits before the checked-out query once all kits are excluded.
+    expect(db.kit.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does NOT throw when the newly-added kits are all available", async () => {
+    mockKitsAlreadyOnBooking([]);
+    mockCheckedOutKits([]); // none checked out
+
+    await assertKitsAddableToActiveBooking({
+      kitIds: ["kit-1", "kit-2"],
+      existingAssetKitIds: new Set(),
+      bookingStatus: BookingStatus.ONGOING,
+      bookingId: "booking-1",
+      organizationId: "org-1",
+    });
+
+    // With no existing memberships, the assetKit lookup is skipped entirely.
+    expect(db.assetKit.findMany).not.toHaveBeenCalled();
+    expect(db.kit.findMany).toHaveBeenCalled();
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -10776,6 +10776,105 @@ export async function processBooking(
 }
 
 /**
+ * Guards the "add kits to an existing booking" flow: a kit that is physically
+ * CHECKED_OUT on ANOTHER active booking cannot be added to an ONGOING/OVERDUE
+ * booking — there is nothing available to stage. Kits added to an active booking
+ * otherwise stay AVAILABLE until purposefully checked out (progressive
+ * checkout). This is the kit counterpart of the asset guard inside
+ * {@link processBooking}.
+ *
+ * No-op for DRAFT/RESERVED targets — they accept checked-out kits, which become
+ * available by the time the booking starts.
+ *
+ * Kits already represented on the target booking are excluded: their
+ * CHECKED_OUT status can be owned by this same booking, and re-adding only
+ * attaches newly-added members ({@link buildKitSlicesForBooking} skips existing
+ * memberships).
+ *
+ * NOTE: the manage-kits route keeps its own richer, partial-checkin-aware guard
+ * ({@link isKitPartiallyCheckedIn}) because it operates on kits already loaded
+ * with their memberships/status and must permit re-checkout of kits that are
+ * partially checked in within that booking — semantics that don't apply when
+ * adding genuinely-new kits here.
+ *
+ * @param params.kitIds - Org-scoped kit ids the caller wants to add.
+ * @param params.existingAssetKitIds - AssetKit ids already on the target
+ *   booking (from its `bookingAssets[].assetKitId`), used to skip kits that are
+ *   already represented.
+ * @param params.bookingStatus - Current status of the target booking.
+ * @param params.bookingId - Target booking id (for the error payload).
+ * @param params.organizationId - Caller's validated organization id; scopes
+ *   every query so foreign-org kits/memberships can't influence the check.
+ * @throws {ShelfError} 400 if any newly-added kit is checked out elsewhere.
+ */
+export async function assertKitsAddableToActiveBooking({
+  kitIds,
+  existingAssetKitIds,
+  bookingStatus,
+  bookingId,
+  organizationId,
+}: {
+  kitIds: string[];
+  existingAssetKitIds: Set<string>;
+  bookingStatus: BookingStatus;
+  bookingId: string;
+  organizationId: string;
+}): Promise<void> {
+  // Only active bookings gate on checked-out status.
+  if (
+    bookingStatus !== BookingStatus.ONGOING &&
+    bookingStatus !== BookingStatus.OVERDUE
+  ) {
+    return;
+  }
+
+  // Kit ids that already have at least one membership on this booking — their
+  // checked-out status can belong to this same booking, so they're excluded.
+  const kitIdsAlreadyOnBooking = new Set(
+    existingAssetKitIds.size > 0
+      ? (
+          await db.assetKit.findMany({
+            where: {
+              id: { in: [...existingAssetKitIds] },
+              kitId: { in: kitIds },
+              organizationId,
+            },
+            select: { kitId: true },
+          })
+        ).map((ak) => ak.kitId)
+      : []
+  );
+
+  const kitIdsToGuard = kitIds.filter((id) => !kitIdsAlreadyOnBooking.has(id));
+  if (kitIdsToGuard.length === 0) {
+    return;
+  }
+
+  const checkedOutKits = await db.kit.findMany({
+    where: {
+      id: { in: kitIdsToGuard },
+      organizationId,
+      status: KitStatus.CHECKED_OUT,
+    },
+    select: { id: true, name: true },
+  });
+
+  if (checkedOutKits.length > 0) {
+    throw new ShelfError({
+      cause: null,
+      title: "Not allowed. Kits already checked out",
+      message: `The following kits are already checked out and cannot be added to the booking: ${checkedOutKits
+        .map((kit) => kit.name)
+        .join(", ")}`,
+      additionalData: { checkedOutKits, bookingId },
+      status: 400,
+      label,
+      shouldBeCaptured: false,
+    });
+  }
+}
+
+/**
  * Shared function to load booking data for both assets and kits routes for add-to-existing-booking
  * @param params - Parameters required for loading bookings
  * @returns Formatted booking data response

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -1,4 +1,4 @@
-import { BookingStatus, KitStatus, type Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { CalendarCheck } from "lucide-react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import {
@@ -13,9 +13,9 @@ import { Form } from "~/components/custom-form";
 import DynamicSelect from "~/components/dynamic-select/dynamic-select";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
-import { db } from "~/database/db.server";
 
 import {
+  assertKitsAddableToActiveBooking,
   buildKitSlicesForBooking,
   getExistingBookingDetails,
   loadBookingsData,
@@ -167,65 +167,18 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         .filter((id): id is string => id != null)
     );
 
-    // Progressive-checkout guard (parity with the manage-kits route): a kit that
-    // is physically CHECKED_OUT on ANOTHER active booking cannot be added to an
-    // ONGOING/OVERDUE booking. Kits added to an active booking otherwise stay
-    // AVAILABLE until purposefully checked out. Only fires for active targets;
-    // DRAFT/RESERVED bookings still accept checked-out kits.
-    //
-    // Kits already represented on this booking are excluded: their CHECKED_OUT
-    // status can be owned by this same booking, and re-adding only attaches
-    // newly-added members (buildKitSlicesForBooking skips existing memberships).
-    // Mirrors the manage-kits "newly added kits only" guard.
-    if (
-      bookingInfo.status === BookingStatus.ONGOING ||
-      bookingInfo.status === BookingStatus.OVERDUE
-    ) {
-      // Kit ids that already have at least one membership on this booking.
-      const kitIdsAlreadyOnBooking = new Set(
-        existingAssetKitIds.size > 0
-          ? (
-              await db.assetKit.findMany({
-                where: {
-                  id: { in: [...existingAssetKitIds] },
-                  kitId: { in: kitIds },
-                  organizationId,
-                },
-                select: { kitId: true },
-              })
-            ).map((ak) => ak.kitId)
-          : []
-      );
-      const kitIdsToGuard = kitIds.filter(
-        (id) => !kitIdsAlreadyOnBooking.has(id)
-      );
-
-      const checkedOutKits =
-        kitIdsToGuard.length > 0
-          ? await db.kit.findMany({
-              where: {
-                id: { in: kitIdsToGuard },
-                organizationId,
-                status: KitStatus.CHECKED_OUT,
-              },
-              select: { id: true, name: true },
-            })
-          : [];
-
-      if (checkedOutKits.length > 0) {
-        throw new ShelfError({
-          cause: null,
-          title: "Not allowed. Kits already checked out",
-          message: `The following kits are already checked out and cannot be added to the booking: ${checkedOutKits
-            .map((kit) => kit.name)
-            .join(", ")}`,
-          additionalData: { checkedOutKits, bookingId },
-          status: 400,
-          label: "Booking",
-          shouldBeCaptured: false,
-        });
-      }
-    }
+    // Progressive-checkout guard: a kit checked out on another active booking
+    // cannot be added to an ONGOING/OVERDUE booking. No-op for DRAFT/RESERVED;
+    // excludes kits already on this booking. Shared with future callers and
+    // covered by service-layer tests. See the helper's JSDoc for why the
+    // manage-kits route keeps its own partial-checkin-aware variant.
+    await assertKitsAddableToActiveBooking({
+      kitIds,
+      existingAssetKitIds,
+      bookingStatus: bookingInfo.status,
+      bookingId,
+      organizationId,
+    });
 
     // Resolve the kit memberships into kit-driven slice specs (org-scoped),
     // skipping any AssetKit already on the booking. Routing members through


### PR DESCRIPTION
Follow-up to PR #2683 review: the kit "add to existing booking" route hand-rolled its checked-out guard (two Prisma queries + ShelfError) inline, unlike the asset flow which delegates to processBooking. Extract it into assertKitsAddableToActiveBooking in booking/service.server.ts so the logic and its org-scoped queries live in the service layer and get direct unit coverage.

- New exported helper mirrors processBooking's asset guard: no-op for DRAFT/RESERVED, excludes kits already on the target booking, and rejects kits checked out elsewhere for ONGOING/OVERDUE targets.
- Route now calls the helper; drops the now-unused db/KitStatus/BookingStatus imports.
- Add service-layer tests for the helper.

The manage-kits route intentionally keeps its own partial-checkin-aware guard (isKitPartiallyCheckedIn): it operates on kits already loaded with their memberships/status and must permit re-checkout of kits partially checked in within that booking — semantics that don't apply when adding genuinely-new kits. This is documented on the helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter validation when adding kits to an existing booking.

* **Bug Fixes**
  * Prevented adding kits that are already checked out to another active booking.
  * Allowed kits already on the booking to be ignored during validation.
  * Kept draft and reserved bookings unaffected by this check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->