### PR TITLE
fix(custody): close the remaining custody-visibility gaps on detail, mobile and booking payloads

### DIFF
--- a/apps/webapp/app/components/assets/asset-custody-card.tsx
+++ b/apps/webapp/app/components/assets/asset-custody-card.tsx
@@ -25,11 +25,13 @@ export function CustodyCard({
 }: {
   booking:
     | (Pick<Booking, "id" | "name" | "from"> & {
-        custodianUser: Pick<
-          User,
-          "firstName" | "lastName" | "profilePicture" | "email"
+        custodianUser: Partial<
+          Pick<User, "firstName" | "lastName" | "profilePicture" | "email">
         > | null;
-        custodianTeamMember: TeamMember | null;
+        // Only `name` is read (see the branch below). Declaring the whole
+        // `TeamMember` forced the loader selects to fetch the whole row, which
+        // is how the entire record ended up in the payload.
+        custodianTeamMember: Pick<TeamMember, "name"> | null;
       })
     | null
     | undefined;

--- a/apps/webapp/app/modules/asset/data.server.ts
+++ b/apps/webapp/app/modules/asset/data.server.ts
@@ -258,8 +258,23 @@ export async function simpleModeLoader({
                       from: true,
                       to: true,
                       description: true,
-                      custodianTeamMember: true,
-                      custodianUser: true,
+                      // Narrowed from `true` on both: that shipped the whole
+                      // TeamMember row and the ENTIRE User row — email,
+                      // Stripe `customerId`, billing flags — to render a name
+                      // and an avatar. `userId` stays so the redaction can
+                      // tell the viewer's own booking from a colleague's.
+                      custodianTeamMember: {
+                        select: { id: true, name: true, userId: true },
+                      },
+                      custodianUser: {
+                        select: {
+                          id: true,
+                          firstName: true,
+                          lastName: true,
+                          displayName: true,
+                          profilePicture: true,
+                        },
+                      },
                       tags: TAG_WITH_COLOR_SELECT,
                       creator: {
                         select: {

--- a/apps/webapp/app/modules/asset/fields.ts
+++ b/apps/webapp/app/modules/asset/fields.ts
@@ -170,8 +170,21 @@ export const getAssetOverviewFields = (
             id: true,
             name: true,
             from: true,
-            custodianTeamMember: true,
-            custodianUser: true,
+            // Narrowed from `true` on both — that shipped the whole
+            // TeamMember row and the ENTIRE User row (email, Stripe
+            // `customerId`, billing flags). `userId` stays for the redaction.
+            custodianTeamMember: {
+              select: { id: true, name: true, userId: true },
+            },
+            custodianUser: {
+              select: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                displayName: true,
+                profilePicture: true,
+              },
+            },
           },
         },
       },
@@ -279,7 +292,12 @@ export const assetIndexFields = ({
           select: {
             id: true,
             status: true,
-            custodianTeamMember: true,
+            // Narrowed from `true`, which selected the whole TeamMember row.
+            // `userId` is required by `redactCustodianForViewer` to recognise
+            // the viewer's own booking custody.
+            custodianTeamMember: {
+              select: { id: true, name: true, userId: true },
+            },
             custodianUser: {
               select: {
                 firstName: true,
@@ -323,7 +341,11 @@ export const assetIndexFields = ({
               id: true,
               name: true,
               // Custodian fields needed by updateAssetsWithBookingCustodians()
-              custodianTeamMember: true,
+              // Narrowed from `true`; `userId` is what lets the redaction
+              // recognise the viewer's own booking custody.
+              custodianTeamMember: {
+                select: { id: true, name: true, userId: true },
+              },
               custodianUser: {
                 select: {
                   firstName: true,

--- a/apps/webapp/app/modules/asset/query.server.ts
+++ b/apps/webapp/app/modules/asset/query.server.ts
@@ -2014,7 +2014,6 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
                         'id', ctmu.id,
                         'firstName', ctmu."firstName",
                         'lastName', ctmu."lastName",
-                        'email', ctmu.email,
                         'profilePicture', ctmu."profilePicture"
                       )
                     ELSE NULL
@@ -2028,7 +2027,6 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
                   'id', cu.id,
                   'firstName', cu."firstName",
                   'lastName', cu."lastName",
-                  'email', cu.email,
                   'profilePicture', cu."profilePicture"
                 )
               ELSE NULL
@@ -2234,8 +2232,7 @@ export const assetQueryFragment = (options: AssetQueryOptions = {}) => {
                       'id', bu.id,
                       'firstName', bu."firstName",
                       'lastName', bu."lastName",
-                      'profilePicture', bu."profilePicture",
-                      'email', bu.email
+                      'profilePicture', bu."profilePicture"
                     )
                   ELSE NULL
                 END
@@ -2397,8 +2394,7 @@ export const assetQueryJoins = Prisma.sql`
                   'id', u.id,
                   'firstName', u."firstName",
                   'lastName', u."lastName",
-                  'profilePicture', u."profilePicture",
-                  'email', u.email
+                  'profilePicture', u."profilePicture"
                 )
               ELSE NULL
             END
@@ -2602,8 +2598,7 @@ const CUSTODY_SORT_CASE = Prisma.sql`CASE
                       'id', bu.id,
                       'firstName', bu."firstName",
                       'lastName', bu."lastName",
-                      'profilePicture', bu."profilePicture",
-                      'email', bu.email
+                      'profilePicture', bu."profilePicture"
                     )
                   ELSE NULL
                 END
@@ -2673,8 +2668,7 @@ const CHEAP_CUSTODY_JOINS = Prisma.sql`
                     'id', u.id,
                     'firstName', u."firstName",
                     'lastName', u."lastName",
-                    'profilePicture', u."profilePicture",
-                    'email', u.email
+                    'profilePicture', u."profilePicture"
                   )
                 ELSE NULL
               END
@@ -2936,7 +2930,7 @@ export function buildAdvancedAssetsQuery({
         })}
         ${assetQueryJoins}
         WHERE a.id = saq."assetId"
-        GROUP BY a.id, k.id, k.name, k.status, c.id, c.name, c.color, l.id, l."parentId", l.name, custody_agg.custody, kits_agg.kits, locations_agg.locations, b.id, bu.id, bu."firstName", bu."lastName", bu."profilePicture", bu.email, btm.id, btm.name, am.id, am.name
+        GROUP BY a.id, k.id, k.name, k.status, c.id, c.name, c.color, l.id, l."parentId", l.name, custody_agg.custody, kits_agg.kits, locations_agg.locations, b.id, bu.id, bu."firstName", bu."lastName", bu."profilePicture", btm.id, btm.name, am.id, am.name
       ) aq ON TRUE;
     `;
 }

--- a/apps/webapp/app/modules/asset/utils.server.ts
+++ b/apps/webapp/app/modules/asset/utils.server.ts
@@ -534,9 +534,14 @@ export type AllowedCustodianFilterIds = string[] | "all";
  * Applies a custodian allow-list to ids taken from the query string.
  *
  * `"all"` passes them through. Otherwise only ids on the list survive, and a
- * request that asked ONLY for others collapses to a single unmatchable id so
- * the filter returns nothing — dropping it instead would widen the query to
- * every row, which is the opposite of what a refusal should do.
+ * request that asked ONLY for others collapses to a single unmatchable id.
+ *
+ * That id alone is NOT sufficient: it lands in `where.OR`, where a sibling
+ * branch (`uncategorized` / `untagged` / `without-location`) can still match.
+ * `getAssetsWhereInput` therefore also AND-s an unsatisfiable predicate when it
+ * sees the sentinel — see the note at that call site. Dropping the filter
+ * instead of refusing it would widen the query to every row, which is the
+ * opposite of what a refusal should do.
  */
 function applyCustodianAllowList(
   requestedIds: string[],
@@ -700,6 +705,33 @@ export function getAssetsWhereInput({
         ? [{ custody: { none: {} } }]
         : []),
     ];
+
+    /**
+     * A refusal has to survive a sibling OR branch.
+     *
+     * The custody clause is attached with `OR`, and three other filters write
+     * there too — `uncategorized`, `untagged`, `without-location`. Under OR
+     * semantics the refused branch matches nothing while the sibling still
+     * matches plenty, so `?teamMember=<colleague>&category=uncategorized`
+     * returned the sibling's rows rather than none. That leaked nothing (the
+     * result equals the same request with `teamMember` omitted, which anyone
+     * may issue) but it broke the invariant this function documents, and a
+     * future OR branch carrying custody signal would make it a real hole.
+     *
+     * Fixed by AND-ing a predicate nothing satisfies, NOT by moving the custody
+     * clause from OR to AND — that would intersect custody with category/tag/
+     * location for every caller and silently change existing filter results.
+     */
+    if (teamMemberIds.includes(CUSTODY_FILTER_REFUSED)) {
+      where.AND = [
+        ...(Array.isArray(where.AND)
+          ? where.AND
+          : where.AND
+          ? [where.AND]
+          : []),
+        { id: CUSTODY_FILTER_REFUSED },
+      ];
+    }
   }
 
   return where;

--- a/apps/webapp/app/modules/asset/where-input-custodian-scope.server.test.ts
+++ b/apps/webapp/app/modules/asset/where-input-custodian-scope.server.test.ts
@@ -136,3 +136,67 @@ describe("getKitsWhereInput custodian scoping", () => {
     expect(where.custody).toBeUndefined();
   });
 });
+
+describe("getAssetsWhereInput — a refusal survives sibling OR filters", () => {
+  /** Does the clause contain a top-level predicate nothing can satisfy? */
+  function hasUnsatisfiablePredicate(
+    where: ReturnType<typeof getAssetsWhereInput>
+  ): boolean {
+    const and = Array.isArray(where.AND)
+      ? where.AND
+      : where.AND
+      ? [where.AND]
+      : [];
+    return and.some(
+      (clause) =>
+        typeof clause === "object" &&
+        clause !== null &&
+        (clause as { id?: unknown }).id === CUSTODY_FILTER_REFUSED
+    );
+  }
+
+  // The three other filters that write to `where.OR`. Each one used to rescue
+  // a refused custodian filter: under OR semantics the refused branch matched
+  // nothing while the sibling matched plenty, so the query returned the
+  // sibling's rows instead of none.
+  const siblingOrFilters = [
+    ["uncategorized", `category=uncategorized`],
+    ["untagged", `tag=untagged`],
+    ["without-location", `location=without-location`],
+  ] as const;
+
+  it.each(siblingOrFilters)(
+    "refuses even when combined with the %s filter",
+    (_label, queryString) => {
+      const where = getAssetsWhereInput({
+        organizationId: ORG,
+        currentSearchParams: `teamMember=${COLLEAGUE}&${queryString}`,
+        allowedTeamMemberIds: [MINE],
+      });
+
+      expect(hasUnsatisfiablePredicate(where)).toBe(true);
+    }
+  );
+
+  it("adds no unsatisfiable predicate when the filter was NOT refused", () => {
+    const where = getAssetsWhereInput({
+      organizationId: ORG,
+      currentSearchParams: `teamMember=${MINE}&category=uncategorized`,
+      allowedTeamMemberIds: [MINE],
+    });
+
+    // Over-applying this would silently return nothing for a legitimate
+    // combined filter.
+    expect(hasUnsatisfiablePredicate(where)).toBe(false);
+  });
+
+  it("adds no unsatisfiable predicate when no custodian was requested", () => {
+    const where = getAssetsWhereInput({
+      organizationId: ORG,
+      currentSearchParams: "category=uncategorized",
+      allowedTeamMemberIds: [MINE],
+    });
+
+    expect(hasUnsatisfiablePredicate(where)).toBe(false);
+  });
+});

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -1153,25 +1153,69 @@ export async function getTeamMembersForQuantityCustody({
   organizationId,
   request,
   userId,
-  isSelfService,
+  role,
+  canSeeAllCustody,
 }: {
   organizationId: string;
   request: Request;
   userId: string;
-  isSelfService: boolean;
+  /**
+   * Caller's role. Takes the place of an `isSelfService` boolean, which was a
+   * ROLE check where a RULE was needed: it is false for BASE, so the scope
+   * below collapsed to `undefined` and the whole roster shipped to a BASE user
+   * — who cannot assign custody at all (`asset: [read]`).
+   */
+  role: OrganizationRoles;
+  /** Resolved by `resolveCanSeeAllCustody`, for the shared scope resolver. */
+  canSeeAllCustody: boolean;
 }) {
   try {
     const searchParams = getCurrentSearchParams(request);
+
+    /**
+     * This seeds an ASSIGNMENT picker, so the assignment rule governs, not the
+     * custody read rule: BASE may not assign at all, SELF_SERVICE only to
+     * themselves. Same resolver the search endpoint uses for
+     * `custodyPurpose: "custody-assignment"`, so the seed and the list the user
+     * gets after typing cannot disagree.
+     */
+    const scope = resolveCustodianPickerScope({
+      purpose: "custody-assignment",
+      role,
+      canSeeAllCustody,
+      userId,
+    });
+
     const where = {
       deletedAt: null,
       organizationId,
-      userId: isSelfService ? userId : undefined,
+      ...(scope.mode === "self" ? { userId: scope.userId } : {}),
+      // An id no row carries — `mode: "none"` must match NOTHING. Omitting the
+      // clause would widen this back to the whole roster.
+      ...(scope.mode === "none" ? { id: CUSTODY_FILTER_REFUSED } : {}),
     };
 
     const [teamMembers, totalTeamMembers] = await Promise.all([
       db.teamMember.findMany({
         where,
-        include: { user: true },
+        // Only what `resolveTeamMemberName(item, true)` renders. `include: {
+        // user: true }` shipped the entire User row — email, Stripe
+        // `customerId`, `tierId`, `hasUnpaidInvoice` and every other billing
+        // flag — for all 12 roster entries.
+        select: {
+          id: true,
+          name: true,
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              displayName: true,
+              email: true,
+              profilePicture: true,
+            },
+          },
+        },
         orderBy: { userId: "asc" },
         take: searchParams.get("getAll") === "teamMember" ? undefined : 12,
       }),

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
@@ -90,6 +90,7 @@ import { formatAssetValueWithBreakdown } from "~/utils/asset-value";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getClientHint } from "~/utils/client-hints";
 import { formatCurrency } from "~/utils/currency";
+import { redactCustodianForViewer } from "~/utils/custody-visibility.server";
 import { buildCustomFieldLinkHref } from "~/utils/custom-field-link";
 import {
   buildAssetOverviewCustomFields,
@@ -150,6 +151,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       currentOrganization,
       canUseBarcodes,
       role,
+      canSeeAllCustody,
     } = await requirePermission({
       userId,
       request,
@@ -261,7 +263,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           organizationId,
           request,
           userId,
-          isSelfService: role === OrganizationRoles.SELF_SERVICE,
+          // The rule, not a role check: `isSelfService` was false for BASE, so
+          // the seed shipped the whole roster — with every user's email and
+          // Stripe id — to a role that cannot assign custody at all.
+          role,
+          canSeeAllCustody,
         })
       : { teamMembers: [], totalTeamMembers: 0 };
 
@@ -369,10 +375,12 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       : 0;
 
     return payload({
-      asset: {
-        ...asset,
-        customFields,
-      },
+      // Same reasoning as the parent detail route: this payload carries
+      // `custody[].custodian` and is reachable with `asset: read`.
+      asset: redactCustodianForViewer([{ ...asset, customFields }], {
+        canSeeAllCustody,
+        userId,
+      })[0],
       currentOrganization,
       userId,
       lastScan,

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
@@ -42,6 +42,7 @@ import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { redactCustodianForViewer } from "~/utils/custody-visibility.server";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
@@ -98,14 +99,13 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   });
 
   try {
-    const { organizationId, userOrganizations, role } = await requirePermission(
-      {
+    const { organizationId, userOrganizations, role, canSeeAllCustody } =
+      await requirePermission({
         userId,
         request,
         entity: PermissionEntity.asset,
         action: PermissionAction.read,
-      }
-    );
+      });
 
     const asset = await getAsset({
       id,
@@ -244,7 +244,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           organizationId,
           request,
           userId,
-          isSelfService: role === OrganizationRoles.SELF_SERVICE,
+          // The rule, not a role check: `isSelfService` was false for BASE, so
+          // the seed shipped the whole roster — with every user's email and
+          // Stripe id — to a role that cannot assign custody at all.
+          role,
+          canSeeAllCustody,
         })
       : { teamMembers: [], totalTeamMembers: 0 };
 
@@ -252,8 +256,20 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       title: asset.title,
     };
 
+    /**
+     * `custody: { include: { custodian: true } }` selects the whole TeamMember
+     * row, and this route is gated on `asset: read` — held by BASE and
+     * SELF_SERVICE. Redacting the list payloads is not enough on its own: the
+     * ids are in the list, so iterating the detail pages recovers exactly the
+     * identities the index just removed.
+     */
+    const [redactedAsset] = redactCustodianForViewer(
+      [assetWithEffectiveBookingAssets],
+      { canSeeAllCustody, userId }
+    );
+
     return payload({
-      asset: assetWithEffectiveBookingAssets,
+      asset: redactedAsset,
       header,
       teamMembers,
       totalTeamMembers,

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.tsx
@@ -115,7 +115,36 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       include: {
         // Model cover image for an asset with no image of its own
         ...ASSET_MODEL_IMAGE_SELECT,
-        custody: { include: { custodian: true } },
+        // Explicit select rather than `include: { custodian: true }`: the
+        // include returned every `Custody` scalar, `teamMemberId` among them —
+        // a stable per-holder identifier that survives redaction (which only
+        // empties `custodian`) and groups a colleague's items for a restricted
+        // viewer. Mirrors the shape at `modules/asset/fields.ts`. Nothing reads
+        // `custody.teamMemberId` client-side; the release control keys on
+        // `custodian.id`.
+        custody: {
+          select: {
+            createdAt: true,
+            quantity: true,
+            custodian: {
+              select: {
+                id: true,
+                name: true,
+                userId: true,
+                user: {
+                  select: {
+                    id: true,
+                    email: true,
+                    firstName: true,
+                    lastName: true,
+                    displayName: true,
+                    profilePicture: true,
+                  },
+                },
+              },
+            },
+          },
+        },
         assetKits: {
           select: {
             id: true,

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
@@ -55,6 +55,7 @@ import dropdownCss from "~/styles/actions-dropdown.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { formatUnitCount } from "~/utils/asset-quantity";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
+import { redactCustodianForViewer } from "~/utils/custody-visibility.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
 import { payload, error, getParams, parseData } from "~/utils/http.server";
@@ -96,6 +97,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       userOrganizations,
       currentOrganization,
       canUseBarcodes,
+      canSeeAllCustody,
     } = await requirePermission({
       userId,
       request,
@@ -197,7 +199,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     };
 
     return payload({
-      kit,
+      // `GET_KIT_STATIC_INCLUDES` selects `custody.custodian.user` down to
+      // `email`, and this route is gated on `kit: read` — held by BASE and
+      // SELF_SERVICE. A kit has ONE custody row, so the helper's object branch
+      // applies here (assets carry an array).
+      kit: redactCustodianForViewer([kit], { canSeeAllCustody, userId })[0],
       currentBooking,
       header,
       modelName,

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -185,8 +185,23 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
                             // iterating (`kitId: kit.id`), so the DB never
                             // needs to supply it.
                             custodianUserId: true,
-                            custodianTeamMember: true,
-                            custodianUser: true,
+                            // Narrowed from `true` on both: that shipped the
+                            // whole TeamMember row and the ENTIRE User row —
+                            // email, Stripe `customerId`, billing flags — to
+                            // render a name and an avatar on the availability
+                            // calendar.
+                            custodianTeamMember: {
+                              select: { id: true, name: true, userId: true },
+                            },
+                            custodianUser: {
+                              select: {
+                                id: true,
+                                firstName: true,
+                                lastName: true,
+                                displayName: true,
+                                profilePicture: true,
+                              },
+                            },
                           },
                         },
                       },

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -3,10 +3,15 @@ import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import { buildMobileAssetSearchWhere } from "~/modules/api/mobile-asset-search.server";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireOrganizationAccess,
   shapeMobileAssetResponse,
 } from "~/modules/api/mobile-auth.server";
+import {
+  filterMobileCustodyListForViewer,
+  viewerCanSeeLegacyCustody,
+} from "~/modules/api/mobile-custody-visibility.server";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { buildAssetStatusWhere } from "~/modules/asset/search.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -33,6 +38,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
+    const { canSeeAllCustody } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
 
     const url = new URL(request.url);
 
@@ -205,8 +214,38 @@ export async function loader({ request }: LoaderFunctionArgs) {
     // overwrite an inherited thumbnail with null.
     const shapedAssets = assets.map((asset) => {
       const { mainImageExpiration, ...assetForHelper } = asset;
+      const shaped = shapeMobileAssetResponse(assetForHelper);
+
+      /**
+       * Same custody gate the mobile asset DETAIL route applies
+       * (`assets.$assetId.ts`) — this list had none, so a restricted viewer
+       * read every holder's name straight out of the list response while the
+       * detail page for the same asset withheld it.
+       */
+      const { custodyList, custodyListOthersCount } =
+        filterMobileCustodyListForViewer({
+          custodyList: shaped.custodyList,
+          custodyRows: asset.custody,
+          viewerUserId: user.id,
+          canSeeAllCustody,
+        });
+
+      const primaryCustody = asset.custody[0] ?? null;
+      const visibleCustody =
+        primaryCustody &&
+        viewerCanSeeLegacyCustody({
+          custodianUserId: primaryCustody.custodian.userId,
+          viewerUserId: user.id,
+          canSeeAllCustody,
+        })
+          ? shaped.custody
+          : null;
+
       return {
-        ...shapeMobileAssetResponse(assetForHelper),
+        ...shaped,
+        custody: visibleCustody,
+        custodyList,
+        custodyListOthersCount,
         mainImageExpiration,
       };
     });

--- a/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.$kitId.ts
@@ -13,10 +13,12 @@ import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { viewerCanSeeLegacyCustody } from "~/modules/api/mobile-custody-visibility.server";
 import { serializeAssetImage } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { makeShelfError } from "~/utils/error";
@@ -46,6 +48,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
+    const { canSeeAllCustody } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
 
     await requireMobilePermission({
       userId: user.id,
@@ -79,6 +85,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
               select: {
                 id: true,
                 name: true,
+                // why: needed to tell the viewer's OWN custody from a
+                // colleague's — without it the visibility check below cannot
+                // distinguish them and would have to hide both.
+                userId: true,
                 user: {
                   select: { firstName: true, lastName: true, email: true },
                 },
@@ -164,7 +174,26 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       0
     );
 
-    return data({ kit: { ...kitData, assets, totalValue } });
+    /**
+     * `kit: read` is held by BASE and SELF_SERVICE, and this select reaches
+     * `custodian.user.email`. The mobile asset detail route already nulls its
+     * legacy custody field for viewers who may not see it; this one had no
+     * gate at all. Null the whole object rather than emptying the custodian —
+     * that is the established shape on the mobile surface.
+     */
+    const visibleCustody =
+      kitData.custody &&
+      viewerCanSeeLegacyCustody({
+        custodianUserId: kitData.custody.custodian.userId,
+        viewerUserId: user.id,
+        canSeeAllCustody,
+      })
+        ? kitData.custody
+        : null;
+
+    return data({
+      kit: { ...kitData, custody: visibleCustody, assets, totalValue },
+    });
   } catch (cause) {
     const reason = makeShelfError(cause);
     return data(

--- a/apps/webapp/app/routes/api+/mobile+/kits.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.ts
@@ -1,10 +1,12 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { viewerCanSeeLegacyCustody } from "~/modules/api/mobile-custody-visibility.server";
 import { makeShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -24,6 +26,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
+    const { canSeeAllCustody } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
 
     await requireMobilePermission({
       userId: user.id,
@@ -77,7 +83,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
           location: { select: { id: true, name: true } },
           custody: {
             select: {
-              custodian: { select: { id: true, name: true } },
+              // why: `userId` distinguishes the viewer's own custody from a
+              // colleague's for the visibility gate applied to the response.
+              custodian: { select: { id: true, name: true, userId: true } },
             },
           },
         },
@@ -94,6 +102,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const kitsForResponse = kits.map(({ _count, ...rest }) => ({
       ...rest,
       _count: { assets: _count.assetKits },
+      /**
+       * `kit: read` is held by BASE and SELF_SERVICE, and this list had no
+       * custody gate at all — a restricted viewer read every kit's holder
+       * from it. Null the object for holders the viewer may not see, matching
+       * the mobile detail routes; the caller's own custody stays visible.
+       */
+      custody:
+        rest.custody &&
+        viewerCanSeeLegacyCustody({
+          custodianUserId: rest.custody.custodian.userId,
+          viewerUserId: user.id,
+          canSeeAllCustody,
+        })
+          ? rest.custody
+          : null,
     }));
 
     return data({

--- a/apps/webapp/app/utils/custody-visibility.server.test.ts
+++ b/apps/webapp/app/utils/custody-visibility.server.test.ts
@@ -201,3 +201,114 @@ describe("redactCustodianForViewer", () => {
     expect(rows[0].custody?.custodian?.name).toBe("Someone Else");
   });
 });
+
+describe("redactCustodianForViewer — booking-derived custody", () => {
+  /** A CHECKED_OUT row: no `custody`, holder comes from the booking. */
+  const checkedOutByColleague = {
+    id: "asset-1",
+    custody: [],
+    bookingAssets: [
+      {
+        booking: {
+          id: "booking-1",
+          custodianUserId: "someone-else",
+          custodianTeamMember: {
+            id: "tm-colleague",
+            name: "Colleague Name",
+            userId: "someone-else",
+          },
+          custodianUser: { id: "someone-else", email: "colleague@example.com" },
+        },
+      },
+    ],
+  };
+
+  it("empties the booking custodian a restricted viewer may not see", () => {
+    const [row] = redactCustodianForViewer([checkedOutByColleague], {
+      canSeeAllCustody: false,
+      userId: "me",
+    });
+
+    // The bug this pins: redacting only `custody` emptied the COPY that
+    // `updateAssetsWithBookingCustodians` makes, while the source rode along
+    // in the same payload under `bookingAssets`.
+    expect(row.bookingAssets[0].booking.custodianTeamMember.name).toBe("");
+    expect(row.bookingAssets[0].booking.custodianUser).toBeNull();
+    expect(JSON.stringify(row)).not.toContain("Colleague Name");
+    expect(JSON.stringify(row)).not.toContain("colleague@example.com");
+  });
+
+  it("keeps a booking the viewer holds themselves", () => {
+    const [row] = redactCustodianForViewer([checkedOutByColleague], {
+      canSeeAllCustody: false,
+      userId: "someone-else",
+    });
+
+    // Over-redacting here would print "private" on an item the viewer booked.
+    expect(row.bookingAssets[0].booking.custodianTeamMember.name).toBe(
+      "Colleague Name"
+    );
+  });
+
+  it("leaves everything alone for a viewer who may see all custody", () => {
+    const [row] = redactCustodianForViewer([checkedOutByColleague], {
+      canSeeAllCustody: true,
+      userId: "me",
+    });
+
+    expect(row.bookingAssets[0].booking.custodianTeamMember.name).toBe(
+      "Colleague Name"
+    );
+  });
+
+  it("tolerates rows with no bookingAssets at all", () => {
+    const [row] = redactCustodianForViewer(
+      [{ id: "kit-1", custody: { custodian: { name: "X", userId: "other" } } }],
+      { canSeeAllCustody: false, userId: "me" }
+    );
+
+    expect(row.custody.custodian.name).toBe("");
+  });
+
+  it("descends into the kits index nesting (assetKits[].asset.bookingAssets)", () => {
+    // A kit's holder comes from its MEMBER assets' bookings, so the same
+    // custodian sits one level deeper than on the asset index. A top-level
+    // probe alone misses every one of them.
+    const kitRow = {
+      id: "kit-1",
+      custody: null,
+      assetKits: [
+        {
+          id: "ak-1",
+          asset: {
+            id: "asset-1",
+            bookingAssets: [
+              {
+                booking: {
+                  id: "booking-1",
+                  custodianUserId: "someone-else",
+                  custodianTeamMember: {
+                    id: "tm-colleague",
+                    name: "Colleague Name",
+                    userId: "someone-else",
+                  },
+                  custodianUser: { id: "someone-else" },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const [row] = redactCustodianForViewer([kitRow], {
+      canSeeAllCustody: false,
+      userId: "me",
+    });
+
+    expect(
+      row.assetKits[0].asset.bookingAssets[0].booking.custodianTeamMember.name
+    ).toBe("");
+    expect(JSON.stringify(row)).not.toContain("Colleague Name");
+  });
+});

--- a/apps/webapp/app/utils/custody-visibility.server.test.ts
+++ b/apps/webapp/app/utils/custody-visibility.server.test.ts
@@ -234,8 +234,13 @@ describe("redactCustodianForViewer — booking-derived custody", () => {
     // in the same payload under `bookingAssets`.
     expect(row.bookingAssets[0].booking.custodianTeamMember.name).toBe("");
     expect(row.bookingAssets[0].booking.custodianUser).toBeNull();
+    // The scalar FK is identity too: an opaque uuid still links rows to one
+    // holder, and `ORGANIZATION_SELECT_FIELDS` ships `owner: { id, email }` to
+    // every role, so it resolves outright when the holder is the owner.
+    expect(row.bookingAssets[0].booking.custodianUserId).toBeNull();
     expect(JSON.stringify(row)).not.toContain("Colleague Name");
     expect(JSON.stringify(row)).not.toContain("colleague@example.com");
+    expect(JSON.stringify(row)).not.toContain("someone-else");
   });
 
   it("keeps a booking the viewer holds themselves", () => {
@@ -309,6 +314,12 @@ describe("redactCustodianForViewer — booking-derived custody", () => {
     expect(
       row.assetKits[0].asset.bookingAssets[0].booking.custodianTeamMember.name
     ).toBe("");
+    // `kits._index` is the ONE loader that selects this scalar, and it selects
+    // it exactly here — inside the availability nesting.
+    expect(
+      row.assetKits[0].asset.bookingAssets[0].booking.custodianUserId
+    ).toBeNull();
     expect(JSON.stringify(row)).not.toContain("Colleague Name");
+    expect(JSON.stringify(row)).not.toContain("someone-else");
   });
 });

--- a/apps/webapp/app/utils/custody-visibility.server.ts
+++ b/apps/webapp/app/utils/custody-visibility.server.ts
@@ -57,6 +57,30 @@ export type RowWithCustody = {
 };
 
 /**
+ * The SECOND path to the same identity, walked at runtime rather than declared
+ * on {@link RowWithCustody}.
+ *
+ * A CHECKED_OUT item has no `Custody` row — its holder is the custodian of the
+ * ONGOING/OVERDUE booking. `assetIndexFields()` selects that inline, and
+ * `updateAssetsWithBookingCustodians` copies it into `custody.custodian` for
+ * the chip, so redacting only `custody` emptied the COPY while the source rode
+ * along untouched in the same payload.
+ *
+ * It is deliberately NOT part of the public constraint: adding a field there
+ * makes every call site fail to infer `T`, which collapses to the constraint
+ * and strips loader consumers of their real row types (the same trap the
+ * `Record<string, unknown>` note above describes). The rows are probed
+ * structurally instead.
+ */
+type BookingCustodianCarrier = {
+  booking?: {
+    custodianUserId?: string | null;
+    custodianTeamMember?: CustodianIdentity;
+    custodianUser?: { id?: string | null } | null;
+  } | null;
+};
+
+/**
  * What a redacted custodian looks like on the wire.
  *
  * Every identifying field is emptied rather than removed, so the shape stays
@@ -110,15 +134,90 @@ export function redactCustodianForViewer<T extends RowWithCustody>(
   // shape. TypeScript cannot verify a spread still satisfies `T`, and widening
   // the signature instead erases the caller's row type — which is exactly what
   // the loader's consumers are typed against.
+  /**
+   * Whether the viewer is themselves the custodian of this booking — checked
+   * across all three shapes the select may provide, since callers differ in
+   * which of them they ask for.
+   */
+  const ownsBooking = (
+    booking: NonNullable<BookingCustodianCarrier["booking"]>
+  ) =>
+    !!userId &&
+    (booking.custodianUserId === userId ||
+      booking.custodianTeamMember?.userId === userId ||
+      booking.custodianUser?.id === userId);
+
+  /** Empties the booking-derived custodian on one `bookingAssets` entry. */
+  const redactBookingAsset = (entry: BookingCustodianCarrier) => {
+    if (!entry?.booking || ownsBooking(entry.booking)) {
+      return entry;
+    }
+
+    return {
+      ...entry,
+      booking: {
+        ...entry.booking,
+        custodianTeamMember: entry.booking.custodianTeamMember
+          ? { ...REDACTED_CUSTODIAN }
+          : entry.booking.custodianTeamMember,
+        custodianUser: entry.booking.custodianUser ? null : undefined,
+      },
+    };
+  };
+
   return rows.map((row) => {
+    // Structural probe — see `BookingCustodianCarrier` for why this is not on
+    // the public type.
+    const rawBookingAssets = (row as { bookingAssets?: unknown }).bookingAssets;
+    const bookingAssets = Array.isArray(rawBookingAssets)
+      ? (rawBookingAssets as BookingCustodianCarrier[]).map(redactBookingAsset)
+      : rawBookingAssets;
+
+    /**
+     * The kits index nests the same booking custodians one level deeper —
+     * `assetKits[].asset.bookingAssets` — because a kit's holder is derived
+     * from its member assets' bookings. A top-level probe alone misses every
+     * one of them.
+     */
+    const rawAssetKits = (row as { assetKits?: unknown }).assetKits;
+    const assetKits = Array.isArray(rawAssetKits)
+      ? (
+          rawAssetKits as Array<{ asset?: { bookingAssets?: unknown } | null }>
+        ).map((ak) => {
+          const nested = ak?.asset?.bookingAssets;
+          if (!Array.isArray(nested)) {
+            return ak;
+          }
+
+          return {
+            ...ak,
+            asset: {
+              ...ak.asset,
+              bookingAssets: (nested as BookingCustodianCarrier[]).map(
+                redactBookingAsset
+              ),
+            },
+          };
+        })
+      : rawAssetKits;
+
+    const withBookings = {
+      ...row,
+      ...(rawBookingAssets === undefined ? {} : { bookingAssets }),
+      ...(rawAssetKits === undefined ? {} : { assetKits }),
+    };
+
     if (Array.isArray(row.custody)) {
-      return { ...row, custody: row.custody.map(redactEntry) } as T;
+      return {
+        ...withBookings,
+        custody: row.custody.map(redactEntry),
+      } as T;
     }
 
     if (!row.custody) {
-      return row;
+      return withBookings as T;
     }
 
-    return { ...row, custody: redactEntry(row.custody) } as T;
+    return { ...withBookings, custody: redactEntry(row.custody) } as T;
   });
 }

--- a/apps/webapp/app/utils/custody-visibility.server.ts
+++ b/apps/webapp/app/utils/custody-visibility.server.ts
@@ -75,6 +75,7 @@ export type RowWithCustody = {
 type BookingCustodianCarrier = {
   booking?: {
     custodianUserId?: string | null;
+    custodianTeamMemberId?: string | null;
     custodianTeamMember?: CustodianIdentity;
     custodianUser?: { id?: string | null } | null;
   } | null;
@@ -161,6 +162,27 @@ export function redactCustodianForViewer<T extends RowWithCustody>(
           ? { ...REDACTED_CUSTODIAN }
           : entry.booking.custodianTeamMember,
         custodianUser: entry.booking.custodianUser ? null : undefined,
+        /**
+         * The scalar FKs are identity too, and the spread above preserved them.
+         * An opaque uuid still links rows to a single holder ("these seven kits
+         * are held by the same person, and it isn't me"), and
+         * `ORGANIZATION_SELECT_FIELDS` ships `owner: { id, email }` to every
+         * role through the `_layout` loader — so it resolves outright whenever
+         * the holder is the workspace owner.
+         *
+         * `kits._index` is the one loader selecting `custodianUserId` today;
+         * `custodianTeamMemberId` is cleared on the same principle so it cannot
+         * become the next instance the moment someone selects it.
+         *
+         * Absent stays absent: writing `null` onto a field the caller never
+         * selected would invent one.
+         */
+        ...(entry.booking.custodianUserId === undefined
+          ? {}
+          : { custodianUserId: null }),
+        ...(entry.booking.custodianTeamMemberId === undefined
+          ? {}
+          : { custodianTeamMemberId: null }),
       },
     };
   };

--- a/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
@@ -388,6 +388,37 @@ describe("GET /api/mobile/assets — custody visibility", () => {
     expect(JSON.stringify(body)).not.toContain("Colleague Name");
   });
 
+  it("keeps the viewer's OWN custody visible to a restricted viewer", async () => {
+    // The direction the other two cases miss. Hiding here would take an item
+    // away from the person actually holding it, and the gate is supposed to
+    // reject on OWNERSHIP, not on the role alone.
+    // why: same fixture as above with the custodian re-pointed at the caller —
+    // isolates ownership as the only variable.
+    findManyMock.mockResolvedValue([
+      {
+        ...colleaguesAsset,
+        custody: [
+          {
+            ...colleaguesAsset.custody[0],
+            custodian: {
+              ...colleaguesAsset.custody[0].custodian,
+              userId: FAKE_USER_ID,
+            },
+          },
+        ],
+      },
+    ] as never);
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      canSeeAllCustody: false,
+    } as Awaited<ReturnType<typeof getMobileUserContext>>);
+
+    const response = await loader(createLoaderArgs({}));
+    const body = (response as any).data ?? (await (response as any).json());
+
+    expect(body.assets[0].custody).not.toBeNull();
+    expect(body.assets[0].custodyList).toHaveLength(1);
+  });
+
   it("keeps custody visible for a viewer who may see all of it", async () => {
     vi.mocked(getMobileUserContext).mockResolvedValue({
       canSeeAllCustody: true,

--- a/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
@@ -22,6 +22,7 @@ import { createLoaderArgs } from "@mocks/remix";
 import { db } from "~/database/db.server";
 import type * as MobileAuthServer from "~/modules/api/mobile-auth.server";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
@@ -58,6 +59,12 @@ vi.mock("~/modules/api/mobile-auth.server", async () => {
     ...actual,
     requireMobileAuth: vi.fn(),
     requireOrganizationAccess: vi.fn(),
+    // why: the route now resolves custody visibility here. Default the
+    // existing shape assertions to "may see all" so they keep measuring the
+    // shaper, not the custody gate — which has its own tests below.
+    getMobileUserContext: vi.fn().mockResolvedValue({
+      canSeeAllCustody: true,
+    }),
   };
 });
 
@@ -326,5 +333,69 @@ describe("GET /api/mobile/assets — search", () => {
       { createdAt: "desc" },
       { id: "asc" },
     ]);
+  });
+});
+
+describe("GET /api/mobile/assets — custody visibility", () => {
+  /** One asset held by a colleague, shaped as the select returns it. */
+  const colleaguesAsset = {
+    id: "asset-1",
+    title: "Camera",
+    status: "IN_CUSTODY",
+    mainImage: null,
+    thumbnailImage: null,
+    mainImageExpiration: null,
+    assetModel: null,
+    availableToBook: true,
+    category: null,
+    type: "INDIVIDUAL",
+    quantity: null,
+    minQuantity: null,
+    unitOfMeasure: null,
+    consumptionType: null,
+    assetKits: [],
+    assetLocations: [],
+    custody: [
+      {
+        quantity: 1,
+        kitCustodyId: null,
+        custodian: {
+          id: "tm-colleague",
+          name: "Colleague Name",
+          userId: "someone-else",
+        },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    findManyMock.mockResolvedValue([colleaguesAsset] as never);
+    vi.mocked(db.asset.count).mockResolvedValue(1 as never);
+  });
+
+  it("hides a colleague's custody from a viewer who may not see all custody", async () => {
+    // The mobile asset DETAIL route gated this; the list did not, so the same
+    // holder name was readable one endpoint over.
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      canSeeAllCustody: false,
+    } as Awaited<ReturnType<typeof getMobileUserContext>>);
+
+    const response = await loader(createLoaderArgs({}));
+    const body = (response as any).data ?? (await (response as any).json());
+
+    expect(body.assets[0].custody).toBeNull();
+    expect(body.assets[0].custodyList).toEqual([]);
+    expect(JSON.stringify(body)).not.toContain("Colleague Name");
+  });
+
+  it("keeps custody visible for a viewer who may see all of it", async () => {
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      canSeeAllCustody: true,
+    } as Awaited<ReturnType<typeof getMobileUserContext>>);
+
+    const response = await loader(createLoaderArgs({}));
+    const body = (response as any).data ?? (await (response as any).json());
+
+    expect(body.assets[0].custody?.custodian?.name).toBe("Colleague Name");
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile+/kits.$kitId.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/kits.$kitId.test.ts
@@ -19,6 +19,7 @@ import {
   requireMobileAuth,
   requireMobilePermission,
   requireOrganizationAccess,
+  getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
 
 import { loader } from "~/routes/api+/mobile+/kits.$kitId";
@@ -43,12 +44,16 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
   requireMobileAuth: vi.fn(),
   requireOrganizationAccess: vi.fn(),
   requireMobilePermission: vi.fn(),
+  // why: the route resolves custody visibility from this; each test sets the
+  // flag directly rather than constructing an org whose overrides imply it.
+  getMobileUserContext: vi.fn(),
 }));
 
 const findFirstMock = vi.mocked(db.kit.findFirst);
 const requireMobileAuthMock = vi.mocked(requireMobileAuth);
 const requireOrganizationAccessMock = vi.mocked(requireOrganizationAccess);
 const requireMobilePermissionMock = vi.mocked(requireMobilePermission);
+const getMobileUserContextMock = vi.mocked(getMobileUserContext);
 
 const FAKE_USER_ID = "user-abc";
 const FAKE_ORG_ID = "org-xyz";
@@ -81,6 +86,9 @@ beforeEach(() => {
   } as Awaited<ReturnType<typeof requireMobileAuth>>);
   requireOrganizationAccessMock.mockResolvedValue(FAKE_ORG_ID);
   requireMobilePermissionMock.mockResolvedValue(undefined);
+  getMobileUserContextMock.mockResolvedValue({
+    canSeeAllCustody: true,
+  } as Awaited<ReturnType<typeof getMobileUserContext>>);
 });
 
 describe("GET /api/mobile/kits/:kitId", () => {
@@ -167,5 +175,75 @@ describe("GET /api/mobile/kits/:kitId", () => {
     // 10 × 5 (kit units) + 20 × 1 (individual) = 70.
     // NOT 10 × 100 (workspace stock) + 20 × 1 = 1020.
     expect(body.kit.totalValue).toBe(70);
+  });
+});
+
+describe("GET /api/mobile/kits/:kitId — custody visibility", () => {
+  /** Kit fixture holding custody by a named colleague, with their email. */
+  function kitInColleaguesCustody() {
+    return {
+      ...buildKitFixture([]),
+      custody: {
+        createdAt: new Date("2026-01-01"),
+        custodian: {
+          id: "tm-colleague",
+          name: "Colleague",
+          userId: "someone-else",
+          user: {
+            firstName: "Colleague",
+            lastName: "Name",
+            email: "colleague@example.com",
+          },
+        },
+      },
+    };
+  }
+
+  it("nulls a colleague's custody for a viewer who may not see all custody", async () => {
+    // `kit: read` is held by BASE and SELF_SERVICE, and this select reaches
+    // `custodian.user.email` — so without a gate the whole identity shipped.
+    getMobileUserContextMock.mockResolvedValue({
+      canSeeAllCustody: false,
+    } as Awaited<ReturnType<typeof getMobileUserContext>>);
+    findFirstMock.mockResolvedValue(kitInColleaguesCustody() as never);
+
+    const response = await loader(
+      createLoaderArgs({ params: { kitId: "kit-1" } })
+    );
+    assertIsDataWithResponseInit(response);
+    const body = response.data as { kit: { custody: any } };
+
+    expect(body.kit.custody).toBeNull();
+    expect(JSON.stringify(body)).not.toContain("colleague@example.com");
+  });
+
+  it("keeps the viewer's OWN custody visible", async () => {
+    getMobileUserContextMock.mockResolvedValue({
+      canSeeAllCustody: false,
+    } as Awaited<ReturnType<typeof getMobileUserContext>>);
+    const own = kitInColleaguesCustody();
+    own.custody.custodian.userId = FAKE_USER_ID;
+    findFirstMock.mockResolvedValue(own as never);
+
+    const response = await loader(
+      createLoaderArgs({ params: { kitId: "kit-1" } })
+    );
+    assertIsDataWithResponseInit(response);
+    const body = response.data as { kit: { custody: any } };
+
+    // Over-redacting here would hide a kit from the person actually holding it.
+    expect(body.kit.custody).not.toBeNull();
+  });
+
+  it("keeps custody visible for a viewer who may see all of it", async () => {
+    findFirstMock.mockResolvedValue(kitInColleaguesCustody() as never);
+
+    const response = await loader(
+      createLoaderArgs({ params: { kitId: "kit-1" } })
+    );
+    assertIsDataWithResponseInit(response);
+    const body = response.data as { kit: { custody: any } };
+
+    expect(body.kit.custody?.custodian?.name).toBe("Colleague");
   });
 });


### PR DESCRIPTION
## What

Follow-up to #2840. That PR closed custody visibility on the list payloads and the select-all query paths; this one closes the surfaces it left open — detail pages, mobile, booking-derived custodians, and two over-fetch paths that shipped far more than a name.

All of these are **pre-existing on `main`**, not regressions from #2840.

## The findings

**1. The quantity-custody picker seed shipped the whole roster.** `getTeamMembersForQuantityCustody` scoped on `isSelfService` — a role check standing in for a rule. It is `false` for BASE, so the scope collapsed to `undefined` and, with `include: { user: true }`, every asset detail page for a quantity-tracked asset returned all 12 team members carrying **email, Stripe `customerId`, `tierId`, `hasUnpaidInvoice`** and the rest of the `User` row. BASE holds `asset: [read]` and cannot assign custody at all — this was a picker roster for an action the role cannot perform.

Now routed through `resolveCustodianPickerScope({ purpose: "custody-assignment" })`, the same resolver the *search* endpoint already used for this picker, so the seed and the post-typing list can no longer disagree. The select is narrowed to the fields `resolveTeamMemberName` renders.

**2. Detail pages re-exposed what the index redacted.** Asset and kit detail shipped `custody.custodian` (whole `TeamMember` on the asset side, `user.email` on the kit side) under `asset: read` / `kit: read` — both held by BASE and SELF_SERVICE. Since the ids are in the list, iterating detail pages recovered exactly the dataset the index had just removed.

**3. Three mobile endpoints had no custody gate at all.** Mobile asset *detail* already resolved `canSeeAllCustody` and filtered; the asset list, kit list and kit detail never referenced it — so identity refused on one endpoint was readable one endpoint over, including `custodian.user.email` on kit detail. Both kit endpoints needed `custodian.userId` added to their select: without it there is no way to tell the viewer's own custody from a colleague's, and a gate would have to hide both.

**4. Booking-derived custodians bypassed the redaction.** A CHECKED_OUT item has no `Custody` row — its holder is the custodian of the ONGOING/OVERDUE booking. `updateAssetsWithBookingCustodians` copies that into `custody.custodian` for the chip, so redacting only `custody` emptied the **copy** while the source rode along under `bookingAssets` in the same payload. The redaction now walks that path, including the kits-index nesting (`assetKits[].asset.bookingAssets`) where a kit's holder derives from its members' bookings.

Four selects asked for `custodianTeamMember: true` / `custodianUser: true` — the whole `TeamMember` row and the **entire** `User` row — to render a name and an avatar. All four are now explicit. `CustodyCard` declared its prop as the full `TeamMember` while reading only `.name`, which is what kept the wide select looking justified.

**5. A refused custodian filter could be rescued by a sibling OR branch.** `CUSTODY_FILTER_REFUSED` lands in `where.OR`, and `uncategorized` / `untagged` / `without-location` write there too. Under OR semantics the refused branch matched nothing while the sibling matched plenty. Fixed by AND-ing an unsatisfiable predicate when the sentinel is present — **not** by moving the custody clause to AND, which would intersect custody with category/tag/location for every caller and change existing filter results.

**6. The advanced index projected custodian emails in raw SQL.** Six `jsonb_build_object` projections nested a `user` carrying `email`, unreachable by any Prisma `select`. Nothing renders them — the advanced columns use `resolveUserDisplayName`, whose parameter type does not include email. Over-fetch hygiene rather than a live hole, since ADVANCED is ADMIN/OWNER-only.

## Verification

Every fix was exercised against a **live BASE session** (`baseUserCanSeeCustody` off), not just tests.

| Fix | Evidence |
| --- | --- |
| Roster seed | `teamMembers: []`, `totalTeamMembers: 0` — was 12 with emails + Stripe ids |
| Detail loaders | `custodian: { userId: null, name: "", user: null }` on both the array (asset) and object (kit) shapes |
| Mobile ×3 | asset list: 41 assets, exactly one custody visible — **the viewer's own**; kit list: 0 of 3 held kits visible; kit detail (Woox's kit): `custody: null` |
| Booking custodians | `custodianTeamMember` decodes to `{ userId: null, name: "", user: null }`; only Stripe id in the payload is the viewer's own |
| OR-branch refusal | `category=uncategorized` alone → **16 assets**; with `teamMember=<colleague>` → **0**. The control matters: the zero is the guard firing, not an empty category |
| Raw SQL | advanced index loaded as OWNER and renders — typecheck cannot see raw SQL, and a dangling comma would 500 the page silently |

The mobile result is the one that proves both directions: the single visible row is the viewer's **own** custody, so the gate rejects on ownership rather than blanket-hiding.

Regression tests were checked against the vulnerable code rather than merely passing beside it — with the gate disabled they fail (`expected { …(2) } to be null`, `expected false to be true`).

Full suite: **4679 passed**. `pnpm turbo typecheck` clean.

## Reviewer notes

- `bookingAssets` is walked by structural probe rather than declared on `RowWithCustody`. Adding it to the public constraint made every call site fail to infer `T`, collapsing it to the constraint and stripping loader consumers of their real row types — the same trap the existing `Record<string, unknown>` note describes.
- The redaction deliberately keeps the viewer's own custody visible in every case; over-redacting would hide an item from the person holding it.
- `mode: "none"` on the roster uses the unmatchable sentinel rather than omitting the clause — omitting would widen back to the whole roster.

## Investigated and deliberately NOT changed

`getTeamMembersForNotify` takes no viewer argument and returns ADMIN/OWNER team members **with email** to any caller, including BASE. That reads like a leak but is not: `NotificationRecipientsField` calls `resolveTeamMemberName(item, true)` — `includeEmail` is deliberate, for disambiguating same-named people — the field has no role gating, and BASE and SELF_SERVICE both hold `booking: create`, so they are intended users of the picker. Scoping it would strip a disambiguator from a feature those roles are meant to use.

## Still open

`custody[].teamMemberId` remains in payloads after redaction. No name, no email, but a stable identifier that groups items by holder ("these five are held by the same person"). Pseudonymous now that the custodian search endpoint is scoped; called out so it is a decision rather than an oversight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Privacy**
  - Restricted custody details are now hidden from viewers without permission across web and mobile asset and kit views.
  - Your own custody information remains visible when appropriate.
  - Sensitive account details are no longer included unnecessarily.

- **Bug Fixes**
  - Refused custodian filters now reliably return no results, including when combined with other filters.
  - Custody visibility is consistently enforced for direct and nested kit assets.

- **Tests**
  - Added coverage for custody visibility, mobile responses, nested kit assets, and filter restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->