### PR TITLE
perf(bookings,assets): paginate-first quick wins from the #2692 playbook

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/add-assets-to-existing-booking-dialog.tsx
@@ -24,6 +24,14 @@ import { useAutoFocus } from "~/hooks/use-auto-focus";
 import { handleActivationKeyPress } from "~/utils/keyboard";
 import { tw } from "~/utils/tw";
 
+/**
+ * Slim booking shape returned by `/api/bookings/get-all` (see
+ * `getMinimalBookings`). Only the fields this picker renders — deliberately not
+ * the full Prisma `Booking`, so nobody reads a column the endpoint no longer
+ * sends.
+ */
+type PickerBooking = Pick<Booking, "id" | "name" | "status" | "from" | "to">;
+
 export const addAssetsToExistingBookingSchema = z.object({
   id: z
     .string({ required_error: "Please select booking." })
@@ -39,8 +47,8 @@ export const addAssetsToExistingBookingSchema = z.object({
  * check-marked selection, date range per row) but is fed directly from the
  * `/api/bookings/get-all` fetch instead of route-loader data — the assets-index
  * loader does not (and should not, for perf) carry booking data. `get-all`
- * returns every open booking (`takeAll`), so filtering is done client-side for
- * instant results.
+ * returns every open booking (slim projection), so filtering is done
+ * client-side for instant results.
  *
  * @see {@link file://./../../../routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx}
  *   the singular-asset flow this is styled to match.
@@ -52,7 +60,7 @@ function BookingSelect({
   errorMessage,
 }: {
   /** All open bookings returned by `/api/bookings/get-all`. */
-  bookings: Booking[];
+  bookings: PickerBooking[];
   /** Whether the bookings fetch is still in flight. */
   isLoading: boolean;
   /** Disable the trigger (e.g. while the form is submitting). */
@@ -239,7 +247,7 @@ export default function AddAssetsToExistingBookingDialog() {
     data: bookingsData,
     isLoading: isFetchingBookings,
     error: _bookingsError,
-  } = useApiQuery<{ error: null; bookings: Booking[] }>({
+  } = useApiQuery<{ error: null; bookings: PickerBooking[] }>({
     api: "/api/bookings/get-all",
     enabled: isDialogOpen,
   });

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -1052,7 +1052,15 @@ export async function getAssets(params: {
             }),
             ...extraInclude,
           },
-          orderBy: { [orderBy]: orderDirection },
+          // Stable `id` tiebreaker for deterministic skip/take paging when
+          // rows tie on the sort key (bulk-imported assets share createdAt
+          // down to the millisecond). Mirrors the tiebreaker the advanced
+          // index uses (parseSortingOptions in query.server.ts). Skipped when
+          // the caller already sorts by id.
+          orderBy: [
+            { [orderBy]: orderDirection },
+            ...(orderBy !== "id" ? [{ id: "asc" as const }] : []),
+          ],
         }),
         db.asset.count({ where: assetWhere }),
       ]);

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -7407,6 +7407,8 @@ describe("getMinimalBookings", () => {
   });
 
   it("defaults to excluding archived & cancelled when no statuses are given", async () => {
+    // why: stub the query so we can assert the default status where-clause
+    // getMinimalBookings builds, not real DB behavior.
     const findMany = db.booking.findMany as unknown as ReturnType<
       typeof vitest.fn
     >;
@@ -7423,6 +7425,8 @@ describe("getMinimalBookings", () => {
   });
 
   it("scopes to a custodian when custodianUserId is provided (self-service)", async () => {
+    // why: stub the query so we can assert the custodian where-clause
+    // getMinimalBookings adds for self-service callers, not real DB behavior.
     const findMany = db.booking.findMany as unknown as ReturnType<
       typeof vitest.fn
     >;

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -45,6 +45,8 @@ import {
   getExistingBookingDetails,
   assertKitsAddableToActiveBooking,
   getOngoingBookingForAsset,
+  getMinimalBookings,
+  bookingDraftVisibilityClause,
   bulkArchiveBookings,
   bulkCancelBookings,
   // Phase 3c helpers
@@ -7345,5 +7347,94 @@ describe("booking notes + events — qty-tracked axis", () => {
         content: expect.stringContaining("removed 80 units of"),
       })
     );
+  });
+});
+
+describe("bookingDraftVisibilityClause", () => {
+  it("shows non-DRAFT bookings to everyone and DRAFTs only to their creator", () => {
+    // The permission-sensitive rule shared by getBookings and
+    // getMinimalBookings. Locking its shape here so the two list queries
+    // cannot silently diverge on who can see a draft.
+    expect(bookingDraftVisibilityClause("user-1")).toEqual({
+      OR: [
+        { status: { not: "DRAFT" } },
+        { AND: [{ status: "DRAFT" }, { creatorId: "user-1" }] },
+      ],
+    });
+  });
+});
+
+describe("getMinimalBookings", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("selects only the picker fields and applies the id sort tiebreaker", async () => {
+    // why: assert the slim projection + deterministic order, not DB behavior.
+    const findMany = db.booking.findMany as unknown as ReturnType<
+      typeof vitest.fn
+    >;
+    findMany.mockResolvedValueOnce([]);
+
+    await getMinimalBookings({
+      organizationId: "org-1",
+      userId: "user-1",
+      statuses: ["DRAFT", "RESERVED", "ONGOING", "OVERDUE"],
+    });
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    const arg = findMany.mock.calls[0][0];
+
+    // Slim select: exactly the columns the add-to-booking picker renders.
+    expect(arg.select).toEqual({
+      id: true,
+      name: true,
+      status: true,
+      from: true,
+      to: true,
+    });
+    // No heavy include, and no count query (only one findMany, no db.booking.count).
+    expect(arg.include).toBeUndefined();
+    expect(db.booking.count).not.toHaveBeenCalled();
+    // `from` primary + `id` tiebreaker => deterministic, unpaginated order.
+    expect(arg.orderBy).toEqual([{ from: "asc" }, { id: "asc" }]);
+    // Carries the shared DRAFT-visibility rule, scoped to the org + viewer.
+    expect(arg.where.organizationId).toBe("org-1");
+    expect(arg.where.AND).toEqual([bookingDraftVisibilityClause("user-1")]);
+    expect(arg.where.status).toEqual({
+      in: ["DRAFT", "RESERVED", "ONGOING", "OVERDUE"],
+    });
+  });
+
+  it("defaults to excluding archived & cancelled when no statuses are given", async () => {
+    const findMany = db.booking.findMany as unknown as ReturnType<
+      typeof vitest.fn
+    >;
+    findMany.mockResolvedValueOnce([]);
+
+    await getMinimalBookings({ organizationId: "org-1", userId: "user-1" });
+
+    const arg = findMany.mock.calls[0][0];
+    expect(arg.where.status).toEqual({
+      notIn: [BookingStatus.ARCHIVED, BookingStatus.CANCELLED],
+    });
+    // No custodian scope unless asked for.
+    expect(arg.where.custodianUserId).toBeUndefined();
+  });
+
+  it("scopes to a custodian when custodianUserId is provided (self-service)", async () => {
+    const findMany = db.booking.findMany as unknown as ReturnType<
+      typeof vitest.fn
+    >;
+    findMany.mockResolvedValueOnce([]);
+
+    await getMinimalBookings({
+      organizationId: "org-1",
+      userId: "user-1",
+      custodianUserId: "user-1",
+    });
+
+    const arg = findMany.mock.calls[0][0];
+    expect(arg.where.custodianUserId).toBe("user-1");
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -7878,6 +7878,97 @@ export async function getBookingsFilterData({
   };
 }
 
+/**
+ * DRAFT-visibility rule shared by every booking-list query: bookings that are
+ * not DRAFT are visible to everyone in the org, while DRAFT bookings are only
+ * visible to their creator. Extracted so heavy ({@link getBookings}) and slim
+ * ({@link getMinimalBookings}) list queries cannot drift apart on this
+ * permission-sensitive predicate.
+ *
+ * @param userId - The viewer, matched against `Booking.creatorId` for drafts.
+ * @returns A `Prisma.BookingWhereInput` OR-clause to push into `where.AND`.
+ */
+export function bookingDraftVisibilityClause(
+  userId: Booking["creatorId"]
+): Prisma.BookingWhereInput {
+  return {
+    OR: [
+      { status: { not: "DRAFT" } },
+      { AND: [{ status: "DRAFT" }, { creatorId: userId }] },
+    ],
+  };
+}
+
+/**
+ * Slim booking list for pickers that render only a name + date range and
+ * filter client-side (e.g. the bulk "add to existing booking" dialog). Unlike
+ * {@link getBookings} it selects a handful of scalar columns instead of the
+ * heavy asset/kit/custodian projection, and runs no count query — the caller
+ * gets every matching row (paginate-first is moot when only ~5 columns per row
+ * are fetched). Shares {@link bookingDraftVisibilityClause} so it honours the
+ * same DRAFT-creator visibility as the full index.
+ *
+ * @param params.organizationId - Workspace scope.
+ * @param params.userId - Viewer, for the DRAFT-visibility rule.
+ * @param params.statuses - Explicit status filter; defaults to excluding
+ *   ARCHIVED + CANCELLED (mirrors {@link getBookings}).
+ * @param params.custodianUserId - Restrict to a custodian (self-service views).
+ * @returns `{ bookings }` — id, name, status, from, to, ordered by `from`
+ *   with a stable `id` tiebreaker.
+ * @throws {ShelfError} If the query fails.
+ */
+export async function getMinimalBookings(params: {
+  organizationId: Organization["id"];
+  userId: Booking["creatorId"];
+  statuses?: Booking["status"][] | null;
+  custodianUserId?: Booking["custodianUserId"] | null;
+}) {
+  const { organizationId, userId, statuses, custodianUserId } = params;
+
+  try {
+    const where: Prisma.BookingWhereInput = {
+      organizationId,
+      AND: [bookingDraftVisibilityClause(userId)],
+    };
+
+    if (statuses?.length) {
+      where.status = { in: statuses };
+    } else {
+      // Default: hide archived & cancelled, matching getBookings.
+      where.status = {
+        notIn: [BookingStatus.ARCHIVED, BookingStatus.CANCELLED],
+      };
+    }
+
+    if (custodianUserId) {
+      where.custodianUserId = custodianUserId;
+    }
+
+    const bookings = await db.booking.findMany({
+      where,
+      select: {
+        id: true,
+        name: true,
+        status: true,
+        from: true,
+        to: true,
+      },
+      // `id` tiebreaker so the (unpaginated) order is stable across requests.
+      orderBy: [{ from: "asc" }, { id: "asc" }],
+    });
+
+    return { bookings };
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message:
+        "Something went wrong while fetching the bookings. Please try again or contact support.",
+      additionalData: { ...params },
+      label,
+    });
+  }
+}
+
 export async function getBookings(params: {
   organizationId: Organization["id"];
   /** Page number. Starts at 1 */
@@ -7933,27 +8024,7 @@ export async function getBookings(params: {
     /** The idea is that only the creator of a draft booking can see it
      * This condition will fetch all bookings that are not in 'DRAFT' status, and also the bookings that are in 'DRAFT' status but only if their creatorId is the same as the userId
      */
-    where.AND = [
-      {
-        OR: [
-          {
-            status: {
-              not: "DRAFT",
-            },
-          },
-          {
-            AND: [
-              {
-                status: "DRAFT",
-              },
-              {
-                creatorId: userId,
-              },
-            ],
-          },
-        ],
-      },
-    ];
+    where.AND = [bookingDraftVisibilityClause(userId)];
 
     /** If the search string exists, add it to the where object */
     if (search?.trim()?.length) {
@@ -8148,11 +8219,15 @@ export async function getBookings(params: {
                       color: true,
                     },
                   },
-                  bookingAssets: {
-                    select: {
-                      bookingId: true,
-                    },
-                  },
+                  // NOTE: deliberately NO `bookingAssets` here. A previous
+                  // version selected each asset's entire lifetime
+                  // `bookingAssets: { bookingId }` pivot history, which grows
+                  // without bound and had zero consumers (every reader of
+                  // `asset.bookingAssets` needs `ba.booking.{id,status}` from
+                  // asset-centric queries, which this shape cannot provide).
+                  // If a surface ever needs conflict info here, scope it with
+                  // a `where` on active statuses + date overlap like
+                  // getBookingFlags does.
                   assetKits: {
                     select: {
                       // See the comment in `bookings.$bookingId.overview.tsx`
@@ -8192,7 +8267,16 @@ export async function getBookings(params: {
           },
           ...(extraInclude || undefined),
         },
-        orderBy: { [orderBy]: orderDirection },
+        // Stable `id` tiebreaker so rows tied on the sort key (same `from`
+        // date, same name, ...) keep a fixed order across requests. Without
+        // it, skip/take paging over ties can duplicate or drop rows between
+        // pages. Skipped when the caller already sorts by id (duplicate
+        // ORDER BY key). Mirrors the tiebreaker the advanced asset index
+        // uses (see parseSortingOptions in asset/query.server.ts).
+        orderBy: [
+          { [orderBy]: orderDirection },
+          ...(orderBy !== "id" ? [{ id: "asc" as const }] : []),
+        ],
       }),
       db.booking.count({ where }),
     ]);

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -1245,7 +1245,13 @@ export async function getAssetsForKits({
         take,
         where: finalQuery,
         select: KIT_SELECT_FIELDS_FOR_LIST_ITEMS,
-        orderBy: { [orderBy]: orderDirection },
+        // Stable `id` tiebreaker for deterministic skip/take paging when rows
+        // tie on the sort key (see the matching comment in
+        // asset/service.server.ts). Skipped when already sorting by id.
+        orderBy: [
+          { [orderBy]: orderDirection },
+          ...(orderBy !== "id" ? [{ id: "asc" as const }] : []),
+        ],
       }),
       db.asset.count({ where: finalQuery }),
     ]);

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -1010,7 +1010,9 @@ async function fetchOverdueRows(
 
   const bookings = await db.booking.findMany({
     where,
-    orderBy: { to: "asc" }, // Most overdue first (earliest scheduled end)
+    // Most overdue first (earliest scheduled end); `id` tiebreaker keeps
+    // skip/take paging deterministic for bookings sharing the same `to`.
+    orderBy: [{ to: "asc" }, { id: "asc" }],
     skip: (page - 1) * pageSize,
     take: pageSize,
     select: {
@@ -1408,7 +1410,9 @@ async function fetchIdleAssetRows(
         },
       },
     },
-    orderBy: { updatedAt: "asc" }, // Least recently updated first
+    // Least recently updated first; `id` tiebreaker keeps skip/take paging
+    // deterministic for assets sharing an `updatedAt` (bulk operations).
+    orderBy: [{ updatedAt: "asc" }, { id: "asc" }],
     skip: (page - 1) * pageSize,
     take: pageSize,
     select: {
@@ -1802,7 +1806,9 @@ async function fetchCustodyRows(
   // `refreshExpiredAssetImages` below without an extra round-trip.
   const custodyRecords = await db.custody.findMany({
     where,
-    orderBy: { createdAt: "desc" },
+    // `id` tiebreaker keeps skip/take paging deterministic for rows sharing
+    // a `createdAt` (bulk operations land in the same millisecond).
+    orderBy: [{ createdAt: "desc" }, { id: "asc" }],
     skip: (page - 1) * pageSize,
     take: pageSize,
     select: {
@@ -3042,7 +3048,9 @@ async function fetchInventoryRows(
   // extra round-trip.
   const assets = await db.asset.findMany({
     where,
-    orderBy: { createdAt: "desc" },
+    // `id` tiebreaker keeps skip/take paging deterministic for rows sharing
+    // a `createdAt` (bulk operations land in the same millisecond).
+    orderBy: [{ createdAt: "desc" }, { id: "asc" }],
     skip: (page - 1) * pageSize,
     take: pageSize,
     select: {
@@ -3791,7 +3799,9 @@ export async function assetActivityReport(
     const [events, totalCount] = await Promise.all([
       db.activityEvent.findMany({
         where,
-        orderBy: { occurredAt: "desc" },
+        // `id` tiebreaker keeps skip/take paging deterministic for events
+        // sharing an `occurredAt` (bulk mutations emit same-instant events).
+        orderBy: [{ occurredAt: "desc" }, { id: "asc" }],
         skip: (page - 1) * pageSize,
         take: pageSize,
       }),

--- a/apps/webapp/app/routes/api+/bookings.get-all.ts
+++ b/apps/webapp/app/routes/api+/bookings.get-all.ts
@@ -1,8 +1,7 @@
 import { data, type LoaderFunctionArgs } from "react-router";
-import { getBookings } from "~/modules/booking/service.server";
+import { getMinimalBookings } from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
-import { payload, error, getCurrentSearchParams } from "~/utils/http.server";
-import { getParamsValues } from "~/utils/list";
+import { payload, error } from "~/utils/http.server";
 import {
   PermissionAction,
   PermissionEntity,
@@ -21,17 +20,16 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       action: PermissionAction.read,
     });
 
-    const { page, search } = getParamsValues(getCurrentSearchParams(request));
-    const { bookings } = await getBookings({
+    // The "add to existing booking" dialog renders only a name + date range and
+    // filters client-side, so fetch the slim projection (no per-booking asset /
+    // kit / custodian tree, no count query) instead of the full index shape.
+    const { bookings } = await getMinimalBookings({
       organizationId,
-      page,
-      search,
       userId,
-      // Include active bookings so the bulk "add to existing booking" dialog can
-      // target ONGOING/OVERDUE bookings too (added assets stay AVAILABLE —
-      // progressive checkout), not just DRAFT/RESERVED ones.
+      // Include active bookings so the dialog can target ONGOING/OVERDUE
+      // bookings too (added assets stay AVAILABLE — progressive checkout), not
+      // just DRAFT/RESERVED ones.
       statuses: ["DRAFT", "RESERVED", "ONGOING", "OVERDUE"],
-      takeAll: true,
       ...(isSelfServiceOrBase && { custodianUserId: userId }),
     });
 

--- a/packages/database/prisma/migrations/20260706180000_add_booking_and_scan_pagination_indexes/migration.sql
+++ b/packages/database/prisma/migrations/20260706180000_add_booking_and_scan_pagination_indexes/migration.sql
@@ -1,0 +1,29 @@
+-- Two composite indexes following the paginate-first pattern established by
+-- Asset_organizationId_createdAt_id_idx (see 20260706120000): filter column
+-- first, then the sort key in query direction, then id as the pagination
+-- tiebreaker, so page selection early-terminates instead of scanning +
+-- sorting the whole set.
+--
+-- 1. Booking: serves the bookings index default view (getBookings):
+--      WHERE "organizationId" = ? ORDER BY "from" ASC, "id" ASC LIMIT n
+--    Booking previously had only single-column indexes, so every page load
+--    scanned and sorted the workspace's entire booking history.
+--
+-- 2. Scan: serves getScanByQrId (the last-scan card on asset overview and
+--    kit detail pages):
+--      WHERE "rawQrId" = ? ORDER BY "createdAt" DESC LIMIT 1
+--    Scan is a global, append-only table (public QR hits + companion scans,
+--    never pruned) with no index on rawQrId, so every one of these page
+--    views paid a sequential scan over all scan history. rawQrId seeks the
+--    QR; createdAt lets the top-1 sort early-terminate (Postgres walks the
+--    btree backwards for DESC, so no explicit direction is needed).
+--
+-- Locking: plain (non-CONCURRENT) CREATE INDEX, matching repo convention.
+-- Both tables build their index in at most a few seconds under the brief
+-- lock at current production sizes.
+
+CREATE INDEX IF NOT EXISTS "Booking_organizationId_from_id_idx"
+  ON public."Booking" ("organizationId", "from", "id");
+
+CREATE INDEX IF NOT EXISTS "Scan_rawQrId_createdAt_idx"
+  ON public."Scan" ("rawQrId", "createdAt");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -747,6 +747,13 @@ model Scan {
   // Indexes for foreign keys
   @@index([qrId])
   @@index([userId])
+  // Serves getScanByQrId (last-scan card on asset overview + kit detail):
+  // WHERE rawQrId = ? ORDER BY createdAt DESC LIMIT 1. Scan is a global,
+  // append-only table (public QR hits + companion scans, never pruned), so
+  // without this index every page view pays a full sequential scan of all
+  // tenants' scan history. rawQrId seeks the QR; createdAt lets the top-1
+  // sort early-terminate (Postgres walks the btree backwards for DESC).
+  @@index([rawQrId, createdAt])
 }
 
 model Location {
@@ -1532,6 +1539,13 @@ model Booking {
   // Speeds up status filtering when joining from Asset → Booking
   // (e.g. fetching ONGOING/OVERDUE bookings for asset custodian display)
   @@index([status])
+  // Serves the bookings index default view (getBookings): WHERE
+  // organizationId = ? ORDER BY "from" ASC LIMIT n. Column order (org first,
+  // then the sort key, then id as the pagination tiebreaker) lets Postgres
+  // seek the org and read the page straight off the index instead of
+  // scanning + sorting every booking in the workspace. Same pattern as
+  // Asset_organizationId_createdAt_id_idx.
+  @@index([organizationId, from, id])
 }
 
 model BookingSettings {


### PR DESCRIPTION
## What & why

Reverse-engineers the reusable lessons from #2692 (paginate/count the **slim** set before building the heavy per-row projection) and applies them to the highest-value spots outside the advanced asset index. Each item below was found by an audit sweep and then verified by reading the actual code path and the consuming loader/route.

The transferable principles this PR acts on:
- **Pay only for what you use** — drop projection that no surface consumes.
- **Deterministic paging** — every `LIMIT/OFFSET` needs a unique `id` tiebreaker.
- **Slim the picker** — a name+date dropdown shouldn't fetch the full entity tree or a count.
- **Index the pagination pattern** — `(filter, sortKey dir, id)`, same shape #2692 added for assets.

## Changes

**1. Delete the dead `asset.bookingAssets` include in `getBookings`**
It selected each asset's *entire lifetime* `bookingAssets: { bookingId }` pivot history (grows without bound) on **every** booking surface (index, calendar, home, mobile dashboard, CSV export, `get-all`) — with **zero consumers**. Both mirrored consumer types (`bookings._index` row component, `BookingAssetsSidebar`) already omit the field, and every real reader of `asset.bookingAssets` needs `booking.{id,status}`, which a `{ bookingId }`-only select can't provide. Removing it lightens all of those surfaces at once. If conflict info is ever needed here, it should be scoped with a `where` on active statuses + date overlap like `getBookingFlags` does.

**2. Stable `id` sort tiebreakers on paginated queries**
`getBookings`, the simple asset index (`getAssets`), kit assets (`getPaginatedAndFilterableKits`/`getAssetsForKits`), and the paginated report tables (overdue, idle, custody, inventory, activity) all sorted by a single non-unique column. Rows tied on the sort key (same `from`, or the same `createdAt`/`updatedAt` under bulk import) could **duplicate or vanish between pages**. Each now carries an `id` tiebreaker (skipped when the client already sorts by `id`), mirroring what #2692 added to the advanced index.

**3. Slim the `/api/bookings/get-all` endpoint**
The bulk "add to existing booking" picker renders only a name + date range and filters client-side, but the endpoint fetched the full booking index shape (asset/kit/custodian tree) plus a discarded `count`. Introduces `getMinimalBookings` (selects `id, name, status, from, to` only, no count). The DRAFT-visibility rule is extracted into a shared `bookingDraftVisibilityClause` so the slim and full list queries can't drift on that permission-sensitive predicate. The client type is narrowed to a `PickerBooking` `Pick<>` so nobody reads a field the endpoint no longer sends.

**4. Two composite indexes (same pattern as #2692's `Asset_organizationId_createdAt_id_idx`)**
- `Booking(organizationId, from, id)` — the bookings index default view (`WHERE organizationId ORDER BY from LIMIT n`). Booking previously had **only single-column indexes**, so each page scanned + sorted the workspace's booking history.
- `Scan(rawQrId, createdAt)` — serves `getScanByQrId` (the last-scan card on asset overview + kit detail). `rawQrId` had **no index**, so every one of those page views sequentially scanned the global, append-only `Scan` table.

## Verification
- `pnpm turbo typecheck` clean; `pnpm webapp:lint` clean (0 errors).
- Unit tests: 807 existing pass + 4 new (`getMinimalBookings` slim-select/default-status/custodian scope, and `bookingDraftVisibilityClause` shape).
- `prisma migrate diff` confirms the hand-written migration is byte-equivalent to what Prisma generates from the schema change.
- Ran a live dev server: bookings index renders correctly after the include delete, and `/api/bookings/get-all` returns exactly `{id,name,status,from,to}` (no `bookingAssets`).

## Notes / follow-ups
This is the "quick wins" slice of a broader audit applying the #2692 pattern. The larger rewrites are filed as separate issues:
- #2694 — audit module: paginate & slim `getAuditSessionDetails`
- #2695 — Reporting v2: paginate-first the report generators
- #2696 — slim unbounded collection loaders (calendar, activity feeds, CSV)
- #2697 — slim pickers/polled endpoints & remaining pagination-determinism gaps

Related: #2692


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The “Add to existing booking” flow now loads a lighter booking list for faster selection.

* **Bug Fixes**
  * Improved pagination reliability by adding a stable tie-breaker when multiple records share the same primary sort value (bookings, assets/kits, and report lists).
  * Enhanced booking visibility so draft bookings remain restricted to their creator while non-drafts stay broadly visible.

* **Chores**
  * Added database composite indexes to speed up common booking and scan lookup queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
