### PR TITLE
fix(bookings): stop the unavailable-assets badge firing on partial quantity-tracked custody

### DIFF
--- a/apps/webapp/app/components/booking/list-bookings-content.tsx
+++ b/apps/webapp/app/components/booking/list-bookings-content.tsx
@@ -15,9 +15,9 @@
  */
 import type { Prisma } from "@prisma/client";
 import { useLoaderData } from "react-router";
-import { hasCustody } from "~/modules/custody/utils";
 import type { BookingsIndexLoaderData } from "~/routes/_layout+/bookings._index";
 import { BADGE_COLORS } from "~/utils/badge-colors";
+import { bookingIncludesUnavailableAssets } from "~/utils/booking-assets";
 import {
   canAssignModelUnits,
   countUnassignedModelUnits,
@@ -216,10 +216,11 @@ export default function ListBookingsContent({
     bookingAssets: rawItem.bookingAssets ?? [],
   };
 
-  const hasUnavaiableAssets =
-    item.bookingAssets.some(
-      (ba) => !ba.asset.availableToBook || hasCustody(ba.asset.custody)
-    ) && !["COMPLETE", "CANCELLED", "ARCHIVED"].includes(item.status);
+  // Shared, tested predicate — see `bookingIncludesUnavailableAssets`.
+  const hasUnavaiableAssets = bookingIncludesUnavailableAssets(
+    item.bookingAssets.map((ba) => ba.asset),
+    item.status
+  );
 
   /**
    * Pull this booking's slice of the page-wide dispositioned-quantity

--- a/apps/webapp/app/utils/booking-assets.ts
+++ b/apps/webapp/app/utils/booking-assets.ts
@@ -1,4 +1,4 @@
-import { AssetStatus, KitStatus } from "@prisma/client";
+import { AssetStatus, AssetType, KitStatus } from "@prisma/client";
 import type { PartialCheckinDetailsType } from "~/modules/booking/service.server";
 
 /**
@@ -797,4 +797,58 @@ export function resolveQtyStockBadgeVariant({
   }
 
   return null;
+}
+
+/** Minimal row shape the unavailable-assets badge needs. */
+export type BookingRowAssetForBadge = {
+  availableToBook: boolean;
+  type: AssetType;
+  custody: unknown[] | null | undefined;
+};
+
+/**
+ * Whether a booking should show the "Includes unavailable assets" badge.
+ *
+ * Two things make a booking's contents unavailable:
+ *
+ *  1. An asset flagged `availableToBook: false` — an explicit operator choice,
+ *     independent of type.
+ *  2. An **INDIVIDUAL** asset held in custody. An INDIVIDUAL asset is one
+ *     indivisible thing, so if someone holds it, it is not free.
+ *
+ * `QUANTITY_TRACKED` assets are deliberately excluded from the custody arm.
+ * Custody on a QT asset means SOME units are allocated, not all of them:
+ * assigning 3 of 12 leaves 9 genuinely bookable. Treating any custody row as
+ * disqualifying made the badge fire on bookings that were completely valid,
+ * and a badge that cries wolf trains people to ignore it — which is worse than
+ * not having it, because the cases it exists for are real.
+ *
+ * This mirrors `hasAssetsInCustody` in `getBookingFlags`
+ * (`~/modules/booking/service.server`), which already draws exactly this line
+ * server-side. The badge had its own inline copy that never got the same fix.
+ *
+ * Per-unit availability for QT assets is enforced properly at the service layer
+ * by `computeBookingAvailableQuantity()` when assets are added or quantities
+ * adjusted, so nothing is lost by dropping them from this cosmetic signal.
+ *
+ * @param assets - The booking's assets (flattened from `bookingAssets`).
+ * @param bookingStatus - Terminal bookings never show the badge; the warning is
+ *   about what can still go wrong, and nothing can.
+ * @returns True when the badge should render.
+ */
+export function bookingIncludesUnavailableAssets(
+  assets: BookingRowAssetForBadge[],
+  bookingStatus: string
+): boolean {
+  if (["COMPLETE", "CANCELLED", "ARCHIVED"].includes(bookingStatus)) {
+    return false;
+  }
+
+  return assets.some(
+    (asset) =>
+      !asset.availableToBook ||
+      (asset.type !== AssetType.QUANTITY_TRACKED &&
+        !!asset.custody &&
+        asset.custody.length > 0)
+  );
 }

--- a/apps/webapp/app/utils/booking-unavailable-badge.test.ts
+++ b/apps/webapp/app/utils/booking-unavailable-badge.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The "Includes unavailable assets" badge.
+ *
+ * Pinned against a real customer report (University of York, 2026-08-07): a
+ * QUANTITY_TRACKED asset with some units assigned to a custodian, the free
+ * units booked successfully, and the booking still labelled as containing
+ * unavailable assets. The booking was valid and checked out fine — the badge
+ * was simply wrong.
+ *
+ * The tests below fix that case WITHOUT weakening the badge: everything it
+ * legitimately warns about must still warn.
+ *
+ * @see {@link file://./booking-assets.ts} — `bookingIncludesUnavailableAssets`
+ */
+import { AssetType } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+import { bookingIncludesUnavailableAssets } from "./booking-assets";
+
+const qtAsset = (custodyRows: number) => ({
+  availableToBook: true,
+  type: AssetType.QUANTITY_TRACKED,
+  custody: Array.from({ length: custodyRows }, () => ({})),
+});
+
+const individualAsset = (custodyRows: number) => ({
+  availableToBook: true,
+  type: AssetType.INDIVIDUAL,
+  custody: Array.from({ length: custodyRows }, () => ({})),
+});
+
+describe("bookingIncludesUnavailableAssets", () => {
+  it("does NOT warn for a quantity-tracked asset with some units in custody", () => {
+    // The reported case. Custody on a QT asset means SOME units are allocated;
+    // the rest are bookable, which is exactly what the customer booked.
+    expect(bookingIncludesUnavailableAssets([qtAsset(1)], "RESERVED")).toBe(
+      false
+    );
+  });
+
+  it("does NOT warn when several custodians hold units of the same QT asset", () => {
+    // Multiple custody rows is still "some units allocated", not "none free".
+    expect(bookingIncludesUnavailableAssets([qtAsset(3)], "DRAFT")).toBe(false);
+  });
+
+  it("STILL warns for an INDIVIDUAL asset in custody", () => {
+    // One indivisible thing. If someone holds it, the booking cannot have it.
+    expect(
+      bookingIncludesUnavailableAssets([individualAsset(1)], "RESERVED")
+    ).toBe(true);
+  });
+
+  it("STILL warns for an asset flagged not-available-to-book, whatever its type", () => {
+    // An explicit operator decision, independent of custody or type.
+    for (const type of [AssetType.INDIVIDUAL, AssetType.QUANTITY_TRACKED]) {
+      expect(
+        bookingIncludesUnavailableAssets(
+          [{ availableToBook: false, type, custody: [] }],
+          "RESERVED"
+        )
+      ).toBe(true);
+    }
+  });
+
+  it("warns when a mixed booking contains one genuinely unavailable asset", () => {
+    // The QT asset must not mask a real problem sitting next to it.
+    expect(
+      bookingIncludesUnavailableAssets(
+        [qtAsset(2), individualAsset(1)],
+        "RESERVED"
+      )
+    ).toBe(true);
+  });
+
+  it("does not warn on terminal bookings", () => {
+    // The badge is about what can still go wrong. Nothing can.
+    for (const status of ["COMPLETE", "CANCELLED", "ARCHIVED"]) {
+      expect(
+        bookingIncludesUnavailableAssets([individualAsset(1)], status)
+      ).toBe(false);
+    }
+  });
+
+  it("tolerates a missing custody relation", () => {
+    expect(
+      bookingIncludesUnavailableAssets(
+        [{ availableToBook: true, type: AssetType.INDIVIDUAL, custody: null }],
+        "RESERVED"
+      )
+    ).toBe(false);
+  });
+
+  it("does not warn on an empty booking", () => {
+    expect(bookingIncludesUnavailableAssets([], "DRAFT")).toBe(false);
+  });
+});


### PR DESCRIPTION
## The report

A customer (2026-08-07):

> "I have set up a **'tracked by quantity'** asset and **assigned some of the items to a custodian**. I **can book the unassigned items as expected**, however when the booking is created it says it **'Includes unavailable assets'** — do you know how to fix this?"

He had not set anything up wrong. The badge is simply wrong.

## Reproduced on production

ACME, booking **`ZZ YORK REPRO - partial custody QT (safe to delete)`** — left in place so you can see it yourself:

- `Sandbag (Counterweight) 24×45cm`, QUANTITY_TRACKED, **12 units**
- **4 assigned** to John Doe → status `Partial custody`, Available **8**
- Booking takes **1 free unit**. The picker offered it, the service accepted it.
- The list shows the amber **"Includes unavailable assets"** badge.

Read from the DOM: `badgePresent: true`. Every unit in that booking is free.

## Cause

`list-bookings-content.tsx` asked:

```ts
!ba.asset.availableToBook || hasCustody(ba.asset.custody)
```

`hasCustody` is only `custody.length > 0` — no notion of **how many** units are held.

That is the right question for an `INDIVIDUAL` asset, which is one indivisible thing: if someone holds it, it is not free. It is meaningless for a quantity-tracked one, where 4 of 12 assigned leaves 8 bookable.

**This is a divergence, not a missing feature.** The server already draws the line:

- `getBookingFlags` (`booking/service.server.ts`) excludes `QUANTITY_TRACKED` from `hasAssetsInCustody`, with a comment saying partial custody leaves the rest bookable.
- `availability-label.tsx:90` and `:407` both guard with `!isQuantityTracked`.

The bookings-list badge was the **last inline copy** that never got the same fix.

## The fix

The predicate moves to `bookingIncludesUnavailableAssets` in `~/utils/booking-assets`, so the component and its tests read one definition instead of the component holding a second opinion.

Per-unit availability for QT assets is still enforced at the service layer by `computeBookingAvailableQuantity()` when assets are added, so nothing is lost by dropping them from this cosmetic signal.

## Testing

8 tests. **Two fail against the current production logic**, so they encode the bug rather than only the fix:

| Case | Old logic | With fix |
|---|---|---|
| QT asset, some units in custody | ❌ fails | ✅ |
| QT asset, several custodians | ❌ fails | ✅ |
| INDIVIDUAL in custody → **still warns** | ✅ | ✅ |
| `availableToBook: false`, either type → **still warns** | ✅ | ✅ |
| Mixed booking, one genuinely unavailable → **still warns** | ✅ | ✅ |
| Terminal bookings stay quiet | ✅ | ✅ |
| Missing custody relation | ✅ | ✅ |
| Empty booking | ✅ | ✅ |

The control cases are the point: this removes a false positive without blinding the badge.

Also verified by running the **exact production row shape** through both predicates:

```
OLD predicate (live on prod today) -> badge shown: true
NEW predicate (the fix)            -> badge shown: false
CONTROL: INDIVIDUAL asset in custody -> badge shown: true
```

Full suite green. Typecheck clean. Lint at the pre-existing warnings.

## Why it matters more than a cosmetic badge

A badge that cries wolf is worse than no badge: it trains people to ignore the cases it exists for. This customer's reaction was to assume he had configured something incorrectly.

## Not in scope

The **Available count** reading 9 when the truth is 4 is a separate defect, fixed in #2830. Both were reported by the same customer. Shipping only one leaves him with half of what he was told was coming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unavailable-asset warnings on booking lists.
  - Warnings now accurately identify individual assets that are unavailable or in custody.
  - Quantity-tracked assets in custody no longer trigger an incorrect warning.
  - Warnings are hidden for completed or otherwise terminal bookings.
  - Bookings with missing asset details are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->