### PR TITLE
fix(audits): admins/owners can act on audits with assignees; scanning joins the assignee gate

### DIFF
--- a/apps/webapp/app/components/audit/edit-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/edit-audit-dialog.tsx
@@ -186,9 +186,8 @@ export function EditAuditDialog({
               <Separator className="md:hidden" />
               <p className="p-3 pb-0 font-medium">Select assignee (optional)</p>
               <p className="border-b p-3">
-                If no assignee is selected, any admin user can perform the
-                audit. This can also be done by multiple users at different
-                times.
+                Admins can perform any audit. Choosing assignees also lets those
+                people perform it, including several at different times.
               </p>
               <AuditTeamMemberSelector
                 error={assigneeError}

--- a/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
+++ b/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
@@ -171,8 +171,8 @@ export function StartAuditDialogContent({
           <Separator className="md:hidden" />
           <p className="p-3 pb-0 font-medium">Select assignee (optional).</p>
           <p className="border-b p-3 ">
-            If no assignee is selected, any admin user can perform the audit.
-            This can also be done by multiple users at different times.
+            Admins can perform any audit. Choosing assignees also lets those
+            people perform it, including several at different times.
           </p>
           <AuditTeamMemberSelector error={assigneeError} />
         </div>

--- a/apps/webapp/app/components/audit/start-audit-from-context-dialog.tsx
+++ b/apps/webapp/app/components/audit/start-audit-from-context-dialog.tsx
@@ -272,9 +272,8 @@ export function StartAuditFromContextDialog({
                   Select assignee (optional).
                 </p>
                 <p className="border-b p-3 ">
-                  If no assignee is selected, any admin user can perform the
-                  audit. This can also be done by multiple users at different
-                  times.
+                  Admins can perform any audit. Choosing assignees also lets
+                  those people perform it, including several at different times.
                 </p>
                 <AuditTeamMemberSelector />
               </div>

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -2168,14 +2168,9 @@ describe("audit service", () => {
       userId: "user-1",
     };
 
-    /** Minimal session shape for the assignee check via getAuditSessionDetails */
+    /** Slim shape returned by requireAuditAssignee's assignment lookup */
     function mockSessionWithAssignments(assignments: { userId: string }[]) {
-      mockDb.auditSession.findFirst.mockResolvedValue({
-        id: "session-1",
-        organizationId: "org-1",
-        assignments,
-        assets: [],
-      });
+      mockDb.auditSession.findFirst.mockResolvedValue({ assignments });
     }
 
     beforeEach(() => {
@@ -2207,6 +2202,14 @@ describe("audit service", () => {
       await expect(
         requireAuditAssignee({ ...baseArgs, isSelfServiceOrBase: true })
       ).rejects.toMatchObject({ status: 403 });
+    });
+
+    it("returns 404 for a BASE/SELF_SERVICE user when the session is not in the org", async () => {
+      mockDb.auditSession.findFirst.mockResolvedValue(null);
+
+      await expect(
+        requireAuditAssignee({ ...baseArgs, isSelfServiceOrBase: true })
+      ).rejects.toMatchObject({ status: 404 });
     });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -19,6 +19,7 @@ import {
   bulkDeleteAudits,
   duplicateAuditSession,
   recordAuditScan,
+  requireAuditAssignee,
 } from "./service.server";
 
 // why: storage.server calls Supabase over HTTP; mock so delete tests stay offline
@@ -2157,6 +2158,55 @@ describe("audit service", () => {
         status: 404,
         shouldBeCaptured: false,
       });
+    });
+  });
+
+  describe("requireAuditAssignee", () => {
+    const baseArgs = {
+      auditSessionId: "session-1",
+      organizationId: "org-1",
+      userId: "user-1",
+    };
+
+    /** Minimal session shape for the assignee check via getAuditSessionDetails */
+    function mockSessionWithAssignments(assignments: { userId: string }[]) {
+      mockDb.auditSession.findFirst.mockResolvedValue({
+        id: "session-1",
+        organizationId: "org-1",
+        assignments,
+        assets: [],
+      });
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("allows ADMIN/OWNER even when the audit has other assignees", async () => {
+      await expect(
+        requireAuditAssignee({ ...baseArgs, isSelfServiceOrBase: false })
+      ).resolves.toBeUndefined();
+
+      // why: the admin path must not depend on the assignee list at all —
+      // the pre-fix rule blocked admins as soon as an audit had assignees,
+      // which locked audit creators out of their own audits.
+      expect(mockDb.auditSession.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("allows a BASE/SELF_SERVICE user who is an assignee", async () => {
+      mockSessionWithAssignments([{ userId: "user-1" }]);
+
+      await expect(
+        requireAuditAssignee({ ...baseArgs, isSelfServiceOrBase: true })
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects a BASE/SELF_SERVICE user who is not an assignee with 403", async () => {
+      mockSessionWithAssignments([{ userId: "user-2" }]);
+
+      await expect(
+        requireAuditAssignee({ ...baseArgs, isSelfServiceOrBase: true })
+      ).rejects.toMatchObject({ status: 403 });
     });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2040,13 +2040,15 @@ export async function getAuditsForOrganization(params: {
 }
 
 /**
- * Validates that the user is assigned to the audit session.
- * Throws a 403 ShelfError if the user is not an assignee.
+ * Validates that the user may act on the audit session.
  *
- * When isSelfServiceOrBase is false (admin/owner), allows the user to perform
- * actions if the audit has no assignees.
+ * ADMIN/OWNER users (isSelfServiceOrBase = false) always pass: they manage
+ * every audit in their workspace, mirroring both
+ * requireAuditAssigneeForBaseSelfService and the ADMIN/OWNER allow-all
+ * short-circuit in @shelf/permissions. BASE/SELF_SERVICE users must be
+ * assignees of the audit.
  *
- * @throws {ShelfError} 403 error if user is not an assignee
+ * @throws {ShelfError} 403 error if a BASE/SELF_SERVICE user is not an assignee
  */
 export async function requireAuditAssignee({
   auditSessionId,
@@ -2059,23 +2061,23 @@ export async function requireAuditAssignee({
   organizationId: string;
   userId: string;
   request?: Request;
-  /** When true, always require assignee. When false (admin/owner), allow if no assignees. */
+  /** When true (BASE/SELF_SERVICE), require assignee. When false (admin/owner), always allow. */
   isSelfServiceOrBase?: boolean;
 }): Promise<void> {
+  // ADMIN/OWNER act on any audit in their workspace. Returning before the
+  // session fetch is safe: every caller's downstream service re-verifies the
+  // session against organizationId (recordAuditScan, completeAuditSession,
+  // requireAuditAssetInSession all 404 on cross-org ids).
+  if (!isSelfServiceOrBase) {
+    return;
+  }
+
   const { session } = await getAuditSessionDetails({
     id: auditSessionId,
     organizationId,
     userOrganizations: [],
     request,
   });
-
-  const hasNoAssignees = session.assignments.length === 0;
-  const isAdminOrOwner = !isSelfServiceOrBase;
-
-  // Allow admin/owner to perform actions if audit has no assignees
-  if (isAdminOrOwner && hasNoAssignees) {
-    return;
-  }
 
   const isAssignee = session.assignments.some(
     (assignment) => assignment.userId === userId

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2054,13 +2054,11 @@ export async function requireAuditAssignee({
   auditSessionId,
   organizationId,
   userId,
-  request,
   isSelfServiceOrBase = true,
 }: {
   auditSessionId: string;
   organizationId: string;
   userId: string;
-  request?: Request;
   /** When true (BASE/SELF_SERVICE), require assignee. When false (admin/owner), always allow. */
   isSelfServiceOrBase?: boolean;
 }): Promise<void> {
@@ -2072,12 +2070,34 @@ export async function requireAuditAssignee({
     return;
   }
 
-  const { session } = await getAuditSessionDetails({
-    id: auditSessionId,
-    organizationId,
-    userOrganizations: [],
-    request,
-  });
+  // why: this guard runs on the per-scan hot path, so it fetches only the
+  // assignment user ids — not the full session details with every expected
+  // asset (that would make an N-asset audit O(N²) in transferred data).
+  let session: { assignments: { userId: string }[] } | null;
+  try {
+    session = await db.auditSession.findFirst({
+      where: { id: auditSessionId, organizationId },
+      select: { assignments: { select: { userId: true } } },
+    });
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message:
+        "Something went wrong while validating audit access. Please try again or contact support.",
+      additionalData: { auditSessionId, organizationId },
+      label,
+    });
+  }
+
+  if (!session) {
+    throw new ShelfError({
+      cause: null,
+      message: "Audit session not found",
+      additionalData: { auditSessionId, organizationId },
+      status: 404,
+      label,
+    });
+  }
 
   const isAssignee = session.assignments.some(
     (assignment) => assignment.userId === userId

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -177,7 +177,6 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         auditSessionId: auditId,
         organizationId,
         userId,
-        request,
         isSelfServiceOrBase,
       });
 
@@ -438,7 +437,7 @@ export default function AuditOverview() {
                           iconClassName="size-4"
                           content={
                             <p className="text-sm text-gray-600">
-                              Any user with access can perform this audit
+                              Workspace admins and owners can perform this audit
                               because it has no specific assignee.
                             </p>
                           }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -171,8 +171,8 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const intent = formData.get("intent");
 
     if (intent === "complete-audit") {
-      // Only assignees can complete the audit
-      // Exception: if audit has no assignees, admins/owners can complete
+      // Assignee-gated: ADMIN/OWNER may complete any audit,
+      // BASE/SELF_SERVICE only when assigned.
       await requireAuditAssignee({
         auditSessionId: auditId,
         organizationId,

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.tsx
@@ -123,7 +123,6 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       auditSessionId: auditId,
       organizationId,
       userId,
-      request,
       isSelfServiceOrBase,
     });
 
@@ -305,16 +304,12 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       return redirect(`/audits/${auditId}/overview`);
     }
 
-    // Permission logic for scan access:
-    // - If audit has assignees: only assignees can scan
-    // - If audit has NO assignees: admins/owners can scan, BASE/SELF_SERVICE cannot
-    const hasNoAssignees = session.assignments.length === 0;
-    const shouldForceAssigneeCheck = isSelfServiceOrBase || !hasNoAssignees;
-
+    // Scan access: ADMIN/OWNER can scan any audit,
+    // BASE/SELF_SERVICE only when assigned.
     requireAuditAssigneeForBaseSelfService({
       audit: session,
       userId,
-      isSelfServiceOrBase: shouldForceAssigneeCheck,
+      isSelfServiceOrBase,
       auditId,
     });
 

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.tsx
@@ -117,8 +117,8 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       });
     }
 
-    // Only assignees can complete the audit via scan route
-    // Exception: if audit has no assignees, admins/owners can complete
+    // Assignee-gated: ADMIN/OWNER may act on any audit,
+    // BASE/SELF_SERVICE only when assigned.
     await requireAuditAssignee({
       auditSessionId: auditId,
       organizationId,

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -131,7 +131,6 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         auditSessionId: auditId,
         organizationId,
         userId,
-        request,
         isSelfServiceOrBase,
       });
 
@@ -363,9 +362,9 @@ export default function AuditDetailsPage() {
     (assignment) => assignment.userId === userId
   );
 
-  // Allow admin/owner to scan/complete if audit has no assignees
-  const hasNoAssignees = session.assignments.length === 0;
-  const canScanAndComplete = isAssignee || (isAdminOrOwner && hasNoAssignees);
+  // ADMIN/OWNER can scan/complete any audit;
+  // BASE/SELF_SERVICE only when assigned
+  const canScanAndComplete = isAssignee || isAdminOrOwner;
 
   // The activity loader requires `auditNote:read` and 403s without it, so the
   // tab follows the same gate rather than routing the user into an error.

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -125,8 +125,8 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     }
 
     if (intent === "complete-audit") {
-      // Only assignees can complete the audit
-      // Exception: if audit has no assignees, admins/owners can complete
+      // Assignee-gated: ADMIN/OWNER may complete any audit,
+      // BASE/SELF_SERVICE only when assigned.
       await requireAuditAssignee({
         auditSessionId: auditId,
         organizationId,

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
@@ -116,7 +116,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         auditNotesCount: s.auditNotesCount,
         auditImagesCount: s.auditImagesCount,
       })),
-      canScan: session.status === "PENDING" || session.status === "ACTIVE",
+      // why: same eligibility as record-scan's server-side gate, so the app
+      // never offers a scanner whose submissions are guaranteed to 403
+      canScan:
+        (session.status === "PENDING" || session.status === "ACTIVE") &&
+        (isAssignee || !isSelfServiceOrBase),
       canComplete: canCompleteAudit,
     });
   } catch (cause) {

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
@@ -53,17 +53,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     ]);
 
     // why: completing is assignee-gated server-side (requireAuditAssignee in
-    // audits.complete.ts): only an assignee may complete, except admins/owners
-    // may complete an audit that has no assignees. Encode that eligibility in
+    // audits.complete.ts): ADMIN/OWNER may complete any audit, BASE and
+    // SELF_SERVICE only when assigned. Encode that eligibility in
     // `canComplete` so the client never shows a "Complete Audit" CTA that
-    // 403s after confirmation — e.g. an admin viewing another user's audit in
-    // the all-workspace list. Mirrors the endpoint's own rule exactly.
+    // 403s after confirmation. Mirrors the endpoint's own rule exactly.
     const isSelfServiceOrBase = role === "SELF_SERVICE" || role === "BASE";
-    const hasNoAssignees = session.assignments.length === 0;
     const isAssignee = session.assignments.some((a) => a.user.id === user.id);
     const canCompleteAudit =
       (session.status === "ACTIVE" || session.status === "PENDING") &&
-      (isAssignee || (!isSelfServiceOrBase && hasNoAssignees));
+      (isAssignee || !isSelfServiceOrBase);
 
     return data({
       audit: {

--- a/apps/webapp/app/routes/api+/mobile+/audits.complete.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.complete.ts
@@ -72,8 +72,8 @@ export async function action({ request }: ActionFunctionArgs) {
       })
       .parse(body);
 
-    // Only assignees can complete the audit (matches webapp behavior).
-    // Exception: admins/owners can complete if audit has no assignees.
+    // Assignee-gated (matches webapp behavior): ADMIN/OWNER may complete any
+    // audit, BASE/SELF_SERVICE only when assigned.
     await requireAuditAssignee({
       auditSessionId: sessionId,
       organizationId,

--- a/apps/webapp/app/routes/api+/mobile+/audits.record-scan.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.record-scan.ts
@@ -6,7 +6,10 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
-import { recordAuditScan } from "~/modules/audit/service.server";
+import {
+  recordAuditScan,
+  requireAuditAssignee,
+} from "~/modules/audit/service.server";
 import { makeShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -33,7 +36,7 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
-    const { canUseAudits } = await getMobileUserContext(
+    const { canUseAudits, role } = await getMobileUserContext(
       user.id,
       organizationId
     );
@@ -65,6 +68,17 @@ export async function action({ request }: ActionFunctionArgs) {
         isExpected: z.boolean(),
       })
       .parse(body);
+
+    // Scanning writes audit data, so it is gated exactly like note, photo and
+    // complete: ADMIN/OWNER act on any audit, BASE/SELF_SERVICE must be
+    // assignees. Without this gate a scan is recorded (and can start the
+    // audit) for users whose evidence uploads are then rejected.
+    await requireAuditAssignee({
+      auditSessionId,
+      organizationId,
+      userId: user.id,
+      isSelfServiceOrBase: role === "SELF_SERVICE" || role === "BASE",
+    });
 
     const { scanId, auditAssetId, foundAssetCount, unexpectedAssetCount } =
       await recordAuditScan({

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.record-scan.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.record-scan.test.ts
@@ -108,7 +108,7 @@ describe("POST /api/mobile/audits/record-scan", () => {
       canUseBarcodes: true,
     });
     (requireMobilePermission as any).mockResolvedValue(undefined);
-    (requireAuditAssignee as any).mockResolvedValue(undefined);
+    vi.mocked(requireAuditAssignee).mockResolvedValue(undefined);
   });
 
   it("should record a scan and return scan data with counts", async () => {
@@ -160,11 +160,13 @@ describe("POST /api/mobile/audits/record-scan", () => {
       canUseAudits: true,
       canUseBarcodes: true,
     });
-    const assigneeError = new Error(
-      "Only users assigned to this audit can perform this action. Please contact the audit creator to be assigned."
+    const assigneeError = Object.assign(
+      new Error(
+        "Only users assigned to this audit can perform this action. Please contact the audit creator to be assigned."
+      ),
+      { status: 403 }
     );
-    (assigneeError as any).status = 403;
-    (requireAuditAssignee as any).mockRejectedValue(assigneeError);
+    vi.mocked(requireAuditAssignee).mockRejectedValue(assigneeError);
     (makeShelfError as any).mockReturnValue({
       message: assigneeError.message,
       status: 403,

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.record-scan.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.record-scan.test.ts
@@ -41,6 +41,7 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
 // why: external service — we mock audit scan recording to avoid database calls
 vi.mock("~/modules/audit/service.server", () => ({
   recordAuditScan: vi.fn(),
+  requireAuditAssignee: vi.fn(),
 }));
 
 // why: we need to control error formatting in the catch block
@@ -61,7 +62,10 @@ import {
   getMobileUserContext,
   requireMobilePermission,
 } from "~/modules/api/mobile-auth.server";
-import { recordAuditScan } from "~/modules/audit/service.server";
+import {
+  recordAuditScan,
+  requireAuditAssignee,
+} from "~/modules/audit/service.server";
 import { makeShelfError } from "~/utils/error";
 
 const mockUser = {
@@ -104,6 +108,7 @@ describe("POST /api/mobile/audits/record-scan", () => {
       canUseBarcodes: true,
     });
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    (requireAuditAssignee as any).mockResolvedValue(undefined);
   });
 
   it("should record a scan and return scan data with counts", async () => {
@@ -138,6 +143,54 @@ describe("POST /api/mobile/audits/record-scan", () => {
       userId: "user-1",
       organizationId: "org-1",
     });
+
+    // why: ADMIN role must map to isSelfServiceOrBase: false so admins can
+    // scan into any audit of their workspace
+    expect(requireAuditAssignee).toHaveBeenCalledWith({
+      auditSessionId: "session-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
+    });
+  });
+
+  it("should return 403 when a BASE user is not assigned to the audit", async () => {
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "BASE",
+      canUseAudits: true,
+      canUseBarcodes: true,
+    });
+    const assigneeError = new Error(
+      "Only users assigned to this audit can perform this action. Please contact the audit creator to be assigned."
+    );
+    (assigneeError as any).status = 403;
+    (requireAuditAssignee as any).mockRejectedValue(assigneeError);
+    (makeShelfError as any).mockReturnValue({
+      message: assigneeError.message,
+      status: 403,
+    });
+
+    const request = createRecordScanRequest({
+      auditSessionId: "session-1",
+      qrId: "qr-abc",
+      assetId: "asset-1",
+      isExpected: true,
+    });
+    const result = await action(createActionArgs({ request }));
+
+    expect((result as unknown as Response).status).toBe(403);
+    const body = await (result as unknown as Response).json();
+    expect(body.error.message).toContain("assigned to this audit");
+
+    expect(requireAuditAssignee).toHaveBeenCalledWith({
+      auditSessionId: "session-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: true,
+    });
+    // why: the scan must not be recorded when the assignee gate rejects —
+    // the pre-fix behavior wrote scans for users who could not complete
+    expect(recordAuditScan).not.toHaveBeenCalled();
   });
 
   it("should return 403 when user lacks audit update permission", async () => {


### PR DESCRIPTION
## Problem

An ADMIN/OWNER who creates an audit and assigns it to someone else gets a broken flow in the mobile Audit Scanner:

1. They see the audit and can open the scanner.
2. Their scans are recorded and even start the audit (progress reaches 1/1 found).
3. Then note save, photo upload, and Complete Audit all fail with **"Only users assigned to this audit can perform this action. Please contact the audit creator to be assigned."** The blocked user often *is* the audit creator.

The same admin can add notes and images to that audit on web, so mobile and web disagreed about the same action.

## Cause

Two assignee helpers with opposite admin semantics were mixed across endpoints:

- `requireAuditAssigneeForBaseSelfService` (web note/image/activity/loaders): ADMIN/OWNER always pass.
- `requireAuditAssignee` (mobile evidence + complete, web complete): ADMIN/OWNER were blocked whenever the audit had at least one assignee.
- The mobile `record-scan` endpoint used neither, so scans were recorded for users whose follow-up actions were then rejected.

## Fix

One rule everywhere, matching the allow-all short-circuit in `@shelf/permissions`:

> ADMIN/OWNER can act on any audit in their workspace. BASE/SELF_SERVICE must be assignees.

- `requireAuditAssignee`: ADMIN/OWNER always pass (early return; every downstream service re-verifies the session against `organizationId`).
- Mobile `record-scan`: now runs the same assignee gate as note/photo/complete, so scanning and finishing an audit are allowed for exactly the same users.
- Mobile audit detail: `canCompleteAudit` mirrors the new rule, so the app's Complete CTA matches what the server will accept.
- Stale call-site comments updated.

No schema changes. Server-only deploy; no companion release needed.

## Tests

- `requireAuditAssignee`: admin passes with assignees present (no session fetch), BASE assignee passes, BASE non-assignee gets 403.
- `record-scan`: admin maps to `isSelfServiceOrBase: false`; unassigned BASE user gets 403 and no scan is recorded.
- Full audit test net: 173 tests across 14 files pass; webapp typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Access Control**
  - Administrators and owners can complete and scan any audit.
  - Base and self-service users can complete and scan only audits assigned to them.
  - Unauthorized actions return a 403 response without recording changes.

- **User Guidance**
  - Updated audit assignment and completion guidance to clarify permissions.

- **Tests**
  - Added coverage for administrator access, assignment checks, and rejection of unassigned base users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->