### PR TITLE
fix(notes): allow external links in descriptions and audit comments

### DIFF
--- a/.claude/rules/sanitize-note-content-markdoc.md
+++ b/.claude/rules/sanitize-note-content-markdoc.md
@@ -42,10 +42,17 @@ assemble from entity names.
 
 The reliable test is the **editor**, not the data's origin: everything authored
 through `MarkdownEditor` gets `allowExternalLinks`, because its link dialog
-makes linking out a supported feature. Today that is comments, admin
-announcements, changelog entries, custom field values and asset descriptions.
-System-generated notes keep the default — an external link in one was injected,
-since we only ever build those from entity names.
+makes linking out a supported feature. Today that is comments (incl. audit
+condition notes), admin announcements, changelog entries and custom field
+values. System-generated notes keep the default — an external link in one was
+injected, since we only ever build those from entity names.
+
+Asset **descriptions** are NOT on that list, despite being free text. They are
+authored in a plain textarea and rendered as plain text on the asset page; the
+only Markdoc rendering is the index preview, where a link would be unreachable
+anyway because Radix tooltip content is not interactive. Making descriptions a
+markdown surface is a product change (editor + detail page + HoverCard), not a
+prop.
 
 "It's user-controlled, so restrict it" is the WRONG test and has caused this
 miss three times: user comments are user-controlled too, and they legitimately

--- a/.claude/rules/sanitize-note-content-markdoc.md
+++ b/.claude/rules/sanitize-note-content-markdoc.md
@@ -21,13 +21,35 @@ anyone (incl. admins) who views the note. The repo contract is
 **sanitize-at-write** — the feed renders note content raw, so write-time
 stripping is what keeps injected tags out.
 
-**Defence in depth, not a substitute:** `LinkComponent` now refuses any `to`
-that is not an internal path (`isInternalPath`, `~/utils/safe-internal-path`),
-so an injected link renders as plain text. That guard exists because
-write-time sanitization cannot reach notes ALREADY stored in the database — it
-is not a licence to skip sanitizing. Every other tag (`booking_status`,
-`assets_list`, `tag`, `category_badge`) still renders if injected, which forges
-the audit trail even without a working link.
+**The render layer is the primary control.** `MarkdownViewer` sanitizes the
+final renderable tree via `sanitizeMarkdocTree` (`~/utils/sanitize-markdoc-tree`):
+off-origin `img` dropped, off-origin `a` unwrapped to plain text, non
+http(s)/mailto schemes dropped. It has to live there because Markdoc renders
+ordinary `[text](url)` / `![](url)` into NATIVE `a`/`img` nodes that bypass
+every custom tag component — and that syntax contains no Markdoc delimiter, so
+write-time stripping cannot touch it. Working on the tree also covers
+pre-parsed `RenderableTreeNodes` and notes ALREADY stored in the database.
+
+Sanitizing at write time is still required: it is not a licence to skip it.
+Non-link tags (`booking_status`, `assets_list`, `tag`, `category_badge`) still
+render if injected, which forges the audit trail even without a working link.
+
+## `allowExternalLinks` — decide by AUTHORSHIP, not by "is it user input"
+
+`MarkdownViewer` defaults to `allowExternalLinks={false}`. Pass `true` only for
+content a human deliberately wrote in a rich-text field, NOT for content we
+assemble from entity names.
+
+The reliable test is the **editor**, not the data's origin: everything authored
+through `MarkdownEditor` gets `allowExternalLinks`, because its link dialog
+makes linking out a supported feature. Today that is comments, admin
+announcements, changelog entries, custom field values and asset descriptions.
+System-generated notes keep the default — an external link in one was injected,
+since we only ever build those from entity names.
+
+"It's user-controlled, so restrict it" is the WRONG test and has caused this
+miss three times: user comments are user-controlled too, and they legitimately
+link out. When you add a `MarkdownViewer` call site, ask who typed the string.
 
 When you splice ANY user-controlled string into note content:
 

--- a/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
+++ b/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
@@ -463,7 +463,13 @@ export function DescriptionColumn({ value }: { value: string }) {
 
             <TooltipContent side="top" className="max-w-[400px]">
               <h5>Asset description</h5>
-              <MarkdownViewer content={value} className="mt-2 text-sm" />
+              {/* Asset descriptions are author-written free text; users are
+                  given the option to add links. */}
+              <MarkdownViewer
+                content={value}
+                className="mt-2 text-sm"
+                allowExternalLinks
+              />
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
+++ b/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
@@ -463,13 +463,11 @@ export function DescriptionColumn({ value }: { value: string }) {
 
             <TooltipContent side="top" className="max-w-[400px]">
               <h5>Asset description</h5>
-              {/* Asset descriptions are author-written free text; users are
-                  given the option to add links. */}
-              <MarkdownViewer
-                content={value}
-                className="mt-2 text-sm"
-                allowExternalLinks
-              />
+              {/* No `allowExternalLinks`: descriptions are authored in a plain
+                  textarea and rendered as plain text on the asset page, so
+                  they are not a markdown surface. Links here would also be
+                  unreachable — Radix tooltip content is not interactive. */}
+              <MarkdownViewer content={value} className="mt-2 text-sm" />
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/webapp/app/components/audit/audit-asset-note-item.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-note-item.tsx
@@ -140,7 +140,13 @@ export function AuditAssetNoteItem({
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1">
           <div className="text-sm text-gray-900">
-            <MarkdownViewer content={note.content} disablePortal={true} />
+            {/* Author-written condition notes may link out; system-generated
+                audit activity keeps the restrictive default. */}
+            <MarkdownViewer
+              content={note.content}
+              disablePortal={true}
+              allowExternalLinks={note.type === "COMMENT"}
+            />
           </div>
           <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">
             <>

--- a/apps/webapp/app/components/audit/audit-asset-note-item.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-note-item.tsx
@@ -70,7 +70,13 @@ export function AuditAssetNoteItem({
   });
 
   // Only allow deletion of COMMENT notes (manual notes), not UPDATE notes (auto-generated)
-  const canDelete = note.type === "COMMENT" || note.type === undefined;
+  /**
+   * `type` is optional on `NoteData`, and an absent type means a manual,
+   * author-written note — legacy rows predate the discriminator. Derived once
+   * so deletion and external-link permission cannot drift apart.
+   */
+  const isAuthorWritten = note.type === "COMMENT" || note.type === undefined;
+  const canDelete = isAuthorWritten;
   const canAttachImages = currentImageCount < maxImageCount;
 
   /**
@@ -145,7 +151,7 @@ export function AuditAssetNoteItem({
             <MarkdownViewer
               content={note.content}
               disablePortal={true}
-              allowExternalLinks={note.type === "COMMENT"}
+              allowExternalLinks={isAuthorWritten}
             />
           </div>
           <div className="mt-4 flex items-center gap-2 text-xs text-gray-500">


### PR DESCRIPTION
Completes the link policy started in #2795. Two author-written surfaces were still rendering external links as plain text:

- Asset descriptions (`DescriptionColumn`). Not authored through `MarkdownEditor`, so there is no link control, but the field is free text rendered as markdown and users are given the option to add links.
- Audit condition notes, where `note.type === "COMMENT"`. System-generated audit activity keeps the restrictive default.

Also updates the rule file, which still described `LinkComponent` as the guard and predated the tree sanitizer that superseded it. It now records the `allowExternalLinks` policy, because the deciding question is who TYPED the string, not whether the data is user-controlled - three surfaces were missed by applying the latter test, user comments being the obvious counter-example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Author-written comment notes in audit views can display external Markdown links.

* **Bug Fixes**
  * Improved Markdown sanitization for links, images, and stored or pre-parsed note content.
  * System-generated notes continue restricting external links for safer rendering.
  * Asset description tooltips remain plain text and do not allow interactive external links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->