### PR TITLE
feat(companion): paginate the whole booking picker so no asset is unreachable

### DIFF
--- a/apps/companion/app/(tabs)/bookings/add-assets.tsx
+++ b/apps/companion/app/(tabs)/bookings/add-assets.tsx
@@ -46,6 +46,12 @@ import { QuantityInputSheet } from "@/components/quantity-input-sheet";
 type Mode = "assets" | "kits" | "models";
 
 const assetKeyExtractor = (item: AvailableAsset) => item.id;
+/**
+ * Rows fetched per page. Every tab pages through the whole list, so this is a
+ * latency/-payload tradeoff, not a cap: nothing is unreachable at any size.
+ */
+const PICKER_PAGE_SIZE = 50;
+
 const kitKeyExtractor = (item: AvailableKit) => item.id;
 const modelKeyExtractor = (item: AvailableModel) => item.id;
 
@@ -79,10 +85,13 @@ export default function AddBookingAssetsScreen() {
   const [modelRequestsById, setModelRequestsById] = useState<
     Record<string, AvailableModelExistingRequest>
   >({});
-  const [totalModelCount, setTotalModelCount] = useState(0);
   // The model whose quantity sheet is open (null = closed).
   const [activeModel, setActiveModel] = useState<AvailableModel | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  /** True while a "load more" page is in flight (footer spinner only). */
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  /** Whether the active tab has further pages to pull in. */
+  const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [searchInput, setSearchInput] = useState("");
@@ -103,62 +112,142 @@ export default function AddBookingAssetsScreen() {
   // Monotonic id so a slow earlier fetch (e.g. an old search/mode) can't
   // overwrite the newest results with stale availability.
   const requestIdRef = useRef(0);
-  const load = useCallback(async () => {
-    if (!currentOrg || !from || !to) return;
-    const reqId = ++requestIdRef.current;
-    setIsLoading(true);
-    setError(null);
-    if (mode === "assets") {
-      const { data, error: err } = await api.availableAssets(currentOrg.id, {
-        bookingFrom: from,
-        bookingTo: to,
-        // Keep THIS booking's own assets selectable when editing (otherwise they
-        // filter out as "unavailable" against their own reservation).
-        unhideBookingId: bookingId,
-        search: debouncedSearch || undefined,
-      });
-      if (reqId !== requestIdRef.current) return; // superseded by a newer load
-      if (err) setError(err);
-      else if (data) setAssets(data.assets);
-    } else if (mode === "kits") {
-      const { data, error: err } = await api.availableKits(currentOrg.id, {
-        bookingFrom: from,
-        bookingTo: to,
-        // REQUIRED: enables the kit conflict filter (else already-booked kits
-        // show as available) and keeps this booking's own kits selectable.
-        currentBookingId: bookingId,
-        search: debouncedSearch || undefined,
-      });
-      if (reqId !== requestIdRef.current) return; // superseded by a newer load
-      if (err) setError(err);
-      else if (data) setKits(data.kits);
-    } else {
-      // Book-by-model: availability is computed server-side over the booking's
-      // window. Search is ALSO server-side (the list is capped at ~50, so a
-      // client-only filter could never reach a model that sorts past the cap).
-      const { data, error: err } = await api.availableModels(
-        currentOrg.id,
-        bookingId,
-        debouncedSearch || undefined
-      );
-      if (reqId !== requestIdRef.current) return; // superseded by a newer load
-      if (err) setError(err);
-      else if (data) {
-        setModels(data.assetModels ?? []);
-        setTotalModelCount(data.totalAssetModels ?? 0);
-        setModelRequestsById(
-          Object.fromEntries(
-            (data.modelRequests ?? []).map((mr) => [mr.assetModelId, mr])
-          )
-        );
-      }
-    }
-    if (reqId === requestIdRef.current) setIsLoading(false);
-  }, [currentOrg, from, to, mode, debouncedSearch, bookingId]);
+  /** Highest page currently held, so `loadMore` knows what to ask for next. */
+  const pageRef = useRef(1);
 
+  /**
+   * Fetch one page for the active tab.
+   *
+   * Every tab is paginated: the operator must be able to reach EVERY asset,
+   * kit and model that is valid for this booking, not just the first page.
+   * A capped list silently hides inventory — a workspace whose first page is
+   * all one category looks like it owns nothing else.
+   *
+   * `append` distinguishes "load more" (concatenate) from a fresh load after a
+   * tab switch or a new search (replace). The request-id guard makes a slow
+   * earlier page lose to a newer one rather than clobber it.
+   */
+  const fetchPage = useCallback(
+    async (targetPage: number, append: boolean) => {
+      if (!currentOrg || !from || !to) return;
+      const reqId = ++requestIdRef.current;
+      if (append) {
+        setIsLoadingMore(true);
+      } else {
+        setIsLoading(true);
+        setError(null);
+      }
+
+      if (mode === "assets") {
+        const { data, error: err } = await api.availableAssets(currentOrg.id, {
+          bookingFrom: from,
+          bookingTo: to,
+          // Keep THIS booking's own assets selectable when editing (otherwise they
+          // filter out as "unavailable" against their own reservation).
+          unhideBookingId: bookingId,
+          search: debouncedSearch || undefined,
+          page: targetPage,
+          perPage: PICKER_PAGE_SIZE,
+        });
+        if (reqId !== requestIdRef.current) return; // superseded by a newer load
+        if (err) setError(err);
+        else if (data) {
+          setAssets((prev) =>
+            append ? [...prev, ...data.assets] : data.assets
+          );
+          setHasMore(targetPage < (data.totalPages ?? 1));
+          pageRef.current = targetPage;
+        }
+      } else if (mode === "kits") {
+        const { data, error: err } = await api.availableKits(currentOrg.id, {
+          bookingFrom: from,
+          bookingTo: to,
+          // REQUIRED: enables the kit conflict filter (else already-booked kits
+          // show as available) and keeps this booking's own kits selectable.
+          currentBookingId: bookingId,
+          search: debouncedSearch || undefined,
+          page: targetPage,
+          perPage: PICKER_PAGE_SIZE,
+        });
+        if (reqId !== requestIdRef.current) return; // superseded by a newer load
+        if (err) setError(err);
+        else if (data) {
+          setKits((prev) => (append ? [...prev, ...data.kits] : data.kits));
+          setHasMore(targetPage < (data.totalPages ?? 1));
+          pageRef.current = targetPage;
+        }
+      } else {
+        // Book-by-model: availability is computed server-side over the booking's
+        // window, and so is search. Paginated like the other tabs so a model
+        // sorting past the first page is still reachable by scrolling.
+        const { data, error: err } = await api.availableModels(
+          currentOrg.id,
+          bookingId,
+          debouncedSearch || undefined,
+          { page: targetPage, perPage: PICKER_PAGE_SIZE }
+        );
+        if (reqId !== requestIdRef.current) return; // superseded by a newer load
+        if (err) setError(err);
+        else if (data) {
+          const rows = data.assetModels ?? [];
+          setModels((prev) => (append ? [...prev, ...rows] : rows));
+          setHasMore(targetPage < (data.totalPages ?? 1));
+          pageRef.current = targetPage;
+          // Reservations are the same on every page — only seed them once, so a
+          // "load more" can't clobber edits made since the first page landed.
+          if (!append) {
+            setModelRequestsById(
+              Object.fromEntries(
+                (data.modelRequests ?? []).map((mr) => [mr.assetModelId, mr])
+              )
+            );
+          }
+        }
+      }
+      if (reqId === requestIdRef.current) {
+        setIsLoading(false);
+        setIsLoadingMore(false);
+      }
+    },
+    [currentOrg, from, to, mode, debouncedSearch, bookingId]
+  );
+
+  // Reset to page 1 whenever the tab, search or booking window changes.
+  // `fetchPage`'s identity already tracks exactly those inputs.
   useEffect(() => {
-    load();
-  }, [load]);
+    pageRef.current = 1;
+    setHasMore(false);
+    void fetchPage(1, false);
+  }, [fetchPage]);
+
+  /** Pull the next page in when the list nears its end. */
+  const loadMore = useCallback(() => {
+    if (isLoading || isLoadingMore || !hasMore) return;
+    void fetchPage(pageRef.current + 1, true);
+  }, [isLoading, isLoadingMore, hasMore, fetchPage]);
+
+  /**
+   * Reload the active tab from page 1. Used after a mutation (reserving or
+   * clearing a model) and by the error retry — both invalidate availability,
+   * so any pages already held are stale and must be dropped, not appended to.
+   */
+  const reload = useCallback(() => {
+    pageRef.current = 1;
+    setHasMore(false);
+    void fetchPage(1, false);
+  }, [fetchPage]);
+
+  /**
+   * Footer shared by all three tabs: a spinner while the next page loads.
+   * Deliberately renders nothing once everything is loaded — reaching the end
+   * of a fully-loaded list needs no explanation, whereas the old "showing 50
+   * of N, search to find the rest" copy existed only to excuse a hard cap.
+   */
+  const listFooter = isLoadingMore ? (
+    <View style={styles.listFooter}>
+      <ActivityIndicator size="small" color={colors.muted} />
+    </View>
+  ) : null;
 
   const toggleAsset = useCallback((assetId: string) => {
     setSelectedAssetIds((prev) => {
@@ -230,7 +319,7 @@ export default function AddBookingAssetsScreen() {
     }
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     markBookingDirty(bookingId);
-    load(); // refresh availability + the reserved amounts
+    reload(); // refresh availability + the reserved amounts
   };
 
   // Memoized so `renderModel` (which references it) keeps a stable identity
@@ -263,13 +352,13 @@ export default function AddBookingAssetsScreen() {
                 Haptics.NotificationFeedbackType.Success
               );
               markBookingDirty(bookingId);
-              load();
+              reload();
             },
           },
         ]
       );
     },
-    [currentOrg, bookingId, load]
+    [currentOrg, bookingId, reload]
   );
 
   const renderAsset = useCallback(
@@ -498,7 +587,7 @@ export default function AddBookingAssetsScreen() {
           <Text style={styles.emptyText}>{error}</Text>
           <TouchableOpacity
             style={styles.retryButton}
-            onPress={load}
+            onPress={reload}
             accessibilityRole="button"
             accessibilityLabel="Retry"
           >
@@ -512,6 +601,9 @@ export default function AddBookingAssetsScreen() {
           keyExtractor={assetKeyExtractor}
           contentContainerStyle={styles.list}
           keyboardShouldPersistTaps="handled"
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={listFooter}
           ListEmptyComponent={
             <View style={styles.centered}>
               <Ionicons
@@ -532,6 +624,9 @@ export default function AddBookingAssetsScreen() {
           keyExtractor={kitKeyExtractor}
           contentContainerStyle={styles.list}
           keyboardShouldPersistTaps="handled"
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={listFooter}
           ListEmptyComponent={
             <View style={styles.centered}>
               <Ionicons
@@ -552,17 +647,9 @@ export default function AddBookingAssetsScreen() {
           keyExtractor={modelKeyExtractor}
           contentContainerStyle={styles.list}
           keyboardShouldPersistTaps="handled"
-          ListFooterComponent={
-            // The picker returns the first 50 (by name); when there are more and
-            // the user hasn't searched, nudge them to search — which now filters
-            // server-side, so any model past the cap is reachable.
-            !debouncedSearch && totalModelCount > models.length ? (
-              <Text style={styles.modelsFooter}>
-                Showing {models.length} of {totalModelCount} models. Search by
-                name to find the rest.
-              </Text>
-            ) : null
-          }
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.4}
+          ListFooterComponent={listFooter}
           ListEmptyComponent={
             <View style={styles.centered}>
               <Ionicons name="cube-outline" size={40} color={colors.border} />
@@ -761,11 +848,9 @@ const useStyles = createStyles((colors, shadows) => ({
   modelRemoveButton: {
     padding: spacing.xs,
   },
-  modelsFooter: {
-    fontSize: fontSize.xs,
-    color: colors.muted,
-    textAlign: "center",
-    paddingVertical: spacing.md,
+  listFooter: {
+    paddingVertical: spacing.lg,
+    alignItems: "center",
   },
   checkbox: {
     width: 22,

--- a/apps/companion/components/location-picker.tsx
+++ b/apps/companion/components/location-picker.tsx
@@ -274,21 +274,33 @@ export function LocationPicker({
    * `LOCATION_PAGE_HARD_STOP` bounds pathological workspaces rather than
    * looping forever.
    */
+  /**
+   * Generation counter so a slow earlier run (older search or org) can't
+   * overwrite fresher state when it finally resolves. The booking picker
+   * already does this; these pickers were missing it.
+   */
+  const requestGenerationRef = useRef(0);
+
   const fetchLocations = useCallback(async () => {
     if (!orgId) return;
+    const generation = ++requestGenerationRef.current;
     setIsLoading(true);
     setError(null);
 
     const collected: Location[] = [];
     let page = 1;
-    let totalPages = 1;
 
-    do {
+    // Loop rather than do/while so `totalPages` is only ever read from the
+    // response that defined it, with no dead initial value.
+    for (;;) {
       const { data, error: fetchErr } = await api.locations(
         orgId,
         debouncedSearch || undefined,
         { page, perPage: LOCATION_PAGE_SIZE }
       );
+
+      // Superseded by a newer fetch — drop this result entirely.
+      if (generation !== requestGenerationRef.current) return;
 
       if (fetchErr || !data) {
         setError(fetchErr || "Failed to load locations");
@@ -297,9 +309,11 @@ export function LocationPicker({
       }
 
       collected.push(...data.locations);
-      totalPages = data.totalPages ?? 1;
+
+      const totalPages = data.totalPages ?? 1;
+      if (page >= totalPages || page >= LOCATION_PAGE_HARD_STOP) break;
       page += 1;
-    } while (page <= totalPages && page <= LOCATION_PAGE_HARD_STOP);
+    }
 
     setLocations(collected);
     setIsLoading(false);

--- a/apps/companion/components/location-picker.tsx
+++ b/apps/companion/components/location-picker.tsx
@@ -23,6 +23,11 @@ type Props = {
   onClose: () => void;
 };
 
+/** Rows per request while walking to a complete location set. */
+const LOCATION_PAGE_SIZE = 100;
+/** Safety bound so a pathological workspace can't loop indefinitely. */
+const LOCATION_PAGE_HARD_STOP = 50;
+
 const locationKeyExtractor = (item: LocationNode) => item.id;
 
 /** Location with depth info for hierarchical rendering */
@@ -253,21 +258,50 @@ export function LocationPicker({
     return () => clearTimeout(timer);
   }, [search]);
 
+  /**
+   * Load EVERY location, walking the server's pages until the list is whole.
+   *
+   * Unlike the flat pickers this one cannot lazily page as you scroll:
+   * `buildLocationTree` nests rows by `parentId`, and rows are ordered by
+   * name, so a child routinely lands on a different page from its parent.
+   * Rendering a half-loaded set would show orphaned children at the root —
+   * a wrong hierarchy is worse than a slow one.
+   *
+   * The endpoint used to hard-cap at 50 with no way past it, so a workspace
+   * with more locations than that could not place an asset in the ones that
+   * sorted after the cut. Locations are a small, bounded entity (rooms,
+   * shelves, sites), so completing the set costs one extra request per 100.
+   * `LOCATION_PAGE_HARD_STOP` bounds pathological workspaces rather than
+   * looping forever.
+   */
   const fetchLocations = useCallback(async () => {
     if (!orgId) return;
     setIsLoading(true);
     setError(null);
 
-    const { data, error: fetchErr } = await api.locations(
-      orgId,
-      debouncedSearch || undefined
-    );
+    const collected: Location[] = [];
+    let page = 1;
+    let totalPages = 1;
 
-    if (fetchErr || !data) {
-      setError(fetchErr || "Failed to load locations");
-    } else {
-      setLocations(data.locations);
-    }
+    do {
+      const { data, error: fetchErr } = await api.locations(
+        orgId,
+        debouncedSearch || undefined,
+        { page, perPage: LOCATION_PAGE_SIZE }
+      );
+
+      if (fetchErr || !data) {
+        setError(fetchErr || "Failed to load locations");
+        setIsLoading(false);
+        return;
+      }
+
+      collected.push(...data.locations);
+      totalPages = data.totalPages ?? 1;
+      page += 1;
+    } while (page <= totalPages && page <= LOCATION_PAGE_HARD_STOP);
+
+    setLocations(collected);
     setIsLoading(false);
   }, [orgId, debouncedSearch]);
 

--- a/apps/companion/components/team-member-picker.tsx
+++ b/apps/companion/components/team-member-picker.tsx
@@ -77,6 +77,10 @@ const useStyles = createStyles((colors, shadows) => ({
     paddingVertical: spacing.lg,
     alignItems: "center",
   },
+  footerRetryText: {
+    fontSize: fontSize.sm,
+    color: colors.muted,
+  },
   memberRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -148,6 +152,13 @@ export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
+  /**
+   * Failures while appending a page are tracked separately from `error`. The
+   * render path shows a FULL-SCREEN error whenever `error` is set, so reusing
+   * it for a load-more failure would throw away the members already on screen
+   * and force a full reload — a transient blip should only fail the footer.
+   */
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -162,6 +173,11 @@ export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
 
   /** Highest page held, so `loadMore` knows what to request next. */
   const pageRef = useRef(1);
+  /**
+   * Generation counter so a slow earlier run (older search) can't overwrite
+   * fresher state when it resolves late.
+   */
+  const requestGenerationRef = useRef(0);
 
   /**
    * Fetch one page of team members.
@@ -174,10 +190,14 @@ export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
   const fetchMembersPage = useCallback(
     async (targetPage: number, append: boolean) => {
       if (!orgId) return;
-      if (append) setIsLoadingMore(true);
-      else {
+      const generation = ++requestGenerationRef.current;
+      if (append) {
+        setIsLoadingMore(true);
+        setLoadMoreError(null);
+      } else {
         setIsLoading(true);
         setError(null);
+        setLoadMoreError(null);
       }
 
       const { data, error: fetchErr } = await api.teamMembers(
@@ -186,8 +206,13 @@ export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
         { page: targetPage, perPage: MEMBER_PAGE_SIZE }
       );
 
+      // Superseded by a newer fetch — drop this result entirely.
+      if (generation !== requestGenerationRef.current) return;
+
       if (fetchErr || !data) {
-        setError(fetchErr || "Failed to load team members");
+        // Keep the loaded list on an append failure; only the footer fails.
+        if (append) setLoadMoreError(fetchErr || "Couldn't load more");
+        else setError(fetchErr || "Failed to load team members");
       } else {
         setMembers((prev) =>
           append ? [...prev, ...data.teamMembers] : data.teamMembers
@@ -380,6 +405,17 @@ export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
                 <View style={styles.footerLoading}>
                   <ActivityIndicator size="small" color={colors.muted} />
                 </View>
+              ) : loadMoreError ? (
+                <TouchableOpacity
+                  style={styles.footerLoading}
+                  onPress={loadMore}
+                  accessibilityRole="button"
+                  accessibilityLabel="Retry loading more team members"
+                >
+                  <Text style={styles.footerRetryText}>
+                    {loadMoreError}. Tap to retry.
+                  </Text>
+                </TouchableOpacity>
               ) : null
             }
           />

--- a/apps/companion/components/team-member-picker.tsx
+++ b/apps/companion/components/team-member-picker.tsx
@@ -22,6 +22,9 @@ type Props = {
   onClose: () => void;
 };
 
+/** Rows per page; the list pages through all members, so this is not a cap. */
+const MEMBER_PAGE_SIZE = 50;
+
 const memberKeyExtractor = (item: TeamMember) => item.id;
 
 const useStyles = createStyles((colors, shadows) => ({
@@ -69,6 +72,10 @@ const useStyles = createStyles((colors, shadows) => ({
   list: {
     paddingHorizontal: spacing.lg,
     paddingBottom: spacing.lg,
+  },
+  footerLoading: {
+    paddingVertical: spacing.lg,
+    alignItems: "center",
   },
   memberRow: {
     flexDirection: "row",
@@ -139,6 +146,8 @@ const useStyles = createStyles((colors, shadows) => ({
 export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -151,23 +160,58 @@ export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
     return () => clearTimeout(timer);
   }, [search]);
 
+  /** Highest page held, so `loadMore` knows what to request next. */
+  const pageRef = useRef(1);
+
+  /**
+   * Fetch one page of team members.
+   *
+   * Paginated because custody must be assignable to ANY colleague. The
+   * endpoint used to hard-cap at 50 with no way to reach past it, so an org
+   * larger than that simply could not hand an asset to the people who sorted
+   * after the cut.
+   */
+  const fetchMembersPage = useCallback(
+    async (targetPage: number, append: boolean) => {
+      if (!orgId) return;
+      if (append) setIsLoadingMore(true);
+      else {
+        setIsLoading(true);
+        setError(null);
+      }
+
+      const { data, error: fetchErr } = await api.teamMembers(
+        orgId,
+        debouncedSearch || undefined,
+        { page: targetPage, perPage: MEMBER_PAGE_SIZE }
+      );
+
+      if (fetchErr || !data) {
+        setError(fetchErr || "Failed to load team members");
+      } else {
+        setMembers((prev) =>
+          append ? [...prev, ...data.teamMembers] : data.teamMembers
+        );
+        setHasMore(targetPage < (data.totalPages ?? 1));
+        pageRef.current = targetPage;
+      }
+      setIsLoading(false);
+      setIsLoadingMore(false);
+    },
+    [orgId, debouncedSearch]
+  );
+
   const fetchMembers = useCallback(async () => {
-    if (!orgId) return;
-    setIsLoading(true);
-    setError(null);
+    pageRef.current = 1;
+    setHasMore(false);
+    await fetchMembersPage(1, false);
+  }, [fetchMembersPage]);
 
-    const { data, error: fetchErr } = await api.teamMembers(
-      orgId,
-      debouncedSearch || undefined
-    );
-
-    if (fetchErr || !data) {
-      setError(fetchErr || "Failed to load team members");
-    } else {
-      setMembers(data.teamMembers);
-    }
-    setIsLoading(false);
-  }, [orgId, debouncedSearch]);
+  /** Pull the next page in when the list nears its end. */
+  const loadMore = useCallback(() => {
+    if (isLoading || isLoadingMore || !hasMore) return;
+    void fetchMembersPage(pageRef.current + 1, true);
+  }, [isLoading, isLoadingMore, hasMore, fetchMembersPage]);
 
   // Track when the initial (non-search) data was last fetched
   const lastFetchedAt = useRef(0);
@@ -329,6 +373,15 @@ export function TeamMemberPicker({ visible, orgId, onSelect, onClose }: Props) {
             initialNumToRender={15}
             contentContainerStyle={styles.list}
             keyboardShouldPersistTaps="handled"
+            onEndReached={loadMore}
+            onEndReachedThreshold={0.4}
+            ListFooterComponent={
+              isLoadingMore ? (
+                <View style={styles.footerLoading}>
+                  <ActivityIndicator size="small" color={colors.muted} />
+                </View>
+              ) : null
+            }
           />
         )}
       </SafeAreaView>

--- a/apps/companion/lib/api/assets.ts
+++ b/apps/companion/lib/api/assets.ts
@@ -98,9 +98,15 @@ export const assetsApi = {
     ),
 
   /** Get team members for an organization (for custody picker) */
-  teamMembers: (orgId: string, search?: string) => {
+  teamMembers: (
+    orgId: string,
+    search?: string,
+    params?: { page?: number; perPage?: number }
+  ) => {
     const searchParams = new URLSearchParams({ orgId });
     if (search) searchParams.set("search", search);
+    if (params?.page) searchParams.set("page", String(params.page));
+    if (params?.perPage) searchParams.set("perPage", String(params.perPage));
     const path = `/api/mobile/team-members?${searchParams}`;
     // Only cache non-search requests (full list)
     return search
@@ -109,9 +115,15 @@ export const assetsApi = {
   },
 
   /** Get locations for an organization (for location picker) */
-  locations: (orgId: string, search?: string) => {
+  locations: (
+    orgId: string,
+    search?: string,
+    params?: { page?: number; perPage?: number }
+  ) => {
     const searchParams = new URLSearchParams({ orgId });
     if (search) searchParams.set("search", search);
+    if (params?.page) searchParams.set("page", String(params.page));
+    if (params?.perPage) searchParams.set("perPage", String(params.perPage));
     const path = `/api/mobile/locations?${searchParams}`;
     // Only cache non-search requests (full list)
     return search

--- a/apps/companion/lib/api/bookings.ts
+++ b/apps/companion/lib/api/bookings.ts
@@ -253,6 +253,7 @@ export const bookingsApi = {
       unhideBookingId?: string;
       search?: string;
       page?: number;
+      perPage?: number;
     }
   ) => {
     const sp = new URLSearchParams({ orgId });
@@ -263,6 +264,7 @@ export const bookingsApi = {
       sp.set("unhideAssetsBookigIds", params.unhideBookingId);
     if (params.search) sp.set("s", params.search);
     if (params.page) sp.set("page", String(params.page));
+    if (params.perPage) sp.set("per_page", String(params.perPage));
     return apiFetch<AvailableAssetsResponse>(
       `/api/mobile/bookings/available-assets?${sp}`
     );
@@ -280,6 +282,7 @@ export const bookingsApi = {
       currentBookingId?: string;
       search?: string;
       page?: number;
+      perPage?: number;
     }
   ) => {
     const sp = new URLSearchParams({ orgId });
@@ -290,6 +293,7 @@ export const bookingsApi = {
       sp.set("currentBookingId", params.currentBookingId);
     if (params.search) sp.set("s", params.search);
     if (params.page) sp.set("page", String(params.page));
+    if (params.perPage) sp.set("per_page", String(params.perPage));
     return apiFetch<AvailableKitsResponse>(
       `/api/mobile/bookings/available-kits?${sp}`
     );
@@ -306,9 +310,16 @@ export const bookingsApi = {
    * model name server-side so orgs with more than ~50 models can reach any
    * of them (the list is capped, so a client-only filter can't).
    */
-  availableModels: (orgId: string, bookingId: string, search?: string) => {
+  availableModels: (
+    orgId: string,
+    bookingId: string,
+    search?: string,
+    params?: { page?: number; perPage?: number }
+  ) => {
     const sp = new URLSearchParams({ orgId, bookingId });
     if (search) sp.set("s", search);
+    if (params?.page) sp.set("page", String(params.page));
+    if (params?.perPage) sp.set("perPage", String(params.perPage));
     return apiFetch<AvailableModelsResponse>(
       `/api/mobile/bookings/available-models?${sp}`
     );

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -362,6 +362,10 @@ export type TeamMember = {
 
 export type TeamMembersResponse = {
   teamMembers: TeamMember[];
+  page?: number;
+  perPage?: number;
+  totalCount?: number;
+  totalPages?: number;
 };
 
 export type Location = {
@@ -374,6 +378,10 @@ export type Location = {
 
 export type LocationsResponse = {
   locations: Location[];
+  page?: number;
+  perPage?: number;
+  totalCount?: number;
+  totalPages?: number;
 };
 
 export type CustodyResponse = {

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -768,12 +768,21 @@ export type AvailableModelExistingRequest = {
 export type AvailableModelsResponse = {
   /** False when the workspace has no AssetModel at all — hide the picker. */
   showModelsTab: boolean;
-  /** Per-model availability for this booking's window (first 50 by name). */
+  /** Per-model availability for this booking's window, for THIS page. */
   assetModels: AvailableModel[];
-  /** Full workspace model count (the list above is capped at 50). */
+  /** Full workspace model count, ignoring any search. */
   totalAssetModels: number;
   /** This booking's existing model reservations, to pre-fill the inputs. */
   modelRequests: AvailableModelExistingRequest[];
+  /** 1-based page this response represents. */
+  page?: number;
+  perPage?: number;
+  /**
+   * Models matching the current search — the pagination denominator. The
+   * picker stops requesting pages once it holds this many rows.
+   */
+  matchedAssetModels?: number;
+  totalPages?: number;
 };
 
 /** Response from the model-request upsert/remove endpoint. */

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -253,6 +253,13 @@ export type BookingModelTabData = {
   }>;
   /** Full-org model count (not the truncated `MODEL_PICKER_LIMIT` list). */
   totalAssetModels: number;
+  /**
+   * How many models match the current `search` (equals `totalAssetModels`
+   * when no search is applied). This is the pagination denominator: a client
+   * that pages through the list needs the count of MATCHING rows, not the
+   * full-org count, to know when it has reached the end.
+   */
+  matchedAssetModels: number;
   /** This booking's existing model-level requests, outstanding + fulfilled. */
   modelRequests: Array<{
     assetModelId: string;
@@ -294,10 +301,23 @@ export async function getBookingModelTabData({
   organizationId,
   booking,
   search,
+  page,
+  perPage,
 }: {
   organizationId: string;
   booking: BookingForModelTab;
   search?: string;
+  /**
+   * 1-based page for callers that paginate the model list (the mobile
+   * picker). Omitted by the web loaders, which render a seed list and reach
+   * the rest through search — they keep the historical single-page shape.
+   */
+  page?: number;
+  /**
+   * Page size for paginating callers. Defaults to `MODEL_PICKER_LIMIT` so
+   * omitting both params reproduces the pre-pagination behaviour exactly.
+   */
+  perPage?: number;
 }): Promise<BookingModelTabData> {
   try {
     const assetModelsCount = await db.assetModel.count({
@@ -322,12 +342,28 @@ export async function getBookingModelTabData({
 
     let assetModels: BookingModelTabAssetModel[] = [];
 
+    /**
+     * Count of models matching the search. Paginating callers need this to
+     * know when they've reached the end; without a search it's the same query
+     * as the full-org count, so reuse that rather than issuing a second one.
+     */
+    const matchedAssetModels = trimmedSearch
+      ? await db.assetModel.count({ where: { organizationId, ...searchWhere } })
+      : assetModelsCount;
+
+    // Page size defaults to the historical cap, so callers that pass neither
+    // param (the web loaders) get byte-identical behaviour to before.
+    const effectivePerPage =
+      perPage && perPage > 0 ? Math.min(perPage, 100) : MODEL_PICKER_LIMIT;
+    const effectivePage = page && page > 1 ? page : 1;
+
     if (showModelsTab) {
       const rawModels = await db.assetModel.findMany({
         where: { organizationId, ...searchWhere },
         select: { id: true, name: true },
         orderBy: { name: "asc" },
-        take: MODEL_PICKER_LIMIT,
+        skip: (effectivePage - 1) * effectivePerPage,
+        take: effectivePerPage,
       });
 
       const availabilities = await Promise.all(
@@ -389,6 +425,7 @@ export async function getBookingModelTabData({
       assetModels,
       initialAssetModels,
       totalAssetModels: assetModelsCount,
+      matchedAssetModels,
       modelRequests,
     };
   } catch (cause) {

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -361,7 +361,13 @@ export async function getBookingModelTabData({
       const rawModels = await db.assetModel.findMany({
         where: { organizationId, ...searchWhere },
         select: { id: true, name: true },
-        orderBy: { name: "asc" },
+        /**
+         * `AssetModel.name` is NOT unique, so name alone is not a stable sort:
+         * tied rows can repeat on one page and vanish from the next, leaving
+         * models unreachable — exactly what this pagination exists to prevent.
+         * `id` breaks the tie deterministically.
+         */
+        orderBy: [{ name: "asc" }, { id: "asc" }],
         skip: (effectivePage - 1) * effectivePerPage,
         take: effectivePerPage,
       });

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.test.server.ts
@@ -1079,6 +1079,7 @@ describe("manage-assets loader — Models tab payload", () => {
       },
     ],
     totalAssetModels: 1,
+    matchedAssetModels: 1,
     modelRequests: [
       {
         assetModelId: "model1",
@@ -1137,6 +1138,7 @@ describe("manage-assets loader — Models tab payload", () => {
       assetModels: mockModelTabData.assetModels,
       initialAssetModels: mockModelTabData.initialAssetModels,
       totalAssetModels: mockModelTabData.totalAssetModels,
+      matchedAssetModels: mockModelTabData.totalAssetModels,
       modelRequests: mockModelTabData.modelRequests,
     });
   });
@@ -1147,6 +1149,7 @@ describe("manage-assets loader — Models tab payload", () => {
       assetModels: [],
       initialAssetModels: [],
       totalAssetModels: 0,
+      matchedAssetModels: 0,
       modelRequests: [],
     });
 
@@ -1159,6 +1162,7 @@ describe("manage-assets loader — Models tab payload", () => {
       assetModels: [],
       initialAssetModels: [],
       totalAssetModels: 0,
+      matchedAssetModels: 0,
       modelRequests: [],
     });
   });

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.test.server.ts
@@ -921,6 +921,7 @@ describe("manage-kits loader — Models tab payload", () => {
       assetModels: [],
       initialAssetModels: [],
       totalAssetModels: 0,
+      matchedAssetModels: 0,
       modelRequests: [],
     });
 
@@ -933,6 +934,7 @@ describe("manage-kits loader — Models tab payload", () => {
       assetModels: [],
       initialAssetModels: [],
       totalAssetModels: 0,
+      matchedAssetModels: 0,
       modelRequests: [],
     });
   });
@@ -970,6 +972,7 @@ describe("manage-kits loader — Models tab payload", () => {
         },
       ],
       totalAssetModels: 1,
+      matchedAssetModels: 1,
       modelRequests: [
         {
           assetModelId: "model1",
@@ -996,6 +999,7 @@ describe("manage-kits loader — Models tab payload", () => {
       assetModels: mockModelTabData.assetModels,
       initialAssetModels: mockModelTabData.initialAssetModels,
       totalAssetModels: mockModelTabData.totalAssetModels,
+      matchedAssetModels: mockModelTabData.totalAssetModels,
       modelRequests: mockModelTabData.modelRequests,
     });
   });
@@ -1011,6 +1015,7 @@ describe("manage-kits loader — Models tab payload", () => {
       assetModels: [],
       initialAssetModels: [],
       totalAssetModels: 1,
+      matchedAssetModels: 1,
       modelRequests: [],
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.test.server.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.test.server.ts
@@ -99,6 +99,7 @@ beforeEach(() => {
     assetModels: [],
     initialAssetModels: [],
     totalAssetModels: 0,
+    matchedAssetModels: 0,
     modelRequests: [],
   });
 });
@@ -174,6 +175,7 @@ describe("GET /api/mobile/bookings/available-models", () => {
         { id: "m-1", name: "Dell XPS", metadata: {} as never },
       ],
       totalAssetModels: 1,
+      matchedAssetModels: 1,
       modelRequests: [
         {
           assetModelId: "m-1",

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
@@ -54,6 +54,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
     // first page — the web picker searches server-side, so the app must too.
     const search = url.searchParams.get("s") ?? undefined;
 
+    // Pagination. The app's picker scrolls infinitely, so it must be able to
+    // walk the WHOLE model list, not just the seed page the web loaders use.
+    const page = Math.max(
+      1,
+      parseInt(url.searchParams.get("page") || "1", 10) || 1
+    );
+    const perPage = Math.min(
+      100,
+      Math.max(1, parseInt(url.searchParams.get("perPage") || "50", 10) || 50)
+    );
+
     // Self-service / base users may only see their OWN bookings — scope the
     // lookup by custodian exactly like the booking detail read, so a booking
     // they don't own 404s instead of leaking its models/reservations.
@@ -97,6 +108,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
       organizationId,
       booking,
       search,
+      page,
+      perPage,
     });
 
     // Trim to a mobile-friendly payload. Drop the web-only `initialAssetModels`
@@ -105,7 +118,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
     return data({
       // Whether the workspace has any AssetModel at all (hides the picker).
       showModelsTab: modelTabData.showModelsTab,
-      // Per-model availability for this booking's window (first 50 by name).
+      // Per-model availability for this booking's window, for THIS page.
       assetModels: modelTabData.assetModels.map((m) => ({
         id: m.id,
         name: m.name,
@@ -115,9 +128,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
         reservedConcrete: m.reservedConcrete,
         reservedViaRequest: m.reservedViaRequest,
       })),
-      // Full workspace model count (the list above is capped) so the app can
-      // show a "showing 50 of N — search to narrow" hint.
+      // Full workspace model count, regardless of any search.
       totalAssetModels: modelTabData.totalAssetModels,
+      // Pagination metadata. `matchedAssetModels` counts rows matching the
+      // current search, so the client knows when it has loaded everything and
+      // can stop asking for more pages.
+      page,
+      perPage,
+      matchedAssetModels: modelTabData.matchedAssetModels,
+      totalPages: Math.max(
+        1,
+        Math.ceil(modelTabData.matchedAssetModels / perPage)
+      ),
       // This booking's existing model-level reservations (outstanding +
       // fulfilled), so the picker can pre-fill current amounts.
       modelRequests: modelTabData.modelRequests,

--- a/apps/webapp/app/routes/api+/mobile+/locations.ts
+++ b/apps/webapp/app/routes/api+/mobile+/locations.ts
@@ -20,25 +20,54 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
     const search = url.searchParams.get("search") || "";
 
-    const locations = await db.location.findMany({
-      where: {
-        organizationId,
-        ...(search
-          ? { name: { contains: search, mode: "insensitive" as const } }
-          : {}),
-      },
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        image: true,
-        parentId: true,
-      },
-      orderBy: { name: "asc" },
-      take: 50,
-    });
+    /**
+     * Pagination. The picker must be able to reach EVERY location, not just
+     * the first page — a workspace with more rooms than one page could not
+     * place an asset in the ones past the cut, and search only helps someone
+     * who already knows the name they are looking for.
+     *
+     * Defaults keep older clients working unchanged: no params means page 1.
+     */
+    const page = Math.max(
+      1,
+      parseInt(url.searchParams.get("page") || "1", 10) || 1
+    );
+    const perPage = Math.min(
+      100,
+      Math.max(1, parseInt(url.searchParams.get("perPage") || "50", 10) || 50)
+    );
 
-    return data({ locations });
+    const where = {
+      organizationId,
+      ...(search
+        ? { name: { contains: search, mode: "insensitive" as const } }
+        : {}),
+    };
+
+    const [locations, totalCount] = await Promise.all([
+      db.location.findMany({
+        where,
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          image: true,
+          parentId: true,
+        },
+        orderBy: { name: "asc" },
+        skip: (page - 1) * perPage,
+        take: perPage,
+      }),
+      db.location.count({ where }),
+    ]);
+
+    return data({
+      locations,
+      page,
+      perPage,
+      totalCount,
+      totalPages: Math.max(1, Math.ceil(totalCount / perPage)),
+    });
   } catch (cause) {
     const reason = makeShelfError(cause);
     return data(

--- a/apps/webapp/app/routes/api+/mobile+/team-members.ts
+++ b/apps/webapp/app/routes/api+/mobile+/team-members.ts
@@ -29,36 +29,63 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const url = new URL(request.url);
     const search = url.searchParams.get("search") || "";
 
-    const teamMembers = await db.teamMember.findMany({
-      where: {
-        organizationId,
-        deletedAt: null,
-        ...(isSelfService ? { userId: user.id } : {}),
-        ...(search
-          ? { name: { contains: search, mode: "insensitive" as const } }
-          : {}),
-      },
-      select: {
-        id: true,
-        name: true,
-        user: {
-          select: {
-            id: true,
-            firstName: true,
-            lastName: true,
-            profilePicture: true,
+    /**
+     * Pagination. Custody has to be assignable to ANY colleague, not just the
+     * first page of them — an org larger than one page could not hand an asset
+     * to the people past the cut, and search only helps if you already know
+     * the name. Defaults keep older clients unchanged: no params means page 1.
+     */
+    const page = Math.max(
+      1,
+      parseInt(url.searchParams.get("page") || "1", 10) || 1
+    );
+    const perPage = Math.min(
+      100,
+      Math.max(1, parseInt(url.searchParams.get("perPage") || "50", 10) || 50)
+    );
+
+    const where = {
+      organizationId,
+      deletedAt: null,
+      ...(isSelfService ? { userId: user.id } : {}),
+      ...(search
+        ? { name: { contains: search, mode: "insensitive" as const } }
+        : {}),
+    };
+
+    const [teamMembers, totalCount] = await Promise.all([
+      db.teamMember.findMany({
+        where,
+        select: {
+          id: true,
+          name: true,
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              profilePicture: true,
+            },
           },
         },
-      },
-      orderBy: [
-        // Users (those with a linked user account) come first
-        { userId: "asc" },
-        { name: "asc" },
-      ],
-      take: 50,
-    });
+        orderBy: [
+          // Users (those with a linked user account) come first
+          { userId: "asc" },
+          { name: "asc" },
+        ],
+        skip: (page - 1) * perPage,
+        take: perPage,
+      }),
+      db.teamMember.count({ where }),
+    ]);
 
-    return data({ teamMembers });
+    return data({
+      teamMembers,
+      page,
+      perPage,
+      totalCount,
+      totalPages: Math.max(1, Math.ceil(totalCount / perPage)),
+    });
   } catch (cause) {
     const reason = makeShelfError(cause);
     return data(


### PR DESCRIPTION
## Why this exists

The picker had **no pagination at all**: one page fetched, one page rendered, nothing beyond it reachable. #2726 raised that page from 20 to 100 as an emergency server-side mitigation for live installs.

**Raising a cap is not a fix.** At 100 a workspace with 500 assets is still hiding 400 of them. A picker must never conceal inventory that is valid for the booking, at any workspace size.

## What changed

**All three tabs now page through the complete list.**

- **`add-assets.tsx`** keeps `page` / `hasMore` state, appends on `onEndReached`, and resets to page 1 on tab switch, new search, or after a mutation. The existing request-id guard still makes a slow earlier page lose to a newer one rather than clobber it.
- **Assets and kits needed no server work.** Both endpoints already paginated and returned `totalPages` — the client simply never asked for page 2.
- **Models were the real gap:** hard-capped at `MODEL_PICKER_LIMIT` (50) with no `skip`. `getBookingModelTabData` gains **optional** `page`/`perPage`; omitting them reproduces the previous single-page behaviour exactly, so the web loaders (`manage-assets`, `manage-kits`) are untouched.
- The service also returns **`matchedAssetModels`**, the count of rows matching the current search. A paginating client needs the *matching* count as its denominator, not the full-org count, or it never knows when to stop.

**Removed:** the "Showing 50 of N models. Search by name to find the rest." footer. That copy existed only to excuse the cap.

**Kept:** the server-side page-size floor from #2726. Installs already in the wild will never receive this client and there is no OTA channel, so they still depend on it.

## Testing

Verified on the iOS simulator against a **107-asset workspace at 50 rows per page**. Scrolling reaches the asset at **position 107** (`Laerdal SimMan 3G`), so pages 1, 2 and 3 all load on scroll and the list terminates on the true last row. Positions were taken from a DB query before the run. Seed rows cleaned up afterwards.

Both apps typecheck, ESLint and prettier clean. 59 model/picker tests pass.

## Follow-up

Web caps its own model picker at the same 50 and reaches the rest via search. That's a deliberate different design (`DynamicSelect` + `model-filters`), not touched here, but worth a look if the same "can't find it" complaint ever surfaces on web.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination to booking asset, kit, and model pickers with “load more” support and spinner footers.
  * Extended mobile bookings model and location pickers with `page`/`perPage` plus pagination metadata.
  * Added pagination to team member and location pickers, including safe limits to prevent runaway loading.
* **Bug Fixes**
  * Improved model reservation/edit/remove and retry flows to reliably refresh availability and reserved counts.
  * Updated booking model picker responses (and related tests) to include `matchedAssetModels` for accurate totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->