### PR TITLE
fix(booking,kit): return 400 for handled cancel/custody validation races

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -9296,3 +9296,36 @@ describe("getMinimalBookings", () => {
     expect(arg.where.custodianUserId).toBe("user-1");
   });
 });
+
+describe("cancelBooking — handled validation (SHELF-WEBAPP-222)", () => {
+  it("rejects a non-cancellable booking as a handled 400, not a captured 500", async () => {
+    // why: the guard loads the booking fresh; return a COMPLETE booking (not in
+    // the allowed-to-cancel set) so cancelBooking hits the status guard.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      id: "booking-1",
+      status: BookingStatus.COMPLETE,
+      bookingAssets: [],
+    });
+
+    let thrown: unknown;
+    try {
+      await cancelBooking({
+        id: "booking-1",
+        organizationId: "org-1",
+        hints: { timeZone: "UTC", locale: "en-US" } as never,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ShelfError);
+    const err = thrown as ShelfError;
+    expect(err.message).toContain("cannot be cancelled");
+    // The outer catch re-wraps, but ShelfError inherits status/shouldBeCaptured
+    // from the cause, so the handled-client classification survives.
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
+  });
+});

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -9327,5 +9327,11 @@ describe("cancelBooking — handled validation (SHELF-WEBAPP-222)", () => {
     // from the cause, so the handled-client classification survives.
     expect(err.status).toBe(400);
     expect(err.shouldBeCaptured).toBe(false);
+    // ...and additionalData is forwarded through the wrapper (not inherited by
+    // ShelfError automatically), so the debug context survives.
+    expect(err.additionalData).toMatchObject({
+      bookingId: "booking-1",
+      status: BookingStatus.COMPLETE,
+    });
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -8631,6 +8631,12 @@ export async function cancelBooking({
       message: isLikeShelfError(cause)
         ? cause.message
         : "Something went wrong while cancelling the booking, please try again.",
+      // ShelfError inherits status/shouldBeCaptured from a ShelfError cause but
+      // NOT additionalData — forward it so the handled-400 branch's { bookingId,
+      // status } debug context survives the re-wrap. See SHELF-WEBAPP-222.
+      additionalData: isLikeShelfError(cause)
+        ? cause.additionalData
+        : undefined,
     });
   }
 }

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -8494,10 +8494,18 @@ export async function cancelBooking({
     ];
 
     if (!allowedStatusForCancel.includes(bookingFound.status)) {
+      // User-input validation, not a server fault: the Cancel action is gated in
+      // the UI, so this only fires on a genuine race (the booking's status
+      // changed elsewhere between render and submit). A 400 keeps it out of the
+      // Sentry error pipeline; the outer catch inherits status/shouldBeCaptured
+      // from this cause. See SHELF-WEBAPP-222.
       throw new ShelfError({
         cause: null,
         label,
         message: "Booking cannot be cancelled at the current state.",
+        status: 400,
+        shouldBeCaptured: false,
+        additionalData: { bookingId: id, status: bookingFound.status },
       });
     }
 

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -3893,3 +3893,74 @@ describe("preserveKitDrivenPlacements", () => {
     expect(db.assetLocation.delete).not.toHaveBeenCalled();
   });
 });
+
+describe("bulkAssignKitCustody — handled validation (SHELF-WEBAPP-226)", () => {
+  it("rejects an unavailable kit as a handled 400, not a captured 500", async () => {
+    // why: the availability guard reads freshly-queried kit status; return an
+    // IN_CUSTODY (not AVAILABLE) kit so the unavailable-kits guard fires.
+    (db.kit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      { id: "kit-1", name: "Kit 1", status: "IN_CUSTODY", assetKits: [] },
+    ]);
+
+    let thrown: unknown;
+    try {
+      await bulkAssignKitCustody({
+        kitIds: ["kit-1"],
+        organizationId: "org-1",
+        custodianId: "tm-1",
+        custodianName: "Bob",
+        userId: "user-1",
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ShelfError);
+    const err = thrown as ShelfError;
+    expect(err.message).toContain("unavailable kits");
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
+  });
+
+  it("rejects an unavailable INDIVIDUAL asset in a kit as a handled 400", async () => {
+    // why: the kit is AVAILABLE but holds an INDIVIDUAL asset that is IN_CUSTODY,
+    // so the unavailable-assets-in-kits guard fires.
+    (db.kit.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      {
+        id: "kit-1",
+        name: "Kit 1",
+        status: "AVAILABLE",
+        assetKits: [
+          {
+            asset: {
+              id: "asset-1",
+              title: "Drill",
+              status: "IN_CUSTODY",
+              type: "INDIVIDUAL",
+              quantity: null,
+            },
+          },
+        ],
+      },
+    ]);
+
+    let thrown: unknown;
+    try {
+      await bulkAssignKitCustody({
+        kitIds: ["kit-1"],
+        organizationId: "org-1",
+        custodianId: "tm-1",
+        custodianName: "Bob",
+        userId: "user-1",
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ShelfError);
+    const err = thrown as ShelfError;
+    expect(err.message).toContain("unavailable assets");
+    expect(err.status).toBe(400);
+    expect(err.shouldBeCaptured).toBe(false);
+  });
+});

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -2349,11 +2349,17 @@ export async function bulkAssignKitCustody({
 
     const someKitsNotAvailable = kits.some((kit) => kit.status !== "AVAILABLE");
     if (someKitsNotAvailable) {
+      // User-input validation against a freshly-queried, real-time availability
+      // guard — not a server fault. A 400 keeps it out of the Sentry error
+      // pipeline (the outer catch inherits status/shouldBeCaptured from this
+      // cause). See SHELF-WEBAPP-226.
       throw new ShelfError({
         cause: null,
         message:
           "There are some unavailable kits. Please make sure you are selecting only available kits.",
         label,
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 
@@ -2378,11 +2384,15 @@ export async function bulkAssignKitCustody({
         asset.type !== "QUANTITY_TRACKED" && asset.status !== "AVAILABLE"
     );
     if (someAssetsUnavailable) {
+      // Same handled-validation class as the unavailable-kits guard above:
+      // a 400, not a captured 500. See SHELF-WEBAPP-226.
       throw new ShelfError({
         cause: null,
         message:
           "There are some unavailable assets in some kits. Please make sure you have all available assets in kits.",
         label,
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 


### PR DESCRIPTION
Two production Sentry 500s that were actually **handled user-input validation** — now returned as 400s and kept out of the Sentry error pipeline.

### SHELF-WEBAPP-222 — booking cancel (`Fixes SHELF-WEBAPP-222`)
`cancelBooking`'s "Booking cannot be cancelled at the current state" guard threw a bare `ShelfError` → captured 500. The Cancel action is UI-gated, so it only fires on a **render→submit race** (the booking's status changed elsewhere between render and submit). Now `status: 400, shouldBeCaptured: false` (+ `additionalData`); the outer catch inherits both through `ShelfError`.

### SHELF-WEBAPP-226 — bulk kit custody (`Fixes SHELF-WEBAPP-226`)
`bulkAssignKitCustody`'s two availability guards (`unavailable kits`, `unavailable assets in some kits`) threw bare `ShelfError`s → captured 500s. Both check **freshly-queried, real-time** status, so they're handled validation. Now `400` + `shouldBeCaptured: false` on both.

Each fix ships with a regression test asserting the thrown error is a `400` / `shouldBeCaptured: false`. Typecheck, eslint, and the security review pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when cancelling completed bookings, returning a clear client error instead of a generic server error.
  - Improved bulk kit custody assignment validation for unavailable kits and individual assets, with clear client-facing error messages.
  - Error responses now include relevant booking or kit status details while avoiding unnecessary error capture.
  - Invalid cancellation and custody assignment requests now consistently return a handled HTTP 400 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->