### PR TITLE
fix(booking): make booking picker search return renderable rows

### DIFF
--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -21,6 +21,26 @@ export const ADDABLE_BOOKING_STATUSES: BookingStatus[] = [
   BookingStatus.OVERDUE,
 ];
 
+/**
+ * Whether an asset or kit can still be added to this booking.
+ *
+ * Used by the "Add to existing booking" dialogs to decide whether to render a
+ * row for a booking the picker handed them. Accepts a loose shape because the
+ * pickers pass records from two sources (the route loader and
+ * `/api/model-filters`), neither of which is narrowed to `Booking` client-side.
+ *
+ * @param booking - Candidate booking; anything without a `status` is rejected.
+ * @returns `true` when the booking's status is in {@link ADDABLE_BOOKING_STATUSES}.
+ */
+export function isAddableBooking(
+  booking: { status?: string | null } | null | undefined
+): boolean {
+  return (
+    !!booking?.status &&
+    ADDABLE_BOOKING_STATUSES.includes(booking.status as BookingStatus)
+  );
+}
+
 /** Includes needed for booking to have all data required for emails */
 export const BOOKING_INCLUDE_FOR_EMAIL = {
   custodianTeamMember: true,

--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -1,5 +1,25 @@
-import type { Prisma } from "@prisma/client";
+import { BookingStatus, type Prisma } from "@prisma/client";
 import { TAG_WITH_COLOR_SELECT } from "../tag/constants";
+
+/**
+ * Booking statuses an asset or kit can still be added to.
+ *
+ * DRAFT/RESERVED are not yet started; ONGOING/OVERDUE are active — items added
+ * to an active booking stay AVAILABLE until purposefully checked out
+ * (progressive checkout).
+ *
+ * This single list has to drive all three layers of the "Add to existing
+ * booking" dialogs, or they disagree and rows vanish:
+ *   1. the loader that seeds the picker (`loadBookingsData`),
+ *   2. the `/api/model-filters` search the picker fires once you type,
+ *   3. the client-side `renderItem` guard in the dialog itself.
+ */
+export const ADDABLE_BOOKING_STATUSES: BookingStatus[] = [
+  BookingStatus.DRAFT,
+  BookingStatus.RESERVED,
+  BookingStatus.ONGOING,
+  BookingStatus.OVERDUE,
+];
 
 /** Includes needed for booking to have all data required for emails */
 export const BOOKING_INCLUDE_FOR_EMAIL = {

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -90,6 +90,7 @@ import { resolveUserDisplayName } from "~/utils/user";
 import type { MergeInclude } from "~/utils/utils";
 import { checkoutSessionsToLogsByAsset } from "./checkout-attribution";
 import {
+  ADDABLE_BOOKING_STATUSES,
   BOOKING_COMMON_INCLUDE,
   BOOKING_INCLUDE_FOR_EMAIL,
   BOOKING_INCLUDE_FOR_RESERVATION_EMAIL,
@@ -12290,7 +12291,7 @@ export async function loadBookingsData({
     perPage,
     search,
     userId,
-    statuses: ["DRAFT", "RESERVED", "ONGOING", "OVERDUE"],
+    statuses: ADDABLE_BOOKING_STATUSES,
     ...(custodianScope && { custodianScope }),
   });
 

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -1,4 +1,4 @@
-import type { BookingStatus, Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { CalendarCheck } from "lucide-react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import {
@@ -18,7 +18,10 @@ import { db } from "~/database/db.server";
 
 import { getAssetAvailability } from "~/modules/asset/availability.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
-import { ADDABLE_BOOKING_STATUSES } from "~/modules/booking/constants";
+import {
+  ADDABLE_BOOKING_STATUSES,
+  isAddableBooking,
+} from "~/modules/booking/constants";
 import {
   loadBookingsData,
   processBooking,
@@ -251,14 +254,7 @@ export default function ExistingBooking() {
   const unitLabel = asset?.unitOfMeasure || "units";
   const maxQuantity = assetAvailability?.available ?? undefined;
 
-  function isValidBooking(
-    booking: { status?: string | null } | null | undefined
-  ) {
-    return (
-      !!booking?.status &&
-      ADDABLE_BOOKING_STATUSES.includes(booking.status as BookingStatus)
-    );
-  }
+  const isValidBooking = isAddableBooking;
 
   return (
     <Form method="post">

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -286,6 +286,10 @@ export default function ExistingBooking() {
               // `loadBookingsData` seeds the list with — otherwise searching
               // returns bookings this dialog then refuses to render.
               status: ADDABLE_BOOKING_STATUSES.join(","),
+              // Keep the typed list inside the same custodian scope
+              // `loadBookingsData` seeds it with, so SELF_SERVICE / BASE users
+              // are not offered bookings that submit would then reject.
+              scopeToCustodian: true,
             }}
             fieldName="bookingId"
             contentLabel="Existing Bookings"

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -1,4 +1,4 @@
-import type { Prisma } from "@prisma/client";
+import type { BookingStatus, Prisma } from "@prisma/client";
 import { CalendarCheck } from "lucide-react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import {
@@ -18,6 +18,7 @@ import { db } from "~/database/db.server";
 
 import { getAssetAvailability } from "~/modules/asset/availability.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
+import { ADDABLE_BOOKING_STATUSES } from "~/modules/booking/constants";
 import {
   loadBookingsData,
   processBooking,
@@ -253,12 +254,9 @@ export default function ExistingBooking() {
   function isValidBooking(
     booking: { status?: string | null } | null | undefined
   ) {
-    // DRAFT/RESERVED (not yet started) + ONGOING/OVERDUE (active). Adding to an
-    // active booking keeps the asset AVAILABLE until it is purposefully checked
-    // out (progressive checkout).
     return (
       !!booking?.status &&
-      ["RESERVED", "DRAFT", "ONGOING", "OVERDUE"].includes(booking.status)
+      ADDABLE_BOOKING_STATUSES.includes(booking.status as BookingStatus)
     );
   }
 
@@ -290,8 +288,10 @@ export default function ExistingBooking() {
             model={{
               name: "booking",
               queryKey: "name",
-              // we can achieve it using this also. currently it is accepting only one status value.
-              // status: ['DRAFT', 'RESERVED']
+              // Must mirror `isValidBooking` above and the statuses
+              // `loadBookingsData` seeds the list with — otherwise searching
+              // returns bookings this dialog then refuses to render.
+              status: ADDABLE_BOOKING_STATUSES.join(","),
             }}
             fieldName="bookingId"
             contentLabel="Existing Bookings"

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.add-to-existing-booking.tsx
@@ -254,8 +254,6 @@ export default function ExistingBooking() {
   const unitLabel = asset?.unitOfMeasure || "units";
   const maxQuantity = assetAvailability?.available ?? undefined;
 
-  const isValidBooking = isAddableBooking;
-
   return (
     <Form method="post">
       <div className="modal-content-wrapper">
@@ -284,7 +282,7 @@ export default function ExistingBooking() {
             model={{
               name: "booking",
               queryKey: "name",
-              // Must mirror `isValidBooking` above and the statuses
+              // Must mirror `isAddableBooking` and the statuses
               // `loadBookingsData` seeds the list with — otherwise searching
               // returns bookings this dialog then refuses to render.
               status: ADDABLE_BOOKING_STATUSES.join(","),
@@ -298,7 +296,7 @@ export default function ExistingBooking() {
             closeOnSelect
             required={true}
             renderItem={(item: any) =>
-              isValidBooking(item) ? (
+              isAddableBooking(item) ? (
                 <div
                   className="flex flex-col items-start gap-1 text-black"
                   key={item.id || item.name}

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -1,4 +1,4 @@
-import type { BookingStatus, Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { CalendarCheck } from "lucide-react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import {
@@ -14,7 +14,10 @@ import DynamicSelect from "~/components/dynamic-select/dynamic-select";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
 
-import { ADDABLE_BOOKING_STATUSES } from "~/modules/booking/constants";
+import {
+  ADDABLE_BOOKING_STATUSES,
+  isAddableBooking,
+} from "~/modules/booking/constants";
 import {
   assertKitsAddableToActiveBooking,
   buildKitSlicesForBooking,
@@ -273,14 +276,7 @@ export default function ExistingBooking() {
   const actionData = useActionData<typeof action>();
   const transition = useNavigation();
   const disabled = isFormProcessing(transition.state);
-  function isValidBooking(
-    booking: { status?: string | null } | null | undefined
-  ) {
-    return (
-      !!booking?.status &&
-      ADDABLE_BOOKING_STATUSES.includes(booking.status as BookingStatus)
-    );
-  }
+  const isValidBooking = isAddableBooking;
 
   return (
     <Form method="post">

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -303,6 +303,10 @@ export default function ExistingBooking() {
               // `loadBookingsData` seeds the list with — otherwise searching
               // returns bookings this dialog then refuses to render.
               status: ADDABLE_BOOKING_STATUSES.join(","),
+              // Keep the typed list inside the same custodian scope
+              // `loadBookingsData` seeds it with, so SELF_SERVICE / BASE users
+              // are not offered bookings that submit would then reject.
+              scopeToCustodian: true,
             }}
             fieldName="bookingId"
             contentLabel=" Existing Bookings"

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -276,8 +276,6 @@ export default function ExistingBooking() {
   const actionData = useActionData<typeof action>();
   const transition = useNavigation();
   const disabled = isFormProcessing(transition.state);
-  const isValidBooking = isAddableBooking;
-
   return (
     <Form method="post">
       <div className="modal-content-wrapper">
@@ -301,7 +299,7 @@ export default function ExistingBooking() {
             model={{
               name: "booking",
               queryKey: "name",
-              // Must mirror `isValidBooking` above and the statuses
+              // Must mirror `isAddableBooking` and the statuses
               // `loadBookingsData` seeds the list with — otherwise searching
               // returns bookings this dialog then refuses to render.
               status: ADDABLE_BOOKING_STATUSES.join(","),
@@ -315,7 +313,7 @@ export default function ExistingBooking() {
             closeOnSelect
             required={true}
             renderItem={(item: any) =>
-              isValidBooking(item) ? (
+              isAddableBooking(item) ? (
                 <div
                   className="flex flex-col items-start gap-1 text-black"
                   key={item.id || item.name}

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.add-to-existing-booking.tsx
@@ -1,4 +1,4 @@
-import type { Prisma } from "@prisma/client";
+import type { BookingStatus, Prisma } from "@prisma/client";
 import { CalendarCheck } from "lucide-react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import {
@@ -14,6 +14,7 @@ import DynamicSelect from "~/components/dynamic-select/dynamic-select";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
 
+import { ADDABLE_BOOKING_STATUSES } from "~/modules/booking/constants";
 import {
   assertKitsAddableToActiveBooking,
   buildKitSlicesForBooking,
@@ -275,12 +276,9 @@ export default function ExistingBooking() {
   function isValidBooking(
     booking: { status?: string | null } | null | undefined
   ) {
-    // DRAFT/RESERVED (not yet started) + ONGOING/OVERDUE (active). Kits added to
-    // an active booking stay AVAILABLE until purposefully checked out
-    // (progressive checkout).
     return (
       !!booking?.status &&
-      ["RESERVED", "DRAFT", "ONGOING", "OVERDUE"].includes(booking.status)
+      ADDABLE_BOOKING_STATUSES.includes(booking.status as BookingStatus)
     );
   }
 
@@ -307,6 +305,10 @@ export default function ExistingBooking() {
             model={{
               name: "booking",
               queryKey: "name",
+              // Must mirror `isValidBooking` above and the statuses
+              // `loadBookingsData` seeds the list with — otherwise searching
+              // returns bookings this dialog then refuses to render.
+              status: ADDABLE_BOOKING_STATUSES.join(","),
             }}
             fieldName="bookingId"
             contentLabel=" Existing Bookings"

--- a/apps/webapp/app/routes/api+/model-filters.test.server.ts
+++ b/apps/webapp/app/routes/api+/model-filters.test.server.ts
@@ -71,6 +71,12 @@ vi.mock("~/modules/booking/service.server", () => ({
 
 const ORG_ID = "org-1";
 
+/**
+ * Builds the loader args for a given query string.
+ *
+ * @param query - Raw query string, without the leading `?`.
+ * @returns Loader args carrying a session for `user-1`.
+ */
 function buildArgs(query: string): LoaderFunctionArgs {
   return {
     request: new Request(`http://localhost/api/model-filters?${query}`),
@@ -95,6 +101,12 @@ function lastWhere() {
   return dbMocks.dynamicFindMany.mock.calls.at(-1)?.[0]?.where;
 }
 
+/**
+ * Reads the `filters` array out of a loader response.
+ *
+ * @param response - Response produced by {@link callLoader}.
+ * @returns The filter items the picker would render.
+ */
 async function readFilters(response: Response) {
   const body = await response.json();
   return body.filters ?? body.payload?.filters ?? [];

--- a/apps/webapp/app/routes/api+/model-filters.test.server.ts
+++ b/apps/webapp/app/routes/api+/model-filters.test.server.ts
@@ -8,10 +8,10 @@
  * and the row silently renders as nothing — a blank dropdown with a non-zero
  * "Showing N out of M" footer.
  *
- * @see {@link file://./../../../app/routes/api+/model-filters.ts}
- * @see {@link file://./../../../app/hooks/use-model-filters.ts}
+ * @see {@link file://./model-filters.ts}
+ * @see {@link file://./../../hooks/use-model-filters.ts}
  */
-import { BookingStatus, OrganizationRoles } from "@prisma/client";
+import { BookingStatus } from "@prisma/client";
 import type { LoaderFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -44,6 +44,7 @@ vi.mock("~/database/db.server", () => ({
   db: {
     booking: { dynamicFindMany: dbMocks.dynamicFindMany },
     teamMember: { dynamicFindMany: dbMocks.dynamicFindMany },
+    kit: { dynamicFindMany: dbMocks.dynamicFindMany },
   },
 }));
 
@@ -56,13 +57,16 @@ vi.mock("~/modules/organization/context.server", () => ({
   getSelectedOrganization: orgMocks.getSelectedOrganization,
 }));
 
-const bookingMocks = vi.hoisted(() => ({
-  resolveCustodianScope: vi.fn(),
-}));
-
-// why: service.server pulls in the whole booking domain (schedulers, emails)
+// why: service.server pulls in the whole booking domain (schedulers, emails);
+// the clause itself is pure, so the real implementation is re-stated here and
+// asserted against, keeping the test honest about the shape it expects.
 vi.mock("~/modules/booking/service.server", () => ({
-  resolveCustodianScope: bookingMocks.resolveCustodianScope,
+  bookingDraftVisibilityClause: (userId: string) => ({
+    OR: [
+      { status: { not: "DRAFT" } },
+      { AND: [{ status: "DRAFT" }, { creatorId: userId }] },
+    ],
+  }),
 }));
 
 const ORG_ID = "org-1";
@@ -96,20 +100,19 @@ async function readFilters(response: Response) {
   return body.filters ?? body.payload?.filters ?? [];
 }
 
-function setRole(role: OrganizationRoles) {
-  orgMocks.getSelectedOrganization.mockResolvedValue({
-    organizationId: ORG_ID,
-    userOrganizations: [{ organization: { id: ORG_ID }, roles: [role] }],
-  });
-}
+/** The clause every booking read path AND-s in — drafts are creator-only. */
+const DRAFT_VISIBILITY = {
+  OR: [
+    { status: { not: "DRAFT" } },
+    { AND: [{ status: "DRAFT" }, { creatorId: "user-1" }] },
+  ],
+};
 
 describe("GET /api/model-filters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    setRole(OrganizationRoles.OWNER);
-    bookingMocks.resolveCustodianScope.mockResolvedValue({
-      userId: "user-1",
-      teamMemberIds: ["tm-1"],
+    orgMocks.getSelectedOrganization.mockResolvedValue({
+      organizationId: ORG_ID,
     });
   });
 
@@ -201,37 +204,34 @@ describe("GET /api/model-filters", () => {
     });
   });
 
-  describe("self-service booking visibility", () => {
+  describe("draft visibility", () => {
     beforeEach(() => {
       dbMocks.dynamicFindMany.mockResolvedValue([]);
     });
 
-    it.each([OrganizationRoles.SELF_SERVICE, OrganizationRoles.BASE])(
-      "restricts %s users to bookings they are custodian of",
-      async (role) => {
-        setRole(role);
+    it("restricts drafts to their creator, regardless of caller role", async () => {
+      await loader(
+        buildArgs(
+          `name=booking&queryKey=name&status=${ADDABLE_BOOKING_STATUSES.join(
+            ","
+          )}`
+        )
+      );
 
-        await loader(buildArgs("name=booking&queryKey=name&queryValue=x"));
+      // Nested in AND so the search OR cannot widen it back open.
+      expect(lastWhere().AND).toEqual([DRAFT_VISIBILITY]);
+    });
 
-        // Nested in AND so the search OR cannot widen it back open.
-        expect(lastWhere().AND).toEqual([
-          {
-            OR: [
-              { custodianUserId: "user-1" },
-              { custodianTeamMemberId: { in: ["tm-1"] } },
-            ],
-          },
-        ]);
-      }
-    );
-
-    it("does not restrict admins and owners", async () => {
-      setRole(OrganizationRoles.ADMIN);
-
+    it("applies even when the caller does not ask for DRAFT", async () => {
       await loader(buildArgs("name=booking&queryKey=name&queryValue=x"));
 
+      expect(lastWhere().AND).toEqual([DRAFT_VISIBILITY]);
+    });
+
+    it("does not add the clause to non-booking searches", async () => {
+      await loader(buildArgs("name=kit&queryKey=name&queryValue=x"));
+
       expect(lastWhere().AND).toBeUndefined();
-      expect(bookingMocks.resolveCustodianScope).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/webapp/app/routes/api+/model-filters.test.server.ts
+++ b/apps/webapp/app/routes/api+/model-filters.test.server.ts
@@ -57,16 +57,29 @@ vi.mock("~/modules/organization/context.server", () => ({
   getSelectedOrganization: orgMocks.getSelectedOrganization,
 }));
 
-// why: service.server pulls in the whole booking domain (schedulers, emails);
-// the clause itself is pure, so the real implementation is re-stated here and
-// asserted against, keeping the test honest about the shape it expects.
-vi.mock("~/modules/booking/service.server", () => ({
-  bookingDraftVisibilityClause: (userId: string) => ({
+/**
+ * Single definition of the draft-visibility clause, shared by the mock below
+ * and by the assertions, so the two can never drift apart.
+ *
+ * Hoisted because `vi.mock` factories are lifted above module scope.
+ *
+ * The real implementation's shape is pinned by its own test in
+ * `modules/booking/service.server.test.ts`, so restating it here cannot mask a
+ * production change — that test fails first.
+ */
+const clause = vi.hoisted(() => ({
+  buildDraftVisibility: (userId: string) => ({
     OR: [
       { status: { not: "DRAFT" } },
       { AND: [{ status: "DRAFT" }, { creatorId: userId }] },
     ],
   }),
+}));
+
+// why: service.server pulls in the whole booking domain (schedulers, emails);
+// the clause itself is pure, so a local equivalent keeps the test fast.
+vi.mock("~/modules/booking/service.server", () => ({
+  bookingDraftVisibilityClause: clause.buildDraftVisibility,
 }));
 
 const ORG_ID = "org-1";
@@ -113,12 +126,7 @@ async function readFilters(response: Response) {
 }
 
 /** The clause every booking read path AND-s in — drafts are creator-only. */
-const DRAFT_VISIBILITY = {
-  OR: [
-    { status: { not: "DRAFT" } },
-    { AND: [{ status: "DRAFT" }, { creatorId: "user-1" }] },
-  ],
-};
+const DRAFT_VISIBILITY = clause.buildDraftVisibility("user-1");
 
 describe("GET /api/model-filters", () => {
   beforeEach(() => {

--- a/apps/webapp/app/routes/api+/model-filters.test.server.ts
+++ b/apps/webapp/app/routes/api+/model-filters.test.server.ts
@@ -11,7 +11,7 @@
  * @see {@link file://./model-filters.ts}
  * @see {@link file://./../../hooks/use-model-filters.ts}
  */
-import { BookingStatus } from "@prisma/client";
+import { BookingStatus, OrganizationRoles } from "@prisma/client";
 import type { LoaderFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -76,10 +76,15 @@ const clause = vi.hoisted(() => ({
   }),
 }));
 
+const bookingMocks = vi.hoisted(() => ({
+  resolveCustodianScope: vi.fn(),
+}));
+
 // why: service.server pulls in the whole booking domain (schedulers, emails);
 // the clause itself is pure, so a local equivalent keeps the test fast.
 vi.mock("~/modules/booking/service.server", () => ({
   bookingDraftVisibilityClause: clause.buildDraftVisibility,
+  resolveCustodianScope: bookingMocks.resolveCustodianScope,
 }));
 
 const ORG_ID = "org-1";
@@ -128,12 +133,18 @@ async function readFilters(response: Response) {
 /** The clause every booking read path AND-s in — drafts are creator-only. */
 const DRAFT_VISIBILITY = clause.buildDraftVisibility("user-1");
 
+/** Points the session at a workspace where the caller holds `role`. */
+function setRole(role: OrganizationRoles) {
+  orgMocks.getSelectedOrganization.mockResolvedValue({
+    organizationId: ORG_ID,
+    userOrganizations: [{ organization: { id: ORG_ID }, roles: [role] }],
+  });
+}
+
 describe("GET /api/model-filters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    orgMocks.getSelectedOrganization.mockResolvedValue({
-      organizationId: ORG_ID,
-    });
+    setRole(OrganizationRoles.OWNER);
   });
 
   describe("result shape", () => {
@@ -177,7 +188,8 @@ describe("GET /api/model-filters", () => {
       expect(filters[0].name).toBe("Ada Lovelace");
       expect(filters[0].color).toBe("#fff");
       expect(filters[0].metadata).toMatchObject({ id: "tm-1" });
-      // Same bug class: `renderItem` reads `item.metadata?.userId` here.
+      // The record's own columns are now top-level too, matching what a route
+      // loader hands the picker.
       expect(filters[0].userId).toBe("user-9");
     });
   });
@@ -252,6 +264,57 @@ describe("GET /api/model-filters", () => {
       await loader(buildArgs("name=kit&queryKey=name&queryValue=x"));
 
       expect(lastWhere().AND).toBeUndefined();
+    });
+  });
+
+  describe("scopeToCustodian", () => {
+    beforeEach(() => {
+      dbMocks.dynamicFindMany.mockResolvedValue([]);
+      bookingMocks.resolveCustodianScope.mockResolvedValue({
+        userId: "user-1",
+        teamMemberIds: ["tm-1"],
+      });
+    });
+
+    it.each([OrganizationRoles.SELF_SERVICE, OrganizationRoles.BASE])(
+      "restricts %s callers that opt in to bookings they are custodian of",
+      async (role) => {
+        setRole(role);
+
+        await loader(
+          buildArgs("name=booking&queryKey=name&scopeToCustodian=true")
+        );
+
+        expect(lastWhere().AND).toEqual([
+          DRAFT_VISIBILITY,
+          {
+            OR: [
+              { custodianUserId: "user-1" },
+              { custodianTeamMemberId: { in: ["tm-1"] } },
+            ],
+          },
+        ]);
+      }
+    );
+
+    it("is a no-op for admins and owners", async () => {
+      setRole(OrganizationRoles.ADMIN);
+
+      await loader(
+        buildArgs("name=booking&queryKey=name&scopeToCustodian=true")
+      );
+
+      expect(lastWhere().AND).toEqual([DRAFT_VISIBILITY]);
+      expect(bookingMocks.resolveCustodianScope).not.toHaveBeenCalled();
+    });
+
+    it("leaves callers that do not opt in unscoped (advanced filter)", async () => {
+      setRole(OrganizationRoles.SELF_SERVICE);
+
+      await loader(buildArgs("name=booking&queryKey=name&queryValue=x"));
+
+      expect(lastWhere().AND).toEqual([DRAFT_VISIBILITY]);
+      expect(bookingMocks.resolveCustodianScope).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/webapp/app/routes/api+/model-filters.ts
+++ b/apps/webapp/app/routes/api+/model-filters.ts
@@ -1,8 +1,8 @@
-import { BookingStatus, OrganizationRoles, TagUseFor } from "@prisma/client";
+import { BookingStatus, TagUseFor } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
-import { resolveCustodianScope } from "~/modules/booking/service.server";
+import { bookingDraftVisibilityClause } from "~/modules/booking/service.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
 import { makeShelfError } from "~/utils/error";
 import { payload, error, parseData } from "~/utils/http.server";
@@ -96,12 +96,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
   const { userId } = authSession;
 
   try {
-    const { organizationId, userOrganizations } = await getSelectedOrganization(
-      {
-        userId,
-        request,
-      }
-    );
+    const { organizationId } = await getSelectedOrganization({
+      userId,
+      request,
+    });
 
     /** Getting all the query parameters from url */
     const url = new URL(request.url);
@@ -172,42 +170,17 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       };
 
       /**
-       * Self-service / base users may only work with their own bookings. The
-       * route loaders that seed these pickers apply this restriction via
-       * `loadBookingsData` → `getBookings({ custodianScope })`; without the
-       * same restriction here, typing in the search box would surface every
-       * booking in the organization.
+       * A DRAFT booking is visible only to its creator. Every other booking
+       * read path enforces this — `getBookings`, `getMinimalBookings`, the CSV
+       * export and the mobile booking APIs all AND in the same clause — so a
+       * search that can now return DRAFT rows has to enforce it too, or typing
+       * would surface drafts the seeding loader deliberately hides.
+       *
+       * Server-derived from the session `userId`, never from a request param,
+       * and nested in a single AND member so the search `OR` above cannot widen
+       * it back open.
        */
-      const role =
-        userOrganizations.find((o) => o.organization.id === organizationId)
-          ?.roles?.[0] ?? OrganizationRoles.BASE;
-
-      if (
-        role === OrganizationRoles.SELF_SERVICE ||
-        role === OrganizationRoles.BASE
-      ) {
-        const custodianScope = await resolveCustodianScope({
-          userId,
-          organizationId,
-        });
-
-        const selfBranches: Array<Record<string, unknown>> = [
-          { custodianUserId: custodianScope.userId },
-        ];
-
-        if (custodianScope.teamMemberIds.length) {
-          selfBranches.push({
-            custodianTeamMemberId: { in: custodianScope.teamMemberIds },
-          });
-        }
-
-        // Nested inside a single AND member so the search `OR` above cannot
-        // widen it back open.
-        where.AND = [
-          ...(where.AND ?? []),
-          selfBranches.length === 1 ? selfBranches[0] : { OR: selfBranches },
-        ];
-      }
+      where.AND = [...(where.AND ?? []), bookingDraftVisibilityClause(userId)];
     }
 
     if (modelFilters.name === "tag" && modelFilters.useFor) {

--- a/apps/webapp/app/routes/api+/model-filters.ts
+++ b/apps/webapp/app/routes/api+/model-filters.ts
@@ -1,11 +1,19 @@
+import type { Prisma } from "@prisma/client";
 import { BookingStatus, TagUseFor } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
-import { bookingDraftVisibilityClause } from "~/modules/booking/service.server";
+import {
+  bookingDraftVisibilityClause,
+  resolveCustodianScope,
+} from "~/modules/booking/service.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
 import { makeShelfError } from "~/utils/error";
 import { payload, error, parseData } from "~/utils/http.server";
+import {
+  isSelfServiceOrBaseRole,
+  resolveEffectiveRole,
+} from "~/utils/roles.server";
 
 /**
  * Booking statuses a booking search returns when the caller does not ask for a
@@ -81,6 +89,25 @@ export const ModelFiltersSchema = z.discriminatedUnion("name", [
             ),
         { message: "Invalid booking status" }
       ),
+
+    /**
+     * Opt in to the same custodian restriction the seeding loader applies.
+     *
+     * Set by the "Add to existing booking" dialogs, whose loader runs
+     * `loadBookingsData` → `getBookings({ custodianScope })` for SELF_SERVICE /
+     * BASE callers. Without it, typing replaces their custodian-scoped list with
+     * bookings they do not own, which `validateBookingOwnership` then rejects on
+     * submit — a dead end.
+     *
+     * The asset-index advanced filter does NOT set it, so that surface keeps
+     * seeing the same rows before and after typing.
+     *
+     * This is a request-controlled *toggle*, never a request-controlled *value*:
+     * the ids it restricts to are resolved server-side from the session user, so
+     * it cannot be used to widen or retarget the scope (the hazard documented on
+     * `getMinimalBookings`). It is also a no-op for ADMIN / OWNER.
+     */
+    scopeToCustodian: z.coerce.boolean().optional(),
   }),
   BasicModelFilters.extend({
     name: z.literal("assetModel"),
@@ -96,10 +123,9 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
   const { userId } = authSession;
 
   try {
-    const { organizationId } = await getSelectedOrganization({
-      userId,
-      request,
-    });
+    const { organizationId, userOrganizations } = await getSelectedOrganization(
+      { userId, request }
+    );
 
     /** Getting all the query parameters from url */
     const url = new URL(request.url);
@@ -181,6 +207,36 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
        * it back open.
        */
       where.AND = [...(where.AND ?? []), bookingDraftVisibilityClause(userId)];
+
+      /**
+       * Callers that opted in get the seeding loader's custodian restriction,
+       * resolved here from the session — see the `scopeToCustodian` docs above.
+       */
+      if (
+        modelFilters.scopeToCustodian &&
+        isSelfServiceOrBaseRole(
+          resolveEffectiveRole({ userOrganizations, organizationId })
+        )
+      ) {
+        const custodianScope = await resolveCustodianScope({
+          userId,
+          organizationId,
+        });
+
+        const selfBranches: Prisma.BookingWhereInput[] = [
+          { custodianUserId: custodianScope.userId },
+        ];
+
+        if (custodianScope.teamMemberIds.length) {
+          selfBranches.push({
+            custodianTeamMemberId: { in: custodianScope.teamMemberIds },
+          });
+        }
+
+        where.AND.push(
+          selfBranches.length === 1 ? selfBranches[0] : { OR: selfBranches }
+        );
+      }
     }
 
     if (modelFilters.name === "tag" && modelFilters.useFor) {
@@ -226,11 +282,11 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
          * `renderItem`.
          *
          * Spreading the raw record first is what keeps those two shapes in
-         * agreement: without it a `renderItem` reading e.g. `item.status`
-         * (booking pickers) or `item.metadata.userId` (team-member pickers)
-         * silently got `undefined` the moment the user typed, and the row
-         * rendered as nothing at all. The explicit keys below still win, so the
-         * `id` / `name` / `color` / `metadata` / `user` contract is unchanged.
+         * agreement: without it a `renderItem` reading a plain column — e.g.
+         * `item.status` in the booking pickers — silently got `undefined` the
+         * moment the user typed, and the row rendered as nothing at all. The
+         * explicit keys below still win, so the `id` / `name` / `color` /
+         * `metadata` / `user` contract is unchanged.
          *
          * No new data is exposed: `metadata` already carried the whole record.
          */

--- a/apps/webapp/app/routes/api+/model-filters.ts
+++ b/apps/webapp/app/routes/api+/model-filters.ts
@@ -1,10 +1,23 @@
-import { TagUseFor } from "@prisma/client";
+import { BookingStatus, OrganizationRoles, TagUseFor } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import { resolveCustodianScope } from "~/modules/booking/service.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
 import { makeShelfError } from "~/utils/error";
 import { payload, error, parseData } from "~/utils/http.server";
+
+/**
+ * Booking statuses a booking search returns when the caller does not ask for a
+ * specific set. Matches the historical behaviour of this endpoint: "upcoming"
+ * bookings only, which is what the asset-index advanced filter means by
+ * "Has upcoming bookings".
+ */
+const DEFAULT_BOOKING_SEARCH_STATUSES: BookingStatus[] = [
+  BookingStatus.RESERVED,
+  BookingStatus.ONGOING,
+  BookingStatus.OVERDUE,
+];
 
 const BasicModelFilters = z.object({
   /** key of field for which we have to filter values */
@@ -46,6 +59,28 @@ export const ModelFiltersSchema = z.discriminatedUnion("name", [
   }),
   BasicModelFilters.extend({
     name: z.literal("booking"),
+    /**
+     * Comma-separated `BookingStatus` values the caller wants to search across.
+     *
+     * Different surfaces need different sets: the asset/kit "Add to existing
+     * booking" dialogs also offer DRAFT bookings, while the asset-index
+     * advanced filter is about *upcoming* bookings and deliberately excludes
+     * them. Defaults to the upcoming-only set so existing callers are
+     * unaffected.
+     */
+    status: z
+      .string()
+      .optional()
+      .refine(
+        (val) =>
+          val === undefined ||
+          val
+            .split(",")
+            .every((s) =>
+              Object.values(BookingStatus).includes(s.trim() as BookingStatus)
+            ),
+        { message: "Invalid booking status" }
+      ),
   }),
   BasicModelFilters.extend({
     name: z.literal("assetModel"),
@@ -61,10 +96,12 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
   const { userId } = authSession;
 
   try {
-    const { organizationId } = await getSelectedOrganization({
-      userId,
-      request,
-    });
+    const { organizationId, userOrganizations } = await getSelectedOrganization(
+      {
+        userId,
+        request,
+      }
+    );
 
     /** Getting all the query parameters from url */
     const url = new URL(request.url);
@@ -126,7 +163,51 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     }
 
     if (modelFilters.name === "booking") {
-      where.status = { in: ["RESERVED", "ONGOING", "OVERDUE"] };
+      where.status = {
+        in: modelFilters.status
+          ? (modelFilters.status
+              .split(",")
+              .map((s) => s.trim()) as BookingStatus[])
+          : DEFAULT_BOOKING_SEARCH_STATUSES,
+      };
+
+      /**
+       * Self-service / base users may only work with their own bookings. The
+       * route loaders that seed these pickers apply this restriction via
+       * `loadBookingsData` → `getBookings({ custodianScope })`; without the
+       * same restriction here, typing in the search box would surface every
+       * booking in the organization.
+       */
+      const role =
+        userOrganizations.find((o) => o.organization.id === organizationId)
+          ?.roles?.[0] ?? OrganizationRoles.BASE;
+
+      if (
+        role === OrganizationRoles.SELF_SERVICE ||
+        role === OrganizationRoles.BASE
+      ) {
+        const custodianScope = await resolveCustodianScope({
+          userId,
+          organizationId,
+        });
+
+        const selfBranches: Array<Record<string, unknown>> = [
+          { custodianUserId: custodianScope.userId },
+        ];
+
+        if (custodianScope.teamMemberIds.length) {
+          selfBranches.push({
+            custodianTeamMemberId: { in: custodianScope.teamMemberIds },
+          });
+        }
+
+        // Nested inside a single AND member so the search `OR` above cannot
+        // widen it back open.
+        where.AND = [
+          ...(where.AND ?? []),
+          selfBranches.length === 1 ? selfBranches[0] : { OR: selfBranches },
+        ];
+      }
     }
 
     if (modelFilters.name === "tag" && modelFilters.useFor) {
@@ -165,12 +246,28 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
 
     return data(
       payload({
+        /**
+         * Search results must carry the SAME top-level fields as the records a
+         * route loader seeds the picker with, because `DynamicSelect` /
+         * `DynamicDropdown` hand whichever list is active to the very same
+         * `renderItem`.
+         *
+         * Spreading the raw record first is what keeps those two shapes in
+         * agreement: without it a `renderItem` reading e.g. `item.status`
+         * (booking pickers) or `item.metadata.userId` (team-member pickers)
+         * silently got `undefined` the moment the user typed, and the row
+         * rendered as nothing at all. The explicit keys below still win, so the
+         * `id` / `name` / `color` / `metadata` / `user` contract is unchanged.
+         *
+         * No new data is exposed: `metadata` already carried the whole record.
+         */
         filters: queryData.map((item) => ({
+          ...item,
           id: item.id,
           name: item[queryKey],
           color: item?.color,
           metadata: item,
-          user: item?.user as any,
+          user: item?.user,
         })),
       })
     );

--- a/apps/webapp/app/utils/roles.server.ts
+++ b/apps/webapp/app/utils/roles.server.ts
@@ -46,6 +46,48 @@ export async function isAdmin(context: Record<string, any>) {
   return !!user;
 }
 
+/**
+ * The caller's effective role in one organization.
+ *
+ * A membership's `roles` is an array, but the app treats the **first** entry as
+ * authoritative everywhere a single role is needed. Exported so callers outside
+ * {@link requirePermission} (e.g. `/api/model-filters`) resolve the role the
+ * exact same way — a different rule here would make a search disagree with the
+ * loader that seeded it.
+ *
+ * @param args.userOrganizations - Memberships from `getSelectedOrganization`.
+ * @param args.organizationId - Workspace whose membership to read.
+ * @returns The effective role, defaulting to `BASE` when no membership matches.
+ */
+export function resolveEffectiveRole({
+  userOrganizations,
+  organizationId,
+}: {
+  userOrganizations: Array<{
+    organization: { id: string };
+    roles: OrganizationRoles[];
+  }>;
+  organizationId: string;
+}): OrganizationRoles {
+  const roles = userOrganizations.find(
+    (o) => o.organization.id === organizationId
+  )?.roles;
+
+  return roles?.[0] ?? OrganizationRoles.BASE;
+}
+
+/**
+ * Whether a role is one of the two restricted, "own records only" roles.
+ *
+ * @param role - Effective role from {@link resolveEffectiveRole}.
+ * @returns `true` for SELF_SERVICE and BASE.
+ */
+export function isSelfServiceOrBaseRole(role: OrganizationRoles): boolean {
+  return (
+    role === OrganizationRoles.SELF_SERVICE || role === OrganizationRoles.BASE
+  );
+}
+
 export async function requirePermission({
   userId,
   request,
@@ -91,10 +133,9 @@ export async function requirePermission({
   Sentry.setUser({ id: userId });
   Sentry.setTag("organizationId", organizationId);
 
-  const role = roles ? roles[0] : OrganizationRoles.BASE;
+  const role = resolveEffectiveRole({ userOrganizations, organizationId });
 
-  const isSelfServiceOrBase =
-    role === OrganizationRoles.SELF_SERVICE || role === OrganizationRoles.BASE;
+  const isSelfServiceOrBase = isSelfServiceOrBaseRole(role);
 
   /**
    * This checks the organization settings permissions overrides for BASE and SELF_SERVICE roles

--- a/apps/webapp/test/routes-tests/api+/model-filters.test.ts
+++ b/apps/webapp/test/routes-tests/api+/model-filters.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Regression tests for `/api/model-filters`.
+ *
+ * This endpoint backs the search box inside every `DynamicSelect` /
+ * `DynamicDropdown`. The picker renders the ROUTE LOADER's records until the
+ * user types, then swaps to this endpoint's results and passes both through the
+ * same `renderItem`. If the two shapes disagree, `renderItem` reads `undefined`
+ * and the row silently renders as nothing — a blank dropdown with a non-zero
+ * "Showing N out of M" footer.
+ *
+ * @see {@link file://./../../../app/routes/api+/model-filters.ts}
+ * @see {@link file://./../../../app/hooks/use-model-filters.ts}
+ */
+import { BookingStatus, OrganizationRoles } from "@prisma/client";
+import type { LoaderFunctionArgs } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ADDABLE_BOOKING_STATUSES } from "~/modules/booking/constants";
+import { loader } from "~/routes/api+/model-filters";
+
+// why: mocking Remix's data() so the loader returns a plain Response we can read
+const createDataMock = vi.hoisted(
+  () => () =>
+    vi.fn(
+      (payload: unknown, init?: ResponseInit) =>
+        new Response(JSON.stringify(payload), {
+          status: init?.status || 200,
+          headers: { "Content-Type": "application/json" },
+        })
+    )
+);
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+const dbMocks = vi.hoisted(() => ({
+  dynamicFindMany: vi.fn(),
+}));
+
+// why: exercising the where-clause + response shaping without a real database
+vi.mock("~/database/db.server", () => ({
+  db: {
+    booking: { dynamicFindMany: dbMocks.dynamicFindMany },
+    teamMember: { dynamicFindMany: dbMocks.dynamicFindMany },
+  },
+}));
+
+const orgMocks = vi.hoisted(() => ({
+  getSelectedOrganization: vi.fn(),
+}));
+
+// why: bypassing cookie/session resolution to drive the caller's role directly
+vi.mock("~/modules/organization/context.server", () => ({
+  getSelectedOrganization: orgMocks.getSelectedOrganization,
+}));
+
+const bookingMocks = vi.hoisted(() => ({
+  resolveCustodianScope: vi.fn(),
+}));
+
+// why: service.server pulls in the whole booking domain (schedulers, emails)
+vi.mock("~/modules/booking/service.server", () => ({
+  resolveCustodianScope: bookingMocks.resolveCustodianScope,
+}));
+
+const ORG_ID = "org-1";
+
+function buildArgs(query: string): LoaderFunctionArgs {
+  return {
+    request: new Request(`http://localhost/api/model-filters?${query}`),
+    params: {},
+    context: { getSession: () => ({ userId: "user-1" }) },
+  } as unknown as LoaderFunctionArgs;
+}
+
+/**
+ * Invokes the loader and returns the mocked `data()` Response.
+ *
+ * The double cast is needed because React Router types `data()` as returning
+ * `DataWithResponseInit`; our mock returns a real `Response` instead so the
+ * test can read the serialized body.
+ */
+async function callLoader(query: string): Promise<Response> {
+  return (await loader(buildArgs(query))) as unknown as Response;
+}
+
+/** Returns the `where` Prisma passed on the most recent query. */
+function lastWhere() {
+  return dbMocks.dynamicFindMany.mock.calls.at(-1)?.[0]?.where;
+}
+
+async function readFilters(response: Response) {
+  const body = await response.json();
+  return body.filters ?? body.payload?.filters ?? [];
+}
+
+function setRole(role: OrganizationRoles) {
+  orgMocks.getSelectedOrganization.mockResolvedValue({
+    organizationId: ORG_ID,
+    userOrganizations: [{ organization: { id: ORG_ID }, roles: [role] }],
+  });
+}
+
+describe("GET /api/model-filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setRole(OrganizationRoles.OWNER);
+    bookingMocks.resolveCustodianScope.mockResolvedValue({
+      userId: "user-1",
+      teamMemberIds: ["tm-1"],
+    });
+  });
+
+  describe("result shape", () => {
+    it("exposes the record's own fields at the top level so renderItem sees them", async () => {
+      // A booking as the route loader would hand it to the picker.
+      dbMocks.dynamicFindMany.mockResolvedValue([
+        {
+          id: "booking-1",
+          name: "Barclays Vibra",
+          status: BookingStatus.RESERVED,
+          from: new Date("2026-09-01T10:00:00Z"),
+          to: new Date("2026-09-02T10:00:00Z"),
+        },
+      ]);
+
+      const filters = await readFilters(
+        await callLoader("name=booking&queryKey=name&queryValue=Barclays")
+      );
+
+      // The bug: `status` was absent, so the dialogs' `isValidBooking(item)`
+      // returned false and the row rendered as `null`.
+      expect(filters[0]).toMatchObject({
+        id: "booking-1",
+        name: "Barclays Vibra",
+        status: BookingStatus.RESERVED,
+      });
+      expect(filters[0].from).toBeDefined();
+      expect(filters[0].to).toBeDefined();
+    });
+
+    it("keeps the id/name/color/metadata contract that existing pickers rely on", async () => {
+      dbMocks.dynamicFindMany.mockResolvedValue([
+        { id: "tm-1", name: "Ada Lovelace", userId: "user-9", color: "#fff" },
+      ]);
+
+      const filters = await readFilters(
+        await callLoader("name=teamMember&queryKey=name&queryValue=Ada")
+      );
+
+      expect(filters[0].id).toBe("tm-1");
+      expect(filters[0].name).toBe("Ada Lovelace");
+      expect(filters[0].color).toBe("#fff");
+      expect(filters[0].metadata).toMatchObject({ id: "tm-1" });
+      // Same bug class: `renderItem` reads `item.metadata?.userId` here.
+      expect(filters[0].userId).toBe("user-9");
+    });
+  });
+
+  describe("booking status scoping", () => {
+    beforeEach(() => {
+      dbMocks.dynamicFindMany.mockResolvedValue([]);
+    });
+
+    it("defaults to upcoming bookings only, so the advanced filter is unchanged", async () => {
+      await loader(buildArgs("name=booking&queryKey=name&queryValue=x"));
+
+      expect(lastWhere().status).toEqual({
+        in: [
+          BookingStatus.RESERVED,
+          BookingStatus.ONGOING,
+          BookingStatus.OVERDUE,
+        ],
+      });
+    });
+
+    it("honours the statuses a caller asks for, including DRAFT", async () => {
+      await loader(
+        buildArgs(
+          `name=booking&queryKey=name&queryValue=x&status=${ADDABLE_BOOKING_STATUSES.join(
+            ","
+          )}`
+        )
+      );
+
+      expect(lastWhere().status.in).toContain(BookingStatus.DRAFT);
+      expect(lastWhere().status.in).toEqual(
+        expect.arrayContaining([...ADDABLE_BOOKING_STATUSES])
+      );
+    });
+
+    it("rejects a status value that is not a BookingStatus", async () => {
+      const response = await callLoader(
+        "name=booking&queryKey=name&status=NOT_A_STATUS"
+      );
+
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      expect(dbMocks.dynamicFindMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("self-service booking visibility", () => {
+    beforeEach(() => {
+      dbMocks.dynamicFindMany.mockResolvedValue([]);
+    });
+
+    it.each([OrganizationRoles.SELF_SERVICE, OrganizationRoles.BASE])(
+      "restricts %s users to bookings they are custodian of",
+      async (role) => {
+        setRole(role);
+
+        await loader(buildArgs("name=booking&queryKey=name&queryValue=x"));
+
+        // Nested in AND so the search OR cannot widen it back open.
+        expect(lastWhere().AND).toEqual([
+          {
+            OR: [
+              { custodianUserId: "user-1" },
+              { custodianTeamMemberId: { in: ["tm-1"] } },
+            ],
+          },
+        ]);
+      }
+    );
+
+    it("does not restrict admins and owners", async () => {
+      setRole(OrganizationRoles.ADMIN);
+
+      await loader(buildArgs("name=booking&queryKey=name&queryValue=x"));
+
+      expect(lastWhere().AND).toBeUndefined();
+      expect(bookingMocks.resolveCustodianScope).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

In the **Add to Existing Booking** dialogs (asset and kit), typing into the booking picker renders **zero rows** while the footer still reports a non-zero match count — e.g. `Showing 1 out of 137` above an empty list. The booking is found; it just never draws.

## Root cause

`useModelFilters` feeds the picker from **two different sources**, and they did not agree on shape:

| | Source | Shape |
|---|---|---|
| No search query | route loader (`loadBookingsData`) | full `Booking` records — `status`, `from`, `to` at the top level |
| Search query entered | `/api/model-filters` | `{ id, name, color, metadata, user }` — **no `status`** |

`DynamicSelect` passes whichever list is active to the **same** `renderItem`. Both dialogs guard on `item.status` before drawing a row, so on search results that read `undefined`, `renderItem` returned `null`, and [`dynamic-select.tsx`](https://github.com/Shelf-nu/shelf.nu/blob/main/apps/webapp/app/components/dynamic-select/dynamic-select.tsx) dropped the row via `if (!value) return null`. `items.length` still counted it, producing the phantom footer.

`DynamicSelect` also calls `renderItem({ ...item, metadata: item })`, which **overwrites** the API's `metadata`, so the raw record was not reachable as a fallback either.

Only reproducible above the client-side filter threshold: `isAllDataLoaded` is `items.length === totalItems` and `loadBookingsData` pages at 20, so workspaces with ≤20 addable bookings filter locally on the loader's shape and behave correctly.

## Changes

1. **`/api/model-filters` returns loader-compatible items** — spreads the queried record so search results carry the same top-level fields. The explicit `id`/`name`/`color`/`metadata`/`user` keys still win, so the existing contract is unchanged, and no new data is exposed (`metadata` already carried the whole record).

2. **Optional `status` param on the booking filter schema** — the endpoint hardcoded `RESERVED, ONGOING, OVERDUE`, so a **Draft** booking could never be found by search even though both dialogs state Draft is allowed. The param defaults to the previous set, leaving the asset-index advanced filter (`Has upcoming bookings`) untouched; the two dialogs opt into `DRAFT`.

3. **Single source of truth for the status list** — new `ADDABLE_BOOKING_STATUSES` in `modules/booking/constants.ts` now drives `loadBookingsData`, the search param, and each dialog's `isValidBooking`, so the three layers can no longer drift apart. This drift is what made the bug invisible to types.

4. **Draft visibility on booking search** — a `DRAFT` booking is visible only to its creator, enforced by `getBookings`, `getMinimalBookings`, the CSV export and the mobile booking APIs. Enabling `DRAFT` here without `bookingDraftVisibilityClause(userId)` would have let typing surface another creator's draft. Now AND-ed onto every booking search, derived from the session user.

5. **Custodian scoping for the dialogs only** — making rows renderable also made bookings a SELF_SERVICE / BASE user is not custodian of selectable, and `validateBookingOwnership` then rejects them on submit. An opt-in `scopeToCustodian` toggle applies the seeding loader's restriction; the request carries intent only, with the ids resolved server-side from the session. The asset-index advanced filter does not set it and is unchanged. `resolveEffectiveRole` / `isSelfServiceOrBaseRole` are shared with `requirePermission` so search and loader agree on the caller's role.

6. **Regression tests** — `test/routes-tests/api+/model-filters.test.ts` covers result shape, status scoping (default vs. explicit vs. invalid), and role scoping. Verified they fail against the pre-fix implementation.

## Verification

Reproduced the reported behaviour on unmodified `main` in a workspace with >20 bookings, then repeated the identical steps with the fix:

- Searching a booking by name renders the row, selects it, and submits successfully.
- A `DRAFT`-only booking now appears in search results.
- Both the asset dialog and the kit dialog.
- Advanced-filter picker unchanged: same query returns `0` drafts by default vs. `7` when the dialogs' param is supplied.
- `teamMember`, `tag`, `kit` and `category` searches still return the documented `id`/`name`/`color`/`metadata` contract.

`pnpm webapp:validate` clean (typecheck, ESLint, 3843 tests).

## Not included

The picker's **Show all** button writes `getAll=<model>` to the URL, but no server loader reads that param (`loadBookingsData` hardcodes `perPage = 20`), so the button does nothing on these dialogs. Out of scope here — happy to follow up separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking searches now support filtering by booking status.
  * Results can include draft, reserved, ongoing, and overdue bookings where permitted.
  * Draft bookings are visible only to their creators.
  * Search results retain complete booking details alongside standard information.

* **Bug Fixes**
  * Improved consistency when adding assets or kits to existing bookings.
  * Invalid booking-status filters are now rejected with validation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
