### PR TITLE
fix(bookings): let an in-flight booking check out assets a later reservation holds

### DIFF
--- a/apps/webapp/app/modules/booking-note/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-note/service.server.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   createBookingNote,
   createSystemBookingNote,
+  createSystemBookingNotes,
   deleteBookingNote,
   getBookingNotes,
 } from "./service.server";
@@ -11,11 +12,13 @@ vi.mock("~/database/db.server", () => ({
   db: {
     bookingNote: {
       create: vi.fn(),
+      createMany: vi.fn(),
       findMany: vi.fn(),
       deleteMany: vi.fn(),
     },
     booking: {
       findFirst: vi.fn(),
+      findMany: vi.fn(),
     },
   },
 }));
@@ -196,6 +199,75 @@ describe("BookingNote Service", () => {
       ).rejects.toThrow("Booking not found or access denied");
 
       expect(mockDb.db.bookingNote.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("createSystemBookingNotes", () => {
+    it("validates every target booking and inserts in a single batch", async () => {
+      // The whole point of the plural helper: a fixed TWO statements no matter
+      // how many notes are written, so a large batch can't burn the caller's
+      // transaction budget on audit notes.
+      (mockDb.db.booking.findMany as any).mockResolvedValue([
+        { id: "booking-1" },
+        { id: "booking-2" },
+      ]);
+      (mockDb.db.bookingNote.createMany as any).mockResolvedValue({ count: 3 });
+
+      await createSystemBookingNotes({
+        notes: [
+          { bookingId: "booking-1", content: "a" },
+          { bookingId: "booking-2", content: "b" },
+          { bookingId: "booking-1", content: "c" },
+        ],
+        organizationId: "org-1",
+      });
+
+      // One ownership check covering the DISTINCT booking ids...
+      expect(mockDb.db.booking.findMany).toHaveBeenCalledTimes(1);
+      expect(mockDb.db.booking.findMany).toHaveBeenCalledWith({
+        where: {
+          id: { in: ["booking-1", "booking-2"] },
+          organizationId: "org-1",
+        },
+        select: { id: true },
+      });
+      // ...and one insert for all three notes, all typed as system notes.
+      expect(mockDb.db.bookingNote.createMany).toHaveBeenCalledTimes(1);
+      expect(mockDb.db.bookingNote.createMany).toHaveBeenCalledWith({
+        data: [
+          { bookingId: "booking-1", content: "a", type: "UPDATE" },
+          { bookingId: "booking-2", content: "b", type: "UPDATE" },
+          { bookingId: "booking-1", content: "c", type: "UPDATE" },
+        ],
+      });
+    });
+
+    it("writes nothing when a target booking is outside the organization", async () => {
+      // Cross-org guard: the caller passes booking ids derived from related
+      // records, so a foreign id must abort the whole batch rather than
+      // silently writing the notes it could match.
+      (mockDb.db.booking.findMany as any).mockResolvedValue([
+        { id: "booking-1" },
+      ]);
+
+      await expect(
+        createSystemBookingNotes({
+          notes: [
+            { bookingId: "booking-1", content: "a" },
+            { bookingId: "foreign-booking", content: "b" },
+          ],
+          organizationId: "org-1",
+        })
+      ).rejects.toThrow("Booking not found or access denied");
+
+      expect(mockDb.db.bookingNote.createMany).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op for an empty list (no ownership query, no insert)", async () => {
+      await createSystemBookingNotes({ notes: [], organizationId: "org-1" });
+
+      expect(mockDb.db.booking.findMany).not.toHaveBeenCalled();
+      expect(mockDb.db.bookingNote.createMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/app/modules/booking-note/service.server.ts
+++ b/apps/webapp/app/modules/booking-note/service.server.ts
@@ -18,11 +18,20 @@ export type BookingNoteTxClient = {
       where: { id: string; organizationId: string };
       select: { id: true };
     }) => Promise<{ id: string } | null>;
+    /** Batched ownership check used by {@link createSystemBookingNotes} */
+    findMany: (args: {
+      where: { id: { in: string[] }; organizationId: string };
+      select: { id: true };
+    }) => Promise<{ id: string }[]>;
   };
   bookingNote: {
     create: (args: {
       data: Prisma.BookingNoteCreateInput;
     }) => Promise<BookingNote>;
+    /** Batched insert used by {@link createSystemBookingNotes} */
+    createMany: (args: {
+      data: Prisma.BookingNoteCreateManyInput[];
+    }) => Promise<{ count: number }>;
   };
 };
 
@@ -203,6 +212,80 @@ export function createSystemBookingNote(
     },
     tx
   );
+}
+
+/**
+ * Bulk variant of {@link createSystemBookingNote} — writes many system notes,
+ * possibly spanning several bookings, in a fixed TWO statements regardless of
+ * how many notes are passed.
+ *
+ * The singular helper costs two statements PER note (ownership check + insert),
+ * which is fine one-off but adds up inside a transaction: a caller writing
+ * notes for N bookings issues 2N serial round-trips against the 15s
+ * transaction budget. This validates every distinct booking in ONE query, then
+ * inserts with a single `createMany`.
+ *
+ * @param notes - Note content paired with its target booking id
+ * @param organizationId - Organization ALL target bookings must belong to
+ * @param tx - Optional transaction client so the check + insert commit with the
+ *   caller's mutation
+ * @throws {ShelfError} 404 if any target booking is not in `organizationId`
+ */
+export async function createSystemBookingNotes(
+  {
+    notes,
+    organizationId,
+  }: {
+    notes: Array<Pick<BookingNote, "content"> & { bookingId: Booking["id"] }>;
+    organizationId: string;
+  },
+  tx?: BookingNoteTxClient
+) {
+  if (notes.length === 0) {
+    return;
+  }
+
+  try {
+    const client = tx ?? db;
+    const bookingIds = [...new Set(notes.map((note) => note.bookingId))];
+
+    // Single ownership check covering every target booking. Same invariant the
+    // singular helper enforces per note — a missing id means it either doesn't
+    // exist or belongs to another organization; both are a hard 404.
+    const found = await client.booking.findMany({
+      where: { id: { in: bookingIds }, organizationId },
+      select: { id: true },
+    });
+
+    if (found.length !== bookingIds.length) {
+      throw new ShelfError({
+        cause: null,
+        message: "Booking not found or access denied",
+        additionalData: { bookingIds, organizationId },
+        label,
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    }
+
+    await client.bookingNote.createMany({
+      data: notes.map((note) => ({
+        content: note.content,
+        type: "UPDATE" as const,
+        bookingId: note.bookingId,
+      })),
+    });
+  } catch (cause) {
+    if (cause instanceof ShelfError) {
+      throw cause;
+    }
+    throw new ShelfError({
+      cause,
+      message: "Something went wrong while creating booking notes",
+      additionalData: { organizationId },
+      label,
+    });
+  }
 }
 
 /**

--- a/apps/webapp/app/modules/booking/helpers.test.ts
+++ b/apps/webapp/app/modules/booking/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   countRemainingCheckoutAssets,
   filterBookingAssets,
   groupAndSortAssetsByKit,
+  hasAssetBookingConflicts,
   isAssetCheckoutEligible,
   isBookingArchivable,
   shouldPromptEarlyCheckout,
@@ -552,5 +553,88 @@ describe("shouldPromptEarlyCheckout", () => {
     expect(shouldPromptEarlyCheckout(BookingStatus.RESERVED, past())).toBe(
       false
     );
+  });
+});
+
+describe("hasAssetBookingConflicts", () => {
+  /** Builds the minimal asset shape the helper reads. */
+  const assetWith = (
+    status: string,
+    bookings: Array<{ id: string; status: string }>,
+    type = "INDIVIDUAL"
+  ) => ({
+    status,
+    type,
+    bookingAssets: bookings.map((booking) => ({ booking })),
+  });
+
+  const CURRENT = "booking-current";
+
+  it("treats an overlapping RESERVED booking as a conflict by default", () => {
+    const asset = assetWith(AssetStatus.AVAILABLE, [
+      { id: "other", status: BookingStatus.RESERVED },
+    ]);
+    expect(hasAssetBookingConflicts(asset, CURRENT)).toBe(true);
+  });
+
+  it("ignores an ONGOING booking while the asset is not physically checked out", () => {
+    const asset = assetWith(AssetStatus.AVAILABLE, [
+      { id: "other", status: BookingStatus.ONGOING },
+    ]);
+    expect(hasAssetBookingConflicts(asset, CURRENT)).toBe(false);
+  });
+
+  it("treats an ONGOING booking as a conflict once the asset is CHECKED_OUT", () => {
+    const asset = assetWith(AssetStatus.CHECKED_OUT, [
+      { id: "other", status: BookingStatus.ONGOING },
+    ]);
+    expect(hasAssetBookingConflicts(asset, CURRENT)).toBe(true);
+  });
+
+  it("never conflicts on the current booking's own rows", () => {
+    const asset = assetWith(AssetStatus.CHECKED_OUT, [
+      { id: CURRENT, status: BookingStatus.ONGOING },
+    ]);
+    expect(hasAssetBookingConflicts(asset, CURRENT)).toBe(false);
+  });
+
+  describe("ignoreReservedConflicts", () => {
+    // The reported bug: a booking that is already ONGOING could never check out
+    // its remaining assets once ANY overlapping RESERVED booking held them —
+    // and that reservation was itself allowed precisely because this booking
+    // had not physically checked the asset out yet. An in-flight booking
+    // outranks a reservation that has taken nothing.
+    it("does NOT conflict on a RESERVED booking when reserved conflicts are ignored", () => {
+      const asset = assetWith(AssetStatus.AVAILABLE, [
+        { id: "other", status: BookingStatus.RESERVED },
+      ]);
+      expect(
+        hasAssetBookingConflicts(asset, CURRENT, {
+          ignoreReservedConflicts: true,
+        })
+      ).toBe(false);
+    });
+
+    it("still conflicts when the asset is physically CHECKED_OUT elsewhere", () => {
+      // The flag must not disarm the guard wholesale — an asset genuinely out
+      // on another in-flight booking is not on the shelf to be handed over.
+      const asset = assetWith(AssetStatus.CHECKED_OUT, [
+        { id: "other", status: BookingStatus.OVERDUE },
+      ]);
+      expect(
+        hasAssetBookingConflicts(asset, CURRENT, {
+          ignoreReservedConflicts: true,
+        })
+      ).toBe(true);
+    });
+
+    it("leaves QUANTITY_TRACKED assets to the service-layer quantity guards", () => {
+      const asset = assetWith(
+        AssetStatus.AVAILABLE,
+        [{ id: "other", status: BookingStatus.RESERVED }],
+        "QUANTITY_TRACKED"
+      );
+      expect(hasAssetBookingConflicts(asset, CURRENT)).toBe(false);
+    });
   });
 });

--- a/apps/webapp/app/modules/booking/helpers.ts
+++ b/apps/webapp/app/modules/booking/helpers.ts
@@ -422,6 +422,28 @@ export function isBookingArchivable({
 }
 
 /**
+ * Whether a booking in this status outranks an overlapping RESERVED booking
+ * when competing for the same asset.
+ *
+ * An ONGOING/OVERDUE booking is physically in flight: its custodian is holding
+ * (or collecting) the assets right now. A RESERVED booking has taken nothing —
+ * it is a claim on the future. So the in-flight booking wins, and the loser is
+ * told at ITS check-out, where `hasAssetBookingConflicts` correctly reports the
+ * asset as CHECKED_OUT on an in-flight booking.
+ *
+ * Without this asymmetry the priority inverts: because an ONGOING booking does
+ * not "occupy" an asset it has not yet checked out, anyone could reserve that
+ * asset afterwards — and that later reservation would then permanently block
+ * the in-flight booking from checking out an asset it already holds.
+ *
+ * @param status - The booking's current status
+ * @returns `true` when the booking is in flight (ONGOING or OVERDUE)
+ */
+export function outranksReservations(status: string): boolean {
+  return status === BookingStatus.ONGOING || status === BookingStatus.OVERDUE;
+}
+
+/**
  * Core logic for determining if an asset has booking conflicts.
  * Assets now reference bookings through the BookingAsset pivot table,
  * so we traverse `asset.bookingAssets[].booking` instead of the
@@ -435,6 +457,12 @@ export function isBookingArchivable({
  * `computeBookingAvailableQuantity()`.
  *
  * Used by both isAssetAlreadyBooked and kit-related functions.
+ *
+ * @param asset - Minimal asset shape (status, type, pivot rows to bookings)
+ * @param currentBookingId - Booking being evaluated; its own rows never conflict
+ * @param options.ignoreReservedConflicts - Drop the "RESERVED always conflicts"
+ *   rule. Pass this ONLY when the current booking is itself already in flight
+ *   (ONGOING/OVERDUE) — see {@link outranksReservations}.
  */
 export function hasAssetBookingConflicts(
   asset: {
@@ -442,7 +470,8 @@ export function hasAssetBookingConflicts(
     type?: string;
     bookingAssets?: { booking: { id: string; status: string } }[];
   },
-  currentBookingId: string
+  currentBookingId: string,
+  options?: { ignoreReservedConflicts?: boolean }
 ): boolean {
   /**
    * QUANTITY_TRACKED assets can appear in multiple concurrent bookings,
@@ -460,10 +489,13 @@ export function hasAssetBookingConflicts(
 
   if (conflictingBookings.length === 0) return false;
 
-  // Check if any conflicting booking is RESERVED (always conflicts)
-  const hasReservedConflict = conflictingBookings.some(
-    (b) => b.status === BookingStatus.RESERVED
-  );
+  // Check if any conflicting booking is RESERVED (always conflicts).
+  // `ignoreReservedConflicts` suppresses this rule for callers whose own
+  // booking already outranks a reservation — a reservation has taken nothing
+  // yet, so it must not block a booking that is physically in flight.
+  const hasReservedConflict =
+    !options?.ignoreReservedConflicts &&
+    conflictingBookings.some((b) => b.status === BookingStatus.RESERVED);
 
   if (hasReservedConflict) return true;
 

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -1,3 +1,4 @@
+import Markdoc from "@markdoc/markdoc";
 import { BookingStatus, AssetStatus, AssetType } from "@prisma/client";
 import { CheckoutIntentEnum } from "~/components/booking/checkout-dialog";
 
@@ -7,6 +8,7 @@ import { createSystemBookingNote } from "~/modules/booking-note/service.server";
 import * as quantityLock from "~/modules/consumption-log/quantity-lock.server";
 import { ShelfError } from "~/utils/error";
 import {
+  buildOverriddenReservationNotes,
   computeBookingAssetSliceRemainingToCheckOut,
   getRemainingCheckoutAssetIds,
   getRemainingCheckoutPayload,
@@ -774,6 +776,77 @@ describe("partialCheckoutBooking", () => {
 
     // No partial record written when conflict validation rejects.
     expect(db.partialBookingCheckout.create).not.toHaveBeenCalled();
+  });
+
+  it("lets an ONGOING booking check out an asset an overlapping RESERVED booking also holds", async () => {
+    expect.assertions(3);
+
+    // The reported bug. This booking is already ONGOING (an earlier asset was
+    // checked out), and while its remaining asset sat AVAILABLE another
+    // booking was allowed to reserve the same asset — precisely because an
+    // ONGOING booking does not "occupy" an asset it has not physically checked
+    // out yet. The reverse direction then blocked this booking from EVER
+    // checking that asset out ("Cannot check out. Some assets are already
+    // booked or checked out elsewhere"), with no way to resolve it in-product.
+    // An in-flight booking outranks a reservation that has taken nothing.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({ ...reservedBooking, status: BookingStatus.ONGOING });
+
+    // why: mirrors the default echo impl (see beforeEach) but hangs an
+    // overlapping RESERVED booking off asset-1, which is what the production
+    // conflict lookup returns for a double-booked asset.
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+      (args?: any) => {
+        const ids = args?.where?.id?.in;
+        return Promise.resolve(
+          Array.isArray(ids)
+            ? ids.map((assetId: string) => ({
+                id: assetId,
+                title: `Asset ${assetId}`,
+                status: AssetStatus.AVAILABLE,
+                assetKits: [],
+                bookingAssets:
+                  assetId === "asset-1"
+                    ? [
+                        {
+                          booking: {
+                            id: "other-booking",
+                            status: BookingStatus.RESERVED,
+                            name: "Forensic Event A",
+                          },
+                        },
+                      ]
+                    : [],
+              }))
+            : []
+        );
+      }
+    );
+
+    await expect(
+      partialCheckoutBooking({ ...baseParams, assetIds: ["asset-1"] })
+    ).resolves.toBeTruthy();
+
+    const noteArgs = (
+      createSystemBookingNote as ReturnType<typeof vitest.fn>
+    ).mock.calls.map(([args]) => args);
+
+    // The override is recorded on THIS booking...
+    expect(noteArgs).toContainEqual(
+      expect.objectContaining({
+        bookingId: "booking-1",
+        content: expect.stringContaining("Forensic Event A"),
+      })
+    );
+    // ...and on the reservation, so its owner learns the asset is gone rather
+    // than discovering it when their own check-out fails.
+    expect(noteArgs).toContainEqual(
+      expect.objectContaining({
+        bookingId: "other-booking",
+        content: expect.stringContaining("Test Booking"),
+      })
+    );
   });
 
   it("rejects (and writes nothing) when a scanned asset is not part of the booking", async () => {
@@ -2875,5 +2948,80 @@ describe("getRemainingCheckoutPayload", () => {
       ]),
       expect.anything()
     );
+  });
+});
+
+describe("buildOverriddenReservationNotes", () => {
+  const current = { id: "booking-1", name: "Loaning things to Carlos" };
+
+  it("names both bookings and the assets on each side of the clash", () => {
+    const notes = buildOverriddenReservationNotes(
+      {
+        id: "other-booking",
+        name: "Forensic Event A",
+        assets: [{ id: "asset-1", title: "Apple Mac Pro (2023)" }],
+      },
+      current
+    );
+
+    // The checking-out booking records WHAT it overrode...
+    expect(notes.currentBookingNote).toContain("Forensic Event A");
+    expect(notes.currentBookingNote).toContain("Apple Mac Pro (2023)");
+    // ...and the reservation records WHO took its asset.
+    expect(notes.reservedBookingNote).toContain("Loaning things to Carlos");
+  });
+
+  it("uses plural phrasing when more than one asset is taken", () => {
+    const notes = buildOverriddenReservationNotes(
+      {
+        id: "other-booking",
+        name: "Forensic Event A",
+        assets: [
+          { id: "asset-1", title: "Mac Pro" },
+          { id: "asset-2", title: "Tripod" },
+        ],
+      },
+      current
+    );
+
+    expect(notes.currentBookingNote).toContain("were");
+    expect(notes.currentBookingNote).toContain("them");
+  });
+
+  it("cannot be used to inject a live Markdoc tag via a booking name", () => {
+    // Booking names and asset titles are free-form user input, and the note
+    // feed renders stored content through Markdoc — so a raw `{% … %}` splice
+    // would be a stored XSS. Every user value must land inside a quoted,
+    // escaped tag attribute, never as a bare tag.
+    const notes = buildOverriddenReservationNotes(
+      {
+        id: "other-booking",
+        name: '{% link to="javascript:alert(document.cookie)" /%}',
+        assets: [
+          {
+            id: "asset-1",
+            title: '" /%}{% link to="javascript:alert(1)" text="pwned',
+          },
+        ],
+      },
+      current
+    );
+
+    for (const note of [notes.currentBookingNote, notes.reservedBookingNote]) {
+      // Parse the note exactly as the feed does: the injected `{% … %}` must
+      // survive as inert text inside an escaped attribute, never as a tag node.
+      const tags = [...Markdoc.parse(note).walk()].filter(
+        (node) => node.type === "tag"
+      );
+
+      // Only the tags WE emit exist...
+      expect(
+        tags.every((node) => node.tag === "link" || node.tag === "assets_list")
+      ).toBe(true);
+      // ...and none of them points anywhere the attacker chose.
+      for (const node of tags) {
+        expect(String(node.attributes?.to ?? "")).not.toMatch(/^javascript:/i);
+      }
+    }
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -4,7 +4,10 @@ import { CheckoutIntentEnum } from "~/components/booking/checkout-dialog";
 
 import { db } from "~/database/db.server";
 import * as activityEventService from "~/modules/activity-event/service.server";
-import { createSystemBookingNote } from "~/modules/booking-note/service.server";
+import {
+  createSystemBookingNote,
+  createSystemBookingNotes,
+} from "~/modules/booking-note/service.server";
 import * as quantityLock from "~/modules/consumption-log/quantity-lock.server";
 import { ShelfError } from "~/utils/error";
 import {
@@ -88,7 +91,7 @@ vitest.mock("~/database/db.server", () => {
         // call db.asset.findMany. Default to echoing the requested ids with no
         // conflicts/custody so the happy path passes; individual tests override.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        findMany: vitest.fn().mockImplementation((args?: any) => {
+        findMany: vitest.fn().mockImplementation((args?: IdInArgs) => {
           const ids = args?.where?.id?.in;
           return Promise.resolve(
             Array.isArray(ids)
@@ -104,7 +107,16 @@ vitest.mock("~/database/db.server", () => {
               : []
           );
         }),
-        updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
+        // why: the INDIVIDUAL flip is guarded by `count === ids.length` to
+        // detect an asset taken by a concurrent check-out, so the mock must
+        // report the realistic "every targeted row matched" count rather than
+        // a fixed 0 (which would read as "all taken" and abort every batch).
+        updateMany: vitest.fn().mockImplementation((args?: IdInArgs) => {
+          const ids = args?.where?.id?.in;
+          return Promise.resolve({
+            count: Array.isArray(ids) ? ids.length : 0,
+          });
+        }),
         // why: the qty-path per-asset status flip uses singular `update` (the
         // assetId comes from the validated qtySummaries set, so `updateMany`
         // would be overkill). The mock just needs to resolve.
@@ -252,9 +264,21 @@ vitest.mock("~/modules/note/service.server", () => ({
   createNotes: vitest.fn().mockResolvedValue(undefined),
 }));
 
+/**
+ * The exact slice of a Prisma `findMany` / `updateMany` argument these db mocks
+ * read: the `{ where: { id: { in: [...] } } }` filter they echo back.
+ *
+ * Deliberately NOT `Prisma.AssetFindManyArgs` — that type's `where.id` is
+ * `string | StringFilter<"Asset">`, so `args.where.id.in` needs narrowing at
+ * every call site. Naming only what the mocks depend on keeps them honest
+ * without `any`.
+ */
+type IdInArgs = { where?: { id?: { in?: string[] } } };
+
 // why: testing the service without writing real booking notes.
 vitest.mock("~/modules/booking-note/service.server", () => ({
   createSystemBookingNote: vitest.fn().mockResolvedValue({}),
+  createSystemBookingNotes: vitest.fn().mockResolvedValue(undefined),
   createStatusTransitionNote: vitest.fn().mockResolvedValue({}),
 }));
 
@@ -355,7 +379,7 @@ describe("partialCheckoutBooking", () => {
     // set by a prior test. Restore the default "echo requested ids, no conflicts"
     // implementation so each test starts from a clean happy-path baseline.
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
-      (args?: any) => {
+      (args?: IdInArgs) => {
         const ids = args?.where?.id?.in;
         return Promise.resolve(
           Array.isArray(ids)
@@ -369,6 +393,17 @@ describe("partialCheckoutBooking", () => {
               }))
             : []
         );
+      }
+    );
+    // why: same reasoning as `asset.findMany` above — a prior test's
+    // `mockResolvedValue({ count: 0 })` (the concurrent-takeover case) would
+    // otherwise persist and read as "every asset was taken" in later tests.
+    (db.asset.updateMany as ReturnType<typeof vitest.fn>).mockImplementation(
+      (args?: IdInArgs) => {
+        const ids = args?.where?.id?.in;
+        return Promise.resolve({
+          count: Array.isArray(ids) ? ids.length : 0,
+        });
       }
     );
     // why: `computeBookingAssetsRemainingToCheckOut` reads the BookingAsset
@@ -452,9 +487,17 @@ describe("partialCheckoutBooking", () => {
       assetIds: ["asset-1", "asset-2"],
     });
 
-    // Scanned assets flipped to CHECKED_OUT, org-scoped.
+    // Scanned assets flipped to CHECKED_OUT, org-scoped. The status
+    // precondition is what makes the flip safe against a concurrent
+    // check-out claiming the same asset mid-transaction.
     expect(db.asset.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["asset-1", "asset-2"] }, organizationId: "org-1" },
+      where: {
+        id: { in: ["asset-1", "asset-2"] },
+        organizationId: "org-1",
+        status: {
+          notIn: [AssetStatus.CHECKED_OUT, AssetStatus.IN_CUSTODY],
+        },
+      },
       data: { status: AssetStatus.CHECKED_OUT },
     });
 
@@ -585,7 +628,7 @@ describe("partialCheckoutBooking", () => {
     // kit-member asset whose kit isn't fully checked out. Pivot shape: kit
     // membership lives under `asset.assetKits[0].kit`, not `asset.kit`.
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
-      (args?: any) => {
+      (args?: IdInArgs) => {
         const ids = args?.where?.id?.in;
         return Promise.resolve(
           Array.isArray(ids)
@@ -779,7 +822,7 @@ describe("partialCheckoutBooking", () => {
   });
 
   it("lets an ONGOING booking check out an asset an overlapping RESERVED booking also holds", async () => {
-    expect.assertions(3);
+    expect.assertions(4);
 
     // The reported bug. This booking is already ONGOING (an earlier asset was
     // checked out), and while its remaining asset sat AVAILABLE another
@@ -797,7 +840,7 @@ describe("partialCheckoutBooking", () => {
     // overlapping RESERVED booking off asset-1, which is what the production
     // conflict lookup returns for a double-booked asset.
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
-      (args?: any) => {
+      (args?: IdInArgs) => {
         const ids = args?.where?.id?.in;
         return Promise.resolve(
           Array.isArray(ids)
@@ -828,12 +871,16 @@ describe("partialCheckoutBooking", () => {
       partialCheckoutBooking({ ...baseParams, assetIds: ["asset-1"] })
     ).resolves.toBeTruthy();
 
-    const noteArgs = (
-      createSystemBookingNote as ReturnType<typeof vitest.fn>
-    ).mock.calls.map(([args]) => args);
+    // Override notes go through the BATCHED helper — one call regardless of
+    // how many reservations were overridden, so a large batch can't spend the
+    // transaction's timeout budget writing audit notes.
+    const batched = (createSystemBookingNotes as ReturnType<typeof vitest.fn>)
+      .mock.calls;
+    expect(batched).toHaveLength(1);
+    const notes = batched[0][0].notes;
 
     // The override is recorded on THIS booking...
-    expect(noteArgs).toContainEqual(
+    expect(notes).toContainEqual(
       expect.objectContaining({
         bookingId: "booking-1",
         content: expect.stringContaining("Forensic Event A"),
@@ -841,12 +888,40 @@ describe("partialCheckoutBooking", () => {
     );
     // ...and on the reservation, so its owner learns the asset is gone rather
     // than discovering it when their own check-out fails.
-    expect(noteArgs).toContainEqual(
+    expect(notes).toContainEqual(
       expect.objectContaining({
         bookingId: "other-booking",
         content: expect.stringContaining("Test Booking"),
       })
     );
+  });
+
+  it("aborts the batch when an asset is checked out elsewhere mid-transaction", async () => {
+    expect.assertions(2);
+
+    // The window the in-flight override opens: the conflict guard reads a
+    // PRE-transaction snapshot, so a booking that merely looked RESERVED there
+    // can check the asset out before this transaction writes. Without a
+    // precondition on the flip, both bookings would record a check-out of the
+    // same physical asset.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({ ...reservedBooking, status: BookingStatus.ONGOING });
+
+    // why: stands in for Postgres re-evaluating the guarded `where` after the
+    // competing transaction commits — the row no longer matches, so the update
+    // reports fewer rows than we targeted. Only `updateMany` is overridden so
+    // the pre-transaction conflict lookup keeps its realistic shape.
+    (db.asset.updateMany as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      count: 0,
+    });
+
+    await expect(
+      partialCheckoutBooking({ ...baseParams, assetIds: ["asset-1"] })
+    ).rejects.toThrow("while this check-out was being processed");
+
+    // The whole batch rolls back — no partial-checkout record is written.
+    expect(db.partialBookingCheckout.create).not.toHaveBeenCalled();
   });
 
   it("rejects (and writes nothing) when a scanned asset is not part of the booking", async () => {
@@ -1783,16 +1858,24 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     });
 
     // INDIVIDUAL row goes through the assetIds → individualToFlip updateMany
-    // (always flips on a partial-checkout batch).
-    expect(db.asset.updateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["asset-ind-1"] }, organizationId: "org-1" },
+    // (always flips on a partial-checkout batch), guarded against a
+    // concurrent check-out having claimed it mid-transaction.
+    const individualFlip = {
+      where: {
+        id: { in: ["asset-ind-1"] },
+        organizationId: "org-1",
+        status: {
+          notIn: [AssetStatus.CHECKED_OUT, AssetStatus.IN_CUSTODY],
+        },
+      },
       data: { status: AssetStatus.CHECKED_OUT },
-    });
+    };
+    expect(db.asset.updateMany).toHaveBeenCalledWith(individualFlip);
 
     // QTY row did NOT flip (10 of 50 = partial claim).
     expect(db.asset.updateMany).not.toHaveBeenCalledWith({
-      where: { id: { in: ["asset-qty-1"] }, organizationId: "org-1" },
-      data: { status: AssetStatus.CHECKED_OUT },
+      ...individualFlip,
+      where: { ...individualFlip.where, id: { in: ["asset-qty-1"] } },
     });
 
     // Session row records both rows positionally: qty disposition first

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -114,6 +114,7 @@ import {
   isBookingArchivable,
   isBookingEarlyCheckin,
   isBookingEarlyCheckout,
+  outranksReservations,
 } from "./helpers";
 import { getBookingNotificationRecipients } from "./notification-recipients.server";
 import type { NotificationRecipient } from "./notification-recipients.server";
@@ -5092,6 +5093,66 @@ function buildQtyPerAssetFragment(
 }
 
 /**
+ * A reservation that was outranked by an in-flight booking's check-out.
+ *
+ * @see {@link buildOverriddenReservationNotes}
+ */
+export type OverriddenReservation = {
+  /** The RESERVED booking that lost the asset(s) */
+  id: string;
+  /** Its user-supplied name — untrusted, must never be spliced raw */
+  name: string;
+  /** The assets it reserved that were just checked out elsewhere */
+  assets: Array<{ id: string; title: string }>;
+};
+
+/**
+ * Build the pair of system notes recording that an in-flight booking checked
+ * out an asset an overlapping RESERVED booking also held.
+ *
+ * Both sides get a note so the clash is never silent: the checking-out booking
+ * records what it overrode, and the reservation records that its asset is gone
+ * — the reservation's owner would otherwise not discover it until their own
+ * check-out failed.
+ *
+ * All user-supplied values (booking names, asset titles) go through the
+ * markdoc wrappers, which place them inside quoted, escaped tag attributes —
+ * never raw — so a booking named `{% link to="javascript:…" /%}` cannot inject
+ * a live tag into the rendered note feed.
+ *
+ * @param reservation - The outranked reservation and the assets it lost
+ * @param current - The in-flight booking that checked the assets out
+ * @returns Note content for the current booking and for the reservation
+ */
+export function buildOverriddenReservationNotes(
+  reservation: OverriddenReservation,
+  current: { id: string; name: string }
+): { currentBookingNote: string; reservedBookingNote: string } {
+  const assetsFragment = wrapAssetsWithDataForNote(
+    reservation.assets,
+    "checked out"
+  );
+  const isPlural = reservation.assets.length > 1;
+  const verb = isPlural ? "were" : "was";
+  const pronoun = isPlural ? "them" : "it";
+
+  const reservationLink = wrapLinkForNote(
+    `/bookings/${reservation.id}`,
+    reservation.name
+  );
+  const currentLink = wrapLinkForNote(`/bookings/${current.id}`, current.name);
+
+  return {
+    currentBookingNote:
+      `${assetsFragment} ${verb} also reserved by ${reservationLink} for an overlapping period. ` +
+      `This booking is already checked out, so it takes priority — that reservation may need ${pronoun} replaced.`,
+    reservedBookingNote:
+      `${assetsFragment} ${verb} checked out by ${currentLink}, which overlaps this reservation and is already in progress. ` +
+      `You may need to replace ${pronoun} before this booking starts.`,
+  };
+}
+
+/**
  * Build a markdoc fragment naming each qty-tracked slice checked OUT in this
  * session. Mirror of {@link buildQtyPerAssetFragment} but unidirectional —
  * checkout only carries one count per slice (no return/consume/loss/damage
@@ -6577,7 +6638,9 @@ export async function partialCheckoutBooking({
           }),
           select: {
             booking: {
-              select: { id: true, status: true },
+              // `name` powers the overridden-reservation note below — a
+              // conflict the user can act on has to name the other booking.
+              select: { id: true, status: true, name: true },
             },
           },
         },
@@ -6607,9 +6670,48 @@ export async function partialCheckoutBooking({
       });
     }
 
+    /**
+     * An already-in-flight booking outranks a not-yet-started reservation for
+     * the same asset, so overlapping RESERVED bookings do not block THIS
+     * check-out (see {@link outranksReservations}). A RESERVED booking checking
+     * out still hits the full guard — this only relaxes the ONGOING/OVERDUE
+     * direction, and only for reservations: an asset physically CHECKED_OUT on
+     * another in-flight booking is still a hard block.
+     */
+    const inFlight = outranksReservations(bookingFound.status);
+
+    /**
+     * Reservations we are overriding by checking out anyway, deduped by booking
+     * id. Drives the system notes written after the transaction commits so the
+     * clash is visible to both sides instead of silently resolving in favour of
+     * whoever clicked first.
+     */
+    const overriddenReservations = new Map<
+      string,
+      { id: string; name: string; assets: { id: string; title: string }[] }
+    >();
+    if (inFlight && bookingFound.from && bookingFound.to) {
+      for (const asset of scannedAssetsWithConflicts) {
+        // Only INDIVIDUAL assets can be starved this way — the helper leaves
+        // QUANTITY_TRACKED availability to the per-slice caps inside the tx.
+        if (isQuantityTracked(asset)) continue;
+        for (const { booking } of asset.bookingAssets) {
+          if (booking.id === id) continue;
+          if (booking.status !== BookingStatus.RESERVED) continue;
+          const entry = overriddenReservations.get(booking.id) ?? {
+            id: booking.id,
+            name: booking.name,
+            assets: [],
+          };
+          entry.assets.push({ id: asset.id, title: asset.title });
+          overriddenReservations.set(booking.id, entry);
+        }
+      }
+    }
+
     if (bookingFound.from && bookingFound.to) {
       const conflicted = scannedAssetsWithConflicts.filter((a) =>
-        hasAssetBookingConflicts(a, id)
+        hasAssetBookingConflicts(a, id, { ignoreReservedConflicts: inFlight })
       );
       if (conflicted.length > 0) {
         const names = conflicted
@@ -7368,6 +7470,42 @@ export async function partialCheckoutBooking({
           },
           tx
         );
+
+        /**
+         * Record every reservation this check-out outranked, on BOTH bookings.
+         * Written inside the tx so a rolled-back check-out can't leave a note
+         * claiming an asset was taken. Only populated when this booking is
+         * already in flight — see the guard above.
+         */
+        for (const reservation of overriddenReservations.values()) {
+          // An idempotent re-scan carries assets that were already out; only
+          // the ones this batch actually took belong in the note.
+          const takenNow = reservation.assets.filter((asset) =>
+            assetIdsToCheckOut.includes(asset.id)
+          );
+          if (takenNow.length === 0) continue;
+
+          const { currentBookingNote, reservedBookingNote } =
+            buildOverriddenReservationNotes(
+              { ...reservation, assets: takenNow },
+              { id, name: bookingFound.name }
+            );
+
+          // eslint-disable-next-line no-await-in-loop -- bounded by the number of distinct reservations overlapping this batch; sequential keeps the tx's statement order deterministic
+          await createSystemBookingNote(
+            { bookingId: id, organizationId, content: currentBookingNote },
+            tx
+          );
+          // eslint-disable-next-line no-await-in-loop -- see above
+          await createSystemBookingNote(
+            {
+              bookingId: reservation.id,
+              organizationId,
+              content: reservedBookingNote,
+            },
+            tx
+          );
+        }
 
         /**
          * Unit-level remaining count + completion. For each unique booking

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -131,7 +131,10 @@ import {
 } from "./utils.server";
 import { recordEvent, recordEvents } from "../activity-event/service.server";
 import type { ActivityEventInput } from "../activity-event/types";
-import { createSystemBookingNote } from "../booking-note/service.server";
+import {
+  createSystemBookingNote,
+  createSystemBookingNotes,
+} from "../booking-note/service.server";
 import { createNotes } from "../note/service.server";
 
 import { TAG_WITH_COLOR_SELECT } from "../tag/constants";
@@ -7114,10 +7117,60 @@ export async function partialCheckoutBooking({
           (assetId) => assetTypeById.get(assetId) !== AssetType.QUANTITY_TRACKED
         );
         if (individualToFlip.length > 0) {
-          await tx.asset.updateMany({
-            where: { id: { in: individualToFlip }, organizationId },
+          /**
+           * The conflict + custody guards above ran on a PRE-transaction
+           * snapshot. An overlapping booking can check one of these assets out
+           * (or take custody) in the window between that read and this write —
+           * the in-flight override widens that window, because a booking that
+           * merely looked RESERVED at read time no longer blocks us. Without a
+           * precondition both bookings would record a check-out of the same
+           * physical asset.
+           *
+           * Constraining the UPDATE itself makes the re-check atomic: Postgres
+           * blocks on any row a concurrent transaction is updating, then
+           * re-evaluates this `where` against the committed row. A row taken
+           * meanwhile no longer matches, so `count` comes up short and we abort
+           * the whole batch rather than double-claiming it.
+           */
+          const flipped = await tx.asset.updateMany({
+            where: {
+              id: { in: individualToFlip },
+              organizationId,
+              status: {
+                notIn: [AssetStatus.CHECKED_OUT, AssetStatus.IN_CUSTODY],
+              },
+            },
             data: { status: AssetStatus.CHECKED_OUT },
           });
+
+          if (flipped.count !== individualToFlip.length) {
+            // Error path only — resolve the titles for a message that names
+            // what was lost instead of failing anonymously.
+            const taken = await tx.asset.findMany({
+              where: {
+                id: { in: individualToFlip },
+                organizationId,
+                status: {
+                  in: [AssetStatus.CHECKED_OUT, AssetStatus.IN_CUSTODY],
+                },
+              },
+              select: { title: true },
+            });
+            const names = taken
+              .slice(0, 3)
+              .map((a) => a.title)
+              .join(", ");
+            const more =
+              taken.length > 3 ? ` and ${taken.length - 3} more` : "";
+            throw new ShelfError({
+              cause: null,
+              status: 409,
+              label,
+              title: "Booking conflict",
+              message: `Cannot check out. Some assets were checked out or taken into custody elsewhere while this check-out was being processed: ${names}${more}. Refresh and try again.`,
+              shouldBeCaptured: false,
+            });
+          }
         }
 
         /**
@@ -7476,7 +7529,13 @@ export async function partialCheckoutBooking({
          * Written inside the tx so a rolled-back check-out can't leave a note
          * claiming an asset was taken. Only populated when this booking is
          * already in flight — see the guard above.
+         *
+         * Collected first and written in ONE batch: a large batch can override
+         * many distinct reservations, and two singular note writes each (a
+         * check + an insert apiece) would spend the transaction's 15s budget on
+         * audit notes and roll the check-out back.
          */
+        const overrideNotes: Array<{ content: string; bookingId: string }> = [];
         for (const reservation of overriddenReservations.values()) {
           // An idempotent re-scan carries assets that were already out; only
           // the ones this batch actually took belong in the note.
@@ -7491,21 +7550,15 @@ export async function partialCheckoutBooking({
               { id, name: bookingFound.name }
             );
 
-          // eslint-disable-next-line no-await-in-loop -- bounded by the number of distinct reservations overlapping this batch; sequential keeps the tx's statement order deterministic
-          await createSystemBookingNote(
-            { bookingId: id, organizationId, content: currentBookingNote },
-            tx
-          );
-          // eslint-disable-next-line no-await-in-loop -- see above
-          await createSystemBookingNote(
-            {
-              bookingId: reservation.id,
-              organizationId,
-              content: reservedBookingNote,
-            },
-            tx
+          overrideNotes.push(
+            { bookingId: id, content: currentBookingNote },
+            { bookingId: reservation.id, content: reservedBookingNote }
           );
         }
+        await createSystemBookingNotes(
+          { notes: overrideNotes, organizationId },
+          tx
+        );
 
         /**
          * Unit-level remaining count + completion. For each unique booking


### PR DESCRIPTION
An ONGOING/OVERDUE booking could never check out its remaining assets once any overlapping RESERVED booking also held them. That reservation was itself allowed precisely because an ONGOING booking does not "occupy" an asset it has not physically checked out yet, so the priority inverted: a reservation created AFTER the booking started blocked it permanently, with no in-product way out. The asset row still rendered "Available" (the already-booked badge is suppressed on ONGOING bookings), so the action was offered right up until it failed with "Some assets are already booked or checked out elsewhere".

`hasAssetBookingConflicts` now accepts an `ignoreReservedConflicts` option, and `partialCheckoutBooking` passes it only when the booking is already in flight (new `outranksReservations` helper). Everything else is unchanged: a RESERVED-vs-RESERVED clash still blocks, and an asset physically CHECKED_OUT on another in-flight booking still blocks. The losing reservation is told at its own check-out, exactly as before.

Both bookings get a system note naming the clash so the override is never silent - the reservation's owner would otherwise not discover it until their own check-out failed. User-supplied booking names and asset titles go through the markdoc wrappers, with a regression test asserting a name containing a Markdoc tag cannot inject one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progressive checkouts can proceed with individually tracked assets that overlap reservations.
  * Booking notes identify overridden reservations, affected assets, and required follow-up.
  * Notes safely format booking and asset names, including special characters.

* **Bug Fixes**
  * Improved conflict handling for ongoing and overdue bookings.
  * Active bookings and quantity-tracked asset limits continue to block unavailable conflicts.
  * Checkout protections prevent assets concurrently checked out or placed into custody from being reassigned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->