### PR TITLE
fix: pg-boss error handler + healthcheck busy≠dead (deploy resilience)

### DIFF
--- a/apps/webapp/app/routes/healthcheck.test.ts
+++ b/apps/webapp/app/routes/healthcheck.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the Fly.io healthcheck loader's "busy ≠ dead" behavior.
+ *
+ * Covers the three outcomes of racing the DB probe against
+ * `HEALTHCHECK_DB_TIMEOUT_MS`: a fast healthy probe, a fast genuine failure,
+ * and a probe that is still pending when the internal timeout fires (the
+ * pool-saturation case this route exists to protect against -- see the
+ * file-level doc on `healthcheck.tsx`).
+ *
+ * @see {@link file://./healthcheck.tsx} loader under test
+ */
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+
+import { loader, HEALTHCHECK_DB_TIMEOUT_MS } from "./healthcheck";
+import { assertIsDataWithResponseInit } from "../../test/helpers/assertions";
+
+// why: isolate the loader from a real Prisma connection -- only
+// `db.user.findFirst` is exercised by the route, so only it needs stubbing.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    user: { findFirst: vi.fn() },
+  },
+}));
+
+// why: assert the "busy" branch logs a warning without letting pino/Sentry
+// wiring run (and without polluting test output).
+vi.mock("~/utils/logger", () => ({
+  Logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    handledClientError: vi.fn(),
+  },
+}));
+
+const findFirstMock = vi.mocked(db.user.findFirst);
+
+describe("healthcheck loader", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 when the DB probe resolves quickly", async () => {
+    findFirstMock.mockResolvedValue({ id: "user-1" } as never);
+
+    const result = await loader();
+
+    assertIsDataWithResponseInit(result);
+    expect(result.init?.status).toBe(200);
+    expect((result.data as { status: string }).status).toBe("OK");
+  });
+
+  it("returns 503 when the DB probe rejects quickly (genuine connection failure)", async () => {
+    findFirstMock.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    const result = await loader();
+
+    assertIsDataWithResponseInit(result);
+    expect(result.init?.status).toBe(503);
+  });
+
+  describe("when the DB probe is still pending after the internal timeout", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    it("returns 200 (busy-but-alive) and never surfaces the late rejection as unhandled", async () => {
+      // A deferred promise standing in for a probe blocked on a saturated
+      // pool: it will not settle until we explicitly reject it below.
+      let rejectProbe: (reason: unknown) => void = () => {};
+      const pendingProbe = new Promise((_resolve, reject) => {
+        rejectProbe = reject;
+      });
+      findFirstMock.mockReturnValue(pendingProbe as never);
+
+      const resultPromise = loader();
+
+      // Advance the fake clock past the internal budget so the race's
+      // timeout side wins while the probe is still unsettled.
+      await vi.advanceTimersByTimeAsync(HEALTHCHECK_DB_TIMEOUT_MS);
+
+      const result = await resultPromise;
+      assertIsDataWithResponseInit(result);
+      expect(result.init?.status).toBe(200);
+      expect((result.data as { degraded?: boolean }).degraded).toBe(true);
+
+      // Track any unhandled rejection raised while the deferred probe
+      // settles after the request has already responded -- the loader must
+      // have attached its own `.catch` to prevent this.
+      let unhandled: unknown;
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandled = reason;
+      };
+      process.on("unhandledRejection", onUnhandledRejection);
+
+      rejectProbe(new Error("connect ETIMEDOUT"));
+      // Flush microtasks (using real timers here, since the rejection
+      // handling itself doesn't depend on the fake clock) so the rejection
+      // has a chance to propagate before we assert.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      process.off("unhandledRejection", onUnhandledRejection);
+      expect(unhandled).toBeUndefined();
+    });
+  });
+});

--- a/apps/webapp/app/routes/healthcheck.tsx
+++ b/apps/webapp/app/routes/healthcheck.tsx
@@ -1,27 +1,114 @@
-// learn more: https://fly.io/docs/reference/configuration/#services-http_checks
+/**
+ * Fly.io HTTP health check endpoint.
+ *
+ * @see https://fly.io/docs/reference/configuration/#services-http_checks
+ *
+ * ## "Busy ≠ dead"
+ *
+ * Fly's health check (`fly.toml`: `services.http_checks`) has a hard 2s
+ * timeout. The DB probe below goes through Prisma's pooled connection, and
+ * when that pool saturates, the query BLOCKS waiting for a free connection
+ * (up to `pool_timeout`, ~20s) instead of failing fast. If we let that block
+ * the HTTP response, Fly's 2s check times out, marks the machine unhealthy,
+ * and reboots it -- which throws a cold-start connection burst at the
+ * already-saturated pooler, crash-looping the whole fleet. This exact chain
+ * was confirmed on 2026-07-20: a DB-connectivity storm ran ~09:00-10:11
+ * across 6 machine IDs on a 5-machine fleet, interleaved with
+ * `Healthcheck failed` events.
+ *
+ * The fix: race the DB probe against a short internal timeout, well under
+ * Fly's 2s budget.
+ * - Probe resolves first -> DB is healthy -> 200.
+ * - Internal timeout wins first -> the process is alive, just waiting on a
+ *   busy pool -> still 200 (with a `degraded: true` body flag), so Fly does
+ *   NOT reboot a merely-busy machine. The still-pending probe's eventual
+ *   settlement is swallowed so it can never surface as an unhandled
+ *   rejection once this request has already responded.
+ * - Probe rejects first (e.g. DB unreachable) -> genuine failure -> 503, so
+ *   Fly CAN recycle an actually-dead machine.
+ */
 import { data } from "react-router";
 
 import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 import { payload, error } from "~/utils/http.server";
+import { Logger } from "~/utils/logger";
 
+/**
+ * Internal budget for the DB probe, comfortably under Fly's 2s check
+ * timeout (`fly.toml`: `services.http_checks.timeout = "2s"`). Leaves
+ * headroom for request routing/serialization so a "busy" verdict still
+ * makes it back to Fly inside its window instead of racing it.
+ */
+export const HEALTHCHECK_DB_TIMEOUT_MS = 1000;
+
+/**
+ * Sentinel value resolved by the internal timeout when it wins the race
+ * against the DB probe. Distinguishes "timed out" from "probe resolved with
+ * an actual (falsy) value" without relying on `undefined`.
+ */
+const HEALTHCHECK_TIMEOUT = Symbol("healthcheck-timeout");
+
+/**
+ * Fly.io HTTP health check loader. See the file-level doc above for the
+ * busy-vs-dead rationale.
+ *
+ * @returns A `data()` response:
+ * - `200` when the DB probe resolves in time (healthy), or when the probe is
+ *   still pending after {@link HEALTHCHECK_DB_TIMEOUT_MS} (busy, but the
+ *   process itself is alive).
+ * - `503` only when the probe rejects within the timeout window (a genuine
+ *   DB connection failure).
+ */
 export async function loader() {
+  // Deliberately runs against the pooled Prisma client -- a saturated pool is
+  // exactly the failure mode this route needs to detect and NOT treat as
+  // death.
+  const probe = db.user.findFirst({
+    select: { id: true },
+  });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<typeof HEALTHCHECK_TIMEOUT>((resolve) => {
+    timer = setTimeout(() => {
+      resolve(HEALTHCHECK_TIMEOUT);
+    }, HEALTHCHECK_DB_TIMEOUT_MS);
+  });
+
   try {
-    // if we can connect to the database and make a simple query
-    // and make a HEAD request to ourselves, then we're good.
-    await db.user.findFirst({
-      select: { id: true },
-    });
-    return data(payload({ status: "OK" }));
+    const result = await Promise.race([probe, timeout]);
+
+    if (result === HEALTHCHECK_TIMEOUT) {
+      // why: the probe lost the race but is still in flight. Attach a no-op
+      // handler so its eventual rejection can't surface as an unhandled
+      // promise rejection after this request has already responded.
+      void probe.catch(() => {});
+
+      Logger.warn(
+        `Healthcheck: DB probe did not resolve within ${HEALTHCHECK_DB_TIMEOUT_MS}ms. ` +
+          "Pool is busy, not dead -- responding 200 so Fly doesn't reboot the machine."
+      );
+      return data(payload({ status: "OK", degraded: true }), { status: 200 });
+    }
+
+    return data(payload({ status: "OK" }), { status: 200 });
   } catch (cause) {
+    // Genuine, fast DB failure (e.g. connection refused) -- the machine is
+    // actually unhealthy, so let Fly recycle it.
     return data(
       error(
         new ShelfError({
           cause,
           message: "Healthcheck failed",
           label: "Healthcheck",
+          shouldBeCaptured: true,
         })
-      )
+      ),
+      { status: 503 }
     );
+  } finally {
+    // Clears the timer whichever side of the race won -- avoids a dangling
+    // timer keeping the event loop busy when the probe wins.
+    clearTimeout(timer);
   }
 }

--- a/apps/webapp/app/routes/healthcheck.tsx
+++ b/apps/webapp/app/routes/healthcheck.tsx
@@ -79,6 +79,19 @@ export async function loader() {
     const result = await Promise.race([probe, timeout]);
 
     if (result === HEALTHCHECK_TIMEOUT) {
+      // Accepted tradeoff: elapsed time alone can't tell a busy pool apart from
+      // a genuinely-broken-but-slow DB path (a wedged socket / stalled TLS
+      // handshake that hangs instead of erroring). Both land here and return
+      // 200, so a truly-wedged machine could keep receiving traffic. We accept
+      // this because the alternative -- rebooting on slowness -- reintroduces
+      // the fleet-wide crashloop this route exists to prevent, and because
+      // failures that error *quickly* (connection refused, P1001) already fall
+      // through to the 503 path below. Distinguishing a *persistently* unhealthy
+      // machine from a transient blip needs a consecutive-failure signal (a Fly
+      // unhealthy-threshold), not time-based escalation here -- escalating to
+      // 503 after N slow checks would re-trigger the cascade under a sustained
+      // fleet-wide saturation.
+
       // why: the probe lost the race but is still in flight. Attach a no-op
       // handler so its eventual rejection can't surface as an unhandled
       // promise rejection after this request has already responded.

--- a/apps/webapp/app/utils/scheduler.server.ts
+++ b/apps/webapp/app/utils/scheduler.server.ts
@@ -1,4 +1,6 @@
 import PgBoss from "pg-boss";
+import { ShelfError } from "./error";
+import { Logger } from "./logger";
 import { DATABASE_URL, NODE_ENV } from "../utils/env";
 
 export enum QueueNames {
@@ -40,6 +42,31 @@ export const init = async () => {
       }
       pgBossInstance = global.pgBossScheduler;
     }
+
+    // Register an error handler before starting. PgBoss extends EventEmitter and
+    // re-emits worker/maintenance failures (e.g. transient EAUTHTIMEOUT / 08006)
+    // as 'error' events. An unhandled 'error' event on an EventEmitter throws and
+    // crashes the Node process (the SHELF-WEBAPP-1KJ / 21E production crashes and
+    // subsequent machine restarts). Logging it keeps the process alive.
+    //
+    // why the listenerCount guard: in dev the instance is a surviving `global`
+    // while the `!pgBossInstance` guard above is on a module-local that resets on
+    // every Vite hot reload, so init() re-runs against the same instance. Without
+    // this guard each reload attaches another listener (MaxListenersExceededWarning
+    // + duplicate logs). Attaching only when none exists is idempotent.
+    if (pgBossInstance.listenerCount("error") === 0) {
+      pgBossInstance.on("error", (cause: unknown) => {
+        Logger.error(
+          new ShelfError({
+            cause,
+            message: "pg-boss worker error",
+            label: "Scheduler",
+            shouldBeCaptured: true,
+          })
+        );
+      });
+    }
+
     await pgBossInstance.start();
   }
   return;


### PR DESCRIPTION
## Summary

Deploy-resilience hardening, split out of the reminders incident work. Two independent
changes that stop transient database pressure from cascading into machine restarts.

Context: on 2026-07-20 a connection-pool exhaustion event (fixed at the source in #2722)
cascaded into a ~70-minute fleet-wide crashloop. Two amplifiers turned a transient blip into
an outage; this PR removes both.

### 1. pg-boss error handler — stop worker errors from crashing the process

`PgBoss` extends Node's `EventEmitter` and re-emits worker/maintenance failures (e.g. the
transient `EAUTHTIMEOUT` / `08006` seen under pooler pressure) as `'error'` events. Nothing
registered an `error` listener, and an **unhandled `'error'` event on an EventEmitter throws**
— crashing the Node process and restarting the Fly machine. That is SHELF-WEBAPP-1KJ and
SHELF-WEBAPP-21E (`handled: no`, `mechanism: auto.node.onunhandledrejection`).

Now a handler logs the error via `ShelfError` (`shouldBeCaptured: true`) instead of letting it
throw. A `listenerCount("error") === 0` guard keeps the dev hot-reload path — which reuses a
surviving `global` pg-boss instance while the module-local init guard resets — from stacking
duplicate listeners.

### 2. Healthcheck "busy ≠ dead" — a saturated pool must not reboot the machine

`/healthcheck` ran `db.user.findFirst()` (a **pooled** query) against Fly's 2s check timeout.
Under pool saturation that query blocks waiting for a connection (up to `pool_timeout`, ~20s),
so the response never returns within 2s → Fly marks the machine unhealthy and reboots it → the
cold-start hits the already-saturated pooler harder → a self-sustaining reboot crashloop
(SHELF-WEBAPP-15T healthcheck failures interleaved with the connectivity storm that day).

The probe now races a 1s internal timeout:

| Outcome | Status | Rationale |
|---|---|---|
| DB responds | 200 | healthy |
| DB slow (pool busy) | 200 | process is **alive** — it serves once the pool frees; a busy machine is not a dead one |
| DB errors fast (genuine failure) | **503** | genuinely unhealthy → Fly can recycle it |

This also fixes a latent bug: the previous code returned `data(error(...))` with **no status**,
i.e. HTTP 200 even on a real DB failure. The still-pending probe's late rejection is swallowed
so it can't surface as an unhandled rejection.

## Deliberately NOT included: scheduler leader guard

An idempotency audit of all five job queues concluded a leader guard is **not needed for
correctness**: pg-boss uses competing-consumer delivery (`FOR UPDATE SKIP LOCKED`) so each job
runs on exactly one machine fleet-wide, and there are no cron/recurring enqueues
(`noScheduling: true`). Running the scheduler on all machines only costs redundant polling, not
duplicate execution. The one real, machine-count-independent risk the audit surfaced (the email
queue's `retryLimit: 15` with a non-idempotent send) is tracked for a later reminder-reliability
PR. `fly.toml` is untouched.

## Test plan

- `pnpm webapp:validate`: 3397 tests pass, 0 lint errors, typecheck clean.
- New `healthcheck.test.ts`: DB resolves → 200; DB rejects fast → 503; DB hangs past the 1s
  timeout (fake timers) → 200 `degraded`, with an assertion that the late probe rejection never
  surfaces as an unhandled rejection.
- pg-boss handler is exercised by manual/integration verification (a forced emitter error is
  logged, not thrown) — it's not unit-testable without a live PgBoss.

## Sentry

Fixes SHELF-WEBAPP-1KJ, SHELF-WEBAPP-21E (the unhandled pg-boss crash). SHELF-WEBAPP-15T
(healthcheck-failure reboots) should stop firing on merely-busy machines; will verify
post-deploy before resolving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Health checks now distinguish a busy database from an unavailable one, returning a degraded success response when the database is slow but still responsive.
  - Health checks now return an explicit service-unavailable response when the database fails promptly (improving monitoring accuracy).
  - Scheduler errors are now handled and logged safely to avoid unexpected application crashes.

- **Tests**
  - Added a new suite covering fast success, fast failure, timeout/degraded behavior, and ensuring delayed probe failures don’t cause unhandled rejection events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->