### PR TITLE
fix: stop reminders revalidation storm + booking-settings pool exhaustion

### DIFF
--- a/apps/webapp/app/components/asset-reminder/actions-dropdown.tsx
+++ b/apps/webapp/app/components/asset-reminder/actions-dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import type { Prisma } from "@prisma/client";
 import { PencilIcon } from "lucide-react";
 import { VerticalDotsIcon } from "~/components/icons/library";
@@ -26,6 +26,16 @@ export default function ActionsDropdown({ reminder }: ActionsDropdownProps) {
 
   const now = new Date();
   const isPending = now < new Date(reminder.alertDateTime);
+
+  /**
+   * Stable identity so `SetOrEditReminderDialog`'s success-handling effect
+   * (dependency: `onClose`) doesn't re-fire on every unrelated re-render —
+   * same sibling-occurrence fix as `reminders-table.tsx`'s create dialog.
+   * See `.claude/rules/react-render-stability.md`.
+   */
+  const handleCloseEditDialog = useCallback(() => {
+    setIsEditDialogOpen(false);
+  }, []);
 
   return (
     <DropdownMenu
@@ -72,9 +82,7 @@ export default function ActionsDropdown({ reminder }: ActionsDropdownProps) {
           teamMembers: reminder.teamMembers.map((tm) => tm.id),
         }}
         open={isEditDialogOpen}
-        onClose={() => {
-          setIsEditDialogOpen(false);
-        }}
+        onClose={handleCloseEditDialog}
       />
     </DropdownMenu>
   );

--- a/apps/webapp/app/components/asset-reminder/reminders-table.tsx
+++ b/apps/webapp/app/components/asset-reminder/reminders-table.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import type { Prisma } from "@prisma/client";
 import { useParams } from "react-router";
 import colors from "tailwindcss/colors";
@@ -32,6 +32,18 @@ export default function RemindersTable({
 }: RemindersTableProps) {
   const [isReminderDialogOpen, setIsReminderDialogOpen] = useState(false);
   const { assetId } = useParams<{ assetId: string }>();
+
+  /**
+   * Stable identity across renders so `SetOrEditReminderDialog`'s
+   * success-handling effect (which lists `onClose` as a dependency) doesn't
+   * re-fire on every unrelated re-render. See
+   * `.claude/rules/react-render-stability.md` and the `successHandledRef`
+   * latch in `set-or-edit-reminder-dialog.tsx` for the full mechanism this
+   * guards against.
+   */
+  const handleCloseReminderDialog = useCallback(() => {
+    setIsReminderDialogOpen(false);
+  }, []);
 
   const emptyStateTitle = isAssetReminderPage
     ? "No reminders for this asset"
@@ -92,9 +104,7 @@ export default function RemindersTable({
       <SetOrEditReminderDialog
         action={isAssetReminderPage ? `/assets/${assetId}` : undefined}
         open={isReminderDialogOpen}
-        onClose={() => {
-          setIsReminderDialogOpen(false);
-        }}
+        onClose={handleCloseReminderDialog}
       />
     </ListContentWrapper>
   );

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.test.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.test.tsx
@@ -5,6 +5,12 @@
  * dialog + strip the param) exactly once — not on every re-render while the
  * strip navigation is still committing.
  *
+ * Also covers the follow-up "21x mini-storm" fix: the reminders table mounts
+ * one create dialog plus one closed edit dialog per row, and every mounted
+ * instance observes the same `?success=true` param. Only the dialog that is
+ * actually `open` may act on it — a closed instance must not call `onClose`
+ * or `setSearchParams`.
+ *
  * @see {@link file://./set-or-edit-reminder-dialog.tsx}
  */
 import type { ComponentProps, ReactNode } from "react";
@@ -93,10 +99,16 @@ vi.mock("react-router", async () => {
   };
 });
 
-function renderDialog(onClose: () => void) {
+/**
+ * Renders the dialog inside a `MemoryRouter`. Defaults to `open={true}` since
+ * most tests below exercise the "originating" dialog whose submit produced
+ * the success param; pass `open: false` to simulate a sibling row's closed
+ * edit dialog observing the same param.
+ */
+function renderDialog(onClose: () => void, { open = true } = {}) {
   return render(
     <MemoryRouter>
-      <SetOrEditReminderDialog open onClose={onClose} />
+      <SetOrEditReminderDialog open={open} onClose={onClose} />
     </MemoryRouter>
   );
 }
@@ -145,6 +157,20 @@ describe("SetOrEditReminderDialog success-handling effect", () => {
     currentSearchParams = new URLSearchParams();
 
     renderDialog(makeOnClose());
+
+    expect(onCloseCallCount).toBe(0);
+    expect(setSearchParamsCallCount).toBe(0);
+  });
+
+  it("does not call onClose or setSearchParams when the dialog is not open, even if success=true", () => {
+    // Simulates a sibling row's closed edit dialog: every mounted instance
+    // of SetOrEditReminderDialog observes the same `?success=true` param
+    // after ANY row's create/edit submits, but only the dialog that is
+    // actually `open` should react — otherwise an N-row page produces N
+    // competing navigations/revalidations (the "21x mini-storm" bug).
+    currentSearchParams = new URLSearchParams("success=true");
+
+    renderDialog(makeOnClose(), { open: false });
 
     expect(onCloseCallCount).toBe(0);
     expect(setSearchParamsCallCount).toBe(0);

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.test.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Regression test for the `reminders.data` infinite-revalidation-loop
+ * incident: creating a reminder redirects to `?...&success=true`, and the
+ * dialog's `handleOnSuccess` effect must handle that signal (close the
+ * dialog + strip the param) exactly once — not on every re-render while the
+ * strip navigation is still committing.
+ *
+ * @see {@link file://./set-or-edit-reminder-dialog.tsx}
+ */
+import type { ComponentProps, ReactNode } from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import SetOrEditReminderDialog from "./set-or-edit-reminder-dialog";
+
+// why: TeamMembersSelector pulls in `useApiQuery` (a real network call) and is
+// unrelated to the success-effect under test; stub it so the dialog can
+// render without hitting the network.
+vi.mock("./team-members-selector", () => ({
+  default: () => <div data-testid="team-members-selector" />,
+}));
+
+// why: Dialog/DialogPortal pull in imperative <dialog> + Radix-adjacent focus
+// trapping that is irrelevant to the success-effect under test; render
+// children directly (mirrors asset-image/component.test.tsx's stub).
+vi.mock("../layout/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogPortal: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+/** Total times any `onClose` instance handed to the dialog was invoked. */
+let onCloseCallCount = 0;
+/** Returns a fresh `onClose` reference each call — mirrors the pre-fix
+ * `RemindersTable`/`ActionsDropdown` inline arrow (a new identity every
+ * render) so the test proves the effect is loop-proof even when a caller
+ * does NOT stabilize `onClose`. */
+function makeOnClose() {
+  return () => {
+    onCloseCallCount += 1;
+  };
+}
+
+/** Total times `setSearchParams` was invoked, across every distinct function
+ * identity handed out below (the mock intentionally returns a new closure
+ * per render, like the pre-memoization `customSetSearchParams`). */
+let setSearchParamsCallCount = 0;
+/** Backing store for the mocked `searchParams`; reassigned between renders in
+ * the tests below to control what `searchParams.get("success")` returns and
+ * to force the effect's dependency array to change identity across
+ * re-renders (a real `URLSearchParams` never has stable identity across
+ * `customSetSearchParams` calls either). */
+let currentSearchParams = new URLSearchParams();
+
+// why: control search params without a real router; mirrors the pattern in
+// list/filters/sort-by.test.tsx for components that read `~/hooks/search-params`.
+// A new setter closure is returned on every call to reproduce the incident's
+// unstable `customSetSearchParams` identity, proving the ref-latch guard
+// (not identity stability) is what makes the effect loop-proof.
+vi.mock("~/hooks/search-params", () => ({
+  useSearchParams: () =>
+    [
+      currentSearchParams,
+      (...args: unknown[]) => {
+        setSearchParamsCallCount += 1;
+        const [nextInit] = args;
+        // Apply the updater so the "success" key is actually removed,
+        // matching real `setSearchParams` semantics used by the effect.
+        if (typeof nextInit === "function") {
+          currentSearchParams = (
+            nextInit as (prev: URLSearchParams) => URLSearchParams
+          )(currentSearchParams);
+        }
+      },
+    ] as const,
+}));
+
+// why: useNavigation/useActionData require a data router (RouterProvider),
+// which is unnecessary ceremony for this effect-focused test; stub them.
+// useLocation and the plain <Form> are overridden too so no data-router
+// context is needed at all — only `MemoryRouter` (for the real `Link` inside
+// the "See a sample" Button) is required.
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-router");
+  return {
+    ...actual,
+    useNavigation: () => ({ state: "idle" as const }),
+    useActionData: () => undefined,
+    useLocation: () => ({ pathname: "/assets/asset-1" }),
+    Form: (props: ComponentProps<"form">) => <form {...props} />,
+  };
+});
+
+function renderDialog(onClose: () => void) {
+  return render(
+    <MemoryRouter>
+      <SetOrEditReminderDialog open onClose={onClose} />
+    </MemoryRouter>
+  );
+}
+
+describe("SetOrEditReminderDialog success-handling effect", () => {
+  beforeEach(() => {
+    onCloseCallCount = 0;
+    setSearchParamsCallCount = 0;
+    currentSearchParams = new URLSearchParams();
+  });
+
+  it("calls onClose and setSearchParams exactly once when success=true, even across re-renders with unstable identities", () => {
+    currentSearchParams = new URLSearchParams("success=true");
+
+    const { rerender } = renderDialog(makeOnClose());
+
+    expect(onCloseCallCount).toBe(1);
+    expect(setSearchParamsCallCount).toBe(1);
+    // The mocked setter applied the updater, so success should be stripped —
+    // but simulate the incident condition where the strip navigation hasn't
+    // committed yet: the effect may still see a re-render with the OLD
+    // (uncommitted) `success=true` params, exactly like the production bug.
+    currentSearchParams = new URLSearchParams("success=true");
+
+    // Re-render a couple more times with brand-new `onClose`/`searchParams`
+    // identities (as the pre-fix inline arrow + unmemoized setter would
+    // produce on every parent re-render).
+    rerender(
+      <MemoryRouter>
+        <SetOrEditReminderDialog open onClose={makeOnClose()} />
+      </MemoryRouter>
+    );
+    currentSearchParams = new URLSearchParams("success=true");
+    rerender(
+      <MemoryRouter>
+        <SetOrEditReminderDialog open onClose={makeOnClose()} />
+      </MemoryRouter>
+    );
+
+    // The one-shot latch must have prevented any further action.
+    expect(onCloseCallCount).toBe(1);
+    expect(setSearchParamsCallCount).toBe(1);
+  });
+
+  it("does not call onClose or setSearchParams when success is absent", () => {
+    currentSearchParams = new URLSearchParams();
+
+    renderDialog(makeOnClose());
+
+    expect(onCloseCallCount).toBe(0);
+    expect(setSearchParamsCallCount).toBe(0);
+  });
+
+  it("re-arms after success clears, so creating a second reminder auto-closes again", () => {
+    currentSearchParams = new URLSearchParams("success=true");
+    const { rerender } = renderDialog(makeOnClose());
+
+    expect(onCloseCallCount).toBe(1);
+    expect(setSearchParamsCallCount).toBe(1);
+
+    // The strip navigation commits: `success` is now gone from the URL.
+    currentSearchParams = new URLSearchParams();
+    rerender(
+      <MemoryRouter>
+        <SetOrEditReminderDialog open onClose={makeOnClose()} />
+      </MemoryRouter>
+    );
+
+    expect(onCloseCallCount).toBe(1);
+    expect(setSearchParamsCallCount).toBe(1);
+
+    // A second reminder is created: the form redirects to `?success=true`
+    // again. The latch must have re-armed so this is handled too.
+    currentSearchParams = new URLSearchParams("success=true");
+    rerender(
+      <MemoryRouter>
+        <SetOrEditReminderDialog open onClose={makeOnClose()} />
+      </MemoryRouter>
+    );
+
+    expect(onCloseCallCount).toBe(2);
+    expect(setSearchParamsCallCount).toBe(2);
+  });
+});

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Form, useNavigation, useLocation, useActionData } from "react-router";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
@@ -64,16 +64,60 @@ export default function SetOrEditReminderDialog({
   /** Ref for the first field so we can focus it on open without autoFocus. */
   const nameInputRef = useAutoFocus<HTMLInputElement>({ when: open });
 
+  /**
+   * One-shot latch guarding {@link handleOnSuccess} against re-firing while
+   * the `success=true` param is still present but not yet stripped from the
+   * committed URL.
+   *
+   * Root cause of the production incident this guards against: the reminder
+   * form action redirects to `?...&success=true`. Handling that (closing the
+   * dialog + stripping the param) is *itself* a second navigation, and until
+   * that navigation commits, `searchParams` keeps reading `success=true` on
+   * every intermediate re-render. Both `onClose` (an inline arrow in some
+   * callers) and `setSearchParams` can also get a fresh identity every
+   * render. Without a latch, any one of those re-renders re-runs this effect,
+   * which calls `setSearchParams` again — aborting the in-flight strip
+   * navigation before it commits — so `success` never clears and the effect
+   * fires again on the next render: an infinite `reminders.data`
+   * revalidation loop. This latch makes the effect body idempotent
+   * regardless of dependency-identity churn (defense in depth on top of
+   * stabilizing `onClose`/`setSearchParams` at the call sites).
+   */
+  const successHandledRef = useRef(false);
+
   useEffect(
     function handleOnSuccess() {
-      if (searchParams.get("success") === "true") {
-        onClose && onClose();
+      const success = searchParams.get("success");
 
-        setSearchParams((prev) => {
+      if (success !== "true") {
+        // Re-arm the latch once the param is gone (or was never set) so a
+        // *subsequent* success (e.g. creating another reminder) still closes
+        // the dialog and strips the param.
+        successHandledRef.current = false;
+        return;
+      }
+
+      if (successHandledRef.current) {
+        // Already handled this success signal — the strip navigation may
+        // still be in flight; do not act again until `success` clears.
+        return;
+      }
+      successHandledRef.current = true;
+
+      onClose && onClose();
+
+      // TODO(follow-up): migrate this form to `useFetcher` so success is
+      // signalled via fetcher state instead of a `?success=true` redirect +
+      // param-strip navigation. That would remove this whole class of loop,
+      // but changing the form's action/redirect contract is out of scope for
+      // this hotfix — it's shared with the global reminders page.
+      setSearchParams(
+        (prev) => {
           prev.delete("success");
           return prev;
-        });
-      }
+        },
+        { replace: true, preventScrollReset: true }
+      );
     },
     [onClose, searchParams, setSearchParams]
   );

--- a/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
+++ b/apps/webapp/app/components/asset-reminder/set-or-edit-reminder-dialog.tsx
@@ -87,15 +87,25 @@ export default function SetOrEditReminderDialog({
 
   useEffect(
     function handleOnSuccess() {
-      const success = searchParams.get("success");
+      const isSuccess = searchParams.get("success") === "true";
 
-      if (success !== "true") {
+      if (!isSuccess) {
         // Re-arm the latch once the param is gone (or was never set) so a
         // *subsequent* success (e.g. creating another reminder) still closes
         // the dialog and strips the param.
         successHandledRef.current = false;
         return;
       }
+
+      // Gate on `open`: the reminders table mounts ONE create dialog plus,
+      // inside every row's `ActionsDropdown`, one (closed) edit dialog. All
+      // of those instances observe the same `?success=true` param, so
+      // without this gate every mounted instance — each with its own
+      // independently-false latch — would call `setSearchParams` once,
+      // producing N competing navigations/`.data` revalidations on an
+      // N-row page. Only the dialog that is actually `open` (the one whose
+      // submit produced this success) should react.
+      if (!open) return;
 
       if (successHandledRef.current) {
         // Already handled this success signal — the strip navigation may
@@ -119,7 +129,7 @@ export default function SetOrEditReminderDialog({
         { replace: true, preventScrollReset: true }
       );
     },
-    [onClose, searchParams, setSearchParams]
+    [open, onClose, searchParams, setSearchParams]
   );
 
   return (

--- a/apps/webapp/app/hooks/search-params/index.test.tsx
+++ b/apps/webapp/app/hooks/search-params/index.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for {@link useSearchParams} in `./index.ts`.
+ *
+ * Focused on the render-stability fix: the cookie-aware `customSetSearchParams`
+ * setter must keep a stable reference across re-renders when its inputs are
+ * unchanged, so consumers that place the returned setter in a `useEffect` /
+ * `useCallback` dependency array (e.g. the asset-reminder dialog) don't re-fire
+ * on every render. See `.claude/rules/react-render-stability.md`.
+ *
+ * @see {@link file://./index.ts}
+ */
+
+import { renderHook } from "@testing-library/react";
+import Cookies from "js-cookie";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: renderHook re-invokes the hook body on every render, so instead of a
+// static object we return live values from these hoisted refs, letting each
+// test control what react-router "sees" without re-mocking the module.
+const routerMocks = vi.hoisted(() => ({
+  searchParams: new URLSearchParams("status=AVAILABLE"),
+  setSearchParams: vi.fn(),
+  pathname: "/assets",
+  loaderData: { filters: "", settings: { mode: "SIMPLE" } } as Record<
+    string,
+    unknown
+  >,
+  routeLoaderData: {
+    currentOrganization: { id: "org-1" },
+  } as Record<string, unknown> | undefined,
+}));
+
+// why: useSearchParams (module under test) composes several react-router hooks
+// (directly, and transitively via useCurrentOrganization / useAssetIndexViewState
+// in sibling files) — mocking react-router at this boundary controls every one
+// of them without needing to mock the module under test itself (which would
+// also replace the real `useSearchParams` export we're testing).
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-router");
+  return {
+    ...actual,
+    useSearchParams: () =>
+      [routerMocks.searchParams, routerMocks.setSearchParams] as const,
+    useLocation: () => ({
+      pathname: routerMocks.pathname,
+      search: "",
+      hash: "",
+      state: null,
+      key: "test",
+    }),
+    useLoaderData: () => routerMocks.loaderData,
+    useRouteLoaderData: () => routerMocks.routeLoaderData,
+  };
+});
+
+import { useSearchParams } from "./index";
+
+describe("useSearchParams", () => {
+  beforeEach(() => {
+    // why: each test mutates the shared hoisted mock state (pathname / loader
+    // data) — reset to known defaults so tests don't leak into one another.
+    routerMocks.searchParams = new URLSearchParams("status=AVAILABLE");
+    routerMocks.setSearchParams = vi.fn();
+    routerMocks.pathname = "/assets";
+    routerMocks.loaderData = { filters: "", settings: { mode: "SIMPLE" } };
+    routerMocks.routeLoaderData = { currentOrganization: { id: "org-1" } };
+  });
+
+  it("keeps a stable customSetSearchParams identity across re-renders on a cookie-filtered page", () => {
+    // Cookie-filtered page ("/assets") with a resolved organization takes the
+    // memoized customSetSearchParams branch.
+    const { result, rerender } = renderHook(() => useSearchParams());
+    const firstSetter = result.current[1];
+
+    rerender();
+    rerender();
+
+    expect(result.current[1]).toBe(firstSetter);
+  });
+
+  it("returns the raw react-router setter unchanged on a page without cookie filters", () => {
+    // "/settings" is not in ALLOWED_FILTER_PATHNAMES, so the hook must take the
+    // early-return-equivalent branch and hand back the raw setSearchParams as-is.
+    routerMocks.pathname = "/settings";
+    routerMocks.routeLoaderData = { currentOrganization: { id: "org-1" } };
+
+    const { result, rerender } = renderHook(() => useSearchParams());
+
+    expect(result.current[1]).toBe(routerMocks.setSearchParams);
+
+    rerender();
+
+    expect(result.current[1]).toBe(routerMocks.setSearchParams);
+  });
+
+  it("returns the raw react-router setter unchanged when there is no current organization", () => {
+    // No organization resolved (e.g. still loading) also takes the raw-setter
+    // branch, even on an otherwise cookie-filtered pathname.
+    routerMocks.pathname = "/assets";
+    routerMocks.routeLoaderData = undefined;
+
+    const { result, rerender } = renderHook(() => useSearchParams());
+
+    expect(result.current[1]).toBe(routerMocks.setSearchParams);
+
+    rerender();
+
+    expect(result.current[1]).toBe(routerMocks.setSearchParams);
+  });
+
+  it("still forwards to the raw setter and destroys the matching cookie key when a param is removed", () => {
+    // why: `useCookieDestroy`'s returned function was refactored (ref-latch,
+    // see index.ts) purely for identity stability — this test guards that its
+    // *observable* behavior (forwarding + cookie mutation) is unchanged.
+    routerMocks.loaderData = {
+      filters: "status=AVAILABLE",
+      settings: { mode: "SIMPLE" },
+    };
+    Cookies.set("org-1_assetFilter_v2", "status=AVAILABLE", { path: "/" });
+
+    const { result } = renderHook(() => useSearchParams());
+    const [, customSetSearchParams] = result.current;
+
+    // Non-functional-updater form: "status" is dropped from the next params,
+    // which should be detected as a removed key and stripped from the cookie.
+    customSetSearchParams(new URLSearchParams(""));
+
+    expect(routerMocks.setSearchParams).toHaveBeenCalledTimes(1);
+    expect(routerMocks.setSearchParams.mock.calls[0][0]).toBeInstanceOf(
+      URLSearchParams
+    );
+    // The cookie had only "status", so removing it deletes the cookie entirely.
+    expect(Cookies.get("org-1_assetFilter_v2")).toBeUndefined();
+  });
+});

--- a/apps/webapp/app/hooks/search-params/index.test.tsx
+++ b/apps/webapp/app/hooks/search-params/index.test.tsx
@@ -64,6 +64,10 @@ describe("useSearchParams", () => {
     routerMocks.pathname = "/assets";
     routerMocks.loaderData = { filters: "", settings: { mode: "SIMPLE" } };
     routerMocks.routeLoaderData = { currentOrganization: { id: "org-1" } };
+    // why: the last test in this suite sets this cookie directly (bypassing
+    // the mocked setter) to exercise real `js-cookie` read/remove behavior —
+    // clear it so a later run (or a failed assertion) can't leak it forward.
+    Cookies.remove("org-1_assetFilter_v2", { path: "/" });
   });
 
   it("keeps a stable customSetSearchParams identity across re-renders on a cookie-filtered page", () => {

--- a/apps/webapp/app/hooks/search-params/index.ts
+++ b/apps/webapp/app/hooks/search-params/index.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import Cookies from "js-cookie";
 import {
   useLoaderData,
@@ -124,52 +124,67 @@ export const useSearchParams = (): [
   const isPageWithCookieFilters = useIsPageWithCookieFilters();
   const currentOrganization = useCurrentOrganization();
 
-  /** In those cases, we return the default searchParams and setSearchParams as we dont need to handle cookies */
-  if (!isPageWithCookieFilters || !currentOrganization) {
-    return [searchParams, setSearchParams];
-  }
+  /**
+   * Cookie-aware setter used on pages that persist filters in a cookie (assets,
+   * bookings, kits). Memoized with `useCallback` so consumers that put the returned
+   * setter in an effect/callback dependency array (e.g. `set-or-edit-reminder-dialog.tsx`)
+   * get a stable identity across renders instead of a new function every render — an
+   * unstable identity there re-fires those effects on every render and can sustain a
+   * revalidation loop.
+   *
+   * NOTE: this hook is called unconditionally on every render (rules of hooks). The
+   * conditional choice of *which* setter to return happens after, at the `return`
+   * statement below.
+   */
+  const customSetSearchParams = useCallback<
+    (
+      nextInit: Parameters<SetSearchParamsType>[0],
+      navigateOptions?: Parameters<SetSearchParamsType>[1]
+    ) => void
+  >(
+    (nextInit, navigateOptions) => {
+      const prevParams = new URLSearchParams(searchParams.toString());
 
-  const customSetSearchParams: (
-    nextInit: Parameters<SetSearchParamsType>[0],
-    navigateOptions?: Parameters<SetSearchParamsType>[1]
-  ) => void = (nextInit, navigateOptions) => {
-    const prevParams = new URLSearchParams(searchParams.toString());
+      const checkAndDestroyCookies = (newParams: URLSearchParams) => {
+        const removedKeys: string[] = [];
+        prevParams.forEach((_value, key) => {
+          if (!newParams.has(key)) {
+            removedKeys.push(key);
+          }
+        });
 
-    const checkAndDestroyCookies = (newParams: URLSearchParams) => {
-      const removedKeys: string[] = [];
-      prevParams.forEach((_value, key) => {
-        if (!newParams.has(key)) {
-          removedKeys.push(key);
+        if (removedKeys.length > 0) {
+          destroyCookieValues(removedKeys);
         }
-      });
+      };
 
-      if (removedKeys.length > 0) {
-        destroyCookieValues(removedKeys);
-      }
-    };
-
-    if (typeof nextInit === "function") {
-      setSearchParams((prev) => {
-        let newParams = nextInit(prev);
+      if (typeof nextInit === "function") {
+        setSearchParams((prev) => {
+          let newParams = nextInit(prev);
+          // Ensure newParams is an instance of URLSearchParams
+          if (!(newParams instanceof URLSearchParams)) {
+            newParams = new URLSearchParams(newParams as any);
+          }
+          checkAndDestroyCookies(newParams);
+          return newParams;
+        }, navigateOptions);
+      } else {
+        let newParams = nextInit;
         // Ensure newParams is an instance of URLSearchParams
         if (!(newParams instanceof URLSearchParams)) {
           newParams = new URLSearchParams(newParams as any);
         }
         checkAndDestroyCookies(newParams);
-        return newParams;
-      }, navigateOptions);
-    } else {
-      let newParams = nextInit;
-      // Ensure newParams is an instance of URLSearchParams
-      if (!(newParams instanceof URLSearchParams)) {
-        newParams = new URLSearchParams(newParams as any);
+        setSearchParams(newParams, navigateOptions);
       }
-      checkAndDestroyCookies(newParams);
-      setSearchParams(newParams, navigateOptions);
-    }
-  };
+    },
+    [searchParams, setSearchParams, destroyCookieValues]
+  );
 
-  return [searchParams, customSetSearchParams];
+  /** In those cases, we return the default searchParams and setSearchParams as we dont need to handle cookies */
+  return isPageWithCookieFilters && currentOrganization
+    ? [searchParams, customSetSearchParams]
+    : [searchParams, setSearchParams];
 };
 
 type SetSearchParams = (
@@ -363,11 +378,59 @@ export function useCookieDestroy() {
   const location = useLocation();
 
   /**
+   * Latch holding this render's closed-over values. `_destroyCookieValues` (below)
+   * reads from this ref at *call time* instead of closing over these values
+   * directly, so its identity can stay stable across renders (empty-deps
+   * `useCallback` below) while still always acting on the freshest state when
+   * it's actually invoked — the standard "latest ref" pattern for giving an
+   * event-handler-like callback a stable identity without going stale.
+   *
+   * This keeps `destroyCookieValues`'s reference stable for consumers that put
+   * it in an effect/callback dependency array (e.g. `useSearchParams`'s
+   * `customSetSearchParams`, which closes over it) — see
+   * `.claude/rules/react-render-stability.md`.
+   *
+   * IMPORTANT: `cookieSearchParams` itself must stay a *fresh* URLSearchParams
+   * instance every render (not memoized) — `destroyCookieValues()` mutates it
+   * via `.delete()`, and caching it across renders would leak those mutations
+   * into a later render that reuses the same instance before its inputs
+   * change. The ref only stabilizes the *function identity*, never the
+   * search-params object itself.
+   */
+  const latestRef = useRef({
+    cookieSearchParams,
+    currentOrganization,
+    isAssetIndexPage,
+    modeIsAdvanced,
+    isPageWithCookieFilters,
+    pathname: location.pathname,
+  });
+  latestRef.current = {
+    cookieSearchParams,
+    currentOrganization,
+    isAssetIndexPage,
+    modeIsAdvanced,
+    isPageWithCookieFilters,
+    pathname: location.pathname,
+  };
+
+  /**
    * Function to destroy specific keys from cookies if on the asset index page.
+   * Referentially stable across renders (see `latestRef` above), so it is
+   * safe for consumers to place in a `useEffect`/`useCallback` dependency array.
    *
    * @param {string[]} keys - Array of keys (strings) to be removed from the cookies.
    */
-  function _destroyCookieValues(keys: string[]) {
+  const _destroyCookieValues = useCallback((keys: string[]) => {
+    const {
+      isPageWithCookieFilters,
+      currentOrganization,
+      isAssetIndexPage,
+      modeIsAdvanced,
+      pathname,
+      cookieSearchParams,
+    } = latestRef.current;
+
     // Check if the current page supports cookie filters
     if (
       isPageWithCookieFilters &&
@@ -383,7 +446,7 @@ export function useCookieDestroy() {
       const cookieName = getCookieName(
         currentOrganization.id,
         effectiveModeIsAdvanced,
-        location.pathname
+        pathname
       );
 
       // Always use root path to match server-side cookie path
@@ -393,7 +456,7 @@ export function useCookieDestroy() {
       // Call the destroyCookieValues utility function to delete keys from cookies and update the cookie
       destroyCookieValues(cookieName, keys, cookieSearchParams, cookiePath);
     }
-  }
+  }, []);
 
   return { destroyCookieValues: _destroyCookieValues };
 }

--- a/apps/webapp/app/hooks/search-params/index.ts
+++ b/apps/webapp/app/hooks/search-params/index.ts
@@ -163,7 +163,9 @@ export const useSearchParams = (): [
           let newParams = nextInit(prev);
           // Ensure newParams is an instance of URLSearchParams
           if (!(newParams instanceof URLSearchParams)) {
-            newParams = new URLSearchParams(newParams as any);
+            newParams = new URLSearchParams(
+              newParams as ConstructorParameters<typeof URLSearchParams>[0]
+            );
           }
           checkAndDestroyCookies(newParams);
           return newParams;
@@ -172,7 +174,9 @@ export const useSearchParams = (): [
         let newParams = nextInit;
         // Ensure newParams is an instance of URLSearchParams
         if (!(newParams instanceof URLSearchParams)) {
-          newParams = new URLSearchParams(newParams as any);
+          newParams = new URLSearchParams(
+            newParams as ConstructorParameters<typeof URLSearchParams>[0]
+          );
         }
         checkAndDestroyCookies(newParams);
         setSearchParams(newParams, navigateOptions);
@@ -181,7 +185,7 @@ export const useSearchParams = (): [
     [searchParams, setSearchParams, destroyCookieValues]
   );
 
-  /** In those cases, we return the default searchParams and setSearchParams as we dont need to handle cookies */
+  /** In those cases, we return the default searchParams and setSearchParams as we don't need to handle cookies */
   return isPageWithCookieFilters && currentOrganization
     ? [searchParams, customSetSearchParams]
     : [searchParams, setSearchParams];

--- a/apps/webapp/app/modules/booking-settings/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.test.ts
@@ -2,6 +2,7 @@ import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 
 import {
+  BOOKING_SETTINGS_SELECT,
   getBookingSettingsForOrganization,
   updateBookingSettings,
 } from "./service.server";
@@ -52,36 +53,9 @@ describe("getBookingSettingsForOrganization", () => {
 
     expect(db.bookingSettings.findUnique).toHaveBeenCalledWith({
       where: { organizationId: mockOrganizationId },
-      select: {
-        id: true,
-        bufferStartTime: true,
-        maxBookingLength: true,
-        maxBookingLengthSkipClosedDays: true,
-        tagsRequired: true,
-        autoArchiveBookings: true,
-        autoArchiveDays: true,
-        autoArchiveExpiredReservations: true,
-        requireExplicitCheckinForAdmin: true,
-        requireExplicitCheckinForSelfService: true,
-        countKitsAsSingleUnit: true,
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-        alwaysNotifyTeamMembers: {
-          select: {
-            id: true,
-            name: true,
-            user: {
-              select: {
-                id: true,
-                email: true,
-                firstName: true,
-                lastName: true,
-                profilePicture: true,
-              },
-            },
-          },
-        },
-      },
+      // Reuse the production projection so this assertion can't silently
+      // drift from what `getBookingSettingsForOrganization` actually selects.
+      select: BOOKING_SETTINGS_SELECT,
     });
     // why: the whole point of the read-first change is that an existing row
     // never triggers a write — this is the regression guard for the
@@ -127,36 +101,9 @@ describe("getBookingSettingsForOrganization", () => {
         notifyAdminsOnNewBooking: true,
         organizationId: mockOrganizationId,
       },
-      select: {
-        id: true,
-        bufferStartTime: true,
-        tagsRequired: true,
-        maxBookingLength: true,
-        maxBookingLengthSkipClosedDays: true,
-        autoArchiveBookings: true,
-        autoArchiveDays: true,
-        autoArchiveExpiredReservations: true,
-        requireExplicitCheckinForAdmin: true,
-        requireExplicitCheckinForSelfService: true,
-        countKitsAsSingleUnit: true,
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-        alwaysNotifyTeamMembers: {
-          select: {
-            id: true,
-            name: true,
-            user: {
-              select: {
-                id: true,
-                email: true,
-                firstName: true,
-                lastName: true,
-                profilePicture: true,
-              },
-            },
-          },
-        },
-      },
+      // Reuse the production projection so this assertion can't silently
+      // drift from what `getBookingSettingsForOrganization` actually selects.
+      select: BOOKING_SETTINGS_SELECT,
     });
     expect(result).toEqual(defaultSettings);
   });

--- a/apps/webapp/app/modules/booking-settings/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.test.ts
@@ -13,6 +13,7 @@ import {
 vitest.mock("~/database/db.server", () => ({
   db: {
     bookingSettings: {
+      findUnique: vitest.fn(),
       upsert: vitest.fn(),
       update: vitest.fn(),
     },
@@ -34,41 +35,29 @@ const mockOrganizationId = "org-1";
 describe("getBookingSettingsForOrganization", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+    // why: keep each test self-contained — default the read-first lookup to
+    // "not found" so tests that only care about the upsert fallback don't
+    // have to know about the new findUnique call. Tests exercising the
+    // existing-row path override this explicitly.
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.findUnique.mockResolvedValue(null);
   });
 
-  it("should get existing booking settings successfully", async () => {
-    expect.assertions(2);
+  it("should return the existing row without writing when one is found", async () => {
+    expect.assertions(3);
     //@ts-expect-error missing vitest type
-    db.bookingSettings.upsert.mockResolvedValue(mockBookingSettingsData);
+    db.bookingSettings.findUnique.mockResolvedValue(mockBookingSettingsData);
 
     const result = await getBookingSettingsForOrganization(mockOrganizationId);
 
-    expect(db.bookingSettings.upsert).toHaveBeenCalledWith({
-      where: {
-        organizationId: mockOrganizationId,
-      },
-      update: {},
-      create: {
-        bufferStartTime: 0,
-        tagsRequired: false,
-        maxBookingLength: null,
-        maxBookingLengthSkipClosedDays: false,
-        autoArchiveBookings: false,
-        autoArchiveDays: 2,
-        autoArchiveExpiredReservations: false,
-        requireExplicitCheckinForAdmin: false,
-        requireExplicitCheckinForSelfService: false,
-        countKitsAsSingleUnit: false,
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-        organizationId: mockOrganizationId,
-      },
+    expect(db.bookingSettings.findUnique).toHaveBeenCalledWith({
+      where: { organizationId: mockOrganizationId },
       select: {
         id: true,
         bufferStartTime: true,
-        tagsRequired: true,
         maxBookingLength: true,
         maxBookingLengthSkipClosedDays: true,
+        tagsRequired: true,
         autoArchiveBookings: true,
         autoArchiveDays: true,
         autoArchiveExpiredReservations: true,
@@ -94,11 +83,15 @@ describe("getBookingSettingsForOrganization", () => {
         },
       },
     });
+    // why: the whole point of the read-first change is that an existing row
+    // never triggers a write — this is the regression guard for the
+    // connection-pool-exhaustion incident this task fixes.
+    expect(db.bookingSettings.upsert).not.toHaveBeenCalled();
     expect(result).toEqual(mockBookingSettingsData);
   });
 
   it("should create new booking settings with default values when none exist", async () => {
-    expect.assertions(2);
+    expect.assertions(3);
     const defaultSettings = {
       id: "booking-settings-new",
       bufferStartTime: 0,
@@ -107,10 +100,13 @@ describe("getBookingSettingsForOrganization", () => {
       organizationId: mockOrganizationId,
     };
     //@ts-expect-error missing vitest type
+    db.bookingSettings.findUnique.mockResolvedValue(null);
+    //@ts-expect-error missing vitest type
     db.bookingSettings.upsert.mockResolvedValue(defaultSettings);
 
     const result = await getBookingSettingsForOrganization(mockOrganizationId);
 
+    expect(db.bookingSettings.upsert).toHaveBeenCalledTimes(1);
     expect(db.bookingSettings.upsert).toHaveBeenCalledWith({
       where: {
         organizationId: mockOrganizationId,
@@ -165,9 +161,29 @@ describe("getBookingSettingsForOrganization", () => {
     expect(result).toEqual(defaultSettings);
   });
 
-  it("should throw ShelfError when database operation fails", async () => {
+  it("should throw ShelfError when the read-first lookup fails", async () => {
     expect.assertions(2);
     const dbError = new Error("Database connection failed");
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.findUnique.mockRejectedValue(dbError);
+
+    await expect(
+      getBookingSettingsForOrganization(mockOrganizationId)
+    ).rejects.toThrow(ShelfError);
+
+    await expect(
+      getBookingSettingsForOrganization(mockOrganizationId)
+    ).rejects.toMatchObject({
+      message: "Failed to retrieve booking settings configuration",
+      additionalData: { organizationId: mockOrganizationId },
+    });
+  });
+
+  it("should throw ShelfError when the upsert fallback fails", async () => {
+    expect.assertions(2);
+    const dbError = new Error("Database connection failed");
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.findUnique.mockResolvedValue(null);
     //@ts-expect-error missing vitest type
     db.bookingSettings.upsert.mockRejectedValue(dbError);
 
@@ -185,6 +201,9 @@ describe("getBookingSettingsForOrganization", () => {
 
   it("should handle missing organization id", async () => {
     expect.assertions(1);
+    const dbError = new Error("Database connection failed");
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.findUnique.mockRejectedValue(dbError);
 
     await expect(getBookingSettingsForOrganization("")).rejects.toThrow(
       ShelfError

--- a/apps/webapp/app/modules/booking-settings/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.test.ts
@@ -146,7 +146,7 @@ describe("getBookingSettingsForOrganization", () => {
     });
   });
 
-  it("should handle missing organization id", async () => {
+  it("wraps a findUnique failure in a ShelfError", async () => {
     expect.assertions(1);
     const dbError = new Error("Database connection failed");
     //@ts-expect-error missing vitest type

--- a/apps/webapp/app/modules/booking-settings/service.server.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.ts
@@ -4,11 +4,81 @@ import { ShelfError } from "~/utils/error";
 
 const label = "Booking Settings";
 
+/**
+ * Shared `select` clause for `BookingSettings` reads/writes in this module.
+ *
+ * Hoisted to module scope so the read-first `findUnique` in
+ * {@link getBookingSettingsForOrganization} and its upsert fallback always
+ * return the exact same shape — a single source of truth prevents the two
+ * code paths from drifting apart over time.
+ */
+const BOOKING_SETTINGS_SELECT = {
+  id: true,
+  bufferStartTime: true,
+  maxBookingLength: true,
+  maxBookingLengthSkipClosedDays: true,
+  tagsRequired: true,
+  autoArchiveBookings: true,
+  autoArchiveDays: true,
+  autoArchiveExpiredReservations: true,
+  requireExplicitCheckinForAdmin: true,
+  requireExplicitCheckinForSelfService: true,
+  countKitsAsSingleUnit: true,
+  notifyBookingCreator: true,
+  notifyAdminsOnNewBooking: true,
+  alwaysNotifyTeamMembers: {
+    select: {
+      id: true,
+      name: true,
+      user: {
+        select: {
+          id: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+          profilePicture: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.BookingSettingsSelect;
+
+/**
+ * Retrieves the `BookingSettings` row for an organization, creating a
+ * default row only on first access.
+ *
+ * This is called from the root authenticated layout loader
+ * (`_layout+/_layout.tsx`), so it runs on **every** authenticated page load
+ * and React Router `.data` revalidation. It is deliberately **read-first**:
+ * a plain `findUnique` satisfies the overwhelming majority of calls (the row
+ * almost always already exists), avoiding an unconditional write + row lock
+ * on every request. Only when the row is genuinely absent do we fall
+ * through to an `upsert` (not a bare `create`) so two concurrent first
+ * requests for the same organization can't race into a unique-constraint
+ * error.
+ *
+ * @param organizationId - The organization whose settings to fetch
+ * @returns The organization's booking settings, creating defaults if absent
+ * @throws {ShelfError} If the database operation fails
+ */
 export async function getBookingSettingsForOrganization(
   organizationId: string
 ) {
   try {
-    // First try to find existing working hours
+    // Hot path: the row exists for almost every call, so a plain read avoids
+    // taking a write lock on every authenticated page load.
+    const existing = await db.bookingSettings.findUnique({
+      where: { organizationId },
+      select: BOOKING_SETTINGS_SELECT,
+    });
+
+    if (existing) {
+      return existing;
+    }
+
+    // Cold path: first access for this organization. Use `upsert` (not
+    // `create`) so a concurrent first-hit from another request doesn't
+    // throw a unique-constraint error.
     const bookingSettings = await db.bookingSettings.upsert({
       where: {
         organizationId,
@@ -29,36 +99,7 @@ export async function getBookingSettingsForOrganization(
         notifyAdminsOnNewBooking: true,
         organizationId,
       },
-      select: {
-        id: true,
-        bufferStartTime: true,
-        maxBookingLength: true,
-        maxBookingLengthSkipClosedDays: true,
-        tagsRequired: true,
-        autoArchiveBookings: true,
-        autoArchiveDays: true,
-        autoArchiveExpiredReservations: true,
-        requireExplicitCheckinForAdmin: true,
-        requireExplicitCheckinForSelfService: true,
-        countKitsAsSingleUnit: true,
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-        alwaysNotifyTeamMembers: {
-          select: {
-            id: true,
-            name: true,
-            user: {
-              select: {
-                id: true,
-                email: true,
-                firstName: true,
-                lastName: true,
-                profilePicture: true,
-              },
-            },
-          },
-        },
-      },
+      select: BOOKING_SETTINGS_SELECT,
     });
 
     return bookingSettings;

--- a/apps/webapp/app/modules/booking-settings/service.server.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.ts
@@ -5,12 +5,13 @@ import { ShelfError } from "~/utils/error";
 const label = "Booking Settings";
 
 /**
- * Shared `select` clause for `BookingSettings` reads/writes in this module.
+ * Shared `select` clause for the full `BookingSettings` shape.
  *
  * Hoisted to module scope so the read-first `findUnique` in
- * {@link getBookingSettingsForOrganization} and its upsert fallback always
- * return the exact same shape — a single source of truth prevents the two
- * code paths from drifting apart over time.
+ * {@link getBookingSettingsForOrganization}, its `upsert` fallback, and the
+ * `update` in {@link updateBookingSettings} all return the exact same shape —
+ * a single source of truth keeps those paths from drifting apart over time.
+ * (The notification-only helpers below deliberately select a leaner subset.)
  */
 export const BOOKING_SETTINGS_SELECT = {
   id: true,
@@ -175,36 +176,7 @@ export async function updateBookingSettings({
     const bookingSettings = await db.bookingSettings.update({
       where: { organizationId },
       data: updateData,
-      select: {
-        id: true,
-        bufferStartTime: true,
-        tagsRequired: true,
-        maxBookingLength: true,
-        maxBookingLengthSkipClosedDays: true,
-        autoArchiveBookings: true,
-        autoArchiveDays: true,
-        autoArchiveExpiredReservations: true,
-        requireExplicitCheckinForAdmin: true,
-        requireExplicitCheckinForSelfService: true,
-        countKitsAsSingleUnit: true,
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-        alwaysNotifyTeamMembers: {
-          select: {
-            id: true,
-            name: true,
-            user: {
-              select: {
-                id: true,
-                email: true,
-                firstName: true,
-                lastName: true,
-                profilePicture: true,
-              },
-            },
-          },
-        },
-      },
+      select: BOOKING_SETTINGS_SELECT,
     });
 
     return bookingSettings;

--- a/apps/webapp/app/modules/booking-settings/service.server.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.ts
@@ -12,7 +12,7 @@ const label = "Booking Settings";
  * return the exact same shape — a single source of truth prevents the two
  * code paths from drifting apart over time.
  */
-const BOOKING_SETTINGS_SELECT = {
+export const BOOKING_SETTINGS_SELECT = {
   id: true,
   bufferStartTime: true,
   maxBookingLength: true,


### PR DESCRIPTION
## Summary

Fixes the production incident where creating an asset reminder put the page into an
unbounded `GET /assets/:id/reminders.data` revalidation loop, which hammered the database
and surfaced as **"We're experiencing temporary database connectivity issues"** (503) errors
in Sentry. A user reported it on 2026-07-20.

It turned out to be **two stacked bugs** — a client-side loop that generated the request
storm, and a server-side write on the hot path that turned each storm request into a
connection-pool timeout (`P2024`):

### 1. Client: the reminder dialog's `?success=true` revalidation loop

Creating a reminder redirects to `…/reminders?success=true`. The dialog's `handleOnSuccess`
effect strips that param via `setSearchParams`. Because the effect's dependencies were
unstable (an inline `onClose` arrow, and `customSetSearchParams` which was recreated every
render), the effect re-fired on every re-render while the committed URL still read
`success=true` — each iteration aborting the in-flight `reminders.data` fetch (`NS_BINDING_ABORTED`)
and starting another. The URL never committed, so `success` never cleared: an infinite loop,
capped only by the server rate-limiter returning HTTP 429.

**Fix:** a one-shot `useRef` latch so the effect body runs at most once per success signal
(and re-arms when `success` clears, so a second reminder still auto-closes), `replace: true`
on the param strip, and stabilized `onClose` handlers. Also stabilized `customSetSearchParams`
and its dependency `useCookieDestroy` (both were recreated every render) — an app-wide
render-stability fix, since any effect depending on that setter was re-running every render.

### 2. Server: `getBookingSettingsForOrganization` wrote on every page load

`getBookingSettingsForOrganization` ran `db.bookingSettings.upsert()` from the **root
authenticated layout loader**, so every authenticated page load and every `.data`
revalidation issued a write that took a row lock on the org's settings row. Under concurrent
same-org requests (exactly what the loop above produces) this serialized traffic on one lock
and exhausted the Prisma connection pool → `P2024` → the 503s.

**Fix:** read-first — `findUnique` on the hot path, `upsert` only when the row is genuinely
absent. A shared `BOOKING_SETTINGS_SELECT` const keeps both branches' selections identical.
This matches the pattern already used by the sibling `getWorkingHoursForOrganization` and the
explicit note in `bookings.$bookingId.overview.tsx` warning that this helper does an upsert
write.

## Commits
- `fix(booking-settings): read-first to stop write-on-every-page-load pool exhaustion`
- `fix(search-params): stabilize customSetSearchParams and useCookieDestroy identities`
- `fix(asset-reminder): stop success-param revalidation loop after creating a reminder`

## How to test
1. Open an asset → **Reminders** tab.
2. Actions → create a new reminder (name, message, date, assignee) → Submit.
3. **Before:** the dialog closes but the Network tab shows a flood of `reminders.data`
   requests (429 / `NS_BINDING_ABORTED`) until rate-limited.
   **After:** exactly one `reminders.data` revalidation fires; the new reminder appears; no loop.
4. Optionally confirm no `bookingSettings` write is issued on a normal authenticated page load
   (the layout loader now reads instead of upserts).

## Validation
- `pnpm webapp:validate`: 3393 tests pass, 0 lint errors, typecheck clean.
- New regression tests: the dialog fires `onClose`/`setSearchParams` exactly once (verified to
  fail against pre-fix code); the search-params setter keeps a stable identity across renders;
  `getBookingSettingsForOrganization` issues no write when the row exists.

## Sentry
Fixes SHELF-WEBAPP-1HE, 1HF, 1N4, 1N5, 1HN, 1N6, 1HP, 218 (the reminders "temporary database
connectivity" cluster).

## Follow-ups (separate PRs)
- pg-boss `error` handler (unhandled emitter error crashes the process — SHELF-WEBAPP-1KJ/21E)
- healthcheck "busy ≠ dead" so a saturated pool doesn't reboot machines
- scheduler leader/placement, reminder-job retry, restore Prisma transient-retry
- `useFetcher` migration of the reminder form (removes the `?success=true` round-trip entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reminder dialogs that could repeatedly close and cause reminder refresh loops when returning from a successful action via URL parameters.
  * Improved dialog close behavior to avoid unintended re-triggering across intermediate renders.
  * Enhanced search-parameter handling so cookie cleanup and URL updates remain consistent and reliable.
  * Standardized booking settings retrieval to return a consistent data shape across read-first and fallback creation paths.
* **Tests**
  * Added/updated regression coverage for reminder success handling, stable URL/cookie behavior, and booking-settings read/upsert/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->