### PR TITLE
fix(booking): assets added to an ongoing booking can't be checked out after an all-at-once checkout

### DIFF
--- a/apps/webapp/app/modules/asset/availability.server.test.ts
+++ b/apps/webapp/app/modules/asset/availability.server.test.ts
@@ -11,6 +11,7 @@
  * (inline `db` mock with `$transaction` routing the callback through the same
  * mock, plus per-method `mockResolvedValue` overrides per test).
  */
+import { AssetStatus } from "@prisma/client";
 import { describe, expect, it, vitest } from "vitest";
 import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
@@ -1032,6 +1033,11 @@ describe("getAssetAvailabilityBatch", () => {
         assetId: "a1",
         bookingId: "legacy",
         quantity: 5,
+        // The legacy branch is gated on the asset being flagged off the shelf,
+        // which is what an all-at-once checkout does to every asset it
+        // processed. Without it this row is treated as "added later" and
+        // contributes 0 (GitHub #2815).
+        asset: { status: AssetStatus.CHECKED_OUT },
         booking: {
           from: new Date("2026-01-01"),
           to: new Date("2026-01-05"),
@@ -1041,6 +1047,7 @@ describe("getAssetAvailabilityBatch", () => {
         assetId: "a1",
         bookingId: "partial",
         quantity: 8,
+        asset: { status: AssetStatus.CHECKED_OUT },
         booking: {
           from: new Date("2026-01-01"),
           to: new Date("2026-01-05"),
@@ -1158,6 +1165,12 @@ describe("getAssetAvailabilityBatch", () => {
         assetId: "a1",
         bookingId: "od1",
         quantity: 4,
+        // This OVERDUE booking was checked out all-at-once (no session rows),
+        // which flips the asset itself to CHECKED_OUT — the flag the legacy
+        // branch is gated on. The singular side is stubbed to report the same
+        // 4 units, so omitting it would break batch/singular parity for a
+        // reason unrelated to the windowing this test is about.
+        asset: { status: AssetStatus.CHECKED_OUT },
         booking: {
           from: new Date("2026-07-01T00:00:00Z"),
           to: new Date("2026-07-10T00:00:00Z"),

--- a/apps/webapp/app/modules/asset/availability.server.ts
+++ b/apps/webapp/app/modules/asset/availability.server.ts
@@ -1029,35 +1029,36 @@ async function computeCheckedOutBreakdownBatch(
 
   for (const [bookingId, byAsset] of slicesByBookingByAsset) {
     const sessionsForBooking = sessionsByBooking.get(bookingId) ?? [];
-    // A booking with zero sessions was checked out via the legacy
-    // all-at-once flow (the partial flow always writes a session row) —
-    // since these pivots are already scoped to ONGOING/OVERDUE, every
-    // booked unit that was on the booking AT THAT POINT is physically off
-    // the shelf. Which assets those are is decided per asset below; an
-    // asset added later is still AVAILABLE and holds no units.
-    const bookingIsLegacyAllAtOnce = sessionsForBooking.length === 0;
-    // Safe to build unconditionally: a legacy booking has no sessions, so
-    // this is an empty map and the non-legacy path naturally yields 0.
     const logsByAsset = checkoutSessionsToLogsByAsset(
       sessionsForBooking,
       (id) => byAsset.has(id)
     );
 
     for (const [assetId, slices] of byAsset) {
+      const claimedBySlice = attributeDispositionsByBookingAsset({
+        bookingAssetRows: slices,
+        consumptionLogs: logsByAsset.get(assetId) ?? [],
+      });
+
+      // Legacy all-at-once checkout, decided PER ASSET — mirror of
+      // `computeCheckedOutBreakdownForAsset`. This asset is flagged off the
+      // shelf and has NO recorded claims on this booking, so its zeroed
+      // counters are the all-at-once flow's silence rather than "still on the
+      // shelf". Keying on the asset (not on the booking having zero sessions)
+      // keeps it correct once a later batch records a session for a DIFFERENT
+      // asset, and leaves an asset added after the checkout — still AVAILABLE —
+      // holding no units (GitHub #2815).
+      const assetHasClaims = slices.some(
+        (slice) => (claimedBySlice.get(slice.id) ?? 0) > 0
+      );
       const assetIsLegacyAllAtOnce =
-        bookingIsLegacyAllAtOnce && checkedOutAssetIds.has(assetId);
-      const claimedBySlice = assetIsLegacyAllAtOnce
-        ? null
-        : attributeDispositionsByBookingAsset({
-            bookingAssetRows: slices,
-            consumptionLogs: logsByAsset.get(assetId) ?? [],
-          });
+        checkedOutAssetIds.has(assetId) && !assetHasClaims;
 
       const acc = breakdownByAsset.get(assetId) ?? { total: 0, standalone: 0 };
       for (const slice of slices) {
         const checkedOutSlice = assetIsLegacyAllAtOnce
           ? slice.quantity
-          : Math.min(slice.quantity, claimedBySlice?.get(slice.id) ?? 0);
+          : Math.min(slice.quantity, claimedBySlice.get(slice.id) ?? 0);
         acc.total += checkedOutSlice;
         // Standalone (free-pool) iff no kit FK — `!= null` matches
         // `attributeDispositionsByBookingAsset`'s kit-driven test.

--- a/apps/webapp/app/modules/asset/availability.server.ts
+++ b/apps/webapp/app/modules/asset/availability.server.ts
@@ -911,7 +911,8 @@ type CheckedOutBreakdown = { total: number; standalone: number };
  *
  * Per (booking, asset), attribution mirrors
  * {@link computeCheckedOutBreakdownForAsset} exactly:
- *   - legacy all-at-once booking (zero {@link PartialBookingCheckout} sessions)
+ *   - legacy all-at-once asset (live `CHECKED_OUT` with no
+ *     {@link PartialBookingCheckout} claims of its own on this booking)
  *     ⇒ every slice's checked-out = its full `quantity`;
  *   - otherwise the booking's claims for the asset are attributed across its
  *     slices via {@link attributeDispositionsByBookingAsset} (standalone-first
@@ -920,9 +921,9 @@ type CheckedOutBreakdown = { total: number; standalone: number };
  * `booked − remaining` the pre-split code computed, so `total` is unchanged.
  *
  * Booking statuses are pre-filtered to ONGOING/OVERDUE by the pivots query,
- * so — unlike the singular helper, which fetches `Booking.status` separately
- * to test the legacy-ONGOING fallback — every booking that shows up here
- * already satisfies that condition; the loop below never reads
+ * so — unlike the check-out-side helpers, which fetch `Booking.status`
+ * separately to bound the legacy fallback to an active booking — every booking
+ * that shows up here already satisfies that condition; the loop below never reads
  * `booking.status` (it's only selected because {@link AvailabilityBatchClient}
  * shares one `bookingAsset.findMany` select shape with the reserved-rows
  * read, which DOES need it — see that type's doc).

--- a/apps/webapp/app/modules/asset/availability.server.ts
+++ b/apps/webapp/app/modules/asset/availability.server.ts
@@ -62,7 +62,7 @@
  */
 
 import type { Prisma } from "@prisma/client";
-import { BookingStatus } from "@prisma/client";
+import { AssetStatus, BookingStatus } from "@prisma/client";
 import {
   checkQuantityAvailable,
   computeAvailability,
@@ -546,6 +546,10 @@ export type AvailabilityBatchClient = {
         quantity: true;
         assetKitId?: true;
         booking: { select: { from: true; to: true; status: true } };
+        // Optional like `id`/`assetKitId`: only the checked-out read needs the
+        // live asset status (to gate the legacy all-at-once branch per asset);
+        // the reserved-rows read leaves it off.
+        asset?: { select: { status: true } };
       };
     }) => Promise<
       Array<{
@@ -555,6 +559,7 @@ export type AvailabilityBatchClient = {
         quantity: number;
         assetKitId?: string | null;
         booking: { from: Date; to: Date; status: BookingStatus } | null;
+        asset?: { status: AssetStatus } | null;
       }>
     >;
   };
@@ -954,10 +959,28 @@ async function computeCheckedOutBreakdownBatch(
       quantity: true,
       assetKitId: true,
       booking: { select: { from: true, to: true, status: true } },
+      // Live asset status — the per-asset half of the legacy all-at-once
+      // detection below. Must stay in step with the singular
+      // `computeCheckedOutBreakdownForAsset`, which the parity test pins.
+      asset: { select: { status: true } },
     },
   });
 
   if (pivots.length === 0) return breakdownByAsset;
+
+  /**
+   * Assets currently flagged off the shelf. The all-at-once checkout sets
+   * CHECKED_OUT on every asset it processed, so this separates "was on the
+   * booking when it was checked out" from "added afterwards" (which
+   * `updateBookingAssets` leaves AVAILABLE on purpose). Only the former may
+   * take the legacy branch below — see GitHub #2815.
+   */
+  const checkedOutAssetIds = new Set<string>();
+  for (const p of pivots) {
+    if (p.asset?.status === AssetStatus.CHECKED_OUT) {
+      checkedOutAssetIds.add(p.assetId);
+    }
+  }
 
   /** slices grouped: bookingId → assetId → its slices on that booking. */
   type Slice = { id: string; quantity: number; assetKitId: string | null };
@@ -1009,25 +1032,30 @@ async function computeCheckedOutBreakdownBatch(
     // A booking with zero sessions was checked out via the legacy
     // all-at-once flow (the partial flow always writes a session row) —
     // since these pivots are already scoped to ONGOING/OVERDUE, every
-    // booked unit on this booking is physically off the shelf.
-    const isLegacyOngoing = sessionsForBooking.length === 0;
-    const logsByAsset = isLegacyOngoing
-      ? null
-      : checkoutSessionsToLogsByAsset(sessionsForBooking, (id) =>
-          byAsset.has(id)
-        );
+    // booked unit that was on the booking AT THAT POINT is physically off
+    // the shelf. Which assets those are is decided per asset below; an
+    // asset added later is still AVAILABLE and holds no units.
+    const bookingIsLegacyAllAtOnce = sessionsForBooking.length === 0;
+    // Safe to build unconditionally: a legacy booking has no sessions, so
+    // this is an empty map and the non-legacy path naturally yields 0.
+    const logsByAsset = checkoutSessionsToLogsByAsset(
+      sessionsForBooking,
+      (id) => byAsset.has(id)
+    );
 
     for (const [assetId, slices] of byAsset) {
-      const claimedBySlice = isLegacyOngoing
+      const assetIsLegacyAllAtOnce =
+        bookingIsLegacyAllAtOnce && checkedOutAssetIds.has(assetId);
+      const claimedBySlice = assetIsLegacyAllAtOnce
         ? null
         : attributeDispositionsByBookingAsset({
             bookingAssetRows: slices,
-            consumptionLogs: logsByAsset?.get(assetId) ?? [],
+            consumptionLogs: logsByAsset.get(assetId) ?? [],
           });
 
       const acc = breakdownByAsset.get(assetId) ?? { total: 0, standalone: 0 };
       for (const slice of slices) {
-        const checkedOutSlice = isLegacyOngoing
+        const checkedOutSlice = assetIsLegacyAllAtOnce
           ? slice.quantity
           : Math.min(slice.quantity, claimedBySlice?.get(slice.id) ?? 0);
         acc.total += checkedOutSlice;

--- a/apps/webapp/app/modules/asset/checked-out-batch-parity.test.ts
+++ b/apps/webapp/app/modules/asset/checked-out-batch-parity.test.ts
@@ -36,7 +36,7 @@
  * // singleton directly; both take their Prisma client as an explicit `tx`/`db`
  * // argument, which this suite always supplies as the fixture-backed fake.
  */
-import { BookingStatus } from "@prisma/client";
+import { AssetStatus, BookingStatus } from "@prisma/client";
 import { describe, expect, it, vitest } from "vitest";
 import { computeCheckedOutForAsset } from "~/modules/booking/checked-out.server";
 import type { AvailabilityBatchClient } from "./availability.server";
@@ -125,6 +125,14 @@ function createFakeClient(fixture: {
   sessions: FixtureSession[];
   assets?: FixtureAsset[];
   assetKits?: FixtureAssetKit[];
+  /**
+   * Live `Asset.status` per asset id. Both formulas gate their legacy
+   * all-at-once branch on this, because a quick checkout flips every asset it
+   * processed to CHECKED_OUT while an asset ADDED to the booking later stays
+   * AVAILABLE (GitHub #2815). Defaults to CHECKED_OUT, which is what the
+   * pre-existing fixtures model: assets that really are off the shelf.
+   */
+  assetStatuses?: Record<string, AssetStatus>;
 }) {
   const bookingById = new Map(fixture.bookings.map((b) => [b.id, b]));
   const assets = fixture.assets ?? [];
@@ -211,6 +219,13 @@ function createFakeClient(fixture: {
               bookingId: row.bookingId,
               quantity: row.quantity,
               assetKitId: row.assetKitId,
+              // Both formulas read the live asset status to decide whether the
+              // legacy all-at-once branch applies to THIS asset.
+              asset: {
+                status:
+                  fixture.assetStatuses?.[row.assetId] ??
+                  AssetStatus.CHECKED_OUT,
+              },
               // Neither formula under test reads `booking.from`/`.to` for the
               // checked-out computation (that's only consulted by the
               // `reserved` side of `getAssetAvailabilityBatch`, which this
@@ -260,6 +275,42 @@ describe("getAssetAvailabilityBatch vs computeCheckedOutForAsset (real implement
 
     expect(real).toBe(5);
     expect(batch.get("a1")?.checkedOut).toBe(real);
+  });
+
+  it("agree that an asset added AFTER an all-at-once checkout holds no units", async () => {
+    // GitHub #2815. Both assets sit on the SAME zero-session ONGOING booking,
+    // so the booking-level legacy signal fires for both. Only the live asset
+    // status tells them apart: `a1` was on the booking when it was checked out
+    // (CHECKED_OUT), `a2` was added afterwards and `updateBookingAssets`
+    // deliberately left it AVAILABLE. Treating `a2` as fully checked out
+    // inflated its checked-out count and starved its availability.
+    const client = createFakeClient({
+      bookingAssets: [
+        { assetId: "a1", bookingId: "legacy", quantity: 5 },
+        { assetId: "a2", bookingId: "legacy", quantity: 20 },
+      ],
+      bookings: [
+        { id: "legacy", status: BookingStatus.ONGOING, organizationId: ORG_ID },
+      ],
+      sessions: [],
+      assetStatuses: {
+        a1: AssetStatus.CHECKED_OUT,
+        a2: AssetStatus.AVAILABLE,
+      },
+    });
+
+    const realA1 = await computeCheckedOutForAsset(client, "a1", ORG_ID);
+    const realA2 = await computeCheckedOutForAsset(client, "a2", ORG_ID);
+    const batch = await getAssetAvailabilityBatch(["a1", "a2"], {
+      organizationId: ORG_ID,
+      window: null,
+      db: client as unknown as AvailabilityBatchClient,
+    });
+
+    expect(realA1).toBe(5);
+    expect(realA2).toBe(0);
+    expect(batch.get("a1")?.checkedOut).toBe(realA1);
+    expect(batch.get("a2")?.checkedOut).toBe(realA2);
   });
 
   it("agree on a partial checkout (booked minus claimed remains on the shelf)", async () => {

--- a/apps/webapp/app/modules/booking/checked-out.server.ts
+++ b/apps/webapp/app/modules/booking/checked-out.server.ts
@@ -12,7 +12,7 @@
  * @see {@link file://./checkout-attribution.ts} — per-slice attribution + the shared session parser.
  * @see {@link file://../asset/availability.server.ts} — the main consumer (`getAssetAvailability`).
  */
-import { BookingStatus, type Asset } from "@prisma/client";
+import { AssetStatus, BookingStatus, type Asset } from "@prisma/client";
 
 import {
   attributeDispositionsByBookingAsset,
@@ -156,15 +156,30 @@ export async function computeCheckedOutBreakdownForAsset(
       quantity: true,
       assetKitId: true,
       bookingId: true,
+      // Live asset status — the per-asset half of the legacy all-at-once
+      // detection below. Joined here so it costs no extra round-trip.
+      asset: { select: { status: true } },
     },
   })) as Array<{
     id: string;
     quantity: number;
     assetKitId: string | null;
     bookingId: string;
+    asset?: { status: AssetStatus } | null;
   }>;
 
   if (slices.length === 0) return { total: 0, standalone: 0 };
+
+  /**
+   * Whether the asset itself is currently flipped off the shelf. The
+   * all-at-once checkout sets `CHECKED_OUT` on every asset it processed, so
+   * this is what distinguishes "was on the booking when it was checked out"
+   * from "added to the booking afterwards" (which `updateBookingAssets` leaves
+   * AVAILABLE on purpose). Only the former may take the legacy branch below.
+   */
+  const assetIsCheckedOut = slices.some(
+    (slice) => slice.asset?.status === AssetStatus.CHECKED_OUT
+  );
 
   // Group this asset's slices by booking — an asset can have multiple slices on
   // one booking (a standalone free-pool slice + one or more kit-driven slices),
@@ -228,8 +243,10 @@ export async function computeCheckedOutBreakdownForAsset(
     const bookingSessions = sessionsByBooking.get(bookingId) ?? [];
     // Legacy all-at-once checkout: a booking with ZERO sessions (these slices
     // are already scoped to ONGOING/OVERDUE) had every booked unit flipped off
-    // the shelf at once — mirrors the parent's legacy-ONGOING branch.
-    const isLegacyOngoing = bookingSessions.length === 0;
+    // the shelf at once — mirrors the parent's legacy branch, INCLUDING its
+    // per-asset CHECKED_OUT guard, so an asset added to the booking after that
+    // checkout is not counted as off the shelf (GitHub #2815).
+    const isLegacyOngoing = bookingSessions.length === 0 && assetIsCheckedOut;
 
     // Claimed-per-slice map: exact for tagged logs, standalone-first greedy for
     // untagged/legacy-attribution logs. Skipped for legacy-ONGOING bookings,

--- a/apps/webapp/app/modules/booking/checked-out.server.ts
+++ b/apps/webapp/app/modules/booking/checked-out.server.ts
@@ -241,26 +241,29 @@ export async function computeCheckedOutBreakdownForAsset(
 
   for (const [bookingId, bookingSlices] of slicesByBooking) {
     const bookingSessions = sessionsByBooking.get(bookingId) ?? [];
-    // Legacy all-at-once checkout: a booking with ZERO sessions (these slices
-    // are already scoped to ONGOING/OVERDUE) had every booked unit flipped off
-    // the shelf at once — mirrors the parent's legacy branch, INCLUDING its
-    // per-asset CHECKED_OUT guard, so an asset added to the booking after that
-    // checkout is not counted as off the shelf (GitHub #2815).
-    const isLegacyOngoing = bookingSessions.length === 0 && assetIsCheckedOut;
-
     // Claimed-per-slice map: exact for tagged logs, standalone-first greedy for
-    // untagged/legacy-attribution logs. Skipped for legacy-ONGOING bookings,
-    // where every slice is fully off the shelf regardless of session data.
-    const claimedBySlice = isLegacyOngoing
-      ? null
-      : attributeDispositionsByBookingAsset({
-          bookingAssetRows: bookingSlices,
-          consumptionLogs:
-            checkoutSessionsToLogsByAsset(
-              bookingSessions,
-              (id) => id === assetId
-            ).get(assetId) ?? [],
-        });
+    // untagged/legacy-attribution logs. Built first so the legacy test below can
+    // ask whether THIS asset has any claims at all.
+    const claimedBySlice = attributeDispositionsByBookingAsset({
+      bookingAssetRows: bookingSlices,
+      consumptionLogs:
+        checkoutSessionsToLogsByAsset(
+          bookingSessions,
+          (id) => id === assetId
+        ).get(assetId) ?? [],
+    });
+    const assetHasClaims = bookingSlices.some(
+      (slice) => (claimedBySlice.get(slice.id) ?? 0) > 0
+    );
+
+    // Legacy all-at-once checkout — mirrors the parent's per-asset branch: this
+    // asset is flagged off the shelf and has NO recorded claims on this
+    // booking, so the zeroed counters are the all-at-once flow's silence rather
+    // than "still on the shelf". Keyed on the asset, not on the booking having
+    // zero sessions, so a later batch for a DIFFERENT asset can't resurrect it,
+    // and an asset added after the checkout (still AVAILABLE) is never counted
+    // as out (GitHub #2815).
+    const isLegacyOngoing = assetIsCheckedOut && !assetHasClaims;
 
     for (const slice of bookingSlices) {
       const checkedOutSlice = isLegacyOngoing

--- a/apps/webapp/app/modules/booking/checked-out.server.ts
+++ b/apps/webapp/app/modules/booking/checked-out.server.ts
@@ -111,10 +111,13 @@ export async function computeCheckedOutForAsset(
  * Attribution mirrors {@link computeCheckedOutForAsset} EXACTLY so `total`
  * parity holds:
  *   - Same active-booking scope (`ONGOING`/`OVERDUE`, org-scoped).
- *   - Same legacy-ONGOING fallback: a booking with ZERO
- *     {@link PartialBookingCheckout} sessions was checked out via the legacy
- *     all-at-once flow, so every booked unit of every slice is physically off
- *     the shelf (each slice's checked-out = its full `quantity`).
+ *   - Same legacy all-at-once fallback, decided PER ASSET: the asset is live
+ *     `CHECKED_OUT` and has NO {@link PartialBookingCheckout} claims of its own
+ *     on this booking, so its zeroed counters are that flow's silence rather
+ *     than "still on the shelf" ⇒ every slice's checked-out = its full
+ *     `quantity`. Keyed on the asset rather than on the BOOKING having zero
+ *     sessions, so one later batch for a different asset can't resurrect it and
+ *     an asset added after the checkout (still AVAILABLE) is never counted.
  *   - Otherwise, each booking's checkout claims for this asset are attributed
  *     to individual slices via {@link attributeDispositionsByBookingAsset}
  *     (standalone-first greedy fill over the SAME shared positional parser
@@ -203,8 +206,8 @@ export async function computeCheckedOutBreakdownForAsset(
   }
 
   // Fetch every checkout session for the involved bookings ONCE. Grouped by
-  // booking so the legacy-ONGOING detection (does the BOOKING have ANY
-  // sessions) matches the parent's per-booking check exactly.
+  // booking because claims are attributed per (booking, asset) — the legacy
+  // test below then asks whether THIS asset has any claims on THIS booking.
   const bookingIds = [...slicesByBooking.keys()];
   const sessions = (await tx.partialBookingCheckout.findMany({
     where: { bookingId: { in: bookingIds } },

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -276,6 +276,31 @@ vitest.mock("~/modules/note/service.server", () => ({
 type IdInArgs = { where?: { id?: { in?: string[] } } };
 
 /**
+ * The stateful `PartialBookingCheckout` escape hatches the `~/database/db.server`
+ * mock hangs off the `db` object (see the top-of-mock comment). They exist only
+ * in this suite, so the real `PrismaClient` type has no knowledge of them —
+ * naming them structurally here keeps the call sites typed instead of casting
+ * the whole client to `any` at every use.
+ */
+type PbcTestHooks = {
+  /** Clears the in-memory session log between tests. */
+  __resetPbcState?: () => void;
+  /** Pre-populates sessions to model "a prior batch already claimed X units". */
+  __seedPbcSessions?: (
+    sessions: Array<{
+      assetIds: string[];
+      quantities: number[];
+      bookingAssetIds?: string[];
+    }>
+  ) => void;
+  /** Re-installs the stateful create/findMany impls after `clearAllMocks`. */
+  __installStatefulPbcMocks?: (db_: unknown) => void;
+};
+
+/** The mocked `db` viewed through its test-only hooks. */
+const pbcHooks = db as unknown as PbcTestHooks;
+
+/**
  * The slice of a `bookingAsset.findMany` argument the #2815 mocks read. Both
  * remaining-to-check-out readers narrow by one of these two filters, so a mock
  * standing in for that query has to honour whichever one it was handed.
@@ -379,10 +404,8 @@ describe("partialCheckoutBooking", () => {
     // calculations, and re-install the stateful PBC impls (clearAllMocks does
     // NOT restore a prior test's mockResolvedValue / mockImplementation
     // overrides). See the top-of-file mock comment for full rationale.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__resetPbcState?.();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__installStatefulPbcMocks?.(db);
+    pbcHooks.__resetPbcState?.();
+    pbcHooks.__installStatefulPbcMocks?.(db);
 
     // why: clearAllMocks resets call history but not mockResolvedValue overrides
     // set by a prior test. Restore the default "echo requested ids, no conflicts"
@@ -731,8 +754,7 @@ describe("partialCheckoutBooking", () => {
     // appends to the same log — the post-write `remainingAssetCount` loop
     // must see ALL three assets as checked out to report isComplete=true.
     // (mockResolvedValue would freeze findMany at the prior session.)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-1", "asset-2"], quantities: [1, 1] },
     ]);
 
@@ -1107,10 +1129,8 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     // calculations, and re-install the stateful PBC impls (clearAllMocks does
     // NOT restore a prior test's mockResolvedValue / mockImplementation
     // overrides). See the top-of-file mock comment for full rationale.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__resetPbcState?.();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__installStatefulPbcMocks?.(db);
+    pbcHooks.__resetPbcState?.();
+    pbcHooks.__installStatefulPbcMocks?.(db);
 
     // Default echo-no-conflicts for the scanned-batch lookup; tests that
     // need conflicts/custody override per-call.
@@ -1697,8 +1717,7 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
       ).mockResolvedValue(makeGlovesBooking());
 
       // Prior session: 20 boxes of the STANDALONE slice already checked out.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (db as any).__seedPbcSessions?.([
+      pbcHooks.__seedPbcSessions?.([
         {
           assetIds: ["asset-gloves"],
           quantities: [20],
@@ -1933,8 +1952,7 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     // `partialBookingCheckout.findMany` so the test infra still tracks the
     // current-batch writes for downstream reads (and so this override doesn't
     // leak into later tests via the persistent impl).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-qty-1"], quantities: [45] },
     ]);
 
@@ -2064,8 +2082,7 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     // Seed via the stateful helper so the new top-off write appends to the
     // session log (mockResolvedValue would freeze findMany and the post-write
     // remaining lookup would miss the new row).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-qty-1"], quantities: [5] },
     ]);
 
@@ -2153,8 +2170,7 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     // Seed the prior 10-unit consumption through the stateful helper so the
     // in-tx remaining lookup sees the same row as the outer alreadyCheckedOut
     // detection.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-qty-1"], quantities: [10] },
     ]);
 
@@ -2208,8 +2224,7 @@ describe("partialCheckoutBooking - quantity-tracked dispositions", () => {
     (
       db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>
     ).mockResolvedValue({ quantity: 10 });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-qty-1"], quantities: [10] },
     ]);
 
@@ -2518,10 +2533,8 @@ describe("getRemainingCheckoutAssetIds", () => {
 describe("computeBookingAssetSliceRemainingToCheckOut", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__resetPbcState?.();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__installStatefulPbcMocks?.(db);
+    pbcHooks.__resetPbcState?.();
+    pbcHooks.__installStatefulPbcMocks?.(db);
   });
 
   it("subtracts prior PartialBookingCheckout claims from the slice cap on a single-slice asset", async () => {
@@ -2551,8 +2564,7 @@ describe("computeBookingAssetSliceRemainingToCheckOut", () => {
         assetKitId: null,
       },
     ]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-qty-1"], quantities: [5] },
     ]);
 
@@ -2626,8 +2638,7 @@ describe("computeBookingAssetSliceRemainingToCheckOut", () => {
       },
     ]);
     // Legacy seed — no `bookingAssetIds` → the whole 30-unit pool is greedy.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-qty-1"], quantities: [30] },
     ]);
 
@@ -2694,8 +2705,7 @@ describe("computeBookingAssetSliceRemainingToCheckOut", () => {
       },
     ]);
     // Tagged session: 10 units checked out against the standalone slice.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       {
         assetIds: ["asset-batt"],
         quantities: [10],
@@ -2766,8 +2776,7 @@ describe("computeBookingAssetSliceRemainingToCheckOut", () => {
         assetKitId: null,
       },
     ]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       {
         assetIds: ["asset-batt"],
         quantities: [5],
@@ -2829,10 +2838,8 @@ describe("computeBookingAssetSliceRemainingToCheckOut", () => {
 describe("getRemainingCheckoutPayload", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__resetPbcState?.();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__installStatefulPbcMocks?.(db);
+    pbcHooks.__resetPbcState?.();
+    pbcHooks.__installStatefulPbcMocks?.(db);
   });
 
   it("emits per-slice remaining (NOT full booked qty) for a partially-checked-out QT asset", async () => {
@@ -2882,8 +2889,7 @@ describe("getRemainingCheckoutPayload", () => {
         assetKitId: null,
       },
     ]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-pencils"], quantities: [5] },
     ]);
 
@@ -2943,8 +2949,7 @@ describe("getRemainingCheckoutPayload", () => {
         assetKitId: null,
       },
     ]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__seedPbcSessions?.([
+    pbcHooks.__seedPbcSessions?.([
       { assetIds: ["asset-pencils"], quantities: [5] },
     ]);
 
@@ -3046,10 +3051,8 @@ describe("getRemainingCheckoutPayload", () => {
 describe("all-at-once checkout leaves nothing remaining (GitHub #2814)", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__resetPbcState?.();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__installStatefulPbcMocks?.(db);
+    pbcHooks.__resetPbcState?.();
+    pbcHooks.__installStatefulPbcMocks?.(db);
     // The shape under test: an all-at-once "Check out" flips every asset to
     // CHECKED_OUT but writes NO PartialBookingCheckout rows, so the booking is
     // ONGOING with zero sessions. That is the ONLY way this state is reachable
@@ -3231,13 +3234,65 @@ describe("all-at-once checkout leaves nothing remaining (GitHub #2814)", () => {
   });
 });
 
+describe("legacy fallback survives a later checkout session (PR #2816 review)", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    pbcHooks.__resetPbcState?.();
+    pbcHooks.__installStatefulPbcMocks?.(db);
+    (db.booking.findUnique as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      status: BookingStatus.ONGOING,
+    });
+  });
+
+  it("keeps an already-out QT slice at 0 once a later batch records a session", async () => {
+    expect.assertions(2);
+
+    // The exact sequence the fix for #2814 creates: the booking starts with
+    // ZERO PartialBookingCheckout rows (all-at-once checkout), then a
+    // successful "check out remaining" for a newly-added asset writes the
+    // booking's FIRST session row — for a DIFFERENT asset.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      {
+        id: "ba-pencils-1",
+        assetId: "asset-pencils",
+        quantity: 50,
+        assetKitId: null,
+        asset: { status: AssetStatus.CHECKED_OUT },
+      },
+    ]);
+
+    await expect(
+      computeBookingAssetSliceRemainingToCheckOut(
+        db,
+        "booking-1",
+        "ba-pencils-1"
+      )
+    ).resolves.toBe(0);
+
+    pbcHooks.__seedPbcSessions?.([
+      { assetIds: ["asset-camera"], quantities: [1], bookingAssetIds: [""] },
+    ]);
+
+    // Pencils has no claims of its own and is still flagged CHECKED_OUT, so it
+    // must stay at 0. A booking-level test read 50 here, which would have
+    // offered stock that is already in the field for a duplicate checkout.
+    await expect(
+      computeBookingAssetSliceRemainingToCheckOut(
+        db,
+        "booking-1",
+        "ba-pencils-1"
+      )
+    ).resolves.toBe(0);
+  });
+});
+
 describe("assets added after an all-at-once checkout (GitHub #2815)", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__resetPbcState?.();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db as any).__installStatefulPbcMocks?.(db);
+    pbcHooks.__resetPbcState?.();
+    pbcHooks.__installStatefulPbcMocks?.(db);
     (db.booking.findUnique as ReturnType<typeof vitest.fn>).mockResolvedValue({
       status: BookingStatus.ONGOING,
     });

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -275,6 +275,15 @@ vitest.mock("~/modules/note/service.server", () => ({
  */
 type IdInArgs = { where?: { id?: { in?: string[] } } };
 
+/**
+ * The slice of a `bookingAsset.findMany` argument the #2815 mocks read. Both
+ * remaining-to-check-out readers narrow by one of these two filters, so a mock
+ * standing in for that query has to honour whichever one it was handed.
+ */
+type BookingAssetFindManyArgs = {
+  where?: { id?: { in?: string[] }; assetId?: { in?: string[] } };
+};
+
 // why: testing the service without writing real booking notes.
 vitest.mock("~/modules/booking-note/service.server", () => ({
   createSystemBookingNote: vitest.fn().mockResolvedValue({}),
@@ -3086,6 +3095,10 @@ describe("all-at-once checkout leaves nothing remaining (GitHub #2814)", () => {
         assetId: "asset-pencils",
         quantity: 50,
         assetKitId: null,
+        // The all-at-once checkout flipped this asset off the shelf. Both
+        // remaining-to-check-out readers gate their legacy branch on exactly
+        // this, so the pivot join has to carry it.
+        asset: { status: AssetStatus.CHECKED_OUT },
       },
     ]);
   }
@@ -3101,6 +3114,10 @@ describe("all-at-once checkout leaves nothing remaining (GitHub #2814)", () => {
         assetId: "asset-pencils",
         quantity: 50,
         assetKitId: null,
+        // The all-at-once checkout flipped this asset off the shelf. Both
+        // remaining-to-check-out readers gate their legacy branch on exactly
+        // this, so the pivot join has to carry it.
+        asset: { status: AssetStatus.CHECKED_OUT },
       },
     ]);
 
@@ -3208,6 +3225,200 @@ describe("all-at-once checkout leaves nothing remaining (GitHub #2814)", () => {
         data: expect.objectContaining({
           assetIds: ["asset-camera"],
           quantities: [1],
+        }),
+      })
+    );
+  });
+});
+
+describe("assets added after an all-at-once checkout (GitHub #2815)", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db as any).__resetPbcState?.();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db as any).__installStatefulPbcMocks?.(db);
+    (db.booking.findUnique as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      status: BookingStatus.ONGOING,
+    });
+  });
+
+  /**
+   * Pencils were on the booking when it was checked out all-at-once (so the
+   * asset is CHECKED_OUT); Tape was added to the ongoing booking afterwards and
+   * `updateBookingAssets` deliberately left it AVAILABLE. Both slices live on
+   * the same zero-session ONGOING booking, so only the live asset status tells
+   * them apart.
+   */
+  const PIVOTS = [
+    {
+      id: "ba-pencils-1",
+      assetId: "asset-pencils",
+      quantity: 50,
+      assetKitId: null,
+      asset: { status: AssetStatus.CHECKED_OUT },
+    },
+    {
+      id: "ba-tape-1",
+      assetId: "asset-tape",
+      quantity: 20,
+      assetKitId: null,
+      asset: { status: AssetStatus.AVAILABLE },
+    },
+  ];
+
+  it("keeps the real remaining for a QT asset added after the checkout", async () => {
+    expect.assertions(2);
+
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue(PIVOTS);
+
+    // The already-out asset still reads 0 — the legacy branch is intact.
+    await expect(
+      computeBookingAssetSliceRemainingToCheckOut(
+        db,
+        "booking-1",
+        "ba-pencils-1"
+      )
+    ).resolves.toBe(0);
+
+    // The asset added afterwards keeps its full booked quantity. Pre-fix the
+    // fallback was booking-level, so this read 0 too and the asset could never
+    // be checked out on this booking.
+    await expect(
+      computeBookingAssetSliceRemainingToCheckOut(db, "booking-1", "ba-tape-1")
+    ).resolves.toBe(20);
+  });
+
+  it("proposes the newly added QT asset in the Check-out-remaining payload", async () => {
+    expect.assertions(2);
+
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      bookingAssets: [
+        {
+          id: "ba-pencils-1",
+          asset: {
+            id: "asset-pencils",
+            status: AssetStatus.CHECKED_OUT,
+            type: AssetType.QUANTITY_TRACKED,
+          },
+        },
+        {
+          id: "ba-tape-1",
+          asset: {
+            id: "asset-tape",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.QUANTITY_TRACKED,
+          },
+        },
+      ],
+      partialCheckins: [],
+    });
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue(PIVOTS);
+
+    const payload = await getRemainingCheckoutPayload({
+      bookingId: "booking-1",
+      organizationId: "org-1",
+    });
+
+    expect(payload.assetIds).toEqual([]);
+    // Only Tape — Pencils is already out and must not be re-proposed.
+    expect(payload.checkouts).toEqual([
+      { assetId: "asset-tape", bookingAssetId: "ba-tape-1", quantity: 20 },
+    ]);
+  });
+
+  it("checks the newly added QT asset out instead of rejecting it", async () => {
+    expect.assertions(1);
+
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      id: "booking-1",
+      name: "Test Booking",
+      status: BookingStatus.ONGOING,
+      organizationId: "org-1",
+      custodianUserId: "user-1",
+      custodianTeamMemberId: null,
+      from: futureFrom,
+      to: futureTo,
+      _count: { bookingAssets: 2 },
+      bookingAssets: [
+        {
+          id: "ba-pencils-1",
+          quantity: 50,
+          assetKitId: null,
+          asset: {
+            id: "asset-pencils",
+            status: AssetStatus.CHECKED_OUT,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Pencils",
+            unitOfMeasure: null,
+            assetKits: [],
+          },
+        },
+        {
+          id: "ba-tape-1",
+          quantity: 20,
+          assetKitId: null,
+          asset: {
+            id: "asset-tape",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Tape",
+            unitOfMeasure: null,
+            assetKits: [],
+          },
+        },
+      ],
+    });
+    // why: both readers narrow this query — the asset-level helper by
+    // `where.assetId.in`, the per-slice helper by `where.id.in`. A mock that
+    // ignores the filter would leak Pencils' CHECKED_OUT row into Tape's
+    // lookup and mask the very behaviour under test, so mirror Prisma here.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockImplementation((args?: BookingAssetFindManyArgs) => {
+      const byAsset = args?.where?.assetId?.in;
+      const bySlice = args?.where?.id?.in;
+      return Promise.resolve(
+        PIVOTS.filter(
+          (row) =>
+            (!byAsset || byAsset.includes(row.assetId)) &&
+            (!bySlice || bySlice.includes(row.id))
+        )
+      );
+    });
+    (
+      quantityLock.lockAssetForQuantityUpdate as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      id: "asset-tape",
+      title: "Tape",
+      type: AssetType.QUANTITY_TRACKED,
+      unitOfMeasure: null,
+      quantity: 20,
+    });
+
+    // Pre-fix this threw `Only 0 units left to check out for "Tape"` — the
+    // asset-level cap zeroed every asset on the zero-session ONGOING booking.
+    await partialCheckoutBooking({
+      ...baseParams,
+      assetIds: [],
+      checkouts: [
+        { assetId: "asset-tape", bookingAssetId: "ba-tape-1", quantity: 20 },
+      ],
+    });
+
+    expect(db.partialBookingCheckout.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          assetIds: ["asset-tape"],
+          quantities: [20],
         }),
       })
     );

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -3034,6 +3034,186 @@ describe("getRemainingCheckoutPayload", () => {
   });
 });
 
+describe("all-at-once checkout leaves nothing remaining (GitHub #2814)", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db as any).__resetPbcState?.();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db as any).__installStatefulPbcMocks?.(db);
+    // The shape under test: an all-at-once "Check out" flips every asset to
+    // CHECKED_OUT but writes NO PartialBookingCheckout rows, so the booking is
+    // ONGOING with zero sessions. That is the ONLY way this state is reachable
+    // — the progressive flow writes a session row on every batch.
+    (db.booking.findUnique as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      status: BookingStatus.ONGOING,
+    });
+  });
+
+  /** Booking graph for `getRemainingCheckoutPayload`'s narrower select. */
+  function primePayloadLookup() {
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      bookingAssets: [
+        {
+          id: "ba-pencils-1",
+          asset: {
+            id: "asset-pencils",
+            status: AssetStatus.CHECKED_OUT,
+            type: AssetType.QUANTITY_TRACKED,
+          },
+        },
+        {
+          id: "ba-camera-1",
+          asset: {
+            id: "asset-camera",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.INDIVIDUAL,
+          },
+        },
+      ],
+      partialCheckins: [],
+    });
+    // why: the single 50-unit pivot slice the per-slice OUT helper reads to
+    // derive this slice's remaining. Zero PBC sessions + ONGOING booking means
+    // the legacy-ONGOING fallback should report 0, not the raw 50.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      {
+        id: "ba-pencils-1",
+        assetId: "asset-pencils",
+        quantity: 50,
+        assetKitId: null,
+      },
+    ]);
+  }
+
+  it("reports 0 per-slice remaining for a QT slice already out via all-at-once checkout", async () => {
+    expect.assertions(1);
+
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      {
+        id: "ba-pencils-1",
+        assetId: "asset-pencils",
+        quantity: 50,
+        assetKitId: null,
+      },
+    ]);
+
+    const remaining = await computeBookingAssetSliceRemainingToCheckOut(
+      db,
+      "booking-1",
+      "ba-pencils-1"
+    );
+
+    // Pre-fix this returned the raw booked 50: the per-slice reader had no
+    // legacy-ONGOING fallback, so it disagreed with its asset-level sibling
+    // (which already reported 0) on exactly this booking shape.
+    expect(remaining).toBe(0);
+  });
+
+  it("keeps the already-out QT slice out of the Check-out-remaining payload", async () => {
+    expect.assertions(2);
+
+    primePayloadLookup();
+
+    const payload = await getRemainingCheckoutPayload({
+      bookingId: "booking-1",
+      organizationId: "org-1",
+    });
+
+    // Only the asset that is genuinely still Booked — an INDIVIDUAL asset added
+    // to the booking after it went ONGOING — is proposed.
+    expect(payload.assetIds).toEqual(["asset-camera"]);
+    expect(payload.checkouts).toEqual([]);
+  });
+
+  it("checks out an asset added to the ongoing booking instead of rejecting the batch", async () => {
+    expect.assertions(2);
+
+    primePayloadLookup();
+
+    // Resolve the payload the booking-header "Check out remaining" action
+    // dispatches, then feed it straight into the service — the exact wire the
+    // action follows, minus the response wrapper.
+    const { assetIds, checkouts } = await getRemainingCheckoutPayload({
+      bookingId: "booking-1",
+      organizationId: "org-1",
+    });
+
+    // Re-prime for partialCheckoutBooking's wider select (slice quantity, asset
+    // type / title / unitOfMeasure, kit memberships).
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      id: "booking-1",
+      name: "Test Booking",
+      status: BookingStatus.ONGOING,
+      organizationId: "org-1",
+      custodianUserId: "user-1",
+      custodianTeamMemberId: null,
+      from: futureFrom,
+      to: futureTo,
+      _count: { bookingAssets: 2 },
+      bookingAssets: [
+        {
+          id: "ba-pencils-1",
+          quantity: 50,
+          assetKitId: null,
+          asset: {
+            id: "asset-pencils",
+            status: AssetStatus.CHECKED_OUT,
+            type: AssetType.QUANTITY_TRACKED,
+            title: "Pencils",
+            unitOfMeasure: null,
+            assetKits: [],
+          },
+        },
+        {
+          id: "ba-camera-1",
+          quantity: 1,
+          assetKitId: null,
+          asset: {
+            id: "asset-camera",
+            status: AssetStatus.AVAILABLE,
+            type: AssetType.INDIVIDUAL,
+            title: "Camera",
+            unitOfMeasure: null,
+            assetKits: [],
+          },
+        },
+      ],
+    });
+
+    // Pre-fix this threw `Only 0 units left to check out for "Pencils"`: the
+    // payload carried a ghost 50-unit claim for the already-out QT slice, the
+    // in-transaction cap rejected it, and the rollback took the genuinely
+    // outstanding Camera down with it — the asset stayed AVAILABLE.
+    await partialCheckoutBooking({ ...baseParams, assetIds, checkouts });
+
+    expect(db.asset.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: { in: ["asset-camera"] } }),
+        data: { status: AssetStatus.CHECKED_OUT },
+      })
+    );
+    // The ghost QT claim is absent from the session ledger — only the Camera
+    // was recorded, at the implicit INDIVIDUAL quantity of 1.
+    expect(db.partialBookingCheckout.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          assetIds: ["asset-camera"],
+          quantities: [1],
+        }),
+      })
+    );
+  });
+});
+
 describe("buildOverriddenReservationNotes", () => {
   const current = { id: "booking-1", name: "Loaning things to Carlos" };
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -3579,6 +3579,17 @@ export async function computeBookingAssetSliceRemainingToCheckOut(
  * set-membership predicate so the `""` → greedy sentinel and the aligned/legacy
  * quantity handling match every other read site.
  *
+ * That parity INCLUDES the legacy-ONGOING fallback (booked > 0, zero sessions,
+ * booking ONGOING/OVERDUE ⇒ remaining 0). Without it this per-slice reader
+ * disagreed with its asset-level sibling on exactly one booking shape — one
+ * checked out all-at-once — and the disagreement was load-bearing:
+ * {@link getRemainingCheckoutPayload} PROPOSES from here while
+ * {@link partialCheckoutBooking} CAPS with the asset-level helper, so "Check
+ * out remaining" proposed the full booked quantity for an already-out QT slice,
+ * the cap rejected it as "Only 0 units left…", and the whole batch rolled back
+ * — taking any genuinely-outstanding asset in the same batch down with it
+ * (GitHub #2814).
+ *
  * @param tx - Prisma transaction client (or the default `db` client)
  * @param bookingId - Booking the slices belong to
  * @param bookingAssetIds - BookingAsset row ids to measure (deduped internally).
@@ -3647,9 +3658,11 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
   const involvedAssetIdList = [...involvedAssetIds];
 
   // (2) The FULL slice set of every involved asset (the greedy standalone-first
-  // fill needs every sibling, not just the requested ones) + (3) ALL sessions,
-  // both fetched ONCE.
-  const [allSlices, sessions] = await Promise.all([
+  // fill needs every sibling, not just the requested ones) + (3) ALL sessions +
+  // (4) the booking's status, all fetched ONCE and in parallel. The status read
+  // is a cheap indexed-PK lookup and rides along in the same round-trip batch,
+  // so the fixed-query-count guarantee in the JSDoc is unaffected.
+  const [allSlices, sessions, booking] = await Promise.all([
     tx.bookingAsset.findMany({
       where: { bookingId, assetId: { in: involvedAssetIdList } },
       select: { id: true, assetId: true, quantity: true, assetKitId: true },
@@ -3658,7 +3671,31 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
       where: { bookingId },
       select: { assetIds: true, quantities: true, bookingAssetIds: true },
     }),
+    tx.booking.findUnique({
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: pure read helper called from already-org-scoped contexts (the bookingId was resolved by callers via an org-scoped findUniqueOrThrow). Only reads non-sensitive `status` metadata. Mirrors computeBookingAssetsRemainingToCheckOut.
+      where: { id: bookingId },
+      select: { status: true },
+    }),
   ]);
+
+  const sessionsArr = sessions as Array<{
+    assetIds: string[];
+    quantities: number[];
+    bookingAssetIds: string[];
+  }>;
+
+  // Booking-level legacy-ONGOING signal — the per-slice mirror of the branch in
+  // {@link computeBookingAssetsRemainingToCheckOut}. An ONGOING/OVERDUE booking
+  // with ZERO PartialBookingCheckout rows was checked out via the all-at-once
+  // flow (the progressive flow writes a session row on every batch), so every
+  // booked unit is already physically off the shelf and NOTHING remains to
+  // check out. The per-slice `quantity > 0` guard below is what actually gates
+  // it, exactly as the asset-level helper's `booked > 0` guard does.
+  const bookingStatus = (booking as { status: BookingStatus } | null)?.status;
+  const isLegacyOngoing =
+    sessionsArr.length === 0 &&
+    (bookingStatus === BookingStatus.ONGOING ||
+      bookingStatus === BookingStatus.OVERDUE);
 
   // Group each involved asset's slices so the attributor sees its full set.
   const slicesByAsset = new Map<
@@ -3688,13 +3725,8 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
   // involved assets via set membership so the parser's INDIVIDUAL-vs-QT skip
   // never drops a requested asset. Logs tagged with an exact `bookingAssetId`
   // attribute to that slice; untagged (`""` → null) logs greedy-fill.
-  const logsByAsset = checkoutSessionsToLogsByAsset(
-    sessions as Array<{
-      assetIds: string[];
-      quantities: number[];
-      bookingAssetIds: string[];
-    }>,
-    (id) => involvedAssetIds.has(id)
+  const logsByAsset = checkoutSessionsToLogsByAsset(sessionsArr, (id) =>
+    involvedAssetIds.has(id)
   );
 
   // Attribute each involved asset's claims across its full slice set ONCE, then
@@ -3716,6 +3748,13 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
     const requested = requestedById.get(sliceId);
     // Unknown slice (not on the booking) → keep the seeded 0.
     if (!requested) continue;
+    // Legacy-ONGOING fallback — guarded on `quantity > 0` so a zero-unit slice
+    // short-circuits through the normal math rather than synthesizing "fully
+    // checked out". Mirrors the asset-level helper's `booked > 0` guard.
+    if (isLegacyOngoing && requested.quantity > 0) {
+      remainingBySlice.set(sliceId, 0);
+      continue;
+    }
     const claimed = claimedBySliceId.get(sliceId) ?? 0;
     remainingBySlice.set(sliceId, Math.max(0, requested.quantity - claimed));
   }

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -3369,7 +3369,16 @@ export async function computeBookingAssetsRemainingToCheckOut(
   const [pivots, sessions, booking] = await Promise.all([
     tx.bookingAsset.findMany({
       where: { bookingId, assetId: { in: uniqueAssetIds } },
-      select: { assetId: true, quantity: true },
+      // `asset.status` is the per-asset half of the legacy fallback below: the
+      // all-at-once checkout flips every asset it processed to CHECKED_OUT, so
+      // that flag — not merely "this booking is ONGOING" — is what marks a row
+      // as already off the shelf. Joined here rather than fetched separately so
+      // the fixed-query-count guarantee in the JSDoc still holds.
+      select: {
+        assetId: true,
+        quantity: true,
+        asset: { select: { status: true } },
+      },
     }),
     tx.partialBookingCheckout.findMany({
       where: { bookingId },
@@ -3385,6 +3394,15 @@ export async function computeBookingAssetsRemainingToCheckOut(
     }),
   ]);
 
+  /**
+   * Live asset status per requested asset, read off the pivot join. Feeds the
+   * per-asset half of the legacy fallback below. Absent (asset row not
+   * projected by a test mock) ⇒ treated as NOT checked out, which is the safe
+   * direction: the asset keeps its real `booked − claimed` remaining rather
+   * than being silently zeroed.
+   */
+  const statusByAsset = new Map<string, AssetStatus>();
+
   // Booked total per requested asset (Σ pivot quantities across its slices).
   const bookedByAsset = new Map<string, number>();
   if (uniqueAssetIds.length === 1) {
@@ -3392,17 +3410,29 @@ export async function computeBookingAssetsRemainingToCheckOut(
     // so every returned row provably belongs to it — sum them directly. This
     // keeps parity with the singular helper's original "sum all returned
     // pivots" and does not depend on each row projecting its own `assetId`.
-    const booked = (pivots as Array<{ quantity: number }>).reduce(
-      (sum, p) => sum + (p.quantity ?? 0),
-      0
-    );
+    const rows = pivots as Array<{
+      quantity: number;
+      asset?: { status: AssetStatus } | null;
+    }>;
+    const booked = rows.reduce((sum, p) => sum + (p.quantity ?? 0), 0);
     bookedByAsset.set(uniqueAssetIds[0], booked);
+    const status = rows.find((p) => p.asset?.status)?.asset?.status;
+    if (status) {
+      statusByAsset.set(uniqueAssetIds[0], status);
+    }
   } else {
-    for (const p of pivots as Array<{ assetId: string; quantity: number }>) {
+    for (const p of pivots as Array<{
+      assetId: string;
+      quantity: number;
+      asset?: { status: AssetStatus } | null;
+    }>) {
       bookedByAsset.set(
         p.assetId,
         (bookedByAsset.get(p.assetId) ?? 0) + (p.quantity ?? 0)
       );
+      if (p.asset?.status) {
+        statusByAsset.set(p.assetId, p.asset.status);
+      }
     }
   }
 
@@ -3411,13 +3441,12 @@ export async function computeBookingAssetsRemainingToCheckOut(
     quantities: number[];
     bookingAssetIds: string[];
   }>;
-  // Booking-level legacy-ONGOING signal (see JSDoc): an ONGOING/OVERDUE booking
-  // with ZERO PartialBookingCheckout rows was checked out via the all-at-once
-  // flow, so every booked unit is physically off the shelf. Computed once here
-  // (it does not vary per asset) — the per-asset `booked > 0` guard below is
-  // what actually gates it, exactly as the singular helper does.
+  // Booking-level half of the legacy signal (see JSDoc): an ONGOING/OVERDUE
+  // booking with ZERO PartialBookingCheckout rows was checked out via the
+  // all-at-once flow. Computed once here since it does not vary per asset; the
+  // per-asset CHECKED_OUT guard below decides which rows it actually covers.
   const bookingStatus = (booking as { status: BookingStatus } | null)?.status;
-  const isLegacyOngoing =
+  const isLegacyAllAtOnceBooking =
     sessionsArr.length === 0 &&
     (bookingStatus === BookingStatus.ONGOING ||
       bookingStatus === BookingStatus.OVERDUE);
@@ -3432,10 +3461,20 @@ export async function computeBookingAssetsRemainingToCheckOut(
   for (const assetId of uniqueAssetIds) {
     const booked = bookedByAsset.get(assetId) ?? 0;
 
-    // Legacy-ONGOING fallback — guarded on `booked > 0` so an asset that isn't
-    // actually on the booking (no pivots) short-circuits through the normal
-    // `Math.max(0, 0 - claimed)` rather than synthesizing "fully checked out".
-    if (booked > 0 && isLegacyOngoing) {
+    // Legacy fallback — guarded on `booked > 0` so an asset that isn't actually
+    // on the booking (no pivots) short-circuits through the normal
+    // `Math.max(0, 0 - claimed)` rather than synthesizing "fully checked out",
+    // AND on the asset's own live CHECKED_OUT status. The status guard is what
+    // keeps the inference honest: the all-at-once flow flipped every asset it
+    // processed to CHECKED_OUT, but an asset ADDED to the booking afterwards is
+    // still AVAILABLE (updateBookingAssets deliberately does not auto-check-out
+    // on an ONGOING booking). Zeroing those too made them permanently
+    // un-checkoutable on that booking (GitHub #2815).
+    if (
+      booked > 0 &&
+      isLegacyAllAtOnceBooking &&
+      statusByAsset.get(assetId) === AssetStatus.CHECKED_OUT
+    ) {
       remainingByAsset.set(assetId, 0);
       continue;
     }
@@ -3628,12 +3667,21 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
   // than relying only on the downstream assetCap to neutralize it.
   const requestedRows = (await tx.bookingAsset.findMany({
     where: { bookingId, id: { in: uniqueSliceIds } },
-    select: { id: true, assetId: true, quantity: true, assetKitId: true },
+    // `asset.status` feeds the per-asset half of the legacy fallback below —
+    // see the asset-level sibling for the full rationale.
+    select: {
+      id: true,
+      assetId: true,
+      quantity: true,
+      assetKitId: true,
+      asset: { select: { status: true } },
+    },
   })) as Array<{
     id: string;
     assetId: string;
     quantity: number;
     assetKitId: string | null;
+    asset?: { status: AssetStatus } | null;
   }>;
 
   // Keep only genuinely-requested rows (a widened query or a static test mock
@@ -3641,12 +3689,16 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
   const requestedSet = new Set(uniqueSliceIds);
   const requestedById = new Map<
     string,
-    { assetId: string; quantity: number }
+    { assetId: string; quantity: number; status?: AssetStatus }
   >();
   const involvedAssetIds = new Set<string>();
   for (const row of requestedRows) {
     if (!requestedSet.has(row.id)) continue;
-    requestedById.set(row.id, { assetId: row.assetId, quantity: row.quantity });
+    requestedById.set(row.id, {
+      assetId: row.assetId,
+      quantity: row.quantity,
+      status: row.asset?.status,
+    });
     involvedAssetIds.add(row.assetId);
   }
   // No requested id resolved to a real slice → every entry stays 0, no further
@@ -3684,15 +3736,16 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
     bookingAssetIds: string[];
   }>;
 
-  // Booking-level legacy-ONGOING signal — the per-slice mirror of the branch in
-  // {@link computeBookingAssetsRemainingToCheckOut}. An ONGOING/OVERDUE booking
-  // with ZERO PartialBookingCheckout rows was checked out via the all-at-once
-  // flow (the progressive flow writes a session row on every batch), so every
-  // booked unit is already physically off the shelf and NOTHING remains to
-  // check out. The per-slice `quantity > 0` guard below is what actually gates
-  // it, exactly as the asset-level helper's `booked > 0` guard does.
+  // Booking-level half of the legacy signal — the per-slice mirror of the
+  // branch in {@link computeBookingAssetsRemainingToCheckOut}. An
+  // ONGOING/OVERDUE booking with ZERO PartialBookingCheckout rows was checked
+  // out via the all-at-once flow (the progressive flow writes a session row on
+  // every batch). The per-slice `quantity > 0` + live-CHECKED_OUT guards below
+  // decide which slices it actually covers, exactly as the asset-level sibling
+  // does — so a slice whose asset was added AFTER that checkout keeps its real
+  // remaining instead of being zeroed (GitHub #2815).
   const bookingStatus = (booking as { status: BookingStatus } | null)?.status;
-  const isLegacyOngoing =
+  const isLegacyAllAtOnceBooking =
     sessionsArr.length === 0 &&
     (bookingStatus === BookingStatus.ONGOING ||
       bookingStatus === BookingStatus.OVERDUE);
@@ -3748,10 +3801,16 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
     const requested = requestedById.get(sliceId);
     // Unknown slice (not on the booking) → keep the seeded 0.
     if (!requested) continue;
-    // Legacy-ONGOING fallback — guarded on `quantity > 0` so a zero-unit slice
+    // Legacy fallback — guarded on `quantity > 0` so a zero-unit slice
     // short-circuits through the normal math rather than synthesizing "fully
-    // checked out". Mirrors the asset-level helper's `booked > 0` guard.
-    if (isLegacyOngoing && requested.quantity > 0) {
+    // checked out", and on the asset's own live CHECKED_OUT status so a slice
+    // added after the all-at-once checkout keeps its real remaining. Mirrors
+    // the asset-level helper's `booked > 0` + status guards.
+    if (
+      isLegacyAllAtOnceBooking &&
+      requested.quantity > 0 &&
+      requested.status === AssetStatus.CHECKED_OUT
+    ) {
       remainingBySlice.set(sliceId, 0);
       continue;
     }

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -3441,15 +3441,15 @@ export async function computeBookingAssetsRemainingToCheckOut(
     quantities: number[];
     bookingAssetIds: string[];
   }>;
-  // Booking-level half of the legacy signal (see JSDoc): an ONGOING/OVERDUE
-  // booking with ZERO PartialBookingCheckout rows was checked out via the
-  // all-at-once flow. Computed once here since it does not vary per asset; the
-  // per-asset CHECKED_OUT guard below decides which rows it actually covers.
+  // Booking-level half of the legacy signal (see JSDoc): only an active booking
+  // can have units physically off the shelf. Deliberately NOT "the booking has
+  // zero sessions" — one progressive batch for ONE asset would otherwise
+  // switch every OTHER all-at-once asset back to "fully remaining" and invite a
+  // duplicate checkout. The per-asset test below is what decides coverage.
   const bookingStatus = (booking as { status: BookingStatus } | null)?.status;
-  const isLegacyAllAtOnceBooking =
-    sessionsArr.length === 0 &&
-    (bookingStatus === BookingStatus.ONGOING ||
-      bookingStatus === BookingStatus.OVERDUE);
+  const isActiveBooking =
+    bookingStatus === BookingStatus.ONGOING ||
+    bookingStatus === BookingStatus.OVERDUE;
 
   // Parse every session ONCE into per-asset checkout logs through the shared
   // positional-array parser, scoped to the requested assets via set membership
@@ -3460,29 +3460,38 @@ export async function computeBookingAssetsRemainingToCheckOut(
 
   for (const assetId of uniqueAssetIds) {
     const booked = bookedByAsset.get(assetId) ?? 0;
+    const claimed = (logsByAsset.get(assetId) ?? []).reduce(
+      (sum, log) => sum + log.quantity,
+      0
+    );
 
-    // Legacy fallback — guarded on `booked > 0` so an asset that isn't actually
-    // on the booking (no pivots) short-circuits through the normal
-    // `Math.max(0, 0 - claimed)` rather than synthesizing "fully checked out",
-    // AND on the asset's own live CHECKED_OUT status. The status guard is what
-    // keeps the inference honest: the all-at-once flow flipped every asset it
-    // processed to CHECKED_OUT, but an asset ADDED to the booking afterwards is
-    // still AVAILABLE (updateBookingAssets deliberately does not auto-check-out
-    // on an ONGOING booking). Zeroing those too made them permanently
-    // un-checkoutable on that booking (GitHub #2815).
+    // Legacy all-at-once fallback, decided entirely PER ASSET:
+    //   - `booked > 0`: an asset that isn't on the booking (no pivots) falls
+    //     through to the normal math rather than synthesizing "fully out".
+    //   - `claimed === 0`: nothing was ever progressively checked out for this
+    //     asset, so its zeroed counters are the all-at-once flow's silence
+    //     rather than a real "still on the shelf" reading. An asset WITH claims
+    //     needs no fallback — `booked − claimed` is already exact.
+    //   - live `CHECKED_OUT`: the flag the all-at-once flow actually writes.
+    //     An asset ADDED to the booking afterwards is still AVAILABLE
+    //     (updateBookingAssets deliberately does not auto-check-out on an
+    //     ONGOING booking), so it keeps its real remaining (GitHub #2815).
+    //
+    // Keying on the ASSET rather than "the booking has zero sessions" is what
+    // makes this survive a later batch: once "check out remaining" records the
+    // first session for a newly-added asset, a booking-level test would flip
+    // every already-out asset back to "fully remaining" and allow a duplicate
+    // checkout of stock that is already in the field.
     if (
       booked > 0 &&
-      isLegacyAllAtOnceBooking &&
+      claimed === 0 &&
+      isActiveBooking &&
       statusByAsset.get(assetId) === AssetStatus.CHECKED_OUT
     ) {
       remainingByAsset.set(assetId, 0);
       continue;
     }
 
-    const claimed = (logsByAsset.get(assetId) ?? []).reduce(
-      (sum, log) => sum + log.quantity,
-      0
-    );
     remainingByAsset.set(assetId, Math.max(0, booked - claimed));
   }
 
@@ -3737,18 +3746,15 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
   }>;
 
   // Booking-level half of the legacy signal — the per-slice mirror of the
-  // branch in {@link computeBookingAssetsRemainingToCheckOut}. An
-  // ONGOING/OVERDUE booking with ZERO PartialBookingCheckout rows was checked
-  // out via the all-at-once flow (the progressive flow writes a session row on
-  // every batch). The per-slice `quantity > 0` + live-CHECKED_OUT guards below
-  // decide which slices it actually covers, exactly as the asset-level sibling
-  // does — so a slice whose asset was added AFTER that checkout keeps its real
-  // remaining instead of being zeroed (GitHub #2815).
+  // branch in {@link computeBookingAssetsRemainingToCheckOut}. Only an active
+  // booking can have units physically off the shelf; everything else about the
+  // decision is per slice below. Deliberately NOT "the booking has zero
+  // sessions": one progressive batch for one asset would otherwise flip every
+  // other already-out slice back to "fully remaining".
   const bookingStatus = (booking as { status: BookingStatus } | null)?.status;
-  const isLegacyAllAtOnceBooking =
-    sessionsArr.length === 0 &&
-    (bookingStatus === BookingStatus.ONGOING ||
-      bookingStatus === BookingStatus.OVERDUE);
+  const isActiveBooking =
+    bookingStatus === BookingStatus.ONGOING ||
+    bookingStatus === BookingStatus.OVERDUE;
 
   // Group each involved asset's slices so the attributor sees its full set.
   const slicesByAsset = new Map<
@@ -3801,20 +3807,23 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
     const requested = requestedById.get(sliceId);
     // Unknown slice (not on the booking) → keep the seeded 0.
     if (!requested) continue;
-    // Legacy fallback — guarded on `quantity > 0` so a zero-unit slice
-    // short-circuits through the normal math rather than synthesizing "fully
-    // checked out", and on the asset's own live CHECKED_OUT status so a slice
-    // added after the all-at-once checkout keeps its real remaining. Mirrors
-    // the asset-level helper's `booked > 0` + status guards.
+    const claimed = claimedBySliceId.get(sliceId) ?? 0;
+    // Legacy all-at-once fallback, decided per SLICE — mirror of the
+    // asset-level sibling's `booked > 0` + `claimed === 0` + live-CHECKED_OUT
+    // guards. A slice with claims needs no fallback (`quantity − claimed` is
+    // exact), and a slice whose asset was added after the checkout is still
+    // AVAILABLE so it keeps its real remaining (GitHub #2815). Keying on the
+    // slice rather than the booking is what keeps an already-out slice at 0
+    // after a later batch records the booking's first session row.
     if (
-      isLegacyAllAtOnceBooking &&
+      isActiveBooking &&
       requested.quantity > 0 &&
+      claimed === 0 &&
       requested.status === AssetStatus.CHECKED_OUT
     ) {
       remainingBySlice.set(sliceId, 0);
       continue;
     }
-    const claimed = claimedBySliceId.get(sliceId) ?? 0;
     remainingBySlice.set(sliceId, Math.max(0, requested.quantity - claimed));
   }
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -3336,8 +3336,9 @@ type CheckoutRemainingTxClient = Pick<
  *
  * Per-asset semantics are byte-for-byte identical to the singular helper:
  * `Σ(BookingAsset.quantity for the asset) − Σ(PartialBookingCheckout claims for
- * the asset)`, floored at 0 — INCLUDING the legacy-ONGOING/OVERDUE fallback
- * (booked > 0, zero sessions, booking ONGOING/OVERDUE ⇒ remaining 0). The
+ * the asset)`, floored at 0 — INCLUDING the legacy all-at-once fallback
+ * (booked > 0, no claims for the asset, live CHECKED_OUT, booking
+ * ONGOING/OVERDUE ⇒ remaining 0). The
  * shared positional parser {@link checkoutSessionsToLogsByAsset} is reused with
  * a set-membership predicate so the aligned/legacy quantity handling and the
  * `""` → greedy sentinel match every other read site.
@@ -3384,7 +3385,7 @@ export async function computeBookingAssetsRemainingToCheckOut(
       where: { bookingId },
       select: { assetIds: true, quantities: true, bookingAssetIds: true },
     }),
-    // Cheap PK read — needed only so the legacy-ONGOING fallback below can
+    // Cheap PK read — needed only so the legacy all-at-once fallback below can
     // distinguish "checked out via all-at-once (no PBC rows by design)" from
     // "RESERVED, not yet touched". Mirrors the singular helper exactly.
     tx.booking.findUnique({
@@ -3513,20 +3514,24 @@ export async function computeBookingAssetsRemainingToCheckOut(
  * keeps the read backward-compatible with the existing all-at-once and
  * pre-Wave-B partial-checkout history without a backfill.
  *
- * Legacy-ONGOING fallback (bug #96 follow-up): an ONGOING/OVERDUE booking
- * with ZERO {@link PartialBookingCheckout} rows can only exist if it was
- * checked out via the legacy all-at-once flow (the new partial flow writes
- * a session row on every batch, so an ONGOING booking born from it always
- * has ≥1 row). In that legacy state, EVERY booked unit is physically off
- * the shelf — the per-asset `AssetStatus.CHECKED_OUT` flip the all-at-once
- * path performs is the equivalent signal — so `remaining` is 0, not
- * `booked`. Without this fallback, {@link computeCheckedOutForAsset}
- * (which reads `booked − remaining` as the checked-out portion) would
- * compute `booked − booked = 0` for legacy ONGOING bookings and the asset
- * overview "checked out" tile would silently drop them. RESERVED bookings
- * never trip the fallback (no units out yet). The fetch is a single
- * indexed-PK read against `Booking.status`, idempotent and safe to call
- * from inside or outside a transaction.
+ * Legacy all-at-once fallback (bug #96 follow-up): the all-at-once checkout
+ * flips every asset it processes to `AssetStatus.CHECKED_OUT` but writes NO
+ * {@link PartialBookingCheckout} rows, so an asset that is live CHECKED_OUT
+ * with no claims of its own on an ONGOING/OVERDUE booking has every booked
+ * unit physically off the shelf — `remaining` is 0, not `booked`. Without
+ * this, {@link computeCheckedOutForAsset} (which reads `booked − remaining`
+ * as the checked-out portion) would compute `booked − booked = 0` and the
+ * asset overview "checked out" tile would silently drop them.
+ *
+ * The test is PER ASSET, deliberately not "this booking has zero sessions":
+ * one progressive batch for ONE asset would otherwise switch every other
+ * all-at-once asset back to "fully remaining" and invite a duplicate checkout
+ * of stock already in the field. An asset WITH claims needs no fallback
+ * (`booked − claimed` is exact), and an asset ADDED after the checkout is
+ * still AVAILABLE so it keeps its real remaining (GitHub #2815). RESERVED
+ * bookings never trip it (no units out yet). The status fetch is a single
+ * indexed-PK read against `Booking.status`, idempotent and safe to call from
+ * inside or outside a transaction.
  *
  * @param tx - Prisma transaction client (or default `db`)
  * @param bookingId - Booking the asset belongs to
@@ -3540,7 +3545,7 @@ export async function computeBookingAssetRemainingToCheckOut(
 ): Promise<number> {
   // Delegate to the batched core with a single-element set so this helper stays
   // byte-for-byte identical for its ~6 external callers while the attribution,
-  // legacy-ONGOING fallback, and positional-parser handling live in ONE place.
+  // legacy all-at-once fallback, and positional-parser handling live in ONE place.
   const remainingByAsset = await computeBookingAssetsRemainingToCheckOut(
     tx,
     bookingId,
@@ -3627,8 +3632,9 @@ export async function computeBookingAssetSliceRemainingToCheckOut(
  * set-membership predicate so the `""` → greedy sentinel and the aligned/legacy
  * quantity handling match every other read site.
  *
- * That parity INCLUDES the legacy-ONGOING fallback (booked > 0, zero sessions,
- * booking ONGOING/OVERDUE ⇒ remaining 0). Without it this per-slice reader
+ * That parity INCLUDES the legacy all-at-once fallback (quantity > 0, no claims
+ * for the slice, live CHECKED_OUT, booking ONGOING/OVERDUE ⇒ remaining 0).
+ * Without it this per-slice reader
  * disagreed with its asset-level sibling on exactly one booking shape — one
  * checked out all-at-once — and the disagreement was load-bearing:
  * {@link getRemainingCheckoutPayload} PROPOSES from here while

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -859,33 +859,34 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     // `booked − 0 = booked` and wrongly offers a fully-out QT asset for more
     // checkout in the bulk-checkout dialog + scanner drawer.
     //
-    // Gated per asset on the live CHECKED_OUT status, NOT on the booking alone:
-    // an asset ADDED to the booking after that checkout is still AVAILABLE and
-    // genuinely has units left to check out. Zeroing those made them impossible
-    // to check out on this booking (GitHub #2815).
+    // Decided PER ASSET, not per booking: an asset ADDED after that checkout is
+    // still AVAILABLE and genuinely has units left (GitHub #2815), and an asset
+    // that already has progressive claims needs no fallback at all. Keying on
+    // the booking having zero sessions would also flip every already-out asset
+    // back to "fully remaining" the moment one later batch records a session.
     //
     // KEEP IN SYNC with the canonical `computeBookingAssetRemainingToCheckOut`
     // (modules/booking/service.server.ts), which the checkout-assets route uses;
     // this loader mirrors that logic in-memory to avoid an extra query per asset.
-    const isLegacyAllAtOnceCheckout =
-      checkoutSessions.length === 0 &&
-      (booking.status === BookingStatus.ONGOING ||
-        booking.status === BookingStatus.OVERDUE);
+    const isActiveBooking =
+      booking.status === BookingStatus.ONGOING ||
+      booking.status === BookingStatus.OVERDUE;
 
     const remainingToCheckOutByAsset: Record<string, number> = {};
     for (const [assetId, rows] of bookingAssetRowsByAsset) {
       const totalBooked = rows.reduce((sum, row) => sum + row.quantity, 0);
+      let totalCheckedOut = 0;
+      for (const row of rows) {
+        totalCheckedOut += checkedOutByBookingAsset.get(row.id) ?? 0;
+      }
       if (
-        isLegacyAllAtOnceCheckout &&
+        isActiveBooking &&
         totalBooked > 0 &&
+        totalCheckedOut === 0 &&
         assetStatusByAsset.get(assetId) === AssetStatus.CHECKED_OUT
       ) {
         remainingToCheckOutByAsset[assetId] = 0;
         continue;
-      }
-      let totalCheckedOut = 0;
-      for (const row of rows) {
-        totalCheckedOut += checkedOutByBookingAsset.get(row.id) ?? 0;
       }
       remainingToCheckOutByAsset[assetId] = Math.max(
         0,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -665,6 +665,13 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         assetKitId: string | null;
       }>
     >();
+    /**
+     * Live asset status per qty-tracked asset on this booking. Feeds the
+     * per-asset half of the legacy all-at-once fallback below — the status
+     * already rides along on `BOOKING_WITH_ASSETS_INCLUDE`, so this costs no
+     * extra query.
+     */
+    const assetStatusByAsset = new Map<string, AssetStatus>();
     for (const ba of booking.bookingAssets) {
       if (ba.asset?.type !== "QUANTITY_TRACKED") continue;
       const arr = bookingAssetRowsByAsset.get(ba.assetId) ?? [];
@@ -674,6 +681,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         assetKitId: ba.assetKitId ?? null,
       });
       bookingAssetRowsByAsset.set(ba.assetId, arr);
+      assetStatusByAsset.set(ba.assetId, ba.asset.status);
     }
 
     /** Logs grouped by assetId (each carries its own category). */
@@ -851,6 +859,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     // `booked − 0 = booked` and wrongly offers a fully-out QT asset for more
     // checkout in the bulk-checkout dialog + scanner drawer.
     //
+    // Gated per asset on the live CHECKED_OUT status, NOT on the booking alone:
+    // an asset ADDED to the booking after that checkout is still AVAILABLE and
+    // genuinely has units left to check out. Zeroing those made them impossible
+    // to check out on this booking (GitHub #2815).
+    //
     // KEEP IN SYNC with the canonical `computeBookingAssetRemainingToCheckOut`
     // (modules/booking/service.server.ts), which the checkout-assets route uses;
     // this loader mirrors that logic in-memory to avoid an extra query per asset.
@@ -862,7 +875,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     const remainingToCheckOutByAsset: Record<string, number> = {};
     for (const [assetId, rows] of bookingAssetRowsByAsset) {
       const totalBooked = rows.reduce((sum, row) => sum + row.quantity, 0);
-      if (isLegacyAllAtOnceCheckout && totalBooked > 0) {
+      if (
+        isLegacyAllAtOnceCheckout &&
+        totalBooked > 0 &&
+        assetStatusByAsset.get(assetId) === AssetStatus.CHECKED_OUT
+      ) {
         remainingToCheckOutByAsset[assetId] = 0;
         continue;
       }


### PR DESCRIPTION
## The bug

Fixes #2814 and #2815 — the same bug reported two ways.

Check a booking out with the all-at-once **Check out** button, then add assets to it while it's ongoing:

- adding an **individually tracked** asset → **Check out remaining** silently fails, the asset stays *Available*, and any error names an unrelated asset (#2814, as reported)
- adding a **quantity-tracked** asset → it can never be checked out on that booking at all (#2815)

## Why

A full check-out flips every asset it processes to `CHECKED_OUT` but writes **no** `PartialBookingCheckout` rows, so the progressive counters read 0 while the assets are physically out. Five separate readers compensate with the same inference:

> `ONGOING`/`OVERDUE` + zero checkout sessions ⇒ checked out all-at-once ⇒ nothing remains

That is right for the assets that were on the booking **at that moment**, and wrong for anything added later — which `updateBookingAssets` deliberately leaves `AVAILABLE` so an ongoing booking stays flexible.

The two symptoms are the two ways that inference goes wrong:

**#2814** — the per-slice reader never got the rule at all (it landed in the Wave-B qty work, before the sweep in a2bfbfe9d). "Check out remaining" *proposes* from that reader and the service *caps* with the asset-level one, so the proposal carried a full-quantity ghost claim for an already-out slice, the cap rejected it with `Only 0 units left to check out`, and the whole transaction rolled back — taking the genuinely outstanding asset down with it.

**#2815** — the rule was booking-level everywhere it did exist, so a later-added asset inherited "already out" from its booking.

## The fix

Gate the branch on the asset's own live `CHECKED_OUT` status — the signal the all-at-once path actually writes, and the one `qtyBucketOf` was already changed to trust in a2bfbfe9d. Assets present at checkout still read 0 remaining; assets added afterwards keep their real remaining.

Applied to all five implementations so they cannot disagree:

| | |
| --- | --- |
| `computeBookingAssetsRemainingToCheckOut` | the check-out cap |
| `computeBookingAssetsSliceRemainingToCheckOut` | what **Check out remaining** proposes |
| `bookings.$bookingId.overview.tsx` inline mirror | bulk dialog + scanner eligibility |
| `computeCheckedOutBreakdownForAsset` | the "checked out" count |
| `getAssetAvailabilityBatch` | `bookable` / available stock |

The status rides along on joins these queries already make, so there are no extra round-trips and the fixed-query-count guarantees are unchanged.

Nothing changes for a booking that has any `PartialBookingCheckout` row or is outside `ONGOING`/`OVERDUE` — the branch cannot fire there.

## Availability

Two of those five feed availability, so the behaviour change there is stated explicitly: a quantity-tracked asset added to an all-at-once-checked-out booking was being counted as fully checked out, which inflated its "checked out" figure and subtracted phantom units from `bookable`. It no longer is. That is a correction in the same direction as the rest of this PR, not a new behaviour.

`checked-out-batch-parity.test.ts` exists to stop `getAssetAvailabilityBatch` drifting from its singular twin, and it caught that divergence when only one side had been updated — which is how the fifth site was found. It now also pins the case this PR is about: two assets on one legacy booking, one checked out and one added later, with both implementations agreeing the added one holds zero units.

## Tests

- **#2814**: per-slice reader reports 0 for an already-out slice; that slice is absent from the payload; end-to-end on the action's own wire, an added individual asset flips to `CHECKED_OUT` instead of the batch being rejected
- **#2815**: per-slice reader keeps the real remaining for an added QT asset while the already-out one still reads 0; the payload proposes only the added asset; `partialCheckoutBooking` accepts it
- **parity**: both checked-out implementations agree an asset added after an all-at-once checkout holds no units

Three fixtures were updated to set the asset status their scenario implies — they described "checked out all at once" only through the absence of session rows, which was sufficient when the rule was booking-level.

`pnpm webapp:validate` green: 322 files, 4225 tests, 0 lint errors.

Closes #2814
Closes #2815


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legacy all-at-once checkout handling using each asset’s current status.
  - Ensured bookings with no remaining slices don’t block newly added items.
  - Corrected checkout, availability, and booking overview calculations so newly added assets retain proper eligibility.

- **Tests**
  - Added regression and end-to-end coverage for legacy and overdue checkout scenarios, including newly added assets and cross-implementation parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->