### PR TITLE
feat: bring book-by-model (asset models) to the companion app

### DIFF
--- a/apps/companion/.maestro/flows/bookings/13-book-by-model.yaml
+++ b/apps/companion/.maestro/flows/bookings/13-book-by-model.yaml
@@ -1,0 +1,128 @@
+appId: com.shelf.companion.carlos
+name: "Bookings - Book by model (reserve, edit, remove, see)"
+tags:
+  - bookings
+  - models
+  - high-impact
+
+---
+# Full book-by-model lifecycle on the mobile app (feature parity with the web
+# "Models" tab): create a DRAFT booking -> open the availability picker's
+# Models tab -> reserve N units of an asset model -> edit that reservation ->
+# see it on the booking detail's "Reserved models" section -> remove it.
+#
+# PRECONDITIONS (like the sibling lifecycle flow 07):
+#   - GRANULAR WORKSPACE (TEAM) selected
+#   - team member "Dr. Sarah Mitchell" exists
+#   - the workspace has at least one AssetModel with available INDIVIDUAL units
+#     (the Models picker is empty otherwise — book-by-model needs models)
+#
+# @see ../../../app/(tabs)/bookings/add-assets.tsx  Models segment
+# @see ../../../app/(tabs)/bookings/[id].tsx        Reserved models section
+
+- runFlow: ../../shared/login.yaml
+
+- tapOn: "Settings"
+- extendedWaitUntil:
+    visible: ".*Current workspace.*"
+    timeout: 8000
+- tapOn: ".*Current workspace.*"
+- tapOn: "GRANULAR WORKSPACE"
+- waitForAnimationToEnd
+
+# ── Create a DRAFT booking to reserve models against ──
+- tapOn: "Bookings"
+- extendedWaitUntil:
+    visible: "Create booking"
+    timeout: 15000
+- tapOn: "Create booking"
+- extendedWaitUntil:
+    visible: "Booking name, required"
+    timeout: 15000
+- tapOn: "Booking name, required"
+- inputText: "QA Model Booking"
+- scrollUntilVisible:
+    element:
+      text: "Select a custodian"
+    direction: DOWN
+    timeout: 10000
+- tapOn: "Select a custodian"
+- extendedWaitUntil:
+    visible: "Select Team Member"
+    timeout: 15000
+- tapOn: ".*Sarah Mitchell.*"
+- extendedWaitUntil:
+    visible: "Create booking"
+    timeout: 10000
+- tapOn: "Create booking"
+- extendedWaitUntil:
+    visible: "QA Model Booking"
+    timeout: 20000
+
+# ── Open the availability picker and switch to the Models tab ──
+- extendedWaitUntil:
+    visible: "Browse available assets and kits to add"
+    timeout: 15000
+- tapOn: "Browse available assets and kits to add"
+- extendedWaitUntil:
+    visible: "Models"
+    timeout: 15000
+- tapOn: "Models"
+- waitForAnimationToEnd
+- takeScreenshot: booking-models-picker
+
+# ── Reserve the first available model ──
+# Tap whatever model row exposes a "Reserve" action (accessibilityLabel
+# "Reserve units of <name>"). If this fails, the workspace has no models with
+# availability — seed one first (see preconditions).
+- extendedWaitUntil:
+    visible: ".*Reserve units of.*"
+    timeout: 15000
+- tapOn: ".*Reserve units of.*"
+# Quantity sheet opens ("Reserve model"); the default seeded value is fine.
+- extendedWaitUntil:
+    visible: "Reserve model"
+    timeout: 10000
+- takeScreenshot: booking-model-quantity-sheet
+- tapOn: "Reserve"
+# Back on the picker — the reserved row now offers "Edit" instead of "Reserve".
+- extendedWaitUntil:
+    visible: ".*reservation, currently.*"
+    timeout: 15000
+- takeScreenshot: booking-model-reserved
+
+# ── Edit the reservation quantity ──
+- tapOn: ".*reservation, currently.*"
+- extendedWaitUntil:
+    visible: "Edit reservation"
+    timeout: 10000
+- tapOn:
+    "Increase quantity"
+    # bump the reserved count by one (guarded by availability cap in the sheet)
+- tapOn: "Reserve"
+- extendedWaitUntil:
+    visible: ".*reservation, currently.*"
+    timeout: 15000
+
+# ── Go back to the booking detail and confirm it shows under Reserved models ──
+- back
+- extendedWaitUntil:
+    visible: ".*Reserved models.*"
+    timeout: 20000
+- takeScreenshot: booking-detail-reserved-models
+
+# ── Manage -> remove the reservation ──
+# "Manage reserved models" opens the picker's Models tab directly (mode=models).
+- tapOn: "Manage reserved models"
+- extendedWaitUntil:
+    visible: ".*Remove.*reservation.*"
+    timeout: 15000
+- tapOn: ".*Remove.*reservation.*"
+- extendedWaitUntil:
+    visible: "Remove reservation"
+    timeout: 10000
+- tapOn: "Remove"
+- extendedWaitUntil:
+    visible: ".*Reserve units of.*"
+    timeout: 15000
+- takeScreenshot: booking-model-removed

--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shelf",
     "slug": "shelf-companion",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "shelf",

--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -29,6 +29,7 @@ import {
   spacing,
   borderRadius,
   formatStatus,
+  getQuantityStatusLabel,
   formatDate,
   formatCurrency,
 } from "@/lib/constants";
@@ -283,6 +284,13 @@ export default function AssetDetailScreen() {
   // activity (server's getQuantityData null contract) — we fall back to the
   // plain total in that case.
   const breakdown = isQtyTracked ? asset.quantityBreakdown ?? null : null;
+  // Status pill label. For a QUANTITY_TRACKED asset whose units span states
+  // (e.g. some held, some free), the raw enum ("IN_CUSTODY") reads wrong — the
+  // web shows a derived "Partial custody". Use the shared quantity-aware label
+  // (identical precedence to web getQuantityBadgeLabelAndColor); fall back to
+  // the plain enum label for INDIVIDUAL assets or QT assets with no breakdown.
+  const statusLabel =
+    getQuantityStatusLabel(breakdown) ?? formatStatus(asset.status);
   const unitSuffix = asset.unitOfMeasure?.trim()
     ? ` ${asset.unitOfMeasure.trim()}`
     : "";
@@ -348,7 +356,7 @@ export default function AssetDetailScreen() {
                 style={[styles.statusDot, { backgroundColor: badge.text }]}
               />
               <Text style={[styles.statusText, { color: badge.text }]}>
-                {formatStatus(asset.status)}
+                {statusLabel}
               </Text>
             </View>
           </View>

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -757,6 +757,40 @@ export default function BookingDetailScreen() {
     reservedCount > 0 &&
     ["RESERVED", "ONGOING", "OVERDUE"].includes(booking.status);
 
+  // Book-by-model reservations still awaiting assignment. Fulfilled rows
+  // (`fulfilledAt` set) are hidden here — the concrete assets they became
+  // already appear in the assets list, so showing them too would double up.
+  // Mirrors the web booking overview (booking-assets-column.tsx). The `?? []`
+  // matches the web guard + this file's cross-version convention: a booking
+  // detail from a not-yet-updated server (rolling deploy) omits the field, and
+  // an unguarded `.filter` would crash the whole screen to the error boundary.
+  const outstandingModelRequests = (booking.modelRequests ?? []).filter(
+    (mr) => mr.fulfilledAt === null
+  );
+
+  // Same gate the manage buttons use: an editable booking, and self-service
+  // users only on their own DRAFTs (server re-checks ownership + status).
+  const canManageModels =
+    !["COMPLETE", "ARCHIVED", "CANCELLED"].includes(booking.status) &&
+    (!isSelfService || booking.status === "DRAFT");
+
+  /**
+   * Open the model-reservation manager (the picker's Models tab) for this
+   * booking. Editing quantity / adding / removing all live there so the
+   * availability cap is computed in one place.
+   */
+  const openModelManager = () => {
+    router.push(
+      `/(tabs)/bookings/add-assets?bookingId=${
+        booking.id
+      }&bookingName=${encodeURIComponent(
+        booking.name
+      )}&from=${encodeURIComponent(booking.from)}&to=${encodeURIComponent(
+        booking.to
+      )}&mode=models`
+    );
+  };
+
   return (
     <View style={styles.container}>
       {isActioning && (
@@ -1231,6 +1265,107 @@ export default function BookingDetailScreen() {
               </View>
             )}
 
+            {/* Reserved models (book-by-model): outstanding reservations that
+                still need assets assigned via scan/browse. Shown above the
+                assets list, matching the web booking overview. */}
+            {outstandingModelRequests.length > 0 && (
+              <View style={styles.modelsSection}>
+                <View style={styles.modelsSectionHeader}>
+                  <Text style={styles.sectionTitle}>
+                    Reserved models ({outstandingModelRequests.length})
+                  </Text>
+                  {canManageModels && (
+                    <TouchableOpacity
+                      onPress={openModelManager}
+                      accessibilityLabel="Manage reserved models"
+                      accessibilityRole="button"
+                      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    >
+                      <Text style={styles.modelsManageLink}>Manage</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+                {booking.outstandingModelUnitCount > 0 && (
+                  <Text style={styles.modelsSubtitle}>
+                    {booking.outstandingModelUnitCount} unit
+                    {booking.outstandingModelUnitCount === 1 ? "" : "s"} still
+                    to assign. Scan or browse to add matching assets.
+                  </Text>
+                )}
+                {outstandingModelRequests.map((mr) => {
+                  const remaining = mr.outstandingQuantity;
+                  const row = (
+                    <>
+                      <View
+                        style={[
+                          styles.modelIcon,
+                          { backgroundColor: colors.warningBg },
+                        ]}
+                      >
+                        <Ionicons
+                          name="cube-outline"
+                          size={18}
+                          color={colors.warning}
+                        />
+                      </View>
+                      <View style={styles.modelInfo}>
+                        <Text style={styles.modelName} numberOfLines={1}>
+                          {mr.assetModelName}
+                        </Text>
+                        <View
+                          style={[
+                            styles.modelBadge,
+                            { backgroundColor: colors.warningBg },
+                          ]}
+                        >
+                          <Text
+                            style={[
+                              styles.modelBadgeText,
+                              { color: colors.warning },
+                            ]}
+                          >
+                            Reserved model
+                          </Text>
+                        </View>
+                        {mr.fulfilledQuantity > 0 && (
+                          <Text style={styles.modelProgress}>
+                            {mr.fulfilledQuantity} of {mr.quantity} assigned
+                          </Text>
+                        )}
+                      </View>
+                      <Text style={styles.modelQty}>× {remaining}</Text>
+                      {canManageModels && (
+                        <Ionicons
+                          name="chevron-forward"
+                          size={18}
+                          color={colors.muted}
+                        />
+                      )}
+                    </>
+                  );
+                  return canManageModels ? (
+                    <TouchableOpacity
+                      key={mr.id}
+                      style={styles.modelCard}
+                      onPress={openModelManager}
+                      accessibilityRole="button"
+                      accessibilityLabel={`${mr.assetModelName}, ${remaining} reserved and awaiting assignment. Tap to manage.`}
+                    >
+                      {row}
+                    </TouchableOpacity>
+                  ) : (
+                    <View
+                      key={mr.id}
+                      style={styles.modelCard}
+                      accessibilityLabel={`${mr.assetModelName}, ${remaining} reserved and awaiting assignment`}
+                    >
+                      {row}
+                    </View>
+                  );
+                })}
+              </View>
+            )}
+
             {/* Assets section header */}
             <Text style={styles.sectionTitle}>
               Assets ({booking.assetCount})
@@ -1575,6 +1710,73 @@ const useStyles = createStyles((colors, shadows) => ({
     fontWeight: "600",
     color: colors.foreground,
     marginTop: spacing.xs,
+  },
+
+  // Reserved-models (book-by-model) section
+  modelsSection: {
+    gap: spacing.sm,
+  },
+  modelsSectionHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  modelsManageLink: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.primary,
+    marginTop: spacing.xs,
+  },
+  modelsSubtitle: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
+    lineHeight: 16,
+  },
+  modelCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    gap: spacing.sm,
+  },
+  modelIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.sm,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  modelInfo: {
+    flex: 1,
+    gap: 3,
+  },
+  modelName: {
+    fontSize: fontSize.base,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  modelBadge: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: borderRadius.pill,
+  },
+  modelBadgeText: {
+    fontSize: fontSize.xs,
+    fontWeight: "600",
+  },
+  modelProgress: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
+  },
+  modelQty: {
+    fontSize: fontSize.base,
+    fontWeight: "700",
+    color: colors.foreground,
   },
 
   // Asset cards

--- a/apps/companion/app/(tabs)/bookings/add-assets.tsx
+++ b/apps/companion/app/(tabs)/bookings/add-assets.tsx
@@ -134,10 +134,12 @@ export default function AddBookingAssetsScreen() {
       else if (data) setKits(data.kits);
     } else {
       // Book-by-model: availability is computed server-side over the booking's
-      // window; there's no server-side search, so we client-filter by name.
+      // window. Search is ALSO server-side (the list is capped at ~50, so a
+      // client-only filter could never reach a model that sorts past the cap).
       const { data, error: err } = await api.availableModels(
         currentOrg.id,
-        bookingId
+        bookingId,
+        debouncedSearch || undefined
       );
       if (reqId !== requestIdRef.current) return; // superseded by a newer load
       if (err) setError(err);
@@ -342,13 +344,6 @@ export default function AddBookingAssetsScreen() {
     [selectedKitIds, toggleKit, colors, styles]
   );
 
-  // Client-side name filter for models (the endpoint has no server search).
-  const filteredModels = debouncedSearch
-    ? models.filter((m) =>
-        m.name.toLowerCase().includes(debouncedSearch.toLowerCase())
-      )
-    : models;
-
   const renderModel = useCallback(
     ({ item }: { item: AvailableModel }) => {
       const existing = modelRequestsById[item.id];
@@ -532,18 +527,19 @@ export default function AddBookingAssetsScreen() {
         />
       ) : (
         <FlatList
-          data={filteredModels}
+          data={models}
           renderItem={renderModel}
           keyExtractor={modelKeyExtractor}
           contentContainerStyle={styles.list}
           keyboardShouldPersistTaps="handled"
           ListFooterComponent={
-            // The picker returns the first 50 models; tell the user to search
-            // if there are more (mirrors the web "showing N of M" hint).
-            totalModelCount > models.length ? (
+            // The picker returns the first 50 (by name); when there are more and
+            // the user hasn't searched, nudge them to search — which now filters
+            // server-side, so any model past the cap is reachable.
+            !debouncedSearch && totalModelCount > models.length ? (
               <Text style={styles.modelsFooter}>
-                Showing {models.length} of {totalModelCount} models. Search to
-                narrow.
+                Showing {models.length} of {totalModelCount} models. Search by
+                name to find the rest.
               </Text>
             ) : null
           }

--- a/apps/companion/app/(tabs)/bookings/add-assets.tsx
+++ b/apps/companion/app/(tabs)/bookings/add-assets.tsx
@@ -29,33 +29,59 @@ import { Image } from "expo-image";
 import * as Haptics from "expo-haptics";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
-import { api, type AvailableAsset, type AvailableKit } from "@/lib/api";
+import {
+  api,
+  type AvailableAsset,
+  type AvailableKit,
+  type AvailableModel,
+  type AvailableModelExistingRequest,
+} from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { markBookingDirty } from "@/lib/booking-refresh";
 import { fontSize, spacing, borderRadius, hitSlop } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
+import { QuantityInputSheet } from "@/components/quantity-input-sheet";
 
-type Mode = "assets" | "kits";
+type Mode = "assets" | "kits" | "models";
 
 const assetKeyExtractor = (item: AvailableAsset) => item.id;
 const kitKeyExtractor = (item: AvailableKit) => item.id;
+const modelKeyExtractor = (item: AvailableModel) => item.id;
 
 export default function AddBookingAssetsScreen() {
   const router = useRouter();
-  const { bookingId, from, to } = useLocalSearchParams<{
+  const {
+    bookingId,
+    from,
+    to,
+    mode: initialMode,
+  } = useLocalSearchParams<{
     bookingId: string;
     bookingName?: string;
     from: string;
     to: string;
+    /** When "models", open straight to the book-by-model tab (from detail). */
+    mode?: string;
   }>();
   const { currentOrg } = useOrg();
   const { colors } = useTheme();
   const styles = useStyles();
 
-  const [mode, setMode] = useState<Mode>("assets");
+  const [mode, setMode] = useState<Mode>(
+    initialMode === "models" ? "models" : "assets"
+  );
   const [assets, setAssets] = useState<AvailableAsset[]>([]);
   const [kits, setKits] = useState<AvailableKit[]>([]);
+  const [models, setModels] = useState<AvailableModel[]>([]);
+  // This booking's existing model reservations, keyed by model id, so each row
+  // knows its current reserved amount and fulfilled count.
+  const [modelRequestsById, setModelRequestsById] = useState<
+    Record<string, AvailableModelExistingRequest>
+  >({});
+  const [totalModelCount, setTotalModelCount] = useState(0);
+  // The model whose quantity sheet is open (null = closed).
+  const [activeModel, setActiveModel] = useState<AvailableModel | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -94,7 +120,7 @@ export default function AddBookingAssetsScreen() {
       if (reqId !== requestIdRef.current) return; // superseded by a newer load
       if (err) setError(err);
       else if (data) setAssets(data.assets);
-    } else {
+    } else if (mode === "kits") {
       const { data, error: err } = await api.availableKits(currentOrg.id, {
         bookingFrom: from,
         bookingTo: to,
@@ -106,6 +132,24 @@ export default function AddBookingAssetsScreen() {
       if (reqId !== requestIdRef.current) return; // superseded by a newer load
       if (err) setError(err);
       else if (data) setKits(data.kits);
+    } else {
+      // Book-by-model: availability is computed server-side over the booking's
+      // window; there's no server-side search, so we client-filter by name.
+      const { data, error: err } = await api.availableModels(
+        currentOrg.id,
+        bookingId
+      );
+      if (reqId !== requestIdRef.current) return; // superseded by a newer load
+      if (err) setError(err);
+      else if (data) {
+        setModels(data.assetModels ?? []);
+        setTotalModelCount(data.totalAssetModels ?? 0);
+        setModelRequestsById(
+          Object.fromEntries(
+            (data.modelRequests ?? []).map((mr) => [mr.assetModelId, mr])
+          )
+        );
+      }
     }
     if (reqId === requestIdRef.current) setIsLoading(false);
   }, [currentOrg, from, to, mode, debouncedSearch, bookingId]);
@@ -152,6 +196,79 @@ export default function AddBookingAssetsScreen() {
     markBookingDirty(bookingId);
     router.back();
   };
+
+  // ── Book-by-model reserve / edit / remove ────────────────────────────────
+
+  /**
+   * Upper bound for reserving a model: what's free in the window PLUS the units
+   * this booking has already had assigned (they can't be re-reserved away but
+   * the total can't drop below them). Mirrors the server cap in
+   * `upsertBookingModelRequest` (available + existingFulfilled).
+   */
+  const reserveMax = (model: AvailableModel) => {
+    const existing = modelRequestsById[model.id];
+    return model.available + (existing?.fulfilledQuantity ?? 0);
+  };
+
+  const handleReserveSubmit = async (quantity: number) => {
+    if (!currentOrg || !bookingId || !activeModel) return;
+    const model = activeModel;
+    setActiveModel(null); // the sheet's confirm IS the confirmation step
+    setIsSubmitting(true);
+    const { error: err } = await api.upsertModelRequest(
+      currentOrg.id,
+      bookingId,
+      model.id,
+      quantity
+    );
+    setIsSubmitting(false);
+    if (err) {
+      Alert.alert("Couldn't reserve model", err);
+      return;
+    }
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    markBookingDirty(bookingId);
+    load(); // refresh availability + the reserved amounts
+  };
+
+  // Memoized so `renderModel` (which references it) keeps a stable identity
+  // across renders — avoids the FlatList row remount churn the render-stability
+  // rule warns about.
+  const handleRemoveModel = useCallback(
+    (model: AvailableModel) => {
+      if (!currentOrg || !bookingId) return;
+      Alert.alert(
+        "Remove reservation",
+        `Remove the reservation for ${model.name}?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Remove",
+            style: "destructive",
+            onPress: async () => {
+              setIsSubmitting(true);
+              const { error: err } = await api.removeModelRequest(
+                currentOrg.id,
+                bookingId,
+                model.id
+              );
+              setIsSubmitting(false);
+              if (err) {
+                Alert.alert("Couldn't remove reservation", err);
+                return;
+              }
+              Haptics.notificationAsync(
+                Haptics.NotificationFeedbackType.Success
+              );
+              markBookingDirty(bookingId);
+              load();
+            },
+          },
+        ]
+      );
+    },
+    [currentOrg, bookingId, load]
+  );
 
   const renderAsset = useCallback(
     ({ item }: { item: AvailableAsset }) => {
@@ -225,29 +342,105 @@ export default function AddBookingAssetsScreen() {
     [selectedKitIds, toggleKit, colors, styles]
   );
 
-  return (
-    <View style={styles.container}>
-      {/* Segmented Assets / Kits */}
-      <View style={styles.segment}>
-        {(["assets", "kits"] as Mode[]).map((m) => (
+  // Client-side name filter for models (the endpoint has no server search).
+  const filteredModels = debouncedSearch
+    ? models.filter((m) =>
+        m.name.toLowerCase().includes(debouncedSearch.toLowerCase())
+      )
+    : models;
+
+  const renderModel = useCallback(
+    ({ item }: { item: AvailableModel }) => {
+      const existing = modelRequestsById[item.id];
+      const reserved = existing?.quantity ?? 0;
+      const max = item.available + (existing?.fulfilledQuantity ?? 0);
+      // Nothing free to reserve AND nothing already reserved → can't act.
+      const canReserve = max >= 1;
+      return (
+        <View style={styles.row}>
+          <View style={[styles.thumb, styles.thumbPlaceholder]}>
+            <Ionicons name="cube-outline" size={18} color={colors.gray300} />
+          </View>
+          <View style={styles.modelInfo}>
+            <Text style={styles.rowTitle} numberOfLines={1}>
+              {item.name}
+            </Text>
+            <Text style={styles.modelMeta}>
+              {item.available} of {item.total} available
+              {reserved > 0 ? ` · ${reserved} reserved here` : ""}
+            </Text>
+          </View>
+          {reserved > 0 && (
+            <TouchableOpacity
+              style={styles.modelRemoveButton}
+              onPress={() => handleRemoveModel(item)}
+              disabled={isSubmitting}
+              hitSlop={hitSlop.sm}
+              accessibilityRole="button"
+              accessibilityLabel={`Remove ${item.name} reservation`}
+            >
+              <Ionicons name="trash-outline" size={18} color={colors.error} />
+            </TouchableOpacity>
+          )}
           <TouchableOpacity
-            key={m}
-            style={[styles.segmentItem, mode === m && styles.segmentItemActive]}
-            onPress={() => setMode(m)}
-            accessibilityRole="tab"
-            accessibilityState={{ selected: mode === m }}
-            accessibilityLabel={m === "assets" ? "Assets" : "Kits"}
+            style={[
+              styles.modelReserveButton,
+              !canReserve && styles.modelReserveButtonDisabled,
+            ]}
+            onPress={() => setActiveModel(item)}
+            disabled={!canReserve || isSubmitting}
+            accessibilityRole="button"
+            accessibilityLabel={
+              reserved > 0
+                ? `Edit ${item.name} reservation, currently ${reserved}`
+                : `Reserve units of ${item.name}`
+            }
           >
             <Text
               style={[
-                styles.segmentText,
-                mode === m && styles.segmentTextActive,
+                styles.modelReserveText,
+                !canReserve && styles.modelReserveTextDisabled,
               ]}
             >
-              {m === "assets" ? "Assets" : "Kits"}
+              {reserved > 0 ? "Edit" : "Reserve"}
             </Text>
           </TouchableOpacity>
-        ))}
+        </View>
+      );
+    },
+    [modelRequestsById, isSubmitting, colors, styles, handleRemoveModel]
+  );
+
+  return (
+    <View style={styles.container}>
+      {/* Segmented Assets / Kits / Models */}
+      <View style={styles.segment}>
+        {(["assets", "kits", "models"] as Mode[]).map((m) => {
+          const label =
+            m === "assets" ? "Assets" : m === "kits" ? "Kits" : "Models";
+          return (
+            <TouchableOpacity
+              key={m}
+              style={[
+                styles.segmentItem,
+                mode === m && styles.segmentItemActive,
+              ]}
+              onPress={() => setMode(m)}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: mode === m }}
+              accessibilityLabel={label}
+            >
+              <Text
+                style={[
+                  styles.segmentText,
+                  mode === m && styles.segmentTextActive,
+                ]}
+              >
+                {label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
       </View>
 
       {/* Search */}
@@ -317,7 +510,7 @@ export default function AddBookingAssetsScreen() {
             </View>
           }
         />
-      ) : (
+      ) : mode === "kits" ? (
         <FlatList
           data={kits}
           renderItem={renderKit}
@@ -337,7 +530,53 @@ export default function AddBookingAssetsScreen() {
             </View>
           }
         />
+      ) : (
+        <FlatList
+          data={filteredModels}
+          renderItem={renderModel}
+          keyExtractor={modelKeyExtractor}
+          contentContainerStyle={styles.list}
+          keyboardShouldPersistTaps="handled"
+          ListFooterComponent={
+            // The picker returns the first 50 models; tell the user to search
+            // if there are more (mirrors the web "showing N of M" hint).
+            totalModelCount > models.length ? (
+              <Text style={styles.modelsFooter}>
+                Showing {models.length} of {totalModelCount} models. Search to
+                narrow.
+              </Text>
+            ) : null
+          }
+          ListEmptyComponent={
+            <View style={styles.centered}>
+              <Ionicons name="cube-outline" size={40} color={colors.border} />
+              <Text style={styles.emptyText}>
+                {debouncedSearch
+                  ? "No models match your search"
+                  : "This workspace has no asset models yet"}
+              </Text>
+            </View>
+          }
+        />
       )}
+
+      {/* Reserve/edit quantity sheet for book-by-model */}
+      <QuantityInputSheet
+        visible={activeModel !== null}
+        title={
+          activeModel && modelRequestsById[activeModel.id]
+            ? "Edit reservation"
+            : "Reserve model"
+        }
+        subtitle={activeModel?.name}
+        max={activeModel ? reserveMax(activeModel) : 1}
+        defaultValue={
+          activeModel ? modelRequestsById[activeModel.id]?.quantity ?? 1 : 1
+        }
+        confirmLabel="Reserve"
+        onSubmit={handleReserveSubmit}
+        onClose={() => setActiveModel(null)}
+      />
 
       {/* Add bar */}
       {totalSelected > 0 && (
@@ -455,6 +694,41 @@ const useStyles = createStyles((colors, shadows) => ({
     fontSize: fontSize.base,
     fontWeight: "600",
     color: colors.foreground,
+  },
+  // Book-by-model rows
+  modelInfo: {
+    flex: 1,
+    gap: 2,
+  },
+  modelMeta: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
+  },
+  modelReserveButton: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: 7,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.primaryBg,
+  },
+  modelReserveButtonDisabled: {
+    backgroundColor: colors.backgroundTertiary,
+  },
+  modelReserveText: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.primary,
+  },
+  modelReserveTextDisabled: {
+    color: colors.muted,
+  },
+  modelRemoveButton: {
+    padding: spacing.xs,
+  },
+  modelsFooter: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
+    textAlign: "center",
+    paddingVertical: spacing.md,
   },
   checkbox: {
     width: 22,

--- a/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
+++ b/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
@@ -360,7 +360,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -392,7 +392,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/companion/ios/Shelf/Info.plist
+++ b/apps/companion/ios/Shelf/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apps/companion/lib/api/bookings.ts
+++ b/apps/companion/lib/api/bookings.ts
@@ -11,6 +11,8 @@ import type {
   RemoveBookingAssetsResponse,
   AvailableAssetsResponse,
   AvailableKitsResponse,
+  AvailableModelsResponse,
+  ModelRequestMutationResponse,
   BookingTagsResponse,
 } from "./types";
 
@@ -270,4 +272,51 @@ export const bookingsApi = {
   /** Tags assignable to bookings (for the booking-form tag picker). */
   bookingTags: (orgId: string) =>
     apiFetch<BookingTagsResponse>(`/api/mobile/bookings/tags?orgId=${orgId}`),
+
+  /**
+   * Book-by-model picker: the workspace's asset models with how many units are
+   * free to reserve in this booking's window, plus the booking's existing
+   * model reservations (to pre-fill inputs). Read-only.
+   */
+  availableModels: (orgId: string, bookingId: string) =>
+    apiFetch<AvailableModelsResponse>(
+      `/api/mobile/bookings/available-models?orgId=${orgId}&bookingId=${bookingId}`
+    ),
+
+  /**
+   * Reserve (or edit) `quantity` units of an asset model on a booking.
+   * `quantity` is the ABSOLUTE reserved total, not a delta — the server upserts
+   * to it. DRAFT/RESERVED only; availability + ownership enforced server-side.
+   */
+  upsertModelRequest: (
+    orgId: string,
+    bookingId: string,
+    assetModelId: string,
+    quantity: number
+  ) =>
+    apiFetch<ModelRequestMutationResponse>(
+      `/api/mobile/bookings/${bookingId}/model-requests?orgId=${orgId}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ assetModelId, quantity }),
+      }
+    ),
+
+  /**
+   * Cancel a model-level reservation on a booking. Idempotent; blocked
+   * server-side if units have already been assigned (edit the quantity down
+   * instead). DRAFT/RESERVED only.
+   */
+  removeModelRequest: (
+    orgId: string,
+    bookingId: string,
+    assetModelId: string
+  ) =>
+    apiFetch<ModelRequestMutationResponse>(
+      `/api/mobile/bookings/${bookingId}/model-requests?orgId=${orgId}`,
+      {
+        method: "DELETE",
+        body: JSON.stringify({ assetModelId }),
+      }
+    ),
 };

--- a/apps/companion/lib/api/bookings.ts
+++ b/apps/companion/lib/api/bookings.ts
@@ -276,12 +276,17 @@ export const bookingsApi = {
   /**
    * Book-by-model picker: the workspace's asset models with how many units are
    * free to reserve in this booking's window, plus the booking's existing
-   * model reservations (to pre-fill inputs). Read-only.
+   * model reservations (to pre-fill inputs). Read-only. `search` filters by
+   * model name server-side so orgs with more than ~50 models can reach any
+   * of them (the list is capped, so a client-only filter can't).
    */
-  availableModels: (orgId: string, bookingId: string) =>
-    apiFetch<AvailableModelsResponse>(
-      `/api/mobile/bookings/available-models?orgId=${orgId}&bookingId=${bookingId}`
-    ),
+  availableModels: (orgId: string, bookingId: string, search?: string) => {
+    const sp = new URLSearchParams({ orgId, bookingId });
+    if (search) sp.set("s", search);
+    return apiFetch<AvailableModelsResponse>(
+      `/api/mobile/bookings/available-models?${sp}`
+    );
+  },
 
   /**
    * Reserve (or edit) `quantity` units of an asset model on a booking.

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -472,6 +472,22 @@ export type BookingAsset = {
   kit: { id: string; name: string } | null;
 };
 
+/**
+ * A book-by-model reservation on a booking: intent to reserve `quantity` units
+ * of an `AssetModel` without picking specific assets upfront. `outstanding` is
+ * how many are still waiting to be assigned via scan-to-assign;
+ * `fulfilledAt` non-null means every unit has been assigned (read-only history).
+ */
+export type BookingModelRequest = {
+  id: string;
+  assetModelId: string;
+  assetModelName: string;
+  quantity: number;
+  fulfilledQuantity: number;
+  outstandingQuantity: number;
+  fulfilledAt: string | null;
+};
+
 export type BookingDetail = {
   id: string;
   name: string;
@@ -500,6 +516,12 @@ export type BookingDetail = {
   assets: BookingAsset[];
   assetCount: number;
   checkedOutCount: number;
+  /** Book-by-model reservations (outstanding + fulfilled), matching the web. */
+  modelRequests: BookingModelRequest[];
+  /** Number of distinct models reserved (rows in `modelRequests`). */
+  modelRequestCount: number;
+  /** Total units still to assign across all model requests. */
+  outstandingModelUnitCount: number;
 };
 
 export type BookingDetailResponse = {
@@ -641,6 +663,51 @@ export type AvailableKitsResponse = {
   perPage: number;
   totalCount: number;
   totalPages: number;
+};
+
+/**
+ * A bookable asset model in the book-by-model picker, with how many units are
+ * free to reserve in the booking's window. `available` = total − in-custody −
+ * reserved (concrete + via other model requests). Server-computed; the app
+ * caps the reserve input at `available` + the amount already fulfilled.
+ */
+export type AvailableModel = {
+  id: string;
+  name: string;
+  total: number;
+  available: number;
+  inCustody: number;
+  reservedConcrete: number;
+  reservedViaRequest: number;
+};
+
+/**
+ * The booking's existing model-level reservations as returned by the picker
+ * (leaner than {@link BookingModelRequest} — no id/outstanding, since the
+ * picker only needs current amounts to pre-fill inputs).
+ */
+export type AvailableModelExistingRequest = {
+  assetModelId: string;
+  assetModelName: string;
+  quantity: number;
+  fulfilledQuantity: number;
+  fulfilledAt: string | null;
+};
+
+export type AvailableModelsResponse = {
+  /** False when the workspace has no AssetModel at all — hide the picker. */
+  showModelsTab: boolean;
+  /** Per-model availability for this booking's window (first 50 by name). */
+  assetModels: AvailableModel[];
+  /** Full workspace model count (the list above is capped at 50). */
+  totalAssetModels: number;
+  /** This booking's existing model reservations, to pre-fill the inputs. */
+  modelRequests: AvailableModelExistingRequest[];
+};
+
+/** Response from the model-request upsert/remove endpoint. */
+export type ModelRequestMutationResponse = {
+  success: boolean;
 };
 
 export type BookingTag = { id: string; name: string };

--- a/apps/companion/lib/constants.ts
+++ b/apps/companion/lib/constants.ts
@@ -7,6 +7,13 @@
  * backward-compat during migration and will be removed.
  */
 
+import {
+  ASSET_STATUS_LABELS,
+  ASSET_QTY_STATUS_LABELS,
+  ASSET_BOOKING_PSEUDO_STATUS_LABELS,
+  BOOKING_STATUS_LABELS,
+} from "@shelf/labels";
+
 // ── Deprecated re-exports (use useTheme() instead) ─────────────────────────
 export { lightColors as colors } from "./theme-colors";
 export { lightShadows as shadows } from "./theme-colors";
@@ -60,34 +67,56 @@ export const hitSlop = {
 // ── Utility functions ──────────────────────────────────────────────────────
 
 /**
- * Format status enums into user-friendly labels consistent with the webapp.
- * Webapp uses sentence-case ("In custody", "Checked out") not Title Case.
+ * Format status enums into user-facing labels IDENTICAL to the webapp.
+ *
+ * All asset + booking status strings come from the shared `@shelf/labels`
+ * package (the single source of truth both apps import), so the phone can
+ * never drift from the website's wording. This mirrors the web
+ * `userFriendlyAssetStatus()` enum path, including the booking-context
+ * "partially checked in/out" pseudo-statuses that previously fell through to
+ * the default branch and rendered as raw text like "Partially checked out qty".
+ *
+ * Note: the quantity-aware badge labels ("Partial custody", "Partially
+ * reserved") are NOT enum values — they are derived from a quantity breakdown,
+ * not this map. Use {@link getQuantityStatusLabel} for those.
+ *
+ * @param status - an asset/booking/audit status enum string from the API
+ * @returns the user-facing label
  */
 export function formatStatus(status: string) {
-  // Asset statuses — match webapp's userFriendlyAssetStatus()
   switch (status) {
+    // ── Asset statuses (shared with web userFriendlyAssetStatus) ──
     case "IN_CUSTODY":
-      return "In custody";
+      return ASSET_STATUS_LABELS.IN_CUSTODY;
     case "CHECKED_OUT":
-      return "Checked out";
+      return ASSET_STATUS_LABELS.CHECKED_OUT;
     case "AVAILABLE":
-      return "Available";
-    // Booking statuses — match webapp's booking-status-badge
+      return ASSET_STATUS_LABELS.AVAILABLE;
+    // ── Booking-context pseudo-statuses (web userFriendlyAssetStatus) ──
+    // Previously missing -> the default branch mangled them (stray "qty").
+    case "PARTIALLY_CHECKED_IN":
+      return ASSET_BOOKING_PSEUDO_STATUS_LABELS.ALREADY_CHECKED_IN;
+    case "PARTIALLY_CHECKED_IN_QTY":
+      return ASSET_BOOKING_PSEUDO_STATUS_LABELS.PARTIALLY_CHECKED_IN;
+    case "PARTIALLY_CHECKED_OUT_QTY":
+    case "PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN":
+      return ASSET_BOOKING_PSEUDO_STATUS_LABELS.PARTIALLY_CHECKED_OUT;
+    // ── Booking statuses (shared with web booking-status-badge) ──
     case "DRAFT":
-      return "Draft";
+      return BOOKING_STATUS_LABELS.DRAFT;
     case "RESERVED":
-      return "Reserved";
+      return BOOKING_STATUS_LABELS.RESERVED;
     case "ONGOING":
-      return "Ongoing";
+      return BOOKING_STATUS_LABELS.ONGOING;
     case "OVERDUE":
-      return "Overdue";
+      return BOOKING_STATUS_LABELS.OVERDUE;
     case "COMPLETE":
-      return "Complete";
+      return BOOKING_STATUS_LABELS.COMPLETE;
     case "ARCHIVED":
-      return "Archived";
+      return BOOKING_STATUS_LABELS.ARCHIVED;
     case "CANCELLED":
-      return "Cancelled";
-    // Audit statuses
+      return BOOKING_STATUS_LABELS.CANCELLED;
+    // ── Audit statuses (companion-only; no web asset-badge equivalent) ──
     case "PENDING":
       return "Pending";
     case "ACTIVE":
@@ -100,6 +129,52 @@ export function formatStatus(status: string) {
       return words.charAt(0).toUpperCase() + words.slice(1);
     }
   }
+}
+
+/**
+ * Quantity-aware status label for a QUANTITY_TRACKED asset, IDENTICAL to the
+ * web `getQuantityBadgeLabelAndColor` (asset-status-badge/quantity-data.ts).
+ *
+ * A quantity-tracked asset whose units span states shows a derived badge (e.g.
+ * "Partial custody" when some units are held and some are still available),
+ * NOT the raw enum. Labels come from the shared `@shelf/labels` package.
+ *
+ * Precedence mirrors web exactly: checked-out, then in-custody, then reserved,
+ * each "Partial…" when units remain available.
+ *
+ * @param breakdown - the per-status unit counts from the asset detail endpoint
+ * @returns the label, or null when there is no breakdown (caller falls back to
+ *          {@link formatStatus} on the raw enum)
+ */
+export function getQuantityStatusLabel(
+  breakdown:
+    | {
+        available: number;
+        inCustody: number;
+        reserved: number;
+        checkedOut: number;
+      }
+    | null
+    | undefined
+): string | null {
+  if (!breakdown) return null;
+  const { available, inCustody, reserved, checkedOut } = breakdown;
+  if (checkedOut > 0) {
+    return available <= 0
+      ? ASSET_QTY_STATUS_LABELS.CHECKED_OUT
+      : ASSET_QTY_STATUS_LABELS.PARTIALLY_CHECKED_OUT;
+  }
+  if (inCustody > 0) {
+    return available <= 0
+      ? ASSET_QTY_STATUS_LABELS.IN_CUSTODY
+      : ASSET_QTY_STATUS_LABELS.PARTIAL_CUSTODY;
+  }
+  if (reserved > 0) {
+    return available <= 0
+      ? ASSET_QTY_STATUS_LABELS.RESERVED
+      : ASSET_QTY_STATUS_LABELS.PARTIALLY_RESERVED;
+  }
+  return ASSET_QTY_STATUS_LABELS.AVAILABLE;
 }
 
 export function formatDate(dateStr: string) {

--- a/apps/companion/package.json
+++ b/apps/companion/package.json
@@ -30,6 +30,7 @@
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "@sentry/react-native": "~7.2.0",
+    "@shelf/labels": "workspace:*",
     "@supabase/supabase-js": "^2.49.1",
     "expo": "~54.0.33",
     "expo-av": "^16.0.8",

--- a/apps/webapp/app/components/assets/asset-status-badge/quantity-data.ts
+++ b/apps/webapp/app/components/assets/asset-status-badge/quantity-data.ts
@@ -16,6 +16,7 @@
  */
 
 import type { AssetType } from "@prisma/client";
+import { ASSET_QTY_STATUS_LABELS } from "@shelf/labels";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import { BADGE_COLORS, type BadgeColorScheme } from "~/utils/badge-colors";
 
@@ -158,26 +159,38 @@ export function getQuantityBadgeLabelAndColor(data: QuantityBreakdown): {
 
   if (checkedOut > 0) {
     return {
-      label: available <= 0 ? "Checked out" : "Partially checked out",
+      label:
+        available <= 0
+          ? ASSET_QTY_STATUS_LABELS.CHECKED_OUT
+          : ASSET_QTY_STATUS_LABELS.PARTIALLY_CHECKED_OUT,
       colors: BADGE_COLORS.violet,
     };
   }
 
   if (inCustody > 0) {
     return {
-      label: available <= 0 ? "In custody" : "Partial custody",
+      label:
+        available <= 0
+          ? ASSET_QTY_STATUS_LABELS.IN_CUSTODY
+          : ASSET_QTY_STATUS_LABELS.PARTIAL_CUSTODY,
       colors: BADGE_COLORS.blue,
     };
   }
 
   if (reserved > 0) {
     return {
-      label: available <= 0 ? "Reserved" : "Partially reserved",
+      label:
+        available <= 0
+          ? ASSET_QTY_STATUS_LABELS.RESERVED
+          : ASSET_QTY_STATUS_LABELS.PARTIALLY_RESERVED,
       colors: BADGE_COLORS.blue,
     };
   }
 
   /* Fallback — shouldn't be reached because getQuantityData returns
    * null when all counts are zero, but be defensive */
-  return { label: "Available", colors: BADGE_COLORS.green };
+  return {
+    label: ASSET_QTY_STATUS_LABELS.AVAILABLE,
+    colors: BADGE_COLORS.green,
+  };
 }

--- a/apps/webapp/app/components/assets/asset-status-badge/status-labels.ts
+++ b/apps/webapp/app/components/assets/asset-status-badge/status-labels.ts
@@ -10,6 +10,10 @@
  */
 
 import { AssetStatus } from "@prisma/client";
+import {
+  ASSET_STATUS_LABELS,
+  ASSET_BOOKING_PSEUDO_STATUS_LABELS,
+} from "@shelf/labels";
 import { BADGE_COLORS, type BadgeColorScheme } from "~/utils/badge-colors";
 import type { ExtendedAssetStatus } from "~/utils/booking-assets";
 
@@ -17,37 +21,40 @@ import type { ExtendedAssetStatus } from "~/utils/booking-assets";
  * Maps a status (including the booking-context-only `PARTIALLY_CHECKED_IN`
  * pseudo-statuses) to its user-facing label.
  *
+ * All label strings come from the shared `@shelf/labels` package so the
+ * companion app renders the exact same wording (single source of truth).
+ *
  * @param status The asset status, or a booking-context pseudo-status
  * @returns Short human-readable label suitable for a badge
  */
 export const userFriendlyAssetStatus = (status: ExtendedAssetStatus) => {
   switch (status) {
     case AssetStatus.IN_CUSTODY:
-      return "In custody";
+      return ASSET_STATUS_LABELS.IN_CUSTODY;
     case AssetStatus.CHECKED_OUT:
-      return "Checked out";
+      return ASSET_STATUS_LABELS.CHECKED_OUT;
     case "PARTIALLY_CHECKED_IN":
-      return "Already checked in";
+      return ASSET_BOOKING_PSEUDO_STATUS_LABELS.ALREADY_CHECKED_IN;
     case "PARTIALLY_CHECKED_IN_QTY":
       // Legacy Phase 3c label — kept for any caller that still needs the
       // "partially in" wording. Booking rows use PARTIALLY_CHECKED_OUT_QTY
       // instead to emphasise "work still outstanding".
-      return "Partially checked in";
+      return ASSET_BOOKING_PSEUDO_STATUS_LABELS.PARTIALLY_CHECKED_IN;
     case "PARTIALLY_CHECKED_OUT_QTY":
       // Qty-tracked: some units of THIS row dispositioned, some still
       // outstanding. Wording matches the global qty-aware breakdown so
       // a row that's partly returned reads consistently with how it
       // looks on the asset index / asset overview.
-      return "Partially checked out";
+      return ASSET_BOOKING_PSEUDO_STATUS_LABELS.PARTIALLY_CHECKED_OUT;
     case "PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN":
       // Qty-tracked: some units progressively checked out, but no
       // disposition (return/consume/loss/damage) recorded yet. Same
       // user-facing wording as the violet "Partially checked out" state —
       // the amber colour carries the "no returns yet, action required"
       // semantic without inventing a second label users have to learn.
-      return "Partially checked out";
+      return ASSET_BOOKING_PSEUDO_STATUS_LABELS.PARTIALLY_CHECKED_OUT;
     default:
-      return "Available";
+      return ASSET_STATUS_LABELS.AVAILABLE;
   }
 };
 

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -282,14 +282,22 @@ export type BookingModelTabData = {
  * scopes both the model count and list, preventing cross-org leakage.
  * @param booking - The booking these models are being reserved against.
  * Only `id`, `from`, `to`, and `modelRequests` are read.
+ * @param search - Optional case-insensitive name filter. The seed list is
+ * capped at `MODEL_PICKER_LIMIT`, so without this a model sorting after the
+ * cap is unreachable. The web's DynamicSelect searches beyond the seed via
+ * the `model-filters` endpoint; passing `search` here gives the same reach
+ * to callers (e.g. the mobile picker) that render this list directly.
+ * `totalAssetModels` stays the full-org count so "showing N of M" is honest.
  * @returns The Models tab payload; see {@link BookingModelTabData}.
  */
 export async function getBookingModelTabData({
   organizationId,
   booking,
+  search,
 }: {
   organizationId: string;
   booking: BookingForModelTab;
+  search?: string;
 }): Promise<BookingModelTabData> {
   try {
     const assetModelsCount = await db.assetModel.count({
@@ -297,11 +305,18 @@ export async function getBookingModelTabData({
     });
     const showModelsTab = assetModelsCount > 0;
 
+    // Case-insensitive name filter, applied to the seed fetch only (not the
+    // full-org count/showModelsTab). Trimmed; blank search = no filter.
+    const trimmedSearch = search?.trim();
+    const searchWhere = trimmedSearch
+      ? { name: { contains: trimmedSearch, mode: "insensitive" as const } }
+      : {};
+
     let assetModels: BookingModelTabAssetModel[] = [];
 
     if (showModelsTab) {
       const rawModels = await db.assetModel.findMany({
-        where: { organizationId },
+        where: { organizationId, ...searchWhere },
         select: { id: true, name: true },
         orderBy: { name: "asc" },
         take: MODEL_PICKER_LIMIT,

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -307,9 +307,17 @@ export async function getBookingModelTabData({
 
     // Case-insensitive name filter, applied to the seed fetch only (not the
     // full-org count/showModelsTab). Trimmed; blank search = no filter.
+    // Escape the LIKE metacharacters (`%` `_` and the escape char `\`) so a
+    // literal search like "model_1" matches literally instead of treating `_`
+    // as a single-char wildcard (Prisma `contains` compiles to ILIKE).
     const trimmedSearch = search?.trim();
     const searchWhere = trimmedSearch
-      ? { name: { contains: trimmedSearch, mode: "insensitive" as const } }
+      ? {
+          name: {
+            contains: trimmedSearch.replace(/[\\%_]/g, "\\$&"),
+            mode: "insensitive" as const,
+          },
+        }
       : {};
 
     let assetModels: BookingModelTabAssetModel[] = [];

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.test.server.ts
@@ -222,4 +222,22 @@ describe("POST/DELETE /api/mobile/bookings/:bookingId/model-requests", () => {
     expect(response.init?.status).toBe(404);
     expect(upsertMock).not.toHaveBeenCalled();
   });
+
+  it("400s on an invalid body (validation), not 500, without calling the service", async () => {
+    withRole(OrganizationRoles.ADMIN);
+    findFirstMock.mockResolvedValue({
+      id: BOOKING_ID,
+      custodianUserId: CALLER_ID,
+    } as never);
+
+    // quantity 0 fails UpsertSchema (.positive) → must be a 400, not a raw
+    // ZodError that makeShelfError would surface as a 500.
+    const response = await action(
+      makeArgs("POST", { assetModelId: MODEL_ID, quantity: 0 })
+    );
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(400);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.test.server.ts
@@ -1,0 +1,225 @@
+/**
+ * Security + verb-routing tests for the mobile Book-by-Model mutation endpoint.
+ *
+ * The shared services (`upsertBookingModelRequest` /
+ * `removeBookingModelRequest`) org-scope the booking but do NOT check custodian
+ * ownership, so the ROUTE must: a SELF_SERVICE / BASE user may only edit model
+ * reservations on a booking THEY own — otherwise it's a cross-user IDOR within
+ * the org (the exact class the web twin guards against). These tests pin that
+ * guard plus POST→upsert / DELETE→remove routing.
+ *
+ * @see {@link file://./bookings.$bookingId.model-requests.ts} route under test
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createActionArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import type * as MobileAuthServer from "~/modules/api/mobile-auth.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+import {
+  removeBookingModelRequest,
+  upsertBookingModelRequest,
+} from "~/modules/booking-model-request/service.server";
+
+import { action } from "./bookings.$bookingId.model-requests";
+
+import { assertIsDataWithResponseInit } from "../../../../test/helpers/assertions";
+
+// @vitest-environment node
+
+// why: db is the integration boundary — we assert the route reads the booking's
+// custodianUserId to gate the mutation. Mock only booking.findFirst.
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
+// why: auth/permission/entitlement helpers are out of scope for these guard
+// tests — stub them to resolve, but keep `getMobileUserContext` a spy so each
+// test can pick the caller's role. The real module is otherwise preserved.
+vi.mock("~/modules/api/mobile-auth.server", async () => {
+  const actual = await vi.importActual<typeof MobileAuthServer>(
+    "~/modules/api/mobile-auth.server"
+  );
+  return {
+    ...actual,
+    requireMobileAuth: vi.fn(),
+    requireOrganizationAccess: vi.fn(),
+    requireMobilePermission: vi.fn(),
+    assertMobileCanUseBookings: vi.fn(),
+    getMobileUserContext: vi.fn(),
+  };
+});
+
+// why: rate limiting is infra, not the behavior under test — no-op it.
+vi.mock("~/utils/rate-limit.server", () => ({
+  enforceUserRateLimit: vi.fn().mockResolvedValue(undefined),
+}));
+
+// why: the services are the seam the route delegates to; spying on them lets us
+// assert the route BLOCKS the call for a non-owner and FORWARDS it for an owner.
+vi.mock("~/modules/booking-model-request/service.server", () => ({
+  upsertBookingModelRequest: vi.fn(),
+  removeBookingModelRequest: vi.fn(),
+}));
+
+const findFirstMock = vi.mocked(db.booking.findFirst);
+const requireMobileAuthMock = vi.mocked(requireMobileAuth);
+const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
+const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+const upsertMock = vi.mocked(upsertBookingModelRequest);
+const removeMock = vi.mocked(removeBookingModelRequest);
+
+const CALLER_ID = "user-self";
+const OTHER_ID = "user-other";
+const ORG_ID = "org-1";
+const BOOKING_ID = "booking-1";
+const MODEL_ID = "model-1";
+
+/** Build an action request for this endpoint with a JSON body + verb. */
+function makeArgs(method: "POST" | "DELETE", body: Record<string, unknown>) {
+  return createActionArgs({
+    request: new Request(
+      `http://localhost:3000/api/mobile/bookings/${BOOKING_ID}/model-requests`,
+      {
+        method,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    ),
+    params: { bookingId: BOOKING_ID },
+  });
+}
+
+/** Point `getMobileUserContext` at a specific role for the next call. */
+function withRole(role: OrganizationRoles) {
+  getMobileUserContextMock.mockResolvedValue({
+    role,
+    canUseBarcodes: true,
+    canUseAudits: true,
+    canSeeAllCustody: true,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireMobileAuthMock.mockResolvedValue({
+    user: { id: CALLER_ID },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  requireOrganizationAccessMock.mockResolvedValue(ORG_ID);
+  upsertMock.mockResolvedValue({ id: "req-1" } as never);
+  removeMock.mockResolvedValue(undefined as never);
+});
+
+describe("POST/DELETE /api/mobile/bookings/:bookingId/model-requests", () => {
+  it("403s a SELF_SERVICE user editing a booking they do not own, without calling the service", async () => {
+    withRole(OrganizationRoles.SELF_SERVICE);
+    // Booking is owned by someone else.
+    findFirstMock.mockResolvedValue({
+      id: BOOKING_ID,
+      custodianUserId: OTHER_ID,
+    } as never);
+
+    const response = await action(
+      makeArgs("POST", { assetModelId: MODEL_ID, quantity: 2 })
+    );
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(403);
+    // The IDOR guard must fire BEFORE the service is reached.
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it("403s a BASE user the same way (BASE is as restricted as SELF_SERVICE)", async () => {
+    withRole(OrganizationRoles.BASE);
+    findFirstMock.mockResolvedValue({
+      id: BOOKING_ID,
+      custodianUserId: OTHER_ID,
+    } as never);
+
+    const response = await action(
+      makeArgs("DELETE", { assetModelId: MODEL_ID })
+    );
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(403);
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it("lets a SELF_SERVICE user reserve on a booking they own (POST → upsert)", async () => {
+    withRole(OrganizationRoles.SELF_SERVICE);
+    findFirstMock.mockResolvedValue({
+      id: BOOKING_ID,
+      custodianUserId: CALLER_ID, // owns it
+    } as never);
+
+    const response = await action(
+      makeArgs("POST", { assetModelId: MODEL_ID, quantity: 3 })
+    );
+
+    assertIsDataWithResponseInit(response);
+    expect(response.data).toMatchObject({ success: true });
+    expect(upsertMock).toHaveBeenCalledWith({
+      bookingId: BOOKING_ID,
+      assetModelId: MODEL_ID,
+      quantity: 3,
+      organizationId: ORG_ID,
+      userId: CALLER_ID,
+    });
+  });
+
+  it("lets an ADMIN edit any booking's reservation (no custodian restriction)", async () => {
+    withRole(OrganizationRoles.ADMIN);
+    findFirstMock.mockResolvedValue({
+      id: BOOKING_ID,
+      custodianUserId: OTHER_ID, // not the admin — allowed anyway
+    } as never);
+
+    const response = await action(
+      makeArgs("POST", { assetModelId: MODEL_ID, quantity: 1 })
+    );
+
+    assertIsDataWithResponseInit(response);
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes DELETE to removeBookingModelRequest", async () => {
+    withRole(OrganizationRoles.OWNER);
+    findFirstMock.mockResolvedValue({
+      id: BOOKING_ID,
+      custodianUserId: OTHER_ID,
+    } as never);
+
+    const response = await action(
+      makeArgs("DELETE", { assetModelId: MODEL_ID })
+    );
+
+    assertIsDataWithResponseInit(response);
+    expect(response.data).toMatchObject({ success: true });
+    expect(removeMock).toHaveBeenCalledWith({
+      bookingId: BOOKING_ID,
+      assetModelId: MODEL_ID,
+      organizationId: ORG_ID,
+      userId: CALLER_ID,
+    });
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it("404s when the booking is not in the caller's workspace", async () => {
+    withRole(OrganizationRoles.ADMIN);
+    findFirstMock.mockResolvedValue(null);
+
+    const response = await action(
+      makeArgs("POST", { assetModelId: MODEL_ID, quantity: 1 })
+    );
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(404);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.ts
@@ -1,0 +1,167 @@
+import { OrganizationRoles } from "@prisma/client";
+import { data, type ActionFunctionArgs } from "react-router";
+import { z } from "zod";
+import { db } from "~/database/db.server";
+import {
+  requireMobileAuth,
+  requireMobilePermission,
+  requireOrganizationAccess,
+  getMobileUserContext,
+  assertMobileCanUseBookings,
+} from "~/modules/api/mobile-auth.server";
+import {
+  removeBookingModelRequest,
+  upsertBookingModelRequest,
+} from "~/modules/booking-model-request/service.server";
+import { makeShelfError, notAllowedMethod, ShelfError } from "~/utils/error";
+import { getParams, isDelete, isPost } from "~/utils/http.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { enforceUserRateLimit } from "~/utils/rate-limit.server";
+
+/**
+ * Booking model-level reservations (Book-by-Model) — mobile twin of the web
+ * route `api+/bookings.$bookingId.model-requests.ts`.
+ *
+ * - `POST`   — reserve/edit N units of an `AssetModel`: `{ assetModelId, quantity }`
+ * - `DELETE` — cancel a model-level reservation: `{ assetModelId }`
+ *
+ * Both verbs wrap the SAME shared services the web route uses
+ * (`upsertBookingModelRequest` / `removeBookingModelRequest`), so the
+ * availability guard, the "DRAFT/RESERVED only" rule, the
+ * can't-shrink-below-fulfilled rule and the activity notes all stay identical.
+ *
+ * Security stack (mirrors `bookings.add-scanned-assets.ts` — the services do
+ * NOT check custodian ownership, so a naive wrapper would be a cross-user
+ * IDOR): auth → per-user rate limit → org access → `booking:update`
+ * permission → TEAM-tier gate → org-scoped booking lookup → SELF_SERVICE/BASE
+ * may only touch a booking they own.
+ *
+ * @see {@link file://../bookings.$bookingId.model-requests.ts} web twin
+ * @see {@link file://../../../modules/booking-model-request/service.server.ts} shared services
+ */
+
+/**
+ * POST body — target quantity for a `(booking, assetModel)` pair. Quantity is
+ * the ABSOLUTE reserved total (not a delta); the service upserts to it.
+ */
+const UpsertSchema = z.object({
+  assetModelId: z.string().min(1, "Asset model ID is required"),
+  quantity: z.coerce
+    .number()
+    .int()
+    .positive("Quantity must be a positive integer"),
+});
+
+/** DELETE body — which model reservation to cancel. */
+const DeleteSchema = z.object({
+  assetModelId: z.string().min(1, "Asset model ID is required"),
+});
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  let userId: string | undefined;
+
+  try {
+    const { user } = await requireMobileAuth(request);
+    userId = user.id;
+    // Per-user rate limit — model edits touch the same availability
+    // computation as bulk asset adds; bucket them together.
+    await enforceUserRateLimit(user.id, "bulk");
+
+    const organizationId = await requireOrganizationAccess(request, user.id);
+
+    // Only users who can UPDATE a booking may edit its model reservations —
+    // same gate the web route enforces via requirePermission.
+    await requireMobilePermission({
+      userId: user.id,
+      organizationId,
+      entity: PermissionEntity.booking,
+      action: PermissionAction.update,
+    });
+
+    // Bookings are a TEAM-tier (premium) feature. Gate like every other
+    // booking mutation so a PERSONAL workspace can't reserve models via mobile.
+    await assertMobileCanUseBookings(organizationId);
+
+    const { bookingId } = getParams(
+      params,
+      z.object({ bookingId: z.string().min(1) }),
+      { additionalData: { userId } }
+    );
+
+    // Org-scoped booking lookup — a foreign-org booking id 404s here.
+    const booking = await db.booking.findFirst({
+      where: { id: bookingId, organizationId },
+      select: { id: true, custodianUserId: true },
+    });
+
+    if (!booking) {
+      return data(
+        { error: { message: "Booking not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    // BASE is as restricted as SELF_SERVICE here (own bookings only). Keying
+    // only on SELF_SERVICE would let a BASE user edit anyone's reservations.
+    const isSelfServiceOrBase =
+      role === OrganizationRoles.SELF_SERVICE ||
+      role === OrganizationRoles.BASE;
+
+    // The `booking:update` permission is granted to SELF_SERVICE / BASE, so
+    // the permission check alone lets any user in the org reach any bookingId.
+    // Without this ownership check those roles could manipulate other users'
+    // model reservations (cross-user IDOR within the org) — the shared
+    // service does not scope by custodian.
+    if (isSelfServiceOrBase && booking.custodianUserId !== user.id) {
+      throw new ShelfError({
+        cause: null,
+        message: "You can only modify your own bookings.",
+        label: "Booking",
+        status: 403,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (isPost(request)) {
+      const { assetModelId, quantity } = UpsertSchema.parse(
+        await request.json()
+      );
+
+      const modelRequest = await upsertBookingModelRequest({
+        bookingId,
+        assetModelId,
+        quantity,
+        organizationId,
+        userId: user.id,
+      });
+
+      return data({ success: true, request: modelRequest });
+    }
+
+    if (isDelete(request)) {
+      const { assetModelId } = DeleteSchema.parse(await request.json());
+
+      await removeBookingModelRequest({
+        bookingId,
+        assetModelId,
+        organizationId,
+        userId: user.id,
+      });
+
+      return data({ success: true });
+    }
+
+    // Only POST / DELETE are supported.
+    throw notAllowedMethod("POST, DELETE");
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId });
+    return data(
+      { error: { message: reason.message } },
+      { status: reason.status }
+    );
+  }
+}

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.model-requests.ts
@@ -60,6 +60,25 @@ const DeleteSchema = z.object({
   assetModelId: z.string().min(1, "Asset model ID is required"),
 });
 
+/**
+ * Validate `body` against `schema`, throwing a 400 `ShelfError` (not the raw
+ * `ZodError`, which `makeShelfError` maps to a 500) on failure. Mirrors what
+ * `parseData` does for form/query input, for a JSON body.
+ */
+function parseOr400<T>(schema: z.ZodType<T>, body: unknown): T {
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw new ShelfError({
+      cause: parsed.error,
+      message: parsed.error.issues[0]?.message ?? "Invalid request body.",
+      label: "Booking",
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
+  return parsed.data;
+}
+
 export async function action({ request, params }: ActionFunctionArgs) {
   let userId: string | undefined;
 
@@ -126,12 +145,27 @@ export async function action({ request, params }: ActionFunctionArgs) {
       });
     }
 
-    if (isPost(request)) {
-      const { assetModelId, quantity } = UpsertSchema.parse(
-        await request.json()
-      );
+    // Parse the JSON body once. Malformed JSON or a schema mismatch is a
+    // CLIENT error (400) — without this guard the raw SyntaxError/ZodError
+    // reaches makeShelfError, which doesn't special-case them and returns a
+    // generic 500.
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      throw new ShelfError({
+        cause: null,
+        message: "Request body must be valid JSON.",
+        label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
 
-      const modelRequest = await upsertBookingModelRequest({
+    if (isPost(request)) {
+      const { assetModelId, quantity } = parseOr400(UpsertSchema, body);
+
+      await upsertBookingModelRequest({
         bookingId,
         assetModelId,
         quantity,
@@ -139,11 +173,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
         userId: user.id,
       });
 
-      return data({ success: true, request: modelRequest });
+      // Return only `{ success: true }` (like DELETE). The client refetches the
+      // booking; it never consumes the upserted row, so we don't ship the raw
+      // Prisma record (which wouldn't match the client's BookingModelRequest
+      // shape anyway).
+      return data({ success: true });
     }
 
     if (isDelete(request)) {
-      const { assetModelId } = DeleteSchema.parse(await request.json());
+      const { assetModelId } = parseOr400(DeleteSchema, body);
 
       await removeBookingModelRequest({
         bookingId,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.serialization.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.serialization.test.server.ts
@@ -1,0 +1,201 @@
+/**
+ * Response-contract test for the mobile booking detail endpoint's Book-by-Model
+ * payload. The companion app renders "Reserved model" rows + a scan-to-assign
+ * progress from these fields, so the serialization (outstanding = quantity −
+ * fulfilled, ISO `fulfilledAt`, and the roll-up counts) is a contract the app
+ * depends on. This pins it.
+ *
+ * @see {@link file://./bookings.$bookingId.ts} loader under test
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoaderArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import type * as MobileAuthServer from "~/modules/api/mobile-auth.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+
+import { loader } from "./bookings.$bookingId";
+
+import { assertIsDataWithResponseInit } from "../../../../test/helpers/assertions";
+
+// @vitest-environment node
+
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
+vi.mock("~/modules/api/mobile-auth.server", async () => {
+  const actual = await vi.importActual<typeof MobileAuthServer>(
+    "~/modules/api/mobile-auth.server"
+  );
+  return {
+    ...actual,
+    requireMobileAuth: vi.fn(),
+    requireOrganizationAccess: vi.fn(),
+    assertMobileCanUseBookings: vi.fn(),
+    getMobileUserContext: vi.fn(),
+  };
+});
+
+// why: booking settings + permission checks are unrelated to the model-request
+// serialization under test — stub them to fixed values.
+vi.mock("~/modules/booking-settings/service.server", () => ({
+  getBookingSettingsForOrganization: vi.fn().mockResolvedValue({
+    requireExplicitCheckinForAdmin: false,
+    requireExplicitCheckinForSelfService: false,
+  }),
+}));
+vi.mock("~/utils/permissions/permission.validator.server", () => ({
+  hasPermission: vi.fn().mockResolvedValue(false),
+}));
+
+const findFirstMock = vi.mocked(db.booking.findFirst);
+const requireMobileAuthMock = vi.mocked(requireMobileAuth);
+const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
+const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireMobileAuthMock.mockResolvedValue({
+    user: { id: "user-1" },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  requireOrganizationAccessMock.mockResolvedValue("org-1");
+  getMobileUserContextMock.mockResolvedValue({
+    role: OrganizationRoles.ADMIN,
+    canUseBarcodes: true,
+    canUseAudits: true,
+    canSeeAllCustody: true,
+  });
+});
+
+describe("GET /api/mobile/bookings/:bookingId — model requests", () => {
+  it("serializes model requests with outstanding math, ISO dates and roll-up counts", async () => {
+    const fulfilledDate = new Date("2026-01-02T03:04:05.000Z");
+    findFirstMock.mockResolvedValue({
+      id: "booking-1",
+      name: "Shoot",
+      description: null,
+      status: "DRAFT", // DRAFT → skips getPartiallyCheckedInAssetIds
+      from: null,
+      to: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      creator: null,
+      custodianUser: null,
+      custodianTeamMember: null,
+      tags: [],
+      bookingAssets: [],
+      modelRequests: [
+        {
+          id: "mr-1",
+          assetModelId: "model-a",
+          quantity: 3,
+          fulfilledQuantity: 1,
+          fulfilledAt: null,
+          assetModel: { id: "model-a", name: "Dell XPS" },
+        },
+        {
+          id: "mr-2",
+          assetModelId: "model-b",
+          quantity: 2,
+          fulfilledQuantity: 2,
+          fulfilledAt: fulfilledDate,
+          assetModel: { id: "model-b", name: "Canon R5" },
+        },
+      ],
+      _count: { bookingAssets: 0 },
+    } as never);
+
+    const response = await loader(
+      createLoaderArgs({
+        request: new Request(
+          "http://localhost:3000/api/mobile/bookings/booking-1"
+        ),
+        params: { bookingId: "booking-1" },
+      })
+    );
+
+    assertIsDataWithResponseInit(response);
+    const body = response.data as {
+      booking: {
+        modelRequests: Array<{
+          id: string;
+          assetModelId: string;
+          assetModelName: string;
+          quantity: number;
+          fulfilledQuantity: number;
+          outstandingQuantity: number;
+          fulfilledAt: string | null;
+        }>;
+        modelRequestCount: number;
+        outstandingModelUnitCount: number;
+      };
+    };
+
+    // Outstanding = quantity − fulfilled; still-open request stays open.
+    expect(body.booking.modelRequests[0]).toMatchObject({
+      id: "mr-1",
+      assetModelName: "Dell XPS",
+      quantity: 3,
+      fulfilledQuantity: 1,
+      outstandingQuantity: 2,
+      fulfilledAt: null,
+    });
+    // Fully-fulfilled request: outstanding 0, ISO timestamp preserved.
+    expect(body.booking.modelRequests[1]).toMatchObject({
+      id: "mr-2",
+      outstandingQuantity: 0,
+      fulfilledAt: "2026-01-02T03:04:05.000Z",
+    });
+    // Roll-ups: 2 distinct models, 2 units still to assign (2 + 0).
+    expect(body.booking.modelRequestCount).toBe(2);
+    expect(body.booking.outstandingModelUnitCount).toBe(2);
+  });
+
+  it("returns empty model-request fields when the booking reserves no models", async () => {
+    findFirstMock.mockResolvedValue({
+      id: "booking-2",
+      name: "Empty",
+      description: null,
+      status: "DRAFT",
+      from: null,
+      to: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      creator: null,
+      custodianUser: null,
+      custodianTeamMember: null,
+      tags: [],
+      bookingAssets: [],
+      modelRequests: [],
+      _count: { bookingAssets: 0 },
+    } as never);
+
+    const response = await loader(
+      createLoaderArgs({
+        request: new Request(
+          "http://localhost:3000/api/mobile/bookings/booking-2"
+        ),
+        params: { bookingId: "booking-2" },
+      })
+    );
+
+    assertIsDataWithResponseInit(response);
+    const body = response.data as {
+      booking: {
+        modelRequests: unknown[];
+        modelRequestCount: number;
+        outstandingModelUnitCount: number;
+      };
+    };
+    expect(body.booking.modelRequests).toEqual([]);
+    expect(body.booking.modelRequestCount).toBe(0);
+    expect(body.booking.outstandingModelUnitCount).toBe(0);
+  });
+});

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -121,6 +121,23 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             { asset: { createdAt: "asc" } },
           ],
         },
+        // Book-by-model reservations: intent rows for N units of an
+        // AssetModel that have NOT yet been assigned to concrete assets.
+        // Shipped alongside bookingAssets so the app can render "Reserved
+        // model" rows plus the scan-to-assign progress. We ship ALL rows
+        // (outstanding + already-fulfilled) like the web booking-detail
+        // tab (getBookingModelTabData) so fulfilled rows read as history.
+        modelRequests: {
+          select: {
+            id: true,
+            assetModelId: true,
+            quantity: true,
+            fulfilledQuantity: true,
+            fulfilledAt: true,
+            assetModel: { select: { id: true, name: true } },
+          },
+          orderBy: { assetModel: { name: "asc" } },
+        },
         _count: {
           select: { bookingAssets: true },
         },
@@ -276,6 +293,29 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         canDeletePerm,
     };
 
+    // Flatten book-by-model reservations into a mobile-friendly shape. Each
+    // row is one AssetModel the booking reserved N units of. `outstanding`
+    // is the count still waiting to be assigned to concrete assets (what the
+    // scan-to-assign flow works down); `fulfilledAt` non-null = fully
+    // assigned, kept as read-only history to match the web tab.
+    const modelRequests = booking.modelRequests.map((mr) => ({
+      id: mr.id,
+      assetModelId: mr.assetModelId,
+      assetModelName: mr.assetModel.name,
+      quantity: mr.quantity,
+      fulfilledQuantity: mr.fulfilledQuantity,
+      outstandingQuantity: Math.max(mr.quantity - mr.fulfilledQuantity, 0),
+      fulfilledAt: mr.fulfilledAt ? mr.fulfilledAt.toISOString() : null,
+    }));
+    // Number of distinct models reserved (rows) and total units still
+    // outstanding across all of them — lets the app show a compact
+    // "3 models, 5 units to assign" summary without re-summing client-side.
+    const modelRequestCount = modelRequests.length;
+    const outstandingModelUnitCount = modelRequests.reduce(
+      (sum, mr) => sum + mr.outstandingQuantity,
+      0
+    );
+
     return data({
       booking: {
         id: booking.id,
@@ -293,6 +333,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         assets,
         assetCount: totalAssets,
         checkedOutCount,
+        modelRequests,
+        modelRequestCount,
+        outstandingModelUnitCount,
       },
       checkedInAssetIds,
       canCheckout,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.test.server.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the mobile Book-by-Model picker endpoint.
+ *
+ * Two behaviors matter: (1) the booking read is custodian-scoped for
+ * SELF_SERVICE / BASE — they may only pick models against a booking they own
+ * (same rule as the booking detail read), and (2) the response is trimmed to a
+ * mobile shape (drops the web-only DynamicSelect seed list).
+ *
+ * @see {@link file://./bookings.available-models.ts} route under test
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoaderArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import type * as MobileAuthServer from "~/modules/api/mobile-auth.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+import { getBookingModelTabData } from "~/modules/booking-model-request/service.server";
+
+import { loader } from "./bookings.available-models";
+
+import { assertIsDataWithResponseInit } from "../../../../test/helpers/assertions";
+
+// @vitest-environment node
+
+// why: db is the integration boundary — we assert the `where` the route builds
+// so the custodian scoping is provably applied. Mock booking.findFirst only.
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
+// why: auth/entitlement helpers are out of scope; stub them but keep
+// getMobileUserContext a spy so tests can vary the caller's role.
+vi.mock("~/modules/api/mobile-auth.server", async () => {
+  const actual = await vi.importActual<typeof MobileAuthServer>(
+    "~/modules/api/mobile-auth.server"
+  );
+  return {
+    ...actual,
+    requireMobileAuth: vi.fn(),
+    requireOrganizationAccess: vi.fn(),
+    assertMobileCanUseBookings: vi.fn(),
+    getMobileUserContext: vi.fn(),
+  };
+});
+
+// why: the availability math is covered by the service's own unit tests; here
+// we only assert the route forwards the booking and trims the payload.
+vi.mock("~/modules/booking-model-request/service.server", () => ({
+  getBookingModelTabData: vi.fn(),
+}));
+
+const findFirstMock = vi.mocked(db.booking.findFirst);
+const requireMobileAuthMock = vi.mocked(requireMobileAuth);
+const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
+const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+const getTabDataMock = vi.mocked(getBookingModelTabData);
+
+const CALLER_ID = "user-self";
+const ORG_ID = "org-1";
+const BOOKING_ID = "booking-1";
+
+function withRole(role: OrganizationRoles) {
+  getMobileUserContextMock.mockResolvedValue({
+    role,
+    canUseBarcodes: true,
+    canUseAudits: true,
+    canSeeAllCustody: true,
+  });
+}
+
+function makeArgs() {
+  return createLoaderArgs({
+    request: new Request(
+      `http://localhost:3000/api/mobile/bookings/available-models?bookingId=${BOOKING_ID}`
+    ),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requireMobileAuthMock.mockResolvedValue({
+    user: { id: CALLER_ID },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  requireOrganizationAccessMock.mockResolvedValue(ORG_ID);
+  findFirstMock.mockResolvedValue({
+    id: BOOKING_ID,
+    from: null,
+    to: null,
+    modelRequests: [],
+  } as never);
+  getTabDataMock.mockResolvedValue({
+    showModelsTab: true,
+    assetModels: [],
+    initialAssetModels: [],
+    totalAssetModels: 0,
+    modelRequests: [],
+  });
+});
+
+describe("GET /api/mobile/bookings/available-models", () => {
+  it("scopes the booking read to the caller's custody for SELF_SERVICE", async () => {
+    withRole(OrganizationRoles.SELF_SERVICE);
+
+    await loader(makeArgs());
+
+    const where = findFirstMock.mock.calls[0]![0]!.where;
+    expect(where).toMatchObject({
+      id: BOOKING_ID,
+      organizationId: ORG_ID,
+      custodianUserId: CALLER_ID,
+    });
+  });
+
+  it("does NOT custody-scope the booking read for ADMIN", async () => {
+    withRole(OrganizationRoles.ADMIN);
+
+    await loader(makeArgs());
+
+    const where = findFirstMock.mock.calls[0]![0]!.where;
+    expect(where).not.toHaveProperty("custodianUserId");
+  });
+
+  it("404s when the booking is not visible to the caller", async () => {
+    withRole(OrganizationRoles.SELF_SERVICE);
+    findFirstMock.mockResolvedValue(null);
+
+    const response = await loader(makeArgs());
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(404);
+    expect(getTabDataMock).not.toHaveBeenCalled();
+  });
+
+  it("trims the payload to the mobile shape (drops initialAssetModels)", async () => {
+    withRole(OrganizationRoles.ADMIN);
+    getTabDataMock.mockResolvedValue({
+      showModelsTab: true,
+      assetModels: [
+        {
+          id: "m-1",
+          name: "Dell XPS",
+          total: 10,
+          available: 6,
+          inCustody: 1,
+          reservedConcrete: 2,
+          reservedViaRequest: 1,
+        },
+      ],
+      initialAssetModels: [
+        { id: "m-1", name: "Dell XPS", metadata: {} as never },
+      ],
+      totalAssetModels: 1,
+      modelRequests: [
+        {
+          assetModelId: "m-1",
+          assetModelName: "Dell XPS",
+          quantity: 3,
+          fulfilledQuantity: 1,
+          fulfilledAt: null,
+        },
+      ],
+    });
+
+    const response = await loader(makeArgs());
+    assertIsDataWithResponseInit(response);
+    const body = response.data as {
+      showModelsTab: boolean;
+      assetModels: Array<{ id: string; available: number }>;
+      totalAssetModels: number;
+      modelRequests: Array<{ assetModelId: string }>;
+      initialAssetModels?: unknown;
+    };
+
+    expect(body.showModelsTab).toBe(true);
+    expect(body.assetModels[0]).toMatchObject({ id: "m-1", available: 6 });
+    expect(body.totalAssetModels).toBe(1);
+    expect(body.modelRequests[0]).toMatchObject({ assetModelId: "m-1" });
+    // Web-only seed list must NOT leak into the mobile payload.
+    expect(body.initialAssetModels).toBeUndefined();
+  });
+});

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.test.server.ts
@@ -126,6 +126,24 @@ describe("GET /api/mobile/bookings/available-models", () => {
     expect(where).not.toHaveProperty("custodianUserId");
   });
 
+  it("forwards the `s` query param to getBookingModelTabData as `search` (server-side model search)", async () => {
+    // Regression for the >50-models gap: the picker list is capped, so search
+    // must reach the server — a client-only filter can't find later models.
+    withRole(OrganizationRoles.ADMIN);
+
+    await loader(
+      createLoaderArgs({
+        request: new Request(
+          `http://localhost:3000/api/mobile/bookings/available-models?bookingId=${BOOKING_ID}&s=dell`
+        ),
+      })
+    );
+
+    expect(getTabDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: ORG_ID, search: "dell" })
+    );
+  });
+
   it("404s when the booking is not visible to the caller", async () => {
     withRole(OrganizationRoles.SELF_SERVICE);
     findFirstMock.mockResolvedValue(null);

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
@@ -1,0 +1,127 @@
+import { OrganizationRoles } from "@prisma/client";
+import { data, type LoaderFunctionArgs } from "react-router";
+import { z } from "zod";
+import { db } from "~/database/db.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+  assertMobileCanUseBookings,
+} from "~/modules/api/mobile-auth.server";
+import { getBookingModelTabData } from "~/modules/booking-model-request/service.server";
+import { makeShelfError } from "~/utils/error";
+import { getParams } from "~/utils/http.server";
+
+/**
+ * GET /api/mobile/bookings/available-models?bookingId=…&orgId=…
+ *
+ * Book-by-model picker for the booking add-assets flow — the mobile twin of
+ * the web "Models" tab in the manage-assets drawer
+ * (`bookings.$bookingId.overview.manage-assets.tsx`). Wraps the SAME shared
+ * `getBookingModelTabData` service the web loader uses, so availability math
+ * (total − in-custody − reserved-concrete − reserved-via-request) stays
+ * identical across web and mobile. No new query logic here.
+ *
+ * Returns each `AssetModel` in the workspace with how many units are free to
+ * reserve in this booking's window, plus this booking's existing model-level
+ * reservations so the app can show current amounts and offer edits.
+ *
+ * Read-only. Org-scoped, and — like the booking detail read
+ * (`bookings.$bookingId.ts`) — custodian-scoped for SELF_SERVICE / BASE so
+ * they can only pick models against a booking they own. The actual
+ * reserve/edit/remove mutation is enforced separately in
+ * `bookings.$bookingId.model-requests.ts`.
+ *
+ * @see {@link file://./../../_layout+/bookings.$bookingId.overview.manage-assets.tsx} web twin
+ * @see {@link file://./../../../modules/booking-model-request/service.server.ts} shared service
+ */
+export async function loader({ request }: LoaderFunctionArgs) {
+  try {
+    const { user } = await requireMobileAuth(request);
+    const organizationId = await requireOrganizationAccess(request, user.id);
+
+    // Bookings are a TEAM-tier (premium) feature — gate this booking read like
+    // the other booking endpoints so a PERSONAL workspace can't query it.
+    await assertMobileCanUseBookings(organizationId);
+
+    const url = new URL(request.url);
+    const { bookingId } = getParams(
+      { bookingId: url.searchParams.get("bookingId") ?? undefined },
+      z.object({ bookingId: z.string().min(1) })
+    );
+
+    // Self-service / base users may only see their OWN bookings — scope the
+    // lookup by custodian exactly like the booking detail read, so a booking
+    // they don't own 404s instead of leaking its models/reservations.
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    const isSelfServiceOrBase =
+      role === OrganizationRoles.SELF_SERVICE ||
+      role === OrganizationRoles.BASE;
+
+    const booking = await db.booking.findFirst({
+      where: {
+        id: bookingId,
+        organizationId,
+        ...(isSelfServiceOrBase && { custodianUserId: user.id }),
+      },
+      select: {
+        id: true,
+        from: true,
+        to: true,
+        // The booking's existing model-level reservations, shaped exactly as
+        // `getBookingModelTabData` expects (`BookingForModelTab`).
+        modelRequests: {
+          select: {
+            assetModelId: true,
+            quantity: true,
+            fulfilledQuantity: true,
+            fulfilledAt: true,
+            assetModel: { select: { name: true } },
+          },
+        },
+      },
+    });
+
+    if (!booking) {
+      return data(
+        { error: { message: "Booking not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+
+    const modelTabData = await getBookingModelTabData({
+      organizationId,
+      booking,
+    });
+
+    // Trim to a mobile-friendly payload. Drop the web-only `initialAssetModels`
+    // (shaped for the web DynamicSelect seed list) — the app renders its own
+    // list from `assetModels`.
+    return data({
+      // Whether the workspace has any AssetModel at all (hides the picker).
+      showModelsTab: modelTabData.showModelsTab,
+      // Per-model availability for this booking's window (first 50 by name).
+      assetModels: modelTabData.assetModels.map((m) => ({
+        id: m.id,
+        name: m.name,
+        total: m.total,
+        available: m.available,
+        inCustody: m.inCustody,
+        reservedConcrete: m.reservedConcrete,
+        reservedViaRequest: m.reservedViaRequest,
+      })),
+      // Full workspace model count (the list above is capped) so the app can
+      // show a "showing 50 of N — search to narrow" hint.
+      totalAssetModels: modelTabData.totalAssetModels,
+      // This booking's existing model-level reservations (outstanding +
+      // fulfilled), so the picker can pre-fill current amounts.
+      modelRequests: modelTabData.modelRequests,
+    });
+  } catch (cause) {
+    const reason = makeShelfError(cause);
+    return data(
+      { error: { message: reason.message } },
+      { status: reason.status }
+    );
+  }
+}

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
@@ -49,6 +49,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       { bookingId: url.searchParams.get("bookingId") ?? undefined },
       z.object({ bookingId: z.string().min(1) })
     );
+    // Optional server-side model name search (`s`), so orgs with more than
+    // MODEL_PICKER_LIMIT models can still reach a model that sorts past the
+    // first page — the web picker searches server-side, so the app must too.
+    const search = url.searchParams.get("s") ?? undefined;
 
     // Self-service / base users may only see their OWN bookings — scope the
     // lookup by custodian exactly like the booking detail read, so a booking
@@ -92,6 +96,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const modelTabData = await getBookingModelTabData({
       organizationId,
       booking,
+      search,
     });
 
     // Trim to a mobile-friendly payload. Drop the web-only `initialAssetModels`

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -62,6 +62,7 @@
     "@remix-run/form-data-parser": "^0.14.0",
     "@sentry/react-router": "^10.47.0",
     "@shelf/database": "workspace:*",
+    "@shelf/labels": "workspace:*",
     "@supabase/supabase-js": "^2.103.0",
     "@tanstack/react-table": "^8.21.3",
     "@tremor/react": "^3.18.7",

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -48,7 +48,7 @@ const httpsConfig =
 export default defineConfig({
   envDir: "../..",
   ssr: {
-    noExternal: ["@shelf/database"],
+    noExternal: ["@shelf/database", "@shelf/labels"],
   },
   server: {
     port: 3000,

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Type declarations for @shelf/labels (see index.js).
+ * Hand-written to keep the package build-step-free.
+ */
+export declare const ASSET_STATUS_LABELS: {
+  readonly AVAILABLE: "Available";
+  readonly IN_CUSTODY: "In custody";
+  readonly CHECKED_OUT: "Checked out";
+};
+
+export declare const ASSET_QTY_STATUS_LABELS: {
+  readonly AVAILABLE: "Available";
+  readonly IN_CUSTODY: "In custody";
+  readonly PARTIAL_CUSTODY: "Partial custody";
+  readonly CHECKED_OUT: "Checked out";
+  readonly PARTIALLY_CHECKED_OUT: "Partially checked out";
+  readonly RESERVED: "Reserved";
+  readonly PARTIALLY_RESERVED: "Partially reserved";
+};
+
+export declare const ASSET_BOOKING_PSEUDO_STATUS_LABELS: {
+  readonly ALREADY_CHECKED_IN: "Already checked in";
+  readonly PARTIALLY_CHECKED_IN: "Partially checked in";
+  readonly PARTIALLY_CHECKED_OUT: "Partially checked out";
+};
+
+export declare const BOOKING_STATUS_LABELS: {
+  readonly DRAFT: "Draft";
+  readonly RESERVED: "Reserved";
+  readonly ONGOING: "Ongoing";
+  readonly OVERDUE: "Overdue";
+  readonly COMPLETE: "Complete";
+  readonly ARCHIVED: "Archived";
+  readonly CANCELLED: "Cancelled";
+};

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -1,0 +1,59 @@
+/**
+ * @shelf/labels — canonical user-facing label strings.
+ *
+ * Single source of truth for status/booking terminology shared by BOTH the
+ * webapp (`apps/webapp`) and the companion app (`apps/companion`). Plain ESM
+ * JS + a hand-written `index.d.ts` (no build step) so it loads unchanged in
+ * Vite (web) and Metro (React Native) — Metro does not transform TS inside
+ * node_modules, so this file is authored as .js on purpose. It is authored as
+ * ESM (matching the `@shelf/database` sibling): Vite 7's dev-SSR module runner
+ * evaluates inlined modules as ES modules and has no CommonJS `module` global,
+ * so a `module.exports` here 500s the whole webapp dev server. Metro's Babel
+ * transform lowers these `export const`s to CJS at bundle time, so RN is fine.
+ *
+ * Rule: never hard-code a status label string in either app. Import it here.
+ * Web `userFriendlyAssetStatus` / `getQuantityBadgeLabelAndColor` and companion
+ * `formatStatus` all read from these maps, so the phone can never show a
+ * different word than the website (the 1.1.x "In custody" vs "Partial custody"
+ * drift class).
+ */
+
+// Base asset status enum (AssetStatus in the Prisma schema).
+export const ASSET_STATUS_LABELS = Object.freeze({
+  AVAILABLE: "Available",
+  IN_CUSTODY: "In custody",
+  CHECKED_OUT: "Checked out",
+});
+
+// Quantity-aware asset status labels. A QUANTITY_TRACKED asset whose units are
+// split across states derives its badge from the quantity breakdown, not the
+// raw enum. These are the labels that helper can emit (web canonical: the
+// quantity path in asset-status-badge/quantity-data.ts).
+export const ASSET_QTY_STATUS_LABELS = Object.freeze({
+  AVAILABLE: "Available",
+  IN_CUSTODY: "In custody",
+  PARTIAL_CUSTODY: "Partial custody",
+  CHECKED_OUT: "Checked out",
+  PARTIALLY_CHECKED_OUT: "Partially checked out",
+  RESERVED: "Reserved",
+  PARTIALLY_RESERVED: "Partially reserved",
+});
+
+// Booking-context pseudo-statuses an asset row can show inside a booking
+// (web canonical: the enum path in asset-status-badge/status-labels.ts).
+export const ASSET_BOOKING_PSEUDO_STATUS_LABELS = Object.freeze({
+  ALREADY_CHECKED_IN: "Already checked in",
+  PARTIALLY_CHECKED_IN: "Partially checked in",
+  PARTIALLY_CHECKED_OUT: "Partially checked out",
+});
+
+// Booking status enum (BookingStatus in the Prisma schema).
+export const BOOKING_STATUS_LABELS = Object.freeze({
+  DRAFT: "Draft",
+  RESERVED: "Reserved",
+  ONGOING: "Ongoing",
+  OVERDUE: "Overdue",
+  COMPLETE: "Complete",
+  ARCHIVED: "Archived",
+  CANCELLED: "Cancelled",
+});

--- a/packages/labels/package.json
+++ b/packages/labels/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@shelf/labels",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Canonical user-facing label strings shared by the webapp and the companion app so their terminology never drifts.",
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@sentry/react-native':
         specifier: ~7.2.0
         version: 7.2.0(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.1.0))(react@19.1.0)
+      '@shelf/labels':
+        specifier: workspace:*
+        version: link:../../packages/labels
       '@supabase/supabase-js':
         specifier: ^2.49.1
         version: 2.98.0
@@ -281,6 +284,9 @@ importers:
       '@shelf/database':
         specifier: workspace:*
         version: link:../../packages/database
+      '@shelf/labels':
+        specifier: workspace:*
+        version: link:../../packages/labels
       '@supabase/supabase-js':
         specifier: ^2.103.0
         version: 2.105.1
@@ -703,6 +709,8 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
+
+  packages/labels: {}
 
   tooling/typescript: {}
 
@@ -1972,7 +1980,6 @@ packages:
 
   '@evilmartians/lefthook@2.1.6':
     resolution: {integrity: sha512-ysZbzryf74wlISmgm0PH/n1lJ0HD7AHmI6DoJgWO9qzIETQknhGdmKbkOi0MjLYtiOHWQl8Dr2qwg0ksDpNZjA==}
-    cpu: [x64, arm64, ia32]
     os: [darwin, linux, win32]
     hasBin: true
 


### PR DESCRIPTION
## What & why

The companion app dropped **book-by-model** reservations entirely — a booking that reserves N units of an `AssetModel` (without concrete assets yet) showed nothing on the app. This brings the flow to full parity with the web: **see → add → edit quantity → remove → scan-to-assign**. Targets companion **1.2.0**.

## Server (webapp)

- `GET /api/mobile/bookings/:id` now returns `modelRequests` (outstanding + fulfilled) with per-model outstanding counts and roll-ups.
- **New** `GET /api/mobile/bookings/available-models` — availability-aware model picker, wraps `getBookingModelTabData`.
- **New** `POST`/`DELETE /api/mobile/bookings/:id/model-requests` — reserve/edit and remove, wrapping `upsert`/`removeBookingModelRequest`.
- Tests for all three (IDOR guard, custodian scoping, response shape).

All three wrap existing web services — no new availability/quantity math.

## Shared terminology — `@shelf/labels`

New tiny ESM package: one source of truth for status labels shared by web + companion so the two can't drift (the "In custody" vs "Partial custody" class of bug). Web `userFriendlyAssetStatus` + `getQuantityBadgeLabelAndColor` now read from it; companion `formatStatus` gains the missing quantity-tracked labels + a new `getQuantityStatusLabel` (fixes the asset-detail status pill).

## Companion

- Reserved-models section on the booking detail.
- Models tab in the add-assets picker (reserve/edit via the shared `QuantityInputSheet`, remove).
- API client + types; version → 1.2.0.

## ⚠️ Review notes

1. **This PR edits two web files** (`asset-status-badge/quantity-data.ts`, `status-labels.ts`) to consume `@shelf/labels`. Same strings as before — but flagging because it touches the web asset badge. @DonKoko please confirm you're OK with the web side reading from the shared package.
2. **Custodian guard convention:** the mobile `model-requests` endpoint adds a custodian-ownership check that the shared services do **not** enforce (they scope by org + status only). Without it, a `SELF_SERVICE`/`BASE` user could edit another user's booking (cross-user IDOR). Mirrors `add-scanned-assets.ts`.

## Verification

- Web: typecheck, lint, full suite (3171 tests incl. the 3 new endpoint suites).
- Companion: typecheck, lint, react-doctor (0 new errors).
- Server exercised end-to-end over HTTP against a real DB (reserve → see → availability → scan-fulfill → remove), and the UI driven on the iOS simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added book-by-model support in the companion app, including a Models picker (with search), and the ability to reserve, edit, and remove reserved model quantities.
  * Booking details now include a “Reserved models” section with counts, progress, and model management.
  * Added mobile endpoints for listing available models and creating/updating/removing model reservations.
* **Bug Fixes**
  * Improved and unified asset/booking and quantity-aware status labels using shared label definitions.
* **Tests**
  * Added Maestro end-to-end flow and server-side integration tests covering the model picker, responses, and model-request authorization/validation.
* **Chores**
  * Bumped app version to 1.2.0 and added shared label package/config updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->