### PR TITLE
fix(kits): scope new-member booking propagation to bookings holding the kit

### DIFF
--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -138,6 +138,9 @@ vitest.mock("~/database/db.server", () => ({
       // and `mergeStandaloneCollisionsForKitDetachment` folds a kit-driven
       // row's units into a colliding standalone row via `update`.
       update: vitest.fn().mockResolvedValue({}),
+      // why: `updateKitAssets` propagates a newly-added kit member into the
+      // bookings that already hold this kit, one `createMany` per booking.
+      createMany: vitest.fn().mockResolvedValue({ count: 0 }),
       deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
     },
     // why: the same helper re-opens any `BookingModelRequest` the deleted
@@ -5152,5 +5155,218 @@ describe("bulkAssignKitCustody — handled validation (SHELF-WEBAPP-226)", () =>
     expect(err.message).toContain("unavailable assets");
     expect(err.status).toBe(400);
     expect(err.shouldBeCaptured).toBe(false);
+  });
+});
+
+/**
+ * Regression cover for "a kit I never added showed up in my booking".
+ *
+ * `updateKitAssets` propagates a newly-added kit member into the bookings that
+ * already hold this kit. It used to derive that booking list from the FIRST kit
+ * member that had ANY `BookingAsset` row at all:
+ *
+ *   kit.assets.find((a) => a.bookingAssets.length > 0)?.bookingAssets
+ *
+ * with the underlying `bookingAssets` include carrying no `where` clause. A
+ * QUANTITY_TRACKED asset can belong to several kits, so that member's rows
+ * could belong to a DIFFERENT kit's booking. The new member was then written
+ * into a booking that never contained this kit, tagged with THIS kit's
+ * `assetKitId` — the booking rendered an extra kit nobody added, and the stray
+ * asset produced reservation conflicts that silently disabled Reserve.
+ *
+ * The rule these tests pin: propagate into exactly the bookings holding a slice
+ * of THIS kit — a `BookingAsset` whose `assetKitId` is one of this kit's
+ * `AssetKit` ids — and into ALL of them, not just the first member's.
+ */
+describe("updateKitAssets - kit-booking propagation scope", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  /**
+   * Kit B holds two members:
+   *  - `shared-banner`, a QT asset ALSO in Kit A, whose only booking row is a
+   *    Kit A slice on `booking-foreign` (a booking Kit B is not part of);
+   *  - `kit-b-member`, whose booking row IS a Kit B slice on `booking-own`.
+   *
+   * `shared-banner` sorts first, so the old `.find()` locked onto it and got
+   * exactly the wrong answer in both directions.
+   */
+  function arrangeKitB() {
+    const mockKit = {
+      id: "kit-b",
+      name: "Kit B",
+      status: KitStatus.AVAILABLE,
+      location: null,
+      custody: null,
+      assetKits: [
+        {
+          id: "ak-shared-kitb",
+          kitId: "kit-b",
+          quantity: 1,
+          asset: {
+            id: "shared-banner",
+            title: "Shared banner",
+            type: AssetType.QUANTITY_TRACKED,
+            unitOfMeasure: null,
+            assetKits: [{ kitId: "kit-a" }, { kitId: "kit-b" }],
+            bookingAssets: [
+              {
+                id: "ba-foreign",
+                bookingId: "booking-foreign",
+                assetId: "shared-banner",
+                // Kit A's membership — this row is NOT Kit B's business.
+                assetKitId: "ak-shared-kita",
+                sourceKitId: "kit-a",
+                quantity: 1,
+                booking: { id: "booking-foreign", status: BookingStatus.DRAFT },
+              },
+            ],
+          },
+        },
+        {
+          id: "ak-member-kitb",
+          kitId: "kit-b",
+          quantity: 1,
+          asset: {
+            id: "kit-b-member",
+            title: "Kit B member",
+            type: AssetType.INDIVIDUAL,
+            unitOfMeasure: null,
+            assetKits: [{ kitId: "kit-b" }],
+            bookingAssets: [
+              {
+                id: "ba-own",
+                bookingId: "booking-own",
+                assetId: "kit-b-member",
+                assetKitId: "ak-member-kitb",
+                sourceKitId: "kit-b",
+                quantity: 1,
+                booking: { id: "booking-own", status: BookingStatus.RESERVED },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    /** Full submitted membership: both existing members plus the new one. */
+    const mockAssetsForKit = [
+      {
+        id: "shared-banner",
+        title: "Shared banner",
+        type: AssetType.QUANTITY_TRACKED,
+        quantity: 10,
+        unitOfMeasure: null,
+        assetKits: [{ kitId: "kit-a" }, { kitId: "kit-b" }],
+        custody: [],
+        bookingAssets: [],
+        assetLocations: [],
+      },
+      {
+        id: "kit-b-member",
+        title: "Kit B member",
+        type: AssetType.INDIVIDUAL,
+        quantity: null,
+        unitOfMeasure: null,
+        assetKits: [{ kitId: "kit-b" }],
+        custody: [],
+        bookingAssets: [],
+        assetLocations: [],
+      },
+      {
+        id: "hp-laserjet",
+        title: "HP LaserJet",
+        type: AssetType.INDIVIDUAL,
+        quantity: null,
+        unitOfMeasure: null,
+        assetKits: [],
+        custody: [],
+        bookingAssets: [],
+        assetLocations: [],
+      },
+    ];
+
+    //@ts-expect-error missing vitest type
+    db.kit.findUniqueOrThrow.mockResolvedValue(mockKit);
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue(mockAssetsForKit);
+    // The AssetKit row the pivot insert just created for the new member.
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-hp-kitb", assetId: "hp-laserjet", quantity: 1 },
+    ]);
+  }
+
+  /** Booking ids that received a propagated row, across all createMany calls. */
+  function propagatedBookingIds(): string[] {
+    // `mock.calls` is `any[][]`; narrow it to the single argument shape this
+    // delegate is ever called with so the assertions stay type-checked.
+    const calls = (db.bookingAsset.createMany as ReturnType<typeof vitest.fn>)
+      .mock.calls as Array<[{ data: Array<{ bookingId: string }> }]>;
+    return calls.flatMap(([arg]) => arg.data.map((row) => row.bookingId));
+  }
+
+  async function addNewMemberToKitB() {
+    const { updateKitAssets } = await import("./service.server");
+    await updateKitAssets({
+      kitId: "kit-b",
+      assetIds: ["shared-banner", "kit-b-member", "hp-laserjet"],
+      userId: "user-1",
+      organizationId: "org-1",
+      request: new Request("http://test.com"),
+    });
+  }
+
+  it("does not add the new member to a booking that holds a different kit", async () => {
+    arrangeKitB();
+
+    await addNewMemberToKitB();
+
+    // `booking-foreign` holds Kit A only. Writing here is the reported bug:
+    // the booking grows an asset AND a whole kit its owner never added.
+    expect(propagatedBookingIds()).not.toContain("booking-foreign");
+  });
+
+  it("adds the new member to a booking holding this kit even when an earlier member only has foreign rows", async () => {
+    arrangeKitB();
+
+    await addNewMemberToKitB();
+
+    // The mirror-image failure of the same `.find()`: locking onto
+    // `shared-banner` meant `booking-own` — which genuinely holds Kit B — was
+    // skipped, so the kit silently drifted out of sync with its own booking.
+    expect(propagatedBookingIds()).toContain("booking-own");
+  });
+
+  it("records a BOOKING_ASSETS_ADDED event for each propagated row", async () => {
+    arrangeKitB();
+
+    await addNewMemberToKitB();
+
+    // `ActivityEvent` is reporting data, not the booking's notes feed — no
+    // note is expected here, since nobody acted on the booking. Before this,
+    // the propagated row landed with no trace in any table, which is why the
+    // cross-kit leak could not be reconstructed after the fact.
+    const addedEvents = (
+      recordEvents as ReturnType<typeof vitest.fn>
+    ).mock.calls
+      .flatMap(([events]) => events as Array<Record<string, unknown>>)
+      .filter((event) => event.action === "BOOKING_ASSETS_ADDED");
+
+    expect(addedEvents).toEqual([
+      expect.objectContaining({
+        organizationId: "org-1",
+        actorUserId: "user-1",
+        action: "BOOKING_ASSETS_ADDED",
+        entityType: "BOOKING",
+        entityId: "booking-own",
+        bookingId: "booking-own",
+        assetId: "hp-laserjet",
+        // Names the kit that pulled the asset in — the provenance whose
+        // absence made the stray rows untraceable in the booking feed.
+        kitId: "kit-b",
+      }),
+    ]);
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -5369,4 +5369,23 @@ describe("updateKitAssets - kit-booking propagation scope", () => {
       }),
     ]);
   });
+
+  it("writes the propagated rows and their events on one transaction client", async () => {
+    arrangeKitB();
+
+    await addNewMemberToKitB();
+
+    // A propagated row that commits without its event is unrecoverable, not
+    // merely untidy: the membership transaction has already persisted the
+    // AssetKit row, so a retried call computes `newlyAddedAssets` as empty,
+    // skips propagation entirely and never re-emits the event. Passing the
+    // transaction client to `recordEvents` is what makes the row and its
+    // audit trail commit or roll back together.
+    expect(recordEvents).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ action: "BOOKING_ASSETS_ADDED" }),
+      ]),
+      expect.anything()
+    );
+  });
 });

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -5837,47 +5837,6 @@ export async function updateKitAssets({
           : [];
       const akByAssetId = new Map(newAssetKits.map((ak) => [ak.assetId, ak]));
 
-      await Promise.all(
-        bookingsToUpdate.flatMap((booking) => {
-          const ops = [];
-          if (newlyAddedAssets.length > 0) {
-            ops.push(
-              db.bookingAsset.createMany({
-                data: newlyAddedAssets.map((a) => {
-                  const ak = akByAssetId.get(a.id);
-                  return {
-                    bookingId: booking.id,
-                    assetId: a.id,
-                    quantity: ak?.quantity ?? 1,
-                    assetKitId: ak?.id ?? null,
-                    // Mirror the assetKitId branch exactly: a row that falls
-                    // back to standalone has no kit provenance either. Writing
-                    // one without the other breaks the
-                    // "assetKitId non-null ⇔ sourceKitId non-null" invariant.
-                    sourceKitId: ak ? kit.id : null,
-                  };
-                }),
-                skipDuplicates: true,
-              })
-            );
-          }
-          // why: removing an asset from a kit no longer deletes its
-          // BookingAsset rows from active bookings. The DB-level
-          // `BookingAsset.assetKitId` FK fires `ON DELETE SET NULL` when
-          // the AssetKit row is dropped (the actual delete happens in
-          // the outer tx above), converting the kit-driven booking slice
-          // into a standalone reservation. A per-booking system note
-          // emitted by `emitAssetKitDetachmentNotes` explains the
-          // conversion to the user. Deleting the row here would undo
-          // the SET NULL and silently shrink the booking — the opposite
-          // of the documented behaviour.
-          //
-          // Asset-bulk-remove (asset-side flow) is unaffected; it still
-          // goes through `removeAssets` which deletes the rows explicitly.
-          return ops;
-        })
-      );
-
       /**
        * Reporting events for the rows just propagated above.
        *
@@ -5905,9 +5864,6 @@ export async function updateKitAssets({
        * The `ak`-less fallback writes a standalone row that MAY be skipped
        * against an existing one, and claiming an add that did not happen would
        * make the trail lie.
-       *
-       * Emitted outside the transaction because the inserts above are too —
-       * they run on `db`, after the membership tx has committed.
        */
       const propagatedEvents = bookingsToUpdate.flatMap((booking) =>
         newlyAddedAssets.flatMap((asset) => {
@@ -5929,9 +5885,75 @@ export async function updateKitAssets({
         })
       );
 
-      if (propagatedEvents.length > 0) {
-        await recordEvents(propagatedEvents);
+      /**
+       * Propagated rows and their events commit together.
+       *
+       * A row that lands without its event is not merely untidy, it is
+       * unrecoverable: the membership transaction above has already persisted
+       * the `AssetKit` rows, so a retried call recomputes `newlyAddedAssets` as
+       * empty (it diffs the submitted ids against the kit's CURRENT members),
+       * skips this block entirely, and never re-emits the event. The booking
+       * would keep an asset whose arrival nothing recorded — the exact
+       * untraceability these events exist to prevent.
+       *
+       * A NEW narrow transaction rather than the membership one above: that tx
+       * already carries the detachment-impact fetch, collision merge, placement
+       * preservation, location cascade and a `consumptionLog.groupBy`, and has
+       * produced P2028 on large operations. Reads stay outside it (the
+       * `assetKit.findMany` above, and the event array is pure computation) so
+       * it holds writes only.
+       *
+       * Sequential, not `Promise.all`: an interactive transaction runs on a
+       * single connection, so concurrent queries on one `tx` client are unsafe.
+       * `bookingsToUpdate` is the set of bookings holding this kit — small.
+       *
+       * Residual, deliberately accepted: the membership tx has already
+       * committed, so a failure here still surfaces an error over a partly
+       * applied operation. This guarantees only that the propagated rows and
+       * their audit trail live or die together.
+       */
+      if (newlyAddedAssets.length > 0) {
+        await db.$transaction(async (tx) => {
+          for (const booking of bookingsToUpdate) {
+            await tx.bookingAsset.createMany({
+              data: newlyAddedAssets.map((a) => {
+                const ak = akByAssetId.get(a.id);
+                return {
+                  bookingId: booking.id,
+                  assetId: a.id,
+                  quantity: ak?.quantity ?? 1,
+                  assetKitId: ak?.id ?? null,
+                  // Mirror the assetKitId branch exactly: a row that falls
+                  // back to standalone has no kit provenance either. Writing
+                  // one without the other breaks the
+                  // "assetKitId non-null ⇔ sourceKitId non-null" invariant.
+                  sourceKitId: ak ? kit.id : null,
+                };
+              }),
+              skipDuplicates: true,
+            });
+          }
+
+          if (propagatedEvents.length > 0) {
+            await recordEvents(propagatedEvents, tx);
+          }
+        });
       }
+
+      // why: there is deliberately no delete counterpart here. Removing an
+      // asset from a kit does not delete its BookingAsset rows from ACTIVE
+      // bookings — the DB-level `BookingAsset.assetKitId` FK fires
+      // `ON DELETE SET NULL` when the AssetKit row is dropped (the actual
+      // delete happens in the membership tx above), converting the kit-driven
+      // slice into a standalone reservation, and
+      // `emitAssetKitDetachmentNotes` writes a per-booking system note
+      // explaining the conversion. Deleting the row here would undo that SET
+      // NULL and silently shrink the booking. Planning-status bookings are the
+      // exception and are handled by `removeKitSlicesFromPlanningBookings`,
+      // inside that same tx.
+      //
+      // Asset-bulk-remove (asset-side flow) is unaffected; it still goes
+      // through `removeAssets`, which deletes the rows explicitly.
     }
 
     /**

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -4688,6 +4688,11 @@ export async function updateKitAssets({
           // `asset.assetKits[0]?.kitId`.
           assetKits: {
             select: {
+              // This kit's OWN membership ids. `BookingAsset.assetKitId` points
+              // at one of these exactly when a booking holds a slice of THIS
+              // kit, which is how the `kitBookings` derivation below scopes the
+              // new-member propagation.
+              id: true,
               kitId: true,
               // This kit's per-row slice — surfaced in the membership-remove
               // note + ASSET_KIT_CHANGED event ("removed 50 units from ...").
@@ -5034,10 +5039,45 @@ export async function updateKitAssets({
       });
     }
 
-    const kitBookings =
-      kit.assets
-        .find((a) => a.bookingAssets.length > 0)
-        ?.bookingAssets.map((ba) => ba.booking) ?? [];
+    /**
+     * Bookings that hold a slice of THIS kit.
+     *
+     * A booking carries this kit exactly when it has a `BookingAsset` whose
+     * `assetKitId` is one of this kit's own `AssetKit` ids. Anything else on a
+     * member asset — a standalone row, or a slice belonging to another kit the
+     * asset also happens to be in — is a different booking's business.
+     *
+     * This used to be `kit.assets.find((a) => a.bookingAssets.length > 0)`,
+     * taking one arbitrary member's ENTIRE booking list (the `bookingAssets`
+     * include carries no `where`). That was wrong in both directions, and a
+     * QUANTITY_TRACKED asset shared between kits triggered both at once:
+     *
+     *  - false positive: the member's row belonged to ANOTHER kit's booking, so
+     *    a newly-added member was written into a booking that never contained
+     *    this kit — surfacing a whole extra kit nobody added, and creating
+     *    reservation conflicts that silently disabled that booking's Reserve
+     *    button;
+     *  - false negative: once `.find()` locked onto that member, bookings which
+     *    genuinely DO hold this kit were skipped, so the kit drifted out of
+     *    sync with its own bookings.
+     *
+     * Deduped by booking id: several members of this kit normally sit in the
+     * same booking, and each would otherwise contribute a duplicate insert.
+     */
+    const thisKitAssetKitIds = new Set(
+      kitWithRelations.assetKits.map((ak) => ak.id)
+    );
+    const kitBookings = [
+      ...new Map(
+        kit.assets
+          .flatMap((asset) => asset.bookingAssets)
+          .filter(
+            (ba) =>
+              ba.assetKitId != null && thisKitAssetKitIds.has(ba.assetKitId)
+          )
+          .map((ba) => [ba.booking.id, ba.booking] as const)
+      ).values(),
+    ];
 
     // The old kit.update({ data: { assets: { connect, disconnect } } })
     // block becomes direct pivot writes inside a single $transaction so
@@ -5837,6 +5877,61 @@ export async function updateKitAssets({
           return ops;
         })
       );
+
+      /**
+       * Reporting events for the rows just propagated above.
+       *
+       * These are `ActivityEvent` rows — reporting data, NOT the booking's
+       * notes feed (that is `BookingNote`, which the Activity tab and its CSV
+       * export read). No note is written here deliberately: nobody acted on
+       * the booking, so there is nothing to tell its watchers.
+       *
+       * Emitting them matters because this insert is the only way a booking
+       * gains an asset without anybody touching the booking. Until now it left
+       * no trace in ANY table, which is what made the cross-kit leak this
+       * scoping fix addresses impossible to reconstruct after the fact.
+       * `BOOKING_ASSETS_ADDED` has no report consumer yet — it is recorded for
+       * the same reason `updateBookingAssets` records it, so the history exists
+       * when one arrives.
+       *
+       * One event per (booking, asset) pair rather than one per booking, so the
+       * data stays aggregable — see `.claude/rules/record-event-payload-shapes.md`.
+       * `kitId` names the kit that pulled the asset in, which is the provenance
+       * needed to explain why the row is there.
+       *
+       * Scoped to assets with a resolved `AssetKit`: those rows are keyed on a
+       * brand-new `assetKitId`, so the `(bookingId, assetKitId)` partial unique
+       * cannot collide and `skipDuplicates` cannot have silently dropped them.
+       * The `ak`-less fallback writes a standalone row that MAY be skipped
+       * against an existing one, and claiming an add that did not happen would
+       * make the trail lie.
+       *
+       * Emitted outside the transaction because the inserts above are too —
+       * they run on `db`, after the membership tx has committed.
+       */
+      const propagatedEvents = bookingsToUpdate.flatMap((booking) =>
+        newlyAddedAssets.flatMap((asset) => {
+          const ak = akByAssetId.get(asset.id);
+          if (!ak) return [];
+          return [
+            {
+              organizationId,
+              actorUserId: userId,
+              action: "BOOKING_ASSETS_ADDED" as const,
+              entityType: "BOOKING" as const,
+              entityId: booking.id,
+              bookingId: booking.id,
+              assetId: asset.id,
+              kitId: kit.id,
+              meta: assetQtyMeta(asset, ak.quantity),
+            },
+          ];
+        })
+      );
+
+      if (propagatedEvents.length > 0) {
+        await recordEvents(propagatedEvents);
+      }
     }
 
     /**


### PR DESCRIPTION
## The bug

A customer reported kits appearing in bookings she never added them to, extra items showing up, and some bookings refusing to reserve. Confirmed in her production data and reproduced locally.

`updateKitAssets` propagates a newly-added kit member into the bookings the kit is already part of. It derived that booking list from the **first kit member that had any `BookingAsset` row at all**, through an include carrying no `where` clause:

```js
kit.assets.find((a) => a.bookingAssets.length > 0)?.bookingAssets
```

A `QUANTITY_TRACKED` asset can belong to several kits, so that member's rows could belong to a **different** kit's booking. Wrong in both directions:

- **False positive** — the new member was written into a booking that never contained this kit, tagged with this kit's `assetKitId`. The booking rendered a whole extra kit nobody added, and the stray asset created reservation conflicts that silently disabled its Reserve button (the reason only appears in a hover tooltip on the disabled button, so it reads as "nothing happens").
- **False negative** — once `.find()` locked onto that member, bookings that genuinely **do** hold this kit were skipped, so new members never reached them. This half was never reported and isn't visible in the customer's data; it surfaced while writing the second test.

## Evidence

In the reporter's org, booking `Maki & Ramen Freshers 2026` held 3 rows from `Maki & Ramen` plus exactly one each from `Top Cash Back` and `Adventure 360`. `Fabric Banner` (QT, member of 4 kits) was the bridge. Each stray `BookingAsset` row was created **~450ms after** the `AssetKit` membership it points at — same operation:

| stray asset | membership created | booking row created |
| --- | --- | --- |
| Spinning Wheel (SPW3) → Adventure 360 | `09:09:17.719` | `09:09:18.165` |
| Spinning Wheel (SPW4) → Top Cash Back | `13:00:05.934` | `13:00:06.381` |

Reproduced locally end to end: a QT asset in Kit A and Kit B, a booking holding only Kit A, then adding an asset to Kit B — the new asset landed in the Kit-A-only booking, 18ms after the membership row.

## The fix

Derive the booking list from `BookingAsset` rows whose `assetKitId` is one of **this kit's own** `AssetKit` ids, across all members, deduped by booking. Requires `id: true` on the `assetKits` select.

Also records one `BOOKING_ASSETS_ADDED` `ActivityEvent` per propagated `(booking, asset)` pair, carrying `kitId`. This insert is the only way a booking gains an asset without anybody acting on the booking, and it previously left **no trace in any table** — which is what made the leak impossible to reconstruct. Deliberately no `BookingNote`: nobody acted on the booking, so there is nothing to tell its watchers.

## Tests

Three tests under `updateKitAssets - kit-booking propagation scope`, fixture matching the reporter's exact shape. All three were written first and watched fail — the first with `expected [ 'booking-foreign' ] to not include 'booking-foreign'`, i.e. the bug reproduced in a unit test.

- does not add the new member to a booking that holds a different kit
- adds the new member to a booking holding this kit even when an earlier member only has foreign rows
- records a `BOOKING_ASSETS_ADDED` event for each propagated row

`pnpm webapp:validate`: typecheck clean, lint clean, 4656 tests pass. The two `activity[.csv]` route suites hit the known 10s `hookTimeout` flake and pass with `--hookTimeout=30000` (6/6); neither touches this code.

## Reviewer notes

- **`recordEvents` runs outside the transaction.** Against the letter of `.claude/rules/use-record-event.md`. Deliberate: the `bookingAsset.createMany` inserts it describes also run on `db` after the membership tx commits, so the event shares the mutation's boundary rather than diverging from it. Exposure is a partial audit trail if the process dies between the two. Wrapping both in one `$transaction` would close it, at the cost of changing the existing insert path rather than only adding to it — happy to do that if preferred.
- **Events are emitted only for assets with a resolved `AssetKit`.** Those rows key on a brand-new `assetKitId`, so `skipDuplicates` cannot have dropped them. The `ak`-less fallback writes a standalone row that may legitimately be skipped, and claiming an add that did not happen would make the trail lie.

## Not in this PR

- **Cleaning the affected customer's existing stray rows.** Two rows; deleting them also clears the `CONFLICT` blocking her Reserve. Follow-up.
- **The "assets & kits I added just vanish" complaint.** Separate from this bug. Leading candidate is `removeKitSlicesFromPlanningBookings` (#2812), which deletes kit-driven rows from DRAFT/RESERVED bookings when a kit member is removed — working as designed, but destructive and surprising. Being confirmed against her data via the `meta.viaKitRemoval` flag; likely a product call rather than a fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Newly added kit members now propagate only to bookings containing the corresponding kit.
  * Updates are applied consistently across all matching active bookings.
  * Booking activity history now records added assets with relevant kit and quantity details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->