### PR TITLE
fix(booking): default a bare quantity-tracked scan to all remaining units on partial check-in/out

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -1006,6 +1006,75 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     });
   });
 
+  it("bare scan of a booked-50 QT asset (no explicit count) checks out ALL 50 units, and does NOT delegate with a wrong count", async () => {
+    expect.assertions(2);
+
+    // RESERVED single-QT-asset booking. A bare `assetIds` scan carries the
+    // sentinel quantity=1, so `qtyClaimsCoverFullRemaining` (1 < 50) is false
+    // and the booking does NOT delegate to the full checkoutBooking; it stays
+    // on the partial path, where the in-tx loop resolves the bare disposition
+    // to "all remaining" (50). Had it delegated, the delegate-path ledger would
+    // record quantities:[1] for a fully-checked-out booked-50 asset (the
+    // split-brain) — so asserting quantities:[50] proves BOTH the all-remaining
+    // default AND that no delegation happened.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue(qtyOnlyBooking);
+
+    await partialCheckoutBooking({
+      ...baseParams,
+      assetIds: ["asset-qty-1"],
+    });
+
+    expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
+      data: {
+        bookingId: "booking-1",
+        checkedOutById: "user-1",
+        assetIds: ["asset-qty-1"],
+        quantities: [50],
+        bookingAssetIds: [""],
+        checkoutCount: 1,
+      },
+      select: { id: true },
+    });
+
+    // All 50 units claimed → the asset flips CHECKED_OUT (org-scoped).
+    expect(db.asset.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["asset-qty-1"] }, organizationId: "org-1" },
+      data: { status: AssetStatus.CHECKED_OUT },
+    });
+  });
+
+  it("explicit per-unit checkout of quantity 1 stays exactly 1 — the all-remaining default only applies to bare scans", async () => {
+    expect.assertions(1);
+
+    // ONGOING so we stay on the partial path and observe the ledger write.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({ ...qtyOnlyBooking, status: BookingStatus.ONGOING });
+
+    await partialCheckoutBooking({
+      ...baseParams,
+      checkouts: [
+        { assetId: "asset-qty-1", bookingAssetId: "ba-qty-1", quantity: 1 },
+      ],
+    });
+
+    // An explicit `checkouts` entry carries no `defaultAllRemaining` flag, so a
+    // genuine 1-unit partial is recorded as 1, never bumped to all-remaining.
+    expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
+      data: {
+        bookingId: "booking-1",
+        checkedOutById: "user-1",
+        assetIds: ["asset-qty-1"],
+        quantities: [1],
+        bookingAssetIds: ["ba-qty-1"],
+        checkoutCount: 1,
+      },
+      select: { id: true },
+    });
+  });
+
   it("records BOTH slices of a same-asset multi-slice checkout positionally (standalone + kit in one session)", async () => {
     expect.assertions(2);
 

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -1879,6 +1879,56 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     expect(db.partialBookingCheckout.create).not.toHaveBeenCalled();
   });
 
+  it("rejects a BARE re-scan of a QUANTITY_TRACKED asset when remaining === 0 (keeps the sentinel, writes no quantities:[0] row)", async () => {
+    expect.assertions(2);
+
+    // Same "fully out" state as the explicit re-scan test above, but scanned
+    // BARE (assetIds only) — the native path. A bare scan must reject exactly
+    // like the explicit re-scan: resolving to `cap` (0) would otherwise persist
+    // a bogus quantities:[0] row + audit events for an already-out asset.
+    const smallQtyBooking = {
+      ...qtyOnlyBooking,
+      status: BookingStatus.ONGOING,
+      bookingAssets: [
+        {
+          id: "ba-qty-1",
+          quantity: 10,
+          asset: {
+            id: "asset-qty-1",
+            status: AssetStatus.CHECKED_OUT,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Pens",
+            unitOfMeasure: null,
+            assetKits: [],
+          },
+        },
+      ],
+    };
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue(smallQtyBooking);
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([{ quantity: 10 }]);
+    (
+      db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({ quantity: 10 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db as any).__seedPbcSessions?.([
+      { assetIds: ["asset-qty-1"], quantities: [10] },
+    ]);
+
+    await expect(
+      partialCheckoutBooking({
+        ...baseParams,
+        assetIds: ["asset-qty-1"],
+      })
+    ).rejects.toThrow(/Only 0 units left/);
+
+    // No new row written for the rejected bare re-scan.
+    expect(db.partialBookingCheckout.create).not.toHaveBeenCalled();
+  });
+
   it("event meta carries quantity for qty-tracked rows and omits it for INDIVIDUAL", async () => {
     expect.assertions(2);
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -6191,6 +6191,36 @@ describe("partialCheckinBooking — qty-tracked dispositions", () => {
     ).rejects.toThrow(/no units remain to check in/);
   });
 
+  it("bare full-coverage scan of a single QT asset is accepted (not rejected by the guard) and completes via the delegate path", async () => {
+    expect.assertions(1);
+
+    // Single-QT-asset booking (default makeQtyBooking): a bare scan covers ALL
+    // outstanding units, so `hasQuantityDispositions` is false and the batch
+    // takes the "all remaining scanned → complete check-in" early-exit that
+    // delegates to the full checkinBooking. This is the common native case, and
+    // pre-fix it would have thrown at the non-zero-disposition guard. We assert
+    // the batch is accepted and completes (isComplete) — proof the bare id
+    // reaches the delegate. checkinBooking's own all-remaining default is
+    // exercised by its dedicated tests; asserting its internal ConsumptionLog
+    // here would just re-test that function under partialCheckinBooking's mocks.
+    setupQtyMocks();
+    (
+      db.partialBookingCheckin.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([]);
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: mockQtyAssetId, title: "Pens", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    const result = await partialCheckinBooking({
+      ...baseParams,
+      assetIds: [mockQtyAssetId],
+    });
+
+    // Full-coverage batch delegates and completes the booking (it did not throw
+    // the "must include a non-zero disposition" guard the bare id used to hit).
+    expect(result.isComplete).toBe(true);
+  });
+
   it("writes three logs and decrements pool when returned+lost+damaged equals remaining", async () => {
     expect.assertions(5);
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -6142,6 +6142,55 @@ describe("partialCheckinBooking — qty-tracked dispositions", () => {
     );
   });
 
+  it("rejects a BARE re-scan of a QT asset that is already fully checked in (no units remain)", async () => {
+    expect.assertions(1);
+
+    // Asset booked 10, all 10 already logged back → remaining 0. A bare scan
+    // must reject rather than write a no-op PartialBookingCheckin + event.
+    setupQtyMocks({ logged: 10 });
+
+    // Two-asset booking (QT fully reconciled + an INDIVIDUAL still out) so the
+    // batch does not cover all outstanding and stays on the partial path.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      ...makeQtyBooking(),
+      bookingAssets: [
+        {
+          assetId: mockQtyAssetId,
+          quantity: 10,
+          asset: {
+            id: mockQtyAssetId,
+            type: AssetType.QUANTITY_TRACKED,
+            assetKits: [],
+          },
+        },
+        {
+          assetId: "asset-individual-2",
+          quantity: 1,
+          asset: {
+            id: "asset-individual-2",
+            type: AssetType.INDIVIDUAL,
+            assetKits: [],
+          },
+        },
+      ],
+    });
+    (
+      db.partialBookingCheckin.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([]);
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: mockQtyAssetId, title: "Pens", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    await expect(
+      partialCheckinBooking({
+        ...baseParams,
+        assetIds: [mockQtyAssetId],
+      })
+    ).rejects.toThrow(/no units remain to check in/);
+  });
+
   it("writes three logs and decrements pool when returned+lost+damaged equals remaining", async () => {
     expect.assertions(5);
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -6019,6 +6019,129 @@ describe("partialCheckinBooking — qty-tracked dispositions", () => {
     );
   });
 
+  it("bare scan (no disposition) of a TWO_WAY QT asset in a partial batch defaults to RETURN of ALL remaining units", async () => {
+    expect.assertions(1);
+
+    setupQtyMocks();
+
+    // Two-asset booking: the QT "Pens" (booked 10) + an INDIVIDUAL asset that
+    // is NOT scanned this batch. Because the batch does not cover every
+    // outstanding asset, the flow stays on the partial path (it does not
+    // delegate to the full checkinBooking), so the in-tx default resolution is
+    // what we're exercising here.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      ...makeQtyBooking(),
+      bookingAssets: [
+        {
+          assetId: mockQtyAssetId,
+          quantity: 10,
+          asset: {
+            id: mockQtyAssetId,
+            type: AssetType.QUANTITY_TRACKED,
+            assetKits: [],
+          },
+        },
+        {
+          assetId: "asset-individual-2",
+          quantity: 1,
+          asset: {
+            id: "asset-individual-2",
+            type: AssetType.INDIVIDUAL,
+            assetKits: [],
+          },
+        },
+      ],
+    });
+    // No prior check-ins → both assets outstanding (keeps us off the early-exit).
+    (
+      db.partialBookingCheckin.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([]);
+    // The scanned QT asset is checked out (passes the progressive-checkout guard).
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: mockQtyAssetId, title: "Pens", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    // Bare scan — no `checkins` disposition, exactly what the native app sends.
+    await partialCheckinBooking({
+      ...baseParams,
+      assetIds: [mockQtyAssetId],
+    });
+
+    // Resolved to "all remaining" (10) → one RETURN log for the full amount
+    // (default lock stub has no consumptionType → treated as returnable).
+    expect(consumptionLogService.createConsumptionLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: mockQtyAssetId,
+        category: "RETURN",
+        quantity: 10,
+        bookingId: mockQtyBookingId,
+      })
+    );
+  });
+
+  it("bare scan (no disposition) of a ONE_WAY (consumable) QT asset defaults to CONSUME of ALL remaining units", async () => {
+    expect.assertions(1);
+
+    setupQtyMocks();
+    // Mark the locked asset consumable so the default resolves to CONSUME.
+    (
+      quantityLock.lockAssetForQuantityUpdate as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      id: mockQtyAssetId,
+      title: "Pens",
+      quantity: 100,
+      consumptionType: ConsumptionType.ONE_WAY,
+    });
+
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      ...makeQtyBooking(),
+      bookingAssets: [
+        {
+          assetId: mockQtyAssetId,
+          quantity: 10,
+          asset: {
+            id: mockQtyAssetId,
+            type: AssetType.QUANTITY_TRACKED,
+            assetKits: [],
+          },
+        },
+        {
+          assetId: "asset-individual-2",
+          quantity: 1,
+          asset: {
+            id: "asset-individual-2",
+            type: AssetType.INDIVIDUAL,
+            assetKits: [],
+          },
+        },
+      ],
+    });
+    (
+      db.partialBookingCheckin.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([]);
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: mockQtyAssetId, title: "Pens", status: AssetStatus.CHECKED_OUT },
+    ]);
+
+    await partialCheckinBooking({
+      ...baseParams,
+      assetIds: [mockQtyAssetId],
+    });
+
+    expect(consumptionLogService.createConsumptionLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: mockQtyAssetId,
+        category: "CONSUME",
+        quantity: 10,
+        bookingId: mockQtyBookingId,
+      })
+    );
+  });
+
   it("writes three logs and decrements pool when returned+lost+damaged equals remaining", async () => {
     expect.assertions(5);
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -5098,9 +5098,20 @@ export async function partialCheckinBooking({
         // never overrides an operator's explicit returned/consumed split.
         if (
           bareCheckinAssetIds.has(disp.assetId) &&
-          sumDisposition(disp) === 0 &&
-          cap > 0
+          sumDisposition(disp) === 0
         ) {
+          // Re-scan of an asset with no units left to check in (`cap === 0`):
+          // reject instead of writing a no-op PartialBookingCheckin + event.
+          // Matches the `claimed > cap` rejection an explicit re-scan gets.
+          if (cap <= 0) {
+            throw new ShelfError({
+              cause: null,
+              status: 400,
+              label,
+              message: `Cannot check in "${lockedAsset.title}" — no units remain to check in on this booking.`,
+              shouldBeCaptured: false,
+            });
+          }
           if (lockedAsset.consumptionType === "ONE_WAY") {
             disp.consumed = cap;
           } else {
@@ -6333,7 +6344,13 @@ export async function partialCheckoutBooking({
         // `PartialBookingCheckout.quantities[]` ledger write below records the
         // real units, not the sentinel 1. Mirrors the "Check Out All" default;
         // explicit per-unit `quantity` payloads are left untouched.
-        if (disp.defaultAllRemaining) {
+        //
+        // Only resolve when units remain. On a re-scan of an already
+        // fully-checked-out asset `cap === 0`; we KEEP the sentinel
+        // `quantity: 1` so the `claimed > cap` guard below throws
+        // "Only 0 units left…" — the same rejection an explicit re-scan gets —
+        // instead of persisting a bogus `quantities: [0]` row + audit events.
+        if (disp.defaultAllRemaining && cap > 0) {
           disp.quantity = cap;
         }
         const claimed = disp.quantity;

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -4517,6 +4517,15 @@ export type CheckoutDispositionInput = {
   /** Units to claim from this asset's BookingAsset slice on this booking.
    *  Required for QUANTITY_TRACKED; clamped to [1, remaining-to-check-out]. */
   quantity: number;
+  /**
+   * INTERNAL ONLY — never set by an API caller. The legacy `assetIds[]`
+   * fallback tags a QUANTITY_TRACKED asset scanned with no explicit count so
+   * the in-tx loop resolves it to "all remaining units" (the per-asset cap
+   * under the row lock) instead of the sentinel `quantity: 1`. Mirrors the
+   * "Check Out All" default so a bare mobile scan takes the whole line, not one
+   * unit. Explicit per-unit `quantity` payloads are honored verbatim.
+   */
+  defaultAllRemaining?: boolean;
 };
 
 /**
@@ -4728,6 +4737,14 @@ export async function partialCheckinBooking({
      */
     const seenDispositionKeys = new Set<string>();
     const assetIdsWithDisposition = new Set<string>();
+    /**
+     * Bare (assetIds-only) scans of QUANTITY_TRACKED assets. These carry no
+     * disposition and mean "check in all remaining units" for that asset —
+     * resolved in the tx loop below (mirrors checkinBooking's big-button
+     * default). Tracked so the zero-disposition guard exempts them: only an
+     * EXPLICIT drawer disposition must carry a non-zero amount.
+     */
+    const bareCheckinAssetIds = new Set<string>();
     for (const d of checkins ?? []) {
       const key = `${d.assetId}::${d.bookingAssetId ?? "null"}`;
       if (seenDispositionKeys.has(key)) continue;
@@ -4747,6 +4764,7 @@ export async function partialCheckinBooking({
       if (!assetIdsWithDisposition.has(assetId)) {
         assetIdsWithDisposition.add(assetId);
         dispositions.push({ assetId });
+        bareCheckinAssetIds.add(assetId);
       }
     }
 
@@ -4848,7 +4866,14 @@ export async function partialCheckinBooking({
     // defend server-side too.
     for (const d of dispositions) {
       const isQty = assetTypeById.get(d.assetId) === AssetType.QUANTITY_TRACKED;
-      if (isQty && sumDisposition(d) === 0) {
+      // Bare scans (assetIds-only) auto-default to "all remaining" in the tx
+      // loop below, so exempt them here — only an EXPLICIT drawer disposition
+      // must carry a non-zero amount.
+      if (
+        isQty &&
+        sumDisposition(d) === 0 &&
+        !bareCheckinAssetIds.has(d.assetId)
+      ) {
         throw new ShelfError({
           cause: null,
           status: 400,
@@ -5045,7 +5070,6 @@ export async function partialCheckinBooking({
           id,
           disp.assetId
         );
-        const claimed = sumDisposition(disp);
 
         /**
          * Per-slice cap (Polish-7b): when the drawer targets a specific
@@ -5065,6 +5089,26 @@ export async function partialCheckinBooking({
           );
           cap = Math.min(cap, sliceRemaining);
         }
+
+        // Bare scan of a QUANTITY_TRACKED asset (no explicit disposition):
+        // default to "all remaining" — return all for a returnable (TWO_WAY)
+        // asset, consume all for a consumable (ONE_WAY) one. Mirrors
+        // checkinBooking's big-button default. Only bare ids reach here with a
+        // zero disposition (the guard above rejects an explicit zero), so this
+        // never overrides an operator's explicit returned/consumed split.
+        if (
+          bareCheckinAssetIds.has(disp.assetId) &&
+          sumDisposition(disp) === 0 &&
+          cap > 0
+        ) {
+          if (lockedAsset.consumptionType === "ONE_WAY") {
+            disp.consumed = cap;
+          } else {
+            disp.returned = cap;
+          }
+        }
+
+        const claimed = sumDisposition(disp);
 
         if (claimed > cap) {
           throw new ShelfError({
@@ -5680,8 +5724,14 @@ export async function partialCheckoutBooking({
     for (const assetId of assetIds) {
       if (!assetIdsWithDisposition.has(assetId)) {
         assetIdsWithDisposition.add(assetId);
-        // Legacy / INDIVIDUAL fallback: implicit quantity = 1, no slice tag.
-        dispositions.push({ assetId, quantity: 1 });
+        // Legacy / INDIVIDUAL fallback: no slice tag. INDIVIDUAL keeps the
+        // implicit quantity = 1; a QUANTITY_TRACKED asset scanned with no
+        // explicit count is tagged `defaultAllRemaining` so the in-tx loop
+        // resolves it to "all remaining units". The sentinel 1 is still used by
+        // the delegate gate below (where `1 < remaining` keeps a >1-unit QT
+        // asset on this partial path — so it never delegates with a wrong
+        // count). Harmless for INDIVIDUAL: the flag is only read on the QT path.
+        dispositions.push({ assetId, quantity: 1, defaultAllRemaining: true });
       }
     }
 
@@ -6277,6 +6327,15 @@ export async function partialCheckoutBooking({
           cap = Math.min(cap, sliceCap);
         }
 
+        // Bare QUANTITY_TRACKED scan (assetIds-only, no explicit count):
+        // resolve to "all remaining" for this asset — the per-asset `cap`
+        // computed under the row lock above. Mutating the disposition so the
+        // `PartialBookingCheckout.quantities[]` ledger write below records the
+        // real units, not the sentinel 1. Mirrors the "Check Out All" default;
+        // explicit per-unit `quantity` payloads are left untouched.
+        if (disp.defaultAllRemaining) {
+          disp.quantity = cap;
+        }
         const claimed = disp.quantity;
         if (claimed > cap) {
           // Render `cap` with the asset's unit of measure so qty-tracked rows


### PR DESCRIPTION
## What & why

The companion app checks a quantity-tracked asset in/out by scanning it — the request carries only the `assetId`, with no per-unit count. Two bugs on the current live 1.1.0 app (#2701):

- **Check-in** (Scan / Select to Check In) throws `Quantity-tracked assets must include at least one non-zero disposition (returned, consumed, lost, or damaged)`.
- **Check-out** (Scan / Select to Check Out) silently checks out **1 unit** no matter how many are booked, leaving the rest stuck reserved.

Web never hits these because the check-in/out drawer collects an explicit per-unit disposition before submitting.

## Fix — server-only, no app release

A **bare** disposition — one that arrived via the legacy `assetIds[]` bucket rather than an explicit `checkins[]` / `checkouts[]` payload — for a `QUANTITY_TRACKED` asset now resolves to **all remaining units** for that asset, computed inside the transaction under the existing `lockAssetForQuantityUpdate` row lock:

- **`partialCheckoutBooking`** — resolves the claim to the per-asset remaining and records it in `PartialBookingCheckout.quantities[]`.
- **`partialCheckinBooking`** — exempts bare scans from the non-zero-disposition guard and defaults to **return-all** (`TWO_WAY`) / **consume-all** (`ONE_WAY`) from the asset's `consumptionType`.

This mirrors what the **Check Out All** / **Check In All** buttons already do. **Explicit per-unit payloads are untouched** — a genuine "2 of 5" still records 2.

The check-out **delegate gate is deliberately left alone**: a bare scan keeps its sentinel `quantity: 1`, so a booked-more-than-1 asset never satisfies `qtyClaimsCoverFullRemaining` and never delegates to the full `checkoutBooking` with a wrong count. That avoids a `PartialBookingCheckout` "split-brain" where a fully-checked-out asset would be recorded as 1 unit and corrupt the later check-in remaining math.

Because the fix is server-side, it reaches every companion 1.1.0 install on deploy — no App Store release. The native quantity / disposition picker (so operators can split returned/consumed/lost/damaged and take partial counts) is the planned follow-up UI.

## Tests

- `partialCheckoutBooking`: bare booked-50 scan → all 50 out, `quantities: [50]`, and no delegation; explicit `quantity: 1` still records exactly 1.
- `partialCheckinBooking`: bare scan → one RETURN log for all remaining (`TWO_WAY`); one CONSUME log for all remaining (`ONE_WAY`).
- Full booking test suite green (733 passed); typecheck, ESLint and Prettier clean.

Refs #2701


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quantity-tracked bookings now correctly interpret scan-only (assetIds-only) dispositions as consuming/returning **all remaining** instead of a sentinel unit.
  * Explicit per-quantity values provided by the request are still applied exactly as entered.
  * Prevents re-scans that would result in zero-quantity consumption/return records.
* **Tests**
  * Added/expanded unit coverage for quantity-tracked “bare scan” checkout and check-in flows, including correct consume/return behavior for different asset types and remaining-quantity edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->