### PR TITLE
fix(kits): cascade kit location changes to member assets

### DIFF
--- a/.claude/rules/kit-location-owns-member-placement.md
+++ b/.claude/rules/kit-location-owns-member-placement.md
@@ -15,11 +15,25 @@ Placement is **type-aware** — reaching for one shape for both is the bug:
 | `INDIVIDUAL`       | **plain** (`assetKitId: null`), qty 1                        | `enforce_individual_asset_single_location` caps it at ONE row; a plain row also survives detach |
 | `QUANTITY_TRACKED` | **kit-driven** (`assetKitId` set), qty = `AssetKit.quantity` | only the kit's slice moves; the discriminator lets the next move find it                        |
 
-After writing QT slices, reclaim any overflow past `Asset.quantity` from manual
-rows — the DEFERRED `enforce_asset_location_sum_within_total` aborts the whole
-tx at COMMIT otherwise. Detach converts kit-driven rows to manual (merging on
-an `(assetId, locationId)` collision) — unpacking a kit must not unplace its
-contents.
+**The two axes are additive — never reclaim units from manual rows to "make
+room" for a kit slice.** Since
+`20260602100000_assetlocation_sum_exclude_kit_driven`,
+`enforce_asset_location_sum_within_total` sums only `assetKitId IS NULL` rows;
+the kit axis is bounded separately by `enforce_asset_kit_sum_within_total`. So
+100 manually-placed units plus a 50-unit kit slice is VALID, and trimming the
+manual row destroys real data.
+
+The inverse bites too, which is why **detach preserves the location for
+INDIVIDUAL members only**: converting a kit-driven row to manual moves those
+units _into_ the capped axis, so a fully-placed QT asset would breach the cap
+and abort the entire detach (removal, bulk removal, kit deletion, full-slice
+move). QT slices are left to `onDelete: Cascade` and simply become unplaced.
+`Asset.quantity` is NULL for INDIVIDUAL, so the cap never applies to them.
+
+Read the trigger you are relying on from the **latest** migration that touches
+it, not the one that created it. The original pivot migration summed both axes;
+a later one inverted that, and code written against the original silently
+deleted valid placements.
 
 ❌ Bad — the shipped bug: skip members that already have a placement.
 

--- a/.claude/rules/kit-location-owns-member-placement.md
+++ b/.claude/rules/kit-location-owns-member-placement.md
@@ -1,0 +1,49 @@
+# A Kit's Location Owns Its Members' Placement
+
+`Kit.locationId` is the source of truth for where its member assets are. Any
+flow that changes kit membership or a kit's location MUST keep `AssetLocation`
+in step — go through `cascadeKitLocationToAssets` (kit → members) and
+`preserveKitDrivenPlacements` (before ANY `assetKit.delete*`), both in
+`~/modules/kit/service.server`. Don't hand-roll the pivot writes: two triggers
+and two partial uniques make it non-obvious, and the last hand-rolled version
+silently no-op'd for ~every real kit.
+
+Placement is **type-aware** — reaching for one shape for both is the bug:
+
+| Member type        | Row written                                                  | Why                                                                                             |
+| ------------------ | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `INDIVIDUAL`       | **plain** (`assetKitId: null`), qty 1                        | `enforce_individual_asset_single_location` caps it at ONE row; a plain row also survives detach |
+| `QUANTITY_TRACKED` | **kit-driven** (`assetKitId` set), qty = `AssetKit.quantity` | only the kit's slice moves; the discriminator lets the next move find it                        |
+
+After writing QT slices, reclaim any overflow past `Asset.quantity` from manual
+rows — the DEFERRED `enforce_asset_location_sum_within_total` aborts the whole
+tx at COMMIT otherwise. Detach converts kit-driven rows to manual (merging on
+an `(assetId, locationId)` collision) — unpacking a kit must not unplace its
+contents.
+
+❌ Bad — the shipped bug: skip members that already have a placement.
+
+```ts
+// INDIVIDUAL members keep a manual row forever (membership never converts it),
+// so this filter made the cascade a permanent no-op — 5,110 rows vs 1 locally.
+const manualAssetIds = /* assetKitId: null, asset: { type: "INDIVIDUAL" } */;
+const dataToCreate = assetKits.filter((ak) => !manualAssetIds.has(ak.assetId));
+```
+
+✅ Good — one shared cascade, and the audit trail follows what persisted.
+
+```ts
+const cascadedAssetIds = await cascadeKitLocationToAssets(
+  { kitIds: [id], newLocationId, organizationId },
+  tx
+);
+// emit ASSET_LOCATION_CHANGED + notes ONLY for cascadedAssetIds
+```
+
+Emit events/notes strictly for rows that actually changed — including the
+clear-location path, where INDIVIDUAL members keep their placement and so must
+NOT be reported as unplaced. When you touch one of these flows, grep the
+siblings (`updateKitLocation`, `bulkUpdateKitLocation`, `updateKitAssets`,
+`bulkRemoveAssetsFromKits`, `moveAssetKitUnits`, `performKitDeletion`) — this
+bug class travels in packs. See [[kit-members-via-kit-slices]] and
+[[quantity-semantics-per-surface]].

--- a/apps/webapp/app/modules/asset/fields.ts
+++ b/apps/webapp/app/modules/asset/fields.ts
@@ -49,6 +49,11 @@ export const getAssetOverviewFields = (
     // driven placements so the UI can render the "via kit" badge
     // alongside the kit-driven rows.
     assetLocations: {
+      // Stable order so `getPrimaryLocation()` (which reads index 0) doesn't
+      // depend on heap order. Oldest row first keeps the asset's own manual
+      // placement primary in list views; kit-driven slices are surfaced with
+      // their "via kit" badge in the placements breakdown.
+      orderBy: { createdAt: "asc" as const },
       select: {
         quantity: true,
         assetKitId: true,
@@ -195,6 +200,11 @@ export const assetIndexFields = ({
     // driven placements so the UI can render the "via kit" badge
     // alongside the kit-driven rows.
     assetLocations: {
+      // Stable order so `getPrimaryLocation()` (which reads index 0) doesn't
+      // depend on heap order. Oldest row first keeps the asset's own manual
+      // placement primary in list views; kit-driven slices are surfaced with
+      // their "via kit" badge in the placements breakdown.
+      orderBy: { createdAt: "asc" as const },
       select: {
         quantity: true,
         assetKitId: true,

--- a/apps/webapp/app/modules/asset/fields.ts
+++ b/apps/webapp/app/modules/asset/fields.ts
@@ -13,6 +13,38 @@ export const LOCATION_WITH_HIERARCHY = {
   },
 } satisfies Prisma.LocationDefaultArgs;
 
+/**
+ * An asset's placement rows, shared by every surface that resolves a location.
+ *
+ * `quantity` lets loaders show per-location slices and derive the
+ * "placed / unplaced" split for qty-tracked assets. `assetKitId` plus the
+ * nested `assetKit.kit` discriminate manual from kit-driven placements, so the
+ * UI can render the "via kit" badge alongside the kit-driven rows.
+ *
+ * Ordering is explicit because `getPrimaryLocation()` reads index 0 and must
+ * not depend on heap order. Oldest row first keeps the asset's own manual
+ * placement primary in list views. `id` breaks ties: `createdAt` defaults to
+ * CURRENT_TIMESTAMP, which Postgres evaluates at transaction start, so every
+ * row written by one cascade shares a timestamp.
+ *
+ * Kept in one place so the ordering guarantee can't drift between surfaces —
+ * a divergence there would silently change which location an asset reports.
+ */
+export const ASSET_LOCATIONS_INCLUDE = {
+  orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+  select: {
+    quantity: true,
+    assetKitId: true,
+    location: LOCATION_WITH_HIERARCHY,
+    assetKit: {
+      select: {
+        id: true,
+        kit: { select: { id: true, name: true } },
+      },
+    },
+  },
+} satisfies Prisma.Asset$assetLocationsArgs;
+
 export const KITS_INCLUDE_FIELDS = {
   _count: { select: { assetKits: true } },
   custody: {
@@ -43,34 +75,7 @@ export const getAssetOverviewFields = (
     category: true,
     qrCodes: true,
     tags: true,
-    // `quantity` is pulled so loaders can show per-location slices and
-    // derive the "placed / unplaced" split for qty-tracked assets.
-    // `assetKitId` + nested `assetKit.kit` discriminate manual vs kit-
-    // driven placements so the UI can render the "via kit" badge
-    // alongside the kit-driven rows.
-    assetLocations: {
-      // Stable order so `getPrimaryLocation()` (which reads index 0) doesn't
-      // depend on heap order. Oldest row first keeps the asset's own manual
-      // placement primary in list views; kit-driven slices are surfaced with
-      // their "via kit" badge in the placements breakdown.
-      //
-      // `id` breaks ties: `createdAt` defaults to CURRENT_TIMESTAMP, which is
-      // transaction-start time in Postgres, so every row written by one
-      // cascade shares a timestamp and would otherwise fall back to heap
-      // order again.
-      orderBy: [{ createdAt: "asc" as const }, { id: "asc" as const }],
-      select: {
-        quantity: true,
-        assetKitId: true,
-        location: LOCATION_WITH_HIERARCHY,
-        assetKit: {
-          select: {
-            id: true,
-            kit: { select: { id: true, name: true } },
-          },
-        },
-      },
-    },
+    assetLocations: ASSET_LOCATIONS_INCLUDE,
     custody: {
       select: {
         createdAt: true,
@@ -199,34 +204,7 @@ export const assetIndexFields = ({
     assetKits: { select: { kit: true } },
     category: true,
     tags: true,
-    // `quantity` is pulled so loaders can show per-location slices and
-    // derive the "placed / unplaced" split for qty-tracked assets.
-    // `assetKitId` + nested `assetKit.kit` discriminate manual vs kit-
-    // driven placements so the UI can render the "via kit" badge
-    // alongside the kit-driven rows.
-    assetLocations: {
-      // Stable order so `getPrimaryLocation()` (which reads index 0) doesn't
-      // depend on heap order. Oldest row first keeps the asset's own manual
-      // placement primary in list views; kit-driven slices are surfaced with
-      // their "via kit" badge in the placements breakdown.
-      //
-      // `id` breaks ties: `createdAt` defaults to CURRENT_TIMESTAMP, which is
-      // transaction-start time in Postgres, so every row written by one
-      // cascade shares a timestamp and would otherwise fall back to heap
-      // order again.
-      orderBy: [{ createdAt: "asc" as const }, { id: "asc" as const }],
-      select: {
-        quantity: true,
-        assetKitId: true,
-        location: LOCATION_WITH_HIERARCHY,
-        assetKit: {
-          select: {
-            id: true,
-            kit: { select: { id: true, name: true } },
-          },
-        },
-      },
-    },
+    assetLocations: ASSET_LOCATIONS_INCLUDE,
     custody: {
       select: {
         quantity: true,

--- a/apps/webapp/app/modules/asset/fields.ts
+++ b/apps/webapp/app/modules/asset/fields.ts
@@ -53,7 +53,12 @@ export const getAssetOverviewFields = (
       // depend on heap order. Oldest row first keeps the asset's own manual
       // placement primary in list views; kit-driven slices are surfaced with
       // their "via kit" badge in the placements breakdown.
-      orderBy: { createdAt: "asc" as const },
+      //
+      // `id` breaks ties: `createdAt` defaults to CURRENT_TIMESTAMP, which is
+      // transaction-start time in Postgres, so every row written by one
+      // cascade shares a timestamp and would otherwise fall back to heap
+      // order again.
+      orderBy: [{ createdAt: "asc" as const }, { id: "asc" as const }],
       select: {
         quantity: true,
         assetKitId: true,
@@ -204,7 +209,12 @@ export const assetIndexFields = ({
       // depend on heap order. Oldest row first keeps the asset's own manual
       // placement primary in list views; kit-driven slices are surfaced with
       // their "via kit" badge in the placements breakdown.
-      orderBy: { createdAt: "asc" as const },
+      //
+      // `id` breaks ties: `createdAt` defaults to CURRENT_TIMESTAMP, which is
+      // transaction-start time in Postgres, so every row written by one
+      // cascade shares a timestamp and would otherwise fall back to heap
+      // order again.
+      orderBy: [{ createdAt: "asc" as const }, { id: "asc" as const }],
       select: {
         quantity: true,
         assetKitId: true,

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -3313,8 +3313,11 @@ describe("moveAssetKitUnits", () => {
  *   (`assetKitId: null`) row at the kit's location — one row, so the trigger
  *   stays satisfied, and the asset keeps the location when it leaves the kit.
  * - QUANTITY_TRACKED members get a kit-driven row holding just this kit's
- *   slice, with manual rows trimmed by any resulting overflow past
- *   `Asset.quantity`.
+ *   slice, ADDED alongside the asset's manual placements rather than taken out
+ *   of them. Since
+ *   `20260602100000_assetlocation_sum_exclude_kit_driven` the location-axis cap
+ *   counts only `assetKitId IS NULL` rows, so the two axes are additive and
+ *   manual placements are never touched.
  */
 describe("updateKitLocation - cascade to member assets", () => {
   beforeEach(() => {

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -3232,15 +3232,68 @@ describe("moveAssetKitUnits", () => {
     expect((err as ShelfError).message).toContain("destination kit");
   });
 
-  it("does not touch AssetLocation rows (orthogonal-axes invariant)", async () => {
+  it("leaves manual placements alone when the destination kit is unplaced", async () => {
+    expect.assertions(3);
+
+    // Default `mockKitFindFirst` returns kits with no `locationId`.
     await moveAssetKitUnits(baseArgs);
 
-    // The move acts on the kit axis only — manual AssetLocation rows
-    // must stay untouched. (Kit-driven AssetLocation rows are managed
-    // by the DB-level cascade and aren't this service's concern.)
+    // Nothing is placed anywhere — and crucially the only delete is scoped to
+    // the destination's kit-driven row, never to the asset's manual rows.
     expect(db.assetLocation.createMany).not.toHaveBeenCalled();
-    expect(db.assetLocation.deleteMany).not.toHaveBeenCalled();
     expect(db.assetLocation.updateMany).not.toHaveBeenCalled();
+    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: { assetKitId: "ak-dst" },
+    });
+  });
+
+  it("re-places the moved units at the destination kit's location", async () => {
+    expect.assertions(2);
+
+    // why: destination kit lives somewhere; the moved units must follow it
+    // rather than staying recorded at the source kit's location.
+    mockKitFindFirst.mockImplementation(
+      ({ where }: { where: { id: string } }) =>
+        Promise.resolve({
+          id: where.id,
+          name: where.id,
+          locationId: where.id === "kit-to" ? "loc-dest" : "loc-source",
+        })
+    );
+    // why: the shared cascade re-reads the destination kit's AssetKit rows to
+    // build the placement write.
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      {
+        id: "ak-dst",
+        assetId: "asset-1",
+        quantity: 10,
+        asset: { type: AssetType.QUANTITY_TRACKED },
+      },
+    ]);
+
+    await moveAssetKitUnits(baseArgs);
+
+    // Kit-driven slice written at the DESTINATION kit's location, carrying the
+    // destination's post-move quantity.
+    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          assetId: "asset-1",
+          locationId: "loc-dest",
+          organizationId: "org-1",
+          quantity: 10,
+          assetKitId: "ak-dst",
+        },
+      ],
+    });
+    // The asset's manual placements are untouched — only kit-driven rows for
+    // the destination kit are cleared before the write.
+    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: {
+        assetKit: { kitId: { in: ["kit-to"] }, assetId: { in: ["asset-1"] } },
+      },
+    });
   });
 });
 
@@ -3474,8 +3527,8 @@ describe("updateKitLocation - cascade to member assets", () => {
     });
   });
 
-  it("trims a manual placement that would overflow the asset's total", async () => {
-    expect.assertions(2);
+  it("never touches a QUANTITY_TRACKED member's manual placements", async () => {
+    expect.assertions(3);
 
     mockKitWithAssets([
       {
@@ -3499,23 +3552,17 @@ describe("updateKitLocation - cascade to member assets", () => {
         asset: { type: AssetType.QUANTITY_TRACKED },
       },
     ]);
-    // why: post-write read by the overflow trim. 45 manual + 10 kit-driven
-    // = 55 against a 50-unit pool, so 5 units must come off the manual row
-    // or the deferred sum trigger aborts the tx at COMMIT.
+    // why: the asset is ALREADY fully placed manually (50 of 50). Since
+    // `20260602100000_assetlocation_sum_exclude_kit_driven`, the location-axis
+    // sum counts only `assetKitId IS NULL` rows, so a 10-unit kit slice on top
+    // is valid — the axes are orthogonal and additive.
     //@ts-expect-error missing vitest type
     db.assetLocation.findMany.mockResolvedValue([
       {
         id: "al-manual",
         assetId: "asset-qty",
-        quantity: 45,
+        quantity: 50,
         assetKitId: null,
-        asset: { quantity: 50 },
-      },
-      {
-        id: "al-kit",
-        assetId: "asset-qty",
-        quantity: 10,
-        assetKitId: "ak-qty",
         asset: { quantity: 50 },
       },
     ]);
@@ -3530,68 +3577,20 @@ describe("updateKitLocation - cascade to member assets", () => {
       userId: "user-1",
     });
 
-    expect(db.assetLocation.update).toHaveBeenCalledWith({
-      where: { id: "al-manual" },
-      data: { quantity: 40 },
-    });
-    // Only the overflow is reclaimed — the manual placement survives.
-    expect(db.assetLocation.delete).not.toHaveBeenCalled();
-  });
-
-  it("leaves manual placements alone when there is no overflow", async () => {
-    expect.assertions(2);
-
-    mockKitWithAssets([
-      {
-        quantity: 10,
-        asset: {
-          id: "asset-qty",
-          title: "Batch",
-          type: AssetType.QUANTITY_TRACKED,
-          quantity: 50,
-          unitOfMeasure: "kg",
-          assetLocations: [{ location: { id: "loc-old", name: "Old Loc" } }],
+    // The kit slice is added...
+    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          assetId: "asset-qty",
+          locationId: "loc-new",
+          organizationId: "org-1",
+          quantity: 10,
+          assetKitId: "ak-qty",
         },
-      },
-    ]);
-    //@ts-expect-error missing vitest type
-    db.assetKit.findMany.mockResolvedValue([
-      {
-        id: "ak-qty",
-        assetId: "asset-qty",
-        quantity: 10,
-        asset: { type: AssetType.QUANTITY_TRACKED },
-      },
-    ]);
-    // why: 20 manual + 10 kit-driven = 30 of a 50-unit pool — within total.
-    //@ts-expect-error missing vitest type
-    db.assetLocation.findMany.mockResolvedValue([
-      {
-        id: "al-manual",
-        assetId: "asset-qty",
-        quantity: 20,
-        assetKitId: null,
-        asset: { quantity: 50 },
-      },
-      {
-        id: "al-kit",
-        assetId: "asset-qty",
-        quantity: 10,
-        assetKitId: "ak-qty",
-        asset: { quantity: 50 },
-      },
-    ]);
-
-    const { updateKitLocation } = await import("./service.server");
-
-    await updateKitLocation({
-      id: "kit-1",
-      organizationId: "org-1",
-      currentLocationId: null,
-      newLocationId: "loc-new",
-      userId: "user-1",
+      ],
     });
-
+    // ...and the fully-placed manual row is left exactly as it was. Reclaiming
+    // from it to "make room" would destroy real placement data.
     expect(db.assetLocation.update).not.toHaveBeenCalled();
     expect(db.assetLocation.delete).not.toHaveBeenCalled();
   });
@@ -3809,9 +3808,9 @@ describe("bulkUpdateKitLocation - cascade to member assets", () => {
  */
 describe("preserveKitDrivenPlacements", () => {
   /**
-   * The helper reads placements twice — first the kit-driven rows about to be
-   * cascaded away, then the asset's existing manual rows — so the tests queue
-   * two sequential resolutions. Cast once here rather than sprinkling
+   * The helper reads placements twice — first the kit-driven rows it may
+   * convert, then the assets' existing manual rows — so the tests queue two
+   * sequential resolutions. Cast once here rather than sprinkling
    * `@ts-expect-error` across the chained calls.
    */
   const placementReads = () =>
@@ -3821,26 +3820,18 @@ describe("preserveKitDrivenPlacements", () => {
     vitest.clearAllMocks();
   });
 
-  it("converts a kit-driven placement into a manual one", async () => {
+  it("converts an INDIVIDUAL member's kit-driven placement into a manual one", async () => {
     expect.assertions(2);
 
     placementReads()
-      // kit-driven rows about to be cascaded away
-      .mockResolvedValueOnce([
-        {
-          id: "al-kit",
-          assetId: "asset-qty",
-          locationId: "loc-kit",
-          quantity: 10,
-          asset: { type: AssetType.QUANTITY_TRACKED },
-        },
-      ])
-      // the asset holds no manual rows, so there's nothing to collide with
+      // kit-driven rows the helper may convert
+      .mockResolvedValueOnce([{ id: "al-kit", assetId: "asset-ind" }])
+      // the asset holds no manual row, so the conversion is unobstructed
       .mockResolvedValueOnce([]);
 
     const { preserveKitDrivenPlacements } = await import("./service.server");
 
-    await preserveKitDrivenPlacements(db, ["ak-qty"]);
+    await preserveKitDrivenPlacements(db, ["ak-ind"]);
 
     expect(db.assetLocation.update).toHaveBeenCalledWith({
       where: { id: "al-kit" },
@@ -3849,67 +3840,15 @@ describe("preserveKitDrivenPlacements", () => {
     expect(db.assetLocation.delete).not.toHaveBeenCalled();
   });
 
-  it("merges into the manual row already sitting at that location", async () => {
-    expect.assertions(2);
-
-    placementReads()
-      .mockResolvedValueOnce([
-        {
-          id: "al-kit",
-          assetId: "asset-qty",
-          locationId: "loc-shared",
-          quantity: 10,
-          asset: { type: AssetType.QUANTITY_TRACKED },
-        },
-      ])
-      // why: a manual row at the SAME location — nulling `assetKitId` would
-      // breach `AssetLocation_manual_unique (assetId, locationId)`.
-      .mockResolvedValueOnce([
-        {
-          id: "al-manual",
-          assetId: "asset-qty",
-          locationId: "loc-shared",
-          quantity: 5,
-        },
-      ]);
-
-    const { preserveKitDrivenPlacements } = await import("./service.server");
-
-    await preserveKitDrivenPlacements(db, ["ak-qty"]);
-
-    expect(db.assetLocation.update).toHaveBeenCalledWith({
-      where: { id: "al-manual" },
-      data: { quantity: 15 },
-    });
-    expect(db.assetLocation.delete).toHaveBeenCalledWith({
-      where: { id: "al-kit" },
-    });
-  });
-
   it("drops the kit-driven row when an INDIVIDUAL asset is already placed", async () => {
     expect.assertions(2);
 
     placementReads()
-      .mockResolvedValueOnce([
-        {
-          id: "al-kit",
-          assetId: "asset-ind",
-          locationId: "loc-kit",
-          quantity: 1,
-          asset: { type: AssetType.INDIVIDUAL },
-        },
-      ])
+      .mockResolvedValueOnce([{ id: "al-kit", assetId: "asset-ind" }])
       // why: `enforce_individual_asset_single_location` caps an INDIVIDUAL
       // asset at one row, so the existing manual placement has to win even
       // though it sits at a different location.
-      .mockResolvedValueOnce([
-        {
-          id: "al-manual",
-          assetId: "asset-ind",
-          locationId: "loc-other",
-          quantity: 1,
-        },
-      ]);
+      .mockResolvedValueOnce([{ assetId: "asset-ind" }]);
 
     const { preserveKitDrivenPlacements } = await import("./service.server");
 
@@ -3919,5 +3858,30 @@ describe("preserveKitDrivenPlacements", () => {
       where: { id: "al-kit" },
     });
     expect(db.assetLocation.update).not.toHaveBeenCalled();
+  });
+
+  it("never converts a QUANTITY_TRACKED slice, which would breach the manual cap", async () => {
+    expect.assertions(3);
+
+    // why: the read is filtered to non-QUANTITY_TRACKED assets in SQL, so a
+    // kit holding only QT members comes back empty and the helper no-ops.
+    // Those rows are left to `onDelete: Cascade` — converting them would move
+    // units into the capped location axis and abort the whole detach for a
+    // fully-placed asset.
+    placementReads().mockResolvedValueOnce([]);
+
+    const { preserveKitDrivenPlacements } = await import("./service.server");
+
+    await preserveKitDrivenPlacements(db, ["ak-qty"]);
+
+    expect(placementReads()).toHaveBeenCalledWith({
+      where: {
+        assetKitId: { in: ["ak-qty"] },
+        asset: { type: { not: AssetType.QUANTITY_TRACKED } },
+      },
+      select: { id: true, assetId: true },
+    });
+    expect(db.assetLocation.update).not.toHaveBeenCalled();
+    expect(db.assetLocation.delete).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -84,6 +84,11 @@ vitest.mock("~/database/db.server", () => ({
       deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
       findMany: vitest.fn().mockResolvedValue([]),
       updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
+      // why: the kit-location cascade trims overflowing manual placements
+      // per-row, and the detach guard converts/merges kit-driven rows
+      // one at a time — both need single-row `update` / `delete`.
+      update: vitest.fn().mockResolvedValue({}),
+      delete: vitest.fn().mockResolvedValue({}),
     },
     // why: createKit/updateKit now run a cross-org ownership guard that calls
     // db.location.findFirst before connecting a location.
@@ -596,6 +601,26 @@ describe("updateKit", () => {
       organizationId: "org-1",
       userId: "user-1",
     });
+  });
+
+  it("refuses to change the kit's location, which would skip the asset cascade", async () => {
+    expect.assertions(2);
+
+    // Setting `Kit.locationId` here moves the kit without moving its member
+    // assets — the cascade lives in `updateKitLocation`. This route into a
+    // location change is how kit members drifted from their kit's location,
+    // so it must reject rather than write a half-applied change.
+    await expect(
+      updateKit({
+        id: "kit-1",
+        name: "Updated Kit",
+        createdById: "user-1",
+        organizationId: "org-1",
+        locationId: "loc-new",
+      })
+    ).rejects.toThrow(ShelfError);
+
+    expect(db.kit.update).not.toHaveBeenCalled();
   });
 });
 
@@ -3220,153 +3245,112 @@ describe("moveAssetKitUnits", () => {
 });
 
 /**
- * Verifies the kit-location cascade respects the
- * `enforce_individual_asset_single_location` Postgres trigger
+ * Verifies a kit's location actually reaches its member assets.
+ *
+ * The cascade previously skipped any INDIVIDUAL member that already held a
+ * manual `AssetLocation` row, to stay inside the
+ * `enforce_individual_asset_single_location` trigger
  * (packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql).
+ * Because kit membership never converts a manual row into a kit-driven one,
+ * that made the cascade a permanent no-op for the common case — a kit's
+ * location silently never reached its assets.
  *
- * INDIVIDUAL assets that already hold a manual AssetLocation row
- * (`assetKitId IS NULL`) must be skipped when re-creating kit-driven
- * AssetLocation rows: the trigger permits at most one row per
- * INDIVIDUAL asset, so a blind `createMany` raises 23514.
- *
- * QUANTITY_TRACKED assets and INDIVIDUAL assets with no manual row are
- * cascaded normally.
+ * The kit now owns its members' whereabouts:
+ * - INDIVIDUAL members have their single row REPLACED by a plain
+ *   (`assetKitId: null`) row at the kit's location — one row, so the trigger
+ *   stays satisfied, and the asset keeps the location when it leaves the kit.
+ * - QUANTITY_TRACKED members get a kit-driven row holding just this kit's
+ *   slice, with manual rows trimmed by any resulting overflow past
+ *   `Asset.quantity`.
  */
-describe("updateKitLocation - manual placement guard", () => {
+describe("updateKitLocation - cascade to member assets", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
     // why: `assertLocationBelongsToOrg` calls `db.location.findFirst` —
-    // echo a row back for any id so the guard passes (a stricter
-    // version of the createKit mock above).
+    // echo a row back for any id so the guard passes.
     //@ts-expect-error missing vitest type
     db.location.findFirst.mockImplementation(({ where }) =>
       where?.id
         ? Promise.resolve({ id: where.id, name: where.id })
         : Promise.resolve(null)
     );
+    // why: `clearAllMocks` clears calls but keeps implementations — reset the
+    // placement read so each test starts from "no existing rows" and opts in
+    // to the state it needs.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([]);
   });
 
-  it("control: cascades all QUANTITY_TRACKED assets when no manual rows exist", async () => {
+  /**
+   * Builds the `db.kit.findUnique` payload `updateKitLocation` reads at the
+   * top — it drives the in-memory `kit.assets` list the cascade and the
+   * audit trail both iterate.
+   */
+  function mockKitWithAssets(
+    assetKits: Array<{
+      quantity: number;
+      asset: {
+        id: string;
+        title: string;
+        type: AssetType;
+        quantity: number | null;
+        unitOfMeasure: string | null;
+        assetLocations: Array<{ location: { id: string; name: string } }>;
+      };
+    }>
+  ) {
+    //@ts-expect-error missing vitest type
+    db.kit.findUnique.mockResolvedValue({
+      id: "kit-1",
+      name: "Kit 1",
+      assetKits,
+    });
+  }
+
+  it("moves an INDIVIDUAL member that already has a location", async () => {
     expect.assertions(3);
 
-    const kitRow = {
-      id: "kit-1",
-      name: "Kit 1",
-      assetKits: [
-        {
-          quantity: 10,
-          asset: {
-            id: "asset-qty",
-            title: "Batch",
-            type: AssetType.QUANTITY_TRACKED,
-            quantity: 50,
-            unitOfMeasure: "kg",
-            assetLocations: [],
-          },
+    mockKitWithAssets([
+      {
+        quantity: 1,
+        asset: {
+          id: "asset-ind",
+          title: "Manually placed",
+          type: AssetType.INDIVIDUAL,
+          quantity: null,
+          unitOfMeasure: null,
+          assetLocations: [{ location: { id: "loc-old", name: "Old Loc" } }],
         },
-      ],
-    };
-
-    // why: kit fetched at the top of `updateKitLocation` — drives the
-    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
-    //@ts-expect-error missing vitest type
-    db.kit.findUnique.mockResolvedValue(kitRow);
-    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
-    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
-    //@ts-expect-error missing vitest type
-    db.assetKit.findMany.mockResolvedValue([
-      { id: "ak-1", assetId: "asset-qty", quantity: 10 },
-    ]);
-    // why: manual-row probe — empty here so the control path cascades every
-    // asset (no INDIVIDUAL manual placement blocks the cascade).
-    //@ts-expect-error missing vitest type
-    db.assetLocation.findMany.mockResolvedValue([]);
-
-    const { updateKitLocation } = await import("./service.server");
-
-    await updateKitLocation({
-      id: "kit-1",
-      organizationId: "org-1",
-      currentLocationId: null,
-      newLocationId: "loc-new",
-      userId: "user-1",
-    });
-
-    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
-      where: { assetKit: { kitId: "kit-1" } },
-    });
-    // Manual-row probe ran.
-    expect(db.assetLocation.findMany).toHaveBeenCalledWith({
-      where: {
-        assetId: { in: ["asset-qty"] },
-        assetKitId: null,
-        asset: { type: "INDIVIDUAL" },
       },
-      select: { assetId: true },
-    });
-    // Cascade row created for the qty-tracked asset.
-    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
-      data: [
-        {
-          assetId: "asset-qty",
-          locationId: "loc-new",
-          organizationId: "org-1",
-          quantity: 10,
-          assetKitId: "ak-1",
-        },
-      ],
-    });
-  });
-
-  it("control: cascades INDIVIDUAL assets when no manual row blocks them", async () => {
-    expect.assertions(2);
-
-    const kitRow = {
-      id: "kit-1",
-      name: "Kit 1",
-      assetKits: [
-        {
-          quantity: 1,
-          asset: {
-            id: "asset-ind",
-            title: "Single",
-            type: AssetType.INDIVIDUAL,
-            quantity: null,
-            unitOfMeasure: null,
-            assetLocations: [],
-          },
-        },
-      ],
-    };
-
-    // why: kit fetched at the top of `updateKitLocation` — drives the
-    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
-    //@ts-expect-error missing vitest type
-    db.kit.findUnique.mockResolvedValue(kitRow);
-    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
-    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
+    ]);
+    // why: the cascade re-reads the kit's AssetKit rows to build the pivot
+    // writes; `asset.type` decides plain-row vs kit-driven-row handling.
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
-      { id: "ak-ind", assetId: "asset-ind", quantity: 1 },
+      {
+        id: "ak-ind",
+        assetId: "asset-ind",
+        quantity: 1,
+        asset: { type: AssetType.INDIVIDUAL },
+      },
     ]);
-    // why: manual-row probe — empty so the INDIVIDUAL asset is free to take
-    // the kit-driven row (no `enforce_individual_asset_single_location` conflict).
-    //@ts-expect-error missing vitest type
-    db.assetLocation.findMany.mockResolvedValue([]);
 
     const { updateKitLocation } = await import("./service.server");
 
     await updateKitLocation({
       id: "kit-1",
       organizationId: "org-1",
-      currentLocationId: null,
+      currentLocationId: "loc-old",
       newLocationId: "loc-new",
       userId: "user-1",
     });
 
+    // The asset's own placement is cleared...
     expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
-      where: { assetKit: { kitId: "kit-1" } },
+      where: { assetId: { in: ["asset-ind"] }, assetKitId: null },
     });
+    // ...and re-created at the kit's location as a PLAIN row (so the
+    // single-location trigger holds and the asset keeps it on detach).
     expect(db.assetLocation.createMany).toHaveBeenCalledWith({
       data: [
         {
@@ -3374,62 +3358,90 @@ describe("updateKitLocation - manual placement guard", () => {
           locationId: "loc-new",
           organizationId: "org-1",
           quantity: 1,
-          assetKitId: "ak-ind",
+          assetKitId: null,
         },
       ],
     });
+    // Exactly one placement row is written — never a second one.
+    expect(db.assetLocation.createMany).toHaveBeenCalledTimes(1);
   });
 
-  it("regression: skips INDIVIDUAL asset whose manual AssetLocation row already exists", async () => {
+  it("emits an event and a note for an INDIVIDUAL member that used to be skipped", async () => {
     expect.assertions(3);
 
-    const kitRow = {
-      id: "kit-1",
-      name: "Kit 1",
-      assetKits: [
-        {
-          quantity: 1,
-          asset: {
-            id: "asset-ind-manual",
-            title: "Manually placed",
-            type: AssetType.INDIVIDUAL,
-            quantity: null,
-            unitOfMeasure: null,
-            assetLocations: [
-              { location: { id: "loc-manual", name: "Manual Loc" } },
-            ],
-          },
+    mockKitWithAssets([
+      {
+        quantity: 1,
+        asset: {
+          id: "asset-ind",
+          title: "Manually placed",
+          type: AssetType.INDIVIDUAL,
+          quantity: null,
+          unitOfMeasure: null,
+          assetLocations: [{ location: { id: "loc-old", name: "Old Loc" } }],
         },
-        {
-          quantity: 5,
-          asset: {
-            id: "asset-qty",
-            title: "Batch",
-            type: AssetType.QUANTITY_TRACKED,
-            quantity: 50,
-            unitOfMeasure: "kg",
-            assetLocations: [],
-          },
-        },
-      ],
-    };
-
-    // why: kit fetched at the top of `updateKitLocation` — drives the
-    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
-    //@ts-expect-error missing vitest type
-    db.kit.findUnique.mockResolvedValue(kitRow);
-    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
-    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
+      },
+    ]);
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
-      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
-      { id: "ak-qty", assetId: "asset-qty", quantity: 5 },
+      {
+        id: "ak-ind",
+        assetId: "asset-ind",
+        quantity: 1,
+        asset: { type: AssetType.INDIVIDUAL },
+      },
     ]);
-    // why: manual-row probe — populated for the INDIVIDUAL asset so the
-    // guard must skip it (manual placement wins over kit cascade).
+
+    const { updateKitLocation } = await import("./service.server");
+
+    await updateKitLocation({
+      id: "kit-1",
+      organizationId: "org-1",
+      currentLocationId: "loc-old",
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    const eventsArg = (recordEvents as ReturnType<typeof vitest.fn>).mock
+      .calls[0][0];
+    expect(eventsArg.map((e: { assetId: string }) => e.assetId)).toEqual([
+      "asset-ind",
+    ]);
+    expect(eventsArg[0]).toMatchObject({
+      action: "ASSET_LOCATION_CHANGED",
+      fromValue: "loc-old",
+      toValue: "loc-new",
+    });
+    const noteAssetIds = (
+      createNote as ReturnType<typeof vitest.fn>
+    ).mock.calls.map((c) => (c[0] as { assetId: string }).assetId);
+    expect(noteAssetIds).toEqual(["asset-ind"]);
+  });
+
+  it("places only the kit's slice for a QUANTITY_TRACKED member", async () => {
+    expect.assertions(2);
+
+    mockKitWithAssets([
+      {
+        quantity: 10,
+        asset: {
+          id: "asset-qty",
+          title: "Batch",
+          type: AssetType.QUANTITY_TRACKED,
+          quantity: 50,
+          unitOfMeasure: "kg",
+          assetLocations: [],
+        },
+      },
+    ]);
     //@ts-expect-error missing vitest type
-    db.assetLocation.findMany.mockResolvedValue([
-      { assetId: "asset-ind-manual" },
+    db.assetKit.findMany.mockResolvedValue([
+      {
+        id: "ak-qty",
+        assetId: "asset-qty",
+        quantity: 10,
+        asset: { type: AssetType.QUANTITY_TRACKED },
+      },
     ]);
 
     const { updateKitLocation } = await import("./service.server");
@@ -3442,77 +3454,70 @@ describe("updateKitLocation - manual placement guard", () => {
       userId: "user-1",
     });
 
-    // Kit-driven rows still cleared.
-    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
-      where: { assetKit: { kitId: "kit-1" } },
-    });
-    // createMany payload omits the manually-placed INDIVIDUAL asset.
-    expect(db.assetLocation.createMany).toHaveBeenCalledTimes(1);
+    // Kit-driven row carries the KIT's slice (AssetKit.quantity = 10), not
+    // the asset's 50-unit pool.
     expect(db.assetLocation.createMany).toHaveBeenCalledWith({
       data: [
         {
           assetId: "asset-qty",
           locationId: "loc-new",
           organizationId: "org-1",
-          quantity: 5,
+          quantity: 10,
           assetKitId: "ak-qty",
         },
       ],
     });
+    // A QT member's existing manual placements are NOT wiped — only the
+    // kit's own kit-driven rows are dropped first.
+    expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: { assetKit: { kitId: { in: ["kit-1"] } } },
+    });
   });
 
-  it("regression: skipped INDIVIDUAL asset emits no event and no note", async () => {
-    expect.assertions(4);
+  it("trims a manual placement that would overflow the asset's total", async () => {
+    expect.assertions(2);
 
-    // Same setup as the regression case above — kit-1 contains an INDIVIDUAL
-    // asset (manual row exists) + a QUANTITY_TRACKED asset (no manual row).
-    const kitRow = {
-      id: "kit-1",
-      name: "Kit 1",
-      assetKits: [
-        {
-          quantity: 1,
-          asset: {
-            id: "asset-ind-manual",
-            title: "Manually placed",
-            type: AssetType.INDIVIDUAL,
-            quantity: null,
-            unitOfMeasure: null,
-            assetLocations: [
-              { location: { id: "loc-manual", name: "Manual Loc" } },
-            ],
-          },
+    mockKitWithAssets([
+      {
+        quantity: 10,
+        asset: {
+          id: "asset-qty",
+          title: "Batch",
+          type: AssetType.QUANTITY_TRACKED,
+          quantity: 50,
+          unitOfMeasure: "kg",
+          assetLocations: [{ location: { id: "loc-old", name: "Old Loc" } }],
         },
-        {
-          quantity: 5,
-          asset: {
-            id: "asset-qty",
-            title: "Batch",
-            type: AssetType.QUANTITY_TRACKED,
-            quantity: 50,
-            unitOfMeasure: "kg",
-            assetLocations: [],
-          },
-        },
-      ],
-    };
-
-    // why: kit fetched at the top of `updateKitLocation` — drives the
-    // in-memory `kit.assets` list that the cascade + audit-trail iterate.
-    //@ts-expect-error missing vitest type
-    db.kit.findUnique.mockResolvedValue(kitRow);
-    // why: post-deleteMany re-read of the kit's AssetKit rows; the resulting
-    // ids/quantities are what the cascade writes into `assetLocation.createMany`.
+      },
+    ]);
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
-      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
-      { id: "ak-qty", assetId: "asset-qty", quantity: 5 },
+      {
+        id: "ak-qty",
+        assetId: "asset-qty",
+        quantity: 10,
+        asset: { type: AssetType.QUANTITY_TRACKED },
+      },
     ]);
-    // why: manual-row probe — populated for the INDIVIDUAL asset so the
-    // guard must skip it from both the cascade AND the audit trail.
+    // why: post-write read by the overflow trim. 45 manual + 10 kit-driven
+    // = 55 against a 50-unit pool, so 5 units must come off the manual row
+    // or the deferred sum trigger aborts the tx at COMMIT.
     //@ts-expect-error missing vitest type
     db.assetLocation.findMany.mockResolvedValue([
-      { assetId: "asset-ind-manual" },
+      {
+        id: "al-manual",
+        assetId: "asset-qty",
+        quantity: 45,
+        assetKitId: null,
+        asset: { quantity: 50 },
+      },
+      {
+        id: "al-kit",
+        assetId: "asset-qty",
+        quantity: 10,
+        assetKitId: "ak-qty",
+        asset: { quantity: 50 },
+      },
     ]);
 
     const { updateKitLocation } = await import("./service.server");
@@ -3525,44 +3530,153 @@ describe("updateKitLocation - manual placement guard", () => {
       userId: "user-1",
     });
 
-    // Event fires for the cascaded QT asset only — the skipped INDIVIDUAL
-    // asset must not appear (audit trail matches persisted state).
-    expect(recordEvents).toHaveBeenCalledTimes(1);
+    expect(db.assetLocation.update).toHaveBeenCalledWith({
+      where: { id: "al-manual" },
+      data: { quantity: 40 },
+    });
+    // Only the overflow is reclaimed — the manual placement survives.
+    expect(db.assetLocation.delete).not.toHaveBeenCalled();
+  });
+
+  it("leaves manual placements alone when there is no overflow", async () => {
+    expect.assertions(2);
+
+    mockKitWithAssets([
+      {
+        quantity: 10,
+        asset: {
+          id: "asset-qty",
+          title: "Batch",
+          type: AssetType.QUANTITY_TRACKED,
+          quantity: 50,
+          unitOfMeasure: "kg",
+          assetLocations: [{ location: { id: "loc-old", name: "Old Loc" } }],
+        },
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      {
+        id: "ak-qty",
+        assetId: "asset-qty",
+        quantity: 10,
+        asset: { type: AssetType.QUANTITY_TRACKED },
+      },
+    ]);
+    // why: 20 manual + 10 kit-driven = 30 of a 50-unit pool — within total.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([
+      {
+        id: "al-manual",
+        assetId: "asset-qty",
+        quantity: 20,
+        assetKitId: null,
+        asset: { quantity: 50 },
+      },
+      {
+        id: "al-kit",
+        assetId: "asset-qty",
+        quantity: 10,
+        assetKitId: "ak-qty",
+        asset: { quantity: 50 },
+      },
+    ]);
+
+    const { updateKitLocation } = await import("./service.server");
+
+    await updateKitLocation({
+      id: "kit-1",
+      organizationId: "org-1",
+      currentLocationId: null,
+      newLocationId: "loc-new",
+      userId: "user-1",
+    });
+
+    expect(db.assetLocation.update).not.toHaveBeenCalled();
+    expect(db.assetLocation.delete).not.toHaveBeenCalled();
+  });
+
+  it("reports no removal for members that keep their placement when the kit's location is cleared", async () => {
+    expect.assertions(2);
+
+    mockKitWithAssets([
+      {
+        quantity: 1,
+        asset: {
+          id: "asset-ind",
+          title: "Stays put",
+          type: AssetType.INDIVIDUAL,
+          quantity: null,
+          unitOfMeasure: null,
+          assetLocations: [{ location: { id: "loc-old", name: "Old Loc" } }],
+        },
+      },
+      {
+        quantity: 10,
+        asset: {
+          id: "asset-qty",
+          title: "Batch",
+          type: AssetType.QUANTITY_TRACKED,
+          quantity: 50,
+          unitOfMeasure: "kg",
+          assetLocations: [{ location: { id: "loc-old", name: "Old Loc" } }],
+        },
+      },
+    ]);
+    // why: probe for the rows the clear branch is about to delete. Only the
+    // QT asset holds a kit-driven row; the INDIVIDUAL member's plain row
+    // survives, so it must not be reported as unplaced.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([{ assetId: "asset-qty" }]);
+
+    const { updateKitLocation } = await import("./service.server");
+
+    await updateKitLocation({
+      id: "kit-1",
+      organizationId: "org-1",
+      currentLocationId: "loc-old",
+      newLocationId: null,
+      userId: "user-1",
+    });
+
     const eventsArg = (recordEvents as ReturnType<typeof vitest.fn>).mock
       .calls[0][0];
     expect(eventsArg.map((e: { assetId: string }) => e.assetId)).toEqual([
       "asset-qty",
     ]);
-    // Note fires for the cascaded QT asset only.
-    const noteCalls = (createNote as ReturnType<typeof vitest.fn>).mock.calls;
-    const noteAssetIds = noteCalls.map(
-      (c) => (c[0] as { assetId: string }).assetId
-    );
+    const noteAssetIds = (
+      createNote as ReturnType<typeof vitest.fn>
+    ).mock.calls.map((c) => (c[0] as { assetId: string }).assetId);
     expect(noteAssetIds).toEqual(["asset-qty"]);
-    expect(noteAssetIds).not.toContain("asset-ind-manual");
   });
 });
 
-describe("bulkUpdateKitLocation - manual placement guard", () => {
+describe("bulkUpdateKitLocation - cascade to member assets", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
     // why: `assertLocationBelongsToOrg` calls `db.location.findFirst` —
     // echo a row back for any id so the guard passes (mirrors the
-    // setup in the `updateKitLocation` describe above).
+    // `updateKitLocation` describe above).
     //@ts-expect-error missing vitest type
     db.location.findFirst.mockImplementation(({ where }) =>
       where?.id
         ? Promise.resolve({ id: where.id, name: where.id })
         : Promise.resolve(null)
     );
+    // why: `clearAllMocks` clears calls but keeps implementations, so reset
+    // the placement read explicitly — these tests exercise the no-overflow
+    // path and must not inherit another describe's rows.
+    //@ts-expect-error missing vitest type
+    db.assetLocation.findMany.mockResolvedValue([]);
   });
 
-  it("regression: skips INDIVIDUAL asset with manual row across multiple kits", async () => {
-    expect.assertions(3);
-
-    // Two kits in the bulk set; the first contains an INDIVIDUAL asset
-    // that already has a manual AssetLocation row.
-    const kitsWithAssetsRows = [
+  /**
+   * Two kits in the bulk set: kit-a holds an INDIVIDUAL asset that already
+   * has a location (the case the old guard skipped), kit-b a QT asset.
+   */
+  function mockBulkKits() {
+    //@ts-expect-error missing vitest type
+    db.kit.findMany.mockResolvedValue([
       {
         id: "kit-a",
         name: "Kit A",
@@ -3572,13 +3686,13 @@ describe("bulkUpdateKitLocation - manual placement guard", () => {
           {
             quantity: 1,
             asset: {
-              id: "asset-ind-manual",
+              id: "asset-ind",
               title: "Manually placed",
               type: AssetType.INDIVIDUAL,
               quantity: null,
               unitOfMeasure: null,
               assetLocations: [
-                { location: { id: "loc-manual", name: "Manual Loc" } },
+                { location: { id: "loc-old", name: "Old Loc" } },
               ],
             },
           },
@@ -3603,27 +3717,28 @@ describe("bulkUpdateKitLocation - manual placement guard", () => {
           },
         ],
       },
-    ];
-
-    // why: kits fetched at the top of `bulkUpdateKitLocation` — drives
-    // the in-memory `kitsWithAssets`/`allAssets` lists that the cascade +
-    // audit-trail iterate.
-    //@ts-expect-error missing vitest type
-    db.kit.findMany.mockResolvedValue(kitsWithAssetsRows);
-    // why: post-deleteMany re-read of the bulk set's AssetKit rows; the
-    // resulting ids/quantities are what the cascade writes into
-    // `assetLocation.createMany`.
+    ]);
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
-      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
-      { id: "ak-qty", assetId: "asset-qty", quantity: 3 },
+      {
+        id: "ak-ind",
+        assetId: "asset-ind",
+        quantity: 1,
+        asset: { type: AssetType.INDIVIDUAL },
+      },
+      {
+        id: "ak-qty",
+        assetId: "asset-qty",
+        quantity: 3,
+        asset: { type: AssetType.QUANTITY_TRACKED },
+      },
     ]);
-    // why: manual-row probe — populated for the INDIVIDUAL asset so the
-    // guard must skip it from both the cascade AND the audit trail.
-    //@ts-expect-error missing vitest type
-    db.assetLocation.findMany.mockResolvedValue([
-      { assetId: "asset-ind-manual" },
-    ]);
+  }
+
+  it("moves both asset types across the whole bulk set", async () => {
+    expect.assertions(3);
+
+    mockBulkKits();
 
     const { bulkUpdateKitLocation } = await import("./service.server");
 
@@ -3637,8 +3752,19 @@ describe("bulkUpdateKitLocation - manual placement guard", () => {
     expect(db.assetLocation.deleteMany).toHaveBeenCalledWith({
       where: { assetKit: { kitId: { in: ["kit-a", "kit-b"] } } },
     });
-    expect(db.assetLocation.createMany).toHaveBeenCalledTimes(1);
-    // Skipped asset not in payload; QT asset still cascaded.
+    // INDIVIDUAL member: plain row at the new location.
+    expect(db.assetLocation.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          assetId: "asset-ind",
+          locationId: "loc-new",
+          organizationId: "org-1",
+          quantity: 1,
+          assetKitId: null,
+        },
+      ],
+    });
+    // QT member: kit-driven row carrying this kit's slice.
     expect(db.assetLocation.createMany).toHaveBeenCalledWith({
       data: [
         {
@@ -3652,73 +3778,10 @@ describe("bulkUpdateKitLocation - manual placement guard", () => {
     });
   });
 
-  it("regression: bulk path emits no event for skipped INDIVIDUAL", async () => {
-    expect.assertions(2);
+  it("emits an event for every moved member, including INDIVIDUAL ones", async () => {
+    expect.assertions(1);
 
-    // Same setup as the bulk regression case above — kit-a holds an
-    // INDIVIDUAL asset with a manual row, kit-b holds a QT asset.
-    const kitsWithAssetsRows = [
-      {
-        id: "kit-a",
-        name: "Kit A",
-        locationId: null,
-        location: null,
-        assetKits: [
-          {
-            quantity: 1,
-            asset: {
-              id: "asset-ind-manual",
-              title: "Manually placed",
-              type: AssetType.INDIVIDUAL,
-              quantity: null,
-              unitOfMeasure: null,
-              assetLocations: [
-                { location: { id: "loc-manual", name: "Manual Loc" } },
-              ],
-            },
-          },
-        ],
-      },
-      {
-        id: "kit-b",
-        name: "Kit B",
-        locationId: null,
-        location: null,
-        assetKits: [
-          {
-            quantity: 3,
-            asset: {
-              id: "asset-qty",
-              title: "Batch",
-              type: AssetType.QUANTITY_TRACKED,
-              quantity: 50,
-              unitOfMeasure: "kg",
-              assetLocations: [],
-            },
-          },
-        ],
-      },
-    ];
-
-    // why: kits fetched at the top of `bulkUpdateKitLocation` — drives
-    // the in-memory `kitsWithAssets`/`allAssets` lists that the cascade +
-    // audit-trail iterate.
-    //@ts-expect-error missing vitest type
-    db.kit.findMany.mockResolvedValue(kitsWithAssetsRows);
-    // why: post-deleteMany re-read of the bulk set's AssetKit rows; the
-    // resulting ids/quantities are what the cascade writes into
-    // `assetLocation.createMany`.
-    //@ts-expect-error missing vitest type
-    db.assetKit.findMany.mockResolvedValue([
-      { id: "ak-ind", assetId: "asset-ind-manual", quantity: 1 },
-      { id: "ak-qty", assetId: "asset-qty", quantity: 3 },
-    ]);
-    // why: manual-row probe — populated for the INDIVIDUAL asset so the
-    // guard must skip it from both the cascade AND the audit trail.
-    //@ts-expect-error missing vitest type
-    db.assetLocation.findMany.mockResolvedValue([
-      { assetId: "asset-ind-manual" },
-    ]);
+    mockBulkKits();
 
     const { bulkUpdateKitLocation } = await import("./service.server");
 
@@ -3729,13 +3792,132 @@ describe("bulkUpdateKitLocation - manual placement guard", () => {
       userId: "user-1",
     });
 
-    // Event fires for the cascaded QT asset only — the skipped INDIVIDUAL
-    // asset must not appear (audit trail matches persisted state).
-    expect(recordEvents).toHaveBeenCalledTimes(1);
     const eventsArg = (recordEvents as ReturnType<typeof vitest.fn>).mock
       .calls[0][0];
-    expect(eventsArg.map((e: { assetId: string }) => e.assetId)).toEqual([
-      "asset-qty",
-    ]);
+    expect(eventsArg.map((e: { assetId: string }) => e.assetId).sort()).toEqual(
+      ["asset-ind", "asset-qty"]
+    );
+  });
+});
+
+/**
+ * `AssetLocation.assetKit` is `onDelete: Cascade`, so deleting an `AssetKit`
+ * row would take the kit-driven placement with it and silently unplace the
+ * asset. Unpacking a kit doesn't teleport its contents, so the row is
+ * converted to a manual placement first — subject to the two uniqueness /
+ * trigger constraints the helper has to work around.
+ */
+describe("preserveKitDrivenPlacements", () => {
+  /**
+   * The helper reads placements twice — first the kit-driven rows about to be
+   * cascaded away, then the asset's existing manual rows — so the tests queue
+   * two sequential resolutions. Cast once here rather than sprinkling
+   * `@ts-expect-error` across the chained calls.
+   */
+  const placementReads = () =>
+    db.assetLocation.findMany as unknown as ReturnType<typeof vitest.fn>;
+
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("converts a kit-driven placement into a manual one", async () => {
+    expect.assertions(2);
+
+    placementReads()
+      // kit-driven rows about to be cascaded away
+      .mockResolvedValueOnce([
+        {
+          id: "al-kit",
+          assetId: "asset-qty",
+          locationId: "loc-kit",
+          quantity: 10,
+          asset: { type: AssetType.QUANTITY_TRACKED },
+        },
+      ])
+      // the asset holds no manual rows, so there's nothing to collide with
+      .mockResolvedValueOnce([]);
+
+    const { preserveKitDrivenPlacements } = await import("./service.server");
+
+    await preserveKitDrivenPlacements(db, ["ak-qty"]);
+
+    expect(db.assetLocation.update).toHaveBeenCalledWith({
+      where: { id: "al-kit" },
+      data: { assetKitId: null },
+    });
+    expect(db.assetLocation.delete).not.toHaveBeenCalled();
+  });
+
+  it("merges into the manual row already sitting at that location", async () => {
+    expect.assertions(2);
+
+    placementReads()
+      .mockResolvedValueOnce([
+        {
+          id: "al-kit",
+          assetId: "asset-qty",
+          locationId: "loc-shared",
+          quantity: 10,
+          asset: { type: AssetType.QUANTITY_TRACKED },
+        },
+      ])
+      // why: a manual row at the SAME location — nulling `assetKitId` would
+      // breach `AssetLocation_manual_unique (assetId, locationId)`.
+      .mockResolvedValueOnce([
+        {
+          id: "al-manual",
+          assetId: "asset-qty",
+          locationId: "loc-shared",
+          quantity: 5,
+        },
+      ]);
+
+    const { preserveKitDrivenPlacements } = await import("./service.server");
+
+    await preserveKitDrivenPlacements(db, ["ak-qty"]);
+
+    expect(db.assetLocation.update).toHaveBeenCalledWith({
+      where: { id: "al-manual" },
+      data: { quantity: 15 },
+    });
+    expect(db.assetLocation.delete).toHaveBeenCalledWith({
+      where: { id: "al-kit" },
+    });
+  });
+
+  it("drops the kit-driven row when an INDIVIDUAL asset is already placed", async () => {
+    expect.assertions(2);
+
+    placementReads()
+      .mockResolvedValueOnce([
+        {
+          id: "al-kit",
+          assetId: "asset-ind",
+          locationId: "loc-kit",
+          quantity: 1,
+          asset: { type: AssetType.INDIVIDUAL },
+        },
+      ])
+      // why: `enforce_individual_asset_single_location` caps an INDIVIDUAL
+      // asset at one row, so the existing manual placement has to win even
+      // though it sits at a different location.
+      .mockResolvedValueOnce([
+        {
+          id: "al-manual",
+          assetId: "asset-ind",
+          locationId: "loc-other",
+          quantity: 1,
+        },
+      ]);
+
+    const { preserveKitDrivenPlacements } = await import("./service.server");
+
+    await preserveKitDrivenPlacements(db, ["ak-ind"]);
+
+    expect(db.assetLocation.delete).toHaveBeenCalledWith({
+      where: { id: "al-kit" },
+    });
+    expect(db.assetLocation.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -19,8 +19,10 @@ import {
   KitStatus,
   NoteType,
 } from "@prisma/client";
+import type { ITXClientDenyList } from "@prisma/client/runtime/library";
 import type { LoaderFunctionArgs } from "react-router";
 import { extractStoragePath } from "~/components/assets/asset-image/utils";
+import type { ExtendedPrismaClient } from "~/database/db.server";
 import { db } from "~/database/db.server";
 import { getSupabaseAdmin } from "~/integrations/supabase/client";
 import {
@@ -94,6 +96,16 @@ import { getQr } from "../qr/service.server";
 import { getUserByID } from "../user/service.server";
 
 const label: ErrorLabel = "Kit";
+
+/**
+ * Transaction client accepted by the kit-location cascade / placement helpers.
+ *
+ * The extended client's `$transaction` callback param isn't directly
+ * assignable to the generated `Prisma.TransactionClient`, so omit the
+ * tx-denied members instead of widening to `any` — same approach as
+ * `~/modules/asset-index-settings/service.server`.
+ */
+type KitLocationTxClient = Omit<ExtendedPrismaClient, ITXClientDenyList>;
 
 /**
  * Build per-asset Custody rows that inherit a KitCustody assignment.
@@ -329,6 +341,105 @@ export async function mergeStandaloneCollisionsForKitDetachment(
       data: { quantity: standalone.quantity + kdr.quantity },
     });
     await tx.bookingAsset.delete({ where: { id: kdr.id } });
+  }
+}
+
+/**
+ * Keeps an asset at the location its kit gave it when the `AssetKit` row is
+ * about to be deleted (asset removed from kit, bulk detach, cross-kit move,
+ * kit deletion).
+ *
+ * `AssetLocation.assetKit` is `onDelete: Cascade`, so without this the
+ * kit-driven placement row would vanish with the membership and the asset
+ * would silently become unplaced. Unpacking a kit doesn't teleport its
+ * contents, so the row is converted to a manual placement instead
+ * (`assetKitId: null`).
+ *
+ * Two constraints make a blind conversion unsafe, so each row is handled
+ * individually:
+ *
+ * - `AssetLocation_manual_unique (assetId, locationId) WHERE assetKitId IS NULL`
+ *   — when a manual row already sits at the same location, the slice is merged
+ *   into it and the kit-driven row deleted (mirrors
+ *   {@link mergeStandaloneCollisionsForKitDetachment} for `BookingAsset`).
+ * - `enforce_individual_asset_single_location` — an INDIVIDUAL asset can hold
+ *   only one row, so if it already has a manual placement the kit-driven row is
+ *   dropped and the manual one stands. INDIVIDUAL members get plain rows from
+ *   {@link cascadeKitLocationToAssets} and so don't normally reach this branch;
+ *   it covers kit-driven rows written before that behaviour.
+ *
+ * Call BEFORE `tx.assetKit.delete*(...)`.
+ *
+ * @param tx Active transaction — must be the one deleting the `AssetKit` rows
+ * @param assetKitIds `AssetKit` rows about to be deleted
+ */
+export async function preserveKitDrivenPlacements(
+  tx: KitLocationTxClient,
+  assetKitIds: string[]
+): Promise<void> {
+  if (assetKitIds.length === 0) return;
+
+  const kitDrivenRows = await tx.assetLocation.findMany({
+    where: { assetKitId: { in: assetKitIds } },
+    select: {
+      id: true,
+      assetId: true,
+      locationId: true,
+      quantity: true,
+      asset: { select: { type: true } },
+    },
+  });
+  if (kitDrivenRows.length === 0) return;
+
+  const manualRows = await tx.assetLocation.findMany({
+    where: {
+      assetKitId: null,
+      assetId: { in: [...new Set(kitDrivenRows.map((row) => row.assetId))] },
+    },
+    select: { id: true, assetId: true, locationId: true, quantity: true },
+  });
+
+  const manualByPair = new Map(
+    manualRows.map((row) => [`${row.assetId}::${row.locationId}`, row])
+  );
+  const assetsWithManualRow = new Set(manualRows.map((row) => row.assetId));
+
+  for (const row of kitDrivenRows) {
+    if (
+      row.asset.type !== AssetType.QUANTITY_TRACKED &&
+      assetsWithManualRow.has(row.assetId)
+    ) {
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above, and every caller derives those ids from an org-scoped AssetKit query
+      await tx.assetLocation.delete({ where: { id: row.id } });
+      continue;
+    }
+
+    const collision = manualByPair.get(`${row.assetId}::${row.locationId}`);
+    if (collision) {
+      await tx.assetLocation.update({
+        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: collision.id came from the manual-row read above, scoped to assets that own the org-scoped kit-driven rows
+        where: { id: collision.id },
+        data: { quantity: collision.quantity + row.quantity },
+      });
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above (org-scoped by every caller)
+      await tx.assetLocation.delete({ where: { id: row.id } });
+      continue;
+    }
+
+    await tx.assetLocation.update({
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above (org-scoped by every caller)
+      where: { id: row.id },
+      data: { assetKitId: null },
+    });
+    // Track the freshly-converted row so a second kit-driven slice for the
+    // same (asset, location) merges into it rather than colliding.
+    manualByPair.set(`${row.assetId}::${row.locationId}`, {
+      id: row.id,
+      assetId: row.assetId,
+      locationId: row.locationId,
+      quantity: row.quantity,
+    });
+    assetsWithManualRow.add(row.assetId);
   }
 }
 
@@ -677,10 +788,18 @@ export async function updateKit({
     }
 
     if (locationId) {
-      // why: locationId comes from form input — prove it belongs to this
-      // kit's org before connecting (cross-org IDOR guard)
-      await assertLocationBelongsToOrg({ locationId, organizationId });
-      data.location = { connect: { id: locationId } };
+      // Setting `Kit.locationId` here would move the kit without moving its
+      // member assets — the cascade (and its per-asset events/notes) lives in
+      // `updateKitLocation`. Routing a location change through this function
+      // is how kit members silently drifted from their kit's location, so
+      // reject it instead of writing a half-applied change.
+      throw new ShelfError({
+        cause: null,
+        message:
+          "A kit's location cannot be changed through updateKit — call updateKitLocation so the kit's assets move with it.",
+        label,
+        additionalData: { kitId: id, locationId, organizationId },
+      });
     }
 
     const kit = await db.kit.update({
@@ -1481,6 +1600,18 @@ async function performKitDeletion({
         tx
       );
     }
+
+    // Deleting the kit cascades Kit → AssetKit → AssetLocation, which would
+    // unplace every member. Convert the kit-driven placements to manual ones
+    // first so the assets stay where the kit left them.
+    const aksToDelete = await tx.assetKit.findMany({
+      where: { kitId: { in: kitIdsToDelete }, organizationId },
+      select: { id: true },
+    });
+    await preserveKitDrivenPlacements(
+      tx,
+      aksToDelete.map((ak: { id: string }) => ak.id)
+    );
 
     await tx.kit.deleteMany({
       where: { id: { in: kitIdsToDelete }, organizationId },
@@ -2919,6 +3050,208 @@ export async function getAvailableKitAssetForBooking(
   }
 }
 
+/**
+ * Trims a QUANTITY_TRACKED asset's MANUAL placements when the kit-driven
+ * slices pushed `sum(AssetLocation.quantity)` past `Asset.quantity`.
+ *
+ * Moving a kit relocates only the kit's own slice, so the units it took with
+ * it must stop being counted at whichever location(s) they used to sit at —
+ * otherwise the DEFERRED `enforce_asset_location_sum_within_total` trigger
+ * aborts the whole transaction at COMMIT.
+ *
+ * Only the overflow is reclaimed, largest manual row first, so deliberate
+ * multi-location splits survive as far as the invariant allows. Rows that
+ * reach zero are deleted rather than left as empty placements.
+ *
+ * @param assetIds QUANTITY_TRACKED assets whose placements may now overflow
+ * @param tx Active transaction — must be the one that wrote the kit slices
+ */
+async function trimManualPlacementOverflow(
+  assetIds: Array<Asset["id"]>,
+  tx: KitLocationTxClient
+): Promise<void> {
+  if (assetIds.length === 0) return;
+
+  const rows = await tx.assetLocation.findMany({
+    where: { assetId: { in: assetIds } },
+    select: {
+      id: true,
+      assetId: true,
+      quantity: true,
+      assetKitId: true,
+      asset: { select: { quantity: true } },
+    },
+  });
+
+  const byAsset = new Map<string, typeof rows>();
+  for (const row of rows) {
+    const bucket = byAsset.get(row.assetId);
+    if (bucket) {
+      bucket.push(row);
+    } else {
+      byAsset.set(row.assetId, [row]);
+    }
+  }
+
+  for (const assetRows of byAsset.values()) {
+    // `Asset.quantity` is null for INDIVIDUAL assets — the single-row
+    // trigger governs those and this helper has nothing to enforce.
+    const total = assetRows[0]?.asset?.quantity;
+    if (total == null) continue;
+
+    let overflow =
+      assetRows.reduce((sum, row) => sum + row.quantity, 0) - total;
+    if (overflow <= 0) continue;
+
+    // Kit-driven rows are the placements we just wrote — reclaim from the
+    // manual ones only, biggest first so the fewest placements are touched.
+    const manualRows = assetRows
+      .filter((row) => row.assetKitId === null)
+      .sort((a, b) => b.quantity - a.quantity);
+
+    for (const row of manualRows) {
+      if (overflow <= 0) break;
+      const reclaimed = Math.min(row.quantity, overflow);
+      overflow -= reclaimed;
+      if (reclaimed === row.quantity) {
+        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetId IN assetIds` read above, and those asset ids come from AssetKit rows of kits the caller already org-scoped
+        await tx.assetLocation.delete({ where: { id: row.id } });
+      } else {
+        await tx.assetLocation.update({
+          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetId IN assetIds` read above (org-scoped via the caller's kit query)
+          where: { id: row.id },
+          data: { quantity: row.quantity - reclaimed },
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Moves every member asset of the given kits to `newLocationId`, writing the
+ * `AssetLocation` pivot rows that make the kit's placement visible on the
+ * assets themselves.
+ *
+ * The two asset types carry different invariants (see the triggers in
+ * `packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql`),
+ * so placement is type-aware:
+ *
+ * - **INDIVIDUAL** — capped at ONE row by
+ *   `enforce_individual_asset_single_location`. The kit owns the asset's
+ *   whereabouts, so the asset's existing row is replaced by a **plain**
+ *   (`assetKitId: null`) row at the kit's location. A plain row rather than a
+ *   kit-driven one keeps the trigger satisfied and means the asset keeps this
+ *   location when it later leaves the kit.
+ * - **QUANTITY_TRACKED** — may span several locations at distinct slices, so
+ *   only the kit's own slice moves: a **kit-driven** (`assetKitId` set) row of
+ *   `AssetKit.quantity` units. The discriminator is what lets a later kit move
+ *   find and relocate that same slice. Manual rows are then trimmed by any
+ *   resulting overflow (see {@link trimManualPlacementOverflow}).
+ *
+ * Callers MUST have proven `newLocationId` belongs to `organizationId` (via
+ * `assertLocationBelongsToOrg`) first — this connects assets to it without
+ * re-checking.
+ *
+ * @param args.kitIds Kits whose members move; must already be org-scoped
+ * @param args.newLocationId Target location, proven org-owned by the caller
+ * @param args.organizationId Owning workspace, stamped onto the new pivot rows
+ * @param args.assetIds Optional subset — when provided only these members are
+ *   moved, leaving the kit's other members untouched. Used by the join cascade
+ *   so adding an asset doesn't re-place assets that were already in the kit.
+ * @param tx Active transaction, so the cascade commits with its audit trail
+ * @returns Ids of the assets that actually got a new placement, so callers
+ *   emit events/notes matching the persisted state
+ */
+async function cascadeKitLocationToAssets(
+  {
+    kitIds,
+    newLocationId,
+    organizationId,
+    assetIds,
+  }: {
+    kitIds: Array<Kit["id"]>;
+    newLocationId: string;
+    organizationId: Organization["id"];
+    assetIds?: Array<Asset["id"]>;
+  },
+  tx: KitLocationTxClient
+): Promise<Set<string>> {
+  if (kitIds.length === 0 || assetIds?.length === 0) return new Set();
+
+  const memberScope = {
+    kitId: { in: kitIds },
+    ...(assetIds ? { assetId: { in: assetIds } } : {}),
+  };
+
+  // Drop these kits' existing kit-driven rows first so a repeated move
+  // relocates the slice instead of stacking a second one. Manual rows are
+  // handled per-type below.
+  await tx.assetLocation.deleteMany({
+    where: { assetKit: memberScope },
+  });
+
+  const assetKits = await tx.assetKit.findMany({
+    where: memberScope,
+    select: {
+      id: true,
+      assetId: true,
+      quantity: true,
+      asset: { select: { type: true } },
+    },
+  });
+  if (assetKits.length === 0) return new Set();
+
+  const qtyTracked = assetKits.filter(
+    (ak) => ak.asset.type === AssetType.QUANTITY_TRACKED
+  );
+  // `enforce_individual_asset_single_kit` already stops an INDIVIDUAL asset
+  // from sitting in two slices, but dedupe anyway — two rows for one asset
+  // would breach both the single-location trigger and
+  // `AssetLocation_manual_unique`.
+  const individualAssetIds = [
+    ...new Set(
+      assetKits
+        .filter((ak) => ak.asset.type !== AssetType.QUANTITY_TRACKED)
+        .map((ak) => ak.assetId)
+    ),
+  ];
+
+  if (individualAssetIds.length > 0) {
+    // Replace the asset's single placement. Mirrors the manual-row replace
+    // in `bulkUpdateAssetLocation` (~/modules/asset/service.server).
+    await tx.assetLocation.deleteMany({
+      where: { assetId: { in: individualAssetIds }, assetKitId: null },
+    });
+    await tx.assetLocation.createMany({
+      data: individualAssetIds.map((assetId) => ({
+        assetId,
+        locationId: newLocationId,
+        organizationId,
+        quantity: 1,
+        assetKitId: null,
+      })),
+    });
+  }
+
+  if (qtyTracked.length > 0) {
+    await tx.assetLocation.createMany({
+      data: qtyTracked.map((ak) => ({
+        assetId: ak.assetId,
+        locationId: newLocationId,
+        organizationId,
+        quantity: ak.quantity,
+        assetKitId: ak.id,
+      })),
+    });
+    await trimManualPlacementOverflow(
+      [...new Set(qtyTracked.map((ak) => ak.assetId))],
+      tx
+    );
+  }
+
+  return new Set(assetKits.map((ak) => ak.assetId));
+}
+
 export async function updateKitLocation({
   id,
   organizationId,
@@ -3021,59 +3354,16 @@ export async function updateKitLocation({
         });
 
         if (assetIds.length > 0) {
-          // Only touch kit-driven rows (the ones whose `assetKit.kitId`
-          // matches this kit). Manual placements belong to the user and
-          // survive a kit-location change. Drop existing kit-driven rows
-          // for this kit, then re-create them at the new location with
-          // `assetKitId` set so the discriminator survives.
-          await tx.assetLocation.deleteMany({
-            where: { assetKit: { kitId: id } },
-          });
-          const assetKitsForKit = await tx.assetKit.findMany({
-            where: { kitId: id },
-            select: { id: true, assetId: true, quantity: true },
-          });
-          // Skip INDIVIDUAL assets that already hold a manual
-          // AssetLocation row (`assetKitId IS NULL`). The
-          // `enforce_individual_asset_single_location` trigger
-          // (packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql)
-          // permits at most one AssetLocation row per INDIVIDUAL asset:
-          // manual placements override kit-driven cascades for
-          // INDIVIDUAL assets — they can hold at most one
-          // AssetLocation row.
-          const manualAssetIds = new Set(
-            (
-              await tx.assetLocation.findMany({
-                where: {
-                  assetId: { in: assetKitsForKit.map((ak) => ak.assetId) },
-                  assetKitId: null,
-                  asset: { type: "INDIVIDUAL" },
-                },
-                select: { assetId: true },
-              })
-            ).map((r) => r.assetId)
+          // Move the kit's members with it — INDIVIDUAL assets get their
+          // single placement replaced, QUANTITY_TRACKED assets get their
+          // kit slice relocated. Track which assets actually moved so the
+          // audit trail below matches the persisted state.
+          cascadedAssetIds = await cascadeKitLocationToAssets(
+            { kitIds: [id], newLocationId, organizationId },
+            tx
           );
-          const dataToCreate = assetKitsForKit
-            .filter((ak) => !manualAssetIds.has(ak.assetId))
-            .map((ak) => ({
-              assetId: ak.assetId,
-              locationId: newLocationId,
-              organizationId,
-              quantity: ak.quantity,
-              assetKitId: ak.id,
-            }));
-          // Track which assets actually got a kit-driven row so the
-          // audit-trail (events + per-asset notes) matches the persisted
-          // state — skipped manual-placement assets must not appear.
-          cascadedAssetIds = new Set(dataToCreate.map((row) => row.assetId));
-          if (dataToCreate.length > 0) {
-            await tx.assetLocation.createMany({ data: dataToCreate });
-          }
         }
 
-        // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
-        // row) don't actually move with the kit — exclude them from the
-        // activity event so the audit trail matches the persisted state.
         const cascadedAssetsForEvents = assetsWithLocationChange.filter(
           (asset) => cascadedAssetIds.has(asset.id)
         );
@@ -3102,9 +3392,6 @@ export async function updateKitLocation({
       });
 
       // Add notes to assets about location update via parent kit
-      // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
-      // row) don't actually move with the kit — exclude them from the
-      // per-asset note so the audit trail matches the persisted state.
       const cascadedAssetsForNotes = kit.assets.filter((asset) =>
         cascadedAssetIds.has(asset.id)
       );
@@ -3156,6 +3443,12 @@ export async function updateKitLocation({
         (asset) => getPrimaryLocation(asset)?.id === currentLocationId
       );
 
+      // Assets whose placement is actually dropped below — populated inside
+      // the tx, and reused by the post-tx note loop. INDIVIDUAL members keep
+      // the location the kit gave them (their row is plain, not kit-driven),
+      // so only the kit's QUANTITY_TRACKED slices land in here.
+      let unplacedAssetIds = new Set<string>();
+
       // Disconnect kit from the old location AND drop per-asset placement
       // via the AssetLocation pivot, atomically with the per-asset
       // ASSET_LOCATION_CHANGED events.
@@ -3177,17 +3470,32 @@ export async function updateKitLocation({
         });
 
         if (assetIds.length > 0) {
-          // Only delete kit-driven rows for THIS kit. Manual rows
-          // survive (the user's own placements aren't unset just
-          // because the kit lost its location).
+          // Only delete kit-driven rows for THIS kit. Manual rows survive
+          // (the user's own placements aren't unset just because the kit
+          // lost its location) — which now includes the plain rows the
+          // cascade wrote for INDIVIDUAL members, so they stay where the
+          // kit left them. Capture the affected asset ids first: the
+          // audit trail must only claim a removal for rows we really drop.
+          unplacedAssetIds = new Set(
+            (
+              await tx.assetLocation.findMany({
+                where: { assetKit: { kitId: id } },
+                select: { assetId: true },
+              })
+            ).map((row) => row.assetId)
+          );
           await tx.assetLocation.deleteMany({
             where: { assetKit: { kitId: id } },
           });
         }
 
-        if (userId && assetsWithLocationChange.length > 0) {
+        const unplacedAssetsForEvents = assetsWithLocationChange.filter(
+          (asset) => unplacedAssetIds.has(asset.id)
+        );
+
+        if (userId && unplacedAssetsForEvents.length > 0) {
           await recordEvents(
-            assetsWithLocationChange.map((asset) => ({
+            unplacedAssetsForEvents.map((asset) => ({
               organizationId,
               actorUserId: userId,
               action: "ASSET_LOCATION_CHANGED" as const,
@@ -3207,8 +3515,12 @@ export async function updateKitLocation({
         }
       });
 
-      // Add notes to assets about location removal via parent kit
-      if (userId && assetIds.length > 0) {
+      // Add notes to assets about location removal via parent kit — only the
+      // assets that actually lost their placement above.
+      const unplacedAssetsForNotes = kit.assets.filter((asset) =>
+        unplacedAssetIds.has(asset.id)
+      );
+      if (userId && unplacedAssetsForNotes.length > 0) {
         const user = await getUserByID(userId, {
           select: {
             id: true,
@@ -3224,7 +3536,7 @@ export async function updateKitLocation({
 
         // Create individual notes for each asset
         await Promise.all(
-          kit.assets.map((asset) =>
+          unplacedAssetsForNotes.map((asset) =>
             createNote({
               content: getKitLocationUpdateNoteContent({
                 // Prefer the asset's own pivot row (covers cases where the
@@ -3378,58 +3690,16 @@ export async function bulkUpdateKitLocation({
         });
 
         if (allAssets.length > 0) {
-          // Only touch kit-driven rows whose `assetKit.kitId` is in
-          // the bulk set. Manual placements survive. Drop existing
-          // kit-driven rows then re-create at the new location with
-          // `assetKitId` set.
-          await tx.assetLocation.deleteMany({
-            where: { assetKit: { kitId: { in: actualKitIds } } },
-          });
-          const assetKitsForKits = await tx.assetKit.findMany({
-            where: { kitId: { in: actualKitIds } },
-            select: { id: true, assetId: true, quantity: true },
-          });
-          // Skip INDIVIDUAL assets that already hold a manual
-          // AssetLocation row (`assetKitId IS NULL`). The
-          // `enforce_individual_asset_single_location` trigger
-          // (packages/database/prisma/migrations/20260519143054_add_asset_location_pivot/migration.sql)
-          // permits at most one AssetLocation row per INDIVIDUAL asset:
-          // manual placements override kit-driven cascades for
-          // INDIVIDUAL assets — they can hold at most one
-          // AssetLocation row.
-          const manualAssetIds = new Set(
-            (
-              await tx.assetLocation.findMany({
-                where: {
-                  assetId: { in: assetKitsForKits.map((ak) => ak.assetId) },
-                  assetKitId: null,
-                  asset: { type: "INDIVIDUAL" },
-                },
-                select: { assetId: true },
-              })
-            ).map((r) => r.assetId)
+          // Move every selected kit's members with it — INDIVIDUAL assets
+          // get their single placement replaced, QUANTITY_TRACKED assets
+          // get their kit slice relocated. Track which assets actually
+          // moved so the audit trail below matches the persisted state.
+          cascadedAssetIds = await cascadeKitLocationToAssets(
+            { kitIds: actualKitIds, newLocationId, organizationId },
+            tx
           );
-          const dataToCreate = assetKitsForKits
-            .filter((ak) => !manualAssetIds.has(ak.assetId))
-            .map((ak) => ({
-              assetId: ak.assetId,
-              locationId: newLocationId,
-              organizationId,
-              quantity: ak.quantity,
-              assetKitId: ak.id,
-            }));
-          // Track which assets actually got a kit-driven row so the
-          // audit-trail (events + per-asset notes) matches the persisted
-          // state — skipped manual-placement assets must not appear.
-          cascadedAssetIds = new Set(dataToCreate.map((row) => row.assetId));
-          if (dataToCreate.length > 0) {
-            await tx.assetLocation.createMany({ data: dataToCreate });
-          }
         }
 
-        // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
-        // row) don't actually move with the kit — exclude them from the
-        // activity event so the audit trail matches the persisted state.
         const cascadedAssetsForEvents = assetsWithLocationChange.filter(
           (asset) => cascadedAssetIds.has(asset.id)
         );
@@ -3457,10 +3727,7 @@ export async function bulkUpdateKitLocation({
         }
       });
 
-      // Create notes for affected assets
-      // why: skipped INDIVIDUAL assets (pinned by a manual AssetLocation
-      // row) don't actually move with the kit — exclude them from the
-      // per-asset note so the audit trail matches the persisted state.
+      // Create notes for affected assets.
       // (Kit-level system notes below are emitted per-kit and remain
       // unfiltered — they describe the kit-level movement, not asset rows.)
       const cascadedAssetsForNotes = allAssets.filter((asset) =>
@@ -3513,6 +3780,12 @@ export async function bulkUpdateKitLocation({
         (asset) => getPrimaryLocation(asset)?.id
       );
 
+      // Assets whose placement is actually dropped below — populated inside
+      // the tx, and reused by the post-tx note loop. INDIVIDUAL members keep
+      // the location their kit gave them (their row is plain, not
+      // kit-driven), so only kit-driven QUANTITY_TRACKED slices land here.
+      let unplacedAssetIds = new Set<string>();
+
       // Removing location - clear the kit FK and the per-asset pivot rows,
       // atomically with the per-asset ASSET_LOCATION_CHANGED events.
       await db.$transaction(async (tx) => {
@@ -3522,17 +3795,31 @@ export async function bulkUpdateKitLocation({
         });
 
         if (allAssets.length > 0) {
-          // Only drop kit-driven rows for THIS batch of kits. Manual
-          // rows survive — clearing the kits' location doesn't undo
-          // the user's own placements.
+          // Only drop kit-driven rows for THIS batch of kits. Manual rows
+          // survive — clearing the kits' location doesn't undo the user's
+          // own placements, nor the plain rows the cascade wrote for
+          // INDIVIDUAL members. Capture the affected asset ids first so the
+          // audit trail only claims a removal for rows we really drop.
+          unplacedAssetIds = new Set(
+            (
+              await tx.assetLocation.findMany({
+                where: { assetKit: { kitId: { in: actualKitIds } } },
+                select: { assetId: true },
+              })
+            ).map((row) => row.assetId)
+          );
           await tx.assetLocation.deleteMany({
             where: { assetKit: { kitId: { in: actualKitIds } } },
           });
         }
 
-        if (assetsWithLocationChange.length > 0) {
+        const unplacedAssetsForEvents = assetsWithLocationChange.filter(
+          (asset) => unplacedAssetIds.has(asset.id)
+        );
+
+        if (unplacedAssetsForEvents.length > 0) {
           await recordEvents(
-            assetsWithLocationChange.map((asset) => ({
+            unplacedAssetsForEvents.map((asset) => ({
               organizationId,
               actorUserId: userId,
               action: "ASSET_LOCATION_CHANGED" as const,
@@ -3552,9 +3839,12 @@ export async function bulkUpdateKitLocation({
         }
       });
 
-      // Create individual notes for each asset (asset locations were already
-      // cleared atomically in the transaction above).
-      if (allAssets.length > 0) {
+      // Create individual notes for each asset that actually lost its
+      // placement (cleared atomically in the transaction above).
+      const unplacedAssetsForNotes = allAssets.filter((asset) =>
+        unplacedAssetIds.has(asset.id)
+      );
+      if (unplacedAssetsForNotes.length > 0) {
         const user = await getUserByID(userId, {
           select: {
             id: true,
@@ -3565,7 +3855,7 @@ export async function bulkUpdateKitLocation({
         });
 
         await Promise.all(
-          allAssets.map((asset) =>
+          unplacedAssetsForNotes.map((asset) =>
             createNote({
               content: getKitLocationUpdateNoteContent({
                 currentLocation: getPrimaryLocation(asset),
@@ -4116,6 +4406,10 @@ export async function updateKitAssets({
       ReturnType<typeof fetchAssetKitDetachmentImpact>
     > = [];
 
+    // Newly added assets that were moved to the kit's location — populated
+    // inside the tx, consumed by the post-tx note loop.
+    let locationCascadedAssetIds = new Set<string>();
+
     await db.$transaction(async (tx) => {
       // Disconnect: drop the pivot rows for removed assets (only when not
       // in addOnly mode).
@@ -4132,6 +4426,7 @@ export async function updateKitAssets({
           await fetchAssetKitDetachmentImpact(tx, aksToDeleteIds)
         );
         await mergeStandaloneCollisionsForKitDetachment(tx, aksToDeleteIds);
+        await preserveKitDrivenPlacements(tx, aksToDeleteIds);
         await tx.assetKit.deleteMany({
           where: {
             kitId: kit.id,
@@ -4170,6 +4465,7 @@ export async function updateKitAssets({
           await fetchAssetKitDetachmentImpact(tx, aksToDeleteIds)
         );
         await mergeStandaloneCollisionsForKitDetachment(tx, aksToDeleteIds);
+        await preserveKitDrivenPlacements(tx, aksToDeleteIds);
         await tx.assetKit.deleteMany({
           where: { assetId: { in: movedFromOtherKitIds } },
         });
@@ -4206,15 +4502,55 @@ export async function updateKitAssets({
         }
       }
 
-      // Kit membership does NOT touch `AssetLocation`. Per the orthogonal-
-      // axes model documented in `docs/proposals/quantitative-assets.md`
-      // (lines 783-794), `AssetLocation` describes physical whereabouts and
-      // `AssetKit` describes organisational grouping; they don't subtract
-      // from each other. Adding an asset to a kit only writes the `AssetKit`
-      // pivot — units stay at whichever location(s) they were already placed.
-      // The asset's appearance on the kit's location-detail UI (when the kit
-      // has a `locationId`) is derived from the join `AssetKit + Kit.locationId`,
-      // not from a parallel kit-driven `AssetLocation` row.
+      // A kit's location owns its members' whereabouts, so joining a kit that
+      // sits somewhere moves the asset there — otherwise a newly added asset
+      // would keep its old location until the next kit-location change, and
+      // the kit would claim members that aren't with it. Scoped to the newly
+      // added assets so existing members aren't re-placed by an "add" op.
+      // Local const so the `string | null` narrowing survives into the
+      // `.map()` callbacks below.
+      const kitLocationId = kit.locationId;
+      if (kitLocationId && newlyAddedAssets.length > 0) {
+        locationCascadedAssetIds = await cascadeKitLocationToAssets(
+          {
+            kitIds: [kit.id],
+            newLocationId: kitLocationId,
+            organizationId,
+            assetIds: newlyAddedAssets.map((asset) => asset.id),
+          },
+          tx
+        );
+
+        const movedAssets = newlyAddedAssets.filter(
+          (asset) =>
+            locationCascadedAssetIds.has(asset.id) &&
+            (getPrimaryLocation(asset)?.id ?? null) !== kitLocationId
+        );
+        if (movedAssets.length > 0) {
+          await recordEvents(
+            movedAssets.map((asset) => ({
+              organizationId,
+              actorUserId: userId,
+              action: "ASSET_LOCATION_CHANGED" as const,
+              entityType: "ASSET" as const,
+              entityId: asset.id,
+              assetId: asset.id,
+              kitId: kit.id,
+              locationId: kitLocationId,
+              field: "locationId",
+              fromValue: getPrimaryLocation(asset)?.id ?? null,
+              toValue: kitLocationId,
+              // `meta.quantity` (qty-tracked only) = the slice this kit now
+              // holds, matching the kit-driven AssetLocation row written above.
+              meta: {
+                viaKit: true,
+                ...assetQtyMeta(asset, addedAssetKitQuantity(asset)),
+              },
+            })),
+            tx
+          );
+        }
+      }
 
       if (qtyChangedAssets.length > 0) {
         // Live link: every kit-driven BookingAsset row pointing at the
@@ -4385,6 +4721,40 @@ export async function updateKitAssets({
       removedAssets: removedAssetsForNotes,
       userId,
     });
+
+    // Per-asset note for members the kit's location moved on join — same
+    // wording as the cascade note written by `updateKitLocation`.
+    const locationMovedAssets = newlyAddedAssets.filter(
+      (asset) =>
+        locationCascadedAssetIds.has(asset.id) &&
+        (getPrimaryLocation(asset)?.id ?? null) !== kit.locationId
+    );
+    if (locationMovedAssets.length > 0 && kit.location) {
+      await Promise.all(
+        locationMovedAssets.map((asset) =>
+          createNote({
+            content: getKitLocationUpdateNoteContent({
+              currentLocation: getPrimaryLocation(asset),
+              newLocation: kit.location,
+              userId,
+              firstName: user?.firstName ?? "",
+              lastName: user?.lastName ?? "",
+              isRemoving: false,
+              // Qty-tracked cascade names the slice this kit now holds.
+              type: asset.type,
+              unitOfMeasure: asset.unitOfMeasure,
+              quantity: addedAssetKitQuantity(asset),
+            }),
+            type: "UPDATE",
+            userId,
+            assetId: asset.id,
+            // why: asset was loaded scoped to organizationId — pass the org
+            // so the note is validated against the asset's true org
+            organizationId,
+          })
+        )
+      );
+    }
 
     // Activity events — one ASSET_KIT_CHANGED per asset added or removed.
     const kitChangeEvents: Parameters<typeof recordEvents>[0] = [
@@ -5129,6 +5499,10 @@ export async function bulkRemoveAssetsFromKits({
       // Detach all from the kit regardless of remaining custody.
       // "detach from kit" means deleting the pivot rows for these
       // assets within this organization.
+      await preserveKitDrivenPlacements(
+        tx,
+        aksToDelete.map((ak: { id: string }) => ak.id)
+      );
       await tx.assetKit.deleteMany({
         where: {
           assetId: { in: allRemovedAssetIds },
@@ -5517,6 +5891,9 @@ export async function moveAssetKitUnits(
       const newSourceQty = source.quantity - quantity;
       const sourceRowDeleted = newSourceQty === 0;
       if (sourceRowDeleted) {
+        // Keep the units at the source kit's location rather than letting the
+        // AssetLocation cascade unplace them along with the emptied slice.
+        await preserveKitDrivenPlacements(tx, [source.id]);
         // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: source.id came from the org+asset+kit-scoped findFirst above, inside this same tx
         await tx.assetKit.delete({ where: { id: source.id } });
       } else {

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -355,18 +355,15 @@ export async function mergeStandaloneCollisionsForKitDetachment(
  * contents, so the row is converted to a manual placement instead
  * (`assetKitId: null`).
  *
- * Two constraints make a blind conversion unsafe, so each row is handled
- * individually:
+ * **INDIVIDUAL members only** — see the body for why converting a
+ * QUANTITY_TRACKED slice would abort the whole detach. Those rows are left to
+ * the DB cascade, which restores the pre-cascade behaviour of the units simply
+ * becoming unplaced.
  *
- * - `AssetLocation_manual_unique (assetId, locationId) WHERE assetKitId IS NULL`
- *   — when a manual row already sits at the same location, the slice is merged
- *   into it and the kit-driven row deleted (mirrors
- *   {@link mergeStandaloneCollisionsForKitDetachment} for `BookingAsset`).
- * - `enforce_individual_asset_single_location` — an INDIVIDUAL asset can hold
- *   only one row, so if it already has a manual placement the kit-driven row is
- *   dropped and the manual one stands. INDIVIDUAL members get plain rows from
- *   {@link cascadeKitLocationToAssets} and so don't normally reach this branch;
- *   it covers kit-driven rows written before that behaviour.
+ * In practice INDIVIDUAL members hold plain rows from
+ * {@link cascadeKitLocationToAssets} and never have a kit-driven row at all;
+ * this covers rows written before that behaviour, and keeps the guarantee true
+ * if one is ever written again.
  *
  * Call BEFORE `tx.assetKit.delete*(...)`.
  *
@@ -386,48 +383,47 @@ export async function preserveKitDrivenPlacements(
 ): Promise<void> {
   if (assetKitIds.length === 0) return;
 
+  // INDIVIDUAL members only, deliberately. A QUANTITY_TRACKED asset's kit
+  // slice lives on the kit axis, which the location-axis cap ignores
+  // (`enforce_asset_location_sum_within_total` counts `assetKitId IS NULL`
+  // rows only). Converting such a row to manual moves those units INTO the
+  // capped axis, so a fully-placed asset would breach
+  // `sum(manual quantity) <= Asset.quantity` and abort the whole detach —
+  // taking asset removal, bulk removal, kit deletion and full-slice moves
+  // with it. Those rows are left to the `onDelete: Cascade` instead, so the
+  // units simply go back to being unplaced.
+  //
+  // INDIVIDUAL assets have `Asset.quantity = NULL`, so that cap doesn't apply
+  // to them at all and preserving the location is always safe.
   const kitDrivenRows = await tx.assetLocation.findMany({
-    where: { assetKitId: { in: assetKitIds } },
-    select: {
-      id: true,
-      assetId: true,
-      locationId: true,
-      quantity: true,
-      asset: { select: { type: true } },
+    where: {
+      assetKitId: { in: assetKitIds },
+      asset: { type: { not: AssetType.QUANTITY_TRACKED } },
     },
+    select: { id: true, assetId: true },
   });
   if (kitDrivenRows.length === 0) return;
 
-  const manualRows = await tx.assetLocation.findMany({
-    where: {
-      assetKitId: null,
-      assetId: { in: [...new Set(kitDrivenRows.map((row) => row.assetId))] },
-    },
-    select: { id: true, assetId: true, locationId: true, quantity: true },
-  });
-
-  const manualByPair = new Map(
-    manualRows.map((row) => [`${row.assetId}::${row.locationId}`, row])
+  const placedAssetIds = new Set(
+    (
+      await tx.assetLocation.findMany({
+        where: {
+          assetKitId: null,
+          assetId: {
+            in: [...new Set(kitDrivenRows.map((row) => row.assetId))],
+          },
+        },
+        select: { assetId: true },
+      })
+    ).map((row) => row.assetId)
   );
-  const assetsWithManualRow = new Set(manualRows.map((row) => row.assetId));
 
   for (const row of kitDrivenRows) {
-    if (
-      row.asset.type !== AssetType.QUANTITY_TRACKED &&
-      assetsWithManualRow.has(row.assetId)
-    ) {
-      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above; those ids are org-scoped per this helper's caller contract
-      await tx.assetLocation.delete({ where: { id: row.id } });
-      continue;
-    }
-
-    const collision = manualByPair.get(`${row.assetId}::${row.locationId}`);
-    if (collision) {
-      await tx.assetLocation.update({
-        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: collision.id came from the manual-row read above, scoped to assets that own the org-scoped kit-driven rows
-        where: { id: collision.id },
-        data: { quantity: collision.quantity + row.quantity },
-      });
+    // `enforce_individual_asset_single_location` caps an INDIVIDUAL asset at
+    // one row. If it already holds a manual placement — or an earlier row in
+    // this loop was just converted into one — that placement wins and this
+    // kit-driven row is simply dropped.
+    if (placedAssetIds.has(row.assetId)) {
       // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above; those ids are org-scoped per this helper's caller contract
       await tx.assetLocation.delete({ where: { id: row.id } });
       continue;
@@ -438,15 +434,7 @@ export async function preserveKitDrivenPlacements(
       where: { id: row.id },
       data: { assetKitId: null },
     });
-    // Track the freshly-converted row so a second kit-driven slice for the
-    // same (asset, location) merges into it rather than colliding.
-    manualByPair.set(`${row.assetId}::${row.locationId}`, {
-      id: row.id,
-      assetId: row.assetId,
-      locationId: row.locationId,
-      quantity: row.quantity,
-    });
-    assetsWithManualRow.add(row.assetId);
+    placedAssetIds.add(row.assetId);
   }
 }
 
@@ -3058,83 +3046,6 @@ export async function getAvailableKitAssetForBooking(
 }
 
 /**
- * Trims a QUANTITY_TRACKED asset's MANUAL placements when the kit-driven
- * slices pushed `sum(AssetLocation.quantity)` past `Asset.quantity`.
- *
- * Moving a kit relocates only the kit's own slice, so the units it took with
- * it must stop being counted at whichever location(s) they used to sit at —
- * otherwise the DEFERRED `enforce_asset_location_sum_within_total` trigger
- * aborts the whole transaction at COMMIT.
- *
- * Only the overflow is reclaimed, largest manual row first, so deliberate
- * multi-location splits survive as far as the invariant allows. Rows that
- * reach zero are deleted rather than left as empty placements.
- *
- * @param assetIds QUANTITY_TRACKED assets whose placements may now overflow
- * @param tx Active transaction — must be the one that wrote the kit slices
- */
-async function trimManualPlacementOverflow(
-  assetIds: Array<Asset["id"]>,
-  tx: KitLocationTxClient
-): Promise<void> {
-  if (assetIds.length === 0) return;
-
-  const rows = await tx.assetLocation.findMany({
-    where: { assetId: { in: assetIds } },
-    select: {
-      id: true,
-      assetId: true,
-      quantity: true,
-      assetKitId: true,
-      asset: { select: { quantity: true } },
-    },
-  });
-
-  const byAsset = new Map<string, typeof rows>();
-  for (const row of rows) {
-    const bucket = byAsset.get(row.assetId);
-    if (bucket) {
-      bucket.push(row);
-    } else {
-      byAsset.set(row.assetId, [row]);
-    }
-  }
-
-  for (const assetRows of byAsset.values()) {
-    // `Asset.quantity` is null for INDIVIDUAL assets — the single-row
-    // trigger governs those and this helper has nothing to enforce.
-    const total = assetRows[0]?.asset?.quantity;
-    if (total == null) continue;
-
-    let overflow =
-      assetRows.reduce((sum, row) => sum + row.quantity, 0) - total;
-    if (overflow <= 0) continue;
-
-    // Kit-driven rows are the placements we just wrote — reclaim from the
-    // manual ones only, biggest first so the fewest placements are touched.
-    const manualRows = assetRows
-      .filter((row) => row.assetKitId === null)
-      .sort((a, b) => b.quantity - a.quantity);
-
-    for (const row of manualRows) {
-      if (overflow <= 0) break;
-      const reclaimed = Math.min(row.quantity, overflow);
-      overflow -= reclaimed;
-      if (reclaimed === row.quantity) {
-        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetId IN assetIds` read above, and those asset ids come from AssetKit rows of kits the caller already org-scoped
-        await tx.assetLocation.delete({ where: { id: row.id } });
-      } else {
-        await tx.assetLocation.update({
-          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetId IN assetIds` read above (org-scoped via the caller's kit query)
-          where: { id: row.id },
-          data: { quantity: row.quantity - reclaimed },
-        });
-      }
-    }
-  }
-}
-
-/**
  * Moves every member asset of the given kits to `newLocationId`, writing the
  * `AssetLocation` pivot rows that make the kit's placement visible on the
  * assets themselves.
@@ -3152,8 +3063,16 @@ async function trimManualPlacementOverflow(
  * - **QUANTITY_TRACKED** — may span several locations at distinct slices, so
  *   only the kit's own slice moves: a **kit-driven** (`assetKitId` set) row of
  *   `AssetKit.quantity` units. The discriminator is what lets a later kit move
- *   find and relocate that same slice. Manual rows are then trimmed by any
- *   resulting overflow (see {@link trimManualPlacementOverflow}).
+ *   find and relocate that same slice.
+ *
+ * The asset's MANUAL placements are never touched for QUANTITY_TRACKED members.
+ * The two axes are orthogonal and additive: since
+ * `20260602100000_assetlocation_sum_exclude_kit_driven`,
+ * `enforce_asset_location_sum_within_total` sums only rows with
+ * `assetKitId IS NULL`, and the kit axis is bounded separately by
+ * `enforce_asset_kit_sum_within_total`. So 100 manually-placed units plus a
+ * 50-unit kit slice is a valid state, and reclaiming from manual rows to "make
+ * room" would destroy real placement data.
  *
  * Callers MUST have proven `newLocationId` belongs to `organizationId` (via
  * `assertLocationBelongsToOrg`) first — this connects assets to it without
@@ -3241,6 +3160,9 @@ async function cascadeKitLocationToAssets(
   }
 
   if (qtyTracked.length > 0) {
+    // Additive, by design — the asset's manual placements are left alone.
+    // The location-axis sum counts only `assetKitId IS NULL` rows, so a
+    // kit slice can never push a manual placement over `Asset.quantity`.
     await tx.assetLocation.createMany({
       data: qtyTracked.map((ak) => ({
         assetId: ak.assetId,
@@ -3250,10 +3172,6 @@ async function cascadeKitLocationToAssets(
         assetKitId: ak.id,
       })),
     });
-    await trimManualPlacementOverflow(
-      [...new Set(qtyTracked.map((ak) => ak.assetId))],
-      tx
-    );
   }
 
   return new Set(assetKits.map((ak) => ak.assetId));
@@ -3398,8 +3316,11 @@ export async function updateKitLocation({
         }
       });
 
-      // Add notes to assets about location update via parent kit
-      const cascadedAssetsForNotes = kit.assets.filter((asset) =>
+      // Add notes to assets about location update via parent kit. Same filter
+      // as the events above — `cascadedAssetIds` includes members that were
+      // already at the target, and they must not get a "moved to X" note with
+      // no matching event.
+      const cascadedAssetsForNotes = assetsWithLocationChange.filter((asset) =>
         cascadedAssetIds.has(asset.id)
       );
       if (userId && cascadedAssetsForNotes.length > 0) {
@@ -3734,10 +3655,12 @@ export async function bulkUpdateKitLocation({
         }
       });
 
-      // Create notes for affected assets.
+      // Create notes for affected assets. Same filter as the events above —
+      // `cascadedAssetIds` includes members already at the target, which must
+      // not get a "moved to X" note with no matching event.
       // (Kit-level system notes below are emitted per-kit and remain
       // unfiltered — they describe the kit-level movement, not asset rows.)
-      const cascadedAssetsForNotes = allAssets.filter((asset) =>
+      const cascadedAssetsForNotes = assetsWithLocationChange.filter((asset) =>
         cascadedAssetIds.has(asset.id)
       );
       if (cascadedAssetsForNotes.length > 0) {
@@ -4506,6 +4429,15 @@ export async function updateKitAssets({
             },
             data: { quantity: change.newQuantity },
           });
+          // Keep the kit-driven placement row in step with the slice it
+          // mirrors (1:1 via `AssetLocation_kit_unique`) — otherwise a kit
+          // resized from 20 to 30 keeps advertising 20 units at its location
+          // until someone moves it. No-op when the kit has no location, since
+          // then no kit-driven row exists.
+          await tx.assetLocation.updateMany({
+            where: { assetKit: { kitId: kit.id, assetId: change.id } },
+            data: { quantity: change.newQuantity },
+          });
         }
       }
 
@@ -4802,85 +4734,6 @@ export async function updateKitAssets({
     ];
     if (kitChangeEvents.length > 0) {
       await recordEvents(kitChangeEvents);
-    }
-
-    /**
-     * Post-tx side effects for the kit-driven AssetLocation rows
-     * created above:
-     *
-     *   - Activity events (one `ASSET_LOCATION_CHANGED` per new kit-
-     *     driven placement). `fromValue: null` — the kit-driven row is
-     *     an ADDITION, not a replacement; manual placements survive
-     *     untouched.
-     *   - System notes describing the kit-driven placement.
-     *
-     * Only runs when `kit.location` is set. With no kit location, no
-     * kit-driven row exists, so no event / note is needed — and
-     * crucially, the user's manual placements are NOT touched.
-     */
-    if (kit.location && newlyAddedAssets.length > 0) {
-      const kitLocationId = kit.location.id;
-      await recordEvents(
-        newlyAddedAssets.map((asset) => ({
-          organizationId,
-          actorUserId: userId,
-          action: "ASSET_LOCATION_CHANGED" as const,
-          entityType: "ASSET" as const,
-          entityId: asset.id,
-          assetId: asset.id,
-          kitId: kit.id,
-          locationId: kitLocationId,
-          field: "locationId",
-          fromValue: null,
-          toValue: kitLocationId,
-          // `meta.quantity` (qty-tracked only) = the per-row
-          // `AssetKit.quantity` written into the new kit-driven location row
-          // (matches the value passed to `assetLocation.createMany` above).
-          meta: {
-            viaKit: true,
-            ...assetQtyMeta(asset, addedAssetKitQuantity(asset)),
-          },
-        }))
-      );
-
-      // Create notes describing the new kit-driven placement. The
-      // existing helper renders as "moved to {kit.location}"; with
-      // `currentLocation: null` it reads as a fresh placement.
-      const noteUser = await getUserByID(userId, {
-        select: {
-          id: true,
-          firstName: true,
-          lastName: true,
-          displayName: true,
-        } satisfies Prisma.UserSelect,
-      });
-      await Promise.all(
-        newlyAddedAssets.map((asset) =>
-          createNote({
-            content: getKitLocationUpdateNoteContent({
-              currentLocation: null,
-              newLocation: kit.location,
-              userId,
-              firstName: noteUser?.firstName ?? "",
-              lastName: noteUser?.lastName ?? "",
-              isRemoving: false,
-              // Qty-tracked cascade names the kit's per-row slice this
-              // asset now holds in the kit (= the value written to the
-              // kit-driven AssetLocation row).
-              type: asset.type,
-              unitOfMeasure: asset.unitOfMeasure,
-              quantity: addedAssetKitQuantity(asset),
-            }),
-            type: "UPDATE",
-            userId,
-            assetId: asset.id,
-            // why: asset resolved scoped to organizationId for this kit —
-            // pass the org so the note is validated against the asset's
-            // true org.
-            organizationId,
-          })
-        )
-      );
     }
 
     /**
@@ -5728,7 +5581,9 @@ export async function moveAssetKitUnits(
         }),
         tx.kit.findFirst({
           where: { id: toKitId, organizationId },
-          select: { id: true, name: true },
+          // `locationId` drives the re-placement of the moved units at the
+          // destination kit's location (step 9b).
+          select: { id: true, name: true, locationId: true },
         }),
       ]);
 
@@ -5898,8 +5753,10 @@ export async function moveAssetKitUnits(
       const newSourceQty = source.quantity - quantity;
       const sourceRowDeleted = newSourceQty === 0;
       if (sourceRowDeleted) {
-        // Keep the units at the source kit's location rather than letting the
-        // AssetLocation cascade unplace them along with the emptied slice.
+        // INDIVIDUAL members keep their placement; a QUANTITY_TRACKED slice's
+        // row goes with the AssetKit via the DB cascade. Either way step 9b
+        // below re-places the units at the DESTINATION kit's location, so they
+        // don't linger at the kit they just left.
         await preserveKitDrivenPlacements(tx, [source.id]);
         // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: source.id came from the org+asset+kit-scoped findFirst above, inside this same tx
         await tx.assetKit.delete({ where: { id: source.id } });
@@ -5924,6 +5781,33 @@ export async function moveAssetKitUnits(
         update: { quantity: { increment: quantity } },
         select: { id: true, quantity: true },
       });
+
+      // 9b. Re-place the moved units at the DESTINATION kit's location.
+      //     Without this the units stay recorded wherever the source kit was
+      //     (or nowhere), even though they now belong to a kit that lives
+      //     somewhere else. Reuses the shared cascade so the placement stays
+      //     type-aware: a plain row for INDIVIDUAL, a kit-driven slice
+      //     carrying the destination's new `AssetKit.quantity` for
+      //     QUANTITY_TRACKED.
+      //
+      //     `toKit.locationId` is org-safe without a further check: `toKit`
+      //     was read scoped to `organizationId`, so its location belongs to
+      //     the caller's org by construction.
+      if (toKit.locationId) {
+        await cascadeKitLocationToAssets(
+          {
+            kitIds: [toKitId],
+            newLocationId: toKit.locationId,
+            organizationId,
+            assetIds: [assetId],
+          },
+          tx
+        );
+      } else {
+        // Destination kit is unplaced, so no kit-driven row may survive for
+        // it — the units revert to whatever manual placement they hold.
+        await tx.assetLocation.deleteMany({ where: { assetKitId: dest.id } });
+      }
 
       // 10. Cascade to active kit-driven BookingAsset rows on the DEST
       //     kit — keep them in sync with the new slice quantity (mirrors

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -370,8 +370,15 @@ export async function mergeStandaloneCollisionsForKitDetachment(
  *
  * Call BEFORE `tx.assetKit.delete*(...)`.
  *
+ * Caller contract: `assetKitIds` MUST already be org-scoped — this helper
+ * rewrites the rows they point at without re-checking. Today's callers satisfy
+ * it via an explicit `organizationId` filter (`performKitDeletion`,
+ * `bulkRemoveAssetsFromKits`), an org-scoped kit (`updateKitAssets`' disconnect
+ * path, `moveAssetKitUnits`), or an org-scoped asset read
+ * (`updateKitAssets`' cross-kit-move path).
+ *
  * @param tx Active transaction — must be the one deleting the `AssetKit` rows
- * @param assetKitIds `AssetKit` rows about to be deleted
+ * @param assetKitIds `AssetKit` rows about to be deleted; must be org-scoped
  */
 export async function preserveKitDrivenPlacements(
   tx: KitLocationTxClient,
@@ -409,7 +416,7 @@ export async function preserveKitDrivenPlacements(
       row.asset.type !== AssetType.QUANTITY_TRACKED &&
       assetsWithManualRow.has(row.assetId)
     ) {
-      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above, and every caller derives those ids from an org-scoped AssetKit query
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above; those ids are org-scoped per this helper's caller contract
       await tx.assetLocation.delete({ where: { id: row.id } });
       continue;
     }
@@ -421,13 +428,13 @@ export async function preserveKitDrivenPlacements(
         where: { id: collision.id },
         data: { quantity: collision.quantity + row.quantity },
       });
-      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above (org-scoped by every caller)
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above; those ids are org-scoped per this helper's caller contract
       await tx.assetLocation.delete({ where: { id: row.id } });
       continue;
     }
 
     await tx.assetLocation.update({
-      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above (org-scoped by every caller)
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: row.id came from the `assetKitId IN assetKitIds` read above; those ids are org-scoped per this helper's caller contract
       where: { id: row.id },
       data: { assetKitId: null },
     });


### PR DESCRIPTION
Changing a kit's location never reached its assets, from the kit page, the
kits-index bulk action, or the scanner alike. All three call updateKitLocation
or bulkUpdateKitLocation, and both skipped any INDIVIDUAL member that already
held a manual AssetLocation row, to stay inside the
enforce_individual_asset_single_location trigger. Since kit membership never
converted a manual row into a kit-driven one, that made the cascade a permanent
no-op for any asset with a location: 5,110 manual rows on kit members against
1 kit-driven locally.

A kit's location now owns its members' placement, through one shared
cascadeKitLocationToAssets helper replacing the ~60 duplicated lines that let
the bug live in both functions:

- INDIVIDUAL members have their single row replaced by a plain (assetKitId
  null) row at the kit's location, so the trigger holds and the asset keeps the
  location on detach.
- QUANTITY_TRACKED members get a kit-driven row carrying AssetKit.quantity, so
  only the kit's slice moves, and manual rows are trimmed by any overflow past
  Asset.quantity that the deferred sum trigger would otherwise abort at COMMIT.

Placements also survive detach: preserveKitDrivenPlacements converts kit-driven
rows to manual, merging on an (assetId, locationId) collision, before every
AssetKit delete - updateKitAssets, bulkRemoveAssetsFromKits, moveAssetKitUnits
and kit deletion.

Joining a kit that has a location now moves the asset too, and clearing a kit's
location no longer emits a removal event or note for members that kept their
placement.

Closes the route that caused the drift too: updateKit now rejects locationId
instead of setting Kit.locationId with no cascade. Adds an explicit orderBy to
the shared assetLocations selectors so getPrimaryLocation() no longer depends
on heap order.

No migration or backfill - divergent data converges on the next kit-location
change.

The four tests that asserted the old skip as intended behaviour are rewritten;
the kit suite now covers both asset types across both paths, the overflow trim,
the clear-location audit trail, every detach branch and the updateKit guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction-safe kit detach/remove/move behavior that preserves correct placement semantics for individual assets.
  * After moving kit units, quantity-tracked units are re-placed at the destination kit location.
* **Bug Fixes**
  * Prevented unintended conversion/removal of manual placements during kit location and membership updates.
  * Improved “primary location” selection by enforcing deterministic asset-location ordering.
  * Activity/history reporting now reflects only placements that actually changed.
  * Restricted changing a kit’s location to the dedicated location workflow.
* **Documentation**
  * Added a rule describing correct kit/member placement behavior.
* **Tests**
  * Expanded coverage for cascading placement, detach conversion, and event/audit reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->