### PR TITLE
fix(companion): book-by-model checkout is no longer a dead-end

### DIFF
--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -1414,36 +1414,43 @@ export default function BookingDetailScreen() {
                 has no checkout button (the server hard-blocks checkout until
                 every reserved unit is assigned to a concrete asset). Instead of
                 a dead-end, point the operator straight at the assign step — the
-                actual path to checkout — mirroring web's fulfil-and-checkout. */}
-            {booking.status === "RESERVED" && hasOutstandingModelRequests && (
-              <TouchableOpacity
-                style={styles.actionButton}
-                onPress={() =>
-                  router.push(
-                    `/(tabs)/bookings/add-assets?bookingId=${
-                      booking.id
-                    }&bookingName=${encodeURIComponent(
-                      booking.name
-                    )}&from=${encodeURIComponent(
-                      booking.from
-                    )}&to=${encodeURIComponent(booking.to)}`
-                  )
-                }
-                accessibilityLabel={`Assign ${booking.outstandingModelUnitCount} reserved units to check out`}
-                accessibilityRole="button"
-              >
-                <Ionicons
-                  name="cube-outline"
-                  size={18}
-                  color={colors.primaryForeground}
-                />
-                <Text style={styles.actionButtonText}>
-                  Assign {booking.outstandingModelUnitCount} unit
-                  {booking.outstandingModelUnitCount === 1 ? "" : "s"} to check
-                  out
-                </Text>
-              </TouchableOpacity>
-            )}
+                actual path to checkout — mirroring web's fulfil-and-checkout.
+                Gated `!isSelfService` to match the add/browse affordances above:
+                a self-service custodian can only edit a DRAFT booking, and the
+                mobile add-scanned-assets action rejects their non-DRAFT edits,
+                so on a RESERVED booking the assign flow can't succeed for them —
+                showing the CTA would just lead to a rejected submit. */}
+            {!isSelfService &&
+              booking.status === "RESERVED" &&
+              hasOutstandingModelRequests && (
+                <TouchableOpacity
+                  style={styles.actionButton}
+                  onPress={() =>
+                    router.push(
+                      `/(tabs)/bookings/add-assets?bookingId=${
+                        booking.id
+                      }&bookingName=${encodeURIComponent(
+                        booking.name
+                      )}&from=${encodeURIComponent(
+                        booking.from
+                      )}&to=${encodeURIComponent(booking.to)}`
+                    )
+                  }
+                  accessibilityLabel={`Assign ${booking.outstandingModelUnitCount} reserved units to check out`}
+                  accessibilityRole="button"
+                >
+                  <Ionicons
+                    name="cube-outline"
+                    size={18}
+                    color={colors.primaryForeground}
+                  />
+                  <Text style={styles.actionButtonText}>
+                    Assign {booking.outstandingModelUnitCount} unit
+                    {booking.outstandingModelUnitCount === 1 ? "" : "s"} to
+                    check out
+                  </Text>
+                </TouchableOpacity>
+              )}
 
             {canCheckin && (
               <View style={styles.checkinActions}>

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -932,16 +932,6 @@ export default function BookingDetailScreen() {
   // omits the card rather than crashing.
   const lp = booking.lifecycleProgress ?? null;
 
-  // Progressive check-out stays available while the booking is active AND still
-  // holds never-checked-out assets. The server (`partialCheckoutBooking`) accepts
-  // RESERVED/ONGOING/OVERDUE, but the loader's `canCheckout` is RESERVED-only (it
-  // gates the full "Check Out All" button), so we derive our own flag for the
-  // partial path — otherwise "Select to Check Out" disappears the moment the
-  // first batch flips the booking to ONGOING.
-  const canPartialCheckout =
-    reservedCount > 0 &&
-    ["RESERVED", "ONGOING", "OVERDUE"].includes(booking.status);
-
   // Book-by-model reservations still awaiting assignment. Fulfilled rows
   // (`fulfilledAt` set) are hidden here — the concrete assets they became
   // already appear in the assets list, so showing them too would double up.
@@ -952,6 +942,24 @@ export default function BookingDetailScreen() {
   const outstandingModelRequests = (booking.modelRequests ?? []).filter(
     (mr) => mr.fulfilledAt === null
   );
+  // A booking with unfulfilled model reservations can't be checked out at all
+  // (full OR partial): the shared checkout service hard-blocks RESERVED →
+  // ONGOING until every request is assigned to concrete assets. So gate BOTH
+  // checkout paths on this — the app surfaces an "Assign to check out" CTA
+  // instead of a checkout the server would reject. (`canCheckout` from the
+  // loader already accounts for this; `canPartialCheckout` is derived here.)
+  const hasOutstandingModelRequests = outstandingModelRequests.length > 0;
+
+  // Progressive check-out stays available while the booking is active AND still
+  // holds never-checked-out assets. The server (`partialCheckoutBooking`) accepts
+  // RESERVED/ONGOING/OVERDUE, but the loader's `canCheckout` is RESERVED-only (it
+  // gates the full "Check Out All" button), so we derive our own flag for the
+  // partial path — otherwise "Select to Check Out" disappears the moment the
+  // first batch flips the booking to ONGOING.
+  const canPartialCheckout =
+    reservedCount > 0 &&
+    !hasOutstandingModelRequests &&
+    ["RESERVED", "ONGOING", "OVERDUE"].includes(booking.status);
 
   // Same gate the manage buttons use: an editable booking, and self-service
   // users only on their own DRAFTs (server re-checks ownership + status).
@@ -1058,6 +1066,11 @@ export default function BookingDetailScreen() {
                     {booking.assetCount} total
                     {booking.checkedOutCount > 0 &&
                       `, ${booking.checkedOutCount} checked out`}
+                    {/* Book-by-model: surface reserved-but-not-yet-assigned
+                        units so "0 total" never reads as an empty booking when
+                        it actually holds a reservation. */}
+                    {booking.outstandingModelUnitCount > 0 &&
+                      `, ${booking.outstandingModelUnitCount} reserved`}
                   </Text>
                 </View>
 
@@ -1393,6 +1406,41 @@ export default function BookingDetailScreen() {
                   ]}
                 >
                   {selectMode === "checkout" ? "Cancel" : "Select to Check Out"}
+                </Text>
+              </TouchableOpacity>
+            )}
+
+            {/* Book-by-model: a RESERVED booking with unfulfilled reservations
+                has no checkout button (the server hard-blocks checkout until
+                every reserved unit is assigned to a concrete asset). Instead of
+                a dead-end, point the operator straight at the assign step — the
+                actual path to checkout — mirroring web's fulfil-and-checkout. */}
+            {booking.status === "RESERVED" && hasOutstandingModelRequests && (
+              <TouchableOpacity
+                style={styles.actionButton}
+                onPress={() =>
+                  router.push(
+                    `/(tabs)/bookings/add-assets?bookingId=${
+                      booking.id
+                    }&bookingName=${encodeURIComponent(
+                      booking.name
+                    )}&from=${encodeURIComponent(
+                      booking.from
+                    )}&to=${encodeURIComponent(booking.to)}`
+                  )
+                }
+                accessibilityLabel={`Assign ${booking.outstandingModelUnitCount} reserved units to check out`}
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name="cube-outline"
+                  size={18}
+                  color={colors.primaryForeground}
+                />
+                <Text style={styles.actionButtonText}>
+                  Assign {booking.outstandingModelUnitCount} unit
+                  {booking.outstandingModelUnitCount === 1 ? "" : "s"} to check
+                  out
                 </Text>
               </TouchableOpacity>
             )}

--- a/apps/companion/app/(tabs)/bookings/index.tsx
+++ b/apps/companion/app/(tabs)/bookings/index.tsx
@@ -370,19 +370,33 @@ function BookingsListContent() {
 
           {isActive && (
             <View style={styles.actionHint}>
+              {/* A RESERVED booking is only "ready to check out" when it has
+                  concrete assets AND no outstanding book-by-model reservations
+                  (the server hard-blocks checkout until every reserved unit is
+                  assigned). Otherwise the honest next step is to assign/add
+                  assets, so the hint points there instead of promising a
+                  checkout that isn't possible yet. */}
               <Ionicons
                 name={
-                  item.status === "RESERVED"
+                  item.status !== "RESERVED"
+                    ? "log-in-outline"
+                    : (item.outstandingModelCount ?? 0) > 0
+                    ? "cube-outline"
+                    : item.assetCount > 0
                     ? "log-out-outline"
-                    : "log-in-outline"
+                    : "add-outline"
                 }
                 size={14}
                 color={colors.iconDefault}
               />
               <Text style={styles.actionHintText}>
-                {item.status === "RESERVED"
+                {item.status !== "RESERVED"
+                  ? "Tap to check in"
+                  : (item.outstandingModelCount ?? 0) > 0
+                  ? "Assign assets to check out"
+                  : item.assetCount > 0
                   ? "Ready to check out"
-                  : "Tap to check in"}
+                  : "Add assets to check out"}
               </Text>
             </View>
           )}

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -452,6 +452,13 @@ export type BookingListItem = {
   custodianName: string | null;
   custodianImage: string | null;
   assetCount: number;
+  /**
+   * Outstanding book-by-model reservations still to assign (units reserved at
+   * the model level with no concrete asset behind them yet). > 0 means the
+   * booking can't be checked out until matching assets are assigned. Optional
+   * for back-compat with an older server response.
+   */
+  outstandingModelCount?: number;
 };
 
 export type BookingsResponse = {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -240,7 +240,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     ).length;
     const totalAssets = assets.length;
 
-    const canCheckout = booking.status === "RESERVED" && totalAssets > 0;
+    // Book-by-model: a booking with unfulfilled model reservations cannot be
+    // checked out. The shared checkout service hard-blocks the RESERVED →
+    // ONGOING transition until every `BookingModelRequest` is assigned to
+    // concrete assets (`checkoutBookingWritesWithinTx` throws a 400 while any
+    // `fulfilledAt: null` row remains). Fold that into `canCheckout` so the app
+    // never offers a "Check Out" the server would reject — the app instead
+    // guides the operator to assign the reserved units first (see the
+    // booking-detail "Assign to check out" CTA).
+    const hasOutstandingModelRequests = booking.modelRequests.some(
+      (mr) => mr.fulfilledAt === null
+    );
+
+    const canCheckout =
+      booking.status === "RESERVED" &&
+      totalAssets > 0 &&
+      !hasOutstandingModelRequests;
     // Checkinable while ONGOING/OVERDUE AND something is still to check in.
     // INDIVIDUAL: global status CHECKED_OUT. QUANTITY_TRACKED: booked units not
     // yet reconciled = remainingToCheckIn > 0 (booked − returned/consumed/lost/

--- a/apps/webapp/app/routes/api+/mobile+/bookings.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.ts
@@ -122,7 +122,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
             select: { name: true },
           },
           _count: {
-            select: { bookingAssets: true },
+            select: {
+              bookingAssets: true,
+              // Outstanding book-by-model reservations (units reserved but not
+              // yet assigned to concrete assets). Lets the list card tell a
+              // "reserved but nothing physical to check out yet" booking apart
+              // from a genuinely check-out-ready one, so it never mislabels a
+              // model-only reservation as "Ready to check out".
+              modelRequests: { where: { fulfilledAt: null } },
+            },
           },
         },
         orderBy: [{ [sortBy]: sortOrder }],
@@ -148,6 +156,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
           null,
         custodianImage: b.custodianUser?.profilePicture || null,
         assetCount: b._count.bookingAssets,
+        // Outstanding book-by-model reservations still to assign. > 0 means the
+        // booking holds reserved units with no concrete assets behind them yet.
+        outstandingModelCount: b._count.modelRequests,
       })),
       page,
       perPage,


### PR DESCRIPTION
## What

A companion booking that reserves units **by model** (book-by-model) could reach a dead-end: a `RESERVED` booking with unfulfilled model reservations showed **no checkout affordance at all** (checkout was gated on concrete `assetCount > 0`), so an operator couldn't see how to check it out. The bookings **list card** also still said "Ready to check out" for that same booking, and the header read a bare "0 total". This makes the flagship book-by-model flow look broken at the exact "I'm grabbing the items now" moment.

This mirrors web's fulfil-and-checkout intent: keep the checkout goal visible, but route the operator through assigning the reserved units first (the shared checkout service already hard-blocks `RESERVED → ONGOING` until every `BookingModelRequest` is fulfilled).

## Changes (companion + its mobile endpoints)

- **Booking detail** — when reservations are outstanding, show a primary **"Assign N units to check out"** CTA (opens the add-assets picker) instead of a blank, and suppress the raw Check Out buttons (a raw checkout would 400 against the server's model-request guard).
- **`canCheckout`** (mobile booking detail endpoint) now also requires no outstanding model reservations, matching that guard, so the app never offers a checkout the server rejects.
- **List card** — "Ready to check out" only when there are concrete assets and no outstanding reservations; otherwise "Assign assets to check out" (model reservation) or "Add assets to check out" (empty). Adds an outstanding-model count to the list endpoint.
- **Header** — surfaces reserved-but-unassigned units (`0 total, 5 reserved`) so a reservation-only booking doesn't read as empty.

## Testing

- **iOS simulator, end-to-end** on the exact scenario: a reservation-only booking now shows the honest header count (`0 total, 5 reserved`), the corrected list hint ("Assign assets to check out"), and the "Assign 5 units to check out" CTA, which opens the assign picker (a real path to checkout, not a relabeled dead-end).
- `typecheck` (webapp + companion), `lint`, `react-doctor`, `prettier`, and the 605 booking unit tests pass.

## Rollout

The server bits (`canCheckout`, the list count) are additive and back-compat. This is intended to ship in the companion **1.2.0** build alongside #2702 (book-by-model) and #2706 (QT check-in): merge + deploy, then rebuild the app from merged main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved booking cards to provide more accurate guidance for reserved bookings, including icon/message changes based on whether assets are available and whether model reservations are still outstanding.
  * Booking details now display a reserved suffix when unfulfilled model reservations exist, and may show an “Assign … unit(s) to check out” action for reserved bookings.

* **Bug Fixes**
  * Tightened checkout and partial-checkout eligibility to block checkout while reserved bookings still have unfulfilled model reservations.
  * Booking APIs now expose an outstanding reservations count for more consistent UI messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->