### PR TITLE
fix(assets): repair checked-out status overwritten by custody writes

### DIFF
--- a/packages/database/prisma/migrations/20260813150000_repair_custody_masked_checkout_status/migration.sql
+++ b/packages/database/prisma/migrations/20260813150000_repair_custody_masked_checkout_status/migration.sql
@@ -1,0 +1,45 @@
+-- Repair: assets whose CHECKED_OUT status was overwritten by a custody write.
+--
+-- Until #2830 landed, custody flows set `Asset.status` unconditionally. Taking
+-- custody of an asset that was already out on a booking overwrote CHECKED_OUT
+-- with IN_CUSTODY. Releasing the last custody row overwrote it with AVAILABLE.
+--
+-- That single column is what the availability maths asks "are you checked
+-- out?". With the answer wrong, `computeCheckedOutBreakdownBatch` never takes
+-- its legacy all-at-once branch, counts ZERO units as out, and the free-stock
+-- figure overstates by exactly the booked quantity. A quantity-tracked asset
+-- with 29 total, 20 in custody and 5 out on an active booking advertised 9
+-- free when only 4 were.
+--
+-- #2830 guards every custody-driven write, so no NEW asset can enter this
+-- state. It shipped no repair, so rows that broke BEFORE it deployed stay
+-- broken and do not self-heal: the status reads IN_CUSTODY, so the new
+-- `not: CHECKED_OUT` guard does not match and a later release still walks it
+-- to AVAILABLE.
+--
+-- WHAT COUNTS AS "STILL OUT" — deliberately mirrors the application's own
+-- definition rather than inventing one. Per `isAssetPartiallyCheckedIn` and the
+-- booking CSV export in `app/utils/booking-assets.ts`, an asset is checked out
+-- when its booking is ONGOING/OVERDUE *and* it does not appear in that
+-- booking's partial check-ins. Assets that were returned via a partial check-in
+-- are excluded, so a returned asset is never re-flagged as out.
+--
+-- Safe to re-run: the WHERE clause stops matching once a row is repaired.
+UPDATE "Asset" a
+SET status = 'CHECKED_OUT'
+WHERE a.status = 'IN_CUSTODY'
+  AND EXISTS (
+    SELECT 1
+    FROM "BookingAsset" ba
+    JOIN "Booking" b ON b.id = ba."bookingId"
+    WHERE ba."assetId" = a.id
+      AND b.status IN ('ONGOING', 'OVERDUE')
+      -- Belt and braces: never let a cross-org row drive the decision.
+      AND b."organizationId" = a."organizationId"
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "PartialBookingCheckin" pc
+        WHERE pc."bookingId" = b.id
+          AND a.id = ANY (pc."assetIds")
+      )
+  );

--- a/packages/database/prisma/migrations/20260813150000_repair_custody_masked_checkout_status/migration.sql
+++ b/packages/database/prisma/migrations/20260813150000_repair_custody_masked_checkout_status/migration.sql
@@ -1,30 +1,50 @@
--- Repair: assets whose CHECKED_OUT status was overwritten by a custody write.
+-- Repair: assets whose checked-out status was overwritten by a custody write.
 --
--- Until #2830 landed, custody flows set `Asset.status` unconditionally. Taking
--- custody of an asset that was already out on a booking overwrote CHECKED_OUT
--- with IN_CUSTODY. Releasing the last custody row overwrote it with AVAILABLE.
+-- Until #2830, custody flows set `Asset.status` unconditionally. Taking custody
+-- of an asset already out on a booking overwrote CHECKED_OUT with IN_CUSTODY;
+-- releasing the last custody row overwrote it with AVAILABLE.
 --
 -- That single column is what the availability maths asks "are you checked
 -- out?". With the answer wrong, `computeCheckedOutBreakdownBatch` never takes
--- its legacy all-at-once branch, counts ZERO units as out, and the free-stock
--- figure overstates by exactly the booked quantity. A quantity-tracked asset
--- with 29 total, 20 in custody and 5 out on an active booking advertised 9
--- free when only 4 were.
+-- its legacy all-at-once branch, counts ZERO units as out, and free stock
+-- overstates by exactly the booked quantity. A quantity-tracked asset with 29
+-- total, 20 in custody and 5 out on an active booking advertised 9 free when
+-- only 4 were.
 --
--- #2830 guards every custody-driven write, so no NEW asset can enter this
--- state. It shipped no repair, so rows that broke BEFORE it deployed stay
--- broken and do not self-heal: the status reads IN_CUSTODY, so the new
--- `not: CHECKED_OUT` guard does not match and a later release still walks it
--- to AVAILABLE.
+-- #2830 guards every custody-driven write, so no NEW asset can reach this
+-- state. It shipped no repair, and these rows do not self-heal.
 --
--- WHAT COUNTS AS "STILL OUT" — deliberately mirrors the application's own
--- definition rather than inventing one. Per `isAssetPartiallyCheckedIn` and the
--- booking CSV export in `app/utils/booking-assets.ts`, an asset is checked out
--- when its booking is ONGOING/OVERDUE *and* it does not appear in that
--- booking's partial check-ins. Assets that were returned via a partial check-in
--- are excluded, so a returned asset is never re-flagged as out.
+-- ---------------------------------------------------------------------------
+-- PROVING AN ASSET ACTUALLY WENT OUT
+-- ---------------------------------------------------------------------------
+-- "On a booking that is ONGOING" is NOT sufficient evidence, and treating it as
+-- such would corrupt data rather than repair it. `partialCheckoutBooking` moves
+-- a booking to ONGOING once the first asset is scanned, leaving the unscanned
+-- ones untouched. An unscanned asset that is legitimately in someone's custody
+-- would satisfy a naive EXISTS, be flipped to CHECKED_OUT, and — having no
+-- checkout claim of its own — be read by `computeCheckedOutBreakdownBatch` as a
+-- legacy all-at-once checkout, so its ENTIRE booked quantity would count as
+-- out. That is the same bug this migration exists to fix, inverted.
 --
--- Safe to re-run: the WHERE clause stops matching once a row is repaired.
+-- `PartialBookingCheckout` rows are written by `partialCheckoutBooking` and by
+-- nothing else, so their presence is a reliable discriminator:
+--
+--   * booking has NO PartialBookingCheckout rows  -> all-at-once checkout;
+--     everything on the booking went out together, so membership is proof.
+--   * booking HAS PartialBookingCheckout rows     -> progressive checkout;
+--     ONLY assets named in those rows went out. Membership proves nothing.
+--
+-- This mirrors the discriminator the application itself uses (see the
+-- "legacy all-at-once" branch in `computeCheckedOutBreakdownBatch`).
+--
+-- Not-yet-returned reuses the app's own definition too: per
+-- `isAssetPartiallyCheckedIn` and the booking CSV export in
+-- `app/utils/booking-assets.ts`, an asset is back once it appears in the
+-- booking's partial check-ins.
+--
+-- Safe to re-run: both predicates stop matching once a row is repaired.
+
+-- 1. Custody overwrote CHECKED_OUT with IN_CUSTODY.
 UPDATE "Asset" a
 SET status = 'CHECKED_OUT'
 WHERE a.status = 'IN_CUSTODY'
@@ -34,12 +54,47 @@ WHERE a.status = 'IN_CUSTODY'
     JOIN "Booking" b ON b.id = ba."bookingId"
     WHERE ba."assetId" = a.id
       AND b.status IN ('ONGOING', 'OVERDUE')
-      -- Belt and braces: never let a cross-org row drive the decision.
       AND b."organizationId" = a."organizationId"
+      AND (
+        EXISTS (
+          SELECT 1 FROM "PartialBookingCheckout" pco
+          WHERE pco."bookingId" = b.id AND a.id = ANY (pco."assetIds")
+        )
+        OR NOT EXISTS (
+          SELECT 1 FROM "PartialBookingCheckout" pco2
+          WHERE pco2."bookingId" = b.id
+        )
+      )
       AND NOT EXISTS (
-        SELECT 1
-        FROM "PartialBookingCheckin" pc
-        WHERE pc."bookingId" = b.id
-          AND a.id = ANY (pc."assetIds")
+        SELECT 1 FROM "PartialBookingCheckin" pc
+        WHERE pc."bookingId" = b.id AND a.id = ANY (pc."assetIds")
+      )
+  );
+
+-- 2. A custody RELEASE overwrote CHECKED_OUT with AVAILABLE.
+--
+-- Deliberately stricter than statement 1: positive per-asset checkout evidence
+-- only, never the all-at-once inference. `updateBookingAssets` leaves an asset
+-- AVAILABLE on purpose when it is added to a booking AFTER checkout (#2815),
+-- and on an all-at-once booking there is no per-asset record to tell that
+-- apart from a wrongly-reset row. Assets in that ambiguous set are left alone;
+-- over-reporting stock is bad, but claiming an on-shelf asset is out is worse.
+UPDATE "Asset" a
+SET status = 'CHECKED_OUT'
+WHERE a.status = 'AVAILABLE'
+  AND EXISTS (
+    SELECT 1
+    FROM "BookingAsset" ba
+    JOIN "Booking" b ON b.id = ba."bookingId"
+    WHERE ba."assetId" = a.id
+      AND b.status IN ('ONGOING', 'OVERDUE')
+      AND b."organizationId" = a."organizationId"
+      AND EXISTS (
+        SELECT 1 FROM "PartialBookingCheckout" pco
+        WHERE pco."bookingId" = b.id AND a.id = ANY (pco."assetIds")
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM "PartialBookingCheckin" pc
+        WHERE pc."bookingId" = b.id AND a.id = ANY (pc."assetIds")
       )
   );


### PR DESCRIPTION
Follow-up to #2830. That PR stopped the bug happening again but shipped no repair, so every asset that broke **before** it deployed is still wrong.

## What users see

A quantity-tracked asset with units in someone's custody **and** units out on an active booking reports more free stock than it has. A live example: 29 total, 20 in custody, 5 out on an ONGOING booking, displayed as **9 available** when the true figure is **4**.

## Why

Custody flows used to write `Asset.status` unconditionally, so taking custody of an asset already out on a booking overwrote `CHECKED_OUT` with `IN_CUSTODY`.

That one column is what the availability maths asks "are you checked out?". With the answer wrong, `computeCheckedOutBreakdownBatch` never takes its legacy all-at-once branch, counts **zero** units as out, and free stock overstates by exactly the booked quantity.

It does not self-heal. The status reads `IN_CUSTODY`, so #2830's new `not: CHECKED_OUT` guard never matches, and a later custody release still walks the asset to `AVAILABLE`.

## What counts as "still out"

Deliberately the application's own definition, not a new one. Per `isAssetPartiallyCheckedIn` and the booking CSV export in `app/utils/booking-assets.ts`, an asset is checked out when its booking is ONGOING/OVERDUE **and** it does not appear in that booking's partial check-ins.

So an asset returned via a partial check-in is never re-flagged as out. That exclusion is the part most likely to cause damage if wrong, so it is tested below rather than assumed.

## Verification

Run against the QA database, since no rows in QA were naturally in the broken state:

| Case | Expected | Result |
|---|---|---|
| Out on an active booking, no check-in, status forced to `IN_CUSTODY` | repaired | ✅ `CHECKED_OUT` |
| Present in a partial check-in, status `IN_CUSTODY` | left alone | ✅ untouched, `UPDATE 0` |
| Re-run after repair | no-op | ✅ `UPDATE 0` |

All probe rows were removed and QA was returned to its prior state.

## Deploy

Data-only migration, no schema change, no lock on a hot table beyond the update itself. It auto-runs via the Fly `release_command`. There is precedent for data-only migrations in this repo (e.g. `20231016174627_migrate_user_org_role`).

Safe to re-run: the WHERE clause stops matching once a row is repaired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected asset statuses when ongoing or overdue bookings show that assets are checked out.
  * Preserved accurate statuses for assets returned through partial check-ins.
  * Improved status recovery for both all-at-once and progressive checkouts.
  * Avoided changing assets when checkout details are ambiguous.
  * Ensured repairs can be safely applied without repeatedly modifying already corrected records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->