### PR TITLE
fix: three production Sentry 500s (advanced-filter select-all, import clear, booking kit-add)

### DIFF
--- a/apps/webapp/app/modules/asset/bulk-operations-helper.server.test.ts
+++ b/apps/webapp/app/modules/asset/bulk-operations-helper.server.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { Prisma } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+import { buildAdvancedFilteredAssetIdsQuery } from "./bulk-operations-helper.server";
+
+// why: the module imports the db client at module scope; stub it so importing
+// this pure query-builder never touches a real database.
+vi.mock("~/database/db.server", () => ({ db: {} }));
+
+describe("buildAdvancedFilteredAssetIdsQuery", () => {
+  // Raw SQL isn't typechecked, so the join/column shape is guarded by a string
+  // assertion per `.claude/rules/raw-sql-respects-prisma-map.md`. Regression for
+  // SHELF-WEBAPP-21X: the query referenced the dropped `Asset.locationId`
+  // column and 500'd (`42703: column a.locationId does not exist`).
+  const sql = buildAdvancedFilteredAssetIdsQuery(Prisma.empty).strings.join(
+    "?"
+  );
+
+  it("joins location through the AssetLocation pivot (LATERAL primary-pick)", () => {
+    expect(sql).toContain('public."AssetLocation"');
+    expect(sql).toContain("LEFT JOIN LATERAL");
+  });
+
+  it("does not reference the dropped Asset.locationId column", () => {
+    expect(sql).not.toContain('a."locationId"');
+  });
+
+  it("still selects distinct asset ids and interpolates the where clause", () => {
+    const withWhere = buildAdvancedFilteredAssetIdsQuery(
+      Prisma.sql`WHERE a."organizationId" = ${"org-1"}`
+    );
+    expect(withWhere.strings.join("?")).toContain("SELECT DISTINCT a.id");
+    // The org id is carried as a bound parameter, never interpolated inline.
+    expect(withWhere.values).toContain("org-1");
+  });
+});

--- a/apps/webapp/app/modules/asset/bulk-operations-helper.server.ts
+++ b/apps/webapp/app/modules/asset/bulk-operations-helper.server.ts
@@ -10,6 +10,50 @@ import type { Column } from "../asset-index-settings/helpers";
 const label = "Assets";
 
 /**
+ * Builds the raw SQL that resolves asset IDs for an advanced-filter bulk
+ * operation. Extracted so the join/column shape is unit-testable without a DB —
+ * raw SQL can't be typechecked, so a string assertion is the regression guard
+ * (see `.claude/rules/raw-sql-respects-prisma-map.md` and the co-located test).
+ *
+ * The joins mirror the main paginated query because {@link generateWhereClause}
+ * may reference the joined aliases (c.name, l.name, t.id, tm.name, …). Asset
+ * placement lives on the `AssetLocation` pivot — there is no `Asset.locationId`
+ * FK — so location is joined via a LATERAL primary-pick (oldest pivot row),
+ * exactly like the index query. The previous `LEFT JOIN "Location" l ON
+ * a."locationId" = l.id` referenced a dropped column and 500'd on every
+ * advanced-mode select-all (SHELF-WEBAPP-21X).
+ *
+ * @param whereClause - The `Prisma.Sql` WHERE fragment from generateWhereClause.
+ * @returns The composed `Prisma.Sql` SELECT query.
+ */
+export function buildAdvancedFilteredAssetIdsQuery(
+  whereClause: Prisma.Sql
+): Prisma.Sql {
+  return Prisma.sql`
+    SELECT DISTINCT a.id
+    FROM public."Asset" a
+    LEFT JOIN public."Category" c ON a."categoryId" = c.id
+    -- Placement lives on the AssetLocation pivot (no Asset.locationId FK).
+    -- LATERAL primary-pick yields one location per asset so the search
+    -- clause's l.name reference resolves without row fan-out.
+    LEFT JOIN LATERAL (
+      SELECT l.id, l.name, l."parentId"
+      FROM public."AssetLocation" al
+      JOIN public."Location" l ON al."locationId" = l.id
+      WHERE al."assetId" = a.id
+      ORDER BY al."createdAt" ASC, al.id ASC
+      LIMIT 1
+    ) l ON TRUE
+    LEFT JOIN public."_AssetToTag" att ON a.id = att."A"
+    LEFT JOIN public."Tag" t ON att."B" = t.id
+    LEFT JOIN public."Custody" cu ON cu."assetId" = a.id
+    LEFT JOIN public."TeamMember" tm ON cu."teamMemberId" = tm.id
+    LEFT JOIN public."User" u ON tm."userId" = u.id
+    ${whereClause}
+  `;
+}
+
+/**
  * Gets asset IDs matching advanced filters - optimized for bulk operations
  *
  * Uses the same filter parsing and where clause generation as the advanced
@@ -56,20 +100,10 @@ async function getAdvancedFilteredAssetIds({
       availableToBookOnly
     );
 
-    // Minimal query: only SELECT id, but include necessary joins
-    // Joins are needed because WHERE clause may reference: c.name, l.name, t.id, tm.name, etc.
-    const query = Prisma.sql`
-      SELECT DISTINCT a.id
-      FROM public."Asset" a
-      LEFT JOIN public."Category" c ON a."categoryId" = c.id
-      LEFT JOIN public."Location" l ON a."locationId" = l.id
-      LEFT JOIN public."_AssetToTag" att ON a.id = att."A"
-      LEFT JOIN public."Tag" t ON att."B" = t.id
-      LEFT JOIN public."Custody" cu ON cu."assetId" = a.id
-      LEFT JOIN public."TeamMember" tm ON cu."teamMemberId" = tm.id
-      LEFT JOIN public."User" u ON tm."userId" = u.id
-      ${whereClause}
-    `;
+    // Minimal query: only SELECT id, but include the same joins the main
+    // paginated query uses, because the WHERE clause may reference joined
+    // aliases (c.name, l.name, t.id, tm.name, etc.).
+    const query = buildAdvancedFilteredAssetIdsQuery(whereClause);
 
     const results = await db.$queryRaw<Array<{ id: string }>>(query);
     return results.map((r) => r.id);

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -42,6 +42,7 @@ import {
   removeAssets,
   addScannedAssetsToBooking,
   processBooking,
+  getAvailableAssetsIdsForBooking,
   getExistingBookingDetails,
   assertKitsAddableToActiveBooking,
   getOngoingBookingForAsset,
@@ -7412,6 +7413,50 @@ describe("getExistingBookingDetails — addable statuses", () => {
     await expect(
       getExistingBookingDetails("booking-1", "org-1")
     ).rejects.toThrow(/Draft, Reserved, Ongoing or Overdue/i);
+  });
+});
+
+describe("getAvailableAssetsIdsForBooking", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("returns the ids of assets that don't belong to a kit", async () => {
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "asset-1", status: AssetStatus.AVAILABLE, assetKits: [] },
+      { id: "asset-2", status: AssetStatus.AVAILABLE, assetKits: [] },
+    ]);
+
+    await expect(
+      getAvailableAssetsIdsForBooking(["asset-1", "asset-2"], "org-1")
+    ).resolves.toEqual(["asset-1", "asset-2"]);
+  });
+
+  it("rejects a kit-member asset as a handled 400, not a captured 500 (SHELF-WEBAPP-21Y)", async () => {
+    // A selected asset that belongs to a kit is user-input validation, not a
+    // server fault, so it must be a 400 kept out of the Sentry error pipeline.
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      {
+        id: "asset-1",
+        status: AssetStatus.AVAILABLE,
+        assetKits: [{ kitId: "kit-1" }],
+      },
+    ]);
+
+    let thrown: unknown;
+    try {
+      await getAvailableAssetsIdsForBooking(["asset-1"], "org-1");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ShelfError);
+    const err = thrown as ShelfError;
+    expect(err.message).toContain("belong to a kit");
+    // The outer catch re-wraps, but ShelfError inherits status/shouldBeCaptured
+    // from the cause, so the handled-client classification survives.
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -7422,6 +7422,8 @@ describe("getAvailableAssetsIdsForBooking", () => {
   });
 
   it("returns the ids of assets that don't belong to a kit", async () => {
+    // why: stub the org-scoped asset lookup so the function resolves against
+    // deterministic rows without a real DB; neither asset belongs to a kit.
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
       { id: "asset-1", status: AssetStatus.AVAILABLE, assetKits: [] },
       { id: "asset-2", status: AssetStatus.AVAILABLE, assetKits: [] },
@@ -7435,6 +7437,8 @@ describe("getAvailableAssetsIdsForBooking", () => {
   it("rejects a kit-member asset as a handled 400, not a captured 500 (SHELF-WEBAPP-21Y)", async () => {
     // A selected asset that belongs to a kit is user-input validation, not a
     // server fault, so it must be a 400 kept out of the Sentry error pipeline.
+    // why: stub the org-scoped lookup to return one asset that IS a kit member
+    // (assetKits non-empty) — the rejection branch under test.
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
       {
         id: "asset-1",

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -11766,10 +11766,17 @@ export async function getAvailableAssetsIdsForBooking(
     });
 
     if (selectedAssets.some((asset) => asset.assetKits.length > 0)) {
+      // User-input validation, not a server fault: adding kit-member assets
+      // directly is disallowed (kits are added as a unit). A 400 keeps this out
+      // of the Sentry error pipeline (handled client error). The outer catch
+      // re-wraps but inherits status/shouldBeCaptured from this cause. See
+      // SHELF-WEBAPP-21Y.
       throw new ShelfError({
         cause: null,
         message: "Cannot add assets that belong to a kit.",
         label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 

--- a/apps/webapp/app/utils/import-update.server.test.ts
+++ b/apps/webapp/app/utils/import-update.server.test.ts
@@ -472,7 +472,8 @@ describe("applyBulkUpdatesFromImport — qty-tracked + AssetModel", () => {
 
 describe("applyBulkUpdatesFromImport — custom field clearing (SHELF-WEBAPP-21W)", () => {
   it("clears a custom field by emitting `undefined`, never a `{ raw: '' }` value", async () => {
-    // Org has a TEXT custom field "Notes".
+    // why: give the org one TEXT custom field ("Notes") so the "Notes" CSV
+    // header resolves to a customField column instead of being ignored.
     vi.mocked(db.customField.findMany).mockResolvedValue([
       {
         id: "cf-notes",
@@ -488,8 +489,9 @@ describe("applyBulkUpdatesFromImport — custom field clearing (SHELF-WEBAPP-21W
       },
     ] as unknown as Awaited<ReturnType<typeof db.customField.findMany>>);
 
-    // The asset currently HAS a value for "Notes", so a blank cell clears it
-    // (detectClearing only fires when there's an existing non-empty value).
+    // why: the asset must already HAVE a "Notes" value so a blank cell is
+    // detected as a clear (detectClearing only fires on an existing non-empty
+    // value) — that's the branch that produced the invalid write.
     vi.mocked(db.asset.findMany).mockResolvedValueOnce([
       makeDbAsset({
         customFields: [

--- a/apps/webapp/app/utils/import-update.server.test.ts
+++ b/apps/webapp/app/utils/import-update.server.test.ts
@@ -469,3 +469,64 @@ describe("applyBulkUpdatesFromImport — qty-tracked + AssetModel", () => {
     expect(result.summary.updated).toBe(0);
   });
 });
+
+describe("applyBulkUpdatesFromImport — custom field clearing (SHELF-WEBAPP-21W)", () => {
+  it("clears a custom field by emitting `undefined`, never a `{ raw: '' }` value", async () => {
+    // Org has a TEXT custom field "Notes".
+    vi.mocked(db.customField.findMany).mockResolvedValue([
+      {
+        id: "cf-notes",
+        name: "Notes",
+        type: "TEXT",
+        helpText: null,
+        required: false,
+        active: true,
+        organizationId,
+        categoryId: null,
+        options: [],
+        deletedAt: null,
+      },
+    ] as unknown as Awaited<ReturnType<typeof db.customField.findMany>>);
+
+    // The asset currently HAS a value for "Notes", so a blank cell clears it
+    // (detectClearing only fires when there's an existing non-empty value).
+    vi.mocked(db.asset.findMany).mockResolvedValueOnce([
+      makeDbAsset({
+        customFields: [
+          {
+            customField: { id: "cf-notes", name: "Notes" },
+            value: { raw: "old note" },
+          },
+        ],
+      }),
+    ] as unknown as Awaited<ReturnType<typeof db.asset.findMany>>);
+
+    const csvData = [
+      ["Asset ID", "Notes"],
+      ["SAM-0001", ""], // blank cell → clear the existing value
+    ];
+
+    const result = await applyBulkUpdatesFromImport({
+      csvData,
+      organizationId,
+      userId,
+      request,
+    });
+
+    // Previously this row 500'd on the `ensure_value_structure_and_types`
+    // CHECK and landed in `failed`; now it applies as an update.
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.updated).toBe(1);
+    expect(updateAsset).toHaveBeenCalledTimes(1);
+
+    // The clearing signal must reach updateAsset as `undefined` (→ deleteMany),
+    // NOT the invalid `{ raw: "" }` shape that violated the CHECK constraint.
+    const payload = vi.mocked(updateAsset).mock.calls[0][0];
+    expect(payload.customFieldsValues).toHaveLength(1);
+    expect(payload.customFieldsValues?.[0]?.id).toBe("cf-notes");
+    expect(payload.customFieldsValues?.[0]?.value).toBeUndefined();
+    expect(JSON.stringify(payload.customFieldsValues)).not.toContain(
+      '"raw":""'
+    );
+  });
+});

--- a/apps/webapp/app/utils/import-update.server.ts
+++ b/apps/webapp/app/utils/import-update.server.ts
@@ -550,7 +550,11 @@ export async function applyBulkUpdatesFromImport({
       let assetModelIdPatch: UpdateAssetPayload["assetModelId"];
       const customFieldsValues: {
         id: string;
-        value: ICustomFieldValueJson;
+        // `undefined` is the deletion signal updateAsset expects: it routes
+        // falsy-value entries to deleteMany. The clearing branch below emits it
+        // (mirrors the normal form path, where buildCustomFieldValue returns
+        // undefined for empty). See SHELF-WEBAPP-21W.
+        value: ICustomFieldValueJson | undefined;
       }[] = [];
 
       // Pull this asset's qty-tracked patch (may be undefined if no
@@ -670,12 +674,14 @@ export async function applyBulkUpdatesFromImport({
               const fullCf = cfByName.get(col.cfDef.name.toLowerCase());
               if (fullCf) {
                 if (change.clearing) {
-                  // Clear custom field by passing empty value
-                  // buildCustomFieldValue returns undefined for empty,
-                  // which signals deletion in updateAsset
+                  // Clearing = delete the value row. updateAsset routes a
+                  // FALSY value to deleteMany, so emit `undefined`. A truthy
+                  // `{ raw: "" }` was instead routed to create/update and
+                  // violated the `ensure_value_structure_and_types` CHECK
+                  // (Postgres 23514) — see SHELF-WEBAPP-21W.
                   customFieldsValues.push({
                     id: fullCf.id,
-                    value: { raw: "" },
+                    value: undefined,
                   });
                 } else {
                   // For AMOUNT/NUMBER fields, pre-normalize and validate


### PR DESCRIPTION
Fixes three unrelated production 500s surfaced in Sentry, one commit each.

### 21X — advanced-mode select-all crashes (`Fixes SHELF-WEBAPP-21X`)
`getAdvancedFilteredAssetIds` joined `Location ON a."locationId"`, a column dropped
when placement moved to the `AssetLocation` pivot → `42703: column a.locationId does
not exist` on every advanced-mode select-all bulk op (audits, bulk edits, exports…).
Replaced with the LATERAL primary-pick the index query uses; extracted a testable
query builder + a raw-SQL regression test. Swept all raw queries — this was the only
offender.

### 21W — bulk import fails to clear custom fields (`Fixes SHELF-WEBAPP-21W`)
The import "clear a custom field" branch wrote `{ raw: "" }` instead of the `undefined`
deletion signal `updateAsset` expects, so it violated the `ensure_value_structure_and_types`
CHECK constraint (`23514`) and failed every cleared row in a bulk import. Now emits
`undefined` (matching the normal form path) and widens the local type; added the first
test for the clearing branch (its absence is how this shipped).

### 21Y — kit-member add pages as a 500 (`Fixes SHELF-WEBAPP-21Y`)
`getAvailableAssetsIdsForBooking`'s "belongs to a kit" validation threw with no status,
defaulting to a captured 500. It's user-input validation, so it's now a handled `400`
(`shouldBeCaptured: false`); the outer catch inherits both through `ShelfError`.

Each fix ships with tests; typecheck, eslint, and the security review pass on all three
commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved advanced asset filtering so location-based criteria are applied consistently.
  * Prevented kit-member assets from being selected for bookings, returning a handled validation error (400) to the client.
  * Fixed bulk import clearing for custom fields so blank values properly delete existing text data.
* **Tests**
  * Added coverage for advanced filtering SQL behavior, booking asset validation, and import-based custom field clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->