### PR TITLE
feat(assets): collapse duplicate booking bars in availability view

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.test.ts
@@ -48,7 +48,9 @@ vi.mock(
   })
 );
 
-/** Builds a minimal AdvancedAssetBooking with sane defaults. */
+/** Builds a minimal AdvancedAssetBooking with sane defaults. Advanced-mode
+ * elements carry the per-slice `assetKitId`/`kitName`/`quantity` inline, so
+ * overriding those on the booking mirrors one flattened advanced-mode row. */
 function makeBooking(
   overrides: Partial<AdvancedAssetBooking> = {}
 ): AdvancedAssetBooking {
@@ -61,6 +63,29 @@ function makeBooking(
     to: "2026-07-11T09:00:00.000Z",
     tags: [],
     ...overrides,
+  };
+}
+
+/** Builds one simple-mode `bookingAssets[]` element: a BookingAsset pivot row
+ * with its nested booking plus the slice-level fields the fold reads. */
+function makeSlice(
+  booking: AdvancedAssetBooking,
+  slice: {
+    assetKitId?: string | null;
+    kitName?: string | null;
+    quantity?: number;
+  } = {}
+): {
+  booking: AdvancedAssetBooking;
+  assetKitId: string | null;
+  kitName: string | null;
+  quantity: number;
+} {
+  return {
+    booking,
+    assetKitId: slice.assetKitId ?? null,
+    kitName: slice.kitName ?? null,
+    quantity: slice.quantity ?? 1,
   };
 }
 
@@ -119,5 +144,229 @@ describe("useAssetAvailabilityData", () => {
     expect(result.current.events).toHaveLength(0);
     // The asset row (resource) still renders even without bookings.
     expect(result.current.resources).toHaveLength(1);
+  });
+
+  it("(a) folds a standalone + kit slice on ONE booking into one event", () => {
+    // Advanced shape: two pivot rows for the same booking id.
+    const items = [
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          makeBooking({ id: "b1", assetKitId: null, quantity: 2 }),
+          makeBooking({
+            id: "b1",
+            assetKitId: "ak1",
+            kitName: "Camera Kit",
+            quantity: 3,
+          }),
+        ],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(1);
+    const props = result.current.events[0].extendedProps;
+    expect(props.sliceCount).toBe(2);
+    expect(props.bookedTotal).toBe(5);
+    expect(props.slices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ assetKitId: null, quantity: 2 }),
+        expect.objectContaining({
+          assetKitId: "ak1",
+          kitName: "Camera Kit",
+          quantity: 3,
+        }),
+      ])
+    );
+  });
+
+  it("(b) folds 3 slices (standalone + 2 kits) into one event", () => {
+    const items = [
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          makeBooking({ id: "b1", assetKitId: null, quantity: 1 }),
+          makeBooking({
+            id: "b1",
+            assetKitId: "ak1",
+            kitName: "Kit A",
+            quantity: 2,
+          }),
+          makeBooking({
+            id: "b1",
+            assetKitId: "ak2",
+            kitName: "Kit B",
+            quantity: 4,
+          }),
+        ],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(1);
+    const props = result.current.events[0].extendedProps;
+    expect(props.sliceCount).toBe(3);
+    expect(props.bookedTotal).toBe(7);
+  });
+
+  it("(c) keeps kit attribution for a single kit-only slice", () => {
+    const items = [
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [
+          makeBooking({
+            id: "b1",
+            assetKitId: "ak1",
+            kitName: "Camera Kit",
+            quantity: 1,
+          }),
+        ],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(1);
+    const props = result.current.events[0].extendedProps;
+    expect(props.sliceCount).toBe(1);
+    expect(props.slices[0].assetKitId).toBe("ak1");
+    expect(props.slices[0].kitName).toBe("Camera Kit");
+  });
+
+  it("(d) leaves a plain single standalone booking unchanged", () => {
+    const items = [
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [makeBooking({ id: "b1" })],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(1);
+    const props = result.current.events[0].extendedProps;
+    expect(props.sliceCount).toBe(1);
+    expect(props.slices[0].assetKitId).toBeNull();
+    expect(props.bookedTotal).toBe(1);
+  });
+
+  it("(e) merges the simple-mode shape identically to advanced mode", () => {
+    // Simple-mode mirror of case (a): two BookingAsset pivot rows, same booking.
+    const b1 = makeBooking({ id: "b1" });
+    const items = [
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookingAssets: [
+          makeSlice(b1, { assetKitId: null, quantity: 2 }),
+          makeSlice(b1, {
+            assetKitId: "ak1",
+            kitName: "Camera Kit",
+            quantity: 3,
+          }),
+        ],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    expect(result.current.events).toHaveLength(1);
+    const props = result.current.events[0].extendedProps;
+    expect(props.sliceCount).toBe(2);
+    expect(props.bookedTotal).toBe(5);
+    // Assert content parity with advanced-mode case (a): the simple-mode pivot
+    // must carry per-slice kit attribution through the collapse, not just counts.
+    expect(props.slices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ assetKitId: null, quantity: 2 }),
+        expect.objectContaining({
+          assetKitId: "ak1",
+          kitName: "Camera Kit",
+          quantity: 3,
+        }),
+      ])
+    );
+  });
+
+  it("(g) uses BookingAsset.quantity (booked units), never Asset.quantity (stock)", () => {
+    // Quantity-semantics guard (.claude/rules/quantity-semantics-per-surface.md):
+    // the asset carries a workspace stock of 100 units, but the booking only
+    // reserved 5. The fold must multiply by BOOKED units, never asset stock.
+    const items = [
+      {
+        id: "asset-1",
+        title: "Camera",
+        quantity: 100,
+        bookings: [makeBooking({ id: "b1", assetKitId: null, quantity: 5 })],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    const props = result.current.events[0].extendedProps;
+    expect(props.bookedTotal).toBe(5);
+    expect(props.slices[0].quantity).toBe(5);
+  });
+
+  it("(f) does not over-merge across bookings or across assets", () => {
+    // Two DIFFERENT bookings on one asset → two events (no fold across bookings).
+    const twoBookings = [
+      {
+        id: "asset-1",
+        title: "Camera",
+        bookings: [makeBooking({ id: "b1" }), makeBooking({ id: "b2" })],
+      },
+    ] as unknown as Items;
+    const { result: r1 } = renderHook(() =>
+      useAssetAvailabilityData(twoBookings)
+    );
+    expect(r1.current.events).toHaveLength(2);
+
+    // Two DIFFERENT assets sharing booking id "b1" → two events, distinct
+    // resourceIds (grouping is keyed per-asset, not globally).
+    const twoAssets = [
+      { id: "asset-1", title: "Camera", bookings: [makeBooking({ id: "b1" })] },
+      { id: "asset-2", title: "Lens", bookings: [makeBooking({ id: "b1" })] },
+    ] as unknown as Items;
+    const { result: r2 } = renderHook(() =>
+      useAssetAvailabilityData(twoAssets)
+    );
+    expect(r2.current.events).toHaveLength(2);
+    expect(new Set(r2.current.events.map((e) => e.resourceId)).size).toBe(2);
+  });
+
+  it("(h) flags quantityTracked from the asset type so the bar can hide Qty for INDIVIDUAL", () => {
+    const items = [
+      {
+        id: "asset-qt",
+        title: "Cables",
+        type: "QUANTITY_TRACKED",
+        bookings: [makeBooking({ id: "b1", quantity: 3 })],
+      },
+      {
+        id: "asset-ind",
+        title: "Camera",
+        type: "INDIVIDUAL",
+        bookings: [
+          makeBooking({ id: "b1", assetKitId: "ak1", kitName: "Kit" }),
+        ],
+      },
+    ] as unknown as Items;
+
+    const { result } = renderHook(() => useAssetAvailabilityData(items));
+
+    const byResource = new Map(
+      result.current.events.map((e) => [e.resourceId, e.extendedProps])
+    );
+    expect(byResource.get("asset-qt")?.quantityTracked).toBe(true);
+    // INDIVIDUAL asset booked via a kit → quantityTracked false, so the
+    // renderer suppresses the redundant "Qty 1".
+    expect(byResource.get("asset-ind")?.quantityTracked).toBe(false);
   });
 });

--- a/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-asset-availability-data.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { AssetType } from "@prisma/client";
 import type { useLoaderData } from "react-router";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
@@ -14,6 +15,22 @@ import { resolveUserDisplayName } from "~/utils/user";
 type Items = NonNullable<
   ReturnType<typeof useLoaderData<AssetIndexLoaderData>>["items"]
 >;
+
+/** One BookingAsset pivot slice normalized from either loader shape. */
+type BookingSlice = {
+  booking: AdvancedAssetBooking;
+  assetKitId: string | null;
+  kitName: string | null;
+  quantity: number;
+};
+
+/** Simple-mode `asset.bookingAssets[]` element: pivot row + nested booking. */
+type SimpleModeBookingAsset = {
+  booking: AdvancedAssetBooking;
+  assetKitId?: string | null;
+  kitName?: string | null;
+  quantity?: number;
+};
 
 export function useAssetAvailabilityData(items: Items) {
   const { roles } = useUserRoleHelper();
@@ -62,90 +79,133 @@ export function useAssetAvailabilityData(items: Items) {
       };
     });
 
-    const events = safeItems
-      .map((asset) => {
-        // The availability calendar is fed by two loaders with two booking
-        // shapes: simple mode (`data.server.ts`) includes the `BookingAsset`
-        // pivot relation → `asset.bookingAssets: { booking }[]`, while advanced
-        // mode (`query.server.ts` raw SQL) aggregates the pivot into a flat
-        // `asset.bookings: AdvancedAssetBooking[]`. Normalize both to a flat
-        // booking list so events render in either mode — otherwise advanced
-        // mode renders the asset rows but no bookings on the timeline.
-        const bookings: AdvancedAssetBooking[] =
-          "bookingAssets" in asset && asset.bookingAssets
-            ? (
-                asset.bookingAssets as unknown as {
-                  booking: AdvancedAssetBooking;
-                }[]
-              ).map((ba) => ba.booking)
-            : "bookings" in asset && asset.bookings
-            ? (asset.bookings as unknown as AdvancedAssetBooking[])
-            : [];
+    const events = safeItems.flatMap((asset) => {
+      // The availability calendar is fed by two loaders with two booking
+      // shapes: simple mode (`data.server.ts`) includes the `BookingAsset`
+      // pivot relation → `asset.bookingAssets: { booking }[]`, while advanced
+      // mode (`query.server.ts` raw SQL) aggregates the pivot into a flat
+      // `asset.bookings: AdvancedAssetBooking[]`. Normalize both into per-slice
+      // records that keep the pivot-level metadata (assetKitId, quantity,
+      // kitName) alongside the booking — simple mode carries these on the
+      // BookingAsset pivot row; advanced mode carries them on each flattened
+      // booking element.
+      const slices: BookingSlice[] =
+        "bookingAssets" in asset && asset.bookingAssets
+          ? (asset.bookingAssets as unknown as SimpleModeBookingAsset[]).map(
+              (ba) => ({
+                booking: ba.booking,
+                assetKitId: ba.assetKitId ?? null,
+                kitName: ba.kitName ?? null,
+                quantity: ba.quantity ?? 1,
+              })
+            )
+          : "bookings" in asset && asset.bookings
+          ? (asset.bookings as unknown as AdvancedAssetBooking[]).map((b) => ({
+              booking: b,
+              assetKitId: b.assetKitId ?? null,
+              kitName: b.kitName ?? null,
+              quantity: b.quantity ?? 1,
+            }))
+          : [];
 
-        return bookings.map((booking) => {
-          const custodianName = booking?.custodianUser
-            ? resolveUserDisplayName(booking.custodianUser)
-            : booking.custodianTeamMember?.name;
+      // Quantities are only meaningful for QUANTITY_TRACKED assets. An
+      // INDIVIDUAL asset is a single physical unit (always qty 1), so the bar
+      // hides the per-slice `Qty` and the booked-units total for it — showing
+      // "Qty 1" on an individual asset booked via a kit is redundant noise.
+      const quantityTracked = asset.type === AssetType.QUANTITY_TRACKED;
 
-          let title = booking.name;
-          if (canSeeAllCustody) {
-            title += ` | ${custodianName}`;
-          }
+      // Collapse slices that share a booking into ONE event. Lossless:
+      // BookingAsset carries no dates, so every slice of a booking shares
+      // booking.from/to/status/name — only per-slice kit/quantity differs.
+      // Keyed within THIS asset's slice list, so the same booking across
+      // different assets stays as distinct resource rows.
+      const groups = new Map<string, BookingSlice[]>();
+      for (const slice of slices) {
+        const existing = groups.get(slice.booking.id);
+        if (existing) existing.push(slice);
+        else groups.set(slice.booking.id, [slice]);
+      }
 
-          return {
-            title,
-            resourceId: asset.id,
-            start: toIsoDateTimeToUserTimezone(booking.from, timeZone),
-            end: toIsoDateTimeToUserTimezone(booking.to, timeZone),
-            classNames: [
-              `bookingId-${booking.id}`,
-              ...getStatusClasses(
-                booking.status,
-                isOneDayEvent(new Date(booking.from), new Date(booking.to)),
-                "px-1"
-              ),
-            ],
-            extendedProps: {
-              url: `/bookings/${booking.id}`,
-              id: booking.id,
-              name: booking.name,
-              status: booking.status,
-              title: booking.name,
-              description: booking.description,
-              start: booking.from,
-              end: booking.to,
-              custodian: {
-                name: custodianName,
-                user: booking.custodianUser
-                  ? {
-                      id: booking.custodianUser?.id,
-                      firstName: booking.custodianUser?.firstName,
-                      lastName: booking.custodianUser?.lastName,
-                      profilePicture: booking.custodianUser?.profilePicture,
-                    }
-                  : undefined,
-              },
-              creator: booking.creator
+      return Array.from(groups.values()).map((group) => {
+        const booking = group[0].booking;
+        const custodianName = booking?.custodianUser
+          ? resolveUserDisplayName(booking.custodianUser)
+          : booking.custodianTeamMember?.name;
+
+        let title = booking.name;
+        if (canSeeAllCustody) {
+          title += ` | ${custodianName}`;
+        }
+
+        // Per-slice breakdown for the collapsed bar. `quantity` is always
+        // BookingAsset.quantity (booked units), never Asset.quantity.
+        const availabilitySlices = group.map((s) => ({
+          assetKitId: s.assetKitId,
+          kitName: s.kitName,
+          quantity: s.quantity,
+        }));
+        const bookedTotal = availabilitySlices.reduce(
+          (sum, s) => sum + s.quantity,
+          0
+        );
+
+        return {
+          title,
+          resourceId: asset.id,
+          start: toIsoDateTimeToUserTimezone(booking.from, timeZone),
+          end: toIsoDateTimeToUserTimezone(booking.to, timeZone),
+          classNames: [
+            `bookingId-${booking.id}`,
+            ...getStatusClasses(
+              booking.status,
+              isOneDayEvent(new Date(booking.from), new Date(booking.to)),
+              "px-1"
+            ),
+          ],
+          extendedProps: {
+            url: `/bookings/${booking.id}`,
+            id: booking.id,
+            name: booking.name,
+            status: booking.status,
+            title: booking.name,
+            description: booking.description,
+            start: booking.from,
+            end: booking.to,
+            custodian: {
+              name: custodianName,
+              user: booking.custodianUser
                 ? {
-                    name: booking.creator
-                      ? resolveUserDisplayName(booking.creator)
-                      : "Unknown",
-                    user: booking.creator
-                      ? {
-                          id: booking.creator.id,
-                          firstName: booking.creator.firstName,
-                          lastName: booking.creator.lastName,
-                          profilePicture: booking.creator.profilePicture,
-                        }
-                      : null,
+                    id: booking.custodianUser?.id,
+                    firstName: booking.custodianUser?.firstName,
+                    lastName: booking.custodianUser?.lastName,
+                    profilePicture: booking.custodianUser?.profilePicture,
                   }
                 : undefined,
-              tags: booking.tags,
             },
-          };
-        });
-      })
-      .flat();
+            creator: booking.creator
+              ? {
+                  name: booking.creator
+                    ? resolveUserDisplayName(booking.creator)
+                    : "Unknown",
+                  user: booking.creator
+                    ? {
+                        id: booking.creator.id,
+                        firstName: booking.creator.firstName,
+                        lastName: booking.creator.lastName,
+                        profilePicture: booking.creator.profilePicture,
+                      }
+                    : null,
+                }
+              : undefined,
+            tags: booking.tags,
+            slices: availabilitySlices,
+            sliceCount: availabilitySlices.length,
+            bookedTotal,
+            quantityTracked,
+          },
+        };
+      });
+    });
 
     return { resources, events };
   }, [canSeeAllCustody, items, timeZone]);

--- a/apps/webapp/app/components/calendar/event-card.test.tsx
+++ b/apps/webapp/app/components/calendar/event-card.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Shared calendar event-card renderer tests
+ *
+ * `renderEventCard` / `EventCardContent` are shared by TWO calendars:
+ *   - the availability view (`assets._index`) which sets `slices` /
+ *     `sliceCount` / `bookedTotal` on the event's extended props, and
+ *   - the main booking calendar (`routes/_layout+/calendar.tsx`) which never
+ *     sets them.
+ *
+ * The feature contract is that the kit glyph and the per-slice "Reserved on
+ * this booking" breakdown are gated behind that OPTIONAL availability data, so
+ * the booking calendar stays visually unaffected. These tests lock in the
+ * gating from both directions: the booking-calendar shape suppresses both
+ * surfaces, and the availability shape renders them (ordered standalone-first,
+ * pluralized total).
+ *
+ * @see {@link file://./event-card.tsx}
+ */
+import type { EventContentArg } from "@fullcalendar/core";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  AvailabilitySlice,
+  CalendarExtendedProps,
+} from "~/routes/_layout+/calendar";
+import renderEventCard, { EventCardContent } from "./event-card";
+
+// why: DateS reads client hints from Remix context unavailable in the test;
+// stub to a plain node since date formatting is orthogonal to slice gating.
+vi.mock("~/components/shared/date", () => ({
+  DateS: () => <span>date</span>,
+}));
+
+// why: TeamMemberBadge pulls roles/org/user from Remix loader data; the
+// custodian/creator rendering is orthogonal to the breakdown under test.
+vi.mock("~/components/user/team-member-badge", () => ({
+  TeamMemberBadge: () => <span>member</span>,
+}));
+
+// why: BookingStatusBadge reads user data + roles from Remix context; the
+// status chip is orthogonal to the slice breakdown/glyph gating.
+vi.mock("~/components/booking/booking-status-badge", () => ({
+  BookingStatusBadge: () => <span>status</span>,
+}));
+
+/** Builds a CalendarExtendedProps booking with sane defaults. Omit
+ * `slices`/`sliceCount`/`bookedTotal` to mirror the booking-calendar shape. */
+function makeBooking(
+  overrides: Partial<CalendarExtendedProps> = {}
+): CalendarExtendedProps {
+  return {
+    id: "b1",
+    status: "RESERVED",
+    name: "Test Booking",
+    description: null,
+    start: "2026-07-10T09:00:00.000Z",
+    end: "2026-07-11T09:00:00.000Z",
+    custodian: { name: "Alice", user: null },
+    creator: { name: "Bob", user: null },
+    tags: [],
+    ...overrides,
+  };
+}
+
+/** Wraps a booking in the minimal FullCalendar EventContentArg shape that
+ * `renderEventCard` reads (view type, title, extendedProps). */
+function makeEventArg(booking: CalendarExtendedProps): EventContentArg {
+  return {
+    event: {
+      title: booking.name,
+      extendedProps: booking,
+      _context: { calendarApi: { view: { type: "resourceTimelineMonth" } } },
+    },
+  } as unknown as EventContentArg;
+}
+
+const STANDALONE: AvailabilitySlice = {
+  assetKitId: null,
+  kitName: null,
+  quantity: 2,
+};
+const KIT_SLICE: AvailabilitySlice = {
+  assetKitId: "ak1",
+  kitName: "Camera Kit",
+  quantity: 3,
+};
+
+describe("EventCardContent — per-slice breakdown gating", () => {
+  it("suppresses the breakdown for the booking-calendar shape (no slices)", () => {
+    render(<EventCardContent booking={makeBooking()} />);
+
+    // The booking calendar never sets `slices` → no breakdown must render.
+    expect(screen.queryByText("Reserved on this booking:")).toBeNull();
+  });
+
+  it("suppresses the breakdown for a single standalone slice", () => {
+    render(
+      <EventCardContent
+        booking={makeBooking({
+          slices: [{ assetKitId: null, kitName: null, quantity: 1 }],
+          sliceCount: 1,
+          bookedTotal: 1,
+        })}
+      />
+    );
+
+    expect(screen.queryByText("Reserved on this booking:")).toBeNull();
+  });
+
+  it("renders an ordered, pluralized breakdown for standalone + kit slices", () => {
+    // Pass kit-first to prove the component sorts standalone before kit.
+    const { container } = render(
+      <EventCardContent
+        booking={makeBooking({
+          slices: [KIT_SLICE, STANDALONE],
+          sliceCount: 2,
+          bookedTotal: 5,
+          quantityTracked: true,
+        })}
+      />
+    );
+
+    expect(screen.getByText("Reserved on this booking:")).toBeInTheDocument();
+    expect(screen.getByText("Standalone")).toBeInTheDocument();
+    expect(screen.getByText('via "Camera Kit"')).toBeInTheDocument();
+    expect(screen.getByText("Qty 2")).toBeInTheDocument();
+    expect(screen.getByText("Qty 3")).toBeInTheDocument();
+    // Plural "units" for a total > 1.
+    expect(screen.getByText("Total reserved 5 units")).toBeInTheDocument();
+
+    // Standalone row sorts first even though it was supplied last.
+    const rows = container.querySelectorAll("li");
+    expect(rows[0]).toHaveTextContent("Standalone");
+    expect(rows[1]).toHaveTextContent('via "Camera Kit"');
+  });
+
+  it("uses the singular unit label for a single-unit kit-only slice", () => {
+    render(
+      <EventCardContent
+        booking={makeBooking({
+          slices: [{ assetKitId: "ak1", kitName: "Kit X", quantity: 1 }],
+          sliceCount: 1,
+          bookedTotal: 1,
+          quantityTracked: true,
+        })}
+      />
+    );
+
+    // A kit-only slice still shows the breakdown; total must read "1 unit".
+    expect(screen.getByText("Total reserved 1 unit")).toBeInTheDocument();
+  });
+
+  it("hides Qty and the total for INDIVIDUAL assets (qty is redundant)", () => {
+    render(
+      <EventCardContent
+        booking={makeBooking({
+          // INDIVIDUAL asset added to a booking via a kit: it is a single
+          // physical unit, so `quantityTracked` is false and "Qty 1" would be
+          // noise. Attribution ("via Kit") must still render.
+          slices: [{ assetKitId: "ak1", kitName: "Camera Kit", quantity: 1 }],
+          sliceCount: 1,
+          bookedTotal: 1,
+          quantityTracked: false,
+        })}
+      />
+    );
+
+    // Kit attribution still shows...
+    expect(screen.getByText('via "Camera Kit"')).toBeInTheDocument();
+    // ...but the redundant per-slice Qty and the total are suppressed.
+    expect(screen.queryByText(/^Qty /)).toBeNull();
+    expect(screen.queryByText(/Total reserved/)).toBeNull();
+  });
+});
+
+describe("renderEventCard — kit glyph gating", () => {
+  it("hides the glyph for the booking-calendar shape (no slices)", () => {
+    render(<>{renderEventCard(makeEventArg(makeBooking()))}</>);
+
+    expect(screen.queryByTitle(/Reserved .* times on this booking/)).toBeNull();
+    expect(screen.queryByTitle("Booked via a kit")).toBeNull();
+  });
+
+  it("hides the glyph for a single standalone slice", () => {
+    render(
+      <>
+        {renderEventCard(
+          makeEventArg(
+            makeBooking({
+              slices: [{ assetKitId: null, kitName: null, quantity: 1 }],
+              sliceCount: 1,
+              bookedTotal: 1,
+            })
+          )
+        )}
+      </>
+    );
+
+    expect(screen.queryByTitle("Booked via a kit")).toBeNull();
+    expect(screen.queryByTitle(/Reserved .* times on this booking/)).toBeNull();
+  });
+
+  it("renders the glyph with a slice count for standalone + kit slices", () => {
+    render(
+      <>
+        {renderEventCard(
+          makeEventArg(
+            makeBooking({
+              slices: [STANDALONE, KIT_SLICE],
+              sliceCount: 2,
+              bookedTotal: 5,
+            })
+          )
+        )}
+      </>
+    );
+
+    const glyph = screen.getByTitle("Reserved 2 times on this booking");
+    expect(glyph).toHaveTextContent("2");
+  });
+});

--- a/apps/webapp/app/components/calendar/event-card.test.tsx
+++ b/apps/webapp/app/components/calendar/event-card.test.tsx
@@ -174,9 +174,15 @@ describe("EventCardContent — per-slice breakdown gating", () => {
   });
 });
 
+// Capitalized alias so the shared renderer is instantiated as a JSX element
+// rather than called as a function — the direct-call form trips react-doctor's
+// no-render-in-render rule (which ignores eslint-disable comments; only a
+// refactor silences it). `makeEventArg` returns the `{ event }` props shape.
+const RenderedEventCard = renderEventCard;
+
 describe("renderEventCard — kit glyph gating", () => {
   it("hides the glyph for the booking-calendar shape (no slices)", () => {
-    render(<>{renderEventCard(makeEventArg(makeBooking()))}</>);
+    render(<RenderedEventCard {...makeEventArg(makeBooking())} />);
 
     expect(screen.queryByTitle(/Reserved .* times on this booking/)).toBeNull();
     expect(screen.queryByTitle("Booked via a kit")).toBeNull();
@@ -184,17 +190,15 @@ describe("renderEventCard — kit glyph gating", () => {
 
   it("hides the glyph for a single standalone slice", () => {
     render(
-      <>
-        {renderEventCard(
-          makeEventArg(
-            makeBooking({
-              slices: [{ assetKitId: null, kitName: null, quantity: 1 }],
-              sliceCount: 1,
-              bookedTotal: 1,
-            })
-          )
+      <RenderedEventCard
+        {...makeEventArg(
+          makeBooking({
+            slices: [{ assetKitId: null, kitName: null, quantity: 1 }],
+            sliceCount: 1,
+            bookedTotal: 1,
+          })
         )}
-      </>
+      />
     );
 
     expect(screen.queryByTitle("Booked via a kit")).toBeNull();
@@ -203,17 +207,15 @@ describe("renderEventCard — kit glyph gating", () => {
 
   it("renders the glyph with a slice count for standalone + kit slices", () => {
     render(
-      <>
-        {renderEventCard(
-          makeEventArg(
-            makeBooking({
-              slices: [STANDALONE, KIT_SLICE],
-              sliceCount: 2,
-              bookedTotal: 5,
-            })
-          )
+      <RenderedEventCard
+        {...makeEventArg(
+          makeBooking({
+            slices: [STANDALONE, KIT_SLICE],
+            sliceCount: 2,
+            bookedTotal: 5,
+          })
         )}
-      </>
+      />
     );
 
     const glyph = screen.getByTitle("Reserved 2 times on this booking");

--- a/apps/webapp/app/components/calendar/event-card.tsx
+++ b/apps/webapp/app/components/calendar/event-card.tsx
@@ -234,7 +234,7 @@ export default function renderEventCard({ event }: EventCardProps) {
                   >
                     {sliceCount}
                   </span>
-                ) : null
+                ) : null}
               </span>
             ) : null}
             <ExternalLinkIcon

--- a/apps/webapp/app/components/calendar/event-card.tsx
+++ b/apps/webapp/app/components/calendar/event-card.tsx
@@ -1,7 +1,7 @@
 import type { EventContentArg } from "@fullcalendar/core";
 import { HoverCardPortal } from "@radix-ui/react-hover-card";
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
-import { ArrowRightIcon } from "lucide-react";
+import { ArrowRightIcon, Boxes } from "lucide-react";
 
 import { type CalendarExtendedProps } from "~/routes/_layout+/calendar";
 import { bookingStatusColorMap } from "~/utils/bookings";
@@ -30,6 +30,19 @@ export default function renderEventCard({ event }: EventCardProps) {
   const viewType = event._context.calendarApi.view.type;
   const booking = event.extendedProps as CalendarExtendedProps;
   const _isOneDayEvent = isOneDayEvent(booking.start, booking.end);
+
+  // Availability view only — booking calendar never sets `slices` → glyph hidden.
+  const slices = booking.slices ?? [];
+  const sliceCount = booking.sliceCount ?? slices.length;
+  const hasKitSlice = slices.some((s) => s.assetKitId !== null);
+  const showKitGlyph = hasKitSlice || sliceCount > 1;
+  // End-user copy (avoid internal "slice"/pivot jargon). Multi-slice reads as a
+  // reservation count; the hover tooltip carries the full standalone/kit
+  // breakdown. Singular guarded so a lone reservation never reads "1 times".
+  const glyphLabel =
+    sliceCount > 1
+      ? `Reserved ${sliceCount} times on this booking`
+      : "Booked via a kit";
 
   // Ref callback to set up scroll tracking
   const triggerRefCallback = (element: HTMLDivElement | null) => {
@@ -206,6 +219,20 @@ export default function renderEventCard({ event }: EventCardProps) {
             )}
             <DateS date={booking.start} options={{ timeStyle: "short" }} /> |{" "}
             {event.title}
+            {showKitGlyph ? (
+              <span
+                className="inline-flex items-center gap-0.5"
+                title={glyphLabel}
+                aria-label={glyphLabel}
+              >
+                <Boxes className="size-3" aria-hidden="true" />
+                {sliceCount > 1 ? (
+                  <span className="text-xs font-medium tabular-nums">
+                    {sliceCount}
+                  </span>
+                ) : null}
+              </span>
+            ) : null}
             <ExternalLinkIcon
               className={tw("external-link-icon mt-px", "hidden")}
             />
@@ -231,6 +258,28 @@ export function EventCardContent({
 }: {
   booking: CalendarExtendedProps;
 }) {
+  const slices = booking.slices ?? [];
+  const showBreakdown =
+    slices.length >= 2 || slices.some((s) => s.assetKitId !== null);
+  // Quantities only carry meaning for QUANTITY_TRACKED assets. For INDIVIDUAL
+  // assets (single physical units, always qty 1) hide the per-slice `Qty` and
+  // the total — the kit/standalone attribution still shows, just without the
+  // redundant "Qty 1" / "Total reserved 1 unit".
+  const showQuantities = booking.quantityTracked === true;
+  const bookedTotal =
+    booking.bookedTotal ?? slices.reduce((sum, s) => sum + s.quantity, 0);
+
+  // Deterministic display order: the standalone slice (assetKitId === null)
+  // sorts first, then kit-driven slices by kit name. Neither loader guarantees
+  // order (advanced-mode `jsonb_agg` has no ORDER BY; the simple-mode Prisma
+  // include is unordered), so sort here so the tooltip always reads
+  // "Standalone" before `via "Kit"`.
+  const orderedSlices = [...slices].sort((a, b) => {
+    if (a.assetKitId === null && b.assetKitId !== null) return -1;
+    if (a.assetKitId !== null && b.assetKitId === null) return 1;
+    return (a.kitName ?? "").localeCompare(b.kitName ?? "");
+  });
+
   return (
     <>
       <div className="mb-3 mt-2 flex items-center gap-2 ">
@@ -269,6 +318,36 @@ export function EventCardContent({
               <GrayBadge key={tag.id}>{tag.name}</GrayBadge>
             ))}
           </div>
+        </>
+      ) : null}
+
+      {showBreakdown ? (
+        <>
+          <p className="mb-1 text-sm font-normal">Reserved on this booking:</p>
+          <ul className="mb-3 flex flex-col gap-1">
+            {orderedSlices.map((slice, index) => (
+              <li
+                key={slice.assetKitId ?? `standalone-${index}`}
+                className="flex items-center justify-between gap-4 text-sm text-gray-600"
+              >
+                <span>
+                  {slice.assetKitId === null
+                    ? "Standalone"
+                    : slice.kitName
+                    ? `via "${slice.kitName}"`
+                    : "via a kit"}
+                </span>
+                {showQuantities ? (
+                  <span className="tabular-nums">Qty {slice.quantity}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+          {showQuantities ? (
+            <p className="mb-3 text-sm font-medium text-gray-700">
+              Total reserved {bookedTotal} unit{bookedTotal === 1 ? "" : "s"}
+            </p>
+          ) : null}
         </>
       ) : null}
 

--- a/apps/webapp/app/components/calendar/event-card.tsx
+++ b/apps/webapp/app/components/calendar/event-card.tsx
@@ -223,14 +223,18 @@ export default function renderEventCard({ event }: EventCardProps) {
               <span
                 className="inline-flex items-center gap-0.5"
                 title={glyphLabel}
+                role="img"
                 aria-label={glyphLabel}
               >
                 <Boxes className="size-3" aria-hidden="true" />
                 {sliceCount > 1 ? (
-                  <span className="text-xs font-medium tabular-nums">
+                  <span
+                    className="text-xs font-medium tabular-nums"
+                    aria-hidden="true"
+                  >
                     {sliceCount}
                   </span>
-                ) : null}
+                ) : null
               </span>
             ) : null}
             <ExternalLinkIcon

--- a/apps/webapp/app/modules/asset/data.server.test.ts
+++ b/apps/webapp/app/modules/asset/data.server.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Asset index data-loader tests
+ *
+ * Covers `attachKitNamesToBookingAssets`, the availability-view helper that
+ * resolves the kit name onto each kit-driven `BookingAsset` slice. The function
+ * has a cross-org security dimension (it org-scopes the `AssetKit` read per
+ * .claude/rules/org-scope-user-supplied-ids) and mutates slices in place, so
+ * these tests lock in: standalone slices are untouched, kit slices get the
+ * resolved name/id, kit ids are deduped into ONE read, and a kit outside the
+ * caller's org yields `kitName: null` rather than leaking a name.
+ *
+ * @see {@link file://./data.server.ts}
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+import { attachKitNamesToBookingAssets } from "./data.server";
+
+// why: the helper's only DB touch is `db.assetKit.findMany`; stub it so the
+// unit test never hits Postgres and we can assert the org-scoped read shape.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    assetKit: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+/** Minimal in-place-mutable slice shape the helper reads/writes. */
+type Slice = {
+  assetKitId: string | null;
+  kitId?: string | null;
+  kitName?: string | null;
+};
+
+/** Casts loosely-typed test assets to the helper's expected input type. */
+type Assets = Parameters<typeof attachKitNamesToBookingAssets>[0]["assets"];
+
+const findManyMock = vi.mocked(db.assetKit.findMany);
+
+describe("attachKitNamesToBookingAssets", () => {
+  beforeEach(() => {
+    findManyMock.mockReset();
+  });
+
+  it("resolves kit names on kit slices, leaves standalone slices untouched, and dedupes the read", async () => {
+    findManyMock.mockResolvedValue([
+      // why: Prisma's typed return is richer than the helper reads; only
+      // `id` + `kit` matter, so a narrow object cast keeps the fixture small.
+      { id: "ak1", kit: { id: "k1", name: "Kit One" } },
+      { id: "ak2", kit: { id: "k2", name: "Kit Two" } },
+    ] as never);
+
+    // `ak1` appears on both assets — it must collapse to ONE id in the read.
+    const assets = [
+      {
+        bookingAssets: [
+          { assetKitId: null } satisfies Slice,
+          { assetKitId: "ak1" } satisfies Slice,
+        ],
+      },
+      {
+        bookingAssets: [
+          { assetKitId: "ak1" } satisfies Slice,
+          { assetKitId: "ak2" } satisfies Slice,
+        ],
+      },
+    ];
+
+    await attachKitNamesToBookingAssets({
+      assets: assets as unknown as Assets,
+      organizationId: "org-1",
+    });
+
+    // Exactly one org-scoped read, with the deduped kit ids.
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["ak1", "ak2"] }, organizationId: "org-1" },
+      })
+    );
+
+    // Standalone slice is never mutated.
+    const standalone = assets[0].bookingAssets[0] as Slice;
+    expect(standalone.kitName).toBeUndefined();
+    expect(standalone.kitId).toBeUndefined();
+
+    // Kit slices carry the resolved name/id.
+    const kitSliceA = assets[0].bookingAssets[1] as Slice;
+    expect(kitSliceA.kitName).toBe("Kit One");
+    expect(kitSliceA.kitId).toBe("k1");
+
+    const kitSliceB = assets[1].bookingAssets[1] as Slice;
+    expect(kitSliceB.kitName).toBe("Kit Two");
+    expect(kitSliceB.kitId).toBe("k2");
+  });
+
+  it("yields kitName: null for a kit outside the caller's org (not leaked)", async () => {
+    // The org-scoped read returns nothing for a kit that belongs to another
+    // org, so the slice resolves to null rather than surfacing a foreign name.
+    findManyMock.mockResolvedValue([] as never);
+
+    const assets = [
+      { bookingAssets: [{ assetKitId: "ak-other" } satisfies Slice] },
+    ];
+
+    await attachKitNamesToBookingAssets({
+      assets: assets as unknown as Assets,
+      organizationId: "org-1",
+    });
+
+    const slice = assets[0].bookingAssets[0] as Slice;
+    expect(slice.kitName).toBeNull();
+    expect(slice.kitId).toBeNull();
+  });
+
+  it("early-returns without a DB read when there are no kit slices", async () => {
+    const assets = [
+      { bookingAssets: [{ assetKitId: null } satisfies Slice] },
+      { bookingAssets: [] },
+      {},
+    ];
+
+    await attachKitNamesToBookingAssets({
+      assets: assets as unknown as Assets,
+      organizationId: "org-1",
+    });
+
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/asset/data.server.ts
+++ b/apps/webapp/app/modules/asset/data.server.ts
@@ -92,10 +92,14 @@ type MutableBookingAssetSlice = {
  * org-scoped read and mutates the slices in place. Standalone slices
  * (assetKitId === null) are left untouched. Availability view only.
  *
+ * Kit names are supplementary UI data, so the availability loader wraps this
+ * call and degrades gracefully (logs + continues) if the read fails — the raw
+ * Prisma error propagates here and is handled at the call site rather than
+ * being rethrown as a ShelfError.
+ *
  * @param args.assets - Loaded assets, each optionally carrying `bookingAssets`.
  * @param args.organizationId - Active org; scopes the AssetKit read (defense in
  *   depth per org-scope-user-supplied-ids).
- * @throws {ShelfError} If the AssetKit read fails.
  */
 export async function attachKitNamesToBookingAssets({
   assets,
@@ -319,12 +323,28 @@ export async function simpleModeLoader({
   // structural cast — `bookingAssets` is an availability-only extraInclude not
   // in the base asset type (same pattern the availability hook uses).
   if (view === "availability") {
-    await attachKitNamesToBookingAssets({
-      assets: assets as unknown as Array<{
-        bookingAssets?: MutableBookingAssetSlice[];
-      }>,
-      organizationId,
-    });
+    // Kit-name attribution is supplementary UI data — mirror the graceful
+    // degradation of the image-refresh above so a transient AssetKit read
+    // failure logs and continues instead of 500-ing the whole availability
+    // page. The calendar simply falls back to "via a kit" without the name.
+    try {
+      await attachKitNamesToBookingAssets({
+        assets: assets as unknown as Array<{
+          bookingAssets?: MutableBookingAssetSlice[];
+        }>,
+        organizationId,
+      });
+    } catch (cause) {
+      Logger.error(
+        new ShelfError({
+          cause,
+          message: "Failed to attach kit names to booking assets",
+          label: "Assets",
+          additionalData: { organizationId, assetCount: assets.length },
+          shouldBeCaptured: true,
+        })
+      );
+    }
   }
 
   const userName = resolveUserDisplayName(user);

--- a/apps/webapp/app/modules/asset/data.server.ts
+++ b/apps/webapp/app/modules/asset/data.server.ts
@@ -76,6 +76,62 @@ Search assets based on asset fields. Separate your keywords by a comma(,) to sea
 - Barcodes values
 `;
 
+/** Minimal structural shape of one BookingAsset pivot row returned under the
+ * availability `extraInclude`. Only the fields this helper reads/writes. */
+type MutableBookingAssetSlice = {
+  assetKitId: string | null;
+  kitId?: string | null;
+  kitName?: string | null;
+};
+
+/**
+ * Attaches the kit name (and kit id) onto every kit-driven BookingAsset slice.
+ *
+ * `BookingAsset.assetKitId` is a bare FK with no Prisma relation accessor, so
+ * the kit name cannot be nested-selected. This resolves all names in ONE
+ * org-scoped read and mutates the slices in place. Standalone slices
+ * (assetKitId === null) are left untouched. Availability view only.
+ *
+ * @param args.assets - Loaded assets, each optionally carrying `bookingAssets`.
+ * @param args.organizationId - Active org; scopes the AssetKit read (defense in
+ *   depth per org-scope-user-supplied-ids).
+ * @throws {ShelfError} If the AssetKit read fails.
+ */
+export async function attachKitNamesToBookingAssets({
+  assets,
+  organizationId,
+}: {
+  assets: Array<{ bookingAssets?: MutableBookingAssetSlice[] }>;
+  organizationId: string;
+}): Promise<void> {
+  const assetKitIds = Array.from(
+    new Set(
+      assets.flatMap((a) =>
+        (a.bookingAssets ?? [])
+          .map((ba) => ba.assetKitId)
+          .filter((id): id is string => id !== null)
+      )
+    )
+  );
+  if (assetKitIds.length === 0) return;
+
+  const assetKits = await db.assetKit.findMany({
+    where: { id: { in: assetKitIds }, organizationId },
+    select: { id: true, kit: { select: { id: true, name: true } } },
+  });
+  const byId = new Map(assetKits.map((ak) => [ak.id, ak.kit]));
+
+  for (const a of assets) {
+    for (const ba of a.bookingAssets ?? []) {
+      if (ba.assetKitId) {
+        const kit = byId.get(ba.assetKitId);
+        ba.kitId = kit?.id ?? null;
+        ba.kitName = kit?.name ?? null;
+      }
+    }
+  }
+}
+
 export async function simpleModeLoader({
   request,
   userId,
@@ -255,6 +311,20 @@ export async function simpleModeLoader({
         shouldBeCaptured: true,
       })
     );
+  }
+
+  // Availability view only: resolve kit names for kit-driven booking slices so
+  // the calendar can show per-slice attribution. `assetKitId`/`quantity` are
+  // already present (BookingAsset scalars via the include). One `as unknown as`
+  // structural cast — `bookingAssets` is an availability-only extraInclude not
+  // in the base asset type (same pattern the availability hook uses).
+  if (view === "availability") {
+    await attachKitNamesToBookingAssets({
+      assets: assets as unknown as Array<{
+        bookingAssets?: MutableBookingAssetSlice[];
+      }>,
+      organizationId,
+    });
   }
 
   const userName = resolveUserDisplayName(user);

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -814,6 +814,43 @@ describe("assetQueryFragment", () => {
       expect(sql).not.toContain("_CategoryToCustomField");
     });
   });
+
+  describe("withBookings option (availability view)", () => {
+    /**
+     * The availability calendar folds the per-(asset, booking) BookingAsset
+     * pivot rows into one bar and needs each slice's `assetKitId`, booked
+     * `quantity`, and resolved kit name. Typecheck cannot validate the raw SQL
+     * (`Prisma.sql` is just a string to TS), so a wrong-column refactor would
+     * only surface as a 500 — per .claude/rules/raw-sql-respects-prisma-map
+     * item 4, guard the column/join names with a cheap string assertion.
+     * (No @map trap here: BookingAsset.quantity/assetKitId and Kit.name are
+     * unmapped, so the Prisma field names equal the DB column names.)
+     */
+    it("projects per-slice pivot columns and resolves kit name via joins", () => {
+      const fragment = assetQueryFragment({ withBookings: true });
+      const sql = getFragmentSqlString(fragment);
+
+      // Per-slice pivot metadata the fold reads (booked units, kit membership).
+      expect(sql).toContain('atb."assetKitId"');
+      expect(sql).toContain('atb."quantity"');
+      // Kit name resolved through the AssetKit -> Kit joins.
+      expect(sql).toContain("'kitName', k.name");
+      expect(sql).toContain(
+        'LEFT JOIN public."AssetKit" ak ON atb."assetKitId" = ak.id'
+      );
+      expect(sql).toContain('LEFT JOIN public."Kit" k ON ak."kitId" = k.id');
+    });
+
+    it("omits the bookings subquery entirely when withBookings is false", () => {
+      const fragment = assetQueryFragment();
+      const sql = getFragmentSqlString(fragment);
+
+      // Default (table views) must not pay for the availability-only subquery.
+      expect(sql).not.toContain("AS bookings");
+      expect(sql).not.toContain('atb."assetKitId"');
+      expect(sql).not.toContain("'kitName', k.name");
+    });
+  });
 });
 
 describe("generateWhereClause - barcode value case normalization", () => {

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -833,12 +833,15 @@ describe("assetQueryFragment", () => {
       // Per-slice pivot metadata the fold reads (booked units, kit membership).
       expect(sql).toContain('atb."assetKitId"');
       expect(sql).toContain('atb."quantity"');
-      // Kit name resolved through the AssetKit -> Kit joins.
-      expect(sql).toContain("'kitName', k.name");
+      // Kit name resolved through org-scoped AssetKit -> Kit joins, using
+      // aliases (bk_ak/bk_kit) distinct from the outer query's own-kit ak/k.
+      expect(sql).toContain("'kitName', bk_kit.name");
+      expect(sql).toContain('LEFT JOIN public."AssetKit" bk_ak');
+      // Org-scoped so a cross-org assetKitId resolves to NULL, never a leak.
+      expect(sql).toContain('bk_ak."organizationId" = a."organizationId"');
       expect(sql).toContain(
-        'LEFT JOIN public."AssetKit" ak ON atb."assetKitId" = ak.id'
+        'LEFT JOIN public."Kit" bk_kit ON bk_ak."kitId" = bk_kit.id'
       );
-      expect(sql).toContain('LEFT JOIN public."Kit" k ON ak."kitId" = k.id');
     });
 
     it("omits the bookings subquery entirely when withBookings is false", () => {
@@ -848,7 +851,7 @@ describe("assetQueryFragment", () => {
       // Default (table views) must not pay for the availability-only subquery.
       expect(sql).not.toContain("AS bookings");
       expect(sql).not.toContain('atb."assetKitId"');
-      expect(sql).not.toContain("'kitName', k.name");
+      expect(sql).not.toContain("'kitName', bk_kit.name");
     });
   });
 });

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1865,7 +1865,7 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
             END,
             'assetKitId', atb."assetKitId",
             'quantity', atb."quantity",
-            'kitName', k.name
+            'kitName', bk_kit.name
           )
         ),
         '[]'::jsonb
@@ -1876,11 +1876,15 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
       LEFT JOIN public."User" ctmu ON ctm."userId" = ctmu.id
       LEFT JOIN public."User" cu ON bk."custodianUserId" = cu.id
       LEFT JOIN public."User" cr ON bk."creatorId" = cr.id
-      -- AssetKit -> Kit resolves the per-slice kit name. Implicitly org-scoped:
-      -- atb rows are asset-scoped (atb."assetId" = a.id below) and a.id is
-      -- org-filtered by the outer query, so ak/k always share the asset's org.
-      LEFT JOIN public."AssetKit" ak ON atb."assetKitId" = ak.id
-      LEFT JOIN public."Kit" k ON ak."kitId" = k.id
+      -- Booking-slice kit attribution. Org-scoped (bk_ak."organizationId" =
+      -- a."organizationId") so a tampered / cross-org assetKitId resolves to
+      -- NULL instead of leaking another workspace's kit name — mirrors the
+      -- simple-mode helper. Distinct aliases (bk_ak/bk_kit) so this correlated
+      -- subquery does not shadow the outer query's ak/k (the asset's own kit).
+      LEFT JOIN public."AssetKit" bk_ak
+        ON atb."assetKitId" = bk_ak.id
+        AND bk_ak."organizationId" = a."organizationId"
+      LEFT JOIN public."Kit" bk_kit ON bk_ak."kitId" = bk_kit.id
       WHERE
         atb."assetId" = a.id
         AND bk.status IN ('RESERVED', 'ONGOING', 'OVERDUE')

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1853,7 +1853,7 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
                 )
               ELSE NULL
             END,
-            'creator', CASE 
+            'creator', CASE
               WHEN bk."creatorId" IS NOT NULL THEN
                 jsonb_build_object(
                   'id', cr.id,
@@ -1862,7 +1862,10 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
                   'profilePicture', cr."profilePicture"
                 )
               ELSE NULL
-            END
+            END,
+            'assetKitId', atb."assetKitId",
+            'quantity', atb."quantity",
+            'kitName', k.name
           )
         ),
         '[]'::jsonb
@@ -1873,7 +1876,12 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
       LEFT JOIN public."User" ctmu ON ctm."userId" = ctmu.id
       LEFT JOIN public."User" cu ON bk."custodianUserId" = cu.id
       LEFT JOIN public."User" cr ON bk."creatorId" = cr.id
-      WHERE 
+      -- AssetKit -> Kit resolves the per-slice kit name. Implicitly org-scoped:
+      -- atb rows are asset-scoped (atb."assetId" = a.id below) and a.id is
+      -- org-filtered by the outer query, so ak/k always share the asset's org.
+      LEFT JOIN public."AssetKit" ak ON atb."assetKitId" = ak.id
+      LEFT JOIN public."Kit" k ON ak."kitId" = k.id
+      WHERE
         atb."assetId" = a.id
         AND bk.status IN ('RESERVED', 'ONGOING', 'OVERDUE')
     ) AS bookings`

--- a/apps/webapp/app/modules/asset/types.ts
+++ b/apps/webapp/app/modules/asset/types.ts
@@ -162,6 +162,15 @@ export type AdvancedAssetBooking = Pick<
     "id" | "firstName" | "lastName" | "profilePicture"
   >;
   creator?: Pick<User, "id" | "firstName" | "lastName" | "profilePicture">;
+  /** BookingAsset.assetKitId of THIS slice: null = standalone (free pool),
+   * non-null = kit-driven (FK → AssetKit.id). Availability view only. */
+  assetKitId?: string | null;
+  /** BookingAsset.quantity — booked units for THIS slice. Never Asset.quantity
+   * (workspace stock). Availability view only. */
+  quantity?: number;
+  /** Kit name for THIS slice (null when standalone), resolved via
+   * AssetKit → Kit.name. Availability view only. */
+  kitName?: string | null;
 };
 
 /** Type for advanced index query. We cannot infer it because we do a raw query so we need to create it ourselves. */

--- a/apps/webapp/app/routes/_layout+/calendar.tsx
+++ b/apps/webapp/app/routes/_layout+/calendar.tsx
@@ -61,6 +61,15 @@ export const handle = {
   breadcrumb: () => <Link to="/calendar">Calendar</Link>,
 };
 
+/** One folded BookingAsset pivot slice on a collapsed availability bar.
+ * `assetKitId === null` ⇒ standalone (free pool); non-null ⇒ kit-driven.
+ * `quantity` is booked units (BookingAsset.quantity). Availability view only. */
+export type AvailabilitySlice = {
+  assetKitId: string | null;
+  kitName: string | null;
+  quantity: number;
+};
+
 export type CalendarExtendedProps = {
   id: string;
   status: BookingStatus;
@@ -71,6 +80,17 @@ export type CalendarExtendedProps = {
   custodian: TeamMemberForBadge;
   creator: TeamMemberForBadge;
   tags: Pick<Tag, "id" | "name">[];
+  /** Availability view only: per-slice breakdown of one (asset, booking).
+   * Absent on the booking calendar (which never sets it). */
+  slices?: AvailabilitySlice[];
+  /** Number of folded slices (>1 ⇒ show glyph count on the bar). */
+  sliceCount?: number;
+  /** Sum of BookingAsset.quantity across folded slices (booked-units total). */
+  bookedTotal?: number;
+  /** True only for QUANTITY_TRACKED assets. INDIVIDUAL assets are single
+   * physical units (always qty 1), so the calendar hides the per-slice `Qty`
+   * and the booked-units total for them — the number is redundant noise. */
+  quantityTracked?: boolean;
 };
 
 // Loader Function to Return Bookings Data


### PR DESCRIPTION
An asset can appear on one booking through multiple BookingAsset pivot rows (booked standalone and as a kit member, or via several kits). The availability calendar rendered one bar per pivot row, producing duplicate overlapping bars on the asset's row.

Collapse to one bar per (asset, booking) and surface the breakdown instead:
- Advanced-mode SQL and the simple-mode loader now carry per-slice assetKitId, quantity, and kit name (kit names batch-resolved in simple mode; no schema migration).
- The hook groups slices by (asset, booking) and attaches slices/sliceCount/bookedTotal.
- The shared event card shows a non-color kit glyph on the bar and a 'Reserved on this booking' tooltip breakdown (Standalone / via 'Kit'), gated behind optional data so the booking calendar is unaffected.
- Quantities render only for QUANTITY_TRACKED assets; INDIVIDUAL assets hide the redundant 'Qty 1' and total, keeping just the kit attribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Availability and booking calendars now show a per-slice breakdown (including kit attribution) when slice data is available.
  * Events display updated glyphs/labels and hover details, with slice counts and total reserved units.

* **Bug Fixes**
  * Correctly merges related slices into a single calendar event without over-merging across different bookings or assets.
  * Uses booked units (not stock) for quantities and hides quantity details for quantity-untracked assets.

* **Tests**
  * Expanded automated coverage for slice normalization across advanced/simple data shapes and for event-card rendering/gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->