### PR TITLE
fix(assets): show friendly 400 when over-allocating a quantity-tracked asset

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -95,6 +95,7 @@ import {
   isLikeShelfError,
   isNotFoundError,
   maybeUniqueConstraintViolation,
+  throwIfAssetQuantityOverAllocation,
 } from "~/utils/error";
 import { getRedirectUrlFromRequest } from "~/utils/http";
 import { getCurrentSearchParams } from "~/utils/http.server";
@@ -3516,6 +3517,16 @@ export async function replaceAssetPlacements({
 
     return { ok: true as const };
   } catch (cause) {
+    // Backstop: the sum-within-total pre-check above (step 5) rejects most
+    // over-submissions with a friendly 400, but a concurrent placement / qty
+    // edit can still trip the DEFERRED `AssetLocation ... exceeds
+    // Asset.quantity` trigger at COMMIT. Translate that race to the same
+    // friendly 400 instead of a generic 500. No-ops for every other error.
+    throwIfAssetQuantityOverAllocation(cause, {
+      label: "Assets",
+      additionalData: { assetId, userId, organizationId },
+    });
+
     if (isLikeShelfError(cause)) throw cause;
     throw new ShelfError({
       cause,
@@ -8265,6 +8276,22 @@ export async function placeUnplacedUnits(
       moveCorrelationId,
     };
   } catch (cause) {
+    // Backstop: the `quantity > unplaced` pre-check above rejects most
+    // over-submissions with a friendly 400, but two concurrent place-units
+    // requests can each pass their own check and still trip the DEFERRED
+    // `AssetLocation ... exceeds Asset.quantity` trigger at COMMIT. Translate
+    // that race to the same friendly 400. No-ops for every other error.
+    throwIfAssetQuantityOverAllocation(cause, {
+      label,
+      additionalData: {
+        assetId,
+        organizationId,
+        userId,
+        toLocationId,
+        quantity,
+      },
+    });
+
     if (isLikeShelfError(cause)) {
       throw cause;
     }

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3052,6 +3052,17 @@ export async function updateAsset({
 
     return asset;
   } catch (cause) {
+    // Translate the DB `AssetLocation total ... exceeds Asset.quantity` trigger
+    // violation into a friendly 400. updateAsset writes AssetLocation pivot rows
+    // in its transaction; a submitted quantity can pass the pre-check yet trip
+    // the DEFERRED trigger at COMMIT if a concurrent request lowered
+    // Asset.quantity in between. No-ops for every other error. See
+    // SHELF-WEBAPP-219 / 21N (race backstop, matching replaceAssetPlacements).
+    throwIfAssetQuantityOverAllocation(cause, {
+      label: "Assets",
+      additionalData: { userId, id, organizationId },
+    });
+
     // If it's already a ShelfError (kit guard, qty validator, org-scope
     // guard, etc.), re-throw as-is so the upstream status / title /
     // message survive. `isLikeShelfError` includes a duck-type fallback

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -38,6 +38,7 @@ import {
   isNotFoundError,
   maybeUniqueConstraintViolation,
   ShelfError,
+  throwIfAssetQuantityOverAllocation,
   VALIDATION_ERROR,
 } from "~/utils/error";
 import { extractImageNameFromSupabaseUrl } from "~/utils/extract-image-name-from-supabase-url";
@@ -4885,6 +4886,14 @@ export async function updateKitAssets({
 
     return kit;
   } catch (cause) {
+    // Translate the DB `AssetKit total ... exceeds Asset.quantity` trigger
+    // violation into a friendly 400 (user tried to put more units in kits
+    // than the asset has). No-ops for every other error. See SHELF-WEBAPP-219.
+    throwIfAssetQuantityOverAllocation(cause, {
+      label,
+      additionalData: { kitId, assetIds },
+    });
+
     const isShelfError = isLikeShelfError(cause);
 
     throw new ShelfError({

--- a/apps/webapp/app/modules/location/service.location-notes.test.ts
+++ b/apps/webapp/app/modules/location/service.location-notes.test.ts
@@ -132,6 +132,11 @@ vi.mock("~/utils/error", () => {
     // generic 500 wrap from the outer catch
     isLikeShelfError: (cause: unknown) => cause instanceof ShelfError,
     isNotFoundError: () => false,
+    // why: no-op here — production only translates the DB "exceeds
+    // Asset.quantity" trigger error; these tests exercise other errors (403
+    // org-scope guard, 400 quantity pre-check) which must fall through to
+    // their own status unchanged, exactly as the real helper does for them
+    throwIfAssetQuantityOverAllocation: () => {},
     maybeUniqueConstraintViolation: (
       _cause: unknown,
       _label: string,

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -21,6 +21,7 @@ import {
   isLikeShelfError,
   isNotFoundError,
   maybeUniqueConstraintViolation,
+  throwIfAssetQuantityOverAllocation,
 } from "~/utils/error";
 import { geolocate } from "~/utils/geolocate.server";
 import { getRedirectUrlFromRequest } from "~/utils/http";
@@ -2379,6 +2380,15 @@ export async function updateLocationAssets({
       assetQuantities,
     });
   } catch (cause) {
+    // Translate the DB `AssetLocation total ... exceeds Asset.quantity` trigger
+    // violation into a friendly 400 (user tried to place more units across
+    // locations than the asset has). No-ops for every other error. See
+    // SHELF-WEBAPP-21N.
+    throwIfAssetQuantityOverAllocation(cause, {
+      label,
+      additionalData: { assetIds, organizationId, locationId },
+    });
+
     if (isLikeShelfError(cause)) {
       throw cause;
     }

--- a/apps/webapp/app/utils/error.test.ts
+++ b/apps/webapp/app/utils/error.test.ts
@@ -1,10 +1,12 @@
 import {
   ShelfError,
+  isAssetQuantityOverAllocationError,
   isHandledClientError,
   isLikeShelfError,
   isPrismaTransientError,
   makeShelfError,
   notAllowedMethod,
+  throwIfAssetQuantityOverAllocation,
 } from "./error";
 
 // @vitest-environment node
@@ -469,6 +471,134 @@ describe(notAllowedMethod.name, () => {
   it("produces an error that flows through makeShelfError without throwing", () => {
     const error = notAllowedMethod("POST");
     expect(() => makeShelfError(error)).not.toThrow();
+  });
+});
+
+describe(isAssetQuantityOverAllocationError.name, () => {
+  // why: emulate the runtime shape of the trigger violation — a
+  // `PrismaClientUnknownRequestError` is just an Error whose `message` carries
+  // the raw `RAISE EXCEPTION` text. We don't import the Prisma class to keep
+  // this a pure unit test.
+  const assetKitTriggerError = new Error(
+    "Invalid `prisma.assetKit.createMany()` invocation: AssetKit total 6 exceeds Asset.quantity 3 for asset abc123"
+  );
+  const assetLocationTriggerError = new Error(
+    "Invalid `prisma.assetLocation.createMany()` invocation: AssetLocation total 2 exceeds Asset.quantity 1 for asset abc123"
+  );
+
+  it("detects the AssetKit over-allocation trigger message", () => {
+    expect(isAssetQuantityOverAllocationError(assetKitTriggerError)).toBe(true);
+  });
+
+  it("detects the AssetLocation over-allocation trigger message", () => {
+    expect(isAssetQuantityOverAllocationError(assetLocationTriggerError)).toBe(
+      true
+    );
+  });
+
+  it("detects the trigger error when wrapped inside a ShelfError", () => {
+    const wrapped = new ShelfError({
+      cause: assetKitTriggerError,
+      label: "Kit",
+      message: "Something went wrong while updating kit assets.",
+    });
+    expect(isAssetQuantityOverAllocationError(wrapped)).toBe(true);
+  });
+
+  it("detects the trigger error nested two ShelfError layers deep", () => {
+    const inner = new ShelfError({
+      cause: assetLocationTriggerError,
+      label: "Location",
+      message: "Something went wrong while updating the location assets.",
+    });
+    const outer = new ShelfError({
+      cause: inner,
+      label: "Location",
+      message: "wrapper",
+    });
+    expect(isAssetQuantityOverAllocationError(outer)).toBe(true);
+  });
+
+  it("does NOT match unrelated errors", () => {
+    expect(isAssetQuantityOverAllocationError(new Error("boom"))).toBe(false);
+    // A different Prisma unique-constraint violation must not be swallowed.
+    expect(
+      isAssetQuantityOverAllocationError(
+        new Error("Unique constraint failed on the fields: (`qrId`)")
+      )
+    ).toBe(false);
+    // Another trigger that mentions the same tables but a DIFFERENT invariant.
+    expect(
+      isAssetQuantityOverAllocationError(
+        new Error("INDIVIDUAL asset abc123 already linked to a kit")
+      )
+    ).toBe(false);
+    expect(isAssetQuantityOverAllocationError(null)).toBe(false);
+    expect(isAssetQuantityOverAllocationError("exceeds Asset.quantity")).toBe(
+      false
+    );
+  });
+});
+
+describe(throwIfAssetQuantityOverAllocation.name, () => {
+  const triggerError = new Error(
+    "AssetKit total 6 exceeds Asset.quantity 3 for asset abc123"
+  );
+
+  it("throws a friendly 400, non-captured ShelfError for the trigger violation", () => {
+    let thrown: unknown;
+    try {
+      throwIfAssetQuantityOverAllocation(triggerError, {
+        label: "Kit",
+        additionalData: { kitId: "kit-1", assetIds: ["a1"] },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ShelfError);
+    const shelfError = thrown as ShelfError;
+    expect(shelfError.status).toBe(400);
+    expect(shelfError.shouldBeCaptured).toBe(false);
+    expect(shelfError.label).toBe("Kit");
+    expect(shelfError.cause).toBe(triggerError);
+    expect(shelfError.additionalData).toEqual({
+      kitId: "kit-1",
+      assetIds: ["a1"],
+    });
+    // Non-technical, actionable user message.
+    expect(shelfError.message).toContain("Lower the quantity");
+  });
+
+  it("also translates the AssetLocation variant", () => {
+    expect(() =>
+      throwIfAssetQuantityOverAllocation(
+        new Error("AssetLocation total 2 exceeds Asset.quantity 1 for asset x"),
+        { label: "Location" }
+      )
+    ).toThrow(ShelfError);
+  });
+
+  it("does NOT throw (passes through) for any other error", () => {
+    expect(() =>
+      throwIfAssetQuantityOverAllocation(new Error("some other DB error"), {
+        label: "Assets",
+      })
+    ).not.toThrow();
+    expect(() =>
+      throwIfAssetQuantityOverAllocation(null, { label: "Assets" })
+    ).not.toThrow();
+  });
+
+  it("resulting error is a handled client error (Sentry log, not issue)", () => {
+    let thrown: unknown;
+    try {
+      throwIfAssetQuantityOverAllocation(triggerError, { label: "Assets" });
+    } catch (error) {
+      thrown = error;
+    }
+    // 400 → routed to Sentry logs, kept out of the error/issue pipeline.
+    expect(isHandledClientError(thrown)).toBe(true);
   });
 });
 

--- a/apps/webapp/app/utils/error.test.ts
+++ b/apps/webapp/app/utils/error.test.ts
@@ -538,6 +538,32 @@ describe(isAssetQuantityOverAllocationError.name, () => {
       false
     );
   });
+
+  it("returns false (does not stack-overflow) on a self-referential cause cycle", () => {
+    // why: a malformed error whose `.cause` points at itself must terminate the
+    // walk instead of recursing forever — the visited-set guards against it.
+    const cyclic: { message: string; cause?: unknown } = { message: "boom" };
+    cyclic.cause = cyclic;
+    expect(isAssetQuantityOverAllocationError(cyclic)).toBe(false);
+  });
+
+  it("returns false on a two-object cause cycle", () => {
+    const a: { message: string; cause?: unknown } = { message: "a" };
+    const b: { message: string; cause?: unknown } = { message: "b", cause: a };
+    a.cause = b; // a -> b -> a
+    expect(isAssetQuantityOverAllocationError(a)).toBe(false);
+  });
+
+  it("still detects the marker even when the cause graph is cyclic", () => {
+    // The marker on an outer node is found before the cycle is revisited.
+    const inner: { message: string; cause?: unknown } = { message: "inner" };
+    const outer: { message: string; cause?: unknown } = {
+      message: "AssetKit total 6 exceeds Asset.quantity 3 for asset abc123",
+      cause: inner,
+    };
+    inner.cause = outer; // cycle, but the marker is on `outer`
+    expect(isAssetQuantityOverAllocationError(outer)).toBe(true);
+  });
 });
 
 describe(throwIfAssetQuantityOverAllocation.name, () => {

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -337,6 +337,102 @@ export function isPrismaTransientError(cause: unknown): boolean {
 }
 
 /**
+ * Substring shared by BOTH quantity over-allocation trigger exceptions.
+ *
+ * Two DB triggers enforce `sum(pivot.quantity) <= Asset.quantity` for
+ * QUANTITY_TRACKED assets and raise (via `RAISE EXCEPTION`) when the invariant
+ * is violated:
+ *
+ *   - `AssetKit total % exceeds Asset.quantity % for asset %`
+ *     ({@link file://./../../../../packages/database/prisma/migrations/20260514100000_drop_asset_kit_unique_add_triggers/migration.sql})
+ *   - `AssetLocation total % exceeds Asset.quantity % for asset %`
+ *     ({@link file://./../../../../packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql})
+ *
+ * Both surface at runtime as a `PrismaClientUnknownRequestError` whose message
+ * contains this substring. It is intentionally NARROW — it appears only in
+ * these two trigger messages, so matching on it never swallows unrelated
+ * `PrismaClientUnknownRequestError`s.
+ */
+export const ASSET_QUANTITY_OVER_ALLOCATION_MARKER = "exceeds Asset.quantity";
+
+/**
+ * Detects the "assigning more of a QUANTITY_TRACKED asset than `Asset.quantity`
+ * allows" DB-trigger violation anywhere in an error's `cause` chain.
+ *
+ * The raw trigger error is a `PrismaClientUnknownRequestError`, but a
+ * service-layer `try/catch` may already have re-wrapped it inside a
+ * `ShelfError` (with the original as `.cause`) by the time we inspect it — so
+ * we walk the chain, mirroring {@link hasTransientCause} / {@link hasNotFoundCause}.
+ *
+ * @param cause - Any thrown value (error, wrapper, or unknown).
+ * @returns `true` when the over-allocation trigger message is present in the
+ * error or any nested `cause`; otherwise `false`.
+ */
+export function isAssetQuantityOverAllocationError(cause: unknown): boolean {
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof (cause as { message: unknown }).message === "string" &&
+    (cause as { message: string }).message.includes(
+      ASSET_QUANTITY_OVER_ALLOCATION_MARKER
+    )
+  ) {
+    return true;
+  }
+  // Walk the cause chain — the trigger error is frequently nested inside a
+  // service-layer ShelfError wrapper.
+  if (typeof cause === "object" && cause !== null && "cause" in cause) {
+    return isAssetQuantityOverAllocationError(
+      (cause as { cause: unknown }).cause
+    );
+  }
+  return false;
+}
+
+/**
+ * Translates the quantity over-allocation DB-trigger violation into a
+ * user-facing `ShelfError` and throws it. No-ops (returns) for every other
+ * error so the caller's existing error wrapping runs unchanged.
+ *
+ * This is a user-input validation failure (the user asked to assign more units
+ * than exist), so the thrown error is a **400** with `shouldBeCaptured: false`:
+ * per repo convention (see {@link isHandledClientError}) these are recorded as
+ * low-severity Sentry LOGS, not paged as Sentry ISSUES.
+ *
+ * Wire this in as the FIRST line of a `catch (cause)` block at any service path
+ * that writes `AssetKit` / `AssetLocation` rows and can trip the triggers.
+ *
+ * @param cause - The caught error to inspect.
+ * @param options.label - The `ShelfError` label for the throwing surface
+ * (e.g. `"Kit"`, `"Location"`, `"Assets"`).
+ * @param options.additionalData - Debugging context (asset/kit/location ids)
+ * preserved on the thrown error.
+ * @throws {ShelfError} A 400, non-captured error when `cause` is the
+ * over-allocation trigger violation.
+ */
+export function throwIfAssetQuantityOverAllocation(
+  cause: unknown,
+  {
+    label,
+    additionalData,
+  }: { label: ErrorLabel; additionalData?: AdditionalData }
+): void {
+  if (!isAssetQuantityOverAllocationError(cause)) {
+    return;
+  }
+  throw new ShelfError({
+    cause,
+    label,
+    message:
+      "You're trying to assign more of this asset than are available. Lower the quantity and try again.",
+    status: 400,
+    shouldBeCaptured: false,
+    additionalData,
+  });
+}
+
+/**
  * Walks the cause chain of an error to detect if a transient
  * Prisma error is buried inside ShelfError wrappers.
  */

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -369,23 +369,25 @@ export const ASSET_QUANTITY_OVER_ALLOCATION_MARKER = "exceeds Asset.quantity";
  * error or any nested `cause`; otherwise `false`.
  */
 export function isAssetQuantityOverAllocationError(cause: unknown): boolean {
-  if (
-    typeof cause === "object" &&
-    cause !== null &&
-    "message" in cause &&
-    typeof (cause as { message: unknown }).message === "string" &&
-    (cause as { message: string }).message.includes(
-      ASSET_QUANTITY_OVER_ALLOCATION_MARKER
-    )
-  ) {
-    return true;
-  }
-  // Walk the cause chain — the trigger error is frequently nested inside a
-  // service-layer ShelfError wrapper.
-  if (typeof cause === "object" && cause !== null && "cause" in cause) {
-    return isAssetQuantityOverAllocationError(
-      (cause as { cause: unknown }).cause
-    );
+  // Walk the cause chain iteratively — the trigger error is frequently nested
+  // inside a service-layer ShelfError wrapper. A `visited` set makes the walk
+  // cycle-safe: a self-referential or mutually-referential `.cause` graph
+  // terminates and returns false instead of recursing into a stack overflow.
+  const visited = new Set<object>();
+  let current = cause;
+  while (typeof current === "object" && current !== null) {
+    if (visited.has(current)) {
+      return false;
+    }
+    visited.add(current);
+    const error = current as { message?: unknown; cause?: unknown };
+    if (
+      typeof error.message === "string" &&
+      error.message.includes(ASSET_QUANTITY_OVER_ALLOCATION_MARKER)
+    ) {
+      return true;
+    }
+    current = error.cause;
   }
   return false;
 }


### PR DESCRIPTION
Assigning more of a QUANTITY_TRACKED asset to a kit or location than its Asset.quantity allows is correctly rejected by a DB trigger, but the app surfaced it as a generic 500 "Something went wrong". Two Sentry issues, one root cause.

The DEFERRABLE triggers raise "AssetKit total ... exceeds Asset.quantity ..." and "AssetLocation total ... exceeds Asset.quantity ..." at COMMIT, surfacing as a PrismaClientUnknownRequestError. Add a narrow detector (isAssetQuantityOverAllocationError, matching the shared "exceeds Asset.quantity" marker across the cause chain) and a translator
(throwIfAssetQuantityOverAllocation) in utils/error.ts that throws a 400 / shouldBeCaptured:false ShelfError with an actionable message, and no-ops for every other error.

Wired at the four write sites that can trip the triggers: updateKitAssets, updateLocationAssets, and (as race backstops behind their own pre-checks) replaceAssetPlacements and placeUnplacedUnits. Swept all other AssetKit / AssetLocation writers and confirmed they cannot newly exceed the sum (quantity-preserving moves, full-pool replacements, INDIVIDUAL-only, or kit-driven rows the location trigger excludes).

Fixes SHELF-WEBAPP-219
Fixes SHELF-WEBAPP-21N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asset quantity over-allocation errors during asset placement updates, kit asset updates, and location asset updates.
  * Users now receive consistent, user-friendly 400-level responses with guidance to lower the quantity (instead of generic server errors).
  * Preserved existing handling for unrelated errors.

* **Tests**
  * Added unit test coverage for detecting over-allocation trigger errors, including wrapped and nested error scenarios, and for verifying the thrown user-facing error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->