### PR TITLE
fix(availability): keep thumbnails fixed-size and truncate long names

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/assets-list.tsx
+++ b/apps/webapp/app/components/assets/assets-index/assets-list.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { m } from "framer-motion";
 import { Package } from "lucide-react";
-import { useFetcher, useFetchers, useLoaderData } from "react-router";
+import { Link, useFetcher, useFetchers, useLoaderData } from "react-router";
 import { List, type ListProps } from "~/components/list";
 import { ListContentWrapper } from "~/components/list/content-wrapper";
 import { LocationBadge } from "~/components/location/location-badge";
@@ -173,21 +173,30 @@ export const AssetsList = ({
                             resource.extendedProps?.mainImageExpiration,
                         }}
                         alt={`Image of ${resource.title}`}
-                        className="size-14 rounded border object-cover"
+                        className="size-14 shrink-0 rounded border object-cover"
                         withPreview
                       />
-                      <div className="flex flex-col gap-1">
-                        <div className="min-w-0 flex-1 truncate">
-                          <Button
-                            to={`/assets/${resource.id}`}
-                            variant="link"
-                            className="text-left font-medium text-gray-900 hover:text-gray-700"
-                            target={"_blank"}
-                            onlyNewTabIconOnHover={true}
-                          >
-                            {resource.title}
-                          </Button>
-                        </div>
+                      <div className="flex min-w-0 flex-1 flex-col gap-1">
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Link
+                                to={`/assets/${resource.id}`}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="block truncate text-left font-medium text-gray-900 hover:text-gray-700"
+                              >
+                                {resource.title}
+                              </Link>
+                            </TooltipTrigger>
+                            <TooltipContent
+                              side="top"
+                              className="max-w-[400px]"
+                            >
+                              <p className="text-sm">{resource.title}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                         <div className="flex flex-wrap items-center gap-2">
                           <AssetStatusBadge
                             id={resource.id}

--- a/apps/webapp/app/components/assets/assets-index/assets-list.tsx
+++ b/apps/webapp/app/components/assets/assets-index/assets-list.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { m } from "framer-motion";
 import { Package } from "lucide-react";
-import { Link, useFetcher, useFetchers, useLoaderData } from "react-router";
+import { useFetcher, useFetchers, useLoaderData } from "react-router";
 import { List, type ListProps } from "~/components/list";
 import { ListContentWrapper } from "~/components/list/content-wrapper";
 import { LocationBadge } from "~/components/location/location-badge";
@@ -45,6 +45,7 @@ import AssetQuickActions from "./asset-quick-actions";
 import { AssetIndexFilters } from "./filters";
 import { ListItemTagsColumn } from "./list-item-tags-column";
 import AvailabilityCalendar from "../../availability-calendar/availability-calendar";
+import { ResourceTitleLink } from "../../availability-calendar/resource-title-link";
 import { CategoryBadge } from "../category-badge";
 import { useAssetAvailabilityData } from "./use-asset-availability-data";
 
@@ -177,26 +178,10 @@ export const AssetsList = ({
                         withPreview
                       />
                       <div className="flex min-w-0 flex-1 flex-col gap-1">
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Link
-                                to={`/assets/${resource.id}`}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="block truncate text-left font-medium text-gray-900 hover:text-gray-700"
-                              >
-                                {resource.title}
-                              </Link>
-                            </TooltipTrigger>
-                            <TooltipContent
-                              side="top"
-                              className="max-w-[400px]"
-                            >
-                              <p className="text-sm">{resource.title}</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <ResourceTitleLink
+                          to={`/assets/${resource.id}`}
+                          title={resource.title}
+                        />
                         <div className="flex flex-wrap items-center gap-2">
                           <AssetStatusBadge
                             id={resource.id}

--- a/apps/webapp/app/components/availability-calendar/availability-calendar.tsx
+++ b/apps/webapp/app/components/availability-calendar/availability-calendar.tsx
@@ -199,6 +199,7 @@ export default function AvailabilityCalendar({
               ]}
               slotLabelClassNames="font-normal text-gray-600"
               slotMinWidth={100}
+              resourceAreaWidth="35%"
               resourceLabelContent={resourceLabelContent}
               eventContent={renderEventCard}
               eventClassNames={(eventInfo) => {

--- a/apps/webapp/app/components/availability-calendar/resource-title-link.tsx
+++ b/apps/webapp/app/components/availability-calendar/resource-title-link.tsx
@@ -1,0 +1,64 @@
+/**
+ * Resource Title Link
+ *
+ * Renders the clickable asset/kit title shown in the left-hand label column of
+ * the availability (resource-timeline) calendar. The title truncates to a
+ * single line with an ellipsis when it overflows the fixed-width column, and a
+ * tooltip (surfaced on hover and keyboard focus) reveals the full title so it
+ * is never permanently hidden.
+ *
+ * Shared by the assets and kits availability views so the markup, truncation,
+ * tooltip, and focus styling stay identical across both surfaces.
+ *
+ * @see {@link file://./availability-calendar.tsx}
+ * @see {@link file://./../assets/assets-index/assets-list.tsx}
+ * @see {@link file://./../../routes/_layout+/kits._index.tsx}
+ */
+import { Link } from "react-router";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/components/shared/tooltip";
+
+/** Props for {@link ResourceTitleLink}. */
+type ResourceTitleLinkProps = {
+  /** Destination path for the asset/kit detail page (opened in a new tab). */
+  to: string;
+  /** Full title, used both as the visible (truncated) label and tooltip text. */
+  title: string;
+};
+
+/**
+ * A truncating, tooltip-backed title link for availability-calendar rows.
+ *
+ * The detail page opens in a new tab (the calendar is a working surface users
+ * don't want to navigate away from). The visible label truncates with an
+ * ellipsis; the Radix tooltip fires on hover and on keyboard focus, and a
+ * `focus-visible` ring keeps the link accessible to keyboard users.
+ *
+ * @param props - See {@link ResourceTitleLinkProps}.
+ * @returns The tooltip-wrapped, truncating title link.
+ */
+export function ResourceTitleLink({ to, title }: ResourceTitleLinkProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            to={to}
+            target="_blank"
+            rel="noreferrer"
+            className="block truncate rounded-sm text-left font-medium text-gray-900 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-1"
+          >
+            {title}
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[400px]">
+          <p className="text-sm">{title}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -30,6 +30,12 @@ import { Button } from "~/components/shared/button";
 import { Card } from "~/components/shared/card";
 import { GrayBadge } from "~/components/shared/gray-badge";
 import { InfoTooltip } from "~/components/shared/info-tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/components/shared/tooltip";
 import { Td, Th } from "~/components/table";
 import { TeamMemberBadge } from "~/components/user/team-member-badge";
 import { db } from "~/database/db.server";
@@ -349,21 +355,27 @@ export default function KitsIndexPage() {
                       alt: resource.title,
                     }}
                     alt={resource.title}
-                    className="size-14 rounded border object-cover"
+                    className="size-14 shrink-0 rounded border object-cover"
                     withPreview
                   />
-                  <div className="flex flex-col gap-1">
-                    <div className="min-w-0 flex-1 truncate">
-                      <Button
-                        to={`/kits/${resource.id}/assets`}
-                        variant="link"
-                        className="text-left font-medium text-gray-900 hover:text-gray-700"
-                        target={"_blank"}
-                        onlyNewTabIconOnHover={true}
-                      >
-                        {resource.title}
-                      </Button>
-                    </div>
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Link
+                            to={`/kits/${resource.id}/assets`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="block truncate text-left font-medium text-gray-900 hover:text-gray-700"
+                          >
+                            {resource.title}
+                          </Link>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-[400px]">
+                          <p className="text-sm">{resource.title}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                     <div className="flex items-center gap-2">
                       <KitStatusBadge
                         status={resource.extendedProps?.status}

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -12,6 +12,7 @@ import { useKitAvailabilityData } from "~/components/assets/assets-index/use-kit
 import { AvailabilityViewToggle } from "~/components/assets/assets-index/view-toggle";
 import { CategoryBadge } from "~/components/assets/category-badge";
 import AvailabilityCalendar from "~/components/availability-calendar/availability-calendar";
+import { ResourceTitleLink } from "~/components/availability-calendar/resource-title-link";
 import { StatusFilter } from "~/components/booking/status-filter";
 import DynamicDropdown from "~/components/dynamic-dropdown/dynamic-dropdown";
 import { ChevronRight } from "~/components/icons/library";
@@ -30,12 +31,6 @@ import { Button } from "~/components/shared/button";
 import { Card } from "~/components/shared/card";
 import { GrayBadge } from "~/components/shared/gray-badge";
 import { InfoTooltip } from "~/components/shared/info-tooltip";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "~/components/shared/tooltip";
 import { Td, Th } from "~/components/table";
 import { TeamMemberBadge } from "~/components/user/team-member-badge";
 import { db } from "~/database/db.server";
@@ -359,23 +354,10 @@ export default function KitsIndexPage() {
                     withPreview
                   />
                   <div className="flex min-w-0 flex-1 flex-col gap-1">
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Link
-                            to={`/kits/${resource.id}/assets`}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="block truncate text-left font-medium text-gray-900 hover:text-gray-700"
-                          >
-                            {resource.title}
-                          </Link>
-                        </TooltipTrigger>
-                        <TooltipContent side="top" className="max-w-[400px]">
-                          <p className="text-sm">{resource.title}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
+                    <ResourceTitleLink
+                      to={`/kits/${resource.id}/assets`}
+                      title={resource.title}
+                    />
                     <div className="flex items-center gap-2">
                       <KitStatusBadge
                         status={resource.extendedProps?.status}


### PR DESCRIPTION
The assets and kits availability (resource-timeline) views rendered each row's image as a bare flex child, so a long asset/kit name shrank the thumbnail. Long names were also hard-clipped at the fixed-width label column with no ellipsis or tooltip, because the name link was a nested-span Button that stops text-overflow from rendering.

- Add shrink-0 to the thumbnail so it holds its 56px size regardless of name length (matches the regular list view).
- Replace the name Button with a truncating Link showing an ellipsis plus a hover tooltip with the full title; give the text block min-w-0 flex-1 so truncation engages.
- Widen the resource label column via resourceAreaWidth="35%".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated, linked titles for asset and kit entries in the availability calendar, with accessible hover/focus tooltips to reveal full names.
  * Updated those labels to open in a new browser tab for smoother navigation.
  * Improved calendar readability by constraining the resource area width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->