### PR TITLE
fix(mobile): apply web's draft-booking privacy rule to the mobile endpoints

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -9,6 +9,7 @@ import {
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import {
+  bookingDraftVisibilityClause,
   computeBookingAssetRemaining,
   computeBookingAssetRemainingToCheckOut,
   getPartiallyCheckedInAssetIds,
@@ -56,6 +57,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         id: bookingId,
         organizationId,
         ...(isSelfServiceOrBase && { custodianUserId: user.id }),
+        /**
+         * Draft privacy (web parity). A DRAFT booking is private to its
+         * creator — web gates the detail route on the same shared clause, so
+         * without it a direct GET here returns a colleague's unfinished draft
+         * even though the list would (now) hide it. The list fix alone is not
+         * enough: booking ids are guessable-adjacent and the detail endpoint
+         * is reachable directly.
+         */
+        AND: [bookingDraftVisibilityClause(user.id)],
       },
       select: {
         id: true,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.ts
@@ -6,6 +6,7 @@ import {
   requireMobileAuth,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { bookingDraftVisibilityClause } from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
 
 /**
@@ -83,6 +84,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
       organizationId,
       status: { in: statusFilter },
       ...(isSelfServiceOrBase && { custodianUserId: user.id }),
+      /**
+       * Draft privacy (web parity). A DRAFT booking is private to whoever
+       * created it — web enforces this in `getBookings`, the slim picker list
+       * and the CSV export via this same shared clause. Mobile applied it
+       * nowhere, so every user saw every colleague's unfinished drafts.
+       *
+       * AND-ed rather than merged into the search `OR` below: an OR at this
+       * level would widen the search clause instead of restricting it.
+       */
+      AND: [bookingDraftVisibilityClause(user.id)],
       // Keyword search over booking name + description (the field-tech "find my
       // booking" case). Web also searches tags/custodian/asset names; name +
       // description covers the common case without a heavier query.


### PR DESCRIPTION
## The bug

Web treats a **DRAFT booking as private to its creator**, enforced via the shared `bookingDraftVisibilityClause`:

```ts
OR: [
  { status: { not: "DRAFT" } },
  { AND: [{ status: "DRAFT" }, { creatorId: userId }] },
]
```

Applied on web in `getBookings`, the slim picker list and the CSV export, and covered by four test files.

**The mobile list and detail endpoints applied it nowhere.** Every user saw every colleague's unfinished drafts in the app, and could open them.

Found in the field: web's booking list filtered to Draft showed **nothing**, while the same workspace on mobile listed **five** drafts created by three different people. Same-workspace exposure only, not cross-org, but it breaks the repo rule that mobile must never be more permissive than web.

## The fix

Apply the shared clause in the two endpoints that were missing it.

- **`AND`-ed**, not merged into the list's search `OR` — an OR at that level would have widened the search clause instead of restricting it.
- **The detail endpoint needs it independently.** Hiding a row from the list still leaves it fetchable by id, so both were required.

**The mobile dashboard was already safe** and is untouched: it delegates to `getBookings`, which applies the clause internally, and only ever queries RESERVED/ONGOING/OVERDUE. (My first pass reported "zero occurrences in all three endpoints" — that was counting the literal helper name, not whether the protection was reached.)

## Testing

Verified on the iOS simulator against the QA workspace with **both controls**:

| Draft | Creator | Result |
|---|---|---|
| `ZZ DRAFT THEIRS` | the signed-in user | **visible** ✅ |
| `ZZ DRAFT MINE` | a different user | **hidden from the list** ✅, and **"Booking not found"** on a direct deep link ✅ |

Before this change both appeared. Test rows cleaned up afterwards.

482 booking + mobile-route tests pass. Typecheck, ESLint and prettier clean.

## Related product question (not this PR)

Web hides other people's drafts **even from workspace admins**, so an admin cannot see or clean up drafts left by their team on either platform. Whether admins should get a "see all drafts" capability is a design decision that must be answered for web and mobile together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy for draft bookings in mobile booking lists and details.
  * Draft bookings are now visible only to their creator, including when accessed directly by booking ID.
  * Existing pagination, sorting, status filters, and booking responses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->