### PR TITLE
perf(assets): move two conditional writes off the /assets index read path

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -503,12 +503,14 @@ describe("refreshExpiredAssetImages", () => {
     await vi.waitFor(() =>
       expect(mockUpdateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          // Guarded on the original mainImage so a concurrent image replace
-          // can't be clobbered by this deferred write.
+          // Guarded on the original mainImage AND thumbnailImage (a thumbnail is
+          // written here) so a concurrent replace of either can't be clobbered
+          // by this deferred write.
           where: {
             id: "asset-1",
             organizationId: "org-1",
             mainImage: "https://old-signed-url.com",
+            thumbnailImage: "https://old-thumbnail-url.com",
           },
           data: expect.objectContaining({
             mainImage: "https://new-main-url.com",

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -490,16 +490,23 @@ describe("refreshExpiredAssetImages", () => {
 
     const result = await refreshExpiredAssetImages(assets);
 
+    // The return value carries the fresh URLs synchronously — re-signing stays
+    // awaited, only the DB persist is deferred.
     expect(result[0].mainImage).toBe("https://new-main-url.com");
     expect(result[0].thumbnailImage).toBe("https://new-thumbnail-url.com");
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "asset-1", organizationId: "org-1" },
-        data: expect.objectContaining({
-          mainImage: "https://new-main-url.com",
-          thumbnailImage: "https://new-thumbnail-url.com",
-        }),
-      })
+
+    // The persist now runs in a fire-and-forget background batch, so wait for
+    // the flush before asserting the write happened.
+    await vi.waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "asset-1", organizationId: "org-1" },
+          data: expect.objectContaining({
+            mainImage: "https://new-main-url.com",
+            thumbnailImage: "https://new-thumbnail-url.com",
+          }),
+        })
+      )
     );
   });
 
@@ -511,16 +518,20 @@ describe("refreshExpiredAssetImages", () => {
 
     // Should return original asset (no refresh)
     expect(result[0].mainImage).toBe("https://old-signed-url.com");
-    // Should bump expiration to prevent retry storm
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "asset-1", organizationId: "org-1" },
-        data: expect.objectContaining({
-          mainImageExpiration: expect.any(Date),
-        }),
-      })
-    );
     expect(mockCreateSignedUrl).not.toHaveBeenCalled();
+
+    // The backoff bump is now persisted in the deferred background batch —
+    // wait for the flush before asserting the write.
+    await vi.waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "asset-1", organizationId: "org-1" },
+          data: expect.objectContaining({
+            mainImageExpiration: expect.any(Date),
+          }),
+        })
+      )
+    );
   });
 
   it("logs error and applies backoff when createSignedUrl fails", async () => {
@@ -538,17 +549,25 @@ describe("refreshExpiredAssetImages", () => {
 
     // Asset should be returned unchanged
     expect(result[0].mainImage).toBe("https://old-signed-url.com");
-    // Backoff update should have been called
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          mainImageExpiration: expect.any(Date),
-        }),
-      })
+
+    // Backoff update is deferred to the background batch — wait for the flush.
+    await vi.waitFor(() =>
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            mainImageExpiration: expect.any(Date),
+          }),
+        })
+      )
     );
   });
 
-  it("handles deleted asset (P2025) gracefully without logging error", async () => {
+  it("returns fresh URLs even when the background persist fails (P2025)", async () => {
+    // Regression guard for the deferred-write refactor: the DB persist runs
+    // fire-and-forget AFTER the response value is built. If the asset was
+    // deleted between the read and the write (P2025), the returned URLs must
+    // still be the freshly re-signed ones and the function must NOT throw — the
+    // next load simply re-signs (idempotent).
     const { Prisma: ActualPrisma } = await import("@prisma/client");
     mockUpdate.mockRejectedValue(
       new ActualPrisma.PrismaClientKnownRequestError(
@@ -558,10 +577,24 @@ describe("refreshExpiredAssetImages", () => {
     );
     const assets = [makeAsset()];
 
+    // Resolves (no throw) with the freshly re-signed URL.
     const result = await refreshExpiredAssetImages(assets);
+    expect(result[0].mainImage).toBe("https://new-signed-url.com");
 
-    // Should return original asset (refresh failed gracefully)
-    expect(result[0].mainImage).toBe("https://old-signed-url.com");
+    // The (failing) write was still attempted in the background.
+    await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+  });
+
+  it("returns fresh URLs even when the background persist fails unexpectedly", async () => {
+    // A non-P2025 write failure (e.g. a pool timeout) is swallowed + logged in
+    // the background and must not affect the returned URLs or throw.
+    mockUpdate.mockRejectedValue(new Error("connection pool timeout"));
+    const assets = [makeAsset()];
+
+    const result = await refreshExpiredAssetImages(assets);
+    expect(result[0].mainImage).toBe("https://new-signed-url.com");
+
+    await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled());
   });
 });
 

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -433,7 +433,9 @@ describe("uploadDuplicateAssetMainImage", () => {
 });
 
 describe("refreshExpiredAssetImages", () => {
-  const mockUpdate = db.asset.update as ReturnType<typeof vitest.fn>;
+  // The background flush persists via a guarded updateMany (on the original
+  // mainImage), not update — assert on updateMany here.
+  const mockUpdateMany = db.asset.updateMany as ReturnType<typeof vitest.fn>;
   const mockCreateSignedUrl = createSignedUrl as ReturnType<typeof vitest.fn>;
   const mockExtractStoragePath = extractStoragePath as ReturnType<
     typeof vitest.fn
@@ -443,7 +445,8 @@ describe("refreshExpiredAssetImages", () => {
     vitest.clearAllMocks();
     mockExtractStoragePath.mockReturnValue("org/asset/image.jpg");
     mockCreateSignedUrl.mockResolvedValue("https://new-signed-url.com");
-    mockUpdate.mockResolvedValue({});
+    // Default: the guarded write matches one row (image unchanged since read).
+    mockUpdateMany.mockResolvedValue({ count: 1 });
   });
 
   const makeAsset = (
@@ -474,7 +477,7 @@ describe("refreshExpiredAssetImages", () => {
 
     expect(result).toEqual(assets);
     expect(mockCreateSignedUrl).not.toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
   });
 
   it("refreshes mainImage and thumbnailImage when expired", async () => {
@@ -498,9 +501,15 @@ describe("refreshExpiredAssetImages", () => {
     // The persist now runs in a fire-and-forget background batch, so wait for
     // the flush before asserting the write happened.
     await vi.waitFor(() =>
-      expect(mockUpdate).toHaveBeenCalledWith(
+      expect(mockUpdateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: "asset-1", organizationId: "org-1" },
+          // Guarded on the original mainImage so a concurrent image replace
+          // can't be clobbered by this deferred write.
+          where: {
+            id: "asset-1",
+            organizationId: "org-1",
+            mainImage: "https://old-signed-url.com",
+          },
           data: expect.objectContaining({
             mainImage: "https://new-main-url.com",
             thumbnailImage: "https://new-thumbnail-url.com",
@@ -523,9 +532,13 @@ describe("refreshExpiredAssetImages", () => {
     // The backoff bump is now persisted in the deferred background batch —
     // wait for the flush before asserting the write.
     await vi.waitFor(() =>
-      expect(mockUpdate).toHaveBeenCalledWith(
+      expect(mockUpdateMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { id: "asset-1", organizationId: "org-1" },
+          where: {
+            id: "asset-1",
+            organizationId: "org-1",
+            mainImage: "https://old-signed-url.com",
+          },
           data: expect.objectContaining({
             mainImageExpiration: expect.any(Date),
           }),
@@ -552,7 +565,7 @@ describe("refreshExpiredAssetImages", () => {
 
     // Backoff update is deferred to the background batch — wait for the flush.
     await vi.waitFor(() =>
-      expect(mockUpdate).toHaveBeenCalledWith(
+      expect(mockUpdateMany).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
             mainImageExpiration: expect.any(Date),
@@ -562,39 +575,34 @@ describe("refreshExpiredAssetImages", () => {
     );
   });
 
-  it("returns fresh URLs even when the background persist fails (P2025)", async () => {
-    // Regression guard for the deferred-write refactor: the DB persist runs
-    // fire-and-forget AFTER the response value is built. If the asset was
-    // deleted between the read and the write (P2025), the returned URLs must
-    // still be the freshly re-signed ones and the function must NOT throw — the
-    // next load simply re-signs (idempotent).
-    const { Prisma: ActualPrisma } = await import("@prisma/client");
-    mockUpdate.mockRejectedValue(
-      new ActualPrisma.PrismaClientKnownRequestError(
-        "Record to update not found",
-        { code: "P2025", clientVersion: "5.0.0" }
-      )
-    );
+  it("returns fresh URLs when the row was deleted or its image changed (updateMany count 0)", async () => {
+    // Regression guard for the deferred-write refactor: the persist is a guarded
+    // updateMany that runs fire-and-forget AFTER the response value is built. If
+    // the asset was deleted OR its image was replaced between the read and the
+    // flush, the guard matches no rows and updateMany resolves { count: 0 }
+    // (never throws P2025). The returned URLs must still be the freshly
+    // re-signed ones — the next load simply re-signs (idempotent).
+    mockUpdateMany.mockResolvedValue({ count: 0 });
     const assets = [makeAsset()];
 
     // Resolves (no throw) with the freshly re-signed URL.
     const result = await refreshExpiredAssetImages(assets);
     expect(result[0].mainImage).toBe("https://new-signed-url.com");
 
-    // The (failing) write was still attempted in the background.
-    await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    // The guarded write was still attempted in the background.
+    await vi.waitFor(() => expect(mockUpdateMany).toHaveBeenCalled());
   });
 
-  it("returns fresh URLs even when the background persist fails unexpectedly", async () => {
-    // A non-P2025 write failure (e.g. a pool timeout) is swallowed + logged in
-    // the background and must not affect the returned URLs or throw.
-    mockUpdate.mockRejectedValue(new Error("connection pool timeout"));
+  it("returns fresh URLs even when the background persist throws unexpectedly", async () => {
+    // A non-expected write failure (e.g. a pool timeout) is swallowed + logged
+    // in the background and must not affect the returned URLs or throw.
+    mockUpdateMany.mockRejectedValue(new Error("connection pool timeout"));
     const assets = [makeAsset()];
 
     const result = await refreshExpiredAssetImages(assets);
     expect(result[0].mainImage).toBe("https://new-signed-url.com");
 
-    await vi.waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await vi.waitFor(() => expect(mockUpdateMany).toHaveBeenCalled());
   });
 });
 
@@ -701,12 +709,14 @@ describe("checkOutQuantity — availability accounting", () => {
     mockAssetFindUniqueOrThrow.mockResolvedValue({
       ...lockedAsset,
     });
-    // why: the `refreshExpiredAssetImages` suite earlier in this file
-    // sets `db.asset.update.mockRejectedValue(P2025)`. `clearAllMocks`
-    // only resets call history — the rejection implementation persists
-    // and breaks the new symmetric `tx.asset.update` step inside
-    // `checkOutQuantity`. Restore the resolve.
+    // why: the `refreshExpiredAssetImages` suite earlier in this file leaves
+    // `db.asset.updateMany.mockRejectedValue(...)` set (its last test).
+    // `clearAllMocks` only resets call history — the rejection implementation
+    // persists across suites — so restore both write mocks to a resolve.
     (db.asset.update as ReturnType<typeof vitest.fn>).mockResolvedValue({});
+    (db.asset.updateMany as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      count: 1,
+    });
   });
 
   it("rejects when booking-reserved units push requested qty over available", async () => {
@@ -815,9 +825,12 @@ describe("checkOutQuantity — activity events", () => {
     vitest.clearAllMocks();
     mockLock.mockResolvedValue(lockedAsset);
     // See note on the sibling availability-accounting suite — the
-    // `refreshExpiredAssetImages` test earlier rejects `asset.update`
-    // and that implementation survives `clearAllMocks`.
+    // `refreshExpiredAssetImages` test earlier leaves `asset.updateMany`
+    // rejected, and that implementation survives `clearAllMocks`.
     (db.asset.update as ReturnType<typeof vitest.fn>).mockResolvedValue({});
+    (db.asset.updateMany as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      count: 1,
+    });
   });
 
   it("emits CUSTODY_ASSIGNED with quantity + viaQuantity meta on successful checkout", async () => {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -5268,6 +5268,61 @@ export function isStorageObjectNotFound(error: unknown): boolean {
 }
 
 /**
+ * Process-wide concurrency limiter for background asset-image persists.
+ *
+ * The Prisma connection pool (connection_limit 30) is per-process, so a
+ * per-request write cap gives false protection: N concurrent `/assets` index
+ * loads would each start their own capped batch and the aggregate could still
+ * drain the pool and starve the very reads the deferral is meant to protect
+ * (P2024). Gating every background write through a single module-level counter
+ * guarantees that at most MAX_CONCURRENT_BACKGROUND_PERSISTS writes hold a
+ * connection at any instant, process-wide, regardless of request concurrency.
+ *
+ * A deliberate trade-off vs. a per-write timeout: because Prisma has no query
+ * cancellation, racing each write against a timeout would free the logical slot
+ * while the DB connection stayed held — breaking this very cap. The limiter is
+ * the stronger guarantee (hung writes stay capped at the limit; reads keep the
+ * rest of the pool).
+ */
+const MAX_CONCURRENT_BACKGROUND_PERSISTS = 3;
+
+/** In-flight background persists (0..MAX_CONCURRENT_BACKGROUND_PERSISTS). */
+let activeBackgroundPersists = 0;
+
+/** Resolvers for callers parked until a slot frees up (FIFO). */
+const backgroundPersistWaiters: Array<() => void> = [];
+
+/**
+ * Acquire a background-persist slot, resolving immediately when the process-wide
+ * cap has headroom, or parking the caller in a FIFO queue until a slot frees.
+ *
+ * @returns A promise that resolves once a slot is held by the caller.
+ */
+function acquireBackgroundPersistSlot(): Promise<void> {
+  if (activeBackgroundPersists < MAX_CONCURRENT_BACKGROUND_PERSISTS) {
+    activeBackgroundPersists += 1;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    backgroundPersistWaiters.push(resolve);
+  });
+}
+
+/**
+ * Release a background-persist slot. If a caller is waiting, the slot is handed
+ * straight to it (the active count stays constant); otherwise the active count
+ * is decremented.
+ */
+function releaseBackgroundPersistSlot(): void {
+  const next = backgroundPersistWaiters.shift();
+  if (next) {
+    next();
+  } else {
+    activeBackgroundPersists -= 1;
+  }
+}
+
+/**
  * Refreshes expired signed URLs for asset images server-side.
  * Prevents N+1 client-side calls to /api/asset/refresh-main-image.
  *
@@ -5306,17 +5361,31 @@ export async function refreshExpiredAssetImages<
    * `db.asset.update` burst on this read path was part of what exhausted the
    * Prisma pool (P2024). The response already carries the fresh URLs, so a
    * failed background write is harmless: the next load simply re-signs
-   * (idempotent).
+   * (idempotent). Each entry is an `updateMany` guarded on the original
+   * `mainImage`, so a deferred write can never overwrite an image that changed
+   * between the read and the flush.
    */
-  const pendingWrites: Prisma.AssetUpdateArgs[] = [];
+  const pendingWrites: Array<{
+    assetId: string;
+    args: Prisma.AssetUpdateManyArgs;
+  }> = [];
 
   // Buffer a backoff bump instead of writing it inline. Synchronous now (no DB
   // round-trip on the critical path); the actual write happens in the flush.
+  // Guarded on the original `mainImage` (optimistic concurrency) so a stale
+  // backoff can't land on an image that was replaced between read and flush.
   const applyBackoff = (asset: (typeof expiredAssets)[number]) => {
     const backoffExpiration = new Date(Date.now() + BACKOFF_SECONDS * 1000);
     pendingWrites.push({
-      where: { id: asset.id, organizationId: asset.organizationId },
-      data: { mainImageExpiration: backoffExpiration },
+      assetId: asset.id,
+      args: {
+        where: {
+          id: asset.id,
+          organizationId: asset.organizationId,
+          mainImage: asset.mainImage,
+        },
+        data: { mainImageExpiration: backoffExpiration },
+      },
     });
   };
 
@@ -5373,10 +5442,21 @@ export async function refreshExpiredAssetImages<
       // Defer the persist off the awaited path — buffer the payload and let the
       // single background flush below write it. The response value returned here
       // is independent of whether/when this write lands, so the fresh URLs are
-      // served immediately even if the write later fails.
+      // served immediately even if the write later fails. The `mainImage` guard
+      // makes the write optimistic: if the image was replaced (e.g. by
+      // updateAssetMainImage) between this read and the flush, the guard no
+      // longer matches and the stale re-signed URL is silently skipped instead
+      // of clobbering the newer image.
       pendingWrites.push({
-        where: { id: asset.id, organizationId: asset.organizationId },
-        data: updateData,
+        assetId: asset.id,
+        args: {
+          where: {
+            id: asset.id,
+            organizationId: asset.organizationId,
+            mainImage: asset.mainImage,
+          },
+          data: updateData,
+        },
       });
 
       return {
@@ -5386,13 +5466,10 @@ export async function refreshExpiredAssetImages<
         ...(newThumbnailUrl ? { thumbnailImage: newThumbnailUrl } : {}),
       };
     } catch (error) {
-      // Asset deleted between query and update — not an error
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === "P2025"
-      ) {
-        return null;
-      }
+      // This block only wraps extractStoragePath + createSignedUrl now — the DB
+      // persist was deferred to the background flush — so no Prisma P2025 can
+      // surface here; the flush's guarded updateMany handles deleted/changed
+      // rows (count 0, no throw).
 
       // File deleted from storage — expected, not a bug
       if (isStorageObjectNotFound(error)) {
@@ -5468,47 +5545,44 @@ export async function refreshExpiredAssetImages<
   }
 
   // Flush all buffered writes (re-signed URLs + backoff bumps) OFF the awaited
-  // path in a SINGLE fire-and-forget background task. Serial batches of ≤3 keep
-  // this from re-creating the concurrent write burst that exhausts the Prisma
-  // connection pool (P2024). Running on a long-lived Node server (Fly), the
-  // writes still complete after the response is sent — which is the intent.
-  // Every failure is swallowed and logged (never rethrown): the fresh URL is
-  // already served and the next load simply re-signs, so the write is
-  // idempotent and non-critical.
+  // path in a fire-and-forget background task. Each write goes through the
+  // process-wide persist limiter (acquireBackgroundPersistSlot), so no matter
+  // how many /assets index loads run concurrently the background writes can
+  // never exceed MAX_CONCURRENT_BACKGROUND_PERSISTS connections at once and
+  // starve the reads this deferral protects (P2024). Running on a long-lived
+  // Node server (Fly), the writes still complete after the response is sent —
+  // which is the intent. Every failure is swallowed and logged (never
+  // rethrown): the fresh URL is already served and the next load simply
+  // re-signs, so the write is idempotent and non-critical.
   if (pendingWrites.length > 0) {
-    /** Max concurrent background writes — well under the pool's connection budget. */
-    const PERSIST_CONCURRENCY = 3;
-    void (async () => {
-      for (let i = 0; i < pendingWrites.length; i += PERSIST_CONCURRENCY) {
-        const batch = pendingWrites.slice(i, i + PERSIST_CONCURRENCY);
-        await Promise.all(
-          batch.map((write) =>
-            db.asset.update(write).catch((error: unknown) => {
-              // Asset deleted between query and background write — nothing to
-              // persist, skip silently (same as the inline P2025 handling).
-              if (
-                error instanceof Prisma.PrismaClientKnownRequestError &&
-                error.code === "P2025"
-              ) {
-                return;
-              }
-              // why: URL already served; log as a warning so a persist failure
-              // never becomes an unhandled rejection or a Sentry error.
-              Logger.warn(
-                new ShelfError({
-                  cause: error,
-                  message:
-                    "Background persist of refreshed asset image URLs failed",
-                  additionalData: { assetId: write.where.id },
-                  label: "Assets",
-                  shouldBeCaptured: false,
-                })
-              );
+    void Promise.all(
+      pendingWrites.map(async ({ assetId, args }) => {
+        await acquireBackgroundPersistSlot();
+        try {
+          // updateMany (not update) applies the `mainImage` guard in args.where:
+          // count 0 means the row was deleted OR its image was replaced since
+          // the read, so there is nothing safe to persist. Both are expected
+          // no-ops, and updateMany returns count 0 rather than throwing P2025,
+          // so those cases need no per-write error handling.
+          await db.asset.updateMany(args);
+        } catch (error: unknown) {
+          // why: URL already served; log as a warning so a persist failure
+          // never becomes an unhandled rejection or a Sentry error.
+          Logger.warn(
+            new ShelfError({
+              cause: error,
+              message:
+                "Background persist of refreshed asset image URLs failed",
+              additionalData: { assetId },
+              label: "Assets",
+              shouldBeCaptured: false,
             })
-          )
-        );
-      }
-    })().catch(() => {
+          );
+        } finally {
+          releaseBackgroundPersistSlot();
+        }
+      })
+    ).catch(() => {
       // Extra guard: per-write errors are already swallowed above, but keep the
       // outer background promise from ever surfacing as an unhandled rejection.
     });

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -71,6 +71,7 @@ import {
   formatUnitCount,
   sanitizeUnitOfMeasureLabel,
 } from "~/utils/asset-quantity";
+import { withBackgroundWriteSlot } from "~/utils/background-write-limiter.server";
 import { getLocale } from "~/utils/client-hints";
 import {
   ASSET_MAX_IMAGE_UPLOAD_SIZE,
@@ -5268,61 +5269,6 @@ export function isStorageObjectNotFound(error: unknown): boolean {
 }
 
 /**
- * Process-wide concurrency limiter for background asset-image persists.
- *
- * The Prisma connection pool (connection_limit 30) is per-process, so a
- * per-request write cap gives false protection: N concurrent `/assets` index
- * loads would each start their own capped batch and the aggregate could still
- * drain the pool and starve the very reads the deferral is meant to protect
- * (P2024). Gating every background write through a single module-level counter
- * guarantees that at most MAX_CONCURRENT_BACKGROUND_PERSISTS writes hold a
- * connection at any instant, process-wide, regardless of request concurrency.
- *
- * A deliberate trade-off vs. a per-write timeout: because Prisma has no query
- * cancellation, racing each write against a timeout would free the logical slot
- * while the DB connection stayed held — breaking this very cap. The limiter is
- * the stronger guarantee (hung writes stay capped at the limit; reads keep the
- * rest of the pool).
- */
-const MAX_CONCURRENT_BACKGROUND_PERSISTS = 3;
-
-/** In-flight background persists (0..MAX_CONCURRENT_BACKGROUND_PERSISTS). */
-let activeBackgroundPersists = 0;
-
-/** Resolvers for callers parked until a slot frees up (FIFO). */
-const backgroundPersistWaiters: Array<() => void> = [];
-
-/**
- * Acquire a background-persist slot, resolving immediately when the process-wide
- * cap has headroom, or parking the caller in a FIFO queue until a slot frees.
- *
- * @returns A promise that resolves once a slot is held by the caller.
- */
-function acquireBackgroundPersistSlot(): Promise<void> {
-  if (activeBackgroundPersists < MAX_CONCURRENT_BACKGROUND_PERSISTS) {
-    activeBackgroundPersists += 1;
-    return Promise.resolve();
-  }
-  return new Promise<void>((resolve) => {
-    backgroundPersistWaiters.push(resolve);
-  });
-}
-
-/**
- * Release a background-persist slot. If a caller is waiting, the slot is handed
- * straight to it (the active count stays constant); otherwise the active count
- * is decremented.
- */
-function releaseBackgroundPersistSlot(): void {
-  const next = backgroundPersistWaiters.shift();
-  if (next) {
-    next();
-  } else {
-    activeBackgroundPersists -= 1;
-  }
-}
-
-/**
  * Refreshes expired signed URLs for asset images server-side.
  * Prevents N+1 client-side calls to /api/asset/refresh-main-image.
  *
@@ -5442,11 +5388,14 @@ export async function refreshExpiredAssetImages<
       // Defer the persist off the awaited path — buffer the payload and let the
       // single background flush below write it. The response value returned here
       // is independent of whether/when this write lands, so the fresh URLs are
-      // served immediately even if the write later fails. The `mainImage` guard
-      // makes the write optimistic: if the image was replaced (e.g. by
+      // served immediately even if the write later fails. The guard makes the
+      // write optimistic: if the image was replaced (e.g. by
       // updateAssetMainImage) between this read and the flush, the guard no
       // longer matches and the stale re-signed URL is silently skipped instead
-      // of clobbering the newer image.
+      // of clobbering the newer image. We guard on thumbnailImage too, but only
+      // when this write actually sets one — otherwise a mainImage-only refresh
+      // (thumbnail re-sign failed) would be needlessly skipped by a thumbnail
+      // that changed independently.
       pendingWrites.push({
         assetId: asset.id,
         args: {
@@ -5454,6 +5403,9 @@ export async function refreshExpiredAssetImages<
             id: asset.id,
             organizationId: asset.organizationId,
             mainImage: asset.mainImage,
+            ...(updateData.thumbnailImage !== undefined
+              ? { thumbnailImage: asset.thumbnailImage }
+              : {}),
           },
           data: updateData,
         },
@@ -5546,42 +5498,40 @@ export async function refreshExpiredAssetImages<
 
   // Flush all buffered writes (re-signed URLs + backoff bumps) OFF the awaited
   // path in a fire-and-forget background task. Each write goes through the
-  // process-wide persist limiter (acquireBackgroundPersistSlot), so no matter
-  // how many /assets index loads run concurrently the background writes can
-  // never exceed MAX_CONCURRENT_BACKGROUND_PERSISTS connections at once and
-  // starve the reads this deferral protects (P2024). Running on a long-lived
-  // Node server (Fly), the writes still complete after the response is sent —
-  // which is the intent. Every failure is swallowed and logged (never
-  // rethrown): the fresh URL is already served and the next load simply
-  // re-signs, so the write is idempotent and non-critical.
+  // shared, process-wide background-write limiter (withBackgroundWriteSlot), so
+  // no matter how many /assets index loads run concurrently — or how many other
+  // features defer background writes — the aggregate can never exceed
+  // MAX_CONCURRENT_BACKGROUND_WRITES connections at once and starve the reads
+  // this deferral protects (P2024). Running on a long-lived Node server (Fly),
+  // the writes still complete after the response is sent — which is the intent.
+  // Every failure is swallowed and logged (never rethrown): the fresh URL is
+  // already served and the next load simply re-signs, so the write is
+  // idempotent and non-critical.
   if (pendingWrites.length > 0) {
     void Promise.all(
-      pendingWrites.map(async ({ assetId, args }) => {
-        await acquireBackgroundPersistSlot();
-        try {
-          // updateMany (not update) applies the `mainImage` guard in args.where:
-          // count 0 means the row was deleted OR its image was replaced since
-          // the read, so there is nothing safe to persist. Both are expected
-          // no-ops, and updateMany returns count 0 rather than throwing P2025,
-          // so those cases need no per-write error handling.
-          await db.asset.updateMany(args);
-        } catch (error: unknown) {
-          // why: URL already served; log as a warning so a persist failure
-          // never becomes an unhandled rejection or a Sentry error.
-          Logger.warn(
-            new ShelfError({
-              cause: error,
-              message:
-                "Background persist of refreshed asset image URLs failed",
-              additionalData: { assetId },
-              label: "Assets",
-              shouldBeCaptured: false,
-            })
-          );
-        } finally {
-          releaseBackgroundPersistSlot();
-        }
-      })
+      pendingWrites.map(({ assetId, args }) =>
+        // updateMany (not update) applies the guard in args.where: count 0 means
+        // the row was deleted OR its image changed since the read, so there is
+        // nothing safe to persist. Both are expected no-ops, and updateMany
+        // returns count 0 rather than throwing P2025, so those cases need no
+        // per-write error handling.
+        withBackgroundWriteSlot(() => db.asset.updateMany(args)).catch(
+          (error: unknown) => {
+            // why: URL already served; log as a warning so a persist failure
+            // never becomes an unhandled rejection or a Sentry error.
+            Logger.warn(
+              new ShelfError({
+                cause: error,
+                message:
+                  "Background persist of refreshed asset image URLs failed",
+                additionalData: { assetId },
+                label: "Assets",
+                shouldBeCaptured: false,
+              })
+            );
+          }
+        )
+      )
     ).catch(() => {
       // Extra guard: per-write errors are already swallowed above, but keep the
       // outer background promise from ever surfacing as an unhandled rejection.

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -5298,16 +5298,26 @@ export async function refreshExpiredAssetImages<
   /** Short backoff to prevent retry storms when refresh fails */
   const BACKOFF_SECONDS = 30;
 
-  const applyBackoff = async (asset: (typeof expiredAssets)[number]) => {
-    try {
-      const backoffExpiration = new Date(Date.now() + BACKOFF_SECONDS * 1000);
-      await db.asset.update({
-        where: { id: asset.id, organizationId: asset.organizationId },
-        data: { mainImageExpiration: backoffExpiration },
-      });
-    } catch {
-      // If even the backoff update fails, just move on
-    }
+  /**
+   * DB persist payloads collected while re-signing. Every write this function
+   * would previously `await` inline (the re-signed URLs AND the retry-storm
+   * backoff bumps) is buffered here and flushed OFF the awaited path in a
+   * single background batch after the response value is built — the concurrent
+   * `db.asset.update` burst on this read path was part of what exhausted the
+   * Prisma pool (P2024). The response already carries the fresh URLs, so a
+   * failed background write is harmless: the next load simply re-signs
+   * (idempotent).
+   */
+  const pendingWrites: Prisma.AssetUpdateArgs[] = [];
+
+  // Buffer a backoff bump instead of writing it inline. Synchronous now (no DB
+  // round-trip on the critical path); the actual write happens in the flush.
+  const applyBackoff = (asset: (typeof expiredAssets)[number]) => {
+    const backoffExpiration = new Date(Date.now() + BACKOFF_SECONDS * 1000);
+    pendingWrites.push({
+      where: { id: asset.id, organizationId: asset.organizationId },
+      data: { mainImageExpiration: backoffExpiration },
+    });
   };
 
   const refreshAsset = async (asset: (typeof expiredAssets)[number]) => {
@@ -5315,7 +5325,7 @@ export async function refreshExpiredAssetImages<
       const mainImagePath = extractStoragePath(asset.mainImage!, "assets");
       if (!mainImagePath) {
         // Can't extract path — apply backoff to avoid retrying every load
-        await applyBackoff(asset);
+        applyBackoff(asset);
         return null;
       }
 
@@ -5360,7 +5370,11 @@ export async function refreshExpiredAssetImages<
         updateData.thumbnailImage = newThumbnailUrl;
       }
 
-      await db.asset.update({
+      // Defer the persist off the awaited path — buffer the payload and let the
+      // single background flush below write it. The response value returned here
+      // is independent of whether/when this write lands, so the fresh URLs are
+      // served immediately even if the write later fails.
+      pendingWrites.push({
         where: { id: asset.id, organizationId: asset.organizationId },
         data: updateData,
       });
@@ -5385,7 +5399,7 @@ export async function refreshExpiredAssetImages<
         Logger.info(
           `Image file not found in storage for asset ${asset.id}, applying backoff`
         );
-        await applyBackoff(asset);
+        applyBackoff(asset);
         return null;
       }
 
@@ -5408,7 +5422,7 @@ export async function refreshExpiredAssetImages<
         })
       );
 
-      await applyBackoff(asset);
+      applyBackoff(asset);
       throw error;
     }
   };
@@ -5451,6 +5465,53 @@ export async function refreshExpiredAssetImages<
       }
       refreshedMap.set(result.value.id, entry);
     }
+  }
+
+  // Flush all buffered writes (re-signed URLs + backoff bumps) OFF the awaited
+  // path in a SINGLE fire-and-forget background task. Serial batches of ≤3 keep
+  // this from re-creating the concurrent write burst that exhausts the Prisma
+  // connection pool (P2024). Running on a long-lived Node server (Fly), the
+  // writes still complete after the response is sent — which is the intent.
+  // Every failure is swallowed and logged (never rethrown): the fresh URL is
+  // already served and the next load simply re-signs, so the write is
+  // idempotent and non-critical.
+  if (pendingWrites.length > 0) {
+    /** Max concurrent background writes — well under the pool's connection budget. */
+    const PERSIST_CONCURRENCY = 3;
+    void (async () => {
+      for (let i = 0; i < pendingWrites.length; i += PERSIST_CONCURRENCY) {
+        const batch = pendingWrites.slice(i, i + PERSIST_CONCURRENCY);
+        await Promise.all(
+          batch.map((write) =>
+            db.asset.update(write).catch((error: unknown) => {
+              // Asset deleted between query and background write — nothing to
+              // persist, skip silently (same as the inline P2025 handling).
+              if (
+                error instanceof Prisma.PrismaClientKnownRequestError &&
+                error.code === "P2025"
+              ) {
+                return;
+              }
+              // why: URL already served; log as a warning so a persist failure
+              // never becomes an unhandled rejection or a Sentry error.
+              Logger.warn(
+                new ShelfError({
+                  cause: error,
+                  message:
+                    "Background persist of refreshed asset image URLs failed",
+                  additionalData: { assetId: write.where.id },
+                  label: "Assets",
+                  shouldBeCaptured: false,
+                })
+              );
+            })
+          )
+        );
+      }
+    })().catch(() => {
+      // Extra guard: per-write errors are already swallowed above, but keep the
+      // outer background promise from ever surfacing as an unhandled rejection.
+    });
   }
 
   return assets.map((a) => {

--- a/apps/webapp/app/modules/team-member/service.server.test.ts
+++ b/apps/webapp/app/modules/team-member/service.server.test.ts
@@ -286,10 +286,11 @@ describe("fixTeamMembersNames", () => {
   type Member = Parameters<typeof fixTeamMembersNames>[0][number];
 
   /**
-   * Builds a minimal team-member shaped for `fixTeamMembersNames`. Only the
-   * fields the function reads (`id`, `name`, `organizationId`, `user`) matter;
-   * the rest are filled with plausible defaults and the whole thing is cast to
-   * the private payload type.
+   * Builds a team-member shaped for `fixTeamMembersNames` on top of the shared
+   * `createTeamMember` factory. The factory supplies the real (type-checked)
+   * TeamMember scalar fields — so a schema change surfaces here instead of
+   * silently drifting — and only the narrow `user` projection the function
+   * actually reads (`firstName`/`lastName`/`displayName`/`email`) is layered on.
    */
   const makeMember = (over: {
     id: string;
@@ -299,17 +300,15 @@ describe("fixTeamMembersNames", () => {
       lastName: string | null;
       email: string;
     } | null;
-  }): Member =>
-    ({
+  }): Member => ({
+    ...createTeamMember({
       id: over.id,
-      userId: over.user ? "user-1" : null,
       name: over.name,
       organizationId: "org-1",
-      deletedAt: null,
-      createdAt: new Date("2023-01-01"),
-      updatedAt: new Date("2023-01-01"),
-      user: over.user ? { ...over.user, displayName: null } : null,
-    }) as unknown as Member;
+      userId: over.user ? "user-1" : null,
+    }),
+    user: over.user ? { ...over.user, displayName: null } : null,
+  });
 
   it("updates only user-linked members whose name is blank", async () => {
     const members: Member[] = [

--- a/apps/webapp/app/modules/team-member/service.server.test.ts
+++ b/apps/webapp/app/modules/team-member/service.server.test.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTeamMember } from "@factories";
 
-import { getTeamMember } from "~/modules/team-member/service.server";
+import {
+  fixTeamMembersNames,
+  getTeamMember,
+} from "~/modules/team-member/service.server";
 import { ShelfError } from "~/utils/error";
 
 const dbMocks = vi.hoisted(() => ({
   teamMember: {
     findUniqueOrThrow: vi.fn(),
+    update: vi.fn(),
   },
 }));
 
@@ -15,17 +19,21 @@ vi.mock("~/database/db.server", () => ({
   db: {
     teamMember: {
       findUniqueOrThrow: dbMocks.teamMember.findUniqueOrThrow,
+      update: dbMocks.teamMember.update,
     },
   },
 }));
 
 const mockTeamMemberFindUniqueOrThrow = dbMocks.teamMember.findUniqueOrThrow;
+const mockTeamMemberUpdate = dbMocks.teamMember.update;
 
 const mockTeamMember = createTeamMember();
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockTeamMemberFindUniqueOrThrow.mockReset();
+  mockTeamMemberUpdate.mockReset();
+  mockTeamMemberUpdate.mockResolvedValue({});
 });
 
 describe("getTeamMember", () => {
@@ -270,5 +278,123 @@ describe("getTeamMember", () => {
         expect(shelfError.status).toBe(404);
       }
     });
+  });
+});
+
+describe("fixTeamMembersNames", () => {
+  /** Convenience alias for the (non-exported) element type of the argument. */
+  type Member = Parameters<typeof fixTeamMembersNames>[0][number];
+
+  /**
+   * Builds a minimal team-member shaped for `fixTeamMembersNames`. Only the
+   * fields the function reads (`id`, `name`, `organizationId`, `user`) matter;
+   * the rest are filled with plausible defaults and the whole thing is cast to
+   * the private payload type.
+   */
+  const makeMember = (over: {
+    id: string;
+    name: string;
+    user: {
+      firstName: string | null;
+      lastName: string | null;
+      email: string;
+    } | null;
+  }): Member =>
+    ({
+      id: over.id,
+      userId: over.user ? "user-1" : null,
+      name: over.name,
+      organizationId: "org-1",
+      deletedAt: null,
+      createdAt: new Date("2023-01-01"),
+      updatedAt: new Date("2023-01-01"),
+      user: over.user ? { ...over.user, displayName: null } : null,
+    }) as unknown as Member;
+
+  it("updates only user-linked members whose name is blank", async () => {
+    const members: Member[] = [
+      makeMember({
+        id: "tm-blank-user",
+        name: "",
+        user: { firstName: "Jane", lastName: "Doe", email: "jane@example.com" },
+      }),
+      makeMember({
+        id: "tm-named-user",
+        name: "Already Named",
+        user: { firstName: "John", lastName: "Roe", email: "john@example.com" },
+      }),
+    ];
+
+    await fixTeamMembersNames(members);
+
+    // Only the blank-named, user-linked member is fixed.
+    expect(mockTeamMemberUpdate).toHaveBeenCalledTimes(1);
+    expect(mockTeamMemberUpdate).toHaveBeenCalledWith({
+      where: { id: "tm-blank-user", organizationId: "org-1" },
+      data: { name: "Jane Doe" },
+    });
+  });
+
+  it("ignores NRMs (user === null) even when blank-named", async () => {
+    const members: Member[] = [
+      makeMember({ id: "tm-nrm-blank", name: "", user: null }),
+      makeMember({ id: "tm-nrm-blank-2", name: "   ", user: null }),
+    ];
+
+    await fixTeamMembersNames(members);
+
+    // NRMs cannot be name-fixed; the early-return must not be defeated by them.
+    expect(mockTeamMemberUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no user-linked member is blank-named", async () => {
+    const members: Member[] = [
+      makeMember({
+        id: "tm-named",
+        name: "Has Name",
+        user: { firstName: "A", lastName: "B", email: "a@example.com" },
+      }),
+    ];
+
+    await fixTeamMembersNames(members);
+
+    expect(mockTeamMemberUpdate).not.toHaveBeenCalled();
+  });
+
+  it("derives a name from the email username when the user has no first/last name", async () => {
+    const members: Member[] = [
+      makeMember({
+        id: "tm-email-only",
+        name: "",
+        user: {
+          firstName: null,
+          lastName: null,
+          email: "john.doe@example.com",
+        },
+      }),
+    ];
+
+    await fixTeamMembersNames(members);
+
+    expect(mockTeamMemberUpdate).toHaveBeenCalledWith({
+      where: { id: "tm-email-only", organizationId: "org-1" },
+      data: { name: "John Doe" },
+    });
+  });
+
+  it("does not throw when a DB update fails (runs fire-and-forget)", async () => {
+    // why: the function runs in the background and its callers `void` it, so a
+    // failed update must be caught + logged internally, never rejected.
+    mockTeamMemberUpdate.mockRejectedValue(new Error("db down"));
+
+    const members: Member[] = [
+      makeMember({
+        id: "tm-blank-user",
+        name: "",
+        user: { firstName: "Jane", lastName: "Doe", email: "jane@example.com" },
+      }),
+    ];
+
+    await expect(fixTeamMembersNames(members)).resolves.toBeUndefined();
   });
 });

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -330,8 +330,12 @@ export async function getTeamMemberForCustodianFilter({
       return aName.localeCompare(bName);
     });
 
-    /** Checks and fixes teamMember names if they are broken */
-    await fixTeamMembersNames(teamMembers);
+    /**
+     * Checks and fixes teamMember names if they are broken. Fire-and-forget:
+     * it only writes DB rows (never mutates `teamMembers`) so it must not block
+     * the loader or hold a write-connection on this read path.
+     */
+    void fixTeamMembersNames(teamMembers);
     return {
       teamMembers,
       totalTeamMembers,
@@ -405,7 +409,8 @@ export async function getTeamMemberForForm({
         },
       });
 
-      await fixTeamMembersNames(teamMember ? [teamMember] : []);
+      // Fire-and-forget background cleanup — must not block this loader.
+      void fixTeamMembersNames(teamMember ? [teamMember] : []);
 
       return {
         teamMembers: teamMember ? [teamMember] : [],
@@ -467,7 +472,8 @@ export async function getTeamMemberForForm({
           })
         : null;
 
-      await fixTeamMembersNames(
+      // Fire-and-forget background cleanup — must not block this loader.
+      void fixTeamMembersNames(
         custodianTeamMember ? [custodianTeamMember] : []
       );
 
@@ -705,17 +711,39 @@ function validateTeamMemberName(teamMember: TeamMemberWithUserData) {
 }
 
 /**
- * Fixes team members with invalid names. THis runs as void on the background so it doenst block the main thread
- * @param teamMembers  Array of team members with user data
+ * Fixes team members that have a blank/whitespace-only `name` by deriving one
+ * from their linked user (first/last name, else the email username).
+ *
+ * This is a best-effort DB cleanup — it updates rows only and never mutates the
+ * in-memory `teamMembers` array. User-linked members display via
+ * `resolveUserDisplayName(user)` regardless of the stored `name`, so the result
+ * is invisible to the response. It is therefore invoked **fire-and-forget**
+ * (`void fixTeamMembersNames(...)`) so it never blocks a loader or holds a
+ * write-connection on the critical read path (part of the P2024 pool-exhaustion
+ * fix). All errors are caught and logged here so the returned promise never
+ * rejects — callers can safely `void` it without a `.catch`.
+ *
+ * Only members that are BOTH blank-named AND user-linked are considered: NRMs
+ * (`user === null`) have no user record to derive a name from, so they are
+ * excluded up front — otherwise a blank-named NRM would defeat the early-return
+ * and make this run (and log) for nothing.
+ *
+ * @param teamMembers Array of team members with user data
  */
-async function fixTeamMembersNames(teamMembers: TeamMemberWithUserData[]) {
+export async function fixTeamMembersNames(
+  teamMembers: TeamMemberWithUserData[]
+) {
   try {
-    const teamMembersWithEmptyNames = teamMembers.filter(
-      validateTeamMemberName
+    // Only user-linked blank-named members are fixable — exclude NRMs
+    // (user === null) up front so the early-return below isn't defeated by a
+    // blank-named NRM that can never be fixed anyway.
+    const teamMembersToFix = teamMembers.filter(
+      (teamMember) =>
+        teamMember.user !== null && validateTeamMemberName(teamMember)
     );
 
     /** If there are none, just return */
-    if (teamMembersWithEmptyNames.length === 0) return;
+    if (teamMembersToFix.length === 0) return;
 
     /**
      * Updates team member names by:
@@ -725,34 +753,32 @@ async function fixTeamMembersNames(teamMembers: TeamMemberWithUserData[]) {
      * 4. Using "Unknown" as last resort if no email exists
      */
     await Promise.all(
-      teamMembersWithEmptyNames
-        .filter((teamMember) => teamMember.user !== null)
-        .map((teamMember) => {
-          let name: string;
-          const { firstName, lastName, email } = teamMember.user!;
+      teamMembersToFix.map((teamMember) => {
+        let name: string;
+        const { firstName, lastName, email } = teamMember.user!;
 
-          if (firstName?.trim() || lastName?.trim()) {
-            // At least one name exists - concatenate available names
-            name = [firstName?.trim(), lastName?.trim()]
-              .filter(Boolean)
-              .join(" ");
-          } else {
-            // No names but email exists - use email username
-            name = email.split("@")[0];
-            // Optionally improve email username readability
-            name = name
-              .replace(/[._]/g, " ") // Replace dots/underscores with spaces
-              .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize words
-          }
+        if (firstName?.trim() || lastName?.trim()) {
+          // At least one name exists - concatenate available names
+          name = [firstName?.trim(), lastName?.trim()]
+            .filter(Boolean)
+            .join(" ");
+        } else {
+          // No names but email exists - use email username
+          name = email.split("@")[0];
+          // Optionally improve email username readability
+          name = name
+            .replace(/[._]/g, " ") // Replace dots/underscores with spaces
+            .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize words
+        }
 
-          return db.teamMember.update({
-            where: {
-              id: teamMember.id,
-              organizationId: teamMember.organizationId,
-            },
-            data: { name },
-          });
-        })
+        return db.teamMember.update({
+          where: {
+            id: teamMember.id,
+            organizationId: teamMember.organizationId,
+          },
+          data: { name },
+        });
+      })
     );
 
     /** Log auto-fixed empty names as a warning (not error) since the fix is
@@ -761,17 +787,22 @@ async function fixTeamMembersNames(teamMembers: TeamMemberWithUserData[]) {
       new ShelfError({
         cause: null,
         message: "Team members with empty names found and auto-fixed",
-        additionalData: { teamMembersWithEmptyNames },
+        additionalData: { teamMembersToFix },
         label,
         shouldBeCaptured: false,
       })
     );
   } catch (cause) {
-    throw new ShelfError({
-      cause,
-      message: "Failed to fix team members names",
-      label,
-    });
+    // Runs fire-and-forget in the background, so log instead of rethrowing —
+    // rethrowing here would become an unhandled rejection at the `void` call
+    // sites, and the cleanup is non-critical (next load will retry).
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: "Failed to fix team members names",
+        label,
+      })
+    );
   }
 }
 

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -751,35 +751,43 @@ export async function fixTeamMembersNames(
      * 2. Using just first or last name if one exists
      * 3. Falling back to email username if no name exists
      * 4. Using "Unknown" as last resort if no email exists
+     *
+     * Writes are chunked at WRITE_CONCURRENCY so this background repair can't
+     * fire an unbounded burst of updates (callers may pass getAll:true) — same
+     * connection-pressure rationale as the asset-image background flush.
      */
-    await Promise.all(
-      teamMembersToFix.map((teamMember) => {
-        let name: string;
-        const { firstName, lastName, email } = teamMember.user!;
+    const WRITE_CONCURRENCY = 3;
+    for (let i = 0; i < teamMembersToFix.length; i += WRITE_CONCURRENCY) {
+      const batch = teamMembersToFix.slice(i, i + WRITE_CONCURRENCY);
+      await Promise.all(
+        batch.map((teamMember) => {
+          let name: string;
+          const { firstName, lastName, email } = teamMember.user!;
 
-        if (firstName?.trim() || lastName?.trim()) {
-          // At least one name exists - concatenate available names
-          name = [firstName?.trim(), lastName?.trim()]
-            .filter(Boolean)
-            .join(" ");
-        } else {
-          // No names but email exists - use email username
-          name = email.split("@")[0];
-          // Optionally improve email username readability
-          name = name
-            .replace(/[._]/g, " ") // Replace dots/underscores with spaces
-            .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize words
-        }
+          if (firstName?.trim() || lastName?.trim()) {
+            // At least one name exists - concatenate available names
+            name = [firstName?.trim(), lastName?.trim()]
+              .filter(Boolean)
+              .join(" ");
+          } else {
+            // No names but email exists - use email username
+            name = email.split("@")[0];
+            // Optionally improve email username readability
+            name = name
+              .replace(/[._]/g, " ") // Replace dots/underscores with spaces
+              .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize words
+          }
 
-        return db.teamMember.update({
-          where: {
-            id: teamMember.id,
-            organizationId: teamMember.organizationId,
-          },
-          data: { name },
-        });
-      })
-    );
+          return db.teamMember.update({
+            where: {
+              id: teamMember.id,
+              organizationId: teamMember.organizationId,
+            },
+            data: { name },
+          });
+        })
+      );
+    }
 
     /** Log auto-fixed empty names as a warning (not error) since the fix is
      * applied successfully. Using Logger.warn avoids sending to Sentry. */
@@ -787,7 +795,13 @@ export async function fixTeamMembersNames(
       new ShelfError({
         cause: null,
         message: "Team members with empty names found and auto-fixed",
-        additionalData: { teamMembersToFix },
+        // Log identifiers only — the full records carry user email/first/last
+        // name (PII). shouldBeCaptured:false stops Sentry capture but not
+        // local/log-aggregator retention, so never log the whole array.
+        additionalData: {
+          teamMemberIds: teamMembersToFix.map((tm) => tm.id),
+          count: teamMembersToFix.length,
+        },
         label,
         shouldBeCaptured: false,
       })

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -2,6 +2,7 @@ import type { Organization, Prisma, TeamMember } from "@prisma/client";
 import { BookingStatus, OrganizationRoles } from "@prisma/client";
 import type { LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
+import { withBackgroundWriteSlot } from "~/utils/background-write-limiter.server";
 import { updateCookieWithPerPage } from "~/utils/cookies.server";
 import type { ErrorLabel } from "~/utils/error";
 import { isNotFoundError, ShelfError } from "~/utils/error";
@@ -752,42 +753,42 @@ export async function fixTeamMembersNames(
      * 3. Falling back to email username if no name exists
      * 4. Using "Unknown" as last resort if no email exists
      *
-     * Writes are chunked at WRITE_CONCURRENCY so this background repair can't
-     * fire an unbounded burst of updates (callers may pass getAll:true) — same
-     * connection-pressure rationale as the asset-image background flush.
+     * Each write runs through the shared, process-wide background-write limiter
+     * so this repair (callers may pass getAll:true) can't fire an unbounded
+     * burst of updates, and shares one connection budget with the other
+     * deferred-write paths (e.g. the asset-image flush) rather than adding a
+     * second independent cap.
      */
-    const WRITE_CONCURRENCY = 3;
-    for (let i = 0; i < teamMembersToFix.length; i += WRITE_CONCURRENCY) {
-      const batch = teamMembersToFix.slice(i, i + WRITE_CONCURRENCY);
-      await Promise.all(
-        batch.map((teamMember) => {
-          let name: string;
-          const { firstName, lastName, email } = teamMember.user!;
+    await Promise.all(
+      teamMembersToFix.map((teamMember) => {
+        let name: string;
+        const { firstName, lastName, email } = teamMember.user!;
 
-          if (firstName?.trim() || lastName?.trim()) {
-            // At least one name exists - concatenate available names
-            name = [firstName?.trim(), lastName?.trim()]
-              .filter(Boolean)
-              .join(" ");
-          } else {
-            // No names but email exists - use email username
-            name = email.split("@")[0];
-            // Optionally improve email username readability
-            name = name
-              .replace(/[._]/g, " ") // Replace dots/underscores with spaces
-              .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize words
-          }
+        if (firstName?.trim() || lastName?.trim()) {
+          // At least one name exists - concatenate available names
+          name = [firstName?.trim(), lastName?.trim()]
+            .filter(Boolean)
+            .join(" ");
+        } else {
+          // No names but email exists - use email username
+          name = email.split("@")[0];
+          // Optionally improve email username readability
+          name = name
+            .replace(/[._]/g, " ") // Replace dots/underscores with spaces
+            .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize words
+        }
 
-          return db.teamMember.update({
+        return withBackgroundWriteSlot(() =>
+          db.teamMember.update({
             where: {
               id: teamMember.id,
               organizationId: teamMember.organizationId,
             },
             data: { name },
-          });
-        })
-      );
-    }
+          })
+        );
+      })
+    );
 
     /** Log auto-fixed empty names as a warning (not error) since the fix is
      * applied successfully. Using Logger.warn avoids sending to Sentry. */

--- a/apps/webapp/app/utils/background-write-limiter.server.test.ts
+++ b/apps/webapp/app/utils/background-write-limiter.server.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MAX_CONCURRENT_BACKGROUND_WRITES,
+  withBackgroundWriteSlot,
+} from "./background-write-limiter.server";
+
+describe("withBackgroundWriteSlot", () => {
+  it("runs the task and returns its resolved value", async () => {
+    await expect(
+      withBackgroundWriteSlot(() => Promise.resolve(42))
+    ).resolves.toBe(42);
+  });
+
+  it("releases the slot and rethrows when the task rejects", async () => {
+    await expect(
+      withBackgroundWriteSlot(() => Promise.reject(new Error("boom")))
+    ).rejects.toThrow("boom");
+
+    // The slot must have been released despite the rejection — a later task
+    // still acquires and runs.
+    await expect(
+      withBackgroundWriteSlot(() => Promise.resolve("ok"))
+    ).resolves.toBe("ok");
+  });
+
+  it("never runs more than MAX_CONCURRENT_BACKGROUND_WRITES tasks at once", async () => {
+    let active = 0;
+    let peak = 0;
+    let releaseAll!: () => void;
+    // All tasks park on this shared barrier so we can hold every acquired slot
+    // open at the same time and observe the peak concurrency.
+    const barrier = new Promise<void>((resolve) => {
+      releaseAll = resolve;
+    });
+
+    const task = () =>
+      withBackgroundWriteSlot(async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await barrier;
+        active -= 1;
+      });
+
+    // Launch more tasks than the cap; the excess must queue.
+    const total = MAX_CONCURRENT_BACKGROUND_WRITES + 2;
+    const running = Array.from({ length: total }, task);
+
+    // Only the cap's worth of tasks may hold a slot before we release anything.
+    await vi.waitFor(() =>
+      expect(active).toBe(MAX_CONCURRENT_BACKGROUND_WRITES)
+    );
+    expect(peak).toBe(MAX_CONCURRENT_BACKGROUND_WRITES);
+
+    releaseAll();
+    await Promise.all(running);
+
+    // The queued tasks drained through, but the cap was never exceeded.
+    expect(peak).toBe(MAX_CONCURRENT_BACKGROUND_WRITES);
+  });
+});

--- a/apps/webapp/app/utils/background-write-limiter.server.ts
+++ b/apps/webapp/app/utils/background-write-limiter.server.ts
@@ -1,0 +1,89 @@
+/**
+ * Background-write concurrency limiter (process-wide).
+ *
+ * Some loader/read paths defer non-critical DB writes to a fire-and-forget
+ * background task so they don't hold a Prisma connection on the awaited path
+ * (part of the P2024 pool-exhaustion fix — see
+ * {@link file://./../modules/asset/service.server.ts} `refreshExpiredAssetImages`
+ * and {@link file://./../modules/team-member/service.server.ts}
+ * `fixTeamMembersNames`).
+ *
+ * The Prisma connection pool (connection_limit 30) is per-process, so a
+ * per-request or per-feature write cap gives false protection: N concurrent
+ * requests — or two different features each capping themselves at 3 — could
+ * still aggregate into a burst that drains the pool and starves the very reads
+ * the deferral is meant to protect. Routing EVERY background write through this
+ * single module-level budget guarantees that no more than
+ * {@link MAX_CONCURRENT_BACKGROUND_WRITES} background writes hold a connection
+ * at any instant, process-wide, across all features and all requests.
+ *
+ * Deliberate trade-off vs. a per-write timeout: because Prisma has no query
+ * cancellation, racing each write against a timeout would free the logical slot
+ * while the DB connection stayed held — breaking this very cap. The limiter is
+ * the stronger guarantee (hung writes stay capped; reads keep the rest of the
+ * pool).
+ *
+ * @see {@link file://./../modules/asset/service.server.ts}
+ * @see {@link file://./../modules/team-member/service.server.ts}
+ */
+
+/** Max background writes allowed to hold a connection at once, process-wide. */
+export const MAX_CONCURRENT_BACKGROUND_WRITES = 3;
+
+/** In-flight background writes (0..MAX_CONCURRENT_BACKGROUND_WRITES). */
+let activeBackgroundWrites = 0;
+
+/** Resolvers for callers parked until a slot frees up (FIFO). */
+const backgroundWriteWaiters: Array<() => void> = [];
+
+/**
+ * Acquire a background-write slot, resolving immediately when the process-wide
+ * cap has headroom, or parking the caller in a FIFO queue until a slot frees.
+ *
+ * The capacity check and increment run synchronously with no `await` between
+ * them, so — JS being single-threaded — there is no check-then-act race.
+ *
+ * @returns A promise that resolves once a slot is held by the caller.
+ */
+function acquireBackgroundWriteSlot(): Promise<void> {
+  if (activeBackgroundWrites < MAX_CONCURRENT_BACKGROUND_WRITES) {
+    activeBackgroundWrites += 1;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    backgroundWriteWaiters.push(resolve);
+  });
+}
+
+/**
+ * Release a background-write slot. If a caller is waiting, the slot is handed
+ * straight to it (the active count stays constant); otherwise the active count
+ * is decremented.
+ */
+function releaseBackgroundWriteSlot(): void {
+  const next = backgroundWriteWaiters.shift();
+  if (next) {
+    next();
+  } else {
+    activeBackgroundWrites -= 1;
+  }
+}
+
+/**
+ * Run `fn` while holding a process-wide background-write slot, releasing the
+ * slot whether `fn` resolves or rejects. Errors propagate to the caller so each
+ * call site decides how to handle a failed background write.
+ *
+ * @param fn - The background write to run under the shared concurrency budget.
+ * @returns The resolved value of `fn`.
+ */
+export async function withBackgroundWriteSlot<T>(
+  fn: () => Promise<T>
+): Promise<T> {
+  await acquireBackgroundWriteSlot();
+  try {
+    return await fn();
+  } finally {
+    releaseBackgroundWriteSlot();
+  }
+}


### PR DESCRIPTION
The GET /assets.data loader fans out ~30 concurrent DB queries per request, so a burst of concurrent advanced-index loads exhausts the 30-connection Prisma pool (P2024). Two conditional WRITES still sat on that synchronous read path; move both off it. No change to what the response renders.

- refreshExpiredAssetImages: keep re-signing expired image URLs synchronously (response still carries fresh URLs), but defer the db.asset.update persistence and backoff bumps into a single fire-and-forget background flush, batched at <=3 concurrent so it can't recreate a write burst. A failed background write is harmless: the URL is already served and the next load re-signs (idempotent).
- fixTeamMembersNames: invoke it fire-and-forget at its 3 loader call sites (it only writes DB rows, never mutates the returned array; user-linked members display via resolveUserDisplayName regardless) and skip blank-named NRMs.

First of a layered fix; the loader fan-out cap and scheduler/connection sizing are tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Asset image refreshes now respond quickly while persistence happens asynchronously in the background, with concurrency limiting to keep writes efficient.
  * Team member name cleanup now runs as fire-and-forget background work to keep load/form reads fast.

* **Reliability**
  * Background persistence issues are logged and no longer affect refreshed image URLs or signing flow.
  * Team member name repair targets only user-linked blank/whitespace names, safely handling missing data and DB failures.

* **Tests**
  * Expanded coverage for deferred background writes, including the background write concurrency limiter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->