### PR TITLE
fix(sso): revoke group-claim access the same way the admin path does

### DIFF
--- a/apps/webapp/app/modules/booking/notification-recipients.server.test.ts
+++ b/apps/webapp/app/modules/booking/notification-recipients.server.test.ts
@@ -508,7 +508,9 @@ describe("getBookingNotificationRecipients", () => {
         organizationId: "org-1",
       });
 
-      expect(recipients.map((r) => r.email)).not.toContain("jane@university.edu");
+      expect(recipients.map((r) => r.email)).not.toContain(
+        "jane@university.edu"
+      );
     });
 
     it("is dropped from a booking's own recipient list", async () => {
@@ -524,12 +526,14 @@ describe("getBookingNotificationRecipients", () => {
         organizationId: "org-1",
       });
 
-      expect(recipients.map((r) => r.email)).not.toContain("jane@university.edu");
+      expect(recipients.map((r) => r.email)).not.toContain(
+        "jane@university.edu"
+      );
     });
 
-    it("still notifies them while the group claim holds", async () => {
-      // Guards the assertions above against passing for the wrong reason:
-      // the same fixture WITH the user link must still be notified.
+    it("still notifies them via the always-notify list while the group claim holds", async () => {
+      // Guards the always-notify assertion against passing for the wrong
+      // reason: the same fixture WITH the user link must still be notified.
       mockedGetSettings.mockResolvedValue({
         ...defaultSettings(),
         alwaysNotifyTeamMembers: [activeTeamMember],
@@ -537,6 +541,25 @@ describe("getBookingNotificationRecipients", () => {
 
       const recipients = await getBookingNotificationRecipients({
         booking: buildMockBooking(),
+        eventType: "CHECKIN",
+        organizationId: "org-1",
+      });
+
+      expect(recipients.map((r) => r.email)).toContain("jane@university.edu");
+    });
+
+    it("still notifies them via the booking's own recipient list while the group claim holds", async () => {
+      // The paired control for the booking-recipient drop above. Without it
+      // that assertion also passes if `notificationRecipients` were ignored
+      // entirely, so this proves the null `user` link is what excludes them.
+      const booking = buildMockBooking({
+        notificationRecipients: [
+          activeTeamMember,
+        ] as unknown as BookingForEmail["notificationRecipients"],
+      });
+
+      const recipients = await getBookingNotificationRecipients({
+        booking,
         eventType: "CHECKIN",
         organizationId: "org-1",
       });

--- a/apps/webapp/app/modules/booking/notification-recipients.server.test.ts
+++ b/apps/webapp/app/modules/booking/notification-recipients.server.test.ts
@@ -454,4 +454,94 @@ describe("getBookingNotificationRecipients", () => {
     );
     expect(emptyEmailRecipients).toHaveLength(0);
   });
+  /**
+   * Regression: SSO group-claim revocation.
+   *
+   * When an SSO login drops a workspace's group claim,
+   * `reconcileSsoGroupMembership` revokes access via
+   * `revokeAccessToOrganization`, which disconnects the `TeamMember` from the
+   * `User` and leaves the row behind so custody and booking history keeps a
+   * name. `TeamMember.user === null` is therefore the shape a revoked member
+   * has here, and it is the ONLY signal this resolver gets — none of the
+   * team-member branches re-check membership.
+   *
+   * Before that fix the group-claim path deleted the `UserOrganization` alone,
+   * so `TeamMember.user` still resolved and the revoked person carried on
+   * receiving this workspace's booking emails. For a university running an
+   * annual cohort rollover through IdP groups, that is a whole year group.
+   *
+   * @see {@link file://../user/sso-group-claim-revocation.test.ts}
+   */
+  describe("revoked SSO member", () => {
+    /** The post-revocation shape: row survives, user link gone. */
+    const revokedTeamMember = {
+      id: "tm-revoked",
+      name: "Jane Doe",
+      user: null,
+    };
+
+    /** The same person before revocation, for the contrast. */
+    const activeTeamMember = {
+      id: "tm-revoked",
+      name: "Jane Doe",
+      user: {
+        id: "revoked-user",
+        email: "jane@university.edu",
+        firstName: "Jane",
+        lastName: "Doe",
+        profilePicture: null,
+        ...nullFormatPrefs,
+      },
+    };
+
+    it("is dropped from the org's always-notify list", async () => {
+      mockedGetSettings.mockResolvedValue({
+        ...defaultSettings(),
+        alwaysNotifyTeamMembers: [revokedTeamMember] as unknown as ReturnType<
+          typeof defaultSettings
+        >["alwaysNotifyTeamMembers"],
+      });
+
+      const recipients = await getBookingNotificationRecipients({
+        booking: buildMockBooking(),
+        eventType: "CHECKIN",
+        organizationId: "org-1",
+      });
+
+      expect(recipients.map((r) => r.email)).not.toContain("jane@university.edu");
+    });
+
+    it("is dropped from a booking's own recipient list", async () => {
+      const booking = buildMockBooking({
+        notificationRecipients: [
+          revokedTeamMember,
+        ] as unknown as BookingForEmail["notificationRecipients"],
+      });
+
+      const recipients = await getBookingNotificationRecipients({
+        booking,
+        eventType: "CHECKIN",
+        organizationId: "org-1",
+      });
+
+      expect(recipients.map((r) => r.email)).not.toContain("jane@university.edu");
+    });
+
+    it("still notifies them while the group claim holds", async () => {
+      // Guards the assertions above against passing for the wrong reason:
+      // the same fixture WITH the user link must still be notified.
+      mockedGetSettings.mockResolvedValue({
+        ...defaultSettings(),
+        alwaysNotifyTeamMembers: [activeTeamMember],
+      });
+
+      const recipients = await getBookingNotificationRecipients({
+        booking: buildMockBooking(),
+        eventType: "CHECKIN",
+        organizationId: "org-1",
+      });
+
+      expect(recipients.map((r) => r.email)).toContain("jane@university.edu");
+    });
+  });
 });

--- a/apps/webapp/app/modules/team-member/custodian-filter-scope.server.test.ts
+++ b/apps/webapp/app/modules/team-member/custodian-filter-scope.server.test.ts
@@ -92,6 +92,41 @@ describe("getTeamMemberForCustodianFilter", () => {
   });
 
   /**
+   * Regression: SSO group-claim revocation.
+   *
+   * Revoking access disconnects `TeamMember.user` and leaves the row behind, so
+   * a revoked member is exactly an NRM from this query's point of view. Every
+   * picker that can send them mail — the booking notification-recipient
+   * pickers — passes `usersOnly`, and that narrowing must reach the ROW query,
+   * not just the count, or the revoked person stays selectable.
+   *
+   * The plain custodian picker still lists the bare name, deliberately: it
+   * carries no user and no email, and dropping it would strip the label off
+   * their existing custody and bookings. Same behaviour as the admin revoke.
+   *
+   * @see {@link file://../user/sso-group-claim-revocation.test.ts}
+   */
+  it("excludes user-less rows from the listed rows under usersOnly", async () => {
+    await getTeamMemberForCustodianFilter({
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+      usersOnly: true,
+    });
+
+    expect(rowsWhere().user).toEqual({ isNot: null });
+  });
+
+  it("lists a revoked member's row when the picker allows NRMs", async () => {
+    await getTeamMemberForCustodianFilter({
+      organizationId: ORGANIZATION_ID,
+      userId: USER_ID,
+    });
+
+    expect(rowsWhere().user).toBeUndefined();
+    expect(rowsWhere().deletedAt).toBeNull();
+  });
+
+  /**
    * `selectedTeamMembers` is caller-controlled at almost every call site — it
    * comes from `searchParams.getAll("teamMember")`. Fetching those ids scoped
    * only by `organizationId` handed back any same-org member's row, including

--- a/apps/webapp/app/modules/team-member/custodian-filter-scope.server.test.ts
+++ b/apps/webapp/app/modules/team-member/custodian-filter-scope.server.test.ts
@@ -117,13 +117,31 @@ describe("getTeamMemberForCustodianFilter", () => {
   });
 
   it("lists a revoked member's row when the picker allows NRMs", async () => {
-    await getTeamMemberForCustodianFilter({
+    // why: asserting only the `where` would pass even if later result
+    // processing dropped user-less rows, so stub the post-revocation shape
+    // and prove it survives all the way out to the caller.
+    // mockResolvedValueOnce (not mockResolvedValue) so the stub cannot leak
+    // into the second findMany or into another test.
+    const revokedRow = {
+      id: "tm-revoked",
+      name: "Jane Doe",
+      userId: null,
+      user: null,
+    };
+    dbMocks.findMany
+      .mockResolvedValueOnce([revokedRow])
+      .mockResolvedValueOnce([]);
+
+    const { teamMembers } = await getTeamMemberForCustodianFilter({
       organizationId: ORGANIZATION_ID,
       userId: USER_ID,
     });
 
     expect(rowsWhere().user).toBeUndefined();
     expect(rowsWhere().deletedAt).toBeNull();
+    expect(teamMembers).toContainEqual(
+      expect.objectContaining({ id: "tm-revoked", user: null })
+    );
   });
 
   /**

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -438,10 +438,50 @@ interface UserOrgTransition {
 }
 
 /**
- * Handles the transition of user access when org switches from invite-based to SCIM-based
- * @returns Object containing transition details for logging/notification
+ * Reconciles one workspace's membership against the SAML group claims presented
+ * at login.
+ *
+ * Despite the old name (`handleSCIMTransition`), the only caller is
+ * {@link updateUserFromSSO}'s group-mapping loop — this is the SAML
+ * group-claim path, not SCIM. SCIM has its own lifecycle in
+ * `~/modules/scim/service.server`. The misnomer is why the revocation branch
+ * below sat out of step with every other revoke in the codebase for so long:
+ * it read as SCIM-only code, so nobody compared it to the admin path.
+ *
+ * Runs on EVERY SSO login, once per workspace on the user's email domain.
+ *
+ * Revocation delegates to {@link revokeAccessToOrganization} — the same
+ * function behind the admin "revoke access" UI and
+ * `revokeScimMembership`. It does three things this branch used to skip two
+ * of:
+ *   1. disconnects the `TeamMember` from the `User` (row survives, so custody
+ *      and booking history keeps a name),
+ *   2. deletes the `UserOrganization`,
+ *   3. clears `User.lastSelectedOrganizationId` when it pointed at this org.
+ *
+ * Step 1 is the load-bearing one. A `TeamMember` with no linked user is how the
+ * rest of the codebase recognises revoked access: the booking notification
+ * resolver and the `usersOnly` custodian pickers read straight through
+ * `TeamMember.user` with no membership check, so a revoked user who kept that
+ * link carried on receiving this workspace's booking emails and stayed pickable
+ * as a notification recipient.
+ *
+ * ERROR SEMANTICS — deliberately fail closed. A failure here still aborts the
+ * whole login rather than being logged and skipped per workspace. Swallowing it
+ * would leave the user logged in holding access this call was meant to remove,
+ * which is exactly the leak being fixed; aborting the login denies access
+ * everywhere until the next attempt. `revokeAccessToOrganization` performs the
+ * disconnect and the membership delete in a single `user.update`, so it cannot
+ * half-apply, and its `lastSelectedOrganizationId` cleanup is already
+ * best-effort internally.
+ *
+ * @param userId - The Shelf user signing in
+ * @param organization - The workspace being reconciled
+ * @param currentRoles - Roles the user holds in it right now
+ * @param desiredRole - Role the group claims map to, or `null` to revoke
+ * @returns Transition details for logging/notification
  */
-async function handleSCIMTransition(
+async function reconcileSsoGroupMembership(
   userId: string,
   organization: Organization,
   currentRoles: OrganizationRoles[],
@@ -452,26 +492,22 @@ async function handleSCIMTransition(
     organizationId: organization.id,
     previousRoles: currentRoles,
     newRole: desiredRole,
-    transitionType:
-      currentRoles[0] !== desiredRole ? "ROLE_CHANGE" : "ACCESS_REVOKED",
+    transitionType: desiredRole ? "ROLE_CHANGE" : "ACCESS_REVOKED",
   };
 
   try {
     if (!desiredRole) {
-      // User has no valid SCIM groups, revoke access
-      await db.userOrganization.delete({
-        where: {
-          userId_organizationId: {
-            userId,
-            organizationId: organization.id,
-          },
-        },
+      // No group claim maps to a role here, so access goes — through the same
+      // path as the admin revoke, not a narrower membership delete.
+      await revokeAccessToOrganization({
+        userId,
+        organizationId: organization.id,
       });
 
       transition.transitionType = "ACCESS_REVOKED";
 
       Logger.info({
-        message: "Revoked user access due to SCIM group changes",
+        message: "Revoked user access due to SSO group claim changes",
         additionalData: {
           userId,
           organizationId: organization.id,
@@ -497,7 +533,7 @@ async function handleSCIMTransition(
       transition.transitionType = "ROLE_CHANGE";
 
       Logger.info({
-        message: "Updated user role based on SCIM groups",
+        message: "Updated user role based on SSO group claims",
         additionalData: {
           userId,
           organizationId: organization.id,
@@ -511,7 +547,7 @@ async function handleSCIMTransition(
   } catch (cause) {
     throw new ShelfError({
       cause,
-      message: "Failed to handle SCIM transition",
+      message: "Failed to reconcile SSO group membership",
       additionalData: {
         userId,
         organizationId: organization.id,
@@ -635,7 +671,7 @@ export async function updateUserFromSSO(
         );
 
         if (existingOrgAccess) {
-          const transition = await handleSCIMTransition(
+          const transition = await reconcileSsoGroupMembership(
             userId,
             org,
             existingOrgAccess.roles,
@@ -644,8 +680,8 @@ export async function updateUserFromSSO(
           transitions.push(transition);
 
           // The user keeps access only when a role still maps; a null
-          // desiredRole makes handleSCIMTransition revoke it, so that org must
-          // not become the post-login landing org.
+          // desiredRole makes reconcileSsoGroupMembership revoke it, so that
+          // org must not become the post-login landing org.
           if (desiredRole) {
             firstMatchedOrg ??= org;
           }

--- a/apps/webapp/app/modules/user/sso-group-claim-revocation.test.ts
+++ b/apps/webapp/app/modules/user/sso-group-claim-revocation.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression: an SSO login that drops a workspace's group claim must revoke
+ * access the same way the admin "revoke access" UI does.
+ *
+ * `reconcileSsoGroupMembership` (formerly `handleSCIMTransition`) used to
+ * open-code a bare `userOrganization.delete`. That removed the membership but
+ * left the `TeamMember` still linked to the `User`, and left
+ * `User.lastSelectedOrganizationId` pointing at a workspace the user could no
+ * longer open.
+ *
+ * The surviving `TeamMember.user` link is the part that leaks: the booking
+ * notification resolver and the `usersOnly` custodian pickers read straight
+ * through it with no membership check, so the revoked person kept receiving
+ * that workspace's booking emails and stayed pickable as a recipient. See
+ * `~/modules/booking/notification-recipients.server.test.ts` ("revoked SSO
+ * member") for the downstream half of this regression.
+ *
+ * @see {@link file://./service.server.ts}
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  userUpdate: vi.fn(),
+  teamMemberFindFirst: vi.fn(),
+  userOrganizationDelete: vi.fn(),
+  userOrganizationUpdate: vi.fn(),
+  userOrganizationUpsert: vi.fn(),
+  executeRaw: vi.fn(),
+  scimFindUnique: vi.fn(),
+}));
+
+// why: the subject is the set of writes the revocation issues, not what a
+// database returns
+vi.mock("~/database/db.server", () => ({
+  db: {
+    user: { update: dbMocks.userUpdate },
+    teamMember: { findFirst: dbMocks.teamMemberFindFirst },
+    userOrganization: {
+      delete: dbMocks.userOrganizationDelete,
+      update: dbMocks.userOrganizationUpdate,
+      upsert: dbMocks.userOrganizationUpsert,
+    },
+    userScimExternalId: { findUnique: dbMocks.scimFindUnique },
+    $executeRaw: dbMocks.executeRaw,
+  },
+}));
+
+// why: the SSO org set is a DB read; the test controls which workspaces (and
+// group mappings) the login reconciles against
+vi.mock("../organization/service.server", () => ({
+  getOrganizationsBySsoDomain: vi.fn(),
+}));
+
+// why: the grant branch creates a team member; isolate that side effect
+vi.mock("../team-member/service.server", () => ({
+  createTeamMember: vi.fn(),
+}));
+
+const mockOrg = await import("../organization/service.server");
+
+import { updateUserFromSSO } from "./service.server";
+
+const USER_ID = "user-1";
+const ORG_ID = "org-1";
+const TEAM_MEMBER_ID = "tm-1";
+const EMAIL = "jane@university.edu";
+
+/** A domain workspace that maps the `g-staff` group to the BASE role. */
+function domainOrg() {
+  return {
+    id: ORG_ID,
+    ssoDetails: {
+      adminGroupId: null,
+      baseUserGroupId: "g-staff",
+      selfServiceGroupId: null,
+    },
+  };
+}
+
+/**
+ * Signs the user in with `groups`, against a workspace they already belong to.
+ * Passing groups that map to no role is the revocation case: the annual IdP
+ * cohort rollover that drops someone out of `g-staff`.
+ */
+function login(groups: string[]) {
+  return updateUserFromSSO(
+    { email: EMAIL, userId: USER_ID } as Parameters<
+      typeof updateUserFromSSO
+    >[0],
+    {
+      id: USER_ID,
+      // Matches userData, so the profile-update `user.update` never fires and
+      // every `user.update` call below belongs to the revocation.
+      firstName: "Jane",
+      lastName: "Doe",
+      userOrganizations: [{ organization: { id: ORG_ID }, roles: ["BASE"] }],
+    } as unknown as Parameters<typeof updateUserFromSSO>[1],
+    { firstName: "Jane", lastName: "Doe", groups }
+  );
+}
+
+/** The `data` of the single `user.update` the revocation issues. */
+function revokeData() {
+  return dbMocks.userUpdate.mock.calls[0]?.[0]?.data;
+}
+
+describe("SSO group-claim revocation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // @ts-expect-error - vitest mock type
+    mockOrg.getOrganizationsBySsoDomain.mockResolvedValue([domainOrg()]);
+    dbMocks.teamMemberFindFirst.mockResolvedValue({ id: TEAM_MEMBER_ID });
+    dbMocks.userUpdate.mockResolvedValue({ id: USER_ID });
+    dbMocks.userOrganizationUpdate.mockResolvedValue({});
+    dbMocks.executeRaw.mockResolvedValue(1);
+  });
+
+  it("unlinks the team member as well as deleting the membership", async () => {
+    await login(["g-alumni"]);
+
+    // The leak: without the disconnect, `TeamMember.user` still resolves, and
+    // every notification path reads through it with no membership check.
+    expect(revokeData().teamMembers).toEqual({
+      disconnect: { id: TEAM_MEMBER_ID },
+    });
+    expect(revokeData().userOrganizations).toEqual({
+      delete: {
+        userId_organizationId: { userId: USER_ID, organizationId: ORG_ID },
+      },
+    });
+    // The narrow open-coded delete this path used to take must be gone.
+    expect(dbMocks.userOrganizationDelete).not.toHaveBeenCalled();
+  });
+
+  it("clears lastSelectedOrganizationId so the login cannot land on the revoked org", async () => {
+    await login(["g-alumni"]);
+
+    expect(dbMocks.executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the revocation and returns no landing org", async () => {
+    const result = await login(["g-alumni"]);
+
+    expect(result.transitions).toEqual([
+      {
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        previousRoles: ["BASE"],
+        newRole: null,
+        transitionType: "ACCESS_REVOKED",
+      },
+    ]);
+    expect(result.org).toBeNull();
+  });
+
+  it("still revokes when no team member row is linked", async () => {
+    // NRM-less membership (invite accepted, team member already detached).
+    // The disconnect is skipped; the membership delete must still happen.
+    dbMocks.teamMemberFindFirst.mockResolvedValue(null);
+
+    await login(["g-alumni"]);
+
+    expect(revokeData().teamMembers).toBeUndefined();
+    expect(revokeData().userOrganizations).toEqual({
+      delete: {
+        userId_organizationId: { userId: USER_ID, organizationId: ORG_ID },
+      },
+    });
+  });
+
+  it("fails the login closed when the revocation cannot be applied", async () => {
+    // Deliberate: swallowing this per workspace would leave the user signed in
+    // still holding the access this call exists to remove.
+    dbMocks.userUpdate.mockRejectedValue(new Error("connection lost"));
+
+    await expect(login(["g-alumni"])).rejects.toThrow();
+  });
+
+  it("leaves a still-claimed workspace on the role-update path", async () => {
+    await login(["g-staff"]);
+
+    expect(dbMocks.userUpdate).not.toHaveBeenCalled();
+    expect(dbMocks.userOrganizationUpdate).toHaveBeenCalledWith({
+      where: {
+        userId_organizationId: { userId: USER_ID, organizationId: ORG_ID },
+      },
+      data: { roles: { set: ["BASE"] } },
+    });
+  });
+});


### PR DESCRIPTION
## What

`reconcileSsoGroupMembership` (renamed from `handleSCIMTransition`) is the revocation path taken when an SSO user's SAML group claim no longer maps to a role in a workspace. It runs on **every SSO login, once per workspace on the user's email domain**.

On revocation it did only this:

```ts
await db.userOrganization.delete({ where: { userId_organizationId: { userId, organizationId } } })
```

`revokeAccessToOrganization` — the function behind the admin "revoke access" UI and `revokeScimMembership` — does three things:

1. disconnects the `TeamMember` from the `User` (row survives, so custody and booking history keeps a name),
2. deletes the `UserOrganization`,
3. clears `User.lastSelectedOrganizationId` when it pointed at the revoked org.

The group-claim path did only step 2. This makes it call the same function.

## Why it matters

Step 1 is the load-bearing one. A `TeamMember` with no linked user is how the rest of the codebase recognises revoked access — `revokeScimMembership`'s own docblock already says so. Two paths read straight through `TeamMember.user` with no membership check:

- `getBookingNotificationRecipients` — `alwaysNotifyTeamMembers` and a booking's own `notificationRecipients` both read `tm.user?.email`.
- `getTeamMemberForCustodianFilter` under `usersOnly` — the narrowing is `user: { isNot: null }`, so a row that kept its user link stays selectable. Every picker that can send someone mail passes `usersOnly`.

So removing a person from their IdP group took away their workspace access but left them receiving that workspace's booking email and pickable as a recipient. For an org that runs an annual cohort rollover through IdP groups, that is a whole year group.

Step 3 left `lastSelectedOrganizationId` pointing at a workspace the user can no longer open.

## Also in here

- **Rename.** The only caller is `updateUserFromSSO`'s group-mapping loop — the SAML group-claim path, not SCIM. SCIM has its own lifecycle in `~/modules/scim/service.server`. The old name is why this branch sat out of step with every other revoke: it read as SCIM-only code, so nobody compared it to the admin path. Renamed and documented.
- **Error semantics, checked as asked.** A failure here still aborts the whole login rather than being logged and skipped per workspace, and that is deliberate — swallowing it would leave the user signed in still holding the access the call exists to remove, which is the leak being fixed. Aborting denies access everywhere until the next attempt. `revokeAccessToOrganization` does the disconnect and the membership delete in one `user.update`, so it cannot half-apply, and its `lastSelectedOrganizationId` cleanup is already best-effort internally. Written down in the docblock so the next reader does not "helpfully" wrap it in a try/catch.
- **`transitionType` initialiser** read backwards (`currentRoles[0] !== desiredRole ? "ROLE_CHANGE" : "ACCESS_REVOKED"` labelled an unchanged role as revoked). Overwritten in both branches, so no behaviour change — but it was misleading. Fixed.
- **Swept for other open-coders.** `grep` for `userOrganization.delete` and nested `userOrganizations: { delete }` across `apps/webapp/app`: two hits, this one and the one inside `revokeAccessToOrganization`. No others.

## What this does NOT change

The `TeamMember` row still appears by name in the plain custodian picker after revocation. That is deliberate and matches the admin revoke exactly: the row carries no user and no email, and removing it would strip the label off the person's existing custody and bookings. Pickers that can actually send mail pass `usersOnly` and drop them.

## Tests

New `app/modules/user/sso-group-claim-revocation.test.ts` (6):

- unlinks the team member as well as deleting the membership, and the narrow open-coded delete is gone
- clears `lastSelectedOrganizationId`
- reports `ACCESS_REVOKED` and returns no landing org
- still revokes when no team member row is linked
- fails the login closed when the revocation cannot be applied
- leaves a still-claimed workspace on the role-update path

Downstream halves, so the regression is covered end to end:

- `notification-recipients.server.test.ts` — a revoked member (`user: null`) is dropped from the org always-notify list and from a booking's own recipient list; the same fixture **with** the link is still notified, so the two assertions above cannot pass for the wrong reason.
- `custodian-filter-scope.server.test.ts` — `usersOnly` narrowing reaches the row query, not just the count; and the NRM row is deliberately still listed when the picker allows NRMs.

**Verified the tests fail without the fix:** reverting `service.server.ts` alone turns 4 of the 6 new tests red.

```
Test Files  351 passed (351)
Tests  4631 passed | 1 skipped | 1 todo (4633)
```

Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Revoked SSO group access is now fully removed, including team membership and selected organization access.
  - Users who no longer have an active account link are excluded from notification recipients and relevant team-member filters.
  - Existing memberships remain intact when valid SSO group access is retained.
  - Access revocation fails safely if required updates cannot be completed.
  - Organization access is no longer offered as a landing destination after revocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->