### PR TITLE
fix(audit): kit-scan crash + Not found screen + capture error-screen 4xx + 404-shape eslint rule

### DIFF
--- a/apps/webapp/.eslintrc
+++ b/apps/webapp/.eslintrc
@@ -137,7 +137,8 @@
     "local-rules/require-deleted-at-check-on-custom-field-queries": "error",
     "local-rules/require-meta-export-in-routes": "warn",
     "local-rules/require-button-type": "error",
-    "local-rules/require-org-scope-on-id-queries": "error"
+    "local-rules/require-org-scope-on-id-queries": "error",
+    "local-rules/require-complete-404-shape": "error"
   },
   "overrides": [
     {

--- a/apps/webapp/app/components/audit/audit-asset-actions.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-actions.tsx
@@ -98,26 +98,47 @@ export function AuditAssetActions({
         onChange={handleFileSelected}
       />
 
-      {/* Main action button - opens dialog */}
-      <Button
-        asChild
-        type="button"
-        variant="secondary"
-        size="xs"
-        className="relative"
-        title="Add comment"
-        to={`${auditAssetId}/details`}
-      >
-        <span className="flex items-center gap-1">
-          <MessageSquarePlus className="inline-block size-4" />
-          <span>Add comment</span>
-          {totalCount > 0 && (
-            <span className="absolute -right-2 -top-2 flex size-4 items-center justify-center rounded-full bg-gray-300 text-[10px] font-medium text-gray-800">
-              {totalCount}
-            </span>
-          )}
-        </span>
-      </Button>
+      {/* Main action button - opens dialog. Only render as a navigable link
+          when we actually have an AuditAsset id — `to={`${undefined}/details`}`
+          would produce a broken `/scan/undefined/details` link (404). Callers
+          currently pass `auditAssetId || ""` for rows that don't have one yet
+          (e.g. a kit row that was rejected before reaching this component, or
+          a race where the asset hasn't been persisted to an AuditAsset yet). */}
+      {auditAssetId ? (
+        <Button
+          asChild
+          type="button"
+          variant="secondary"
+          size="xs"
+          className="relative"
+          title="Add comment"
+          to={`${auditAssetId}/details`}
+        >
+          <span className="flex items-center gap-1">
+            <MessageSquarePlus className="inline-block size-4" />
+            <span>Add comment</span>
+            {totalCount > 0 && (
+              <span className="absolute -right-2 -top-2 flex size-4 items-center justify-center rounded-full bg-gray-300 text-[10px] font-medium text-gray-800">
+                {totalCount}
+              </span>
+            )}
+          </span>
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          variant="secondary"
+          size="xs"
+          className="relative"
+          title="Add comment"
+          disabled
+        >
+          <span className="flex items-center gap-1">
+            <MessageSquarePlus className="inline-block size-4" />
+            <span>Add comment</span>
+          </span>
+        </Button>
+      )}
 
       {/* Quick camera/image picker - especially useful on mobile */}
       <Button

--- a/apps/webapp/app/components/audit/audit-drawer.tsx
+++ b/apps/webapp/app/components/audit/audit-drawer.tsx
@@ -384,6 +384,13 @@ export function AuditDrawer({
       searchParams={
         auditSession ? { auditSessionId: auditSession.id } : undefined
       }
+      // Audits are asset-only: kits have no `AuditAsset` record, so a
+      // scanned kit is rejected here (becomes an error row) instead of
+      // entering the normal scanned-asset pipeline — no detail link, no
+      // persistence attempt. See `use-audit-scan-persistence.ts` for the
+      // matching defensive skip.
+      rejectItemType="kit"
+      rejectItemMessage="Audits track assets, not kits — scan the kit's individual assets."
       renderLoading={(pendingQrId: string, error?: string) => (
         <DefaultLoadingState qrId={pendingQrId} error={error} />
       )}
@@ -440,16 +447,25 @@ export function AuditDrawer({
               className="size-[54px] rounded-[2px]"
             />
             <div className="flex flex-col gap-1">
-              <Button
-                asChild
-                variant="link"
-                className="text-left font-medium text-gray-800 hover:text-gray-700 hover:underline"
-                to={`${auditAssetId}/details`}
-              >
-                <span className="word-break whitespace-break-spaces">
+              {/* Only navigate to the details view when we actually have an
+                  AuditAsset id — rendering `to={`${undefined}/details`}` would
+                  produce a broken `/scan/undefined/details` link (404). */}
+              {auditAssetId ? (
+                <Button
+                  asChild
+                  variant="link"
+                  className="text-left font-medium text-gray-800 hover:text-gray-700 hover:underline"
+                  to={`${auditAssetId}/details`}
+                >
+                  <span className="word-break whitespace-break-spaces">
+                    {"title" in data ? data.title : data.name}
+                  </span>
+                </Button>
+              ) : (
+                <span className="word-break whitespace-break-spaces text-left font-medium text-gray-800">
                   {"title" in data ? data.title : data.name}
                 </span>
-              </Button>
+              )}
               {showLocation && data.location?.name && (
                 <span className="text-xs text-gray-500">
                   {data.location.name}
@@ -496,16 +512,24 @@ export function AuditDrawer({
             />
 
             <div className="flex flex-col gap-1">
-              <Button
-                asChild
-                variant="link"
-                className="text-left font-medium text-gray-800 hover:text-gray-700 hover:underline"
-                to={`${asset.auditAssetId}/details`}
-              >
-                <span className="word-break whitespace-break-spaces">
+              {/* Same defensive guard as the scanned-item row above — never
+                  link to `/details` without a real AuditAsset id. */}
+              {asset.auditAssetId ? (
+                <Button
+                  asChild
+                  variant="link"
+                  className="text-left font-medium text-gray-800 hover:text-gray-700 hover:underline"
+                  to={`${asset.auditAssetId}/details`}
+                >
+                  <span className="word-break whitespace-break-spaces">
+                    {asset.name}
+                  </span>
+                </Button>
+              ) : (
+                <span className="word-break whitespace-break-spaces text-left font-medium text-gray-800">
                   {asset.name}
                 </span>
-              </Button>
+              )}
               {showLocation && asset.locationName && (
                 <span className="text-xs text-gray-500">
                   {asset.locationName}

--- a/apps/webapp/app/components/errors/index.test.tsx
+++ b/apps/webapp/app/components/errors/index.test.tsx
@@ -1,7 +1,8 @@
 /**
- * Tests for {@link ErrorContent}'s report-an-issue wiring: the button only
+ * Tests for {@link ErrorContent}: the report-an-issue wiring (button only
  * shows for authenticated app-layout errors, and the feedback modal receives
- * the error context (trace id, status, title, message) rendered on the page.
+ * the error context rendered on the page), the not-found screen for genuine
+ * 404s, and the Sentry capture rules for route-error boundary failures.
  *
  * @see {@link file://./index.tsx}
  */
@@ -29,9 +30,18 @@ vi.mock("~/hooks/use-user-data", () => ({
   useUserData: () => mockUser,
 }));
 
-// why: the Sentry SDK is not initialized in tests
+// why: the Sentry SDK is not initialized in tests; captureException is
+// spied on so capture-vs-no-capture assertions can check call args. Typed
+// with both params (matching how ErrorContent always calls it) so
+// `.mock.calls[i][1]` is a real tuple index, not a TS2493 out-of-bounds
+// access on an inferred 0-arg signature.
+const { mockCaptureException } = vi.hoisted(() => ({
+  mockCaptureException: vi.fn(
+    (_exception: unknown, _hint: Record<string, unknown>) => "evt_abc"
+  ),
+}));
 vi.mock("@sentry/react-router", () => ({
-  captureException: vi.fn(() => "evt_abc"),
+  captureException: mockCaptureException,
 }));
 
 // why: the modal's own rendering is covered by feedback-modal.test.tsx;
@@ -49,6 +59,20 @@ vi.mock("../feedback/feedback-modal", () => ({
   default: mockFeedbackModal,
 }));
 
+// why: Error404Handler's internals (the "switch workspace" form) call
+// useFetcher, which needs a full data router; MemoryRouter (used below) is
+// not one. ErrorContent's own branching logic — whether it routes to
+// Error404Handler at all — is what's under test here, so we assert on the
+// props it receives instead of rendering the real component.
+const { mockError404Handler } = vi.hoisted(() => ({
+  mockError404Handler: vi.fn(
+    (_props: { className?: string; additionalData: unknown }) => null
+  ),
+}));
+vi.mock("./error-404-handler", () => ({
+  default: mockError404Handler,
+}));
+
 import { ErrorContent } from "./index";
 
 /** The Back-to-home/Reload link buttons need a router context to render */
@@ -60,18 +84,70 @@ function renderErrorContent() {
   );
 }
 
-/** Shape-compatible with react-router's isRouteErrorResponse guard */
-function buildRouteError() {
+/**
+ * Shape-compatible with react-router's isRouteErrorResponse guard. Defaults
+ * reproduce the original fixture (a 500 with a custom title); overrides let
+ * individual tests exercise other statuses, labels, and the
+ * workspace-switcher `additionalData` shape.
+ */
+function buildRouteError(overrides?: {
+  status?: number;
+  message?: string;
+  label?: string;
+  additionalData?: unknown;
+}) {
   return {
-    status: 500,
+    status: overrides?.status ?? 500,
     statusText: "Internal Server Error",
     internal: false,
     data: {
       error: {
-        message: "Something went wrong while fetching the kit",
+        message:
+          overrides?.message ?? "Something went wrong while fetching the kit",
         title: "Kit error",
         traceId: "trace_789",
+        label: overrides?.label ?? "Kit",
+        ...(overrides?.additionalData !== undefined
+          ? { additionalData: overrides.additionalData }
+          : {}),
       },
+    },
+  };
+}
+
+/**
+ * A genuine 404 route-error response with no custom title, so the
+ * not-found screen's "Not found" fallback heading is exercised (as opposed
+ * to `buildRouteError`, whose fixture always carries a "Kit error" title).
+ */
+function buildNotFoundRouteError(overrides?: {
+  message?: string;
+  traceId?: string;
+  label?: string;
+}) {
+  return {
+    status: 404,
+    statusText: "Not Found",
+    internal: false,
+    data: {
+      error: {
+        message: overrides?.message ?? "Audit asset not found",
+        traceId: overrides?.traceId ?? "trace_404",
+        label: overrides?.label ?? "Audit",
+      },
+    },
+  };
+}
+
+/** The workspace-switcher `additionalData` shape: a resource that exists,
+ * but in a different organization the user belongs to. */
+function buildWorkspaceSwitcherAdditionalData() {
+  return {
+    id: "asset_1",
+    model: "asset" as const,
+    redirectTo: "/assets",
+    organization: {
+      organization: { id: "org_2", name: "Other workspace" },
     },
   };
 }
@@ -155,5 +231,123 @@ describe("ErrorContent report-an-issue", () => {
     ).toBeTruthy();
 
     consoleError.mockRestore();
+  });
+});
+
+describe("ErrorContent not-found screen", () => {
+  beforeEach(() => {
+    mockUser = { id: "user_123" };
+    mockError404Handler.mockClear();
+  });
+
+  it("renders a calm Not-found screen for a genuine 404 (not the workspace-switcher shape)", () => {
+    mockRouteError = buildNotFoundRouteError({
+      message: "Audit asset not found",
+    });
+    renderErrorContent();
+
+    expect(screen.getByText("Not found")).toBeTruthy();
+    expect(screen.getByText(/Audit asset not found/)).toBeTruthy();
+    expect(screen.getByText(/trace_404/)).toBeTruthy();
+    // Not the alarming generic framing
+    expect(screen.queryByText(/Oops, something went wrong/i)).toBeNull();
+    // Only "Back to home" is offered — no Reload/Report actions
+    expect(screen.queryByRole("link", { name: /reload page/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /report this issue/i })
+    ).toBeNull();
+  });
+
+  it("still routes the workspace-switcher 404 shape to <Error404Handler/> (unchanged)", () => {
+    const additionalData = buildWorkspaceSwitcherAdditionalData();
+    mockRouteError = buildRouteError({
+      status: 404,
+      message: "Asset not found",
+      additionalData,
+    });
+    renderErrorContent();
+
+    expect(mockError404Handler).toHaveBeenCalled();
+    const props = mockError404Handler.mock.calls.at(-1)?.[0];
+    expect(props?.additionalData).toEqual(additionalData);
+    // Not our new not-found screen
+    expect(screen.queryByText("Not found")).toBeNull();
+  });
+});
+
+describe("ErrorContent capturing route-error boundary failures to Sentry", () => {
+  beforeEach(() => {
+    mockUser = { id: "user_123" };
+    mockCaptureException.mockClear();
+    // why: the capture effect is gated on window.env.SENTRY_DSN, mirroring
+    // entry.client.tsx's own Sentry.init gate; no real Sentry SDK runs in
+    // tests, so this just needs to be truthy
+    window.env = { SENTRY_DSN: "test-dsn" } as Window["env"];
+  });
+
+  it("captures a 4xx route error with source=error-boundary and the on-screen trace id", async () => {
+    mockRouteError = buildRouteError({
+      status: 403,
+      message: "You don't have permission to view this audit",
+      label: "Audit permission",
+    });
+    renderErrorContent();
+
+    await waitFor(() => expect(mockCaptureException).toHaveBeenCalled());
+    const hint = mockCaptureException.mock.calls.at(-1)?.[1];
+    expect(hint).toMatchObject({
+      tags: {
+        source: "error-boundary",
+        shelf_trace_id: "trace_789",
+        label: "Audit permission",
+        status: "403",
+      },
+      contexts: { route: { pathname: "/kits" } },
+    });
+  });
+
+  it("captures a genuine 404 (not-found screen) the same way as other 4xx", async () => {
+    mockRouteError = buildNotFoundRouteError({
+      message: "Audit asset not found",
+      traceId: "trace_404",
+      label: "Audit",
+    });
+    renderErrorContent();
+
+    await waitFor(() => expect(mockCaptureException).toHaveBeenCalled());
+    const hint = mockCaptureException.mock.calls.at(-1)?.[1];
+    expect(hint).toMatchObject({
+      tags: {
+        source: "error-boundary",
+        shelf_trace_id: "trace_404",
+        label: "Audit",
+        status: "404",
+      },
+    });
+  });
+
+  it("does not capture the benign workspace-switcher 404 case", async () => {
+    mockError404Handler.mockClear();
+    mockRouteError = buildRouteError({
+      status: 404,
+      message: "Asset not found",
+      additionalData: buildWorkspaceSwitcherAdditionalData(),
+    });
+    renderErrorContent();
+
+    await waitFor(() => expect(mockError404Handler).toHaveBeenCalled());
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("does not capture 5xx route errors (already captured server-side)", async () => {
+    mockRouteError = buildRouteError({ status: 500 });
+    renderErrorContent();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Something went wrong while fetching the kit/)
+      ).toBeTruthy()
+    );
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/components/errors/index.test.tsx
+++ b/apps/webapp/app/components/errors/index.test.tsx
@@ -139,6 +139,24 @@ function buildNotFoundRouteError(overrides?: {
   };
 }
 
+/**
+ * A router-generated 404: what React Router itself throws for an
+ * unmatched/stale URL (an `ErrorResponseImpl` whose `.data` is a plain
+ * `Error`), as opposed to `buildNotFoundRouteError`'s Shelf
+ * `{ error: { message, traceId, label } }` payload. `isRouteErrorResponse`
+ * recognizes this shape (status/statusText/internal/data all present on the
+ * object), but `isRouteError` does not — there's no Shelf error payload to
+ * read `message`/`traceId`/`label` from, so those stay at their defaults.
+ */
+function buildRouterNotFoundError() {
+  return {
+    status: 404,
+    statusText: "Not Found",
+    internal: true,
+    data: new Error('No route matches URL "/stale/path"'),
+  };
+}
+
 /** The workspace-switcher `additionalData` shape: a resource that exists,
  * but in a different organization the user belongs to. */
 function buildWorkspaceSwitcherAdditionalData() {
@@ -258,6 +276,25 @@ describe("ErrorContent not-found screen", () => {
     ).toBeNull();
   });
 
+  it("renders the not-found screen for a router-generated 404 (unmatched/stale URL, no Shelf payload)", () => {
+    mockRouteError = buildRouterNotFoundError();
+    renderErrorContent();
+
+    expect(screen.getByText("Not found")).toBeTruthy();
+    // Generic not-found copy: there is no Shelf `message` to read (the
+    // router error's `.data` is a plain Error, not `{ error: {...} }`)
+    expect(screen.getByText(/doesn't exist/i)).toBeTruthy();
+    // Not the alarming generic framing
+    expect(screen.queryByText(/Oops, something went wrong/i)).toBeNull();
+    // No Shelf trace id to show for a router-generated 404
+    expect(screen.queryByText(/Trace id/)).toBeNull();
+    // Only "Back to home" is offered — no Reload/Report actions
+    expect(screen.queryByRole("link", { name: /reload page/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /report this issue/i })
+    ).toBeNull();
+  });
+
   it("still routes the workspace-switcher 404 shape to <Error404Handler/> (unchanged)", () => {
     const additionalData = buildWorkspaceSwitcherAdditionalData();
     mockRouteError = buildRouteError({
@@ -324,6 +361,21 @@ describe("ErrorContent capturing route-error boundary failures to Sentry", () =>
         status: "404",
       },
     });
+  });
+
+  it("captures a router-generated 404 (unmatched/stale URL) without a shelf_trace_id or label tag", async () => {
+    mockRouteError = buildRouterNotFoundError();
+    renderErrorContent();
+
+    await waitFor(() => expect(mockCaptureException).toHaveBeenCalled());
+    const hint = mockCaptureException.mock.calls.at(-1)?.[1];
+    expect(hint).toMatchObject({
+      tags: { source: "error-boundary", status: "404" },
+    });
+    // No Shelf payload means no traceId/label to report — both tags must be
+    // omitted entirely (not sent as the literal string "undefined")
+    expect(hint?.tags).not.toHaveProperty("shelf_trace_id");
+    expect(hint?.tags).not.toHaveProperty("label");
   });
 
   it("does not capture the benign workspace-switcher 404 case", async () => {

--- a/apps/webapp/app/components/errors/index.tsx
+++ b/apps/webapp/app/components/errors/index.tsx
@@ -154,7 +154,9 @@ function ErrorScreenLayout({
  * - The benign workspace-switcher case (`<Error404Handler/>`): the resource
  *   exists but belongs to another of the user's organizations.
  * - A genuine 404 that is NOT the workspace-switcher shape: a calm
- *   "Not found" screen.
+ *   "Not found" screen. This includes both Shelf-thrown 404s (`{ error }`
+ *   payload) and router-generated 404s for an unmatched/stale URL (a plain
+ *   `Error` payload) — see `isNotFound` below.
  * - Everything else: the generic "Oops, something went wrong" screen.
  *
  * Also captures failures to Sentry: unhandled client-side `Error` instances
@@ -213,9 +215,19 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
    * that is NOT the workspace-switcher shape (that shape renders
    * `<Error404Handler/>` below with its own "switch workspace?" UX instead
    * of this calmer not-found screen).
+   *
+   * Gated on `isRouteErrorResponse` (router shape + status), NOT
+   * `isRouteError` (Shelf payload shape): React Router itself throws a
+   * 404 `ErrorResponse` for an unmatched/stale URL whose `.data` is a plain
+   * `Error`, not Shelf's `{ error: {...} }` payload — `isRouteError` is
+   * `false` for that case even though it is a genuine 404. `error404` above
+   * already handles this safely (`parse404ErrorData` returns
+   * `isError404: false` when there's no Shelf payload to parse).
    */
   const isNotFound =
-    isRouteError(response) && !error404.isError404 && statusCode === 404;
+    isRouteErrorResponse(response) &&
+    !error404.isError404 &&
+    statusCode === 404;
 
   /**
    * Route-error responses in the 4xx range (bad input, permission denials,
@@ -227,13 +239,28 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
    * captured server-side — capturing again here would double-report), and
    * the benign workspace-switcher case is excluded entirely (expected
    * cross-org UX, not a bug).
+   *
+   * Gated on `isRouteErrorResponse` (see `isNotFound` above for why) so
+   * router-generated 4xx responses (e.g. an unmatched-route 404) are
+   * captured too, even though they carry no Shelf payload.
    */
   const shouldCaptureRouteError =
-    isRouteError(response) &&
+    isRouteErrorResponse(response) &&
     !error404.isError404 &&
     statusCode !== undefined &&
     statusCode >= 400 &&
     statusCode < 500;
+
+  /**
+   * Body copy for the not-found screen. A Shelf-thrown 404 carries its own
+   * `message` (extracted above); a router-generated 404 (unmatched/stale
+   * URL) has no Shelf payload, so `message` is still at its generic
+   * "Oops, something went wrong" default — swap in copy appropriate for a
+   * calm not-found screen instead.
+   */
+  const notFoundMessage = isRouteError(response)
+    ? message
+    : "The page or item you're looking for doesn't exist.";
 
   // Capture unhandled Error instances (client-side crashes) client-side,
   // and capturable 4xx route errors (see shouldCaptureRouteError above).
@@ -260,12 +287,17 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
       // groups the issue sensibly by message, like any other captured
       // exception. Not stored in `sentryEventId`: the route-error path
       // shows the shelf trace id to the user, not the Sentry event id.
+      //
+      // `shelf_trace_id`/`label` are only present on Shelf-thrown errors
+      // (see `isRouteError` above); a router-generated 404 has neither, so
+      // both are omitted entirely here rather than sent as the literal
+      // string "undefined".
       Sentry.captureException(new Error(message), {
         tags: {
           source: "error-boundary",
-          shelf_trace_id: traceId,
-          label: errorLabel,
           status: errorStatus,
+          ...(traceId ? { shelf_trace_id: traceId } : {}),
+          ...(errorLabel ? { label: errorLabel } : {}),
         },
         contexts: { route: { pathname: loc.pathname } },
       });
@@ -295,7 +327,7 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
       <ErrorScreenLayout
         className={className}
         title={rawTitle || "Not found"}
-        message={message}
+        message={notFoundMessage}
         traceId={traceId}
         actions={<BackHomeButton />}
       />

--- a/apps/webapp/app/components/errors/index.tsx
+++ b/apps/webapp/app/components/errors/index.tsx
@@ -58,67 +58,60 @@ function splitIntoStableLines(message: string) {
   });
 }
 
-export const ErrorContent = ({ className }: ErrorContentProps) => {
-  const loc = useLocation();
-  const response = useRouteError();
-
-  /* Present when the authenticated app layout rendered (child-route errors).
-   * That is also the only case where /api/feedback can accept a report, so
-   * the "Report this issue" button is gated on it. */
-  const user = useUserData();
-  const [reportOpen, setReportOpen] = useState(false);
-  /* Flipped when the modal chunk fails to load/render: the report UI hides
-   * instead of leaving a button that blanks the page when clicked */
-  const [reportBroken, setReportBroken] = useState(false);
-
-  let title = "Oops, something went wrong";
-  let message =
-    "There was an unexpected error. Please refresh to try again. If the issues persists, please contact support.";
-  let traceId;
-  let errorStatus;
-
-  if (isRouteError(response)) {
-    message = response.data.error.message;
-    title = response.data.error.title || "Oops, something went wrong";
-    traceId = response.data.error.traceId;
+/**
+ * Renders the "(Trace id: …)" line shown under the error message on both
+ * the not-found and generic error screens. Renders nothing when no trace id
+ * is available (e.g. a client-side crash that never reached the server).
+ */
+function TraceIdLine({ traceId }: { traceId?: string }) {
+  if (!traceId) {
+    return null;
   }
+  return <p className="text-gray-400">(Trace id: {traceId})</p>;
+}
 
-  if (isRouteErrorResponse(response)) {
-    errorStatus = String(response.status);
-  }
+/**
+ * The "Back to home" action shared by the not-found and generic error
+ * screens — factored out so both screens render the identical button
+ * instead of duplicating its props.
+ */
+function BackHomeButton() {
+  return (
+    <Button to="/" variant="secondary" icon="home">
+      Back to home
+    </Button>
+  );
+}
 
-  /* For client-side crashes the rendered message is a generic fallback, so
-   * attach the real error message to the report instead */
-  const reportErrorMessage =
-    response instanceof Error ? response.message : message;
+type ErrorScreenLayoutProps = {
+  className?: string;
+  title: string;
+  message: string;
+  traceId?: string;
+  /** Extra content rendered between the trace id line and the action
+   * buttons — e.g. the Sentry event id line on the generic screen. */
+  extra?: ReactNode;
+  /** The screen's action buttons. Content differs per screen (the
+   * not-found screen only offers "Back to home"; the generic screen also
+   * offers Reload / Report), so the caller owns this slot. */
+  actions: ReactNode;
+};
 
-  const error404 = parse404ErrorData(response);
-
-  // Only capture unhandled Error instances client-side.
-  // Route errors from ShelfError are already captured server-side via handleError.
-  const [sentryEventId, setSentryEventId] = useState<string | null>(null);
-  useEffect(() => {
-    if (
-      response instanceof Error &&
-      !error404.isError404 &&
-      window.env?.SENTRY_DSN
-    ) {
-      setSentryEventId(
-        Sentry.captureException(response, {
-          tags: { source: "error-boundary" },
-        })
-      );
-    }
-  }, [response, error404.isError404]);
-  if (error404.isError404) {
-    return (
-      <Error404Handler
-        className={className}
-        additionalData={error404.additionalData}
-      />
-    );
-  }
-
+/**
+ * Shared centered "error screen" chrome — icon, heading, message body, and
+ * trace id line — used by both the not-found screen and the generic
+ * "something went wrong" screen so they don't duplicate this layout block.
+ * Screen-specific content (extra info line, action buttons) is supplied by
+ * the caller via `extra`/`actions`.
+ */
+function ErrorScreenLayout({
+  className,
+  title,
+  message,
+  traceId,
+  extra,
+  actions,
+}: ErrorScreenLayoutProps) {
   // Preserve newlines as <br/> without injecting HTML: split the message on
   // "\n" and interleave <br/> elements between segments. Keeps the same
   // visual output as the previous dangerouslySetInnerHTML approach while
@@ -146,31 +139,204 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
             </span>
           ))}
         </p>
-        {traceId && <p className="text-gray-400">(Trace id: {traceId})</p>}
-        {sentryEventId && (
-          <p className="text-gray-400">(Error ID: {sentryEventId})</p>
-        )}
-        <div className=" mt-8 flex gap-3">
-          <Button to="/" variant="secondary" icon="home">
-            Back to home
-          </Button>
-          <Button to={loc.pathname} reloadDocument>
-            Reload page
-          </Button>
-          {user && !reportBroken ? (
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={() => setReportOpen(true)}
-            >
-              Report this issue
-            </Button>
-          ) : null}
-        </div>
+        <TraceIdLine traceId={traceId} />
+        {extra}
+        <div className="mt-8 flex gap-3">{actions}</div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * App-wide `ErrorBoundary` content, rendered by `root.tsx` and the
+ * authenticated `_layout` route for any error that reaches a route
+ * boundary. Branches into three screens:
+ * - The benign workspace-switcher case (`<Error404Handler/>`): the resource
+ *   exists but belongs to another of the user's organizations.
+ * - A genuine 404 that is NOT the workspace-switcher shape: a calm
+ *   "Not found" screen.
+ * - Everything else: the generic "Oops, something went wrong" screen.
+ *
+ * Also captures failures to Sentry: unhandled client-side `Error` instances
+ * (JS crashes), and route-error 4xx responses that aren't already captured
+ * server-side (5xx is captured server-side by `handleError`/`error()`; the
+ * workspace-switcher case is expected UX, not a bug, so it's never
+ * captured).
+ */
+export const ErrorContent = ({ className }: ErrorContentProps) => {
+  const loc = useLocation();
+  const response = useRouteError();
+
+  /* Present when the authenticated app layout rendered (child-route errors).
+   * That is also the only case where /api/feedback can accept a report, so
+   * the "Report this issue" button is gated on it. */
+  const user = useUserData();
+  const [reportOpen, setReportOpen] = useState(false);
+  /* Flipped when the modal chunk fails to load/render: the report UI hides
+   * instead of leaving a button that blanks the page when clicked */
+  const [reportBroken, setReportBroken] = useState(false);
+
+  // `rawTitle` is the error's own title, if any, BEFORE either screen's
+  // fallback is applied — the not-found screen falls back to "Not found",
+  // the generic screen falls back to "Oops, something went wrong".
+  let rawTitle: string | undefined;
+  let title = "Oops, something went wrong";
+  let message =
+    "There was an unexpected error. Please refresh to try again. If the issues persists, please contact support.";
+  let traceId: string | undefined;
+  let errorLabel: string | undefined;
+  let errorStatus: string | undefined;
+  let statusCode: number | undefined;
+
+  if (isRouteErrorResponse(response)) {
+    statusCode = response.status;
+    errorStatus = String(response.status);
+  }
+
+  if (isRouteError(response)) {
+    message = response.data.error.message;
+    rawTitle = response.data.error.title;
+    title = rawTitle || "Oops, something went wrong";
+    traceId = response.data.error.traceId;
+    errorLabel = response.data.error.label;
+  }
+
+  /* For client-side crashes the rendered message is a generic fallback, so
+   * attach the real error message to the report instead */
+  const reportErrorMessage =
+    response instanceof Error ? response.message : message;
+
+  const error404 = parse404ErrorData(response);
+
+  /**
+   * A genuine "resource not found": a route-error response with HTTP 404
+   * that is NOT the workspace-switcher shape (that shape renders
+   * `<Error404Handler/>` below with its own "switch workspace?" UX instead
+   * of this calmer not-found screen).
+   */
+  const isNotFound =
+    isRouteError(response) && !error404.isError404 && statusCode === 404;
+
+  /**
+   * Route-error responses in the 4xx range (bad input, permission denials,
+   * genuine not-found, …) that reach this boundary are NOT already captured
+   * server-side — `error()` in http.server.ts only routes 5xx (and
+   * uncaught errors) to Sentry via `Logger.error`; handled 4xx land on the
+   * low-severity log trail instead. Capture them here so they're findable
+   * by the same trace id shown to the user. 5xx is excluded (already
+   * captured server-side — capturing again here would double-report), and
+   * the benign workspace-switcher case is excluded entirely (expected
+   * cross-org UX, not a bug).
+   */
+  const shouldCaptureRouteError =
+    isRouteError(response) &&
+    !error404.isError404 &&
+    statusCode !== undefined &&
+    statusCode >= 400 &&
+    statusCode < 500;
+
+  // Capture unhandled Error instances (client-side crashes) client-side,
+  // and capturable 4xx route errors (see shouldCaptureRouteError above).
+  // Route errors that are 5xx are already captured server-side via
+  // handleError, so they're deliberately left uncaptured here.
+  const [sentryEventId, setSentryEventId] = useState<string | null>(null);
+  useEffect(() => {
+    if (!window.env?.SENTRY_DSN) {
+      return;
+    }
+
+    if (response instanceof Error && !error404.isError404) {
+      setSentryEventId(
+        Sentry.captureException(response, {
+          tags: { source: "error-boundary" },
+        })
+      );
+      return;
+    }
+
+    if (shouldCaptureRouteError) {
+      // Synthetic Error (rather than `response`, which is a plain
+      // route-error data object here, not an Error instance) so Sentry
+      // groups the issue sensibly by message, like any other captured
+      // exception. Not stored in `sentryEventId`: the route-error path
+      // shows the shelf trace id to the user, not the Sentry event id.
+      Sentry.captureException(new Error(message), {
+        tags: {
+          source: "error-boundary",
+          shelf_trace_id: traceId,
+          label: errorLabel,
+          status: errorStatus,
+        },
+        contexts: { route: { pathname: loc.pathname } },
+      });
+    }
+  }, [
+    response,
+    error404.isError404,
+    shouldCaptureRouteError,
+    message,
+    traceId,
+    errorLabel,
+    errorStatus,
+    loc.pathname,
+  ]);
+
+  if (error404.isError404) {
+    return (
+      <Error404Handler
+        className={className}
+        additionalData={error404.additionalData}
+      />
+    );
+  }
+
+  if (isNotFound) {
+    return (
+      <ErrorScreenLayout
+        className={className}
+        title={rawTitle || "Not found"}
+        message={message}
+        traceId={traceId}
+        actions={<BackHomeButton />}
+      />
+    );
+  }
+
+  return (
+    <>
+      <ErrorScreenLayout
+        className={className}
+        title={title}
+        message={message}
+        traceId={traceId}
+        extra={
+          sentryEventId ? (
+            <p className="text-gray-400">(Error ID: {sentryEventId})</p>
+          ) : null
+        }
+        actions={
+          <>
+            <BackHomeButton />
+            <Button to={loc.pathname} reloadDocument>
+              Reload page
+            </Button>
+            {user && !reportBroken ? (
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setReportOpen(true)}
+              >
+                Report this issue
+              </Button>
+            ) : null}
+          </>
+        }
+      />
 
       {/* Mounted only while open: keeps the modal's hooks/effects off
-      every error render and resets its state on each reopen */}
+      every error render and resets its state on each reopen. Rendered as
+      a Portal (see DialogPortal), so its position here relative to
+      ErrorScreenLayout has no visual effect. */}
       {user && !reportBroken && reportOpen ? (
         <ReportModalBoundary
           onError={() => {
@@ -193,7 +359,7 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
           </Suspense>
         </ReportModalBoundary>
       ) : null}
-    </div>
+    </>
   );
 };
 

--- a/apps/webapp/app/components/scanner/drawer/generic-item-row.test.tsx
+++ b/apps/webapp/app/components/scanner/drawer/generic-item-row.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Behavior tests for the `rejectItemType` guard on {@link GenericItemRow}.
+ *
+ * Audits are asset-only (kits have no `AuditAsset` record — see
+ * `audit-drawer.tsx`), so the audit drawer passes `rejectItemType="kit"`
+ * into `GenericItemRow`. These tests assert the guard's observable
+ * behavior: a resolved kit item is stored as a plain `error` (never
+ * `data`/`type`), so it renders through the loading/error path instead of
+ * `renderItem` — no detail link, no clickable content — and can't enter a
+ * `data`-driven persistence loop (see `use-audit-scan-persistence.ts`).
+ *
+ * A companion test confirms drawers that DON'T pass `rejectItemType`
+ * (e.g. add-assets-to-kit-drawer) keep resolving kits normally.
+ *
+ * @see {@link file://./generic-item-row.tsx}
+ * @see {@link file://../../audit/audit-drawer.tsx}
+ */
+import type { ComponentProps } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { Provider, useAtomValue } from "jotai";
+import { createStore } from "jotai/vanilla";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { scannedItemsAtom } from "~/atoms/qr-scanner";
+import { GenericItemRow } from "./generic-item-row";
+
+// why: testing the fetch → atom-write pipeline without a real network
+// call. Installed via `spyOn` (not a module mock) so it takes effect
+// after MSW 2's global fetch patch — matches the established pattern in
+// `use-api-query.test.ts`.
+const mockFetch = vi.fn();
+
+type RowOverrides = Partial<
+  Omit<ComponentProps<typeof GenericItemRow>, "qrId" | "item">
+>;
+
+/**
+ * Mounts `GenericItemRow` behind a thin harness that reads `item` back
+ * from `scannedItemsAtom` — mirroring how `AuditDrawer` (and every other
+ * consumer) feeds the row its `item` prop from the shared atom. Without
+ * this round-trip, the row would never observe the `setItem` write its
+ * own fetch triggers.
+ */
+function renderRow(
+  store: ReturnType<typeof createStore>,
+  overrides: RowOverrides = {}
+) {
+  function Harness() {
+    const items = useAtomValue(scannedItemsAtom);
+    return (
+      <table>
+        <tbody>
+          <GenericItemRow
+            qrId="qr-1"
+            item={items["qr-1"]}
+            onRemove={vi.fn()}
+            renderItem={() => <span>rendered item</span>}
+            renderLoading={(qrId, error) => (
+              <span data-testid="loading-row">
+                {error ?? `loading ${qrId}`}
+              </span>
+            )}
+            {...overrides}
+          />
+        </tbody>
+      </table>
+    );
+  }
+
+  return render(
+    <Provider store={store}>
+      <Harness />
+    </Provider>
+  );
+}
+
+describe("GenericItemRow rejectItemType", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stores a resolved kit as an error item, not data, when rejectItemType matches", async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          qr: { type: "kit", kit: { id: "kit-1", name: "Kit A" } },
+        }),
+    });
+
+    const store = createStore();
+    renderRow(store, {
+      rejectItemType: "kit",
+      rejectItemMessage:
+        "Audits track assets, not kits — scan the kit's individual assets.",
+    });
+
+    await waitFor(() => {
+      expect(store.get(scannedItemsAtom)["qr-1"]).toEqual({
+        error:
+          "Audits track assets, not kits — scan the kit's individual assets.",
+      });
+    });
+
+    // Renders through the error/loading path, never the clickable item row.
+    expect(screen.getByTestId("loading-row")).toHaveTextContent(
+      "Audits track assets, not kits"
+    );
+    expect(screen.queryByText("rendered item")).not.toBeInTheDocument();
+  });
+
+  it("falls back to a generic message when rejectItemMessage is omitted", async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          qr: { type: "kit", kit: { id: "kit-1", name: "Kit A" } },
+        }),
+    });
+
+    const store = createStore();
+    renderRow(store, { rejectItemType: "kit" });
+
+    await waitFor(() => {
+      const stored = store.get(scannedItemsAtom)["qr-1"];
+      expect(stored?.error).toBeTruthy();
+      expect(stored?.data).toBeUndefined();
+    });
+  });
+
+  it("still resolves a kit normally when rejectItemType is not set (other drawers support kits)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          qr: { type: "kit", kit: { id: "kit-1", name: "Kit A" } },
+        }),
+    });
+
+    const store = createStore();
+    renderRow(store);
+
+    await waitFor(() => {
+      expect(store.get(scannedItemsAtom)["qr-1"]).toEqual({
+        data: { id: "kit-1", name: "Kit A" },
+        type: "kit",
+        codeType: undefined,
+      });
+    });
+
+    expect(await screen.findByText("rendered item")).toBeInTheDocument();
+  });
+});

--- a/apps/webapp/app/components/scanner/drawer/generic-item-row.tsx
+++ b/apps/webapp/app/components/scanner/drawer/generic-item-row.tsx
@@ -74,6 +74,21 @@ type GenericItemRowProps<T> = {
   searchParams?: Record<string, string>;
   /** Optional className to apply to the row wrapper (Tr) */
   className?: string;
+  /**
+   * Some drawers only support one item type (e.g. audits are asset-only —
+   * kits have no `AuditAsset` record). When the resolved item matches this
+   * type, it is stored with just an `error` instead of `data`/`type` — the
+   * same shape already used for "Failed to fetch item" and duplicate-scan
+   * errors. This routes the row through `renderLoading` (an error row: no
+   * detail link, no clickable content) instead of `renderItem`, and keeps
+   * it out of `data`-driven persistence loops entirely.
+   */
+  rejectItemType?: "asset" | "kit";
+  /**
+   * Message shown in the error row when the item matches `rejectItemType`.
+   * Falls back to a generic message if omitted.
+   */
+  rejectItemMessage?: string;
 };
 
 /**
@@ -90,6 +105,8 @@ export function GenericItemRow<T>({
   kitExtraInclude,
   searchParams: additionalSearchParams,
   className: rowClassName,
+  rejectItemType,
+  rejectItemMessage,
 }: GenericItemRowProps<T>) {
   const setItem = useSetAtom(updateScannedItemAtom);
 
@@ -143,6 +160,23 @@ export function GenericItemRow<T>({
         ? (apiResponse as BarcodeApiResponse).barcode
         : (apiResponse as QrApiResponse).qr;
 
+      // Reject unsupported item types at the point they resolve, before
+      // they ever get `data`/`type` set. Storing only `error` reuses the
+      // existing error-row rendering path (see `shouldShowItem` below),
+      // so a rejected item never becomes clickable and never enters a
+      // `data`-driven persistence pipeline.
+      if (dataSource && dataSource.type === rejectItemType) {
+        setItem({
+          qrId,
+          item: {
+            error:
+              rejectItemMessage ??
+              `Scanning a ${rejectItemType} is not supported here.`,
+          },
+        });
+        return;
+      }
+
       if (dataSource && dataSource.type === "asset") {
         const itemWithType: ScanListItem = {
           data: dataSource.asset,
@@ -163,7 +197,7 @@ export function GenericItemRow<T>({
         }
       }
     },
-    [isBarcode, qrId, setItem]
+    [isBarcode, qrId, setItem, rejectItemType, rejectItemMessage]
   );
 
   /**

--- a/apps/webapp/app/hooks/use-audit-scan-persistence.test.ts
+++ b/apps/webapp/app/hooks/use-audit-scan-persistence.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Behavior tests for {@link useAuditScanPersistence}'s non-asset guard.
+ *
+ * Audits only track assets — kits have no `AuditAsset` record, so
+ * submitting a kit's id as `assetId` to `/api/audits/record-scan` would
+ * fail server-side and (since the hook retries the first un-persisted
+ * item on every effect run) hang the "Saving scans" indicator forever.
+ * The normal path already keeps kits out of `scannedItems` with `data`
+ * populated (see the `rejectItemType` guard in `generic-item-row.tsx`),
+ * but this hook defends independently: it must never submit an item
+ * whose `type` isn't `"asset"`, regardless of how it entered the map.
+ *
+ * @see {@link file://./use-audit-scan-persistence.ts}
+ * @see {@link file://../components/scanner/drawer/generic-item-row.tsx}
+ */
+import { renderHook } from "@testing-library/react";
+import type { FetcherWithComponents } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AuditSessionInfo, ScanListItems } from "~/atoms/qr-scanner";
+import type {
+  AssetFromQr,
+  KitFromQr,
+} from "~/routes/api+/get-scanned-item.$qrId";
+import { useAuditScanPersistence } from "./use-audit-scan-persistence";
+
+const auditSession: Exclude<AuditSessionInfo, null> = {
+  id: "audit-1",
+  name: "Test Audit",
+  expectedAssetCount: 1,
+  foundAssetCount: 0,
+  missingAssetCount: 1,
+  unexpectedAssetCount: 0,
+};
+
+// why: a real `useFetcher()` fetcher requires a full react-router data
+// router context. The hook only reads `.state`/`.data` and calls
+// `.submit()`, so a minimal object satisfying that shape is enough to
+// observe whether persistence attempted a submit.
+function makeFetcher(
+  overrides: Partial<FetcherWithComponents<unknown>> = {}
+): FetcherWithComponents<unknown> {
+  return {
+    state: "idle",
+    data: undefined,
+    submit: vi.fn(),
+    ...overrides,
+  } as unknown as FetcherWithComponents<unknown>;
+}
+
+function makeRefs() {
+  return {
+    persistedItemsRef: { current: new Set<string>() },
+    pendingPersistsRef: { current: new Map<string, string>() },
+    isRestoringRef: { current: false },
+  };
+}
+
+describe("useAuditScanPersistence", () => {
+  it("does not submit a kit's id as assetId", () => {
+    const fetcher = makeFetcher();
+    const refs = makeRefs();
+    const scannedItems: ScanListItems = {
+      "qr-kit": {
+        data: { id: "kit-1", name: "Kit A" } as unknown as KitFromQr,
+        type: "kit",
+      },
+    };
+
+    renderHook(() =>
+      useAuditScanPersistence({
+        auditSession,
+        scannedItems,
+        expectedAssets: [],
+        scanPersistFetcher: fetcher,
+        ...refs,
+      })
+    );
+
+    expect(fetcher.submit).not.toHaveBeenCalled();
+  });
+
+  it("still submits a scanned asset's id as assetId (regression guard)", () => {
+    const fetcher = makeFetcher();
+    const refs = makeRefs();
+    const scannedItems: ScanListItems = {
+      "qr-asset": {
+        data: { id: "asset-1", title: "Asset A" } as unknown as AssetFromQr,
+        type: "asset",
+      },
+    };
+
+    renderHook(() =>
+      useAuditScanPersistence({
+        auditSession,
+        scannedItems,
+        expectedAssets: [],
+        scanPersistFetcher: fetcher,
+        ...refs,
+      })
+    );
+
+    expect(fetcher.submit).toHaveBeenCalledTimes(1);
+    const [formData] = (fetcher.submit as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [FormData, unknown];
+    expect(formData.get("assetId")).toBe("asset-1");
+  });
+
+  it("skips a kit but still submits a co-scanned asset in the same batch", () => {
+    const fetcher = makeFetcher();
+    const refs = makeRefs();
+    const scannedItems: ScanListItems = {
+      "qr-kit": {
+        data: { id: "kit-1", name: "Kit A" } as unknown as KitFromQr,
+        type: "kit",
+      },
+      "qr-asset": {
+        data: { id: "asset-1", title: "Asset A" } as unknown as AssetFromQr,
+        type: "asset",
+      },
+    };
+
+    renderHook(() =>
+      useAuditScanPersistence({
+        auditSession,
+        scannedItems,
+        expectedAssets: [],
+        scanPersistFetcher: fetcher,
+        ...refs,
+      })
+    );
+
+    expect(fetcher.submit).toHaveBeenCalledTimes(1);
+    const [formData] = (fetcher.submit as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [FormData, unknown];
+    expect(formData.get("assetId")).toBe("asset-1");
+  });
+});

--- a/apps/webapp/app/hooks/use-audit-scan-persistence.ts
+++ b/apps/webapp/app/hooks/use-audit-scan-persistence.ts
@@ -86,6 +86,17 @@ export function useAuditScanPersistence({
         continue;
       }
 
+      // Defensive: audits only track assets (kits have no AuditAsset
+      // record and record-scan would reject/fail on a kit id, hanging the
+      // retry loop forever). The normal path already keeps kits out of
+      // `scannedItems` with `data` set (see the `rejectItemType` guard in
+      // `generic-item-row.tsx`), but this check stands on its own so a
+      // non-asset item can never be submitted here regardless of how it
+      // entered the map.
+      if (item.type !== "asset") {
+        continue;
+      }
+
       const assetId = item.data.id;
 
       // Skip if already persisted or currently being persisted

--- a/apps/webapp/eslint-local-rules.cjs
+++ b/apps/webapp/eslint-local-rules.cjs
@@ -6,4 +6,5 @@ module.exports = {
   "require-react-import-when-using-namespace": require("./eslint-local-rules/require-react-import-when-using-namespace.cjs"),
   "require-button-type": require("./eslint-local-rules/require-button-type.cjs"),
   "require-org-scope-on-id-queries": require("./eslint-local-rules/require-org-scope-on-id-queries.cjs"),
+  "require-complete-404-shape": require("./eslint-local-rules/require-complete-404-shape.cjs"),
 };

--- a/apps/webapp/eslint-local-rules/require-complete-404-shape.cjs
+++ b/apps/webapp/eslint-local-rules/require-complete-404-shape.cjs
@@ -1,0 +1,181 @@
+/**
+ * ESLint rule: require a complete workspace-switcher shape on 404 ShelfError
+ * additionalData whenever a developer opts into it by setting `model`.
+ *
+ * `apps/webapp/app/components/errors/utils.ts` (`error404AdditionalDataSchema`)
+ * parses `additionalData` as a discriminated union keyed on `model`. When
+ * `model` is set but the sibling switcher field the schema needs is missing,
+ * `error404AdditionalDataSchema.safeParse` fails and `parse404ErrorData`
+ * silently falls back to the generic "something went wrong" error screen
+ * instead of the organization-switcher UI — with no error surfaced anywhere,
+ * because the parse failure is swallowed by `safeParse`.
+ *
+ * This rule does NOT require the switcher shape on every 404 — plenty of
+ * genuine not-founds have no `model` at all (e.g. `{ id, organizationId }`)
+ * and are correct as-is. It only fires once a developer has opted in by
+ * setting `model` to one of the schema's known enum values.
+ *
+ * Required sibling key per model (matches the REAL working switcher throws,
+ * e.g. `modules/asset/service.server.ts` — see note on `id` below):
+ *   - "asset" | "kit" | "location" | "booking" | "customField" | "audit"
+ *     → requires `organization`
+ *   - "teamMember" → requires `organizations` (plural — a team member can
+ *     belong to more than one of the caller's other organizations)
+ *
+ * NOTE ON `id`: `error404AdditionalDataSchema`'s base schema types `id` as
+ * required (`z.string()`), and most resource-model switcher throws
+ * (asset/location/customField/kit/booking/teamMember) omit it at the `throw`
+ * site. This is NOT a schema bug: the surrounding `try/catch` that re-wraps
+ * these errors merges `{ id, organizationId, ...cause.additionalData }`, so
+ * the client-facing `additionalData` always regains `id` before it reaches
+ * `parse404ErrorData` — the switcher renders correctly. This rule therefore
+ * does NOT enforce `id` (the catch supplies it) and instead enforces
+ * `organization` / `organizations`, which the catch does NOT inject and which
+ * a developer must set at the throw site for the switcher to work.
+ *
+ * ❌ Bad — sets `model` but omits the sibling the schema needs for it:
+ *   throw new ShelfError({
+ *     status: 404,
+ *     additionalData: { model: "asset", organizationId },
+ *   });
+ *
+ * ✅ Good — complete switcher shape:
+ *   throw new ShelfError({
+ *     status: 404,
+ *     additionalData: {
+ *       model: "asset",
+ *       organization: userOrganizations.find(...),
+ *     },
+ *   });
+ *
+ * ✅ Good — genuine not-found, no `model`, not our concern:
+ *   throw new ShelfError({
+ *     status: 404,
+ *     additionalData: { id, organizationId },
+ *   });
+ */
+
+/** Models whose schema branch requires a single `organization` object. */
+const RESOURCE_MODELS = new Set([
+  "asset",
+  "kit",
+  "location",
+  "booking",
+  "customField",
+  "audit",
+]);
+
+/** The one model whose schema branch requires an `organizations` array. */
+const TEAM_MEMBER_MODEL = "teamMember";
+
+const KNOWN_MODELS = new Set([...RESOURCE_MODELS, TEAM_MEMBER_MODEL]);
+
+/**
+ * Find a direct (non-computed, non-spread) `Property` by key name on an
+ * `ObjectExpression`. Returns `undefined` if not present as a direct
+ * property (spread/computed properties are never matched here — callers
+ * that need to tolerate those should check `hasSpread` separately).
+ */
+function findProperty(objectExpression, keyName) {
+  return objectExpression.properties.find(
+    (prop) =>
+      prop.type === "Property" &&
+      !prop.computed &&
+      ((prop.key.type === "Identifier" && prop.key.name === keyName) ||
+        (prop.key.type === "Literal" && prop.key.value === keyName))
+  );
+}
+
+/** Does this object literal spread another value in? (`{ ...rest }`) */
+function hasSpread(objectExpression) {
+  return objectExpression.properties.some(
+    (prop) => prop.type === "SpreadElement"
+  );
+}
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require the workspace-switcher sibling field (organization/organizations) whenever a 404 ShelfError's additionalData sets `model`",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      missingSwitcherField:
+        '404 ShelfError additionalData sets model: "{{model}}" but is missing "{{missingKey}}". ' +
+        "error404AdditionalDataSchema (apps/webapp/app/components/errors/utils.ts) requires " +
+        '"{{missingKey}}" for this model — without it, parse404ErrorData silently fails and this ' +
+        "404 falls back to the generic error screen instead of the organization-switcher UI. " +
+        'Add "{{missingKey}}" to additionalData.',
+    },
+  },
+
+  create(context) {
+    return {
+      NewExpression(node) {
+        // Match: new ShelfError({ ... })
+        if (
+          node.callee.type !== "Identifier" ||
+          node.callee.name !== "ShelfError"
+        ) {
+          return;
+        }
+
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== "ObjectExpression") return;
+
+        // Only 404s are in scope.
+        const statusProp = findProperty(arg, "status");
+        if (
+          !statusProp ||
+          statusProp.value.type !== "Literal" ||
+          statusProp.value.value !== 404
+        ) {
+          return;
+        }
+
+        const additionalDataProp = findProperty(arg, "additionalData");
+        if (!additionalDataProp) return;
+
+        const additionalData = additionalDataProp.value;
+        // Spread/variable additionalData — can't statically verify, skip.
+        if (additionalData.type !== "ObjectExpression") return;
+
+        const modelProp = findProperty(additionalData, "model");
+        // No `model` key at all — genuine not-found, not opted into the
+        // switcher shape. Correct as-is.
+        if (!modelProp) return;
+
+        // Non-literal model (variable/expression) — can't statically verify.
+        if (
+          modelProp.value.type !== "Literal" ||
+          typeof modelProp.value.value !== "string"
+        ) {
+          return;
+        }
+
+        const model = modelProp.value.value;
+        // Not one of the schema's known discriminants — not our concern.
+        if (!KNOWN_MODELS.has(model)) return;
+
+        const requiredKey =
+          model === TEAM_MEMBER_MODEL ? "organizations" : "organization";
+
+        if (findProperty(additionalData, requiredKey)) return; // present, all good
+
+        // The required key might be supplied via a spread we can't inspect
+        // statically (e.g. `{ model: "asset", ...switcherFields }`) — treat
+        // as safe rather than false-positive.
+        if (hasSpread(additionalData)) return;
+
+        context.report({
+          node: additionalData,
+          messageId: "missingSwitcherField",
+          data: { model, missingKey: requiredKey },
+        });
+      },
+    };
+  },
+};

--- a/apps/webapp/eslint-local-rules/require-complete-404-shape.test.cjs
+++ b/apps/webapp/eslint-local-rules/require-complete-404-shape.test.cjs
@@ -1,0 +1,137 @@
+/**
+ * RuleTester coverage for `require-complete-404-shape`.
+ *
+ * No other local rule in this repo had a RuleTester harness wired up yet, so
+ * this file also establishes the pattern (parser + parserOptions needed for
+ * modern syntax) for future local-rule tests.
+ *
+ * Run via the normal webapp test runner: `pnpm webapp:test -- --run
+ * eslint-local-rules/require-complete-404-shape.test.cjs`. Vitest's
+ * `globals: true` config exposes `describe`/`it` as real globals, which is
+ * what ESLint's RuleTester auto-detects to run its cases.
+ */
+
+const { RuleTester } = require("eslint");
+const rule = require("./require-complete-404-shape.cjs");
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+ruleTester.run("require-complete-404-shape", rule, {
+  valid: [
+    // No `model` at all — genuine not-found, correct as-is.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: { id, organizationId },
+        });
+      `,
+    },
+    // Resource model with the required `organization` sibling present.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: {
+            model: "asset",
+            organization: userOrganizations.find((o) => o.organizationId === assetOrgId),
+            redirectTo,
+          },
+        });
+      `,
+    },
+    // teamMember with the required `organizations` (plural) sibling present.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: { model: "teamMember", organizations: otherOrgsForUser },
+        });
+      `,
+    },
+    // Non-404 status — not our concern regardless of shape.
+    {
+      code: `
+        throw new ShelfError({
+          status: 500,
+          additionalData: { model: "asset" },
+        });
+      `,
+    },
+    // additionalData built from a variable — can't statically verify, skip.
+    {
+      code: `
+        throw new ShelfError({ status: 404, additionalData: buildData() });
+      `,
+    },
+    // additionalData spreads in the switcher fields — can't rule out the
+    // required key being present, skip rather than false-positive.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: { model: "kit", ...switcherFields },
+        });
+      `,
+    },
+    // Unknown/non-literal model value — can't statically verify.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: { model: someVariable },
+        });
+      `,
+    },
+  ],
+
+  invalid: [
+    // Resource model missing `organization`.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: { model: "asset", organizationId },
+        });
+      `,
+      errors: [
+        {
+          messageId: "missingSwitcherField",
+          data: { model: "asset", missingKey: "organization" },
+        },
+      ],
+    },
+    // teamMember missing `organizations`.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: { model: "teamMember", id },
+        });
+      `,
+      errors: [
+        {
+          messageId: "missingSwitcherField",
+          data: { model: "teamMember", missingKey: "organizations" },
+        },
+      ],
+    },
+    // Every resource model shares the same required sibling.
+    {
+      code: `
+        throw new ShelfError({
+          status: 404,
+          additionalData: { model: "booking" },
+        });
+      `,
+      errors: [
+        {
+          messageId: "missingSwitcherField",
+          data: { model: "booking", missingKey: "organization" },
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Started from a customer error report — a `404 "Audit asset not found"` (trace id `b9rtpd7u63pdsvgzyv6uyppa`) at `…/audits/…/scan/undefined/details` — that couldn't be found in Sentry. The investigation surfaced one real bug and two gaps.

## The customer bug: scanning a kit during an audit

Audits track **assets, not kits**. When a kit was scanned/searched during an audit it had no `auditAssetId`, which caused two failures the customer described:

- The scanned-items drawer rendered the kit as a clickable row whose detail link was built as `` `${auditAssetId}/details` `` — with `auditAssetId` undefined this resolved to `…/scan/`**`undefined`**`/details`, and clicking it 404'd.
- The persistence hook submitted the kit's id as an `assetId` to `record-scan`, which never matched an asset and retried forever — the *"la carga del elemento no se concluye"* stuck spinner.

**Fix:** a scanned kit is now rejected as a clear error row ("audits track assets, not kits"), reusing the scanner's existing flag-as-error path, so it never enters the asset pipeline. Defensively, a `/details` link is never rendered when `auditAssetId` is falsy, and the persistence loop skips non-asset items so it can't hang.

## Gap 1: genuine 404s showed the alarming generic screen

The "404 screen" (`Error404Handler`) is actually a **cross-workspace switcher** ("this resource is in another of your workspaces, switch?"). A *genuine* not-found (no such resource) fell through to the generic "Oops, something went wrong" screen.

**Fix:** a genuine 404 (not the switcher case) now renders a calm **"Not found"** screen with the error message and trace id.

## Gap 2: error-screen 4xx failures weren't captured in Sentry

4xx errors that reach the full-page error boundary were only logged server-side (never an issue), so a user could report a trace id we couldn't locate.

**Fix:** they're now captured client-side with `tags: { source: "error-boundary", shelf_trace_id: <on-screen trace id>, label, status }` — searchable by the id the user sees. 5xx (already captured server-side) and the benign workspace-switcher are excluded. *Note:* this also captures benign 404s (deleted/stale links) and 403 pages by design ("always capture the error screen") — client-boundary only, so bounded by real user views.

## Guardrail: ESLint rule for 404 switcher-shape completeness

A 404 renders the switcher only if its `additionalData` matches the schema. Setting `model` but omitting `organization`/`organizations` silently fails to parse → generic screen (the class of bug here). New local rule (**hard error**): flags a `new ShelfError({ status: 404, additionalData: { model, … } })` missing the required sibling. Doesn't touch genuine not-founds (no `model`), skips non-literal `additionalData`, and doesn't enforce `id` (the re-wrapping catch injects it). **0 existing violations.**

## Test plan

- `pnpm webapp:validate`: 3419 tests pass (+22 new), 0 lint errors, typecheck clean.
- New tests: kit rejected as error row + not persisted; `undefined/details` link never renders; Not-found screen renders for non-switcher 404s; 4xx boundary capture fires with the right tags (and not for 5xx / switcher); RuleTester cases for the eslint rule.
- Manual: scan a kit during an audit → clear "not a kit" message, no spinner hang, no 404.

## Note
The audit 404 was a handled 4xx (Sentry *log*, not an issue), so there's no Sentry issue to auto-close. Future occurrences of this class will now be captured as issues via the boundary change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented broken navigation when audit asset details are unavailable by disabling or removing “details” links when the identifier is missing.
  * Updated the audit drawer to treat scanned kits as unsupported and guarded navigation for both scanned and pending items.
  * Improved scan persistence by skipping non-asset items to avoid invalid persistence and retry loops.
* **Quality Improvements**
  * Refreshed the error UI layout and routing behavior for clearer “Not found” vs generic error screens and more accurate reporting.
* **Tests**
  * Expanded automated coverage for error rendering/reporting and scanner/audit behaviors.
* **Chores**
  * Added a new lint rule to catch incomplete 404 error shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->