### PR TITLE
feat(companion): adjust stock quantity from the asset detail screen

### DIFF
--- a/apps/companion/.maestro/flows/assets/adjust-quantity.yaml
+++ b/apps/companion/.maestro/flows/assets/adjust-quantity.yaml
@@ -1,0 +1,53 @@
+# Adjust stock quantity on a QUANTITY_TRACKED asset (PR: feat/mobile-adjust-quantity)
+#
+# Precondition: app foregrounded with a signed-in session (qa-admin1 /
+# GRANULAR WORKSPACE) — uses the no-login pattern, so NO launchApp/clearState.
+# Test asset: "QA Qty Test — Tripod (10 pcs)" (cmqzf1xt20001s0iitjd72rkb),
+# starting quantity 10, no custody.
+#
+# Verifies: Adjust button on the quantity card → Add 5 (RESTOCK) → total 15
+# → Adjust → Remove 5 (LOSS) → total restored to 10. DB cross-check happens
+# outside Maestro (prisma script).
+appId: com.shelf.companion
+---
+# Assets tab → find the tripod via search (search now matches web fields)
+- tapOn: "Assets"
+- tapOn:
+    id: "search-input"
+    optional: true
+- inputText: "QA Qty Test"
+- extendedWaitUntil:
+    visible: "QA Qty Test — Tripod (10 pcs)"
+    timeout: 10000
+- tapOn: "QA Qty Test — Tripod (10 pcs)"
+
+# Quantity card shows 10 + the new Adjust affordance
+- extendedWaitUntil:
+    visible: "10 pcs"
+    timeout: 10000
+- assertVisible: "Adjust quantity"
+
+# Add 5 (RESTOCK). The sheet seeds the input with "1" and focuses it on
+# open, so erase before typing or the value becomes "15".
+- tapOn: "Adjust quantity"
+- extendedWaitUntil:
+    visible: "Adjust Quantity"
+    timeout: 5000
+- eraseText
+- inputText: "5"
+- tapOn: "Add"
+- extendedWaitUntil:
+    visible: "15 pcs"
+    timeout: 15000
+
+# Remove 5 (LOSS) → back to 10
+- tapOn: "Adjust quantity"
+- extendedWaitUntil:
+    visible: "Adjust Quantity"
+    timeout: 5000
+- eraseText
+- inputText: "5"
+- tapOn: "Remove"
+- extendedWaitUntil:
+    visible: "10 pcs"
+    timeout: 15000

--- a/apps/companion/.maestro/flows/assets/adjust-quantity.yaml
+++ b/apps/companion/.maestro/flows/assets/adjust-quantity.yaml
@@ -5,27 +5,32 @@
 # Test asset: "QA Qty Test — Tripod (10 pcs)" (cmqzf1xt20001s0iitjd72rkb),
 # starting quantity 10, no custody.
 #
+# Maestro full-matches a11y labels (often composed beyond the visible text),
+# so every text matcher is regex-wrapped with .* per .maestro/LESSONS.md.
+#
 # Verifies: Adjust button on the quantity card → Add 5 (RESTOCK) → total 15
 # → Adjust → Remove 5 (LOSS) → total restored to 10. DB cross-check happens
 # outside Maestro (prisma script).
-appId: com.shelf.companion
+appId: com.shelf.companion.carlos
 ---
-# Assets tab → find the tripod via search (search now matches web fields)
+# Assets tab → find the tripod via search
 - tapOn: "Assets"
-- tapOn:
-    id: "search-input"
-    optional: true
+- tapOn: ".*Search assets.*"
 - inputText: "QA Qty Test"
 - extendedWaitUntil:
-    visible: "QA Qty Test — Tripod (10 pcs)"
+    visible: ".*QA Qty Test — Tripod.*"
     timeout: 10000
-- tapOn: "QA Qty Test — Tripod (10 pcs)"
+# First tap may be consumed dismissing the keyboard — tap twice, second optional.
+- tapOn: ".*QA Qty Test — Tripod.*"
+- tapOn:
+    text: ".*QA Qty Test — Tripod.*"
+    optional: true
 
 # Quantity card shows 10 + the new Adjust affordance
 - extendedWaitUntil:
-    visible: "10 pcs"
+    visible: ".*10 pcs.*"
     timeout: 10000
-- assertVisible: "Adjust quantity"
+- assertVisible: ".*Adjust.*"
 
 # Add 5 (RESTOCK). The sheet seeds the input with "1" and focuses it on
 # open, so erase before typing or the value becomes "15".
@@ -35,9 +40,9 @@ appId: com.shelf.companion
     timeout: 5000
 - eraseText
 - inputText: "5"
-- tapOn: "Add"
+- tapOn: ".*Add.*to stock.*"
 - extendedWaitUntil:
-    visible: "15 pcs"
+    visible: ".*15 pcs.*"
     timeout: 15000
 
 # Remove 5 (LOSS) → back to 10
@@ -47,7 +52,7 @@ appId: com.shelf.companion
     timeout: 5000
 - eraseText
 - inputText: "5"
-- tapOn: "Remove"
+- tapOn: ".*Remove.*from stock.*"
 - extendedWaitUntil:
-    visible: "10 pcs"
+    visible: ".*10 pcs.*"
     timeout: 15000

--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -39,6 +39,7 @@ import { useDateFormatter } from "@/lib/use-date-formatter";
 import { TeamMemberPicker } from "@/components/team-member-picker";
 import { LocationPicker } from "@/components/location-picker";
 import { QuantityInputSheet } from "@/components/quantity-input-sheet";
+import { AdjustQuantitySheet } from "@/components/adjust-quantity-sheet";
 import { AssetDetailSkeleton } from "@/components/skeleton-loader";
 import { AssetHeader } from "@/components/asset-detail/asset-header";
 import { QuickActions } from "@/components/asset-detail/quick-actions";
@@ -132,6 +133,7 @@ export default function AssetDetailScreen() {
   const [showCustodyPicker, setShowCustodyPicker] = useState(false);
   const [showLocationPicker, setShowLocationPicker] = useState(false);
   const [showOverflowMenu, setShowOverflowMenu] = useState(false);
+  const [showAdjustSheet, setShowAdjustSheet] = useState(false);
   const [showImageZoom, setShowImageZoom] = useState(false);
 
   // Quantity-custody steps (QUANTITY_TRACKED assets only). Non-null values
@@ -171,6 +173,35 @@ export default function AssetDetailScreen() {
       asset.id,
       locationId
     );
+    if (err) Alert.alert("Error", err);
+    else {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      await fetchAsset();
+    }
+    setIsActionLoading(false);
+  };
+
+  // ── Adjust Quantity (stock) ─────────────────────────
+
+  /**
+   * Applies a stock adjustment and refreshes the asset. Web
+   * QuickAdjustDialog parity: Add maps to RESTOCK, Remove maps to LOSS —
+   * the server writes the ConsumptionLog row and fires the low-stock alert.
+   */
+  const performAdjustQuantity = async (args: {
+    direction: "add" | "subtract";
+    quantity: number;
+    note?: string;
+  }) => {
+    if (!currentOrg || !asset) return;
+    setShowAdjustSheet(false);
+    setIsActionLoading(true);
+    const { error: err } = await api.adjustQuantity(currentOrg.id, asset.id, {
+      quantity: args.quantity,
+      direction: args.direction,
+      category: args.direction === "add" ? "RESTOCK" : "LOSS",
+      note: args.note,
+    });
     if (err) Alert.alert("Error", err);
     else {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -382,6 +413,25 @@ export default function AssetDetailScreen() {
                     {totalQuantityLabel}
                   </Text>
                   <Text style={styles.quantityTotalLabel}>total</Text>
+                  {/* Stock adjust — server requires asset:update, so the
+                      affordance is hidden from roles that would 403. */}
+                  {canUpdateAsset && (
+                    <TouchableOpacity
+                      style={styles.adjustButton}
+                      onPress={() => setShowAdjustSheet(true)}
+                      disabled={isActionLoading}
+                      activeOpacity={0.7}
+                      accessibilityLabel="Adjust quantity"
+                      accessibilityRole="button"
+                    >
+                      <Ionicons
+                        name="swap-vertical"
+                        size={14}
+                        color={colors.foreground}
+                      />
+                      <Text style={styles.adjustButtonText}>Adjust</Text>
+                    </TouchableOpacity>
+                  )}
                 </View>
                 {/* Per-status slices. When the breakdown is null (no activity)
                     we show only the total above. */}
@@ -741,6 +791,13 @@ export default function AssetDetailScreen() {
               INDIVIDUAL rendering stays byte-identical. */}
           {isQtyTracked && (
             <>
+              <AdjustQuantitySheet
+                visible={showAdjustSheet}
+                availableQuantity={breakdown?.available ?? asset.quantity ?? 0}
+                unitOfMeasure={asset.unitOfMeasure}
+                onSubmit={(args) => void performAdjustQuantity(args)}
+                onClose={() => setShowAdjustSheet(false)}
+              />
               <QuantityInputSheet
                 visible={assignQtyMember != null}
                 title="Assign Quantity"
@@ -995,6 +1052,24 @@ const useStyles = createStyles((colors, shadows) => ({
   quantityTotalLabel: {
     fontSize: fontSize.base,
     color: colors.muted,
+  },
+  adjustButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    marginLeft: "auto",
+    alignSelf: "center",
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 6,
+    borderRadius: borderRadius.sm,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    backgroundColor: colors.white,
+  },
+  adjustButtonText: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.foreground,
   },
   quantityBreakdownRow: {
     flexDirection: "row",

--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -817,7 +817,12 @@ export default function AssetDetailScreen() {
             <>
               <AdjustQuantitySheet
                 visible={showAdjustSheet}
-                availableQuantity={breakdown?.available ?? asset.quantity ?? 0}
+                // Physical removal cap (custodyAvailable chain), NOT
+                // `breakdown.available`: available subtracts the SUM of all
+                // future reservations, which over-restricts Remove when
+                // non-overlapping bookings exist. The server enforces the
+                // real floor (in-custody + peak concurrent reservations).
+                availableQuantity={assignMax}
                 unitOfMeasure={asset.unitOfMeasure}
                 onSubmit={(args) => void performAdjustQuantity(args)}
                 onClose={() => setShowAdjustSheet(false)}

--- a/apps/companion/components/adjust-quantity-sheet.tsx
+++ b/apps/companion/components/adjust-quantity-sheet.tsx
@@ -1,0 +1,389 @@
+/**
+ * AdjustQuantitySheet — a page-sheet modal for adjusting total stock of a
+ * QUANTITY_TRACKED asset. Mobile twin of the web's QuickAdjustDialog
+ * (apps/webapp/app/components/assets/quick-adjust-dialog.tsx): a quantity,
+ * an optional note, and two actions — "Add" (restock) and "Remove" (loss).
+ * The direction→category mapping (add→RESTOCK, subtract→LOSS) matches the
+ * web dialog and is applied by the caller's submit handler.
+ *
+ * Follows the house selection-flow contract (QuantityInputSheet):
+ * `<Modal animationType="slide" presentationStyle="pageSheet">` + SafeAreaView
+ * + header-with-close, digits-only numeric input flanked by -/+ steppers.
+ *
+ * Removing is capped client-side at `availableQuantity` (total minus units
+ * out in custody/bookings) with the web dialog's error copy; the server
+ * enforces the real cap either way. Adding has no upper bound.
+ *
+ * @see {@link file://../app/(tabs)/assets/[id].tsx} the consumer
+ * @see {@link file://./quantity-input-sheet.tsx} the modal contract this mirrors
+ */
+import { useEffect, useRef, useState } from "react";
+import { View, Text, Modal, TextInput, TouchableOpacity } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+import { formatQuantity } from "@/lib/quantity-format";
+
+type Props = {
+  /** Whether the sheet is shown. */
+  visible: boolean;
+  /**
+   * Units removable right now (total minus in-custody/checked-out). Removing
+   * more is blocked with an inline error; adding is unbounded.
+   */
+  availableQuantity: number;
+  /** Display unit echoed in copy (e.g. "pcs"); null/undefined falls back to "units". */
+  unitOfMeasure?: string | null;
+  /**
+   * Called with the confirmed adjustment. `direction` maps to the
+   * ConsumptionLog category exactly like the web dialog: add→RESTOCK,
+   * subtract→LOSS.
+   */
+  onSubmit: (args: {
+    direction: "add" | "subtract";
+    quantity: number;
+    note?: string;
+  }) => void;
+  /** Called when the user dismisses the sheet without confirming. */
+  onClose: () => void;
+};
+
+/**
+ * Stock-adjustment prompt sheet for QUANTITY_TRACKED assets.
+ *
+ * Renders a number-pad TextInput flanked by -/+ stepper buttons, an optional
+ * note field, and Add / Remove actions. Add stays enabled for any positive
+ * quantity; Remove is blocked above `availableQuantity` with the web
+ * dialog's "the rest is in custody" explanation.
+ *
+ * @param props - See {@link Props}.
+ * @returns The modal sheet element.
+ */
+export function AdjustQuantitySheet({
+  visible,
+  availableQuantity,
+  unitOfMeasure,
+  onSubmit,
+  onClose,
+}: Props) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+
+  const [value, setValue] = useState("1");
+  const [note, setNote] = useState("");
+  /** Set when the user attempts a Remove above the available cap. */
+  const [removeError, setRemoveError] = useState<string | null>(null);
+  const inputRef = useRef<TextInput>(null);
+
+  // Re-seed the inputs every time the sheet opens: each open is a fresh
+  // adjustment, so stale values must not leak across.
+  useEffect(() => {
+    if (visible) {
+      setValue("1");
+      setNote("");
+      setRemoveError(null);
+    }
+  }, [visible]);
+
+  const parsed = value ? parseInt(value, 10) : NaN;
+  const hasValue = Number.isFinite(parsed);
+  const isValid = hasValue && parsed >= 1;
+
+  const unitLabel = unitOfMeasure || "units";
+  const echo = hasValue ? formatQuantity(parsed, unitOfMeasure) : null;
+  const availableLabel =
+    formatQuantity(availableQuantity, unitOfMeasure) ??
+    String(availableQuantity);
+
+  /** Step the current value by `delta`, clamped to a minimum of 1. */
+  const step = (delta: number) => {
+    const current = hasValue ? parsed : 0;
+    const next = Math.max(current + delta, 1);
+    setValue(String(next));
+    setRemoveError(null);
+  };
+
+  const submit = (direction: "add" | "subtract") => {
+    if (!isValid) return;
+
+    // Client-side guard mirroring the web dialog: can't remove more than
+    // available (the server enforces the row-locked real cap regardless).
+    if (direction === "subtract" && parsed > availableQuantity) {
+      setRemoveError(
+        `Cannot remove ${parsed} ${unitLabel}. Only ${availableLabel} available (the rest is in custody).`
+      );
+      return;
+    }
+
+    setRemoveError(null);
+    onSubmit({
+      direction,
+      quantity: parsed,
+      note: note.trim() ? note.trim() : undefined,
+    });
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+      // why: imperative focus once the sheet has actually presented — an
+      // autoFocus prop fires before the modal animation and misses the
+      // keyboard (and jsx-a11y/no-autofocus flags it).
+      onShow={() => inputRef.current?.focus()}
+    >
+      <SafeAreaView style={styles.container} accessibilityViewIsModal={true}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>Adjust Quantity</Text>
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.closeButton}
+            accessibilityLabel="Close adjust quantity"
+            accessibilityRole="button"
+          >
+            <Ionicons name="close" size={24} color={colors.foreground} />
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.body}>
+          <Text style={styles.subtitle}>
+            Add or remove stock for this asset. Enter the number of {unitLabel}{" "}
+            to adjust.
+          </Text>
+
+          {/* Quantity row: [-] [input] [+] */}
+          <View style={styles.quantityRow}>
+            <TouchableOpacity
+              style={[
+                styles.stepButton,
+                (!hasValue || parsed <= 1) && styles.stepButtonDisabled,
+              ]}
+              onPress={() => step(-1)}
+              disabled={!hasValue || parsed <= 1}
+              activeOpacity={0.7}
+              accessibilityLabel="Decrease quantity"
+              accessibilityRole="button"
+              accessibilityState={{ disabled: !hasValue || parsed <= 1 }}
+            >
+              <Ionicons name="remove" size={22} color={colors.foreground} />
+            </TouchableOpacity>
+            <TextInput
+              ref={inputRef}
+              style={styles.input}
+              value={value}
+              onChangeText={(text) => {
+                // Digits only — quantities are positive integers
+                // (valuation-field.tsx pattern, minus the decimal point).
+                setValue(text.replace(/[^0-9]/g, ""));
+                setRemoveError(null);
+              }}
+              placeholder="Enter quantity"
+              placeholderTextColor={colors.placeholderText}
+              keyboardType="number-pad"
+              returnKeyType="done"
+              accessibilityLabel="Quantity to adjust"
+            />
+            <TouchableOpacity
+              style={styles.stepButton}
+              onPress={() => step(1)}
+              activeOpacity={0.7}
+              accessibilityLabel="Increase quantity"
+              accessibilityRole="button"
+            >
+              <Ionicons name="add" size={22} color={colors.foreground} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Echo / error under the input */}
+          {removeError ? (
+            <Text style={styles.errorHint}>{removeError}</Text>
+          ) : (
+            <Text style={styles.echoHint}>
+              {echo ?? "Enter a quantity"} · {availableLabel} removable
+            </Text>
+          )}
+
+          {/* Optional note */}
+          <View style={styles.noteBlock}>
+            <Text style={styles.noteLabel}>Note (optional)</Text>
+            <TextInput
+              style={styles.noteInput}
+              value={note}
+              onChangeText={setNote}
+              placeholder="Reason for adjustment..."
+              placeholderTextColor={colors.placeholderText}
+              multiline
+              numberOfLines={3}
+              textAlignVertical="top"
+              accessibilityLabel="Reason for adjustment"
+            />
+          </View>
+
+          {/* Add (restock) */}
+          <TouchableOpacity
+            style={[styles.confirmPrimary, !isValid && styles.confirmDisabled]}
+            onPress={() => submit("add")}
+            disabled={!isValid}
+            activeOpacity={0.7}
+            accessibilityLabel={`Add ${echo ?? "quantity"} to stock`}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !isValid }}
+          >
+            <Ionicons name="add" size={20} color={colors.primaryForeground} />
+            <Text style={styles.confirmText}>Add</Text>
+          </TouchableOpacity>
+
+          {/* Remove (loss) */}
+          <TouchableOpacity
+            style={[styles.removeButton, !isValid && styles.confirmDisabled]}
+            onPress={() => submit("subtract")}
+            disabled={!isValid}
+            activeOpacity={0.7}
+            accessibilityLabel={`Remove ${echo ?? "quantity"} from stock`}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !isValid }}
+          >
+            <Ionicons name="remove" size={20} color={colors.foreground} />
+            <Text style={styles.removeText}>Remove</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const useStyles = createStyles((colors, shadows) => ({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: {
+    fontSize: fontSize.xl,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  closeButton: {
+    padding: spacing.xs,
+  },
+  body: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    gap: spacing.md,
+  },
+  subtitle: {
+    fontSize: fontSize.lg,
+    color: colors.foregroundSecondary,
+    lineHeight: 22,
+  },
+  quantityRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  stepButton: {
+    width: 44,
+    height: 44,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    justifyContent: "center",
+    alignItems: "center",
+    ...shadows.sm,
+  },
+  stepButtonDisabled: {
+    opacity: 0.4,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: fontSize.lg,
+    color: colors.foreground,
+    textAlign: "center",
+    ...shadows.sm,
+  },
+  echoHint: {
+    fontSize: fontSize.sm,
+    color: colors.muted,
+    textAlign: "center",
+  },
+  errorHint: {
+    fontSize: fontSize.sm,
+    color: colors.error,
+    textAlign: "center",
+  },
+  noteBlock: {
+    gap: spacing.xs,
+  },
+  noteLabel: {
+    fontSize: fontSize.sm,
+    color: colors.muted,
+  },
+  noteInput: {
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: fontSize.lg,
+    color: colors.foreground,
+    minHeight: 76,
+    ...shadows.sm,
+  },
+  confirmPrimary: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    marginTop: spacing.sm,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  removeButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  confirmDisabled: {
+    opacity: 0.5,
+  },
+  confirmText: {
+    color: colors.primaryForeground,
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+  },
+  removeText: {
+    color: colors.foreground,
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+  },
+}));

--- a/apps/companion/lib/api/asset-mutations.ts
+++ b/apps/companion/lib/api/asset-mutations.ts
@@ -139,7 +139,7 @@ export const assetMutationsApi = {
     }
   ) =>
     apiFetch<AdjustQuantityResponse>(
-      `/api/mobile/assets/adjust-quantity?orgId=${orgId}`,
+      `/api/mobile/asset/adjust-quantity?orgId=${orgId}`,
       {
         method: "POST",
         body: JSON.stringify({ assetId, ...args }),

--- a/apps/companion/lib/api/asset-mutations.ts
+++ b/apps/companion/lib/api/asset-mutations.ts
@@ -23,6 +23,7 @@ import type {
   UpdateAssetResponse,
   DeleteAssetResponse,
   UpdateImageResponse,
+  AdjustQuantityResponse,
 } from "./types";
 
 export const assetMutationsApi = {
@@ -119,6 +120,34 @@ export const assetMutationsApi = {
       method: "POST",
       body: JSON.stringify({ assetId }),
     }),
+
+  /**
+   * Adjust total stock of a QUANTITY_TRACKED asset (restock / remove /
+   * correction). Mobile twin of the web's /api/assets/adjust-quantity —
+   * the server validates the type gate, org scope and the row-locked
+   * negative-stock check, writes the ConsumptionLog row, and fires the
+   * low-stock alert when the threshold is crossed.
+   */
+  adjustQuantity: (
+    orgId: string,
+    assetId: string,
+    args: {
+      quantity: number;
+      direction: "add" | "subtract";
+      category: "RESTOCK" | "ADJUSTMENT" | "LOSS";
+      note?: string;
+    }
+  ) =>
+    apiFetch<AdjustQuantityResponse>(
+      `/api/mobile/assets/adjust-quantity?orgId=${orgId}`,
+      {
+        method: "POST",
+        body: JSON.stringify({ assetId, ...args }),
+        // why: non-idempotent — a timed-out-but-landed request must not be
+        // auto-retried, or the adjustment double-applies.
+        retry: false,
+      }
+    ),
 
   /** Update asset image (multipart upload) */
   updateImage: (

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -472,12 +472,14 @@ export type QuantityCustodyResponse = {
 
 /**
  * Response of the mobile adjust-quantity endpoint — same envelope as the
- * quantity-custody mutations: `asset` is the refreshed, viewer-shaped asset
- * (may be absent when the refresh failed; the mutation still succeeded).
+ * quantity-custody mutations: `asset` is the refreshed, viewer-shaped asset.
+ * The route always serializes the key and sends `null` when the post-commit
+ * refresh failed (the mutation itself still succeeded), so the type carries
+ * `| null` to match the wire truth.
  */
 export type AdjustQuantityResponse = {
   success: boolean;
-  asset?: AssetDetail;
+  asset?: AssetDetail | null;
 };
 
 export type UpdateLocationResponse = {

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -467,7 +467,12 @@ export type CustodyResponse = {
  */
 export type QuantityCustodyResponse = {
   success: boolean;
-  asset?: AssetDetail;
+  /**
+   * Refreshed viewer-shaped asset. The route always serializes the key and
+   * sends `null` when the post-commit refresh failed (the mutation itself
+   * still succeeded) — same wire contract as {@link AdjustQuantityResponse}.
+   */
+  asset?: AssetDetail | null;
 };
 
 /**

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -465,6 +465,16 @@ export type QuantityCustodyResponse = {
   asset?: AssetDetail;
 };
 
+/**
+ * Response of the mobile adjust-quantity endpoint — same envelope as the
+ * quantity-custody mutations: `asset` is the refreshed, viewer-shaped asset
+ * (may be absent when the refresh failed; the mutation still succeeded).
+ */
+export type AdjustQuantityResponse = {
+  success: boolean;
+  asset?: AssetDetail;
+};
+
 export type UpdateLocationResponse = {
   asset: {
     id: string;

--- a/apps/webapp/app/routes/api+/mobile+/asset.adjust-quantity.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.adjust-quantity.ts
@@ -1,5 +1,10 @@
 /**
- * POST /api/mobile/assets/adjust-quantity
+ * POST /api/mobile/asset/adjust-quantity
+ *
+ * Named `asset.…` (singular) like every other mobile asset mutation — a
+ * plural `assets.adjust-quantity` gets captured by the loader-only
+ * `assets.$assetId` sibling ("adjust-quantity" parses as an asset id) and
+ * the POST 405s. Found the hard way on the simulator.
  *
  * Adjusts total stock of a QUANTITY_TRACKED asset. Mobile twin of the web's
  * `/api/assets/adjust-quantity` route — same Zod schema (incl. the

--- a/apps/webapp/app/routes/api+/mobile+/asset.adjust-quantity.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.adjust-quantity.ts
@@ -112,7 +112,18 @@ export async function action({ request }: ActionFunctionArgs) {
     // why: safeParse + a 400 ShelfError mirrors the web route's parseData
     // behavior; raw `.parse` would surface a ZodError as a 500 through
     // makeShelfError's unknown-error branch (per custody.assign-quantity.ts).
-    const parsed = MobileAdjustQuantitySchema.safeParse(await request.json());
+    // The json() guard matters too: malformed JSON rejects with a
+    // SyntaxError, which the outer catch would otherwise report as a 500.
+    const body: unknown = await request.json().catch((cause) => {
+      throw new ShelfError({
+        cause,
+        message: "Invalid request body",
+        label: "Assets",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    });
+    const parsed = MobileAdjustQuantitySchema.safeParse(body);
     if (!parsed.success) {
       throw new ShelfError({
         cause: parsed.error,

--- a/apps/webapp/app/routes/api+/mobile+/assets.adjust-quantity.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.adjust-quantity.ts
@@ -1,0 +1,224 @@
+/**
+ * POST /api/mobile/assets/adjust-quantity
+ *
+ * Adjusts total stock of a QUANTITY_TRACKED asset. Mobile twin of the web's
+ * `/api/assets/adjust-quantity` route — same Zod schema (incl. the
+ * category/direction pairing refine), same `adjustQuantity` service call,
+ * same best-effort audit note and low-stock check. Only the
+ * auth/permission/envelope skeleton differs (bearer auth + the mobile error
+ * envelope, per `custody.assign-quantity.ts`).
+ *
+ * Body: { assetId: string, quantity: number, category: "RESTOCK"|"ADJUSTMENT"|"LOSS",
+ *         direction: "add"|"subtract", note?: string }
+ * Org: `?orgId=` query param or `x-shelf-organization` header.
+ *
+ * Success envelope: `{ success: true, asset }` where `asset` is the
+ * refreshed asset shaped for mobile (custody visibility already filtered
+ * for the caller) so the app can update state without a second round trip.
+ *
+ * @see {@link file://./../assets.adjust-quantity.ts} — the mirrored web route
+ * @see {@link file://./../../../modules/consumption-log/service.server.ts} — adjustQuantity
+ * @see {@link file://./custody.assign-quantity.ts} — the skeleton this follows
+ */
+
+import type { Prisma } from "@prisma/client";
+import { data, type ActionFunctionArgs } from "react-router";
+import { z } from "zod";
+import {
+  getMobileAssetForViewer,
+  getMobileUserContext,
+  requireMobileAuth,
+  requireMobilePermission,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { checkAndNotifyLowStock } from "~/modules/consumption-log/low-stock.server";
+import { adjustQuantity } from "~/modules/consumption-log/service.server";
+import { createNote } from "~/modules/note/service.server";
+import { getUserByID } from "~/modules/user/service.server";
+import { makeShelfError, ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
+import {
+  appendUserTextToNote,
+  wrapUserLinkForNote,
+} from "~/utils/markdoc-wrappers";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { enforceUserRateLimit } from "~/utils/rate-limit.server";
+
+/**
+ * Zod schema for the adjust-quantity JSON body. Identical to the web's
+ * `AdjustQuantitySchema` (assets.adjust-quantity.ts) — the `.refine`
+ * enforces the category/direction pairing so a `ConsumptionLog` row's
+ * category can never contradict the sign of the change: RESTOCK must add,
+ * LOSS must subtract, ADJUSTMENT can go either way.
+ */
+const MobileAdjustQuantitySchema = z
+  .object({
+    assetId: z.string().min(1, "Asset ID is required"),
+    quantity: z.coerce.number().int().positive("Quantity must be at least 1"),
+    category: z.enum(["RESTOCK", "ADJUSTMENT", "LOSS"]),
+    direction: z.enum(["add", "subtract"]),
+    note: z
+      .string()
+      .optional()
+      .transform((val) => (val === "" ? undefined : val)),
+  })
+  .refine(
+    ({ category, direction }) =>
+      category === "ADJUSTMENT" ||
+      (category === "RESTOCK" && direction === "add") ||
+      (category === "LOSS" && direction === "subtract"),
+    {
+      message:
+        "Invalid category/direction combination — RESTOCK must add, LOSS must subtract.",
+      path: ["direction"],
+    }
+  );
+
+export async function action({ request }: ActionFunctionArgs) {
+  let userId: string | undefined;
+
+  try {
+    const { user } = await requireMobileAuth(request);
+    userId = user.id;
+    // Same limiter bucket as the other mobile quantity mutations — a stuck
+    // retry loop or rapid taps shouldn't hammer a row-locking transaction.
+    await enforceUserRateLimit(user.id, "bulk");
+
+    const organizationId = await requireOrganizationAccess(request, user.id);
+
+    // RBAC: same entity/action the web adjust route requires — SELF_SERVICE
+    // and BASE both 403 (they cannot update assets).
+    await requireMobilePermission({
+      userId: user.id,
+      organizationId,
+      entity: PermissionEntity.asset,
+      action: PermissionAction.update,
+    });
+
+    // canSeeAllCustody shapes the refreshed asset returned to the app.
+    const { canSeeAllCustody } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
+
+    // why: safeParse + a 400 ShelfError mirrors the web route's parseData
+    // behavior; raw `.parse` would surface a ZodError as a 500 through
+    // makeShelfError's unknown-error branch (per custody.assign-quantity.ts).
+    const parsed = MobileAdjustQuantitySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      throw new ShelfError({
+        cause: parsed.error,
+        message: "Invalid request body",
+        additionalData: { validationErrors: parsed.error.flatten() },
+        label: "Assets",
+        status: 400,
+      });
+    }
+    const { assetId, quantity, category, direction, note } = parsed.data;
+
+    // All quantity validation (type gate, org scoping, row-locked
+    // negative-stock check) lives inside the service — no duplication here.
+    await adjustQuantity({
+      assetId,
+      quantity,
+      category,
+      direction,
+      userId: user.id,
+      organizationId,
+      note,
+    });
+
+    /** Best-effort audit note — don't fail the action if note creation fails */
+    try {
+      const actorUser = await getUserByID(user.id, {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        } satisfies Prisma.UserSelect,
+      });
+
+      const actor = wrapUserLinkForNote(actorUser);
+      const sign = direction === "add" ? "+" : "-";
+      const categoryLabel = category.toLowerCase();
+      const baseLine = `${actor} adjusted quantity by **${sign}${quantity}** (${categoryLabel}).`;
+      const noteContent = appendUserTextToNote(baseLine, note);
+
+      await createNote({
+        content: noteContent,
+        type: "UPDATE",
+        userId: user.id,
+        assetId,
+        organizationId,
+      });
+    } catch (noteError) {
+      Logger.error(
+        new ShelfError({
+          cause: noteError,
+          message: "Failed to create audit note for quantity operation",
+          label: "Assets",
+          additionalData: { assetId, userId: user.id },
+        })
+      );
+    }
+
+    // No route-level sendNotification success toast here: that's the web's
+    // SSE emitter and mobile has no listener (matches the custody routes).
+
+    // Everything past adjustQuantity is best-effort: the mutation has
+    // already committed, so a failure here must NOT surface as an action
+    // error — the client would show a failure (and could retry a
+    // non-idempotent adjustment) for a change that actually landed.
+
+    /** Check low-stock threshold and notify if breached (web parity) */
+    try {
+      await checkAndNotifyLowStock({
+        assetId,
+        userId: user.id,
+        organizationId,
+      });
+    } catch (lowStockError) {
+      Logger.error(
+        new ShelfError({
+          cause: lowStockError,
+          message: "Failed low-stock check after quantity adjustment",
+          label: "Assets",
+          additionalData: { assetId, userId: user.id },
+        })
+      );
+    }
+
+    // Refreshed asset, shaped for mobile with the caller's custody
+    // visibility already applied, so the app can update state directly.
+    // Null on failure — the app refetches the detail regardless.
+    let asset = null;
+    try {
+      asset = await getMobileAssetForViewer({
+        assetId,
+        organizationId,
+        viewerUserId: user.id,
+        canSeeAllCustody,
+      });
+    } catch (refreshError) {
+      Logger.error(
+        new ShelfError({
+          cause: refreshError,
+          message: "Failed to refresh asset after quantity adjustment",
+          label: "Assets",
+          additionalData: { assetId, userId: user.id },
+        })
+      );
+    }
+
+    return data({ success: true, asset });
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId });
+    return data(
+      { error: { message: reason.message } },
+      { status: reason.status }
+    );
+  }
+}


### PR DESCRIPTION
Closes #2828.

## What

Adds the missing stock-adjust verb to the companion app for QUANTITY_TRACKED assets. Users could view quantities, assign/release quantity custody, book by model and record check-in dispositions on mobile — but changing stock on hand (restock, loss, correction) was web-only, and restocking a storeroom is exactly a phone moment (customer-reported 2026-08-08).

## Server — `POST /api/mobile/asset/adjust-quantity`

Twin of the web `/api/assets/adjust-quantity` route:

- Same Zod schema, including the category/direction pairing refine (RESTOCK must add, LOSS must subtract, ADJUSTMENT either way).
- Same `adjustQuantity` service call — type gate, org scoping and the row-locked negative-stock check all live there.
- Same best-effort audit note (markdoc-wrapped actor + signed delta + optional user note) and `checkAndNotifyLowStock`.
- Skeleton mirrors `custody.assign-quantity.ts`: bearer auth, `bulk` rate-limit bucket, `asset:update` RBAC via `requireMobilePermission` (BASE and SELF_SERVICE 403, matching web), safeParse → 400 envelope, and everything after the committed mutation is best-effort so a refresh failure can never provoke a client retry of a non-idempotent adjustment. Response returns the refreshed viewer-shaped asset.
- Named `asset.…` (singular) like every other mobile asset mutation: on-device testing proved a plural `assets.adjust-quantity` URL is captured by the loader-only `assets.$assetId` sibling ("adjust-quantity" parses as an asset id) and the POST 405s. Documented in the route JSDoc.

## App

- **`AdjustQuantitySheet`** — house page-sheet contract (mirrors `QuantityInputSheet`): digits-only quantity with −/+ steppers, optional note, and two actions mapping exactly like the web `QuickAdjustDialog`: **Add** → RESTOCK, **Remove** → LOSS. Remove is capped client-side at available units with the web dialog's "the rest is in custody" copy (server enforces the real cap regardless).
- **Adjust button on the asset detail quantity card**, shown only when the role has `asset:update` (mirrors the server gate so BASE/SELF_SERVICE never tap a 403).
- **`api.adjustQuantity`** client with `retry: false` (non-idempotent, same as the quantity-custody mutations).
- Maestro flow `.maestro/flows/assets/adjust-quantity.yaml` (regex matchers per `.maestro/LESSONS.md`).

## Verification

- Webapp typecheck 0, companion typecheck 0, ESLint clean on all changed files.
- **Service-level e2e against the QA database** (the exact service call the route makes, net effect zero): 10 → RESTOCK +5 → 15 → LOSS −3 → 12 → over-subtract 999 **blocked** ("Cannot remove 999 units. The asset only has 12 total units.") → wrong-org **blocked** → ADJUSTMENT −2 → 10 restored; ledger rows exactly RESTOCK 5 / LOSS 3 / ADJUSTMENT 2.
- **On-device Maestro e2e (iOS 26.5 simulator, dev client + local API), full pass:**

```
Tap on "Assets"... COMPLETED
Tap on ".*Search assets.*"... COMPLETED
Input text QA Qty Test... COMPLETED
Assert that ".*QA Qty Test — Tripod.*" is visible... COMPLETED
Tap on ".*QA Qty Test — Tripod.*"... COMPLETED
Assert that ".*10 pcs.*" is visible... COMPLETED
Assert that ".*Adjust.*" is visible... COMPLETED
Tap on "Adjust quantity"... COMPLETED
Erase text... / Input text 5... COMPLETED
Tap on ".*Add.*to stock.*"... COMPLETED
Assert that ".*15 pcs.*" is visible... COMPLETED
Tap on "Adjust quantity"... COMPLETED
Erase text... / Input text 5... COMPLETED
Tap on ".*Remove.*from stock.*"... COMPLETED
Assert that ".*10 pcs.*" is visible... COMPLETED
```

- **DB cross-check after the UI run:** final quantity 10 (restored), ConsumptionLog rows exactly `RESTOCK 5` + `LOSS 5`, and both markdoc audit notes written with the actor link.

Server half is deployable independently; the app half rides the next store build.

cc @DonKoko

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added quantity adjustments for tracked assets in the mobile app.
  - Authorized users can add or remove stock using quantity controls and optional notes.
  - Supports restocking and recording losses with adjustment details.
  - Prevents removing more items than currently available.
  - Asset quantities refresh automatically after successful adjustments.
  - Displays helpful errors when an adjustment cannot be completed.
- **Tests**
  - Added an automated flow covering stock restocking and removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->