### PR TITLE
feat(feedback): readable screenshots, auto-captured context, and error-page reporting

### DIFF
--- a/apps/webapp/app/components/errors/index.test.tsx
+++ b/apps/webapp/app/components/errors/index.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Tests for {@link ErrorContent}'s report-an-issue wiring: the button only
+ * shows for authenticated app-layout errors, and the feedback modal receives
+ * the error context (trace id, status, title, message) rendered on the page.
+ *
+ * @see {@link file://./index.tsx}
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mutable per-test state driving the mocked hooks
+let mockRouteError: unknown;
+let mockUser: { id: string } | undefined;
+
+// why: useRouteError/useLocation need a data router; we drive them per test
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-router");
+  return {
+    ...actual,
+    useRouteError: () => mockRouteError,
+    useLocation: () => ({ pathname: "/kits" }),
+  };
+});
+
+// why: useUserData reads the app layout's loader data, which only exists
+// inside a real router; we toggle it to test the button gating
+vi.mock("~/hooks/use-user-data", () => ({
+  useUserData: () => mockUser,
+}));
+
+// why: the Sentry SDK is not initialized in tests
+vi.mock("@sentry/react-router", () => ({
+  captureException: vi.fn(() => "evt_abc"),
+}));
+
+// why: the modal's own rendering is covered by feedback-modal.test.tsx;
+// here we only assert on the props ErrorContent passes to it
+const { mockFeedbackModal } = vi.hoisted(() => ({
+  mockFeedbackModal: vi.fn(
+    (_props: {
+      open: boolean;
+      onClose: () => void;
+      errorContext?: Record<string, unknown> | null;
+    }) => null
+  ),
+}));
+vi.mock("../feedback/feedback-modal", () => ({
+  default: mockFeedbackModal,
+}));
+
+import { ErrorContent } from "./index";
+
+/** The Back-to-home/Reload link buttons need a router context to render */
+function renderErrorContent() {
+  return render(
+    <MemoryRouter>
+      <ErrorContent />
+    </MemoryRouter>
+  );
+}
+
+/** Shape-compatible with react-router's isRouteErrorResponse guard */
+function buildRouteError() {
+  return {
+    status: 500,
+    statusText: "Internal Server Error",
+    internal: false,
+    data: {
+      error: {
+        message: "Something went wrong while fetching the kit",
+        title: "Kit error",
+        traceId: "trace_789",
+      },
+    },
+  };
+}
+
+describe("ErrorContent report-an-issue", () => {
+  beforeEach(() => {
+    mockFeedbackModal.mockClear();
+    mockRouteError = buildRouteError();
+    mockUser = { id: "user_123" };
+  });
+
+  it("shows the report button for authenticated layout errors", () => {
+    renderErrorContent();
+    expect(
+      screen.getByRole("button", { name: /report this issue/i })
+    ).toBeTruthy();
+  });
+
+  it("hides the report button when the app layout did not render", () => {
+    mockUser = undefined;
+    renderErrorContent();
+    expect(
+      screen.queryByRole("button", { name: /report this issue/i })
+    ).toBeNull();
+    expect(mockFeedbackModal).not.toHaveBeenCalled();
+  });
+
+  it("mounts the modal only when the report button is clicked, with the rendered error details", async () => {
+    renderErrorContent();
+
+    // Lazy + closed: nothing mounted (keeps the modal out of the root chunk
+    // and its hooks off every error render)
+    expect(mockFeedbackModal).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /report this issue/i }));
+
+    await waitFor(() => expect(mockFeedbackModal).toHaveBeenCalled());
+    const props = mockFeedbackModal.mock.calls.at(-1)?.[0];
+    expect(props?.open).toBe(true);
+    expect(props?.errorContext).toMatchObject({
+      traceId: "trace_789",
+      errorStatus: "500",
+      errorTitle: "Kit error",
+      errorMessage: "Something went wrong while fetching the kit",
+    });
+  });
+
+  it("still renders the error message and trace id", () => {
+    renderErrorContent();
+    expect(
+      screen.getByText(/Something went wrong while fetching the kit/)
+    ).toBeTruthy();
+    expect(screen.getByText(/trace_789/)).toBeTruthy();
+  });
+});

--- a/apps/webapp/app/components/errors/index.test.tsx
+++ b/apps/webapp/app/components/errors/index.test.tsx
@@ -78,7 +78,10 @@ function buildRouteError() {
 
 describe("ErrorContent report-an-issue", () => {
   beforeEach(() => {
-    mockFeedbackModal.mockClear();
+    // Reset both calls and any per-test implementation (e.g. the throwing
+    // one in the chunk-crash test), then restore the render-nothing default
+    mockFeedbackModal.mockReset();
+    mockFeedbackModal.mockImplementation(() => null);
     mockRouteError = buildRouteError();
     mockUser = { id: "user_123" };
   });
@@ -125,5 +128,32 @@ describe("ErrorContent report-an-issue", () => {
       screen.getByText(/Something went wrong while fetching the kit/)
     ).toBeTruthy();
     expect(screen.getByText(/trace_789/)).toBeTruthy();
+  });
+
+  it("hides the report UI instead of blanking the page when the modal crashes", async () => {
+    // ErrorContent IS the app-wide boundary: a modal chunk-load failure must
+    // not escape it. The local boundary hides the report UI instead.
+    // why: silence React's expected error-boundary console noise
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockFeedbackModal.mockImplementation(() => {
+      throw new Error("Failed to fetch dynamically imported module");
+    });
+
+    renderErrorContent();
+    fireEvent.click(screen.getByRole("button", { name: /report this issue/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /report this issue/i })
+      ).toBeNull()
+    );
+    // The error page itself survives
+    expect(
+      screen.getByText(/Something went wrong while fetching the kit/)
+    ).toBeTruthy();
+
+    consoleError.mockRestore();
   });
 });

--- a/apps/webapp/app/components/errors/index.tsx
+++ b/apps/webapp/app/components/errors/index.tsx
@@ -1,12 +1,19 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import * as Sentry from "@sentry/react-router";
-import { useLocation, useRouteError } from "react-router";
+import { isRouteErrorResponse, useLocation, useRouteError } from "react-router";
 
+import { useUserData } from "~/hooks/use-user-data";
 import { isRouteError } from "~/utils/http";
 import { tw } from "~/utils/tw";
 import Error404Handler from "./error-404-handler";
 import { parse404ErrorData } from "./utils";
 import { Button } from "../shared/button";
+
+/* Lazy: root.tsx uses ErrorContent as the app-wide ErrorBoundary, so a
+ * static import would pull the feedback modal (crisp-sdk-web, react-zorm,
+ * the dialog) into the root chunk shipped to every visitor. The chunk only
+ * loads when someone actually clicks "Report this issue". */
+const FeedbackModal = lazy(() => import("../feedback/feedback-modal"));
 
 type ErrorContentProps = { className?: string };
 
@@ -29,16 +36,32 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
   const loc = useLocation();
   const response = useRouteError();
 
+  /* Present when the authenticated app layout rendered (child-route errors).
+   * That is also the only case where /api/feedback can accept a report, so
+   * the "Report this issue" button is gated on it. */
+  const user = useUserData();
+  const [reportOpen, setReportOpen] = useState(false);
+
   let title = "Oops, something went wrong";
   let message =
     "There was an unexpected error. Please refresh to try again. If the issues persists, please contact support.";
   let traceId;
+  let errorStatus;
 
   if (isRouteError(response)) {
     message = response.data.error.message;
     title = response.data.error.title || "Oops, something went wrong";
     traceId = response.data.error.traceId;
   }
+
+  if (isRouteErrorResponse(response)) {
+    errorStatus = String(response.status);
+  }
+
+  /* For client-side crashes the rendered message is a generic fallback, so
+   * attach the real error message to the report instead */
+  const reportErrorMessage =
+    response instanceof Error ? response.message : message;
 
   const error404 = parse404ErrorData(response);
 
@@ -105,8 +128,35 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
           <Button to={loc.pathname} reloadDocument>
             Reload page
           </Button>
+          {user ? (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setReportOpen(true)}
+            >
+              Report this issue
+            </Button>
+          ) : null}
         </div>
       </div>
+
+      {/* Mounted only while open: keeps the modal's hooks/effects off
+      every error render and resets its state on each reopen */}
+      {user && reportOpen ? (
+        <Suspense fallback={null}>
+          <FeedbackModal
+            open={reportOpen}
+            onClose={() => setReportOpen(false)}
+            errorContext={{
+              traceId,
+              sentryEventId: sentryEventId ?? undefined,
+              errorStatus,
+              errorTitle: title,
+              errorMessage: reportErrorMessage,
+            }}
+          />
+        </Suspense>
+      ) : null}
     </div>
   );
 };

--- a/apps/webapp/app/components/errors/index.tsx
+++ b/apps/webapp/app/components/errors/index.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Component, lazy, Suspense, useEffect, useState } from "react";
 import * as Sentry from "@sentry/react-router";
 import { isRouteErrorResponse, useLocation, useRouteError } from "react-router";
 
@@ -14,6 +15,31 @@ import { Button } from "../shared/button";
  * the dialog) into the root chunk shipped to every visitor. The chunk only
  * loads when someone actually clicks "Report this issue". */
 const FeedbackModal = lazy(() => import("../feedback/feedback-modal"));
+
+/**
+ * Catches a failed lazy-chunk load (or render crash) of the feedback modal.
+ * ErrorContent already IS the app-wide error boundary, so anything escaping
+ * from here would blank the whole error page; failing to load the report
+ * dialog should degrade to hiding the report UI instead.
+ */
+class ReportModalBoundary extends Component<
+  { onError: () => void; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch() {
+    this.props.onError();
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
 
 type ErrorContentProps = { className?: string };
 
@@ -41,6 +67,9 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
    * the "Report this issue" button is gated on it. */
   const user = useUserData();
   const [reportOpen, setReportOpen] = useState(false);
+  /* Flipped when the modal chunk fails to load/render: the report UI hides
+   * instead of leaving a button that blanks the page when clicked */
+  const [reportBroken, setReportBroken] = useState(false);
 
   let title = "Oops, something went wrong";
   let message =
@@ -128,7 +157,7 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
           <Button to={loc.pathname} reloadDocument>
             Reload page
           </Button>
-          {user ? (
+          {user && !reportBroken ? (
             <Button
               type="button"
               variant="secondary"
@@ -142,20 +171,27 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
 
       {/* Mounted only while open: keeps the modal's hooks/effects off
       every error render and resets its state on each reopen */}
-      {user && reportOpen ? (
-        <Suspense fallback={null}>
-          <FeedbackModal
-            open={reportOpen}
-            onClose={() => setReportOpen(false)}
-            errorContext={{
-              traceId,
-              sentryEventId: sentryEventId ?? undefined,
-              errorStatus,
-              errorTitle: title,
-              errorMessage: reportErrorMessage,
-            }}
-          />
-        </Suspense>
+      {user && !reportBroken && reportOpen ? (
+        <ReportModalBoundary
+          onError={() => {
+            setReportBroken(true);
+            setReportOpen(false);
+          }}
+        >
+          <Suspense fallback={null}>
+            <FeedbackModal
+              open={reportOpen}
+              onClose={() => setReportOpen(false)}
+              errorContext={{
+                traceId,
+                sentryEventId: sentryEventId ?? undefined,
+                errorStatus,
+                errorTitle: title,
+                errorMessage: reportErrorMessage,
+              }}
+            />
+          </Suspense>
+        </ReportModalBoundary>
       ) : null}
     </div>
   );

--- a/apps/webapp/app/components/feedback/feedback-modal.test.tsx
+++ b/apps/webapp/app/components/feedback/feedback-modal.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for {@link FeedbackModal} branching: the regular feedback form vs
+ * the error-report variant (type toggle hidden, error details as hidden
+ * fields, reassurance notice) and the auto-captured page context fields.
+ *
+ * @see {@link file://./feedback-modal.tsx}
+ */
+import type React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import FeedbackModal from "./feedback-modal";
+
+// why: useFetcher needs a data router; we only assert on rendered markup,
+// so a static idle fetcher with a plain <form> stand-in is enough
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-router");
+  return {
+    ...actual,
+    useFetcher: () => ({
+      state: "idle" as const,
+      data: undefined,
+      submit: vi.fn(),
+      load: vi.fn(),
+      Form: (props: React.ComponentProps<"form">) => <form {...props} />,
+    }),
+  };
+});
+
+// why: useDisabled reads navigation state from the router; stabilise to false
+vi.mock("~/hooks/use-disabled", () => ({
+  useDisabled: () => false,
+}));
+
+// why: the Crisp SDK touches window globals it expects the real app to set up
+vi.mock("crisp-sdk-web", () => ({
+  Crisp: { chat: { open: vi.fn() } },
+}));
+
+const ERROR_CONTEXT = {
+  traceId: "trace_789",
+  sentryEventId: "evt_abc",
+  errorStatus: "500",
+  errorTitle: "Oops, something went wrong",
+  errorMessage: "Something went wrong while fetching the kit",
+};
+
+/** Reads a hidden input by name from the portal-rendered form */
+function getHiddenInput(name: string): HTMLInputElement | null {
+  return document.querySelector(`input[type="hidden"][name="${name}"]`);
+}
+
+describe("FeedbackModal", () => {
+  it("shows the Issue/Idea toggle for regular feedback", () => {
+    render(<FeedbackModal open onClose={vi.fn()} />);
+    expect(screen.getByText("Share feedback")).toBeTruthy();
+    // Exact names: the dialog backdrop has role="button" and its accessible
+    // name concatenates all dialog text, so regex queries would be ambiguous
+    expect(
+      screen.getByRole("button", { name: "Issue" }).closest("div.hidden")
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Idea" })).toBeTruthy();
+    expect(
+      screen.queryByText(/attached to your report automatically/i)
+    ).toBeNull();
+  });
+
+  it("captures the current page and viewport as hidden fields", () => {
+    render(<FeedbackModal open onClose={vi.fn()} />);
+    expect(getHiddenInput("currentUrl")?.value).toBe(window.location.href);
+    expect(getHiddenInput("viewport")?.value).toMatch(/^\d+x\d+ @[\d.]+x$/);
+  });
+
+  it("renders the error-report variant when errorContext is set", () => {
+    render(
+      <FeedbackModal open onClose={vi.fn()} errorContext={ERROR_CONTEXT} />
+    );
+
+    expect(screen.getByText("Report this issue")).toBeTruthy();
+    // The toggle is hidden: an error report is always an issue
+    expect(
+      screen.getByRole("button", { name: "Issue" }).closest("div.hidden")
+    ).toBeTruthy();
+    // The user is told the technical details travel along
+    expect(
+      screen.getByText(/attached to your report automatically/i)
+    ).toBeTruthy();
+    expect(screen.getByText(/trace_789/)).toBeTruthy();
+  });
+
+  it("attaches the error details as hidden fields", () => {
+    render(
+      <FeedbackModal open onClose={vi.fn()} errorContext={ERROR_CONTEXT} />
+    );
+
+    expect(getHiddenInput("type")?.value).toBe("issue");
+    expect(getHiddenInput("traceId")?.value).toBe("trace_789");
+    expect(getHiddenInput("sentryEventId")?.value).toBe("evt_abc");
+    expect(getHiddenInput("errorStatus")?.value).toBe("500");
+    expect(getHiddenInput("errorTitle")?.value).toBe(
+      "Oops, something went wrong"
+    );
+    expect(getHiddenInput("errorMessage")?.value).toBe(
+      "Something went wrong while fetching the kit"
+    );
+  });
+
+  it("omits error hidden fields for regular feedback", () => {
+    render(<FeedbackModal open onClose={vi.fn()} />);
+    expect(getHiddenInput("traceId")).toBeNull();
+    expect(getHiddenInput("sentryEventId")).toBeNull();
+    expect(getHiddenInput("errorStatus")).toBeNull();
+  });
+
+  it("truncates oversized error details to the schema limits", () => {
+    // An unclamped value would fail zorm validation on a hidden field and
+    // silently block the submit with no visible error
+    render(
+      <FeedbackModal
+        open
+        onClose={vi.fn()}
+        errorContext={{ ...ERROR_CONTEXT, errorMessage: "x".repeat(5000) }}
+      />
+    );
+    expect(getHiddenInput("errorMessage")?.value.length).toBe(3000);
+  });
+
+  it("discloses the auto-captured context in the regular variant", () => {
+    render(<FeedbackModal open onClose={vi.fn()} />);
+    expect(
+      screen.getByText(/included automatically to help us debug/i)
+    ).toBeTruthy();
+  });
+});

--- a/apps/webapp/app/components/feedback/feedback-modal.tsx
+++ b/apps/webapp/app/components/feedback/feedback-modal.tsx
@@ -64,6 +64,111 @@ const INITIAL_FEEDBACK_STATE: FeedbackState = {
   fileError: null,
 };
 
+const TYPE_OPTIONS = [
+  { value: "issue", label: "Issue", Icon: TriangleAlertIcon },
+  { value: "idea", label: "Idea", Icon: LightbulbIcon },
+] as const;
+
+/** Issue/Idea selector rendered as two toggle buttons */
+function TypeToggle({
+  value,
+  onChange,
+}: {
+  value: "issue" | "idea";
+  onChange: (value: "issue" | "idea") => void;
+}) {
+  return (
+    <fieldset>
+      <legend className="mb-2 text-sm font-medium text-gray-700">Type</legend>
+      <div className="flex gap-2">
+        {TYPE_OPTIONS.map(({ value: option, label, Icon }) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            className={tw(
+              "flex flex-1 items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors",
+              value === option
+                ? "border-primary-400 bg-primary-50 text-primary-700"
+                : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+            )}
+            aria-pressed={value === option}
+          >
+            <Icon className="size-4" />
+            {label}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+/** Optional screenshot picker with preview and remove affordance */
+function ScreenshotField({
+  previewUrl,
+  screenshot,
+  fileError,
+  fileInputRef,
+  onFileChange,
+  onRemove,
+}: {
+  previewUrl: string | null;
+  screenshot: File | null;
+  fileError: string | null;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div>
+      <p className="mb-2 text-sm font-medium text-gray-700">
+        Screenshot <span className="font-normal text-gray-500">(optional)</span>
+      </p>
+
+      {previewUrl && screenshot ? (
+        <div className="relative inline-block">
+          <img
+            src={previewUrl}
+            alt="Screenshot preview"
+            className="h-24 rounded-lg border border-gray-200 object-cover"
+          />
+          <button
+            type="button"
+            onClick={onRemove}
+            className="absolute -right-2 -top-2 rounded-full border border-gray-200 bg-white p-0.5 shadow-sm hover:bg-gray-50"
+            aria-label="Remove screenshot"
+          >
+            <XIcon className="size-3.5 text-gray-500" />
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 px-4 py-3 text-sm text-gray-600 transition-colors hover:border-gray-400 hover:bg-gray-50"
+        >
+          <ImageIcon className="size-4" />
+          Attach a screenshot
+        </button>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        name="screenshot"
+        accept="image/png,image/jpeg,image/webp"
+        onChange={onFileChange}
+        className="hidden"
+        aria-label="Upload screenshot"
+      />
+
+      {fileError ? (
+        <p className="mt-1 text-sm text-error-600">{fileError}</p>
+      ) : null}
+    </div>
+  );
+}
+
 /** Small inline banner used for the server-error and error-report notices */
 function InlineBanner({
   tone,
@@ -301,45 +406,12 @@ export default function FeedbackModal({
               {/* Category toggle. Hidden for error reports: those are always
               issues, so there is nothing to choose. */}
               <div className={errorContext ? "hidden" : undefined}>
-                <fieldset>
-                  <legend className="mb-2 text-sm font-medium text-gray-700">
-                    Type
-                  </legend>
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() =>
-                        dispatch({ type: "set_feedback_type", value: "issue" })
-                      }
-                      className={tw(
-                        "flex flex-1 items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors",
-                        feedbackType === "issue"
-                          ? "border-primary-400 bg-primary-50 text-primary-700"
-                          : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
-                      )}
-                      aria-pressed={feedbackType === "issue"}
-                    >
-                      <TriangleAlertIcon className="size-4" />
-                      Issue
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        dispatch({ type: "set_feedback_type", value: "idea" })
-                      }
-                      className={tw(
-                        "flex flex-1 items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-colors",
-                        feedbackType === "idea"
-                          ? "border-primary-400 bg-primary-50 text-primary-700"
-                          : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
-                      )}
-                      aria-pressed={feedbackType === "idea"}
-                    >
-                      <LightbulbIcon className="size-4" />
-                      Idea
-                    </button>
-                  </div>
-                </fieldset>
+                <TypeToggle
+                  value={feedbackType}
+                  onChange={(value) =>
+                    dispatch({ type: "set_feedback_type", value })
+                  }
+                />
                 <input
                   type="hidden"
                   name={zo.fields.type()}
@@ -411,53 +483,14 @@ export default function FeedbackModal({
               />
 
               {/* Screenshot upload */}
-              <div>
-                <p className="mb-2 text-sm font-medium text-gray-700">
-                  Screenshot{" "}
-                  <span className="font-normal text-gray-500">(optional)</span>
-                </p>
-
-                {previewUrl && screenshot ? (
-                  <div className="relative inline-block">
-                    <img
-                      src={previewUrl}
-                      alt="Screenshot preview"
-                      className="h-24 rounded-lg border border-gray-200 object-cover"
-                    />
-                    <button
-                      type="button"
-                      onClick={removeScreenshot}
-                      className="absolute -right-2 -top-2 rounded-full border border-gray-200 bg-white p-0.5 shadow-sm hover:bg-gray-50"
-                      aria-label="Remove screenshot"
-                    >
-                      <XIcon className="size-3.5 text-gray-500" />
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    className="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 px-4 py-3 text-sm text-gray-600 transition-colors hover:border-gray-400 hover:bg-gray-50"
-                  >
-                    <ImageIcon className="size-4" />
-                    Attach a screenshot
-                  </button>
-                )}
-
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  name="screenshot"
-                  accept="image/png,image/jpeg,image/webp"
-                  onChange={handleFileChange}
-                  className="hidden"
-                  aria-label="Upload screenshot"
-                />
-
-                {fileError ? (
-                  <p className="mt-1 text-sm text-error-600">{fileError}</p>
-                ) : null}
-              </div>
+              <ScreenshotField
+                previewUrl={previewUrl}
+                screenshot={screenshot}
+                fileError={fileError}
+                fileInputRef={fileInputRef}
+                onFileChange={handleFileChange}
+                onRemove={removeScreenshot}
+              />
 
               {/* The error variant discloses this in its banner instead */}
               {!errorContext ? (

--- a/apps/webapp/app/components/feedback/feedback-modal.tsx
+++ b/apps/webapp/app/components/feedback/feedback-modal.tsx
@@ -12,7 +12,12 @@ import {
 import { useFetcher } from "react-router";
 import { useZorm } from "react-zorm";
 import { useDisabled } from "~/hooks/use-disabled";
-import { feedbackSchema } from "~/modules/feedback/schema";
+import type { FeedbackErrorContext } from "~/modules/feedback/schema";
+import {
+  FEEDBACK_ERROR_CONTEXT_FIELDS,
+  FEEDBACK_FIELD_LIMITS,
+  feedbackSchema,
+} from "~/modules/feedback/schema";
 import { DEFAULT_MAX_IMAGE_UPLOAD_SIZE } from "~/utils/constants";
 import { getValidationErrors } from "~/utils/http";
 import type { DataOrErrorResponse } from "~/utils/http.server";
@@ -24,6 +29,12 @@ import { Button } from "../shared/button";
 type FeedbackModalProps = {
   open: boolean;
   onClose: () => void;
+  /**
+   * When set, the modal acts as an error-report form: the type toggle is
+   * hidden (it is always an issue) and the error details travel along as
+   * hidden fields so support can correlate the report with Sentry/logs.
+   */
+  errorContext?: FeedbackErrorContext | null;
 };
 
 /** Local state for the feedback modal. Grouped in a reducer to keep
@@ -53,6 +64,29 @@ const INITIAL_FEEDBACK_STATE: FeedbackState = {
   fileError: null,
 };
 
+/** Small inline banner used for the server-error and error-report notices */
+function InlineBanner({
+  tone,
+  children,
+}: {
+  tone: "info" | "error";
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={tw(
+        "flex items-start gap-2 rounded-lg border px-3 py-2 text-sm",
+        tone === "error"
+          ? "border-error-300 bg-error-50 text-error-700"
+          : "border-gray-200 bg-gray-50 text-gray-600"
+      )}
+    >
+      <AlertCircleIcon className="mt-0.5 size-4 shrink-0" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
 function feedbackReducer(
   state: FeedbackState,
   action: FeedbackAction
@@ -80,7 +114,11 @@ function feedbackReducer(
   }
 }
 
-export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
+export default function FeedbackModal({
+  open,
+  onClose,
+  errorContext,
+}: FeedbackModalProps) {
   const fetcher = useFetcher<DataOrErrorResponse>();
   const disabled = useDisabled(fetcher);
   const zo = useZorm("Feedback", feedbackSchema);
@@ -99,6 +137,24 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
       ? fetcher.data.error.message
       : null;
 
+  /* Auto-captured page context, sent as hidden fields so support can
+   * reproduce reports. The window guards are load-bearing: this body also
+   * runs during SSR (e.g. server-rendered error pages) even though the
+   * portal output only exists client-side. Values are clamped to the schema
+   * max lengths, otherwise an oversized URL would fail validation on a
+   * hidden field and silently block the submission. */
+  const currentUrl =
+    typeof window === "undefined"
+      ? ""
+      : window.location.href.slice(0, FEEDBACK_FIELD_LIMITS.currentUrl);
+  const viewport =
+    typeof window === "undefined"
+      ? ""
+      : `${window.innerWidth}x${window.innerHeight} @${window.devicePixelRatio}x`.slice(
+          0,
+          FEEDBACK_FIELD_LIMITS.viewport
+        );
+
   const handleClose = useCallback(() => {
     if (autoCloseTimerRef.current) {
       clearTimeout(autoCloseTimerRef.current);
@@ -108,9 +164,21 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
     onClose();
   }, [onClose]);
 
+  /* Tracks which fetcher response the success view was already shown for.
+   * Without it, reopening a still-mounted modal after a successful send
+   * replays the stale success data: the user would only ever see the
+   * "Thank you" screen again and could never file a second report. */
+  const handledSuccessDataRef = useRef<unknown>(null);
+
   useEffect(
     function handleSuccess() {
-      if (fetcher.data && !fetcher.data.error && fetcher.state === "idle") {
+      if (
+        fetcher.data &&
+        !fetcher.data.error &&
+        fetcher.state === "idle" &&
+        handledSuccessDataRef.current !== fetcher.data
+      ) {
+        handledSuccessDataRef.current = fetcher.data;
         dispatch({ type: "show_success" });
         autoCloseTimerRef.current = setTimeout(() => {
           autoCloseTimerRef.current = null;
@@ -184,10 +252,12 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
         title={
           <div className="-mb-3 w-full pb-4">
             <h3 className="text-lg font-semibold text-gray-900">
-              Share feedback
+              {errorContext ? "Report this issue" : "Share feedback"}
             </h3>
             <p className="text-sm text-gray-600">
-              What would you like to share?
+              {errorContext
+                ? "Tell us what happened. The technical details are included automatically."
+                : "What would you like to share?"}
             </p>
           </div>
         }
@@ -225,14 +295,12 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
             <div className="space-y-4 px-6 py-4">
               {/* General server error */}
               {generalError ? (
-                <div className="flex items-start gap-2 rounded-lg border border-error-300 bg-error-50 px-3 py-2 text-sm text-error-700">
-                  <AlertCircleIcon className="mt-0.5 size-4 shrink-0" />
-                  <span>{generalError}</span>
-                </div>
+                <InlineBanner tone="error">{generalError}</InlineBanner>
               ) : null}
 
-              {/* Category toggle */}
-              <div>
+              {/* Category toggle. Hidden for error reports: those are always
+              issues, so there is nothing to choose. */}
+              <div className={errorContext ? "hidden" : undefined}>
                 <fieldset>
                   <legend className="mb-2 text-sm font-medium text-gray-700">
                     Type
@@ -279,13 +347,57 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
                 />
               </div>
 
+              {/* Context captured automatically so support can reproduce
+              reports without asking the user follow-up questions. Values are
+              clamped to the schema limits so validation can't fail on a
+              field the user can neither see nor fix. */}
+              <input
+                type="hidden"
+                name={zo.fields.currentUrl()}
+                value={currentUrl}
+              />
+              <input
+                type="hidden"
+                name={zo.fields.viewport()}
+                value={viewport}
+              />
+              {errorContext
+                ? FEEDBACK_ERROR_CONTEXT_FIELDS.map((field) => {
+                    const value = errorContext[field];
+                    return value ? (
+                      <input
+                        key={field}
+                        type="hidden"
+                        name={zo.fields[field]()}
+                        value={value.slice(0, FEEDBACK_FIELD_LIMITS[field])}
+                      />
+                    ) : null;
+                  })
+                : null}
+
+              {/* Reassure the user that the technical details travel along,
+              so they only need to describe what they were doing */}
+              {errorContext ? (
+                <InlineBanner tone="info">
+                  The error details
+                  {errorContext.traceId
+                    ? ` (trace id ${errorContext.traceId})`
+                    : errorContext.sentryEventId
+                    ? ` (error id ${errorContext.sentryEventId})`
+                    : ""}{" "}
+                  are attached to your report automatically.
+                </InlineBanner>
+              ) : null}
+
               {/* Message textarea */}
               <Input
                 inputType="textarea"
                 label="Message"
                 name={zo.fields.message()}
                 placeholder={
-                  feedbackType === "issue"
+                  errorContext
+                    ? "What were you trying to do when this error happened?"
+                    : feedbackType === "issue"
                     ? "Tell us about the issue you're experiencing..."
                     : "Share your idea for improving Shelf..."
                 }
@@ -346,6 +458,14 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
                   <p className="mt-1 text-sm text-error-600">{fileError}</p>
                 ) : null}
               </div>
+
+              {/* The error variant discloses this in its banner instead */}
+              {!errorContext ? (
+                <p className="text-xs text-gray-500">
+                  Your current page and browser details are included
+                  automatically to help us debug.
+                </p>
+              ) : null}
             </div>
 
             {/* Footer */}

--- a/apps/webapp/app/emails/feedback/feedback-email.test.tsx
+++ b/apps/webapp/app/emails/feedback/feedback-email.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Tests for the feedback support email: plain-text/HTML rendering of the
+ * auto-captured context and error-details sections, and the subject/type
+ * labeling for reports started from an error page.
+ *
+ * @see {@link file://./feedback-email.tsx}
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// why: sendEmail makes external network calls
+const { mockSendEmail } = vi.hoisted(() => ({
+  mockSendEmail: vi.fn(),
+}));
+vi.mock("~/emails/mail.server", () => ({
+  sendEmail: mockSendEmail,
+}));
+
+// why: Logger makes external calls
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+vi.mock("~/utils/logger", () => ({
+  Logger: { error: mockLoggerError },
+}));
+
+// why: env vars are read at import time; shelf.config.ts also imports from this module
+vi.mock("~/utils/env", () => ({
+  SERVER_URL: "https://app.shelf.nu",
+  SUPPORT_EMAIL: "support@shelf.nu",
+  SEND_ONBOARDING_EMAIL: false,
+  ENABLE_PREMIUM_FEATURES: false,
+  FREE_TRIAL_DAYS: "7",
+  DISABLE_SIGNUP: false,
+  DISABLE_SSO: false,
+  SHOW_HOW_DID_YOU_FIND_US: false,
+  COLLECT_BUSINESS_INTEL: false,
+  GEOCODING_USER_AGENT: "",
+}));
+
+import {
+  feedbackEmailText,
+  feedbackEmailHtml,
+  sendFeedbackEmail,
+} from "./feedback-email";
+
+const BASE_PROPS = {
+  userName: "Alice Doe",
+  userEmail: "alice@example.com",
+  organizationName: "Acme",
+  type: "issue" as const,
+  message: "The asset list shows the wrong creation time",
+};
+
+const CONTEXT_PROPS = {
+  ...BASE_PROPS,
+  userId: "user_123",
+  organizationId: "org_456",
+  currentUrl: "https://app.shelf.nu/assets",
+  userAgent:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+  viewport: "1512x824 @2x",
+  appVersion: "abc123",
+};
+
+const ERROR_CONTEXT = {
+  traceId: "trace_789",
+  sentryEventId: "evt_abc",
+  errorStatus: "500",
+  errorTitle: "Oops, something went wrong",
+  errorMessage: "Something went wrong while fetching the kit",
+};
+
+describe("feedbackEmailText", () => {
+  it("renders the base fields", () => {
+    const text = feedbackEmailText(BASE_PROPS);
+    expect(text).toContain("Type: Issue");
+    expect(text).toContain("From: Alice Doe (alice@example.com)");
+    expect(text).toContain("Organization: Acme");
+    expect(text).toContain(BASE_PROPS.message);
+  });
+
+  it("labels ideas as Idea", () => {
+    const text = feedbackEmailText({ ...BASE_PROPS, type: "idea" });
+    expect(text).toContain("Type: Idea");
+  });
+
+  it("includes the auto-captured context rows when provided", () => {
+    const text = feedbackEmailText(CONTEXT_PROPS);
+    expect(text).toContain("Page: https://app.shelf.nu/assets");
+    expect(text).toContain("App version: abc123");
+    // The raw user agent is rendered in parsed, human-readable form
+    expect(text).toContain("Browser: Chrome");
+    expect(text).not.toContain("AppleWebKit");
+    expect(text).toContain("Viewport: 1512x824 @2x");
+    expect(text).toContain("Organization id: org_456");
+    expect(text).toContain("User id: user_123");
+  });
+
+  it("falls back to the raw user agent when unparseable", () => {
+    const text = feedbackEmailText({
+      ...BASE_PROPS,
+      userAgent: "curl/8.4.0",
+    });
+    expect(text).toContain("Browser: curl/8.4.0");
+  });
+
+  it("omits context rows that are not provided", () => {
+    const text = feedbackEmailText(BASE_PROPS);
+    expect(text).not.toContain("Page:");
+    expect(text).not.toContain("Browser:");
+    expect(text).not.toContain("Error details:");
+  });
+
+  it("renders the error details block and Error report label", () => {
+    const text = feedbackEmailText({
+      ...CONTEXT_PROPS,
+      errorContext: ERROR_CONTEXT,
+    });
+    expect(text).toContain("Type: Error report");
+    expect(text).toContain("Error details:");
+    expect(text).toContain("Status: 500");
+    expect(text).toContain("Title: Oops, something went wrong");
+    expect(text).toContain(
+      "Message: Something went wrong while fetching the kit"
+    );
+    expect(text).toContain("Trace id: trace_789");
+    expect(text).toContain("Sentry event id: evt_abc");
+  });
+
+  it("includes the screenshot link when present", () => {
+    const text = feedbackEmailText({
+      ...BASE_PROPS,
+      screenshotUrl: "https://cdn.example.com/shot.png",
+    });
+    expect(text).toContain("Screenshot: https://cdn.example.com/shot.png");
+  });
+});
+
+describe("feedbackEmailHtml", () => {
+  it("links the page URL and renders error details", async () => {
+    const html = await feedbackEmailHtml({
+      ...CONTEXT_PROPS,
+      errorContext: ERROR_CONTEXT,
+    });
+    expect(html).toContain('href="https://app.shelf.nu/assets"');
+    expect(html).toContain("Error report");
+    expect(html).toContain("trace_789");
+    expect(html).toContain("evt_abc");
+  });
+
+  it("renders without optional context", async () => {
+    const html = await feedbackEmailHtml(BASE_PROPS);
+    expect(html).toContain("Alice Doe");
+    expect(html).not.toContain("Error details");
+  });
+
+  it("does not link page URLs that point outside the app", async () => {
+    // A crafted submission must not plant a clickable phishing link in
+    // the support inbox; off-origin URLs render as plain text
+    const html = await feedbackEmailHtml({
+      ...BASE_PROPS,
+      currentUrl: "https://evil.example/sso-login",
+    });
+    expect(html).toContain("https://evil.example/sso-login");
+    expect(html).not.toContain('href="https://evil.example/sso-login"');
+  });
+});
+
+describe("sendFeedbackEmail", () => {
+  beforeEach(() => {
+    mockSendEmail.mockClear();
+  });
+
+  it("sends to support with reply-to set to the submitter", async () => {
+    await sendFeedbackEmail(BASE_PROPS);
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "support@shelf.nu",
+        replyTo: "alice@example.com",
+        subject: expect.stringContaining("New feedback [Issue]:"),
+      })
+    );
+  });
+
+  it("uses the Error report subject label when error context is present", async () => {
+    await sendFeedbackEmail({ ...BASE_PROPS, errorContext: ERROR_CONTEXT });
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.stringContaining("New feedback [Error report]:"),
+      })
+    );
+  });
+});

--- a/apps/webapp/app/emails/feedback/feedback-email.test.tsx
+++ b/apps/webapp/app/emails/feedback/feedback-email.test.tsx
@@ -164,6 +164,19 @@ describe("feedbackEmailHtml", () => {
     expect(html).toContain("https://evil.example/sso-login");
     expect(html).not.toContain('href="https://evil.example/sso-login"');
   });
+
+  it("is not fooled by prefix-matching hosts or userinfo tricks", async () => {
+    // Both values start with the literal SERVER_URL string but parse to a
+    // different origin, so a prefix check would wrongly link them
+    for (const url of [
+      "https://app.shelf.nu.evil.com/phish",
+      "https://app.shelf.nu@evil.com/phish",
+      "not a url at all",
+    ]) {
+      const html = await feedbackEmailHtml({ ...BASE_PROPS, currentUrl: url });
+      expect(html).not.toContain(`href="${url}"`);
+    }
+  });
 });
 
 describe("sendFeedbackEmail", () => {

--- a/apps/webapp/app/emails/feedback/feedback-email.tsx
+++ b/apps/webapp/app/emails/feedback/feedback-email.tsx
@@ -106,6 +106,20 @@ function formatUserAgent(userAgent: string) {
   return os ? `${browser} on ${os}` : browser;
 }
 
+/**
+ * Whether a client-supplied URL parses to OUR app origin. Validated by
+ * parsed origin, never by prefix: a prefix check would match
+ * "https://app.shelf.nu.evil.com" or the "https://app.shelf.nu@evil.com"
+ * userinfo trick (same rationale as safeRedirect in ~/utils/http.server.ts).
+ */
+function isAppOriginUrl(value: string) {
+  try {
+    return new URL(value).origin === new URL(SERVER_URL).origin;
+  } catch {
+    return false;
+  }
+}
+
 /** Rows for the auto-captured context section, in display order */
 function getContextRows({
   currentUrl,
@@ -121,11 +135,10 @@ function getContextRows({
     /* The URL is client-supplied: only make it clickable when it points at
      * our own app, so a crafted submission can't plant a phishing link in
      * the support inbox. Off-origin values still show as plain text. */
-    const isAppUrl = currentUrl.startsWith(SERVER_URL);
     rows.push({
       label: "Page",
       value: currentUrl,
-      ...(isAppUrl ? { href: currentUrl } : {}),
+      ...(isAppOriginUrl(currentUrl) ? { href: currentUrl } : {}),
     });
   }
   if (appVersion) {

--- a/apps/webapp/app/emails/feedback/feedback-email.tsx
+++ b/apps/webapp/app/emails/feedback/feedback-email.tsx
@@ -6,7 +6,9 @@ import {
   render,
   Text,
 } from "@react-email/components";
-import { SUPPORT_EMAIL } from "~/utils/env";
+import parser from "ua-parser-js";
+import type { FeedbackErrorContext } from "~/modules/feedback/schema";
+import { SERVER_URL, SUPPORT_EMAIL } from "~/utils/env";
 import { ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
 import { LogoForEmail } from "../logo";
@@ -16,44 +18,44 @@ import { styles } from "../styles";
 interface FeedbackEmailProps {
   userName: string;
   userEmail: string;
+  /** Shelf user id, for looking the reporter up in the admin dashboard */
+  userId?: string | null;
   organizationName: string;
+  organizationId?: string | null;
   type: "issue" | "idea";
   message: string;
   screenshotUrl?: string | null;
+  /** URL of the page the feedback was submitted from */
+  currentUrl?: string | null;
+  /** Browser user agent, captured server-side from the request */
+  userAgent?: string | null;
+  /** Browser viewport, e.g. "1512x824 @2x" */
+  viewport?: string | null;
+  /** Deployed app version ("dev" outside production) */
+  appVersion?: string | null;
+  /** Present when the report was started from an error page */
+  errorContext?: FeedbackErrorContext | null;
 }
 
-export const sendFeedbackEmail = async ({
-  userName,
-  userEmail,
-  organizationName,
-  type,
-  message,
-  screenshotUrl,
-}: FeedbackEmailProps) => {
+/** A label/value line in one of the email's info boxes */
+type DetailRow = { label: string; value: string; href?: string };
+
+/**
+ * Emails a user-submitted feedback entry (issue/idea/error report) to
+ * SUPPORT_EMAIL with reply-to set to the submitter. Fire-and-forget:
+ * failures are logged, never surfaced to the user.
+ */
+export const sendFeedbackEmail = async (props: FeedbackEmailProps) => {
   try {
-    const typeLabel = type === "issue" ? "Issue" : "Idea";
+    const { message, userEmail, type, errorContext } = props;
+    const typeLabel = getTypeLabel(type, errorContext);
     const sanitized = message.replace(/[\r\n\t]+/g, " ").trim();
     const subjectPreview =
       sanitized.length > 50 ? `${sanitized.slice(0, 50)}...` : sanitized;
     const subject = `New feedback [${typeLabel}]: ${subjectPreview}`;
 
-    const html = await feedbackEmailHtml({
-      userName,
-      userEmail,
-      organizationName,
-      type,
-      message,
-      screenshotUrl,
-    });
-
-    const text = feedbackEmailText({
-      userName,
-      userEmail,
-      organizationName,
-      type,
-      message,
-      screenshotUrl,
-    });
+    const html = await feedbackEmailHtml(props);
+    const text = feedbackEmailText(props);
 
     void sendEmail({
       to: SUPPORT_EMAIL,
@@ -67,47 +69,219 @@ export const sendFeedbackEmail = async ({
       new ShelfError({
         cause,
         message: "Something went wrong while sending the feedback email",
-        additionalData: { userEmail, type },
+        additionalData: { userEmail: props.userEmail, type: props.type },
         label: "Email",
       })
     );
   }
 };
 
-export const feedbackEmailText = ({
-  userName,
-  userEmail,
-  organizationName,
-  type,
-  message,
-  screenshotUrl,
-}: FeedbackEmailProps) => {
-  const typeLabel = type === "issue" ? "Issue" : "Idea";
+/**
+ * Label used in the subject and the type badge. Reports coming from an error
+ * page are flagged as "Error report" so support can triage them first.
+ */
+function getTypeLabel(
+  type: FeedbackEmailProps["type"],
+  errorContext?: FeedbackErrorContext | null
+) {
+  if (errorContext) {
+    return "Error report";
+  }
+  return type === "issue" ? "Issue" : "Idea";
+}
+
+/**
+ * Renders a user agent as "Chrome 126 on macOS", far more scannable than
+ * the raw UA string; falls back to the raw string when unparseable.
+ */
+function formatUserAgent(userAgent: string) {
+  const ua = parser(userAgent);
+  const browser = [ua.browser.name, ua.browser.version]
+    .filter(Boolean)
+    .join(" ");
+  const os = [ua.os.name, ua.os.version].filter(Boolean).join(" ");
+  if (!browser) {
+    return userAgent;
+  }
+  return os ? `${browser} on ${os}` : browser;
+}
+
+/** Rows for the auto-captured context section, in display order */
+function getContextRows({
+  currentUrl,
+  appVersion,
+  userAgent,
+  viewport,
+  organizationId,
+  userId,
+}: FeedbackEmailProps): DetailRow[] {
+  const rows: DetailRow[] = [];
+
+  if (currentUrl) {
+    /* The URL is client-supplied: only make it clickable when it points at
+     * our own app, so a crafted submission can't plant a phishing link in
+     * the support inbox. Off-origin values still show as plain text. */
+    const isAppUrl = currentUrl.startsWith(SERVER_URL);
+    rows.push({
+      label: "Page",
+      value: currentUrl,
+      ...(isAppUrl ? { href: currentUrl } : {}),
+    });
+  }
+  if (appVersion) {
+    rows.push({ label: "App version", value: appVersion });
+  }
+  if (userAgent) {
+    rows.push({ label: "Browser", value: formatUserAgent(userAgent) });
+  }
+  if (viewport) {
+    rows.push({ label: "Viewport", value: viewport });
+  }
+  if (organizationId) {
+    rows.push({ label: "Organization id", value: organizationId });
+  }
+  if (userId) {
+    rows.push({ label: "User id", value: userId });
+  }
+
+  return rows;
+}
+
+/** Rows for the error-details section, in display order */
+function getErrorRows(errorContext?: FeedbackErrorContext | null): DetailRow[] {
+  if (!errorContext) {
+    return [];
+  }
+
+  const rows: DetailRow[] = [];
+
+  if (errorContext.errorStatus) {
+    rows.push({ label: "Status", value: errorContext.errorStatus });
+  }
+  if (errorContext.errorTitle) {
+    rows.push({ label: "Title", value: errorContext.errorTitle });
+  }
+  if (errorContext.errorMessage) {
+    rows.push({ label: "Message", value: errorContext.errorMessage });
+  }
+  if (errorContext.traceId) {
+    rows.push({ label: "Trace id", value: errorContext.traceId });
+  }
+  if (errorContext.sentryEventId) {
+    rows.push({ label: "Sentry event id", value: errorContext.sentryEventId });
+  }
+
+  return rows;
+}
+
+/** Plain-text rendering of the feedback email (mirrors the HTML version) */
+export const feedbackEmailText = (props: FeedbackEmailProps) => {
+  const {
+    userName,
+    userEmail,
+    organizationName,
+    type,
+    message,
+    screenshotUrl,
+    errorContext,
+  } = props;
+  const typeLabel = getTypeLabel(type, errorContext);
+  const contextRows = getContextRows(props);
+  const errorRows = getErrorRows(errorContext);
+
+  const contextBlock = contextRows.length
+    ? `\n${contextRows.map((row) => `${row.label}: ${row.value}`).join("\n")}\n`
+    : "";
+
+  const errorBlock = errorRows.length
+    ? `\nError details:\n${errorRows
+        .map((row) => `${row.label}: ${row.value}`)
+        .join("\n")}\n`
+    : "";
 
   return `New feedback received
 
 Type: ${typeLabel}
 From: ${userName} (${userEmail})
 Organization: ${organizationName}
-
+${contextBlock}
 Message:
 ${message}
-${screenshotUrl ? `\nScreenshot: ${screenshotUrl}` : ""}
+${errorBlock}${screenshotUrl ? `\nScreenshot: ${screenshotUrl}` : ""}
 `;
 };
 
-function FeedbackEmailTemplate({
-  userName,
-  userEmail,
-  organizationName,
-  type,
-  message,
-  screenshotUrl,
-}: FeedbackEmailProps) {
-  const typeLabel = type === "issue" ? "Issue" : "Idea";
-  const typeBgColor = type === "issue" ? "#FEE2E2" : "#DBEAFE";
-  const typeBorderColor = type === "issue" ? "#FECACA" : "#BFDBFE";
-  const typeTextColor = type === "issue" ? "#991B1B" : "#1E40AF";
+/** Shared style for the small gray label/value rows in info boxes */
+const detailRowStyle = {
+  ...styles.p,
+  margin: "0 0 4px 0",
+  fontSize: "14px",
+  color: "#6B7280",
+} as const;
+
+/** Gray info box used for the sender and context sections */
+const infoBoxStyle = {
+  backgroundColor: "#F9FAFB",
+  border: "1px solid #E5E7EB",
+  borderRadius: "8px",
+  padding: "16px",
+  marginBottom: "16px",
+} as const;
+
+/** White box holding the user's message */
+const messageBoxStyle = {
+  ...infoBoxStyle,
+  backgroundColor: "#FFFFFF",
+} as const;
+
+/** Red-tinted box holding the error details of an error report */
+const errorBoxStyle = {
+  ...infoBoxStyle,
+  backgroundColor: "#FEF2F2",
+  border: "1px solid #FECACA",
+} as const;
+
+/** Renders label/value rows; links the value when a href is provided */
+function DetailRows({ rows, color }: { rows: DetailRow[]; color?: string }) {
+  return (
+    <>
+      {rows.map((row) => (
+        <Text
+          key={row.label}
+          style={{ ...detailRowStyle, ...(color ? { color } : {}) }}
+        >
+          <strong>{row.label}:</strong>{" "}
+          {row.href ? (
+            <Link href={row.href} style={{ color: "#2563EB" }}>
+              {row.value}
+            </Link>
+          ) : (
+            row.value
+          )}
+        </Text>
+      ))}
+    </>
+  );
+}
+
+function FeedbackEmailTemplate(props: FeedbackEmailProps) {
+  const {
+    userName,
+    userEmail,
+    organizationName,
+    type,
+    message,
+    screenshotUrl,
+    errorContext,
+  } = props;
+  const typeLabel = getTypeLabel(type, errorContext);
+  const isErrorReport = Boolean(errorContext);
+  const showAsIssue = type === "issue" || isErrorReport;
+  const typeBgColor = showAsIssue ? "#FEE2E2" : "#DBEAFE";
+  const typeBorderColor = showAsIssue ? "#FECACA" : "#BFDBFE";
+  const typeTextColor = showAsIssue ? "#991B1B" : "#1E40AF";
+  const contextRows = getContextRows(props);
+  const errorRows = getErrorRows(errorContext);
 
   return (
     <Html>
@@ -121,15 +295,7 @@ function FeedbackEmailTemplate({
         <div style={{ paddingTop: "8px" }}>
           <Text style={{ ...styles.h2 }}>New feedback received</Text>
 
-          <div
-            style={{
-              backgroundColor: "#F9FAFB",
-              border: "1px solid #E5E7EB",
-              borderRadius: "8px",
-              padding: "16px",
-              marginBottom: "16px",
-            }}
-          >
+          <div style={infoBoxStyle}>
             <Text
               style={{
                 ...styles.p,
@@ -153,42 +319,26 @@ function FeedbackEmailTemplate({
                 {typeLabel}
               </span>
             </Text>
-            <Text
-              style={{
-                ...styles.p,
-                margin: "0 0 4px 0",
-                fontSize: "14px",
-                color: "#6B7280",
-              }}
-            >
+            <Text style={detailRowStyle}>
               <strong>From:</strong>{" "}
               <Link href={`mailto:${userEmail}`} style={{ color: "#2563EB" }}>
                 {userName}
               </Link>{" "}
               ({userEmail})
             </Text>
-            <Text
-              style={{
-                ...styles.p,
-                margin: "0",
-                fontSize: "14px",
-                color: "#6B7280",
-              }}
-            >
+            <Text style={{ ...detailRowStyle, margin: "0" }}>
               <strong>Organization:</strong> {organizationName}
             </Text>
           </div>
 
+          {contextRows.length > 0 ? (
+            <div style={infoBoxStyle}>
+              <DetailRows rows={contextRows} />
+            </div>
+          ) : null}
+
           <Text style={{ ...styles.p, fontWeight: "600" }}>Message:</Text>
-          <div
-            style={{
-              backgroundColor: "#FFFFFF",
-              border: "1px solid #E5E7EB",
-              borderRadius: "8px",
-              padding: "16px",
-              marginBottom: "16px",
-            }}
-          >
+          <div style={messageBoxStyle}>
             <Text
               style={{
                 ...styles.p,
@@ -199,6 +349,17 @@ function FeedbackEmailTemplate({
               {message}
             </Text>
           </div>
+
+          {errorRows.length > 0 ? (
+            <>
+              <Text style={{ ...styles.p, fontWeight: "600" }}>
+                Error details:
+              </Text>
+              <div style={errorBoxStyle}>
+                <DetailRows rows={errorRows} color="#991B1B" />
+              </div>
+            </>
+          ) : null}
 
           {screenshotUrl ? (
             <Text style={{ ...styles.p }}>

--- a/apps/webapp/app/modules/feedback/schema.test.ts
+++ b/apps/webapp/app/modules/feedback/schema.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the feedback submission schema: the user-authored fields keep
+ * their existing constraints and the auto-captured context fields stay
+ * optional but bounded.
+ *
+ * @see {@link file://./schema.ts}
+ */
+import { describe, expect, it } from "vitest";
+
+import { feedbackSchema } from "./schema";
+
+const VALID_BASE = {
+  type: "issue",
+  message: "The asset list shows the wrong creation time",
+};
+
+describe("feedbackSchema", () => {
+  it("accepts a submission without any context fields", () => {
+    const result = feedbackSchema.safeParse(VALID_BASE);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a submission with context and error fields", () => {
+    const result = feedbackSchema.safeParse({
+      ...VALID_BASE,
+      currentUrl: "https://app.shelf.nu/assets",
+      viewport: "1512x824 @2x",
+      traceId: "trace_789",
+      sentryEventId: "evt_abc",
+      errorStatus: "500",
+      errorTitle: "Oops, something went wrong",
+      errorMessage: "Something went wrong while fetching the kit",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still rejects too-short messages", () => {
+    const result = feedbackSchema.safeParse({
+      ...VALID_BASE,
+      message: "short",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects oversized context values", () => {
+    const result = feedbackSchema.safeParse({
+      ...VALID_BASE,
+      currentUrl: "https://app.shelf.nu/".padEnd(3000, "a"),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/webapp/app/modules/feedback/schema.ts
+++ b/apps/webapp/app/modules/feedback/schema.ts
@@ -1,9 +1,76 @@
 import { z } from "zod";
 
+/**
+ * Max lengths for the auto-captured context fields. Shared with the client
+ * (feedback-modal.tsx clamps the values before putting them in hidden
+ * inputs) so an oversized URL or crash message can never fail validation
+ * and silently block the submission.
+ */
+export const FEEDBACK_FIELD_LIMITS = {
+  currentUrl: 2048,
+  viewport: 100,
+  traceId: 120,
+  sentryEventId: 120,
+  errorStatus: 10,
+  errorTitle: 300,
+  errorMessage: 3000,
+} as const;
+
+/**
+ * Validation schema for in-app feedback submissions (issues and ideas).
+ *
+ * Besides the user-authored `type` + `message`, the schema accepts optional
+ * context fields that the client attaches automatically (never typed by the
+ * user): the page the feedback was sent from and, for reports started from an
+ * error page, the error details shown on that page. All of them are plain
+ * strings that only travel into the internal support email, but they get max
+ * lengths so the endpoint can't be used to relay arbitrarily large payloads.
+ *
+ * @see {@link file://./../../routes/api+/feedback.ts}
+ * @see {@link file://./../../components/feedback/feedback-modal.tsx}
+ */
 export const feedbackSchema = z.object({
   type: z.enum(["issue", "idea"]),
   message: z
     .string()
     .min(10, "Please provide at least 10 characters")
     .max(5000, "Message is too long"),
+  /** URL of the page the user submitted the feedback from */
+  currentUrl: z.string().max(FEEDBACK_FIELD_LIMITS.currentUrl).optional(),
+  /** Browser viewport, e.g. "1512x824 @2x" */
+  viewport: z.string().max(FEEDBACK_FIELD_LIMITS.viewport).optional(),
+  /** ShelfError trace id shown on the error page the report started from */
+  traceId: z.string().max(FEEDBACK_FIELD_LIMITS.traceId).optional(),
+  /** Sentry event id for client-side crashes captured by the error boundary */
+  sentryEventId: z.string().max(FEEDBACK_FIELD_LIMITS.sentryEventId).optional(),
+  /** HTTP status of the failed response, e.g. "500" */
+  errorStatus: z.string().max(FEEDBACK_FIELD_LIMITS.errorStatus).optional(),
+  /** User-facing title rendered on the error page */
+  errorTitle: z.string().max(FEEDBACK_FIELD_LIMITS.errorTitle).optional(),
+  /** User-facing message rendered on the error page */
+  errorMessage: z.string().max(FEEDBACK_FIELD_LIMITS.errorMessage).optional(),
 });
+
+/** The error-page fields of the schema, in the order they render */
+export const FEEDBACK_ERROR_CONTEXT_FIELDS = [
+  "traceId",
+  "sentryEventId",
+  "errorStatus",
+  "errorTitle",
+  "errorMessage",
+] as const;
+
+const feedbackErrorContextSchema = feedbackSchema.pick({
+  traceId: true,
+  sentryEventId: true,
+  errorStatus: true,
+  errorTitle: true,
+  errorMessage: true,
+});
+
+/**
+ * Error details attached automatically when a report is started from an
+ * error page. Derived from {@link feedbackSchema} so the type can never
+ * drift from the validation.
+ */
+export type FeedbackErrorContext = z.infer<typeof feedbackErrorContextSchema>;

--- a/apps/webapp/app/routes/api+/feedback.ts
+++ b/apps/webapp/app/routes/api+/feedback.ts
@@ -10,6 +10,15 @@ import { makeShelfError } from "~/utils/error";
 import { assertIsPost, error, parseData, payload } from "~/utils/http.server";
 import { getPublicFileURL, parseFileFormData } from "~/utils/storage.server";
 
+/**
+ * Screenshots are bounded on BOTH dimensions (fit "inside" preserves the
+ * aspect ratio). A width-only bound would let a very tall full-page capture
+ * scale past WebP's 16383px dimension limit and crash the whole submission.
+ * 1920 (not the 1200 used for entity photos) because screenshots are
+ * text-dense and need to stay readable.
+ */
+const SCREENSHOT_MAX_DIMENSION = 1920;
+
 export async function action({ context, request }: ActionFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
@@ -21,7 +30,10 @@ export async function action({ context, request }: ActionFunctionArgs) {
     // orphaned files in storage when validation fails
     const clonedRequest = request.clone();
     const rawFormData = await clonedRequest.formData();
-    const { type, message } = parseData(rawFormData, feedbackSchema);
+    const { type, message, currentUrl, viewport, ...errorContext } = parseData(
+      rawFormData,
+      feedbackSchema
+    );
 
     const [user, { currentOrganization }] = await Promise.all([
       getUserByID(userId, {
@@ -41,6 +53,14 @@ export async function action({ context, request }: ActionFunctionArgs) {
       newFileName: `feedback/${userId}/${dateTimeInUnix(Date.now())}`,
       bucketName: "files",
       maxFileSize: DEFAULT_MAX_IMAGE_UPLOAD_SIZE,
+      // Without this, cropImage falls back to its 150x150 avatar-thumbnail
+      // default and screenshots arrive unreadable in the support email
+      resizeOptions: {
+        width: SCREENSHOT_MAX_DIMENSION,
+        height: SCREENSHOT_MAX_DIMENSION,
+        fit: "inside",
+        withoutEnlargement: true,
+      },
     });
 
     const screenshotPath = formData.get("screenshot") as string | null;
@@ -62,10 +82,21 @@ export async function action({ context, request }: ActionFunctionArgs) {
     await sendFeedbackEmail({
       userName,
       userEmail: user.email,
+      userId,
       organizationName,
+      organizationId: currentOrganization?.id,
       type,
       message,
       screenshotUrl,
+      currentUrl,
+      viewport,
+      // The user agent is read server-side so it can't drift from the
+      // browser that actually submitted the report
+      userAgent: request.headers.get("user-agent"),
+      appVersion: context.appVersion,
+      errorContext: Object.values(errorContext).some(Boolean)
+        ? errorContext
+        : null,
     });
 
     return data(payload({ success: true }));

--- a/apps/webapp/app/routes/api+/feedback.ts
+++ b/apps/webapp/app/routes/api+/feedback.ts
@@ -19,6 +19,34 @@ import { getPublicFileURL, parseFileFormData } from "~/utils/storage.server";
  */
 const SCREENSHOT_MAX_DIMENSION = 1920;
 
+/**
+ * Query params with secret-looking names are redacted before the page URL
+ * reaches the support email. Mirrors SENSITIVE_KEY_PATTERN in
+ * server/instrument.server.ts (which is private to that module), plus `otp`
+ * which shows up in URLs. Deliberately no bare `code`/`key`: those would
+ * false-positive on legitimate filter params like `barcode`.
+ */
+const SENSITIVE_QUERY_PARAM =
+  /token|password|secret|verifier|cookie|authorization|credential|jwt|api[-_]?key|otp/i;
+
+/** Redacts secret-looking query param values; passes unparseable input through */
+function redactSensitiveSearchParams(href: string | undefined) {
+  if (!href) {
+    return href;
+  }
+  try {
+    const url = new URL(href);
+    for (const key of [...url.searchParams.keys()]) {
+      if (SENSITIVE_QUERY_PARAM.test(key)) {
+        url.searchParams.set(key, "redacted");
+      }
+    }
+    return url.toString();
+  } catch {
+    return href;
+  }
+}
+
 export async function action({ context, request }: ActionFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
@@ -88,7 +116,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
       type,
       message,
       screenshotUrl,
-      currentUrl,
+      currentUrl: redactSensitiveSearchParams(currentUrl),
       viewport,
       // The user agent is read server-side so it can't drift from the
       // browser that actually submitted the report

--- a/apps/webapp/test/routes-tests/api+/feedback.test.ts
+++ b/apps/webapp/test/routes-tests/api+/feedback.test.ts
@@ -88,7 +88,7 @@ describe("/api/feedback", () => {
     });
 
     (getSelectedOrganization as any).mockResolvedValue({
-      currentOrganization: { name: "Acme Corp" },
+      currentOrganization: { id: "org-1", name: "Acme Corp" },
       organizationId: "org-1",
     });
 
@@ -126,11 +126,75 @@ describe("/api/feedback", () => {
       expect(sendFeedbackEmail).toHaveBeenCalledWith({
         userName: "Jane Doe",
         userEmail: "jane@example.com",
+        userId: "user-1",
         organizationName: "Acme Corp",
+        organizationId: "org-1",
         type: "issue",
         message: "Something is broken in the app",
         screenshotUrl: null,
+        currentUrl: undefined,
+        viewport: undefined,
+        userAgent: null,
+        appVersion: "test",
+        errorContext: null,
       });
+    });
+
+    it("should resize screenshots to a readable size, not a thumbnail", async () => {
+      const request = createFeedbackRequest({
+        type: "issue",
+        message: "Something is broken in the app",
+      });
+
+      await action(createActionArgs({ request, context: mockContext }));
+
+      // Regression guard: without resizeOptions, cropImage falls back to a
+      // 150x150 avatar-thumbnail crop and screenshots arrive unreadable.
+      // Both dimensions are bounded (fit "inside") so a very tall capture
+      // can't exceed WebP's dimension limit and crash the submission.
+      expect(parseFileFormData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resizeOptions: {
+            width: 1920,
+            height: 1920,
+            fit: "inside",
+            withoutEnlargement: true,
+          },
+        })
+      );
+    });
+
+    it("should forward the auto-captured context and error details", async () => {
+      const request = createFeedbackRequest({
+        type: "issue",
+        message: "Something is broken in the app",
+        currentUrl: "https://app.shelf.nu/kits",
+        viewport: "1512x824 @2x",
+        traceId: "trace_789",
+        sentryEventId: "evt_abc",
+        errorStatus: "500",
+        errorTitle: "Kit error",
+        errorMessage: "Something went wrong while fetching the kit",
+      });
+      request.headers.set("user-agent", "Mozilla/5.0 (Macintosh)");
+
+      await action(createActionArgs({ request, context: mockContext }));
+
+      expect(sendFeedbackEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentUrl: "https://app.shelf.nu/kits",
+          viewport: "1512x824 @2x",
+          userAgent: "Mozilla/5.0 (Macintosh)",
+          appVersion: "test",
+          errorContext: {
+            traceId: "trace_789",
+            sentryEventId: "evt_abc",
+            errorStatus: "500",
+            errorTitle: "Kit error",
+            errorMessage: "Something went wrong while fetching the kit",
+          },
+        })
+      );
     });
 
     it("should use the selected organization, not an arbitrary one", async () => {

--- a/apps/webapp/test/routes-tests/api+/feedback.test.ts
+++ b/apps/webapp/test/routes-tests/api+/feedback.test.ts
@@ -164,6 +164,24 @@ describe("/api/feedback", () => {
       );
     });
 
+    it("should redact secret-looking query params from the page URL", async () => {
+      const request = createFeedbackRequest({
+        type: "issue",
+        message: "Something is broken in the app",
+        currentUrl:
+          "https://app.shelf.nu/reset-password?token=supersecret&search=laptop",
+      });
+
+      await action(createActionArgs({ request, context: mockContext }));
+
+      expect(sendFeedbackEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentUrl:
+            "https://app.shelf.nu/reset-password?token=redacted&search=laptop",
+        })
+      );
+    });
+
     it("should forward the auto-captured context and error details", async () => {
       const request = createFeedbackRequest({
         type: "issue",


### PR DESCRIPTION
## What

Three improvements to the in-app feedback flow (the Issue/Idea modal), plus hardening found in review.

### 1. Fix: screenshots arrived as 150x150 thumbnails
`/api/feedback` called `parseFileFormData` without `resizeOptions`, so `cropImage` applied its avatar default (150x150 cover crop + WebP q80). Every screenshot users attached to feedback arrived unreadable. Screenshots are now bounded to 1920px on BOTH dimensions (`fit: "inside"`, aspect ratio preserved, `withoutEnlargement`). Bounding both dimensions also prevents a very tall capture from exceeding WebP's dimension limit, which would have crashed the submission.

### 2. Auto-captured context
Each submission now includes: the page URL the user was on, viewport, user agent (read server-side from the request), app version, organization id and user id. The support email renders these in a context box, with the user agent parsed into a readable form ("Chrome 126 on macOS") via the already-present `ua-parser-js`. The modal discloses that this context is attached.

Because the page URL is client-supplied, it is only rendered as a clickable link when it starts with `SERVER_URL`; off-origin values show as plain text so a crafted submission cannot plant a phishing link in the support inbox.

### 3. Report an issue from the error page
`ErrorContent` now shows a **Report this issue** button next to Back-to-home/Reload (authenticated app-layout errors only, gated on `useUserData()`). It opens the feedback modal in an error-report variant: the Issue/Idea toggle is hidden, and the trace id, Sentry event id, HTTP status, error title and rendered error message travel as hidden fields. The email subject is labeled `[Error report]` for triage, and the error details render in their own box, so a report can be correlated with Sentry/logs with zero user effort.

The modal is **lazy-loaded and mounted only while open**: `root.tsx` uses `ErrorContent` as the app-wide ErrorBoundary, so a static import would have pulled crisp-sdk-web, react-zorm and the dialog into the root chunk shipped to every visitor.

### Hardening (from self-review)
- Auto-captured values are clamped client-side to the schema max lengths. Without this, an oversized URL or crash message would fail zorm validation on a hidden field the user can neither see nor fix, silently blocking the submit, worst exactly on the error page.
- Reopening the modal after a successful send shows a fresh form instead of replaying the stale fetcher success state (previously the user could never file a second report without a remount).

## Verification
- `pnpm webapp:validate` green: 3113 tests (32 new across schema, email template, modal, error boundary, and route), lint, typecheck.
- Live browser e2e on a dev environment:
  - Submitted feedback with a 2560x1440 screenshot: the stored object is 1920x1080 WebP and fully readable (previously 150x150).
  - Triggered a genuine error page, clicked Report this issue, and confirmed the hidden fields carry the exact on-screen trace id, the failing URL, HTTP status, and error message; submission succeeds and the email arrives with all context.
  - Confirmed a second report can be filed after the first one succeeds.
- react-doctor: no findings on changed files.

## Notes / follow-up candidates
- Screenshots keep going to the public `files` bucket (same convention as audit and location images). Signed URLs would be more private but expire after 72h, which is awkward for a support inbox; left as a conscious follow-up decision.
- The report button is gated on the app layout's loader data, so errors thrown by the layout loader itself do not show it (identity cannot be resolved client-side there). Rare; revisit if support wants coverage.
- `cropImage`'s 150x150 default now has no caller depending on it implicitly (all upload paths pass explicit `resizeOptions`); making the parameter required would remove the trap this PR had to opt out of. Left out to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error submissions now include richer diagnostics and trace details, and trigger an updated “error report” feedback experience.
  * Feedback support emails now include expanded context (and optional screenshots) with an “Error report” subject when applicable.

* **Bug Fixes**
  * “Report this issue” is shown only when the required user context is available.
  * Modal loading/render failures no longer blank the error page; the underlying error content remains visible.

* **Tests**
  * Added/updated coverage for the error-report flow, modal behavior, email rendering/sending, validation limits, URL redaction, and bounded screenshot resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->