### PR TITLE
fix(auth): make createUser idempotent and cap passwords at 72 chars

### DIFF
--- a/apps/webapp/app/modules/user/service.server.test.ts
+++ b/apps/webapp/app/modules/user/service.server.test.ts
@@ -1,4 +1,5 @@
 import { Roles, AssetIndexMode, OrganizationRoles } from "@prisma/client";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 
 import { matchRequestUrl, http, HttpResponse } from "msw";
 import { server } from "@mocks";
@@ -19,6 +20,7 @@ import { db } from "~/database/db.server";
 
 import { USER_WITH_SSO_DETAILS_SELECT } from "./fields";
 import {
+  createUser,
   createUserAccountForTesting,
   createUserOrAttachOrg,
   defaultUserCategories,
@@ -36,6 +38,7 @@ vitest.mock("~/database/db.server", () => ({
     user: {
       create: vitest.fn().mockResolvedValue({}),
       findFirst: vitest.fn().mockResolvedValue(null),
+      findUnique: vitest.fn().mockResolvedValue(null),
     },
     organization: {
       findFirst: vitest.fn().mockResolvedValue({
@@ -445,5 +448,89 @@ describe(createUserOrAttachOrg.name, () => {
     expect(result.id).toBe(USER_ID);
     expect(db.userOrganization.upsert).toHaveBeenCalled();
     expect(db.user.create).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Tests for `createUser` idempotency on the primary key (SHELF-WEBAPP-1EA).
+ *
+ * When `user.create` hits a P2002 unique-constraint violation on `id`, a `User`
+ * row already exists for this Supabase auth id (re-signup / partial signup).
+ * Because the create + all side-effects run in one `$transaction`, the P2002
+ * rolls everything back, so returning the pre-existing row is safe and does not
+ * duplicate any side-effects.
+ */
+describe(createUser.name, () => {
+  /** Prisma payload shape the transaction's create returns (subset used here). */
+  const existingUser = {
+    id: USER_ID,
+    email: USER_EMAIL,
+    organizations: [{ id: ORGANIZATION_ID }],
+  };
+
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    // why: the mocked $transaction just invokes the callback with the mocked db,
+    // so the callback's `tx.user.create` resolves to whatever db.user.create does
+    // @ts-expect-error missing vitest type
+    db.$transaction.mockImplementation((callback: any) => callback(db));
+  });
+
+  it("returns the existing user when create throws a P2002 unique violation on id", async () => {
+    // why: simulate Prisma raising a primary-key unique violation (id already
+    // has a User row) so the create inside the transaction rejects with P2002
+    const p2002 = new PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`id`)",
+      { code: "P2002", clientVersion: "test", meta: { target: ["id"] } }
+    );
+    // @ts-expect-error missing vitest type
+    db.user.create.mockRejectedValueOnce(p2002);
+    // @ts-expect-error missing vitest type
+    db.user.findUnique.mockResolvedValueOnce(existingUser);
+
+    const result = await createUser({
+      email: USER_EMAIL,
+      userId: USER_ID,
+      username,
+    });
+
+    expect(result).toEqual(existingUser);
+    // Looks the row up by id, not by any other field
+    expect(db.user.findUnique).toHaveBeenCalledWith({
+      where: { id: USER_ID },
+      select: expect.objectContaining({
+        organizations: { select: { id: true } },
+      }),
+    });
+    // No duplicate side-effects: nothing was re-created
+    expect(db.userOrganization.upsert).not.toHaveBeenCalled();
+  });
+
+  it("throws when P2002 has no matching row for this id (conflict on another unique field)", async () => {
+    // why: a P2002 on e.g. `email` with no row for this id is a genuine conflict
+    const p2002 = new PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`email`)",
+      { code: "P2002", clientVersion: "test", meta: { target: ["email"] } }
+    );
+    // @ts-expect-error missing vitest type
+    db.user.create.mockRejectedValueOnce(p2002);
+    // @ts-expect-error missing vitest type
+    db.user.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      createUser({ email: USER_EMAIL, userId: USER_ID, username })
+    ).rejects.toThrow("We had trouble while creating your account");
+  });
+
+  it("throws when create fails with a non-P2002 error", async () => {
+    // why: a generic DB failure must still surface as a ShelfError, not silently
+    // resolve — and must not attempt the idempotent lookup
+    // @ts-expect-error missing vitest type
+    db.user.create.mockRejectedValueOnce(new Error("connection reset"));
+
+    await expect(
+      createUser({ email: USER_EMAIL, userId: USER_ID, username })
+    ).rejects.toThrow("We had trouble while creating your account");
+    expect(db.user.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/user/service.server.test.ts
+++ b/apps/webapp/app/modules/user/service.server.test.ts
@@ -506,6 +506,79 @@ describe(createUser.name, () => {
     expect(db.userOrganization.upsert).not.toHaveBeenCalled();
   });
 
+  it("reconciles the org association when an invite/SSO caller races a P2002 and the existing user is not yet a member", async () => {
+    // why: the create + org association run in one rolled-back transaction, so a
+    // concurrent P2002 race returns the existing user WITHOUT the requested org.
+    // The recovery path must re-attach it (SHELF-WEBAPP-1EA follow-up).
+    const NEW_ORG_ID = "org-the-user-is-not-in-yet";
+    // Fresh object per test: the recovery path mutates `organizations` via push.
+    const userMissingOrg = {
+      id: USER_ID,
+      email: USER_EMAIL,
+      organizations: [] as { id: string }[],
+    };
+    const p2002 = new PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`id`)",
+      { code: "P2002", clientVersion: "test", meta: { target: ["id"] } }
+    );
+    // @ts-expect-error missing vitest type
+    db.user.create.mockRejectedValueOnce(p2002);
+    // @ts-expect-error missing vitest type
+    db.user.findUnique.mockResolvedValueOnce(userMissingOrg);
+
+    const result = await createUser({
+      email: USER_EMAIL,
+      userId: USER_ID,
+      username,
+      organizationId: NEW_ORG_ID,
+      roles: [OrganizationRoles.ADMIN],
+    });
+
+    // Re-attaches the existing user to the requested org idempotently
+    expect(db.userOrganization.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId_organizationId: {
+            userId: USER_ID,
+            organizationId: NEW_ORG_ID,
+          },
+        },
+      })
+    );
+    // Still returns the pre-existing user, now carrying the reconciled org
+    expect(result).toBe(userMissingOrg);
+    expect(result.organizations).toContainEqual({ id: NEW_ORG_ID });
+  });
+
+  it("does NOT re-attach the org when the racing user is already a member", async () => {
+    // why: re-attaching an existing membership would re-push roles via the
+    // upsert's `push` update branch — the membership check must short-circuit.
+    const userAlreadyMember = {
+      id: USER_ID,
+      email: USER_EMAIL,
+      organizations: [{ id: ORGANIZATION_ID }],
+    };
+    const p2002 = new PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`id`)",
+      { code: "P2002", clientVersion: "test", meta: { target: ["id"] } }
+    );
+    // @ts-expect-error missing vitest type
+    db.user.create.mockRejectedValueOnce(p2002);
+    // @ts-expect-error missing vitest type
+    db.user.findUnique.mockResolvedValueOnce(userAlreadyMember);
+
+    const result = await createUser({
+      email: USER_EMAIL,
+      userId: USER_ID,
+      username,
+      organizationId: ORGANIZATION_ID,
+      roles: [OrganizationRoles.ADMIN],
+    });
+
+    expect(result).toBe(userAlreadyMember);
+    expect(db.userOrganization.upsert).not.toHaveBeenCalled();
+  });
+
   it("throws when P2002 has no matching row for this id (conflict on another unique field)", async () => {
     // why: a P2002 on e.g. `email` with no row for this id is a genuine conflict
     const p2002 = new PrismaClientKnownRequestError(

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -848,6 +848,40 @@ export async function createUser(
     const isUniqueViolation =
       cause instanceof PrismaClientKnownRequestError && cause.code === "P2002";
 
+    /**
+     * Idempotency on `id` (SHELF-WEBAPP-1EA): a P2002 unique-constraint
+     * violation raised on the primary key means a `User` row already exists for
+     * this Supabase auth id — e.g. a re-signup, or a prior partial signup whose
+     * stored email differs from the OTP email, so the route's email-keyed race
+     * guard missed it. The `user.create` and ALL its side-effects (personal
+     * org, org association, team member, asset index settings) run inside one
+     * `$transaction`, so the P2002 rolled the whole thing back — there is no
+     * partial state to reconcile. Return the pre-existing row (using the exact
+     * same select shape the create returns) instead of failing the signup.
+     *
+     * We deliberately do NOT re-fire the `signup_completed` analytics event on
+     * this path: no new account was created. If the lookup unexpectedly finds
+     * no row (P2002 on some OTHER unique field, e.g. `email`, with no row for
+     * this `id`), that is a genuine conflict — fall through and throw.
+     */
+    if (isUniqueViolation) {
+      const existingUser = await db.user.findUnique({
+        where: { id: userId },
+        select: {
+          ...USER_WITH_SSO_DETAILS_SELECT,
+          organizations: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+
+      if (existingUser) {
+        return existingUser;
+      }
+    }
+
     throw new ShelfError({
       cause,
       message: "We had trouble while creating your account. Please try again.",

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -855,9 +855,17 @@ export async function createUser(
      * stored email differs from the OTP email, so the route's email-keyed race
      * guard missed it. The `user.create` and ALL its side-effects (personal
      * org, org association, team member, asset index settings) run inside one
-     * `$transaction`, so the P2002 rolled the whole thing back — there is no
-     * partial state to reconcile. Return the pre-existing row (using the exact
-     * same select shape the create returns) instead of failing the signup.
+     * `$transaction`, so the P2002 rolled the whole thing back. Return the
+     * pre-existing row (using the exact same select shape the create returns)
+     * instead of failing the signup.
+     *
+     * ONE piece of state still needs reconciling: for invite/SSO callers
+     * (`organizationId` present), the rolled-back transaction never created the
+     * requested org association, so a concurrent P2002 race would otherwise
+     * return the existing user un-attached to the org they were invited to. We
+     * re-attach that association idempotently below (only when they aren't
+     * already a member). The personal-org / OTP self-signup case has no
+     * `organizationId`, so there is nothing to reconcile there.
      *
      * We deliberately do NOT re-fire the `signup_completed` analytics event on
      * this path: no new account was created. If the lookup unexpectedly finds
@@ -878,6 +886,23 @@ export async function createUser(
       });
 
       if (existingUser) {
+        // The rolled-back transaction never created the org association. For
+        // invite/SSO callers (organizationId present), a concurrent P2002 race
+        // would otherwise leave the existing user un-attached to the requested
+        // org. Reconcile idempotently — only attach when not already a member
+        // (the membership check avoids re-pushing roles via the upsert's
+        // `push` update branch). SHELF-WEBAPP-1EA follow-up.
+        if (
+          organizationId &&
+          !existingUser.organizations.some((org) => org.id === organizationId)
+        ) {
+          await createUserOrgAssociation(db, {
+            userId,
+            organizationIds: [organizationId],
+            roles: roles ?? [],
+          });
+          existingUser.organizations.push({ id: organizationId });
+        }
         return existingUser;
       }
     }

--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -30,6 +30,7 @@ import {
   readFormData,
 } from "~/utils/http.server";
 import { validEmail } from "~/utils/misc";
+import { passwordSchema } from "~/utils/zod";
 
 const ForgotPasswordSchema = z.object({
   email: z
@@ -44,10 +45,10 @@ const OtpSchema = z
   .object({
     otp: z.string().min(6, "OTP is required."),
     email: z.string().transform((email) => email.toLowerCase()),
-    password: z.string().min(8, "Password is too short. Minimum 8 characters."),
-    confirmPassword: z
-      .string()
-      .min(8, "Password is too short. Minimum 8 characters."),
+    password: passwordSchema("Password is too short. Minimum 8 characters."),
+    confirmPassword: passwordSchema(
+      "Password is too short. Minimum 8 characters."
+    ),
   })
   .superRefine(({ password, confirmPassword, otp, email }, ctx) => {
     if (password !== confirmPassword) {

--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -22,6 +22,7 @@ import {
 } from "~/modules/auth/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError, ShelfError } from "~/utils/error";
+import { getValidationErrors } from "~/utils/http";
 import {
   payload,
   error,
@@ -195,10 +196,22 @@ export default function ForgotPassword() {
     zo.errors.email()?.message || actionData?.error?.message || "";
   const disabled = useDisabled();
 
+  /**
+   * Field-level validation errors from the confirm-otp (password reset) step.
+   * When present, keep the password form mounted so the errors render inline on
+   * their fields — instead of bouncing back to the email step with a generic
+   * message. Hard errors (e.g. an invalid OTP) still fall back to the email step.
+   */
+  const otpValidationErrors = getValidationErrors<typeof OtpSchema>(
+    actionData?.error
+  );
+
   return (
     <div className="flex min-h-full flex-col justify-center">
       <div className="mx-auto w-full">
-        {actionData?.error || !email || email === "" ? (
+        {(actionData?.error && !otpValidationErrors) ||
+        !email ||
+        email === "" ? (
           <div>
             <p className="mb-4 text-center">
               Enter your email address and we'll send you a one-time code to
@@ -268,7 +281,19 @@ function PasswordResetForm({ email }: { email: string }) {
   const zoReset = useZorm("ResetPasswordForm", OtpSchema);
   const disabled = useDisabled();
   const actionData = useActionData<typeof action>();
-  return !email || email === "" || actionData?.error ? (
+
+  /**
+   * Server-side validation errors for the reset fields, shown as a fallback
+   * when client-side zorm validation is bypassed (disabled JS, modified
+   * request, or client/server rule divergence). See CLAUDE.md form pattern.
+   */
+  const validationErrors = getValidationErrors<typeof OtpSchema>(
+    actionData?.error
+  );
+
+  // Keep the form mounted for validation errors so field-level messages render;
+  // only a hard error (e.g. invalid OTP) falls back to the generic message.
+  return !email || email === "" || (actionData?.error && !validationErrors) ? (
     <div>Something went wrong. Please refresh the page and try again.</div>
   ) : (
     <Form method="post" ref={zoReset.ref} className="space-y-2">
@@ -281,7 +306,10 @@ function PasswordResetForm({ email }: { email: string }) {
         type="password"
         autoComplete="new-password"
         disabled={disabled}
-        error={zoReset.errors.password()?.message}
+        error={
+          validationErrors?.password?.message ||
+          zoReset.errors.password()?.message
+        }
         placeholder="********"
         required
       />
@@ -292,7 +320,10 @@ function PasswordResetForm({ email }: { email: string }) {
         type="password"
         autoComplete="new-password"
         disabled={disabled}
-        error={zoReset.errors.confirmPassword()?.message}
+        error={
+          validationErrors?.confirmPassword?.message ||
+          zoReset.errors.confirmPassword()?.message
+        }
         placeholder="********"
         required
       />

--- a/apps/webapp/app/routes/_auth+/join.tsx
+++ b/apps/webapp/app/routes/_auth+/join.tsx
@@ -26,6 +26,7 @@ import {
   notAllowedMethod,
 } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
+import { getValidationErrors } from "~/utils/http";
 import {
   payload,
   error,
@@ -34,6 +35,7 @@ import {
 } from "~/utils/http.server";
 import { validEmail } from "~/utils/misc";
 import { validateNonSSOSignup } from "~/utils/sso.server";
+import { passwordSchema } from "~/utils/zod";
 
 export function loader({ context }: LoaderFunctionArgs) {
   const title = "Create an account";
@@ -71,12 +73,8 @@ const JoinFormSchema = z
       .refine(validEmail, () => ({
         message: "Please enter a valid email",
       })),
-    password: z
-      .string()
-      .min(8, "Your password is too short. Min 8 characters are required."),
-    confirmPassword: z
-      .string()
-      .min(8, "Your password is too short. Min 8 characters are required."),
+    password: passwordSchema(),
+    confirmPassword: passwordSchema(),
     redirectTo: z.string().optional(),
   })
   .superRefine(({ password, confirmPassword }, ctx) => {
@@ -182,7 +180,10 @@ export default function Join() {
             autoComplete="new-password"
             disabled={disabled}
             inputClassName="w-full"
-            error={zo.errors.password()?.message}
+            error={
+              getValidationErrors<typeof JoinFormSchema>(data?.error)?.password
+                ?.message || zo.errors.password()?.message
+            }
           />
           <PasswordInput
             label="Confirm Password"

--- a/apps/webapp/app/routes/_auth+/join.tsx
+++ b/apps/webapp/app/routes/_auth+/join.tsx
@@ -194,7 +194,11 @@ export default function Join() {
             autoComplete="new-password"
             disabled={disabled}
             inputClassName="w-full"
-            error={zo.errors.confirmPassword()?.message}
+            error={
+              getValidationErrors<typeof JoinFormSchema>(data?.error)
+                ?.confirmPassword?.message ||
+              zo.errors.confirmPassword()?.message
+            }
           />
 
           <input

--- a/apps/webapp/app/routes/_welcome+/onboarding.tsx
+++ b/apps/webapp/app/routes/_welcome+/onboarding.tsx
@@ -60,6 +60,7 @@ import {
 } from "~/utils/http.server";
 import { createStripeCustomer } from "~/utils/stripe.server";
 import { tw } from "~/utils/tw";
+import { passwordSchema } from "~/utils/zod";
 
 const trimString = (value: unknown) =>
   typeof value === "string" ? value.trim() : value;
@@ -106,12 +107,15 @@ function createOnboardingSchema({
         .min(4, { message: "Must be at least 4 characters long" }),
       firstName: z.string().min(1, { message: "First name is required" }),
       lastName: z.string().min(1, { message: "Last name is required" }),
+      // When the user already has a password (e.g. signed up via email/pass),
+      // the field is optional and unconstrained — they are not setting one here.
+      // Only the setter branch enforces the 8–72 char bounds.
       password: userSignedUpWithPassword
         ? z.string().optional()
-        : z.string().min(8, "Password is too short. Minimum 8 characters."),
+        : passwordSchema("Password is too short. Minimum 8 characters."),
       confirmPassword: userSignedUpWithPassword
         ? z.string().optional()
-        : z.string().min(8, "Password is too short. Minimum 8 characters."),
+        : passwordSchema("Password is too short. Minimum 8 characters."),
       referralSource: shouldCollectBusinessIntel
         ? z.string().min(5, "Field is required.")
         : z.string().optional().nullable(),

--- a/apps/webapp/app/routes/_welcome+/onboarding.tsx
+++ b/apps/webapp/app/routes/_welcome+/onboarding.tsx
@@ -610,7 +610,11 @@ export default function Onboarding() {
               type="password"
               autoComplete="new-password"
               inputClassName="w-full"
-              error={zo.errors.password()?.message}
+              error={
+                getValidationErrors<typeof OnboardingFormSchema>(
+                  actionData?.error
+                )?.password?.message || zo.errors.password()?.message
+              }
             />
 
             <PasswordInput
@@ -621,7 +625,12 @@ export default function Onboarding() {
               name={zo.fields.confirmPassword()}
               type="password"
               autoComplete="new-password"
-              error={zo.errors.confirmPassword()?.message}
+              error={
+                getValidationErrors<typeof OnboardingFormSchema>(
+                  actionData?.error
+                )?.confirmPassword?.message ||
+                zo.errors.confirmPassword()?.message
+              }
             />
           </>
         )}

--- a/apps/webapp/app/utils/zod.test.ts
+++ b/apps/webapp/app/utils/zod.test.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MAX_LENGTH_MESSAGE,
+  passwordSchema,
+} from "./zod";
+
+/**
+ * Tests for the shared `passwordSchema` used by every password *setter* flow
+ * (signup, onboarding, password reset) — SHELF-WEBAPP-21A.
+ *
+ * The 72-char cap mirrors Supabase/bcrypt so an over-long password is rejected
+ * as a field-level validation error instead of a late, captured 500.
+ */
+describe("passwordSchema", () => {
+  it("rejects a password longer than 72 characters with the max message", () => {
+    const result = passwordSchema().safeParse("a".repeat(73));
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(PASSWORD_MAX_LENGTH_MESSAGE);
+    }
+  });
+
+  it("accepts a password exactly 72 characters long", () => {
+    const result = passwordSchema().safeParse("a".repeat(PASSWORD_MAX_LENGTH));
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a valid in-range password", () => {
+    const result = passwordSchema().safeParse("supersecret");
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a password shorter than 8 characters with the default min message", () => {
+    const result = passwordSchema().safeParse("short");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "Your password is too short. Min 8 characters are required."
+      );
+    }
+  });
+
+  it("uses the flow-specific min message when provided", () => {
+    const result = passwordSchema(
+      "Password is too short. Minimum 8 characters."
+    ).safeParse("short");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "Password is too short. Minimum 8 characters."
+      );
+    }
+  });
+
+  it("still enforces the 72-char cap when wrapped as optional (onboarding setter)", () => {
+    // why: onboarding wraps a setter password with the same bounds; only the
+    // "user already has a password" branch stays unconstrained-optional
+    const optional = passwordSchema().optional();
+
+    expect(optional.safeParse(undefined).success).toBe(true);
+    expect(optional.safeParse("a".repeat(73)).success).toBe(false);
+  });
+});
+
+/**
+ * Guards onboarding's "user already has a password" branch: it must remain an
+ * unconstrained optional string (empty/undefined allowed) so users who signed
+ * up with a password can finish onboarding without re-entering one.
+ */
+describe("onboarding optional password branch", () => {
+  const optionalBranch = z.string().optional();
+
+  it("allows an omitted password", () => {
+    expect(optionalBranch.safeParse(undefined).success).toBe(true);
+  });
+
+  it("allows an empty password", () => {
+    expect(optionalBranch.safeParse("").success).toBe(true);
+  });
+});

--- a/apps/webapp/app/utils/zod.test.ts
+++ b/apps/webapp/app/utils/zod.test.ts
@@ -10,12 +10,14 @@ import {
  * Tests for the shared `passwordSchema` used by every password *setter* flow
  * (signup, onboarding, password reset) — SHELF-WEBAPP-21A.
  *
- * The 72-char cap mirrors Supabase/bcrypt so an over-long password is rejected
- * as a field-level validation error instead of a late, captured 500.
+ * The 72-**byte** cap mirrors Supabase/bcrypt so an over-long password is
+ * rejected as a field-level validation error instead of a late, captured 500.
+ * The bound is measured in UTF-8 bytes (not characters), so a short-looking
+ * multi-byte password can still exceed it.
  */
 describe("passwordSchema", () => {
-  it("rejects a password longer than 72 characters with the max message", () => {
-    const result = passwordSchema().safeParse("a".repeat(73));
+  it("rejects a password longer than 72 bytes with the max message", () => {
+    const result = passwordSchema().safeParse("a".repeat(73)); // 73 bytes
 
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -23,8 +25,33 @@ describe("passwordSchema", () => {
     }
   });
 
-  it("accepts a password exactly 72 characters long", () => {
-    const result = passwordSchema().safeParse("a".repeat(PASSWORD_MAX_LENGTH));
+  it("accepts a password exactly 72 bytes long", () => {
+    const value = "a".repeat(PASSWORD_MAX_LENGTH); // 72 ASCII bytes
+    const result = passwordSchema().safeParse(value);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a multi-byte password over 72 bytes (37 × 'é' = 74 bytes) with the max message", () => {
+    // 37 two-byte characters = 74 UTF-8 bytes; only 37 chars, so a char-based
+    // `.max(72)` would wrongly accept it — the byte refinement rejects it.
+    const value = "é".repeat(37);
+    expect(new TextEncoder().encode(value).length).toBe(74);
+
+    const result = passwordSchema().safeParse(value);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(PASSWORD_MAX_LENGTH_MESSAGE);
+    }
+  });
+
+  it("accepts a multi-byte password of exactly 72 bytes (36 × 'é')", () => {
+    // 36 two-byte characters = exactly 72 UTF-8 bytes — the byte boundary.
+    const value = "é".repeat(36);
+    expect(new TextEncoder().encode(value).length).toBe(PASSWORD_MAX_LENGTH);
+
+    const result = passwordSchema().safeParse(value);
 
     expect(result.success).toBe(true);
   });

--- a/apps/webapp/app/utils/zod.ts
+++ b/apps/webapp/app/utils/zod.ts
@@ -37,12 +37,15 @@ export const stringToJSONSchema = z
   });
 
 /**
- * Maximum password length accepted by Supabase's auth provider.
+ * Maximum password length accepted by Supabase's auth provider, in **UTF-8
+ * bytes** (not characters).
  *
  * GoTrue hashes passwords with bcrypt, which only considers the first 72
  * bytes, so Supabase rejects anything longer with
- * `AuthApiError: Password cannot be longer than 72 characters`. Mirroring the
- * limit in our zod schemas turns that late, captured 500 into an early,
+ * `AuthApiError: Password cannot be longer than 72 characters`. Because bcrypt
+ * counts bytes, a password like `"é".repeat(40)` is only 40 characters but 80
+ * UTF-8 bytes — it must be rejected even though it looks short. Mirroring the
+ * byte limit in our zod schemas turns that late, captured 500 into an early,
  * field-level validation error (SHELF-WEBAPP-21A).
  */
 export const PASSWORD_MAX_LENGTH = 72;
@@ -53,13 +56,19 @@ export const PASSWORD_MAX_LENGTH_MESSAGE =
 
 /**
  * Shared validation schema for password *setter* flows (signup, onboarding,
- * password reset). Enforces both the 8-character minimum and the 72-character
+ * password reset). Enforces both the 8-character minimum and the 72-**byte**
  * bcrypt/Supabase maximum so every setter rejects out-of-range passwords the
  * same way, before they ever reach the auth provider.
  *
+ * The upper bound is checked as UTF-8 byte length rather than `.max()` (which
+ * counts UTF-16 code units) because bcrypt limits by bytes — a 40-character
+ * multi-byte password can be 80 bytes and must still be rejected
+ * (SHELF-WEBAPP-21A).
+ *
  * @param minMessage - Flow-specific "too short" copy so each form keeps its
  *   existing wording. Defaults to the signup message.
- * @returns A `z.ZodString` schema with `min(8)` and `max(72)` checks.
+ * @returns A `z.ZodString` schema with a `min(8)` check and a UTF-8 byte-length
+ *   refinement capped at {@link PASSWORD_MAX_LENGTH}.
  */
 export function passwordSchema(
   minMessage = "Your password is too short. Min 8 characters are required."
@@ -67,5 +76,8 @@ export function passwordSchema(
   return z
     .string()
     .min(8, minMessage)
-    .max(PASSWORD_MAX_LENGTH, PASSWORD_MAX_LENGTH_MESSAGE);
+    .refine(
+      (value) => new TextEncoder().encode(value).length <= PASSWORD_MAX_LENGTH,
+      { message: PASSWORD_MAX_LENGTH_MESSAGE }
+    );
 }

--- a/apps/webapp/app/utils/zod.ts
+++ b/apps/webapp/app/utils/zod.ts
@@ -35,3 +35,37 @@ export const stringToJSONSchema = z
       return z.NEVER;
     }
   });
+
+/**
+ * Maximum password length accepted by Supabase's auth provider.
+ *
+ * GoTrue hashes passwords with bcrypt, which only considers the first 72
+ * bytes, so Supabase rejects anything longer with
+ * `AuthApiError: Password cannot be longer than 72 characters`. Mirroring the
+ * limit in our zod schemas turns that late, captured 500 into an early,
+ * field-level validation error (SHELF-WEBAPP-21A).
+ */
+export const PASSWORD_MAX_LENGTH = 72;
+
+/** User-facing message shown when a password exceeds {@link PASSWORD_MAX_LENGTH}. */
+export const PASSWORD_MAX_LENGTH_MESSAGE =
+  "Password cannot be longer than 72 characters.";
+
+/**
+ * Shared validation schema for password *setter* flows (signup, onboarding,
+ * password reset). Enforces both the 8-character minimum and the 72-character
+ * bcrypt/Supabase maximum so every setter rejects out-of-range passwords the
+ * same way, before they ever reach the auth provider.
+ *
+ * @param minMessage - Flow-specific "too short" copy so each form keeps its
+ *   existing wording. Defaults to the signup message.
+ * @returns A `z.ZodString` schema with `min(8)` and `max(72)` checks.
+ */
+export function passwordSchema(
+  minMessage = "Your password is too short. Min 8 characters are required."
+) {
+  return z
+    .string()
+    .min(8, minMessage)
+    .max(PASSWORD_MAX_LENGTH, PASSWORD_MAX_LENGTH_MESSAGE);
+}


### PR DESCRIPTION
Two signup failures from the Sentry triage.

createUser (SHELF-WEBAPP-1EA): a P2002 unique-constraint violation on the User primary key (id = the Supabase auth id) threw "We had trouble while creating your account" — hit on re-signup or a prior partial signup whose stored email differs from the OTP email (so the route's email-keyed race guard misses it). Since user.create and all its side-effects run in one $transaction, the P2002 rolls the whole thing back with no partial state, so the catch now returns the pre-existing row (identical select shape) instead of throwing. The signup_completed event is not re-fired; a null lookup (P2002 on another unique field) still throws.

Password length (SHELF-WEBAPP-21A): the signup/onboarding/reset flows had no max length, so a >72-char password surfaced Supabase's bcrypt limit (AuthApiError) as a generic captured 500. Add a shared passwordSchema(minMsg?) factory in utils/zod.ts (min 8, max 72) and apply it to join, onboarding (setter branch only — the optional branch stays unconstrained), and forgot-password, preserving each flow's existing min-length copy. Add the required server-side validation-error fallback to the join password field.

Fixes SHELF-WEBAPP-1EA
Fixes SHELF-WEBAPP-21A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared password validation across join, onboarding, and forgot-password flows, including consistent max-length enforcement and unified “too short” messaging.
  * Improved password inputs to display field-specific server validation errors.

* **Bug Fixes**
  * Prevented duplicate account creation during signup races by reusing the existing account when unique-constraint conflicts occur.
  * Ensured recovered signups don’t re-trigger signup-completion tracking, and reliably re-attach the user to the requested organization when needed.

* **Tests**
  * Expanded coverage for password schema edge cases and idempotent account creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->