### PR TITLE
feat: Booking Manager role (#1800) + booking authorization spine

### DIFF
--- a/apps/companion/lib/permissions.ts
+++ b/apps/companion/lib/permissions.ts
@@ -81,7 +81,11 @@ const ROLE_PERMISSIONS: Record<
  */
 export function userCanSeeOrgWideAudits(roles: string[] | undefined): boolean {
   if (!roles?.length) return false;
-  return roles.some((role) => role === "OWNER" || role === "ADMIN");
+  // BOOKING_MANAGER mirrors the server's non-scoped branch (it is not
+  // SELF_SERVICE/BASE), so it sees org-wide audits like admins do.
+  return roles.some(
+    (role) => role === "OWNER" || role === "ADMIN" || role === "BOOKING_MANAGER"
+  );
 }
 
 /**

--- a/apps/companion/lib/permissions.ts
+++ b/apps/companion/lib/permissions.ts
@@ -43,6 +43,15 @@ const ROLE_PERMISSIONS: Record<
     audit: ["read", "update"],
     kit: ["read", "custody"],
   },
+  // Mirrors the webapp Role2PermissionMap entry (issue #1800). Booking
+  // detail buttons are server-flag-driven, so this activates scanner-action
+  // parity at the next binary release; older binaries fail closed.
+  BOOKING_MANAGER: {
+    asset: ["read", "custody"],
+    booking: ["read", "create", "update", "checkout", "checkin"],
+    audit: ["read", "update"],
+    kit: ["read", "custody"],
+  },
   BASE: {
     asset: ["read"],
     booking: ["read"],

--- a/apps/docs/hooks.md
+++ b/apps/docs/hooks.md
@@ -183,6 +183,7 @@ The useUserRoleHelper function returns an object(roles) and helper boolean attri
 - `isAdministratorOrOwner`: A boolean value indicating whether the user has either the 'ADMIN' or 'OWNER'role.
 - `isSelfService`: A boolean value indicating whether the user has the 'SELF_SERVICE' role.
 - `isBase`: A boolean value indicating whether the user has the 'BASE' role.
+- `isBookingManager`: A boolean value indicating whether the user has the 'BOOKING_MANAGER' role.
 - `isBaseOrSelfService`: A boolean value indicating whether the user has either the BASE or 'SELF_SERVICE' role.
 
 **Usage:**

--- a/apps/docs/sso/index.md
+++ b/apps/docs/sso/index.md
@@ -27,7 +27,7 @@ Any existing **standard (non-SSO) accounts** that use the SSO domain — for exa
 
 ### 4. Plan your group-to-role mapping [#](#4-plan-group-mapping)
 
-Shelf decides which role a user gets by matching the groups they belong to in your identity provider. You map those groups to Shelf roles (Administrator, Self service, Base) in the workspace settings.
+Shelf decides which role a user gets by matching the groups they belong to in your identity provider. You map those groups to Shelf roles (Administrator, Self service, Base) in the workspace settings. The Booking manager role cannot currently be assigned via SSO group mapping; assign it manually from Settings > Team (that user must not be SSO-managed, or the mapping will overwrite the role on next login).
 
 > [!NOTE]
 > You only need to map the **roles you actually use** — a single group mapping is enough for SSO to work. You do not need to create a group for every role. See your provider guide below for whether to use group **names** or group **IDs**.

--- a/apps/webapp/app/components/booking/explicit-checkin-settings.tsx
+++ b/apps/webapp/app/components/booking/explicit-checkin-settings.tsx
@@ -49,11 +49,12 @@ export function ExplicitCheckinSettings({
           }}
         >
           <FormRow
-            rowLabel="Require explicit check-in for Admins"
+            rowLabel="Require explicit check-in for Admins & Booking managers"
             subHeading={
               <div>
-                When enabled, administrators must use the scanner-based explicit
-                check-in flow instead of the one-click quick check-in.
+                When enabled, administrators and booking managers must use the
+                scanner-based explicit check-in flow instead of the one-click
+                quick check-in.
               </div>
             }
             className="border-b-0 pb-[10px] pt-0"
@@ -63,13 +64,13 @@ export function ExplicitCheckinSettings({
                 name={zo.fields.requireExplicitCheckinForAdmin()}
                 disabled={!isOwner}
                 defaultChecked={defaultValues.requireExplicitCheckinForAdmin}
-                title="Require explicit check-in for Admins"
+                title="Require explicit check-in for Admins & Booking managers"
               />
               <label
                 htmlFor={`requireExplicitCheckinForAdmin-${zo.fields.requireExplicitCheckinForAdmin()}`}
                 className="hidden text-gray-500"
               >
-                Require explicit check-in for Admins
+                Require explicit check-in for Admins & Booking managers
               </label>
             </div>
           </FormRow>

--- a/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
@@ -146,6 +146,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
     isAdministrator,
     isOwner,
     isSelfService,
+    isBookingManager,
   } = useUserRoleHelper();
 
   const zo = useZorm(
@@ -433,7 +434,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
                 disabled={disabled || isLoadingWorkingHours}
                 requireExplicitCheckin={
                   !isOwner &&
-                  ((isAdministrator &&
+                  (((isAdministrator || isBookingManager) &&
                     bookingSettings.requireExplicitCheckinForAdmin) ||
                     (isSelfService &&
                       bookingSettings.requireExplicitCheckinForSelfService))

--- a/apps/webapp/app/components/settings/import-users-dialog/import-users-dialog.tsx
+++ b/apps/webapp/app/components/settings/import-users-dialog/import-users-dialog.tsx
@@ -132,8 +132,9 @@ export default function ImportUsersDialog({
                   You must use <b>, (comma)</b> as a delimiter in your CSV file.
                 </li>
                 <li>
-                  Only valid roles are <b>ADMIN</b>, <b>BASE</b> and{" "}
-                  <b>SELF_SERVICE</b>. Role column is case-sensitive.
+                  Only valid roles are <b>ADMIN</b>, <b>BASE</b>,{" "}
+                  <b>SELF_SERVICE</b> and <b>BOOKING_MANAGER</b>. Role column is
+                  case-sensitive.
                 </li>
                 <li>
                   Each row represents a new user to be invited. Ensure the email

--- a/apps/webapp/app/components/settings/invite-user-dialog.tsx
+++ b/apps/webapp/app/components/settings/invite-user-dialog.tsx
@@ -49,6 +49,7 @@ export const InviteUserFormSchema = z.object({
         OrganizationRoles.ADMIN,
         OrganizationRoles.BASE,
         OrganizationRoles.SELF_SERVICE,
+        OrganizationRoles.BOOKING_MANAGER,
       ],
       { message: "Please select a role" }
     )
@@ -60,6 +61,7 @@ const organizationRolesMap: Record<string, UserFriendlyRoles> = {
   [OrganizationRoles.ADMIN]: "Administrator",
   [OrganizationRoles.BASE]: "Base",
   [OrganizationRoles.SELF_SERVICE]: "Self service",
+  [OrganizationRoles.BOOKING_MANAGER]: "Booking manager",
 };
 
 export default function InviteUserDialog({

--- a/apps/webapp/app/components/update/update-form.tsx
+++ b/apps/webapp/app/components/update/update-form.tsx
@@ -149,6 +149,17 @@ export function UpdateForm({
             />
             <span className="text-sm">Base</span>
           </label>
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              name="targetBookingManager"
+              defaultChecked={targetRoles.includes(
+                OrganizationRoles.BOOKING_MANAGER
+              )}
+              className="rounded"
+            />
+            <span className="text-sm">Booking manager</span>
+          </label>
           <p className="text-xs text-gray-500">
             Leave all unchecked to make the update visible to all users
           </p>

--- a/apps/webapp/app/components/workspace/change-role-dialog.tsx
+++ b/apps/webapp/app/components/workspace/change-role-dialog.tsx
@@ -28,6 +28,7 @@ const roleOptions: Record<string, UserFriendlyRoles> = {
   [OrganizationRoles.ADMIN]: "Administrator",
   [OrganizationRoles.BASE]: "Base",
   [OrganizationRoles.SELF_SERVICE]: "Self service",
+  [OrganizationRoles.BOOKING_MANAGER]: "Booking manager",
 };
 
 interface EntityCounts {

--- a/apps/webapp/app/hooks/use-sidebar-nav-items.tsx
+++ b/apps/webapp/app/hooks/use-sidebar-nav-items.tsx
@@ -68,7 +68,7 @@ export type NavItem =
 export function useSidebarNavItems() {
   const { isAdmin, canUseBookings, subscription, unreadUpdatesCount } =
     useLoaderData<typeof loader>();
-  const { isBaseOrSelfService } = useUserRoleHelper();
+  const { isBaseOrSelfService, isBookingManager } = useUserRoleHelper();
   const currentOrganization = useCurrentOrganization();
   const isPersonalOrganization = isPersonalOrg(currentOrganization);
 
@@ -110,7 +110,8 @@ export function useSidebarNavItems() {
       title: "Home",
       to: "/home",
       Icon: HomeIcon,
-      hidden: isBaseOrSelfService,
+      // Booking managers have no dashboard permission (issue #1800)
+      hidden: isBaseOrSelfService || isBookingManager,
     },
     {
       type: "child",
@@ -173,7 +174,8 @@ export function useSidebarNavItems() {
       type: "child",
       title: "Reminders",
       Icon: AlarmClockIcon,
-      hidden: isBaseOrSelfService,
+      // Booking managers have no assetReminders permission (issue #1800)
+      hidden: isBaseOrSelfService || isBookingManager,
       to: "/reminders",
     },
     {
@@ -214,7 +216,8 @@ export function useSidebarNavItems() {
       type: "parent",
       title: "Workspace settings",
       Icon: SettingsIcon,
-      hidden: isBaseOrSelfService,
+      // Booking managers administer nothing (issue #1800)
+      hidden: isBaseOrSelfService || isBookingManager,
       children: [
         {
           title: "General",

--- a/apps/webapp/app/hooks/use-sidebar-nav-items.tsx
+++ b/apps/webapp/app/hooks/use-sidebar-nav-items.tsx
@@ -188,13 +188,16 @@ export function useSidebarNavItems() {
     {
       type: "label",
       title: "Organization",
-      hidden: isBaseOrSelfService,
+      // Also hidden for booking managers: the /settings layout loader gates
+      // on generalSettings.read, which their matrix denies (issue #1800) —
+      // their teamMember.read serves the booking-form custodian pickers.
+      hidden: isBaseOrSelfService || isBookingManager,
     },
     {
       type: "parent",
       title: "Team",
       Icon: UsersRoundIcon,
-      hidden: isBaseOrSelfService,
+      hidden: isBaseOrSelfService || isBookingManager,
       children: [
         {
           title: "Users",

--- a/apps/webapp/app/hooks/user-user-role-helper.ts
+++ b/apps/webapp/app/hooks/user-user-role-helper.ts
@@ -17,6 +17,8 @@ export function useUserRoleHelper() {
   const isSelfService =
     roles?.includes(OrganizationRoles.SELF_SERVICE) || false;
   const isBase = roles?.includes(OrganizationRoles.BASE) || false;
+  const isBookingManager =
+    roles?.includes(OrganizationRoles.BOOKING_MANAGER) || false;
 
   /** A lot of actions share the same permissions for base & self service */
   const isBaseOrSelfService = isBase || isSelfService;
@@ -28,6 +30,7 @@ export function useUserRoleHelper() {
     isAdministratorOrOwner,
     isSelfService,
     isBase,
+    isBookingManager,
     isBaseOrSelfService,
   };
 }

--- a/apps/webapp/app/modules/asset/data.server.ts
+++ b/apps/webapp/app/modules/asset/data.server.ts
@@ -6,6 +6,7 @@ import { data, redirect } from "react-router";
 import type { HeaderData } from "~/components/layout/header/types";
 import { db } from "~/database/db.server";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
+import { CUSTODIAN_USER_SAFE_SELECT } from "~/modules/booking/constants";
 import type { AllowedModelNames } from "~/routes/api+/model-filters";
 import { getClientHint } from "~/utils/client-hints";
 import {
@@ -241,7 +242,7 @@ export async function simpleModeLoader({
                       to: true,
                       description: true,
                       custodianTeamMember: true,
-                      custodianUser: true,
+                      custodianUser: CUSTODIAN_USER_SAFE_SELECT,
                       tags: TAG_WITH_COLOR_SELECT,
                       creator: {
                         select: {

--- a/apps/webapp/app/modules/asset/fields.ts
+++ b/apps/webapp/app/modules/asset/fields.ts
@@ -1,4 +1,5 @@
 import type { BookingStatus, Prisma } from "@prisma/client";
+import { CUSTODIAN_USER_SAFE_SELECT } from "~/modules/booking/constants";
 
 export const LOCATION_WITH_HIERARCHY = {
   select: {
@@ -140,7 +141,7 @@ export const getAssetOverviewFields = (
             name: true,
             from: true,
             custodianTeamMember: true,
-            custodianUser: true,
+            custodianUser: CUSTODIAN_USER_SAFE_SELECT,
           },
         },
       },

--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -1,10 +1,29 @@
 import type { Prisma } from "@prisma/client";
 import { TAG_WITH_COLOR_SELECT } from "../tag/constants";
 
+/**
+ * Safe field set whenever a booking payload carries its custodian's User.
+ * The full User row must never ride along: it includes billing/auth fields
+ * (Stripe customerId, hasUnpaidInvoice, sso flags) that no booking surface
+ * needs. Everything display-side resolves names via resolveUserDisplayName
+ * (displayName/firstName/lastName); email feeds notifications/CSV/PDF;
+ * profilePicture feeds avatars (web + companion).
+ */
+export const CUSTODIAN_USER_SAFE_SELECT = {
+  select: {
+    id: true,
+    firstName: true,
+    lastName: true,
+    displayName: true,
+    profilePicture: true,
+    email: true,
+  },
+} satisfies Prisma.UserDefaultArgs;
+
 /** Includes needed for booking to have all data required for emails */
 export const BOOKING_INCLUDE_FOR_EMAIL = {
   custodianTeamMember: true,
-  custodianUser: true,
+  custodianUser: CUSTODIAN_USER_SAFE_SELECT,
   // Include creator details so the notification resolver can add the
   // booking creator as a recipient when the org setting is enabled
   creator: {
@@ -101,7 +120,7 @@ export const BOOKING_EMAIL_ASSETS_DISPLAY_LIMIT = 10;
 /** Common relations to include in a booking */
 export const BOOKING_COMMON_INCLUDE = {
   custodianTeamMember: true,
-  custodianUser: true,
+  custodianUser: CUSTODIAN_USER_SAFE_SELECT,
   tags: TAG_WITH_COLOR_SELECT,
 } as Prisma.BookingInclude;
 

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -45,7 +45,16 @@ export interface PdfDbResult {
   booking: Prisma.BookingGetPayload<{
     include: {
       custodianTeamMember: true;
-      custodianUser: true;
+      custodianUser: {
+        select: {
+          id: true;
+          firstName: true;
+          lastName: true;
+          displayName: true;
+          profilePicture: true;
+          email: true;
+        };
+      };
       tags: typeof TAG_WITH_COLOR_SELECT;
     };
   }>;

--- a/apps/webapp/app/modules/booking/service.server.status-guards.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.status-guards.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+/**
+ * State-transition guards on the FULL checkout/checkin services. Both are
+ * called directly by the web action and the mobile endpoints, so a direct
+ * POST must not be able to check out a DRAFT booking or force a RESERVED
+ * booking to COMPLETE. (The partial/progressive paths carry their own
+ * guards — see service.server.partial-checkout.test.ts.)
+ */
+import { BookingStatus } from "@prisma/client";
+import { db } from "~/database/db.server";
+import { checkinBooking, checkoutBooking } from "./service.server";
+
+// why: guard tests only need the initial booking fetch — the functions must
+// throw BEFORE any other db call, so everything else can be inert stubs
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    booking: {
+      findUniqueOrThrow: vitest.fn(),
+      update: vitest.fn(),
+    },
+    bookingSettings: { findUnique: vitest.fn(), upsert: vitest.fn() },
+    $transaction: vitest.fn(),
+  },
+}));
+
+// why: the scheduler must never be touched by a rejected transition
+vitest.mock("~/utils/scheduler.server", () => ({
+  scheduler: { work: vitest.fn(), cancel: vitest.fn(), sendAfter: vitest.fn() },
+  QueueNames: { bookingQueue: "booking-queue" },
+}));
+
+const HINTS = { timeZone: "UTC", locale: "en-US" };
+
+function mockBooking(status: BookingStatus) {
+  (db.booking.findUniqueOrThrow as any).mockResolvedValue({
+    id: "booking-1",
+    status,
+    from: new Date("2026-07-01T09:00:00Z"),
+    to: new Date("2026-07-02T09:00:00Z"),
+    bookingAssets: [],
+  });
+}
+
+beforeEach(() => {
+  vitest.clearAllMocks();
+});
+
+describe("checkoutBooking status guard", () => {
+  it.each([
+    BookingStatus.DRAFT,
+    BookingStatus.ONGOING,
+    BookingStatus.OVERDUE,
+    BookingStatus.COMPLETE,
+    BookingStatus.CANCELLED,
+    BookingStatus.ARCHIVED,
+  ])("rejects a %s booking before any mutation", async (status) => {
+    mockBooking(status);
+
+    await expect(
+      checkoutBooking({
+        id: "booking-1",
+        organizationId: "org-1",
+        hints: HINTS,
+        userId: "user-1",
+      })
+    ).rejects.toThrow("can't be checked out in its current status");
+
+    expect(db.booking.update).not.toHaveBeenCalled();
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkinBooking status guard", () => {
+  it.each([
+    BookingStatus.DRAFT,
+    BookingStatus.RESERVED,
+    BookingStatus.COMPLETE,
+    BookingStatus.CANCELLED,
+    BookingStatus.ARCHIVED,
+  ])("rejects a %s booking before any mutation", async (status) => {
+    mockBooking(status);
+
+    await expect(
+      checkinBooking({
+        id: "booking-1",
+        organizationId: "org-1",
+        hints: HINTS,
+        userId: "user-1",
+      })
+    ).rejects.toThrow("can't be checked in in its current status");
+
+    expect(db.booking.update).not.toHaveBeenCalled();
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -458,7 +458,16 @@ describe("createBooking", () => {
         },
       },
       include: {
-        custodianUser: true,
+        custodianUser: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            displayName: true,
+            profilePicture: true,
+            email: true,
+          },
+        },
         custodianTeamMember: true,
         organization: true,
         tags: {
@@ -558,7 +567,16 @@ describe("createBooking", () => {
         },
       },
       include: {
-        custodianUser: true,
+        custodianUser: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            displayName: true,
+            profilePicture: true,
+            email: true,
+          },
+        },
         custodianTeamMember: true,
         organization: true,
         tags: {
@@ -763,6 +781,7 @@ describe("partialCheckinBooking", () => {
     //@ts-expect-error missing vitest type
     db.booking.findUniqueOrThrow.mockResolvedValue({
       ...mockBookingData,
+      status: BookingStatus.ONGOING,
       bookingAssets: [
         {
           asset: { id: "asset-1", assetKits: [] },
@@ -812,6 +831,7 @@ describe("partialCheckinBooking", () => {
     //@ts-expect-error missing vitest type
     db.booking.findUniqueOrThrow.mockResolvedValue({
       ...mockBookingData,
+      status: BookingStatus.ONGOING,
       assets: [
         { id: "asset-1", kitId: null },
         { id: "asset-2", kitId: null },
@@ -2292,8 +2312,8 @@ describe("checkoutBooking", () => {
     );
   });
 
-  it("should handle checkout for non-reserved booking", async () => {
-    expect.assertions(1);
+  it("rejects checkout for a non-reserved booking (status guard)", async () => {
+    expect.assertions(2);
 
     const mockBooking = {
       ...mockBookingData,
@@ -2302,14 +2322,11 @@ describe("checkoutBooking", () => {
     };
     //@ts-expect-error missing vitest type
     db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
-    //@ts-expect-error missing vitest type
-    db.booking.update.mockResolvedValue({
-      ...mockBooking,
-      status: BookingStatus.ONGOING,
-    });
 
-    const result = await checkoutBooking(mockCheckoutParams);
-    expect(result).toBeDefined();
+    await expect(checkoutBooking(mockCheckoutParams)).rejects.toThrow(
+      "can't be checked out in its current status"
+    );
+    expect(db.booking.update).not.toHaveBeenCalled();
   });
 
   /**
@@ -3215,20 +3232,17 @@ describe("checkinBooking", () => {
     });
   });
 
-  it("should handle checkin for non-ongoing booking", async () => {
-    expect.assertions(1);
+  it("rejects checkin for a non-ongoing booking (status guard)", async () => {
+    expect.assertions(2);
 
     const mockBooking = { ...mockBookingData, status: BookingStatus.DRAFT };
     //@ts-expect-error missing vitest type
     db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
-    //@ts-expect-error missing vitest type
-    db.booking.update.mockResolvedValue({
-      ...mockBooking,
-      status: BookingStatus.COMPLETE,
-    });
 
-    const result = await checkinBooking(mockCheckinParams);
-    expect(result).toBeDefined();
+    await expect(checkinBooking(mockCheckinParams)).rejects.toThrow(
+      "can't be checked in in its current status"
+    );
+    expect(db.booking.update).not.toHaveBeenCalled();
   });
 
   it("should schedule auto-archive when enabled", async () => {

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -86,6 +86,7 @@ import { QueueNames, scheduler } from "~/utils/scheduler.server";
 import { resolveUserDisplayName } from "~/utils/user";
 import type { MergeInclude } from "~/utils/utils";
 import {
+  CUSTODIAN_USER_SAFE_SELECT,
   BOOKING_COMMON_INCLUDE,
   BOOKING_INCLUDE_FOR_EMAIL,
   BOOKING_INCLUDE_FOR_RESERVATION_EMAIL,
@@ -2197,6 +2198,25 @@ export async function checkoutBooking({
      * (other booking checkouts, direct custody assignments, quantity
      * adjustments) that could oversubscribe the same physical pool.
      */
+    // Reject ineligible booking statuses BEFORE any mutation (mirrors the
+    // partialCheckoutBooking guard). A FULL checkout starts a RESERVED
+    // booking; continuing an ONGOING/OVERDUE booking flows through the
+    // partial/remaining-assets paths, which carry their own status guards.
+    // Both the web action and the mobile endpoint call this service
+    // directly, so without this guard a direct POST against a
+    // DRAFT/ONGOING/COMPLETE/CANCELLED/ARCHIVED booking would flip asset
+    // statuses and re-run the whole checkout side-effect chain.
+    if (bookingFound.status !== BookingStatus.RESERVED) {
+      throw new ShelfError({
+        cause: null,
+        status: 400,
+        label,
+        message:
+          "This booking can't be checked out in its current status. Only reserved bookings can be checked out.",
+        shouldBeCaptured: false,
+      });
+    }
+
     const qtyTrackedBookingAssets = bookingFound.bookingAssets.filter((ba) =>
       isQuantityTracked(ba.asset)
     );
@@ -3610,6 +3630,25 @@ export async function checkinBooking({
           shouldBeCaptured: !isNotFoundError(cause),
         });
       });
+
+    // Reject ineligible booking statuses BEFORE any mutation (mirrors the
+    // partialCheckoutBooking guard). Only checked-out bookings can be
+    // checked in; a direct POST against a DRAFT/RESERVED/COMPLETE booking
+    // would otherwise force it straight to COMPLETE and corrupt asset
+    // statuses.
+    if (
+      bookingFound.status !== BookingStatus.ONGOING &&
+      bookingFound.status !== BookingStatus.OVERDUE
+    ) {
+      throw new ShelfError({
+        cause: null,
+        status: 400,
+        label,
+        message:
+          "This booking can't be checked in in its current status. Only ongoing or overdue bookings can be checked in.",
+        shouldBeCaptured: false,
+      });
+    }
 
     const dataToUpdate: Prisma.BookingUpdateInput = {
       status: BookingStatus.COMPLETE,
@@ -5265,7 +5304,7 @@ export async function partialCheckinBooking({
         where: { id },
         include: {
           bookingAssets: true,
-          custodianUser: true,
+          custodianUser: CUSTODIAN_USER_SAFE_SELECT,
           custodianTeamMember: true,
           _count: { select: { bookingAssets: true } },
         },
@@ -5278,7 +5317,7 @@ export async function partialCheckinBooking({
           data: { status: BookingStatus.COMPLETE },
           include: {
             bookingAssets: true,
-            custodianUser: true,
+            custodianUser: CUSTODIAN_USER_SAFE_SELECT,
             custodianTeamMember: true,
             _count: { select: { bookingAssets: true } },
           },
@@ -6499,7 +6538,7 @@ export async function partialCheckoutBooking({
         where: { id },
         include: {
           bookingAssets: { include: { asset: true } },
-          custodianUser: true,
+          custodianUser: CUSTODIAN_USER_SAFE_SELECT,
           custodianTeamMember: true,
           _count: { select: { bookingAssets: true } },
         },
@@ -9099,7 +9138,7 @@ export async function getBookingsForCalendar(params: {
       tags,
       extraInclude: {
         custodianTeamMember: true,
-        custodianUser: true,
+        custodianUser: CUSTODIAN_USER_SAFE_SELECT,
         creator: {
           select: {
             id: true,

--- a/apps/webapp/app/modules/booking/types.d.ts
+++ b/apps/webapp/app/modules/booking/types.d.ts
@@ -20,7 +20,16 @@ export type BookingWithIncludes = Prisma.BookingGetPayload<{
   include: {
     bookingAssets: true;
     custodianTeamMember: true;
-    custodianUser: true;
+    custodianUser: {
+      select: {
+        id: true;
+        firstName: true;
+        lastName: true;
+        displayName: true;
+        profilePicture: true;
+        email: true;
+      };
+    };
   };
 }>;
 
@@ -45,7 +54,16 @@ export type BookingWithCustodians = Prisma.BookingGetPayload<{
     bookingAssets: true;
     from: true;
     to: true;
-    custodianUser: true;
+    custodianUser: {
+      select: {
+        id: true;
+        firstName: true;
+        lastName: true;
+        displayName: true;
+        profilePicture: true;
+        email: true;
+      };
+    };
     custodianTeamMember: true;
   };
 }>;

--- a/apps/webapp/app/modules/user/utils.server.ts
+++ b/apps/webapp/app/modules/user/utils.server.ts
@@ -216,9 +216,9 @@ export async function resolveUserAction(
       );
 
       /** Find the Role based on its user friendly name */
-      const role = Object.keys(organizationRolesMap).find(
-        (key) => organizationRolesMap[key] === userFriendlyRole
-      ) as OrganizationRoles | undefined;
+      const role = (
+        Object.keys(organizationRolesMap) as OrganizationRoles[]
+      ).find((key) => organizationRolesMap[key] === userFriendlyRole);
 
       if (!role) {
         throw new ShelfError({

--- a/apps/webapp/app/routes/_layout+/admin-dashboard+/updates.$updateId.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/admin-dashboard+/updates.$updateId.edit.tsx
@@ -61,6 +61,8 @@ export const action = async ({
     if (formData.get("targetSelfService"))
       targetRoles.push(OrganizationRoles.SELF_SERVICE);
     if (formData.get("targetBase")) targetRoles.push(OrganizationRoles.BASE);
+    if (formData.get("targetBookingManager"))
+      targetRoles.push(OrganizationRoles.BOOKING_MANAGER);
 
     const payload = parseData(
       formData,

--- a/apps/webapp/app/routes/_layout+/admin-dashboard+/updates.new.tsx
+++ b/apps/webapp/app/routes/_layout+/admin-dashboard+/updates.new.tsx
@@ -42,6 +42,8 @@ export const action = async ({ context, request }: ActionFunctionArgs) => {
     if (formData.get("targetSelfService"))
       targetRoles.push(OrganizationRoles.SELF_SERVICE);
     if (formData.get("targetBase")) targetRoles.push(OrganizationRoles.BASE);
+    if (formData.get("targetBookingManager"))
+      targetRoles.push(OrganizationRoles.BOOKING_MANAGER);
 
     const payload = parseData(
       formData,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.activity.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.activity.tsx
@@ -20,6 +20,7 @@ import {
   deleteBookingNote,
 } from "~/modules/booking-note/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { assertBookingVisibility } from "~/utils/booking-authorization.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
 import {
@@ -51,7 +52,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   try {
     // Parent route already enforces booking.read permission
     // Only check bookingNote.read permission here
-    const { organizationId } = await requirePermission({
+    const { organizationId, canSeeAllBookings } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.bookingNote,
@@ -65,6 +66,12 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         organizationId,
       }),
     ]);
+
+    // Same visibility rule as the overview loader: without see-all rights,
+    // only the booking's custodian may view its activity. Without this, the
+    // tab (and its data payload) is reachable by direct URL for any booking
+    // in the org.
+    assertBookingVisibility({ booking, userId, canSeeAllBookings });
 
     const header: HeaderData = {
       title: `${booking.name}'s activity`,
@@ -101,7 +108,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const requiredAction =
       method === "DELETE" ? PermissionAction.delete : PermissionAction.create;
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, canSeeAllBookings } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.bookingNote,
@@ -119,7 +126,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
      */
     const booking = await db.booking.findFirst({
       where: { id: bookingId, organizationId },
-      select: { id: true },
+      select: { id: true, custodianUserId: true },
     });
 
     if (!booking) {
@@ -132,6 +139,10 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         shouldBeCaptured: false,
       });
     }
+
+    // Visibility parity with the loader: users who cannot view a booking
+    // must not be able to write or delete notes on it either.
+    assertBookingVisibility({ booking, userId, canSeeAllBookings });
 
     switch (method) {
       case "POST": {

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.activity[.csv].ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.activity[.csv].ts
@@ -1,6 +1,7 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import { assertBookingVisibility } from "~/utils/booking-authorization.server";
 import { exportBookingNotesToCsv } from "~/utils/csv.server";
 import { makeShelfError } from "~/utils/error";
 import { buildContentDisposition, error, getParams } from "~/utils/http.server";
@@ -19,7 +20,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   });
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, canSeeAllBookings } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.booking,
@@ -35,8 +36,12 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
 
     const booking = await db.booking.findFirstOrThrow({
       where: { id: bookingId, organizationId },
-      select: { name: true },
+      select: { name: true, custodianUserId: true },
     });
+
+    // Same visibility rule as the activity tab and overview loaders — the
+    // CSV must not expose an activity log the tab itself would 403 on.
+    assertBookingVisibility({ booking, userId, canSeeAllBookings });
 
     const csv = await exportBookingNotesToCsv({
       request,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkin-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkin-assets.tsx
@@ -29,6 +29,7 @@ import {
 import { calculatePartialCheckinProgress } from "~/modules/booking/utils.server";
 import scannerCss from "~/styles/scanner.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { assertBookingProcessAccess } from "~/utils/booking-authorization.server";
 import { canUserManageBookingAssets } from "~/utils/bookings";
 
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -395,11 +396,25 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
 
-    const { organizationId } = await requirePermission({
+    const { organizationId, role } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.booking,
       action: PermissionAction.checkin,
+    });
+
+    // Same direct-POST protection as the checkout twin: the loader's
+    // eligibility/custodian guard does not protect the action, and
+    // PermissionAction.checkin is granted to SELF_SERVICE org-wide.
+    const bookingToProcess = await db.booking.findUniqueOrThrow({
+      where: { id: bookingId, organizationId },
+      select: { custodianUserId: true },
+    });
+    assertBookingProcessAccess({
+      booking: bookingToProcess,
+      userId,
+      role,
+      action: "check in",
     });
 
     const formData = await request.formData();

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.tsx
@@ -55,6 +55,7 @@ import {
 } from "~/modules/booking/service.server";
 import scannerCss from "~/styles/scanner.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { assertBookingProcessAccess } from "~/utils/booking-authorization.server";
 import { canUserManageBookingAssets } from "~/utils/bookings";
 import { getClientHint } from "~/utils/client-hints";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
@@ -136,7 +137,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         userId,
         request,
         entity: PermissionEntity.booking,
-        action: PermissionAction.update,
+        // Mirrors the action: this scanner fulfils AND checks out.
+        action: PermissionAction.checkout,
       }
     );
 
@@ -147,6 +149,14 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       organizationId,
       userOrganizations,
       request,
+    });
+
+    // Authorization spine (see the action): custodian-only for SELF_SERVICE.
+    assertBookingProcessAccess({
+      booking,
+      userId,
+      role,
+      action: "check out",
     });
 
     const canManageAssets = canUserManageBookingAssets(booking, isSelfService);
@@ -262,11 +272,14 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
 
-    const { organizationId } = await requirePermission({
+    // This route performs the RESERVED -> ONGOING checkout transition, so it
+    // is gated on the checkout action (update alone would let roles that can
+    // edit bookings but not check them out reach a checkout side effect).
+    const { organizationId, role } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.booking,
-      action: PermissionAction.update,
+      action: PermissionAction.checkout,
     });
 
     const formData = await request.formData();
@@ -283,7 +296,16 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
      */
     const basicBookingInfo = await db.booking.findUniqueOrThrow({
       where: { id: bookingId, organizationId },
-      select: { from: true, to: true },
+      select: { from: true, to: true, custodianUserId: true },
+    });
+
+    // Authorization spine: prove the caller may process THIS booking
+    // (SELF_SERVICE custodian-only), not just that their role can check out.
+    assertBookingProcessAccess({
+      booking: basicBookingInfo,
+      userId,
+      role,
+      action: "check out",
     });
 
     await fulfilModelRequestsAndCheckout({

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -1661,7 +1661,10 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       case "checkIn": {
         // Enforce explicit check-in requirement based on role and settings
         if (
-          role === OrganizationRoles.ADMIN &&
+          // Booking managers are admin-class operationally, so the admin
+          // explicit-check-in policy applies to them too (unlike OWNER).
+          (role === OrganizationRoles.ADMIN ||
+            role === OrganizationRoles.BOOKING_MANAGER) &&
           bookingSettings.requireExplicitCheckinForAdmin
         ) {
           throw new ShelfError({

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -80,7 +80,10 @@ import { getUserByID } from "~/modules/user/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import bookingPageCss from "~/styles/booking.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
-import { validateBookingOwnership } from "~/utils/booking-authorization.server";
+import {
+  assertBookingProcessAccess,
+  validateBookingOwnership,
+} from "~/utils/booking-authorization.server";
 import { calculateTotalValueOfAssets } from "~/utils/bookings";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getClientHint, getHints } from "~/utils/client-hints";
@@ -1361,6 +1364,38 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const headers = [
       setCookie(await setSelectedOrganizationIdCookie(organizationId)),
     ];
+
+    /**
+     * Authorization spine for booking processing: every check-out/check-in
+     * intent must prove the caller may process THIS booking, not just that
+     * their role holds the permission action. The loader's visibility 403
+     * does not protect actions (they are directly POST-able), and
+     * SELF_SERVICE holds checkout/checkin org-wide in the permission matrix
+     * while only being allowed to process bookings they are custodian of.
+     * Status eligibility is enforced separately in the service layer.
+     */
+    const PROCESS_INTENTS = [
+      "checkOut",
+      "checkOutRemaining",
+      "checkIn",
+      "partial-checkin",
+      "partial-checkout",
+    ] as const;
+    if ((PROCESS_INTENTS as readonly string[]).includes(intent)) {
+      const bookingToProcess = await db.booking.findUniqueOrThrow({
+        where: { id, organizationId },
+        select: { custodianUserId: true },
+      });
+      assertBookingProcessAccess({
+        booking: bookingToProcess,
+        userId,
+        role,
+        action:
+          intent === "checkIn" || intent === "partial-checkin"
+            ? "check in"
+            : "check out",
+      });
+    }
 
     /**
      * Handle delete before fetching booking info.

--- a/apps/webapp/app/routes/_layout+/bookings._index.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings._index.tsx
@@ -574,7 +574,16 @@ const ListBookingsContent = ({
       };
       from: true;
       to: true;
-      custodianUser: true;
+      custodianUser: {
+        select: {
+          id: true;
+          firstName: true;
+          lastName: true;
+          displayName: true;
+          profilePicture: true;
+          email: true;
+        };
+      };
       custodianTeamMember: true;
       tags: { select: { id: true; name: true; color: true } };
       // Included via `extraInclude` in the loader above so the

--- a/apps/webapp/app/routes/_layout+/home.tsx
+++ b/apps/webapp/app/routes/_layout+/home.tsx
@@ -34,6 +34,7 @@ import Header from "~/components/layout/header";
 import type { HeaderData } from "~/components/layout/header/types";
 import { db } from "~/database/db.server";
 import { getUpcomingRemindersForHomePage } from "~/modules/asset-reminder/service.server";
+import { CUSTODIAN_USER_SAFE_SELECT } from "~/modules/booking/constants";
 import { getBookings } from "~/modules/booking/service.server";
 
 import styles from "~/styles/layout/skeleton-loading.css?url";
@@ -206,7 +207,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         statuses: ["ONGOING", "OVERDUE"],
         extraInclude: {
           custodianTeamMember: true,
-          custodianUser: true,
+          custodianUser: CUSTODIAN_USER_SAFE_SELECT,
           _count: { select: { bookingAssets: true } },
         },
       }),
@@ -223,7 +224,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         bookingTo: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
         extraInclude: {
           custodianTeamMember: true,
-          custodianUser: true,
+          custodianUser: CUSTODIAN_USER_SAFE_SELECT,
           _count: { select: { bookingAssets: true } },
         },
       }),
@@ -237,7 +238,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         statuses: ["OVERDUE"],
         extraInclude: {
           custodianTeamMember: true,
-          custodianUser: true,
+          custodianUser: CUSTODIAN_USER_SAFE_SELECT,
           _count: { select: { bookingAssets: true } },
         },
       }),
@@ -251,7 +252,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         statuses: ["ONGOING"],
         extraInclude: {
           custodianTeamMember: true,
-          custodianUser: true,
+          custodianUser: CUSTODIAN_USER_SAFE_SELECT,
           _count: { select: { bookingAssets: true } },
         },
       }),

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -39,6 +39,7 @@ import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { LOCATION_WITH_HIERARCHY } from "~/modules/asset/fields";
 import { getLocationsForCreateAndEdit } from "~/modules/asset/service.server";
 import { resolveDisplayCode } from "~/modules/barcode/display";
+import { CUSTODIAN_USER_SAFE_SELECT } from "~/modules/booking/constants";
 import {
   getPaginatedAndFilterableKits,
   updateKitsWithBookingCustodians,
@@ -169,7 +170,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                             // needs to supply it.
                             custodianUserId: true,
                             custodianTeamMember: true,
-                            custodianUser: true,
+                            custodianUser: CUSTODIAN_USER_SAFE_SELECT,
                           },
                         },
                       },

--- a/apps/webapp/app/routes/_layout+/settings.team.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.tsx
@@ -18,7 +18,8 @@ export type UserFriendlyRoles =
   | "Administrator"
   | "Owner"
   | "Base"
-  | "Self service";
+  | "Self service"
+  | "Booking manager";
 export const meta = () => [{ title: appendToMetaTitle("Team settings") }];
 
 export const loader = async ({ request, context }: LoaderFunctionArgs) => {
@@ -41,11 +42,17 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
   }
 };
 
-export const organizationRolesMap: Record<string, UserFriendlyRoles> = {
+// Record<OrganizationRoles, ...> (not Record<string, ...>) so adding the
+// next role is a compile error here instead of a blank cell in the team list.
+export const organizationRolesMap: Record<
+  OrganizationRoles,
+  UserFriendlyRoles
+> = {
   [OrganizationRoles.ADMIN]: "Administrator",
   [OrganizationRoles.OWNER]: "Owner",
   [OrganizationRoles.BASE]: "Base",
   [OrganizationRoles.SELF_SERVICE]: "Self service",
+  [OrganizationRoles.BOOKING_MANAGER]: "Booking manager",
 };
 
 export default function TeamSettings() {

--- a/apps/webapp/app/routes/_layout+/settings.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.tsx
@@ -66,7 +66,7 @@ export default function SettingsPage() {
     { to: "team", content: "Team" },
   ];
 
-  const { isBaseOrSelfService, isBookingManager } = useUserRoleHelper();
+  const { isBaseOrSelfService } = useUserRoleHelper();
   /** If user is self service, remove the extra items */
   if (isBaseOrSelfService) {
     items = items.filter(
@@ -74,23 +74,6 @@ export default function SettingsPage() {
         ![
           "custom-fields",
           "team",
-          "general",
-          "bookings",
-          "emails",
-          "asset-models",
-        ].includes(item.to)
-    );
-  }
-
-  /**
-   * Booking managers hold teamMember read (issue #1800) so the Team tab
-   * stays; every admin tab would 403 against their empty settings rows.
-   */
-  if (isBookingManager) {
-    items = items.filter(
-      (item) =>
-        ![
-          "custom-fields",
           "general",
           "bookings",
           "emails",

--- a/apps/webapp/app/routes/_layout+/settings.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.tsx
@@ -66,7 +66,7 @@ export default function SettingsPage() {
     { to: "team", content: "Team" },
   ];
 
-  const { isBaseOrSelfService } = useUserRoleHelper();
+  const { isBaseOrSelfService, isBookingManager } = useUserRoleHelper();
   /** If user is self service, remove the extra items */
   if (isBaseOrSelfService) {
     items = items.filter(
@@ -74,6 +74,23 @@ export default function SettingsPage() {
         ![
           "custom-fields",
           "team",
+          "general",
+          "bookings",
+          "emails",
+          "asset-models",
+        ].includes(item.to)
+    );
+  }
+
+  /**
+   * Booking managers hold teamMember read (issue #1800) so the Team tab
+   * stays; every admin tab would 403 against their empty settings rows.
+   */
+  if (isBookingManager) {
+    items = items.filter(
+      (item) =>
+        ![
+          "custom-fields",
           "general",
           "bookings",
           "emails",

--- a/apps/webapp/app/routes/api+/command-palette.search.ts
+++ b/apps/webapp/app/routes/api+/command-palette.search.ts
@@ -151,14 +151,26 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     // Check if this is a personal workspace - they don't have bookings or team members
     const isPersonalWorkspace = isPersonalOrg(currentOrganization);
 
-    // Check permissions for different entity types based on actual roles
-    const hasKitPermission = ["OWNER", "ADMIN"].includes(role);
+    // Check permissions for different entity types based on actual roles.
+    // BOOKING_MANAGER holds read on kit/booking/location/teamMember in the
+    // permission matrix (issue #1800), so it must appear in these lists or
+    // its palette results come back empty despite the granted reads.
+    const hasKitPermission = ["OWNER", "ADMIN", "BOOKING_MANAGER"].includes(
+      role
+    );
     const hasBookingPermission =
       !isPersonalWorkspace &&
-      ["OWNER", "ADMIN", "SELF_SERVICE", "BASE"].includes(role);
-    const hasLocationPermission = ["OWNER", "ADMIN"].includes(role);
+      ["OWNER", "ADMIN", "SELF_SERVICE", "BASE", "BOOKING_MANAGER"].includes(
+        role
+      );
+    const hasLocationPermission = [
+      "OWNER",
+      "ADMIN",
+      "BOOKING_MANAGER",
+    ].includes(role);
     const hasTeamMemberPermission =
-      !isPersonalWorkspace && ["OWNER", "ADMIN"].includes(role);
+      !isPersonalWorkspace &&
+      ["OWNER", "ADMIN", "BOOKING_MANAGER"].includes(role);
     const hasAuditPermission = true;
 
     // Prepare where clauses for other entities

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -208,7 +208,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
     const canQuickCheckin = !(
-      (role === OrganizationRoles.ADMIN &&
+      ((role === OrganizationRoles.ADMIN ||
+        role === OrganizationRoles.BOOKING_MANAGER) &&
         bookingSettings.requireExplicitCheckinForAdmin) ||
       (role === OrganizationRoles.SELF_SERVICE &&
         bookingSettings.requireExplicitCheckinForSelfService)

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
@@ -1,6 +1,7 @@
 import { OrganizationRoles } from "@prisma/client";
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
   requireMobilePermission,
@@ -10,6 +11,7 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { checkinBooking } from "~/modules/booking/service.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
+import { assertBookingProcessAccess } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
@@ -81,6 +83,26 @@ export async function action({ request }: ActionFunctionArgs) {
       ...getClientHint(request),
       ...(timeZone ? { timeZone } : {}),
     };
+
+    // Authorization spine (web parity): SELF_SERVICE may only process
+    // bookings they are custodian of. Org-scoped fetch, so foreign-org ids
+    // 404 before this runs.
+    const bookingToProcess = await db.booking.findFirst({
+      where: { id: bookingId, organizationId },
+      select: { custodianUserId: true },
+    });
+    if (!bookingToProcess) {
+      return data(
+        { error: { message: "Booking not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+    assertBookingProcessAccess({
+      booking: bookingToProcess,
+      userId: user.id,
+      role,
+      action: "check in",
+    });
 
     const booking = await checkinBooking({
       id: bookingId,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
@@ -51,7 +51,9 @@ export async function action({ request }: ActionFunctionArgs) {
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
     const explicitCheckinRequired =
-      (role === OrganizationRoles.ADMIN &&
+      // Booking managers follow the admin policy (web parity).
+      ((role === OrganizationRoles.ADMIN ||
+        role === OrganizationRoles.BOOKING_MANAGER) &&
         bookingSettings.requireExplicitCheckinForAdmin) ||
       (role === OrganizationRoles.SELF_SERVICE &&
         bookingSettings.requireExplicitCheckinForSelfService);

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
+  getMobileUserContext,
   requireMobilePermission,
   requireOrganizationAccess,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import { checkoutBooking } from "~/modules/booking/service.server";
+import { assertBookingProcessAccess } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -56,7 +58,7 @@ export async function action({ request }: ActionFunctionArgs) {
     // foreign-org id 404s.
     const existingBooking = await db.booking.findFirst({
       where: { id: bookingId, organizationId },
-      select: { from: true, to: true },
+      select: { from: true, to: true, custodianUserId: true },
     });
 
     if (!existingBooking) {
@@ -65,6 +67,17 @@ export async function action({ request }: ActionFunctionArgs) {
         { status: 404 }
       );
     }
+
+    // Authorization spine (web parity): SELF_SERVICE may only process
+    // bookings they are custodian of; the permission action alone is
+    // org-wide. Mobile must never be more permissive than the web.
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    assertBookingProcessAccess({
+      booking: existingBooking,
+      userId: user.id,
+      role,
+      action: "check out",
+    });
 
     // Derive hints the standard way: locale from the request's Accept-Language
     // header and timeZone from the CH-time-zone cookie (UTC fallback). Native

--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
@@ -1,12 +1,15 @@
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
+  getMobileUserContext,
   requireMobilePermission,
   requireOrganizationAccess,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import { partialCheckoutBooking } from "~/modules/booking/service.server";
+import { assertBookingProcessAccess } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -81,6 +84,27 @@ export async function action({ request }: ActionFunctionArgs) {
       ...getClientHint(request),
       ...(timeZone ? { timeZone } : {}),
     };
+
+    // Authorization spine (parity with the partial-CHECKIN endpoint and the
+    // web scanner routes): SELF_SERVICE may only process bookings they are
+    // custodian of; the permission action alone is org-wide.
+    const bookingToProcess = await db.booking.findFirst({
+      where: { id: bookingId, organizationId },
+      select: { custodianUserId: true },
+    });
+    if (!bookingToProcess) {
+      return data(
+        { error: { message: "Booking not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    assertBookingProcessAccess({
+      booking: bookingToProcess,
+      userId: user.id,
+      role,
+      action: "check out",
+    });
 
     const result = await partialCheckoutBooking({
       id: bookingId,

--- a/apps/webapp/app/utils/booking-authorization.server.test.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { OrganizationRoles } from "@prisma/client";
+import {
+  assertBookingProcessAccess,
+  assertBookingVisibility,
+} from "./booking-authorization.server";
+
+const CUSTODIAN = "user-custodian";
+const OTHER = "user-other";
+
+describe("assertBookingProcessAccess", () => {
+  const booking = { custodianUserId: CUSTODIAN };
+
+  it.each([OrganizationRoles.ADMIN, OrganizationRoles.OWNER])(
+    "allows %s on any booking",
+    (role) => {
+      expect(() =>
+        assertBookingProcessAccess({
+          booking,
+          userId: OTHER,
+          role,
+          action: "check out",
+        })
+      ).not.toThrow();
+    }
+  );
+
+  it("allows BOOKING_MANAGER on any booking (the role's whole purpose)", () => {
+    expect(() =>
+      assertBookingProcessAccess({
+        booking,
+        userId: OTHER,
+        role: OrganizationRoles.BOOKING_MANAGER,
+        action: "check in",
+      })
+    ).not.toThrow();
+  });
+
+  it("allows SELF_SERVICE only as custodian", () => {
+    expect(() =>
+      assertBookingProcessAccess({
+        booking,
+        userId: CUSTODIAN,
+        role: OrganizationRoles.SELF_SERVICE,
+        action: "check out",
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      assertBookingProcessAccess({
+        booking,
+        userId: OTHER,
+        role: OrganizationRoles.SELF_SERVICE,
+        action: "check out",
+      })
+    ).toThrow("You are not authorized to check out this booking.");
+  });
+
+  it("never allows BASE, even as custodian (defense in depth)", () => {
+    expect(() =>
+      assertBookingProcessAccess({
+        booking,
+        userId: CUSTODIAN,
+        role: OrganizationRoles.BASE,
+        action: "check in",
+      })
+    ).toThrow("You are not authorized to check in this booking.");
+  });
+});
+
+describe("assertBookingVisibility", () => {
+  const booking = { custodianUserId: CUSTODIAN };
+
+  it("allows anyone with see-all rights", () => {
+    expect(() =>
+      assertBookingVisibility({
+        booking,
+        userId: OTHER,
+        canSeeAllBookings: true,
+      })
+    ).not.toThrow();
+  });
+
+  it("allows the custodian without see-all rights", () => {
+    expect(() =>
+      assertBookingVisibility({
+        booking,
+        userId: CUSTODIAN,
+        canSeeAllBookings: false,
+      })
+    ).not.toThrow();
+  });
+
+  it("blocks non-custodians without see-all rights (mirrors the overview loader)", () => {
+    expect(() =>
+      assertBookingVisibility({
+        booking,
+        userId: OTHER,
+        canSeeAllBookings: false,
+      })
+    ).toThrow("You are not authorized to view this booking");
+  });
+});

--- a/apps/webapp/app/utils/booking-authorization.server.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.ts
@@ -1,6 +1,95 @@
 import { OrganizationRoles } from "@prisma/client";
 import { ShelfError } from "./error";
 
+interface AssertBookingProcessAccessParams {
+  booking: {
+    custodianUserId: string | null;
+  };
+  userId: string;
+  role: OrganizationRoles;
+  /** Used in the error message: "check out" | "check in". */
+  action: "check out" | "check in";
+}
+
+/**
+ * THE authorization answer to "may this user process (check out / check in)
+ * this booking?" — every check-out/check-in mutation path must call this
+ * (web overview intents, progressive scanner actions, fulfil-and-checkout,
+ * mobile endpoints). Booking STATUS eligibility is deliberately not decided
+ * here; the service layer owns state-transition guards.
+ *
+ * Rules:
+ * - ADMIN / OWNER: any booking in the organization.
+ * - SELF_SERVICE: only bookings they are the custodian of.
+ * - BASE: never (the permission matrix denies checkout/checkin as well —
+ *   this is defense in depth for surfaces gated on other actions).
+ *
+ * @throws {ShelfError} 403 when the caller may not process this booking
+ */
+export function assertBookingProcessAccess({
+  booking,
+  userId,
+  role,
+  action,
+}: AssertBookingProcessAccessParams): void {
+  if (role === OrganizationRoles.BASE) {
+    throw new ShelfError({
+      cause: null,
+      label: "Booking",
+      message: `You are not authorized to ${action} this booking.`,
+      status: 403,
+      shouldBeCaptured: false,
+    });
+  }
+
+  if (
+    role === OrganizationRoles.SELF_SERVICE &&
+    booking.custodianUserId !== userId
+  ) {
+    throw new ShelfError({
+      cause: null,
+      label: "Booking",
+      message: `You are not authorized to ${action} this booking.`,
+      status: 403,
+      shouldBeCaptured: false,
+    });
+  }
+
+  // ADMIN and OWNER are implicitly allowed - no check needed
+}
+
+interface AssertBookingVisibilityParams {
+  booking: {
+    custodianUserId: string | null;
+  };
+  userId: string;
+  /** The flag requirePermission derives from role + org overrides. */
+  canSeeAllBookings: boolean;
+}
+
+/**
+ * Mirror of the booking overview loader's visibility rule, shared so sibling
+ * surfaces (activity tab, activity CSV, note actions) enforce the SAME gate:
+ * users without see-all rights may only reach bookings they are custodian of.
+ *
+ * @throws {ShelfError} 403 when the caller may not view this booking
+ */
+export function assertBookingVisibility({
+  booking,
+  userId,
+  canSeeAllBookings,
+}: AssertBookingVisibilityParams): void {
+  if (!canSeeAllBookings && booking.custodianUserId !== userId) {
+    throw new ShelfError({
+      cause: null,
+      label: "Booking",
+      message: "You are not authorized to view this booking",
+      status: 403,
+      shouldBeCaptured: false,
+    });
+  }
+}
+
 interface ValidateBookingOwnershipParams {
   booking: {
     creatorId: string | null;

--- a/apps/webapp/app/utils/permissions/permission.data.test.ts
+++ b/apps/webapp/app/utils/permissions/permission.data.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+/**
+ * Shape and floor tests for the static role-permission matrix. The
+ * Record<PermissionEntity, ...> type forces row PRESENCE per entity, but an
+ * empty array compiles fine — these tests pin the rows whose emptiness would
+ * break a role at runtime (403s on surfaces every role must reach).
+ */
+import { OrganizationRoles } from "@prisma/client";
+import {
+  PermissionAction,
+  PermissionEntity,
+  Role2PermissionMap,
+} from "./permission.data";
+
+const MAPPED_ROLES = [
+  OrganizationRoles.BASE,
+  OrganizationRoles.SELF_SERVICE,
+  OrganizationRoles.BOOKING_MANAGER,
+  OrganizationRoles.ADMIN,
+  OrganizationRoles.OWNER,
+] as const;
+
+describe("Role2PermissionMap shape", () => {
+  it("has a row for every entity in every mapped role", () => {
+    for (const role of MAPPED_ROLES) {
+      const entityMap = Role2PermissionMap[role];
+      expect(entityMap, `missing role ${role}`).toBeDefined();
+      for (const entity of Object.values(PermissionEntity)) {
+        expect(
+          entityMap![entity as PermissionEntity],
+          `role ${role} missing entity ${entity}`
+        ).toBeDefined();
+      }
+    }
+  });
+
+  it("gives every role the self-serve floor (own account, updates, palette)", () => {
+    for (const role of MAPPED_ROLES) {
+      const entityMap = Role2PermissionMap[role]!;
+      expect(entityMap[PermissionEntity.userData]).toEqual(
+        expect.arrayContaining([PermissionAction.read, PermissionAction.update])
+      );
+      expect(entityMap[PermissionEntity.update]).toContain(
+        PermissionAction.read
+      );
+      expect(entityMap[PermissionEntity.commandPaletteSearch]).toContain(
+        PermissionAction.read
+      );
+      // The booking form's working-hours validation reads this for every
+      // role that can create bookings.
+      expect(entityMap[PermissionEntity.workingHours]).toContain(
+        PermissionAction.read
+      );
+    }
+  });
+});
+
+describe("BOOKING_MANAGER matrix (issue #1800)", () => {
+  const bm = Role2PermissionMap[OrganizationRoles.BOOKING_MANAGER]!;
+
+  it("holds full booking processing incl. checkout/checkin", () => {
+    expect(bm[PermissionEntity.booking]).toEqual(
+      expect.arrayContaining([
+        PermissionAction.create,
+        PermissionAction.read,
+        PermissionAction.update,
+        PermissionAction.checkout,
+        PermissionAction.checkin,
+        PermissionAction.cancel,
+        PermissionAction.export,
+      ])
+    );
+    // Deliberately NOT granted (absent from #1800's matrix):
+    expect(bm[PermissionEntity.booking]).not.toContain(PermissionAction.extend);
+    expect(bm[PermissionEntity.booking]).not.toContain(
+      PermissionAction.manageKits
+    );
+  });
+
+  it("reads + takes custody of assets and kits, nothing more", () => {
+    expect(bm[PermissionEntity.asset]).toEqual([
+      PermissionAction.read,
+      PermissionAction.custody,
+    ]);
+    expect(bm[PermissionEntity.kit]).toEqual([
+      PermissionAction.read,
+      PermissionAction.custody,
+    ]);
+  });
+
+  it("administers nothing", () => {
+    for (const entity of [
+      PermissionEntity.workspace,
+      PermissionEntity.dashboard,
+      PermissionEntity.generalSettings,
+      PermissionEntity.subscription,
+      PermissionEntity.emailSettings,
+      PermissionEntity.assetReminders,
+      PermissionEntity.teamMemberNote,
+    ]) {
+      expect(bm[entity], `expected ${entity} to be empty`).toEqual([]);
+    }
+  });
+
+  it("does not rank below BASE on audits (view-everything floor)", () => {
+    const base = Role2PermissionMap[OrganizationRoles.BASE]!;
+    for (const action of base[PermissionEntity.audit]) {
+      expect(bm[PermissionEntity.audit]).toContain(action);
+    }
+  });
+
+  it("reads reference data that BASE/SELF_SERVICE cannot (per #1800)", () => {
+    for (const entity of [
+      PermissionEntity.category,
+      PermissionEntity.tag,
+      PermissionEntity.location,
+      PermissionEntity.teamMember,
+      PermissionEntity.custody,
+    ]) {
+      expect(bm[entity]).toContain(PermissionAction.read);
+    }
+  });
+});

--- a/apps/webapp/app/utils/permissions/permission.data.ts
+++ b/apps/webapp/app/utils/permissions/permission.data.ts
@@ -157,6 +157,74 @@ export const Role2PermissionMap: {
     [PermissionEntity.update]: [PermissionAction.read],
     [PermissionEntity.commandPaletteSearch]: [PermissionAction.read],
   },
+  /**
+   * The booking-counter operator (issue #1800): manages bookings end to end
+   * (including check-out/check-in on ANY booking via the booking
+   * authorization spine), views everything booking-adjacent, administers
+   * nothing. Rows not present in #1800's draft matrix are marked; #1800's
+   * custodyAgreement/receipts rows were dropped (those entities no longer
+   * exist in this enum).
+   */
+  [OrganizationRoles.BOOKING_MANAGER]: {
+    [PermissionEntity.asset]: [PermissionAction.read, PermissionAction.custody],
+    [PermissionEntity.assetIndexSettings]: [PermissionAction.read],
+    [PermissionEntity.booking]: [
+      PermissionAction.create,
+      PermissionAction.read,
+      PermissionAction.update,
+      PermissionAction.checkout,
+      PermissionAction.checkin,
+      PermissionAction.delete,
+      PermissionAction.archive,
+      PermissionAction.manageAssets,
+      PermissionAction.cancel,
+      PermissionAction.export,
+    ],
+    // not in #1800 (entity added later): booking managers comment on bookings
+    [PermissionEntity.bookingNote]: [
+      PermissionAction.read,
+      PermissionAction.create,
+    ],
+    // not in #1800: BASE/SELF_SERVICE parity floor — a role meant to "view
+    // everything" should not rank below BASE on audits; trim if undesired
+    [PermissionEntity.auditNote]: [
+      PermissionAction.read,
+      PermissionAction.create,
+    ],
+    [PermissionEntity.audit]: [PermissionAction.read, PermissionAction.update],
+    [PermissionEntity.qr]: [PermissionAction.read],
+    [PermissionEntity.category]: [PermissionAction.read],
+    [PermissionEntity.customField]: [PermissionAction.read],
+    [PermissionEntity.location]: [PermissionAction.read],
+    // not in #1800: read-only, matches the location read grant above
+    [PermissionEntity.locationNote]: [PermissionAction.read],
+    [PermissionEntity.tag]: [PermissionAction.read],
+    [PermissionEntity.teamMember]: [PermissionAction.read],
+    [PermissionEntity.teamMemberProfile]: [PermissionAction.read],
+    [PermissionEntity.workspace]: [],
+    [PermissionEntity.dashboard]: [],
+    [PermissionEntity.generalSettings]: [],
+    // not in #1800: the booking form's working-hours validation reads this
+    [PermissionEntity.workingHours]: [PermissionAction.read],
+    [PermissionEntity.subscription]: [],
+    [PermissionEntity.kit]: [PermissionAction.read, PermissionAction.custody],
+    [PermissionEntity.note]: [PermissionAction.read],
+    [PermissionEntity.scan]: [PermissionAction.read],
+    [PermissionEntity.custody]: [PermissionAction.read],
+    [PermissionEntity.assetReminders]: [],
+    // not in #1800 (entity added later): admin-facing notes stay hidden
+    [PermissionEntity.teamMemberNote]: [],
+    // not in #1800: booking managers fulfil model-request bookings
+    [PermissionEntity.assetModel]: [PermissionAction.read],
+    [PermissionEntity.emailSettings]: [],
+    // not in #1800: own account pages — every role has these
+    [PermissionEntity.userData]: [
+      PermissionAction.read,
+      PermissionAction.update,
+    ],
+    [PermissionEntity.update]: [PermissionAction.read],
+    [PermissionEntity.commandPaletteSearch]: [PermissionAction.read],
+  },
   [OrganizationRoles.ADMIN]: {
     [PermissionEntity.asset]: [
       PermissionAction.create,

--- a/apps/webapp/app/utils/roles.test.ts
+++ b/apps/webapp/app/utils/roles.test.ts
@@ -56,4 +56,27 @@ describe("isDemotion", () => {
       true
     );
   });
+
+  it("treats ADMIN -> BOOKING_MANAGER as a demotion (triggers entity transfer)", () => {
+    // A booking manager cannot own or manage catalog entities, so the
+    // change-role flow must move the demoted admin's created entities.
+    expect(
+      isDemotion(OrganizationRoles.ADMIN, OrganizationRoles.BOOKING_MANAGER)
+    ).toBe(true);
+  });
+
+  it("treats BOOKING_MANAGER as a peer of BASE/SELF_SERVICE (lateral moves)", () => {
+    expect(
+      isDemotion(
+        OrganizationRoles.SELF_SERVICE,
+        OrganizationRoles.BOOKING_MANAGER
+      )
+    ).toBe(false);
+    expect(
+      isDemotion(OrganizationRoles.BOOKING_MANAGER, OrganizationRoles.BASE)
+    ).toBe(false);
+    expect(
+      isDemotion(OrganizationRoles.BOOKING_MANAGER, OrganizationRoles.ADMIN)
+    ).toBe(false);
+  });
 });

--- a/apps/webapp/app/utils/roles.ts
+++ b/apps/webapp/app/utils/roles.ts
@@ -3,6 +3,10 @@ import { OrganizationRoles } from "@prisma/client";
 const ROLE_RANK: Record<OrganizationRoles, number> = {
   [OrganizationRoles.OWNER]: 3,
   [OrganizationRoles.ADMIN]: 2,
+  // Rank 1 on purpose: a booking manager operates bookings but cannot own or
+  // manage catalog entities, so ADMIN -> BOOKING_MANAGER is a demotion and
+  // triggers the created-entities transfer flow in the change-role dialog.
+  [OrganizationRoles.BOOKING_MANAGER]: 1,
   [OrganizationRoles.SELF_SERVICE]: 1,
   [OrganizationRoles.BASE]: 1,
 };

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.activity.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.activity.test.ts
@@ -134,7 +134,7 @@ describe("bookings.$bookingId.activity action — organization scoping", () => {
     // And the booking lookup must have been scoped to the attacker's org
     expect(db.booking.findFirst).toHaveBeenCalledWith({
       where: { id: "victim-booking", organizationId: "org-attacker" },
-      select: { id: true },
+      select: { id: true, custodianUserId: true },
     });
   });
 
@@ -158,6 +158,9 @@ describe("bookings.$bookingId.activity action — organization scoping", () => {
     // Booking IS in the requester's org
     vi.mocked(db.booking.findFirst).mockResolvedValue({
       id: "own-booking",
+      // session user is the custodian: passes the visibility guard without
+      // see-all rights (mirrors the overview loader rule)
+      custodianUserId: "user-attacker",
     } as any);
     vi.mocked(httpServer.getParams).mockReturnValue({
       bookingId: "own-booking",
@@ -183,6 +186,9 @@ describe("bookings.$bookingId.activity action — organization scoping", () => {
   it("requests `bookingNote.create` permission on POST", async () => {
     vi.mocked(db.booking.findFirst).mockResolvedValue({
       id: "own-booking",
+      // session user is the custodian: passes the visibility guard without
+      // see-all rights (mirrors the overview loader rule)
+      custodianUserId: "user-attacker",
     } as any);
     vi.mocked(httpServer.getParams).mockReturnValue({
       bookingId: "own-booking",
@@ -211,6 +217,9 @@ describe("bookings.$bookingId.activity action — organization scoping", () => {
     // delete notes they shouldn't be able to touch.
     vi.mocked(db.booking.findFirst).mockResolvedValue({
       id: "own-booking",
+      // session user is the custodian: passes the visibility guard without
+      // see-all rights (mirrors the overview loader rule)
+      custodianUserId: "user-attacker",
     } as any);
     vi.mocked(httpServer.getParams).mockReturnValue({
       bookingId: "own-booking",
@@ -236,6 +245,9 @@ describe("bookings.$bookingId.activity action — organization scoping", () => {
   it("deletes a note and forwards organizationId to the service on the happy path", async () => {
     vi.mocked(db.booking.findFirst).mockResolvedValue({
       id: "own-booking",
+      // session user is the custodian: passes the visibility guard without
+      // see-all rights (mirrors the overview loader rule)
+      custodianUserId: "user-attacker",
     } as any);
     vi.mocked(httpServer.getParams).mockReturnValue({
       bookingId: "own-booking",

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.activity[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.activity[.csv].test.ts
@@ -72,10 +72,12 @@ describe("app/routes/_layout+/bookings.$bookingId.activity[.csv] loader", () => 
     vi.clearAllMocks();
     requirePermissionMock.mockResolvedValue({
       organizationId: "org-9",
+      canSeeAllBookings: true,
     } as any);
     dbMock.booking.findFirstOrThrow.mockResolvedValue({
       id: "booking-789",
       name: "Field Shoot",
+      custodianUserId: "user-456",
     });
     dbMock.bookingNote.findMany.mockResolvedValue([
       {

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.checkin.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.checkin.test.ts
@@ -35,6 +35,12 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
 }));
 
 // why: external service — we mock the booking checkin to avoid database calls
+// why: the authorization spine fetches the booking's custodian before
+// processing; resolve it to the session user so the guard passes
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
 vi.mock("~/modules/booking/service.server", () => ({
   checkinBooking: vi.fn(),
 }));
@@ -63,6 +69,7 @@ import {
   assertMobileCanUseBookings,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { db } from "~/database/db.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import { checkinBooking } from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
@@ -102,6 +109,9 @@ describe("POST /api/mobile/bookings/checkin", () => {
     (assertMobileCanUseBookings as any).mockResolvedValue(undefined);
     // Default: admin role + explicit check-in NOT required (quick check-in OK).
     (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      custodianUserId: "user-1",
+    });
     (getBookingSettingsForOrganization as any).mockResolvedValue({
       requireExplicitCheckinForAdmin: false,
       requireExplicitCheckinForSelfService: false,
@@ -159,6 +169,9 @@ describe("POST /api/mobile/bookings/checkin", () => {
     // Admin in a workspace that mandates explicit (scan/select) check-in for
     // admins — quick "check in all" must be refused, mirroring the web policy.
     (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      custodianUserId: "user-1",
+    });
     (getBookingSettingsForOrganization as any).mockResolvedValue({
       requireExplicitCheckinForAdmin: true,
       requireExplicitCheckinForSelfService: false,

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
@@ -31,6 +31,9 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
   requireOrganizationAccess: vi.fn(),
   requireMobilePermission: vi.fn(),
   assertMobileCanUseBookings: vi.fn(),
+  // why: the authorization spine resolves the caller's role for the
+  // custodian check; ADMIN passes for any booking
+  getMobileUserContext: vi.fn(),
 }));
 
 // why: external service — we mock the booking checkout to avoid database calls
@@ -57,6 +60,7 @@ vi.mock("~/utils/error", () => ({
 }));
 
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireOrganizationAccess,
   requireMobilePermission,
@@ -105,8 +109,10 @@ describe("POST /api/mobile/bookings/checkout", () => {
     (db.booking.findFirst as any).mockResolvedValue({
       from: BOOKING_FROM,
       to: BOOKING_TO,
+      custodianUserId: "user-1",
     });
     (assertMobileCanUseBookings as any).mockResolvedValue(undefined);
+    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
   });
 
   it("should checkout a booking and pass its window so the conflict guard fires", async () => {

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.partial-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.partial-checkout.test.ts
@@ -33,6 +33,13 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
   // why: the route premium-gates with assertMobileCanUseBookings; mock it so
   // the gate is a no-op in these tests (mirrors the sibling booking tests).
   assertMobileCanUseBookings: vi.fn(),
+  // why: the authorization spine resolves the caller's role
+  getMobileUserContext: vi.fn(),
+}));
+
+// why: the authorization spine fetches the booking's custodian first
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
 }));
 
 // why: external service — we mock the partial checkout to avoid database calls
@@ -53,10 +60,12 @@ vi.mock("~/utils/error", () => ({
 }));
 
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireOrganizationAccess,
   requireMobilePermission,
 } from "~/modules/api/mobile-auth.server";
+import { db } from "~/database/db.server";
 import { partialCheckoutBooking } from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
 
@@ -99,6 +108,10 @@ describe("POST /api/mobile/bookings/partial-checkout", () => {
 
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    (db.booking.findFirst as any).mockResolvedValue({
+      custodianUserId: "user-1",
+    });
+    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
   });
 
   it("accepts legacy { bookingId, assetIds } payload with INDIVIDUAL semantics", async () => {

--- a/packages/database/prisma/migrations/20260706120000_add_booking_manager_role/migration.sql
+++ b/packages/database/prisma/migrations/20260706120000_add_booking_manager_role/migration.sql
@@ -1,0 +1,7 @@
+-- New organization role for booking-counter operations (issue #1800).
+-- Single-statement migration on purpose: a new enum value cannot be USED in
+-- the same transaction that adds it, so any future backfill must live in a
+-- separate migration file (see 20240718142934/20240718144136 precedent).
+
+-- AlterEnum
+ALTER TYPE "OrganizationRoles" ADD VALUE 'BOOKING_MANAGER';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1013,6 +1013,11 @@ enum OrganizationRoles {
   BASE
   OWNER
   SELF_SERVICE
+  // Operational role for people who run the booking counter: full booking
+  // processing (incl. check-out/check-in on ANY booking), read+custody on
+  // assets/kits, read-only reference data, zero administration. See the
+  // Role2PermissionMap entry and issue #1800.
+  BOOKING_MANAGER
 }
 
 model SsoDetails {


### PR DESCRIPTION
Implements #1800 (the Booking Manager role you spec'd). Also hardens the booking check-out/check-in authorization it rides on, as a separate first commit.

## The gap this fills

Shelf's four roles answer who owns the account, who administers the catalog, who borrows, and who looks. None answers **who runs the counter**: the person who hands gear out and takes it back, for everyone, all day. Today that person has to be an Administrator, which drags along delete-assets, team management, settings and exports they never use. This adds the fifth role from #1800 so that job gets a seat that fits it.

## Commit 1: a single authorization spine for booking processing

Before adding a role that checks out *any* booking, "who may process this booking" needed one answer. It had six, and three of them were "only the permission action, which SELF_SERVICE holds org-wide":

- the progressive checkout scanner guarded loader **and** action (correct, with a comment explaining why),
- its check-in twin guarded only the loader,
- the booking page's `checkOut`/`checkIn` intents and the mobile `checkout`/`checkin`/`partial-checkout` endpoints validated only the permission action,
- `fulfil-and-checkout` was gated on `booking:update` while performing the RESERVED to ONGOING transition.

Changes:
- **`assertBookingProcessAccess`** is now the one answer (ADMIN/OWNER any booking, SELF_SERVICE custodian-only, BASE never), threaded through all of the above.
- **Service-layer state guards** mirroring the existing `partialCheckoutBooking` guard: `checkoutBooking` requires RESERVED, `checkinBooking` requires ONGOING/OVERDUE. (Full-checkout callers are already UI-gated to RESERVED; remaining-asset flows go through the partial path, which keeps its own guard.)
- **`assertBookingVisibility`** shares the overview loader's rule with the activity tab, the activity CSV export, and the booking-note actions, which were reachable by direct URL for any booking in the org.
- **Booking payloads stop serializing the custodian's full User row.** `CUSTODIAN_USER_SAFE_SELECT` (id, names, profilePicture, email) replaces `custodianUser: true` on every client-reaching path, dropping billing/auth fields (Stripe id, unpaid-invoice, SSO flags) nothing consumes.

These are tightenings of **existing** roles' behavior; commit 1 stands alone and could ship first if you'd rather stack them.

## Commit 2: the Booking Manager role

Matrix is #1800's, verbatim except where the enum moved under it (each divergence is commented in the file):
- `custodyAgreement`/`receipts` rows dropped (those entities no longer exist),
- entities added after the issue was written get explicit rows: the every-role floor (`userData`, `update`, `commandPaletteSearch`, `workingHours`) so account pages / updates / palette / booking-form validation work; `bookingNote` read+create; `assetModel` read (they fulfil model-request bookings); `audit`/`auditNote` at BASE parity so a "view everything" role isn't *below* BASE on audits.

Wiring, from a recon map of every role-conditional branch:
- `ROLE_RANK` 1 so ADMIN to Booking-manager is a demotion and triggers the created-entities transfer flow.
- Explicit-check-in policy binds them on all four enforcement sites (web action, mobile action, mobile capability flag, client mirror).
- Sidebar hides Home / Reminders / Workspace-settings (their entities are empty); Categories / Tags / Locations / Reports / Team stay (read granted).
- Role maps updated in all copies (team settings, tightened to `Record<OrganizationRoles, ...>` so the next role is compile-forced; invite dialog + schema; change-role dialog; CSV import reverse-lookup; bulk-invite copy).
- **Mobile needs no app-store release**: `requireMobilePermission` reads the same matrix, list/detail scoping keys on `isSelfServiceOrBase` (so they see all bookings), and booking buttons are server-flag-driven. The companion's static map gains the entry for scanner-action parity at the next binary.

Migration is a single-statement `ALTER TYPE ADD VALUE`, verified on a clean Postgres 16 (deploy + zero drift + value usable).

## Verification

`pnpm webapp:validate` green (3178 tests). New tests: matrix shape + floor pins, the spine's role matrix, `ROLE_RANK` demotion semantics, and the checkout/checkin status-guard transitions. An adversarial multi-lens review of the diff surfaced six surface gaps (settings 403, companion audit scope, update targeting, three copy/doc items), all fixed in the third commit. **Not** click-through-verified in a browser yet.

## Decisions for you

1. **Name**: `BOOKING_MANAGER` per your matrix, or `CUSTODY_MANAGER` per your P.S. It's parameterized; a rename is one identifier.
2. **Matrix rows I added beyond #1800** (audit parity, the floor entities) are each commented; trim any you'd rather keep empty.
3. **SSO**: deliberately no `bookingManagerGroupId` in v1, so SSO-managed workspaces can't assign the role yet (documented). Say the word and I'll add the group mapping as a follow-up.
4. **Scope vs the original request**: the customer who prompted this wanted "only check out/in existing bookings"; your matrix is broader (create/cancel/delete). Shipping your matrix; a narrower operational profile is the capability-table conversation from #1642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Booking manager** role across the app, including role management, invitations, update targeting, and UI labels/help text.
  * Booking managers are now supported for relevant booking workflows (for example, check-in/check-out where permitted) and can view org-wide audits.

* **Bug Fixes**
  * Tightened booking visibility and activity actions (including CSV exports) so only authorized users can view or modify booking notes.
  * Strengthened check-in/check-out eligibility and authorization on both web and mobile.
  * Reduced exposed custodial user details in booking-related views and emails.

* **Documentation**
  * Updated guidance for role assignment and clarified the SSO restriction for Booking managers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->