### PR TITLE
fix(companion): count fulfil progress against reservations, not scans

### DIFF
--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -114,6 +114,12 @@ type ScannedItem = {
   kitId: string | null;
   /** Assets only: false when the asset is marked unavailable to book. */
   availableToBook?: boolean;
+  /**
+   * Assets only: the model this asset belongs to, or null. Fulfil mode matches
+   * it against the booking's outstanding reservations, so progress counts only
+   * units that genuinely fulfil one instead of counting every scan.
+   */
+  assetModelId?: string | null;
   /** Kits only: true when any contained asset is unavailable to book. */
   hasUnavailableAssets?: boolean;
   /** Kits only: number of contained assets (shown in the drawer row). */
@@ -221,6 +227,8 @@ function ScannerContent() {
     // Book-by-model reservations still awaiting concrete units, so fulfil mode
     // can tell the operator exactly what (and how many) to scan.
     outstandingModelRequests: {
+      /** Needed to match a scanned asset's model against this reservation. */
+      assetModelId: string;
       assetModelName: string;
       outstandingQuantity: number;
     }[];
@@ -241,6 +249,7 @@ function ScannerContent() {
         outstandingModelRequests: (data.booking.modelRequests ?? [])
           .filter((r) => r.fulfilledAt === null && r.outstandingQuantity > 0)
           .map((r) => ({
+            assetModelId: r.assetModelId,
             assetModelName: r.assetModelName,
             outstandingQuantity: r.outstandingQuantity,
           })),
@@ -419,6 +428,14 @@ function ScannerContent() {
           // below, which is the kit a kit-linked QR points at directly).
           kitId: string | null;
           availableToBook: boolean;
+          /**
+           * Model this asset belongs to, or null. Fulfil mode matches it
+           * against the booking's outstanding reservations so progress counts
+           * only units that actually fulfil one. Optional: an older server
+           * omits it, and the client then treats the match as unknown rather
+           * than claiming false progress.
+           */
+          assetModelId?: string | null;
           category: { name: string } | null;
           location: { name: string } | null;
         } | null;
@@ -903,6 +920,7 @@ function ScannerContent() {
             category: asset.category?.name || null,
             kitId: asset.kitId ?? null,
             availableToBook: asset.availableToBook,
+            assetModelId: asset.assetModelId ?? null,
           };
 
           // ADD mode: no scan-time eligibility gate — the blockers handle
@@ -1441,6 +1459,23 @@ function ScannerContent() {
       return;
     }
 
+    /**
+     * Refuse locally what the server would refuse anyway. Without this the
+     * operator taps a confident-looking CTA and only then learns their scans
+     * don't cover the reservation — the exact round trip this whole change
+     * exists to remove.
+     */
+    if (!fulfilMatch.isComplete) {
+      const short = fulfilMatch.required - fulfilMatch.matched;
+      Alert.alert(
+        "Not ready to check out",
+        `${short} more reserved unit${
+          short === 1 ? "" : "s"
+        } still to assign. Scan units matching the reserved models — items that don't match a reservation don't count towards it.`
+      );
+      return;
+    }
+
     const assetIds = bookingCheckinItems
       .filter((i) => i.type === "asset")
       .map((i) => i.targetId);
@@ -1513,6 +1548,52 @@ function ScannerContent() {
       ]
     );
   };
+
+  /**
+   * Fulfil-mode progress, computed against the RESERVATIONS rather than by
+   * counting scans.
+   *
+   * The previous version divided `bookingCheckinItems.length` by the reserved
+   * unit count, which lied in both directions: scanning a camera against a
+   * "Tablecloth x2" reservation read "1/2 scanned" (it fulfils nothing), and
+   * scanning three tablecloths against x2 read "3/2". The server refuses both
+   * at submit, so the operator only discovered it at the very end.
+   *
+   * Each scanned asset is now matched to an outstanding request for its model
+   * and capped at that model's outstanding quantity, so extra units of a model
+   * that is already satisfied count as unmatched — exactly how the server
+   * treats them (`materializeModelRequestForAsset` returns `matched: false`
+   * once `fulfilledQuantity >= quantity`).
+   */
+  const fulfilMatch = useMemo(() => {
+    const outstanding = bookingCtx?.outstandingModelRequests ?? [];
+    const remainingByModel = new Map(
+      outstanding.map((r) => [r.assetModelId, r.outstandingQuantity])
+    );
+    const unmatchedIds = new Set<string>();
+    let matched = 0;
+
+    for (const item of bookingCheckinItems) {
+      if (item.type !== "asset") continue;
+      const modelId = item.assetModelId ?? null;
+      const remaining = modelId ? remainingByModel.get(modelId) ?? 0 : 0;
+      if (remaining > 0) {
+        remainingByModel.set(modelId as string, remaining - 1);
+        matched += 1;
+      } else {
+        unmatchedIds.add(item.targetId);
+      }
+    }
+
+    const required = bookingCtx?.outstandingModelUnitCount ?? 0;
+    return {
+      matched,
+      required,
+      unmatchedIds,
+      /** Every reserved unit is covered, so the server will accept a checkout. */
+      isComplete: required > 0 && matched >= required,
+    };
+  }, [bookingCheckinItems, bookingCtx]);
 
   const handleBookingCheckin = () => {
     if (!bookingId || !currentOrg || bookingCheckinItems.length === 0) return;
@@ -1746,9 +1827,9 @@ function ScannerContent() {
                             (r) =>
                               `${r.assetModelName} ×${r.outstandingQuantity}`
                           )
-                          .join(", ")}  ·  ${bookingCheckinItems.length}/${
-                          bookingCtx.outstandingModelUnitCount
-                        } scanned`}
+                          .join(", ")}  ·  ${fulfilMatch.matched}/${
+                          fulfilMatch.required
+                        } assigned`}
                       </Text>
                     )}
                 </View>
@@ -1977,9 +2058,13 @@ function ScannerContent() {
               }
               submitLabel={
                 isBookingFulfilMode
-                  ? `Assign & check out ${bookingCheckinItems.length} unit${
-                      bookingCheckinItems.length === 1 ? "" : "s"
-                    }`
+                  ? fulfilMatch.isComplete
+                    ? `Assign & check out ${fulfilMatch.matched} unit${
+                        fulfilMatch.matched === 1 ? "" : "s"
+                      }`
+                    : `${
+                        fulfilMatch.required - fulfilMatch.matched
+                      } more to assign`
                   : isBookingAddMode
                   ? "Add to Booking"
                   : `Check In ${bookingCheckinItems.length} ${

--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -128,6 +128,46 @@ type ScannedItem = {
   hasAssetsInCustody?: boolean;
 };
 
+/**
+ * Match scanned items against a booking's outstanding model reservations.
+ *
+ * Shared by the live progress readout and the pre-submit revalidation, so both
+ * use identical rules. Each asset consumes one unit of an outstanding request
+ * for its model; once a model's remaining count hits zero, further units of it
+ * are unmatched — mirroring `materializeModelRequestForAsset`, which returns
+ * `matched: false` once `fulfilledQuantity >= quantity`.
+ */
+function matchScansToReservations(
+  items: ScannedItem[],
+  outstanding: { assetModelId: string; outstandingQuantity: number }[],
+  required: number
+) {
+  const remainingByModel = new Map(
+    outstanding.map((r) => [r.assetModelId, r.outstandingQuantity])
+  );
+  const unmatchedIds = new Set<string>();
+  let matched = 0;
+
+  for (const item of items) {
+    if (item.type !== "asset") continue;
+    const modelId = item.assetModelId ?? null;
+    const remaining = modelId ? remainingByModel.get(modelId) ?? 0 : 0;
+    if (remaining > 0) {
+      remainingByModel.set(modelId as string, remaining - 1);
+      matched += 1;
+    } else {
+      unmatchedIds.add(item.targetId);
+    }
+  }
+
+  return {
+    matched,
+    required,
+    unmatchedIds,
+    isComplete: required > 0 && matched >= required,
+  };
+}
+
 // ── Scanner Content ─────────────────────────────────────
 
 function ScannerContent() {
@@ -1445,7 +1485,7 @@ function ScannerContent() {
    * submit if any reservation is still unassigned, so the operator gets a clear
    * "still N to assign" error rather than a silent partial checkout.
    */
-  const handleBookingFulfil = () => {
+  const handleBookingFulfil = async () => {
     if (
       !bookingId ||
       !currentOrg ||
@@ -1465,15 +1505,49 @@ function ScannerContent() {
      * don't cover the reservation — the exact round trip this whole change
      * exists to remove.
      */
+    /**
+     * Refuse locally what the server would refuse anyway — but only after
+     * confirming against fresh data.
+     *
+     * `fulfilMatch` is computed from the booking context captured when this
+     * screen opened. If someone else fulfilled or shrank a reservation in the
+     * meantime, that snapshot is stale and a purely local block would strand
+     * the operator on a booking the server would happily check out. So on a
+     * local miss, re-read the booking and re-run the SAME matcher; only refuse
+     * if it is still short.
+     */
     if (!fulfilMatch.isComplete) {
-      const short = fulfilMatch.required - fulfilMatch.matched;
-      Alert.alert(
-        "Not ready to check out",
-        `${short} more reserved unit${
-          short === 1 ? "" : "s"
-        } still to assign. Scan units matching the reserved models — items that don't match a reservation don't count towards it.`
+      setIsBookingSubmitting(true);
+      const { data: fresh } = await api.booking(bookingId, currentOrg.id);
+      setIsBookingSubmitting(false);
+
+      const freshOutstanding = (fresh?.booking.modelRequests ?? [])
+        .filter((r) => r.fulfilledAt === null && r.outstandingQuantity > 0)
+        .map((r) => ({
+          assetModelId: r.assetModelId,
+          outstandingQuantity: r.outstandingQuantity,
+        }));
+      const revalidated = matchScansToReservations(
+        bookingCheckinItems,
+        freshOutstanding,
+        fresh?.booking.outstandingModelUnitCount ?? fulfilMatch.required
       );
-      return;
+
+      if (!revalidated.isComplete) {
+        const short = revalidated.required - revalidated.matched;
+        Alert.alert(
+          "Not ready to check out",
+          `${short} more reserved unit${
+            short === 1 ? "" : "s"
+          } still to assign. Scan units matching the reserved models — items that don't match a reservation don't count towards it.`
+        );
+        // Refresh the on-screen counter so it reflects what we just read.
+        fetchBookingCtx();
+        return;
+      }
+      // Reservations were satisfied server-side while we were open; fall
+      // through and let the submit proceed.
+      fetchBookingCtx();
     }
 
     const assetIds = bookingCheckinItems
@@ -1565,35 +1639,15 @@ function ScannerContent() {
    * treats them (`materializeModelRequestForAsset` returns `matched: false`
    * once `fulfilledQuantity >= quantity`).
    */
-  const fulfilMatch = useMemo(() => {
-    const outstanding = bookingCtx?.outstandingModelRequests ?? [];
-    const remainingByModel = new Map(
-      outstanding.map((r) => [r.assetModelId, r.outstandingQuantity])
-    );
-    const unmatchedIds = new Set<string>();
-    let matched = 0;
-
-    for (const item of bookingCheckinItems) {
-      if (item.type !== "asset") continue;
-      const modelId = item.assetModelId ?? null;
-      const remaining = modelId ? remainingByModel.get(modelId) ?? 0 : 0;
-      if (remaining > 0) {
-        remainingByModel.set(modelId as string, remaining - 1);
-        matched += 1;
-      } else {
-        unmatchedIds.add(item.targetId);
-      }
-    }
-
-    const required = bookingCtx?.outstandingModelUnitCount ?? 0;
-    return {
-      matched,
-      required,
-      unmatchedIds,
-      /** Every reserved unit is covered, so the server will accept a checkout. */
-      isComplete: required > 0 && matched >= required,
-    };
-  }, [bookingCheckinItems, bookingCtx]);
+  const fulfilMatch = useMemo(
+    () =>
+      matchScansToReservations(
+        bookingCheckinItems,
+        bookingCtx?.outstandingModelRequests ?? [],
+        bookingCtx?.outstandingModelUnitCount ?? 0
+      ),
+    [bookingCheckinItems, bookingCtx]
+  );
 
   const handleBookingCheckin = () => {
     if (!bookingId || !currentOrg || bookingCheckinItems.length === 0) return;
@@ -2059,8 +2113,12 @@ function ScannerContent() {
               submitLabel={
                 isBookingFulfilMode
                   ? fulfilMatch.isComplete
-                    ? `Assign & check out ${fulfilMatch.matched} unit${
-                        fulfilMatch.matched === 1 ? "" : "s"
+                    ? // Count every scanned item, not just the matched ones:
+                      // the submit sends the whole list and the service adds
+                      // unmatched assets directly and checks them out too, so
+                      // labelling only `matched` would understate the action.
+                      `Assign & check out ${bookingCheckinItems.length} unit${
+                        bookingCheckinItems.length === 1 ? "" : "s"
                       }`
                     : `${
                         fulfilMatch.required - fulfilMatch.matched

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -243,6 +243,12 @@ export type QrResponse = {
       kitId: string | null;
       /** Drives the scan-to-booking "not available to book" blocker */
       availableToBook: boolean;
+      /**
+       * Model this asset belongs to, or null. The fulfil-and-check-out scanner
+       * matches it against the booking's outstanding reservations so it can
+       * count only units that actually fulfil one. Absent on older servers.
+       */
+      assetModelId?: string | null;
       category: { name: string } | null;
       location: { name: string } | null;
     } | null;
@@ -268,6 +274,12 @@ export type BarcodeResponse = {
       kitId: string | null;
       /** Drives the scan-to-booking "not available to book" blocker */
       availableToBook: boolean;
+      /**
+       * Model this asset belongs to, or null. Lets the fulfil scanner tell a
+       * unit that fulfils a reservation from one that does not. Absent on
+       * older servers.
+       */
+      assetModelId?: string | null;
       category: { name: string } | null;
       location: { name: string } | null;
     } | null;

--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -328,6 +328,12 @@ export const MOBILE_ASSET_SELECT = {
   mainImage: true,
   // why: powers the scan-to-booking "not available to book" blocker.
   availableToBook: true,
+  // why: the fulfil-and-check-out scanner matches each scan against the
+  // booking's outstanding BookingModelRequests. Without the model id the
+  // client cannot tell a matching unit from an off-model one, and can only
+  // count scans — which reads as progress toward a reservation it may not
+  // actually fulfil.
+  assetModelId: true,
   // Quantity fields (additive). INDIVIDUAL assets carry `type: "INDIVIDUAL"`
   // and null quantity columns; QUANTITY_TRACKED assets surface the totals the
   // companion will use to DISPLAY quantity. The shaper passes these through
@@ -463,6 +469,8 @@ export type MobileAssetResponse = {
   id: string;
   title: string;
   status: string;
+  /** Model this asset belongs to, or null. Drives fulfil-scan matching. */
+  assetModelId?: string | null;
   mainImage: string | null;
   availableToBook: boolean;
   category: { name: string } | null;


### PR DESCRIPTION
## The bug

The fulfil scanner divided **scanned items** by **reserved units**, so the number lied in both directions:

- Scan a camera against a `Tablecloth ×2` reservation → **"1/2 scanned"**, despite it fulfilling nothing.
- Scan three tablecloths against `×2` → **"3/2"**.

Either way the operator only discovered the problem at the final tap, when the server refused the checkout. Reported from the field with a screenshot of exactly the first case.

## The fix — match scans to reservations

- **`MOBILE_ASSET_SELECT` now carries `assetModelId`**, so a scanned asset can be matched against an outstanding `BookingModelRequest`. The shaper spreads it through. The field is optional client-side, so an older server leaves the match unknown rather than claiming false progress.
- **Progress counts only matching units**, capped at each model's remaining quantity. An extra unit of an already-satisfied model counts as unmatched — precisely how `materializeModelRequestForAsset` treats it (`matched: false` once `fulfilledQuantity >= quantity`).
- **The CTA tells the truth**: "N more to assign" until the reservations are genuinely covered, and submitting while short is refused locally with the shortfall instead of offering a checkout the server will reject.

## This is the Codex P2 from #2710, properly addressed

I closed that thread at the time arguing the server rejects a bad submit. That was the **safety net, not the UX** — the failure was still deferred to the last tap, and the progress readout actively misinformed the operator on the way there. Codex was more right than I credited.

## Testing

On the iOS simulator, reproducing the exact field report against a 2-unit reservation:

| Step | Banner | CTA |
|---|---|---|
| Scan **off-model** asset | **0/2 assigned** (held) | "2 more to assign" |
| Tap the CTA anyway | — | refused: **"Not ready to check out"** |
| Scan a **matching** unit | **1/2 assigned** | "1 more to assign" |

Previously step 1 read "1/2 scanned" and offered "Assign & check out 1 unit".

482 booking + mobile-route tests pass. Both apps typecheck, ESLint and prettier clean. Test data cleaned up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scanner fulfilment now matches scanned assets to the correct reserved models and tracks progress per model.
  * Fulfilment UI now displays matched vs required units in the header and updates the submit label based on completion status.
  * QR/barcode scans now include model information (when available) to support model-based booking assignments.

* **Bug Fixes**
  * Prevents checkout when scanned units don’t fully satisfy all reserved model quantities.
  * If fulfilment is incomplete, the operator is alerted with the remaining units needed and checkout is aborted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->