### PR TITLE
fix(assets): repair custody sort in advanced index

### DIFF
--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -235,7 +235,15 @@ describe("parseSortingOptions", () => {
 
     it("uses custody jsonb path for custody", () => {
       const { orderByClause } = parseSortingOptions(["custody:desc"]);
-      expect(orderByClause).toContain("custody->>'name'");
+      // Regression (custody-sort no-op): the `custody` column is a jsonb
+      // ARRAY (`Custody[]`) since the quantity-tracked multi-custodian
+      // refactor, not a single object. `custody->>'name'` on an array
+      // returns NULL for every row (asc == desc, only the id tiebreaker
+      // orders), so we must index the first element: `custody->0->>'name'`.
+      expect(orderByClause).toContain("custody->0->>'name'");
+      // Guard against a regression back to the object-shaped key that
+      // silently no-ops on the array.
+      expect(orderByClause).not.toContain("custody->>'name'");
       expect(orderByClause).toContain("desc");
     });
 

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -820,6 +820,19 @@ describe("assetQueryFragment", () => {
       expect(sql).toContain("'quantity', cu.quantity");
     });
 
+    it("orders the custody aggregation deterministically for a stable primary", () => {
+      const sql = getJoinsSqlString(assetQueryJoins);
+
+      // The custody sort key (`custody->0->>'name'`) and the rendered badge
+      // (formatCustodyList picks custody[0]) both rely on element 0 being
+      // the primary custodian. jsonb_agg has an undefined input order without
+      // an explicit ORDER BY, so a multi-custodian (qty-tracked) asset's
+      // primary — and thus its sort key — could otherwise vary by plan and
+      // disagree with the badge. Oldest-first (createdAt, id) matches the
+      // kit/location primary-pick convention.
+      expect(sql).toContain('ORDER BY cu."createdAt" ASC, cu.id ASC');
+    });
+
     it("falls back to '[]'::jsonb when an asset has no custody rows", () => {
       const sql = getJoinsSqlString(assetQueryJoins);
 
@@ -1142,5 +1155,20 @@ describe("buildAdvancedAssetsQuery", () => {
     const sql = getQuerySqlString(build());
     expect(sql).toContain('a.value AS "assetValue"');
     expect(sql).not.toContain("a.valuation");
+  });
+
+  it("sorts custody by the first array element with a deterministic primary", () => {
+    // `custody` is a jsonb array; the sort key must index element 0
+    // (`custody->0->>'name'`), and the cheap-phase custody aggregation must
+    // order its jsonb_agg so element 0 is stable and matches the badge.
+    const sql = getQuerySqlString(build({ sortBy: ["custody:asc"] }));
+
+    // Array-indexed sort key (never the object-shaped no-op `custody->>'name'`).
+    expect(sql).toContain("custody->0->>'name'");
+    expect(sql).not.toContain("custody->>'name'");
+    // Cheap-phase custody aggregation is injected for the sort and carries the
+    // deterministic ordering (mirrors the heavy phase).
+    expect(sql).toContain(") custody_agg ON TRUE");
+    expect(sql).toContain('ORDER BY cu."createdAt" ASC, cu.id ASC');
   });
 });

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1651,8 +1651,12 @@ export function parseSortingOptions(sortBy: string[]): {
       // multi-custodian refactor — see CUSTODY_SORT_CASE. `custody->>'name'`
       // (object-key access) returns NULL on an array, which made this sort a
       // silent no-op (asc == desc, only the id tiebreaker ordered the rows).
-      // Index the first custodian: `custody->0->>'name'`. NULL custody (no
-      // custodian) stays NULL and sorts consistently.
+      // Index the first custodian: `custody->0->>'name'`. Element 0 is the
+      // primary custodian shown in the badge (formatCustodyList picks
+      // custody[0]); the custody aggregations order their jsonb_agg by
+      // (createdAt, id) so element 0 is deterministic and the sort key agrees
+      // with the rendered badge. NULL custody (no custodian) stays NULL and
+      // sorts consistently.
       orderByParts.push(
         getNormalizedSortExpression(`custody->0->>'name'`, field.direction)
       );
@@ -2244,6 +2248,16 @@ export const assetQueryJoins = Prisma.sql`
     -- array. Replaces the previous direct LEFT JOINs on Custody +
     -- TeamMember + User which caused per-custody-row duplication for
     -- qty-tracked assets with multiple custodians (Issue A).
+    --
+    -- The ORDER BY inside jsonb_agg is load-bearing, not cosmetic:
+    -- element 0 is the "primary" custodian both for display
+    -- (formatCustodyList picks custody[0]) and for sorting (the custody
+    -- ORDER BY key indexes custody->0->>'name'). jsonb_agg without an
+    -- explicit ORDER BY has an undefined input order, so the primary
+    -- could differ between rows/plans and the sort key could disagree
+    -- with the rendered badge. Order by oldest custody first
+    -- (createdAt, id) — the same primary-pick convention the kit /
+    -- location LATERALs use. Must stay identical to CHEAP_CUSTODY_JOINS.
     SELECT COALESCE(
       jsonb_agg(
         jsonb_build_object(
@@ -2264,6 +2278,7 @@ export const assetQueryJoins = Prisma.sql`
             END
           )
         )
+        ORDER BY cu."createdAt" ASC, cu.id ASC
       ),
       '[]'::jsonb
     ) AS custody
@@ -2490,7 +2505,10 @@ const CHEAP_LOCATION_JOIN = Prisma.sql`
  * Injected only when a custody FILTER or a custody SORT is active — the custody
  * WHERE predicates reference `jsonb_array_length(custody_agg.custody)` and the
  * custody sort key references the full CASE (which needs `b`/`bu`/`btm`).
- * Verbatim mirror of the custody joins in {@link assetQueryJoins}.
+ * Verbatim mirror of the custody joins in {@link assetQueryJoins} — including
+ * the `ORDER BY cu."createdAt" ASC, cu.id ASC` inside `jsonb_agg` that makes
+ * element 0 (the primary custodian used by the sort key `custody->0->>'name'`)
+ * deterministic and consistent with the heavy phase's rendered badge.
  */
 const CHEAP_CUSTODY_JOINS = Prisma.sql`
     LEFT JOIN LATERAL (
@@ -2514,6 +2532,7 @@ const CHEAP_CUSTODY_JOINS = Prisma.sql`
               END
             )
           )
+          ORDER BY cu."createdAt" ASC, cu.id ASC
         ),
         '[]'::jsonb
       ) AS custody

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -1647,8 +1647,14 @@ export function parseSortingOptions(sortBy: string[]): {
         getNormalizedSortExpression(`"locationName"`, field.direction)
       );
     } else if (field.name === "custody") {
+      // `custody` is a jsonb ARRAY (`Custody[]`) since the quantity-tracked
+      // multi-custodian refactor — see CUSTODY_SORT_CASE. `custody->>'name'`
+      // (object-key access) returns NULL on an array, which made this sort a
+      // silent no-op (asc == desc, only the id tiebreaker ordered the rows).
+      // Index the first custodian: `custody->0->>'name'`. NULL custody (no
+      // custodian) stays NULL and sorts consistently.
       orderByParts.push(
-        getNormalizedSortExpression(`custody->>'name'`, field.direction)
+        getNormalizedSortExpression(`custody->0->>'name'`, field.direction)
       );
     } else if (field.name.startsWith("barcode_")) {
       // The suffix is interpolated into a SQL identifier (`barcode_<suffix>`),
@@ -2409,7 +2415,7 @@ const BARCODE_SORT_KEY_SELECTS = Prisma.sql`(
  * custody for CHECKED_OUT assets otherwise; NULL). Verbatim copy of the heavy
  * projection's custody CASE, including the NRM-name guard (CONCAT vs btm.name,
  * never COALESCE(CONCAT(...))). Emitted `AS custody` in the cheap phase only
- * when a custody sort is active — the `custody->>'name'` sort term needs it.
+ * when a custody sort is active — the `custody->0->>'name'` sort term needs it.
  */
 const CUSTODY_SORT_CASE = Prisma.sql`CASE
         WHEN jsonb_array_length(custody_agg.custody) > 0 THEN custody_agg.custody


### PR DESCRIPTION
The advanced-index custody sort was a silent no-op — ascending and descending produced identical order. The quantity-tracked multi-custodian refactor changed the `custody` projection from a single JSON object to a JSON array (`Custody[]`), but the ORDER BY key stayed `custody->>'name'`.

Object-key access (`->> 'name'`) on a JSON array returns NULL in Postgres, so every row's sort key was NULL: direction had no effect and only the `"assetId" ASC` tiebreaker ordered the rows.

Index the first custodian instead (`custody->0->>'name'`), matching the badge shown in the column. NULL custody (no custodian) stays NULL and sorts consistently. Updated the parseSortingOptions test to assert the array-indexed key and guard against a regression to the object-shaped key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting by custody so results consistently use the first custodian’s name as the primary sort key.
  * Fixed inconsistent custody-based ordering by making the underlying custody aggregation deterministic, ensuring stable and predictable results across repeated queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->