### PR TITLE
fix(sentry): filter unactionable client noise and skip expected 4xx boundary captures

### DIFF
--- a/apps/webapp/app/components/errors/index.test.tsx
+++ b/apps/webapp/app/components/errors/index.test.tsx
@@ -322,11 +322,11 @@ describe("ErrorContent capturing route-error boundary failures to Sentry", () =>
     window.env = { SENTRY_DSN: "test-dsn" } as Window["env"];
   });
 
-  it("captures a 4xx route error with source=error-boundary and the on-screen trace id", async () => {
+  it("captures an unexpected 4xx route error (e.g. 409) with source=error-boundary and the on-screen trace id", async () => {
     mockRouteError = buildRouteError({
-      status: 403,
-      message: "You don't have permission to view this audit",
-      label: "Audit permission",
+      status: 409,
+      message: "This asset is already booked for that window",
+      label: "Booking conflict",
     });
     renderErrorContent();
 
@@ -336,14 +336,31 @@ describe("ErrorContent capturing route-error boundary failures to Sentry", () =>
       tags: {
         source: "error-boundary",
         shelf_trace_id: "trace_789",
-        label: "Audit permission",
-        status: "403",
+        label: "Booking conflict",
+        status: "409",
       },
       contexts: { route: { pathname: "/kits" } },
     });
   });
 
-  it("captures a genuine 404 (not-found screen) the same way as other 4xx", async () => {
+  it("does not capture an expected 403 terminal state (permission/expired claim — normal UX, not a bug)", async () => {
+    mockRouteError = buildRouteError({
+      status: 403,
+      message: "This scan can no longer be updated",
+      label: "Scan",
+    });
+    renderErrorContent();
+
+    // Give the capture effect a chance to run, then assert it did not fire
+    await waitFor(() =>
+      expect(
+        screen.getByText(/This scan can no longer be updated/)
+      ).toBeTruthy()
+    );
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("does not capture a genuine 404 (not-found screen — expected terminal state)", async () => {
     mockRouteError = buildNotFoundRouteError({
       message: "Audit asset not found",
       traceId: "trace_404",
@@ -351,31 +368,16 @@ describe("ErrorContent capturing route-error boundary failures to Sentry", () =>
     });
     renderErrorContent();
 
-    await waitFor(() => expect(mockCaptureException).toHaveBeenCalled());
-    const hint = mockCaptureException.mock.calls.at(-1)?.[1];
-    expect(hint).toMatchObject({
-      tags: {
-        source: "error-boundary",
-        shelf_trace_id: "trace_404",
-        label: "Audit",
-        status: "404",
-      },
-    });
+    await waitFor(() => expect(screen.getByText("Not found")).toBeTruthy());
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
-  it("captures a router-generated 404 (unmatched/stale URL) without a shelf_trace_id or label tag", async () => {
+  it("does not capture a router-generated 404 (unmatched/stale URL — expected terminal state)", async () => {
     mockRouteError = buildRouterNotFoundError();
     renderErrorContent();
 
-    await waitFor(() => expect(mockCaptureException).toHaveBeenCalled());
-    const hint = mockCaptureException.mock.calls.at(-1)?.[1];
-    expect(hint).toMatchObject({
-      tags: { source: "error-boundary", status: "404" },
-    });
-    // No Shelf payload means no traceId/label to report — both tags must be
-    // omitted entirely (not sent as the literal string "undefined")
-    expect(hint?.tags).not.toHaveProperty("shelf_trace_id");
-    expect(hint?.tags).not.toHaveProperty("label");
+    await waitFor(() => expect(screen.getByText("Not found")).toBeTruthy());
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
   it("does not capture the benign workspace-switcher 404 case", async () => {

--- a/apps/webapp/app/components/errors/index.test.tsx
+++ b/apps/webapp/app/components/errors/index.test.tsx
@@ -73,6 +73,10 @@ vi.mock("./error-404-handler", () => ({
   default: mockError404Handler,
 }));
 
+// why: react-doctor flags this as no-barrel-import, but index.tsx DEFINES
+// ErrorContent (it is not a re-export barrel), so this is the only import path.
+// Extracting ErrorContent to its own module would turn index.tsx into a true
+// barrel and flag all ~44 route consumers instead. Advisory-only; left as-is.
 import { ErrorContent } from "./index";
 
 /** The Back-to-home/Reload link buttons need a router context to render */

--- a/apps/webapp/app/components/errors/index.tsx
+++ b/apps/webapp/app/components/errors/index.tsx
@@ -5,6 +5,7 @@ import { isRouteErrorResponse, useLocation, useRouteError } from "react-router";
 
 import { useUserData } from "~/hooks/use-user-data";
 import { isRouteError } from "~/utils/http";
+import { isExpectedErrorBoundaryStatus } from "~/utils/sentry-filters";
 import { tw } from "~/utils/tw";
 import Error404Handler from "./error-404-handler";
 import { parse404ErrorData } from "./utils";
@@ -240,6 +241,13 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
    * the benign workspace-switcher case is excluded entirely (expected
    * cross-org UX, not a bug).
    *
+   * EXPECTED terminal states (403 permission-denied / expired claim, 404
+   * not-found — see `EXPECTED_ERROR_BOUNDARY_STATUSES`) are also excluded:
+   * they are normal UX, not bugs, so they must not open a Sentry issue. All
+   * other 4xx (400/409/422/429, …) stay captured. `beforeSend` re-checks the
+   * `status` tag as defense-in-depth, but this is the primary skip — the
+   * intent is clearest where the status is a number in hand.
+   *
    * Gated on `isRouteErrorResponse` (see `isNotFound` above for why) so
    * router-generated 4xx responses (e.g. an unmatched-route 404) are
    * captured too, even though they carry no Shelf payload.
@@ -249,7 +257,8 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
     !error404.isError404 &&
     statusCode !== undefined &&
     statusCode >= 400 &&
-    statusCode < 500;
+    statusCode < 500 &&
+    !isExpectedErrorBoundaryStatus(statusCode);
 
   /**
    * Body copy for the not-found screen. A Shelf-thrown 404 carries its own

--- a/apps/webapp/app/entry.client.tsx
+++ b/apps/webapp/app/entry.client.tsx
@@ -5,6 +5,8 @@ import { Provider as JotaiProvider } from "jotai";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+import { handleClientBeforeSend } from "~/utils/sentry-filters";
+
 if (window.env?.SENTRY_DSN) {
   Sentry.init({
     dsn: window.env.SENTRY_DSN,
@@ -53,101 +55,9 @@ if (window.env?.SENTRY_DSN) {
 
       return event;
     },
-    beforeSend(event) {
-      const message = event.exception?.values?.[0]?.value || "";
-
-      // Hard-filter browser/framework quirks that are not actionable even
-      // when they bubble up through React Router's error boundary. These
-      // are stream-decode races, React reconciliation aborts mid-navigation,
-      // and browser-extension DOM mutation collisions — all known noise
-      // with no app-side fix. Tradeoff: when one of these surfaces in the
-      // UI, the displayed Error ID will not exist in Sentry. That is
-      // acceptable here because the error itself is not actionable; the
-      // user is told to retry, and Sentry would only collect duplicate
-      // reports of the same untriageable race.
-      const hardIgnoredPatterns = [
-        "Unable to decode turbo-stream",
-        "Error in input stream",
-      ];
-      if (hardIgnoredPatterns.some((pattern) => message.includes(pattern))) {
-        return null;
-      }
-
-      // Same hard-filter for the NotFoundError variants from React DOM
-      // reconciliation (`removeChild`/`insertBefore` on a non-child).
-      // These reach the error boundary because they happen during commit.
-      if (
-        event.exception?.values?.some(
-          (v) =>
-            v.type === "NotFoundError" &&
-            (v.value?.includes("removeChild") ||
-              v.value?.includes("insertBefore"))
-        )
-      ) {
-        return null;
-      }
-
-      // Hard-filter client-side network errors and aborted requests
-      // regardless of source — they bubble up through React Router's error
-      // boundary when a route loader's fetch is interrupted, but they are
-      // *never* actionable from app code (user closed the tab, lost
-      // connection, hit back, or the browser cancelled an in-flight load).
-      // Same Error-ID tradeoff as the hard-filtered patterns above. Also
-      // check `exception.type` for `AbortError` — Sentry serializes the
-      // error name into `.type` separately from `.value` (the message),
-      // and some AbortErrors arrive with empty/generic messages.
-      if (
-        message.includes("Load failed") ||
-        message.includes("Failed to fetch") ||
-        message.includes("NetworkError") ||
-        message.includes("fetch failed") ||
-        message.includes("AbortError") ||
-        message.includes("The operation was aborted") ||
-        message.includes("Fetch is aborted") ||
-        event.exception?.values?.some((v) => v.type === "AbortError")
-      ) {
-        return null;
-      }
-
-      // Hard-filter `<unknown>` messages: these carry no signal, and the
-      // error-boundary path produces them when the failure has no
-      // serializable shape (cross-origin script errors, etc.).
-      if (message === "<unknown>") {
-        return null;
-      }
-
-      // Always send remaining errors from the error boundary — these are
-      // user-visible crashes that must be searchable by the Error ID shown
-      // to the user. Sentry.captureException() returns the event ID
-      // synchronously before beforeSend runs, so filtering past this point
-      // would silently drop the event while the UI still displays the
-      // (now-orphaned) Error ID.
-      if (event.tags?.source === "error-boundary") {
-        return event;
-      }
-
-      // Filter browser compatibility / extension errors (not actionable).
-      // "Expected fetcher: " and "No result found for routeId" are React
-      // Router internal races during navigation. "Cannot submit a <button>"
-      // is a fetcher.submit edge case from React Router's form helper.
-      const ignoredPatterns = [
-        "feature named",
-        "Unexpected identifier 'https'",
-        "Expected fetcher: ",
-        "No result found for routeId",
-        "Cannot submit a <button>",
-      ];
-      if (ignoredPatterns.some((pattern) => message.includes(pattern))) {
-        return null;
-      }
-
-      // Filter non-Error promise rejections with value: false
-      if (message === "false") {
-        return null;
-      }
-
-      return event;
-    },
+    // Drop/keep rules live in `handleClientBeforeSend` (a pure, unit-tested
+    // function) so they can be exercised without hydrating this entry module.
+    beforeSend: handleClientBeforeSend,
   });
 }
 

--- a/apps/webapp/app/utils/sentry-filters.test.ts
+++ b/apps/webapp/app/utils/sentry-filters.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for the client Sentry `beforeSend` drop/keep rules
+ * ({@link handleClientBeforeSend}) and the expected-status helper
+ * ({@link isExpectedErrorBoundaryStatus}).
+ *
+ * Focus: the two Sentry-hygiene behaviors added on top of the existing
+ * hard-filters —
+ *  - unactionable client noise (DataCloneError, bare gateway-status blips) is
+ *    dropped, while
+ *  - expected error-boundary terminal states (403/404) are dropped but every
+ *    other boundary status (incl. 5xx) still passes through.
+ *
+ * @see {@link file://./sentry-filters.ts}
+ */
+import type { ErrorEvent } from "@sentry/react-router";
+import { describe, expect, it } from "vitest";
+
+import {
+  handleClientBeforeSend,
+  isExpectedErrorBoundaryStatus,
+} from "./sentry-filters";
+
+/**
+ * Minimal single-exception Sentry error event. `type`/`value` mirror how
+ * Sentry serializes an Error (constructor name into `type`, message into
+ * `value`); `tags`/`inApp` model the two axes the rules branch on.
+ */
+function makeEvent(opts: {
+  type?: string;
+  value?: string;
+  tags?: Record<string, string>;
+  inApp?: boolean;
+}): ErrorEvent {
+  return {
+    exception: {
+      values: [
+        {
+          type: opts.type ?? "Error",
+          value: opts.value ?? "",
+          ...(opts.inApp !== undefined
+            ? { stacktrace: { frames: [{ in_app: opts.inApp }] } }
+            : {}),
+        },
+      ],
+    },
+    ...(opts.tags ? { tags: opts.tags } : {}),
+  } as ErrorEvent;
+}
+
+describe("isExpectedErrorBoundaryStatus", () => {
+  it("is true only for 403 and 404", () => {
+    expect(isExpectedErrorBoundaryStatus(403)).toBe(true);
+    expect(isExpectedErrorBoundaryStatus(404)).toBe(true);
+  });
+
+  it("is false for other 4xx, all 5xx, and undefined/NaN", () => {
+    for (const status of [400, 409, 422, 429, 500, 502]) {
+      expect(isExpectedErrorBoundaryStatus(status)).toBe(false);
+    }
+    expect(isExpectedErrorBoundaryStatus(undefined)).toBe(false);
+    expect(isExpectedErrorBoundaryStatus(NaN)).toBe(false);
+  });
+});
+
+describe("handleClientBeforeSend — noise filters", () => {
+  it("drops DataCloneError (unactionable structuredClone/postMessage noise)", () => {
+    const event = makeEvent({
+      type: "DataCloneError",
+      value: "The object can not be cloned.",
+    });
+    expect(handleClientBeforeSend(event)).toBeNull();
+  });
+
+  it("drops a bare gateway-status blip (Error: 502 with no first-party frames)", () => {
+    for (const code of ["502", "503", "504"]) {
+      expect(handleClientBeforeSend(makeEvent({ value: code }))).toBeNull();
+    }
+  });
+
+  it("keeps a genuine Error('502') that carries first-party frames", () => {
+    // A real throw from our own code has in_app frames → must stay capturable
+    const event = makeEvent({ value: "502", inApp: true });
+    expect(handleClientBeforeSend(event)).toBe(event);
+  });
+
+  it("keeps a non-gateway numeric message (e.g. 404 as text) — pattern is 5xx-only", () => {
+    const event = makeEvent({ value: "404" });
+    expect(handleClientBeforeSend(event)).toBe(event);
+  });
+
+  it("still drops pre-existing hard-filtered noise (AbortError, <unknown>)", () => {
+    expect(
+      handleClientBeforeSend(
+        makeEvent({ type: "AbortError", value: "The operation was aborted" })
+      )
+    ).toBeNull();
+    expect(
+      handleClientBeforeSend(makeEvent({ value: "<unknown>" }))
+    ).toBeNull();
+  });
+});
+
+describe("handleClientBeforeSend — error-boundary allowlist", () => {
+  it("drops an expected 403 boundary event", () => {
+    const event = makeEvent({
+      value: "This scan can no longer be updated",
+      tags: { source: "error-boundary", status: "403" },
+    });
+    expect(handleClientBeforeSend(event)).toBeNull();
+  });
+
+  it("drops an expected 404 boundary event", () => {
+    const event = makeEvent({
+      value: "Asset not found",
+      tags: { source: "error-boundary", status: "404" },
+    });
+    expect(handleClientBeforeSend(event)).toBeNull();
+  });
+
+  it("keeps a 5xx boundary event (still user-visible, still searchable by Error ID)", () => {
+    const event = makeEvent({
+      value: "Internal error",
+      tags: { source: "error-boundary", status: "500" },
+    });
+    expect(handleClientBeforeSend(event)).toBe(event);
+  });
+
+  it("keeps an unexpected 4xx boundary event (409) unchanged", () => {
+    const event = makeEvent({
+      value: "Conflict",
+      tags: { source: "error-boundary", status: "409" },
+    });
+    expect(handleClientBeforeSend(event)).toBe(event);
+  });
+
+  it("keeps a boundary event with no status tag (client-side JS crash)", () => {
+    const event = makeEvent({
+      type: "TypeError",
+      value: "Cannot read properties of undefined",
+      tags: { source: "error-boundary" },
+    });
+    expect(handleClientBeforeSend(event)).toBe(event);
+  });
+});
+
+describe("handleClientBeforeSend — non-boundary passthrough", () => {
+  it("keeps a normal uncaught client error (no source tag)", () => {
+    // Represents a genuine 5xx-equivalent crash Sentry should still receive
+    const event = makeEvent({
+      type: "TypeError",
+      value: "Something genuinely broke",
+      inApp: true,
+    });
+    expect(handleClientBeforeSend(event)).toBe(event);
+  });
+});

--- a/apps/webapp/app/utils/sentry-filters.test.ts
+++ b/apps/webapp/app/utils/sentry-filters.test.ts
@@ -63,12 +63,24 @@ describe("isExpectedErrorBoundaryStatus", () => {
 });
 
 describe("handleClientBeforeSend — noise filters", () => {
-  it("drops DataCloneError (unactionable structuredClone/postMessage noise)", () => {
+  it("drops a DataCloneError with no first-party frames (browser/extension noise)", () => {
     const event = makeEvent({
       type: "DataCloneError",
       value: "The object can not be cloned.",
     });
     expect(handleClientBeforeSend(event)).toBeNull();
+  });
+
+  it("keeps a DataCloneError that carries first-party frames (fixable app bug)", () => {
+    // A DataCloneError thrown by OUR code (structuredClone/postMessage of a
+    // non-cloneable value) has in_app frames → it flags a fixable bug and must
+    // stay capturable so its on-screen Error ID resolves in Sentry.
+    const event = makeEvent({
+      type: "DataCloneError",
+      value: "The object can not be cloned.",
+      inApp: true,
+    });
+    expect(handleClientBeforeSend(event)).toBe(event);
   });
 
   it("drops a bare gateway-status blip (Error: 502 with no first-party frames)", () => {

--- a/apps/webapp/app/utils/sentry-filters.ts
+++ b/apps/webapp/app/utils/sentry-filters.ts
@@ -1,0 +1,222 @@
+/**
+ * Client-side Sentry event filtering.
+ *
+ * Single source of truth for two related decisions made on the browser:
+ *
+ * 1. Which HTTP statuses the error-boundary treats as EXPECTED terminal
+ *    states (not bugs) and therefore must NOT create Sentry issues for
+ *    (`EXPECTED_ERROR_BOUNDARY_STATUSES` + `isExpectedErrorBoundaryStatus`).
+ *    Consumed at the capture site (`~/components/errors` `ErrorContent`).
+ * 2. The client `beforeSend` hook body (`handleClientBeforeSend`) — extracted
+ *    out of `entry.client.tsx` (which hydrates on import and can't be unit
+ *    tested) so the drop/keep rules are directly testable.
+ *
+ * @see {@link file://./../entry.client.tsx} — wires `handleClientBeforeSend`
+ * @see {@link file://./../components/errors/index.tsx} — the capture site
+ * @see {@link file://./../../server/instrument.server.ts} — server counterpart
+ */
+import type { ErrorEvent } from "@sentry/react-router";
+
+/**
+ * HTTP statuses that represent EXPECTED client-side terminal states rather
+ * than bugs, so the error boundary must not open a Sentry issue for them:
+ *
+ * - `403` — permission denied / an expired or already-consumed claim
+ *   (e.g. "This scan can no longer be updated" on an expired QR claim).
+ * - `404` — the resource genuinely does not exist.
+ *
+ * All OTHER 4xx (400/409/422/429, …) and every 5xx stay captured — those can
+ * indicate real client/server problems worth triaging.
+ */
+export const EXPECTED_ERROR_BOUNDARY_STATUSES = [403, 404] as const;
+
+/**
+ * Whether a status is an expected error-boundary terminal state that must not
+ * be captured to Sentry. Accepts an already-parsed number; call sites that
+ * hold the status as a string/tag should coerce with `Number(...)` first
+ * (a `NaN` from a missing tag is correctly treated as "not expected").
+ *
+ * @param status - The HTTP status code (or `NaN`/`undefined` when unknown)
+ * @returns `true` only for the expected statuses (403, 404)
+ */
+export function isExpectedErrorBoundaryStatus(
+  status: number | undefined
+): boolean {
+  return (
+    status !== undefined &&
+    (EXPECTED_ERROR_BOUNDARY_STATUSES as readonly number[]).includes(status)
+  );
+}
+
+/**
+ * Bare 3-digit gateway codes (502/503/504) that show up as an error `value`
+ * with no JS origin — transient deploy/gateway blips, not app bugs.
+ */
+const BARE_GATEWAY_STATUS_PATTERN = /^50[234]$/;
+
+/**
+ * True for a "bare gateway status" Error: an `Error` whose entire message is
+ * a 5xx gateway code (502/503/504) AND which carries no first-party
+ * (`in_app`) stack frames. Those are transient gateway/deploy blips surfaced
+ * to the browser with no first-party origin.
+ *
+ * The no-`in_app`-frames guard is deliberate and keeps the match narrow: a
+ * genuine `throw new Error("502")` from our own code would carry first-party
+ * frames and therefore stays capturable. Only origin-less status blips are
+ * dropped.
+ *
+ * @param event - The Sentry error event
+ * @returns `true` when the event is a bare gateway-status blip
+ */
+function isBareGatewayStatusError(event: ErrorEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) {
+    return false;
+  }
+  return values.some((v) => {
+    if (v.type !== "Error") {
+      return false;
+    }
+    const value = (v.value ?? "").trim();
+    if (!BARE_GATEWAY_STATUS_PATTERN.test(value)) {
+      return false;
+    }
+    // No first-party frames → no JS origin we could act on.
+    const hasFirstPartyFrame =
+      v.stacktrace?.frames?.some((f) => f.in_app === true) ?? false;
+    return !hasFirstPartyFrame;
+  });
+}
+
+/**
+ * Client `beforeSend` hook body: decides whether a captured browser error is
+ * worth sending to Sentry. Returns the (unchanged) event to send it, or
+ * `null` to drop it.
+ *
+ * Ordering matters: unconditional hard-filters for known-unactionable noise
+ * run first, THEN the `source: "error-boundary"` allowlist (which forces
+ * user-visible crashes through so their on-screen Error ID resolves in
+ * Sentry), and finally the softer pattern filters.
+ *
+ * @param event - The Sentry error event produced on the browser
+ * @returns The event to send, or `null` to drop it
+ */
+export function handleClientBeforeSend(event: ErrorEvent): ErrorEvent | null {
+  const message = event.exception?.values?.[0]?.value || "";
+
+  // Hard-filter browser/framework quirks that are not actionable even
+  // when they bubble up through React Router's error boundary. These
+  // are stream-decode races, React reconciliation aborts mid-navigation,
+  // and browser-extension DOM mutation collisions — all known noise
+  // with no app-side fix. Tradeoff: when one of these surfaces in the
+  // UI, the displayed Error ID will not exist in Sentry. That is
+  // acceptable here because the error itself is not actionable; the
+  // user is told to retry, and Sentry would only collect duplicate
+  // reports of the same untriageable race.
+  const hardIgnoredPatterns = [
+    "Unable to decode turbo-stream",
+    "Error in input stream",
+  ];
+  if (hardIgnoredPatterns.some((pattern) => message.includes(pattern))) {
+    return null;
+  }
+
+  // Same hard-filter for the NotFoundError variants from React DOM
+  // reconciliation (`removeChild`/`insertBefore` on a non-child).
+  // These reach the error boundary because they happen during commit.
+  if (
+    event.exception?.values?.some(
+      (v) =>
+        v.type === "NotFoundError" &&
+        (v.value?.includes("removeChild") || v.value?.includes("insertBefore"))
+    )
+  ) {
+    return null;
+  }
+
+  // Hard-filter `DataCloneError` ("The object can not be cloned."). Thrown by
+  // structuredClone / postMessage / IndexedDB when a non-cloneable value is
+  // passed; always unhandled and never actionable from app code. Matched by
+  // the serialized error name (Sentry puts the constructor name in `.type`).
+  if (event.exception?.values?.some((v) => v.type === "DataCloneError")) {
+    return null;
+  }
+
+  // Hard-filter client-side network errors and aborted requests
+  // regardless of source — they bubble up through React Router's error
+  // boundary when a route loader's fetch is interrupted, but they are
+  // *never* actionable from app code (user closed the tab, lost
+  // connection, hit back, or the browser cancelled an in-flight load).
+  // Same Error-ID tradeoff as the hard-filtered patterns above. Also
+  // check `exception.type` for `AbortError` — Sentry serializes the
+  // error name into `.type` separately from `.value` (the message),
+  // and some AbortErrors arrive with empty/generic messages.
+  if (
+    message.includes("Load failed") ||
+    message.includes("Failed to fetch") ||
+    message.includes("NetworkError") ||
+    message.includes("fetch failed") ||
+    message.includes("AbortError") ||
+    message.includes("The operation was aborted") ||
+    message.includes("Fetch is aborted") ||
+    event.exception?.values?.some((v) => v.type === "AbortError")
+  ) {
+    return null;
+  }
+
+  // Hard-filter bare gateway-status blips (`Error: 502` / `503` / `504` with
+  // no first-party stack). Transient deploy/gateway hiccups with no JS
+  // origin; a real `throw new Error("502")` from our code keeps its
+  // first-party frames and is left capturable (see isBareGatewayStatusError).
+  if (isBareGatewayStatusError(event)) {
+    return null;
+  }
+
+  // Hard-filter `<unknown>` messages: these carry no signal, and the
+  // error-boundary path produces them when the failure has no
+  // serializable shape (cross-origin script errors, etc.).
+  if (message === "<unknown>") {
+    return null;
+  }
+
+  // Always send remaining errors from the error boundary — these are
+  // user-visible crashes that must be searchable by the Error ID shown
+  // to the user. Sentry.captureException() returns the event ID
+  // synchronously before beforeSend runs, so filtering past this point
+  // would silently drop the event while the UI still displays the
+  // (now-orphaned) Error ID.
+  if (event.tags?.source === "error-boundary") {
+    // Defense-in-depth for EXPECTED terminal states (403/404): the capture
+    // site already skips calling captureException for these, but if a
+    // boundary event is ever tagged with an expected status, drop it here
+    // too so it never opens an issue. Boundary events with no `status` tag
+    // (client-side JS crashes) coerce to `NaN` and pass through unchanged.
+    const status = Number(event.tags?.status);
+    if (isExpectedErrorBoundaryStatus(status)) {
+      return null;
+    }
+    return event;
+  }
+
+  // Filter browser compatibility / extension errors (not actionable).
+  // "Expected fetcher: " and "No result found for routeId" are React
+  // Router internal races during navigation. "Cannot submit a <button>"
+  // is a fetcher.submit edge case from React Router's form helper.
+  const ignoredPatterns = [
+    "feature named",
+    "Unexpected identifier 'https'",
+    "Expected fetcher: ",
+    "No result found for routeId",
+    "Cannot submit a <button>",
+  ];
+  if (ignoredPatterns.some((pattern) => message.includes(pattern))) {
+    return null;
+  }
+
+  // Filter non-Error promise rejections with value: false
+  if (message === "false") {
+    return null;
+  }
+
+  return event;
+}

--- a/apps/webapp/app/utils/sentry-filters.ts
+++ b/apps/webapp/app/utils/sentry-filters.ts
@@ -48,6 +48,27 @@ export function isExpectedErrorBoundaryStatus(
   );
 }
 
+/** A single serialized exception entry within a Sentry error event. */
+type SentryExceptionValue = NonNullable<
+  NonNullable<ErrorEvent["exception"]>["values"]
+>[number];
+
+/**
+ * Whether an exception value has NO first-party (`in_app`) stack frame — i.e.
+ * no application-code origin we could act on.
+ *
+ * Noise filters use this to stay narrow: an error thrown by OUR code carries
+ * `in_app` frames (it identifies a fixable bug and its on-screen Error ID must
+ * stay resolvable in Sentry), whereas the browser/extension/gateway noise we
+ * want to drop has no first-party origin.
+ *
+ * @param value - A serialized Sentry exception entry
+ * @returns `true` when none of its frames are first-party
+ */
+function hasNoFirstPartyFrame(value: SentryExceptionValue): boolean {
+  return !(value.stacktrace?.frames?.some((f) => f.in_app === true) ?? false);
+}
+
 /**
  * Bare 3-digit gateway codes (502/503/504) that show up as an error `value`
  * with no JS origin — transient deploy/gateway blips, not app bugs.
@@ -82,9 +103,7 @@ function isBareGatewayStatusError(event: ErrorEvent): boolean {
       return false;
     }
     // No first-party frames → no JS origin we could act on.
-    const hasFirstPartyFrame =
-      v.stacktrace?.frames?.some((f) => f.in_app === true) ?? false;
-    return !hasFirstPartyFrame;
+    return hasNoFirstPartyFrame(v);
   });
 }
 
@@ -134,11 +153,18 @@ export function handleClientBeforeSend(event: ErrorEvent): ErrorEvent | null {
     return null;
   }
 
-  // Hard-filter `DataCloneError` ("The object can not be cloned."). Thrown by
-  // structuredClone / postMessage / IndexedDB when a non-cloneable value is
-  // passed; always unhandled and never actionable from app code. Matched by
-  // the serialized error name (Sentry puts the constructor name in `.type`).
-  if (event.exception?.values?.some((v) => v.type === "DataCloneError")) {
+  // Hard-filter `DataCloneError` ("The object can not be cloned.") that has NO
+  // first-party origin. Thrown by structuredClone / postMessage / IndexedDB on
+  // a non-cloneable value — usually from browser internals or extensions.
+  // Matched by the serialized error name (Sentry puts the constructor name in
+  // `.type`). The no-first-party-frames guard keeps a DataCloneError thrown by
+  // OUR code capturable: it flags a fixable bug and its on-screen Error ID must
+  // stay resolvable in Sentry (see hasNoFirstPartyFrame).
+  if (
+    event.exception?.values?.some(
+      (v) => v.type === "DataCloneError" && hasNoFirstPartyFrame(v)
+    )
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Two Sentry-hygiene changes from the weekly triage:

- The error boundary no longer opens Sentry issues for EXPECTED terminal statuses 403/404 (e.g. an expired/already-claimed QR scan). 5xx and other 4xx (400/409/422/429) still capture. Enforced at the capture site, with a defense-in-depth drop in the client beforeSend.
- The client beforeSend drops two known-unactionable noise classes: DataCloneError (structuredClone/postMessage of a non-cloneable value) and bare gateway-status errors (Error: 502/503/504 with no first-party stack). Matched narrowly; a real `throw new Error("502")` keeps its frames and stays capturable.

Extract the previously-inline client beforeSend into a pure, unit-tested handleClientBeforeSend (entry.client.tsx hydrates on import, so it couldn't be tested before). 27 tests cover the drop/keep rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry issue accuracy by excluding expected error-boundary outcomes for common 403/404 terminal screens.
  * Refined route error reporting to avoid capturing expected 4xx UX states while still reporting unexpected statuses (including other 4xx/5xx).
  * Reduced Sentry noise by filtering known, non-actionable browser/network/gateway error patterns.
* **Tests**
  * Added and expanded automated coverage to validate the new Sentry capture/drop behavior for boundary, route, and noisy error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->