### PR TITLE
feat(webapp): make workspace ownership transfer discoverable

### DIFF
--- a/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
@@ -1,0 +1,187 @@
+import { OrganizationRoles } from "@prisma/client";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "../shared/tooltip";
+
+// ── Mocks ──────────────────────────────────────────────
+
+const mockUseRouteLoaderData = vi.fn();
+const mockUseActionData = vi.fn();
+const mockUseNavigation = vi.fn(() => ({ state: "idle" as const }));
+
+// why: isolate component from react-router hooks that depend on a running router
+vi.mock("react-router", async () => {
+  const actual = (await vi.importActual("react-router")) as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...actual,
+    useRouteLoaderData: (...args: unknown[]) => mockUseRouteLoaderData(...args),
+    useActionData: () => mockUseActionData(),
+    useNavigation: () => mockUseNavigation(),
+    Form: ({ children, ...props }: any) => <form {...props}>{children}</form>,
+    Link: ({ to, children, ...rest }: any) => (
+      <a {...rest} href={typeof to === "string" ? to : undefined}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+// ── Component under test ──
+// Dynamic import must come AFTER the vi.mock() calls above so the mocks are
+// in place before transfer-ownership-card.tsx (and its transitive deps) load.
+
+const { default: TransferOwnershipCard } = await import(
+  "./transfer-ownership-card"
+);
+
+// ── Test data ──────────────────────────────────────────
+
+const OWNER_EMAIL = "owner@example.com";
+
+function createLayoutData({
+  roles = [OrganizationRoles.ADMIN],
+  isShelfAdmin = false,
+}: {
+  roles?: OrganizationRoles[];
+  isShelfAdmin?: boolean;
+} = {}) {
+  return {
+    currentOrganizationUserRoles: roles,
+    currentOrganization: {
+      id: "org-1",
+      name: "Test Org",
+      owner: { id: "owner-1", email: OWNER_EMAIL },
+    },
+    user: {
+      id: "user-1",
+      roles: isShelfAdmin ? [{ name: "ADMIN" }] : [],
+    },
+  };
+}
+
+const admin = {
+  id: "admin-1",
+  firstName: "Julia",
+  lastName: "Mink",
+  email: "julia@example.com",
+};
+
+const noSubscription = {
+  hasActiveSubscription: false,
+  subscriptions: [],
+  tierId: null,
+};
+
+function renderCard({
+  layoutData = createLayoutData(),
+  admins = [admin],
+  isPersonalWorkspace = false,
+}: {
+  layoutData?: ReturnType<typeof createLayoutData>;
+  admins?: (typeof admin)[];
+  isPersonalWorkspace?: boolean;
+} = {}) {
+  mockUseRouteLoaderData.mockReturnValue(layoutData);
+
+  return render(
+    <TooltipProvider>
+      <TransferOwnershipCard
+        admins={admins}
+        ownerSubscriptionInfo={noSubscription}
+        ownerOtherTeamWorkspacesCount={0}
+        premiumIsEnabled={false}
+        isPersonalWorkspace={isPersonalWorkspace}
+      />
+    </TooltipProvider>
+  );
+}
+
+// ── Tests ──────────────────────────────────────────────
+
+describe("TransferOwnershipCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseActionData.mockReturnValue(undefined);
+    mockUseNavigation.mockReturnValue({ state: "idle" as const });
+  });
+
+  it("shows the transfer flow to the workspace owner", () => {
+    renderCard({
+      layoutData: createLayoutData({ roles: [OrganizationRoles.OWNER] }),
+    });
+
+    expect(
+      screen.getByRole("button", { name: /transfer ownership/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /learn more/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("transfer-workspace-ownership")
+    );
+  });
+
+  it("tells non-owner members who can transfer instead of rendering nothing", () => {
+    renderCard({
+      layoutData: createLayoutData({ roles: [OrganizationRoles.ADMIN] }),
+    });
+
+    const explainer = screen.getByText(/only the workspace owner/i, {
+      selector: "p",
+    });
+    expect(explainer).toHaveTextContent(OWNER_EMAIL);
+    // No transfer button for non-owners
+    expect(
+      screen.queryByRole("button", { name: /transfer ownership/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("still shows the transfer flow to Shelf admins who are not the owner", () => {
+    renderCard({
+      layoutData: createLayoutData({
+        roles: [OrganizationRoles.ADMIN],
+        isShelfAdmin: true,
+      }),
+    });
+
+    expect(
+      screen.getByRole("button", { name: /transfer ownership/i })
+    ).toBeInTheDocument();
+  });
+
+  it("explains the account-email alternative for personal workspaces", () => {
+    renderCard({
+      layoutData: createLayoutData({ roles: [OrganizationRoles.OWNER] }),
+      isPersonalWorkspace: true,
+    });
+
+    expect(
+      screen.getByText(/personal workspaces cannot be transferred/i, {
+        selector: "p",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /go to account settings/i })
+    ).toHaveAttribute("href", "/account-details/general");
+    expect(
+      screen.queryByRole("button", { name: /transfer ownership/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an inert transfer button when the workspace has no admins", async () => {
+    const user = userEvent.setup();
+    renderCard({
+      layoutData: createLayoutData({ roles: [OrganizationRoles.OWNER] }),
+      admins: [],
+    });
+
+    // why: disabled-with-reason buttons render without the `disabled`
+    // attribute (HoverCard wrapper prevents the click instead), so we assert
+    // the behavior — clicking must not open the transfer dialog.
+    const button = screen.getByRole("button", { name: /transfer ownership/i });
+    await user.click(button);
+    expect(screen.queryByText(/select new owner/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
@@ -1,3 +1,8 @@
+import type {
+  AnchorHTMLAttributes,
+  FormHTMLAttributes,
+  PropsWithChildren,
+} from "react";
 import { OrganizationRoles } from "@prisma/client";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -21,8 +26,19 @@ vi.mock("react-router", async () => {
     useRouteLoaderData: (...args: unknown[]) => mockUseRouteLoaderData(...args),
     useActionData: () => mockUseActionData(),
     useNavigation: () => mockUseNavigation(),
-    Form: ({ children, ...props }: any) => <form {...props}>{children}</form>,
-    Link: ({ to, children, ...rest }: any) => (
+    Form: ({
+      children,
+      ...props
+    }: PropsWithChildren<FormHTMLAttributes<HTMLFormElement>>) => (
+      <form {...props}>{children}</form>
+    ),
+    Link: ({
+      to,
+      children,
+      ...rest
+    }: PropsWithChildren<
+      AnchorHTMLAttributes<HTMLAnchorElement> & { to?: unknown }
+    >) => (
       <a {...rest} href={typeof to === "string" ? to : undefined}>
         {children}
       </a>

--- a/apps/webapp/app/components/settings/transfer-ownership-card.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Roles } from "@prisma/client";
-import { Form, useActionData } from "react-router";
+import { Form, Link, useActionData } from "react-router";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
@@ -44,6 +44,9 @@ type Admin = {
   email: string;
 };
 
+export const TRANSFER_OWNERSHIP_KB_URL =
+  "https://www.shelf.nu/knowledge-base/transfer-workspace-ownership";
+
 type TransferOwnershipCardProps = {
   className?: string;
   /** Form action URL. Defaults to "/settings/general" */
@@ -58,7 +61,27 @@ type TransferOwnershipCardProps = {
   ownerOtherTeamWorkspacesCount: number;
   /** Whether premium/subscription features are enabled */
   premiumIsEnabled: boolean;
+  /**
+   * Whether the workspace shown is a PERSONAL workspace. Personal workspaces
+   * cannot be transferred, so the card explains the account-email alternative
+   * instead of rendering the transfer flow. The admin-dashboard usage always
+   * targets TEAM workspaces and omits this.
+   */
+  isPersonalWorkspace?: boolean;
 };
+
+function LearnMoreLink() {
+  return (
+    <Link
+      to={TRANSFER_OWNERSHIP_KB_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline"
+    >
+      Learn more
+    </Link>
+  );
+}
 
 export const TransferOwnershipSchema = z.object({
   newOwner: z.string().min(1, "New owner is required"),
@@ -87,6 +110,7 @@ export default function TransferOwnershipCard({
   ownerSubscriptionInfo,
   ownerOtherTeamWorkspacesCount,
   premiumIsEnabled,
+  isPersonalWorkspace = false,
 }: TransferOwnershipCardProps) {
   const { isOwner } = useUserRoleHelper();
   const user = useUserData();
@@ -98,6 +122,13 @@ export default function TransferOwnershipCard({
 
   // Use provided organizationName or fall back to currentOrganization
   const confirmationOrgName = organizationName ?? currentOrganization?.name;
+
+  /**
+   * Shown to non-owner members so they know who to ask. Safe to read from
+   * context here: the non-owner branch only renders on the settings page,
+   * where currentOrganization is the workspace being viewed.
+   */
+  const ownerEmail = currentOrganization?.owner?.email;
 
   const zo = useZorm("TransferOwnership", TransferOwnershipSchema);
   const actionData = useActionData<DataOrErrorResponse>();
@@ -121,18 +152,50 @@ export default function TransferOwnershipCard({
       ? actionData.error.message
       : null;
 
+  /** Personal workspaces cannot be transferred — the server rejects them too */
+  if (isPersonalWorkspace) {
+    return (
+      <Card className={tw(className)} id="transfer-ownership">
+        <h4 className="mb-1 text-text-lg font-semibold">
+          Transfer workspace ownership
+        </h4>
+        <p className="mb-2 text-sm text-gray-600">
+          Personal workspaces cannot be transferred. To hand over this account
+          to someone else, change the email address on your account instead.{" "}
+          <LearnMoreLink />
+        </p>
+        <Button to="/account-details/general" variant="secondary">
+          Go to account settings
+        </Button>
+      </Card>
+    );
+  }
+
+  /** Non-owners cannot transfer, but must still be able to discover who can */
   if (!isOwner && !isShelfAdmin) {
-    return null;
+    return (
+      <Card className={tw(className)} id="transfer-ownership">
+        <h4 className="mb-1 text-text-lg font-semibold">
+          Transfer workspace ownership
+        </h4>
+        <p className="text-sm text-gray-600">
+          Only the workspace owner
+          {ownerEmail ? ` (${ownerEmail})` : ""} can transfer ownership of this
+          workspace. <LearnMoreLink />
+        </p>
+      </Card>
+    );
   }
 
   return (
-    <Card className={tw(className)}>
+    <Card className={tw(className)} id="transfer-ownership">
       <h4 className="mb-1 text-text-lg font-semibold">
         Transfer workspace ownership
       </h4>
       <p className="mb-2 text-sm text-gray-600">
         Transfer workspace to another user. To transfer the workspace, the new
-        owner must be already be part of the workspace as an admin.
+        owner must already be part of the workspace as an admin.{" "}
+        <LearnMoreLink />
       </p>
 
       <When
@@ -142,7 +205,7 @@ export default function TransferOwnershipCard({
             type="button"
             disabled={{
               reason:
-                "No admins found in this workspace. Please add an admin before transferring ownership.",
+                "No admins found in this workspace. Change a team member's role to Administrator first, then transfer ownership.",
             }}
           >
             Transfer Ownership
@@ -161,8 +224,7 @@ export default function TransferOwnershipCard({
               <AlertDialogTitle>Transfer Workspace Ownership</AlertDialogTitle>
               <AlertDialogDescription>
                 Transfer workspace to another user. To transfer the workspace,
-                the new owner must be already be part of the workspace as an
-                admin.
+                the new owner must already be part of the workspace as an admin.
               </AlertDialogDescription>
             </AlertDialogHeader>
 

--- a/apps/webapp/app/components/settings/transfer-ownership-card.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.tsx
@@ -44,6 +44,7 @@ type Admin = {
   email: string;
 };
 
+/** Knowledge-base walkthrough linked from every state of the transfer card */
 export const TRANSFER_OWNERSHIP_KB_URL =
   "https://www.shelf.nu/knowledge-base/transfer-workspace-ownership";
 

--- a/apps/webapp/app/components/shared/card.tsx
+++ b/apps/webapp/app/components/shared/card.tsx
@@ -4,11 +4,14 @@ import { tw } from "~/utils/tw";
 export const Card = ({
   children,
   className,
+  id,
 }: {
   children: ReactNode;
   className?: string;
+  id?: string;
 }) => (
   <div
+    id={id}
     className={tw(
       "card my-4 overflow-hidden rounded border bg-white px-4 py-3",
       className

--- a/apps/webapp/app/routes/_layout+/settings.general.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.general.tsx
@@ -579,6 +579,7 @@ export default function GeneralPage() {
     ownerSubscriptionInfo,
     ownerOtherTeamWorkspacesCount,
     premiumIsEnabled: premiumEnabled,
+    isPersonalWorkspace,
   } = useLoaderData<typeof loader>();
   return (
     <div className="mb-2.5 flex flex-col justify-between">
@@ -610,6 +611,7 @@ export default function GeneralPage() {
         ownerSubscriptionInfo={ownerSubscriptionInfo}
         ownerOtherTeamWorkspacesCount={ownerOtherTeamWorkspacesCount}
         premiumIsEnabled={premiumEnabled}
+        isPersonalWorkspace={isPersonalWorkspace}
       />
     </div>
   );

--- a/apps/webapp/app/routes/_layout+/settings.team.users.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.tsx
@@ -19,6 +19,7 @@ import { InfoTooltip } from "~/components/shared/info-tooltip";
 import { Td, Th } from "~/components/table";
 import { SSOUserBadge } from "~/components/user/sso-user-badge";
 import { TeamUsersActionsDropdown } from "~/components/workspace/users-actions-dropdown";
+import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { TeamMembersWithUserOrInvite } from "~/modules/settings/service.server";
 import { getPaginatedAndFilterableSettingUsers } from "~/modules/settings/service.server";
 import type { RouteHandleWithName } from "~/modules/types";
@@ -234,9 +235,40 @@ function UserRow({ item }: { item: TeamMembersWithUserOrInvite }) {
             role={item.role}
             roleEnum={item.roleEnum}
           />
-        ) : null}
+        ) : (
+          <OwnerRowActions ownerName={item.name} />
+        )}
       </Td>
     </>
+  );
+}
+
+/**
+ * The one owner-level action that belongs with the member list is transferring
+ * ownership, which lives on the general settings page. Surface it here so it
+ * is discoverable where people manage their team.
+ */
+function OwnerRowActions({ ownerName }: { ownerName: string }) {
+  const { isOwner } = useUserRoleHelper();
+
+  if (isOwner) {
+    return (
+      <Button to="/settings/general#transfer-ownership" variant="secondary">
+        Transfer ownership
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      disabled={{
+        reason: `Only the workspace owner (${ownerName}) can transfer ownership of this workspace.`,
+      }}
+    >
+      Transfer ownership
+    </Button>
   );
 }
 

--- a/apps/webapp/app/routes/_layout+/settings.team.users.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { Roles } from "@prisma/client";
 import type { InviteStatuses } from "@prisma/client";
 import type {
   ActionFunctionArgs,
@@ -19,6 +20,7 @@ import { InfoTooltip } from "~/components/shared/info-tooltip";
 import { Td, Th } from "~/components/table";
 import { SSOUserBadge } from "~/components/user/sso-user-badge";
 import { TeamUsersActionsDropdown } from "~/components/workspace/users-actions-dropdown";
+import { useUserData } from "~/hooks/use-user-data";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { TeamMembersWithUserOrInvite } from "~/modules/settings/service.server";
 import { getPaginatedAndFilterableSettingUsers } from "~/modules/settings/service.server";
@@ -250,8 +252,15 @@ function UserRow({ item }: { item: TeamMembersWithUserOrInvite }) {
  */
 function OwnerRowActions({ ownerName }: { ownerName: string }) {
   const { isOwner } = useUserRoleHelper();
+  const user = useUserData();
 
-  if (isOwner) {
+  /**
+   * Shelf staff admins can also run the transfer flow, so they get the same
+   * link as the owner (matches the isShelfAdmin check in TransferOwnershipCard)
+   */
+  const isShelfAdmin = user?.roles?.some((role) => role.name === Roles.ADMIN);
+
+  if (isOwner || isShelfAdmin) {
     return (
       <Button to="/settings/general#transfer-ownership" variant="secondary">
         Transfer ownership


### PR DESCRIPTION
## Why

Support keeps getting "how do I transfer my account?" emails even though ownership transfer has been live since ~March 2026 and documented since July ([KB walkthrough](https://www.shelf.nu/knowledge-base/transfer-workspace-ownership)). Root cause: the flow is invisible to everyone except the owner, and absent from the pages where people look for it. The common case (straight from a real support email this week): the owner handed day-to-day management to an admin — the admin goes looking, and for them the feature doesn't exist anywhere in the UI.

## What

- **Non-owner members** visiting Workspace settings → General now see an informational card naming the owner (email) instead of nothing (`transfer-ownership-card.tsx` returned `null` for them).
- **Settings → Team**: the Owner row's empty Actions cell gets a "Transfer ownership" affordance — a link to `/settings/general#transfer-ownership` for the owner, a disabled button with an explanatory hover reason for everyone else.
- **Personal workspaces** get an honest state — "Personal workspaces cannot be transferred… change the email address on your account instead" with a link to account settings. Previously the card showed "No admins found… add an admin", which is impossible advice on a Personal workspace (and the server throws for them anyway).
- The card links the KB walkthrough ("Learn more", same pattern as the KB link on `settings.team.invites.tsx`), fixes the "must be already be" typo, and gives the no-admins disabled reason actionable copy.
- `Card` accepts an optional `id` (deep-link anchor target).
- New component tests covering all card states: owner, non-owner, shelf admin, personal workspace, no admins.

Admin-dashboard usage is unchanged: the new props are optional and the new branches are unreachable there (shelf admins keep the full dialog).

## Out of scope, considered deliberately

- The admin-dashboard transfer tab on **PERSONAL** orgs keeps its pre-existing behavior (disabled "no admins" button; `transferOwnership` rejects personal transfers server-side). The new personal-workspace copy is written for the owner's own settings page ("change the email address on **your** account") and would mislead a Shelf admin viewing someone else's org, so `isPersonalWorkspace` is intentionally not wired up there.
- `settings.team.invites.tsx` contains a duplicated owner-row branch, but that list only ever renders pending invites, so the branch is dead code — left untouched.
- The new-tab KB link carries `rel="noopener noreferrer"`, matching the reverse-tabnabbing guard the shared `Button` applies to its own new-tab links.

## Testing

- `pnpm webapp:validate` green: 4664 tests across 355 files, typecheck clean, 0 lint errors.
- New: `transfer-ownership-card.test.tsx` (5 tests).

Follow-up to #1906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace owners and authorized administrators can access “Transfer ownership” from team member settings.
  * Non-owners can see the workspace owner and receive guidance about transfer permissions.
  * Personal workspace owners are directed to account settings for ownership management.
  * Added contextual help links and clearer transfer instructions.
* **Bug Fixes**
  * Improved messaging and behavior when no eligible workspace administrator is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->