### PR TITLE
fix: SSR crash on qr link-to-kit (22B) + friendly 429 boundary (21S/221)

### DIFF
--- a/apps/webapp/app/components/errors/index.test.tsx
+++ b/apps/webapp/app/components/errors/index.test.tsx
@@ -2,7 +2,8 @@
  * Tests for {@link ErrorContent}: the report-an-issue wiring (button only
  * shows for authenticated app-layout errors, and the feedback modal receives
  * the error context rendered on the page), the not-found screen for genuine
- * 404s, and the Sentry capture rules for route-error boundary failures.
+ * 404s, the rate-limit screen for 429s, and the Sentry capture rules for
+ * route-error boundary failures.
  *
  * @see {@link file://./index.tsx}
  */
@@ -161,6 +162,24 @@ function buildRouterNotFoundError() {
   };
 }
 
+/**
+ * A rate-limited route error as it actually arrives in production
+ * (SHELF-WEBAPP-21S/221): `appLoaderRateLimit` is Hono middleware that
+ * responds with a plain `c.json(...)` 429 BEFORE the request reaches
+ * Remix's single-fetch data handling, so the client can't decode a Shelf
+ * `{ error: {...} }` payload from it — `.data` ends up a bare `Error`, the
+ * same shape `buildRouterNotFoundError` models for 404. `isRouteErrorResponse`
+ * still recognizes the status; `isRouteError` does not.
+ */
+function buildRateLimitedRouteError() {
+  return {
+    status: 429,
+    statusText: "Too Many Requests",
+    internal: true,
+    data: new Error("Too many requests. Please try again later."),
+  };
+}
+
 /** The workspace-switcher `additionalData` shape: a resource that exists,
  * but in a different organization the user belongs to. */
 function buildWorkspaceSwitcherAdditionalData() {
@@ -316,6 +335,42 @@ describe("ErrorContent not-found screen", () => {
   });
 });
 
+describe("ErrorContent rate-limited screen", () => {
+  beforeEach(() => {
+    mockUser = { id: "user_123" };
+  });
+
+  it("renders a calm rate-limit screen for a 429 (not the generic 'unexpected error' framing)", () => {
+    mockRouteError = buildRateLimitedRouteError();
+    renderErrorContent();
+
+    expect(screen.getByText("Too many requests")).toBeTruthy();
+    expect(screen.getByText(/doing that a bit too quickly/i)).toBeTruthy();
+    // Not the alarming generic framing (SHELF-WEBAPP-21S/221's actual bug:
+    // this text is what real users saw for a transient rate limit)
+    expect(screen.queryByText(/Oops, something went wrong/i)).toBeNull();
+    expect(
+      screen.queryByText(/If the issues persists, please contact support/i)
+    ).toBeNull();
+    // Only "Back to home" is offered — no Reload/Report actions
+    expect(screen.queryByRole("link", { name: /reload page/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /report this issue/i })
+    ).toBeNull();
+  });
+
+  it("prefers a Shelf-shaped 429 payload's own message when present", () => {
+    mockRouteError = buildRouteError({
+      status: 429,
+      message: "You've hit the bulk-action limit. Try again in a minute.",
+      label: "RateLimit",
+    });
+    renderErrorContent();
+
+    expect(screen.getByText(/hit the bulk-action limit/i)).toBeTruthy();
+  });
+});
+
 describe("ErrorContent capturing route-error boundary failures to Sentry", () => {
   beforeEach(() => {
     mockUser = { id: "user_123" };
@@ -373,6 +428,16 @@ describe("ErrorContent capturing route-error boundary failures to Sentry", () =>
     renderErrorContent();
 
     await waitFor(() => expect(screen.getByText("Not found")).toBeTruthy());
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("does not capture a rate-limited 429 (transient — expected terminal state, SHELF-WEBAPP-21S/221)", async () => {
+    mockRouteError = buildRateLimitedRouteError();
+    renderErrorContent();
+
+    await waitFor(() =>
+      expect(screen.getByText("Too many requests")).toBeTruthy()
+    );
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 

--- a/apps/webapp/app/components/errors/index.tsx
+++ b/apps/webapp/app/components/errors/index.tsx
@@ -231,6 +231,24 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
     statusCode === 404;
 
   /**
+   * A rate-limit terminal state: the request tripped a server-side rate
+   * limiter (e.g. `appLoaderRateLimit`'s per-(user, path) cap on `.data`
+   * revalidations — see `server/rate-limit.ts`). This is a transient,
+   * EXPECTED condition, not a bug — the boundary shows a calm "try again in
+   * a moment" screen instead of the alarming generic one.
+   *
+   * Gated purely on `statusCode` (like `isNotFound`), NOT `isRouteError`:
+   * `appLoaderRateLimit` is Hono middleware that responds with a plain
+   * `c.json(...)` 429 BEFORE the request reaches Remix's single-fetch data
+   * handling, so the client can't decode it into the Shelf
+   * `{ error: { message, title, … } }` payload shape — `response.data` ends
+   * up as a bare `Error`, the same way a router-generated 404 does (see
+   * `isNotFound`'s doc comment). Relying on `isRouteError` here would miss
+   * exactly the case this fix exists for.
+   */
+  const isRateLimited = isRouteErrorResponse(response) && statusCode === 429;
+
+  /**
    * Route-error responses in the 4xx range (bad input, permission denials,
    * genuine not-found, …) that reach this boundary are NOT already captured
    * server-side — `error()` in http.server.ts only routes 5xx (and
@@ -242,11 +260,11 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
    * cross-org UX, not a bug).
    *
    * EXPECTED terminal states (403 permission-denied / expired claim, 404
-   * not-found — see `EXPECTED_ERROR_BOUNDARY_STATUSES`) are also excluded:
-   * they are normal UX, not bugs, so they must not open a Sentry issue. All
-   * other 4xx (400/409/422/429, …) stay captured. `beforeSend` re-checks the
-   * `status` tag as defense-in-depth, but this is the primary skip — the
-   * intent is clearest where the status is a number in hand.
+   * not-found, 429 rate-limited — see `EXPECTED_ERROR_BOUNDARY_STATUSES`)
+   * are also excluded: they are normal UX, not bugs, so they must not open a
+   * Sentry issue. All other 4xx (400/409/422, …) stay captured. `beforeSend`
+   * re-checks the `status` tag as defense-in-depth, but this is the primary
+   * skip — the intent is clearest where the status is a number in hand.
    *
    * Gated on `isRouteErrorResponse` (see `isNotFound` above for why) so
    * router-generated 4xx responses (e.g. an unmatched-route 404) are
@@ -270,6 +288,18 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
   const notFoundMessage = isRouteError(response)
     ? message
     : "The page or item you're looking for doesn't exist.";
+
+  /**
+   * Body copy for the rate-limit screen. Same fallback pattern as
+   * `notFoundMessage`: a Shelf-shaped 429 payload (e.g. the mobile
+   * `enforceUserRateLimit` ShelfError) carries its own `message`; the
+   * `appLoaderRateLimit` Hono-middleware 429 (this issue's actual source)
+   * has no Shelf payload, so `message` is still at its generic default —
+   * swap in copy appropriate for a calm "you're going too fast" screen.
+   */
+  const rateLimitMessage = isRouteError(response)
+    ? message
+    : "You're doing that a bit too quickly. Please wait a moment, then refresh the page.";
 
   // Capture unhandled Error instances (client-side crashes) client-side,
   // and capturable 4xx route errors (see shouldCaptureRouteError above).
@@ -337,6 +367,18 @@ export const ErrorContent = ({ className }: ErrorContentProps) => {
         className={className}
         title={rawTitle || "Not found"}
         message={notFoundMessage}
+        traceId={traceId}
+        actions={<BackHomeButton />}
+      />
+    );
+  }
+
+  if (isRateLimited) {
+    return (
+      <ErrorScreenLayout
+        className={className}
+        title={rawTitle || "Too many requests"}
+        message={rateLimitMessage}
         traceId={traceId}
         actions={<BackHomeButton />}
       />

--- a/apps/webapp/app/routes/qr+/_private+/$qrId_.link.kit.tsx
+++ b/apps/webapp/app/routes/qr+/_private+/$qrId_.link.kit.tsx
@@ -36,7 +36,6 @@ import When from "~/components/when/when";
 import { db } from "~/database/db.server";
 
 import { useViewportHeight } from "~/hooks/use-viewport-height";
-import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import {
   getPaginatedAndFilterableKits,
   updateKitQrCode,
@@ -59,7 +58,6 @@ import {
   PermissionAction,
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
-import { userHasPermission } from "~/utils/permissions/permission.validator.client";
 import { requirePermission } from "~/utils/roles.server";
 import { tw } from "~/utils/tw";
 import { resolveTeamMemberName } from "~/utils/user";
@@ -92,6 +90,22 @@ export const loader = async ({
       entity: PermissionEntity.qr,
       action: PermissionAction.update,
     });
+
+    /**
+     * `requirePermission` above already throws (403) unless the caller has
+     * `qr:update`, so reaching this line guarantees it. We derive the flag
+     * here and pass it down as loader data instead of calling the
+     * client-only `userHasPermission` inside the component: that validator
+     * lives in `permission.validator.client.ts`, a `.client.ts` module whose
+     * exports React Router's Vite plugin stubs to `undefined` in the SSR
+     * bundle. Unlike routes nested under `_layout+/_layout` (which defer
+     * rendering until hydration for this exact reason), this `qr+/_private+`
+     * route has no such wrapper, so calling it directly during render
+     * crashed SSR with `TypeError: userHasPermission is not a function`
+     * (SHELF-WEBAPP-22B). See `assets.$assetId.overview.tsx` for the same
+     * pattern applied to `canEditAsset`.
+     */
+    const canManageQrLink = true;
 
     const searchParams = getCurrentSearchParams(request);
     const [
@@ -146,6 +160,7 @@ export const loader = async ({
         subHeading: "Choose an asset to link with this QR tag.",
       },
       qrId,
+      canManageQrLink,
       items: kits,
       search,
       page,
@@ -210,10 +225,9 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => [
 export const links: LinksFunction = () => [{ rel: "stylesheet", href: css }];
 
 export default function QrLinkExisting() {
-  const { header } = useLoaderData<typeof loader>();
+  const { header, canManageQrLink } = useLoaderData<typeof loader>();
   const { qrId } = useParams();
   const [confirmOpen, setConfirmOpen] = useState<boolean>(false);
-  const { roles } = useUserRoleHelper();
 
   /** The id of the asset the user selected to update */
   const [selectedKitId, setSelectedKitId] = useState<string>("");
@@ -233,13 +247,7 @@ export default function QrLinkExisting() {
 
       <Filters className="-mx-4 border-b px-4 py-3">
         <div className="flex flex-1 justify-center pt-3">
-          <When
-            truthy={userHasPermission({
-              roles,
-              entity: PermissionEntity.qr,
-              action: PermissionAction.update,
-            })}
-          >
+          <When truthy={canManageQrLink}>
             <DynamicDropdown
               trigger={
                 <div className="flex cursor-pointer items-center gap-2">

--- a/apps/webapp/app/utils/sentry-filters.test.ts
+++ b/apps/webapp/app/utils/sentry-filters.test.ts
@@ -7,8 +7,8 @@
  * hard-filters —
  *  - unactionable client noise (DataCloneError, bare gateway-status blips) is
  *    dropped, while
- *  - expected error-boundary terminal states (403/404) are dropped but every
- *    other boundary status (incl. 5xx) still passes through.
+ *  - expected error-boundary terminal states (403/404/429) are dropped but
+ *    every other boundary status (incl. 5xx) still passes through.
  *
  * @see {@link file://./sentry-filters.ts}
  */
@@ -48,13 +48,17 @@ function makeEvent(opts: {
 }
 
 describe("isExpectedErrorBoundaryStatus", () => {
-  it("is true only for 403 and 404", () => {
+  it("is true only for 403, 404, and 429", () => {
     expect(isExpectedErrorBoundaryStatus(403)).toBe(true);
     expect(isExpectedErrorBoundaryStatus(404)).toBe(true);
+    // 429 (rate limited) is transient by design, not a bug to triage — see
+    // SHELF-WEBAPP-21S/221 (appLoaderRateLimit tripped by revalidations,
+    // surfaced through the generic "unexpected error" boundary).
+    expect(isExpectedErrorBoundaryStatus(429)).toBe(true);
   });
 
   it("is false for other 4xx, all 5xx, and undefined/NaN", () => {
-    for (const status of [400, 409, 422, 429, 500, 502]) {
+    for (const status of [400, 409, 422, 500, 502]) {
       expect(isExpectedErrorBoundaryStatus(status)).toBe(false);
     }
     expect(isExpectedErrorBoundaryStatus(undefined)).toBe(false);
@@ -125,6 +129,14 @@ describe("handleClientBeforeSend — error-boundary allowlist", () => {
     const event = makeEvent({
       value: "Asset not found",
       tags: { source: "error-boundary", status: "404" },
+    });
+    expect(handleClientBeforeSend(event)).toBeNull();
+  });
+
+  it("drops an expected 429 (rate limited) boundary event", () => {
+    const event = makeEvent({
+      value: "Too many requests. Please try again later.",
+      tags: { source: "error-boundary", status: "429" },
     });
     expect(handleClientBeforeSend(event)).toBeNull();
   });

--- a/apps/webapp/app/utils/sentry-filters.ts
+++ b/apps/webapp/app/utils/sentry-filters.ts
@@ -24,11 +24,14 @@ import type { ErrorEvent } from "@sentry/react-router";
  * - `403` — permission denied / an expired or already-consumed claim
  *   (e.g. "This scan can no longer be updated" on an expired QR claim).
  * - `404` — the resource genuinely does not exist.
+ * - `429` — rate limited (e.g. `appLoaderRateLimit`'s per-(user, path) cap
+ *   on `.data` revalidations). Transient by design — the client is expected
+ *   to hit this occasionally, not a bug to triage.
  *
- * All OTHER 4xx (400/409/422/429, …) and every 5xx stay captured — those can
+ * All OTHER 4xx (400/409/422, …) and every 5xx stay captured — those can
  * indicate real client/server problems worth triaging.
  */
-export const EXPECTED_ERROR_BOUNDARY_STATUSES = [403, 404] as const;
+export const EXPECTED_ERROR_BOUNDARY_STATUSES = [403, 404, 429] as const;
 
 /**
  * Whether a status is an expected error-boundary terminal state that must not
@@ -37,7 +40,7 @@ export const EXPECTED_ERROR_BOUNDARY_STATUSES = [403, 404] as const;
  * (a `NaN` from a missing tag is correctly treated as "not expected").
  *
  * @param status - The HTTP status code (or `NaN`/`undefined` when unknown)
- * @returns `true` only for the expected statuses (403, 404)
+ * @returns `true` only for the expected statuses (403, 404, 429)
  */
 export function isExpectedErrorBoundaryStatus(
   status: number | undefined

--- a/apps/webapp/test/routes-tests/qr+/_private+/$qrId_.link.kit.test.tsx
+++ b/apps/webapp/test/routes-tests/qr+/_private+/$qrId_.link.kit.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Regression test for SHELF-WEBAPP-22B — SSR crash on `GET /qr/:qrId/link/kit`.
+ *
+ * `userHasPermission` lives in `permission.validator.client.ts`, a `.client.ts`
+ * module. React Router's Vite plugin stubs every export of a `.client.ts`
+ * module to `undefined` in the server bundle, so calling it directly during
+ * render throws `TypeError: userHasPermission is not a function` on SSR.
+ * Routes nested under `_layout+/_layout` are shielded from this because that
+ * layout defers rendering until the client hydrates (see the comment in
+ * `_layout+/_layout.tsx`); this `qr+/_private+` route tree has no such
+ * wrapper, so the component crashed on first (server) render.
+ *
+ * The fix derives the permission gate server-side in the loader — it already
+ * calls `requirePermission({ entity: qr, action: update })`, so reaching the
+ * render is itself proof the check passed — and threads it down as
+ * `canManageQrLink` loader data instead of re-checking with the client-only
+ * validator inside the component.
+ *
+ * @see {@link file://../../../../app/routes/qr+/_private+/$qrId_.link.kit.tsx}
+ */
+import type { ReactNode } from "react";
+import type { LoaderFunctionArgs } from "react-router";
+import { MemoryRouter, useLoaderData } from "react-router";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getPaginatedAndFilterableKits } from "~/modules/kit/service.server";
+import { getQr } from "~/modules/qr/service.server";
+import QrLinkExisting, { loader } from "~/routes/qr+/_private+/$qrId_.link.kit";
+import { requirePermission } from "~/utils/roles.server";
+
+// why: isolate the route component from heavy presentational children
+// (List, Header, Filters, DynamicDropdown) so the test targets only the
+// Custodian-filter permission gate, not their own internal hooks / network
+// calls (List and DynamicDropdown read loader data / hit fetchers themselves).
+vi.mock("~/components/list", () => ({ List: () => null }));
+vi.mock("~/components/layout/header", () => ({ default: () => null }));
+vi.mock("~/components/list/filters", () => ({
+  Filters: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("~/components/dynamic-dropdown/dynamic-dropdown", () => ({
+  default: ({ trigger }: { trigger: ReactNode }) => (
+    <div data-testid="custodian-dropdown">{trigger}</div>
+  ),
+}));
+
+vi.mock("~/utils/roles.server", () => ({ requirePermission: vi.fn() }));
+vi.mock("~/modules/qr/service.server", () => ({ getQr: vi.fn() }));
+vi.mock("~/modules/kit/service.server", () => ({
+  getPaginatedAndFilterableKits: vi.fn(),
+  updateKitQrCode: vi.fn(),
+}));
+vi.mock("~/database/db.server", () => ({
+  db: {
+    teamMember: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+  },
+}));
+
+// why: `permission.validator.client.ts` is stubbed to `undefined` exports in
+// the real production SSR bundle — that's the actual root cause of
+// SHELF-WEBAPP-22B. Mocking it identically here reproduces that exact
+// condition: before the fix the component called `userHasPermission(...)`
+// directly and this mock made that throw; after the fix nothing in the
+// component imports it, so this mock has no effect and the test still passes.
+vi.mock("~/utils/permissions/permission.validator.client", () => ({
+  userHasPermission: undefined,
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...(actual as Record<string, unknown>),
+    useLoaderData: vi.fn(),
+    useParams: vi.fn(() => ({ qrId: "qr-1" })),
+    // why: mirrors real production behaviour for this exact route.
+    // `qr+/_private+` is not nested under `_layout+/_layout`, so
+    // `useRouteLoaderData("routes/_layout+/_layout")` (called by
+    // `useUserRoleHelper`) resolves to `undefined` there — it does NOT
+    // throw. Modeling that precisely (rather than letting the real hook
+    // throw "must be used within a data router" for lack of a full router
+    // in this test) means the pre-fix component fails for the SAME reason
+    // it does in production: calling the `.client.ts`-stubbed
+    // `userHasPermission` with `roles: undefined`.
+    useRouteLoaderData: vi.fn(() => undefined),
+    useFetcher: vi.fn(() => ({
+      Form: (props: Record<string, unknown>) => <form {...props} />,
+      data: undefined,
+      state: "idle",
+      submit: vi.fn(),
+    })),
+  };
+});
+
+const requirePermissionMock = vi.mocked(requirePermission);
+const getQrMock = vi.mocked(getQr);
+const getPaginatedAndFilterableKitsMock = vi.mocked(
+  getPaginatedAndFilterableKits
+);
+const useLoaderDataMock = vi.mocked(useLoaderData);
+
+function createLoaderArgs(
+  overrides: Partial<LoaderFunctionArgs> = {}
+): LoaderFunctionArgs {
+  return {
+    context: { getSession: () => ({ userId: "user-123" }) },
+    params: { qrId: "qr-1" },
+    request: new Request("https://example.com/qr/qr-1/link/kit"),
+    ...overrides,
+  } as LoaderFunctionArgs;
+}
+
+describe("qr+/_private+/$qrId_.link.kit loader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("threads canManageQrLink through as loader data once requirePermission passes", async () => {
+    getQrMock.mockResolvedValue({
+      id: "qr-1",
+      assetId: null,
+      kitId: null,
+    } as any);
+    requirePermissionMock.mockResolvedValue({
+      organizationId: "org-1",
+    } as any);
+    getPaginatedAndFilterableKitsMock.mockResolvedValue({
+      kits: [],
+      totalKits: 0,
+      perPage: 20,
+      page: 1,
+      totalPages: 0,
+      search: null,
+    } as any);
+
+    const result = await loader(createLoaderArgs());
+
+    // `requirePermission` above resolving (rather than throwing) is the only
+    // way this line is reached, so `canManageQrLink` must be `true`.
+    expect(result).toEqual(expect.objectContaining({ canManageQrLink: true }));
+  });
+});
+
+describe("QrLinkExisting component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders (no SSR crash) and shows the Custodian filter when canManageQrLink is true", () => {
+    useLoaderDataMock.mockReturnValue({
+      header: { title: "Link with existing asset", subHeading: "Choose a kit" },
+      qrId: "qr-1",
+      canManageQrLink: true,
+      items: [],
+      teamMembers: [],
+      totalTeamMembers: 0,
+    });
+
+    // Before the fix, this threw `TypeError: userHasPermission is not a
+    // function` — reproduced above by stubbing that import to `undefined`,
+    // matching how React Router's Vite plugin treats `.client.ts` exports
+    // during SSR.
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <QrLinkExisting />
+        </MemoryRouter>
+      )
+    ).not.toThrow();
+
+    expect(screen.getByTestId("custodian-dropdown")).toBeInTheDocument();
+    expect(screen.getByText("Custodian")).toBeInTheDocument();
+  });
+
+  it("hides the Custodian filter when canManageQrLink is false", () => {
+    useLoaderDataMock.mockReturnValue({
+      header: { title: "Link with existing asset", subHeading: "Choose a kit" },
+      qrId: "qr-1",
+      canManageQrLink: false,
+      items: [],
+      teamMembers: [],
+      totalTeamMembers: 0,
+    });
+
+    render(
+      <MemoryRouter>
+        <QrLinkExisting />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTestId("custodian-dropdown")).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/test/routes-tests/qr+/_private+/$qrId_.link.kit.test.tsx
+++ b/apps/webapp/test/routes-tests/qr+/_private+/$qrId_.link.kit.test.tsx
@@ -44,6 +44,14 @@ vi.mock("~/components/dynamic-dropdown/dynamic-dropdown", () => ({
   ),
 }));
 
+// why: stub the loader's server dependencies so the loader/render test runs
+// without a real database, permission resolver, or QR/kit services.
+// `roles.server` is mocked so `requirePermission` is controllable (the loader's
+// permission gate can be forced to pass or throw); the qr and kit service
+// modules are mocked to avoid their real DB-hitting calls (`getQr`,
+// `getPaginatedAndFilterableKits`) and keep the loader deterministic; and
+// `db.server`'s `teamMember.findMany/count` are stubbed because the loader
+// queries them to build the Custodian filter.
 vi.mock("~/utils/roles.server", () => ({ requirePermission: vi.fn() }));
 vi.mock("~/modules/qr/service.server", () => ({ getQr: vi.fn() }));
 vi.mock("~/modules/kit/service.server", () => ({


### PR DESCRIPTION
Two legit bugs from the 2026-08-10 Sentry triage. Both are root-cause fixes with regression tests; the rest of the board (flagged / noise / backlog) is tracked separately for a follow-up pass.

## `936adc1b0` — `22B`: SSR crash on `/qr/:qrId/link/kit`

**`TypeError: userHasPermission is not a function`** (3 ev, and the likely bulk of the 192-event `1M1` "Unexpected Server Error" on the same route).

**Root cause:** `qr+/_private+/$qrId_.link.kit.tsx` called the **client-only** `userHasPermission()` (a `*.client.ts` export) during **server render**. React Router's Vite plugin stubs every `*.client.ts` export to `undefined` in the SSR bundle, so the call threw and crashed the route on first render. Routes under `_layout+/_layout` defer rendering to client hydration and are shielded from this; the `qr+` tree is a separate, un-nested route tree with no such wrapper. (Textbook `*.client.ts`-in-SSR class.) As a secondary effect, `useUserRoleHelper()` also read an ancestor loader not in this route's tree, so the Custodian filter was permanently hidden here anyway.

**Fix:** the loader already gates the route with `requirePermission({ entity: qr, action: update })`, so reaching the component proves the permission. Derive `canManageQrLink` server-side in the loader and thread it via `useLoaderData`, dropping the client-only re-check — the same pattern already used for `canEditAsset`. **The permission gate itself is unchanged.**

**Tests:** new route test (`test/routes-tests/qr+/_private+/$qrId_.link.kit.test.tsx`, 3 cases) — reproduces the exact `TypeError` pre-fix, verifies the Custodian filter shows when permitted and stays hidden when not.

## `2b3a33aed` — `21S` / `221`: 429 rendered as a crash

Rate-limited (`429`) `.data` revalidations on `/bookings/:id/…/manage-kits` surfaced the generic "unexpected error… contact support" boundary **and** were captured to Sentry as if they were real bugs.

**Root cause:** `appLoaderRateLimit` (Hono middleware) responds with a plain `429` JSON that doesn't decode into Shelf's `{error:{…}}` payload, so the client got a bare `Error`; `ErrorContent` had no `429` branch, and `EXPECTED_ERROR_BOUNDARY_STATUSES` was `[403, 404]`, so it was also sent to Sentry.

**Fix:** add `429` to the expected set (drops it from Sentry) + a dedicated "Too many requests — wait a moment, then refresh" boundary screen, mirroring the `404` pattern. **The rate limiter itself is untouched.**

**Tests:** `sentry-filters.test.ts` (429 is expected + dropped) and `errors/index.test.tsx` (calm rate-limit screen, never captured). 32 tests green.

> **Follow-up (not in scope):** if `manage-kits` keeps tripping the limiter after this, its loader/fetcher revalidation cadence is worth a separate look — this PR fixes the *presentation*, not any underlying revalidation storm.

## Validation
- `22B` route test 3/3 · `21S` suites 32/32 · `pnpm turbo typecheck` green · lint + pre-commit security review clean.

## Sentry
`Fixes SHELF-WEBAPP-22B`, `Fixes SHELF-WEBAPP-21S`, `Fixes SHELF-WEBAPP-221` — though auto-close is unreliable on this repo, so I'll confirm/resolve them manually after merge. **`1M1` is left open on purpose**: `22B` should reduce it a lot, but it predates `22B`'s first-seen, so it likely has a second cause worth watching post-merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a calm, dedicated screen for rate-limit errors with clear fallback messaging.
  * Prevented expected rate-limit errors from being reported as unexpected errors.
  * Fixed QR kit-link pages that could fail during server-side rendering.
  * Ensured the Custodian filter appears only when permitted.

* **Tests**
  * Added coverage for rate-limit handling and QR kit-link rendering across permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->