### PR TITLE
fix(nrm): scope select-all export and bulk delete to visible NRMs

### DIFF
--- a/apps/webapp/app/components/nrm/bulk-delete-dialog.tsx
+++ b/apps/webapp/app/components/nrm/bulk-delete-dialog.tsx
@@ -10,6 +10,12 @@ import { Button } from "../shared/button";
 
 export const BulkDeleteNRMSchema = z.object({
   nrmIds: z.array(z.string()).min(1),
+  /**
+   * The index's search params at submit time, emitted by
+   * `BulkUpdateDialogContent`. Needed so a select-all delete stays scoped to
+   * the rows matching the active search rather than every NRM in the org.
+   */
+  currentSearchParams: z.string().optional(),
 });
 
 export default function BulkDeleteDialog() {

--- a/apps/webapp/app/modules/settings/service.server.ts
+++ b/apps/webapp/app/modules/settings/service.server.ts
@@ -1,8 +1,13 @@
-import { InviteStatuses } from "@prisma/client";
-import type { Prisma, Organization, OrganizationRoles } from "@prisma/client";
+import type {
+  InviteStatuses,
+  Prisma,
+  Organization,
+  OrganizationRoles,
+} from "@prisma/client";
 
 import type { LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
+import { getNrmIndexWhere } from "~/modules/team-member/nrm-scope";
 import {
   organizationRolesMap,
   type UserFriendlyRoles,
@@ -155,25 +160,10 @@ export async function getPaginatedAndFilterableSettingTeamMembers({
     const take = perPage >= 1 && perPage <= 100 ? perPage : 200;
 
     /**
-     * 1. Don't have any invites(userId:null)
-     * 2. If they have invites, they should not be pending(userId!=null which mean invite is accepted so we only need to worry about pending ones)
+     * The NRM population is defined once in `getNrmIndexWhere` so the export
+     * and bulk-delete select-all paths cannot drift from what this index shows.
      */
-    const where: Prisma.TeamMemberWhereInput = {
-      deletedAt: null,
-      organizationId,
-      userId: null,
-      receivedInvites: {
-        none: { status: InviteStatuses.PENDING },
-      },
-    };
-
-    if (search) {
-      where.OR = [
-        { name: { contains: search, mode: "insensitive" } },
-        { user: { firstName: { contains: search, mode: "insensitive" } } },
-        { user: { lastName: { contains: search, mode: "insensitive" } } },
-      ];
-    }
+    const where = getNrmIndexWhere({ organizationId, search });
 
     const [teamMembers, totalTeamMembers] = await Promise.all([
       db.teamMember.findMany({

--- a/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
+++ b/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
@@ -1,0 +1,92 @@
+import { InviteStatuses } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ALL_SELECTED_KEY } from "~/utils/list";
+
+const dbMocks = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  updateMany: vi.fn(),
+}));
+
+// why: the scope of the delete query IS the behaviour under test, so we assert
+// on the `where` Prisma receives rather than standing up a database.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    teamMember: { findMany: dbMocks.findMany, updateMany: dbMocks.updateMany },
+  },
+}));
+
+const { bulkDeleteNRMs } = await import("~/modules/team-member/service.server");
+
+const ORG = "org-1";
+
+const NRM_BASE_SCOPE = {
+  deletedAt: null,
+  organizationId: ORG,
+  userId: null,
+  receivedInvites: { none: { status: InviteStatuses.PENDING } },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.findMany.mockResolvedValue([]);
+  dbMocks.updateMany.mockResolvedValue({ count: 0 });
+});
+
+describe("bulkDeleteNRMs", () => {
+  it("does not widen a select-all delete to every TeamMember in the org", async () => {
+    await bulkDeleteNRMs({ nrmIds: [ALL_SELECTED_KEY], organizationId: ORG });
+
+    // The regression: `{ organizationId }` alone would have soft-deleted the
+    // rows backing registered users, which this index never lists.
+    expect(dbMocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: NRM_BASE_SCOPE })
+    );
+  });
+
+  it("scopes a select-all delete to the active search", async () => {
+    await bulkDeleteNRMs({
+      nrmIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      search: "john",
+    });
+
+    const { where } = dbMocks.findMany.mock.calls[0][0];
+    expect(where.OR).toHaveLength(3);
+    expect(where.deletedAt).toBeNull();
+  });
+
+  it("refuses to act on explicitly-passed ids that are outside the NRM scope", async () => {
+    await bulkDeleteNRMs({ nrmIds: ["a", "b"], organizationId: ORG });
+
+    expect(dbMocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { ...NRM_BASE_SCOPE, id: { in: ["a", "b"] } },
+      })
+    );
+  });
+
+  it("soft-deletes only the rows the scoped query returned", async () => {
+    dbMocks.findMany.mockResolvedValue([
+      { id: "a", _count: { custodies: 0 } },
+      { id: "b", _count: { custodies: 0 } },
+    ]);
+
+    await bulkDeleteNRMs({ nrmIds: [ALL_SELECTED_KEY], organizationId: ORG });
+
+    expect(dbMocks.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["a", "b"] }, organizationId: ORG },
+        data: { deletedAt: expect.any(Date) },
+      })
+    );
+  });
+
+  it("still refuses the batch when a selected member holds custody", async () => {
+    dbMocks.findMany.mockResolvedValue([{ id: "a", _count: { custodies: 2 } }]);
+
+    await expect(
+      bulkDeleteNRMs({ nrmIds: ["a"], organizationId: ORG })
+    ).rejects.toThrow(/custody/i);
+    expect(dbMocks.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
+++ b/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
@@ -75,10 +75,26 @@ describe("bulkDeleteNRMs", () => {
 
     expect(dbMocks.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: { in: ["a", "b"] }, organizationId: ORG },
+        where: expect.objectContaining({ id: { in: ["a", "b"] } }),
         data: { deletedAt: expect.any(Date) },
       })
     );
+  });
+
+  it("re-asserts the NRM scope and custody guard in the write predicate", async () => {
+    dbMocks.findMany.mockResolvedValue([{ id: "a", _count: { custodies: 0 } }]);
+
+    await bulkDeleteNRMs({ nrmIds: [ALL_SELECTED_KEY], organizationId: ORG });
+
+    // The read and the write are two round trips. A row that stops being an
+    // NRM in between — gains a custody, accepts an invite, is deleted by
+    // someone else — must not be written by ids resolved before that change.
+    const { where } = dbMocks.updateMany.mock.calls[0][0];
+    expect(where).toEqual({
+      ...NRM_BASE_SCOPE,
+      id: { in: ["a"] },
+      custodies: { none: {} },
+    });
   });
 
   it("still refuses the batch when a selected member holds custody", async () => {

--- a/apps/webapp/app/modules/team-member/nrm-scope.test.ts
+++ b/apps/webapp/app/modules/team-member/nrm-scope.test.ts
@@ -1,0 +1,90 @@
+import { InviteStatuses } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import { ALL_SELECTED_KEY } from "~/utils/list";
+import { getNrmIndexWhere, getNrmSelectionWhere } from "./nrm-scope";
+
+const ORG = "org-1";
+
+describe("getNrmIndexWhere", () => {
+  it("excludes soft-deleted members, registered users and pending invites", () => {
+    expect(getNrmIndexWhere({ organizationId: ORG })).toEqual({
+      deletedAt: null,
+      organizationId: ORG,
+      userId: null,
+      receivedInvites: { none: { status: InviteStatuses.PENDING } },
+    });
+  });
+
+  it("adds a name/user search when one is supplied", () => {
+    const where = getNrmIndexWhere({ organizationId: ORG, search: "john" });
+
+    expect(where.OR).toEqual([
+      { name: { contains: "john", mode: "insensitive" } },
+      { user: { firstName: { contains: "john", mode: "insensitive" } } },
+      { user: { lastName: { contains: "john", mode: "insensitive" } } },
+    ]);
+  });
+
+  it("omits the search clause for empty or absent search", () => {
+    expect(
+      getNrmIndexWhere({ organizationId: ORG, search: "" }).OR
+    ).toBeUndefined();
+    expect(
+      getNrmIndexWhere({ organizationId: ORG, search: null }).OR
+    ).toBeUndefined();
+  });
+});
+
+describe("getNrmSelectionWhere", () => {
+  it("keeps the full NRM scope on select-all instead of widening to the whole org", () => {
+    const where = getNrmSelectionWhere({
+      nrmIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+    });
+
+    // The regression: a bare `{ organizationId }` here exported ~5k rows for a
+    // ~2k-row index by pulling in deleted members and registered users.
+    expect(where).toEqual({
+      deletedAt: null,
+      organizationId: ORG,
+      userId: null,
+      receivedInvites: { none: { status: InviteStatuses.PENDING } },
+    });
+    expect(where.id).toBeUndefined();
+  });
+
+  it("applies the active search on select-all", () => {
+    const where = getNrmSelectionWhere({
+      nrmIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      search: "john",
+    });
+
+    expect(where.OR).toHaveLength(3);
+  });
+
+  it("scopes explicit ids to non-deleted NRMs so untrusted ids can't widen the set", () => {
+    const where = getNrmSelectionWhere({
+      nrmIds: ["a", "b"],
+      organizationId: ORG,
+    });
+
+    expect(where).toEqual({
+      deletedAt: null,
+      organizationId: ORG,
+      userId: null,
+      receivedInvites: { none: { status: InviteStatuses.PENDING } },
+      id: { in: ["a", "b"] },
+    });
+  });
+
+  it("ignores search when explicit ids are given (already post-filter)", () => {
+    const where = getNrmSelectionWhere({
+      nrmIds: ["a"],
+      organizationId: ORG,
+      search: "john",
+    });
+
+    expect(where.OR).toBeUndefined();
+  });
+});

--- a/apps/webapp/app/modules/team-member/nrm-scope.ts
+++ b/apps/webapp/app/modules/team-member/nrm-scope.ts
@@ -1,0 +1,100 @@
+/**
+ * NRM (Non-Registered Member) Scope Helpers
+ *
+ * Single source of truth for "which TeamMember rows are NRMs visible on the
+ * /settings/team/nrm index". The index, the CSV export, and bulk delete all
+ * operate on that same population, so they MUST derive their Prisma `where`
+ * from here rather than hand-rolling one.
+ *
+ * Why this exists: the export and bulk-delete select-all branches used a bare
+ * `{ organizationId }`, which silently widened the population to every
+ * TeamMember row in the org — soft-deleted members, the rows belonging to
+ * registered users, and members with a pending invite. Users saw ~2k rows on
+ * the index and got ~5k rows in the export.
+ *
+ * @see {@link file://./service.server.ts} bulkDeleteNRMs (select-all delete)
+ * @see {@link file://./../settings/service.server.ts} getPaginatedAndFilterableSettingTeamMembers (the index)
+ * @see {@link file://./../../utils/csv.server.ts} exportNRMsToCsv (the export)
+ */
+import type { Organization, Prisma } from "@prisma/client";
+import { InviteStatuses } from "@prisma/client";
+import { ALL_SELECTED_KEY } from "~/utils/list";
+
+/**
+ * Builds the base `where` matching exactly the NRMs the index lists.
+ *
+ * The three predicates beyond `organizationId` are what make a TeamMember an
+ * NRM, and every one of them is load-bearing:
+ * - `deletedAt: null` — NRM delete is a SOFT delete, so deleted rows persist.
+ * - `userId: null` — a TeamMember linked to a User is a registered member and
+ *   belongs on the Users tab, not here.
+ * - no PENDING invite — an invited-but-not-yet-accepted member is shown on the
+ *   Invites tab instead.
+ *
+ * @param params.organizationId - The active organization; scopes out other tenants
+ * @param params.search - Optional free-text search, matched against the member
+ *   name and the linked user's first/last name (mirrors the index)
+ * @returns A Prisma `where` selecting only index-visible NRMs
+ */
+export function getNrmIndexWhere({
+  organizationId,
+  search,
+}: {
+  organizationId: Organization["id"];
+  search?: string | null;
+}): Prisma.TeamMemberWhereInput {
+  const where: Prisma.TeamMemberWhereInput = {
+    deletedAt: null,
+    organizationId,
+    userId: null,
+    receivedInvites: {
+      none: { status: InviteStatuses.PENDING },
+    },
+  };
+
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: "insensitive" } },
+      { user: { firstName: { contains: search, mode: "insensitive" } } },
+      { user: { lastName: { contains: search, mode: "insensitive" } } },
+    ];
+  }
+
+  return where;
+}
+
+/**
+ * Builds the `where` for a bulk operation driven by the index's selection,
+ * honouring the ALL_SELECTED_KEY sentinel.
+ *
+ * Both branches keep the full NRM base scope, so an explicitly-passed id that
+ * is soft-deleted (or belongs to a registered user) can never be acted on —
+ * the ids arrive from the client and are not trustworthy on their own.
+ *
+ * `search` is applied ONLY on the select-all branch: "select all" means "every
+ * row matching the filters I currently have applied", whereas an explicit id
+ * list is already the post-filter result and must not be narrowed twice.
+ *
+ * @param params.nrmIds - Selected ids, or a list containing ALL_SELECTED_KEY
+ * @param params.organizationId - The active organization
+ * @param params.search - The index's active search, forwarded on select-all
+ * @returns A Prisma `where` for the selected NRMs
+ */
+export function getNrmSelectionWhere({
+  nrmIds,
+  organizationId,
+  search,
+}: {
+  nrmIds: string[];
+  organizationId: Organization["id"];
+  search?: string | null;
+}): Prisma.TeamMemberWhereInput {
+  if (nrmIds.includes(ALL_SELECTED_KEY)) {
+    return getNrmIndexWhere({ organizationId, search });
+  }
+
+  return {
+    ...getNrmIndexWhere({ organizationId }),
+    id: { in: nrmIds },
+  };
+}

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -695,10 +695,21 @@ export async function bulkDeleteNRMs({
       });
     }
 
+    // The write re-asserts the full read predicate rather than trusting the ids
+    // alone. Selection and write are two round trips, so a row can stop being a
+    // deletable NRM in between — accept an invite, be soft-deleted by someone
+    // else, or acquire custody after the guard above ran. Restating the scope
+    // (plus the custody check, which the read could only evaluate in JS) makes
+    // those rows fall out of the write instead of being soft-deleted on stale
+    // ids. Rows that changed are skipped, not fatal: `updateMany` simply matches
+    // fewer rows.
     return await db.teamMember.updateMany({
       where: {
-        id: { in: teamMembers.map((tm) => tm.id) },
-        organizationId,
+        ...getNrmSelectionWhere({
+          nrmIds: teamMembers.map((tm) => tm.id),
+          organizationId,
+        }),
+        custodies: { none: {} },
       },
       data: { deletedAt: new Date() },
     });

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -7,9 +7,10 @@ import { updateCookieWithPerPage } from "~/utils/cookies.server";
 import type { ErrorLabel } from "~/utils/error";
 import { isNotFoundError, ShelfError } from "~/utils/error";
 import { getCurrentSearchParams } from "~/utils/http.server";
-import { ALL_SELECTED_KEY, getParamsValues } from "~/utils/list";
+import { getParamsValues } from "~/utils/list";
 import { Logger } from "~/utils/logger";
 import { resolveUserDisplayName } from "~/utils/user";
+import { getNrmSelectionWhere } from "./nrm-scope";
 import type { CreateAssetFromContentImportPayload } from "../asset/types";
 
 const label: ErrorLabel = "Team Member";
@@ -648,17 +649,32 @@ export async function getTeamMember({
   }
 }
 
+/**
+ * Soft-deletes the selected NRMs, refusing the whole batch if any of them
+ * still holds custody.
+ *
+ * @param params.nrmIds - Selected ids, or a list containing ALL_SELECTED_KEY
+ * @param params.organizationId - The active organization
+ * @param params.search - The index's active search, forwarded on select-all so
+ *   the delete matches exactly the rows the user had in front of them
+ * @returns The Prisma batch payload for the soft-delete
+ * @throws {ShelfError} If any selected member holds custody, or the write fails
+ */
 export async function bulkDeleteNRMs({
   nrmIds,
   organizationId,
+  search,
 }: {
   nrmIds: TeamMember["id"][];
   organizationId: TeamMember["organizationId"];
+  search?: string | null;
 }) {
   try {
-    const where: Prisma.TeamMemberWhereInput = nrmIds.includes(ALL_SELECTED_KEY)
-      ? { organizationId }
-      : { id: { in: nrmIds }, organizationId };
+    // Derived from the shared NRM scope. A bare `{ organizationId }` here would
+    // soft-delete EVERY TeamMember row in the org on select-all — including the
+    // rows backing registered users, which are not NRMs and are not listed on
+    // this index.
+    const where = getNrmSelectionWhere({ nrmIds, organizationId, search });
 
     const teamMembers = await db.teamMember.findMany({
       where,

--- a/apps/webapp/app/routes/api+/nrm.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/nrm.bulk-actions.ts
@@ -39,9 +39,18 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
     switch (intent) {
       case "bulk-delete": {
-        const { nrmIds } = parseData(formData, BulkDeleteNRMSchema);
+        const { nrmIds, currentSearchParams } = parseData(
+          formData,
+          BulkDeleteNRMSchema
+        );
 
-        await bulkDeleteNRMs({ nrmIds, organizationId });
+        await bulkDeleteNRMs({
+          nrmIds,
+          organizationId,
+          // Forwarded by BulkUpdateDialogContent. On select-all this keeps the
+          // delete scoped to the filtered rows the user was actually looking at.
+          search: new URLSearchParams(currentSearchParams ?? "").get("s"),
+        });
 
         sendNotification({
           title: "Non-registered members deleted",

--- a/apps/webapp/app/routes/api+/settings.export-nrm.$fileName[.csv].ts
+++ b/apps/webapp/app/routes/api+/settings.export-nrm.$fileName[.csv].ts
@@ -34,6 +34,9 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const csvString = await exportNRMsToCsv({
       organizationId,
       nrmIds: nrmIds.split(","),
+      // The export button forwards the index's current search params, so
+      // "select all" exports exactly the filtered set the user can see.
+      search: searchParams.get("s"),
     });
 
     return new Response(csvString, {

--- a/apps/webapp/app/utils/csv.server.export-nrms.test.ts
+++ b/apps/webapp/app/utils/csv.server.export-nrms.test.ts
@@ -1,0 +1,62 @@
+import { InviteStatuses } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ALL_SELECTED_KEY } from "~/utils/list";
+
+const dbMocks = vi.hoisted(() => ({ findMany: vi.fn() }));
+
+// why: the query scope IS the behaviour under test — assert on the `where`
+// Prisma receives rather than standing up a database.
+vi.mock("~/database/db.server", () => ({
+  db: { teamMember: { findMany: dbMocks.findMany } },
+}));
+// why: suppress lottie animation initialization during module imports
+vi.mock("lottie-react", () => ({ default: () => null }));
+
+const { exportNRMsToCsv } = await import("~/utils/csv.server");
+
+const ORG = "org-1";
+
+const NRM_BASE_SCOPE = {
+  deletedAt: null,
+  organizationId: ORG,
+  userId: null,
+  receivedInvites: { none: { status: InviteStatuses.PENDING } },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.findMany.mockResolvedValue([]);
+});
+
+describe("exportNRMsToCsv", () => {
+  it("excludes deleted members and registered users on select-all", async () => {
+    await exportNRMsToCsv({ nrmIds: [ALL_SELECTED_KEY], organizationId: ORG });
+
+    // The reported bug: a ~2k-row index exported ~5k rows because this branch
+    // selected every TeamMember in the org.
+    expect(dbMocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: NRM_BASE_SCOPE })
+    );
+  });
+
+  it("honours the index's active search on select-all", async () => {
+    await exportNRMsToCsv({
+      nrmIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      search: "john",
+    });
+
+    const { where } = dbMocks.findMany.mock.calls[0][0];
+    expect(where.OR).toHaveLength(3);
+  });
+
+  it("keeps explicit ids scoped to live NRMs", async () => {
+    await exportNRMsToCsv({ nrmIds: ["a", "b"], organizationId: ORG });
+
+    expect(dbMocks.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { ...NRM_BASE_SCOPE, id: { in: ["a", "b"] } },
+      })
+    );
+  });
+});

--- a/apps/webapp/app/utils/csv.server.ts
+++ b/apps/webapp/app/utils/csv.server.ts
@@ -46,6 +46,7 @@ import type { BookingWithCustodians } from "~/modules/booking/types";
 import { calculatePartialCheckinProgress } from "~/modules/booking/utils.server";
 import { getPrimaryCustody } from "~/modules/custody/utils";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
+import { getNrmSelectionWhere } from "~/modules/team-member/nrm-scope";
 import { getAssetTotalValue } from "./asset-value";
 import { getBookingAssetCheckinLabel } from "./booking-assets";
 import { checkExhaustiveSwitch } from "./check-exhaustive-switch";
@@ -1579,17 +1580,29 @@ export const buildCsvExportDataFromBookings = (
   return [Object.values(headers), ...rows];
 };
 
+/**
+ * Exports the selected NRMs to CSV.
+ *
+ * @param params.nrmIds - Selected ids, or a list containing ALL_SELECTED_KEY
+ * @param params.organizationId - The active organization
+ * @param params.search - The index's active search, forwarded on select-all so
+ *   "select all" exports what the user is actually looking at
+ * @returns The CSV string
+ * @throws {ShelfError} If the query or serialisation fails
+ */
 export async function exportNRMsToCsv({
   nrmIds,
   organizationId,
+  search,
 }: {
   nrmIds: TeamMember["id"][];
   organizationId: Organization["id"];
+  search?: string | null;
 }) {
   try {
-    const where: Prisma.TeamMemberWhereInput = nrmIds.includes(ALL_SELECTED_KEY)
-      ? { organizationId }
-      : { id: { in: nrmIds }, organizationId };
+    // Derived from the shared NRM scope so the export can never diverge from
+    // the index again (it used to select the whole org on select-all).
+    const where = getNrmSelectionWhere({ nrmIds, organizationId, search });
 
     const teamMembers = await db.teamMember.findMany({
       where,
@@ -1604,7 +1617,7 @@ export async function exportNRMsToCsv({
       message: isLikeShelfError(cause)
         ? cause.message
         : "Something went wrong while exporting NRMs to csv.",
-      additionalData: { nrmIds, organizationId },
+      additionalData: { nrmIds, organizationId, search },
     });
   }
 }


### PR DESCRIPTION
## The bug

Reported on `/settings/team/nrm`: selecting all and exporting produced ~5k rows for an index showing ~2k.

`exportNRMsToCsv` built its select-all query as a bare `{ organizationId }`, while the index filters on **four** predicates:

```ts
// index (getPaginatedAndFilterableSettingTeamMembers)   // export (select-all)
{ deletedAt: null, organizationId,                        { organizationId }
  userId: null,
  receivedInvites: { none: { status: PENDING } } }
```

So the export pulled in three populations the index never shows, and dropped the search as a fourth divergence:

1. **Soft-deleted members** — deleting an NRM only sets `deletedAt`, the rows persist
2. **Registered users** — every registered user has a `TeamMember` row; those belong on the Users tab
3. **Pending invitees** — shown on the Invites tab
4. **Search** — the export button already forwards the index's search params; the route ignored them

## The sibling it travels with

Sweeping for the pattern found `bulkDeleteNRMs` with the **byte-identical** query — and there it is worse than a bad export. On select-all it would soft-delete *every* `TeamMember` row in the org, including the rows backing registered users. The custody guard only masks this when some selected member happens to hold custody; on a workspace where none do, it goes straight through.

## The fix

New `app/modules/team-member/nrm-scope.ts` defines the NRM population once. The index, the export and the bulk delete all derive from it, so the three cannot drift apart again.

Explicitly-passed ids get the same base scope, so a client-supplied id that is soft-deleted or belongs to a registered user cannot be acted on either. Both callers now forward the active search — the export button already sent it in the query string, and `BulkUpdateDialogContent` already posts `currentSearchParams`.

## Tests

15 new tests across `nrm-scope.test.ts`, `bulk-delete-nrms.test.ts` and `csv.server.export-nrms.test.ts`.

Verified they actually pin the regression rather than just passing: reverting the fix fails 3 of them, and they pass again on the fix.

`pnpm webapp:validate` is green — typecheck 0, lint 0. Three route-test files (`*activity[.csv]`, `bookings.$bookingId.overview.scan-assets`) hit the known 10s `hookTimeout` flake; all pass at `--hookTimeout=30000` and are untouched by this change.

## Follow-up not in this PR

This stops the bleeding but does not clean up rows already affected. If any workspace ran a select-all NRM delete before this fix, registered users' `TeamMember` rows may be sitting soft-deleted. Worth a query against production to check whether remediation is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bulk deletion now applies the active search filter when using “select all,” preventing unrelated team members from being removed.
  - CSV exports now match the currently filtered list, excluding deleted or registered members.
  - Explicit selections remain limited to eligible, visible team members.
  - Deletion is prevented when selected members hold custody.

- **Tests**
  - Added coverage for filtered selections, exports, and bulk-deletion safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->