### PR TITLE
docs(import-update): document asset model and qty-tracked updatable columns

### DIFF
--- a/apps/webapp/app/components/assets/bulk-update/index.tsx
+++ b/apps/webapp/app/components/assets/bulk-update/index.tsx
@@ -63,16 +63,29 @@ export const ImportUpdateContent = () => {
               <div>
                 <h5 className="font-semibold">What you can update</h5>
                 <p className="text-[14px] text-gray-600">
-                  Name, Category, Location, Tags, Valuation, Available to book,
-                  and your custom fields (Text, Boolean, Date, Option, Number,
-                  Currency).
+                  Name, Category, Location, Tags, Value, Available to book,{" "}
+                  <b>Asset model</b>, and your custom fields (Text, Boolean,
+                  Date, Option, Number, Currency).
+                </p>
+                <p className="mt-1 text-[14px] text-gray-600">
+                  <b>Asset model</b> is matched by name (case-insensitive) and
+                  created automatically if it doesn't exist yet. It applies to{" "}
+                  <b>individually tracked assets only</b> — on a
+                  quantity-tracked asset the cell is skipped with a warning and
+                  the rest of the row still applies.
+                </p>
+                <p className="mt-1 text-[14px] text-gray-600">
+                  For <b>quantity-tracked</b> assets you can also update
+                  Quantity, Min quantity, Unit of measure, and Consumption type.
+                  These columns are ignored on individually tracked assets.
                 </p>
                 <p className="mt-1 text-[14px] text-gray-600">
                   <b>Not supported yet:</b> Description, Status, Kit, and
                   Custody can't be bulk-updated via CSV — Status and Custody
                   have their own workflows, and Description can lose formatting
-                  during export. These columns will be safely skipped if present
-                  in your file.
+                  during export. Tracking method is fixed once an asset is
+                  created. These columns will be safely skipped if present in
+                  your file.
                 </p>
               </div>
             </div>
@@ -90,6 +103,9 @@ export const ImportUpdateContent = () => {
                   If a field currently has a value and you leave the cell empty,
                   that value will be cleared. Fields that are already empty stay
                   unchanged. Name and boolean fields (Yes/No) cannot be cleared.
+                  <b> Asset model</b> can't be cleared this way either — an
+                  empty cell leaves the current model in place. Remove it from
+                  the asset directly instead.
                 </p>
               </div>
             </div>
@@ -105,8 +121,8 @@ export const ImportUpdateContent = () => {
                 <h5 className="font-semibold">How assets are matched</h5>
                 <p className="text-[14px] text-gray-600">
                   By <b>Asset ID</b> or <b>ID</b> — keep these columns as they
-                  are. Categories, locations, and tags that don't exist yet will
-                  be created for you.
+                  are. Categories, locations, tags, and asset models that don't
+                  exist yet will be created for you.
                 </p>
               </div>
             </div>

--- a/apps/webapp/app/components/assets/bulk-update/index.tsx
+++ b/apps/webapp/app/components/assets/bulk-update/index.tsx
@@ -80,6 +80,16 @@ export const ImportUpdateContent = () => {
                   These columns are ignored on individually tracked assets.
                 </p>
                 <p className="mt-1 text-[14px] text-gray-600">
+                  <b>Heads up — the export isn't re-uploadable as-is here.</b>{" "}
+                  The Asset Index writes Quantity as <code>10 boxes</code> when
+                  the asset has a unit of measure, but this importer needs the
+                  cell to contain the number only (<code>10</code>) — leave the
+                  unit out or the row's quantity update fails. Min quantity,
+                  Unit of measure, and Consumption type aren't part of the
+                  export at all; add those columns yourself using exactly those
+                  header names.
+                </p>
+                <p className="mt-1 text-[14px] text-gray-600">
                   <b>Not supported yet:</b> Description, Status, Kit, and
                   Custody can't be bulk-updated via CSV — Status and Custody
                   have their own workflows, and Description can lose formatting
@@ -103,9 +113,12 @@ export const ImportUpdateContent = () => {
                   If a field currently has a value and you leave the cell empty,
                   that value will be cleared. Fields that are already empty stay
                   unchanged. Name and boolean fields (Yes/No) cannot be cleared.
-                  <b> Asset model</b> can't be cleared this way either — an
-                  empty cell leaves the current model in place. Remove it from
-                  the asset directly instead.
+                </p>
+                <p className="mt-1 text-[14px] text-gray-600">
+                  <b>Exceptions:</b> Asset model, Quantity, Min quantity, Unit
+                  of measure, and Consumption type are never cleared by an empty
+                  cell — blanking them leaves the current value in place. Change
+                  these on the asset itself if you need to remove them.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
The instructions block on /assets/import-update still described the v1 field set, so several columns that the update flow actually applies were undocumented and looked unsupported.

- Add Asset model to "What you can update", with a note that it is matched by name (case-insensitive), auto-created when missing, and INDIVIDUAL-only (on a quantity-tracked row the cell is skipped with a warning and the rest of the row still applies)
- Document the quantity-tracked columns (Quantity, Min quantity, Unit of measure, Consumption type), which are in UPDATABLE_FIELDS but were not mentioned anywhere on the page
- Note that an empty Asset model cell does NOT clear the model, unlike most fields — parseQtyTrackedUpdateRow only sets a lookup key for non-empty cells
- Fix "Valuation" -> "Value": headers are matched exactly against the export labels, so the documented name would land in "unrecognized columns"
- Add Tracking method to the not-supported list; asset type is immutable and the cell is silently ignored
- Add asset models to the list of entities auto-created during matching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified bulk-update instructions for Asset model matching and creation.
  * Added guidance for quantity-tracking fields, formatting, and unsupported tracking behavior.
  * Documented which fields remain unchanged when spreadsheet cells are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->