### PR TITLE
fix(bookings): correct multi-slice QT checkout (render, attribution, notes)

### DIFF
--- a/.claude/rules/sanitize-note-content-markdoc.md
+++ b/.claude/rules/sanitize-note-content-markdoc.md
@@ -1,0 +1,46 @@
+---
+description: User-supplied strings placed into note content (booking, audit, asset — anything rendered through Markdoc) must be sanitized against Markdoc-tag injection. Sanitize at write time.
+globs:
+  [
+    "apps/webapp/app/modules/**/service.server.ts",
+    "apps/webapp/app/modules/booking-note/**",
+    "apps/webapp/app/modules/audit/note-content.server.ts",
+    "apps/webapp/app/utils/markdoc-wrappers.ts",
+  ]
+---
+
+# Sanitize User Input in Markdoc-Rendered Notes
+
+Booking / audit / asset notes are stored as text and rendered through Markdoc
+(`MarkdownViewer` + `markdocConfig`). Any `{% … %}` in stored note content is
+parsed as a live Markdoc **tag** at render time, so a user-controlled string
+(kit name, a title used as literal text, unit of measure, free-form note body)
+spliced RAW into note content is a **stored XSS**: a value like
+`{% link to="javascript:alert(document.cookie)" /%}` renders as a live link that
+fires for anyone (incl. admins) who views the note. The repo contract is
+**sanitize-at-write** — the feed renders note content raw, so write-time
+stripping is what keeps injected tags out.
+
+When you splice ANY user-controlled string into note content:
+
+- Prefer a **wrapper** from `~/utils/markdoc-wrappers.ts` (`wrapLinkForNote`,
+  `wrapKitsWithDataForNote`, …) — they place the value inside a quoted, escaped
+  Markdoc attribute and never emit a raw tag.
+- If the value must appear as **literal text** (not inside a tag), strip the
+  delimiters first with `stripMarkdocDelimiters` (`~/modules/audit/note-content.server`).
+- A length/format check is NOT protection — `Kit.name`, `Asset.title`,
+  `unitOfMeasure`, note bodies have no `{`/`%`/`}` restriction.
+
+```ts
+// ❌ Bad — raw user input becomes a live Markdoc tag when the note renders
+content = `checked out (in kit ${kit.name})`;
+
+// ✅ Good — strip delimiters before splicing as literal text …
+content = `checked out (in kit ${stripMarkdocDelimiters(kit.name)})`;
+// … or wrap it in an escaped attribute
+content = `checked out (${wrapKitsWithDataForNote([kit], "checked out")})`;
+```
+
+Add a regression test asserting a value containing `{% … %}` can't inject a tag.
+When you find one unsanitized splice, grep sibling note builders — this class
+travels in packs (asset unit-of-measure and audit notes were prior instances).

--- a/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.test.tsx
+++ b/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.test.tsx
@@ -140,11 +140,27 @@ function makeLoaderData({
      * `bookedQuantity` the caller put on the selection item).
      */
     quantity?: number;
+    /**
+     * Kit-slice discriminator: `null`/omitted = standalone (free-pool) row;
+     * non-null = kit-driven row (matched against `asset.assetKits[].id`). The
+     * dialog's `assetsList` projection resolves `kit`/`kitId` from this.
+     */
+    assetKitId?: string | null;
     asset: {
       id: string;
       title: string;
       status: AssetStatus;
       type: AssetType;
+      /**
+       * AssetKit memberships surfaced on the asset. A kit-driven slice matches
+       * one via `assetKitId` to resolve its `kit`/`kitId`. Omitted for
+       * standalone-only assets.
+       */
+      assetKits?: Array<{
+        id: string;
+        kitId: string;
+        kit: { id: string; name: string };
+      }>;
     };
   }>;
   checkedOutAssetIds: string[];
@@ -254,6 +270,93 @@ describe("BulkPartialCheckoutDialog — QT partial top-off", () => {
     // `getByRole("button", ...)` would also match the dialog-backdrop's
     // role="button" wrapper (its accessible name includes nested text),
     // so query the named form-submit button directly.
+    const submit = document.querySelector<HTMLButtonElement>(
+      'button[type="submit"][name="intent"][value="partial-checkout"]'
+    );
+    expect(submit).not.toBeNull();
+    expect(submit).not.toBeDisabled();
+  });
+
+  it("renders a selected STANDALONE slice of a multi-slice QT asset (list not empty)", () => {
+    // Batteries: QT asset booked BOTH standalone (10 units, kitId null) and
+    // inside a kit (20 units, kitId kit-1) — two BookingAsset slices sharing
+    // one asset.id. The user selected ONLY the standalone slice. Before the
+    // fix, `assetsList` deduped by asset.id (kit slice won) and the flatten
+    // clobbered the standalone slice's kitId → the row rendered in NEITHER
+    // bucket (empty list). Now both slices survive and the standalone slice
+    // enriches correctly, so its row + qty input render.
+    const standaloneSlice: SelectedAssetRow = {
+      id: "battery-id",
+      title: "Batteries",
+      status: AssetStatus.AVAILABLE,
+      type: AssetType.QUANTITY_TRACKED,
+      bookingAssetId: "ba-standalone",
+      bookedQuantity: 10,
+      kitId: null,
+      thumbnailImage: null,
+      mainImage: null,
+      mainImageExpiration: null,
+      category: null,
+    };
+
+    useLoaderDataMock.mockReturnValue(
+      makeLoaderData({
+        bookingAssets: [
+          // Standalone slice — no assetKitId → kitId resolves to null.
+          {
+            id: "ba-standalone",
+            quantity: 10,
+            assetKitId: null,
+            asset: {
+              id: "battery-id",
+              title: "Batteries",
+              status: AssetStatus.AVAILABLE,
+              type: AssetType.QUANTITY_TRACKED,
+            },
+          },
+          // Kit-driven slice for the SAME asset id — must NOT collapse the
+          // standalone slice out of `assetsList`.
+          {
+            id: "ba-kit",
+            quantity: 20,
+            assetKitId: "ak-1",
+            asset: {
+              id: "battery-id",
+              title: "Batteries",
+              status: AssetStatus.AVAILABLE,
+              type: AssetType.QUANTITY_TRACKED,
+              assetKits: [
+                {
+                  id: "ak-1",
+                  kitId: "kit-1",
+                  kit: { id: "kit-1", name: "Kit" },
+                },
+              ],
+            },
+          },
+        ],
+        checkedOutAssetIds: [],
+        // Asset-level remaining across both slices (10 + 20).
+        remainingToCheckOutByAsset: { "battery-id": 30 },
+      })
+    );
+
+    seedSelection([standaloneSlice]);
+
+    renderDialog();
+
+    // The standalone slice renders — the list is NOT empty.
+    expect(screen.getByText("Batteries")).toBeInTheDocument();
+
+    // Its qty input is present, bounded by the standalone slice's booked units.
+    const qtyInput = screen.getByLabelText(
+      /checkout quantity/i
+    ) as HTMLInputElement;
+    expect(qtyInput).toBeInTheDocument();
+    expect(Number(qtyInput.max)).toBe(10);
+    expect(qtyInput.value).toBe("10");
+
+    // Submit is enabled — there is a slice to check out.
     const submit = document.querySelector<HTMLButtonElement>(
       'button[type="submit"][name="intent"][value="partial-checkout"]'
     );

--- a/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.tsx
+++ b/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.tsx
@@ -172,50 +172,48 @@ export default function BulkPartialCheckoutDialog({
 
   const rawSelectedItems = useAtomValue(selectedBulkItemsAtom);
 
-  // Denormalised, deduplicated asset list derived from the bookingAssets
-  // pivot. `booking.assets` no longer exists post-pivot, so we project the
-  // pivot rows down to one entry per asset id for `flattenSelectedBookingItems`
-  // (which keys lookups by asset id and merges fields into the selection).
+  // Denormalised asset list derived from the bookingAssets pivot — ONE entry
+  // per `BookingAsset` slice (NOT deduped by asset id). A QUANTITY_TRACKED
+  // asset can span multiple slices (standalone + kit-driven), and each slice
+  // must survive so `flattenSelectedBookingItems` (which keys its enrichment
+  // map by `bookingAssetId`) can enrich the exact selected slice. Deduping by
+  // asset.id used to collapse the two slices, clobbering the standalone
+  // slice's `kitId: null` with the kit slice's `kitId` → the row rendered in
+  // neither bucket (the multi-slice checkout bug). This mirrors the check-in
+  // dialog's un-deduped `assetsList`.
+  //
   // We spread the pivot's per-row fields onto each entry — `bookingAssetId`,
   // `bookedQuantity`, plus the row-level `kit`/`kitId` resolved through the
   // BookingAsset's `assetKitId` — so the flattened selection downstream has
-  // everything the qty picker and kit-grouping renderer need. Deduping by
-  // asset.id mirrors the lookup-by-id contract `flattenSelectedBookingItems`
-  // expects (later slices for the same asset are dropped). Memoised so its
+  // everything the qty picker and kit-grouping renderer need. Memoised so its
   // reference stays stable across renders while `booking.bookingAssets`
   // doesn't change — without this, the enriched-selection array would churn
   // → `qtySlices` would recompute → its consumer `useEffect` (which calls
   // `setQtyByBookingAssetId`) would fire on every render and trip React's
   // max-update-depth guard.
   const assetsList = useMemo<AssetWithStatus[]>(
-    () => [
-      ...new Map(
-        booking.bookingAssets.map((ba) => {
-          // Post-Phase-4a pivot: kit membership lives on `asset.assetKits[]`,
-          // not on `asset.kit` directly. When the row was booked under a
-          // specific kit slice, match it via `ba.assetKitId` so kit-driven
-          // rows surface `{ kit, kitId }` and standalone rows leave both
-          // null.
-          const matchedAssetKit = ba.assetKitId
-            ? ba.asset.assetKits?.find((ak) => ak.id === ba.assetKitId) ?? null
-            : null;
-          return [
-            ba.asset.id,
-            {
-              ...ba.asset,
-              bookingAssetId: ba.id,
-              // `?? 1` mirrors the overview loader's projection — defends
-              // against partial fixtures (component tests sometimes omit
-              // BookingAsset.quantity) so spreading this object doesn't
-              // overwrite a caller-supplied bookedQuantity with `undefined`.
-              bookedQuantity: ba.quantity ?? 1,
-              kitId: matchedAssetKit?.kitId ?? null,
-              kit: matchedAssetKit?.kit ?? null,
-            },
-          ];
-        })
-      ).values(),
-    ],
+    () =>
+      booking.bookingAssets.map((ba) => {
+        // Post-Phase-4a pivot: kit membership lives on `asset.assetKits[]`,
+        // not on `asset.kit` directly. When the row was booked under a
+        // specific kit slice, match it via `ba.assetKitId` so kit-driven
+        // rows surface `{ kit, kitId }` and standalone rows leave both
+        // null.
+        const matchedAssetKit = ba.assetKitId
+          ? ba.asset.assetKits?.find((ak) => ak.id === ba.assetKitId) ?? null
+          : null;
+        return {
+          ...ba.asset,
+          bookingAssetId: ba.id,
+          // `?? 1` mirrors the overview loader's projection — defends
+          // against partial fixtures (component tests sometimes omit
+          // BookingAsset.quantity) so spreading this object doesn't
+          // overwrite a caller-supplied bookedQuantity with `undefined`.
+          bookedQuantity: ba.quantity ?? 1,
+          kitId: matchedAssetKit?.kitId ?? null,
+          kit: matchedAssetKit?.kit ?? null,
+        };
+      }),
     [booking.bookingAssets]
   );
 

--- a/apps/webapp/app/modules/booking/checkout-attribution.test.ts
+++ b/apps/webapp/app/modules/booking/checkout-attribution.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { checkoutSessionsToLogsByAsset } from "./checkout-attribution";
+
+/**
+ * Unit tests for the positional-array checkout-session parser.
+ *
+ * These lock the positional `bookingAssetIds` contract (spec section D/F):
+ * `assetIds[i]` / `quantities[i]` / `bookingAssetIds[i]` describe the same
+ * slice; `""` and legacy short/empty arrays mean "greedy" (`bookingAssetId:
+ * null`); non-QT assets are excluded.
+ */
+describe("checkoutSessionsToLogsByAsset", () => {
+  it("attributes a tagged slice exactly to its bookingAssetId", () => {
+    const result = checkoutSessionsToLogsByAsset(
+      [
+        {
+          assetIds: ["asset-qt"],
+          quantities: [7],
+          bookingAssetIds: ["ba-standalone"],
+        },
+      ],
+      () => true
+    );
+
+    expect(result.get("asset-qt")).toEqual([
+      { bookingAssetId: "ba-standalone", quantity: 7 },
+    ]);
+  });
+
+  it("treats the empty-string sentinel as null (greedy)", () => {
+    const result = checkoutSessionsToLogsByAsset(
+      [
+        {
+          assetIds: ["asset-qt"],
+          quantities: [4],
+          bookingAssetIds: [""],
+        },
+      ],
+      () => true
+    );
+
+    expect(result.get("asset-qt")).toEqual([
+      { bookingAssetId: null, quantity: 4 },
+    ]);
+  });
+
+  it("treats a short/empty bookingAssetIds array as null per index (legacy rows)", () => {
+    const result = checkoutSessionsToLogsByAsset(
+      [
+        {
+          assetIds: ["asset-a", "asset-b"],
+          quantities: [2, 3],
+          // Legacy row: column absent → shorter than assetIds.
+          bookingAssetIds: [],
+        },
+      ],
+      () => true
+    );
+
+    expect(result.get("asset-a")).toEqual([
+      { bookingAssetId: null, quantity: 2 },
+    ]);
+    expect(result.get("asset-b")).toEqual([
+      { bookingAssetId: null, quantity: 3 },
+    ]);
+  });
+
+  it("skips non-QT assets", () => {
+    const qtAssetIds = new Set(["asset-qt"]);
+    const result = checkoutSessionsToLogsByAsset(
+      [
+        {
+          assetIds: ["asset-individual", "asset-qt"],
+          quantities: [1, 5],
+          bookingAssetIds: ["", "ba-kit"],
+        },
+      ],
+      (assetId) => qtAssetIds.has(assetId)
+    );
+
+    expect(result.has("asset-individual")).toBe(false);
+    expect(result.get("asset-qt")).toEqual([
+      { bookingAssetId: "ba-kit", quantity: 5 },
+    ]);
+  });
+
+  it("counts one unit per slice when quantities is misaligned with assetIds", () => {
+    const result = checkoutSessionsToLogsByAsset(
+      [
+        {
+          assetIds: ["asset-a", "asset-b"],
+          // Legacy INDIVIDUAL-only session: quantities not aligned 1:1.
+          quantities: [],
+          bookingAssetIds: ["", ""],
+        },
+      ],
+      () => true
+    );
+
+    expect(result.get("asset-a")).toEqual([
+      { bookingAssetId: null, quantity: 1 },
+    ]);
+    expect(result.get("asset-b")).toEqual([
+      { bookingAssetId: null, quantity: 1 },
+    ]);
+  });
+
+  it("accumulates logs for the same asset across multiple sessions", () => {
+    const result = checkoutSessionsToLogsByAsset(
+      [
+        {
+          assetIds: ["asset-qt"],
+          quantities: [10],
+          bookingAssetIds: ["ba-standalone"],
+        },
+        {
+          assetIds: ["asset-qt"],
+          quantities: [6],
+          bookingAssetIds: [""],
+        },
+      ],
+      () => true
+    );
+
+    expect(result.get("asset-qt")).toEqual([
+      { bookingAssetId: "ba-standalone", quantity: 10 },
+      { bookingAssetId: null, quantity: 6 },
+    ]);
+  });
+});

--- a/apps/webapp/app/modules/booking/checkout-attribution.ts
+++ b/apps/webapp/app/modules/booking/checkout-attribution.ts
@@ -1,0 +1,114 @@
+/**
+ * Checkout-session attribution parsing (pure, no DB access).
+ *
+ * `PartialBookingCheckout` persists a checkout session as three POSITIONAL
+ * arrays — `assetIds`, `quantities`, and `bookingAssetIds` — where index `i`
+ * of each describes the SAME booked slice. This module is the single source of
+ * truth for turning those raw sessions into per-asset checkout "logs" that the
+ * attribution layer (`attributeDispositionsByBookingAsset`) consumes, so every
+ * read site attributes identically instead of hand-rolling its own inline
+ * `{ bookingAssetId, quantity }` builder.
+ *
+ * Positional-array contract (INVARIANT): `assetIds[i]`, `quantities[i]`, and
+ * `bookingAssetIds[i]` all describe the same slice. Because Prisma `String[]`
+ * cannot store `null`, the empty string `""` is the sentinel for "no specific
+ * slice known → attribute greedily". Legacy rows written before the
+ * `bookingAssetIds` column existed carry a missing/short array, which the
+ * parser also treats as "greedy" (per-index fallback to `null`).
+ *
+ * @see {@link file://./service.server.ts} attributeDispositionsByBookingAsset — consumer of these logs
+ * @see docs/superpowers/specs/2026-07-03-multislice-qt-checkout-fix-design.md sections D + F
+ */
+
+/**
+ * One raw persisted checkout session, as stored on `PartialBookingCheckout`.
+ *
+ * The three arrays are positional (see module docs): element `i` of each
+ * refers to the same booked slice.
+ */
+export type CheckoutSession = {
+  /** Asset ids checked out in this session (positional with the others). */
+  assetIds: string[];
+  /**
+   * Units checked out per slice. When aligned with `assetIds` (same length),
+   * `quantities[i]` is the count for `assetIds[i]`; otherwise each slice
+   * counts as a single unit (legacy INDIVIDUAL-only sessions).
+   */
+  quantities: number[];
+  /**
+   * Per-slice `BookingAsset.id`, or `""` when the writer did not know the
+   * exact slice (greedy). A missing/short array (legacy rows) is treated the
+   * same as all-`""`.
+   */
+  bookingAssetIds: string[];
+};
+
+/** A single checkout log attributed to (at most) a specific BookingAsset slice. */
+export type CheckoutAttributionLog = {
+  /**
+   * The exact `BookingAsset.id` this checkout belongs to, or `null` when the
+   * slice is unknown and the consumer should greedy-fill.
+   */
+  bookingAssetId: string | null;
+  /** Units checked out. */
+  quantity: number;
+};
+
+/**
+ * Parse persisted `PartialBookingCheckout` sessions into per-asset checkout
+ * logs, honoring the positional `bookingAssetIds` contract.
+ *
+ * For each session, each positional index `i` is processed independently:
+ * - Non-QUANTITY_TRACKED assets are skipped (attribution is a QT-only concern;
+ *   INDIVIDUAL assets are reconciled by presence, not by counted units).
+ * - `quantity` is `quantities[i]` when the `quantities` array is aligned with
+ *   `assetIds` (equal length), falling back to `1` when it is not (legacy
+ *   sessions) or when the element itself is missing.
+ * - `bookingAssetId` is `bookingAssetIds[i] || null`, so both the `""`
+ *   sentinel AND a missing/short array element collapse to `null` → the
+ *   consumer greedy-fills that log.
+ *
+ * @param sessions - Raw persisted checkout sessions (positional arrays).
+ * @param isQtyAsset - Predicate: is this asset id QUANTITY_TRACKED? Non-QT
+ *   assets are excluded from the output.
+ * @returns Map keyed by `assetId` → the list of attribution logs for that
+ *   asset across all sessions. QT assets that never appear are absent from the
+ *   map.
+ */
+export function checkoutSessionsToLogsByAsset(
+  sessions: CheckoutSession[],
+  isQtyAsset: (assetId: string) => boolean
+): Map<string, CheckoutAttributionLog[]> {
+  const logsByAsset = new Map<string, CheckoutAttributionLog[]>();
+
+  for (const session of sessions) {
+    // Default each positional array to `[]` so a legacy/partial row that never
+    // wrote `quantities` or `bookingAssetIds` (the column post-dates the row)
+    // is treated as all-greedy rather than throwing on a missing array — the
+    // "missing/short array" case this parser documents as supported.
+    const assetIds = session.assetIds ?? [];
+    const quantities = session.quantities ?? [];
+    const bookingAssetIds = session.bookingAssetIds ?? [];
+    // `quantities` is only trustworthy per-index when it lines up 1:1 with
+    // `assetIds`; a misaligned/absent array means "one unit per slice".
+    const quantitiesAligned = quantities.length === assetIds.length;
+
+    for (let i = 0; i < assetIds.length; i++) {
+      const assetId = assetIds[i];
+      if (!isQtyAsset(assetId)) continue;
+
+      const quantity = quantitiesAligned ? quantities[i] ?? 1 : 1;
+      // `""` (sentinel) AND a missing/short element both fall through to null.
+      const bookingAssetId = bookingAssetIds[i] || null;
+
+      const existing = logsByAsset.get(assetId);
+      if (existing) {
+        existing.push({ bookingAssetId, quantity });
+      } else {
+        logsByAsset.set(assetId, [{ bookingAssetId, quantity }]);
+      }
+    }
+  }
+
+  return logsByAsset;
+}

--- a/apps/webapp/app/modules/booking/checkout-attribution.ts
+++ b/apps/webapp/app/modules/booking/checkout-attribution.ts
@@ -59,8 +59,12 @@ export type CheckoutAttributionLog = {
  * logs, honoring the positional `bookingAssetIds` contract.
  *
  * For each session, each positional index `i` is processed independently:
- * - Non-QUANTITY_TRACKED assets are skipped (attribution is a QT-only concern;
- *   INDIVIDUAL assets are reconciled by presence, not by counted units).
+ * - An index is included only when `isQtyAsset(assetIds[i])` is true. Callers
+ *   normally pass a QT check (attribution is a QT-only concern, and INDIVIDUAL
+ *   assets are reconciled by presence, not counted units), so non-QT assets are
+ *   skipped — but the predicate is the sole gate: a caller MAY pass a broader
+ *   predicate (e.g. `() => true`, or one scoped to a single assetId) to keep
+ *   whichever assets it needs.
  * - `quantity` is `quantities[i]` when the `quantities` array is aligned with
  *   `assetIds` (equal length), falling back to `1` when it is not (legacy
  *   sessions) or when the element itself is missing.
@@ -69,8 +73,9 @@ export type CheckoutAttributionLog = {
  *   consumer greedy-fills that log.
  *
  * @param sessions - Raw persisted checkout sessions (positional arrays).
- * @param isQtyAsset - Predicate: is this asset id QUANTITY_TRACKED? Non-QT
- *   assets are excluded from the output.
+ * @param isQtyAsset - Inclusion predicate applied per index: an entry whose
+ *   `assetId` returns `false` is skipped. Callers usually pass a
+ *   QUANTITY_TRACKED check, but any predicate is honored (see above).
  * @returns Map keyed by `assetId` → the list of attribution logs for that
  *   asset across all sessions. QT assets that never appear are absent from the
  *   map.

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -47,7 +47,15 @@ afterAll(() => {
 // is the per-test escape hatch invoked from `beforeEach`.
 vitest.mock("~/database/db.server", () => {
   // eslint-disable-next-line prefer-const -- reassigned by __resetPbcState
-  let _pbcSessions: Array<{ assetIds: string[]; quantities: number[] }> = [];
+  let _pbcSessions: Array<{
+    assetIds: string[];
+    quantities: number[];
+    // Positional with `assetIds`/`quantities`: the exact `BookingAsset.id` a
+    // slice was checked out from (or `""`/absent for greedy). Tracked so the
+    // in-tx round-trip reads (via `checkoutSessionsToLogsByAsset`) attribute
+    // per-slice exactly the way production does.
+    bookingAssetIds: string[];
+  }> = [];
   return {
     db: {
       $transaction: vitest
@@ -141,6 +149,9 @@ vitest.mock("~/database/db.server", () => {
           _pbcSessions.push({
             assetIds: Array.isArray(data.assetIds) ? data.assetIds : [],
             quantities: Array.isArray(data.quantities) ? data.quantities : [],
+            bookingAssetIds: Array.isArray(data.bookingAssetIds)
+              ? data.bookingAssetIds
+              : [],
           });
           return Promise.resolve({ id: `pbc-${_pbcSessions.length}` });
         }),
@@ -167,12 +178,19 @@ vitest.mock("~/database/db.server", () => {
       // "prior session(s) already claimed X units" without overriding
       // `.findMany` (which would replace the stateful impl).
       __seedPbcSessions: (
-        sessions: Array<{ assetIds: string[]; quantities: number[] }>
+        sessions: Array<{
+          assetIds: string[];
+          quantities: number[];
+          // Optional: legacy seeds omit it (→ all-greedy); per-slice tests
+          // pass exact `BookingAsset.id`s positional with `assetIds`.
+          bookingAssetIds?: string[];
+        }>
       ) => {
         for (const s of sessions) {
           _pbcSessions.push({
             assetIds: [...s.assetIds],
             quantities: [...s.quantities],
+            bookingAssetIds: s.bookingAssetIds ? [...s.bookingAssetIds] : [],
           });
         }
       },
@@ -189,6 +207,9 @@ vitest.mock("~/database/db.server", () => {
           _pbcSessions.push({
             assetIds: Array.isArray(data.assetIds) ? data.assetIds : [],
             quantities: Array.isArray(data.quantities) ? data.quantities : [],
+            bookingAssetIds: Array.isArray(data.bookingAssetIds)
+              ? data.bookingAssetIds
+              : [],
           });
           return Promise.resolve({ id: `pbc-${_pbcSessions.length}` });
         });
@@ -376,13 +397,15 @@ describe("partialCheckoutBooking", () => {
     });
 
     // why: Wave B writes positionally-aligned quantities[] alongside assetIds[];
-    // legacy INDIVIDUAL-only payloads use 1 per id.
+    // legacy INDIVIDUAL-only payloads use 1 per id. `bookingAssetIds` is also
+    // positional — INDIVIDUAL dispositions carry no slice tag, so `""`.
     expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
         assetIds: ["asset-1"],
         quantities: [1],
+        bookingAssetIds: [""],
         checkoutCount: 1,
       },
       select: { id: true },
@@ -429,6 +452,7 @@ describe("partialCheckoutBooking", () => {
         checkedOutById: "user-1",
         assetIds: ["asset-1", "asset-2"],
         quantities: [1, 1],
+        bookingAssetIds: ["", ""],
         checkoutCount: 2,
       },
       select: { id: true },
@@ -606,13 +630,14 @@ describe("partialCheckoutBooking", () => {
     // the read helpers see every checked-out asset), then delegates to the full
     // checkout. Wave B added positionally-aligned `quantities[]` to the
     // delegate-path write too — INDIVIDUAL outstanding ids carry implicit
-    // qty=1 per slot.
+    // qty=1 per slot and no slice tag (`""`).
     expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
         assetIds: ["asset-1"],
         quantities: [1],
+        bookingAssetIds: [""],
         checkoutCount: 1,
       },
     });
@@ -923,12 +948,14 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     );
 
     // PartialBookingCheckout row records the exact slice: aligned arrays.
+    // `bookingAssetIds` carries the QT disposition's slice tag positionally.
     expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
         assetIds: ["asset-qty-1"],
         quantities: [5],
+        bookingAssetIds: ["ba-qty-1"],
         checkoutCount: 1,
       },
       select: { id: true },
@@ -964,16 +991,338 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
       data: { status: AssetStatus.CHECKED_OUT },
     });
 
-    // Session row records the full 50 units against the same assetId.
+    // Session row records the full 50 units against the same assetId, tagged
+    // to the exact slice via `bookingAssetIds`.
     expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
         assetIds: ["asset-qty-1"],
         quantities: [50],
+        bookingAssetIds: ["ba-qty-1"],
         checkoutCount: 1,
       },
       select: { id: true },
+    });
+  });
+
+  it("records BOTH slices of a same-asset multi-slice checkout positionally (standalone + kit in one session)", async () => {
+    expect.assertions(2);
+
+    // The canonical "batteries" case the whole feature exists for: ONE
+    // QUANTITY_TRACKED asset booked as TWO BookingAsset slices — a standalone
+    // slice (ba-standalone, 10) and a kit-driven slice (ba-kit, 20) — checked
+    // out together in a single session with distinct per-slice quantities.
+    // ONGOING so we stay in the partial path (RESERVED would delegate to the
+    // full checkout) and observe the main `partialBookingCheckout.create`.
+    const multiSliceBooking = {
+      ...qtyOnlyBooking,
+      status: BookingStatus.ONGOING,
+      _count: { bookingAssets: 2 },
+      bookingAssets: [
+        {
+          id: "ba-standalone",
+          quantity: 10,
+          asset: {
+            id: "asset-battery",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Batteries",
+            unitOfMeasure: null,
+            assetKits: [],
+          },
+        },
+        {
+          id: "ba-kit",
+          quantity: 20,
+          asset: {
+            id: "asset-battery",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Batteries",
+            unitOfMeasure: null,
+            assetKits: [{ kitId: "kit-1" }],
+          },
+        },
+      ],
+    };
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue(multiSliceBooking);
+
+    // Booked total across both slices = 10 + 20 = 30 (asset-level remaining).
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([{ quantity: 10 }, { quantity: 20 }]);
+    // why: the per-slice cap read (`computeBookingAssetSliceRemaining`) returns
+    // the same shape for every slice in this mock; 20 is >= both claims so
+    // neither slice trips its cap.
+    (
+      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({ quantity: 20 });
+    // why: the qty loop locks the asset per disposition; return the battery.
+    (
+      quantityLock.lockAssetForQuantityUpdate as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      id: "asset-battery",
+      title: "Batteries",
+      type: AssetType.QUANTITY_TRACKED,
+      unitOfMeasure: null,
+      quantity: 30,
+    });
+
+    await partialCheckoutBooking({
+      ...baseParams,
+      checkouts: [
+        {
+          assetId: "asset-battery",
+          bookingAssetId: "ba-standalone",
+          quantity: 3,
+        },
+        { assetId: "asset-battery", bookingAssetId: "ba-kit", quantity: 4 },
+      ],
+    });
+
+    // Positional contract: the SAME assetId appears twice, once per slice,
+    // and `bookingAssetIds[i]` names the exact slice checked out at index i.
+    // A regression that collapsed same-asset dispositions (e.g. keyed by
+    // assetId) would drop one slice's tag/qty here.
+    expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
+      data: {
+        bookingId: "booking-1",
+        checkedOutById: "user-1",
+        assetIds: ["asset-battery", "asset-battery"],
+        quantities: [3, 4],
+        bookingAssetIds: ["ba-standalone", "ba-kit"],
+        checkoutCount: 2,
+      },
+      select: { id: true },
+    });
+
+    // 7 of 30 claimed → asset stays AVAILABLE (no full-claim status flip).
+    expect(db.asset.updateMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { status: AssetStatus.CHECKED_OUT },
+      })
+    );
+  });
+
+  /**
+   * Layer 3 — per-slice checkout NOTES. A QUANTITY_TRACKED asset ("Gloves")
+   * booked as TWO slices on the "Melones" booking: standalone (22) + kit-driven
+   * (100, kit "Kittington"). The checkout note must attribute each slice
+   * per-slice ("standalone" / "in kit Kittington") with SLICE-level counts, not
+   * fold both into the whole-asset total. These are the exact scenarios from
+   * the live bug report.
+   */
+  describe("Layer 3 per-slice checkout note", () => {
+    /** Grab the "performed a partial check-out" system note content. */
+    const partialCheckoutNoteContent = (): string | undefined =>
+      (createSystemBookingNote as ReturnType<typeof vitest.fn>).mock.calls
+        .map((call) => call[0].content as string)
+        .find((content) => content.includes("performed a partial check-out"));
+
+    /** The asset's kit membership (an AssetKit row) — shared by both slices. */
+    const glovesKitMembership = {
+      id: "ak-kittington",
+      kitId: "kit-1",
+      kit: { name: "Kittington" },
+    };
+
+    /** Build a fresh two-slice "Melones/Gloves" booking (ONGOING, boxes). */
+    const makeGlovesBooking = () => ({
+      id: "booking-1",
+      name: "Melones",
+      status: BookingStatus.ONGOING,
+      organizationId: "org-1",
+      custodianUserId: "user-1",
+      custodianTeamMemberId: null,
+      from: futureFrom,
+      to: futureTo,
+      _count: { bookingAssets: 2 },
+      bookingAssets: [
+        {
+          id: "ba-standalone",
+          quantity: 22,
+          assetKitId: null,
+          asset: {
+            id: "asset-gloves",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Gloves",
+            unitOfMeasure: "boxes",
+            assetKits: [glovesKitMembership],
+          },
+        },
+        {
+          id: "ba-kit",
+          quantity: 100,
+          assetKitId: "ak-kittington",
+          asset: {
+            id: "asset-gloves",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Gloves",
+            unitOfMeasure: "boxes",
+            assetKits: [glovesKitMembership],
+          },
+        },
+      ],
+    });
+
+    beforeEach(() => {
+      // Asset-level booked total across both slices = 22 + 100 = 122.
+      (
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue([{ quantity: 22 }, { quantity: 100 }]);
+      // Per-slice cap reads (`computeBookingAssetSliceRemaining`) resolve each
+      // slice's booked quantity by id; no prior consumption → full cap.
+      (
+        db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+      ).mockImplementation((args?: { where?: { id?: string } }) => {
+        const sliceId = args?.where?.id;
+        if (sliceId === "ba-standalone") {
+          return Promise.resolve({ id: sliceId, quantity: 22 });
+        }
+        if (sliceId === "ba-kit") {
+          return Promise.resolve({ id: sliceId, quantity: 100 });
+        }
+        return Promise.resolve(null);
+      });
+      // The qty loop locks the asset per disposition; return Gloves (boxes).
+      (
+        quantityLock.lockAssetForQuantityUpdate as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue({
+        id: "asset-gloves",
+        title: "Gloves",
+        type: AssetType.QUANTITY_TRACKED,
+        unitOfMeasure: "boxes",
+        quantity: 122,
+      });
+    });
+
+    it("names a standalone qty slice per-slice and drops the redundant asset mention", async () => {
+      expect.assertions(3);
+
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(makeGlovesBooking());
+      // In-tx kit-info read: Gloves with NO complete kit named, so the note's
+      // items-description is purely the qty asset → the redundancy fix renders
+      // the per-slice fragment as the whole description (no "— qty:" tail).
+      (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+        (args?: { where?: { id?: { in?: string[] } } }) => {
+          const ids = args?.where?.id?.in ?? [];
+          return Promise.resolve(
+            ids.map((id) => ({
+              id,
+              title: "Gloves",
+              status: AssetStatus.AVAILABLE,
+              bookingAssets: [],
+              assetKits: [],
+            }))
+          );
+        }
+      );
+
+      // Check out 11 of the 22-box STANDALONE slice only.
+      await partialCheckoutBooking({
+        ...baseParams,
+        checkouts: [
+          {
+            assetId: "asset-gloves",
+            bookingAssetId: "ba-standalone",
+            quantity: 11,
+          },
+        ],
+      });
+
+      const note = partialCheckoutNoteContent();
+      // Per-slice standalone wording with the slice's own booked total (22) and
+      // slice-level remaining (11), NOT the whole asset's 122/111.
+      expect(note).toContain(
+        "· standalone (11 of 22 boxes checked out, 11 still booked)"
+      );
+      // Redundancy fix: no duplicated "{asset} — qty: {asset} ·" phrasing.
+      expect(note).not.toContain("— qty:");
+      // Standalone slice is not labelled as a kit member.
+      expect(note).not.toContain("in kit");
+    });
+
+    it("labels a kit-driven qty slice and omits 'still booked' when the slice is fully out", async () => {
+      expect.assertions(2);
+
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(makeGlovesBooking());
+      // In-tx kit-info read returns Gloves' kit so the note also names the kit;
+      // the per-slice qty fragment must still label the slice "in kit ...".
+      (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+        (args?: { where?: { id?: { in?: string[] } } }) => {
+          const ids = args?.where?.id?.in ?? [];
+          return Promise.resolve(
+            ids.map((id) => ({
+              id,
+              title: "Gloves",
+              status: AssetStatus.AVAILABLE,
+              bookingAssets: [],
+              assetKits: [{ kit: { id: "kit-1", name: "Kittington" } }],
+            }))
+          );
+        }
+      );
+
+      // Check out all 100 boxes of the KIT-driven slice.
+      await partialCheckoutBooking({
+        ...baseParams,
+        checkouts: [
+          { assetId: "asset-gloves", bookingAssetId: "ba-kit", quantity: 100 },
+        ],
+      });
+
+      const note = partialCheckoutNoteContent();
+      // Kit slice labelled + slice-level totals; fully out → no "still booked".
+      expect(note).toContain(
+        "· in kit Kittington (100 of 100 boxes checked out)"
+      );
+      expect(note).not.toContain("still booked");
+    });
+
+    it("falls back to asset-level phrasing for a legacy untagged qty checkout", async () => {
+      expect.assertions(3);
+
+      // Single-slice qty booking; disposition carries NO bookingAssetId (the
+      // scanner / legacy path) → the note keeps the pre-Layer-3 phrasing.
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue({
+        ...qtyOnlyBooking,
+        status: BookingStatus.ONGOING,
+      });
+      (
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue([{ quantity: 50 }]);
+      (
+        quantityLock.lockAssetForQuantityUpdate as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue({
+        id: "asset-qty-1",
+        title: "Pens",
+        type: AssetType.QUANTITY_TRACKED,
+        unitOfMeasure: "boxes",
+        quantity: 50,
+      });
+
+      // No `bookingAssetId` → legacy / greedy disposition.
+      await partialCheckoutBooking({
+        ...baseParams,
+        checkouts: [{ assetId: "asset-qty-1", quantity: 5 }],
+      });
+
+      const note = partialCheckoutNoteContent();
+      // Asset-level fallback: unit-labelled on BOTH counts, no slice label.
+      expect(note).toContain("(5 boxes checked out, 45 boxes still booked)");
+      expect(note).not.toContain("· standalone");
+      expect(note).not.toContain("· in kit");
     });
   });
 
@@ -1040,13 +1389,15 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
 
     // Session row records both rows positionally: qty disposition first
     // (iteration order matches `dispositions[]`: checkouts before assetIds
-    // fallback), INDIVIDUAL gets implicit 1.
+    // fallback), INDIVIDUAL gets implicit 1. `bookingAssetIds` is positional
+    // too: the QT slice carries its tag, the INDIVIDUAL fallback carries `""`.
     expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
         assetIds: ["asset-qty-1", "asset-ind-1"],
         quantities: [10, 1],
+        bookingAssetIds: ["ba-qty-1", ""],
         checkoutCount: 2,
       },
       select: { id: true },
@@ -1225,13 +1576,15 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
       ],
     });
 
-    // A new top-off PBC row was written with the exact claimed quantity.
+    // A new top-off PBC row was written with the exact claimed quantity, tagged
+    // to the exact slice via `bookingAssetIds`.
     expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
         assetIds: ["asset-qty-1"],
         quantities: [10],
+        bookingAssetIds: ["ba-qty-1"],
         checkoutCount: 1,
       },
       select: { id: true },
@@ -1543,42 +1896,28 @@ describe("computeBookingAssetSliceRemainingToCheckOut", () => {
     expect(remaining).toBe(50);
   });
 
-  it("attributes the asset's claim pool to the kit-driven slice first (greedy fill mirrors loader)", async () => {
+  it("attributes an UNTAGGED (legacy) claim pool standalone-slice first (greedy fill mirrors loader)", async () => {
     expect.assertions(2);
 
     // Same QT asset booked twice: once as part of a kit (40 units) and once
     // standalone (10 units), total 50. Prior session claimed 30 units of the
-    // asset — the greedy fill rule (kit-driven first, then standalone) means
-    // the kit slice has 10 remaining and the standalone slice still has 10.
+    // asset with NO per-slice tag (legacy row: empty `bookingAssetIds`). The
+    // greedy fill rule is STANDALONE-first (loose items are scanned
+    // individually; kits are handled as a whole), so the standalone slice
+    // (10 cap) drains fully first and the kit slice absorbs the overflow 20.
     (
       db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
     ).mockResolvedValue([
       { id: "ba-kit", quantity: 40, assetKitId: "kit-1" },
       { id: "ba-standalone", quantity: 10, assetKitId: null },
     ]);
+    // Legacy seed — no `bookingAssetIds` → the whole 30-unit pool is greedy.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (db as any).__seedPbcSessions?.([
       { assetIds: ["asset-qty-1"], quantities: [30] },
     ]);
 
-    // Probe the kit-driven slice: it should be filled first.
-    (
-      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
-    ).mockResolvedValueOnce({
-      id: "ba-kit",
-      assetId: "asset-qty-1",
-      quantity: 40,
-      assetKitId: "kit-1",
-    });
-    const kitSliceRemaining = await computeBookingAssetSliceRemainingToCheckOut(
-      db,
-      "booking-1",
-      "ba-kit"
-    );
-    expect(kitSliceRemaining).toBe(10);
-
-    // Probe the standalone slice: untouched by the 30-unit claim because the
-    // kit slice (40-unit capacity) absorbs it all.
+    // Probe the standalone slice: filled first → fully drained (10 − 10 = 0).
     (
       db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
     ).mockResolvedValueOnce({
@@ -1593,7 +1932,142 @@ describe("computeBookingAssetSliceRemainingToCheckOut", () => {
         "booking-1",
         "ba-standalone"
       );
-    expect(standaloneSliceRemaining).toBe(10);
+    expect(standaloneSliceRemaining).toBe(0);
+
+    // Probe the kit-driven slice: absorbs the remaining 20 of the pool after
+    // the standalone slice fills (40 − 20 = 20 remaining).
+    (
+      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce({
+      id: "ba-kit",
+      assetId: "asset-qty-1",
+      quantity: 40,
+      assetKitId: "kit-1",
+    });
+    const kitSliceRemaining = await computeBookingAssetSliceRemainingToCheckOut(
+      db,
+      "booking-1",
+      "ba-kit"
+    );
+    expect(kitSliceRemaining).toBe(20);
+  });
+
+  it("credits a checkout TAGGED to the standalone slice's bookingAssetId to that exact slice (kit row stays 0)", async () => {
+    expect.assertions(2);
+
+    // The batteries case: a QUANTITY_TRACKED asset booked BOTH inside a kit
+    // (ba-kit, 20 units) AND standalone (ba-standalone, 10 spares). The
+    // operator checks out the 10 loose spares — the dialog tags the checkout
+    // with the STANDALONE slice's `bookingAssetId`. Per-slice attribution must
+    // credit the standalone slice EXACTLY (remaining 0) and leave the kit slice
+    // fully outstanding (remaining 20), NOT pool-and-greedy the two.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { id: "ba-kit", quantity: 20, assetKitId: "kit-1" },
+      { id: "ba-standalone", quantity: 10, assetKitId: null },
+    ]);
+    // Tagged session: 10 units checked out against the standalone slice.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db as any).__seedPbcSessions?.([
+      {
+        assetIds: ["asset-batt"],
+        quantities: [10],
+        bookingAssetIds: ["ba-standalone"],
+      },
+    ]);
+
+    // Standalone slice: exactly credited → 10 − 10 = 0 remaining.
+    (
+      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce({
+      id: "ba-standalone",
+      assetId: "asset-batt",
+      quantity: 10,
+      assetKitId: null,
+    });
+    const standaloneRemaining =
+      await computeBookingAssetSliceRemainingToCheckOut(
+        db,
+        "booking-1",
+        "ba-standalone"
+      );
+    expect(standaloneRemaining).toBe(0);
+
+    // Kit slice: untouched by the standalone-tagged checkout → full 20 remain.
+    // (Under the OLD pool-and-greedy path this would have been credited first,
+    // wrongly showing the kit as partially checked out.)
+    (
+      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce({
+      id: "ba-kit",
+      assetId: "asset-batt",
+      quantity: 20,
+      assetKitId: "kit-1",
+    });
+    const kitRemaining = await computeBookingAssetSliceRemainingToCheckOut(
+      db,
+      "booking-1",
+      "ba-kit"
+    );
+    expect(kitRemaining).toBe(20);
+  });
+
+  it("credits a checkout TAGGED to the kit slice to the kit exactly, beating the standalone-first greedy default", async () => {
+    expect.assertions(2);
+
+    // Disambiguates exact-tagging from greedy coincidence: an UNTAGGED pool of
+    // 5 would greedy-fill the STANDALONE slice first. Here the checkout is
+    // tagged to the KIT slice, so the kit must be credited (remaining 15) and
+    // the standalone left fully outstanding (remaining 10) — proving the exact
+    // `bookingAssetId` wins over the standalone-first default.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { id: "ba-kit", quantity: 20, assetKitId: "kit-1" },
+      { id: "ba-standalone", quantity: 10, assetKitId: null },
+    ]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db as any).__seedPbcSessions?.([
+      {
+        assetIds: ["asset-batt"],
+        quantities: [5],
+        bookingAssetIds: ["ba-kit"],
+      },
+    ]);
+
+    // Kit slice: exactly credited → 20 − 5 = 15 remaining.
+    (
+      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce({
+      id: "ba-kit",
+      assetId: "asset-batt",
+      quantity: 20,
+      assetKitId: "kit-1",
+    });
+    const kitRemaining = await computeBookingAssetSliceRemainingToCheckOut(
+      db,
+      "booking-1",
+      "ba-kit"
+    );
+    expect(kitRemaining).toBe(15);
+
+    // Standalone slice: untouched despite being the greedy-preferred bucket.
+    (
+      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce({
+      id: "ba-standalone",
+      assetId: "asset-batt",
+      quantity: 10,
+      assetKitId: null,
+    });
+    const standaloneRemaining =
+      await computeBookingAssetSliceRemainingToCheckOut(
+        db,
+        "booking-1",
+        "ba-standalone"
+      );
+    expect(standaloneRemaining).toBe(10);
   });
 
   it("returns 0 when the slice is missing (defensive)", async () => {
@@ -1775,12 +2249,15 @@ describe("getRemainingCheckoutPayload", () => {
 
     // Session row records the top-off 45 units against the same assetId,
     // proving the partially-checked-out QT slice was successfully drained.
+    // The disposition (from getRemainingCheckoutPayload) carries the slice tag,
+    // so `bookingAssetIds` records it positionally.
     expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
       data: {
         bookingId: "booking-1",
         checkedOutById: "user-1",
         assetIds: ["asset-pencils"],
         quantities: [45],
+        bookingAssetIds: ["ba-qty-1"],
         checkoutCount: 1,
       },
       select: { id: true },

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -1324,6 +1324,101 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
       expect(note).not.toContain("· standalone");
       expect(note).not.toContain("· in kit");
     });
+
+    it("rejects (and persists nothing) a checkout tagged with a bookingAssetId that is not a slice of the asset on this booking", async () => {
+      // P2 review fix: `bookingAssetId` is caller-supplied and now load-bearing
+      // (exact per-slice attribution). A stale/forged slice id must be rejected
+      // before it is used for caps or stored, or it would credit the wrong
+      // slice and corrupt per-slice remaining + notes.
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(makeGlovesBooking());
+
+      await expect(
+        partialCheckoutBooking({
+          ...baseParams,
+          checkouts: [
+            {
+              assetId: "asset-gloves",
+              // Not one of this booking's slices (ba-standalone / ba-kit).
+              bookingAssetId: "ba-forged",
+              quantity: 5,
+            },
+          ],
+        })
+      ).rejects.toThrow(/Invalid booking asset slice/);
+
+      expect(db.partialBookingCheckout.create).not.toHaveBeenCalled();
+    });
+
+    it("caps a per-slice checkout by the slice's OWN checkout remaining, not the check-in remaining (no cross-session over-claim)", async () => {
+      // P1 review fix: the per-slice cap must subtract prior
+      // PartialBookingCheckout claims on THIS slice. With 20 of the standalone
+      // slice's 22 already out (and the sibling kit slice still full), the
+      // asset-level cap stays high (102) but the standalone slice only has 2
+      // left — a 22-unit re-scan of the standalone must be rejected.
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(makeGlovesBooking());
+
+      // Prior session: 20 boxes of the STANDALONE slice already checked out.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (db as any).__seedPbcSessions?.([
+        {
+          assetIds: ["asset-gloves"],
+          quantities: [20],
+          bookingAssetIds: ["ba-standalone"],
+        },
+      ]);
+
+      // The checkout-side slice-remaining helper needs each slice's assetId +
+      // assetKitId (to pool prior claims across siblings via the attributor).
+      (
+        db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+      ).mockImplementation((args?: { where?: { id?: string } }) => {
+        const sliceId = args?.where?.id;
+        if (sliceId === "ba-standalone") {
+          return Promise.resolve({
+            id: sliceId,
+            assetId: "asset-gloves",
+            quantity: 22,
+            assetKitId: null,
+          });
+        }
+        if (sliceId === "ba-kit") {
+          return Promise.resolve({
+            id: sliceId,
+            assetId: "asset-gloves",
+            quantity: 100,
+            assetKitId: "ak-kittington",
+          });
+        }
+        return Promise.resolve(null);
+      });
+      // Both slices of the asset, for the attributor's full slice set.
+      (
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue([
+        { id: "ba-standalone", quantity: 22, assetKitId: null },
+        { id: "ba-kit", quantity: 100, assetKitId: "ak-kittington" },
+      ]);
+
+      await expect(
+        partialCheckoutBooking({
+          ...baseParams,
+          checkouts: [
+            {
+              assetId: "asset-gloves",
+              bookingAssetId: "ba-standalone",
+              quantity: 22,
+            },
+          ],
+        })
+      ).rejects.toThrow(/Only 2 boxes left to check out/);
+
+      // The over-claim never reaches persistence.
+      expect(db.partialBookingCheckout.create).not.toHaveBeenCalled();
+    });
   });
 
   it("multi-asset mixed (INDIVIDUAL + qty) routes each through its own path", async () => {

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -1419,6 +1419,56 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
       // The over-claim never reaches persistence.
       expect(db.partialBookingCheckout.create).not.toHaveBeenCalled();
     });
+
+    it("strips Markdoc delimiters from a malicious Kit.name so it cannot inject a live tag into the checkout note (stored XSS guard)", async () => {
+      // Kit.name is free-form user input and the note is rendered through
+      // Markdoc; an unsanitized name could smuggle a `{% link %}` tag (stored
+      // XSS). The per-slice label must strip Markdoc delimiters.
+      const evilKitName =
+        'Kittington{% link to="javascript:alert(1)" text="x" /%}';
+      const booking = makeGlovesBooking();
+      // Poison the kit slice's (index 1 = ba-kit) kit name.
+      booking.bookingAssets[1].asset.assetKits = [
+        { id: "ak-kittington", kitId: "kit-1", kit: { name: evilKitName } },
+      ];
+      (
+        db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue(booking);
+      // In-tx kit-info read: no complete kit named, so the note's items body is
+      // the per-slice fragment (which carries the kit label under test).
+      (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+        (args?: { where?: { id?: { in?: string[] } } }) => {
+          const ids = args?.where?.id?.in ?? [];
+          return Promise.resolve(
+            ids.map((id) => ({
+              id,
+              title: "Gloves",
+              status: AssetStatus.AVAILABLE,
+              bookingAssets: [],
+              assetKits: [],
+            }))
+          );
+        }
+      );
+
+      // Check out 50 of the 100-box KIT slice → the note labels it "in kit …".
+      await partialCheckoutBooking({
+        ...baseParams,
+        checkouts: [
+          { assetId: "asset-gloves", bookingAssetId: "ba-kit", quantity: 50 },
+        ],
+      });
+
+      const note = partialCheckoutNoteContent();
+      expect(note).toBeDefined();
+      // Delimiters stripped → the payload renders as inert text, not a tag.
+      expect(note).not.toContain("Kittington{%");
+      // Trusted asset links point at `/assets/…`, so a `{% link to="javascript`
+      // sequence could only come from the injected, unsanitized kit name.
+      expect(note).not.toContain('{% link to="javascript');
+      // Still labelled as a kit slice (with the sanitized name).
+      expect(note).toContain("in kit");
+    });
   });
 
   it("multi-asset mixed (INDIVIDUAL + qty) routes each through its own path", async () => {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -51,6 +51,7 @@ import {
   computeBookingAssetRemaining,
   computeBookingAssetSliceRemaining,
   attributeDispositionsByBookingAsset,
+  attributeCategorizedDispositionsByBookingAsset,
   isBookingFullyCheckedIn,
   // Test helper functions
   getActionTextFromTransition,
@@ -5680,11 +5681,11 @@ describe("computeBookingAssetSliceRemaining", () => {
 });
 
 describe("attributeDispositionsByBookingAsset (legacy NULL + tagged mix)", () => {
-  it("attributes tagged logs exactly and greedy-fills NULL logs (kit-driven first)", () => {
+  it("attributes tagged logs exactly and greedy-fills NULL logs (standalone first)", () => {
     // Two slices of the same asset: a kit-driven slice (50) and a
     // standalone slice (33). One NEW log is tagged to the standalone
     // slice (20); one LEGACY log has no bookingAssetId (40) and must be
-    // greedy-filled — kit-driven slice first.
+    // greedy-filled — standalone slice first.
     const result = attributeDispositionsByBookingAsset({
       bookingAssetRows: [
         { id: "ba-standalone", quantity: 33, assetKitId: null },
@@ -5696,10 +5697,50 @@ describe("attributeDispositionsByBookingAsset (legacy NULL + tagged mix)", () =>
       ],
     });
 
-    // Kit-driven slice fills the 40-unit legacy pool first (capacity 50).
-    expect(result.get("ba-kit")).toBe(40);
-    // Standalone slice keeps only its exactly-tagged 20.
-    expect(result.get("ba-standalone")).toBe(20);
+    // Standalone slice takes its exactly-tagged 20 first, then the greedy
+    // pass fills its remaining capacity (33 − 20 = 13) before touching the
+    // kit → 20 + 13 = 33.
+    expect(result.get("ba-standalone")).toBe(33);
+    // Kit-driven slice absorbs the remaining legacy pool (40 − 13 = 27).
+    expect(result.get("ba-kit")).toBe(27);
+  });
+});
+
+describe("attributeCategorizedDispositionsByBookingAsset (legacy NULL + tagged mix)", () => {
+  it("attributes tagged logs exactly and greedy-fills NULL logs standalone-first", () => {
+    // Two slices of the same asset: a kit-driven slice (50) and a
+    // standalone slice (33). One NEW log is tagged to the standalone slice
+    // (RETURN 20); one LEGACY log has no bookingAssetId (RETURN 40) and must
+    // be greedy-filled standalone-first — consistent with the check-out
+    // fallback in `attributeDispositionsByBookingAsset` so both surfaces
+    // credit the same slice for identical untagged data.
+    const result = attributeCategorizedDispositionsByBookingAsset({
+      bookingAssetRows: [
+        { id: "ba-standalone", quantity: 33, assetKitId: null },
+        { id: "ba-kit", quantity: 50, assetKitId: "ak-1" },
+      ],
+      consumptionLogs: [
+        { bookingAssetId: "ba-standalone", category: "RETURN", quantity: 20 },
+        { bookingAssetId: null, category: "RETURN", quantity: 40 },
+      ],
+    });
+
+    // Standalone slice takes its exactly-tagged 20 first, then the greedy
+    // pass fills its remaining capacity (33 − 20 = 13) before touching the
+    // kit → 20 + 13 = 33 returned.
+    expect(result.get("ba-standalone")).toEqual({
+      returned: 33,
+      consumed: 0,
+      lost: 0,
+      damaged: 0,
+    });
+    // Kit-driven slice absorbs the remaining legacy pool (40 − 13 = 27).
+    expect(result.get("ba-kit")).toEqual({
+      returned: 27,
+      consumed: 0,
+      lost: 0,
+      damaged: 0,
+    });
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -31,6 +31,7 @@ import { bookingUpdatesTemplateString } from "~/emails/bookings-updates-template
 import { sendEmail } from "~/emails/mail.server";
 import type { BookingForEmail } from "~/emails/types";
 import { isQuantityTracked } from "~/modules/asset/utils";
+import { stripMarkdocDelimiters } from "~/modules/audit/note-content.server";
 import { materializeModelRequestForAsset } from "~/modules/booking-model-request/service.server";
 import { lockAssetForQuantityUpdate } from "~/modules/consumption-log/quantity-lock.server";
 import {
@@ -4640,7 +4641,12 @@ function buildQtyPerAssetCheckoutFragment(
     // Per-slice phrasing — dialog checkouts carry the exact BookingAsset id.
     if (s.bookingAssetId) {
       const sliceLabel = s.assetKitId
-        ? `in kit ${s.kitName ?? "kit"}`
+        ? // SECURITY: `kitName` is free-form user input (Kit.name) spliced into
+          // note text that is rendered through Markdoc. Strip Markdoc delimiters
+          // so a kit named e.g. `X{% link to="javascript:..." /%}` cannot inject
+          // a live tag (stored XSS). Sanitize-at-write — see
+          // .claude/rules/sanitize-note-content-markdoc.md.
+          `in kit ${stripMarkdocDelimiters(s.kitName ?? "kit") || "kit"}`
         : "standalone";
       // The unit rides on the slice total via `formatUnitCount` ("22 boxes");
       // the checked-out count stays a bare number so the phrase reads

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -85,6 +85,7 @@ import {
 import { QueueNames, scheduler } from "~/utils/scheduler.server";
 import { resolveUserDisplayName } from "~/utils/user";
 import type { MergeInclude } from "~/utils/utils";
+import { checkoutSessionsToLogsByAsset } from "./checkout-attribution";
 import {
   BOOKING_COMMON_INCLUDE,
   BOOKING_INCLUDE_FOR_EMAIL,
@@ -2802,14 +2803,14 @@ const CHECKIN_DISPOSITION_CATEGORIES = [
  *
  * Logs with a non-null `bookingAssetId` are attributed exactly to
  * that row (the Polish-6+ contract). Logs with `bookingAssetId IS NULL`
- * (legacy rows + back-compat callers) are greedy-filled: kit-driven
- * rows first by `createdAt`, then standalone rows by `createdAt`, each
+ * (legacy rows + back-compat callers) are greedy-filled: standalone
+ * rows first by `createdAt`, then kit-driven rows by `createdAt`, each
  * taking up to its booked quantity until the legacy pool is exhausted.
  *
- * Kit-driven slices fill first because they were created via an
- * automated path (kit add) that the user is unlikely to be returning
- * units against ad-hoc; attribute their fixed allocation as "done"
- * before opening the more flexible standalone pool.
+ * Standalone slices fill first because loose items are scanned/returned
+ * individually, whereas kits are handled as a whole — so an untagged
+ * disposition is more likely the flexible standalone pool than the
+ * kit's fixed allocation.
  *
  * Returns a Map<bookingAssetId, dispositionedQuantity>. Rows with no
  * attribution are present in the map with `0`.
@@ -2845,14 +2846,15 @@ export function attributeDispositionsByBookingAsset(args: {
 
   if (legacyPool === 0) return out;
 
-  // Greedy fill: kit-driven first, then standalone. Within each bucket,
+  // Greedy fill: standalone-first (loose items are scanned individually;
+  // kits are handled as a whole), then kit-driven. Within each bucket,
   // sort by `id` ascending — BookingAsset.id is a cuid, which is
   // chronologically sortable (creation-time prefix), so this stands in
   // for "by createdAt" without needing the column on the model.
   const ordered = [...bookingAssetRows].sort((a, b) => {
     const aIsKit = a.assetKitId != null;
     const bIsKit = b.assetKitId != null;
-    if (aIsKit !== bIsKit) return aIsKit ? -1 : 1;
+    if (aIsKit !== bIsKit) return aIsKit ? 1 : -1;
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
   for (const row of ordered) {
@@ -2943,13 +2945,17 @@ export function attributeCategorizedDispositionsByBookingAsset(args: {
     }
   }
 
-  // Greedy pass: fill legacy pool category-by-category, kit-driven rows
-  // first, respecting the SHARED running total so a row never exceeds
-  // its booked quantity across all categories combined.
+  // Greedy pass: fill legacy pool category-by-category, standalone rows
+  // first (loose items are scanned/returned individually; kits are handled
+  // as a whole), then kit-driven — consistent with
+  // {@link attributeDispositionsByBookingAsset}'s check-out fallback so both
+  // surfaces credit the same slice for identical untagged data. Respects the
+  // SHARED running total so a row never exceeds its booked quantity across
+  // all categories combined.
   const ordered = [...bookingAssetRows].sort((a, b) => {
     const aIsKit = a.assetKitId != null;
     const bIsKit = b.assetKitId != null;
-    if (aIsKit !== bIsKit) return aIsKit ? -1 : 1;
+    if (aIsKit !== bIsKit) return aIsKit ? 1 : -1;
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
   for (const category of ["RETURN", "CONSUME", "LOSS", "DAMAGE"] as const) {
@@ -3097,7 +3103,7 @@ export async function computeBookingAssetRemainingToCheckOut(
     }),
     tx.partialBookingCheckout.findMany({
       where: { bookingId },
-      select: { assetIds: true, quantities: true },
+      select: { assetIds: true, quantities: true, bookingAssetIds: true },
     }),
     // Cheap PK read — needed only so the legacy-ONGOING fallback below can
     // distinguish "checked out via all-at-once (no PBC rows by design)"
@@ -3122,6 +3128,7 @@ export async function computeBookingAssetRemainingToCheckOut(
   const sessionsArr = sessions as Array<{
     assetIds: string[];
     quantities: number[];
+    bookingAssetIds: string[];
   }>;
   const bookingStatus = (booking as { status: BookingStatus } | null)?.status;
   if (
@@ -3133,24 +3140,21 @@ export async function computeBookingAssetRemainingToCheckOut(
     return 0;
   }
 
-  let claimed = 0;
-  for (const session of sessionsArr) {
-    const ids = session.assetIds ?? [];
-    const qtys = session.quantities ?? [];
-    // Wave B: aligned arrays — sum quantities[i] when assetIds[i] matches.
-    // Legacy: quantities[] is empty (pre-Wave-B rows) — count one unit per
-    // occurrence so the historical all-at-once / pre-Wave-B partial paths
-    // remain readable without a backfill.
-    if (qtys.length === ids.length) {
-      for (let i = 0; i < ids.length; i += 1) {
-        if (ids[i] === assetId) claimed += qtys[i] ?? 0;
-      }
-    } else {
-      for (const id_ of ids) {
-        if (id_ === assetId) claimed += 1;
-      }
-    }
-  }
+  // Aggregate the asset's claimed units across every session through the shared
+  // positional-array parser so the aligned/legacy quantity handling (and the
+  // `""` → greedy sentinel) is identical to every other read site. This is an
+  // ASSET-level total — the per-slice `bookingAssetId` tags don't change the
+  // sum — but routing through the parser keeps the contract in one place. The
+  // predicate scopes parsing to the target asset, so the INDIVIDUAL-vs-QT skip
+  // in the parser never drops this asset regardless of its type.
+  const logsByAsset = checkoutSessionsToLogsByAsset(
+    sessionsArr,
+    (id) => id === assetId
+  );
+  const claimed = (logsByAsset.get(assetId) ?? []).reduce(
+    (sum, log) => sum + log.quantity,
+    0
+  );
 
   return Math.max(0, booked - claimed);
 }
@@ -3320,41 +3324,31 @@ export async function computeBookingAssetSliceRemainingToCheckOut(
     }),
     tx.partialBookingCheckout.findMany({
       where: { bookingId },
-      select: { assetIds: true, quantities: true },
+      select: { assetIds: true, quantities: true, bookingAssetIds: true },
     }),
   ]);
 
-  // Sum claims for this assetId across every PartialBookingCheckout session.
-  // Legacy fallback (`quantities.length !== assetIds.length`): each occurrence
-  // counts as one unit — mirror of `computeBookingAssetRemainingToCheckOut`
-  // so per-asset and per-slice agree on the pool size.
-  let totalClaimed = 0;
-  for (const session of sessions as Array<{
-    assetIds: string[];
-    quantities: number[];
-  }>) {
-    const ids = session.assetIds ?? [];
-    const qtys = session.quantities ?? [];
-    if (qtys.length === ids.length) {
-      for (let i = 0; i < ids.length; i += 1) {
-        if (ids[i] === slice.assetId) totalClaimed += qtys[i] ?? 0;
-      }
-    } else {
-      for (const id_ of ids) {
-        if (id_ === slice.assetId) totalClaimed += 1;
-      }
-    }
-  }
+  // Parse every session into per-slice checkout logs via the shared positional
+  // parser. Logs tagged with an exact `bookingAssetId` attribute to that slice;
+  // untagged (`""` → null) logs fall into the greedy pool. This is the core of
+  // the multi-slice fix: a checkout the operator tagged to the STANDALONE slice
+  // no longer leaks into the kit slice's remaining. The predicate scopes
+  // parsing to this asset (the function is only ever called for QT slices, but
+  // scoping also keeps the parser's non-QT skip from dropping the asset).
+  const logsByAsset = checkoutSessionsToLogsByAsset(
+    sessions as Array<{
+      assetIds: string[];
+      quantities: number[];
+      bookingAssetIds: string[];
+    }>,
+    (id) => id === slice.assetId
+  );
+  const claimLogs = logsByAsset.get(slice.assetId) ?? [];
 
-  // Feed the pool into the shared attributor as a single legacy
-  // (`bookingAssetId === null`) entry so the kit-first / id-sort fill order
-  // is identical to what the disposition attributor uses on the check-IN
-  // side. The attributor returns the slice → attributed-claim map; we read
-  // back the entry for the slice we were asked about.
-  const claimLogs =
-    totalClaimed > 0
-      ? [{ bookingAssetId: null as string | null, quantity: totalClaimed }]
-      : [];
+  // Feed the per-slice logs into the shared attributor: exact-tagged claims land
+  // on their slice, and any untagged pool greedy-fills in the SAME
+  // standalone-first / id-sort order the disposition attributor uses on the
+  // check-IN side. We read back the entry for the slice we were asked about.
   const attributed = attributeDispositionsByBookingAsset({
     bookingAssetRows: allSlices,
     consumptionLogs: claimLogs,
@@ -3419,7 +3413,7 @@ export async function isBookingFullyCheckedIn(
     }),
     tx.partialBookingCheckout.findMany({
       where: { bookingId },
-      select: { assetIds: true, quantities: true },
+      select: { assetIds: true, quantities: true, bookingAssetIds: true },
     }),
   ]);
 
@@ -3436,27 +3430,29 @@ export async function isBookingFullyCheckedIn(
   }
 
   // Aggregate per-asset checked-out units across every PartialBookingCheckout
-  // session for this booking. `quantities` is positional with `assetIds`:
-  // INDIVIDUAL rows record `1`, QUANTITY_TRACKED rows record the unit count.
-  // Legacy rows (pre-Wave-B) have an empty `quantities[]` — fall back to a
-  // count of 1 per assetId entry so they still register as "checked out"
-  // (matches their INDIVIDUAL-only origin where 1 unit per id was the only
-  // possibility).
-  const checkedOutAssetIds = new Set<string>();
+  // session for this booking through the shared positional parser. `quantities`
+  // is positional with `assetIds`: INDIVIDUAL rows record `1`, QUANTITY_TRACKED
+  // rows record the unit count; legacy rows (pre-Wave-B) with an empty
+  // `quantities[]` fall back to 1 per entry — all handled inside the parser.
+  // Completion is an ASSET-level obligation, so the per-slice `bookingAssetId`
+  // tags are irrelevant here; we only need the per-asset unit totals. The
+  // `() => true` predicate keeps BOTH INDIVIDUAL and QT assets (the parser's
+  // non-QT skip must not drop INDIVIDUAL ids, which gate the check-in below).
+  const logsByAsset = checkoutSessionsToLogsByAsset(
+    partialCheckouts as Array<{
+      assetIds: string[];
+      quantities: number[];
+      bookingAssetIds: string[];
+    }>,
+    () => true
+  );
+  const checkedOutAssetIds = new Set<string>(logsByAsset.keys());
   const checkedOutUnitsByAsset = new Map<string, number>();
-  for (const row of partialCheckouts as Array<{
-    assetIds: string[];
-    quantities: number[];
-  }>) {
-    for (let i = 0; i < row.assetIds.length; i++) {
-      const id = row.assetIds[i];
-      const units = row.quantities[i] ?? 1;
-      checkedOutAssetIds.add(id);
-      checkedOutUnitsByAsset.set(
-        id,
-        (checkedOutUnitsByAsset.get(id) ?? 0) + units
-      );
-    }
+  for (const [assetId, logs] of logsByAsset) {
+    checkedOutUnitsByAsset.set(
+      assetId,
+      logs.reduce((sum, log) => sum + log.quantity, 0)
+    );
   }
 
   // Detect whether ANY progressive checkout has occurred. If not, preserve the
@@ -4599,13 +4595,20 @@ function buildQtyPerAssetFragment(
 }
 
 /**
- * Build a markdoc fragment naming each qty-tracked asset checked OUT in
- * this session. Mirror of {@link buildQtyPerAssetFragment} but unidirectional —
- * checkout only carries one count per asset (no return/consume/loss/damage
+ * Build a markdoc fragment naming each qty-tracked slice checked OUT in this
+ * session. Mirror of {@link buildQtyPerAssetFragment} but unidirectional —
+ * checkout only carries one count per slice (no return/consume/loss/damage
  * fan-out).
  *
- * Produces something like:
- *   `{% link to="/assets/<id>" text="Pens" /%} (10 checked out, 5 still booked)`
+ * Layer 3: each row is now rendered PER SLICE with a label, so a slice-level
+ * checkout reports slice-level totals instead of the whole asset's booked
+ * count. A tagged slice (dialog checkout, `bookingAssetId` set) produces:
+ *   `{% link ... text="Gloves" /%} · standalone (11 of 22 boxes checked out, 11 still booked)`
+ *   `{% link ... text="Gloves" /%} · in kit Kittington (100 of 100 boxes checked out)`
+ * — the `, N still booked` clause is omitted when the slice is fully out. A
+ * legacy / greedy disposition (no `bookingAssetId`, e.g. the scanner) has no
+ * slice context, so it falls back to the pre-Layer-3 asset-level phrasing:
+ *   `{% link ... text="Pens" /%} (10 boxes checked out, 5 boxes still booked)`
  *
  * Returns an empty string when no row has a positive count so callers can
  * safely concatenate without extra guards.
@@ -4618,6 +4621,10 @@ function buildQtyPerAssetCheckoutFragment(
     unitOfMeasure: string | null;
     checkedOut: number;
     remainingAfter: number;
+    bookingAssetId: string | null;
+    assetKitId: string | null;
+    kitName: string | null;
+    sliceBooked: number;
   }>
 ): string {
   const fragments: string[] = [];
@@ -4628,13 +4635,34 @@ function buildQtyPerAssetCheckoutFragment(
     const fmt = (qty: number) =>
       formatUnitCount({ type: s.type, unitOfMeasure: s.unitOfMeasure }, qty) ??
       String(qty);
+    const link = wrapLinkForNote(`/assets/${s.assetId}`, s.title);
 
+    // Per-slice phrasing — dialog checkouts carry the exact BookingAsset id.
+    if (s.bookingAssetId) {
+      const sliceLabel = s.assetKitId
+        ? `in kit ${s.kitName ?? "kit"}`
+        : "standalone";
+      // The unit rides on the slice total via `formatUnitCount` ("22 boxes");
+      // the checked-out count stays a bare number so the phrase reads
+      // "11 of 22 boxes checked out". `still booked` is a bare number too, and
+      // is omitted entirely when the slice is fully out (remaining 0).
+      const sliceParts = [
+        `${s.checkedOut} of ${fmt(s.sliceBooked)} checked out`,
+      ];
+      if (s.remainingAfter > 0) {
+        sliceParts.push(`${s.remainingAfter} still booked`);
+      }
+      fragments.push(`${link} · ${sliceLabel} (${sliceParts.join(", ")})`);
+      continue;
+    }
+
+    // Legacy / greedy disposition (no slice tag) → asset-level phrasing.
     const parts: string[] = [];
     if (s.checkedOut > 0) parts.push(`${fmt(s.checkedOut)} checked out`);
-    if (s.remainingAfter > 0)
+    if (s.remainingAfter > 0) {
       parts.push(`${fmt(s.remainingAfter)} still booked`);
+    }
     if (parts.length === 0) continue;
-    const link = wrapLinkForNote(`/assets/${s.assetId}`, s.title);
     fragments.push(`${link} (${parts.join(", ")})`);
   }
   return fragments.join(", ");
@@ -5685,6 +5713,10 @@ export async function partialCheckoutBooking({
             select: {
               id: true,
               quantity: true,
+              // Slice discriminator (Layer 2/3): `null` = standalone (free
+              // pool), non-null = kit-driven slice (FK → `AssetKit.id`). Drives
+              // the per-slice checkout note label ("standalone" vs "in kit X").
+              assetKitId: true,
               asset: {
                 select: {
                   id: true,
@@ -5692,7 +5724,18 @@ export async function partialCheckoutBooking({
                   type: true,
                   title: true,
                   unitOfMeasure: true,
-                  assetKits: { select: { kitId: true } },
+                  // `kitId` retained for the complete-kit status logic below.
+                  // `id` + `kit.name` added so the per-slice checkout note can
+                  // resolve a kit-driven slice's kit label by matching the
+                  // slice's `assetKitId` (an `AssetKit.id`) against these
+                  // memberships — no extra round-trip inside the qty loop.
+                  assetKits: {
+                    select: {
+                      id: true,
+                      kitId: true,
+                      kit: { select: { name: true } },
+                    },
+                  },
                 },
               },
             },
@@ -5893,11 +5936,21 @@ export async function partialCheckoutBooking({
       // already recorded in an earlier batch don't get duplicated.
       if (outstandingAssetIds.length > 0) {
         // Mirror the main-path `sessionAssetIds`/`sessionQuantities` invariant:
-        // `assetIds[i]` and `quantities[i]` must be positionally aligned so
-        // downstream readers (computeBookingAssetRemainingToCheckOut, the
-        // completion gate in isBookingFullyCheckedIn) get correct per-slice
-        // figures. INDIVIDUAL ids without an explicit disposition carry the
-        // implicit quantity = 1.
+        // `assetIds[i]`, `quantities[i]` and `bookingAssetIds[i]` must be
+        // positionally aligned so downstream readers
+        // (computeBookingAssetRemainingToCheckOut, the completion gate in
+        // isBookingFullyCheckedIn, and the per-slice attributor) get correct
+        // per-slice figures. INDIVIDUAL ids without an explicit disposition
+        // carry the implicit quantity = 1 and no slice tag (`""` → greedy).
+        // This is the first all-items scan of a RESERVED booking, so
+        // `outstandingAssetIds` is deduped per asset. A multi-slice QT asset
+        // (e.g. standalone + kit slices of the same battery) has more than one
+        // `bookingAssetId`, so a per-asset entry cannot faithfully name a
+        // single slice — recording one arbitrary slice's tag would starve the
+        // other slice's per-slice remaining. Since a full checkout claims
+        // EVERY slice, we record greedy `""` for all entries and let the
+        // standalone-first greedy attributor split the pool across slices on
+        // read.
         const checkoutQtyByAssetId = new Map<string, number>();
         for (const d of checkouts ?? []) {
           checkoutQtyByAssetId.set(d.assetId, d.quantity);
@@ -5905,12 +5958,15 @@ export async function partialCheckoutBooking({
         const outstandingQuantities = outstandingAssetIds.map(
           (assetId) => checkoutQtyByAssetId.get(assetId) ?? 1
         );
+        // Greedy `""` for every deduped entry (see comment above).
+        const outstandingBookingAssetIds = outstandingAssetIds.map(() => "");
         await db.partialBookingCheckout.create({
           data: {
             bookingId: id,
             checkedOutById: userId,
             assetIds: outstandingAssetIds,
             quantities: outstandingQuantities,
+            bookingAssetIds: outstandingBookingAssetIds,
             checkoutCount: outstandingAssetIds.length,
           },
         });
@@ -6051,7 +6107,45 @@ export async function partialCheckoutBooking({
       unitOfMeasure: string | null;
       checkedOut: number;
       remainingAfter: number;
+      /**
+       * The exact `BookingAsset.id` this checked-out slice came from, or `null`
+       * for a legacy / greedy disposition that carried no slice tag. Drives the
+       * per-slice vs. asset-level phrasing in the checkout note.
+       */
+      bookingAssetId: string | null;
+      /** `AssetKit.id` when the slice is kit-driven; `null` when standalone/legacy. */
+      assetKitId: string | null;
+      /** Kit display name for a kit-driven slice; `null` when standalone/legacy. */
+      kitName: string | null;
+      /** `BookingAsset.quantity` — units booked on THIS slice (0 for legacy). */
+      sliceBooked: number;
     };
+
+    /**
+     * Per-slice lookup for the checkout note (Layer 3): `BookingAsset.id` → its
+     * booked quantity + kit label. Built once from the already-loaded booking
+     * graph so the qty loop can attribute each disposition to its exact slice
+     * without an extra DB round-trip. `assetKitId`/`kitName` are `null` for
+     * standalone slices; the kit name is resolved by matching the slice's
+     * `assetKitId` (an `AssetKit.id`) against the asset's `assetKits`
+     * memberships loaded above.
+     */
+    const sliceInfoById = new Map<
+      string,
+      { sliceBooked: number; assetKitId: string | null; kitName: string | null }
+    >();
+    for (const ba of bookingFound.bookingAssets) {
+      const assetKitId = ba.assetKitId ?? null;
+      const kitName = assetKitId
+        ? ba.asset.assetKits.find((ak) => ak.id === assetKitId)?.kit?.name ??
+          null
+        : null;
+      sliceInfoById.set(ba.id, {
+        sliceBooked: ba.quantity ?? 0,
+        assetKitId,
+        kitName,
+      });
+    }
 
     const result = await db.$transaction(async (tx) => {
       /**
@@ -6123,14 +6217,18 @@ export async function partialCheckoutBooking({
          * callers omit `bookingAssetId` → asset-level cap only.
          */
         let cap = assetCap;
+        // Hoisted out of the slice branch so the per-slice `remainingAfter` in
+        // the summary below can reuse them. `null` for a legacy disposition
+        // (no slice tag) → the summary falls back to the asset-level remaining.
+        let sliceCommittedRemaining: number | null = null;
+        let claimedThisSliceSoFar = 0;
         if (disp.bookingAssetId) {
-          const sliceCommittedRemaining =
-            await computeBookingAssetSliceRemaining(
-              tx,
-              id,
-              disp.bookingAssetId
-            );
-          const claimedThisSliceSoFar =
+          sliceCommittedRemaining = await computeBookingAssetSliceRemaining(
+            tx,
+            id,
+            disp.bookingAssetId
+          );
+          claimedThisSliceSoFar =
             claimedBySliceThisBatch.get(disp.bookingAssetId) ?? 0;
           const sliceCap = Math.max(
             0,
@@ -6176,19 +6274,37 @@ export async function partialCheckoutBooking({
           );
         }
 
+        // Layer 3 per-slice attribution for the checkout note. When the
+        // disposition carries a slice tag, resolve the slice's booked total +
+        // kit label from the in-memory booking graph (no round-trip) and report
+        // the PER-SLICE remaining. Legacy dispositions (scanner / untagged)
+        // keep the asset-level remaining and null slice fields, so the note
+        // formatter falls back to the pre-Layer-3 asset-level phrasing.
+        const sliceInfo = disp.bookingAssetId
+          ? sliceInfoById.get(disp.bookingAssetId)
+          : undefined;
+        const remainingAfter =
+          disp.bookingAssetId && sliceCommittedRemaining !== null
+            ? // Per-slice: this slice's committed remaining minus the batch's
+              // running claim for the SAME slice (this iteration inclusive).
+              Math.max(
+                0,
+                sliceCommittedRemaining - claimedThisSliceSoFar - claimed
+              )
+            : // Legacy: asset-level remaining after this iteration.
+              Math.max(0, committedRemaining - claimedSoFarThisBatch - claimed);
+
         qtySummaries.push({
           assetId: disp.assetId,
           title: lockedAsset.title,
           type: lockedAsset.type,
           unitOfMeasure: lockedAsset.unitOfMeasure,
           checkedOut: claimed,
-          // `remainingAfter` here is per-iteration: committedRemaining minus
-          // claims accumulated up to and including this iteration. Aggregated
-          // post-loop into the per-asset summary used by notes / events.
-          remainingAfter: Math.max(
-            0,
-            committedRemaining - claimedSoFarThisBatch - claimed
-          ),
+          bookingAssetId: disp.bookingAssetId ?? null,
+          assetKitId: sliceInfo?.assetKitId ?? null,
+          kitName: sliceInfo?.kitName ?? null,
+          sliceBooked: sliceInfo?.sliceBooked ?? 0,
+          remainingAfter,
         });
       }
 
@@ -6279,6 +6395,13 @@ export async function partialCheckoutBooking({
        */
       const sessionAssetIds: string[] = [];
       const sessionQuantities: number[] = [];
+      // Positional with `sessionAssetIds`/`sessionQuantities`: the exact
+      // `BookingAsset.id` a slice was checked out from, or `""` when the
+      // disposition carries no slice tag (INDIVIDUAL / legacy). Read back by
+      // `checkoutSessionsToLogsByAsset` so per-slice attribution is exact and
+      // `""` collapses to greedy. Prisma `String[]` cannot hold `null`, hence
+      // the `""` sentinel.
+      const sessionBookingAssetIds: string[] = [];
       for (const disp of dispositions) {
         if (!assetIdsToCheckOut.includes(disp.assetId)) continue;
         sessionAssetIds.push(disp.assetId);
@@ -6290,6 +6413,9 @@ export async function partialCheckoutBooking({
             ? disp.quantity
             : 1;
         sessionQuantities.push(qty);
+        // QT dialog dispositions carry `bookingAssetId`; INDIVIDUAL / legacy
+        // fallback dispositions do not → `""` (single-slice, greedy == exact).
+        sessionBookingAssetIds.push(disp.bookingAssetId ?? "");
       }
 
       const createdSession = await tx.partialBookingCheckout.create({
@@ -6298,6 +6424,7 @@ export async function partialCheckoutBooking({
           checkedOutById: userId,
           assetIds: sessionAssetIds,
           quantities: sessionQuantities,
+          bookingAssetIds: sessionBookingAssetIds,
           // `checkoutCount` historically counted distinct assetIds, but the
           // existing reports treat it as the array length — preserve that
           // semantic (one entry per row, including repeated slices).
@@ -6306,25 +6433,12 @@ export async function partialCheckoutBooking({
         select: { id: true },
       });
 
-      /**
-       * Aggregated per-asset summary used by the post-tx note pipeline.
-       * Multiple slices for the same asset (kit + standalone) fold into one
-       * entry: sum `checkedOut`, take the final `remainingAfter` (the running
-       * total after the asset's last iteration in this batch).
-       */
-      const aggregatedQtySummaries: CheckoutQtySummary[] = (() => {
-        const byAsset = new Map<string, CheckoutQtySummary>();
-        for (const s of qtySummaries) {
-          const prev = byAsset.get(s.assetId);
-          if (!prev) {
-            byAsset.set(s.assetId, { ...s });
-          } else {
-            prev.checkedOut += s.checkedOut;
-            prev.remainingAfter = s.remainingAfter;
-          }
-        }
-        return [...byAsset.values()];
-      })();
+      // Layer 3: the per-asset fold that previously collapsed both slices of an
+      // asset into one summary is gone — the checkout note pipeline now renders
+      // one line PER SLICE so a slice-level action reports slice-level totals
+      // (a standalone-slice checkout no longer shows the whole asset's booked
+      // count). The per-slice `qtySummaries` flow straight to the note fragment
+      // and the post-tx per-asset note loop.
 
       // Create audit notes for INDIVIDUAL rows. Qty-tracked rows get their
       // own per-asset note written OUTSIDE the tx (with unit-aware phrasing).
@@ -6514,18 +6628,33 @@ export async function partialCheckoutBooking({
         : "";
 
       /**
-       * Per-asset qty fragment for the booking-side note — names each
-       * qty-tracked asset touched in this session (linked) along with its
-       * `checkedOut` / `remainingAfter` counts. Mirror of the partial-checkin
-       * `qtyTail` pattern: empty string when nothing to say, so the existing
-       * `itemsDescription` concatenation stays clean for INDIVIDUAL-only
-       * batches. Reads from the aggregated summary so multi-slice claims of
-       * the same asset render as a single line.
+       * Per-slice qty fragment for the booking-side note — names each
+       * qty-tracked slice touched in this session (linked) with its
+       * `standalone`/`in kit X` label and `checked out / still booked` counts.
+       * Empty string when there's nothing to say, so the `itemsDescription`
+       * concatenation stays clean for INDIVIDUAL-only batches. Layer 3: fed the
+       * per-slice `qtySummaries` directly (no per-asset fold) so a slice-level
+       * checkout reports slice-level totals.
        */
-      const qtyPerAsset = buildQtyPerAssetCheckoutFragment(
-        aggregatedQtySummaries
-      );
-      const qtyTail = qtyPerAsset ? ` — qty: ${qtyPerAsset}` : "";
+      const qtyPerAsset = buildQtyPerAssetCheckoutFragment(qtySummaries);
+
+      /**
+       * Layer 3 redundancy fix: when the batch is ONLY qty-tracked slices (no
+       * INDIVIDUAL assets, no complete kits), `itemsDescription` merely re-names
+       * the same qty-tracked asset(s) that `qtyPerAsset` already describes in
+       * per-slice detail. In that case render the per-slice fragment as the
+       * whole items description instead of the duplicated
+       * "{asset} checked out — qty: {asset} · standalone (…)". The mixed case
+       * (INDIVIDUAL and/or complete kits present) keeps the "— qty:" tail so
+       * those non-qty items are still named.
+       */
+      const qtyOnlyCheckout =
+        individualToFlip.length === 0 &&
+        completeKits.length === 0 &&
+        qtyPerAsset !== "";
+      const itemsBody = qtyOnlyCheckout
+        ? qtyPerAsset
+        : `${itemsDescription}${qtyPerAsset ? ` — qty: ${qtyPerAsset}` : ""}`;
 
       await createSystemBookingNote(
         {
@@ -6533,7 +6662,7 @@ export async function partialCheckoutBooking({
           organizationId,
           content: `${wrapUserLinkForNote(
             user!
-          )} performed a partial check-out: ${itemsDescription}${qtyTail}${statusNote}.`,
+          )} performed a partial check-out: ${itemsBody}${statusNote}.`,
         },
         tx
       );
@@ -6572,18 +6701,23 @@ export async function partialCheckoutBooking({
         // above, so report completion from the remaining count.
         isComplete: remainingAssetCount === 0,
         bookingStatusChanged,
-        // Pass the aggregated (per-asset) summary downstream so the post-tx
-        // per-asset note loop renders one note per asset rather than per
-        // slice.
-        qtySummaries: aggregatedQtySummaries,
+        // Layer 3: pass the PER-SLICE summaries downstream so the post-tx
+        // per-asset note loop renders one note per slice with slice-level
+        // counts (a standalone-slice checkout no longer reports the whole
+        // asset's remaining). Legacy/untagged dispositions still carry the
+        // asset-level remaining and render the pre-Layer-3 phrasing.
+        qtySummaries,
         individualAssetIds: individualToFlip,
       };
     });
 
     /**
-     * Per-asset qty-tracked notes (post-tx, best-effort). Uses
+     * Per-slice qty-tracked asset-timeline notes (post-tx, best-effort). Uses
      * `wrapAssetWithCountForNote` so qty-tracked rows render as
-     * "You checked out 10 boxes of {asset} on {booking}". Wrapped in
+     * "You checked out 10 boxes of {asset} on {booking}". Layer 3: iterates the
+     * per-slice summaries, so a multi-slice checkout of one asset writes one
+     * note per slice with slice-level `remainingAfter` (tagged slices) or the
+     * asset-level remaining (legacy/untagged dispositions). Wrapped in
      * try/catch — a markdoc hiccup here must not roll back the already-
      * committed checkout.
      */

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -3316,7 +3316,7 @@ export async function computeBookingAssetSliceRemainingToCheckOut(
 
   // Fetch ALL slices of this asset on this booking (kit + standalone, etc.) —
   // the attributor needs the full slice set so the greedy fill order
-  // (kit-driven first, standalone after) matches the loader.
+  // (standalone-first, kit-driven after) matches the loader.
   const [allSlices, sessions] = await Promise.all([
     tx.bookingAsset.findMany({
       where: { bookingId, assetId: slice.assetId },
@@ -5848,6 +5848,33 @@ export async function partialCheckoutBooking({
       }
     }
 
+    // SECURITY (per-slice IDOR / data integrity): `bookingAssetId` is
+    // caller-supplied and now load-bearing — it drives the per-slice checkout
+    // cap AND the exact per-slice attribution persisted on
+    // `PartialBookingCheckout`. A stale UI or a direct/mobile client could tag a
+    // disposition with a slice id from a DIFFERENT asset or booking; the
+    // exact-attribution reader would then credit the wrong slice, corrupting
+    // per-slice remaining + notes. Validate every tagged disposition's slice
+    // belongs to THIS booking AND matches its `assetId` before it is used for
+    // caps or stored (covers both the delegate and progressive paths below).
+    const assetIdBySliceId = new Map(
+      bookingFound.bookingAssets.map((ba) => [ba.id, ba.asset.id])
+    );
+    for (const d of dispositions) {
+      if (
+        d.bookingAssetId &&
+        assetIdBySliceId.get(d.bookingAssetId) !== d.assetId
+      ) {
+        throw new ShelfError({
+          cause: null,
+          status: 400,
+          label,
+          message: "Invalid booking asset slice supplied for check-out.",
+          shouldBeCaptured: false,
+        });
+      }
+    }
+
     // Assets already checked out for THIS booking. Source of truth is the
     // PartialBookingCheckout records, but a booking checked out via the
     // all-at-once flow leaves NO records while its assets are live CHECKED_OUT —
@@ -6223,11 +6250,18 @@ export async function partialCheckoutBooking({
         let sliceCommittedRemaining: number | null = null;
         let claimedThisSliceSoFar = 0;
         if (disp.bookingAssetId) {
-          sliceCommittedRemaining = await computeBookingAssetSliceRemaining(
-            tx,
-            id,
-            disp.bookingAssetId
-          );
+          // Checkout-side per-slice remaining: booked − prior
+          // `PartialBookingCheckout` claims attributed to THIS slice. Must NOT
+          // use the check-IN helper (`computeBookingAssetSliceRemaining`), which
+          // only subtracts return `ConsumptionLog`s and would let a slice with
+          // prior checkouts be over-claimed here — and would mis-report the
+          // note's per-slice "still booked" (which reuses this value below).
+          sliceCommittedRemaining =
+            await computeBookingAssetSliceRemainingToCheckOut(
+              tx,
+              id,
+              disp.bookingAssetId
+            );
           claimedThisSliceSoFar =
             claimedBySliceThisBatch.get(disp.bookingAssetId) ?? 0;
           const sliceCap = Math.max(

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkin-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkin-assets.tsx
@@ -135,7 +135,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
      * Per-row attribution: ConsumptionLog now carries `bookingAssetId`,
      * letting us split a (booking, asset)'s dispositions across its
      * multiple BookingAsset slices (kit-driven + standalone). Legacy
-     * NULL-bookingAssetId rows get greedy-attributed (kit-driven first)
+     * NULL-bookingAssetId rows get greedy-attributed (standalone first)
      * by `attributeDispositionsByBookingAsset`.
      */
     const dispositionLogs =

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -36,6 +36,7 @@ import {
   primeBookingOverviewCache,
   readBookingOverviewCache,
 } from "~/modules/booking/booking-overview-client-cache";
+import { checkoutSessionsToLogsByAsset } from "~/modules/booking/checkout-attribution";
 import { sendBookingUpdatedEmail } from "~/modules/booking/email-helpers";
 import {
   archiveBooking,
@@ -599,8 +600,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
      * booking; ConsumptionLog now carries `bookingAssetId` so each
      * disposition can be attributed exactly. Legacy logs
      * (`bookingAssetId IS NULL`) get greedy-attributed by
-     * `attributeCategorizedDispositionsByBookingAsset` — kit-driven rows
-     * fill first, then standalone.
+     * `attributeCategorizedDispositionsByBookingAsset` — standalone rows
+     * fill first, then kit-driven (consistent with the check-out fallback).
      */
     const dispositionLogs =
       qtyAssetIdsInBooking.length > 0
@@ -729,36 +730,24 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       qtyAssetIdsInBooking.length > 0
         ? await db.partialBookingCheckout.findMany({
             where: { bookingId: booking.id },
-            select: { assetIds: true, quantities: true },
+            select: {
+              assetIds: true,
+              quantities: true,
+              bookingAssetIds: true,
+            },
           })
         : [];
 
-    // Map<assetId, Array<{ bookingAssetId: null, quantity }>> — every entry
-    // is "legacy" from the attributor's POV (no per-row FK on the model).
-    const checkoutLogsByAsset = new Map<
-      string,
-      Array<{ bookingAssetId: null; quantity: number }>
-    >();
-    for (const session of checkoutSessions) {
-      const ids = session.assetIds ?? [];
-      const qtys = session.quantities ?? [];
-      const aligned = qtys.length === ids.length;
-      for (let i = 0; i < ids.length; i += 1) {
-        const assetId = ids[i];
-        // Skip entries for assets that aren't qty-tracked in this booking —
-        // INDIVIDUAL assets share the same table but go through a different
-        // attribution path (asset-status based) and would just no-op below.
-        if (!bookingAssetRowsByAsset.has(assetId)) continue;
-        // Aligned (Wave-B+): quantities[i] is the exact slice. Legacy
-        // (pre-Wave-B): empty/mismatched quantities[] — count one unit per
-        // occurrence (see service.server.ts ~L2862-2870 for the canonical
-        // read pattern this mirrors).
-        const quantity = aligned ? qtys[i] ?? 1 : 1;
-        const arr = checkoutLogsByAsset.get(assetId) ?? [];
-        arr.push({ bookingAssetId: null, quantity });
-        checkoutLogsByAsset.set(assetId, arr);
-      }
-    }
+    // Map<assetId, Array<{ bookingAssetId: string | null, quantity }>> — parsed
+    // via the shared `checkoutSessionsToLogsByAsset` so every read site honors
+    // the positional `bookingAssetIds` contract identically. Entries tagged with
+    // a persisted `bookingAssetId` attribute to their exact slice; `""`/legacy
+    // rows collapse to `null` → the attributor greedy-fills them. An asset is
+    // qty-tracked here iff it has BookingAsset rows in `bookingAssetRowsByAsset`.
+    const checkoutLogsByAsset = checkoutSessionsToLogsByAsset(
+      checkoutSessions,
+      (assetId) => bookingAssetRowsByAsset.has(assetId)
+    );
 
     // Initialize every qty-tracked row to 0 so downstream lookups never
     // see `undefined` for a row that simply hasn't been checked out yet.

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -636,7 +636,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     /**
      * Map<assetId, BookingAsset[]> for the greedy attribution fallback.
      * Built once and shared across all four category attributions so the
-     * kit-driven-fills-first ordering stays consistent.
+     * standalone-fills-first ordering stays consistent.
      */
     const bookingAssetRowsByAsset = new Map<
       string,
@@ -704,7 +704,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
      * disposition attribution above). For each qty-tracked asset, sum the
      * units that have been progressively checked out via
      * `PartialBookingCheckout` rows, then attribute that scalar across the
-     * asset's BookingAsset slices using the same kit-driven-fills-first
+     * asset's BookingAsset slices using the same standalone-fills-first
      * greedy attributor used on the check-IN side.
      *
      * `PartialBookingCheckout` has no per-row FK (no `bookingAssetId`

--- a/apps/webapp/app/utils/booking-assets.test.ts
+++ b/apps/webapp/app/utils/booking-assets.test.ts
@@ -294,11 +294,14 @@ describe("flattenSelectedBookingItems", () => {
     { id: "asset-2", status: "AVAILABLE", kitId: "kit-1" },
   ];
 
-  it("enriches a direct asset entry from the booking record", () => {
-    // Atom entry carries a stale status; the booking record wins.
+  it("fills genuine gaps from the booking record while the selected item wins", () => {
+    // The selection atom holds the authoritative enriched loader row: its own
+    // fields win (status stays AVAILABLE, NOT the record's CHECKED_OUT), and
+    // the booking record only fills genuine gaps (kitId, absent on the item).
     const selected = [{ id: "asset-1", title: "Camera", status: "AVAILABLE" }];
     const [result] = flattenSelectedBookingItems(selected, bookingAssets);
-    expect(result.status).toBe("CHECKED_OUT");
+    expect(result.status).toBe("AVAILABLE"); // selected item wins
+    expect(result.kitId).toBe(null); // filled from booking record
     expect(result.title).toBe("Camera");
   });
 
@@ -335,5 +338,75 @@ describe("flattenSelectedBookingItems", () => {
     const kit = { id: "kit-1", name: "Kit A", _count: { assets: 2 } };
     const [result] = flattenSelectedBookingItems([kit], bookingAssets);
     expect(result).toEqual(kit);
+  });
+
+  // A QUANTITY_TRACKED asset can be booked BOTH standalone (kitId null) and
+  // inside a kit (kitId set) — two BookingAsset slices sharing one asset.id.
+  // The enrichment map keys by bookingAssetId so both slices coexist, and the
+  // selected slice's own bookingAssetId/kitId survive the merge.
+  const multiSliceBookingAssets = [
+    {
+      id: "battery",
+      bookingAssetId: "ba-standalone",
+      status: "CHECKED_OUT",
+      kitId: null,
+    },
+    {
+      id: "battery",
+      bookingAssetId: "ba-kit",
+      status: "CHECKED_OUT",
+      kitId: "kit-1",
+    },
+  ];
+
+  it("preserves a selected STANDALONE slice's kitId:null and its own bookingAssetId when both slices are present", () => {
+    const selected = [
+      {
+        id: "battery",
+        title: "Batteries",
+        bookingAssetId: "ba-standalone",
+        kitId: null,
+        status: "AVAILABLE",
+      },
+    ];
+    const [result] = flattenSelectedBookingItems(
+      selected,
+      multiSliceBookingAssets
+    );
+    // The kit slice's kitId must NOT clobber the selected standalone slice.
+    expect(result.bookingAssetId).toBe("ba-standalone");
+    expect(result.kitId).toBe(null);
+    expect(result.title).toBe("Batteries");
+  });
+
+  it("keeps a selected KIT-MEMBER slice's kitId when both slices are present", () => {
+    const selected = [
+      {
+        id: "battery",
+        title: "Batteries",
+        bookingAssetId: "ba-kit",
+        kitId: "kit-1",
+        status: "AVAILABLE",
+      },
+    ];
+    const [result] = flattenSelectedBookingItems(
+      selected,
+      multiSliceBookingAssets
+    );
+    expect(result.bookingAssetId).toBe("ba-kit");
+    expect(result.kitId).toBe("kit-1");
+  });
+
+  it("enriches a legacy item without bookingAssetId via the id fallback", () => {
+    // Legacy entries (both selection and booking record) lack bookingAssetId,
+    // so the map keys by id and the item is looked up by id — enrichment still
+    // works (status filled from the record).
+    const legacyBookingAssets = [
+      { id: "legacy-asset", status: "CHECKED_OUT", kitId: null },
+    ];
+    const selected = [{ id: "legacy-asset", title: "Old Camera" }];
+    const [result] = flattenSelectedBookingItems(selected, legacyBookingAssets);
+    expect(result.status).toBe("CHECKED_OUT");
+    expect(result.title).toBe("Old Camera");
   });
 });

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -305,10 +305,12 @@ export function flattenSelectedBookingItems(
     bookingAssets.map((asset) => [asset.bookingAssetId ?? asset.id, asset])
   );
 
-  return selectedItems.flatMap((item: any) => {
-    // Pagination wrapper objects (type "asset" with an assets array).
-    if (item.type === "asset" && item.assets) {
-      return item.assets.map((asset: any) => {
+  return selectedItems.flatMap((item) => {
+    // Pagination wrapper objects (type "asset" with an assets array). Guard
+    // that `assets` really is an array before mapping — a malformed entry must
+    // not be treated as a list.
+    if (item.type === "asset" && Array.isArray(item.assets)) {
+      return (item.assets as SelectedBookingItem[]).map((asset) => {
         const bookingAsset = bookingAssetsMap.get(
           asset.bookingAssetId ?? asset.id
         );

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -266,14 +266,32 @@ export function isAssetCheckableOut(
  * - a direct asset (`title`, no `_count`).
  *
  * Asset entries are merged with their booking-scoped record from
- * `bookingAssets` so `status`/`kitId` are authoritative (the atom entry can be
- * stale). Kit entries are returned flattened (`name`/`_count`) for rendering.
- * This logic was previously duplicated verbatim in both dialogs; extracting it
- * removes the drift that caused the bulk check-in bug.
+ * `bookingAssets` so genuine gaps in the selection are filled. Kit entries are
+ * returned flattened (`name`/`_count`) for rendering. This logic was previously
+ * duplicated verbatim in both dialogs; extracting it removes the drift that
+ * caused the bulk check-in bug.
+ *
+ * ### Per-slice enrichment (multi-slice QT support)
+ *
+ * A single `asset.id` can span MULTIPLE `BookingAsset` slices — e.g. a
+ * QUANTITY_TRACKED asset booked both standalone (`kitId: null`) and inside a
+ * kit (`kitId` set) is two distinct rows sharing one `asset.id`. To keep the
+ * two slices distinct we key the enrichment map by `bookingAssetId` (falling
+ * back to `id` for legacy entries that lack one), and look each selected item
+ * up by `item.bookingAssetId ?? item.id`.
+ *
+ * The merge lets the SELECTED item WIN (`{ ...bookingAsset, ...item }`): the
+ * selection atom holds the full enriched loader row, so its
+ * `bookingAssetId`/`kitId`/`kit` are authoritative — the booking record only
+ * fills genuine gaps. Merging the other way round would let a different slice's
+ * `kitId` clobber the selected standalone slice's `kitId: null`, so the row
+ * would render in neither the kit nor the individual bucket (the multi-slice
+ * checkout bug this fix addresses).
  *
  * @param selectedItems - Raw entries from `selectedBulkItemsAtom`.
- * @param bookingAssets - The booking's assets (`booking.assets`), used to
- *   enrich asset entries by id.
+ * @param bookingAssets - The booking's assets (one entry per `BookingAsset`
+ *   slice, each ideally carrying `bookingAssetId`), used to enrich asset
+ *   entries by slice.
  * @returns The flattened, enriched list (assets + kit entries), UNFILTERED —
  *   callers apply their own eligibility filter.
  */
@@ -281,16 +299,21 @@ export function flattenSelectedBookingItems(
   selectedItems: SelectedBookingItem[],
   bookingAssets: AssetWithStatus[]
 ): SelectedBookingItem[] {
+  // Key by `bookingAssetId` so two slices of the same `asset.id` stay
+  // distinct; fall back to `id` for legacy entries without a slice id.
   const bookingAssetsMap = new Map(
-    bookingAssets.map((asset) => [asset.id, asset])
+    bookingAssets.map((asset) => [asset.bookingAssetId ?? asset.id, asset])
   );
 
   return selectedItems.flatMap((item: any) => {
     // Pagination wrapper objects (type "asset" with an assets array).
     if (item.type === "asset" && item.assets) {
       return item.assets.map((asset: any) => {
-        const bookingAsset = bookingAssetsMap.get(asset.id);
-        return bookingAsset ? { ...asset, ...bookingAsset } : asset;
+        const bookingAsset = bookingAssetsMap.get(
+          asset.bookingAssetId ?? asset.id
+        );
+        // Selected item wins so its per-slice bookingAssetId/kitId survive.
+        return bookingAsset ? { ...bookingAsset, ...asset } : asset;
       });
     }
 
@@ -310,8 +333,9 @@ export function flattenSelectedBookingItems(
 
     // Direct asset object (has title, not name) — enrich from booking record.
     if (item.title) {
-      const bookingAsset = bookingAssetsMap.get(item.id);
-      return bookingAsset ? { ...item, ...bookingAsset } : item;
+      const bookingAsset = bookingAssetsMap.get(item.bookingAssetId ?? item.id);
+      // Selected item wins so its per-slice bookingAssetId/kitId survive.
+      return bookingAsset ? { ...bookingAsset, ...item } : item;
     }
 
     // Fallback for any other structure.

--- a/packages/database/prisma/migrations/20260706120000_add_booking_asset_ids_to_partial_booking_checkout/migration.sql
+++ b/packages/database/prisma/migrations/20260706120000_add_booking_asset_ids_to_partial_booking_checkout/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "PartialBookingCheckout"
+    ADD COLUMN "bookingAssetIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1599,7 +1599,14 @@ model PartialBookingCheckout {
   // unit count submitted for the matching `bookingAssetId`. Empty default
   // keeps legacy rows (written before Wave B) readable without a backfill.
   quantities    Int[]    @default([])
-  checkoutCount Int // Number of assets checked out (for quick reference)
+  // BookingAsset (slice) IDs per entry in `assetIds` (positional alignment
+  // with `assetIds`/`quantities`). Disambiguates a QUANTITY_TRACKED asset that
+  // is booked as multiple slices (e.g. standalone + kit member). An empty
+  // string `""` element means "no specific slice known → greedy attribution";
+  // Prisma `String[]` cannot hold `null`, so `""` is the sentinel. Empty
+  // default keeps legacy rows readable without a backfill.
+  bookingAssetIds String[] @default([])
+  checkoutCount   Int // Number of assets checked out (for quick reference)
 
   // Metadata
   checkoutTimestamp DateTime @default(now()) @db.Timestamptz(3)


### PR DESCRIPTION
A QUANTITY_TRACKED asset can be booked both standalone and inside a kit — two BookingAsset slices for the same asset. Three defects are fixed.

Render: selecting the standalone slice opened an empty bulk check-out dialog. flattenSelectedBookingItems now keys enrichment by bookingAssetId and lets the selected slice's own identity win, and the checkout dialog no longer collapses slices by asset id. Both bulk dialogs render standalone-slice selections.

Attribution: checkouts were stored per asset (no slice id), so the app guessed the slice via a greedy fallback and mis-credited standalone checkouts to the kit. PartialBookingCheckout gains a positional bookingAssetIds column (migration
+ schema); partialCheckoutBooking persists the exact slice; a shared checkoutSessionsToLogsByAsset parser feeds every attribution read site (overview loader + the service remaining / slice-remaining helpers). The greedy fallback for untagged scanner/legacy rows now fills standalone-first, since loose items are scanned individually while kits are handled as a whole.

Notes: the checkout activity note aggregated per asset, so a slice-level action reported asset-level totals ("111 still booked" against a 22-unit slice). It is now per-slice and labelled — "Gloves · standalone (11 of 22 checked out, 11 still booked)" / "Gloves · in kit Kittington (100 of 100 checked out)" — and drops the redundant asset mention for qty-only checkouts.

Follow-ups (out of scope): the check-in note has the same per-asset folding; the delegate full-checkout path under-counts per-asset quantity for multi-slice QT (pre-existing); the "Checked out on/by" columns are still asset-keyed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partial checkout and check-in now track quantity-tracked items at a finer “slice” level, improving accuracy when standalone and kit-based items are mixed.
  * Checkout notes are now slice-aware, showing whether an item was checked out standalone or as part of a kit.
* **Bug Fixes**
  * Fixed an issue where selected item details could be overwritten when displaying booking items.
  * Improved attribution consistency for legacy and mixed checkout data, including correct slice-selection precedence.
  * Added protection against stored Markdoc injection in checkout note content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->