### PR TITLE
ci: fix CI on fork PRs by moving off pull_request_target

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -35,11 +35,22 @@ jobs:
       - name: 🔨 Build docs
         run: pnpm docs:build
 
+      # Fork PRs receive no repository secrets, so CLOUDFLARE_API_TOKEN is empty
+      # and the deploy is a guaranteed failure. Skip it for them — the docs
+      # BUILD above still runs, which is the part that can actually regress.
+      # The `push` arm is required: pushes to main have no pull_request context.
       - name: 📥 Install Wrangler
+        if: github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         run: npm install -g wrangler
 
       - name: 🚀 Deploy to Cloudflare Pages
-        run: wrangler pages deploy apps/docs/.vitepress/dist --project-name=shelf-docs --branch=${{ github.event_name == 'push' && 'main' || github.head_ref }}
+        if: github.event_name == 'push' ||
+          github.event.pull_request.head.repo.full_name == github.repository
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # github.head_ref is attacker-controlled PR input (a branch name), so
+          # it goes through env instead of being interpolated into the script.
+          DEPLOY_BRANCH: ${{ github.event_name == 'push' && 'main' || github.head_ref }}
+        run: wrangler pages deploy apps/docs/.vitepress/dist --project-name=shelf-docs --branch="$DEPLOY_BRANCH"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -42,13 +42,23 @@ jobs:
       - name: 📥 Install Wrangler
         if: github.event_name == 'push' ||
           github.event.pull_request.head.repo.full_name == github.repository
-        # Pinned to the major: this step hands CLOUDFLARE_API_TOKEN to whatever
-        # it installs, so resolving "latest" at runtime would let a compromised
-        # release reach the credential. Major-pinned rather than exact so patch
-        # and minor fixes still land — an exact pin goes stale and breaks the
-        # deploy when Cloudflare moves their API forward.
-        # Installed globally rather than via pnpm on purpose (acb25d0d1).
-        run: npm install -g wrangler@4
+        # Pinned EXACTLY, on purpose. This step hands CLOUDFLARE_API_TOKEN to
+        # whatever it installs, so a floating range would let a compromised
+        # release reach the credential. Wrangler pins all of its own non-optional
+        # deps exactly (esbuild, workerd, miniflare, unenv...), so an exact pin
+        # here resolves a deterministic tree without needing a lockfile entry.
+        #
+        # Bumping is MANUAL: Dependabot's github-actions ecosystem parses `uses:`
+        # references, not npm package names inside `run:` scripts, so nothing
+        # updates this automatically. That is the accepted trade — a stale
+        # wrangler fails loudly at deploy time, a compromised one fails silently.
+        #
+        # Not a devDependency of apps/docs: wrangler pulls in workerd (~127MB),
+        # and with no pnpm caching in CI every job in the monorepo would
+        # download it on every PR, to upload a static VitePress site.
+        # Not via pnpm/wrangler-action either — that hits the pnpm
+        # workspace-root restriction this step was written to avoid (acb25d0d1).
+        run: npm install -g wrangler@4.114.0
 
       - name: 🚀 Deploy to Cloudflare Pages
         if: github.event_name == 'push' ||

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -20,6 +20,12 @@ jobs:
 
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
+        with:
+          # `pnpm install` and `pnpm docs:build` below run fork-authored code
+          # (lifecycle scripts, vitepress config) BEFORE the deploy guard, and
+          # checkout persists GITHUB_TOKEN into .git/config by default. Nothing
+          # here needs git auth after checkout, so don't leave it on disk.
+          persist-credentials: false
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -42,7 +42,13 @@ jobs:
       - name: 📥 Install Wrangler
         if: github.event_name == 'push' ||
           github.event.pull_request.head.repo.full_name == github.repository
-        run: npm install -g wrangler
+        # Pinned to the major: this step hands CLOUDFLARE_API_TOKEN to whatever
+        # it installs, so resolving "latest" at runtime would let a compromised
+        # release reach the credential. Major-pinned rather than exact so patch
+        # and minor fixes still land — an exact pin goes stale and breaks the
+        # deploy when Cloudflare moves their API forward.
+        # Installed globally rather than via pnpm on purpose (acb25d0d1).
+        run: npm install -g wrangler@4
 
       - name: 🚀 Deploy to Cloudflare Pages
         if: github.event_name == 'push' ||

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -8,7 +8,7 @@ name: 🩺 React Doctor
 #   2. Fails the check if NEW errors are introduced — warnings stay advisory.
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "apps/webapp/**/*.ts"
       - "apps/webapp/**/*.tsx"
@@ -20,17 +20,12 @@ on:
       - ".github/workflows/react-doctor.yml"
       - ".github/scripts/react-doctor-pr-comment.mjs"
 
-jobs:
-  authorize:
-    environment: ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      'external' || '' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ✓
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
+jobs:
   doctor:
-    needs: authorize
     name: 🩺 React Doctor (${{ matrix.app.name }})
     runs-on: ubuntu-latest
     permissions:
@@ -47,17 +42,19 @@ jobs:
           - name: companion
             dir: apps/companion
     steps:
-      - name: 🛑 Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
-      - name: ⬇️ Checkout PR head
+      - name: ⬇️ Checkout PR merge ref
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # No `ref:` — the default checkout resolves to the PR merge ref and is
+          # exempt from actions/checkout's fork-PR guard. fetch-depth: 0 is
+          # still required so `origin/<base>` exists for the --diff below.
           fetch-depth: 0
+          # Nothing after this step needs git auth, so the token never lands in
+          # .git/config where fork-controlled code could read it back out.
+          persist-credentials: false
 
       - name: 🪢 Re-attach HEAD to a named branch
-        # actions/checkout leaves us on a DETACHED HEAD when given a sha.
+        # actions/checkout leaves us on a DETACHED HEAD at the PR merge ref.
         # react-doctor's --diff path calls `git rev-parse --abbrev-ref HEAD`
         # to find the current branch; in detached state that returns the
         # literal "HEAD", which the CLI interprets as "no branch" and silently
@@ -157,13 +154,32 @@ jobs:
           cat "$RUNNER_TEMP/comment.md"
 
       - name: 💬 Post or update PR comment
+        # Fork and Dependabot PRs run with a read-only GITHUB_TOKEN, so the
+        # comment API 403s for them. Those PRs surface findings through the
+        # inline annotations (emitted as log commands, which need no token) and
+        # the job summary written below.
+        #
+        # Predicate on pull_request.user.login, NOT github.actor: the read-only
+        # token is keyed to who AUTHORED the PR, but github.actor becomes the
+        # re-runner's login on a manual re-run — which would wrongly re-enable
+        # this step on a Dependabot PR re-run.
         if: always() && steps.changes.outputs.changed == 'true'
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && github.event.pull_request.user.login != 'dependabot[bot]'
+        # Backstop for any read-only-token case not enumerated above.
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           # Per-app header so the two matrix jobs maintain separate sticky
           # comments instead of overwriting each other.
           header: react-doctor-${{ matrix.app.name }}
           path: ${{ runner.temp }}/comment.md
+
+      - name: 📋 Write findings to job summary
+        # Runs for EVERY PR including forks and Dependabot — this is the only
+        # aggregated report those PRs get, since the sticky comment is skipped.
+        if: always() && steps.changes.outputs.changed == 'true'
+        run: cat "$RUNNER_TEMP/comment.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: ❌ Fail if errors introduced
         if: steps.changes.outputs.changed == 'true' && steps.doctor.outputs.exit_code != '0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,25 @@
-name: 🧪 Test PR from fork
+name: 🧪 Test
+
+# SECURITY INVARIANT — read this before adding a job to this workflow.
+#
+# This workflow runs on `pull_request`, so fork PRs execute here. GitHub gives
+# those runs a read-only GITHUB_TOKEN and NO repository secrets — that is
+# precisely what makes it safe to run untrusted contributor code automatically.
+#
+# Therefore: any job that consumes a secret MUST NOT live in this workflow.
+# Secret-bearing jobs (e.g. the Playwright/E2E suite below) belong in a separate
+# workflow gated behind the `external` environment, and must never check out
+# fork PR code in that trusted context.
+#
+# Do NOT "fix" a fork PR checkout failure by setting `allow-unsafe-pr-checkout:
+# true` on a checkout step. That re-enables the "pwn request" attack class that
+# actions/checkout began blocking in July 2026.
 
 on:
-  pull_request_target:
+  pull_request:
+  # Called by deploy.yml on pushes to main/dev. The secrets below are declared
+  # for the E2E job that currently lives commented-out at the bottom of this
+  # file; deploy.yml passes all six, so this block must not be removed.
   workflow_call:
     secrets:
       SESSION_SECRET:
@@ -17,28 +35,32 @@ on:
       DATABASE_URL:
         required: true
 
+# Least privilege, pinned explicitly. The repo default is already `read`, but
+# pinning it means a future org-level default change cannot silently escalate
+# these jobs. `contents: read` is what actions/checkout needs to fetch.
+permissions:
+  contents: read
+
+concurrency:
+  # PR number for PR runs; run_id on the workflow_call path so a push to main
+  # gets a unique group and can never be cancelled by a PR run. Note that in a
+  # reusable workflow the `github` context belongs to the CALLER.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  authorize:
-    environment: ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      'external' || '' }}
-
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ✓
-
   lint:
-    needs: authorize
     name: ⬣ ESLint
     runs-on: ubuntu-latest
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          # No `ref:` — the default checkout resolves to the PR merge ref and is
+          # exempt from actions/checkout's fork-PR guard. No credentials
+          # persisted: nothing after this step needs git auth, so the token
+          # never lands in .git/config where fork code could read it.
+          persist-credentials: false
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
@@ -55,17 +77,13 @@ jobs:
         run: pnpm run lint
 
   typecheck:
-    needs: authorize
     name: ʦ TypeScript
     runs-on: ubuntu-latest
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
@@ -82,17 +100,13 @@ jobs:
         run: pnpm run typecheck
 
   vitest:
-    needs: authorize
     name: ⚡ Vitest
     runs-on: ubuntu-latest
     steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v4
@@ -111,19 +125,16 @@ jobs:
       - name: ⚡ Run vitest
         run: pnpm --filter @shelf/webapp test -- --run
 
+  # NOTE: this job consumes secrets — see the SECURITY INVARIANT at the top of
+  # this file. Do NOT re-enable it here. It belongs in its own workflow gated
+  # behind the `external` environment, and must not check out fork PR code.
   # playwright:
-  #   needs: authorize
   #   name: 🎭 Playwright
   #   timeout-minutes: 60
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - name: 🛑 Cancel Previous Runs
-  #       uses: styfle/cancel-workflow-action@0.11.0
-
   #     - name: ⬇️ Checkout repo
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha || github.ref }}
+  #       uses: actions/checkout@v4
 
   #     - name: 🔑 Make envfile
   #       uses: SpicyPizza/create-envfile@v2.0
@@ -137,9 +148,9 @@ jobs:
   #         file_name: .env
 
   #     - name: ⎔ Setup node
-  #       uses: actions/setup-node@v3
+  #       uses: actions/setup-node@v4
   #       with:
-  #         node-version: 18
+  #         node-version: 22
 
   #     - name: 📥 Download deps
   #       uses: bahmutov/npm-install@v1
@@ -153,7 +164,7 @@ jobs:
   #     - name: Run Playwright tests
   #       run: npx playwright test
 
-  #     - uses: actions/upload-artifact@v3
+  #     - uses: actions/upload-artifact@v4
   #       if: always()
   #       with:
   #         name: playwright-report


### PR DESCRIPTION
Closes #2385

## Problem

Every PR opened from a fork currently fails all five CI checks. Jobs die at the checkout step in 4–9s, before installing anything:

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target'
workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets,
default-branch cache scope, and runner access. Fetching and executing a fork's
code in that trusted context commonly leads to "pwn request" vulnerabilities.
```

Example: [run 30000187031](https://github.com/Shelf-nu/shelf.nu/actions/runs/30000187031) (fork `SRF-Consulting-Group-Inc/scim`) — `authorize` passed after manual approval, then ESLint / TypeScript / Vitest each failed at `⬇️ Checkout repo`. React Doctor's two matrix legs failed identically. Three fork PRs are blocked on this right now (#2744, #2737, #2717).

## Root cause

`actions/checkout` added a "pwn request" guard — v7 GA in June 2026, backported to all supported majors (including the `v4` tag we pin) on **2026-07-20**. That date matches our first failures.

The guard is narrow. From [`src/input-helper.ts`](https://github.com/actions/checkout/blob/main/src/input-helper.ts):

```js
const isDefaultCheckout = isWorkflowRepository && !core.getInput('ref')
if (!isDefaultCheckout) {
  unsafePrCheckoutHelper.assertSafePrCheckout({ ... })
}
```

It throws only when the event is `pull_request_target`/`workflow_run` **and** the head repo is a fork **and** the resolved ref points at the fork PR head. A **default checkout (no `ref:`) is exempt.**

So our explicit `ref: ${{ github.event.pull_request.head.sha }}` is precisely what trips it, and removing it is what makes the config legal again.

## What changed

| File | Change |
| --- | --- |
| `test.yml` | `pull_request_target` → `pull_request`; deleted `authorize` job and 3 `ref:` overrides; replaced 3 broken `cancel-workflow-action` steps with native `concurrency`; added `permissions: contents: read`, `persist-credentials: false`, and a SECURITY INVARIANT header. Renamed to `🧪 Test`. |
| `react-doctor.yml` | Same trigger swap and `authorize`/`ref:`/cancel removal; sticky comment gated to writable-token PRs; new job-summary step for every PR. |
| `docs-deploy.yml` | Separate pre-existing bug — fork PRs have no `CLOUDFLARE_API_TOKEN` so the deploy always failed. Guarded the deploy step (not the job, so forks still *build* the docs). Also fixed a `github.head_ref` shell interpolation. |

`workflow_call` and its `secrets:` block stay in `test.yml` — `deploy.yml` passes all six secrets, so removing it would break `deploy.yml` immediately. E2E gets its own gated workflow when it returns.

## Security reasoning — please read this part

**This removes risk rather than adding it.** The instinct is that dropping a gate must be less safe, so it's worth being explicit about why the opposite is true.

Under `on: pull_request` from a fork, **secrets are not passed to the runner at all** — absent, not redacted. Per GitHub's docs: *"With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository."*

A contributor adding `console.log(process.env.DATABASE_URL)` prints `undefined`. And since `pull_request` reads the workflow YAML from the merge commit, a fork *can* edit the workflow to add `env: LEAK: ${{ secrets.DATABASE_URL }}` — it evaluates to the empty string. Secrets aren't withheld from the *code*; they're never handed to the *run*.

**We already have proof of this in our own repo.** `docs-deploy.yml` runs on plain `pull_request` and references `CLOUDFLARE_API_TOKEN`. On fork run [30000188946](https://github.com/Shelf-nu/shelf.nu/actions/runs/30000188946) the log reads `CLOUDFLARE_API_TOKEN: ` — empty. That job's failure *is* the protection working.

**What we have today is the risky configuration.** Under `pull_request_target`, approved fork code runs in the trusted context, and `actions/checkout` defaults `persist-credentials: true` — so the base repo's `GITHUB_TOKEN` is sitting in `.git/config` while fork code executes in the same job. Any fork-controlled code running afterward (a `pnpm install` lifecycle script, a modified vitest config) can read it. In `react-doctor.yml` that token carries `pull-requests: write`.

The structural problem is worse than the current concrete exposure: we're one careless PR away from a real leak. Someone adds `env: DATABASE_URL: ${{ secrets.DATABASE_URL }}` to the vitest job to make an integration test pass, and every fork PR silently exfiltrates the production database URL — no error, no review signal. After this change that same mistake is inert.

This also drops fork PRs from the **default-branch cache scope** to a PR-scoped one. Nothing here uses `actions/cache` today, so there's no active poisoning vector — but the trusted-context exposure goes away regardless.

### Hardening included

1. **`persist-credentials: false`** on all four PR checkouts — the token stops being written to disk, closing that path independently of which trigger is in use.
2. **Explicit `permissions: contents: read`** in `test.yml` — the repo default is already `read`, but pinning it means a future org-level default change can't silently escalate these jobs.
3. **A SECURITY INVARIANT header** in `test.yml` stating the rule: *any job consuming a secret must never check out fork code — it belongs in a separate workflow behind the `external` environment.*

### Residual risk, stated honestly

A fork PR can still execute arbitrary code on an ephemeral runner and consume Actions minutes — bounded by our `first_time_contributors` approval policy — and run lifecycle scripts via a modified lockfile, identical to the risk of any dependency and equally true today. It **cannot** read a secret, write to the repo, poison the default-branch cache, or publish anything.

## Side effects worth knowing

- **The `authorize` check disappears.** Verified safe: branch protection has no required status checks (`contexts: []`, `checks: []`) and the only ruleset is Copilot review.
- **Returning contributors get fully automatic CI.** Our fork-PR policy is `first_time_contributors`, so only genuinely new contributors need an approval click — down from every fork run today. That's the original ask in #2385.
- **React Doctor's sticky comment is skipped on fork *and* Dependabot PRs**, both of which get a read-only token. They get inline annotations (log commands — no token needed) plus a new job summary instead. Dependabot PRs do currently hit this path ([example](https://github.com/Shelf-nu/shelf.nu/actions/runs/30341177664)), so this is a deliberate behaviour change, not an oversight.
- **Tests now run against the merge ref** rather than the raw fork head — standard CI semantics, and it catches semantic conflicts the current setup misses.

## Expect duplicate checks on this PR only

`main` still has `pull_request_target` registered, so its old definition fires alongside this branch's new `pull_request` one — two `⬣ ESLint`, two `ʦ TypeScript`, etc., with identical names. Both should pass (same-repo PRs are exempt from the guard). This disappears on merge and is not a defect.

## Verification

- `actionlint` clean on all three changed files. Repo-wide findings went 5 → 4; the 4 remaining are pre-existing outdated action versions in `deploy.yml` (push-only, not fork-reachable), left alone to keep this PR scoped.
- `deploy.yml` still resolves against the rewritten reusable workflow (no `workflow_call` errors).
- **On this PR:** confirm the React Doctor sticky comment still posts and the job summary renders — this is the internal-PR path forks won't take.
- **Only a fork PR can prove the actual fix**, since the guard fires nowhere else. Post-merge: cancel the six stale `waiting` runs, then close/reopen #2744 and confirm all five checks go green with zero approval clicks.

No contributor needs to rebase — `pull_request` reads its workflow from the merge commit, so this applies to already-open fork PRs on their next event.

## On #2385

The direction there was right, but the snippet couldn't be merged as written:

1. **It wouldn't have fixed the current failure.** It keeps `pull_request_target` registered *with* the `ref:` override, so the checkout guard still fires. The issue predates the guard (filed 2026-03-02; guard landed 2026-07-20), so it addressed the approval friction, not the break.
2. **`needs:` is not an expression context.** `needs: ${{ ... && 'authorize' || '' }}` is resolved when the dependency graph is built, before expressions evaluate.
3. **Registering both triggers duplicates runs** on same-repo PRs unless every job carries an `if:` guard.
4. **`react-doctor.yml` didn't exist yet** (added 2026-04-28), so half the affected surface wasn't covered.

Thanks @iuryeng for filing it — your #2744 is one of the PRs this unblocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR scanning so results diff correctly against the target base instead of reviewing the full codebase.
  * Docs deployment now avoids running the deploy steps on unsupported/forked PRs (docs still build).
  * For forked/automated PRs, moved findings to the job summary when inline commenting may be blocked.
* **Security**
  * Tightened workflow permissions and switched key workflows to safer `pull_request` triggers.
  * Prevented checkout from persisting authentication credentials during CI runs.
* **CI Improvements**
  * Added/updated concurrency controls to automatically cancel outdated runs.
  * Updated tooling versions in the (commented) E2E workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->