### PR TITLE
fix(companion): make audit photo/note capture discoverable on scanned rows

### DIFF
--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -56,6 +56,7 @@ import {
   type ListTab,
 } from "@/components/audit/segmented-control";
 import { EvidenceModal } from "@/components/audit/evidence-modal";
+import { EvidenceCoachmark } from "@/components/audit/evidence-coachmark";
 import type { ScannedItem } from "@/hooks/use-audit-init";
 
 // ── Main Export ──────────────────────────────────────────
@@ -242,12 +243,16 @@ function AuditScannerContent() {
 
   const [evidenceModalVisible, setEvidenceModalVisible] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ScannedItem | null>(null);
+  // Opening the sheet once proves the user found evidence capture, which
+  // retires the coachmark for good.
+  const [hasOpenedEvidence, setHasOpenedEvidence] = useState(false);
   // Wire up setSelectedItem for the scan sync callback
   setSelectedItemRef.current = setSelectedItem;
 
   const handleItemPress = useCallback((item: ScannedItem) => {
     setSelectedItem(item);
     setEvidenceModalVisible(true);
+    setHasOpenedEvidence(true);
   }, []);
 
   const handleCloseEvidenceModal = useCallback(() => {
@@ -1146,6 +1151,15 @@ function AuditScannerContent() {
             scannedCount={scannedItems.length}
             remainingCount={remainingCount}
           />
+
+          {/* why: the evidence sheet lives behind a row tap, so name it once
+              the first row exists — on the Scanned tab, where the rows are. */}
+          {activeTab === "scanned" && (
+            <EvidenceCoachmark
+              enabled={scannedItems.length > 0}
+              hasOpenedEvidence={hasOpenedEvidence}
+            />
+          )}
 
           {/* List content */}
           {activeTab === "scanned" ? (

--- a/apps/companion/components/audit/evidence-coachmark.tsx
+++ b/apps/companion/components/audit/evidence-coachmark.tsx
@@ -1,0 +1,95 @@
+/**
+ * EvidenceCoachmark — one-time discoverability hint for audit evidence.
+ *
+ * Scanning an asset during an audit records it as found, but a field worker
+ * can also attach a condition note and photos to that scan. That was reachable
+ * only by tapping the scanned row, whose sole affordance was a small chevron —
+ * so people finished audits without ever discovering it. The row now carries an
+ * explicit "Add photo/note" action; this bubble names it once, right when the
+ * first row appears.
+ *
+ * Dismisses permanently on "Got it" or as soon as the user opens the evidence
+ * sheet on their own (proof they found it).
+ *
+ * @see {@link file://./scanned-items-list.tsx} the rows it points at
+ * @see {@link file://./evidence-modal.tsx} what the rows open
+ * @see {@link file://../../hooks/use-one-time-hint.ts} the storage contract
+ */
+import { useEffect } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useOneTimeHint } from "@/hooks/use-one-time-hint";
+import { useTheme } from "@/lib/theme-context";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { createStyles } from "@/lib/create-styles";
+
+const STORAGE_KEY = "shelf.audit.evidence-coachmark-dismissed.v1";
+
+type Props = {
+  /** Only worth showing once there is a scanned row to point at. */
+  enabled: boolean;
+  /** True once the user has opened the evidence sheet — counts as discovery. */
+  hasOpenedEvidence: boolean;
+};
+
+/**
+ * One-time "Tap an item to add a photo or note" bubble above the scanned list.
+ * Renders nothing once dismissed (persisted across sessions).
+ */
+export function EvidenceCoachmark({ enabled, hasOpenedEvidence }: Props) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+  const { shouldShow, dismiss } = useOneTimeHint(STORAGE_KEY, enabled);
+
+  // Opening the sheet proves the user found the feature — dismiss permanently.
+  useEffect(() => {
+    if (shouldShow && hasOpenedEvidence) {
+      dismiss();
+    }
+  }, [shouldShow, hasOpenedEvidence, dismiss]);
+
+  if (!shouldShow) return null;
+
+  return (
+    <View style={styles.bubble} accessibilityRole="text">
+      <Ionicons name="camera-outline" size={16} color={colors.primaryText} />
+      <Text style={styles.text}>
+        Tap a scanned item to add a photo or condition note.
+      </Text>
+      <TouchableOpacity
+        onPress={dismiss}
+        accessibilityLabel="Dismiss audit evidence hint"
+        accessibilityRole="button"
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Text style={styles.gotIt}>Got it</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const useStyles = createStyles((colors) => ({
+  bubble: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.primaryBg,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    marginBottom: spacing.sm,
+    gap: spacing.sm,
+  },
+  text: {
+    flex: 1,
+    color: colors.foregroundSecondary,
+    fontSize: fontSize.sm,
+    lineHeight: 18,
+  },
+  gotIt: {
+    color: colors.primaryText,
+    fontSize: fontSize.sm,
+    fontWeight: "700",
+  },
+}));

--- a/apps/companion/components/audit/scanned-items-list.tsx
+++ b/apps/companion/components/audit/scanned-items-list.tsx
@@ -1,3 +1,16 @@
+/**
+ * ScannedItemsList — the "Scanned" tab of the audit scanner.
+ *
+ * Each row is a tap target that opens the evidence sheet for that scan, so the
+ * trailing element must SAY so: a scan carries an optional condition note and
+ * photos, and when the only affordance was a muted chevron, field workers
+ * finished audits without ever discovering it. Rows therefore end in an
+ * explicit "Add photo/note" action, which becomes the evidence count once
+ * something is attached.
+ *
+ * @see {@link file://./evidence-modal.tsx} what a row opens
+ * @see {@link file://./evidence-coachmark.tsx} the one-time hint above the list
+ */
 import React, { useCallback } from "react";
 import { View, Text, FlatList, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
@@ -48,12 +61,6 @@ export function ScannedItemsList({
           <Text style={styles.scannedItemName} numberOfLines={1}>
             {item.name}
           </Text>
-          {hasEvidence && (
-            <View style={styles.evidenceBadge}>
-              <Ionicons name="attach" size={12} color={colors.muted} />
-              <Text style={styles.evidenceCount}>{evidenceCount}</Text>
-            </View>
-          )}
           {syncFailed ? (
             <View style={styles.syncFailedBadge}>
               <Ionicons
@@ -68,7 +75,25 @@ export function ScannedItemsList({
               {item.isExpected ? "Found" : "Unexpected"}
             </Text>
           )}
-          <Ionicons name="chevron-forward" size={16} color={colors.muted} />
+          {/* The row's whole point beyond "found": attach evidence. Say it in
+              words until there is a count to show instead. */}
+          {hasEvidence ? (
+            <View style={styles.evidenceBadge}>
+              <Ionicons name="attach" size={12} color={colors.primaryText} />
+              <Text style={styles.evidenceCount}>{evidenceCount}</Text>
+            </View>
+          ) : (
+            <View style={styles.addEvidenceChip}>
+              <Ionicons
+                name="camera-outline"
+                size={13}
+                color={colors.primaryText}
+              />
+              <Text style={styles.addEvidenceText} numberOfLines={1}>
+                Add photo/note
+              </Text>
+            </View>
+          )}
         </TouchableOpacity>
       );
     },
@@ -138,28 +163,52 @@ const useStyles = createStyles((colors) => ({
   },
   scannedItemName: {
     flex: 1,
+    // why: the name is the ONLY element allowed to give up width — a squeezed
+    // "Add photo/note" chip would wrap or clip and stop reading as an action
+    flexShrink: 1,
     fontSize: fontSize.sm,
     fontWeight: "500",
     color: colors.foreground,
   },
   scannedItemBadge: {
+    flexShrink: 0,
     fontSize: fontSize.xs,
     fontWeight: "500",
     color: colors.muted,
   },
+  addEvidenceChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexShrink: 0,
+    gap: spacing.xs,
+    backgroundColor: colors.primaryBg,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+    borderRadius: borderRadius.sm,
+  },
+  addEvidenceText: {
+    fontSize: fontSize.xs,
+    fontWeight: "600",
+    color: colors.primaryText,
+  },
   evidenceBadge: {
     flexDirection: "row",
     alignItems: "center",
+    flexShrink: 0,
     gap: 2,
-    backgroundColor: colors.borderLight,
-    paddingHorizontal: spacing.xs,
-    paddingVertical: 2,
+    backgroundColor: colors.primaryBg,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
     borderRadius: borderRadius.sm,
   },
   evidenceCount: {
     fontSize: fontSize.xs,
     fontWeight: "600",
-    color: colors.foregroundSecondary,
+    color: colors.primaryText,
   },
   syncFailedBadge: {
     flexDirection: "row",

--- a/apps/companion/components/scanner/action-pills-coachmark.tsx
+++ b/apps/companion/components/scanner/action-pills-coachmark.tsx
@@ -9,14 +9,15 @@
  * away forever once dismissed or once the user switches actions on their
  * own (proof they found the feature).
  *
- * Persistence: a single AsyncStorage flag, versioned so a future redesign
- * can re-show the hint by bumping the key.
+ * Persistence: a single AsyncStorage flag via `useOneTimeHint`, versioned so
+ * a future redesign can re-show the hint by bumping the key.
  *
  * @see {@link file://./action-pills.tsx} the pills it points at
+ * @see {@link file://../../hooks/use-one-time-hint.ts} the storage contract
  */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { View, Text, TouchableOpacity } from "react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useOneTimeHint } from "@/hooks/use-one-time-hint";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { createStyles } from "@/lib/create-styles";
 
@@ -35,40 +36,17 @@ type Props = {
  */
 export function ActionPillsCoachmark({ enabled, currentAction }: Props) {
   const styles = useStyles();
-  // null = storage not read yet (render nothing to avoid a flash)
-  const [dismissed, setDismissed] = useState<boolean | null>(null);
+  const { shouldShow, dismiss } = useOneTimeHint(STORAGE_KEY, enabled);
   const initialActionRef = useRef(currentAction);
-
-  useEffect(() => {
-    let cancelled = false;
-    AsyncStorage.getItem(STORAGE_KEY)
-      .then((value) => {
-        if (!cancelled) setDismissed(value === "1");
-      })
-      .catch(() => {
-        // why: storage failure should never block scanning — just skip the hint
-        if (!cancelled) setDismissed(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const dismiss = () => {
-    setDismissed(true);
-    AsyncStorage.setItem(STORAGE_KEY, "1").catch(() => {
-      // why: best-effort persistence; worst case the hint shows once more
-    });
-  };
 
   // Switching actions proves the user found the pills — dismiss permanently.
   useEffect(() => {
-    if (dismissed === false && currentAction !== initialActionRef.current) {
+    if (shouldShow && currentAction !== initialActionRef.current) {
       dismiss();
     }
-  }, [currentAction, dismissed]);
+  }, [currentAction, shouldShow, dismiss]);
 
-  if (!enabled || dismissed !== false) return null;
+  if (!shouldShow) return null;
 
   return (
     <View

--- a/apps/companion/hooks/use-one-time-hint.ts
+++ b/apps/companion/hooks/use-one-time-hint.ts
@@ -1,0 +1,65 @@
+/**
+ * useOneTimeHint — AsyncStorage-backed state for a discoverability hint that
+ * should appear once and then never again.
+ *
+ * Extracted from the scanner's action-pills coachmark so every "show this tip
+ * until the user gets it" surface stores its flag the same way: one versioned
+ * key, storage failures degrade to "already seen" (a hint must never block the
+ * screen it sits on), and nothing renders until storage has been read so the
+ * bubble can't flash in and out.
+ *
+ * @see {@link file://../components/scanner/action-pills-coachmark.tsx}
+ * @see {@link file://../components/audit/evidence-coachmark.tsx}
+ */
+import { useCallback, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export type OneTimeHint = {
+  /**
+   * True only when storage has been read AND the hint has not been dismissed.
+   * Render the hint on this — never on `!dismissed`, which would flash the
+   * bubble before storage resolves.
+   */
+  shouldShow: boolean;
+  /** Hides the hint now and persists the dismissal (best effort). */
+  dismiss: () => void;
+};
+
+/**
+ * @param storageKey Versioned AsyncStorage key — bump the version suffix to
+ *   re-show the hint after a redesign.
+ * @param enabled When false the hint never shows, but storage is still read so
+ *   flipping this later doesn't cause a flash.
+ */
+export function useOneTimeHint(
+  storageKey: string,
+  enabled: boolean = true
+): OneTimeHint {
+  // null = storage not read yet (render nothing to avoid a flash)
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(storageKey)
+      .then((value) => {
+        if (!cancelled) setDismissed(value === "1");
+      })
+      .catch(() => {
+        // why: storage failure should never block the surface the hint sits
+        // on — treat it as already seen
+        if (!cancelled) setDismissed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [storageKey]);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    AsyncStorage.setItem(storageKey, "1").catch(() => {
+      // why: best-effort persistence; worst case the hint shows once more
+    });
+  }, [storageKey]);
+
+  return { shouldShow: enabled && dismissed === false, dismiss };
+}


### PR DESCRIPTION
## Problem

Reported from the live app: after scanning an asset during an audit, it is not clear you can attach a photo or a condition note to it.

The capability was there, but the only affordance was a small grey chevron at the end of the row. Everything else on the row said "Found". People finish audits without ever discovering evidence capture.

The web scan row has said this out loud for a while (per-row **Add comment** and **Add image** buttons in `audit-asset-actions.tsx`). Mobile is the surface where field workers actually stand in front of the asset, and it was the quiet one.

## Fix

1. **The row says what it does.** The trailing chevron is replaced by an explicit `📷 Add photo/note` action chip in brand orange. Once evidence exists, the chip becomes the attachment count (also brand-tinted, so it still reads as "tap me").
2. **A one-time hint** above the scanned list: "Tap a scanned item to add a photo or condition note." It retires itself on **Got it**, or as soon as the user opens the evidence sheet on their own.
3. **Layout hardening.** The asset name is the only element allowed to give up width, so the chip can never wrap or clip on a narrow screen.
4. **`useOneTimeHint`** extracted from the scanner's action-pills coachmark, so both hints share one versioned AsyncStorage contract instead of duplicating the read/dismiss/failure logic.

Contrast checked against both palettes: chip label `primaryText` on `primaryBg` is 5.07:1, hint body text 8.39:1.

## Verified on a simulator (iPhone 17, iOS 26.5, testapp data)

Real audit, real scan, real note round-tripped to the server:

1. Scanned into "QA select-all Simulation Suites" via manual code entry: 2/14 → 3/14 found.
2. Scanned tab shows the hint and the row `✓ Laerdal Arterial Puncture Simulator · Found · [📷 Add photo/note]`.
3. Tapped the row → evidence sheet opens (Add Photo / condition note / Save Note).
4. Saved a note → sheet header goes to **1 note**.
5. Back on the list the row now shows the orange **📎 1** chip, and the hint is gone (auto-retired by the open).

Companion typecheck and lint both clean. No API or webapp changes; this ships in the next companion build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-time coachmark that guides users to add audit evidence from scanned items.
  * Added clear “Add photo/note” actions when scanned items have no evidence.
  * Evidence attachments now display an item count for easier review.
* **Improvements**
  * Discovery hints now dismiss consistently after being acknowledged or used.
  * Evidence guidance automatically disappears once the evidence view is opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->