### PR TITLE
feat(companion): quantity-tracked check-in disposition + partial check-out

### DIFF
--- a/apps/companion/app/(auth)/login.tsx
+++ b/apps/companion/app/(auth)/login.tsx
@@ -203,6 +203,12 @@ export default function LoginScreen() {
               placeholder="Your password"
               placeholderTextColor={colors.placeholderText}
               secureTextEntry
+              // why: without this iOS applies its default sentence-casing to the
+              // first character, silently sending "Trixie01" for "trixie01" and
+              // failing login for any password that starts with a lowercase
+              // letter. The email field already guards against this.
+              autoCapitalize="none"
+              autoCorrect={false}
               autoComplete="password"
               textContentType="password"
               returnKeyType="go"

--- a/apps/companion/app/(tabs)/assets/index.tsx
+++ b/apps/companion/app/(tabs)/assets/index.tsx
@@ -28,6 +28,7 @@ import {
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { QuantityBadge } from "@/components/quantity-badge";
 import { AssetListSkeleton } from "@/components/skeleton-loader";
 import { useSwipeFilters } from "@/lib/use-swipe-filters";
 import { announce } from "@/lib/a11y";
@@ -292,18 +293,13 @@ function AssetsListContent() {
                   </Text>
                 </View>
               )}
-              {/* Quantity badge — QUANTITY_TRACKED assets only (additive) */}
+              {/* Quantity chip — shared QuantityBadge (QUANTITY_TRACKED only).
+                  The number here is workspace stock. */}
               {quantityLabel && (
-                <View style={styles.quantityBadge}>
-                  <Ionicons
-                    name="layers-outline"
-                    size={11}
-                    color={colors.muted}
-                  />
-                  <Text style={styles.quantityBadgeText} numberOfLines={1}>
-                    {quantityLabel}
-                  </Text>
-                </View>
+                <QuantityBadge
+                  value={item.quantity}
+                  unitOfMeasure={item.unitOfMeasure}
+                />
               )}
             </View>
           </View>
@@ -657,26 +653,6 @@ const useStyles = createStyles((colors, shadows) => ({
   assetLocation: {
     fontSize: fontSize.xs,
     color: colors.mutedLight,
-  },
-
-  // Quantity badge — compact pill for QUANTITY_TRACKED assets. Neutral
-  // (background-tertiary) so it reads as info, not a status. Self-sized via
-  // alignSelf so it hugs its content instead of stretching the meta column.
-  quantityBadge: {
-    flexDirection: "row",
-    alignItems: "center",
-    alignSelf: "flex-start",
-    backgroundColor: colors.backgroundTertiary,
-    borderRadius: borderRadius.pill,
-    paddingHorizontal: 6,
-    paddingVertical: 1,
-    marginTop: 2,
-    gap: 3,
-  },
-  quantityBadgeText: {
-    fontSize: fontSize.xs,
-    fontWeight: "500",
-    color: colors.muted,
   },
 
   // Status badge — pill shape like webapp

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -22,7 +22,13 @@ import {
 } from "@/lib/booking-refresh";
 import { useFocusEffect } from "@react-navigation/native";
 import { Ionicons } from "@expo/vector-icons";
-import { api, type BookingDetail, type BookingAsset } from "@/lib/api";
+import {
+  api,
+  type BookingDetail,
+  type BookingAsset,
+  type CheckoutDisposition,
+  type CheckinDisposition,
+} from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import {
   fontSize,
@@ -34,10 +40,69 @@ import {
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { BookingDetailSkeleton } from "@/components/skeleton-loader";
+import { QuantityInputSheet } from "@/components/quantity-input-sheet";
+import { QuantityBadge } from "@/components/quantity-badge";
+import {
+  CheckinDispositionSheet,
+  type CheckinDispositionValue,
+} from "@/components/checkin-disposition-sheet";
 import { announce } from "@/lib/a11y";
 import { maybeAskForReview } from "@/lib/review-prompt";
 
 const bookingAssetKeyExtractor = (item: BookingAsset) => item.id;
+
+/**
+ * Booking-scoped lifecycle state for a QUANTITY_TRACKED asset row. The asset's
+ * GLOBAL status ("Available") is meaningless on a booking — what matters is how
+ * many of the booked units are reserved / checked out / returned. Derived from
+ * the server's per-asset remaining counts. `key` indexes the shared
+ * `bookingStatusBadge` colours so the row reuses the booking colour vocabulary
+ * (blue reserved, orange in-progress, green complete).
+ *
+ * @param args - booked units, remaining-to-check-out/in, and the parent
+ *   booking's status (to tell a DRAFT line apart from a reserved one).
+ * @returns The badge `{ key, label }` for this asset on this booking.
+ */
+function getBookingAssetState({
+  booked,
+  remOut,
+  remIn,
+  bookingStatus,
+}: {
+  booked: number;
+  remOut?: number;
+  remIn?: number;
+  bookingStatus: string;
+}): { key: string; label: string } {
+  const clampedOut = Math.min(Math.max(remOut ?? booked, 0), booked);
+  const clampedIn = Math.min(Math.max(remIn ?? booked, 0), booked);
+  const checkedOut = booked - clampedOut; // units taken from the workspace
+  const checkedIn = booked - clampedIn; // units reconciled back in
+
+  if (booked <= 0 || checkedOut <= 0) {
+    return bookingStatus === "DRAFT"
+      ? { key: "DRAFT", label: "Draft" }
+      : { key: "RESERVED", label: "Reserved" };
+  }
+  if (checkedIn >= booked) return { key: "COMPLETE", label: "Returned" };
+  if (checkedIn > 0)
+    return { key: "ONGOING", label: `${checkedIn}/${booked} returned` };
+  if (checkedOut >= booked) return { key: "ONGOING", label: "Checked out" };
+  return { key: "ONGOING", label: `${checkedOut}/${booked} out` };
+}
+
+/**
+ * Segment colours for the booking lifecycle progress bar. Fixed hues matched to
+ * the web `BookingLifecycleProgress` component so the bar reads identically on
+ * both platforms: booked = grey, partial = amber, fully out = violet,
+ * returned = green.
+ */
+const LIFECYCLE_COLORS = {
+  booked: "#D1D5DB",
+  partial: "#F59E0B",
+  out: "#7C3AED",
+  returned: "#22C55E",
+} as const;
 
 export default function BookingDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -83,6 +148,25 @@ export default function BookingDetailScreen() {
     "checkin" | "checkout" | "remove" | null
   >(null);
   const isSelectMode = selectMode !== null;
+
+  // Sequential quantity picker for checking out QUANTITY_TRACKED assets: the
+  // user selects the rows, then we walk each QT asset asking "how many units?"
+  // (defaulting to all remaining), collect the dispositions, then submit.
+  const [checkoutQueue, setCheckoutQueue] = useState<{
+    queue: BookingAsset[];
+    index: number;
+    collected: CheckoutDisposition[];
+    individualIds: string[];
+  } | null>(null);
+
+  // Sequential disposition picker for checking IN quantity-tracked assets:
+  // walk each QT asset asking returned/consumed/lost/damaged, then submit.
+  const [checkinQueue, setCheckinQueue] = useState<{
+    queue: BookingAsset[];
+    index: number;
+    collected: CheckinDisposition[];
+    individualIds: string[];
+  } | null>(null);
 
   const lastFetchedAt = useRef(0);
 
@@ -173,7 +257,7 @@ export default function BookingDetailScreen() {
     if (!booking || !currentOrg) return;
     Alert.alert(
       "Check In All",
-      `Check in all assets for "${booking.name}"?\n\nAll ${booking.checkedOutCount} checked-out assets will be returned.`,
+      `Check in all assets for "${booking.name}"?\n\nAll remaining units will be returned and the booking completed.`,
       [
         { text: "Cancel", style: "cancel" },
         {
@@ -210,98 +294,158 @@ export default function BookingDetailScreen() {
     );
   };
 
+  // Send the check-in. `assetIds` = INDIVIDUAL rows (a bare QT id would default
+  // to all-remaining server-side); `checkins` = per-QT-asset dispositions.
+  const submitCheckin = async (
+    assetIds: string[],
+    checkins: CheckinDisposition[]
+  ) => {
+    if (!booking || !currentOrg) return;
+    setIsActioning(true);
+    const { data, error: err } = await api.partialCheckinBooking(
+      currentOrg.id,
+      booking.id,
+      assetIds,
+      getTimeZone(),
+      checkins.length > 0 ? checkins : undefined
+    );
+    setIsActioning(false);
+    if (err) {
+      Alert.alert("Error", err);
+      return;
+    }
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    // Mutation changed this booking — force the list to refetch.
+    markBookingsListDirty();
+    const msg = data?.isComplete
+      ? `All assets checked in. "${booking.name}" is now complete.`
+      : `${data?.checkedInCount ?? "Some"} checked in, ${
+          data?.remainingCount ?? "some"
+        } remaining.`;
+    Alert.alert("Checked In", msg, [
+      {
+        text: "OK",
+        onPress: () => {
+          setSelectedAssetIds(new Set());
+          setSelectMode(null);
+          fetchBooking();
+        },
+      },
+    ]);
+  };
+
   const handlePartialCheckin = () => {
     if (!booking || !currentOrg || selectedAssetIds.size === 0) return;
-    const count = selectedAssetIds.size;
-    Alert.alert(
-      "Check In Selected",
-      `Check in ${count} selected ${count === 1 ? "asset" : "assets"}?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Check In",
-          onPress: async () => {
-            setIsActioning(true);
-            const { data, error: err } = await api.partialCheckinBooking(
-              currentOrg.id,
-              booking.id,
-              Array.from(selectedAssetIds),
-              getTimeZone()
-            );
-            setIsActioning(false);
-            if (err) {
-              Alert.alert("Error", err);
-              return;
-            }
-            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-            // Mutation changed this booking — force the list to refetch.
-            markBookingsListDirty();
-            const msg = data?.isComplete
-              ? `All assets checked in. "${booking.name}" is now complete.`
-              : `${data?.checkedInCount ?? count} checked in, ${
-                  data?.remainingCount ?? "some"
-                } remaining.`;
-            Alert.alert("Checked In", msg, [
-              {
-                text: "OK",
-                onPress: () => {
-                  setSelectedAssetIds(new Set());
-                  setSelectMode(null);
-                  fetchBooking();
-                },
-              },
-            ]);
-          },
-        },
-      ]
+    const selected = booking.assets.filter((a) => selectedAssetIds.has(a.id));
+    // QT assets get a returned/consumed/lost/damaged split; INDIVIDUAL rows
+    // just flip back to available. Checkinable = booked units still to
+    // reconcile (remainingToCheckIn > 0), matching the web check-in drawer.
+    const qtAssets = selected.filter(
+      (a) => a.type === "QUANTITY_TRACKED" && (a.remainingToCheckIn ?? 0) > 0
     );
+    const individualIds = selected
+      .filter((a) => a.type !== "QUANTITY_TRACKED")
+      .map((a) => a.id);
+    if (qtAssets.length === 0) {
+      // No disposition to collect (INDIVIDUAL-only, or the server didn't send
+      // QT metadata) — keep the simple confirm + bare send.
+      const count = selectedAssetIds.size;
+      Alert.alert(
+        "Check In Selected",
+        `Check in ${count} selected ${count === 1 ? "asset" : "assets"}?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Check In",
+            onPress: () => void submitCheckin(individualIds, []),
+          },
+        ]
+      );
+      return;
+    }
+    // Walk each QT asset through the disposition picker before submitting.
+    setCheckinQueue({
+      queue: qtAssets,
+      index: 0,
+      collected: [],
+      individualIds,
+    });
+  };
+
+  // Send the check-out. `assetIds` = INDIVIDUAL rows (implicit 1 unit);
+  // `checkouts` = per-QT-asset quantities the picker collected.
+  const submitCheckout = async (
+    assetIds: string[],
+    checkouts: CheckoutDisposition[]
+  ) => {
+    if (!booking || !currentOrg) return;
+    setIsActioning(true);
+    const { data, error: err } = await api.partialCheckoutBooking(
+      currentOrg.id,
+      booking.id,
+      assetIds,
+      getTimeZone(),
+      checkouts.length > 0 ? checkouts : undefined
+    );
+    setIsActioning(false);
+    if (err) {
+      Alert.alert("Error", err);
+      return;
+    }
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    // Mutation changed this booking — force the list to refetch.
+    markBookingsListDirty();
+    const msg = data?.isComplete
+      ? `All assets are now checked out for "${booking.name}".`
+      : `${data?.checkedOutCount ?? "Some"} checked out, ${
+          data?.remainingCount ?? "some"
+        } still reserved.`;
+    Alert.alert("Checked Out", msg, [
+      {
+        text: "OK",
+        onPress: () => {
+          setSelectedAssetIds(new Set());
+          setSelectMode(null);
+          fetchBooking();
+        },
+      },
+    ]);
   };
 
   const handlePartialCheckout = () => {
     if (!booking || !currentOrg || selectedAssetIds.size === 0) return;
-    const count = selectedAssetIds.size;
-    Alert.alert(
-      "Check Out Selected",
-      `Check out ${count} selected ${count === 1 ? "asset" : "assets"}?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Check Out",
-          onPress: async () => {
-            setIsActioning(true);
-            const { data, error: err } = await api.partialCheckoutBooking(
-              currentOrg.id,
-              booking.id,
-              Array.from(selectedAssetIds),
-              getTimeZone()
-            );
-            setIsActioning(false);
-            if (err) {
-              Alert.alert("Error", err);
-              return;
-            }
-            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-            // Mutation changed this booking — force the list to refetch.
-            markBookingsListDirty();
-            const msg = data?.isComplete
-              ? `All assets are now checked out for "${booking.name}".`
-              : `${data?.checkedOutCount ?? count} checked out, ${
-                  data?.remainingCount ?? "some"
-                } still reserved.`;
-            Alert.alert("Checked Out", msg, [
-              {
-                text: "OK",
-                onPress: () => {
-                  setSelectedAssetIds(new Set());
-                  setSelectMode(null);
-                  fetchBooking();
-                },
-              },
-            ]);
-          },
-        },
-      ]
+    const selected = booking.assets.filter((a) => selectedAssetIds.has(a.id));
+    // QT assets need an explicit quantity; INDIVIDUAL rows are implicit 1 unit.
+    const qtAssets = selected.filter(
+      (a) => a.type === "QUANTITY_TRACKED" && (a.remainingToCheckOut ?? 0) > 0
     );
+    const individualIds = selected
+      .filter((a) => a.type !== "QUANTITY_TRACKED")
+      .map((a) => a.id);
+    if (qtAssets.length === 0) {
+      // No quantity to pick (INDIVIDUAL-only, or the server didn't send QT
+      // metadata) — keep the simple confirm + bare send.
+      const count = selectedAssetIds.size;
+      Alert.alert(
+        "Check Out Selected",
+        `Check out ${count} selected ${count === 1 ? "asset" : "assets"}?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Check Out",
+            onPress: () => void submitCheckout(individualIds, []),
+          },
+        ]
+      );
+      return;
+    }
+    // Walk each QT asset through the quantity picker before submitting.
+    setCheckoutQueue({
+      queue: qtAssets,
+      index: 0,
+      collected: [],
+      individualIds,
+    });
   };
 
   const handleReserve = () => {
@@ -580,22 +724,50 @@ export default function BookingDetailScreen() {
 
   const renderAsset = useCallback(
     ({ item }: { item: BookingAsset }) => {
-      const badge = statusBadge[item.status] ?? {
+      const fallbackBadge = {
         bg: colors.backgroundTertiary,
         text: colors.muted,
       };
+      // QUANTITY_TRACKED rows get a booking-scoped state (reserved / N out /
+      // returned) instead of the asset's global status, which is meaningless on
+      // a booking. INDIVIDUAL rows keep the existing status badge.
+      const qtState =
+        item.type === "QUANTITY_TRACKED"
+          ? getBookingAssetState({
+              booked: item.quantity ?? 0,
+              remOut: item.remainingToCheckOut,
+              remIn: item.remainingToCheckIn,
+              bookingStatus: booking?.status ?? "",
+            })
+          : null;
+      const badge = qtState
+        ? bookingStatusBadge[qtState.key] ?? fallbackBadge
+        : statusBadge[item.status] ?? fallbackBadge;
+      const stateLabel = qtState ? qtState.label : formatStatus(item.status);
       const isCheckedIn = checkedInAssetIds.includes(item.id);
       const isCheckedOut = item.status === "CHECKED_OUT";
       const isSelected = selectedAssetIds.has(item.id);
-      // What's selectable depends on the mode: returning checked-out assets
-      // (check-in) vs. taking never-checked-out assets (check-out). A returned
-      // asset is back to AVAILABLE, so `!isCheckedOut` alone would re-offer it
-      // for check-out — exclude the already-returned ones with `!isCheckedIn`.
+      // QUANTITY_TRACKED selectability is quantity-based, not status-based: a
+      // partially-checked-out QT asset stays AVAILABLE while units remain, so
+      // the global-status test wrongly excluded it. Check-in = booked units
+      // still to reconcile (remainingToCheckIn, the SAME "remaining" the web
+      // check-in drawer caps at); check-out = units still to take
+      // (remainingToCheckOut).
+      const isQt = item.type === "QUANTITY_TRACKED";
+      const qtRemainingIn = isQt ? item.remainingToCheckIn ?? 0 : 0;
+      const qtRemainingOut = isQt ? item.remainingToCheckOut ?? 0 : 0;
+      // What's selectable depends on the mode. A returned INDIVIDUAL asset is
+      // back to AVAILABLE, so `!isCheckedOut` alone would re-offer it for
+      // check-out — exclude the already-returned ones with `!isCheckedIn`.
       const selectable =
         selectMode === "checkin"
-          ? isCheckedOut && !isCheckedIn
+          ? isQt
+            ? qtRemainingIn > 0
+            : isCheckedOut && !isCheckedIn
           : selectMode === "checkout"
-          ? !isCheckedOut && !isCheckedIn
+          ? isQt
+            ? qtRemainingOut > 0
+            : !isCheckedOut && !isCheckedIn
           : selectMode === "remove"
           ? true
           : false;
@@ -615,7 +787,7 @@ export default function BookingDetailScreen() {
               pushIntoTab("/(tabs)/assets", `/(tabs)/assets/${item.id}`);
             }
           }}
-          accessibilityLabel={`${item.title}, ${formatStatus(item.status)}${
+          accessibilityLabel={`${item.title}, ${stateLabel}${
             isCheckedIn ? ", checked in" : ""
           }${isSelected ? ", selected" : ""}${
             selectable ? ". Tap to select" : ""
@@ -660,6 +832,13 @@ export default function BookingDetailScreen() {
             <Text style={styles.assetTitle} numberOfLines={1}>
               {item.title}
             </Text>
+            {item.type === "QUANTITY_TRACKED" && (
+              <QuantityBadge
+                value={item.quantity}
+                unitOfMeasure={item.unitOfMeasure}
+                label="booked"
+              />
+            )}
             {item.kit && (
               <Text style={styles.assetKit} numberOfLines={1}>
                 Kit: {item.kit.name}
@@ -675,7 +854,7 @@ export default function BookingDetailScreen() {
           <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
             <View style={[styles.statusDot, { backgroundColor: badge.text }]} />
             <Text style={[styles.statusText, { color: badge.text }]}>
-              {formatStatus(item.status)}
+              {stateLabel}
             </Text>
           </View>
         </TouchableOpacity>
@@ -691,6 +870,8 @@ export default function BookingDetailScreen() {
       router,
       colors,
       statusBadge,
+      bookingStatusBadge,
+      booking?.status,
       styles,
     ]
   );
@@ -746,6 +927,10 @@ export default function BookingDetailScreen() {
     (booking.checkedOutCount > 0 ||
       checkedInCount > 0 ||
       ["ONGOING", "OVERDUE", "COMPLETE"].includes(booking.status));
+  // Segmented lifecycle progress from the server's shared helper (identical
+  // numbers to the web bar). Guarded so an older server (field absent) simply
+  // omits the card rather than crashing.
+  const lp = booking.lifecycleProgress ?? null;
 
   // Progressive check-out stays available while the booking is active AND still
   // holds never-checked-out assets. The server (`partialCheckoutBooking`) accepts
@@ -891,39 +1076,54 @@ export default function BookingDetailScreen() {
             </View>
 
             {/* Lifecycle progress: reserved → out → returned (single bar) */}
-            {showProgress && (
+            {showProgress && lp && (
               <View style={styles.progressCard}>
                 <View style={styles.progressLabelRow}>
-                  <Text style={styles.progressTitle}>Check-out progress</Text>
+                  <Text style={styles.progressTitle}>
+                    {lp.bookedCount > 0
+                      ? "Check-out progress"
+                      : "Check-in progress"}
+                  </Text>
                   <Text style={styles.progressCount}>
-                    {checkedInCount}/{booking.assetCount} returned
+                    {lp.bookedCount > 0
+                      ? lp.checkoutProgressCount
+                      : lp.checkinProgressCount}{" "}
+                    / {lp.totalUnits}
                   </Text>
                 </View>
                 <View
                   style={styles.progressBar}
-                  accessibilityLabel={`${reservedCount} reserved, ${onJobCount} checked out, ${checkedInCount} returned`}
+                  accessibilityLabel={`${lp.bookedCount} booked, ${lp.partialCount} partial, ${lp.checkedOutCount} fully out, ${lp.returnedCount} returned, of ${lp.totalUnits}`}
                 >
-                  {reservedCount > 0 && (
+                  {lp.bookedCount > 0 && (
                     <View
                       style={{
-                        flex: reservedCount,
-                        backgroundColor: colors.backgroundTertiary,
+                        flex: lp.bookedCount,
+                        backgroundColor: LIFECYCLE_COLORS.booked,
                       }}
                     />
                   )}
-                  {onJobCount > 0 && (
+                  {lp.partialCount > 0 && (
                     <View
                       style={{
-                        flex: onJobCount,
-                        backgroundColor: colors.primary,
+                        flex: lp.partialCount,
+                        backgroundColor: LIFECYCLE_COLORS.partial,
                       }}
                     />
                   )}
-                  {checkedInCount > 0 && (
+                  {lp.checkedOutCount > 0 && (
                     <View
                       style={{
-                        flex: checkedInCount,
-                        backgroundColor: colors.success,
+                        flex: lp.checkedOutCount,
+                        backgroundColor: LIFECYCLE_COLORS.out,
+                      }}
+                    />
+                  )}
+                  {lp.returnedCount > 0 && (
+                    <View
+                      style={{
+                        flex: lp.returnedCount,
+                        backgroundColor: LIFECYCLE_COLORS.returned,
                       }}
                     />
                   )}
@@ -933,31 +1133,46 @@ export default function BookingDetailScreen() {
                     <View
                       style={[
                         styles.legendDot,
-                        { backgroundColor: colors.backgroundTertiary },
+                        { backgroundColor: LIFECYCLE_COLORS.booked },
                       ]}
                     />
                     <Text style={styles.legendText}>
-                      {reservedCount} reserved
+                      Booked {lp.bookedCount}
+                    </Text>
+                  </View>
+                  {lp.partialCount > 0 && (
+                    <View style={styles.legendItem}>
+                      <View
+                        style={[
+                          styles.legendDot,
+                          { backgroundColor: LIFECYCLE_COLORS.partial },
+                        ]}
+                      />
+                      <Text style={styles.legendText}>
+                        Partial {lp.partialCount}
+                      </Text>
+                    </View>
+                  )}
+                  <View style={styles.legendItem}>
+                    <View
+                      style={[
+                        styles.legendDot,
+                        { backgroundColor: LIFECYCLE_COLORS.out },
+                      ]}
+                    />
+                    <Text style={styles.legendText}>
+                      Fully out {lp.checkedOutCount}
                     </Text>
                   </View>
                   <View style={styles.legendItem}>
                     <View
                       style={[
                         styles.legendDot,
-                        { backgroundColor: colors.primary },
-                      ]}
-                    />
-                    <Text style={styles.legendText}>{onJobCount} out</Text>
-                  </View>
-                  <View style={styles.legendItem}>
-                    <View
-                      style={[
-                        styles.legendDot,
-                        { backgroundColor: colors.success },
+                        { backgroundColor: LIFECYCLE_COLORS.returned },
                       ]}
                     />
                     <Text style={styles.legendText}>
-                      {checkedInCount} returned
+                      Returned {lp.returnedCount}
                     </Text>
                   </View>
                 </View>
@@ -1186,7 +1401,10 @@ export default function BookingDetailScreen() {
               <View style={styles.checkinActions}>
                 {/* Quick "Check In All" is hidden when the workspace requires
                     explicit check-in for this role — the scan/select paths
-                    below remain (they ARE explicit check-in). Mirrors web. */}
+                    below remain (they ARE explicit check-in). Mirrors web's
+                    CheckinDropdown, which offers this "Quick check-in" (full
+                    checkinBooking = return all remaining) on any ongoing
+                    booking, partial included. */}
                 {canQuickCheckin && (
                   <TouchableOpacity
                     style={styles.actionButton}
@@ -1462,6 +1680,94 @@ export default function BookingDetailScreen() {
           </View>
         </TouchableOpacity>
       </Modal>
+
+      {/* Check-out quantity picker — walks the selected QT assets one at a
+          time, defaulting to "all remaining" so one tap takes the whole line. */}
+      {checkoutQueue && (
+        <QuantityInputSheet
+          visible
+          title="Check out"
+          subtitle={`How many of ${
+            checkoutQueue.queue[checkoutQueue.index].title
+          } are you taking?`}
+          max={
+            checkoutQueue.queue[checkoutQueue.index].remainingToCheckOut ?? 1
+          }
+          defaultValue={
+            checkoutQueue.queue[checkoutQueue.index].remainingToCheckOut ?? 1
+          }
+          unitOfMeasure={checkoutQueue.queue[checkoutQueue.index].unitOfMeasure}
+          confirmLabel={
+            checkoutQueue.index + 1 < checkoutQueue.queue.length
+              ? "Next"
+              : "Check out"
+          }
+          onSubmit={(quantity) => {
+            const cur = checkoutQueue.queue[checkoutQueue.index];
+            const collected = [
+              ...checkoutQueue.collected,
+              { assetId: cur.id, quantity },
+            ];
+            if (checkoutQueue.index + 1 < checkoutQueue.queue.length) {
+              setCheckoutQueue({
+                ...checkoutQueue,
+                index: checkoutQueue.index + 1,
+                collected,
+              });
+            } else {
+              const { individualIds } = checkoutQueue;
+              setCheckoutQueue(null);
+              void submitCheckout(individualIds, collected);
+            }
+          }}
+          onClose={() => setCheckoutQueue(null)}
+        />
+      )}
+
+      {/* Check-in disposition picker — walks the selected QT assets one at a
+          time, asking returned / consumed / lost / damaged per asset. */}
+      {checkinQueue && (
+        <CheckinDispositionSheet
+          visible
+          assetTitle={checkinQueue.queue[checkinQueue.index].title}
+          // Cap the picker to booked units still to reconcile
+          // (remainingToCheckIn = booked − returned/consumed/lost/damaged), the
+          // SAME "remaining" the web check-in drawer uses.
+          remaining={
+            checkinQueue.queue[checkinQueue.index].remainingToCheckIn ?? 1
+          }
+          consumptionType={
+            checkinQueue.queue[checkinQueue.index].consumptionType
+          }
+          unitOfMeasure={checkinQueue.queue[checkinQueue.index].unitOfMeasure}
+          isLast={checkinQueue.index + 1 >= checkinQueue.queue.length}
+          onSubmit={(value: CheckinDispositionValue) => {
+            const cur = checkinQueue.queue[checkinQueue.index];
+            const collected = [
+              ...checkinQueue.collected,
+              {
+                assetId: cur.id,
+                returned: value.returned,
+                consumed: value.consumed,
+                lost: value.lost,
+                damaged: value.damaged,
+              },
+            ];
+            if (checkinQueue.index + 1 < checkinQueue.queue.length) {
+              setCheckinQueue({
+                ...checkinQueue,
+                index: checkinQueue.index + 1,
+                collected,
+              });
+            } else {
+              const { individualIds } = checkinQueue;
+              setCheckinQueue(null);
+              void submitCheckin(individualIds, collected);
+            }
+          }}
+          onClose={() => setCheckinQueue(null)}
+        />
+      )}
     </View>
   );
 }

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -1685,6 +1685,10 @@ export default function BookingDetailScreen() {
           time, defaulting to "all remaining" so one tap takes the whole line. */}
       {checkoutQueue && (
         <QuantityInputSheet
+          // Remount per asset so the sheet's reset effect (keyed on
+          // max/defaultValue) can't reuse the previous asset's typed value when
+          // two consecutive queued assets share the same remaining quantity.
+          key={checkoutQueue.queue[checkoutQueue.index].id}
           visible
           title="Check out"
           subtitle={`How many of ${
@@ -1728,6 +1732,10 @@ export default function BookingDetailScreen() {
           time, asking returned / consumed / lost / damaged per asset. */}
       {checkinQueue && (
         <CheckinDispositionSheet
+          // Remount per asset so the sheet's reset effect (keyed on
+          // remaining/consumptionType) can't carry the previous asset's typed
+          // disposition into the next queued asset that shares the same values.
+          key={checkinQueue.queue[checkinQueue.index].id}
           visible
           assetTitle={checkinQueue.queue[checkinQueue.index].title}
           // Cap the picker to booked units still to reconcile

--- a/apps/companion/components/checkin-disposition-sheet.tsx
+++ b/apps/companion/components/checkin-disposition-sheet.tsx
@@ -1,0 +1,483 @@
+/**
+ * CheckinDispositionSheet — asks "how are these coming back?" for a
+ * QUANTITY_TRACKED asset. The mobile twin of the web check-in drawer: per
+ * asset, the operator splits the still-checked-out units across
+ * returned / consumed / lost / damaged.
+ *
+ * Design goal is maximum human clarity (not a bare form):
+ *  - It opens as a plain question, with the common case pre-answered: the
+ *    primary bucket (returned for returnable assets, consumed for consumables)
+ *    defaults to all remaining, so "everything came back" is a one-tap confirm.
+ *  - A colour-coded split bar shows, at a glance, how the units are being
+ *    accounted for (green = returned/consumed, amber = lost, red = damaged,
+ *    grey = still checked out).
+ *  - A live status line ("All 6 checked in" / "4 of 6 · 2 stay checked out")
+ *    means the operator can never submit a nonsensical split, and always knows
+ *    what the confirm will do.
+ *
+ * The fields shown depend on the asset's consumption type:
+ *  - TWO_WAY (returnable): Returned, Lost, Damaged
+ *  - ONE_WAY (consumable): Consumed, Lost, Damaged
+ *
+ * Mirrors {@link file://./quantity-input-sheet.tsx}'s modal contract
+ * (`<Modal presentationStyle="pageSheet">` + SafeAreaView + header-with-close).
+ */
+import { useEffect, useState } from "react";
+import { View, Text, Modal, TextInput, TouchableOpacity } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import type { ConsumptionType } from "@/lib/api";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+import { formatQuantity } from "@/lib/quantity-format";
+
+/** How the checked-out units were reconciled. Sum must be in [1, remaining]. */
+export type CheckinDispositionValue = {
+  returned: number;
+  consumed: number;
+  lost: number;
+  damaged: number;
+};
+
+type FieldKey = keyof CheckinDispositionValue;
+
+/**
+ * Disposition colours, shared with the confirm-flow split bar. Fixed hues (not
+ * theme tokens) so the green/amber/red mapping reads the same on every device:
+ * green = the unit is fine, amber = lost, red = damaged.
+ */
+const DISPOSITION_COLOR: Record<FieldKey, string> = {
+  returned: "#639922",
+  consumed: "#639922",
+  lost: "#BA7517",
+  damaged: "#E24B4A",
+};
+
+type Props = {
+  visible: boolean;
+  /** Asset title shown under the header. */
+  assetTitle: string;
+  /** Units still checked out on this booking (the max total). */
+  remaining: number;
+  /** Decides the primary bucket: consume-all for ONE_WAY, return-all otherwise. */
+  consumptionType?: ConsumptionType | null;
+  /** Display unit echoed in the totals (e.g. "pcs"). */
+  unitOfMeasure?: string | null;
+  /**
+   * Whether this is the final asset in the check-in queue. The last asset's
+   * button submits ("Check in N"); earlier ones advance ("Next").
+   */
+  isLast: boolean;
+  onSubmit: (value: CheckinDispositionValue) => void;
+  onClose: () => void;
+};
+
+const ZERO: CheckinDispositionValue = {
+  returned: 0,
+  consumed: 0,
+  lost: 0,
+  damaged: 0,
+};
+
+/**
+ * Disposition prompt sheet for a quantity-tracked check-in.
+ *
+ * @param props - See {@link Props}.
+ * @returns The modal sheet element.
+ */
+export function CheckinDispositionSheet({
+  visible,
+  assetTitle,
+  remaining,
+  consumptionType,
+  unitOfMeasure,
+  isLast,
+  onSubmit,
+  onClose,
+}: Props) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+
+  // The "good" bucket is consume for consumables, return otherwise.
+  const isConsumable = consumptionType === "ONE_WAY";
+  const primaryKey: FieldKey = isConsumable ? "consumed" : "returned";
+  const primaryLabel = isConsumable ? "Consumed" : "Returned";
+
+  const [counts, setCounts] = useState<CheckinDispositionValue>(ZERO);
+
+  // Re-seed each open: default the primary bucket to all remaining so "checked
+  // everything back in" is one tap. Each open targets a fresh asset.
+  useEffect(() => {
+    if (visible) {
+      setCounts({ ...ZERO, [primaryKey]: Math.max(remaining, 0) });
+    }
+    // why: primaryKey derives from consumptionType, already in the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, remaining, consumptionType]);
+
+  const total =
+    counts.returned + counts.consumed + counts.lost + counts.damaged;
+  const remainder = Math.max(remaining - total, 0);
+  const isValid = total >= 1 && total <= remaining;
+
+  /** Set one bucket, clamped so the running total can never exceed `remaining`. */
+  const setField = (key: FieldKey, next: number) => {
+    setCounts((prev) => {
+      const others =
+        prev.returned + prev.consumed + prev.lost + prev.damaged - prev[key];
+      const capped = Math.min(
+        Math.max(next, 0),
+        Math.max(remaining - others, 0)
+      );
+      return { ...prev, [key]: capped };
+    });
+  };
+
+  const remainingLabel =
+    formatQuantity(remaining, unitOfMeasure) ?? String(remaining);
+  const totalLabel = formatQuantity(total, unitOfMeasure) ?? String(total);
+  const question = isConsumable
+    ? `How were these ${remainingLabel} used?`
+    : "How are they coming back?";
+  const confirmLabel = isLast ? `Check in ${totalLabel}` : "Next";
+
+  /** One labelled stepper row (dot + label + -/value/+), capped to remaining. */
+  const renderStepperRow = (key: FieldKey, label: string) => {
+    const cur = counts[key];
+    const canInc = total < remaining;
+    return (
+      <View style={styles.fieldRow}>
+        <View style={styles.fieldLabelWrap}>
+          <View
+            style={[styles.dot, { backgroundColor: DISPOSITION_COLOR[key] }]}
+          />
+          <Text style={styles.fieldLabel}>{label}</Text>
+        </View>
+        <View style={styles.stepperGroup}>
+          <TouchableOpacity
+            style={[styles.stepButton, cur <= 0 && styles.stepButtonDisabled]}
+            onPress={() => setField(key, cur - 1)}
+            disabled={cur <= 0}
+            activeOpacity={0.7}
+            accessibilityLabel={`Decrease ${label.toLowerCase()}`}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: cur <= 0 }}
+          >
+            <Ionicons name="remove" size={20} color={colors.foreground} />
+          </TouchableOpacity>
+          <TextInput
+            style={styles.fieldInput}
+            value={String(cur)}
+            onChangeText={(t) =>
+              setField(key, parseInt(t.replace(/[^0-9]/g, ""), 10) || 0)
+            }
+            keyboardType="number-pad"
+            returnKeyType="done"
+            accessibilityLabel={`${label} quantity`}
+          />
+          <TouchableOpacity
+            style={[styles.stepButton, !canInc && styles.stepButtonDisabled]}
+            onPress={() => setField(key, cur + 1)}
+            disabled={!canInc}
+            activeOpacity={0.7}
+            accessibilityLabel={`Increase ${label.toLowerCase()}`}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !canInc }}
+          >
+            <Ionicons name="add" size={20} color={colors.foreground} />
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  };
+
+  // Split-bar segments: only render non-zero buckets so thin slivers don't
+  // clutter, plus a grey tail for units staying checked out.
+  const segments: { key: string; value: number; color: string }[] = [
+    {
+      key: primaryKey,
+      value: counts[primaryKey],
+      color: DISPOSITION_COLOR[primaryKey],
+    },
+    { key: "lost", value: counts.lost, color: DISPOSITION_COLOR.lost },
+    { key: "damaged", value: counts.damaged, color: DISPOSITION_COLOR.damaged },
+    { key: "remainder", value: remainder, color: colors.gray300 },
+  ].filter((s) => s.value > 0);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.container} accessibilityViewIsModal={true}>
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>Check in</Text>
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.closeButton}
+            accessibilityLabel="Close check-in"
+            accessibilityRole="button"
+          >
+            <Ionicons name="close" size={24} color={colors.foreground} />
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.body}>
+          <Text style={styles.context}>
+            <Text style={styles.contextStrong}>{remainingLabel}</Text> of{" "}
+            {assetTitle} still to check in.
+          </Text>
+          <Text style={styles.question}>{question}</Text>
+
+          {/* Colour-coded split of the checked-out units. */}
+          <View
+            style={styles.splitBar}
+            accessibilityLabel={`${totalLabel} of ${remainingLabel} being checked in`}
+          >
+            {segments.map((s) => (
+              <View
+                key={s.key}
+                style={[
+                  styles.splitSegment,
+                  { flexGrow: s.value, backgroundColor: s.color },
+                ]}
+              >
+                {s.key !== "remainder" ? (
+                  <Text style={styles.splitSegmentText}>{s.value}</Text>
+                ) : null}
+              </View>
+            ))}
+          </View>
+
+          {renderStepperRow(primaryKey, primaryLabel)}
+
+          <View style={styles.problemSection}>
+            <Text style={styles.problemCaption}>Anything wrong with some?</Text>
+            {renderStepperRow("lost", "Lost")}
+            {renderStepperRow("damaged", "Damaged")}
+          </View>
+
+          {/* Live status — the operator always knows what confirm will do. */}
+          <View
+            style={[
+              styles.statusPill,
+              total === remaining
+                ? styles.statusComplete
+                : styles.statusPartial,
+            ]}
+          >
+            <Ionicons
+              name={
+                total === remaining ? "checkmark-circle" : "ellipse-outline"
+              }
+              size={16}
+              color={
+                total === remaining ? "#3B6D11" : colors.foregroundSecondary
+              }
+            />
+            <Text
+              style={[
+                styles.statusText,
+                total === remaining
+                  ? styles.statusTextComplete
+                  : styles.statusTextPartial,
+              ]}
+            >
+              {total === remaining
+                ? `All ${remainingLabel} checked in`
+                : `${totalLabel} of ${remainingLabel} · ${
+                    formatQuantity(remainder, unitOfMeasure) ?? remainder
+                  } still to check in`}
+            </Text>
+          </View>
+
+          <TouchableOpacity
+            style={[styles.confirmPrimary, !isValid && styles.confirmDisabled]}
+            onPress={() => {
+              if (isValid) onSubmit(counts);
+            }}
+            disabled={!isValid}
+            activeOpacity={0.7}
+            accessibilityLabel={confirmLabel}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !isValid }}
+          >
+            <Text style={styles.confirmText}>{confirmLabel}</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const useStyles = createStyles((colors, shadows) => ({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: {
+    fontSize: fontSize.xl,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  closeButton: {
+    padding: spacing.xs,
+  },
+  body: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    gap: spacing.md,
+  },
+  context: {
+    fontSize: fontSize.base,
+    color: colors.foregroundSecondary,
+    lineHeight: 20,
+  },
+  contextStrong: {
+    color: colors.foreground,
+    fontWeight: "600",
+  },
+  question: {
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  splitBar: {
+    flexDirection: "row",
+    height: 30,
+    borderRadius: borderRadius.sm,
+    overflow: "hidden",
+    backgroundColor: colors.gray300,
+  },
+  splitSegment: {
+    flexBasis: 0,
+    minWidth: 22,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  splitSegmentText: {
+    color: colors.white,
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+  },
+  fieldRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.md,
+  },
+  fieldLabelWrap: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    flexShrink: 1,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  fieldLabel: {
+    fontSize: fontSize.base,
+    fontWeight: "500",
+    color: colors.foreground,
+  },
+  stepperGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  stepButton: {
+    width: 40,
+    height: 40,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    justifyContent: "center",
+    alignItems: "center",
+    ...shadows.sm,
+  },
+  stepButtonDisabled: {
+    opacity: 0.4,
+  },
+  fieldInput: {
+    width: 56,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: 8,
+    paddingVertical: 10,
+    fontSize: fontSize.lg,
+    color: colors.foreground,
+    textAlign: "center",
+    ...shadows.sm,
+  },
+  problemSection: {
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: spacing.md,
+    gap: spacing.md,
+  },
+  problemCaption: {
+    fontSize: fontSize.sm,
+    color: colors.muted,
+  },
+  statusPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    borderRadius: borderRadius.sm,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+  },
+  statusComplete: {
+    backgroundColor: "#EAF3DE",
+  },
+  statusPartial: {
+    backgroundColor: colors.backgroundSecondary,
+  },
+  statusText: {
+    fontSize: fontSize.sm,
+    flexShrink: 1,
+  },
+  statusTextComplete: {
+    color: "#3B6D11",
+    fontWeight: "500",
+  },
+  statusTextPartial: {
+    color: colors.foregroundSecondary,
+  },
+  confirmPrimary: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    marginTop: spacing.xs,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  confirmDisabled: {
+    opacity: 0.5,
+  },
+  confirmText: {
+    color: colors.primaryForeground,
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+  },
+}));

--- a/apps/companion/components/quantity-badge.tsx
+++ b/apps/companion/components/quantity-badge.tsx
@@ -1,0 +1,81 @@
+/**
+ * QuantityBadge — the single shared "how many units" chip for
+ * QUANTITY_TRACKED assets. One look everywhere it appears (inventory list,
+ * booking rows, ...) so the same concept never renders four different ways.
+ *
+ * The number's MEANING is surface-specific and the caller owns it: workspace
+ * stock on the assets list, booked units on a booking row, units-in-kit on a
+ * kit. Pass the right `value` plus an optional `label` ("booked", "in kit") to
+ * disambiguate meaning without changing the look — same chip, different value.
+ *
+ * @see {@link file://../lib/quantity-format.ts} formatQuantity
+ * @see {@link file://../app/(tabs)/assets/index.tsx} inventory-list consumer
+ * @see {@link file://../app/(tabs)/bookings/[id].tsx} booking-row consumer
+ */
+import { View, Text } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { fontSize, borderRadius } from "@/lib/constants";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+import { formatQuantity } from "@/lib/quantity-format";
+
+type Props = {
+  /** Unit count for this surface (stock / booked / in-kit — caller decides). */
+  value: number | null | undefined;
+  /** Display unit echoed after the count, e.g. "pcs". */
+  unitOfMeasure?: string | null;
+  /** Optional meaning suffix rendered lighter, e.g. "booked". */
+  label?: string;
+};
+
+/**
+ * Neutral count chip: a layers icon + "N unit" (+ optional meaning label).
+ * Renders nothing when `value` is not a finite number, so callers can drop it
+ * in unconditionally for mixed INDIVIDUAL / QUANTITY_TRACKED lists.
+ *
+ * @param props - See {@link Props}.
+ * @returns The chip element, or null when there is no quantity to show.
+ */
+export function QuantityBadge({ value, unitOfMeasure, label }: Props) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+
+  if (value == null || !Number.isFinite(value)) return null;
+
+  const qty = formatQuantity(value, unitOfMeasure) ?? String(value);
+
+  return (
+    <View
+      style={styles.badge}
+      accessibilityLabel={label ? `${qty} ${label}` : qty}
+    >
+      <Ionicons name="layers-outline" size={11} color={colors.muted} />
+      <Text style={styles.text} numberOfLines={1}>
+        {qty}
+        {label ? <Text style={styles.label}> {label}</Text> : null}
+      </Text>
+    </View>
+  );
+}
+
+const useStyles = createStyles((colors) => ({
+  badge: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    backgroundColor: colors.backgroundTertiary,
+    borderRadius: borderRadius.pill,
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    gap: 3,
+  },
+  text: {
+    fontSize: fontSize.xs,
+    fontWeight: "500",
+    color: colors.muted,
+  },
+  label: {
+    fontWeight: "400",
+    color: colors.muted,
+  },
+}));

--- a/apps/companion/lib/api/bookings.ts
+++ b/apps/companion/lib/api/bookings.ts
@@ -3,6 +3,8 @@ import type {
   BookingsResponse,
   BookingDetailResponse,
   BookingActionResponse,
+  CheckinDisposition,
+  CheckoutDisposition,
   PartialCheckinResponse,
   PartialCheckoutResponse,
   BookingMutationResponse,
@@ -89,13 +91,14 @@ export const bookingsApi = {
     orgId: string,
     bookingId: string,
     assetIds: string[],
-    timeZone?: string
+    timeZone?: string,
+    checkins?: CheckinDisposition[]
   ) =>
     apiFetch<PartialCheckinResponse>(
       `/api/mobile/bookings/partial-checkin?orgId=${orgId}`,
       {
         method: "POST",
-        body: JSON.stringify({ bookingId, assetIds, timeZone }),
+        body: JSON.stringify({ bookingId, assetIds, checkins, timeZone }),
       }
     ),
 
@@ -109,13 +112,14 @@ export const bookingsApi = {
     orgId: string,
     bookingId: string,
     assetIds: string[],
-    timeZone?: string
+    timeZone?: string,
+    checkouts?: CheckoutDisposition[]
   ) =>
     apiFetch<PartialCheckoutResponse>(
       `/api/mobile/bookings/partial-checkout?orgId=${orgId}`,
       {
         method: "POST",
-        body: JSON.stringify({ bookingId, assetIds, timeZone }),
+        body: JSON.stringify({ bookingId, assetIds, checkouts, timeZone }),
       }
     ),
 

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -470,6 +470,43 @@ export type BookingAsset = {
   kitId: string | null;
   category: { id: string; name: string; color: string } | null;
   kit: { id: string; name: string } | null;
+  // Quantity-tracked fields. The server sends `quantity` for every asset;
+  // `type`/`unitOfMeasure`/`consumptionType` + the `remaining*` counts are what
+  // the check-in / check-out pickers use. Optional for back-compat with older
+  // server responses (the app falls back to bare-scan behaviour when absent).
+  type?: AssetType;
+  quantity?: number;
+  unitOfMeasure?: string | null;
+  consumptionType?: ConsumptionType | null;
+  assetKitId?: string | null;
+  /** Units currently checked out on this booking that can still be checked in. */
+  remainingToCheckIn?: number;
+  /** Units still reserved on this booking that can still be checked out. */
+  remainingToCheckOut?: number;
+};
+
+/**
+ * Per-asset check-in disposition for a QUANTITY_TRACKED asset: how many of the
+ * checked-out units were returned / consumed / lost / damaged. Sum must be
+ * <= the asset's `remainingToCheckIn`. Mirrors the web check-in drawer.
+ */
+export type CheckinDisposition = {
+  assetId: string;
+  bookingAssetId?: string | null;
+  returned?: number;
+  consumed?: number;
+  lost?: number;
+  damaged?: number;
+};
+
+/**
+ * Per-asset check-out disposition for a QUANTITY_TRACKED asset: how many units
+ * to take now. `quantity` must be <= the asset's `remainingToCheckOut`.
+ */
+export type CheckoutDisposition = {
+  assetId: string;
+  bookingAssetId?: string | null;
+  quantity: number;
 };
 
 /**
@@ -522,6 +559,26 @@ export type BookingDetail = {
   modelRequestCount: number;
   /** Total units still to assign across all model requests. */
   outstandingModelUnitCount: number;
+  /**
+   * Segmented lifecycle progress (Booked / Partial / Fully out / Returned),
+   * computed server-side by the SAME shared helper the web booking overview
+   * uses, so the mobile progress bar shows identical numbers to web. `null` /
+   * absent from an older server (rolling deploy) — the card is then omitted.
+   */
+  lifecycleProgress?: {
+    totalUnits: number;
+    bookedCount: number;
+    partialCount: number;
+    checkedOutCount: number;
+    returnedCount: number;
+    checkoutProgressCount: number;
+    checkoutProgressPercentage: number;
+    checkinProgressCount: number;
+    checkinProgressPercentage: number;
+    hasPartialCheckouts: boolean;
+    hasPartialCheckins: boolean;
+    countMode: "assets" | "units";
+  } | null;
 };
 
 export type BookingDetailResponse = {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.serialization.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.serialization.test.server.ts
@@ -27,7 +27,14 @@ import { assertIsDataWithResponseInit } from "../../../../test/helpers/assertion
 // @vitest-environment node
 
 vi.mock("~/database/db.server", () => ({
-  db: { booking: { findFirst: vi.fn() } },
+  db: {
+    booking: { findFirst: vi.fn() },
+    // Lifecycle-progress roll-up queries the partial-checkout log to decide
+    // whether an asset was ever checked out. Not relevant to the model-request
+    // serialization under test — stub to an empty log. (Survives
+    // `clearAllMocks`, which clears call history but keeps implementations.)
+    partialBookingCheckout: { findMany: vi.fn().mockResolvedValue([]) },
+  },
 }));
 
 vi.mock("~/modules/api/mobile-auth.server", async () => {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.serialization.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.serialization.test.server.ts
@@ -29,9 +29,9 @@ import { assertIsDataWithResponseInit } from "../../../../test/helpers/assertion
 vi.mock("~/database/db.server", () => ({
   db: {
     booking: { findFirst: vi.fn() },
-    // Lifecycle-progress roll-up queries the partial-checkout log to decide
-    // whether an asset was ever checked out. Not relevant to the model-request
-    // serialization under test — stub to an empty log. (Survives
+    // why: lifecycle-progress roll-up queries the partial-checkout log to
+    // decide whether an asset was ever checked out. Not relevant to the
+    // model-request serialization under test — stub to an empty log. (Survives
     // `clearAllMocks`, which clears call history but keeps implementations.)
     partialBookingCheckout: { findMany: vi.fn().mockResolvedValue([]) },
   },

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -1,4 +1,4 @@
-import { AssetStatus, OrganizationRoles } from "@prisma/client";
+import { AssetStatus, AssetType, OrganizationRoles } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
@@ -8,7 +8,12 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
-import { getPartiallyCheckedInAssetIds } from "~/modules/booking/service.server";
+import {
+  computeBookingAssetRemaining,
+  computeBookingAssetRemainingToCheckOut,
+  getPartiallyCheckedInAssetIds,
+} from "~/modules/booking/service.server";
+import { calculateBookingLifecycleProgress } from "~/modules/booking/utils.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
@@ -99,6 +104,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 id: true,
                 title: true,
                 status: true,
+                // Quantity-tracked metadata so the app can render the
+                // check-in / check-out quantity + disposition pickers: `type`
+                // gates the picker to QT assets, `consumptionType` decides
+                // return-vs-consume wording, `unitOfMeasure` labels the count.
+                type: true,
+                unitOfMeasure: true,
+                consumptionType: true,
                 mainImage: true,
                 category: {
                   select: { id: true, name: true, color: true },
@@ -207,6 +219,21 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       };
     });
 
+    // Per-QUANTITY_TRACKED-asset remaining, computed up-front so the capability
+    // flags below can reason about UNITS, not the asset's global status.
+    const qtRemaining = await Promise.all(
+      assets
+        .filter((a) => a.type === AssetType.QUANTITY_TRACKED)
+        .map(async (a) => {
+          const [remainingToCheckIn, remainingToCheckOut] = await Promise.all([
+            computeBookingAssetRemaining(db, booking.id, a.id),
+            computeBookingAssetRemainingToCheckOut(db, booking.id, a.id),
+          ]);
+          return { assetId: a.id, remainingToCheckIn, remainingToCheckOut };
+        })
+    );
+    const remainingByAsset = new Map(qtRemaining.map((r) => [r.assetId, r]));
+
     // Compute booking capability flags
     const checkedOutCount = assets.filter(
       (a) => a.status === AssetStatus.CHECKED_OUT
@@ -214,9 +241,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const totalAssets = assets.length;
 
     const canCheckout = booking.status === "RESERVED" && totalAssets > 0;
+    // Checkinable while ONGOING/OVERDUE AND something is still to check in.
+    // INDIVIDUAL: global status CHECKED_OUT. QUANTITY_TRACKED: booked units not
+    // yet reconciled = remainingToCheckIn > 0 (booked − returned/consumed/lost/
+    // damaged) — the SAME "remaining" the web check-in drawer caps at. The old
+    // `checkedOutCount > 0` gate hid check-in on a partially-checked-out QT
+    // booking, whose asset status stays AVAILABLE while units are still booked.
+    const hasCheckinable = assets.some((a) => {
+      if (a.type === AssetType.QUANTITY_TRACKED) {
+        const rem = remainingByAsset.get(a.id);
+        return rem ? rem.remainingToCheckIn > 0 : false;
+      }
+      return a.status === AssetStatus.CHECKED_OUT;
+    });
     const canCheckin =
       (booking.status === "ONGOING" || booking.status === "OVERDUE") &&
-      checkedOutCount > 0;
+      hasCheckinable;
 
     // Quick "check in all" is disallowed when the workspace requires EXPLICIT
     // (scan/select) check-in for the caller's role — mirror the web policy
@@ -316,6 +356,62 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       0
     );
 
+    // Attach the per-asset remaining (computed up-front, above) to each QT
+    // asset so the app's pickers can cap inputs; INDIVIDUAL rows pass through
+    // unchanged.
+    const assetsForResponse = assets.map((a) => {
+      const rem = remainingByAsset.get(a.id);
+      return rem
+        ? {
+            ...a,
+            remainingToCheckIn: rem.remainingToCheckIn,
+            remainingToCheckOut: rem.remainingToCheckOut,
+          }
+        : a;
+    });
+
+    // Segmented lifecycle progress (Booked / Partial / Checked out / Returned)
+    // for the booking's progress bar — computed with the SAME shared helper the
+    // web booking overview uses (`calculateBookingLifecycleProgress`), so the
+    // mobile bar and the web bar can never disagree. QT rows bucket by their
+    // per-asset unit counters; INDIVIDUAL rows by status + `checkedInAssetIds`.
+    // `checkedOutAssetIds` (assets with a PartialBookingCheckout record) drives
+    // the COMPLETE-branch "was it ever out?" test; an empty list means an
+    // all-at-once checkout.
+    const partialCheckoutRows = await db.partialBookingCheckout.findMany({
+      where: { bookingId: booking.id },
+      select: { assetIds: true },
+    });
+    const checkedOutAssetIds = [
+      ...new Set(partialCheckoutRows.flatMap((r) => r.assetIds)),
+    ];
+    const lifecycleProgress = calculateBookingLifecycleProgress({
+      bookingAssets: assets.map((a) => {
+        const isQty = a.type === AssetType.QUANTITY_TRACKED;
+        const rem = remainingByAsset.get(a.id);
+        const booked = a.quantity ?? 0;
+        return {
+          id: a.id,
+          kitId: a.kitId,
+          status: a.status,
+          assetType: a.type,
+          bookedQuantity: isQty ? booked : undefined,
+          // checked-out = booked − still-to-check-out; dispositioned =
+          // booked − still-to-check-in. Both from the per-asset remaining
+          // computed above (asset-level sum across slices — exact for the
+          // standalone QT rows that are the mobile-common case).
+          checkedOutQuantity:
+            isQty && rem ? Math.max(0, booked - rem.remainingToCheckOut) : 0,
+          dispositionedQuantity:
+            isQty && rem ? Math.max(0, booked - rem.remainingToCheckIn) : 0,
+        };
+      }),
+      checkedInAssetIds,
+      checkedOutAssetIds,
+      bookingStatus: booking.status,
+      countKitsAsSingleUnit: bookingSettings.countKitsAsSingleUnit ?? false,
+    });
+
     return data({
       booking: {
         id: booking.id,
@@ -330,12 +426,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         custodianUser: booking.custodianUser,
         custodianTeamMember: booking.custodianTeamMember,
         tags: booking.tags,
-        assets,
+        assets: assetsForResponse,
         assetCount: totalAssets,
         checkedOutCount,
         modelRequests,
         modelRequestCount,
         outstandingModelUnitCount,
+        lifecycleProgress,
       },
       checkedInAssetIds,
       canCheckout,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkin.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkin.ts
@@ -51,10 +51,30 @@ export async function action({ request }: ActionFunctionArgs) {
     await assertMobileCanUseBookings(organizationId);
 
     const body = await request.json();
-    const { bookingId, assetIds, timeZone } = z
+    const { bookingId, assetIds, checkins, timeZone } = z
       .object({
         bookingId: z.string().min(1),
-        assetIds: z.array(z.string().min(1)).min(1),
+        // Legacy / INDIVIDUAL: bare asset ids. For a QUANTITY_TRACKED asset a
+        // bare id still means "check in all remaining" (simple case); explicit
+        // per-unit dispositions go in `checkins`. Optional so the picker can
+        // send a QT-only, checkins-only payload.
+        assetIds: z.array(z.string().min(1)).optional(),
+        // Per-asset dispositions for QUANTITY_TRACKED assets — how many units
+        // were returned / consumed / lost / damaged. Powers the mobile
+        // check-in picker; mirrors the web drawer payload the service already
+        // accepts.
+        checkins: z
+          .array(
+            z.object({
+              assetId: z.string().min(1),
+              bookingAssetId: z.string().nullish(),
+              returned: z.number().int().min(0).optional(),
+              consumed: z.number().int().min(0).optional(),
+              lost: z.number().int().min(0).optional(),
+              damaged: z.number().int().min(0).optional(),
+            })
+          )
+          .optional(),
         timeZone: z.string().optional(),
       })
       .parse(body);
@@ -115,6 +135,7 @@ export async function action({ request }: ActionFunctionArgs) {
       id: bookingId,
       organizationId,
       assetIds,
+      checkins,
       userId: user.id,
       hints,
     });

--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
@@ -52,7 +52,11 @@ export async function action({ request }: ActionFunctionArgs) {
     const { bookingId, assetIds, checkouts, timeZone } = z
       .object({
         bookingId: z.string().min(1),
-        assetIds: z.array(z.string().cuid()).min(1),
+        // Optional: a QT-only check-out sends its quantities in `checkouts` with
+        // an empty `assetIds`. INDIVIDUAL rows still flow through `assetIds`. The
+        // service 400s if BOTH are empty, so we don't require a minimum here
+        // (mirrors the partial-checkin route).
+        assetIds: z.array(z.string().cuid()).optional(),
         /**
          * Optional per-asset checkout payload mirroring the webapp check-in
          * JSON shape. When present, the service uses it to perform partial


### PR DESCRIPTION
## What

Adds per-unit **disposition check-in** (returned / consumed / lost / damaged) and **partial check-out** for `QUANTITY_TRACKED` assets in the companion booking detail, matching the web check-in drawer so the mobile and web flows stay in lockstep.

This closes the gap where a QT booking could reach a state the app couldn't reconcile (`Quantity-tracked assets must include at least one non-zero disposition`): the companion had no UI to split checked-out units across dispositions.

## Changes

**Companion**
- **`CheckinDispositionSheet`** (new): question-framed "how are they coming back?", a colour-coded split bar (returned/consumed green, lost amber, damaged red, still-out grey), a live status line, and ONE_WAY vs TWO_WAY wording. The primary bucket defaults to all-remaining, so the common "everything came back" case is a one-tap confirm; the total is clamped to booked-remaining.
- **`QuantityBadge`** (new): one shared "N units" chip, reused on the assets list and booking rows so the concept renders the same way everywhere.
- Booking detail renders **segmented lifecycle progress** (Booked / Partial / Fully out / Returned) using the shared `calculateBookingLifecycleProgress` helper, so the mobile bar mirrors the web overview.

**Mobile API (webapp)**
- `GET /api/mobile/bookings/:id` now returns per-QT-asset `remainingToCheckIn` / `remainingToCheckOut`, QT metadata (`type` / `unitOfMeasure` / `consumptionType`), and `lifecycleProgress`. All fields are additive/optional (older app builds ignore them).
- **`canCheckin` fix:** a partially-checked-out QT booking is now checkinable. Previously the flag keyed off global `CHECKED_OUT` status, which a QT asset never reaches while units are still booked (its status stays `AVAILABLE`), so check-in was silently hidden.
- `partial-checkin` / `partial-checkout` accept optional `assetIds` plus per-asset disposition arrays, so a QT-only submission (empty `assetIds`) succeeds.

**Drive-by**
- login: password field `autoCapitalize="none"` — a lowercase-starting password was silently sentence-cased and failed iOS login.

## Testing

- **Simulator e2e** (iOS): standalone QT assets and **kit-driven QT slices** (render, check-out, disposition check-in), with DB confirmation of `ConsumptionLog` rows (RETURN/LOSS/DAMAGE) and `Asset.quantity` stock decrements (lost + damaged decrement stock; returns do not).
- Verified partial check-in targets the selected slice only (the other slice stays checked out).
- `typecheck`, `lint`, `react-doctor`, `prettier`, and the 599 booking unit tests pass.

## Design note: per-slice attribution

The mobile payload collapses a booking's `BookingAsset` rows to one entry per `assetId` (summed quantity), so mobile check-in/out writes **asset-level** dispositions with `ConsumptionLog.bookingAssetId = null`. This is correct even when the same QT asset appears on one booking as both a kit slice and a standalone free-pool slice: the aggregate is guarded server-side by `computeBookingAssetRemaining`, and the web read layer already greedy-attributes null-tagged logs across the asset's slices (`attributeDispositionsByBookingAsset` / `attributeCategorizedDispositionsByBookingAsset` in `service.server.ts`, standalone-first then kit-driven), so the per-slice display stays correct. Native per-slice `bookingAssetId` tagging would duplicate that read-time attribution, so it's intentionally not added here.
