### PR TITLE
fix(working-hours): race-safe first-access create + retry-wiring regression guard

### DIFF
--- a/apps/webapp/app/modules/booking-settings/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.test.ts
@@ -3,6 +3,7 @@ import { ShelfError } from "~/utils/error";
 
 import {
   BOOKING_SETTINGS_SELECT,
+  getBookingNotificationSettingsForOrg,
   getBookingSettingsForOrganization,
   updateBookingSettings,
 } from "./service.server";
@@ -15,6 +16,7 @@ vitest.mock("~/database/db.server", () => ({
   db: {
     bookingSettings: {
       findUnique: vitest.fn(),
+      findUniqueOrThrow: vitest.fn(),
       upsert: vitest.fn(),
       update: vitest.fn(),
     },
@@ -124,6 +126,33 @@ describe("getBookingSettingsForOrganization", () => {
       message: "Failed to retrieve booking settings configuration",
       additionalData: { organizationId: mockOrganizationId },
     });
+  });
+
+  it("recovers from a concurrent-create P2002 by re-reading the row", async () => {
+    expect.assertions(2);
+    // BOOKING_SETTINGS_SELECT returns a nested relation, so Prisma emulates the
+    // upsert (read + create) and a concurrent first-hit can lose the race and
+    // throw P2002. The function must then re-read the row the winner created,
+    // not surface the unique-constraint error.
+    const p2002 = Object.assign(new Error("Unique constraint failed"), {
+      code: "P2002",
+    });
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.findUnique.mockResolvedValue(null);
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.upsert.mockRejectedValue(p2002);
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.findUniqueOrThrow.mockResolvedValue(
+      mockBookingSettingsData
+    );
+
+    const result = await getBookingSettingsForOrganization(mockOrganizationId);
+
+    expect(db.bookingSettings.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { organizationId: mockOrganizationId },
+      select: BOOKING_SETTINGS_SELECT,
+    });
+    expect(result).toEqual(mockBookingSettingsData);
   });
 
   it("should throw ShelfError when the upsert fallback fails", async () => {
@@ -780,5 +809,63 @@ describe("updateBookingSettings", () => {
         maxBookingLength: 168,
       },
     });
+  });
+});
+
+describe("getBookingNotificationSettingsForOrg", () => {
+  const mockNotificationSettings = {
+    notifyBookingCreator: true,
+    notifyAdminsOnNewBooking: true,
+    alwaysNotifyTeamMembers: [],
+  };
+
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("upserts and returns the notification settings", async () => {
+    expect.assertions(2);
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.upsert.mockResolvedValue(mockNotificationSettings);
+
+    const result =
+      await getBookingNotificationSettingsForOrg(mockOrganizationId);
+
+    expect(db.bookingSettings.upsert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(mockNotificationSettings);
+  });
+
+  it("recovers from a concurrent-create P2002 by re-reading the row", async () => {
+    expect.assertions(2);
+    // The notification select returns a nested relation (alwaysNotifyTeamMembers),
+    // so Prisma emulates the upsert and a concurrent first-hit can throw P2002.
+    const p2002 = Object.assign(new Error("Unique constraint failed"), {
+      code: "P2002",
+    });
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.upsert.mockRejectedValue(p2002);
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.findUniqueOrThrow.mockResolvedValue(
+      mockNotificationSettings
+    );
+
+    const result =
+      await getBookingNotificationSettingsForOrg(mockOrganizationId);
+
+    expect(db.bookingSettings.findUniqueOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { organizationId: mockOrganizationId } })
+    );
+    expect(result).toEqual(mockNotificationSettings);
+  });
+
+  it("wraps a non-P2002 failure in a ShelfError", async () => {
+    expect.assertions(2);
+    //@ts-expect-error missing vitest type
+    db.bookingSettings.upsert.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      getBookingNotificationSettingsForOrg(mockOrganizationId)
+    ).rejects.toBeInstanceOf(ShelfError);
+    expect(db.bookingSettings.findUniqueOrThrow).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/booking-settings/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.test.ts
@@ -2,6 +2,7 @@ import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 
 import {
+  BOOKING_NOTIFICATION_SETTINGS_SELECT,
   BOOKING_SETTINGS_SELECT,
   getBookingNotificationSettingsForOrg,
   getBookingSettingsForOrganization,
@@ -852,9 +853,12 @@ describe("getBookingNotificationSettingsForOrg", () => {
     const result =
       await getBookingNotificationSettingsForOrg(mockOrganizationId);
 
-    expect(db.bookingSettings.findUniqueOrThrow).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { organizationId: mockOrganizationId } })
-    );
+    // Exact-match the re-read args (where + select) so the "single source of
+    // truth" select can't drift between the upsert and the P2002 recovery.
+    expect(db.bookingSettings.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { organizationId: mockOrganizationId },
+      select: BOOKING_NOTIFICATION_SETTINGS_SELECT,
+    });
     expect(result).toEqual(mockNotificationSettings);
   });
 

--- a/apps/webapp/app/modules/booking-settings/service.server.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.ts
@@ -45,6 +45,32 @@ export const BOOKING_SETTINGS_SELECT = {
 } satisfies Prisma.BookingSettingsSelect;
 
 /**
+ * Lean `select` for the notification-only booking settings.
+ *
+ * Hoisted so the `upsert` in {@link getBookingNotificationSettingsForOrg} and
+ * its `P2002` re-read return the exact same shape (single source of truth).
+ */
+const BOOKING_NOTIFICATION_SETTINGS_SELECT = {
+  notifyBookingCreator: true,
+  notifyAdminsOnNewBooking: true,
+  alwaysNotifyTeamMembers: {
+    select: {
+      id: true,
+      name: true,
+      user: {
+        select: {
+          id: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+          profilePicture: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.BookingSettingsSelect;
+
+/**
  * Retrieves the `BookingSettings` row for an organization, creating a
  * default row only on first access.
  *
@@ -53,10 +79,11 @@ export const BOOKING_SETTINGS_SELECT = {
  * and React Router `.data` revalidation. It is deliberately **read-first**:
  * a plain `findUnique` satisfies the overwhelming majority of calls (the row
  * almost always already exists), avoiding an unconditional write + row lock
- * on every request. Only when the row is genuinely absent do we fall
- * through to an `upsert` (not a bare `create`) so two concurrent first
- * requests for the same organization can't race into a unique-constraint
- * error.
+ * on every request. Only when the row is genuinely absent do we fall through
+ * to an `upsert` that also catches `P2002` and re-reads, so two concurrent
+ * first requests for the same organization can't race into a unique-constraint
+ * error (the upsert emulates a read + create because it returns a nested
+ * relation, so it isn't atomic on its own).
  *
  * @param organizationId - The organization whose settings to fetch
  * @returns The organization's booking settings, creating defaults if absent
@@ -77,33 +104,46 @@ export async function getBookingSettingsForOrganization(
       return existing;
     }
 
-    // Cold path: first access for this organization. Use `upsert` (not
-    // `create`) so a concurrent first-hit from another request doesn't
-    // throw a unique-constraint error.
-    const bookingSettings = await db.bookingSettings.upsert({
-      where: {
-        organizationId,
-      },
-      update: {},
-      create: {
-        bufferStartTime: 0,
-        maxBookingLength: null,
-        maxBookingLengthSkipClosedDays: false,
-        tagsRequired: false,
-        autoArchiveBookings: false,
-        autoArchiveDays: 2,
-        autoArchiveExpiredReservations: false,
-        requireExplicitCheckinForAdmin: false,
-        requireExplicitCheckinForSelfService: false,
-        countKitsAsSingleUnit: false,
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-        organizationId,
-      },
-      select: BOOKING_SETTINGS_SELECT,
-    });
-
-    return bookingSettings;
+    // Cold path: first access for this organization. `upsert` (not `create`)
+    // makes a concurrent first-hit idempotent — but because this returns a
+    // nested relation (`alwaysNotifyTeamMembers` in BOOKING_SETTINGS_SELECT),
+    // Prisma emulates the upsert with a separate read + create rather than a
+    // native atomic `INSERT … ON CONFLICT`, so a concurrent create can still
+    // throw P2002. Catch it and re-read the row the winning request created.
+    try {
+      return await db.bookingSettings.upsert({
+        where: {
+          organizationId,
+        },
+        update: {},
+        create: {
+          bufferStartTime: 0,
+          maxBookingLength: null,
+          maxBookingLengthSkipClosedDays: false,
+          tagsRequired: false,
+          autoArchiveBookings: false,
+          autoArchiveDays: 2,
+          autoArchiveExpiredReservations: false,
+          requireExplicitCheckinForAdmin: false,
+          requireExplicitCheckinForSelfService: false,
+          countKitsAsSingleUnit: false,
+          notifyBookingCreator: true,
+          notifyAdminsOnNewBooking: true,
+          organizationId,
+        },
+        select: BOOKING_SETTINGS_SELECT,
+      });
+    } catch (cause) {
+      if (cause instanceof Error && "code" in cause && cause.code === "P2002") {
+        // `await` so a (rare) re-read failure is caught by the outer try and
+        // wrapped in a ShelfError rather than escaping as a bare rejection.
+        return await db.bookingSettings.findUniqueOrThrow({
+          where: { organizationId },
+          select: BOOKING_SETTINGS_SELECT,
+        });
+      }
+      throw cause;
+    }
   } catch (cause) {
     throw new ShelfError({
       cause,
@@ -209,8 +249,11 @@ export async function updateBookingSettings({
  * config, etc.) to keep the notification resolver lightweight and avoid
  * pulling unnecessary data on every booking email.
  *
- * Uses `upsert` to lazily create default settings if the organization
- * doesn't have a `BookingSettings` row yet.
+ * Uses `upsert` to lazily create default settings if the organization doesn't
+ * have a `BookingSettings` row yet. Because the select returns a nested
+ * relation (`alwaysNotifyTeamMembers`), Prisma emulates the upsert with a
+ * separate read + create, so a concurrent first-hit can throw `P2002`; we catch
+ * it and re-read (same as {@link getBookingSettingsForOrganization}).
  *
  * @param organizationId - The organization whose settings to fetch
  * @returns Notification flags and the always-notify team member list
@@ -219,34 +262,28 @@ export async function getBookingNotificationSettingsForOrg(
   organizationId: string
 ) {
   try {
-    return await db.bookingSettings.upsert({
-      where: { organizationId },
-      update: {},
-      create: {
-        organizationId,
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-      },
-      select: {
-        notifyBookingCreator: true,
-        notifyAdminsOnNewBooking: true,
-        alwaysNotifyTeamMembers: {
-          select: {
-            id: true,
-            name: true,
-            user: {
-              select: {
-                id: true,
-                email: true,
-                firstName: true,
-                lastName: true,
-                profilePicture: true,
-              },
-            },
-          },
+    try {
+      return await db.bookingSettings.upsert({
+        where: { organizationId },
+        update: {},
+        create: {
+          organizationId,
+          notifyBookingCreator: true,
+          notifyAdminsOnNewBooking: true,
         },
-      },
-    });
+        select: BOOKING_NOTIFICATION_SETTINGS_SELECT,
+      });
+    } catch (cause) {
+      if (cause instanceof Error && "code" in cause && cause.code === "P2002") {
+        // `await` so a (rare) re-read failure is caught by the outer try and
+        // wrapped in a ShelfError rather than escaping as a bare rejection.
+        return await db.bookingSettings.findUniqueOrThrow({
+          where: { organizationId },
+          select: BOOKING_NOTIFICATION_SETTINGS_SELECT,
+        });
+      }
+      throw cause;
+    }
   } catch (cause) {
     throw new ShelfError({
       cause,

--- a/apps/webapp/app/modules/booking-settings/service.server.ts
+++ b/apps/webapp/app/modules/booking-settings/service.server.ts
@@ -50,7 +50,7 @@ export const BOOKING_SETTINGS_SELECT = {
  * Hoisted so the `upsert` in {@link getBookingNotificationSettingsForOrg} and
  * its `P2002` re-read return the exact same shape (single source of truth).
  */
-const BOOKING_NOTIFICATION_SETTINGS_SELECT = {
+export const BOOKING_NOTIFICATION_SETTINGS_SELECT = {
   notifyBookingCreator: true,
   notifyAdminsOnNewBooking: true,
   alwaysNotifyTeamMembers: {

--- a/apps/webapp/app/modules/working-hours/service.server.test.ts
+++ b/apps/webapp/app/modules/working-hours/service.server.test.ts
@@ -1,0 +1,119 @@
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+
+import {
+  createDefaultWorkingHours,
+  getDefaultWeeklySchedule,
+  getWorkingHoursForOrganization,
+} from "./service.server";
+
+// @vitest-environment node
+// 👋 see https://vitest.dev/guide/environment.html#environments-for-specific-files
+
+// why: testing working-hours service logic without executing actual database operations
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    workingHours: {
+      findUnique: vitest.fn(),
+      upsert: vitest.fn(),
+    },
+  },
+}));
+
+const mockOrganizationId = "org-1";
+
+const mockWorkingHoursData = {
+  id: "working-hours-1",
+  enabled: true,
+  weeklySchedule: getDefaultWeeklySchedule(),
+  organizationId: mockOrganizationId,
+  overrides: [],
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+};
+
+/** The exact args the cold-path/helper must pass to keep the write race-safe. */
+const EXPECTED_UPSERT_ARGS = {
+  where: { organizationId: mockOrganizationId },
+  update: {},
+  create: {
+    organizationId: mockOrganizationId,
+    enabled: false,
+    weeklySchedule: getDefaultWeeklySchedule(),
+  },
+  include: { overrides: { orderBy: { date: "asc" } } },
+};
+
+describe("getWorkingHoursForOrganization", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    // why: default the read-first lookup to "not found" so the cold-path tests
+    // don't have to restate it; the existing-row test overrides this.
+    //@ts-expect-error missing vitest type
+    db.workingHours.findUnique.mockResolvedValue(null);
+  });
+
+  it("returns the existing row without writing when one is found", async () => {
+    expect.assertions(3);
+    //@ts-expect-error missing vitest type
+    db.workingHours.findUnique.mockResolvedValue(mockWorkingHoursData);
+
+    const result = await getWorkingHoursForOrganization(mockOrganizationId);
+
+    expect(db.workingHours.findUnique).toHaveBeenCalledWith({
+      where: { organizationId: mockOrganizationId },
+      include: { overrides: { orderBy: { date: "asc" } } },
+    });
+    // why: the read-first path must never take a write lock when the row
+    // already exists — this is the connection-pool-exhaustion regression guard.
+    expect(db.workingHours.upsert).not.toHaveBeenCalled();
+    expect(result).toEqual(mockWorkingHoursData);
+  });
+
+  it("creates defaults via a race-safe upsert when none exist", async () => {
+    expect.assertions(2);
+    const defaultRow = { ...mockWorkingHoursData, enabled: false };
+    //@ts-expect-error missing vitest type
+    db.workingHours.findUnique.mockResolvedValue(null);
+    //@ts-expect-error missing vitest type
+    db.workingHours.upsert.mockResolvedValue(defaultRow);
+
+    const result = await getWorkingHoursForOrganization(mockOrganizationId);
+
+    // why: cold path must use upsert (not a bare create) with `update: {}` so
+    // two concurrent first requests can't race a unique-constraint violation on
+    // WorkingHours.organizationId.
+    expect(db.workingHours.upsert).toHaveBeenCalledWith(EXPECTED_UPSERT_ARGS);
+    expect(result).toEqual(defaultRow);
+  });
+
+  it("wraps a database failure in a ShelfError", async () => {
+    expect.assertions(2);
+    //@ts-expect-error missing vitest type
+    db.workingHours.findUnique.mockRejectedValue(new Error("db down"));
+
+    await expect(
+      getWorkingHoursForOrganization(mockOrganizationId)
+    ).rejects.toBeInstanceOf(ShelfError);
+    expect(db.workingHours.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDefaultWorkingHours", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("upserts (idempotent) instead of a bare create", async () => {
+    expect.assertions(1);
+    //@ts-expect-error missing vitest type
+    db.workingHours.upsert.mockResolvedValue(mockWorkingHoursData);
+
+    await createDefaultWorkingHours(mockOrganizationId);
+
+    // why: this shared helper is reached from three separate find-then-create
+    // call sites; making it an upsert makes all of them race-safe at once
+    // (update:{} = no-op when a concurrent request already created the row).
+    expect(db.workingHours.upsert).toHaveBeenCalledWith(EXPECTED_UPSERT_ARGS);
+  });
+});

--- a/apps/webapp/app/modules/working-hours/service.server.test.ts
+++ b/apps/webapp/app/modules/working-hours/service.server.test.ts
@@ -16,6 +16,7 @@ vitest.mock("~/database/db.server", () => ({
     workingHours: {
       findUnique: vitest.fn(),
       upsert: vitest.fn(),
+      findUniqueOrThrow: vitest.fn(),
     },
   },
 }));
@@ -32,7 +33,10 @@ const mockWorkingHoursData = {
   updatedAt: new Date("2024-01-01T00:00:00.000Z"),
 };
 
-/** The exact args the cold-path/helper must pass to keep the write race-safe. */
+/** The include the cold path uses both for the upsert and the P2002 re-read. */
+const OVERRIDES_INCLUDE = { overrides: { orderBy: { date: "asc" } } };
+
+/** The exact guarded upsert args the cold path / helper must pass. */
 const EXPECTED_UPSERT_ARGS = {
   where: { organizationId: mockOrganizationId },
   update: {},
@@ -41,8 +45,15 @@ const EXPECTED_UPSERT_ARGS = {
     enabled: false,
     weeklySchedule: getDefaultWeeklySchedule(),
   },
-  include: { overrides: { orderBy: { date: "asc" } } },
+  include: OVERRIDES_INCLUDE,
 };
+
+/** Builds a P2002 unique-constraint error the way Prisma raises one. */
+function p2002Error() {
+  return Object.assign(new Error("Unique constraint failed"), {
+    code: "P2002",
+  });
+}
 
 describe("getWorkingHoursForOrganization", () => {
   beforeEach(() => {
@@ -62,7 +73,7 @@ describe("getWorkingHoursForOrganization", () => {
 
     expect(db.workingHours.findUnique).toHaveBeenCalledWith({
       where: { organizationId: mockOrganizationId },
-      include: { overrides: { orderBy: { date: "asc" } } },
+      include: OVERRIDES_INCLUDE,
     });
     // why: the read-first path must never take a write lock when the row
     // already exists — this is the connection-pool-exhaustion regression guard.
@@ -70,7 +81,7 @@ describe("getWorkingHoursForOrganization", () => {
     expect(result).toEqual(mockWorkingHoursData);
   });
 
-  it("creates defaults via a race-safe upsert when none exist", async () => {
+  it("creates defaults via the guarded upsert when none exist", async () => {
     expect.assertions(2);
     const defaultRow = { ...mockWorkingHoursData, enabled: false };
     //@ts-expect-error missing vitest type
@@ -80,9 +91,9 @@ describe("getWorkingHoursForOrganization", () => {
 
     const result = await getWorkingHoursForOrganization(mockOrganizationId);
 
-    // why: cold path must use upsert (not a bare create) with `update: {}` so
-    // two concurrent first requests can't race a unique-constraint violation on
-    // WorkingHours.organizationId.
+    // Query contract: the cold path must upsert with `update: {}` (the actual
+    // race recovery — losing the create race — is covered by the P2002 test
+    // in the createDefaultWorkingHours suite).
     expect(db.workingHours.upsert).toHaveBeenCalledWith(EXPECTED_UPSERT_ARGS);
     expect(result).toEqual(defaultRow);
   });
@@ -104,16 +115,51 @@ describe("createDefaultWorkingHours", () => {
     vitest.clearAllMocks();
   });
 
-  it("upserts (idempotent) instead of a bare create", async () => {
+  it("passes the guarded upsert args (update:{}) to keep the create idempotent", async () => {
     expect.assertions(1);
     //@ts-expect-error missing vitest type
     db.workingHours.upsert.mockResolvedValue(mockWorkingHoursData);
 
     await createDefaultWorkingHours(mockOrganizationId);
 
-    // why: this shared helper is reached from three separate find-then-create
-    // call sites; making it an upsert makes all of them race-safe at once
-    // (update:{} = no-op when a concurrent request already created the row).
+    // Query contract only — reached from three find-then-create call sites
+    // (loader, override creator, admin dashboard); `update: {}` makes a
+    // concurrent second call a no-op that returns the existing row.
     expect(db.workingHours.upsert).toHaveBeenCalledWith(EXPECTED_UPSERT_ARGS);
+  });
+
+  it("recovers from a concurrent-create P2002 by re-reading the row", async () => {
+    expect.assertions(2);
+    // The `include` forces Prisma to emulate the upsert (read + create), so a
+    // concurrent first-hit can lose the race and throw P2002. The function must
+    // then re-read the row the winner created rather than surface the error —
+    // this is the actual race-safety behavior, not just the query shape.
+    const existingRow = { ...mockWorkingHoursData, enabled: false };
+    //@ts-expect-error missing vitest type
+    db.workingHours.upsert.mockRejectedValue(p2002Error());
+    //@ts-expect-error missing vitest type
+    db.workingHours.findUniqueOrThrow.mockResolvedValue(existingRow);
+
+    const result = await createDefaultWorkingHours(mockOrganizationId);
+
+    expect(db.workingHours.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { organizationId: mockOrganizationId },
+      include: OVERRIDES_INCLUDE,
+    });
+    expect(result).toEqual(existingRow);
+  });
+
+  it("re-throws a non-P2002 database error without re-reading", async () => {
+    expect.assertions(2);
+    const dbError = Object.assign(new Error("connection reset"), {
+      code: "P1001",
+    });
+    //@ts-expect-error missing vitest type
+    db.workingHours.upsert.mockRejectedValue(dbError);
+
+    await expect(createDefaultWorkingHours(mockOrganizationId)).rejects.toBe(
+      dbError
+    );
+    expect(db.workingHours.findUniqueOrThrow).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/working-hours/service.server.ts
+++ b/apps/webapp/app/modules/working-hours/service.server.ts
@@ -4,11 +4,30 @@ import type { WeeklyScheduleForUpdate } from "./types";
 
 const label = "Working hours";
 
+/**
+ * Ensures a default `WorkingHours` row exists for an organization and returns
+ * it (with overrides).
+ *
+ * Uses `upsert` (not a bare `create`) so it is idempotent and race-safe. Every
+ * caller reaches this through a check-then-create ("find, create if absent")
+ * path — the authenticated layout loader cold path
+ * ({@link getWorkingHoursForOrganization}), the override creator, and the admin
+ * dashboard — so two concurrent first requests for the same organization would
+ * otherwise race a unique-constraint violation on `WorkingHours.organizationId`
+ * (the same loader-path write race hardened for booking settings). `update: {}`
+ * makes the losing side of the race a no-op that returns the existing row
+ * instead of throwing.
+ *
+ * @param organizationId - The organization to create/fetch default hours for
+ * @returns The organization's `WorkingHours` row, including its overrides
+ */
 export async function createDefaultWorkingHours(organizationId: string) {
   const defaultSchedule = getDefaultWeeklySchedule();
 
-  const workingHours = await db.workingHours.create({
-    data: {
+  const workingHours = await db.workingHours.upsert({
+    where: { organizationId },
+    update: {},
+    create: {
       organizationId,
       enabled: false,
       weeklySchedule: defaultSchedule,

--- a/apps/webapp/app/modules/working-hours/service.server.ts
+++ b/apps/webapp/app/modules/working-hours/service.server.ts
@@ -8,37 +8,51 @@ const label = "Working hours";
  * Ensures a default `WorkingHours` row exists for an organization and returns
  * it (with overrides).
  *
- * Uses `upsert` (not a bare `create`) so it is idempotent and race-safe. Every
- * caller reaches this through a check-then-create ("find, create if absent")
- * path — the authenticated layout loader cold path
+ * Idempotent and race-safe. Every caller reaches this through a check-then-create
+ * ("find, create if absent") path — the authenticated layout loader cold path
  * ({@link getWorkingHoursForOrganization}), the override creator, and the admin
- * dashboard — so two concurrent first requests for the same organization would
+ * dashboard — so two concurrent first requests for the same organization can
  * otherwise race a unique-constraint violation on `WorkingHours.organizationId`
- * (the same loader-path write race hardened for booking settings). `update: {}`
- * makes the losing side of the race a no-op that returns the existing row
- * instead of throwing.
+ * (the same loader-path write race hardened for booking settings).
+ *
+ * We `upsert` (not a bare `create`), but returning a nested relation
+ * (`include`) makes Prisma **emulate** the upsert with a separate read + write
+ * instead of a native atomic `INSERT … ON CONFLICT`, so a concurrent first-hit
+ * can still surface `P2002`. We therefore also catch `P2002` and re-read the
+ * row the winning request created — closing the race regardless of which path
+ * Prisma takes.
  *
  * @param organizationId - The organization to create/fetch default hours for
  * @returns The organization's `WorkingHours` row, including its overrides
+ * @throws {Error} Re-throws any non-`P2002` database error.
  */
 export async function createDefaultWorkingHours(organizationId: string) {
   const defaultSchedule = getDefaultWeeklySchedule();
+  const include = { overrides: { orderBy: { date: "asc" as const } } };
 
-  const workingHours = await db.workingHours.upsert({
-    where: { organizationId },
-    update: {},
-    create: {
-      organizationId,
-      enabled: false,
-      weeklySchedule: defaultSchedule,
-    },
-    include: {
-      overrides: {
-        orderBy: { date: "asc" },
+  try {
+    return await db.workingHours.upsert({
+      where: { organizationId },
+      update: {},
+      create: {
+        organizationId,
+        enabled: false,
+        weeklySchedule: defaultSchedule,
       },
-    },
-  });
-  return workingHours;
+      include,
+    });
+  } catch (cause) {
+    // Emulated upsert lost the create race: a concurrent request already
+    // inserted the row between this call's read and its insert. The row exists
+    // now, so re-read it instead of surfacing the unique-constraint error.
+    if (cause instanceof Error && "code" in cause && cause.code === "P2002") {
+      return db.workingHours.findUniqueOrThrow({
+        where: { organizationId },
+        include,
+      });
+    }
+    throw cause;
+  }
 }
 
 export async function getWorkingHoursForOrganization(organizationId: string) {

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -386,9 +386,14 @@ test("createDatabaseClient wires the transient-retry extension onto the client",
   const factoryStart = source.indexOf("export function createDatabaseClient");
   assert.notEqual(factoryStart, -1, "createDatabaseClient factory not found");
 
-  // Collapse whitespace so the assertions survive prettier reformatting, and
-  // scope to the factory body so a stray reference elsewhere can't satisfy them.
-  const factory = source.slice(factoryStart).replace(/\s+/g, " ");
+  // Bound the slice to the factory body — stop at the next top-level `export`
+  // (or EOF) so a `$extends` / `withPrismaRetry` reference elsewhere in the file
+  // can't satisfy these assertions after the factory wiring is removed. Collapse
+  // whitespace so the assertions survive prettier reformatting.
+  const afterFactory = source.indexOf("\nexport ", factoryStart + 1);
+  const factory = source
+    .slice(factoryStart, afterFactory === -1 ? undefined : afterFactory)
+    .replace(/\s+/g, " ");
 
   assert.match(
     factory,

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -10,8 +10,10 @@
  *
  * @see ./client.ts
  */
-import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   getRetryableErrorCode,
@@ -363,4 +365,39 @@ test("withPrismaRetry", async (t) => {
     assert.equal(result, 42);
     assert.equal(calls, 1);
   });
+});
+
+test("createDatabaseClient wires the transient-retry extension onto the client", () => {
+  // The retry LOGIC is covered exhaustively above; this guards the WIRING — the
+  // exact regression that already happened once, when the monorepo migration
+  // silently dropped the retry `$extends` from this factory.
+  //
+  // A behavioral guard would have to intercept the applied extension chain, but
+  // Prisma's client is a Proxy (its `$extends` isn't reachable on the prototype)
+  // and injecting a fake base client perturbs Prisma's inferred client type
+  // enough to break downstream typechecks. So this asserts the wiring at the
+  // source level — the same cheap regression guard the repo uses elsewhere for
+  // seams that can't be mocked (see the raw-SQL `@map` column-name rule).
+  const source = readFileSync(
+    fileURLToPath(new URL("./client.ts", import.meta.url)),
+    "utf8"
+  );
+
+  const factoryStart = source.indexOf("export function createDatabaseClient");
+  assert.notEqual(factoryStart, -1, "createDatabaseClient factory not found");
+
+  // Collapse whitespace so the assertions survive prettier reformatting, and
+  // scope to the factory body so a stray reference elsewhere can't satisfy them.
+  const factory = source.slice(factoryStart).replace(/\s+/g, " ");
+
+  assert.match(
+    factory,
+    /\$extends\(\{ query: \{ \$allModels: \{/,
+    "the retry query `$extends` appears to have been removed from createDatabaseClient"
+  );
+  assert.match(
+    factory,
+    /withPrismaRetry\(\(\) => query\(args\)/,
+    "createDatabaseClient no longer routes operations through withPrismaRetry"
+  );
 });


### PR DESCRIPTION
Two P2 follow-ups that close out the connection-pool-exhaustion hardening.

- Loader-path write race (working hours): getWorkingHoursForOrganization, reached from the highest-traffic authenticated _layout loader, created default working hours with a bare `create` on first access. Two concurrent first-hits for one organization race a unique-constraint violation on WorkingHours.organizationId — the same class already hardened for booking settings. Convert the shared createDefaultWorkingHours helper to an idempotent `upsert` (update:{}), which fixes all three find-then-create call sites (loader, override creator, admin dashboard) at once. Adds a service test mirroring the booking-settings coverage.
- Retry-wiring regression guard: the transient-retry `$extends` was silently dropped once during the monorepo migration. Add a test asserting the client factory still routes operations through withPrismaRetry. Prisma's client is a Proxy (its `$extends` can't be intercepted) and injecting a fake base client perturbs the inferred client type enough to break downstream typechecks, so this is a source-level guard — the cheap regression pattern the repo already uses for un-mockable seams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working-hours initialization to be idempotent and safe under concurrent first-time requests, avoiding duplicate-record errors.
  * Improved booking settings and notification settings initialization by recovering from concurrent-create unique-constraint failures via a re-read, while preserving existing error wrapping.
* **New Features**
  * Added a shared notification-only projection for booking notification settings to keep reads consistent.
* **Tests**
  * Expanded unit tests for working-hours (existing, default creation, and failure handling).
  * Expanded unit tests for booking settings/notification settings concurrency recovery.
  * Added a regression test to ensure the database client keeps its retry wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->