### PR TITLE
fix(assets): stop currval() Postgres error flood on New Asset page

### DIFF
--- a/apps/webapp/app/modules/asset/sequential-id.server.test.ts
+++ b/apps/webapp/app/modules/asset/sequential-id.server.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { db } from "~/database/db.server";
 
 import {
   formatSequentialId,
   isValidSequentialIdFormat,
   extractSequenceNumber,
+  estimateNextSequentialId,
 } from "./sequential-id.server";
 
 // why: testing pure sequential ID formatting functions without database connection errors
@@ -161,6 +164,104 @@ describe("Sequential ID Service - Pure Functions", () => {
   });
 });
 
-// Note: Database-dependent functions like getNextSequentialId, createOrganizationSequence,
-// generateBulkSequentialIdsEfficient, etc. require integration tests with a real database
-// and are covered by the E2E tests and integration test suite.
+/**
+ * Reconstructs the static SQL text from a Prisma tagged-template call
+ * (`db.$queryRaw`...``) so a test can assert *which* query ran without depending on
+ * the interpolated bind values (which arrive as separate arguments).
+ */
+function sqlFromCall(strings: unknown): string {
+  return Array.isArray(strings) ? strings.join(" ") : String(strings);
+}
+
+describe("estimateNextSequentialId (pooler-safe sequence peek)", () => {
+  beforeEach(() => {
+    vi.mocked(db.$executeRaw).mockReset();
+    vi.mocked(db.$queryRaw).mockReset();
+    // createOrganizationSequence() runs SELECT create_asset_sequence_for_org(...)
+    // via $executeRaw; it just needs to resolve for these tests.
+    vi.mocked(db.$executeRaw).mockResolvedValue(1 as never);
+  });
+
+  it("never issues a session-local currval() query (must work behind the Supavisor pooler)", async () => {
+    // why: currval() is session-local and throws SQLSTATE 55000 behind Supabase's
+    // transaction pooler because nextval() was never run on the pooled backend. The
+    // estimate must instead read the session-independent pg_sequences catalog. This is
+    // the regression guard for the flood of "currval ... is not yet defined" log errors.
+    vi.mocked(db.$queryRaw).mockImplementation((strings: unknown) => {
+      const sql = sqlFromCall(strings);
+      if (sql.includes("pg_sequences")) {
+        return Promise.resolve([{ last_value: 41n }]) as never;
+      }
+      return Promise.resolve([{ max_num: 0 }]) as never;
+    });
+
+    const result = await estimateNextSequentialId("org_123");
+
+    expect(result).toBe("SAM-0042");
+    const issuedCurrval = vi
+      .mocked(db.$queryRaw)
+      .mock.calls.some(([strings]) => sqlFromCall(strings).includes("currval"));
+    expect(issuedCurrval).toBe(false);
+  });
+
+  it("returns last_value + 1 from the sequence catalog when the sequence has been advanced", async () => {
+    vi.mocked(db.$queryRaw).mockImplementation((strings: unknown) => {
+      const sql = sqlFromCall(strings);
+      if (sql.includes("pg_sequences")) {
+        return Promise.resolve([{ last_value: 100n }]) as never;
+      }
+      return Promise.resolve([{ max_num: 0 }]) as never;
+    });
+
+    expect(await estimateNextSequentialId("org_123")).toBe("SAM-0101");
+  });
+
+  it("falls back to the max existing sequentialId when the sequence has never been advanced", async () => {
+    vi.mocked(db.$queryRaw).mockImplementation((strings: unknown) => {
+      const sql = sqlFromCall(strings);
+      if (sql.includes("pg_sequences")) {
+        // Row exists but the sequence was never advanced -> last_value is NULL.
+        return Promise.resolve([{ last_value: null }]) as never;
+      }
+      if (sql.includes("MAX")) {
+        return Promise.resolve([{ max_num: 7 }]) as never;
+      }
+      return Promise.resolve([]) as never;
+    });
+
+    expect(await estimateNextSequentialId("org_123")).toBe("SAM-0008");
+  });
+
+  it("falls back to the max scan when the catalog read itself fails", async () => {
+    // why: silence the expected fallback console.error so the test output stays pristine.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(db.$queryRaw).mockImplementation((strings: unknown) => {
+      const sql = sqlFromCall(strings);
+      if (sql.includes("pg_sequences")) {
+        return Promise.reject(new Error("boom")) as never;
+      }
+      return Promise.resolve([{ max_num: 3 }]) as never;
+    });
+
+    expect(await estimateNextSequentialId("org_123")).toBe("SAM-0004");
+    errorSpy.mockRestore();
+  });
+
+  it("honours a custom prefix", async () => {
+    vi.mocked(db.$queryRaw).mockImplementation((strings: unknown) => {
+      const sql = sqlFromCall(strings);
+      if (sql.includes("pg_sequences")) {
+        return Promise.resolve([{ last_value: 5n }]) as never;
+      }
+      return Promise.resolve([{ max_num: 0 }]) as never;
+    });
+
+    expect(await estimateNextSequentialId("org_123", "EQUIP")).toBe(
+      "EQUIP-0006"
+    );
+  });
+});
+
+// Note: The remaining database-dependent functions (getNextSequentialId,
+// createOrganizationSequence, generateBulkSequentialIdsEfficient, etc.) mutate sequence
+// state and are covered by the E2E tests and integration test suite.

--- a/apps/webapp/app/modules/asset/sequential-id.server.ts
+++ b/apps/webapp/app/modules/asset/sequential-id.server.ts
@@ -70,36 +70,63 @@ export async function estimateNextSequentialId(
   prefix: string = DEFAULT_PREFIX
 ): Promise<string> {
   try {
-    // Ensure sequence exists without consuming a value
+    // Ensure the sequence exists (this does not consume a value).
     await createOrganizationSequence(organizationId);
 
-    // Get current sequence value without incrementing
-    const result = await db.$queryRaw<[{ currval: bigint }]>`
-      SELECT currval('org_' || ${organizationId} || '_asset_sequence') as currval
+    // Read the sequence's persisted counter from the pg_sequences catalog rather than
+    // calling currval(). currval() is SESSION-LOCAL: it only returns a value when
+    // nextval() was already called in the *same* backend session. Behind Supabase's
+    // Supavisor connection pooler (transaction mode) each statement can run on a
+    // different backend, so this page's session had almost never run nextval() for the
+    // org's sequence — currval() then threw "currval of sequence ... is not yet defined
+    // in this session" (SQLSTATE 55000) on every New Asset page load, flooding the
+    // Postgres error logs. pg_sequences.last_value is session-independent and works in
+    // every pooling mode. It is NULL when the sequence has never been advanced (i.e. the
+    // org has not created any assets yet), in which case we fall through to the
+    // max-based estimate below.
+    const seqResult = await db.$queryRaw<{ last_value: bigint | null }[]>`
+      SELECT last_value
+      FROM pg_sequences
+      WHERE schemaname = 'public'
+        AND sequencename = 'org_' || ${organizationId} || '_asset_sequence'
     `;
 
-    const nextValue = Number(result[0].currval) + 1;
-    return formatSequentialId(nextValue, prefix);
-  } catch (_error) {
-    // If currval fails, sequence might not have been used yet
-    // Find the highest existing sequential ID using proper numeric extraction
-    // This avoids string sorting issues when IDs go beyond 9999
-    const maxExisting = await db.$queryRaw<[{ max_num: number | null }]>`
-      SELECT COALESCE(MAX(
-        CASE 
-          WHEN "sequentialId" ~ ('^' || ${prefix} || '-[0-9]+$')
-          THEN CAST(SUBSTRING("sequentialId" FROM (${prefix} || '-([0-9]+)')) AS INTEGER)
-          ELSE 0 
-        END
-      ), 0) as max_num
-      FROM "Asset"
-      WHERE "organizationId" = ${organizationId} 
-      AND "sequentialId" IS NOT NULL
-    `;
-
-    const highestNumber = maxExisting[0]?.max_num || 0;
-    return formatSequentialId(highestNumber + 1, prefix);
+    const lastValue = seqResult[0]?.last_value;
+    if (lastValue != null) {
+      // The sequence has been advanced; the next value nextval() will hand out is
+      // last_value + 1 (the sequences are created with the default CACHE 1, so
+      // last_value reflects the real last value dispensed).
+      return formatSequentialId(Number(lastValue) + 1, prefix);
+    }
+    // Sequence exists but has never been advanced -> fall through to the max-based
+    // estimate (handles the "org has no assets yet" case).
+  } catch (error) {
+    // Non-fatal: any failure reading the sequence just falls back to the max-based
+    // estimate below. Logged (not swallowed) so a genuinely broken catalog read is
+    // still visible, while no longer emitting a Postgres ERROR on every page load.
+    console.error(
+      `Failed to read asset sequence for organization ${organizationId}, falling back to max scan:`,
+      error
+    );
   }
+
+  // Fallback: derive the estimate from the highest existing sequential ID using proper
+  // numeric extraction. This avoids string-sorting issues once IDs grow beyond 9999.
+  const maxExisting = await db.$queryRaw<[{ max_num: number | null }]>`
+    SELECT COALESCE(MAX(
+      CASE
+        WHEN "sequentialId" ~ ('^' || ${prefix} || '-[0-9]+$')
+        THEN CAST(SUBSTRING("sequentialId" FROM (${prefix} || '-([0-9]+)')) AS INTEGER)
+        ELSE 0
+      END
+    ), 0) as max_num
+    FROM "Asset"
+    WHERE "organizationId" = ${organizationId}
+    AND "sequentialId" IS NOT NULL
+  `;
+
+  const highestNumber = maxExisting[0]?.max_num || 0;
+  return formatSequentialId(highestNumber + 1, prefix);
 }
 
 /**


### PR DESCRIPTION
estimateNextSequentialId peeked at the per-org asset sequence with currval(), which is session-local. Behind Supabase's Supavisor transaction pooler each statement can run on a different backend, so the New Asset loader's session had almost never called nextval() for the org's sequence — currval() then threw SQLSTATE 55000 ("currval of sequence ... is not yet defined in this session") on every page load. The error was caught and the code fell back to a MAX() scan, so users were unaffected, but it flooded the Postgres logs.

Read the sequence's persisted counter from the pg_sequences catalog instead. last_value is session-independent and works in every pooling mode; it is NULL for a never-advanced sequence, in which case we still fall back to the MAX-based estimate. Verified against production: last_value matches MAX(sequentialId) exactly.

Add unit tests for the pg_sequences path, the fresh-org and failure fallbacks, and a regression guard asserting currval() is never issued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sequential ID estimation for pooled and transaction-based database connections.
  * Prevented failures when a sequence has not yet advanced or sequence metadata is unavailable.
  * Added support for custom sequential ID prefixes.
  * Ensured the next ID is estimated without advancing the underlying sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->