### PR TITLE
fix: reminder-job reliability — Prisma transient-retry (ex-P2024), worker rethrow/retry, email at-least-once

### DIFF
--- a/apps/webapp/app/emails/email.worker.server.ts
+++ b/apps/webapp/app/emails/email.worker.server.ts
@@ -12,6 +12,22 @@ export const SOFT_DELETED_EMAIL_DOMAIN = "@deleted.shelf.nu";
 // increase teamSize if you need better concurrency
 // but keep email provider rate limiting and a potential n/w throughput load on postgress in mind
 // teamSize of 20-25 is a good limit if we need to scale email throughput in the future
+/**
+ * Registers the pg-boss worker that processes queued emails
+ * (`~/emails/mail.server.ts` pushes onto this queue with `retryLimit: 15`
+ * when a synchronous `triggerEmail` attempt fails).
+ *
+ * why: at-least-once delivery is an accepted trade-off, not a bug. If the
+ * process dies AFTER `transporter.sendMail` succeeds but BEFORE pg-boss
+ * records the job as completed, the retry loop re-sends the same email on
+ * the next attempt — `transporter.sendMail` is not idempotent and pg-boss
+ * has no way to know the send already happened. We accept this rare,
+ * non-catastrophic duplicate rather than build exactly-once delivery, which
+ * would require a dedup store (an idempotency key + a table/cache to check
+ * it against) that does not exist today. If duplicate sends become a real
+ * user complaint, that dedup store is the fix — not a smaller retryLimit
+ * (which would trade duplicates for silently-dropped emails instead).
+ */
 export const registerEmailWorkers = async () => {
   await scheduler.work<EmailPayloadType>(
     QueueNames.emailQueue,
@@ -20,10 +36,14 @@ export const registerEmailWorkers = async () => {
       try {
         await triggerEmail(job.data);
       } catch (cause) {
+        // why: pg-boss increments retrycount at fetch time, so with N retries
+        // the handler observes retrycount = 0, 1, 2, ... N — the final attempt
+        // has retrycount === retrylimit. Using `- 1` here double-logs (fires on
+        // both the second-to-last AND the final attempt).
         const isLastRetry =
           job.retrycount != null &&
           job.retrylimit != null &&
-          job.retrycount >= job.retrylimit - 1;
+          job.retrycount >= job.retrylimit;
 
         if (isLastRetry) {
           Logger.error(

--- a/apps/webapp/app/modules/asset-reminder/scheduler.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/scheduler.server.test.ts
@@ -33,36 +33,43 @@ vi.mock("~/utils/scheduler.server", () => ({
   },
 }));
 
+/**
+ * Builds a `scheduleAssetReminder` input with sensible defaults, so each test
+ * only states the fields it actually cares about.
+ *
+ * @param overrides - Partial fields to override the defaults.
+ * @returns The `{ data, when }` argument for `scheduleAssetReminder`.
+ */
+function buildScheduleInput(
+  overrides: Partial<Parameters<typeof scheduleAssetReminder>[0]> = {}
+): Parameters<typeof scheduleAssetReminder>[0] {
+  return {
+    data: { reminderId: "reminder-1", eventType: "REMINDER" as const },
+    when: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
 describe("scheduleAssetReminder", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("enqueues with a bounded retry policy (retryLimit + retryDelay)", async () => {
-    const data = {
-      reminderId: "reminder-1",
-      eventType: "REMINDER" as const,
-    };
-    const when = new Date("2026-01-01T00:00:00Z");
+    const input = buildScheduleInput();
 
-    await scheduleAssetReminder({ data, when });
+    await scheduleAssetReminder(input);
 
     expect(scheduler.sendAfter).toHaveBeenCalledWith(
       QueueNames.assetsQueue,
-      data,
+      input.data,
       { retryLimit: 2, retryDelay: 60 },
-      when
+      input.when
     );
   });
 
   it("persists the returned scheduler reference on the reminder", async () => {
-    const data = {
-      reminderId: "reminder-1",
-      eventType: "REMINDER" as const,
-    };
-    const when = new Date("2026-01-01T00:00:00Z");
-
-    await scheduleAssetReminder({ data, when });
+    await scheduleAssetReminder(buildScheduleInput());
 
     expect(db.assetReminder.update).toHaveBeenCalledWith({
       where: { id: "reminder-1" },
@@ -76,10 +83,7 @@ describe("scheduleAssetReminder", () => {
     scheduler.sendAfter.mockRejectedValue(cause);
 
     await expect(
-      scheduleAssetReminder({
-        data: { reminderId: "reminder-1", eventType: "REMINDER" },
-        when: new Date("2026-01-01T00:00:00Z"),
-      })
+      scheduleAssetReminder(buildScheduleInput())
     ).rejects.toMatchObject({
       message: "Something went wrong while schedulng asset alert",
     });

--- a/apps/webapp/app/modules/asset-reminder/scheduler.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/scheduler.server.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the asset-reminder scheduler enqueue helpers.
+ *
+ * Focus: `scheduleAssetReminder` must pass a bounded retry policy to
+ * pg-boss's `sendAfter` — previously `{}` was passed, so even after
+ * `regierAssetWorkers` started rethrowing on failure, pg-boss had no retry
+ * configured and the job would still be lost on first failure.
+ *
+ * @see {@link file://./scheduler.server.ts}
+ */
+import { db } from "~/database/db.server";
+import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import { scheduleAssetReminder } from "./scheduler.server";
+
+// @vitest-environment node
+
+// why: asserting the DB write without touching a real database
+vi.mock("~/database/db.server", () => ({
+  db: {
+    assetReminder: {
+      update: vi.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+// why: capturing the arguments passed to pg-boss without scheduling a real job
+vi.mock("~/utils/scheduler.server", () => ({
+  scheduler: {
+    sendAfter: vi.fn().mockResolvedValue("scheduler-ref-1"),
+  },
+  QueueNames: {
+    assetsQueue: "assets-queue",
+  },
+}));
+
+describe("scheduleAssetReminder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enqueues with a bounded retry policy (retryLimit + retryDelay)", async () => {
+    const data = {
+      reminderId: "reminder-1",
+      eventType: "REMINDER" as const,
+    };
+    const when = new Date("2026-01-01T00:00:00Z");
+
+    await scheduleAssetReminder({ data, when });
+
+    expect(scheduler.sendAfter).toHaveBeenCalledWith(
+      QueueNames.assetsQueue,
+      data,
+      { retryLimit: 2, retryDelay: 60 },
+      when
+    );
+  });
+
+  it("persists the returned scheduler reference on the reminder", async () => {
+    const data = {
+      reminderId: "reminder-1",
+      eventType: "REMINDER" as const,
+    };
+    const when = new Date("2026-01-01T00:00:00Z");
+
+    await scheduleAssetReminder({ data, when });
+
+    expect(db.assetReminder.update).toHaveBeenCalledWith({
+      where: { id: "reminder-1" },
+      data: { activeSchedulerReference: "scheduler-ref-1" },
+    });
+  });
+
+  it("wraps a sendAfter failure in a ShelfError", async () => {
+    const cause = new Error("pg-boss unavailable");
+    // @ts-expect-error missing vitest type
+    scheduler.sendAfter.mockRejectedValue(cause);
+
+    await expect(
+      scheduleAssetReminder({
+        data: { reminderId: "reminder-1", eventType: "REMINDER" },
+        when: new Date("2026-01-01T00:00:00Z"),
+      })
+    ).rejects.toMatchObject({
+      message: "Something went wrong while schedulng asset alert",
+    });
+  });
+});

--- a/apps/webapp/app/modules/asset-reminder/scheduler.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/scheduler.server.ts
@@ -28,10 +28,15 @@ export async function scheduleAssetReminder({
   when: Date;
 }) {
   try {
+    // why: bounded retry recovers transient failures (e.g. a momentary DB
+    // blip); a small limit + the reminder handler's non-idempotent
+    // email/note sends mean we cap duplicate exposure (paired with the
+    // query-level DB retry from the sibling task, most failures are already
+    // handled before the job throws).
     const reference = await scheduler.sendAfter(
       QueueNames.assetsQueue,
       data,
-      {},
+      { retryLimit: 2, retryDelay: 60 },
       when
     );
 

--- a/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the asset-reminder pg-boss worker.
+ *
+ * Focus: the worker-wrapping behavior around `regierAssetWorkers` — the
+ * catch/log/rethrow contract that determines whether pg-boss retries a
+ * failed reminder job or silently marks it COMPLETED. The handler is
+ * exercised through the callback captured from `scheduler.work`, since the
+ * event handlers themselves are not exported.
+ *
+ * @see {@link file://./worker.server.ts}
+ */
+import type PgBoss from "pg-boss";
+import { db } from "~/database/db.server";
+import { Logger } from "~/utils/logger";
+import { QueueNames, scheduler } from "~/utils/scheduler.server";
+import type { AssetsSchedulerData } from "./scheduler.server";
+import { regierAssetWorkers } from "./worker.server";
+
+// @vitest-environment node
+
+// why: testing worker handlers without executing actual database operations
+vi.mock("~/database/db.server", () => ({
+  db: {
+    assetReminder: {
+      findFirst: vi.fn(),
+    },
+    user: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+// why: preventing actual job scheduling during tests; captures the
+// registered callback + options so we can invoke it directly below
+vi.mock("~/utils/scheduler.server", () => ({
+  scheduler: {
+    work: vi.fn(),
+  },
+  QueueNames: {
+    assetsQueue: "assets-queue",
+  },
+}));
+
+// why: preventing actual email rendering/sending during worker tests
+vi.mock("./emails", () => ({
+  assetAlertEmailHtmlString: vi.fn().mockResolvedValue("<html></html>"),
+  assetAlertEmailText: vi.fn().mockReturnValue("text body"),
+}));
+
+vi.mock("~/emails/mail.server", () => ({
+  sendEmail: vi.fn(),
+}));
+
+// why: avoiding actual note creation during worker tests
+vi.mock("../note/service.server", () => ({
+  createNote: vi.fn().mockResolvedValue({}),
+}));
+
+// why: spying on Logger to verify logging behavior without touching Sentry/pino
+vi.mock("~/utils/logger", () => ({
+  Logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+/**
+ * Helper mirroring `apps/webapp/app/modules/booking/worker.server.test.ts`:
+ * registers the worker and extracts the callback pg-boss would invoke per
+ * job, since `ASSET_SCHEDULER_EVENT_HANDLERS` is module-private.
+ */
+async function getWorkerHandler(): Promise<{
+  handler: (job: PgBoss.JobWithMetadata<AssetsSchedulerData>) => Promise<void>;
+  queueName: unknown;
+  options: unknown;
+}> {
+  await regierAssetWorkers();
+  const workMock = scheduler.work as ReturnType<typeof vi.fn>;
+  // scheduler.work is called with (queueName, options, callback). Captured
+  // here (rather than read from workMock.mock.calls in a test body) because
+  // beforeEach clears mock call history between tests below.
+  const [queueName, options, handler] = workMock.mock.calls[0];
+  return { handler, queueName, options };
+}
+
+function buildJob(
+  overrides: Partial<PgBoss.JobWithMetadata<AssetsSchedulerData>> = {}
+): PgBoss.JobWithMetadata<AssetsSchedulerData> {
+  return {
+    id: "job-1",
+    name: QueueNames.assetsQueue,
+    data: { reminderId: "reminder-1", eventType: "REMINDER" },
+    retrycount: 0,
+    retrylimit: 2,
+    ...overrides,
+  } as PgBoss.JobWithMetadata<AssetsSchedulerData>;
+}
+
+describe("regierAssetWorkers", () => {
+  let workerHandler: (
+    job: PgBoss.JobWithMetadata<AssetsSchedulerData>
+  ) => Promise<void>;
+  let registeredQueueName: unknown;
+  let registeredOptions: unknown;
+
+  beforeAll(async () => {
+    const registration = await getWorkerHandler();
+    workerHandler = registration.handler;
+    registeredQueueName = registration.queueName;
+    registeredOptions = registration.options;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers the queue with includeMetadata so retrycount/retrylimit are available", () => {
+    expect(registeredQueueName).toBe(QueueNames.assetsQueue);
+    expect(registeredOptions).toEqual(
+      expect.objectContaining({ includeMetadata: true })
+    );
+  });
+
+  it("returns cleanly (no throw) when the reminder no longer exists", async () => {
+    // @ts-expect-error missing vitest type
+    db.assetReminder.findFirst.mockResolvedValue(null);
+
+    await expect(workerHandler(buildJob())).resolves.toBeUndefined();
+
+    expect(Logger.warn).toHaveBeenCalled();
+    expect(Logger.error).not.toHaveBeenCalled();
+  });
+
+  it("rethrows when the handler fails, so pg-boss retries the job", async () => {
+    const dbError = new Error("connection lost");
+    // @ts-expect-error missing vitest type
+    db.assetReminder.findFirst.mockRejectedValue(dbError);
+
+    await expect(
+      workerHandler(buildJob({ retrycount: 0, retrylimit: 2 }))
+    ).rejects.toThrow("connection lost");
+  });
+
+  it("does not log on an intermediate retry attempt (noise control)", async () => {
+    const dbError = new Error("connection lost");
+    // @ts-expect-error missing vitest type
+    db.assetReminder.findFirst.mockRejectedValue(dbError);
+
+    // pg-boss increments retrycount at fetch time, so with retrylimit 2 the
+    // handler observes retrycount 0, 1, 2 — the final attempt is retrycount
+    // === retrylimit (2). retrycount 1 is an intermediate retry: it should
+    // still rethrow (so pg-boss retries again) but must NOT log yet.
+    await expect(
+      workerHandler(buildJob({ retrycount: 1, retrylimit: 2 }))
+    ).rejects.toThrow();
+
+    expect(Logger.error).not.toHaveBeenCalled();
+  });
+
+  it("logs once on the final retry attempt before rethrowing", async () => {
+    const dbError = new Error("connection lost");
+    // @ts-expect-error missing vitest type
+    db.assetReminder.findFirst.mockRejectedValue(dbError);
+
+    // retrycount 2 of retrylimit 2 → this IS the true final attempt, since
+    // pg-boss's retrycount reaches retrylimit (not retrylimit - 1) on the
+    // last try.
+    await expect(
+      workerHandler(buildJob({ retrycount: 2, retrylimit: 2 }))
+    ).rejects.toThrow();
+
+    expect(Logger.error).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
+++ b/apps/webapp/app/modules/asset-reminder/worker.server.test.ts
@@ -47,6 +47,8 @@ vi.mock("./emails", () => ({
   assetAlertEmailText: vi.fn().mockReturnValue("text body"),
 }));
 
+// why: preventing real email delivery while exercising the worker's
+// failure/retry paths — the tests assert on rethrow + logging, not on email I/O
 vi.mock("~/emails/mail.server", () => ({
   sendEmail: vi.fn(),
 }));

--- a/apps/webapp/app/modules/asset-reminder/worker.server.ts
+++ b/apps/webapp/app/modules/asset-reminder/worker.server.ts
@@ -152,24 +152,55 @@ const ASSET_SCHEDULER_EVENT_HANDLERS: Record<
 /**
  * This function is used to register asset workers.
  * Workers are used to process scheduled events.
+ *
+ * On handler failure we log (last-retry only, mirroring the email worker's
+ * noise control in `emails/email.worker.server.ts`) and **rethrow** so
+ * pg-boss marks the job failed and retries it per the bounded `retryLimit`
+ * set on enqueue in `scheduler.server.ts`. Previously the catch swallowed the
+ * error and returned, so pg-boss marked the job COMPLETED even on failure —
+ * silently losing the reminder with no retry.
+ *
+ * @throws {ShelfError} Rethrows the wrapped cause after logging, so pg-boss
+ * treats the job as failed and retries it.
  */
 export async function regierAssetWorkers() {
   await scheduler.work<AssetsSchedulerData>(
     QueueNames.assetsQueue,
+    // why: includeMetadata exposes job.retrycount/job.retrylimit on the job
+    // object below, which we need to only log on the final retry attempt
+    { includeMetadata: true },
     async (job) => {
       const handler = ASSET_SCHEDULER_EVENT_HANDLERS[job.data.eventType];
 
       try {
         await handler(job);
       } catch (cause) {
-        Logger.error(
-          new ShelfError({
-            cause,
-            message: "Something went wrong while executing scheduled work.",
-            additionalData: { data: job.data, work: job.data.eventType },
-            label: "Asset Scheduler",
-          })
-        );
+        // why: pg-boss increments retrycount at fetch time, so with N retries
+        // the handler observes retrycount = 0, 1, 2, ... N — the final attempt
+        // has retrycount === retrylimit. Using `- 1` here double-logs (fires on
+        // both the second-to-last AND the final attempt).
+        const isLastRetry =
+          job.retrycount != null &&
+          job.retrylimit != null &&
+          job.retrycount >= job.retrylimit;
+
+        if (isLastRetry) {
+          Logger.error(
+            new ShelfError({
+              cause,
+              message: "Something went wrong while executing scheduled work.",
+              additionalData: {
+                data: job.data,
+                work: job.data.eventType,
+                retryCount: job.retrycount,
+                retryLimit: job.retrylimit,
+              },
+              label: "Asset Scheduler",
+            })
+          );
+        }
+
+        throw cause;
       }
     }
   );

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "prisma generate",
+    "test": "node --import tsx --test",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate deploy",
     "db:prepare-migration": "prisma generate && prisma migrate dev --create-only --skip-seed && tsx src/post-migration.ts",

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the Prisma transient-error retry wrapper in `client.ts`.
+ *
+ * Run with `pnpm --filter @shelf/database test` (Node's built-in test
+ * runner via `tsx`, already a package devDependency — no vitest/harness
+ * needed for this small, dependency-free package).
+ *
+ * These tests never touch a real database: the "query" is a plain mock
+ * function that throws/resolves on cue.
+ *
+ * @see ./client.ts
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isRetryablePrismaError,
+  PRISMA_RETRYABLE_ERROR_CODES,
+  withPrismaRetry,
+} from "./client";
+
+/**
+ * Builds a Prisma-shaped error (a plain object carrying a `code`), the same
+ * shape `Prisma.PrismaClientKnownRequestError` instances have at runtime.
+ *
+ * why: constructing the real `PrismaClientKnownRequestError` requires
+ * private constructor args tied to an engine version; a plain object with
+ * `.code` is exactly what `isRetryablePrismaError`'s structural check reads,
+ * so it exercises the same code path without an engine dependency.
+ */
+function prismaError(code: string): Error & { code: string } {
+  return Object.assign(new Error(`mock prisma error ${code}`), { code });
+}
+
+/**
+ * Type-safe check for "did this rejection carry the given Prisma error
+ * code", used as the matcher argument to `assert.rejects`. Avoids narrowing
+ * through `instanceof Error` (which doesn't know about `.code`) and avoids
+ * `any` — mirrors the structural check `isRetryablePrismaError` itself uses.
+ */
+function rejectedWithCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code: unknown }).code === code
+  );
+}
+
+test("isRetryablePrismaError", async (t) => {
+  await t.test("returns true for every retryable code", () => {
+    for (const code of PRISMA_RETRYABLE_ERROR_CODES) {
+      assert.equal(isRetryablePrismaError(prismaError(code)), true);
+    }
+  });
+
+  await t.test("returns false for P2024 (pool exhaustion)", () => {
+    assert.equal(isRetryablePrismaError(prismaError("P2024")), false);
+  });
+
+  await t.test("returns false for a non-Prisma error (no code)", () => {
+    assert.equal(isRetryablePrismaError(new Error("boom")), false);
+  });
+
+  await t.test("returns false for non-object thrown values", () => {
+    assert.equal(isRetryablePrismaError("just a string"), false);
+    assert.equal(isRetryablePrismaError(null), false);
+    assert.equal(isRetryablePrismaError(undefined), false);
+  });
+});
+
+test("withPrismaRetry", async (t) => {
+  await t.test(
+    "retries a P1017 error and returns the eventual success",
+    async () => {
+      let calls = 0;
+      const delays: number[] = [];
+      const logs: string[] = [];
+
+      const result = await withPrismaRetry(
+        async () => {
+          calls += 1;
+          if (calls === 1) throw prismaError("P1017");
+          return "ok";
+        },
+        {
+          // why: skip the real setTimeout-based backoff so the test runs
+          // instantly instead of waiting out the 500ms/1000ms delays.
+          delay: async (ms) => {
+            delays.push(ms);
+          },
+          log: (message) => logs.push(message),
+        }
+      );
+
+      assert.equal(result, "ok");
+      assert.equal(calls, 2);
+      assert.deepEqual(delays, [500]);
+      assert.equal(logs.length, 1);
+      assert.match(logs[0], /P1017/);
+      assert.match(logs[0], /retry 1\/2/);
+    }
+  );
+
+  await t.test(
+    "does NOT retry P2024 (pool exhaustion) — throws immediately",
+    async () => {
+      let calls = 0;
+      const logs: string[] = [];
+
+      await assert.rejects(
+        () =>
+          withPrismaRetry(
+            async () => {
+              calls += 1;
+              throw prismaError("P2024");
+            },
+            { log: (message) => logs.push(message) }
+          ),
+        (error: unknown) => rejectedWithCode(error, "P2024")
+      );
+
+      assert.equal(calls, 1, "P2024 must fail fast, never retried");
+      assert.equal(
+        logs.length,
+        0,
+        "no retry log line for a non-retryable error"
+      );
+    }
+  );
+
+  await t.test(
+    "does not retry a non-Prisma error — throws immediately",
+    async () => {
+      let calls = 0;
+
+      await assert.rejects(
+        () =>
+          withPrismaRetry(async () => {
+            calls += 1;
+            throw new Error("totally unrelated failure");
+          }),
+        /totally unrelated failure/
+      );
+
+      assert.equal(calls, 1);
+    }
+  );
+
+  await t.test(
+    "throws the final error once retries are exhausted",
+    async () => {
+      let calls = 0;
+      const delays: number[] = [];
+
+      await assert.rejects(
+        () =>
+          withPrismaRetry(
+            async () => {
+              calls += 1;
+              throw prismaError("P1001");
+            },
+            {
+              delay: async (ms) => {
+                delays.push(ms);
+              },
+              log: () => {},
+            }
+          ),
+        (error: unknown) => rejectedWithCode(error, "P1001")
+      );
+
+      // MAX_RETRIES = 2 -> 3 total attempts, 2 backoff delays (500ms, 1000ms).
+      assert.equal(calls, 3);
+      assert.deepEqual(delays, [500, 1000]);
+    }
+  );
+
+  await t.test("returns immediately on first-try success", async () => {
+    let calls = 0;
+    const result = await withPrismaRetry(async () => {
+      calls += 1;
+      return 42;
+    });
+    assert.equal(result, 42);
+    assert.equal(calls, 1);
+  });
+});

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -14,29 +14,46 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  getRetryableErrorCode,
   isRetryablePrismaError,
   PRISMA_RETRYABLE_ERROR_CODES,
   withPrismaRetry,
 } from "./client";
 
 /**
- * Builds a Prisma-shaped error (a plain object carrying a `code`), the same
- * shape `Prisma.PrismaClientKnownRequestError` instances have at runtime.
+ * Builds a `PrismaClientKnownRequestError`-shaped error (a plain object
+ * carrying a `code`) — the shape Prisma raises while executing a query.
  *
  * why: constructing the real `PrismaClientKnownRequestError` requires
  * private constructor args tied to an engine version; a plain object with
- * `.code` is exactly what `isRetryablePrismaError`'s structural check reads,
- * so it exercises the same code path without an engine dependency.
+ * `.code` is exactly what the structural check reads, so it exercises the same
+ * code path without an engine dependency.
  */
 function prismaError(code: string): Error & { code: string } {
   return Object.assign(new Error(`mock prisma error ${code}`), { code });
 }
 
 /**
+ * Builds a `PrismaClientInitializationError`-shaped error (a plain object
+ * carrying an `errorCode`) — the shape Prisma raises when the lazy client
+ * fails to establish its FIRST connection during a DB outage. Crucially the
+ * transient code lands on `errorCode`, NOT `code`.
+ *
+ * why: same as {@link prismaError} — the real error's constructor is
+ * engine-coupled, and the structural check only reads `errorCode`, so a plain
+ * object reproduces the startup/reconnection path faithfully.
+ */
+function prismaInitError(errorCode: string): Error & { errorCode: string } {
+  return Object.assign(new Error(`mock prisma init error ${errorCode}`), {
+    errorCode,
+  });
+}
+
+/**
  * Type-safe check for "did this rejection carry the given Prisma error
  * code", used as the matcher argument to `assert.rejects`. Avoids narrowing
  * through `instanceof Error` (which doesn't know about `.code`) and avoids
- * `any` — mirrors the structural check `isRetryablePrismaError` itself uses.
+ * `any` — mirrors the structural check the client itself uses.
  */
 function rejectedWithCode(error: unknown, code: string): boolean {
   return (
@@ -47,31 +64,118 @@ function rejectedWithCode(error: unknown, code: string): boolean {
   );
 }
 
-test("isRetryablePrismaError", async (t) => {
-  await t.test("returns true for every retryable code", () => {
-    for (const code of PRISMA_RETRYABLE_ERROR_CODES) {
-      assert.equal(isRetryablePrismaError(prismaError(code)), true);
-    }
+test("getRetryableErrorCode", async (t) => {
+  await t.test("reads `code` from a known-request error shape", () => {
+    assert.equal(getRetryableErrorCode(prismaError("P1001")), "P1001");
   });
 
+  await t.test("reads `errorCode` from an initialization error shape", () => {
+    // Regression: a DB outage at cold start surfaces the code on `errorCode`,
+    // not `code`; a predicate reading only `code` would never retry it.
+    assert.equal(getRetryableErrorCode(prismaInitError("P1002")), "P1002");
+  });
+
+  await t.test("returns null for P2024 and non-transient codes", () => {
+    assert.equal(getRetryableErrorCode(prismaError("P2024")), null);
+    assert.equal(getRetryableErrorCode(prismaError("P2002")), null);
+    assert.equal(getRetryableErrorCode(prismaInitError("P1003")), null);
+  });
+
+  await t.test("returns null for non-Prisma / non-object values", () => {
+    assert.equal(getRetryableErrorCode(new Error("boom")), null);
+    assert.equal(getRetryableErrorCode("just a string"), null);
+    assert.equal(getRetryableErrorCode(null), null);
+    assert.equal(getRetryableErrorCode(undefined), null);
+  });
+});
+
+test("isRetryablePrismaError", async (t) => {
+  await t.test(
+    "connection-level codes (P1001/P1002) retry for reads AND writes",
+    () => {
+      for (const code of ["P1001", "P1002"]) {
+        assert.equal(
+          isRetryablePrismaError(prismaError(code), { operationIsRead: true }),
+          true
+        );
+        assert.equal(
+          isRetryablePrismaError(prismaError(code), { operationIsRead: false }),
+          true
+        );
+      }
+    }
+  );
+
+  await t.test(
+    "in-flight codes (P1008/P1017) retry for reads but NOT writes",
+    () => {
+      for (const code of ["P1008", "P1017"]) {
+        assert.equal(
+          isRetryablePrismaError(prismaError(code), { operationIsRead: true }),
+          true
+        );
+        assert.equal(
+          isRetryablePrismaError(prismaError(code), { operationIsRead: false }),
+          false,
+          `${code} must not be retried on a write (may already have applied)`
+        );
+      }
+    }
+  );
+
+  await t.test(
+    "initialization errors retry via `errorCode` (write-safe connect codes)",
+    () => {
+      assert.equal(
+        isRetryablePrismaError(prismaInitError("P1001"), {
+          operationIsRead: false,
+        }),
+        true
+      );
+    }
+  );
+
   await t.test("returns false for P2024 (pool exhaustion)", () => {
-    assert.equal(isRetryablePrismaError(prismaError("P2024")), false);
+    assert.equal(
+      isRetryablePrismaError(prismaError("P2024"), { operationIsRead: true }),
+      false
+    );
   });
 
   await t.test("returns false for a non-Prisma error (no code)", () => {
-    assert.equal(isRetryablePrismaError(new Error("boom")), false);
+    assert.equal(
+      isRetryablePrismaError(new Error("boom"), { operationIsRead: true }),
+      false
+    );
   });
 
   await t.test("returns false for non-object thrown values", () => {
-    assert.equal(isRetryablePrismaError("just a string"), false);
-    assert.equal(isRetryablePrismaError(null), false);
-    assert.equal(isRetryablePrismaError(undefined), false);
+    assert.equal(
+      isRetryablePrismaError("just a string", { operationIsRead: true }),
+      false
+    );
+    assert.equal(
+      isRetryablePrismaError(null, { operationIsRead: true }),
+      false
+    );
+    assert.equal(
+      isRetryablePrismaError(undefined, { operationIsRead: true }),
+      false
+    );
+  });
+
+  await t.test("PRISMA_RETRYABLE_ERROR_CODES excludes P2024", () => {
+    assert.equal(PRISMA_RETRYABLE_ERROR_CODES.has("P2024"), false);
+    // The union of both severity buckets, for documentation/consumers.
+    for (const code of ["P1001", "P1002", "P1008", "P1017"]) {
+      assert.equal(PRISMA_RETRYABLE_ERROR_CODES.has(code), true);
+    }
   });
 });
 
 test("withPrismaRetry", async (t) => {
   await t.test(
-    "retries a P1017 error and returns the eventual success",
+    "retries an in-flight P1017 error on a READ and returns the eventual success",
     async () => {
       let calls = 0;
       const delays: number[] = [];
@@ -84,6 +188,7 @@ test("withPrismaRetry", async (t) => {
           return "ok";
         },
         {
+          operationIsRead: true,
           // why: skip the real setTimeout-based backoff so the test runs
           // instantly instead of waiting out the 500ms/1000ms delays.
           delay: async (ms) => {
@@ -99,6 +204,79 @@ test("withPrismaRetry", async (t) => {
       assert.equal(logs.length, 1);
       assert.match(logs[0], /P1017/);
       assert.match(logs[0], /retry 1\/2/);
+    }
+  );
+
+  await t.test(
+    "does NOT retry an in-flight P1017 error on a WRITE — throws immediately",
+    async () => {
+      // The mutation may already have committed before the connection dropped;
+      // retrying could duplicate a row. Writes only retry connection-level codes.
+      let calls = 0;
+      const logs: string[] = [];
+
+      await assert.rejects(
+        () =>
+          withPrismaRetry(
+            async () => {
+              calls += 1;
+              throw prismaError("P1017");
+            },
+            { operationIsRead: false, log: (message) => logs.push(message) }
+          ),
+        (error: unknown) => rejectedWithCode(error, "P1017")
+      );
+
+      assert.equal(calls, 1, "in-flight code on a write must fail fast");
+      assert.equal(logs.length, 0, "no retry log line for a non-retried write");
+    }
+  );
+
+  await t.test(
+    "retries a connection-level P1001 error on a WRITE (query never reached the DB)",
+    async () => {
+      let calls = 0;
+      const delays: number[] = [];
+
+      const result = await withPrismaRetry(
+        async () => {
+          calls += 1;
+          if (calls === 1) throw prismaError("P1001");
+          return "ok";
+        },
+        {
+          operationIsRead: false,
+          delay: async (ms) => {
+            delays.push(ms);
+          },
+          log: () => {},
+        }
+      );
+
+      assert.equal(result, "ok");
+      assert.equal(calls, 2);
+      assert.deepEqual(delays, [500]);
+    }
+  );
+
+  await t.test(
+    "retries an initialization error (code on `errorCode`) on a WRITE",
+    async () => {
+      // Regression for the cold-start/reconnection outage: the transient code
+      // lands on `errorCode`; a `.code`-only predicate would never retry it.
+      let calls = 0;
+
+      const result = await withPrismaRetry(
+        async () => {
+          calls += 1;
+          if (calls === 1) throw prismaInitError("P1001");
+          return "ok";
+        },
+        { operationIsRead: false, delay: async () => {}, log: () => {} }
+      );
+
+      assert.equal(result, "ok");
+      assert.equal(calls, 2);
     }
   );
 

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -1,24 +1,158 @@
+/**
+ * Database client factory for `@shelf/database`.
+ *
+ * Owns the single `PrismaClient` construction point shared by every consuming
+ * app (webapp, background jobs, scripts). Extensions added here (dynamic
+ * `findMany`, transient-error retry) apply uniformly to all consumers.
+ *
+ * This package cannot depend on `@shelf/webapp`'s `Logger`/`delay`/error
+ * utilities (that would invert the dependency direction), so anything needed
+ * for the retry behavior below (logging, delay, error-code classification)
+ * is defined locally.
+ *
+ * @see apps/webapp/app/database/db.server.ts — thin re-export consumed by the webapp.
+ */
+
 import { Prisma, PrismaClient } from "@prisma/client";
 
 export type ExtendedPrismaClient = ReturnType<typeof createDatabaseClient>;
 
 /**
+ * Prisma error codes that indicate a transient, connection-level failure —
+ * the client could not establish or hold a connection to the database — as
+ * opposed to the query itself being invalid or the data not existing. These
+ * are safe to retry because the query almost certainly never reached the
+ * database.
+ *
+ * `P2024` (timed out fetching a connection from the pool) is DELIBERATELY
+ * excluded: pool exhaustion means the database is already saturated, and
+ * retrying re-queues the same work onto an already-overloaded pool —
+ * deepening the incident instead of recovering from it. Callers should let
+ * `P2024` fail fast (it's mapped to a 503 at the app layer) rather than have
+ * it retried here.
+ *
+ * @see apps/webapp/app/utils/error.ts `PRISMA_TRANSIENT_ERROR_CODES` — a
+ * different list used for 5xx status-code mapping, which DOES include
+ * `P2024`. Do not reuse that list for retry decisions.
+ */
+export const PRISMA_RETRYABLE_ERROR_CODES = new Set([
+  "P1001", // Can't reach database server
+  "P1002", // The database server was reached but timed out
+  "P1008", // Operations timed out
+  "P1017", // Server has closed the connection
+]);
+
+/** Maximum number of retry attempts for a transient Prisma error. */
+const MAX_RETRIES = 2;
+
+/** Base backoff unit (ms); actual delay is `BASE_DELAY_MS * attempt`. */
+const BASE_DELAY_MS = 500;
+
+/**
+ * Narrows an unknown thrown value to a Prisma-style error carrying a string
+ * `code`, and reports whether that code is one of
+ * {@link PRISMA_RETRYABLE_ERROR_CODES}.
+ *
+ * Deliberately checks structurally (`"code" in error`) rather than
+ * `instanceof Prisma.PrismaClientKnownRequestError` so that plain mocked
+ * errors in tests are also recognized correctly.
+ *
+ * @param error - The unknown value thrown by a Prisma query.
+ * @returns `true` if `error` should be retried.
+ */
+export function isRetryablePrismaError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return false;
+  }
+  const { code } = error as { code: unknown };
+  return typeof code === "string" && PRISMA_RETRYABLE_ERROR_CODES.has(code);
+}
+
+/**
+ * Runs `operation`, retrying it when it throws a transient, connection-level
+ * Prisma error (see {@link isRetryablePrismaError}). Uses a linear backoff of
+ * `BASE_DELAY_MS * attempt` (500ms, then 1000ms) between attempts.
+ * Non-retryable errors — including `P2024` pool exhaustion — rethrow
+ * immediately on the first failure, exactly like a call with no wrapper.
+ *
+ * Extracted out of {@link createDatabaseClient}'s `$allOperations` extension
+ * so the retry/backoff logic can be unit-tested without a real Prisma client
+ * or database connection.
+ *
+ * @param operation - The Prisma operation to execute (and retry on failure).
+ * @param options - Optional overrides, used by tests to avoid real delays
+ *   and to assert on the retry log line without polluting stdout.
+ * @param options.log - Called once per retry with a human-readable message.
+ *   Defaults to `console.warn` (the package has no `Logger`; retries are
+ *   infrequent so stdout is fine — it surfaces in Fly/Sentry logs).
+ * @param options.delay - Called with the backoff duration (ms) and awaited
+ *   before the next attempt. Defaults to a real `setTimeout`-based delay.
+ * @returns The resolved value of `operation`.
+ * @throws The final error, once retries are exhausted or the error isn't retryable.
+ */
+export async function withPrismaRetry<T>(
+  operation: () => Promise<T>,
+  options?: {
+    log?: (message: string) => void;
+    delay?: (ms: number) => Promise<void>;
+  }
+): Promise<T> {
+  const log = options?.log ?? console.warn;
+  const delay =
+    options?.delay ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (isRetryablePrismaError(error) && attempt <= MAX_RETRIES) {
+        const code = (error as { code: string }).code;
+        const delayMs = BASE_DELAY_MS * attempt;
+        log(
+          `[db] transient Prisma error [${code}], retry ${attempt}/${MAX_RETRIES} in ${delayMs}ms`
+        );
+        await delay(delayMs);
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  // Unreachable: the loop above always either returns or throws.
+  throw new Error("Retry loop exited unexpectedly");
+}
+
+/**
  * Creates a new PrismaClient instance with custom extensions.
  * Each app should create its own singleton using this factory.
+ *
+ * Extensions applied (in order):
+ * 1. `dynamicFindMany` — allows calling `findMany` generically across models.
+ * 2. Transient-error retry — retries connection-level failures (see
+ *    {@link PRISMA_RETRYABLE_ERROR_CODES}) across all operations, on all models.
  */
 export function createDatabaseClient(url?: string) {
-  const client = new PrismaClient(
-    url ? { datasourceUrl: url } : undefined
-  ).$extends({
-    model: {
-      $allModels: {
-        dynamicFindMany<T>(this: T, options: Prisma.Args<T, "findMany">) {
-          const ctx = Prisma.getExtensionContext(this) as any;
-          return ctx.findMany(options);
+  const client = new PrismaClient(url ? { datasourceUrl: url } : undefined)
+    .$extends({
+      model: {
+        $allModels: {
+          dynamicFindMany<T>(this: T, options: Prisma.Args<T, "findMany">) {
+            const ctx = Prisma.getExtensionContext(this) as any;
+            return ctx.findMany(options);
+          },
         },
       },
-    },
-  });
+    })
+    .$extends({
+      query: {
+        $allModels: {
+          async $allOperations({ args, query }) {
+            return withPrismaRetry(() => query(args));
+          },
+        },
+      },
+    });
 
   return client;
 }

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -18,14 +18,40 @@ import { Prisma, PrismaClient } from "@prisma/client";
 export type ExtendedPrismaClient = ReturnType<typeof createDatabaseClient>;
 
 /**
- * Prisma error codes that indicate a transient, connection-level failure —
- * the client could not establish or hold a connection to the database — as
- * opposed to the query itself being invalid or the data not existing. These
- * are safe to retry because the query almost certainly never reached the
- * database.
+ * Transient Prisma error codes where the query **never reached the database**
+ * — the client could not establish or hold a connection. Because no statement
+ * was ever executed, these are safe to retry for **any** operation, reads and
+ * writes alike (a retry cannot duplicate a write that never happened).
+ *
+ *  - `P1001`: Can't reach database server
+ *  - `P1002`: The database server was reached but timed out (connect timeout)
+ *
+ * `PrismaClientInitializationError` (the lazy client failing to establish its
+ * FIRST connection during a DB outage) also surfaces these codes — see
+ * {@link getRetryableErrorCode}, which reads that error's `errorCode` field.
+ */
+const CONNECTION_ERROR_CODES = new Set(["P1001", "P1002"]);
+
+/**
+ * Transient Prisma error codes that can surface **after** a statement was
+ * already sent to the server — so a mutation may already have been applied
+ * when the error is raised. Safe to retry for idempotent **reads**, but NOT
+ * for writes: retrying a `create`/`update`/`delete` here can duplicate a row
+ * or re-apply a mutation. See the read/write gate in {@link withPrismaRetry}.
+ *
+ *  - `P1008`: Operations timed out
+ *  - `P1017`: Server has closed the connection
+ */
+const IN_FLIGHT_ERROR_CODES = new Set(["P1008", "P1017"]);
+
+/**
+ * Every transient code this layer may retry (connection-level + in-flight).
+ * Retry eligibility is further gated by operation type — connection-level
+ * codes retry unconditionally, in-flight codes only for reads (see
+ * {@link isRetryablePrismaError}).
  *
  * `P2024` (timed out fetching a connection from the pool) is DELIBERATELY
- * excluded: pool exhaustion means the database is already saturated, and
+ * absent: pool exhaustion means the database is already saturated, and
  * retrying re-queues the same work onto an already-overloaded pool —
  * deepening the incident instead of recovering from it. Callers should let
  * `P2024` fail fast (it's mapped to a 503 at the app layer) rather than have
@@ -36,10 +62,27 @@ export type ExtendedPrismaClient = ReturnType<typeof createDatabaseClient>;
  * `P2024`. Do not reuse that list for retry decisions.
  */
 export const PRISMA_RETRYABLE_ERROR_CODES = new Set([
-  "P1001", // Can't reach database server
-  "P1002", // The database server was reached but timed out
-  "P1008", // Operations timed out
-  "P1017", // Server has closed the connection
+  ...CONNECTION_ERROR_CODES,
+  ...IN_FLIGHT_ERROR_CODES,
+]);
+
+/**
+ * Prisma model operations that only READ. A read never mutates state, so it is
+ * safe to retry on the ambiguous {@link IN_FLIGHT_ERROR_CODES} (a re-run can't
+ * duplicate anything). Any operation NOT in this set is treated as a write and
+ * is only retried on the write-safe {@link CONNECTION_ERROR_CODES}.
+ *
+ * @see https://www.prisma.io/docs/orm/reference/prisma-client-reference#model-queries
+ */
+const READ_OPERATIONS = new Set([
+  "findUnique",
+  "findUniqueOrThrow",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "count",
+  "aggregate",
+  "groupBy",
 ]);
 
 /** Maximum number of retry attempts for a transient Prisma error. */
@@ -49,39 +92,90 @@ const MAX_RETRIES = 2;
 const BASE_DELAY_MS = 500;
 
 /**
- * Narrows an unknown thrown value to a Prisma-style error carrying a string
- * `code`, and reports whether that code is one of
- * {@link PRISMA_RETRYABLE_ERROR_CODES}.
+ * Extracts a transient Prisma error code from an unknown thrown value, reading
+ * BOTH shapes Prisma uses to report one:
  *
- * Deliberately checks structurally (`"code" in error`) rather than
- * `instanceof Prisma.PrismaClientKnownRequestError` so that plain mocked
- * errors in tests are also recognized correctly.
+ *  - `PrismaClientKnownRequestError.code` — errors raised while executing a
+ *    query against an already-open connection.
+ *  - `PrismaClientInitializationError.errorCode` — errors raised while the
+ *    lazy client establishes its FIRST connection. A DB outage at cold start
+ *    or reconnection surfaces `P1001`/`P1002` HERE, on `errorCode`, never on
+ *    `code` — so a predicate that only reads `code` silently fails to retry in
+ *    exactly the startup/reconnection scenario the retry exists for.
  *
- * @param error - The unknown value thrown by a Prisma query.
- * @returns `true` if `error` should be retried.
+ * Deliberately structural (duck-typed) rather than `instanceof
+ * Prisma.PrismaClientKnownRequestError` so plain mocked errors in tests are
+ * recognized the same way.
+ *
+ * @param error - The unknown value thrown by a Prisma operation.
+ * @returns the recognized transient code, or `null` if `error` isn't one.
  */
-export function isRetryablePrismaError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null || !("code" in error)) {
-    return false;
+export function getRetryableErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
   }
-  const { code } = error as { code: unknown };
-  return typeof code === "string" && PRISMA_RETRYABLE_ERROR_CODES.has(code);
+  const code =
+    "code" in error && typeof (error as { code: unknown }).code === "string"
+      ? (error as { code: string }).code
+      : "errorCode" in error &&
+        typeof (error as { errorCode: unknown }).errorCode === "string"
+      ? (error as { errorCode: string }).errorCode
+      : null;
+  if (code === null) {
+    return null;
+  }
+  return PRISMA_RETRYABLE_ERROR_CODES.has(code) ? code : null;
 }
 
 /**
- * Runs `operation`, retrying it when it throws a transient, connection-level
- * Prisma error (see {@link isRetryablePrismaError}). Uses a linear backoff of
- * `BASE_DELAY_MS * attempt` (500ms, then 1000ms) between attempts.
- * Non-retryable errors — including `P2024` pool exhaustion — rethrow
- * immediately on the first failure, exactly like a call with no wrapper.
+ * Reports whether an error should be retried, given whether the failed
+ * operation was a read.
+ *
+ *  - Connection-level codes ({@link CONNECTION_ERROR_CODES}) → always
+ *    retryable: the query never reached the database, so no write could have
+ *    been applied.
+ *  - In-flight codes ({@link IN_FLIGHT_ERROR_CODES}) → retryable ONLY for
+ *    reads: a write may already have committed before the error surfaced, so
+ *    retrying it could duplicate a row or re-apply a mutation.
+ *
+ * @param error - The unknown value thrown by a Prisma operation.
+ * @param options.operationIsRead - `true` if the wrapped operation is one of
+ *   {@link READ_OPERATIONS}. Writes pass `false` and skip in-flight retries.
+ * @returns `true` if `error` should be retried for this operation.
+ */
+export function isRetryablePrismaError(
+  error: unknown,
+  { operationIsRead }: { operationIsRead: boolean }
+): boolean {
+  const code = getRetryableErrorCode(error);
+  if (code === null) {
+    return false;
+  }
+  if (CONNECTION_ERROR_CODES.has(code)) {
+    return true;
+  }
+  // Remaining codes are in-flight/ambiguous — only safe to retry for reads.
+  return operationIsRead;
+}
+
+/**
+ * Runs `operation`, retrying it when it throws a transient Prisma error that is
+ * retryable for this operation (see {@link isRetryablePrismaError}). Uses a
+ * linear backoff of `BASE_DELAY_MS * attempt` (500ms, then 1000ms) between
+ * attempts. Non-retryable errors — `P2024` pool exhaustion, and the in-flight
+ * codes `P1008`/`P1017` on a WRITE — rethrow immediately on the first failure,
+ * exactly like a call with no wrapper.
  *
  * Extracted out of {@link createDatabaseClient}'s `$allOperations` extension
  * so the retry/backoff logic can be unit-tested without a real Prisma client
  * or database connection.
  *
  * @param operation - The Prisma operation to execute (and retry on failure).
- * @param options - Optional overrides, used by tests to avoid real delays
- *   and to assert on the retry log line without polluting stdout.
+ * @param options - Optional overrides.
+ * @param options.operationIsRead - `true` when the wrapped operation only
+ *   reads ({@link READ_OPERATIONS}), permitting retries on the ambiguous
+ *   in-flight codes. Defaults to `false` (write-safe): an un-classified caller
+ *   never risks re-applying a mutation, only the connection-level codes retry.
  * @param options.log - Called once per retry with a human-readable message.
  *   Defaults to `console.warn` (the package has no `Logger`; retries are
  *   infrequent so stdout is fine — it surfaces in Fly/Sentry logs).
@@ -93,10 +187,12 @@ export function isRetryablePrismaError(error: unknown): boolean {
 export async function withPrismaRetry<T>(
   operation: () => Promise<T>,
   options?: {
+    operationIsRead?: boolean;
     log?: (message: string) => void;
     delay?: (ms: number) => Promise<void>;
   }
 ): Promise<T> {
+  const operationIsRead = options?.operationIsRead ?? false;
   const log = options?.log ?? console.warn;
   const delay =
     options?.delay ??
@@ -106,8 +202,12 @@ export async function withPrismaRetry<T>(
     try {
       return await operation();
     } catch (error) {
-      if (isRetryablePrismaError(error) && attempt <= MAX_RETRIES) {
-        const code = (error as { code: string }).code;
+      if (
+        isRetryablePrismaError(error, { operationIsRead }) &&
+        attempt <= MAX_RETRIES
+      ) {
+        // Non-null: isRetryablePrismaError only returns true for a known code.
+        const code = getRetryableErrorCode(error);
         const delayMs = BASE_DELAY_MS * attempt;
         log(
           `[db] transient Prisma error [${code}], retry ${attempt}/${MAX_RETRIES} in ${delayMs}ms`
@@ -130,7 +230,9 @@ export async function withPrismaRetry<T>(
  * Extensions applied (in order):
  * 1. `dynamicFindMany` — allows calling `findMany` generically across models.
  * 2. Transient-error retry — retries connection-level failures (see
- *    {@link PRISMA_RETRYABLE_ERROR_CODES}) across all operations, on all models.
+ *    {@link PRISMA_RETRYABLE_ERROR_CODES}) on all models. Reads additionally
+ *    retry the ambiguous in-flight codes; writes do not, to avoid re-applying
+ *    a mutation that may already have committed (see {@link withPrismaRetry}).
  */
 export function createDatabaseClient(url?: string) {
   const client = new PrismaClient(url ? { datasourceUrl: url } : undefined)
@@ -147,8 +249,10 @@ export function createDatabaseClient(url?: string) {
     .$extends({
       query: {
         $allModels: {
-          async $allOperations({ args, query }) {
-            return withPrismaRetry(() => query(args));
+          async $allOperations({ operation, args, query }) {
+            return withPrismaRetry(() => query(args), {
+              operationIsRead: READ_OPERATIONS.has(operation),
+            });
           },
         },
       },


### PR DESCRIPTION
## Summary

The last of the scheduler/reminder reliability backlog from the Sentry investigation. Three
related fixes so transient DB blips and job failures stop silently losing reminders.

## 1. Restore the Prisma transient-retry extension — excluding P2024

A Prisma `$extends` wrapper that retried transient DB **connection** errors existed before the
monorepo migration and was silently dropped. Restored in `packages/database/src/client.ts`, with
one deliberate change: **do not retry `P2024`** (connection-pool exhaustion). Retrying pool
exhaustion re-queues work onto an already-saturated pool and deepens the incident — it fails fast
to a 503 at the app layer instead.

- Retries `P1001` / `P1002` / `P1008` / `P1017` (connection-level) up to 2× with 500ms/1000ms backoff.
- Codes defined locally in the package (it can't import the webapp's error utils); retries
  `console.warn`.
- This is the root-cause layer: most reminder-job failures are transient DB blips, now handled at
  the *query* level so the job rarely throws at all.

## 2. Reminder worker: retry instead of silently losing

`asset-reminder/worker.server.ts` caught handler errors, logged them, and **returned** — so pg-boss
marked the job **completed** even on failure and the reminder was silently lost. The enqueue also
passed no `retryLimit`.

- Rethrow after logging so pg-boss retries; enqueue with `retryLimit: 2` / `retryDelay: 60`.
- Log (Sentry-captured) only on the true final attempt (`retrycount >= retrylimit` — pg-boss
  increments `retrycount` up to `retrylimit` on the last attempt).
- The missing-reminder path still returns cleanly (no throw, no retry).
- **Trade-off:** the handler isn't idempotent, so a partial-failure retry could re-send an email —
  an accepted, bounded trade-off ("delivered twice" beats "silently never delivered"); with fix #1
  handling DB blips at the query level, job failures are rare. True idempotency needs a schema
  field (migration), out of scope.

## 3. Email: fix a last-retry log off-by-one + document at-least-once delivery

Reviewing #2 surfaced a pre-existing off-by-one in the email worker's "log only on the last retry"
gate (`retrycount >= retrylimit - 1` logged twice on permanent failure). Fixed to
`retrycount >= retrylimit`. Also documented the accepted at-least-once behavior: `transporter.sendMail`
isn't idempotent and pg-boss retries, so a crash between a successful send and the job ack can
re-send — a rare, non-catastrophic duplicate we accept rather than building a dedup store.

## Test plan

- `pnpm --filter @shelf/database test` (Node's built-in runner, no new dep): 11/11 — covers all four
  retryable codes, P2024 explicitly excluded, retry-then-succeed, exhaustion rethrows the original error.
- Webapp: worker rethrows on failure / missing-reminder no-throw; enqueue asserts `retryLimit: 2`;
  final-attempt logs once, intermediate retry logs zero. `pnpm webapp:validate` — typecheck + lint
  clean, 0 test assertions fail. (A pre-existing `activity[.csv]` route-test flakes on timeout under
  parallel load — passes in isolation, mocks the db, unrelated.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved database resilience by automatically retrying eligible transient Prisma failures, with safer behavior for reads vs writes.
  * Asset reminder scheduling now uses bounded retries to reduce transient failures while limiting duplicate notifications.
  * Asset reminder jobs now log/alert only on the final retry attempt, improving signal-to-noise.
  * Email delivery handling was adjusted to better align with retry behavior and acknowledge possible duplicate sends when failures occur.

* **Bug Fixes**
  * Corrected retry-limit handling so permanent failure behavior triggers exactly at the final attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->