### PR TITLE
fix(mobile-api): mobile assets search matches the web search (shared clause)

### DIFF
--- a/apps/webapp/app/modules/api/mobile-asset-search.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Test suite for the mobile assets-list search fragment.
+ *
+ * Pins which fields the companion's asset search matches — title, SAM id
+ * (sequentialId), description, category name, tag names — so the mobile API
+ * can't silently drift back to title-only search (users trained on the web
+ * search read a zero-result list as "search is broken") and can't silently
+ * grow the heavy web branches (custodian traversal, custom-fields JSON) that
+ * are deliberately excluded on mobile. Pure module — no mocks needed.
+ *
+ * @see {@link file://./mobile-asset-search.server.ts}
+ */
+import { buildMobileAssetSearchWhere } from "./mobile-asset-search.server";
+
+// @vitest-environment node
+
+describe("buildMobileAssetSearchWhere", () => {
+  it("returns an empty fragment when search is empty", () => {
+    expect(buildMobileAssetSearchWhere("")).toEqual({});
+  });
+
+  it("matches title, sequentialId, description, category and tags", () => {
+    const contains = { contains: "tripod", mode: "insensitive" };
+
+    expect(buildMobileAssetSearchWhere("tripod")).toEqual({
+      OR: [
+        { title: contains },
+        { sequentialId: contains },
+        { description: contains },
+        { category: { name: contains } },
+        { tags: { some: { name: contains } } },
+      ],
+    });
+  });
+
+  it("matches every field case-insensitively", () => {
+    const { OR } = buildMobileAssetSearchWhere("SAM-0001");
+
+    const modes = (OR ?? []).map(
+      (branch) =>
+        JSON.stringify(branch).match(/"mode":"(\w+)"/)?.[1] ?? "MISSING"
+    );
+
+    expect(modes).toEqual(Array(5).fill("insensitive"));
+  });
+
+  it("does not traverse custody, custom fields, locations or codes", () => {
+    const fragment = JSON.stringify(buildMobileAssetSearchWhere("term"));
+
+    for (const heavyBranch of [
+      "custody",
+      "customFields",
+      "assetLocations",
+      "qrCodes",
+      "barcodes",
+    ]) {
+      expect(fragment).not.toContain(heavyBranch);
+    }
+  });
+});

--- a/apps/webapp/app/modules/api/mobile-asset-search.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.test.ts
@@ -1,60 +1,81 @@
 /**
- * Test suite for the mobile assets-list search fragment.
+ * Test suite for the mobile assets-list search clauses.
  *
- * Pins which fields the companion's asset search matches — title, SAM id
- * (sequentialId), description, category name, tag names — so the mobile API
- * can't silently drift back to title-only search (users trained on the web
- * search read a zero-result list as "search is broken") and can't silently
- * grow the heavy web branches (custodian traversal, custom-fields JSON) that
- * are deliberately excluded on mobile. Pure module — no mocks needed.
+ * Pins the parity contract: mobile search uses the SAME shared clause
+ * builders as the web `getAssets` fetcher — same fields, same ID-shaped
+ * fast path, same zero-row fallback intent. A drift back to a mobile-only
+ * field list (the original title-only bug users read as "search is broken")
+ * fails here. Pure module — no mocks needed.
  *
  * @see {@link file://./mobile-asset-search.server.ts}
+ * @see {@link file://./../asset/search.server.ts}
  */
+import {
+  buildFullAssetSearchOr,
+  buildNarrowAssetSearchOr,
+} from "~/modules/asset/search.server";
 import { buildMobileAssetSearchWhere } from "./mobile-asset-search.server";
 
 // @vitest-environment node
 
 describe("buildMobileAssetSearchWhere", () => {
-  it("returns an empty fragment when search is empty", () => {
-    expect(buildMobileAssetSearchWhere("")).toEqual({});
-  });
-
-  it("matches title, sequentialId, description, category and tags", () => {
-    const contains = { contains: "tripod", mode: "insensitive" };
-
-    expect(buildMobileAssetSearchWhere("tripod")).toEqual({
-      OR: [
-        { title: contains },
-        { sequentialId: contains },
-        { description: contains },
-        { category: { name: contains } },
-        { tags: { some: { name: contains } } },
-      ],
+  it("returns an empty primary and no fallback when there is nothing to search", () => {
+    expect(buildMobileAssetSearchWhere("")).toEqual({
+      primary: {},
+      fallback: null,
+    });
+    expect(buildMobileAssetSearchWhere("  , ")).toEqual({
+      primary: {},
+      fallback: null,
     });
   });
 
-  it("matches every field case-insensitively", () => {
-    const { OR } = buildMobileAssetSearchWhere("SAM-0001");
+  it("uses the web full clause verbatim for word searches, with no fallback", () => {
+    const { primary, fallback } = buildMobileAssetSearchWhere("tripod");
 
-    const modes = (OR ?? []).map(
-      (branch) =>
-        JSON.stringify(branch).match(/"mode":"(\w+)"/)?.[1] ?? "MISSING"
-    );
-
-    expect(modes).toEqual(Array(5).fill("insensitive"));
+    expect(primary).toEqual({ OR: buildFullAssetSearchOr(["tripod"]) });
+    expect(fallback).toBeNull();
   });
 
-  it("does not traverse custody, custom fields, locations or codes", () => {
-    const fragment = JSON.stringify(buildMobileAssetSearchWhere("term"));
-
-    for (const heavyBranch of [
-      "custody",
-      "customFields",
-      "assetLocations",
-      "qrCodes",
-      "barcodes",
+  it("matches description, tags, category, location, custodians, codes and custom fields", () => {
+    // The complaint class this module exists to prevent: a term that only
+    // lives in a description or tag must be part of the clause.
+    const serialized = JSON.stringify(buildMobileAssetSearchWhere("beamer"));
+    for (const fieldPath of [
+      '"description"',
+      '"tags"',
+      '"category"',
+      '"assetLocations"',
+      '"custody"',
+      '"qrCodes"',
+      '"barcodes"',
+      '"customFields"',
     ]) {
-      expect(fragment).not.toContain(heavyBranch);
+      expect(serialized).toContain(fieldPath);
     }
+  });
+
+  it("takes the narrow fast path for ID-shaped searches and offers the full fallback", () => {
+    const { primary, fallback } = buildMobileAssetSearchWhere("SAM-0001");
+
+    expect(primary).toEqual({ OR: buildNarrowAssetSearchOr(["sam-0001"]) });
+    expect(fallback).toEqual({ OR: buildFullAssetSearchOr(["sam-0001"]) });
+  });
+
+  it("goes straight to the full clause when any term is not ID-shaped", () => {
+    const { primary, fallback } =
+      buildMobileAssetSearchWhere("sam-0001,tripod");
+
+    expect(primary).toEqual({
+      OR: buildFullAssetSearchOr(["sam-0001", "tripod"]),
+    });
+    expect(fallback).toBeNull();
+  });
+
+  it("normalizes terms the same way as web search (lowercase, comma-split)", () => {
+    expect(buildMobileAssetSearchWhere("  Tripod, Canon ")).toEqual({
+      primary: { OR: buildFullAssetSearchOr(["tripod", "canon"]) },
+      fallback: null,
+    });
   });
 });

--- a/apps/webapp/app/modules/api/mobile-asset-search.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.test.ts
@@ -19,15 +19,22 @@ import { buildMobileAssetSearchWhere } from "./mobile-asset-search.server";
 // @vitest-environment node
 
 describe("buildMobileAssetSearchWhere", () => {
-  it("returns an empty primary and no fallback when there is nothing to search", () => {
+  it("returns an empty primary and no fallback for a truly empty search", () => {
     expect(buildMobileAssetSearchWhere("")).toEqual({
       primary: {},
       fallback: null,
     });
-    expect(buildMobileAssetSearchWhere("  , ")).toEqual({
-      primary: {},
-      fallback: null,
-    });
+  });
+
+  it("matches NOTHING for non-blank input that yields zero terms", () => {
+    // A typed space or bare comma in a debounced type-ahead must not
+    // flash the full unfiltered list. `id: { in: [] }` is always false.
+    for (const input of ["  , ", "   ", ","]) {
+      expect(buildMobileAssetSearchWhere(input)).toEqual({
+        primary: { id: { in: [] } },
+        fallback: null,
+      });
+    }
   });
 
   it("uses the web full clause verbatim for word searches, with no fallback", () => {
@@ -35,6 +42,12 @@ describe("buildMobileAssetSearchWhere", () => {
 
     expect(primary).toEqual({ OR: buildFullAssetSearchOr(["tripod"]) });
     expect(fallback).toBeNull();
+
+    // Structural pins, independent of the builder (the equality above is
+    // wiring-only — it would still pass if the shared clause lost a field).
+    const groups = primary.OR as Array<{ OR: unknown[] }>;
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.OR).toHaveLength(10);
   });
 
   it("matches description, tags, category, location, custodians, codes and custom fields", () => {
@@ -60,6 +73,12 @@ describe("buildMobileAssetSearchWhere", () => {
 
     expect(primary).toEqual({ OR: buildNarrowAssetSearchOr(["sam-0001"]) });
     expect(fallback).toEqual({ OR: buildFullAssetSearchOr(["sam-0001"]) });
+
+    // Structural pins: narrow = flat 5-column OR with no heavy branches;
+    // fallback = the 10-branch full group.
+    expect(primary.OR).toHaveLength(5);
+    expect(JSON.stringify(primary)).not.toContain("customFields");
+    expect((fallback!.OR as Array<{ OR: unknown[] }>)[0]!.OR).toHaveLength(10);
   });
 
   it("goes straight to the full clause when any term is not ID-shaped", () => {

--- a/apps/webapp/app/modules/api/mobile-asset-search.server.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.ts
@@ -2,7 +2,7 @@ import type { Prisma } from "@prisma/client";
 import {
   buildFullAssetSearchOr,
   buildNarrowAssetSearchOr,
-  looksLikeAssetId,
+  isIdShapedSearch,
   splitAssetSearchTerms,
 } from "~/modules/asset/search.server";
 
@@ -49,10 +49,18 @@ export function buildMobileAssetSearchWhere(
   const searchTerms = splitAssetSearchTerms(search);
 
   if (searchTerms.length === 0) {
+    // Typed input that yields zero terms (whitespace / bare commas) must
+    // match NOTHING, not everything: in a debounced type-ahead a single
+    // typed space would otherwise flash the full unfiltered list.
+    // `id: { in: [] }` is the canonical always-false Prisma clause. Only a
+    // genuinely empty search string means "no filter".
+    if (search.length > 0) {
+      return { primary: { id: { in: [] } }, fallback: null };
+    }
     return { primary: {}, fallback: null };
   }
 
-  if (searchTerms.every(looksLikeAssetId)) {
+  if (isIdShapedSearch(searchTerms)) {
     return {
       primary: { OR: buildNarrowAssetSearchOr(searchTerms) },
       fallback: { OR: buildFullAssetSearchOr(searchTerms) },

--- a/apps/webapp/app/modules/api/mobile-asset-search.server.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.ts
@@ -1,44 +1,66 @@
 import type { Prisma } from "@prisma/client";
+import {
+  buildFullAssetSearchOr,
+  buildNarrowAssetSearchOr,
+  looksLikeAssetId,
+  splitAssetSearchTerms,
+} from "~/modules/asset/search.server";
 
 /**
- * Search fragment for the mobile assets list
+ * Search clauses for the mobile assets list
  * (routes/api+/mobile+/assets.ts).
  *
- * Mirrors the LIGHT branches of the web asset search (`buildFullSearchOr`,
- * modules/asset/service.server.ts): title, sequentialId, description,
- * category name and tag names. Every branch rides an existing GIN trigram
- * index (compound Asset title+description, Category.name, Tag.name — see
- * migration 20260525110348_add_trigram_indexes_for_simple_search), so no new
- * index is needed.
+ * Thin composition over the SHARED simple-mode search module
+ * (`modules/asset/search.server.ts`) — the same clause builders the web
+ * `getAssets` fetcher uses. Mobile search therefore matches exactly the
+ * fields web search matches (title, sequentialId, description, category,
+ * location, tags, custodian names, QR/barcode, custom fields) and inherits
+ * web's ID-shaped fast-path strategy: narrow indexed clause first, full
+ * clause only when the narrow one finds nothing.
+ */
+
+/** The two-step where fragments the mobile assets route queries with. */
+export interface MobileAssetSearchClauses {
+  /** Fragment for the first query. `{}` when there is nothing to search. */
+  primary: Prisma.AssetWhereInput;
+  /**
+   * Full-clause fragment to re-query with when `primary` (the narrow
+   * ID-shaped fast path) returns zero rows. `null` when `primary` already IS
+   * the full clause — or when there is no search — meaning no second query
+   * is ever needed.
+   */
+  fallback: Prisma.AssetWhereInput | null;
+}
+
+/**
+ * Builds the search fragments for the mobile assets list.
  *
- * Deliberately still NOT the web search's heavy branches — custodian-name
- * traversal, custom-fields JSON ILIKE, location names and QR/barcode values.
- * The first two are slow (relation fan-out + unindexed JSON scan), and codes
- * are scanned rather than typed on mobile.
+ * Mirrors `getAssets`' strategy exactly: ID-shaped terms (see
+ * `looksLikeAssetId`) take the narrow indexed clause with the full clause as
+ * a zero-row fallback; anything else goes straight to the full clause.
  *
  * @param search - Raw (already length-capped) search term from the request
- * @returns A spreadable `Prisma.AssetWhereInput` fragment — `{}` when the
- *   term is empty, otherwise an `OR` across the searchable fields
+ * @returns Spreadable primary/fallback where fragments — see
+ *   {@link MobileAssetSearchClauses}
  */
 export function buildMobileAssetSearchWhere(
   search: string
-): Prisma.AssetWhereInput {
-  if (!search) {
-    return {};
+): MobileAssetSearchClauses {
+  const searchTerms = splitAssetSearchTerms(search);
+
+  if (searchTerms.length === 0) {
+    return { primary: {}, fallback: null };
   }
 
-  const contains = { contains: search, mode: "insensitive" as const };
+  if (searchTerms.every(looksLikeAssetId)) {
+    return {
+      primary: { OR: buildNarrowAssetSearchOr(searchTerms) },
+      fallback: { OR: buildFullAssetSearchOr(searchTerms) },
+    };
+  }
 
   return {
-    OR: [
-      { title: contains },
-      // SAM id (e.g. "SAM-0001") — when the workspace display preference is
-      // SAM every asset row shows it, so a typed id must match here.
-      // `sequentialId` is indexed; a normal word term can't false-positive it.
-      { sequentialId: contains },
-      { description: contains },
-      { category: { name: contains } },
-      { tags: { some: { name: contains } } },
-    ],
+    primary: { OR: buildFullAssetSearchOr(searchTerms) },
+    fallback: null,
   };
 }

--- a/apps/webapp/app/modules/api/mobile-asset-search.server.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.ts
@@ -1,0 +1,44 @@
+import type { Prisma } from "@prisma/client";
+
+/**
+ * Search fragment for the mobile assets list
+ * (routes/api+/mobile+/assets.ts).
+ *
+ * Mirrors the LIGHT branches of the web asset search (`buildFullSearchOr`,
+ * modules/asset/service.server.ts): title, sequentialId, description,
+ * category name and tag names. Every branch rides an existing GIN trigram
+ * index (compound Asset title+description, Category.name, Tag.name — see
+ * migration 20260525110348_add_trigram_indexes_for_simple_search), so no new
+ * index is needed.
+ *
+ * Deliberately still NOT the web search's heavy branches — custodian-name
+ * traversal, custom-fields JSON ILIKE, location names and QR/barcode values.
+ * The first two are slow (relation fan-out + unindexed JSON scan), and codes
+ * are scanned rather than typed on mobile.
+ *
+ * @param search - Raw (already length-capped) search term from the request
+ * @returns A spreadable `Prisma.AssetWhereInput` fragment — `{}` when the
+ *   term is empty, otherwise an `OR` across the searchable fields
+ */
+export function buildMobileAssetSearchWhere(
+  search: string
+): Prisma.AssetWhereInput {
+  if (!search) {
+    return {};
+  }
+
+  const contains = { contains: search, mode: "insensitive" as const };
+
+  return {
+    OR: [
+      { title: contains },
+      // SAM id (e.g. "SAM-0001") — when the workspace display preference is
+      // SAM every asset row shows it, so a typed id must match here.
+      // `sequentialId` is indexed; a normal word term can't false-positive it.
+      { sequentialId: contains },
+      { description: contains },
+      { category: { name: contains } },
+      { tags: { some: { name: contains } } },
+    ],
+  };
+}

--- a/apps/webapp/app/modules/asset/query.server.test.ts
+++ b/apps/webapp/app/modules/asset/query.server.test.ts
@@ -307,6 +307,30 @@ function getSqlString(sql: ReturnType<typeof generateWhereClause>): string {
   return sql.strings.join("?");
 }
 
+describe("generateWhereClause - search fail-closed", () => {
+  const orgId = "org-1";
+
+  it("matches nothing for typed input that yields zero terms", () => {
+    // why: `?s=%20` arrives untrimmed as " " — truthy but zero terms. The
+    // advanced path must fail closed like getAssets does in simple mode,
+    // or the same search box answers differently per index mode.
+    const result = generateWhereClause(orgId, "   ", []);
+    expect(getSqlString(result)).toContain("AND FALSE");
+  });
+
+  it("does not fail closed for a genuinely empty search", () => {
+    const result = generateWhereClause(orgId, null, []);
+    expect(getSqlString(result)).not.toContain("AND FALSE");
+  });
+
+  it("builds search conditions for real terms", () => {
+    const result = generateWhereClause(orgId, "tripod", []);
+    const sql = getSqlString(result);
+    expect(sql).toContain("ILIKE");
+    expect(sql).not.toContain("AND FALSE");
+  });
+});
+
 describe("generateWhereClause - special filter values", () => {
   const orgId = "test-org-id";
 

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -10,6 +10,7 @@ import { Logger } from "~/utils/logger";
 import { isSafeSqlIdentifier } from "~/utils/sql";
 import { parseFilters } from "./filter-parsing";
 import { expandLocationHierarchyFilters } from "./location-filter.server";
+import { CUSTOM_FIELD_SEARCH_PATHS } from "./search.server";
 import type { CustomFieldSorting } from "./types";
 import type { Column } from "../asset-index-settings/helpers";
 
@@ -19,15 +20,6 @@ import type { Column } from "../asset-index-settings/helpers";
  * assets are not incorrectly shown as "in custody".
  */
 const ASSET_IS_CHECKED_OUT = Prisma.sql`a.status = 'CHECKED_OUT'`;
-
-export const CUSTOM_FIELD_SEARCH_PATHS = [
-  "valueText",
-  "valueMultiLineText",
-  "valueOption",
-  "valueDate",
-  "valueBoolean",
-  "raw",
-] as const;
 
 /**
  * Generates the SQL WHERE clause for asset filtering

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -137,6 +137,11 @@ export function generateWhereClause(
         searchConditions,
         " OR "
       )})`;
+    } else {
+      // Typed input yielding zero terms (whitespace / bare commas) matches
+      // nothing — mirrors getAssets' fail-closed guard so the same search
+      // box behaves identically in simple and advanced mode.
+      whereClause = Prisma.sql`${whereClause} AND FALSE`;
     }
   }
 

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -10,7 +10,10 @@ import { Logger } from "~/utils/logger";
 import { isSafeSqlIdentifier } from "~/utils/sql";
 import { parseFilters } from "./filter-parsing";
 import { expandLocationHierarchyFilters } from "./location-filter.server";
-import { CUSTOM_FIELD_SEARCH_PATHS } from "./search.server";
+import {
+  CUSTOM_FIELD_SEARCH_PATHS,
+  splitAssetSearchTerms,
+} from "./search.server";
 import type { CustomFieldSorting } from "./types";
 import type { Column } from "../asset-index-settings/helpers";
 
@@ -64,11 +67,10 @@ export function generateWhereClause(
   }
 
   if (search) {
-    const words = search
-      .trim()
-      .split(",")
-      .map((term) => term.trim())
-      .filter(Boolean);
+    // Shared bounded parser (lowercasing is neutral under ILIKE): caps the
+    // honored terms at MAX_ASSET_SEARCH_TERMS so a malformed comma paste
+    // cannot fan into unbounded OR groups in the generated SQL.
+    const words = splitAssetSearchTerms(search);
 
     if (words.length > 0) {
       // Create OR conditions for each search term, searching across multiple fields

--- a/apps/webapp/app/modules/asset/search.server.test.ts
+++ b/apps/webapp/app/modules/asset/search.server.test.ts
@@ -30,6 +30,11 @@ describe("splitAssetSearchTerms", () => {
     expect(splitAssetSearchTerms("   ")).toEqual([]);
     expect(splitAssetSearchTerms(" , , ")).toEqual([]);
   });
+
+  it("caps the number of honored terms as a query-cost guard", () => {
+    const fifteen = Array.from({ length: 15 }, (_, i) => `term${i}`).join(",");
+    expect(splitAssetSearchTerms(fifteen)).toHaveLength(10);
+  });
 });
 
 describe("looksLikeAssetId", () => {
@@ -61,27 +66,64 @@ describe("buildFullAssetSearchOr", () => {
     // tags, custodian names, QR id, barcode value, custom fields.
     expect(branches).toHaveLength(10);
 
-    const serialized = JSON.stringify(branches);
-    for (const fieldPath of [
-      '"title"',
-      '"sequentialId"',
-      '"description"',
-      '"category"',
-      '"assetLocations"',
-      '"tags"',
-      '"custody"',
-      '"firstName"',
-      '"lastName"',
-      '"qrCodes"',
-      '"barcodes"',
-      '"customFields"',
-    ]) {
-      expect(serialized).toContain(fieldPath);
+    // Walk the clause and collect EVERY substring filter — asserting the
+    // exact count and per-filter mode means losing case-insensitivity on
+    // any single branch fails, unlike a >= floor.
+    const containsFilters: Array<Record<string, unknown>> = [];
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        node.forEach(walk);
+        return;
+      }
+      if (node && typeof node === "object") {
+        const record = node as Record<string, unknown>;
+        if ("contains" in record || "string_contains" in record) {
+          containsFilters.push(record);
+        }
+        Object.values(record).forEach(walk);
+      }
+    };
+    walk(branches);
+
+    // title, sequentialId, description, category.name, location.name,
+    // tag.name, custodian (name + firstName + lastName), qr id, barcode
+    // value, 6 custom-field JSON paths = 17 substring filters.
+    expect(containsFilters).toHaveLength(17);
+    for (const filter of containsFilters) {
+      expect(filter.mode).toBe("insensitive");
+      expect(filter.contains ?? filter.string_contains).toBe("tripod");
     }
 
-    // Every contains-filter is case-insensitive.
-    const modes = serialized.match(/"mode":"insensitive"/g) ?? [];
-    expect(modes.length).toBeGreaterThanOrEqual(10);
+    // Pin the matched COLUMNS structurally, not via substring presence.
+    /* eslint-disable @typescript-eslint/no-explicit-any -- why: intentional
+       deep-path probing of a where-clause literal; per-node types add noise
+       without safety here. */
+    const [
+      title,
+      sequentialId,
+      description,
+      category,
+      location,
+      tags,
+      custody,
+      qrCodes,
+      barcodes,
+      customFields,
+    ] = branches as Array<any>;
+    expect(title.title.contains).toBe("tripod");
+    expect(sequentialId.sequentialId.contains).toBe("tripod");
+    expect(description.description.contains).toBe("tripod");
+    expect(category.category.name.contains).toBe("tripod");
+    expect(location.assetLocations.some.location.name.contains).toBe("tripod");
+    expect(tags.tags.some.name.contains).toBe("tripod");
+    const custodianOr = custody.custody.some.custodian.OR;
+    expect(custodianOr[0].name.contains).toBe("tripod");
+    expect(custodianOr[1].user.OR[0].firstName.contains).toBe("tripod");
+    expect(custodianOr[1].user.OR[1].lastName.contains).toBe("tripod");
+    expect(qrCodes.qrCodes.some.id.contains).toBe("tripod");
+    expect(barcodes.barcodes.some.value.contains).toBe("tripod");
+    expect(customFields.customFields.some.OR).toHaveLength(6);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
   });
 
   it("searches every custom-field value shape", () => {

--- a/apps/webapp/app/modules/asset/search.server.test.ts
+++ b/apps/webapp/app/modules/asset/search.server.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Test suite for the shared simple-mode asset search clause builders.
+ *
+ * These builders are consumed by BOTH the web `getAssets` fetcher and the
+ * mobile assets endpoint, so this suite pins the searchable field set — a
+ * field silently dropped here would degrade search on every surface at once.
+ * Pure module — no mocks needed.
+ *
+ * @see {@link file://./search.server.ts}
+ */
+import {
+  buildFullAssetSearchOr,
+  buildNarrowAssetSearchOr,
+  looksLikeAssetId,
+  splitAssetSearchTerms,
+} from "./search.server";
+
+// @vitest-environment node
+
+describe("splitAssetSearchTerms", () => {
+  it("lowercases, trims, splits on commas and drops empties", () => {
+    expect(splitAssetSearchTerms("  Tripod, Canon EOS ,,")).toEqual([
+      "tripod",
+      "canon eos",
+    ]);
+  });
+
+  it("returns an empty array for empty and whitespace-only input", () => {
+    expect(splitAssetSearchTerms("")).toEqual([]);
+    expect(splitAssetSearchTerms("   ")).toEqual([]);
+    expect(splitAssetSearchTerms(" , , ")).toEqual([]);
+  });
+});
+
+describe("looksLikeAssetId", () => {
+  it("matches bare numerics and canonical sequential ids", () => {
+    expect(looksLikeAssetId("21035")).toBe(true);
+    expect(looksLikeAssetId("123456789012")).toBe(true);
+    expect(looksLikeAssetId("sam-0001")).toBe(true);
+    expect(looksLikeAssetId("SAM-0001")).toBe(true);
+  });
+
+  it("rejects loose word-like terms", () => {
+    expect(looksLikeAssetId("lab-12")).toBe(false); // fewer than 4 digits
+    expect(looksLikeAssetId("AS1000")).toBe(false); // no dash
+    expect(looksLikeAssetId("tripod")).toBe(false);
+    expect(looksLikeAssetId("sam-0001x")).toBe(false);
+  });
+});
+
+describe("buildFullAssetSearchOr", () => {
+  it("builds one OR-group per term", () => {
+    expect(buildFullAssetSearchOr(["a", "b"])).toHaveLength(2);
+  });
+
+  it("covers every searchable field, case-insensitively", () => {
+    const [group] = buildFullAssetSearchOr(["tripod"]);
+    const branches = group.OR ?? [];
+
+    // 10 branches: title, sequentialId, description, category, location,
+    // tags, custodian names, QR id, barcode value, custom fields.
+    expect(branches).toHaveLength(10);
+
+    const serialized = JSON.stringify(branches);
+    for (const fieldPath of [
+      '"title"',
+      '"sequentialId"',
+      '"description"',
+      '"category"',
+      '"assetLocations"',
+      '"tags"',
+      '"custody"',
+      '"firstName"',
+      '"lastName"',
+      '"qrCodes"',
+      '"barcodes"',
+      '"customFields"',
+    ]) {
+      expect(serialized).toContain(fieldPath);
+    }
+
+    // Every contains-filter is case-insensitive.
+    const modes = serialized.match(/"mode":"insensitive"/g) ?? [];
+    expect(modes.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("searches every custom-field value shape", () => {
+    const [group] = buildFullAssetSearchOr(["x"]);
+    const serialized = JSON.stringify(group);
+    for (const jsonPath of [
+      "valueText",
+      "valueMultiLineText",
+      "valueOption",
+      "valueDate",
+      "valueBoolean",
+      "raw",
+    ]) {
+      expect(serialized).toContain(jsonPath);
+    }
+  });
+});
+
+describe("buildNarrowAssetSearchOr", () => {
+  it("builds a flat 5-branch clause per term over the indexed columns", () => {
+    const clauses = buildNarrowAssetSearchOr(["sam-0001", "21035"]);
+    expect(clauses).toHaveLength(10);
+
+    const serialized = JSON.stringify(clauses);
+    for (const fieldPath of [
+      '"sequentialId"',
+      '"barcodes"',
+      '"qrCodes"',
+      '"title"',
+      '"description"',
+    ]) {
+      expect(serialized).toContain(fieldPath);
+    }
+    // The slow paths must NOT be in the narrow clause.
+    for (const heavy of ['"custody"', '"customFields"', '"tags"']) {
+      expect(serialized).not.toContain(heavy);
+    }
+  });
+});

--- a/apps/webapp/app/modules/asset/search.server.ts
+++ b/apps/webapp/app/modules/asset/search.server.ts
@@ -1,5 +1,21 @@
-import type { Prisma } from "@prisma/client";
-import { CUSTOM_FIELD_SEARCH_PATHS } from "./query.server";
+import { AssetStatus, type Prisma } from "@prisma/client";
+
+/**
+ * JSON paths inside `AssetCustomFieldValue.value` that hold searchable text.
+ * Owned here (not `query.server.ts`) so this module stays standalone — it
+ * previously imported the constant from the 2900-line advanced-index module,
+ * which transitively touches `db.server` and made these "pure" builders drag
+ * a database connection into their unit tests. `query.server.ts` imports it
+ * back from here for the advanced-index SQL.
+ */
+export const CUSTOM_FIELD_SEARCH_PATHS = [
+  "valueText",
+  "valueMultiLineText",
+  "valueOption",
+  "valueDate",
+  "valueBoolean",
+  "raw",
+] as const;
 
 /**
  * Single source of truth for the simple-mode asset search clauses.
@@ -17,10 +33,19 @@ import { CUSTOM_FIELD_SEARCH_PATHS } from "./query.server";
  */
 
 /**
+ * Upper bound on comma-separated terms honored per search. Each term adds a
+ * full 10-branch OR group (including the unindexed custom-fields JSON ILIKE),
+ * so an unbounded paste could fan a single request into an arbitrarily
+ * expensive query. Ten is far beyond any real search-box usage.
+ */
+export const MAX_ASSET_SEARCH_TERMS = 10;
+
+/**
  * Splits a raw search string into normalized search terms.
  *
- * Mirrors the historical `getAssets` behavior exactly: lowercase, trim, split
- * on commas (comma = "match any of these"), trim each term, drop empties.
+ * Mirrors the historical `getAssets` behavior: lowercase, trim, split on
+ * commas (comma = "match any of these"), trim each term, drop empties —
+ * capped at {@link MAX_ASSET_SEARCH_TERMS} terms as a query-cost guard.
  *
  * @param search - Raw search string from the request
  * @returns Normalized terms; empty array when nothing searchable remains
@@ -31,7 +56,53 @@ export function splitAssetSearchTerms(search: string): string[] {
     .trim()
     .split(",")
     .map((term) => term.trim())
-    .filter(Boolean);
+    .filter(Boolean)
+    .slice(0, MAX_ASSET_SEARCH_TERMS);
+}
+
+/**
+ * The shared narrow-vs-full policy: a search takes the narrow indexed fast
+ * path only when every term is ID-shaped. Both `getAssets` and the mobile
+ * assets endpoint make this decision through here so the policy cannot
+ * drift between surfaces.
+ *
+ * @param searchTerms - Normalized terms from {@link splitAssetSearchTerms}
+ * @returns true when the caller should query the narrow clause first and
+ *   fall back to the full clause on zero rows
+ */
+export function isIdShapedSearch(searchTerms: string[]): boolean {
+  return searchTerms.length > 0 && searchTerms.every(looksLikeAssetId);
+}
+
+/**
+ * Status fragment shared by every asset list surface.
+ *
+ * AVAILABLE is QT-aware: a QUANTITY_TRACKED row's status flips to
+ * IN_CUSTODY/CHECKED_OUT as soon as ANY unit is allocated even while free
+ * stock remains, so a raw equality filter would hide those rows from an
+ * "Available" view. AVAILABLE therefore matches available INDIVIDUAL rows OR
+ * any QUANTITY_TRACKED row; every other status keeps raw equality (already
+ * truthful for QT rows).
+ *
+ * Callers compose it per their local convention: the AVAILABLE form is an
+ * `OR` group meant to be appended to a `where.AND` (so it cannot collide
+ * with search `OR`s); the equality form can be spread at the top level.
+ *
+ * @param status - A validated `AssetStatus` enum value
+ * @returns A `Prisma.AssetWhereInput` fragment for the status filter
+ */
+export function buildAssetStatusWhere(
+  status: AssetStatus
+): Prisma.AssetWhereInput {
+  if (status === AssetStatus.AVAILABLE) {
+    return {
+      OR: [
+        { type: "INDIVIDUAL", status: AssetStatus.AVAILABLE },
+        { type: "QUANTITY_TRACKED" },
+      ],
+    };
+  }
+  return { status };
 }
 
 /**

--- a/apps/webapp/app/modules/asset/search.server.ts
+++ b/apps/webapp/app/modules/asset/search.server.ts
@@ -1,0 +1,218 @@
+import type { Prisma } from "@prisma/client";
+import { CUSTOM_FIELD_SEARCH_PATHS } from "./query.server";
+
+/**
+ * Single source of truth for the simple-mode asset search clauses.
+ *
+ * Consumed by BOTH:
+ * - the web `getAssets` fetcher (assets index simple mode + every picker that
+ *   goes through it) — see `service.server.ts`, and
+ * - the mobile assets endpoint (`routes/api+/mobile+/assets.ts` via
+ *   `modules/api/mobile-asset-search.server.ts`).
+ *
+ * Change a field here and BOTH surfaces change together — that is the point:
+ * web and mobile search can no longer drift apart field-by-field. The
+ * advanced-mode index searches via raw SQL instead (`query.server.ts`,
+ * `generateWhereClause`) and is deliberately not covered by this module.
+ */
+
+/**
+ * Splits a raw search string into normalized search terms.
+ *
+ * Mirrors the historical `getAssets` behavior exactly: lowercase, trim, split
+ * on commas (comma = "match any of these"), trim each term, drop empties.
+ *
+ * @param search - Raw search string from the request
+ * @returns Normalized terms; empty array when nothing searchable remains
+ */
+export function splitAssetSearchTerms(search: string): string[] {
+  return search
+    .toLowerCase()
+    .trim()
+    .split(",")
+    .map((term) => term.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Matches the shape of an asset identifier or barcode / QR id. Two forms:
+ *   - bare numeric ("21035", or a 12-digit UPC) — users commonly drop the
+ *     prefix when scanning or typing an ID
+ *   - canonical sequential ID ("SAM-0001") — letter prefix + dash + 4+
+ *     digits, matching the format produced by getNextSequentialId
+ *
+ * Used to run ID-shaped queries against the narrow OR clause
+ * ({@link buildNarrowAssetSearchOr}) first, instead of the full 10-branch
+ * chain. The narrow clause skips the slow paths — custodian name traversal
+ * and the unindexed customFields JSON ILIKE — while still covering every
+ * place an ID-shaped value is *most likely* to live.
+ *
+ * Because a bare number can equally be a real barcode OR a value embedded in
+ * a title / description / custom field (indistinguishable by shape), callers
+ * fall back to the full search when the narrow clause returns zero rows — so
+ * nothing is ever silently missed. See the fallback re-query in `getAssets`
+ * and the mobile route's mirror of it.
+ *
+ * Loose terms like "lab-12" or "AS1000" don't match here and go straight to
+ * the full search, since they're more likely substrings of titles, custom
+ * fields, etc.
+ *
+ * @param term - A single normalized search term
+ * @returns true when the term should take the narrow indexed fast path
+ */
+export function looksLikeAssetId(term: string): boolean {
+  return /^\d+$/.test(term) || /^[a-z]+-\d{4,}$/i.test(term);
+}
+
+/**
+ * Full multi-column search clause: matches a term anywhere it can
+ * legitimately live — title, sequentialId, description, category, location,
+ * tags, custodian names, QR/barcode, and custom fields.
+ *
+ * This is the slow path (custodian relation traversal + an unindexed
+ * customFields JSON ILIKE), so for ID-shaped searches callers run
+ * {@link buildNarrowAssetSearchOr} first and only use this when it finds
+ * nothing.
+ *
+ * Returns one `{ OR: [...] }` entry per term; assigning the array to a
+ * where's `OR` makes the terms match-any (comma semantics).
+ *
+ * @param searchTerms - Normalized terms from {@link splitAssetSearchTerms}
+ * @returns One OR-group per term, ready to assign to `where.OR`
+ */
+export function buildFullAssetSearchOr(
+  searchTerms: string[]
+): Prisma.AssetWhereInput[] {
+  return searchTerms.map((term) => ({
+    OR: [
+      // Search in asset fields
+      { title: { contains: term, mode: "insensitive" } },
+      // Search in asset sequential id
+      { sequentialId: { contains: term, mode: "insensitive" } },
+      // Search in asset description
+      { description: { contains: term, mode: "insensitive" } },
+      // Search in related category
+      { category: { name: { contains: term, mode: "insensitive" } } },
+      // Search in related location — traverses the AssetLocation pivot
+      // since an asset can be placed at multiple locations.
+      {
+        assetLocations: {
+          some: {
+            location: {
+              name: { contains: term, mode: "insensitive" },
+            },
+          },
+        },
+      },
+      // Search in related tags
+      {
+        tags: {
+          some: { name: { contains: term, mode: "insensitive" } },
+        },
+      },
+      // Search in custodian names — custody is a list relation, so
+      // traverse it with `some`.
+      {
+        custody: {
+          some: {
+            custodian: {
+              OR: [
+                { name: { contains: term, mode: "insensitive" } },
+                {
+                  user: {
+                    OR: [
+                      {
+                        firstName: {
+                          contains: term,
+                          mode: "insensitive",
+                        },
+                      },
+                      {
+                        lastName: {
+                          contains: term,
+                          mode: "insensitive",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      // Search qr code id
+      {
+        qrCodes: {
+          some: { id: { contains: term, mode: "insensitive" } },
+        },
+      },
+      // Search barcode values
+      {
+        barcodes: {
+          some: { value: { contains: term, mode: "insensitive" } },
+        },
+      },
+      // Search in custom fields
+      {
+        customFields: {
+          some: {
+            OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
+              value: {
+                path: [jsonPath],
+                string_contains: term,
+                mode: "insensitive",
+              },
+            })),
+          },
+        },
+      },
+    ],
+  }));
+}
+
+/**
+ * Narrow indexed fast path for ID-shaped searches: the columns where an
+ * ID-shaped value can legitimately live — sequentialId, barcode value, QR id,
+ * plus title and description. The ID columns are covered by trigram GIN
+ * indexes added in migration 20260525110348, and title/description are
+ * covered by the composite trigram GIN index Asset_title_description_idx —
+ * so the planner stays on indexed scans and a real ID lookup (the common
+ * case) returns immediately.
+ *
+ * title + description are included here (not deferred to the fallback)
+ * because a bare-numeric term often lives ONLY inside a title — e.g.
+ * searching "451" must match "KCI-451 Kids Resources Box". Without these
+ * branches the narrow query can still return rows (some OTHER asset matches
+ * "451" in an ID column), which suppresses the zero-row fallback and
+ * silently drops the title-only match.
+ *
+ * Callers must still fall back to {@link buildFullAssetSearchOr} on zero
+ * rows so the remaining slow-path columns (custodian names,
+ * category/location/tags, custom-field JSON ILIKE) stay covered.
+ *
+ * @param searchTerms - Normalized terms from {@link splitAssetSearchTerms}
+ * @returns A flat OR list covering every term, ready to assign to `where.OR`
+ */
+export function buildNarrowAssetSearchOr(
+  searchTerms: string[]
+): Prisma.AssetWhereInput[] {
+  return searchTerms.flatMap((term) => [
+    { sequentialId: { contains: term, mode: "insensitive" } },
+    {
+      barcodes: {
+        some: { value: { contains: term, mode: "insensitive" } },
+      },
+    },
+    {
+      qrCodes: {
+        some: { id: { contains: term, mode: "insensitive" } },
+      },
+    },
+    // Trigram-indexed (Asset_title_description_idx) — matches a
+    // bare-numeric substring embedded in a title/description directly
+    // in the fast path, without relying on the zero-row fallback.
+    { title: { contains: term, mode: "insensitive" } },
+    { description: { contains: term, mode: "insensitive" } },
+  ]);
+}

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -3809,6 +3809,19 @@ describe("getAssets search fallback", () => {
     countMock.mockReset();
   });
 
+  it("matches nothing for typed input that yields zero terms", async () => {
+    // why: whitespace / bare-comma input must not return the full list —
+    // mirrors the mobile composer's fail-closed guard.
+    findManyMock.mockResolvedValueOnce([] as never);
+    countMock.mockResolvedValueOnce(0 as never);
+
+    await getAssets({ ...baseParams, search: " , " });
+
+    const where = (findManyMock.mock.calls[0][0] as any).where;
+    expect(where.id).toEqual({ in: [] });
+    expect(where.OR).toBeUndefined();
+  });
+
   it("runs only the narrow indexed clause when an ID-shaped query matches", async () => {
     // why: first (and only) fetch returns a row, so no fallback is needed.
     findManyMock.mockResolvedValueOnce([{ id: "a1" }] as never);

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -649,7 +649,12 @@ export async function getAssets(params: {
     if (search) {
       const searchTerms = splitAssetSearchTerms(search);
 
-      if (searchTerms.length > 0) {
+      if (searchTerms.length === 0) {
+        // Typed input that yields zero terms (whitespace / bare commas)
+        // matches NOTHING — a debounced type-ahead sending a single space
+        // must not return the full list. Mirrors the mobile composer.
+        where.id = { in: [] };
+      } else {
         // Full multi-column clause (title, sequentialId, description,
         // category, location, tags, custodian names, QR/barcode, custom
         // fields) — shared with the mobile assets endpoint via

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -151,12 +151,17 @@ import type {
 } from "./move-units.types";
 import { validateQtyTrackedFields } from "./qty-validation.server";
 import {
-  CUSTOM_FIELD_SEARCH_PATHS,
   buildAdvancedAssetsQuery,
   generateWhereClause,
   parseFiltersWithHierarchy,
   parseSortingOptions,
 } from "./query.server";
+import {
+  buildFullAssetSearchOr,
+  buildNarrowAssetSearchOr,
+  looksLikeAssetId,
+  splitAssetSearchTerms,
+} from "./search.server";
 import { getNextSequentialId } from "./sequential-id.server";
 import type {
   AdvancedIndexAsset,
@@ -566,33 +571,6 @@ const unavailableBookingStatuses = [
 ];
 
 /**
- * Matches the shape of an asset identifier or barcode / QR id. Two forms:
- *   - bare numeric ("21035", or a 12-digit UPC) — users commonly drop the
- *     prefix when scanning or typing an ID
- *   - canonical sequential ID ("SAM-0001") — letter prefix + dash + 4+
- *     digits, matching the format produced by getNextSequentialId
- *
- * Used by getAssets to run ID-shaped queries against a narrower OR clause
- * (sequentialId / barcodes.value / qrCodes.id) first, instead of the full
- * 10-branch chain. The narrower clause skips the slow paths — custodian
- * name traversal and the unindexed customFields JSON ILIKE — while still
- * covering every place an ID-shaped value is *most likely* to live.
- *
- * Because a bare number can equally be a real barcode OR a value embedded
- * in a title / description / custom field (indistinguishable by shape),
- * getAssets falls back to the full search when this narrow clause returns
- * zero rows — so nothing is ever silently missed. See the fallback re-query
- * in {@link getAssets}.
- *
- * Loose terms like "lab-12" or "AS1000" don't match here and go straight to
- * the full search, since they're more likely substrings of titles, custom
- * fields, etc.
- */
-function looksLikeAssetId(term: string): boolean {
-  return /^\d+$/.test(term) || /^[a-z]+-\d{4,}$/i.test(term);
-}
-
-/**
  * Fetches assets directly from the asset table with enhanced search capabilities
  * @param params Search and filtering parameters for asset queries
  * @returns Assets and total count matching the criteria
@@ -668,150 +646,26 @@ export async function getAssets(params: {
     }
 
     if (search) {
-      const searchTerms = search
-        .toLowerCase()
-        .trim()
-        .split(",")
-        .map((term) => term.trim())
-        .filter(Boolean);
+      const searchTerms = splitAssetSearchTerms(search);
 
       if (searchTerms.length > 0) {
-        // Builder for the full multi-column clause: matches a term anywhere it
-        // can legitimately live — title, sequentialId, description, category,
-        // location, tags, custodian names, QR/barcode, and custom fields. It
-        // is the slow path (custodian relation traversal + an unindexed
-        // customFields JSON ILIKE), so for ID-shaped searches we run the
-        // narrow clause first and only build/use this when it finds nothing
-        // (see the fallback re-query further down). Defined as a closure so the
-        // clause is constructed only when actually needed.
-        buildFullSearchOr = () =>
-          searchTerms.map((term) => ({
-            OR: [
-              // Search in asset fields
-              { title: { contains: term, mode: "insensitive" } },
-              // Search in asset sequential id
-              { sequentialId: { contains: term, mode: "insensitive" } },
-              // Search in asset description
-              { description: { contains: term, mode: "insensitive" } },
-              // Search in related category
-              { category: { name: { contains: term, mode: "insensitive" } } },
-              // Search in related location — traverses the AssetLocation pivot
-              // since an asset can be placed at multiple locations.
-              {
-                assetLocations: {
-                  some: {
-                    location: {
-                      name: { contains: term, mode: "insensitive" },
-                    },
-                  },
-                },
-              },
-              // Search in related tags
-              {
-                tags: {
-                  some: { name: { contains: term, mode: "insensitive" } },
-                },
-              },
-              // Search in custodian names — custody is a list relation, so
-              // traverse it with `some`.
-              {
-                custody: {
-                  some: {
-                    custodian: {
-                      OR: [
-                        { name: { contains: term, mode: "insensitive" } },
-                        {
-                          user: {
-                            OR: [
-                              {
-                                firstName: {
-                                  contains: term,
-                                  mode: "insensitive",
-                                },
-                              },
-                              {
-                                lastName: {
-                                  contains: term,
-                                  mode: "insensitive",
-                                },
-                              },
-                            ],
-                          },
-                        },
-                      ],
-                    },
-                  },
-                },
-              },
-              // Search qr code id
-              {
-                qrCodes: {
-                  some: { id: { contains: term, mode: "insensitive" } },
-                },
-              },
-              // Search barcode values
-              {
-                barcodes: {
-                  some: { value: { contains: term, mode: "insensitive" } },
-                },
-              },
-              // Search in custom fields
-              {
-                customFields: {
-                  some: {
-                    OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
-                      value: {
-                        path: [jsonPath],
-                        string_contains: term,
-                        mode: "insensitive",
-                      },
-                    })),
-                  },
-                },
-              },
-            ],
-          }));
+        // Full multi-column clause (title, sequentialId, description,
+        // category, location, tags, custodian names, QR/barcode, custom
+        // fields) — shared with the mobile assets endpoint via
+        // modules/asset/search.server.ts so web and mobile search can't
+        // drift apart. It is the slow path, so for ID-shaped searches we run
+        // the narrow clause first and only build/use this when it finds
+        // nothing (see the fallback re-query further down). Kept as a
+        // closure so the clause is constructed only when actually needed.
+        buildFullSearchOr = () => buildFullAssetSearchOr(searchTerms);
 
-        // Fast path: when every term looks like an asset identifier — either
-        // bare digits ("21035", a UPC barcode) or canonical sequentialId
-        // ("SAM-0001") — narrow the OR clause to the columns where an
-        // ID-shaped value can legitimately live: sequentialId, barcode value,
-        // QR id, plus title and description. The ID columns are covered by
-        // trigram GIN indexes added in migration 20260525110348, and
-        // title/description are covered by the composite trigram GIN index
-        // Asset_title_description_idx — so the planner stays on indexed scans
-        // and a real ID lookup (the common case) returns immediately.
-        //
-        // title + description are included here (not deferred to the fallback)
-        // because a bare-numeric term often lives ONLY inside a title — e.g.
-        // searching "451" must match "KCI-451 Kids Resources Box". Without
-        // these branches the narrow query can still return rows (some OTHER
-        // asset matches "451" in an ID column), which suppresses the
-        // zero-row fallback and silently drops the title-only match.
-        //
-        // The fallback flag stays set so the remaining slow-path columns
-        // (custodian names, category/location/tags, custom-field JSON ILIKE)
-        // are still covered when this clause returns zero rows.
+        // Fast path for ID-shaped terms: narrow indexed clause first, full
+        // clause only when it returns zero rows (fallback re-query below).
+        // Column choice + rationale live on buildNarrowAssetSearchOr in
+        // modules/asset/search.server.ts.
         if (searchTerms.every(looksLikeAssetId)) {
           shouldFallbackToFullSearch = true;
-          where.OR = searchTerms.flatMap((term) => [
-            { sequentialId: { contains: term, mode: "insensitive" } },
-            {
-              barcodes: {
-                some: { value: { contains: term, mode: "insensitive" } },
-              },
-            },
-            {
-              qrCodes: {
-                some: { id: { contains: term, mode: "insensitive" } },
-              },
-            },
-            // Trigram-indexed (Asset_title_description_idx) — matches a
-            // bare-numeric substring embedded in a title/description directly
-            // in the fast path, without relying on the zero-row fallback.
-            { title: { contains: term, mode: "insensitive" } },
-            { description: { contains: term, mode: "insensitive" } },
-          ]);
+          where.OR = buildNarrowAssetSearchOr(searchTerms);
           // Remember how many entries belong to the search so the fallback can
           // swap them out without disturbing filter clauses appended later.
           narrowSearchOrCount = where.OR.length;

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -157,9 +157,10 @@ import {
   parseSortingOptions,
 } from "./query.server";
 import {
+  buildAssetStatusWhere,
   buildFullAssetSearchOr,
   buildNarrowAssetSearchOr,
-  looksLikeAssetId,
+  isIdShapedSearch,
   splitAssetSearchTerms,
 } from "./search.server";
 import { getNextSequentialId } from "./sequential-id.server";
@@ -663,7 +664,7 @@ export async function getAssets(params: {
         // clause only when it returns zero rows (fallback re-query below).
         // Column choice + rationale live on buildNarrowAssetSearchOr in
         // modules/asset/search.server.ts.
-        if (searchTerms.every(looksLikeAssetId)) {
+        if (isIdShapedSearch(searchTerms)) {
           shouldFallbackToFullSearch = true;
           where.OR = buildNarrowAssetSearchOr(searchTerms);
           // Remember how many entries belong to the search so the fallback can
@@ -686,18 +687,15 @@ export async function getAssets(params: {
       // truthful for qty-tracked — the row enters those states whenever ANY
       // unit does).
       if (status === AssetStatus.AVAILABLE) {
+        // QT-aware fragment shared with getAssetsWhereInput and the mobile
+        // assets endpoint — see buildAssetStatusWhere for the rationale.
         where.AND = [
           ...(Array.isArray(where.AND)
             ? where.AND
             : where.AND
             ? [where.AND]
             : []),
-          {
-            OR: [
-              { type: "INDIVIDUAL", status: AssetStatus.AVAILABLE },
-              { type: "QUANTITY_TRACKED" },
-            ],
-          },
+          buildAssetStatusWhere(status),
         ];
       } else {
         where.status = status;

--- a/apps/webapp/app/modules/asset/utils.server.ts
+++ b/apps/webapp/app/modules/asset/utils.server.ts
@@ -10,6 +10,7 @@ import _ from "lodash";
 import { z } from "zod";
 import type { Filter } from "~/components/assets/assets-index/advanced-filters/schema";
 import { filterOperatorSchema } from "~/components/assets/assets-index/advanced-filters/schema";
+import { buildAssetStatusWhere } from "~/modules/asset/search.server";
 import { formatUnitCount } from "~/utils/asset-quantity";
 import { getCustomFieldDisplayValue } from "~/utils/custom-fields";
 import { getParamsValues } from "~/utils/list";
@@ -552,18 +553,15 @@ export function getAssetsWhereInput({
     // status flipped to IN_CUSTODY/CHECKED_OUT can still have available
     // units, so AVAILABLE filter must include them.
     if (status === "AVAILABLE") {
+      // QT-aware fragment shared with getAssets and the mobile assets
+      // endpoint — see buildAssetStatusWhere for the rationale.
       where.AND = [
         ...(Array.isArray(where.AND)
           ? where.AND
           : where.AND
           ? [where.AND]
           : []),
-        {
-          OR: [
-            { type: "INDIVIDUAL", status: "AVAILABLE" },
-            { type: "QUANTITY_TRACKED" },
-          ],
-        },
+        buildAssetStatusWhere(status),
       ];
     } else {
       where.status = status;

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -7,7 +7,8 @@ import {
   requireOrganizationAccess,
   shapeMobileAssetResponse,
 } from "~/modules/api/mobile-auth.server";
-import { makeShelfError } from "~/utils/error";
+import { buildAssetStatusWhere } from "~/modules/asset/search.server";
+import { makeShelfError, ShelfError } from "~/utils/error";
 
 /**
  * GET /api/mobile/assets?orgId=xxx&search=xxx&page=1&perPage=20&myCustody=true&status=IN_CUSTODY
@@ -53,6 +54,28 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const myCustody = url.searchParams.get("myCustody") === "true";
     const statusFilter = url.searchParams.get("status");
 
+    // An unknown status must fail loudly: silently dropping the filter
+    // would return the entire unfiltered list under what the client
+    // believes is a filtered request, and letting it through to Prisma
+    // used to crash with a 500. 400 matches the validation contract of
+    // the mobile mutation routes.
+    if (
+      statusFilter &&
+      !(Object.values(AssetStatus) as string[]).includes(statusFilter)
+    ) {
+      throw new ShelfError({
+        cause: null,
+        message: `Invalid status filter: ${statusFilter}`,
+        additionalData: { statusFilter },
+        label: "Assets",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+    const statusWhere = statusFilter
+      ? buildAssetStatusWhere(statusFilter as AssetStatus)
+      : null;
+
     const baseWhere: Prisma.AssetWhereInput = {
       organizationId,
       ...(myCustody
@@ -71,35 +94,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
             },
           }
         : {}),
-      // Only pass through real enum values — an unknown status string used
-      // to reach Prisma and 500; now it simply doesn't filter. Checked via
-      // `Object.values` (not `in`) so prototype-chain keys like "toString"
-      // can't slip through.
-      //
-      // AVAILABLE is QT-aware, mirroring `getAssets`: a QUANTITY_TRACKED
-      // row's status flips to IN_CUSTODY/CHECKED_OUT as soon as ANY unit is
-      // allocated even while free stock remains, so raw equality would hide
-      // those rows from the Available pill. AVAILABLE therefore matches
-      // available INDIVIDUAL rows OR any QUANTITY_TRACKED row; the other
-      // statuses keep raw equality (already truthful for QT rows). Kept in
-      // `AND` so it composes with the search fragment's `OR`.
-      ...(statusFilter &&
-      (Object.values(AssetStatus) as string[]).includes(statusFilter)
-        ? statusFilter === AssetStatus.AVAILABLE
-          ? {
-              AND: [
-                {
-                  OR: [
-                    {
-                      type: "INDIVIDUAL" as const,
-                      status: AssetStatus.AVAILABLE,
-                    },
-                    { type: "QUANTITY_TRACKED" as const },
-                  ],
-                },
-              ],
-            }
-          : { status: statusFilter as AssetStatus }
+      // Status delegates to the QT-aware fragment shared with getAssets
+      // and getAssetsWhereInput (see buildAssetStatusWhere). The AVAILABLE
+      // form is an OR group, so it rides in `AND` to compose with the
+      // search fragment's `OR`; the equality form spreads at the top level.
+      ...(statusWhere
+        ? statusWhere.OR
+          ? { AND: [statusWhere] }
+          : statusWhere
         : {}),
     };
 
@@ -134,6 +136,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
             minQuantity: true,
             unitOfMeasure: true,
             consumptionType: true,
+            // Canonical MOBILE_ASSET_SELECT parity — this list select had
+            // drifted (the detail endpoint already returns it).
+            assetModelId: true,
             // Keep `id` (list extra); helper only types `{ name }` but
             // structurally accepts the wider shape.
             category: { select: { id: true, name: true } },
@@ -166,7 +171,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
               },
             },
           },
-          orderBy: { createdAt: "desc" },
+          // Stable `id` tiebreaker for deterministic skip/take paging when
+          // rows tie on createdAt (bulk-imported assets share timestamps
+          // down to the millisecond) — mirrors getAssets.
+          orderBy: [{ createdAt: "desc" as const }, { id: "asc" as const }],
           skip,
           take: perPage,
         }),

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -1,3 +1,4 @@
+import { AssetStatus, type Prisma } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import { buildMobileAssetSearchWhere } from "~/modules/api/mobile-asset-search.server";
@@ -15,6 +16,11 @@ import { makeShelfError } from "~/utils/error";
  * Optional filters:
  *   - myCustody=true  → only assets in the current user's custody
  *   - status=X         → filter by asset status (e.g. AVAILABLE, IN_CUSTODY, CHECKED_OUT)
+ *
+ * Search matches the same fields as the web asset search — the clause comes
+ * from the shared builder (modules/asset/search.server.ts via
+ * modules/api/mobile-asset-search.server.ts), including web's ID-shaped
+ * fast path + zero-row full-clause fallback.
  *
  * Image URLs are returned as-stored along with `mainImageExpiration`. Mobile
  * clients should call `/api/mobile/asset/refresh-image/:assetId` lazily when
@@ -47,12 +53,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const myCustody = url.searchParams.get("myCustody") === "true";
     const statusFilter = url.searchParams.get("status");
 
-    const where: Record<string, unknown> = {
+    const baseWhere: Prisma.AssetWhereInput = {
       organizationId,
-      // Which fields match (title, SAM id, description, category, tags) and
-      // which web branches stay deliberately excluded is documented on the
-      // builder — see modules/api/mobile-asset-search.server.ts.
-      ...buildMobileAssetSearchWhere(search),
       ...(myCustody
         ? {
             // Phase 2/4 widened `Asset.custody` from 1:1 to 1:many for
@@ -69,74 +71,92 @@ export async function loader({ request }: LoaderFunctionArgs) {
             },
           }
         : {}),
-      ...(statusFilter ? { status: statusFilter } : {}),
+      // Only pass through real enum values — an unknown status string used
+      // to reach Prisma and 500; now it simply doesn't filter.
+      ...(statusFilter && statusFilter in AssetStatus
+        ? { status: statusFilter as AssetStatus }
+        : {}),
     };
 
-    const [assets, totalCount] = await Promise.all([
-      db.asset.findMany({
-        where,
-        // Mirrors `MOBILE_ASSET_SELECT` (the canonical shape consumed by
-        // `shapeMobileAssetResponse`) PLUS list-only extras the companion
-        // already consumes: `mainImageExpiration` (drives the lazy
-        // refresh-image flow), `thumbnailImage`, and `category.id`. Keeping
-        // these here — rather than narrowing to `MOBILE_ASSET_SELECT` —
-        // preserves the legacy list-response contract for the in-App-Store
-        // companion (since 2026-05-20).
-        select: {
-          id: true,
-          title: true,
-          status: true,
-          mainImage: true,
-          mainImageExpiration: true,
-          thumbnailImage: true,
-          // why: powers the scan-to-booking "not available to book" blocker.
-          availableToBook: true,
-          // Quantity fields (additive) — mirror `MOBILE_ASSET_SELECT` so the
-          // helper's now-required quantity scalars are satisfied and the
-          // companion list can DISPLAY quantity. Null for INDIVIDUAL assets.
-          type: true,
-          quantity: true,
-          minQuantity: true,
-          unitOfMeasure: true,
-          consumptionType: true,
-          // Keep `id` (list extra); helper only types `{ name }` but
-          // structurally accepts the wider shape.
-          category: { select: { id: true, name: true } },
-          // Kit linkage via the AssetKit pivot — flattened to top-level
-          // `kit` + `kitId` by `shapeMobileAssetResponse`.
-          assetKits: {
-            select: { kit: { select: { id: true, name: true } } },
-          },
-          // Location via the AssetLocation pivot — flattened to top-level
-          // `location` by the helper.
-          assetLocations: {
-            select: { location: { select: { id: true, name: true } } },
-          },
-          // Custody is now 1:many (Phase 2/4); helper flattens `custody[0]`
-          // so the companion's single-or-null `asset.custody?.custodian`
-          // read keeps working. `quantity` feeds the helper's many-aware
-          // `custodyList`.
-          custody: {
-            // Oldest-first so the flattened single custody + custodyList are
-            // deterministic (the relation is otherwise unordered).
-            orderBy: { createdAt: "asc" as const },
-            select: {
-              quantity: true,
-              // why: operator-vs-kit discriminator for `releasableQuantity`.
-              kitCustodyId: true,
-              custodian: {
-                // why: `userId` lets the app recognize the caller's own row.
-                select: { id: true, name: true, userId: true },
+    const { primary, fallback } = buildMobileAssetSearchWhere(search);
+
+    /** Fetches one page + total count for the given where clause. */
+    const fetchPage = (where: Prisma.AssetWhereInput) =>
+      Promise.all([
+        db.asset.findMany({
+          where,
+          // Mirrors `MOBILE_ASSET_SELECT` (the canonical shape consumed by
+          // `shapeMobileAssetResponse`) PLUS list-only extras the companion
+          // already consumes: `mainImageExpiration` (drives the lazy
+          // refresh-image flow), `thumbnailImage`, and `category.id`. Keeping
+          // these here — rather than narrowing to `MOBILE_ASSET_SELECT` —
+          // preserves the legacy list-response contract for the in-App-Store
+          // companion (since 2026-05-20).
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            mainImage: true,
+            mainImageExpiration: true,
+            thumbnailImage: true,
+            // why: powers the scan-to-booking "not available to book" blocker.
+            availableToBook: true,
+            // Quantity fields (additive) — mirror `MOBILE_ASSET_SELECT` so the
+            // helper's now-required quantity scalars are satisfied and the
+            // companion list can DISPLAY quantity. Null for INDIVIDUAL assets.
+            type: true,
+            quantity: true,
+            minQuantity: true,
+            unitOfMeasure: true,
+            consumptionType: true,
+            // Keep `id` (list extra); helper only types `{ name }` but
+            // structurally accepts the wider shape.
+            category: { select: { id: true, name: true } },
+            // Kit linkage via the AssetKit pivot — flattened to top-level
+            // `kit` + `kitId` by `shapeMobileAssetResponse`.
+            assetKits: {
+              select: { kit: { select: { id: true, name: true } } },
+            },
+            // Location via the AssetLocation pivot — flattened to top-level
+            // `location` by the helper.
+            assetLocations: {
+              select: { location: { select: { id: true, name: true } } },
+            },
+            // Custody is now 1:many (Phase 2/4); helper flattens `custody[0]`
+            // so the companion's single-or-null `asset.custody?.custodian`
+            // read keeps working. `quantity` feeds the helper's many-aware
+            // `custodyList`.
+            custody: {
+              // Oldest-first so the flattened single custody + custodyList are
+              // deterministic (the relation is otherwise unordered).
+              orderBy: { createdAt: "asc" as const },
+              select: {
+                quantity: true,
+                // why: operator-vs-kit discriminator for `releasableQuantity`.
+                kitCustodyId: true,
+                custodian: {
+                  // why: `userId` lets the app recognize the caller's own row.
+                  select: { id: true, name: true, userId: true },
+                },
               },
             },
           },
-        },
-        orderBy: { createdAt: "desc" },
-        skip,
-        take: perPage,
-      }),
-      db.asset.count({ where }),
-    ]);
+          orderBy: { createdAt: "desc" },
+          skip,
+          take: perPage,
+        }),
+        db.asset.count({ where }),
+      ]);
+
+    let [assets, totalCount] = await fetchPage({ ...baseWhere, ...primary });
+
+    // An ID-shaped search ran the narrow clause but matched no assets. The
+    // term may be embedded in a title, description, or custom field rather
+    // than being a real identifier, so re-run with the full search clause
+    // before giving up — mirrors the fallback re-query in `getAssets`.
+    if (totalCount === 0 && fallback) {
+      [assets, totalCount] = await fetchPage({ ...baseWhere, ...fallback });
+    }
 
     // Flatten kit/location/custody pivots into the legacy flat shape via the
     // shared helper, then re-attach the list-only extras

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -1,5 +1,6 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
+import { buildMobileAssetSearchWhere } from "~/modules/api/mobile-asset-search.server";
 import {
   requireMobileAuth,
   requireOrganizationAccess,
@@ -48,26 +49,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
     const where: Record<string, unknown> = {
       organizationId,
-      // Match on title OR sequentialId (SAM id, e.g. "SAM-0001"). When the
-      // workspace display preference is SAM, every asset row shows its SAM id,
-      // so a user typing that number must be able to find it here. Mirrors the
-      // web search's sequentialId branch (modules/asset/service.server.ts) but
-      // intentionally NOT the heavy branches (custodian-name traversal,
-      // custom-fields JSON) — those are slow and low-value on mobile.
-      // `sequentialId` is indexed; a normal word term can't false-positive it.
-      ...(search
-        ? {
-            OR: [
-              { title: { contains: search, mode: "insensitive" as const } },
-              {
-                sequentialId: {
-                  contains: search,
-                  mode: "insensitive" as const,
-                },
-              },
-            ],
-          }
-        : {}),
+      // Which fields match (title, SAM id, description, category, tags) and
+      // which web branches stay deliberately excluded is documented on the
+      // builder — see modules/api/mobile-asset-search.server.ts.
+      ...buildMobileAssetSearchWhere(search),
       ...(myCustody
         ? {
             // Phase 2/4 widened `Asset.custody` from 1:1 to 1:many for

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -72,8 +72,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
           }
         : {}),
       // Only pass through real enum values — an unknown status string used
-      // to reach Prisma and 500; now it simply doesn't filter.
-      ...(statusFilter && statusFilter in AssetStatus
+      // to reach Prisma and 500; now it simply doesn't filter. Checked via
+      // `Object.values` (not `in`) so prototype-chain keys like "toString"
+      // can't slip through.
+      ...(statusFilter &&
+      (Object.values(AssetStatus) as string[]).includes(statusFilter)
         ? { status: statusFilter as AssetStatus }
         : {}),
     };

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -75,9 +75,31 @@ export async function loader({ request }: LoaderFunctionArgs) {
       // to reach Prisma and 500; now it simply doesn't filter. Checked via
       // `Object.values` (not `in`) so prototype-chain keys like "toString"
       // can't slip through.
+      //
+      // AVAILABLE is QT-aware, mirroring `getAssets`: a QUANTITY_TRACKED
+      // row's status flips to IN_CUSTODY/CHECKED_OUT as soon as ANY unit is
+      // allocated even while free stock remains, so raw equality would hide
+      // those rows from the Available pill. AVAILABLE therefore matches
+      // available INDIVIDUAL rows OR any QUANTITY_TRACKED row; the other
+      // statuses keep raw equality (already truthful for QT rows). Kept in
+      // `AND` so it composes with the search fragment's `OR`.
       ...(statusFilter &&
       (Object.values(AssetStatus) as string[]).includes(statusFilter)
-        ? { status: statusFilter as AssetStatus }
+        ? statusFilter === AssetStatus.AVAILABLE
+          ? {
+              AND: [
+                {
+                  OR: [
+                    {
+                      type: "INDIVIDUAL" as const,
+                      status: AssetStatus.AVAILABLE,
+                    },
+                    { type: "QUANTITY_TRACKED" as const },
+                  ],
+                },
+              ],
+            }
+          : { status: statusFilter as AssetStatus }
         : {}),
     };
 

--- a/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
@@ -214,6 +214,7 @@ describe("GET /api/mobile/assets — status filter", () => {
       (response.data as { error: { message: string } }).error.message
     ).toContain("Invalid status filter");
     expect(findManyMock).not.toHaveBeenCalled();
+    expect(countMock).not.toHaveBeenCalled();
   });
 
   it("makes AVAILABLE QT-aware via the shared fragment", async () => {

--- a/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
@@ -194,3 +194,136 @@ describe("GET /api/mobile/assets", () => {
     });
   });
 });
+
+describe("GET /api/mobile/assets — status filter", () => {
+  it("returns 400 for an unknown status instead of silently unfiltering", async () => {
+    // Regression: an unrecognized status used to reach Prisma and 500;
+    // a later guard silently dropped the filter, which returned the FULL
+    // list under what the client believes is a filtered request. The
+    // contract is a loud 400.
+    const args = createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/assets?status=toString"
+      ),
+    });
+
+    const response = await loader(args);
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(400);
+    expect(
+      (response.data as { error: { message: string } }).error.message
+    ).toContain("Invalid status filter");
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("makes AVAILABLE QT-aware via the shared fragment", async () => {
+    // A QUANTITY_TRACKED row's status flips as soon as ANY unit is
+    // allocated even while free stock remains — raw equality would hide it
+    // from the Available pill. Mirrors getAssets.
+    const args = createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/assets?status=AVAILABLE"
+      ),
+    });
+
+    await loader(args);
+
+    const where = findManyMock.mock.calls[0]![0]!.where!;
+    expect(where.AND).toEqual([
+      {
+        OR: [
+          { type: "INDIVIDUAL", status: "AVAILABLE" },
+          { type: "QUANTITY_TRACKED" },
+        ],
+      },
+    ]);
+    expect(where).not.toHaveProperty("status");
+  });
+
+  it("keeps raw equality for non-AVAILABLE statuses", async () => {
+    const args = createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/assets?status=IN_CUSTODY"
+      ),
+    });
+
+    await loader(args);
+
+    const where = findManyMock.mock.calls[0]![0]!.where!;
+    expect(where).toMatchObject({ status: "IN_CUSTODY" });
+    expect(where).not.toHaveProperty("AND");
+  });
+});
+
+describe("GET /api/mobile/assets — search", () => {
+  it("re-queries with the full clause when an ID-shaped search matches nothing", async () => {
+    // The only two-query sequence in this loader. A regression here is
+    // silent (users just get zero results — the exact complaint that
+    // opened this ticket), so pin the mechanism: narrow first, full on
+    // zero rows, mirroring getAssets' fallback.
+    countMock.mockResolvedValueOnce(0).mockResolvedValueOnce(2);
+
+    const args = createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/assets?search=SAM-0001"
+      ),
+    });
+
+    await loader(args);
+
+    expect(findManyMock).toHaveBeenCalledTimes(2);
+    const first = findManyMock.mock.calls[0]![0]!.where!;
+    const second = findManyMock.mock.calls[1]![0]!.where!;
+    // Narrow clause: flat OR over the 5 indexed columns.
+    expect(first.OR).toHaveLength(5);
+    expect(JSON.stringify(first)).not.toContain("customFields");
+    // Full clause: one 10-branch group per term, heavy branches included.
+    expect(second.OR).toHaveLength(1);
+    const fullGroup = (second.OR as Array<{ OR: unknown[] }>)[0]!;
+    expect(fullGroup.OR).toHaveLength(10);
+    expect(JSON.stringify(second)).toContain("customFields");
+  });
+
+  it("does not re-query when the narrow ID search finds rows", async () => {
+    countMock.mockResolvedValueOnce(3);
+
+    const args = createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/assets?search=21035"
+      ),
+    });
+
+    await loader(args);
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches nothing (not everything) for whitespace/comma-only search", async () => {
+    // In a debounced type-ahead a single typed space must not flash the
+    // full unfiltered list.
+    const args = createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/assets?search=%20%2C%20"
+      ),
+    });
+
+    await loader(args);
+
+    expect(findManyMock).toHaveBeenCalledTimes(1);
+    const where = findManyMock.mock.calls[0]![0]!.where!;
+    expect(where).toMatchObject({ id: { in: [] } });
+  });
+
+  it("pages deterministically with an id tiebreaker", async () => {
+    const args = createLoaderArgs({
+      request: new Request("http://localhost:3000/api/mobile/assets"),
+    });
+
+    await loader(args);
+
+    expect(findManyMock.mock.calls[0]![0]!.orderBy).toEqual([
+      { createdAt: "desc" },
+      { id: "asc" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

A customer reported (2026-08-08, iOS): *"searching asset by tag and description is not working on the ios app."*

It isn't a client bug — the mobile assets endpoint (`GET /api/mobile/assets`) matched **`title` + `sequentialId` only**, while the web asset search matches description, category, location, tags, custodian names, codes and custom fields. Users trained on the web search type a description or tag term on the phone and read the silent zero-result list as broken search.

## Change

Rather than bolting extra fields onto the mobile clause (where they would drift from web again), the web search clause itself is now shared:

- **`modules/asset/search.server.ts`** — the single source of truth for the simple-mode search clauses, extracted **verbatim** from `getAssets`: `splitAssetSearchTerms` (capped at 10 terms), `looksLikeAssetId` + `isIdShapedSearch` (the shared narrow-vs-full policy), `buildFullAssetSearchOr` (10-branch full clause), `buildNarrowAssetSearchOr` (indexed ID fast path), and `buildAssetStatusWhere` (the QT-aware status rule). It owns `CUSTOM_FIELD_SEARCH_PATHS` so the module is standalone (`query.server.ts` imports it back).
- **`getAssets` and `getAssetsWhereInput`** delegate to the shared builders — including the QT-aware `AVAILABLE` rule, which previously existed as two hand-copies and would have become three with this PR's mobile change. All three call sites now share one implementation.
- **`modules/api/mobile-asset-search.server.ts`** composes the same builders for mobile and returns `{ primary, fallback }`.
- **`routes/api+/mobile+/assets.ts`** runs the primary clause and mirrors web's fallback re-query: an ID-shaped search that matches nothing re-runs with the full clause. The `where` is typed `Prisma.AssetWhereInput`. Unknown `status` values 400 loudly. Paging gains the `id` tiebreaker `getAssets` already has, and the list select regains `assetModelId` (canonical `MOBILE_ASSET_SELECT` parity).

Mobile search now matches **exactly** what web search matches — title, SAM id, description, category, location, tags, custodian names, QR ids, barcode values, custom fields — with the same comma-separated multi-term semantics and the same ID-shaped fast-path strategy. Any future change to the shared clause reaches both surfaces at once.

## Behavior changes (server-side — reach shipped installs on deploy)

1. **Search fields widen to full web parity** (the point of the PR). Comma now means "match any of these" on mobile, matching web.
2. **`status=AVAILABLE` is QT-aware** like `getAssets`: it matches available INDIVIDUAL rows OR any QUANTITY_TRACKED row, because a QT row's status flips once any unit is allocated even while free stock remains. Note: a fully-allocated QT asset therefore appears under the Available pill (badged with its real status), and the pill count can disagree with `/api/mobile/dashboard`'s raw `groupBy` counts — that desync is a known follow-up candidate, not addressed here.
3. **Typed input that yields zero terms (whitespace / bare commas) matches nothing** instead of returning the unfiltered list — a debounced type-ahead sending a single space must not flash the full asset list. Applies to **both** surfaces (`getAssets` and mobile). A genuinely empty search still means "no filter".
4. **Unknown `status` values return 400** instead of silently unfiltering (and instead of the original 500).
5. **Search terms cap at 10 per request** as a query-cost guard — shared by the simple path, the mobile path, and the advanced-index SQL path (`generateWhereClause` now parses through the same bounded splitter).

## Verification

- `search.server.test.ts` pins the shared clauses: term splitting + cap, ID-shape policy, all 10 full-clause branches with **every matched column pinned structurally** and an exact 17-filter case-insensitivity walk, narrow-clause columns + slow-path exclusions.
- `mobile-asset-search.server.test.ts` pins mobile parity with structural assertions independent of the builders, plus the match-nothing semantics.
- `test/routes-tests/api+/mobile+/assets.test.ts` covers the route: 400 on unknown status, QT-aware AVAILABLE where-shape, the narrow→full **fallback re-query sequence**, match-nothing search, and the orderBy tiebreaker.
- Existing `service.server.test.ts` suite (131 tests, incl. "getAssets search fallback") passes with its pre-existing assertions untouched — the extraction is behavior-preserving for web. It gains ONE new test pinning the fail-closed zero-term behavior.
- All suites: 157 passed / 1 skipped. `pnpm --filter @shelf/webapp typecheck` 0 errors; ESLint clean.
- Runtime proof against the QA database (read-only, exact fragments): matched a real asset by description word, tag name (incl. uppercased), category name, custodian first name, barcode value, and sequentialId via the narrow fast path; gibberish returned 0. The QT-aware AVAILABLE fragment was probed directly: a CHECKED_OUT QT asset (qty 29) excluded before, included now; busy INDIVIDUAL assets stay hidden.

**No migration needed:** all clause columns are covered by the existing trigram GIN indexes. **No app release needed:** search runs server-side, so shipped companion builds (1.2.0) get full parity as soon as this deploys.

Sibling gap filed: #2837 (mobile kits list: unguarded status + name-only search).

cc @DonKoko

🤖 Generated with [Claude Code](https://claude.com/claude-code)
