### PR TITLE
fix(bookings): guard mobile fulfil-and-checkout against cross-user checkout

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/bookings.fulfil-and-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.fulfil-and-checkout.ts
@@ -6,8 +6,10 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
   assertMobileCanUseBookings,
+  getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
 import { fulfilModelRequestsAndCheckout } from "~/modules/booking/service.server";
+import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -76,9 +78,15 @@ export async function action({ request }: ActionFunctionArgs) {
     // Load the booking's reservation window so the service can run its
     // asset-conflict guard (gated on `from && to`, exactly as the plain
     // checkout endpoint does). Org-scoped, so a foreign-org id 404s.
+    // `creatorId`/`custodianUserId` feed the ownership guard below.
     const existingBooking = await db.booking.findFirst({
       where: { id: bookingId, organizationId },
-      select: { from: true, to: true },
+      select: {
+        from: true,
+        to: true,
+        creatorId: true,
+        custodianUserId: true,
+      },
     });
 
     if (!existingBooking) {
@@ -87,6 +95,22 @@ export async function action({ request }: ActionFunctionArgs) {
         { status: 404 }
       );
     }
+
+    // Cross-user IDOR guard: SELF_SERVICE/BASE hold `booking:checkout` in the
+    // permission map, so the role gate above passes for ANY booking id they
+    // send — they may only fulfil + check out bookings they created or are
+    // custodian of. No-op for ADMIN/OWNER. Web enforces the equivalent via
+    // `canUserManageBookingAssets` in the fulfil-and-checkout loader, and
+    // `fulfilModelRequestsAndCheckout` does NOT check ownership itself (unlike
+    // the scan-add path, whose guard lives in `processBooking`), so without
+    // this the mobile route would be more permissive than web.
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    validateBookingOwnership({
+      booking: existingBooking,
+      userId: user.id,
+      role,
+      action: "check out",
+    });
 
     // Same hint derivation as the plain checkout endpoint: native clients can't
     // set the CH-time-zone cookie, so prefer the device timeZone from the body.


### PR DESCRIPTION
## What

`POST /api/mobile/bookings/fulfil-and-checkout` (added in #2710) had no booking-ownership check.

`SELF_SERVICE` and `BASE` both hold `booking:checkout` in the permission map, so `requireMobilePermission` passes for **any** booking id a restricted user sends. And unlike the scan-add path — whose cross-user guard lives inside `processBooking` — `fulfilModelRequestsAndCheckout` does not check ownership itself. Web's `fulfil-and-checkout` loader blocks this with `canUserManageBookingAssets`, so the mobile route was strictly **more permissive than web**: a restricted user could fulfil the model reservations of, and check out, another user's booking.

Fix: apply the shared `validateBookingOwnership` guard (creator-or-custodian for SELF_SERVICE/BASE, no-op for ADMIN/OWNER) immediately after the org-scoped booking lookup — the same pattern the sibling mobile `cancel` / `archive` / `delete` / `duplicate` routes already use.

## Exposure

Introduced by #2710 (merged 2026-07-13). **Not in any store build** — the newest companion build (29) predates that merge — but the endpoint is live wherever `main` is deployed, so it's reachable by any authenticated mobile client.

## Testing

`booking-authorization.server.test.ts` (8 tests) plus the booking module + mobile API route suites: **481 tests passing**. Typecheck and prettier clean. No route-level test added: the four sibling guarded mobile routes have none either, the helper is unit-tested centrally.

## Related, not fixed here

Several other mobile booking routes lack the route-level guard (`checkout`, `checkin`, `partial-checkout`, `partial-checkin`, `reserve`, `update`, `remove-assets`, `model-requests`). Some are covered at the service layer (`add-scanned-assets` is, via `processBooking`), so each needs individual verification rather than a blanket patch. Worth a follow-up sweep — happy to do it if you want.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an explicit ownership and permission check for mobile booking checkout.
  * Ensures callers can only “check out” bookings they are authorized to access, preventing unauthorized cross-account actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->