### PR TITLE
docs(mobile): correct the page-size explanation left by #2726

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
@@ -60,10 +60,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
      * The companion's picker has NO pagination UI — `add-assets.tsx` renders a
      * FlatList with no `onEndReached` and no page state, so whatever this one
      * response contains is the entire set the operator can ever browse. The
-     * shared service defaults to `perPage = 8`, and the client never sends a
-     * `per_page`, so every live 1.1.0 install has been silently capped at 8
-     * assets — a workspace with 20 tablecloths could not reach anything else
-     * except via search.
+     * client never sends a `per_page`, so the size comes from
+     * `updateCookieWithPerPage`, whose default is 20 for a request with no
+     * cookie — and mobile never sends one. Every live 1.1.0 install was
+     * therefore capped at 20 assets: a workspace holding exactly 20
+     * tablecloths could reach nothing else except via search.
      *
      * Until the app ships real infinite scroll (which needs a store release,
      * and there is no OTA channel), request the service's maximum page size


### PR DESCRIPTION
Comment-only follow-up to #2726.

That PR's inline comment blamed `getAssets`' own `perPage = 8` default, which is a different function and not on this code path. The effective size comes from `updateCookieWithPerPage`, whose default is **20** for a request with no cookie — and mobile never sends one.

So live installs were capped at **20**, not 8. That figure is also what actually explains the field report: the workspace held exactly 20 tablecloths, so they filled the page precisely and everything else fell past the cutoff.

**No behaviour change** — the fix in #2726 was correct, only its explanation was wrong. This stops the next person debugging from being sent to the wrong function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the mobile bookings asset endpoint documentation to reflect the effective default limit of 20 assets when no page size is provided.
  * Clarified that runtime behavior and endpoint functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->