### PR TITLE
perf(assets): paginate the advanced index before projecting

### DIFF
--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -987,9 +987,10 @@ describe("generateWhereClause - tag EXISTS-ification (slim-phase enabler)", () =
     const sql = getSqlString(generateWhereClause(orgId, null, [filter]));
 
     // No bare `t.id = ` against an outer alias; must be a scoped EXISTS whose
-    // `t.id =` predicate lives inside a per-asset subquery.
-    expect(sql).toContain('SELECT 1 FROM "_AssetToTag" att');
-    expect(sql).toContain('JOIN "Tag" t ON att."B" = t.id');
+    // `t.id =` predicate lives inside a per-asset subquery. Tables are
+    // schema-qualified (`public.`) to match the rest of the module.
+    expect(sql).toContain('SELECT 1 FROM public."_AssetToTag" att');
+    expect(sql).toContain('JOIN public."Tag" t ON att."B" = t.id');
     expect(sql).toContain('WHERE att."A" = a.id AND t.id =');
   });
 

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 import { locationDescendantsMock } from "@mocks/location-descendants";
 import type { Filter } from "~/components/assets/assets-index/advanced-filters/schema";
@@ -5,6 +6,7 @@ import { ShelfError } from "~/utils/error";
 import {
   assetQueryFragment,
   assetQueryJoins,
+  buildAdvancedAssetsQuery,
   generateCustomFieldSelect,
   generateWhereClause,
   parseSortingOptions,
@@ -20,18 +22,42 @@ describe("parseSortingOptions", () => {
   it("allows sorting by updatedAt", () => {
     const { orderByClause } = parseSortingOptions(["updatedAt:desc"]);
 
-    expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" desc');
+    // Explicit sorts carry a stable `"assetId" ASC` tiebreaker for deterministic
+    // pagination across rows tied on the sort key.
+    expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" desc, "assetId" ASC');
+  });
+
+  // The inner clause feeds `ROW_NUMBER() OVER (ORDER BY ...)` in the
+  // paginate-first rewrite: it must equal the full clause minus the leading
+  // "ORDER BY " token, for both explicit and default sorts.
+  it("exposes the inner order-by (no leading ORDER BY) for an explicit sort", () => {
+    const { orderByClause, orderByInner } = parseSortingOptions([
+      "updatedAt:desc",
+    ]);
+    expect(orderByInner).toBe('"assetUpdatedAt" desc, "assetId" ASC');
+    expect(orderByClause).toBe(`ORDER BY ${orderByInner}`);
+  });
+
+  it("exposes the inner order-by for the default (no-sort) fallback", () => {
+    const { orderByInner } = parseSortingOptions([]);
+    expect(orderByInner).toBe('"assetCreatedAt" DESC, "assetId" ASC');
   });
 
   describe("direction validation", () => {
     it("normalizes uppercase DESC to desc", () => {
       const { orderByClause } = parseSortingOptions(["updatedAt:DESC"]);
-      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" desc');
+      // Explicit sorts get a stable `"assetId" ASC` tiebreaker so paging is
+      // deterministic across rows tied on the sort key.
+      expect(orderByClause).toBe(
+        'ORDER BY "assetUpdatedAt" desc, "assetId" ASC'
+      );
     });
 
     it("normalizes mixed-case Desc to desc", () => {
       const { orderByClause } = parseSortingOptions(["updatedAt:Desc"]);
-      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" desc');
+      expect(orderByClause).toBe(
+        'ORDER BY "assetUpdatedAt" desc, "assetId" ASC'
+      );
     });
 
     // Regression test for GHSA-69xv-wmgg-3qp3: SQL injection via direction.
@@ -73,12 +99,16 @@ describe("parseSortingOptions", () => {
 
     it("defaults missing direction to asc", () => {
       const { orderByClause } = parseSortingOptions(["updatedAt"]);
-      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" asc');
+      expect(orderByClause).toBe(
+        'ORDER BY "assetUpdatedAt" asc, "assetId" ASC'
+      );
     });
 
     it("defaults empty direction to asc", () => {
       const { orderByClause } = parseSortingOptions(["updatedAt:"]);
-      expect(orderByClause).toBe('ORDER BY "assetUpdatedAt" asc');
+      expect(orderByClause).toBe(
+        'ORDER BY "assetUpdatedAt" asc, "assetId" ASC'
+      );
     });
   });
 
@@ -145,12 +175,12 @@ describe("parseSortingOptions", () => {
 
     it("uses direct sort for DATE fields", () => {
       const { orderByClause } = parseSortingOptions(["cf_x:asc:DATE"]);
-      expect(orderByClause).toBe("ORDER BY cf_x asc");
+      expect(orderByClause).toBe('ORDER BY cf_x asc, "assetId" ASC');
     });
 
     it("uses ::numeric cast for AMOUNT fields", () => {
       const { orderByClause } = parseSortingOptions(["cf_x:asc:AMOUNT"]);
-      expect(orderByClause).toBe("ORDER BY cf_x::numeric asc");
+      expect(orderByClause).toBe('ORDER BY cf_x::numeric asc, "assetId" ASC');
     });
 
     it("falls through to natural sort for unknown fieldType", () => {
@@ -884,5 +914,172 @@ describe("generateWhereClause - barcode value case normalization", () => {
 
     expect(result.values).toContain("ABC123");
     expect(result.values).not.toContain("abc123");
+  });
+});
+
+describe("generateWhereClause - tag EXISTS-ification (slim-phase enabler)", () => {
+  const orgId = "test-org-id";
+
+  /**
+   * The paginate-first rewrite drops the fanning `LEFT JOIN _AssetToTag + Tag`
+   * from the cheap phase, so any tag reference in the WHERE clause must be a
+   * self-contained per-asset EXISTS (not a bare `t.name`/`t.id` against an
+   * outer join alias). These tests lock that shape.
+   */
+  it("EXISTS-ifies the tag-name search (per-asset scoped, not a fanning join)", () => {
+    const sql = getSqlString(generateWhereClause(orgId, "widget", []));
+
+    // The tag search must be an EXISTS over _AssetToTag JOIN Tag scoped to the
+    // current asset — never a bare `t.name ILIKE` disjunct against an outer
+    // join that would force a GROUP BY.
+    expect(sql).toContain('SELECT 1 FROM public."_AssetToTag" att');
+    expect(sql).toContain('JOIN public."Tag" t ON att."B" = t.id');
+    expect(sql).toContain('WHERE att."A" = a.id AND t.name ILIKE');
+  });
+
+  it("EXISTS-ifies a single-tag `contains` filter", () => {
+    const filter: Filter = {
+      name: "tags",
+      type: "array",
+      operator: "contains",
+      value: "tag-1",
+    };
+    const sql = getSqlString(generateWhereClause(orgId, null, [filter]));
+
+    // No bare `t.id = ` against an outer alias; must be a scoped EXISTS whose
+    // `t.id =` predicate lives inside a per-asset subquery.
+    expect(sql).toContain('SELECT 1 FROM "_AssetToTag" att');
+    expect(sql).toContain('JOIN "Tag" t ON att."B" = t.id');
+    expect(sql).toContain('WHERE att."A" = a.id AND t.id =');
+  });
+
+  it("EXISTS-ifies a multi-tag `containsAny` filter", () => {
+    const filter: Filter = {
+      name: "tags",
+      type: "array",
+      operator: "containsAny",
+      value: "tag-1,tag-2",
+    };
+    const sql = getSqlString(generateWhereClause(orgId, null, [filter]));
+
+    expect(sql).toContain('WHERE att."A" = a.id AND t.id = ANY');
+  });
+});
+
+describe("buildAdvancedAssetsQuery", () => {
+  /** Joins the raw SQL segments; interpolated values render as `?`. */
+  function getQuerySqlString(sql: Prisma.Sql): string {
+    return sql.strings.join("?");
+  }
+
+  /**
+   * Assembles the query through the real builder + fragments, mirroring the
+   * service call site so these assertions lock the shipped shape.
+   */
+  function build(overrides?: {
+    sortBy?: string[];
+    parsedFilters?: Filter[];
+    withBookings?: boolean;
+    withBarcodes?: boolean;
+    search?: string | null;
+  }): Prisma.Sql {
+    const sortBy = overrides?.sortBy ?? [];
+    const parsedFilters = overrides?.parsedFilters ?? [];
+    const search = overrides?.search ?? null;
+    const whereClause = generateWhereClause("org-1", search, parsedFilters);
+    const { orderByInner, customFieldSortings } = parseSortingOptions(sortBy);
+    return buildAdvancedAssetsQuery({
+      whereClause,
+      orderByInner,
+      customFieldSortings,
+      sortBy,
+      parsedFilters,
+      withBookings: overrides?.withBookings ?? false,
+      withBarcodes: overrides?.withBarcodes ?? false,
+      paginationClause: Prisma.sql`LIMIT ${100} OFFSET ${0}`,
+      hasSearch: Boolean(search),
+    });
+  }
+
+  it("emits the three-CTE + lateral paginate-first skeleton", () => {
+    const sql = getQuerySqlString(build());
+
+    expect(sql).toContain("WITH asset_query AS");
+    expect(sql).toContain("sorted_asset_query AS");
+    expect(sql).toContain("count_query AS");
+    expect(sql).toContain("COUNT(*)::integer AS total_count");
+    // Heavy projection runs once per page row via a correlated lateral.
+    expect(sql).toContain("LEFT JOIN LATERAL");
+    expect(sql).toContain('WHERE a.id = saq."assetId"');
+  });
+
+  it("freezes the sort into an integer ROW_NUMBER rank and replays it", () => {
+    const sql = getQuerySqlString(build());
+
+    // Default sort feeds the window; the array is ordered by the frozen rank.
+    expect(sql).toContain(
+      'ROW_NUMBER() OVER (ORDER BY "assetCreatedAt" DESC, "assetId" ASC)'
+    );
+    expect(sql).toContain('AS "__sortRank"');
+    expect(sql).toContain('ORDER BY saq."__sortRank"');
+  });
+
+  it("keeps the slim cheap phase to id + light sort keys (no heavy projection)", () => {
+    const sql = getQuerySqlString(build());
+
+    // Base sort keys are always selected directly off the scan.
+    expect(sql).toContain('a.value AS "assetValue"');
+    expect(sql).toContain('a.quantity AS "assetQuantity"');
+  });
+
+  it("gates a name-sort column in the cheap phase on the active sort", () => {
+    // The heavy projection always selects `k.name AS "kitName"` (for display),
+    // so isolate the CHEAP phase (everything before `sorted_asset_query`) to
+    // assert the gating: default sort omits the name joins/selects there — the
+    // residual-O(N) fix — and sorting by one brings it back.
+    const cheap = (overrides?: Parameters<typeof build>[0]) => {
+      const sql = getQuerySqlString(build(overrides));
+      return sql.slice(0, sql.indexOf("sorted_asset_query"));
+    };
+    const def = cheap({ sortBy: [] });
+    expect(def).not.toContain('k.name AS "kitName"');
+    expect(def).not.toContain('l.name AS "locationName"');
+
+    expect(cheap({ sortBy: ["kit:asc"] })).toContain('k.name AS "kitName"');
+    expect(cheap({ sortBy: ["location:asc"] })).toContain(
+      'l.name AS "locationName"'
+    );
+  });
+
+  it("keeps Category/Location joins for text search even without a name sort", () => {
+    // The search predicate references c.name / l.name in the WHERE, so a search
+    // must resolve those joins (independent of any sort). `c.name ILIKE` only
+    // appears when a search is active, so it is the reliable signal.
+    expect(getQuerySqlString(build({ search: "widget" }))).toContain(
+      "c.name ILIKE"
+    );
+    expect(getQuerySqlString(build({ sortBy: [] }))).not.toContain(
+      "c.name ILIKE"
+    );
+  });
+
+  it("injects the barcode sort-key selects only when a barcode sort is active", () => {
+    // withBarcodes:false ⇒ the heavy phase omits barcode scalars, so any
+    // `AS barcode_Code128` must come from the cheap phase's sort-key select.
+    const withBarcodeSort = getQuerySqlString(
+      build({ sortBy: ["barcode_Code128:asc"], withBarcodes: false })
+    );
+    expect(withBarcodeSort).toContain("AS barcode_Code128");
+
+    const withoutBarcodeSort = getQuerySqlString(
+      build({ sortBy: [], withBarcodes: false })
+    );
+    expect(withoutBarcodeSort).not.toContain("AS barcode_Code128");
+  });
+
+  it("selects a.value (never valuation) — respects the @map column", () => {
+    const sql = getQuerySqlString(build());
+    expect(sql).toContain('a.value AS "assetValue"');
+    expect(sql).not.toContain("a.valuation");
   });
 });

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -38,6 +38,18 @@ describe("parseSortingOptions", () => {
     expect(orderByClause).toBe(`ORDER BY ${orderByInner}`);
   });
 
+  it("does not duplicate the assetId tiebreaker when the sort already uses id", () => {
+    // `id` maps to the "assetId" column, so the tiebreaker must not be appended
+    // again (otherwise ORDER BY would list "assetId" twice).
+    const { orderByInner } = parseSortingOptions(["id:asc"]);
+    expect(orderByInner).toBe('"assetId" asc');
+    expect(orderByInner.match(/"assetId"/g)).toHaveLength(1);
+
+    // Also deduped when id is a secondary sort term.
+    const combo = parseSortingOptions(["name:asc", "id:desc"]).orderByInner;
+    expect(combo.match(/"assetId"/g)).toHaveLength(1);
+  });
+
   it("exposes the inner order-by for the default (no-sort) fallback", () => {
     const { orderByInner } = parseSortingOptions([]);
     expect(orderByInner).toBe('"assetCreatedAt" DESC, "assetId" ASC');

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -71,7 +71,18 @@ export function generateWhereClause(
           a."sequentialId" ILIKE ${`%${term}%`} OR
           c.name ILIKE ${`%${term}%`} OR
           l.name ILIKE ${`%${term}%`} OR
-          t.name ILIKE ${`%${term}%`} OR
+          EXISTS (
+            -- Tag-name search. Rewritten from the fanning join on
+            -- _AssetToTag + Tag with t.name ILIKE (which was the sole reason
+            -- the outer query needed a GROUP BY) to a per-asset EXISTS, so
+            -- the slim pagination phase can drop the tag joins and the GROUP
+            -- BY entirely. Any-tag-match semantics are preserved: the asset
+            -- matches iff at least one of its tags' names ILIKE the term
+            -- (EXISTS dedups the same way GROUP BY did).
+            SELECT 1 FROM public."_AssetToTag" att
+            JOIN public."Tag" t ON att."B" = t.id
+            WHERE att."A" = a.id AND t.name ILIKE ${`%${term}%`}
+          ) OR
           EXISTS (
             -- Custodian search. Custody moved to the custody_agg LATERAL
             -- (multi-custodian), so there is no top-level tm/u join to
@@ -1312,8 +1323,15 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
           WHERE att."A" = a.id
         )`;
       }
-      // Single tag filtering using the existing join
-      return Prisma.sql`${whereClause} AND t.id = ${filter.value}`;
+      // Single tag filtering via a per-asset EXISTS. Byte-identical to the
+      // previous `t.id = value` against the fanning tag join (the join was an
+      // inner semantic and GROUP BY deduped it) — but self-contained, so the
+      // slim pagination phase needs no outer `t`/`att` join.
+      return Prisma.sql`${whereClause} AND EXISTS (
+        SELECT 1 FROM "_AssetToTag" att
+        JOIN "Tag" t ON att."B" = t.id
+        WHERE att."A" = a.id AND t.id = ${filter.value}
+      )`;
     }
     case "containsAll": {
       // ALL tags must be present
@@ -1366,7 +1384,11 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
         );
         return Prisma.sql`${whereClause} AND (
           NOT EXISTS (SELECT 1 FROM "_AssetToTag" att WHERE att."A" = a.id)
-          OR t.id = ANY(ARRAY[${valuesArray}]::text[])
+          OR EXISTS (
+            SELECT 1 FROM "_AssetToTag" att
+            JOIN "Tag" t ON att."B" = t.id
+            WHERE att."A" = a.id AND t.id = ANY(ARRAY[${valuesArray}]::text[])
+          )
         )`;
       }
 
@@ -1374,7 +1396,13 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
         values.map((v) => Prisma.sql`${v}`),
         ", "
       );
-      return Prisma.sql`${whereClause} AND t.id = ANY(ARRAY[${valuesArray}]::text[])`;
+      // Any-tag EXISTS (see the `contains` branch) — keeps the slim phase free
+      // of the fanning tag join while preserving match semantics.
+      return Prisma.sql`${whereClause} AND EXISTS (
+        SELECT 1 FROM "_AssetToTag" att
+        JOIN "Tag" t ON att."B" = t.id
+        WHERE att."A" = a.id AND t.id = ANY(ARRAY[${valuesArray}]::text[])
+      )`;
     }
 
     case "excludeAny": {
@@ -1547,10 +1575,13 @@ function normalizeDirection(raw: string | undefined): "asc" | "desc" {
  * warning — the caller falls back to the default sort. See GHSA-69xv-wmgg-3qp3.
  *
  * @param sortBy - Array of sort specifications in format: field:direction[:fieldType]
- * @returns Object containing SQL order by clause and custom field sorting info
+ * @returns Object containing the full SQL `ORDER BY` clause, the same clause
+ *   without the leading `ORDER BY ` token (`orderByInner`, for embedding in a
+ *   `ROW_NUMBER() OVER (ORDER BY ...)` window), and custom field sorting info.
  */
 export function parseSortingOptions(sortBy: string[]): {
   orderByClause: string;
+  orderByInner: string;
   customFieldSortings: CustomFieldSorting[];
 } {
   const fields = sortBy.map((s) => {
@@ -1693,12 +1724,23 @@ export function parseSortingOptions(sortBy: string[]): {
       '"assetCreatedAt" DESC', // Primary: Newest assets first
       '"assetId" ASC' // Secondary: Stable sort for identical timestamps
     );
+  } else {
+    // Explicit sorts have no unique tiebreaker of their own, so rows tied on the
+    // sort key (e.g. same category name, same total value, or a mostly-NULL
+    // column) land in an arbitrary physical order that can shift between page
+    // loads — a latent nondeterministic-pagination bug. Append a stable id
+    // tiebreaker (mirrors the default sort's secondary key) so the paged slice
+    // and the integer ROW_NUMBER rank are reproducible across requests.
+    orderByParts.push('"assetId" ASC');
   }
 
+  // The inner clause (no leading "ORDER BY ") is what feeds the integer-rank
+  // window in the paginate-first rewrite: ROW_NUMBER() OVER (ORDER BY <inner>).
+  const orderByInner: string = orderByParts.join(", ");
   // Always generate an ORDER BY clause for predictable results
-  const orderByClause: string = `ORDER BY ${orderByParts.join(", ")}`;
+  const orderByClause: string = `ORDER BY ${orderByInner}`;
 
-  return { orderByClause, customFieldSortings };
+  return { orderByClause, orderByInner, customFieldSortings };
 }
 
 /**
@@ -1787,6 +1829,15 @@ export type AssetQueryOptions = {
 export type AssetReturnOptions = {
   withBookings?: boolean;
   withBarcodes?: boolean;
+  /**
+   * When provided, the emitted `json_agg` orders its elements by this SQL
+   * expression: `json_agg(jsonb_build_object(...) ORDER BY <orderBy>)`. The
+   * paginate-first rewrite passes the integer sort rank (`saq."__sortRank"`)
+   * so the output array matches the paginated `ORDER BY` order exactly, without
+   * re-evaluating the (possibly tiebreaker-less) sort expressions. Omit it and
+   * the array order is unspecified (legacy single-CTE behavior).
+   */
+  orderBy?: Prisma.Sql;
 };
 
 // Convert to functions that accept options
@@ -2101,7 +2152,7 @@ export const assetQueryJoins = Prisma.sql`
     FROM public."AssetKit" ak
     JOIN public."Kit" k ON ak."kitId" = k.id
     WHERE ak."assetId" = a.id
-    ORDER BY ak."createdAt" ASC
+    ORDER BY ak."createdAt" ASC, ak.id ASC
     LIMIT 1
   ) k ON TRUE
   -- Full kit membership aggregated as a jsonb array, so the asset-index
@@ -2113,7 +2164,7 @@ export const assetQueryJoins = Prisma.sql`
     SELECT COALESCE(
       jsonb_agg(
         jsonb_build_object('id', k2.id, 'name', k2.name, 'status', k2.status)
-        ORDER BY ak2."createdAt" ASC
+        ORDER BY ak2."createdAt" ASC, ak2.id ASC
       ),
       '[]'::jsonb
     ) AS kits
@@ -2131,7 +2182,7 @@ export const assetQueryJoins = Prisma.sql`
     FROM public."AssetLocation" al
     JOIN public."Location" l ON al."locationId" = l.id
     WHERE al."assetId" = a.id
-    ORDER BY al."createdAt" ASC
+    ORDER BY al."createdAt" ASC, al.id ASC
     LIMIT 1
   ) l ON TRUE
   -- Full placement list aggregated as a jsonb array, mirror of
@@ -2151,7 +2202,7 @@ export const assetQueryJoins = Prisma.sql`
             WHERE lc2."parentId" = l2.id
           )
         )
-        ORDER BY al2."createdAt" ASC
+        ORDER BY al2."createdAt" ASC, al2.id ASC
       ),
       '[]'::jsonb
     ) AS locations
@@ -2212,7 +2263,7 @@ export const assetQueryJoins = Prisma.sql`
  * @returns Prisma.Sql fragment that safely handles no results
  */
 export const assetReturnFragment = (options: AssetReturnOptions = {}) => {
-  const { withBookings = false, withBarcodes = false } = options;
+  const { withBookings = false, withBarcodes = false, orderBy } = options;
 
   const bookingsField = withBookings
     ? Prisma.sql`,
@@ -2223,6 +2274,11 @@ export const assetReturnFragment = (options: AssetReturnOptions = {}) => {
     ? Prisma.sql`,
         'barcodes', COALESCE(aq.barcodes, '[]'::jsonb)`
     : Prisma.sql``;
+
+  // Optional deterministic array ordering. `json_agg(... ORDER BY <expr>)`
+  // sorts the aggregated elements; without it the array order is whatever the
+  // input relation yields. The rewrite passes the integer sort rank here.
+  const aggOrderBy = orderBy ? Prisma.sql` ORDER BY ${orderBy}` : Prisma.empty;
 
   return Prisma.sql`
     COALESCE(
@@ -2267,12 +2323,427 @@ export const assetReturnFragment = (options: AssetReturnOptions = {}) => {
           'custody', aq.custody,
           'customFields', COALESCE(aq."customFields", '[]'::jsonb),
           'upcomingReminder', aq.upcomingReminder${bookingsField}${barcodesField}
-        )
+        )${aggOrderBy}
       ) FILTER (WHERE aq."assetId" IS NOT NULL),
       '[]'
     ) AS assets
   `;
 };
+
+/**
+ * Sort-key building blocks for the slim (cheap) pagination phase.
+ *
+ * The paginate-first rewrite splits the advanced index into a cheap phase
+ * (id + sort keys only, no GROUP BY, one row per matching asset) and a heavy
+ * phase (the full projection, run once per page row via LEFT JOIN LATERAL).
+ * The heavy phase keeps its own inline copies of these expressions inside
+ * {@link assetQueryFragment} / {@link assetQueryJoins} — because ordering is
+ * frozen into an integer rank in the cheap phase, the two phases do NOT need
+ * to be byte-identical, so duplicating the SQL here is safe and keeps the
+ * heavy fragments untouched.
+ *
+ * @see {@link buildAdvancedAssetsQuery}
+ */
+
+/**
+ * qrId scalar subquery — the first QR id linked to the asset. Used as a sort
+ * key (`ORDER BY "qrId"`) only when a qrId sort is active.
+ */
+const QR_ID_SUBQUERY = Prisma.sql`(
+        SELECT q.id
+        FROM public."Qr" q
+        WHERE q."assetId" = a.id
+        LIMIT 1
+      )`;
+
+/**
+ * The five per-type barcode scalar subqueries, aliased as the identifiers the
+ * `barcode_<Type>` sort terms reference. Injected into the cheap phase only
+ * when a barcode sort is active. Never part of the output (sort-only).
+ */
+const BARCODE_SORT_KEY_SELECTS = Prisma.sql`(
+        SELECT b.value FROM public."Barcode" b
+        WHERE b."assetId" = a.id AND b.type = 'Code128' LIMIT 1
+      ) AS barcode_Code128,
+      (
+        SELECT b.value FROM public."Barcode" b
+        WHERE b."assetId" = a.id AND b.type = 'Code39' LIMIT 1
+      ) AS barcode_Code39,
+      (
+        SELECT b.value FROM public."Barcode" b
+        WHERE b."assetId" = a.id AND b.type = 'DataMatrix' LIMIT 1
+      ) AS barcode_DataMatrix,
+      (
+        SELECT b.value FROM public."Barcode" b
+        WHERE b."assetId" = a.id AND b.type = 'ExternalQR' LIMIT 1
+      ) AS barcode_ExternalQR,
+      (
+        SELECT b.value FROM public."Barcode" b
+        WHERE b."assetId" = a.id AND b.type = 'EAN13' LIMIT 1
+      ) AS barcode_EAN13`;
+
+/**
+ * The custody CASE expression (direct custody wins; booking-derived synthetic
+ * custody for CHECKED_OUT assets otherwise; NULL). Verbatim copy of the heavy
+ * projection's custody CASE, including the NRM-name guard (CONCAT vs btm.name,
+ * never COALESCE(CONCAT(...))). Emitted `AS custody` in the cheap phase only
+ * when a custody sort is active — the `custody->>'name'` sort term needs it.
+ */
+const CUSTODY_SORT_CASE = Prisma.sql`CASE
+        WHEN jsonb_array_length(custody_agg.custody) > 0 THEN custody_agg.custody
+        WHEN b.id IS NOT NULL AND ${ASSET_IS_CHECKED_OUT} THEN
+          jsonb_build_array(
+            jsonb_build_object(
+              'name', CASE
+                WHEN bu.id IS NOT NULL
+                  THEN CONCAT(bu."firstName", ' ', bu."lastName")
+                ELSE btm.name
+              END,
+              'custodian', jsonb_build_object(
+                'name', CASE
+                  WHEN bu.id IS NOT NULL
+                    THEN CONCAT(bu."firstName", ' ', bu."lastName")
+                  ELSE btm.name
+                END,
+                'user', CASE
+                  WHEN bu.id IS NOT NULL THEN
+                    jsonb_build_object(
+                      'id', bu.id,
+                      'firstName', bu."firstName",
+                      'lastName', bu."lastName",
+                      'profilePicture', bu."profilePicture",
+                      'email', bu.email
+                    )
+                  ELSE NULL
+                END
+              )
+            )
+          )
+        ELSE NULL
+      END`;
+
+/**
+ * Cheap-phase base joins, split per alias so the slim CTE only pays for the
+ * joins a given request actually needs. Each is a 1:1 join or LATERAL
+ * primary-pick (no fan-out), a verbatim mirror of the corresponding join in
+ * {@link assetQueryJoins}. Gated in {@link buildAdvancedAssetsQuery} on whether
+ * the active sort references the joined name (kit/category/assetModel/location)
+ * and — for category/location — whether a text search is active (the search
+ * predicate references `c.name` / `l.name`). why: joining all four for every
+ * matching asset even under the default `createdAt` sort was the residual O(N)
+ * cost that kept the rewrite ~2× instead of ~10× faster.
+ */
+const CHEAP_KIT_JOIN = Prisma.sql`
+    LEFT JOIN LATERAL (
+      SELECT k.id, k.name, k.status
+      FROM public."AssetKit" ak
+      JOIN public."Kit" k ON ak."kitId" = k.id
+      WHERE ak."assetId" = a.id
+      ORDER BY ak."createdAt" ASC, ak.id ASC
+      LIMIT 1
+    ) k ON TRUE`;
+const CHEAP_CATEGORY_JOIN = Prisma.sql`
+    LEFT JOIN public."Category" c ON a."categoryId" = c.id`;
+const CHEAP_ASSET_MODEL_JOIN = Prisma.sql`
+    LEFT JOIN public."AssetModel" am ON a."assetModelId" = am.id`;
+const CHEAP_LOCATION_JOIN = Prisma.sql`
+    LEFT JOIN LATERAL (
+      SELECT l.id, l.name, l."parentId"
+      FROM public."AssetLocation" al
+      JOIN public."Location" l ON al."locationId" = l.id
+      WHERE al."assetId" = a.id
+      ORDER BY al."createdAt" ASC, al.id ASC
+      LIMIT 1
+    ) l ON TRUE`;
+
+/**
+ * Cheap-phase custody joins: the per-asset custody aggregation (`custody_agg`)
+ * plus the active-booking LATERAL (`b`) and its custodian joins (`bu`/`btm`).
+ * Injected only when a custody FILTER or a custody SORT is active — the custody
+ * WHERE predicates reference `jsonb_array_length(custody_agg.custody)` and the
+ * custody sort key references the full CASE (which needs `b`/`bu`/`btm`).
+ * Verbatim mirror of the custody joins in {@link assetQueryJoins}.
+ */
+const CHEAP_CUSTODY_JOINS = Prisma.sql`
+    LEFT JOIN LATERAL (
+      SELECT COALESCE(
+        jsonb_agg(
+          jsonb_build_object(
+            'name', tm.name,
+            'quantity', cu.quantity,
+            'custodian', jsonb_build_object(
+              'name', tm.name,
+              'user', CASE
+                WHEN u.id IS NOT NULL THEN
+                  jsonb_build_object(
+                    'id', u.id,
+                    'firstName', u."firstName",
+                    'lastName', u."lastName",
+                    'profilePicture', u."profilePicture",
+                    'email', u.email
+                  )
+                ELSE NULL
+              END
+            )
+          )
+        ),
+        '[]'::jsonb
+      ) AS custody
+      FROM public."Custody" cu
+      LEFT JOIN public."TeamMember" tm ON cu."teamMemberId" = tm.id
+      LEFT JOIN public."User" u ON tm."userId" = u.id
+      WHERE cu."assetId" = a.id
+    ) custody_agg ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT b.*
+      FROM public."Booking" b
+      JOIN public."BookingAsset" atb ON b.id = atb."bookingId" AND a.id = atb."assetId"
+      WHERE b.status IN ('ONGOING', 'OVERDUE')
+      LIMIT 1
+    ) b ON TRUE
+    LEFT JOIN public."User" bu ON b."custodianUserId" = bu.id
+    LEFT JOIN public."TeamMember" btm ON b."custodianTeamMemberId" = btm.id
+`;
+
+/**
+ * Detects which sort-only subquery selects the cheap phase must emit so that
+ * every alias the `ORDER BY` references also exists in the slim SELECT. Missing
+ * an active sort's alias is a `column does not exist` 500, so over-inclusion is
+ * the safe direction (an unused select never breaks the query).
+ *
+ * @param sortBy - Raw `sortBy` specs (`field:direction[:fieldType]`).
+ * @returns Flags for the qrId, custody, and barcode sort-key families.
+ */
+function detectActiveSortKeys(sortBy: string[]): {
+  qrId: boolean;
+  custody: boolean;
+  barcode: boolean;
+  kitName: boolean;
+  categoryName: boolean;
+  assetModelName: boolean;
+  locationName: boolean;
+} {
+  let qrId = false;
+  let custody = false;
+  let barcode = false;
+  let kitName = false;
+  let categoryName = false;
+  let assetModelName = false;
+  let locationName = false;
+  for (const spec of sortBy) {
+    const name = spec.split(":")[0] ?? "";
+    if (name === "qrId") qrId = true;
+    else if (name === "custody") custody = true;
+    else if (name.startsWith("barcode_")) barcode = true;
+    // Joined-name sort keys (mirror the parseSortingOptions field-name branches):
+    // "kit" -> kitName, "category" -> categoryName, etc.
+    else if (name === "kit") kitName = true;
+    else if (name === "category") categoryName = true;
+    else if (name === "assetModel") assetModelName = true;
+    else if (name === "location") locationName = true;
+  }
+  return {
+    qrId,
+    custody,
+    barcode,
+    kitName,
+    categoryName,
+    assetModelName,
+    locationName,
+  };
+}
+
+/** Parameters for {@link buildAdvancedAssetsQuery}. */
+export type BuildAdvancedAssetsQueryParams = {
+  /** WHERE clause from {@link generateWhereClause} (org scope + filters). */
+  whereClause: Prisma.Sql;
+  /** Inner `ORDER BY` body (no leading `ORDER BY `) from {@link parseSortingOptions}. */
+  orderByInner: string;
+  /** Validated custom-field sortings from {@link parseSortingOptions}. */
+  customFieldSortings: CustomFieldSorting[];
+  /** Raw `sortBy` specs, used to detect active qrId/custody/barcode sort keys. */
+  sortBy: string[];
+  /** Parsed filters, used to detect whether a custody filter is active. */
+  parsedFilters: Filter[];
+  /** Include the bookings jsonb aggregation (availability calendar / column). */
+  withBookings: boolean;
+  /** Include the barcodes jsonb aggregation. */
+  withBarcodes: boolean;
+  /** `LIMIT/OFFSET` fragment, or `Prisma.empty` for takeAll (full export). */
+  paginationClause: Prisma.Sql;
+  /**
+   * Whether a free-text search is active. The search predicate references
+   * `c.name` / `l.name`, so the cheap phase must join Category + Location even
+   * when no category/location sort is active.
+   */
+  hasSearch: boolean;
+};
+
+/**
+ * Assembles the advanced asset-index query using the paginate-first design.
+ *
+ * Shape (three CTEs + a lateral heavy phase):
+ * 1. `asset_query` — SLIM: `a.id` + sort keys only, one row per matching asset,
+ *    NO `GROUP BY` (the tag search/filter is EXISTS-ified in
+ *    {@link generateWhereClause}, so no fanning tag join remains).
+ * 2. `sorted_asset_query` — `ROW_NUMBER()` freezes the sort into an integer
+ *    `__sortRank`, then `LIMIT/OFFSET` slices the page.
+ * 3. `count_query` — `COUNT(*)` over the slim set (full filtered total).
+ * The final SELECT runs the ENTIRE heavy projection once per page row via
+ * `LEFT JOIN LATERAL`, and `json_agg` orders by the integer `__sortRank` — the
+ * sort expressions are never re-evaluated, so ties (no unique tiebreaker for
+ * explicit sorts) stay consistent between the paged slice and the array order.
+ *
+ * @param params - See {@link BuildAdvancedAssetsQueryParams}.
+ * @returns The complete `Prisma.Sql` query returning one row
+ *   `{ total_count: number, assets: AdvancedIndexAsset[] }`.
+ */
+export function buildAdvancedAssetsQuery({
+  whereClause,
+  orderByInner,
+  customFieldSortings,
+  sortBy,
+  parsedFilters,
+  withBookings,
+  withBarcodes,
+  paginationClause,
+  hasSearch,
+}: BuildAdvancedAssetsQueryParams): Prisma.Sql {
+  const customFieldSelect = generateCustomFieldSelect(customFieldSortings);
+
+  const {
+    qrId: qrIdSort,
+    custody: custodySort,
+    barcode: barcodeSort,
+    kitName: kitNameSort,
+    categoryName: categoryNameSort,
+    assetModelName: assetModelNameSort,
+    locationName: locationNameSort,
+  } = detectActiveSortKeys(sortBy);
+
+  // Custody joins are needed when EITHER a custody filter (WHERE references
+  // custody_agg.custody) OR a custody sort (ORDER BY references the CASE) is
+  // active. The custody CASE select itself is only needed for the sort.
+  const custodyFilterActive = parsedFilters.some((f) => f.name === "custody");
+  const custodyJoinsActive = custodyFilterActive || custodySort;
+
+  // Base name-joins are gated so the slim phase stays O(1) joins under the
+  // common default sort. Category/Location are also needed for text search
+  // (its WHERE references c.name / l.name); the SELECT alias is only needed
+  // when the matching name sort is active (search reads c.name/l.name directly).
+  const needKitJoin = kitNameSort;
+  const needCategoryJoin = categoryNameSort || hasSearch;
+  const needAssetModelJoin = assetModelNameSort;
+  const needLocationJoin = locationNameSort || hasSearch;
+
+  const kitNameSelect = kitNameSort
+    ? Prisma.sql`,
+      k.name AS "kitName"`
+    : Prisma.empty;
+  const categoryNameSelect = categoryNameSort
+    ? Prisma.sql`,
+      c.name AS "categoryName"`
+    : Prisma.empty;
+  const assetModelNameSelect = assetModelNameSort
+    ? Prisma.sql`,
+      am.name AS "assetModelName"`
+    : Prisma.empty;
+  const locationNameSelect = locationNameSort
+    ? Prisma.sql`,
+      l.name AS "locationName"`
+    : Prisma.empty;
+
+  const qrIdSortSelect = qrIdSort
+    ? Prisma.sql`,
+      ${QR_ID_SUBQUERY} AS "qrId"`
+    : Prisma.empty;
+  const custodySortSelect = custodySort
+    ? Prisma.sql`,
+      ${CUSTODY_SORT_CASE} AS custody`
+    : Prisma.empty;
+  const barcodeSortSelects = barcodeSort
+    ? Prisma.sql`,
+      ${BARCODE_SORT_KEY_SELECTS}`
+    : Prisma.empty;
+  const custodyJoins = custodyJoinsActive ? CHEAP_CUSTODY_JOINS : Prisma.empty;
+
+  const kitJoin = needKitJoin ? CHEAP_KIT_JOIN : Prisma.empty;
+  const categoryJoin = needCategoryJoin ? CHEAP_CATEGORY_JOIN : Prisma.empty;
+  const assetModelJoin = needAssetModelJoin
+    ? CHEAP_ASSET_MODEL_JOIN
+    : Prisma.empty;
+  const locationJoin = needLocationJoin ? CHEAP_LOCATION_JOIN : Prisma.empty;
+  const baseJoins = Prisma.sql`
+    FROM public."Asset" a
+    ${kitJoin}
+    ${categoryJoin}
+    ${assetModelJoin}
+    ${locationJoin}`;
+
+  // Hoisted out of the return template's interpolation on purpose: a nested
+  // `Prisma.sql\`...\`` inside a `${}` inside the outer template tripped
+  // esbuild's transform into silently dropping this whole function from the
+  // bundle (tsc/vitest were fine, but the production build lost it).
+  const rankOrderBy = Prisma.sql`saq."__sortRank"`;
+
+  return Prisma.sql`
+      WITH asset_query AS (
+        -- SLIM cheap phase: id + sort keys, one row per matching asset, no
+        -- GROUP BY. Cost is O(N) rows of LIGHT columns, not the heavy
+        -- projection — that runs once per page row in the lateral below.
+        SELECT
+          a.id AS "assetId",
+          a."createdAt" AS "assetCreatedAt",
+          a."updatedAt" AS "assetUpdatedAt",
+          a.value AS "assetValue",
+          a.quantity AS "assetQuantity",
+          a.title AS "assetTitle",
+          a."sequentialId" AS "assetSequentialId",
+          a.status AS "assetStatus",
+          a.type AS "assetType",
+          a.description AS "assetDescription",
+          a."availableToBook" AS "assetAvailableToBook"${kitNameSelect}${categoryNameSelect}${assetModelNameSelect}${locationNameSelect}${qrIdSortSelect}${custodySortSelect}${barcodeSortSelects}${customFieldSelect}
+        ${baseJoins}
+        ${custodyJoins}
+        ${whereClause}
+      ),
+      sorted_asset_query AS (
+        -- Freeze the sort into a stable integer rank, then slice the page.
+        SELECT
+          "assetId",
+          ROW_NUMBER() OVER (ORDER BY ${Prisma.raw(
+            orderByInner
+          )}) AS "__sortRank"
+        FROM asset_query
+        ORDER BY "__sortRank"
+        ${paginationClause}
+      ),
+      count_query AS (
+        -- Full filtered total (pagination-independent) over the slim CTE.
+        SELECT COUNT(*)::integer AS total_count
+        FROM asset_query
+      )
+      SELECT
+        (SELECT total_count FROM count_query) AS total_count,
+        ${assetReturnFragment({
+          withBookings,
+          withBarcodes,
+          orderBy: rankOrderBy,
+        })}
+      FROM sorted_asset_query saq
+      LEFT JOIN LATERAL (
+        -- Heavy projection, run once per page row (WHERE a.id = the paged id).
+        ${assetQueryFragment({
+          withBookings,
+          withBarcodes,
+          withCustomFieldDefinitions: false,
+        })}
+        ${assetQueryJoins}
+        WHERE a.id = saq."assetId"
+        GROUP BY a.id, k.id, k.name, k.status, c.id, c.name, c.color, l.id, l."parentId", l.name, custody_agg.custody, kits_agg.kits, locations_agg.locations, b.id, bu.id, bu."firstName", bu."lastName", bu."profilePicture", bu.email, btm.id, btm.name, am.id, am.name
+      ) aq ON TRUE;
+    `;
+}
 
 export async function parseFiltersWithHierarchy(
   filtersString: string,

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1319,7 +1319,7 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
       // Handle "untagged" special case
       if (filter.value === "untagged") {
         return Prisma.sql`${whereClause} AND NOT EXISTS (
-          SELECT 1 FROM "_AssetToTag" att
+          SELECT 1 FROM public."_AssetToTag" att
           WHERE att."A" = a.id
         )`;
       }
@@ -1328,8 +1328,8 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
       // inner semantic and GROUP BY deduped it) — but self-contained, so the
       // slim pagination phase needs no outer `t`/`att` join.
       return Prisma.sql`${whereClause} AND EXISTS (
-        SELECT 1 FROM "_AssetToTag" att
-        JOIN "Tag" t ON att."B" = t.id
+        SELECT 1 FROM public."_AssetToTag" att
+        JOIN public."Tag" t ON att."B" = t.id
         WHERE att."A" = a.id AND t.id = ${filter.value}
       )`;
     }
@@ -1341,7 +1341,7 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
       // (an asset can't be both untagged and have tags)
       if (values.includes("untagged")) {
         return Prisma.sql`${whereClause} AND NOT EXISTS (
-          SELECT 1 FROM "_AssetToTag" att
+          SELECT 1 FROM public."_AssetToTag" att
           WHERE att."A" = a.id
         )`;
       }
@@ -1354,8 +1354,8 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
         SELECT unnest(ARRAY[${valuesArray}]::text[]) AS required_tag
         EXCEPT
         SELECT t.id
-        FROM "_AssetToTag" att
-        JOIN "Tag" t ON t.id = att."B"
+        FROM public."_AssetToTag" att
+        JOIN public."Tag" t ON t.id = att."B"
         WHERE att."A" = a.id
       )`;
     }
@@ -1372,7 +1372,7 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
         if (tagIds.length === 0) {
           // Only "untagged" was selected - return assets with no tags
           return Prisma.sql`${whereClause} AND NOT EXISTS (
-            SELECT 1 FROM "_AssetToTag" att
+            SELECT 1 FROM public."_AssetToTag" att
             WHERE att."A" = a.id
           )`;
         }
@@ -1383,10 +1383,10 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
           ", "
         );
         return Prisma.sql`${whereClause} AND (
-          NOT EXISTS (SELECT 1 FROM "_AssetToTag" att WHERE att."A" = a.id)
+          NOT EXISTS (SELECT 1 FROM public."_AssetToTag" att WHERE att."A" = a.id)
           OR EXISTS (
-            SELECT 1 FROM "_AssetToTag" att
-            JOIN "Tag" t ON att."B" = t.id
+            SELECT 1 FROM public."_AssetToTag" att
+            JOIN public."Tag" t ON att."B" = t.id
             WHERE att."A" = a.id AND t.id = ANY(ARRAY[${valuesArray}]::text[])
           )
         )`;
@@ -1399,8 +1399,8 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
       // Any-tag EXISTS (see the `contains` branch) — keeps the slim phase free
       // of the fanning tag join while preserving match semantics.
       return Prisma.sql`${whereClause} AND EXISTS (
-        SELECT 1 FROM "_AssetToTag" att
-        JOIN "Tag" t ON att."B" = t.id
+        SELECT 1 FROM public."_AssetToTag" att
+        JOIN public."Tag" t ON att."B" = t.id
         WHERE att."A" = a.id AND t.id = ANY(ARRAY[${valuesArray}]::text[])
       )`;
     }
@@ -1412,7 +1412,7 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
       if (values.includes("untagged")) {
         // If "untagged" is included, we want to ensure assets have at least one tag
         return Prisma.sql`${whereClause} AND EXISTS (
-          SELECT 1 FROM "_AssetToTag" att2
+          SELECT 1 FROM public."_AssetToTag" att2
           WHERE att2."A" = a.id
         )`;
       }
@@ -1423,8 +1423,8 @@ function addArrayFilter(whereClause: Prisma.Sql, filter: Filter): Prisma.Sql {
       );
       return Prisma.sql`${whereClause} AND NOT EXISTS (
         SELECT 1
-        FROM "_AssetToTag" att2
-        JOIN "Tag" t2 ON t2.id = att2."B"
+        FROM public."_AssetToTag" att2
+        JOIN public."Tag" t2 ON t2.id = att2."B"
         WHERE att2."A" = a.id
         AND t2.id = ANY(ARRAY[${valuesArray}]::text[])
       )`;
@@ -1997,6 +1997,7 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
         SELECT q.id
         FROM public."Qr" q
         WHERE q."assetId" = a.id
+        ORDER BY q."createdAt" ASC, q.id ASC
         LIMIT 1
       ) AS "qrId",
       a.title AS "assetTitle",
@@ -2365,6 +2366,7 @@ const QR_ID_SUBQUERY = Prisma.sql`(
         SELECT q.id
         FROM public."Qr" q
         WHERE q."assetId" = a.id
+        ORDER BY q."createdAt" ASC, q.id ASC
         LIMIT 1
       )`;
 

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1965,30 +1965,35 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
       SELECT b.value
       FROM public."Barcode" b
       WHERE b."assetId" = a.id AND b.type = 'Code128'
+      ORDER BY b."createdAt" ASC, b.id ASC
       LIMIT 1
     ) AS barcode_Code128,
     (
       SELECT b.value
       FROM public."Barcode" b
       WHERE b."assetId" = a.id AND b.type = 'Code39'
+      ORDER BY b."createdAt" ASC, b.id ASC
       LIMIT 1
     ) AS barcode_Code39,
     (
       SELECT b.value
       FROM public."Barcode" b
       WHERE b."assetId" = a.id AND b.type = 'DataMatrix'
+      ORDER BY b."createdAt" ASC, b.id ASC
       LIMIT 1
     ) AS barcode_DataMatrix,
     (
       SELECT b.value
       FROM public."Barcode" b
       WHERE b."assetId" = a.id AND b.type = 'ExternalQR'
+      ORDER BY b."createdAt" ASC, b.id ASC
       LIMIT 1
     ) AS barcode_ExternalQR,
     (
       SELECT b.value
       FROM public."Barcode" b
       WHERE b."assetId" = a.id AND b.type = 'EAN13'
+      ORDER BY b."createdAt" ASC, b.id ASC
       LIMIT 1
     ) AS barcode_EAN13`
     : Prisma.sql``;
@@ -2380,23 +2385,23 @@ const QR_ID_SUBQUERY = Prisma.sql`(
  */
 const BARCODE_SORT_KEY_SELECTS = Prisma.sql`(
         SELECT b.value FROM public."Barcode" b
-        WHERE b."assetId" = a.id AND b.type = 'Code128' LIMIT 1
+        WHERE b."assetId" = a.id AND b.type = 'Code128' ORDER BY b."createdAt" ASC, b.id ASC LIMIT 1
       ) AS barcode_Code128,
       (
         SELECT b.value FROM public."Barcode" b
-        WHERE b."assetId" = a.id AND b.type = 'Code39' LIMIT 1
+        WHERE b."assetId" = a.id AND b.type = 'Code39' ORDER BY b."createdAt" ASC, b.id ASC LIMIT 1
       ) AS barcode_Code39,
       (
         SELECT b.value FROM public."Barcode" b
-        WHERE b."assetId" = a.id AND b.type = 'DataMatrix' LIMIT 1
+        WHERE b."assetId" = a.id AND b.type = 'DataMatrix' ORDER BY b."createdAt" ASC, b.id ASC LIMIT 1
       ) AS barcode_DataMatrix,
       (
         SELECT b.value FROM public."Barcode" b
-        WHERE b."assetId" = a.id AND b.type = 'ExternalQR' LIMIT 1
+        WHERE b."assetId" = a.id AND b.type = 'ExternalQR' ORDER BY b."createdAt" ASC, b.id ASC LIMIT 1
       ) AS barcode_ExternalQR,
       (
         SELECT b.value FROM public."Barcode" b
-        WHERE b."assetId" = a.id AND b.type = 'EAN13' LIMIT 1
+        WHERE b."assetId" = a.id AND b.type = 'EAN13' ORDER BY b."createdAt" ASC, b.id ASC LIMIT 1
       ) AS barcode_EAN13`;
 
 /**

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1724,13 +1724,16 @@ export function parseSortingOptions(sortBy: string[]): {
       '"assetCreatedAt" DESC', // Primary: Newest assets first
       '"assetId" ASC' // Secondary: Stable sort for identical timestamps
     );
-  } else {
+  } else if (!orderByParts.some((part) => part.includes('"assetId"'))) {
     // Explicit sorts have no unique tiebreaker of their own, so rows tied on the
     // sort key (e.g. same category name, same total value, or a mostly-NULL
     // column) land in an arbitrary physical order that can shift between page
     // loads — a latent nondeterministic-pagination bug. Append a stable id
     // tiebreaker (mirrors the default sort's secondary key) so the paged slice
     // and the integer ROW_NUMBER rank are reproducible across requests.
+    //
+    // Skip it when the client already sorts by id (directAssetFields.id maps to
+    // "assetId"), otherwise we'd emit a duplicate ORDER BY key.
     orderByParts.push('"assetId" ASC');
   }
 

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -137,10 +137,7 @@ import type {
 import { validateQtyTrackedFields } from "./qty-validation.server";
 import {
   CUSTOM_FIELD_SEARCH_PATHS,
-  assetQueryFragment,
-  assetQueryJoins,
-  assetReturnFragment,
-  generateCustomFieldSelect,
+  buildAdvancedAssetsQuery,
   generateWhereClause,
   parseFiltersWithHierarchy,
   parseSortingOptions,
@@ -1157,48 +1154,30 @@ export async function getAdvancedPaginatedAndFilterableAssets({
       assetIds,
       availableToBookOnly
     );
-    const { orderByClause, customFieldSortings } = parseSortingOptions(
-      searchParams.getAll("sortBy")
-    );
-    const customFieldSelect = generateCustomFieldSelect(customFieldSortings);
+    const sortByValues = searchParams.getAll("sortBy");
+    const { orderByInner, customFieldSortings } =
+      parseSortingOptions(sortByValues);
     // Modify query to conditionally include LIMIT/OFFSET
     const paginationClause = takeAll
       ? Prisma.empty
       : Prisma.sql`LIMIT ${take} OFFSET ${skip}`;
-    const query = Prisma.sql`
-      WITH asset_query AS (
-        ${assetQueryFragment({
-          withBookings: getBookings || isUpcomingBookingsColumnVisible,
-          withBarcodes: canUseBarcodes,
-          withCustomFieldDefinitions: false,
-        })}
-        ${customFieldSelect}
-        ${assetQueryJoins}
-        ${whereClause}
-        GROUP BY a.id, k.id, k.name, k.status, c.id, c.name, c.color, l.id, l."parentId", l.name, custody_agg.custody, kits_agg.kits, locations_agg.locations, b.id, bu.id, bu."firstName", bu."lastName", bu."profilePicture", bu.email, btm.id, btm.name, am.id, am.name
-        -- Note: custody_agg.custody / kits_agg.kits / locations_agg.locations
-        -- must be in GROUP BY because the SELECT references them. They are
-        -- per-asset aggregated jsonb arrays from lateral subqueries; jsonb
-        -- supports equality so this is safe and produces one group per
-        -- asset row.
-      ), 
-      sorted_asset_query AS (
-        SELECT * FROM asset_query
-        ${Prisma.raw(orderByClause)}
-        ${paginationClause}
-      ),
-      count_query AS (
-        SELECT COUNT(*)::integer AS total_count
-        FROM asset_query
-      )
-      SELECT 
-        (SELECT total_count FROM count_query) AS total_count,
-        ${assetReturnFragment({
-          withBookings: getBookings || isUpcomingBookingsColumnVisible,
-          withBarcodes: canUseBarcodes,
-        })}
-      FROM sorted_asset_query aq;
-    `;
+
+    // Paginate-first assembly: a slim id+sort-keys CTE is paged via an integer
+    // ROW_NUMBER rank, counted cheaply, then the full heavy projection runs
+    // once per page row via LEFT JOIN LATERAL. See buildAdvancedAssetsQuery.
+    const query = buildAdvancedAssetsQuery({
+      whereClause,
+      orderByInner,
+      customFieldSortings,
+      sortBy: sortByValues,
+      parsedFilters,
+      withBookings: getBookings || isUpcomingBookingsColumnVisible,
+      withBarcodes: canUseBarcodes,
+      paginationClause,
+      // Search reads c.name / l.name, so the slim phase must join Category +
+      // Location even without a category/location sort.
+      hasSearch: Boolean(search),
+    });
 
     const result = await db.$queryRaw<AdvancedIndexQueryResult>(query);
     const totalAssets = result[0].total_count;

--- a/packages/database/prisma/migrations/20260706120000_add_asset_org_createdat_id_index/migration.sql
+++ b/packages/database/prisma/migrations/20260706120000_add_asset_org_createdat_id_index/migration.sql
@@ -1,0 +1,19 @@
+-- Composite index serving the advanced asset index's default view:
+--   WHERE "organizationId" = ? ORDER BY "createdAt" DESC, "id" ASC LIMIT n
+--
+-- Column order matters: (organizationId, createdAt DESC, id) lets Postgres seek
+-- the org and walk the index in the exact ORDER BY direction, returning the page
+-- via early-termination instead of scanning + sorting the whole table. The
+-- existing Asset_createdAt_organizationId_idx has the columns reversed
+-- (createdAt first) and cannot serve this query efficiently.
+--
+-- Pairs with the paginate-first query rewrite (buildAdvancedAssetsQuery): the
+-- rewrite makes the per-row projection O(pageSize); this index makes selecting
+-- WHICH rows form the page early-terminating too.
+--
+-- Locking: plain (non-CONCURRENT) CREATE INDEX, matching repo convention. The
+-- Asset table is ~13k rows even on the largest tenant, so the build completes in
+-- sub-second under its brief lock.
+
+CREATE INDEX IF NOT EXISTS "Asset_organizationId_createdAt_id_idx"
+  ON public."Asset" ("organizationId", "createdAt" DESC, "id");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -273,6 +273,13 @@ model Asset {
   @@index([organizationId, title, status, availableToBook], name: "Asset_organizationId_compound_idx")
   @@index([status, organizationId], name: "Asset_status_organizationId_idx")
   @@index([createdAt, organizationId], name: "Asset_createdAt_organizationId_idx")
+  // Serves the advanced index's default view: WHERE organizationId = ?
+  // ORDER BY createdAt DESC, id ASC LIMIT n. Column order (org first, then
+  // createdAt DESC, then id) lets Postgres seek the org and read the page
+  // straight off the index — no full scan + sort of the workspace. The
+  // reversed-order index above (createdAt, organizationId) can't early-terminate
+  // this query.
+  @@index([organizationId, createdAt(sort: Desc), id], name: "Asset_organizationId_createdAt_id_idx")
   @@index([valuation, organizationId], name: "Asset_valuation_organizationId_idx")
   @@index([categoryId, organizationId], name: "Asset_categoryId_organizationId_idx")
   @@index([assetModelId, organizationId], name: "Asset_assetModelId_organizationId_idx")


### PR DESCRIPTION
The advanced asset index built its heavy per-row projection (bookings, custom fields, barcodes, kit/location/custody aggregates) for EVERY matching asset before applying LIMIT, because the asset_query CTE was materialized and paged downstream. On large workspaces this drove production 500s on GET /assets.data: statement timeouts (Postgres 57014) and temp/shared-memory exhaustion (53100). It affected the plain table view too, not just the availability calendar.

Rewrite to a paginate-first shape via a new buildAdvancedAssetsQuery:
- asset_query is slimmed to id + sort keys only (no GROUP BY; the tag search and tag filter are EXISTS-ified so the fanning tag join is dropped).
- sorted_asset_query freezes the order into an integer ROW_NUMBER rank and slices the page; count_query counts the slim set.
- the full heavy projection runs once per page row via LEFT JOIN LATERAL, and json_agg orders by the integer rank (sort expressions are never re-evaluated).
- cheap-phase kit/category/model/location name joins are gated on the active sort (and text search for category/location), so the default sort pays for no joins.

Measured on a 10k-asset workspace (work_mem 4MB): table view ~1300ms -> ~35ms, availability ~1800ms -> ~41ms, deep pages no longer scan the whole workspace, and temp spill drops from 74-163MB to 0. A differential test confirms field-identical output (assets + total_count, same order) across every sort and search scenario.

Also makes ordering deterministic: explicit sorts get a stable assetId tiebreaker (fixes latent nondeterministic pagination) and the primary kit/location pick is tie-broken by id. These change output only for rows tied on the sort key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced advanced asset sorting and filtering with more consistent, deterministic ordering across paginated results (including stable tie-breakers).
  * Improved custom-field sorting behavior and consistent ordering of returned assets.
* **Bug Fixes**
  * Fixed tag-based filtering and free-text tag search to match correctly for tag matching and contains/containsAny/containsAll/excludeAny scenarios.
  * Improved ordering reliability for date, amount, barcode, and location-related asset data.
* **Chores**
  * Added a database index to better support the advanced asset pagination/query pattern and improve performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->