### PR TITLE
fix(bookings): one activity note per model on bulk fulfilment, not one per asset

### DIFF
--- a/apps/webapp/app/modules/booking-model-request/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.test.ts
@@ -1133,6 +1133,10 @@ describe("fulfilModelRequestsForAssets — note volume", () => {
       fulfilledAt: null as Date | null,
       assetModel: { name: "Dell Latitude 5550" },
     };
+    // why: every simulated claim must read and mutate the SAME row, so the
+    // loop's next read sees the previous increment — that is what a committed
+    // row does, and returning a fresh object each call would hide a lost
+    // update instead of exposing it.
     // @ts-expect-error mocked
     db.bookingModelRequest.findUnique.mockImplementation(() =>
       Promise.resolve(row)
@@ -1166,6 +1170,28 @@ describe("fulfilModelRequestsForAssets — note volume", () => {
     const content = vitest.mocked(db.bookingNote.create).mock.calls[0][0].data
       .content as string;
     expect(content).toContain("0 × Dell Latitude 5550 remaining");
+  });
+
+  it("states a count instead of embedding ids once the batch is large", async () => {
+    expect.assertions(2);
+    stageRequest(40);
+
+    await fulfilModelRequestsForAssets({
+      bookingId: BOOKING_ID,
+      assets: assetsOfModel(40),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      tx,
+    });
+
+    const content = vitest.mocked(db.bookingNote.create).mock.calls[0][0].data
+      .content as string;
+
+    // `assets_list` copies every id into the query string of GET /api/assets,
+    // so an unbounded batch of 25-char CUIDs exceeds Node's request-target
+    // limit and the activity entry answers 431 instead of opening.
+    expect(content).not.toContain("assets_list");
+    expect(content).toContain("**40 assets**");
   });
 
   it("keeps the single-asset wording byte-identical to the per-asset note", async () => {

--- a/apps/webapp/app/modules/booking-model-request/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.test.ts
@@ -527,7 +527,6 @@ describe("materializeModelRequestForAsset", () => {
         type: AssetType.INDIVIDUAL,
       },
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -572,7 +571,6 @@ describe("materializeModelRequestForAsset", () => {
         type: AssetType.INDIVIDUAL,
       },
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -609,7 +607,6 @@ describe("materializeModelRequestForAsset", () => {
         type: AssetType.INDIVIDUAL,
       },
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -631,7 +628,6 @@ describe("materializeModelRequestForAsset", () => {
         type: AssetType.INDIVIDUAL,
       },
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -899,7 +895,6 @@ describe("fulfilModelRequestsForAssets", () => {
       bookingId: BOOKING_ID,
       assets: [asset("asset-1")],
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -915,7 +910,6 @@ describe("fulfilModelRequestsForAssets", () => {
       bookingId: BOOKING_ID,
       assets: [asset("asset-1"), asset("asset-2", null)],
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -949,7 +943,6 @@ describe("fulfilModelRequestsForAssets", () => {
       bookingId: BOOKING_ID,
       assets: [asset("a1"), asset("a2"), asset("a3")],
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -981,7 +974,6 @@ describe("fulfilModelRequestsForAssets", () => {
       bookingId: BOOKING_ID,
       assets: [asset("a1"), asset("a2"), asset("a3")],
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -1067,7 +1059,6 @@ describe("materializeModelRequestForAsset — concurrent claims", () => {
       bookingId: BOOKING_ID,
       asset,
       organizationId: ORG_ID,
-      userId: USER_ID,
       tx,
     });
 
@@ -1102,7 +1093,6 @@ describe("materializeModelRequestForAsset — concurrent claims", () => {
         bookingId: BOOKING_ID,
         asset: { ...asset, id },
         organizationId: ORG_ID,
-        userId: USER_ID,
         tx,
       });
     }
@@ -1112,5 +1102,107 @@ describe("materializeModelRequestForAsset — concurrent claims", () => {
     // (`2 < 2` is false) while the checkout guard blocks on it, and
     // `removeBookingModelRequest` refuses to delete it. Nothing to click.
     expect(row.fulfilledAt).not.toBeNull();
+  });
+});
+
+/**
+ * Note volume on bulk fulfilment.
+ *
+ * The countdown wording was designed for the scanner, which discharges one unit
+ * at a time. Routing "Manage assets" through the same helper made bulk
+ * fulfilment reachable — tick 20 matching assets, save once — and the per-asset
+ * note turned that into 20 near-identical lines counting down, all INSERTed
+ * inside the caller's interactive transaction.
+ */
+describe("fulfilModelRequestsForAssets — note volume", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tx = db as any;
+
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    installClaimSimulator();
+  });
+
+  const stageRequest = (quantity: number) => {
+    const row = {
+      id: "req-1",
+      bookingId: BOOKING_ID,
+      assetModelId: MODEL_ID,
+      quantity,
+      fulfilledQuantity: 0,
+      fulfilledAt: null as Date | null,
+      assetModel: { name: "Dell Latitude 5550" },
+    };
+    // @ts-expect-error mocked
+    db.bookingModelRequest.findUnique.mockImplementation(() =>
+      Promise.resolve(row)
+    );
+    return row;
+  };
+
+  const assetsOfModel = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `asset-${i + 1}`,
+      title: `Laptop #${i + 1}`,
+      assetModelId: MODEL_ID,
+      type: AssetType.INDIVIDUAL,
+    }));
+
+  it("writes ONE note for a batch, not one per asset", async () => {
+    expect.assertions(2);
+    stageRequest(20);
+
+    await fulfilModelRequestsForAssets({
+      bookingId: BOOKING_ID,
+      assets: assetsOfModel(20),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      tx,
+    });
+
+    expect(db.bookingNote.create).toHaveBeenCalledTimes(1);
+
+    // States the FINAL remainder, not a mid-batch countdown.
+    const content = vitest.mocked(db.bookingNote.create).mock.calls[0][0].data
+      .content as string;
+    expect(content).toContain("0 × Dell Latitude 5550 remaining");
+  });
+
+  it("keeps the single-asset wording byte-identical to the per-asset note", async () => {
+    expect.assertions(1);
+    stageRequest(3);
+
+    await fulfilModelRequestsForAssets({
+      bookingId: BOOKING_ID,
+      assets: assetsOfModel(1),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      tx,
+    });
+
+    // `wrapAssetsWithDataForNote` emits the same `{% link %}` tag at count 1
+    // that `wrapLinkForNote` produced, so the scanner feed is unchanged.
+    const content = vitest.mocked(db.bookingNote.create).mock.calls[0][0].data
+      .content as string;
+    expect(content).toContain(
+      '{% link to="/assets/asset-1" text="Laptop #1" /%}'
+    );
+  });
+
+  it("writes no note when nothing was claimed", async () => {
+    expect.assertions(1);
+    // why: findUnique default is null — no reservation exists for this model.
+    // @ts-expect-error mocked
+    db.bookingModelRequest.findUnique.mockResolvedValue(null);
+
+    await fulfilModelRequestsForAssets({
+      bookingId: BOOKING_ID,
+      assets: assetsOfModel(5),
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      tx,
+    });
+
+    expect(db.bookingNote.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -39,7 +39,10 @@ import { db } from "~/database/db.server";
 import type { ErrorLabel } from "~/utils/error";
 import { ShelfError } from "~/utils/error";
 import { stripMarkdocDelimiters } from "~/utils/markdoc-sanitize";
-import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
+import {
+  wrapAssetsWithDataForNote,
+  wrapUserLinkForNote,
+} from "~/utils/markdoc-wrappers";
 import { createSystemBookingNote } from "../booking-note/service.server";
 import { getUserByID } from "../user/service.server";
 
@@ -784,15 +787,6 @@ type MaterializeArgs = {
   asset: Pick<Asset, "id" | "title" | "assetModelId" | "type">;
   organizationId: string;
   /**
-   * Actor for the activity note. Optional because not every add-assets path
-   * threads one through (`api/assets.add-to-booking` writes its own
-   * user-attributed note instead, so passing a user here would duplicate it).
-   * Fulfilment itself must not depend on attribution — a reservation that
-   * silently survived because the caller had no `userId` would hard-block
-   * check-out. Without an actor the note is written in the system voice.
-   */
-  userId?: string;
-  /**
    * Interactive Prisma transaction client. Required — this function
    * must run in the same tx as the caller's `BookingAsset.create`
    * (typically `addScannedAssetsToBooking`) so a failure anywhere in
@@ -828,7 +822,6 @@ type MaterializeArgs = {
 export async function materializeModelRequestForAsset({
   bookingId,
   asset,
-  userId,
   tx,
 }: MaterializeArgs): Promise<
   | { matched: true; requestId: string; remaining: number; modelName: string }
@@ -933,23 +926,12 @@ export async function materializeModelRequestForAsset({
       claimed[0].quantity - claimed[0].fulfilledQuantity
     );
 
-    // Activity note — IN the tx so the note rolls back with the
-    // materialization if anything later in the pipeline fails.
-    const actor = userId ? await loadActor(userId) : null;
-    const assetLink = wrapLinkForNote(`/assets/${asset.id}`, asset.title);
-    const modelNameForNote = stripMarkdocDelimiters(existing.assetModel.name);
-    // Same sentence either way; only the subject changes, so the feed reads
-    // consistently whether or not the caller threaded an actor through.
-    const content = actor
-      ? `${actor} assigned ${assetLink} (${modelNameForNote}) to this booking — ${remaining} × ${modelNameForNote} remaining.`
-      : `${assetLink} (${modelNameForNote}) was assigned to this booking — ${remaining} × ${modelNameForNote} remaining.`;
-    await tx.bookingNote.create({
-      data: {
-        type: "UPDATE",
-        content,
-        booking: { connect: { id: bookingId } },
-      },
-    });
+    // NOTE: no activity note here on purpose. The caller
+    // ({@link fulfilModelRequestsForAssets}) writes ONE aggregated note per
+    // model once the batch is done. Writing per asset is fine at the scanner's
+    // one-at-a-time pace but turns a 20-asset pick into 20 near-identical
+    // lines ("19 remaining", "18 remaining", ...), all INSERTed inside the
+    // caller's interactive transaction.
 
     return {
       matched: true,
@@ -1039,6 +1021,19 @@ export async function fulfilModelRequestsForAssets({
   const fulfilledRequestIdByAssetId = new Map<string, string>();
 
   /**
+   * What each reservation absorbed on this call, so the note is written once
+   * per model instead of once per asset.
+   */
+  const claimsByRequest = new Map<
+    string,
+    {
+      modelName: string;
+      assets: Array<{ id: string; title: string }>;
+      remaining: number;
+    }
+  >();
+
+  /**
    * Short-circuit the overwhelmingly common case: the booking has no
    * outstanding reservations, so no asset can discharge one.
    *
@@ -1067,12 +1062,59 @@ export async function fulfilModelRequestsForAssets({
       bookingId,
       asset,
       organizationId,
-      userId,
       tx,
     });
 
-    if (result.matched) {
-      fulfilledRequestIdByAssetId.set(asset.id, result.requestId);
+    if (!result.matched) continue;
+
+    fulfilledRequestIdByAssetId.set(asset.id, result.requestId);
+
+    const claim = claimsByRequest.get(result.requestId);
+    if (claim) {
+      claim.assets.push({ id: asset.id, title: asset.title });
+      claim.remaining = result.remaining;
+    } else {
+      claimsByRequest.set(result.requestId, {
+        modelName: result.modelName,
+        assets: [{ id: asset.id, title: asset.title }],
+        remaining: result.remaining,
+      });
+    }
+  }
+
+  /**
+   * ONE note per model, written after the batch.
+   *
+   * For a single asset this is byte-identical to the per-asset note it
+   * replaces: `wrapAssetsWithDataForNote` emits the same `{% link %}` tag at
+   * count 1 that `wrapLinkForNote` did, so the scanner's one-at-a-time feed
+   * reads exactly as before. For several it collapses to the repo's standard
+   * `{% assets_list %}` popover, so a 20-asset pick is one line naming all
+   * twenty rather than twenty lines counting down.
+   *
+   * `remaining` is the value after the LAST claim, which is the only figure a
+   * reader cares about. `loadActor` also moves here: it was one user lookup
+   * PER ASSET inside the caller's transaction.
+   */
+  if (claimsByRequest.size > 0) {
+    const actor = userId ? await loadActor(userId) : null;
+
+    for (const claim of claimsByRequest.values()) {
+      const assetsFragment = wrapAssetsWithDataForNote(claim.assets, "assigned");
+      // Model name is literal text, so delimiters must be stripped or a name
+      // containing `{% … %}` renders as a live Markdoc tag.
+      const modelName = stripMarkdocDelimiters(claim.modelName);
+      const content = actor
+        ? `${actor} assigned ${assetsFragment} (${modelName}) to this booking — ${claim.remaining} × ${modelName} remaining.`
+        : `${assetsFragment} (${modelName}) was assigned to this booking — ${claim.remaining} × ${modelName} remaining.`;
+
+      await tx.bookingNote.create({
+        data: {
+          type: "UPDATE",
+          content,
+          booking: { connect: { id: bookingId } },
+        },
+      });
     }
   }
 

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -1100,7 +1100,29 @@ export async function fulfilModelRequestsForAssets({
     const actor = userId ? await loadActor(userId) : null;
 
     for (const claim of claimsByRequest.values()) {
-      const assetsFragment = wrapAssetsWithDataForNote(claim.assets, "assigned");
+      /**
+       * Beyond this many assets the note states a COUNT instead of embedding
+       * every id.
+       *
+       * `{% assets_list ids="…" %}` renders through `AssetsListComponent`,
+       * which copies the whole comma-separated list into the query string of
+       * `GET /api/assets`. CUIDs are 25 characters, so a large enough batch
+       * exceeds Node's request-target limit and clicking the activity entry
+       * returns 431 instead of opening the list. A select-all bulk add can
+       * reach that; the per-asset notes this replaced never could, because
+       * each one carried a single id.
+       *
+       * Nothing is actually lost by dropping the ids past the cap: WHICH
+       * assets discharged the reservation is answerable from data now, via
+       * `BookingAsset.bookingModelRequestId`. The note is a human summary, and
+       * a popover listing 40 assets was never the useful part of it.
+       */
+      const MAX_ASSETS_IN_NOTE_LINK = 20;
+
+      const assetsFragment =
+        claim.assets.length > MAX_ASSETS_IN_NOTE_LINK
+          ? `**${claim.assets.length} assets**`
+          : wrapAssetsWithDataForNote(claim.assets, "assigned");
       // Model name is literal text, so delimiters must be stripped or a name
       // containing `{% … %}` renders as a live Markdoc tag.
       const modelName = stripMarkdocDelimiters(claim.modelName);


### PR DESCRIPTION
Closes the last open item from the #2820 review (finding 9), which was deferred there with your agreement.

## The problem

Tick 20 matching assets in "Manage assets", save once, and the booking's activity feed gets 20 near-identical lines:

> … assigned Laptop #1 (Dell Latitude 5550) to this booking — 19 × Dell Latitude 5550 remaining.
> … assigned Laptop #2 (Dell Latitude 5550) to this booking — 18 × Dell Latitude 5550 remaining.
> … *(eighteen more)*

Plus the route's own summary note. All INSERTed inside the caller's interactive transaction.

That wording was written for the **scanner**, which discharges one unit at a time. #2820 made every add-assets surface discharge reservations, which is exactly what made bulk fulfilment reachable — so the wording had to follow it.

## The fix

`materializeModelRequestForAsset` no longer writes a note. The chokepoint `fulfilModelRequestsForAssets` accumulates what each reservation absorbed and writes **one note per model** after the batch, stating the final remainder instead of a countdown.

**Single-asset wording is byte-identical to before.** `wrapAssetsWithDataForNote` emits the same `{% link %}` tag at count 1 that `wrapLinkForNote` produced, so the scanner's one-at-a-time feed reads exactly as it did today. There is a test pinning that specific string.

Several assets collapse to the repo's standard `{% assets_list %}` popover, so the note names all twenty rather than counting down across twenty rows.

Two things came along for the ride:

- `loadActor` moves to the chokepoint. It was one user lookup **per asset**, inside the transaction.
- `materializeModelRequestForAsset` drops its `userId` param, which existed only for the note it no longer writes.

## Testing

Three new tests:

| Case | Asserts |
|---|---|
| 20 assets, one save | Exactly **1** note, stating `0 × … remaining` |
| 1 asset | Sentence contains the identical `{% link … /%}` tag as before |
| Batch claims nothing | No note written |

Full suite green (346 files / 4563 tests). Typecheck clean. Lint at the pre-existing warnings.

## Scope

Note wording only. No change to what gets discharged, when, or by which surface — that is all #2820 behaviour and its tests still pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fulfilling multiple asset links in a single batch.
  - Activity notes now consolidate multiple fulfilled assets into one summary per request.
  - Fulfilment works without requiring an identified actor in applicable workflows.
- **Bug Fixes**
  - Completed requests consistently receive a fulfilment timestamp.
  - Rejected claims no longer generate activity notes.
  - Single-asset link wording remains unchanged, and empty batches create no notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->