### PR TITLE
fix(mobile): booking asset picker silently capped at 20 assets

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
@@ -13,6 +13,14 @@ import {
 import { makeShelfError } from "~/utils/error";
 
 /**
+ * Page size this endpoint requests when the client doesn't specify one.
+ * 100 is the ceiling `getPaginatedAndFilterableAssets` accepts (anything above
+ * it silently falls back to 20), so this is the most a paginationless client
+ * can be given in a single response.
+ */
+const MOBILE_PICKER_MAX_PAGE_SIZE = 100;
+
+/**
  * GET /api/mobile/bookings/available-assets
  *
  * Availability-aware asset picker for the booking create/edit flow — the mobile
@@ -48,8 +56,33 @@ export async function loader({ request }: LoaderFunctionArgs) {
     // The web booking-asset picker (manage-assets) does NOT scope by
     // self-service custody — any bookable asset is selectable, and the
     // self-service restriction is enforced on the mutation, not the read.
+    /**
+     * The companion's picker has NO pagination UI — `add-assets.tsx` renders a
+     * FlatList with no `onEndReached` and no page state, so whatever this one
+     * response contains is the entire set the operator can ever browse. The
+     * shared service defaults to `perPage = 8`, and the client never sends a
+     * `per_page`, so every live 1.1.0 install has been silently capped at 8
+     * assets — a workspace with 20 tablecloths could not reach anything else
+     * except via search.
+     *
+     * Until the app ships real infinite scroll (which needs a store release,
+     * and there is no OTA channel), request the service's maximum page size
+     * whenever the client didn't ask for a specific one. This reaches existing
+     * installs with a plain webapp deploy. Rebuilding the params and passing
+     * them as `filters` keeps every other query param (booking window,
+     * hideUnavailable, search) intact while overriding only the page size.
+     */
+    const pickerParams = new URL(request.url).searchParams;
+    if (!pickerParams.get("per_page")) {
+      pickerParams.set("per_page", String(MOBILE_PICKER_MAX_PAGE_SIZE));
+    }
+
     const { assets, page, perPage, totalAssets, totalPages } =
-      await getPaginatedAndFilterableAssets({ request, organizationId });
+      await getPaginatedAndFilterableAssets({
+        request,
+        organizationId,
+        filters: pickerParams.toString(),
+      });
 
     // Resolve the workspace's display code (QR Code ID by default, or a SAM ID
     // / barcode per the org's preference) for each asset so the mobile picker


### PR DESCRIPTION
## The bug (live in production since 2026-07-06)

The companion's **Add to Booking** picker silently caps at **20 assets**, with no way to reach the 21st.

Three facts combine:

1. `add-assets.tsx` renders a FlatList with **no `onEndReached`**, no load-more, no page state. Whatever one response contains is everything the operator can ever browse.
2. The mobile client **never sends `per_page`**, so `getPaginatedAndFilterableAssets` falls through to `updateCookieWithPerPage`, whose default is **20** for a request with no cookie — and mobile never sends one.
3. Therefore every install since **v1.1.0 (published 6 July)** has been limited to 20 assets, with search as the only workaround.

Reported from the field as *"why can I only see tablecloths?"*. That workspace holds **exactly 20 tablecloths**, followed by the assets that were invisible. The tablecloths filled the page precisely and everything else sat one row past an invisible cutoff. It was misdiagnosed twice as "that workspace is mostly tablecloths" before anyone read the query.

## The fix

Request the service's maximum page size (100) when the client didn't ask for a specific one. Rebuilding the params and passing them as `filters` overrides only the page size, preserving the booking window, `hideUnavailable` and search.

**This is deliberately a server-side mitigation.** It reaches every existing install on a normal webapp deploy — no store release, and there is no OTA channel. Real infinite scroll in the picker is the actual fix and needs an app build; it's queued for the next companion round.

## Testing

Verified on the iOS simulator against a 27-asset workspace. I queried positions 21-27 from the database **before** the run and predicted them; the picker then rendered all 27 and terminated at position 27 (`Laerdal SimMan 3G Wireless Patient Simulator`), with rows 21-26 matching the query exactly and in order. Previously the list stopped at 20 and none of those seven were reachable.

Typecheck and prettier pass.

## Follow-up (not in this PR)

- Infinite scroll in `add-assets.tsx`, covering workspaces above 100 assets. The Kits and Models tabs share the same paginationless list and need the same treatment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mobile booking asset picker to display more available assets by default.
  * Preserved booking dates, availability filters, and other search parameters when loading results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->