### PR TITLE
fix(assets): degrade advanced-filter lock exhaustion to a retryable 503

### DIFF
--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -25,6 +25,7 @@ import {
   Prisma,
   TagUseFor,
 } from "@prisma/client";
+import { withPrismaRetry } from "@shelf/database";
 import { releaseCategory } from "@shelf/quantity-control";
 import { LRUCache } from "lru-cache";
 import type { LoaderFunctionArgs } from "react-router";
@@ -1240,7 +1241,18 @@ export async function getAdvancedPaginatedAndFilterableAssets({
       hasSearch: Boolean(search),
     });
 
-    const result = await db.$queryRaw<AdvancedIndexQueryResult>(query);
+    // Retry the raw read on transient DB failures. The auto-applied client
+    // retry extension covers model operations but NOT raw escapes like
+    // `$queryRaw`, so wrap it explicitly. This heavy query trips Postgres
+    // shared-lock-table exhaustion (SQLSTATE 53200) under the per-request fan-out
+    // on large workspaces (SHELF-WEBAPP-227); the pressure is momentary, so a
+    // short backed-off retry usually succeeds. `operationIsRead: true` — this is
+    // a pure read, safe to re-run. On exhausted retries it rethrows to the catch
+    // below, which surfaces as the friendly retryable 503 (see makeShelfError).
+    const result = await withPrismaRetry(
+      () => db.$queryRaw<AdvancedIndexQueryResult>(query),
+      { operationIsRead: true }
+    );
     const totalAssets = result[0].total_count;
     const assets: AdvancedIndexAsset[] = result[0].assets;
     const totalPages = Math.ceil(totalAssets / take);

--- a/apps/webapp/app/utils/error.test.ts
+++ b/apps/webapp/app/utils/error.test.ts
@@ -64,6 +64,7 @@ describe(makeShelfError.name, () => {
 
       expect(error.status).toEqual(503);
       expect(error.label).toEqual("DB");
+      expect(error.shouldBeCaptured).toBe(true);
       expect(error.message).toContain("temporary database connectivity");
     });
 
@@ -127,6 +128,26 @@ describe(makeShelfError.name, () => {
       expect(error.label).toEqual("User");
       expect(error.message).toContain("does not exist");
     });
+
+    it("preserves the wrapper's additionalData when P2024 is wrapped", () => {
+      const prismaError = Object.assign(new Error("Connection pool timeout"), {
+        code: "P2024",
+      });
+      const wrappedCause = new ShelfError({
+        cause: prismaError,
+        label: "Assets",
+        message: "Failed to fetch paginated and filterable assets",
+        additionalData: { organizationId: "org-1" },
+      });
+
+      const error = makeShelfError(wrappedCause, { userId: "user-1" });
+
+      expect(error.status).toEqual(503);
+      expect(error.additionalData).toMatchObject({
+        organizationId: "org-1",
+        userId: "user-1",
+      });
+    });
   });
 
   describe("cause is a DB resource-exhaustion (lock table) error", () => {
@@ -139,6 +160,9 @@ describe(makeShelfError.name, () => {
 
       expect(error.status).toEqual(503);
       expect(error.label).toEqual("DB");
+      // Kept captured on purpose (503 >= 500) so the class stays in Sentry;
+      // pin it so a regression that silences capture fails the suite.
+      expect(error.shouldBeCaptured).toBe(true);
       expect(error.message.toLowerCase()).toContain("temporarily overloaded");
     });
 
@@ -159,8 +183,33 @@ describe(makeShelfError.name, () => {
 
       expect(error.status).toEqual(503);
       expect(error.label).toEqual("DB");
+      expect(error.shouldBeCaptured).toBe(true);
       expect(error.message).not.toContain("Failed to fetch");
       expect(error.cause).toBe(wrappedCause);
+    });
+
+    it("preserves the wrapper's additionalData (org + filters) and layers route-level data", () => {
+      // The assets query wraps the raw error with { organizationId, paramsValues }
+      // — the load-dependent context needed to watch the lock exhaustion recede.
+      // The 503 mapping must not drop it.
+      const prismaError = Object.assign(new Error(LOCK_EXHAUSTION_MESSAGE), {
+        code: "P2010",
+      });
+      const wrappedCause = new ShelfError({
+        cause: prismaError,
+        label: "Assets",
+        message: "Failed to fetch paginated and filterable assets",
+        additionalData: { organizationId: "org-1", paramsValues: { page: 1 } },
+      });
+
+      const error = makeShelfError(wrappedCause, { userId: "user-1" });
+
+      expect(error.status).toEqual(503);
+      expect(error.additionalData).toMatchObject({
+        organizationId: "org-1",
+        paramsValues: { page: 1 },
+        userId: "user-1",
+      });
     });
   });
 

--- a/apps/webapp/app/utils/error.test.ts
+++ b/apps/webapp/app/utils/error.test.ts
@@ -1,6 +1,7 @@
 import {
   ShelfError,
   isAssetQuantityOverAllocationError,
+  isDbResourceExhaustionError,
   isHandledClientError,
   isIndividualAssetAlreadyPlacedError,
   isLikeShelfError,
@@ -10,6 +11,15 @@ import {
   throwIfAssetQuantityOverAllocation,
   throwIfIndividualAssetAlreadyPlaced,
 } from "./error";
+
+/**
+ * Realistic Prisma message for a Postgres shared-lock-table exhaustion
+ * (SQLSTATE 53200). Prisma surfaces this as a P2010 (raw query failed) whose
+ * `.message` embeds the Postgres error + hint verbatim. Mirrors the payload
+ * captured in SHELF-WEBAPP-227.
+ */
+const LOCK_EXHAUSTION_MESSAGE =
+  "\nInvalid `prisma.$queryRaw()` invocation:\n\n\nRaw query failed. Code: `53200`. Message: `ERROR: out of shared memory\nHINT: You might need to increase max_locks_per_transaction.`";
 
 // @vitest-environment node
 // 👋 see https://vitest.dev/guide/environment.html#environments-for-specific-files
@@ -116,6 +126,41 @@ describe(makeShelfError.name, () => {
       expect(error.status).toEqual(404);
       expect(error.label).toEqual("User");
       expect(error.message).toContain("does not exist");
+    });
+  });
+
+  describe("cause is a DB resource-exhaustion (lock table) error", () => {
+    it("maps a direct 53200 lock-exhaustion error to a friendly retryable 503", () => {
+      const cause = Object.assign(new Error(LOCK_EXHAUSTION_MESSAGE), {
+        code: "P2010",
+      });
+
+      const error = makeShelfError(cause);
+
+      expect(error.status).toEqual(503);
+      expect(error.label).toEqual("DB");
+      expect(error.message.toLowerCase()).toContain("temporarily overloaded");
+    });
+
+    it("maps 53200 to 503 even when wrapped in a generic 500 ShelfError", () => {
+      // Mirrors the real path: the assets query catch re-wraps the raw Prisma
+      // error into a generic "Failed to fetch…" 500 before it reaches the
+      // route boundary where makeShelfError runs.
+      const prismaError = Object.assign(new Error(LOCK_EXHAUSTION_MESSAGE), {
+        code: "P2010",
+      });
+      const wrappedCause = new ShelfError({
+        cause: prismaError,
+        label: "Assets",
+        message: "Failed to fetch paginated and filterable assets",
+      });
+
+      const error = makeShelfError(wrappedCause);
+
+      expect(error.status).toEqual(503);
+      expect(error.label).toEqual("DB");
+      expect(error.message).not.toContain("Failed to fetch");
+      expect(error.cause).toBe(wrappedCause);
     });
   });
 
@@ -444,6 +489,45 @@ describe(isPrismaTransientError.name, () => {
     error.message = undefined;
     expect(() => isPrismaTransientError(error)).not.toThrow();
     expect(isPrismaTransientError(error)).toBe(false);
+  });
+});
+
+describe(isDbResourceExhaustionError.name, () => {
+  it("detects a direct Postgres 53200 lock-table-exhaustion error", () => {
+    const error = Object.assign(new Error(LOCK_EXHAUSTION_MESSAGE), {
+      code: "P2010",
+    });
+    expect(isDbResourceExhaustionError(error)).toBe(true);
+  });
+
+  it("detects it when wrapped inside a ShelfError cause chain", () => {
+    const prismaError = Object.assign(new Error(LOCK_EXHAUSTION_MESSAGE), {
+      code: "P2010",
+    });
+    const wrapped = new ShelfError({
+      cause: prismaError,
+      label: "Assets",
+      message: "Failed to fetch paginated and filterable assets",
+    });
+    expect(isDbResourceExhaustionError(wrapped)).toBe(true);
+  });
+
+  it("does NOT match a generic P2010 raw-query failure (e.g. a bad column)", () => {
+    // A genuinely broken raw query is also a P2010 — matching on the bare
+    // P2010 code would swallow real bugs. We match only the 53200 signature.
+    const error = Object.assign(
+      new Error(
+        '\nInvalid `prisma.$queryRaw()` invocation:\n\nRaw query failed. Code: `42703`. Message: `column "foo" does not exist`'
+      ),
+      { code: "P2010" }
+    );
+    expect(isDbResourceExhaustionError(error)).toBe(false);
+  });
+
+  it("returns false for unrelated errors and non-objects", () => {
+    expect(isDbResourceExhaustionError(new Error("boom"))).toBe(false);
+    expect(isDbResourceExhaustionError(null)).toBe(false);
+    expect(isDbResourceExhaustionError(undefined)).toBe(false);
   });
 });
 

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -525,6 +525,40 @@ export function throwIfIndividualAssetAlreadyPlaced(
 }
 
 /**
+ * Substring embedded verbatim in the Prisma error message when Postgres raises
+ * SQLSTATE `53200` (`out_of_memory`) because its **cluster-wide shared lock
+ * table is full** — the "You might need to increase max_locks_per_transaction"
+ * hint. Prisma surfaces this as a `P2010` (raw query failed), a code far too
+ * broad to key off (a genuinely broken raw query is *also* `P2010`), so we
+ * match NARROWLY on this hint text, which appears only in this one condition.
+ *
+ * @see SHELF-WEBAPP-227 — the `/assets` advanced-filter raw query trips this on
+ * large workspaces under the per-request query fan-out.
+ */
+export const DB_LOCK_EXHAUSTION_MARKER = "max_locks_per_transaction";
+
+/**
+ * Detects Postgres shared-lock-table exhaustion (SQLSTATE `53200` /
+ * `max_locks_per_transaction`) anywhere in an error's `cause` chain — even when
+ * a service-layer `try/catch` already re-wrapped the raw Prisma error inside a
+ * generic `ShelfError` (as the assets query does before it reaches the route
+ * boundary). Mirrors the cause-chain walk used by the DB-trigger detectors.
+ *
+ * This is a **transient, load-dependent** resource exhaustion, not a bug in the
+ * query and not a connectivity failure: the statement failed while acquiring
+ * its locks under contention, before touching any row. It is therefore safe to
+ * present as a retryable 503 (see {@link makeShelfError}) and safe to re-run a
+ * READ against (see `withPrismaRetry` in `@shelf/database`).
+ *
+ * @param cause - Any thrown value (error, wrapper, or unknown).
+ * @returns `true` when the lock-exhaustion hint is present on any node of the
+ * cause chain; otherwise `false`.
+ */
+export function isDbResourceExhaustionError(cause: unknown): boolean {
+  return causeChainIncludesMessage(cause, DB_LOCK_EXHAUSTION_MARKER);
+}
+
+/**
  * Walks the cause chain of an error to detect if a transient
  * Prisma error is buried inside ShelfError wrappers.
  */
@@ -585,6 +619,26 @@ export function makeShelfError(
       cause,
       message:
         "We're experiencing temporary database connectivity issues. Please try again in a moment.",
+      label: "DB",
+      additionalData,
+      shouldBeCaptured: true,
+      status: 503,
+    });
+  }
+
+  // Detect Postgres shared-lock-table exhaustion (SQLSTATE 53200 /
+  // max_locks_per_transaction) anywhere in the cause chain — even when a
+  // service catch block already re-wrapped it as a generic 5xx ShelfError
+  // (the assets advanced-filter query does exactly that). This is a transient,
+  // load-dependent overload on a READ, so it collapses to a friendly retryable
+  // 503 instead of a hard 500 crash screen. Kept captured (503 ≥ 500 so it
+  // stays in the Sentry error pipeline) so we can watch it recede as the
+  // durable per-request fan-out fix lands. See SHELF-WEBAPP-227.
+  if (isDbResourceExhaustionError(cause)) {
+    return new ShelfError({
+      cause,
+      message:
+        "The server is temporarily overloaded and couldn't load this. Please try again in a moment.",
       label: "DB",
       additionalData,
       shouldBeCaptured: true,

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -615,12 +615,19 @@ export function makeShelfError(
   // This prevents misleading messages like "User not found" when the
   // real issue is a connection pool timeout (P2024).
   if (hasTransientCause(cause)) {
+    // Merge the wrapper's additionalData (a service catch may have attached
+    // context like organizationId before re-throwing) so it survives into the
+    // logged/Sentry payload, mirroring the not-found + generic branches below.
+    const wrapper = isLikeShelfError(cause) ? cause : null;
     return new ShelfError({
       cause,
       message:
         "We're experiencing temporary database connectivity issues. Please try again in a moment.",
       label: "DB",
-      additionalData,
+      additionalData: {
+        ...(wrapper?.additionalData ?? {}),
+        ...additionalData,
+      },
       shouldBeCaptured: true,
       status: 503,
     });
@@ -635,12 +642,20 @@ export function makeShelfError(
   // stays in the Sentry error pipeline) so we can watch it recede as the
   // durable per-request fan-out fix lands. See SHELF-WEBAPP-227.
   if (isDbResourceExhaustionError(cause)) {
+    // Merge the wrapper's additionalData: on the assets path the cause is the
+    // "Failed to fetch…" ShelfError carrying { organizationId, paramsValues },
+    // which is exactly the load-dependent context (which workspace / which
+    // filters) needed to watch this recede. Mirrors the not-found branch.
+    const wrapper = isLikeShelfError(cause) ? cause : null;
     return new ShelfError({
       cause,
       message:
         "The server is temporarily overloaded and couldn't load this. Please try again in a moment.",
       label: "DB",
-      additionalData,
+      additionalData: {
+        ...(wrapper?.additionalData ?? {}),
+        ...additionalData,
+      },
       shouldBeCaptured: true,
       status: 503,
     });

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -114,16 +114,43 @@ test("getRetryableErrorCode", async (t) => {
 });
 
 test("isLockTableExhaustionError", async (t) => {
-  await t.test("detects the SQLSTATE 53200 on `meta.code`", () => {
-    assert.equal(isLockTableExhaustionError(lockExhaustionError()), true);
-  });
+  await t.test(
+    "detects lock-table exhaustion via the max_locks_per_transaction hint",
+    () => {
+      assert.equal(isLockTableExhaustionError(lockExhaustionError()), true);
+    }
+  );
 
-  await t.test("detects the hint text in the message as a fallback", () => {
-    const error = new Error(
-      "Raw query failed: ERROR: out of shared memory HINT: increase max_locks_per_transaction."
-    );
+  await t.test("detects the hint when it rides only on `meta.message`", () => {
+    const error = Object.assign(new Error("Raw query failed. Code: `53200`."), {
+      code: "P2010",
+      meta: {
+        code: "53200",
+        message:
+          "ERROR: out of shared memory\nHINT: You might need to increase max_locks_per_transaction.",
+      },
+    });
     assert.equal(isLockTableExhaustionError(error), true);
   });
+
+  await t.test(
+    "does NOT match a generic 53200 out_of_memory WITHOUT the lock hint",
+    () => {
+      // 53200 is Postgres out_of_memory generally — backend OOM raises it too.
+      // Retrying a real memory-exhaustion read would deepen the incident, so a
+      // 53200 without the max_locks_per_transaction hint must not match.
+      const error = Object.assign(
+        new Error(
+          "Raw query failed. Code: `53200`. Message: `ERROR: out of memory`"
+        ),
+        {
+          code: "P2010",
+          meta: { code: "53200", message: "ERROR: out of memory" },
+        }
+      );
+      assert.equal(isLockTableExhaustionError(error), false);
+    }
+  );
 
   await t.test(
     "does NOT match a generic P2010 raw-query failure (different SQLSTATE)",
@@ -210,6 +237,27 @@ test("isRetryablePrismaError", async (t) => {
         isRetryablePrismaError(lockExhaustionError(), {
           operationIsRead: false,
         }),
+        false
+      );
+    }
+  );
+
+  await t.test(
+    "does NOT retry a generic 53200 out_of_memory (no lock hint) on a read",
+    () => {
+      // Guards the narrowing: a real backend OOM (53200 without the hint) must
+      // fail fast, not get retried into a deeper memory incident.
+      const oom = Object.assign(
+        new Error(
+          "Raw query failed. Code: `53200`. Message: `ERROR: out of memory`"
+        ),
+        {
+          code: "P2010",
+          meta: { code: "53200", message: "ERROR: out of memory" },
+        }
+      );
+      assert.equal(
+        isRetryablePrismaError(oom, { operationIsRead: true }),
         false
       );
     }

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   getRetryableErrorCode,
+  isLockTableExhaustionError,
   isRetryablePrismaError,
   PRISMA_RETRYABLE_ERROR_CODES,
   withPrismaRetry,
@@ -66,6 +67,27 @@ function rejectedWithCode(error: unknown, code: string): boolean {
   );
 }
 
+/**
+ * Builds the Postgres shared-lock-table-exhaustion error (SQLSTATE 53200) as
+ * Prisma surfaces it: a `P2010` (raw query failed) carrying the SQLSTATE on
+ * `meta.code`, with the hint embedded in the message. Mirrors SHELF-WEBAPP-227.
+ *
+ * why: same as {@link prismaError} — the real `PrismaClientKnownRequestError`
+ * constructor is engine-coupled; a plain object with the fields the structural
+ * checks read reproduces the path faithfully.
+ */
+function lockExhaustionError(): Error & {
+  code: string;
+  meta: { code: string };
+} {
+  return Object.assign(
+    new Error(
+      "\nInvalid `prisma.$queryRaw()` invocation:\n\nRaw query failed. Code: `53200`. Message: `ERROR: out of shared memory\nHINT: You might need to increase max_locks_per_transaction.`"
+    ),
+    { code: "P2010", meta: { code: "53200" } }
+  );
+}
+
 test("getRetryableErrorCode", async (t) => {
   await t.test("reads `code` from a known-request error shape", () => {
     assert.equal(getRetryableErrorCode(prismaError("P1001")), "P1001");
@@ -88,6 +110,41 @@ test("getRetryableErrorCode", async (t) => {
     assert.equal(getRetryableErrorCode("just a string"), null);
     assert.equal(getRetryableErrorCode(null), null);
     assert.equal(getRetryableErrorCode(undefined), null);
+  });
+});
+
+test("isLockTableExhaustionError", async (t) => {
+  await t.test("detects the SQLSTATE 53200 on `meta.code`", () => {
+    assert.equal(isLockTableExhaustionError(lockExhaustionError()), true);
+  });
+
+  await t.test("detects the hint text in the message as a fallback", () => {
+    const error = new Error(
+      "Raw query failed: ERROR: out of shared memory HINT: increase max_locks_per_transaction."
+    );
+    assert.equal(isLockTableExhaustionError(error), true);
+  });
+
+  await t.test(
+    "does NOT match a generic P2010 raw-query failure (different SQLSTATE)",
+    () => {
+      // A genuinely broken raw query is also a P2010 — matching on the bare
+      // code would swallow real bugs. Only the 53200 signature must match.
+      const error = Object.assign(
+        new Error(
+          'Raw query failed. Code: `42703`. column "foo" does not exist'
+        ),
+        { code: "P2010", meta: { code: "42703" } }
+      );
+      assert.equal(isLockTableExhaustionError(error), false);
+    }
+  );
+
+  await t.test("returns false for unrelated / non-object values", () => {
+    assert.equal(isLockTableExhaustionError(new Error("boom")), false);
+    assert.equal(isLockTableExhaustionError(prismaError("P1001")), false);
+    assert.equal(isLockTableExhaustionError(null), false);
+    assert.equal(isLockTableExhaustionError(undefined), false);
   });
 });
 
@@ -133,6 +190,27 @@ test("isRetryablePrismaError", async (t) => {
           operationIsRead: false,
         }),
         true
+      );
+    }
+  );
+
+  await t.test(
+    "lock-table exhaustion (53200) retries for reads but NOT writes",
+    () => {
+      // The statement failed acquiring locks before mutating anything, so a
+      // read is safe to re-run; a write path is left to fail fast (gated like
+      // the in-flight codes).
+      assert.equal(
+        isRetryablePrismaError(lockExhaustionError(), {
+          operationIsRead: true,
+        }),
+        true
+      );
+      assert.equal(
+        isRetryablePrismaError(lockExhaustionError(), {
+          operationIsRead: false,
+        }),
+        false
       );
     }
   );
@@ -206,6 +284,61 @@ test("withPrismaRetry", async (t) => {
       assert.equal(logs.length, 1);
       assert.match(logs[0], /P1017/);
       assert.match(logs[0], /retry 1\/2/);
+    }
+  );
+
+  await t.test(
+    "retries a 53200 lock-exhaustion error on a READ and logs the SQLSTATE",
+    async () => {
+      // SHELF-WEBAPP-227: the raw /assets query trips 53200 under load; a
+      // moment later the shared lock table has headroom again, so the retry
+      // succeeds and the user never sees the overload.
+      let calls = 0;
+      const delays: number[] = [];
+      const logs: string[] = [];
+
+      const result = await withPrismaRetry(
+        async () => {
+          calls += 1;
+          if (calls === 1) throw lockExhaustionError();
+          return "ok";
+        },
+        {
+          operationIsRead: true,
+          delay: async (ms) => {
+            delays.push(ms);
+          },
+          log: (message) => logs.push(message),
+        }
+      );
+
+      assert.equal(result, "ok");
+      assert.equal(calls, 2);
+      assert.deepEqual(delays, [500]);
+      assert.equal(logs.length, 1);
+      // The lock error rides on a P2010, so the log falls back to the SQLSTATE.
+      assert.match(logs[0], /53200/);
+    }
+  );
+
+  await t.test(
+    "does NOT retry a 53200 lock-exhaustion error on a WRITE",
+    async () => {
+      let calls = 0;
+
+      await assert.rejects(
+        () =>
+          withPrismaRetry(
+            async () => {
+              calls += 1;
+              throw lockExhaustionError();
+            },
+            { operationIsRead: false, log: () => {} }
+          ),
+        (error: unknown) => rejectedWithCode(error, "P2010")
+      );
+
+      assert.equal(calls, 1, "lock exhaustion on a write must fail fast");
     }
   );
 

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -92,6 +92,56 @@ const MAX_RETRIES = 2;
 const BASE_DELAY_MS = 500;
 
 /**
+ * Postgres SQLSTATE `53200` (`out_of_memory`), raised when the cluster-wide
+ * **shared lock table is full** — the "increase max_locks_per_transaction"
+ * hint. Prisma surfaces it as a `P2010` (raw query failed), a code far too
+ * broad to retry wholesale (a genuinely broken raw query is *also* `P2010`), so
+ * we match NARROWLY: the SQLSTATE lands on the error's `meta.code`, and the
+ * hint text is embedded verbatim in the message as a fallback.
+ */
+const LOCK_EXHAUSTION_SQLSTATE = "53200";
+const LOCK_EXHAUSTION_MESSAGE_MARKER = "max_locks_per_transaction";
+
+/**
+ * Reports whether an error is Postgres shared-lock-table exhaustion
+ * (SQLSTATE `53200`). Unlike the connection/in-flight codes this is a
+ * RESOURCE-exhaustion under load, not a connectivity failure: the statement
+ * failed while ACQUIRING its locks, before touching any row, so it is transient
+ * and idempotent to re-run. {@link isRetryablePrismaError} gates it to READS.
+ *
+ * Duck-typed (reads `meta.code` / `message`) so plain mocked errors are
+ * recognized the same way the rest of this module treats them.
+ *
+ * @see apps/webapp/app/utils/error.ts `isDbResourceExhaustionError` — the app
+ * layer's cause-chain-walking counterpart that maps this class to a 503.
+ * @see SHELF-WEBAPP-227
+ *
+ * @param error - The unknown value thrown by a Prisma operation.
+ * @returns `true` when `error` is the 53200 lock-exhaustion condition.
+ */
+export function isLockTableExhaustionError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  // Prisma carries the Postgres SQLSTATE on `meta.code` for raw-query failures.
+  const meta = (error as { meta?: unknown }).meta;
+  if (
+    typeof meta === "object" &&
+    meta !== null &&
+    "code" in meta &&
+    (meta as { code?: unknown }).code === LOCK_EXHAUSTION_SQLSTATE
+  ) {
+    return true;
+  }
+  // Fallback: the hint text is embedded verbatim in the Prisma error message.
+  const message = (error as { message?: unknown }).message;
+  return (
+    typeof message === "string" &&
+    message.includes(LOCK_EXHAUSTION_MESSAGE_MARKER)
+  );
+}
+
+/**
  * Extracts a transient Prisma error code from an unknown thrown value, reading
  * BOTH shapes Prisma uses to report one:
  *
@@ -147,6 +197,15 @@ export function isRetryablePrismaError(
   error: unknown,
   { operationIsRead }: { operationIsRead: boolean }
 ): boolean {
+  // Postgres shared-lock-table exhaustion (SQLSTATE 53200) is a transient
+  // resource overload, not one of the transient CODES above (it rides on a
+  // P2010). The statement failed acquiring its locks before mutating anything,
+  // so it's safe to re-run — but gated to reads for the same conservatism as
+  // the in-flight codes (a write path that trips it fails fast). See
+  // SHELF-WEBAPP-227.
+  if (isLockTableExhaustionError(error)) {
+    return operationIsRead;
+  }
   const code = getRetryableErrorCode(error);
   if (code === null) {
     return false;
@@ -206,8 +265,10 @@ export async function withPrismaRetry<T>(
         isRetryablePrismaError(error, { operationIsRead }) &&
         attempt <= MAX_RETRIES
       ) {
-        // Non-null: isRetryablePrismaError only returns true for a known code.
-        const code = getRetryableErrorCode(error);
+        // Retryable path only: the code is a known transient code, or (when
+        // getRetryableErrorCode returns null) the 53200 lock-exhaustion class,
+        // which rides on a P2010 rather than a retryable code.
+        const code = getRetryableErrorCode(error) ?? LOCK_EXHAUSTION_SQLSTATE;
         const delayMs = BASE_DELAY_MS * attempt;
         log(
           `[db] transient Prisma error [${code}], retry ${attempt}/${MAX_RETRIES} in ${delayMs}ms`

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -92,52 +92,55 @@ const MAX_RETRIES = 2;
 const BASE_DELAY_MS = 500;
 
 /**
- * Postgres SQLSTATE `53200` (`out_of_memory`), raised when the cluster-wide
- * **shared lock table is full** — the "increase max_locks_per_transaction"
- * hint. Prisma surfaces it as a `P2010` (raw query failed), a code far too
- * broad to retry wholesale (a genuinely broken raw query is *also* `P2010`), so
- * we match NARROWLY: the SQLSTATE lands on the error's `meta.code`, and the
- * hint text is embedded verbatim in the message as a fallback.
+ * SQLSTATE `53200` is Postgres `out_of_memory` — raised for shared-lock-table
+ * exhaustion (which carries the "increase max_locks_per_transaction" hint) but
+ * ALSO for general backend memory exhaustion. So the bare SQLSTATE is NOT a
+ * safe retry signal: retrying a genuine OOM read would deepen the incident. We
+ * key on the `max_locks_per_transaction` HINT text — the string Postgres emits
+ * only for lock-table exhaustion — mirroring the app-layer
+ * `isDbResourceExhaustionError`. The SQLSTATE is retained only as the retry
+ * log label (see {@link withPrismaRetry}).
  */
 const LOCK_EXHAUSTION_SQLSTATE = "53200";
 const LOCK_EXHAUSTION_MESSAGE_MARKER = "max_locks_per_transaction";
 
 /**
- * Reports whether an error is Postgres shared-lock-table exhaustion
- * (SQLSTATE `53200`). Unlike the connection/in-flight codes this is a
- * RESOURCE-exhaustion under load, not a connectivity failure: the statement
+ * Reports whether an error is Postgres shared-lock-table exhaustion — a
+ * RESOURCE exhaustion under load, not a connectivity failure: the statement
  * failed while ACQUIRING its locks, before touching any row, so it is transient
  * and idempotent to re-run. {@link isRetryablePrismaError} gates it to READS.
  *
- * Duck-typed (reads `meta.code` / `message`) so plain mocked errors are
- * recognized the same way the rest of this module treats them.
+ * Keys on the `max_locks_per_transaction` HINT text, NOT the bare SQLSTATE
+ * `53200` (which is general `out_of_memory` and would falsely match — then
+ * retry — a real memory-exhaustion query). The hint can ride on either the
+ * top-level Prisma message or `meta.message`, so both are checked. Duck-typed
+ * so plain mocked errors are recognized the same way.
  *
  * @see apps/webapp/app/utils/error.ts `isDbResourceExhaustionError` — the app
  * layer's cause-chain-walking counterpart that maps this class to a 503.
  * @see SHELF-WEBAPP-227
  *
  * @param error - The unknown value thrown by a Prisma operation.
- * @returns `true` when `error` is the 53200 lock-exhaustion condition.
+ * @returns `true` when `error` is the lock-table-exhaustion condition.
  */
 export function isLockTableExhaustionError(error: unknown): boolean {
   if (typeof error !== "object" || error === null) {
     return false;
   }
-  // Prisma carries the Postgres SQLSTATE on `meta.code` for raw-query failures.
-  const meta = (error as { meta?: unknown }).meta;
+  const err = error as { message?: unknown; meta?: { message?: unknown } };
+  // The hint text identifies lock-table exhaustion specifically; a bare 53200
+  // does not (general out_of_memory raises it too).
   if (
-    typeof meta === "object" &&
-    meta !== null &&
-    "code" in meta &&
-    (meta as { code?: unknown }).code === LOCK_EXHAUSTION_SQLSTATE
+    typeof err.message === "string" &&
+    err.message.includes(LOCK_EXHAUSTION_MESSAGE_MARKER)
   ) {
     return true;
   }
-  // Fallback: the hint text is embedded verbatim in the Prisma error message.
-  const message = (error as { message?: unknown }).message;
+  // Prisma also carries the raw Postgres message (hint included) on `meta`.
+  const metaMessage = err.meta?.message;
   return (
-    typeof message === "string" &&
-    message.includes(LOCK_EXHAUSTION_MESSAGE_MARKER)
+    typeof metaMessage === "string" &&
+    metaMessage.includes(LOCK_EXHAUSTION_MESSAGE_MARKER)
   );
 }
 

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -2,6 +2,11 @@
 export { createDatabaseClient } from "./client";
 export type { ExtendedPrismaClient } from "./client";
 
+// Re-export the transient-error retry wrapper so consumers can extend retry to
+// the raw escapes (`$queryRaw` / `$executeRaw`) that the auto-applied client
+// extension does not cover. See `withPrismaRetry` in ./client.
+export { withPrismaRetry } from "./client";
+
 // Re-export all Prisma types and enums so consumers don't need @prisma/client directly
 export { Prisma, PrismaClient } from "@prisma/client";
 export type * from "@prisma/client";


### PR DESCRIPTION
## Problem

`SHELF-WEBAPP-227` — the `/assets` advanced-filter loader hard-500s with Postgres `53200 (out of shared memory / max_locks_per_transaction)`. Escalating for a large workspace (Amplify Health); the customer couldn't open their asset list.

## Root cause

Not the row cap (100). Postgres takes an `AccessShareLock` on every **relation** a statement touches — the table + each index + TOAST — once per statement, **regardless of row count**. The advanced-filter raw query joins ~20 tables and locks **~130–170 relations per execution** (Asset alone carries 14 indexes = 17 lock entries). The `/assets.data` loader fans out ~30 such queries per request across ~30 connections, each holding its own lock entries, so one big-workspace page load holds ~1,500–3,000 locks for seconds. The shared lock table is cluster-wide and fixed (`max_locks_per_transaction × max_connections`), so 2–3 concurrent advanced loads exhaust it → `53200`. Same class as the booking-read `21D`.

## This PR — defensive layer

Converts the hard crash into a graceful, self-healing path. It does **not** fix the root cause (per-request fan-out); that's a separate follow-up.

- **Friendly 503 (whole class).** `makeShelfError` detects the `53200 / max_locks_per_transaction` signature anywhere in the cause chain (`isDbResourceExhaustionError`) and returns a retryable **503 "server temporarily overloaded, try again"** instead of a 500 crash screen — covering every query that trips it (assets index, booking reads, …). Kept captured (503 ≥ 500) so the class stays watchable in Sentry.
- **Bounded read retry.** `@shelf/database` now recognizes `53200` (`isLockTableExhaustionError`) and retries it **for reads only** (safe — the statement fails while acquiring locks, before mutating a row) via the existing `withPrismaRetry` backoff. The raw `/assets` query is wrapped, so momentary lock pressure self-heals; other auto-wrapped model reads recover too.

## Operational stopgap (already applied on prod)

`max_locks_per_transaction` raised 64 → 256 (5,760 → 23,040 lock-table slots), lifting the crash threshold from ~2–3 to ~11 concurrent loads. Headroom, not a cure — and it doesn't touch the connection-pool ceiling (`max_connections = 90`), which the same fan-out also strains (the P2024 twin).

## Durable follow-up (tracked separately)

Split the single mega-hydration `LATERAL` into narrow batched queries keyed on the 100 paged ids (so no statement locks more than ~a dozen relations, each releasing in ms), plus cap the ~30-wide loader fan-out. Together these retire both the lock-table and connection-pool ceilings.

## Tests

- `apps/webapp/app/utils/error.test.ts` +6 — detector + 503 mapping (incl. nested-in-ShelfError).
- `packages/database/src/client.test.ts` +11 — 53200 detection, read-only retry gate, backoff/log.
- typecheck (both packages) + eslint green.

Sentry: SHELF-WEBAPP-227 (mitigated here; do **not** resolve until a deploy confirms the 500s stop — they'll regroup under a new 503 "DB" issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when database shared-resource limits are temporarily exhausted.
  * Read-only operations now retry automatically when appropriate, reducing avoidable failures.
  * These incidents are reported as retryable service-unavailable errors with clearer messaging.
  * Write operations continue to fail immediately, avoiding unsafe retries.
  * Improved error details and context are preserved for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->