### PR TITLE
fix(audits): one word for unscanned assets, and stop calling them missing

### DIFF
--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -61,18 +61,19 @@ type AssetFilterValue = (typeof ASSET_FILTERS)[number]["value"];
  */
 function isAssetFilterVisible(
   value: AssetFilterValue,
-  audit: { status: string; completedAt: string | null }
+  audit: { completedAt: string | null }
 ): boolean {
-  // why: completion is read from `completedAt`, not the status. Archiving a
-  // completed audit rewrites the status to ARCHIVED, and a status check hid
-  // BOTH pills on it — you could no longer filter an archived audit down to
-  // the assets it recorded as missing.
-  const isOpen = audit.status === "PENDING" || audit.status === "ACTIVE";
+  // why: BOTH branches read `completedAt`, never the status, so the pills can
+  // never disagree with the rows. `displayAssets` classifies an unscanned asset
+  // as PENDING exactly when `completedAt` is null, so gating the pill on
+  // status PENDING/ACTIVE hid it on an archived-cancelled audit that was still
+  // showing "Not scanned" rows under All. Archiving a completed audit has the
+  // mirror problem: the status changes but those assets are still missing.
   const isCompleted = audit.completedAt != null;
   return value === "MISSING"
     ? isCompleted
     : value === "PENDING"
-    ? isOpen
+    ? !isCompleted
     : true;
 }
 

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -28,7 +28,9 @@ import { useDateFormatter } from "@/lib/use-date-formatter";
 import {
   AUDIT_ASSET_STATUS_LABELS,
   AUDIT_STATUS_LABELS,
+  AUDIT_UNASSIGNED_LABELS,
   auditAssetStatusLabel,
+  isAuditCompleted,
 } from "@shelf/labels";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -49,14 +51,32 @@ const ASSET_FILTERS = [
 type AssetFilterValue = (typeof ASSET_FILTERS)[number]["value"];
 
 /**
- * Whether an asset-status filter is meaningful for an audit in the given
- * session status. A live (PENDING/ACTIVE) audit has Pending items but no
- * Missing ones; a COMPLETED audit is the reverse. Shared by the filter pills
- * and the derived `effectiveFilter` (which clamps a now-hidden selection) so
- * the visible pills and the applied filter never drift.
+ * What the list says when a filter matches nothing.
+ *
+ * why a per-filter phrase and not `No ${label.toLowerCase()} assets`: that
+ * template read "No not scanned assets" for the PENDING pill — and PENDING is
+ * the pill a field worker lands on at the END of every audit, when everything
+ * has been scanned. The other filters happened to survive the template, which
+ * is exactly why it went unnoticed. Wording mirrors the web's
+ * `getAuditFilterMetadata` empty states.
+ */
+const ASSET_FILTER_EMPTY_TEXT: Record<AssetFilterValue, string> = {
+  ALL: "No assets in this audit",
+  PENDING: "Nothing left to scan",
+  FOUND: "No assets found yet",
+  MISSING: "No missing assets",
+  UNEXPECTED: "No unexpected assets",
+};
+
+/**
+ * Whether an asset-status filter is meaningful for the given audit. An audit
+ * that has not been CONCLUDED has "Not scanned" items but no Missing ones; a
+ * completed one is the reverse. Shared by the filter pills and the derived
+ * `effectiveFilter` (which clamps a now-hidden selection) so the visible pills
+ * and the applied filter never drift.
  *
  * @param value - the filter being considered
- * @param status - the audit session status
+ * @param audit - the audit session, read for its `completedAt` only
  * @returns true if the filter should be shown / is a valid selection
  */
 function isAssetFilterVisible(
@@ -69,7 +89,7 @@ function isAssetFilterVisible(
   // status PENDING/ACTIVE hid it on an archived-cancelled audit that was still
   // showing "Not scanned" rows under All. Archiving a completed audit has the
   // mirror problem: the status changes but those assets are still missing.
-  const isCompleted = audit.completedAt != null;
+  const isCompleted = isAuditCompleted(audit);
   return value === "MISSING"
     ? isCompleted
     : value === "PENDING"
@@ -297,7 +317,7 @@ function AuditDetailContent() {
     // why: `completedAt`, not `status === "COMPLETED"` — archiving a completed
     // audit switches the status to ARCHIVED while keeping the completion
     // timestamp, and those assets are still genuinely missing.
-    const notFoundStatus: AuditAssetStatus = audit.completedAt
+    const notFoundStatus: AuditAssetStatus = isAuditCompleted(audit)
       ? "MISSING"
       : "PENDING";
 
@@ -501,7 +521,7 @@ function AuditDetailContent() {
   const isActive = audit.status === "PENDING" || audit.status === "ACTIVE";
   // Completion provenance survives archiving; the status does not. See
   // `notFoundStatus` above.
-  const isCompleted = audit.completedAt != null;
+  const isCompleted = isAuditCompleted(audit);
   const progress =
     audit.expectedAssetCount > 0
       ? audit.foundAssetCount / audit.expectedAssetCount
@@ -680,7 +700,7 @@ function AuditDetailContent() {
                       // Administrator / Base / Self service only).
                       numberOfLines={2}
                     >
-                      Unassigned · admins can scan
+                      {AUDIT_UNASSIGNED_LABELS.SHORT}
                     </Text>
                   )}
                 </View>
@@ -892,14 +912,7 @@ function AuditDetailContent() {
               color={colors.border}
             />
             <Text style={styles.emptyListText}>
-              {/* why: read the word from the same map the pills use. Lowercasing
-                  the raw filter value produced "No pending assets" next to a
-                  pill labelled "Not scanned". */}
-              {effectiveFilter === "ALL"
-                ? "No assets in this audit"
-                : `No ${AUDIT_ASSET_STATUS_LABELS[
-                    effectiveFilter
-                  ].toLowerCase()} assets`}
+              {ASSET_FILTER_EMPTY_TEXT[effectiveFilter]}
             </Text>
           </View>
         }

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -694,10 +694,9 @@ function AuditDetailContent() {
                       ]}
                       // why: the ownership line is the one place that states
                       // WHO may act on an unassigned audit, so let it wrap
-                      // rather than truncate. "Admin" is the product's word for
-                      // this: the workspace OWNER passes the same server check
-                      // but is never shown as a role (the invite dialog offers
-                      // Administrator / Base / Self service only).
+                      // rather than truncate — it names both permitted roles
+                      // (see AUDIT_UNASSIGNED_LABELS) and that does not fit on
+                      // one line on a narrow device.
                       numberOfLines={2}
                     >
                       {AUDIT_UNASSIGNED_LABELS.SHORT}

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -662,11 +662,14 @@ function AuditDetailContent() {
                         { color: colors.primaryText, fontWeight: "600" },
                       ]}
                       // why: the ownership line is the one place that states
-                      // WHO may act on an unassigned audit; truncating it to
-                      // "admins and owners c…" defeats the point.
+                      // WHO may act on an unassigned audit, so let it wrap
+                      // rather than truncate. "Admin" is the product's word for
+                      // this: the workspace OWNER passes the same server check
+                      // but is never shown as a role (the invite dialog offers
+                      // Administrator / Base / Self service only).
                       numberOfLines={2}
                     >
-                      Unassigned · admins and owners can scan
+                      Unassigned · admins can scan
                     </Text>
                   )}
                 </View>

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -25,6 +25,10 @@ import {
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useDateFormatter } from "@/lib/use-date-formatter";
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  auditAssetStatusLabel,
+} from "@shelf/labels";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { ErrorBoundary } from "@/components/error-boundary";
@@ -35,10 +39,10 @@ import { useReducedMotion, announce } from "@/lib/a11y";
 
 const ASSET_FILTERS = [
   { label: "All", value: "ALL" },
-  { label: "Pending", value: "PENDING" },
-  { label: "Found", value: "FOUND" },
-  { label: "Missing", value: "MISSING" },
-  { label: "Unexpected", value: "UNEXPECTED" },
+  { label: AUDIT_ASSET_STATUS_LABELS.PENDING, value: "PENDING" },
+  { label: AUDIT_ASSET_STATUS_LABELS.FOUND, value: "FOUND" },
+  { label: AUDIT_ASSET_STATUS_LABELS.MISSING, value: "MISSING" },
+  { label: AUDIT_ASSET_STATUS_LABELS.UNEXPECTED, value: "UNEXPECTED" },
 ] as const;
 
 type AssetFilterValue = (typeof ASSET_FILTERS)[number]["value"];
@@ -277,11 +281,11 @@ function AuditDetailContent() {
       scanMap.set(scan.assetId, scan);
     }
 
-    // why: an expected asset that hasn't been scanned is "Pending" while the
+    // why: an expected asset that hasn't been scanned is "Not scanned" while the
     // audit is still active (the field worker may yet find it) but becomes
     // "Missing" once the audit is completed (it's a real discrepancy). This
-    // mirrors the unified web + companion vocabulary — "Missing" is reserved
-    // for completed audits, never shown mid-scan.
+    // mirrors the unified web + companion vocabulary (@shelf/labels) — "Missing"
+    // is reserved for completed audits, never shown mid-scan.
     const notFoundStatus: AuditAssetStatus =
       audit.status === "COMPLETED" ? "MISSING" : "PENDING";
 
@@ -346,14 +350,9 @@ function AuditDetailContent() {
         text: colors.muted,
       };
 
-      const statusLabel =
-        item.status === "FOUND"
-          ? "Found"
-          : item.status === "PENDING"
-          ? "Pending"
-          : item.status === "MISSING"
-          ? "Missing"
-          : "Unexpected";
+      // Status already encodes the audit state (PENDING while active, MISSING
+      // once completed), so the label map can be read directly.
+      const statusLabel = AUDIT_ASSET_STATUS_LABELS[item.status];
 
       // why: surfacing location / category / custodian inline removes
       // the field worker's reason to navigate away from the audit. Each
@@ -662,9 +661,12 @@ function AuditDetailContent() {
                         // The leading icon keeps the brighter `primary`.
                         { color: colors.primaryText, fontWeight: "600" },
                       ]}
-                      numberOfLines={1}
+                      // why: the ownership line is the one place that states
+                      // WHO may act on an unassigned audit; truncating it to
+                      // "admins and owners c…" defeats the point.
+                      numberOfLines={2}
                     >
-                      Unassigned · anyone can scan
+                      Unassigned · admins and owners can scan
                     </Text>
                   )}
                 </View>
@@ -755,7 +757,11 @@ function AuditDetailContent() {
                     ]}
                   />
                   <Text style={styles.heroStatText}>
-                    {notFoundCount} {isCompleted ? "missing" : "pending"}
+                    {notFoundCount}{" "}
+                    {auditAssetStatusLabel(
+                      "PENDING",
+                      isCompleted
+                    ).toLowerCase()}
                   </Text>
                 </View>
                 {audit.unexpectedAssetCount > 0 ? (

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -27,6 +27,7 @@ import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import {
   AUDIT_ASSET_STATUS_LABELS,
+  AUDIT_STATUS_LABELS,
   auditAssetStatusLabel,
 } from "@shelf/labels";
 import { useTheme } from "@/lib/theme-context";
@@ -60,11 +61,19 @@ type AssetFilterValue = (typeof ASSET_FILTERS)[number]["value"];
  */
 function isAssetFilterVisible(
   value: AssetFilterValue,
-  status: string
+  audit: { status: string; completedAt: string | null }
 ): boolean {
-  const active = status === "PENDING" || status === "ACTIVE";
-  const completed = status === "COMPLETED";
-  return value === "MISSING" ? completed : value === "PENDING" ? active : true;
+  // why: completion is read from `completedAt`, not the status. Archiving a
+  // completed audit rewrites the status to ARCHIVED, and a status check hid
+  // BOTH pills on it — you could no longer filter an archived audit down to
+  // the assets it recorded as missing.
+  const isOpen = audit.status === "PENDING" || audit.status === "ACTIVE";
+  const isCompleted = audit.completedAt != null;
+  return value === "MISSING"
+    ? isCompleted
+    : value === "PENDING"
+    ? isOpen
+    : true;
 }
 
 // ── Combined asset type for display ─────────────────────
@@ -130,9 +139,7 @@ function AuditDetailContent() {
   // the `audit` object identity). When the filter becomes valid again the
   // selection naturally reapplies. (Codex + DonKoko review, PR #2583.)
   const effectiveFilter: AssetFilterValue =
-    audit && isAssetFilterVisible(assetFilter, audit.status)
-      ? assetFilter
-      : "ALL";
+    audit && isAssetFilterVisible(assetFilter, audit) ? assetFilter : "ALL";
 
   // Progress bar animation
   const reduceMotion = useReducedMotion();
@@ -286,8 +293,12 @@ function AuditDetailContent() {
     // "Missing" once the audit is completed (it's a real discrepancy). This
     // mirrors the unified web + companion vocabulary (@shelf/labels) — "Missing"
     // is reserved for completed audits, never shown mid-scan.
-    const notFoundStatus: AuditAssetStatus =
-      audit.status === "COMPLETED" ? "MISSING" : "PENDING";
+    // why: `completedAt`, not `status === "COMPLETED"` — archiving a completed
+    // audit switches the status to ARCHIVED while keeping the completion
+    // timestamp, and those assets are still genuinely missing.
+    const notFoundStatus: AuditAssetStatus = audit.completedAt
+      ? "MISSING"
+      : "PENDING";
 
     const items: DisplayAsset[] = [];
 
@@ -487,7 +498,9 @@ function AuditDetailContent() {
   };
 
   const isActive = audit.status === "PENDING" || audit.status === "ACTIVE";
-  const isCompleted = audit.status === "COMPLETED";
+  // Completion provenance survives archiving; the status does not. See
+  // `notFoundStatus` above.
+  const isCompleted = audit.completedAt != null;
   const progress =
     audit.expectedAssetCount > 0
       ? audit.foundAssetCount / audit.expectedAssetCount
@@ -503,7 +516,7 @@ function AuditDetailContent() {
   // Shares `isAssetFilterVisible` with the derived `effectiveFilter` above so
   // the visible pills and the applied selection can never disagree.
   const visibleFilters = ASSET_FILTERS.filter((f) =>
-    isAssetFilterVisible(f.value, audit.status)
+    isAssetFilterVisible(f.value, audit)
   );
 
   const isOverdue =
@@ -513,14 +526,11 @@ function AuditDetailContent() {
     .filter(Boolean)
     .join(" ");
 
+  // why: read from the shared map rather than a chain that fell through to
+  // "Cancelled" — an ARCHIVED audit was labelled Cancelled on this screen.
   const statusLabel =
-    audit.status === "PENDING"
-      ? "Pending"
-      : audit.status === "ACTIVE"
-      ? "Active"
-      : audit.status === "COMPLETED"
-      ? "Completed"
-      : "Cancelled";
+    AUDIT_STATUS_LABELS[audit.status as keyof typeof AUDIT_STATUS_LABELS] ??
+    audit.status;
 
   const assets = filteredAssets();
 
@@ -881,9 +891,14 @@ function AuditDetailContent() {
               color={colors.border}
             />
             <Text style={styles.emptyListText}>
+              {/* why: read the word from the same map the pills use. Lowercasing
+                  the raw filter value produced "No pending assets" next to a
+                  pill labelled "Not scanned". */}
               {effectiveFilter === "ALL"
                 ? "No assets in this audit"
-                : `No ${effectiveFilter.toLowerCase()} assets`}
+                : `No ${AUDIT_ASSET_STATUS_LABELS[
+                    effectiveFilter
+                  ].toLowerCase()} assets`}
             </Text>
           </View>
         }

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -70,7 +70,7 @@ function AuditsListContent() {
   // landing on an empty "nothing assigned to you" screen — when in fact
   // there were active, unassigned audits anyone could pick up. The list
   // is server-sorted by due date (most urgent first) and every card now
-  // states its ownership ("Unassigned · anyone can scan" / "Assigned to
+  // states its ownership ("Unassigned · admins and owners can scan" / "Assigned to
   // you" / "N assigned"), so the urgency-first flat list is legible
   // without forcing a scope filter. Admins can still narrow to their own
   // work with the toggle below. BASE/SELF_SERVICE are server-scoped to
@@ -307,7 +307,7 @@ function AuditsListContent() {
           ? "due soon"
           : null,
         ownership === "open"
-          ? "unassigned, anyone can scan"
+          ? "unassigned, admins and owners can scan"
           : ownership === "mine"
           ? "assigned to you"
           : null,
@@ -434,7 +434,7 @@ function AuditsListContent() {
                 ]}
               >
                 {ownership === "open"
-                  ? "Unassigned · anyone can scan"
+                  ? "Unassigned · admins and owners can scan"
                   : ownership === "mine"
                   ? item.assigneeCount === 1
                     ? "Assigned to you"

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -16,7 +16,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { api, type AuditListItem } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius, hitSlop } from "@/lib/constants";
-import { formatDue } from "@/lib/audit-format";
+import { auditOwnership, formatDue } from "@/lib/audit-format";
 import { useFormatPrefs } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -71,10 +71,9 @@ function AuditsListContent() {
   // landing on an empty "nothing assigned to you" screen — when in fact
   // there were active, unassigned audits anyone could pick up. The list
   // is server-sorted by due date (most urgent first) and every card now
-  // states its ownership ("Unassigned · admins can scan" / "Assigned to
-  // you" / "N assigned"), so the urgency-first flat list is legible
-  // without forcing a scope filter. Admins can still narrow to their own
-  // work with the toggle below. BASE/SELF_SERVICE are server-scoped to
+  // states its ownership (see `auditOwnership` for the exact wording), so
+  // the urgency-first flat list is legible without forcing a scope filter.
+  // Admins can still narrow to their own work with the toggle below. BASE/SELF_SERVICE are server-scoped to
   // their assignments regardless, and the effect below keeps their
   // (hidden) toggle pinned to true so visible state matches the server.
   const [assignedToMe, setAssignedToMe] = useState(false);
@@ -287,12 +286,13 @@ function AuditsListContent() {
       // with zero assignees is open for anyone to pick up (the case the
       // user flagged as invisible); otherwise it's either theirs or
       // someone else's.
-      const ownership: "open" | "mine" | "others" =
-        item.assigneeCount === 0
-          ? "open"
-          : item.isAssignedToMe
-          ? "mine"
-          : "others";
+      // Shared with the Home dashboard's audit cards so the two screens can
+      // never word ownership differently.
+      const {
+        ownership,
+        label: ownershipLabel,
+        a11yLabel,
+      } = auditOwnership(item);
       // why: the urgency tier (red/amber) and "You" marker are visual-only
       // signals — without surfacing them through the accessibility label,
       // VoiceOver / TalkBack users miss two important pieces of context
@@ -300,18 +300,18 @@ function AuditsListContent() {
       // reads the visible state, not just the static fields.
       const cardA11yLabel = [
         `Audit: ${item.name}`,
-        item.status,
+        // why: the label, not the raw enum. The visible badge below reads
+        // AUDIT_STATUS_LABELS, so announcing `item.status` told screen-reader
+        // users "ARCHIVED" where everyone else saw "Archived".
+        AUDIT_STATUS_LABELS[item.status as keyof typeof AUDIT_STATUS_LABELS] ??
+          item.status,
         `${item.foundAssetCount} of ${item.expectedAssetCount} found`,
         due.tier === "overdue"
           ? "overdue"
           : due.tier === "soon"
           ? "due soon"
           : null,
-        ownership === "open"
-          ? "unassigned, admins can scan"
-          : ownership === "mine"
-          ? "assigned to you"
-          : null,
+        a11yLabel,
       ]
         .filter(Boolean)
         .join(", ");
@@ -408,42 +408,39 @@ function AuditsListContent() {
               </Text>
             </View>
 
-            <View style={styles.metaRow}>
-              <Ionicons
-                name={
-                  ownership === "open"
-                    ? "scan-circle-outline"
-                    : "people-outline"
-                }
-                size={13}
-                color={
-                  ownership === "open" ? colors.primary : colors.mutedLight
-                }
-              />
-              <Text
-                style={[
-                  styles.metaText,
-                  ownership === "open" && {
-                    // why: `primaryText` (deeper orange), not `primary` —
-                    // brand orange is too light for body text on white
-                    // (3.1:1). The icon above keeps the brighter `primary`
-                    // (icons only need 3:1).
-                    color: colors.primaryText,
-                    fontWeight: "500",
-                  },
-                ]}
-              >
-                {ownership === "open"
-                  ? "Unassigned · admins can scan"
-                  : ownership === "mine"
-                  ? item.assigneeCount === 1
-                    ? "Assigned to you"
-                    : `You + ${item.assigneeCount - 1} other${
-                        item.assigneeCount - 1 === 1 ? "" : "s"
-                      }`
-                  : `${item.assigneeCount} assigned`}
-              </Text>
-            </View>
+            {/* why: guarded, like the Home card — a payload without the
+                assignee fields yields a null ownership, and an unguarded row
+                would render a lone icon beside empty text. */}
+            {ownership && (
+              <View style={styles.metaRow}>
+                <Ionicons
+                  name={
+                    ownership === "open"
+                      ? "scan-circle-outline"
+                      : "people-outline"
+                  }
+                  size={13}
+                  color={
+                    ownership === "open" ? colors.primary : colors.mutedLight
+                  }
+                />
+                <Text
+                  style={[
+                    styles.metaText,
+                    ownership === "open" && {
+                      // why: `primaryText` (deeper orange), not `primary` —
+                      // brand orange is too light for body text on white
+                      // (3.1:1). The icon above keeps the brighter `primary`
+                      // (icons only need 3:1).
+                      color: colors.primaryText,
+                      fontWeight: "500",
+                    },
+                  ]}
+                >
+                  {ownershipLabel}
+                </Text>
+              </View>
+            )}
           </View>
 
           {isActive && (

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -70,7 +70,7 @@ function AuditsListContent() {
   // landing on an empty "nothing assigned to you" screen — when in fact
   // there were active, unassigned audits anyone could pick up. The list
   // is server-sorted by due date (most urgent first) and every card now
-  // states its ownership ("Unassigned · admins and owners can scan" / "Assigned to
+  // states its ownership ("Unassigned · admins can scan" / "Assigned to
   // you" / "N assigned"), so the urgency-first flat list is legible
   // without forcing a scope filter. Admins can still narrow to their own
   // work with the toggle below. BASE/SELF_SERVICE are server-scoped to
@@ -307,7 +307,7 @@ function AuditsListContent() {
           ? "due soon"
           : null,
         ownership === "open"
-          ? "unassigned, admins and owners can scan"
+          ? "unassigned, admins can scan"
           : ownership === "mine"
           ? "assigned to you"
           : null,
@@ -434,7 +434,7 @@ function AuditsListContent() {
                 ]}
               >
                 {ownership === "open"
-                  ? "Unassigned · admins and owners can scan"
+                  ? "Unassigned · admins can scan"
                   : ownership === "mine"
                   ? item.assigneeCount === 1
                     ? "Assigned to you"

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -1,3 +1,4 @@
+import { AUDIT_STATUS_LABELS } from "@shelf/labels";
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
   View,
@@ -337,13 +338,12 @@ function AuditsListContent() {
                 style={[styles.statusDot, { backgroundColor: badge.text }]}
               />
               <Text style={[styles.statusText, { color: badge.text }]}>
-                {item.status === "PENDING"
-                  ? "Pending"
-                  : item.status === "ACTIVE"
-                  ? "Active"
-                  : item.status === "COMPLETED"
-                  ? "Completed"
-                  : "Cancelled"}
+                {/* why: the same chain on the detail screen fell through to
+                    "Cancelled", so an ARCHIVED audit was labelled cancelled.
+                    Read the shared map, which covers every status. */}
+                {AUDIT_STATUS_LABELS[
+                  item.status as keyof typeof AUDIT_STATUS_LABELS
+                ] ?? item.status}
               </Text>
             </View>
           </View>

--- a/apps/companion/app/(tabs)/home.tsx
+++ b/apps/companion/app/(tabs)/home.tsx
@@ -1,3 +1,4 @@
+import { AUDIT_STATUS_LABELS } from "@shelf/labels";
 import { useState, useCallback, useRef, memo, useEffect } from "react";
 import {
   View,
@@ -584,11 +585,23 @@ const AuditCard = memo(function AuditCard({
       : "others";
 
   const statusLabel =
-    audit.status === "PENDING"
-      ? "Pending"
-      : audit.status === "ACTIVE"
-      ? "Active"
-      : audit.status;
+    AUDIT_STATUS_LABELS[audit.status as keyof typeof AUDIT_STATUS_LABELS] ??
+    audit.status;
+
+  // why: ONE source for the ownership sentence. `accessibilityLabel` on the
+  // card replaces the concatenated child text, so anything not repeated here is
+  // simply never announced — a screen-reader user was told the name, status and
+  // counts but never who is allowed to scan.
+  const ownershipLabel =
+    ownership === "open"
+      ? "Unassigned · admins can scan"
+      : ownership === "mine"
+      ? audit.assigneeCount === 1
+        ? "Assigned to you"
+        : `You + ${(audit.assigneeCount ?? 1) - 1} other${
+            (audit.assigneeCount ?? 1) - 1 === 1 ? "" : "s"
+          }`
+      : `${audit.assigneeCount} assigned`;
 
   return (
     <TouchableOpacity
@@ -598,7 +611,11 @@ const AuditCard = memo(function AuditCard({
         onPress();
       }}
       activeOpacity={0.6}
-      accessibilityLabel={`Audit: ${audit.name}, ${statusLabel}, ${audit.foundAssetCount} of ${audit.expectedAssetCount} found`}
+      accessibilityLabel={`Audit: ${audit.name}, ${statusLabel}, ${
+        audit.foundAssetCount
+      } of ${audit.expectedAssetCount} found${
+        ownership ? `, ${ownershipLabel}` : ""
+      }`}
       accessibilityRole="button"
     >
       <View style={styles.bookingHeader}>
@@ -672,15 +689,7 @@ const AuditCard = memo(function AuditCard({
                 },
               ]}
             >
-              {ownership === "open"
-                ? "Unassigned · admins can scan"
-                : ownership === "mine"
-                ? audit.assigneeCount === 1
-                  ? "Assigned to you"
-                  : `You + ${(audit.assigneeCount ?? 1) - 1} other${
-                      (audit.assigneeCount ?? 1) - 1 === 1 ? "" : "s"
-                    }`
-                : `${audit.assigneeCount} assigned`}
+              {ownershipLabel}
             </Text>
           </View>
         )}

--- a/apps/companion/app/(tabs)/home.tsx
+++ b/apps/companion/app/(tabs)/home.tsx
@@ -673,7 +673,7 @@ const AuditCard = memo(function AuditCard({
               ]}
             >
               {ownership === "open"
-                ? "Unassigned · admins and owners can scan"
+                ? "Unassigned · admins can scan"
                 : ownership === "mine"
                 ? audit.assigneeCount === 1
                   ? "Assigned to you"

--- a/apps/companion/app/(tabs)/home.tsx
+++ b/apps/companion/app/(tabs)/home.tsx
@@ -673,7 +673,7 @@ const AuditCard = memo(function AuditCard({
               ]}
             >
               {ownership === "open"
-                ? "Unassigned · anyone can scan"
+                ? "Unassigned · admins and owners can scan"
                 : ownership === "mine"
                 ? audit.assigneeCount === 1
                   ? "Assigned to you"

--- a/apps/companion/app/(tabs)/home.tsx
+++ b/apps/companion/app/(tabs)/home.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { pushIntoTab } from "@/lib/navigation";
-import { formatDue } from "@/lib/audit-format";
+import { auditOwnership, formatDue } from "@/lib/audit-format";
 import { useDateFormatter, useFormatPrefs } from "@/lib/use-date-formatter";
 import { userHasPermission } from "@/lib/permissions";
 import {
@@ -569,39 +569,17 @@ const AuditCard = memo(function AuditCard({
       ? colors.warning
       : colors.mutedLight;
 
-  // Same ownership model the Audits list uses: 0 assignees = open for
-  // anyone to scan, otherwise yours or someone else's. `null` when the
-  // dashboard payload predates these fields (older/not-yet-deployed
-  // webapp) — we hide the row entirely rather than render "undefined
-  // assigned". The list endpoint already ships these fields, so the list
-  // shows ownership today; Home lights up once the dashboard deploy lands.
-  const ownership: "open" | "mine" | "others" | null =
-    audit.assigneeCount == null
-      ? null
-      : audit.assigneeCount === 0
-      ? "open"
-      : audit.isAssignedToMe
-      ? "mine"
-      : "others";
+  // Same ownership model the Audits list uses, resolved by the shared helper
+  // so the two screens state it identically: 0 assignees = open for anyone to
+  // scan, otherwise yours or someone else's. `ownership` is null when the
+  // dashboard payload predates these fields (older/not-yet-deployed webapp) —
+  // and so are both labels, so there is no branch that can render "undefined
+  // assigned" if a future edit drops the guard below.
+  const { ownership, label: ownershipLabel, a11yLabel } = auditOwnership(audit);
 
   const statusLabel =
     AUDIT_STATUS_LABELS[audit.status as keyof typeof AUDIT_STATUS_LABELS] ??
     audit.status;
-
-  // why: ONE source for the ownership sentence. `accessibilityLabel` on the
-  // card replaces the concatenated child text, so anything not repeated here is
-  // simply never announced — a screen-reader user was told the name, status and
-  // counts but never who is allowed to scan.
-  const ownershipLabel =
-    ownership === "open"
-      ? "Unassigned · admins can scan"
-      : ownership === "mine"
-      ? audit.assigneeCount === 1
-        ? "Assigned to you"
-        : `You + ${(audit.assigneeCount ?? 1) - 1} other${
-            (audit.assigneeCount ?? 1) - 1 === 1 ? "" : "s"
-          }`
-      : `${audit.assigneeCount} assigned`;
 
   return (
     <TouchableOpacity
@@ -611,10 +589,14 @@ const AuditCard = memo(function AuditCard({
         onPress();
       }}
       activeOpacity={0.6}
+      // why: `a11yLabel`, not the visible `label` — the announcement is a
+      // comma-joined sentence, so it wants the spoken-prose variant
+      // ("assigned to you and 2 others") rather than the card's terse
+      // "You + 2 others", which reads as arithmetic when spoken.
       accessibilityLabel={`Audit: ${audit.name}, ${statusLabel}, ${
         audit.foundAssetCount
       } of ${audit.expectedAssetCount} found${
-        ownership ? `, ${ownershipLabel}` : ""
+        a11yLabel ? `, ${a11yLabel}` : ""
       }`}
       accessibilityRole="button"
     >

--- a/apps/companion/components/audit/segmented-control.tsx
+++ b/apps/companion/components/audit/segmented-control.tsx
@@ -1,3 +1,4 @@
+import { AUDIT_ASSET_STATUS_LABELS } from "@shelf/labels";
 import React from "react";
 import { View, Text, TouchableOpacity } from "react-native";
 import { createStyles } from "@/lib/create-styles";
@@ -51,7 +52,7 @@ export function SegmentedControl({
         activeOpacity={0.7}
         accessibilityRole="tab"
         accessibilityState={{ selected: activeTab === "remaining" }}
-        accessibilityLabel={`Remaining ${remainingCount}`}
+        accessibilityLabel={`${AUDIT_ASSET_STATUS_LABELS.PENDING} ${remainingCount}`}
       >
         <Text
           style={[
@@ -59,7 +60,7 @@ export function SegmentedControl({
             activeTab === "remaining" && styles.segmentedOptionTextActive,
           ]}
         >
-          Remaining ({remainingCount})
+          {AUDIT_ASSET_STATUS_LABELS.PENDING} ({remainingCount})
         </Text>
       </TouchableOpacity>
     </View>

--- a/apps/companion/lib/audit-format.ts
+++ b/apps/companion/lib/audit-format.ts
@@ -15,6 +15,7 @@ import {
   formatDate,
   type ResolvedFormatPrefs,
 } from "@shelf/datetime";
+import { AUDIT_UNASSIGNED_LABELS } from "@shelf/labels";
 
 /**
  * Urgency tier for an audit's deadline.
@@ -70,4 +71,80 @@ export function formatDue(
   if (calDays === 1) return { label: "Due tomorrow", tier: "soon" };
   if (calDays <= 3) return { label: `Due in ${calDays}d`, tier: "soon" };
   return { label: `Due ${formatDate(dueDate, prefs)}`, tier: "neutral" };
+}
+
+/**
+ * Who an audit belongs to, as a card renders it.
+ * - `open`: nobody is assigned, so any admin can pick it up
+ * - `mine`: the acting user is one of the assignees
+ * - `others`: assigned, but not to the acting user
+ * - `null`: the server did not send the assignee fields (an older dashboard
+ *   payload), so the surface must render nothing rather than guess
+ */
+export type AuditOwnership = "open" | "mine" | "others" | null;
+
+/**
+ * Resolves an audit's ownership and the one sentence every surface uses to
+ * state it, in both the visible and the screen-reader register.
+ *
+ * why this is a function and not inline ternaries: the sentence was hand-copied
+ * to five call sites across the Audits list, an audit's detail and the Home
+ * dashboard, in two registers — so a wording change was five edits and the
+ * next one was always going to miss a copy. It also keeps the `null` arm
+ * attached to the label: the Home card used to compute the label outside the
+ * `ownership &&` guard, where a missing `assigneeCount` fell through to the
+ * "N assigned" branch and produced the literal string "undefined assigned".
+ *
+ * The two registers differ on purpose: the card is terse ("You + 2 others"),
+ * the announcement is spoken prose ("assigned to you and 2 others").
+ *
+ * @param audit - the audit's assignee fields, both optional on older payloads
+ * @returns the ownership bucket plus its visible and accessibility labels;
+ *   the labels are null exactly when the ownership is unknown
+ */
+export function auditOwnership(audit: {
+  assigneeCount?: number | null;
+  isAssignedToMe?: boolean | null;
+}): {
+  ownership: AuditOwnership;
+  label: string | null;
+  a11yLabel: string | null;
+} {
+  // why: `== null` — a genuine 0 means "unassigned", which is a real state we
+  // must render, not a missing field.
+  if (audit.assigneeCount == null) {
+    return { ownership: null, label: null, a11yLabel: null };
+  }
+
+  if (audit.assigneeCount === 0) {
+    return {
+      ownership: "open",
+      label: AUDIT_UNASSIGNED_LABELS.SHORT,
+      a11yLabel: AUDIT_UNASSIGNED_LABELS.A11Y,
+    };
+  }
+
+  if (audit.isAssignedToMe) {
+    const others = audit.assigneeCount - 1;
+    const plural = others === 1 ? "" : "s";
+    return {
+      ownership: "mine",
+      // "You + 2 others" is compact enough for a card but reads as an
+      // arithmetic expression when spoken, so the announcement spells it out.
+      label:
+        others === 0 ? "Assigned to you" : `You + ${others} other${plural}`,
+      a11yLabel:
+        others === 0
+          ? "assigned to you"
+          : `assigned to you and ${others} other${plural}`,
+    };
+  }
+
+  // Assigned, but to someone else.
+  const assignedLabel = `${audit.assigneeCount} assigned`;
+  return {
+    ownership: "others",
+    label: assignedLabel,
+    a11yLabel: assignedLabel,
+  };
 }

--- a/apps/companion/lib/constants.ts
+++ b/apps/companion/lib/constants.ts
@@ -11,6 +11,7 @@ import {
   ASSET_STATUS_LABELS,
   ASSET_QTY_STATUS_LABELS,
   ASSET_BOOKING_PSEUDO_STATUS_LABELS,
+  AUDIT_STATUS_LABELS,
   BOOKING_STATUS_LABELS,
 } from "@shelf/labels";
 
@@ -112,17 +113,25 @@ export function formatStatus(status: string) {
       return BOOKING_STATUS_LABELS.OVERDUE;
     case "COMPLETE":
       return BOOKING_STATUS_LABELS.COMPLETE;
+    // These two keys are shared with AuditStatus. Both maps spell them the
+    // same way, so one case serves both — if that ever stops being true, split
+    // them rather than letting audits silently inherit booking wording.
     case "ARCHIVED":
       return BOOKING_STATUS_LABELS.ARCHIVED;
     case "CANCELLED":
       return BOOKING_STATUS_LABELS.CANCELLED;
-    // ── Audit statuses (companion-only; no web asset-badge equivalent) ──
+    // ── Audit statuses (web canonical: AuditStatusBadge) ──
+    // Only the three keys that do not collide with a booking status appear
+    // here; AuditStatus.CANCELLED / .ARCHIVED are handled by the booking cases
+    // above, whose labels are the same words in AUDIT_STATUS_LABELS. Prefer
+    // AUDIT_STATUS_LABELS directly on audit surfaces — this branch exists for
+    // the generic badge helper, which is handed a bare status string.
     case "PENDING":
-      return "Pending";
+      return AUDIT_STATUS_LABELS.PENDING;
     case "ACTIVE":
-      return "Active";
+      return AUDIT_STATUS_LABELS.ACTIVE;
     case "COMPLETED":
-      return "Completed";
+      return AUDIT_STATUS_LABELS.COMPLETED;
     // Fallback: sentence-case (capitalize first word only)
     default: {
       const words = status.replace(/_/g, " ").toLowerCase();

--- a/apps/webapp/app/components/audit/audit-asset-list-item.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-list-item.tsx
@@ -12,6 +12,7 @@
  * @see {@link file://./../../routes/_layout+/audits.$auditId.overview.tsx}
  */
 
+import { isAuditCompleted } from "@shelf/labels";
 import { useLoaderData } from "react-router";
 
 import { AssetCodeBadge } from "~/components/assets/asset-code-badge";
@@ -75,10 +76,13 @@ export function AuditAssetListItem({ item }: { item: AuditAssetItem }) {
     currentFilter === null ||
     currentFilter === "ALL" ||
     currentFilter === "EXPECTED";
-  const isAuditCompleted = session.status === "COMPLETED";
+  // why: the shared `completedAt` rule, NOT `status === "COMPLETED"`. Archiving
+  // a completed audit rewrites the status while keeping the timestamp, so the
+  // status check made these rows read "Not scanned" beside a tile still saying
+  // "Missing" — the same divergence this PR removes elsewhere.
   const auditStatusLabel = getAuditStatusLabel(
     item.auditData,
-    isAuditCompleted
+    isAuditCompleted(session)
   );
 
   const canReadCustody = userHasPermission({

--- a/apps/webapp/app/components/audit/audit-asset-status-badge.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-status-badge.tsx
@@ -9,7 +9,7 @@ interface AuditAssetStatusBadgeProps {
 
 const auditStatusColorMap = (status: AuditStatusLabel): BadgeColorScheme => {
   switch (status) {
-    case "Expected":
+    case "Not scanned":
       return BADGE_COLORS.gray;
     case "Found":
       return BADGE_COLORS.green;

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -1,6 +1,11 @@
 import type React from "react";
 import { Fragment, useEffect, useRef, useState } from "react";
 import type { AuditStatus, AuditAssetStatus } from "@prisma/client";
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  auditAssetStatusLabel,
+  isAuditCompleted,
+} from "@shelf/labels";
 import { useReactToPrint } from "react-to-print";
 import useApiQuery from "~/hooks/use-api-query";
 import { getAuditStatusLabel } from "~/modules/audit/audit-filter-utils";
@@ -165,6 +170,14 @@ const AuditPDFContent = ({
     assetImages,
     activityNotes,
   } = pdfMeta;
+
+  // why: the receipt can be downloaded at ANY point in an audit's life — the
+  // Actions dropdown offers it with no status gate — so it must apply the same
+  // completion rule as the screen it was printed from. `missingAssetCount` is
+  // seeded with the full expected count at creation, so a receipt for a
+  // never-started audit used to assert that every one of its assets was lost.
+  const auditIsCompleted = isAuditCompleted(session);
+  const unscannedLabel = auditAssetStatusLabel("PENDING", auditIsCompleted);
 
   // Format creator name from user data or fallback to email
   const creatorName =
@@ -339,19 +352,23 @@ const AuditPDFContent = ({
             <div className="text-2xl font-bold">
               {session.foundAssetCount ?? 0}
             </div>
-            <div className="text-sm text-gray-600">Found</div>
+            <div className="text-sm text-gray-600">
+              {AUDIT_ASSET_STATUS_LABELS.FOUND}
+            </div>
           </div>
           <div className="border border-gray-300 p-3 text-center">
             <div className="text-2xl font-bold">
               {session.missingAssetCount ?? 0}
             </div>
-            <div className="text-sm text-gray-600">Missing</div>
+            <div className="text-sm text-gray-600">{unscannedLabel}</div>
           </div>
           <div className="border border-gray-300 p-3 text-center">
             <div className="text-2xl font-bold">
               {session.unexpectedAssetCount ?? 0}
             </div>
-            <div className="text-sm text-gray-600">Unexpected</div>
+            <div className="text-sm text-gray-600">
+              {AUDIT_ASSET_STATUS_LABELS.UNEXPECTED}
+            </div>
           </div>
         </div>
       </section>
@@ -490,7 +507,11 @@ const AuditPDFContent = ({
                       )}
                     </td>
                     <td className="border border-gray-300 p-2.5 align-top text-xs">
-                      {/* Convert AuditAssetStatus to AuditStatusLabel for badge display */}
+                      {/* Convert AuditAssetStatus to AuditStatusLabel for badge
+                          display. Pass the audit's completion state so these
+                          rows agree with the Statistics tile above them — the
+                          two used to read "Not scanned" and "Missing" for the
+                          same assets in the same PDF. */}
                       <AuditAssetStatusBadge
                         status={getAuditStatusLabel(
                           asset.auditData.auditStatus
@@ -498,7 +519,8 @@ const AuditPDFContent = ({
                                 expected: boolean;
                                 auditStatus: AuditAssetStatus;
                               })
-                            : null
+                            : null,
+                          auditIsCompleted
                         )}
                       />
                     </td>

--- a/apps/webapp/app/components/audit/audit-status-badge.tsx
+++ b/apps/webapp/app/components/audit/audit-status-badge.tsx
@@ -1,4 +1,5 @@
 import type { AuditStatus } from "@prisma/client";
+import { AUDIT_STATUS_LABELS } from "@shelf/labels";
 import { BADGE_COLORS, type BadgeColorScheme } from "~/utils/badge-colors";
 import { Badge } from "../shared/badge";
 
@@ -10,17 +11,12 @@ const auditStatusColorMap: Record<AuditStatus, BadgeColorScheme> = {
   ARCHIVED: BADGE_COLORS.gray,
 };
 
-const auditStatusLabels: Record<AuditStatus, string> = {
-  PENDING: "Pending",
-  ACTIVE: "Active",
-  COMPLETED: "Completed",
-  CANCELLED: "Cancelled",
-  ARCHIVED: "Archived",
-};
-
 /**
  * Badge component for displaying audit status with appropriate colors.
- * Colors are sourced from the platform's consistent BADGE_COLORS palette.
+ * Colors are sourced from the platform's consistent BADGE_COLORS palette;
+ * the words come from `@shelf/labels` so the companion app's audit cards can
+ * never show a different one. This file used to carry a byte-identical local
+ * copy of that map.
  *
  * @param status - The audit status from Prisma enum
  */
@@ -29,8 +25,11 @@ export function AuditStatusBadge({ status }: { status: AuditStatus }) {
 
   return (
     <Badge color={colors.bg} textColor={colors.text} withDot={false}>
-      <span className="block whitespace-nowrap lowercase first-letter:uppercase">
-        {auditStatusLabels[status]}
+      {/* why: no `lowercase first-letter:uppercase` — AUDIT_STATUS_LABELS is
+          already sentence-cased display text, and the transform would mangle
+          any future label with an internal capital. */}
+      <span className="block whitespace-nowrap">
+        {AUDIT_STATUS_LABELS[status]}
       </span>
     </Badge>
   );

--- a/apps/webapp/app/components/audit/audit-status-filter.tsx
+++ b/apps/webapp/app/components/audit/audit-status-filter.tsx
@@ -11,14 +11,23 @@ import {
 
 type AuditStatusFilterProps = {
   /**
-   * Filter value -> the words shown for it. The KEY is what goes in the URL,
-   * so it must stay the enum name; the VALUE is display text only.
+   * URL value -> the words shown for it. The KEY is what goes in the URL, so
+   * it must stay the enum name; the VALUE is final display text, rendered
+   * verbatim.
    *
    * why: this used to be a value->value map rendered by de-underscoring the
    * enum, which meant the dropdown could only ever say "Missing" while the
    * statistics tile beside it said "Not scanned" for the same rows.
+   *
+   * why the name `statusOptions` and not `statusItems`: the sibling
+   * `~/components/booking/status-filter` takes a `statusItems` prop with the
+   * OPPOSITE contract (values are the URL params, keys are ignored). Both are
+   * `Record<string, string>`, so the compiler cannot tell them apart — passing
+   * one shape to the other component would silently put display text in the
+   * URL and 400 in the loader's Zod enum. A distinct prop name is the only
+   * thing that makes the mix-up a compile error.
    */
-  statusItems: Record<string, string>;
+  statusOptions: Record<string, string>;
   name?: string;
 };
 
@@ -28,7 +37,7 @@ type AuditStatusFilterProps = {
  * Default filter is ALL (shows all assets).
  */
 export function AuditStatusFilter(props: AuditStatusFilterProps) {
-  const { statusItems, name = "auditStatus" } = props;
+  const { statusOptions, name = "auditStatus" } = props;
   const navigation = useNavigation();
   const disabled = isFormProcessing(navigation.state);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -42,6 +51,9 @@ export function AuditStatusFilter(props: AuditStatusFilterProps) {
       } else {
         prev.set(name, value);
       }
+      // Reset pagination when the filter changes — a stale `page` offset can
+      // otherwise land on an empty page. Mirrors the booking StatusFilter.
+      prev.delete("page");
       return prev;
     });
   }
@@ -66,14 +78,19 @@ export function AuditStatusFilter(props: AuditStatusFilterProps) {
           align="start"
         >
           <div className="max-h-[320px] overflow-auto">
-            {[["ALL", "All"] as const, ...Object.entries(statusItems)].map(
+            {[["ALL", "All"] as const, ...Object.entries(statusOptions)].map(
               ([value, itemLabel]) => (
                 <SelectItem
                   value={value}
                   key={value}
                   className="rounded-none border-b border-gray-200 px-6 py-4 pr-[5px]"
                 >
-                  <span className="mr-4 block text-[14px] lowercase text-gray-700 first-letter:uppercase">
+                  {/* why: no `lowercase first-letter:uppercase` here. That
+                      transform existed to sentence-case a RAW ENUM; the prop
+                      now carries final display text, and lowercasing it would
+                      mangle any label with a deliberate internal capital
+                      ("QR code", a proper noun). */}
+                  <span className="mr-4 block text-[14px] text-gray-700">
                     {itemLabel}
                   </span>
                 </SelectItem>

--- a/apps/webapp/app/components/audit/audit-status-filter.tsx
+++ b/apps/webapp/app/components/audit/audit-status-filter.tsx
@@ -10,6 +10,14 @@ import {
 } from "../forms/select";
 
 type AuditStatusFilterProps = {
+  /**
+   * Filter value -> the words shown for it. The KEY is what goes in the URL,
+   * so it must stay the enum name; the VALUE is display text only.
+   *
+   * why: this used to be a value->value map rendered by de-underscoring the
+   * enum, which meant the dropdown could only ever say "Missing" while the
+   * statistics tile beside it said "Not scanned" for the same rows.
+   */
   statusItems: Record<string, string>;
   name?: string;
 };
@@ -58,17 +66,19 @@ export function AuditStatusFilter(props: AuditStatusFilterProps) {
           align="start"
         >
           <div className="max-h-[320px] overflow-auto">
-            {["ALL", ...Object.values(statusItems)].map((value) => (
-              <SelectItem
-                value={value}
-                key={value}
-                className="rounded-none border-b border-gray-200 px-6 py-4 pr-[5px]"
-              >
-                <span className="mr-4 block text-[14px] lowercase text-gray-700 first-letter:uppercase">
-                  {value.split("_").join(" ")}
-                </span>
-              </SelectItem>
-            ))}
+            {[["ALL", "All"] as const, ...Object.entries(statusItems)].map(
+              ([value, itemLabel]) => (
+                <SelectItem
+                  value={value}
+                  key={value}
+                  className="rounded-none border-b border-gray-200 px-6 py-4 pr-[5px]"
+                >
+                  <span className="mr-4 block text-[14px] lowercase text-gray-700 first-letter:uppercase">
+                    {itemLabel}
+                  </span>
+                </SelectItem>
+              )
+            )}
           </div>
         </SelectContent>
       </Select>

--- a/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
+++ b/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
@@ -1,3 +1,7 @@
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  auditAssetStatusLabel,
+} from "@shelf/labels";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -99,7 +103,7 @@ describe("audit filter utils", () => {
     describe("on active/pending audit (isAuditCompleted = false)", () => {
       it("returns Expected when audit data is null", () => {
         const status = getAuditStatusLabel(null);
-        expect(status).toBe("Expected");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.PENDING);
       });
 
       it("returns Found for expected asset that was scanned", () => {
@@ -107,7 +111,7 @@ describe("audit filter utils", () => {
           expected: true,
           auditStatus: "FOUND",
         });
-        expect(status).toBe("Found");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.FOUND);
       });
 
       it("returns Missing for expected asset that wasn't scanned", () => {
@@ -115,7 +119,7 @@ describe("audit filter utils", () => {
           expected: true,
           auditStatus: "MISSING",
         });
-        expect(status).toBe("Missing");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.MISSING);
       });
 
       it("returns Unexpected for non-expected asset that was scanned", () => {
@@ -123,7 +127,7 @@ describe("audit filter utils", () => {
           expected: false,
           auditStatus: "UNEXPECTED",
         });
-        expect(status).toBe("Unexpected");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.UNEXPECTED);
       });
 
       it("returns Expected for expected asset with PENDING status", () => {
@@ -131,7 +135,7 @@ describe("audit filter utils", () => {
           expected: true,
           auditStatus: "PENDING",
         });
-        expect(status).toBe("Expected");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.PENDING);
       });
 
       it("returns Expected for edge case of non-expected FOUND", () => {
@@ -141,7 +145,7 @@ describe("audit filter utils", () => {
           expected: false,
           auditStatus: "FOUND",
         });
-        expect(status).toBe("Expected");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.PENDING);
       });
 
       it("returns Expected for edge case of non-expected MISSING", () => {
@@ -151,14 +155,14 @@ describe("audit filter utils", () => {
           expected: false,
           auditStatus: "MISSING",
         });
-        expect(status).toBe("Expected");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.PENDING);
       });
     });
 
     describe("on completed audit (isAuditCompleted = true)", () => {
       it("returns Missing when audit data is null", () => {
         const status = getAuditStatusLabel(null, true);
-        expect(status).toBe("Missing");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.MISSING);
       });
 
       it("returns Found for expected asset that was scanned", () => {
@@ -169,7 +173,7 @@ describe("audit filter utils", () => {
           },
           true
         );
-        expect(status).toBe("Found");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.FOUND);
       });
 
       it("returns Missing for expected asset with PENDING status", () => {
@@ -181,7 +185,7 @@ describe("audit filter utils", () => {
           },
           true
         );
-        expect(status).toBe("Missing");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.MISSING);
       });
 
       it("returns Missing for expected asset with MISSING status", () => {
@@ -192,7 +196,7 @@ describe("audit filter utils", () => {
           },
           true
         );
-        expect(status).toBe("Missing");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.MISSING);
       });
 
       it("returns Unexpected for non-expected asset that was scanned", () => {
@@ -203,8 +207,29 @@ describe("audit filter utils", () => {
           },
           true
         );
-        expect(status).toBe("Unexpected");
+        expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.UNEXPECTED);
       });
     });
+  });
+});
+
+describe("auditAssetStatusLabel (shared with the companion app)", () => {
+  it("calls an unscanned asset 'Not scanned' while the audit is still open", () => {
+    // why: `missingAssetCount` is seeded with the full expected count at
+    // creation, so labelling it "Missing" told users a brand-new audit had
+    // already lost every asset. Nothing is missing until the audit closes.
+    expect(auditAssetStatusLabel("PENDING", false)).toBe("Not scanned");
+  });
+
+  it("calls an unscanned asset 'Missing' once the audit is completed", () => {
+    expect(auditAssetStatusLabel("PENDING", true)).toBe("Missing");
+  });
+
+  it("leaves resolved statuses untouched in both states", () => {
+    for (const completed of [false, true]) {
+      expect(auditAssetStatusLabel("FOUND", completed)).toBe("Found");
+      expect(auditAssetStatusLabel("MISSING", completed)).toBe("Missing");
+      expect(auditAssetStatusLabel("UNEXPECTED", completed)).toBe("Unexpected");
+    }
   });
 });

--- a/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
+++ b/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
@@ -48,8 +48,10 @@ describe("audit filter utils", () => {
       });
     });
 
-    it("returns correct metadata for MISSING filter", () => {
-      const metadata = getAuditFilterMetadata("MISSING");
+    it("returns correct metadata for MISSING filter on a completed audit", () => {
+      // why: the MISSING filter only means "missing" once the audit is closed.
+      // The open-audit wording is covered in its own describe block below.
+      const metadata = getAuditFilterMetadata("MISSING", true);
 
       expect(metadata).toEqual({
         label: "Missing Assets",
@@ -230,6 +232,34 @@ describe("auditAssetStatusLabel (shared with the companion app)", () => {
       expect(auditAssetStatusLabel("FOUND", completed)).toBe("Found");
       expect(auditAssetStatusLabel("MISSING", completed)).toBe("Missing");
       expect(auditAssetStatusLabel("UNEXPECTED", completed)).toBe("Unexpected");
+    }
+  });
+});
+
+describe("getAuditFilterMetadata — MISSING heading follows the audit state", () => {
+  it("reads 'Not scanned Assets' while the audit is still open", () => {
+    // why: this list is reached by clicking the statistics tile, which reads
+    // "Not scanned" on an open audit. A "Missing Assets" heading would
+    // contradict the control the user just clicked.
+    const metadata = getAuditFilterMetadata("MISSING", false);
+    expect(metadata.label).toBe("Not scanned Assets");
+    expect(metadata.emptyState.title).toBe("Nothing left to scan");
+  });
+
+  it("reads 'Missing Assets' once the audit is completed", () => {
+    const metadata = getAuditFilterMetadata("MISSING", true);
+    expect(metadata.label).toBe("Missing Assets");
+  });
+
+  it("leaves the other filters alone in both states", () => {
+    for (const completed of [false, true]) {
+      expect(getAuditFilterMetadata("FOUND", completed).label).toBe(
+        "Found Assets"
+      );
+      expect(getAuditFilterMetadata("EXPECTED", completed).label).toBe(
+        "Expected Assets"
+      );
+      expect(getAuditFilterMetadata("ALL", completed).label).toBe("All Assets");
     }
   });
 });

--- a/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
+++ b/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
@@ -1,5 +1,6 @@
 import {
   AUDIT_ASSET_STATUS_LABELS,
+  AUDIT_UNASSIGNED_LABELS,
   auditAssetStatusLabel,
   isAuditCompleted,
 } from "@shelf/labels";
@@ -329,5 +330,39 @@ describe("getAuditFilterMetadata — MISSING heading follows the audit state", (
       );
       expect(getAuditFilterMetadata("ALL", completed).label).toBe("All Assets");
     }
+  });
+});
+
+describe("AUDIT_UNASSIGNED_LABELS (shared with the companion app)", () => {
+  // why: the constant's own docstring promises the three registers "can never
+  // say different things about who is allowed to scan" — and nothing enforced
+  // it, so they shipped disagreeing: the terse two said "admins can scan"
+  // while the prose one said "admins and owners". A user on the phone was told
+  // they could not do a thing the same product told them they could on the
+  // web. The promise needs a check, not just a comment.
+  const registers = Object.entries(AUDIT_UNASSIGNED_LABELS);
+
+  it("names BOTH permitted roles in every register", () => {
+    // Ground truth is the server, not the copy: `requireAuditAssignee` returns
+    // early for any caller that is not BASE/SELF_SERVICE, so ADMIN and OWNER
+    // are exactly the roles that may scan an unassigned audit.
+    for (const [name, text] of registers) {
+      const labelled = `${name}: ${text.toLowerCase()}`;
+      expect(labelled).toContain("admin");
+      expect(labelled).toContain("owner");
+    }
+  });
+
+  it("keeps each register in its own voice", () => {
+    // Sharing the FACTS does not mean sharing the phrasing: SHORT is a card
+    // meta line, A11Y is spliced into a comma-joined spoken sentence, and
+    // DETAIL is a tooltip. Collapsing them into one string would regress the
+    // announcement into reading a "·" aloud.
+    expect(AUDIT_UNASSIGNED_LABELS.SHORT).toContain("·");
+    expect(AUDIT_UNASSIGNED_LABELS.A11Y).not.toContain("·");
+    expect(AUDIT_UNASSIGNED_LABELS.A11Y).toBe(
+      AUDIT_UNASSIGNED_LABELS.A11Y.toLowerCase()
+    );
+    expect(AUDIT_UNASSIGNED_LABELS.DETAIL).toMatch(/\.$/);
   });
 });

--- a/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
+++ b/apps/webapp/app/modules/audit/audit-filter-utils.test.ts
@@ -1,6 +1,7 @@
 import {
   AUDIT_ASSET_STATUS_LABELS,
   auditAssetStatusLabel,
+  isAuditCompleted,
 } from "@shelf/labels";
 import { describe, expect, it } from "vitest";
 
@@ -103,7 +104,7 @@ describe("audit filter utils", () => {
 
   describe("getAuditStatusLabel", () => {
     describe("on active/pending audit (isAuditCompleted = false)", () => {
-      it("returns Expected when audit data is null", () => {
+      it("returns Not scanned when audit data is null", () => {
         const status = getAuditStatusLabel(null);
         expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.PENDING);
       });
@@ -132,7 +133,7 @@ describe("audit filter utils", () => {
         expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.UNEXPECTED);
       });
 
-      it("returns Expected for expected asset with PENDING status", () => {
+      it("returns Not scanned for expected asset with PENDING status", () => {
         const status = getAuditStatusLabel({
           expected: true,
           auditStatus: "PENDING",
@@ -140,7 +141,7 @@ describe("audit filter utils", () => {
         expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.PENDING);
       });
 
-      it("returns Expected for edge case of non-expected FOUND", () => {
+      it("returns Not scanned for edge case of non-expected FOUND", () => {
         // Edge case: asset marked as found but not expected
         // This shouldn't happen in practice, but tests defensive behavior
         const status = getAuditStatusLabel({
@@ -150,7 +151,7 @@ describe("audit filter utils", () => {
         expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.PENDING);
       });
 
-      it("returns Expected for edge case of non-expected MISSING", () => {
+      it("returns Not scanned for edge case of non-expected MISSING", () => {
         // Edge case: asset marked as missing but not expected
         // This shouldn't happen in practice, but tests defensive behavior
         const status = getAuditStatusLabel({
@@ -212,6 +213,73 @@ describe("audit filter utils", () => {
         expect(status).toBe(AUDIT_ASSET_STATUS_LABELS.UNEXPECTED);
       });
     });
+  });
+});
+
+describe("isAuditCompleted (shared with the companion app)", () => {
+  /**
+   * Minimal stand-in for an audit session row. Built through a helper rather
+   * than passed as an inline literal so the cases can carry the `status` that
+   * makes them meaningful without tripping excess-property checking.
+   */
+  const auditSession = (session: {
+    status: string;
+    completedAt: Date | string | null;
+  }) => session;
+
+  // why: every audit label in both apps hangs off this one boolean, and the
+  // whole point is that it reads `completedAt` and NOT `status`. Nothing else
+  // in the suite pins that — `auditAssetStatusLabel` is handed the flag
+  // already computed — so "simplifying" this back to a status check used to be
+  // a fully-green change. These cases are the ones that would break.
+  it("is false for an audit that is still running", () => {
+    expect(
+      isAuditCompleted(auditSession({ status: "ACTIVE", completedAt: null }))
+    ).toBe(false);
+  });
+
+  it("is true once the audit has been completed", () => {
+    expect(
+      isAuditCompleted(
+        auditSession({ status: "COMPLETED", completedAt: new Date() })
+      )
+    ).toBe(true);
+  });
+
+  it("stays true after a completed audit is ARCHIVED", () => {
+    // Archiving rewrites status to ARCHIVED but keeps `completedAt` and the
+    // finalised counts. A `status === "COMPLETED"` check flips to false here
+    // and relabels genuinely missing assets as "Not scanned".
+    expect(
+      isAuditCompleted(
+        auditSession({ status: "ARCHIVED", completedAt: new Date() })
+      )
+    ).toBe(true);
+  });
+
+  it("stays false after a CANCELLED audit is ARCHIVED", () => {
+    // The mirror case: archived, but never concluded, so its unscanned assets
+    // must keep the open-audit wording.
+    expect(
+      isAuditCompleted(auditSession({ status: "ARCHIVED", completedAt: null }))
+    ).toBe(false);
+  });
+
+  it("accepts the ISO string the companion receives over JSON", () => {
+    expect(
+      isAuditCompleted(
+        auditSession({
+          status: "COMPLETED",
+          completedAt: "2026-08-17T10:00:00.000Z",
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("is false for a missing or absent audit", () => {
+    expect(isAuditCompleted(null)).toBe(false);
+    expect(isAuditCompleted(undefined)).toBe(false);
+    expect(isAuditCompleted({})).toBe(false);
   });
 });
 

--- a/apps/webapp/app/modules/audit/audit-filter-utils.ts
+++ b/apps/webapp/app/modules/audit/audit-filter-utils.ts
@@ -1,4 +1,9 @@
 import type { AuditAssetStatus } from "@prisma/client";
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  auditAssetStatusLabel,
+  type AuditAssetStatusLabel,
+} from "@shelf/labels";
 
 export type AuditFilterType =
   | "ALL"
@@ -67,15 +72,19 @@ export function getAuditFilterMetadata(
   return FILTER_METADATA[normalizedFilter] || FILTER_METADATA.ALL;
 }
 
-export type AuditStatusLabel = "Expected" | "Found" | "Missing" | "Unexpected";
+/**
+ * Canonical per-asset audit status label, owned by `@shelf/labels` so the
+ * companion app renders the exact same words.
+ */
+export type AuditStatusLabel = AuditAssetStatusLabel;
 
 /**
  * Determine the audit status label for an asset based on its audit data.
  * Used to display status badges in the "ALL" filter view.
  *
  * The label changes based on audit completion state:
- * - Active/Pending audit: Expected assets show "Expected" or "Found"
- * - Completed audit: Expected assets that weren't scanned show "Missing" instead of "Expected"
+ * - Active/Pending audit: expected assets show "Not scanned" or "Found"
+ * - Completed audit: expected assets that weren't scanned show "Missing"
  *
  * @param auditData - The asset's audit status data
  * @param isAuditCompleted - Whether the audit has been completed (default: false)
@@ -84,30 +93,30 @@ export function getAuditStatusLabel(
   auditData: { expected: boolean; auditStatus: AuditAssetStatus } | null,
   isAuditCompleted: boolean = false
 ): AuditStatusLabel {
-  if (!auditData) return isAuditCompleted ? "Missing" : "Expected";
+  if (!auditData) return auditAssetStatusLabel("PENDING", isAuditCompleted);
 
   // Found: Expected asset that was scanned
   if (auditData.expected && auditData.auditStatus === "FOUND") {
-    return "Found";
+    return AUDIT_ASSET_STATUS_LABELS.FOUND;
   }
 
   // Missing: Expected asset that wasn't scanned (always shows as Missing)
   if (auditData.expected && auditData.auditStatus === "MISSING") {
-    return "Missing";
+    return AUDIT_ASSET_STATUS_LABELS.MISSING;
   }
 
   // Unexpected: Asset that was scanned but not expected
   if (!auditData.expected && auditData.auditStatus === "UNEXPECTED") {
-    return "Unexpected";
+    return AUDIT_ASSET_STATUS_LABELS.UNEXPECTED;
   }
 
   // Expected assets with PENDING status:
   // - On completed audit: Show as "Missing" (they weren't scanned)
   // - On active/pending audit: Show as "Expected" (still waiting to be scanned)
   if (auditData.expected && auditData.auditStatus === "PENDING") {
-    return isAuditCompleted ? "Missing" : "Expected";
+    return auditAssetStatusLabel("PENDING", isAuditCompleted);
   }
 
   // Default fallback
-  return isAuditCompleted ? "Missing" : "Expected";
+  return auditAssetStatusLabel("PENDING", isAuditCompleted);
 }

--- a/apps/webapp/app/modules/audit/audit-filter-utils.ts
+++ b/apps/webapp/app/modules/audit/audit-filter-utils.ts
@@ -130,8 +130,8 @@ export function getAuditStatusLabel(
   }
 
   // Expected assets with PENDING status:
-  // - On completed audit: Show as "Missing" (they weren't scanned)
-  // - On active/pending audit: Show as "Expected" (still waiting to be scanned)
+  // - On a completed audit: "Missing" (they were never scanned)
+  // - While the audit is open: "Not scanned" (still waiting to be reached)
   if (auditData.expected && auditData.auditStatus === "PENDING") {
     return auditAssetStatusLabel("PENDING", isAuditCompleted);
   }

--- a/apps/webapp/app/modules/audit/audit-filter-utils.ts
+++ b/apps/webapp/app/modules/audit/audit-filter-utils.ts
@@ -45,7 +45,7 @@ const FILTER_METADATA: Record<AuditFilterType, AuditFilterMetadata> = {
     },
   },
   MISSING: {
-    label: "Missing Assets",
+    label: `${AUDIT_ASSET_STATUS_LABELS.MISSING} Assets`,
     emptyState: {
       title: "No missing assets",
       text: "All expected assets have been found. Great job!",
@@ -65,11 +65,30 @@ const FILTER_METADATA: Record<AuditFilterType, AuditFilterMetadata> = {
  * Falls back to ALL metadata if invalid filter type is provided.
  */
 export function getAuditFilterMetadata(
-  filterType: string | null
+  filterType: string | null,
+  isAuditCompleted: boolean = false
 ): AuditFilterMetadata {
   // If no filter is provided, default to "ALL" (show all assets)
   const normalizedFilter = (filterType || "ALL") as AuditFilterType;
-  return FILTER_METADATA[normalizedFilter] || FILTER_METADATA.ALL;
+  const metadata = FILTER_METADATA[normalizedFilter] || FILTER_METADATA.ALL;
+
+  // why: the MISSING filter is reached by clicking the statistics tile, and
+  // that tile reads "Not scanned" until the audit is completed. Leaving this
+  // heading as "Missing Assets" would contradict the control the user just
+  // clicked, and would re-assert the very claim this rule removes: nothing is
+  // missing until the audit closes. The URL key stays MISSING so existing
+  // links keep working.
+  if (normalizedFilter === "MISSING" && !isAuditCompleted) {
+    return {
+      label: `${AUDIT_ASSET_STATUS_LABELS.PENDING} Assets`,
+      emptyState: {
+        title: "Nothing left to scan",
+        text: "Every expected asset has been found. Great job!",
+      },
+    };
+  }
+
+  return metadata;
 }
 
 /**

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -56,12 +56,21 @@ import { resolveUserDisplayName } from "~/utils/user";
 
 const label = "Audit";
 
-const AUDIT_STATUS_ITEMS = {
-  EXPECTED: "EXPECTED",
-  FOUND: "FOUND",
-  MISSING: "MISSING",
-  UNEXPECTED: "UNEXPECTED",
-};
+/**
+ * Audit-status filter options: URL value -> the words the user reads.
+ *
+ * MISSING is completion-aware for the same reason the statistics tile is —
+ * an expected asset is only "missing" once the audit is closed. Keys stay the
+ * enum names so existing filtered links keep working.
+ */
+function buildAuditStatusItems(isAuditCompleted: boolean) {
+  return {
+    EXPECTED: "Expected",
+    FOUND: AUDIT_ASSET_STATUS_LABELS.FOUND,
+    MISSING: auditAssetStatusLabel("PENDING", isAuditCompleted),
+    UNEXPECTED: AUDIT_ASSET_STATUS_LABELS.UNEXPECTED,
+  };
+}
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => [
   { title: data ? appendToMetaTitle(data.header.title) : "Audit Overview" },
@@ -310,7 +319,10 @@ export default function AuditOverview() {
   const unscannedLabel = auditAssetStatusLabel("PENDING", isAuditCompleted);
   const unexpectedCount = session.unexpectedAssetCount || 0;
 
-  const filterMetadata = getAuditFilterMetadata(currentFilter);
+  const filterMetadata = getAuditFilterMetadata(
+    currentFilter,
+    isAuditCompleted
+  );
 
   return (
     <div className="mt-8 flex flex-col gap-6">
@@ -573,7 +585,9 @@ export default function AuditOverview() {
           className="responsive-filters mb-2"
           slots={{
             "left-of-search": (
-              <AuditStatusFilter statusItems={AUDIT_STATUS_ITEMS} />
+              <AuditStatusFilter
+                statusItems={buildAuditStatusItems(isAuditCompleted)}
+              />
             ),
           }}
         />

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -1,4 +1,4 @@
-import { AuditStatus, OrganizationRoles } from "@prisma/client";
+import { OrganizationRoles } from "@prisma/client";
 import {
   AUDIT_ASSET_STATUS_LABELS,
   auditAssetStatusLabel,
@@ -315,7 +315,13 @@ export default function AuditOverview() {
   // Labelling it "Missing" told users a brand-new audit was already missing
   // every one of its assets. The asset rows have always been completion-aware
   // (getAuditStatusLabel); this makes the tile agree with them.
-  const isAuditCompleted = session.status === AuditStatus.COMPLETED;
+  // why: NOT `status === COMPLETED`. Archiving a completed audit rewrites the
+  // status to ARCHIVED but keeps `completedAt` and the finalised counts, so a
+  // status check would relabel genuinely missing assets as "Not scanned" the
+  // moment someone archives the audit. `completedAt` is the provenance: it is
+  // set only by completion, so an archived-cancelled audit (never concluded)
+  // correctly keeps the open-audit wording.
+  const isAuditCompleted = session.completedAt !== null;
   const unscannedLabel = auditAssetStatusLabel("PENDING", isAuditCompleted);
   const unexpectedCount = session.unexpectedAssetCount || 0;
 

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -1,4 +1,8 @@
-import { OrganizationRoles } from "@prisma/client";
+import { AuditStatus, OrganizationRoles } from "@prisma/client";
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  auditAssetStatusLabel,
+} from "@shelf/labels";
 import type {
   ActionFunctionArgs,
   LoaderFunctionArgs,
@@ -296,6 +300,14 @@ export default function AuditOverview() {
   const expectedCount = session.expectedAssetCount || 0;
   const foundCount = session.foundAssetCount || 0;
   const missingCount = session.missingAssetCount || 0;
+  // why: `missingAssetCount` is seeded with the FULL expected count when the
+  // audit is created and only decrements as assets are found, so before the
+  // audit is completed it is the not-yet-scanned count, not a missing count.
+  // Labelling it "Missing" told users a brand-new audit was already missing
+  // every one of its assets. The asset rows have always been completion-aware
+  // (getAuditStatusLabel); this makes the tile agree with them.
+  const isAuditCompleted = session.status === AuditStatus.COMPLETED;
+  const unscannedLabel = auditAssetStatusLabel("PENDING", isAuditCompleted);
   const unexpectedCount = session.unexpectedAssetCount || 0;
 
   const filterMetadata = getAuditFilterMetadata(currentFilter);
@@ -318,19 +330,19 @@ export default function AuditOverview() {
               isActive={currentFilter === "EXPECTED"}
             />
             <StatCard
-              label="Found"
+              label={AUDIT_ASSET_STATUS_LABELS.FOUND}
               value={foundCount}
               filterType="FOUND"
               isActive={currentFilter === "FOUND"}
             />
             <StatCard
-              label="Missing"
+              label={unscannedLabel}
               value={missingCount}
               filterType="MISSING"
               isActive={currentFilter === "MISSING"}
             />
             <StatCard
-              label="Unexpected"
+              label={AUDIT_ASSET_STATUS_LABELS.UNEXPECTED}
               value={unexpectedCount}
               filterType="UNEXPECTED"
               isActive={currentFilter === "UNEXPECTED"}

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -1,7 +1,9 @@
 import { OrganizationRoles } from "@prisma/client";
 import {
   AUDIT_ASSET_STATUS_LABELS,
+  AUDIT_UNASSIGNED_LABELS,
   auditAssetStatusLabel,
+  isAuditCompleted,
 } from "@shelf/labels";
 import type {
   ActionFunctionArgs,
@@ -63,11 +65,11 @@ const label = "Audit";
  * an expected asset is only "missing" once the audit is closed. Keys stay the
  * enum names so existing filtered links keep working.
  */
-function buildAuditStatusItems(isAuditCompleted: boolean) {
+function buildAuditStatusItems(auditIsCompleted: boolean) {
   return {
     EXPECTED: "Expected",
     FOUND: AUDIT_ASSET_STATUS_LABELS.FOUND,
-    MISSING: auditAssetStatusLabel("PENDING", isAuditCompleted),
+    MISSING: auditAssetStatusLabel("PENDING", auditIsCompleted),
     UNEXPECTED: AUDIT_ASSET_STATUS_LABELS.UNEXPECTED,
   };
 }
@@ -314,19 +316,15 @@ export default function AuditOverview() {
   // Labelling it "Missing" told users a brand-new audit was already missing
   // every one of its assets. The asset rows have always been completion-aware
   // (getAuditStatusLabel); this makes the tile agree with them.
-  // why: NOT `status === COMPLETED`. Archiving a completed audit rewrites the
-  // status to ARCHIVED but keeps `completedAt` and the finalised counts, so a
-  // status check would relabel genuinely missing assets as "Not scanned" the
-  // moment someone archives the audit. `completedAt` is the provenance: it is
-  // set only by completion, so an archived-cancelled audit (never concluded)
-  // correctly keeps the open-audit wording.
-  const isAuditCompleted = session.completedAt !== null;
-  const unscannedLabel = auditAssetStatusLabel("PENDING", isAuditCompleted);
+  // The `completedAt`-not-`status` rule lives in `@shelf/labels` so every
+  // surface in both apps derives it identically — see `isAuditCompleted`.
+  const auditIsCompleted = isAuditCompleted(session);
+  const unscannedLabel = auditAssetStatusLabel("PENDING", auditIsCompleted);
   const unexpectedCount = session.unexpectedAssetCount || 0;
 
   const filterMetadata = getAuditFilterMetadata(
     currentFilter,
-    isAuditCompleted
+    auditIsCompleted
   );
 
   return (
@@ -467,8 +465,7 @@ export default function AuditOverview() {
                           iconClassName="size-4"
                           content={
                             <p className="text-sm text-gray-600">
-                              Workspace admins and owners can perform this audit
-                              because it has no specific assignee.
+                              {AUDIT_UNASSIGNED_LABELS.DETAIL}
                             </p>
                           }
                         />
@@ -591,7 +588,7 @@ export default function AuditOverview() {
           slots={{
             "left-of-search": (
               <AuditStatusFilter
-                statusItems={buildAuditStatusItems(isAuditCompleted)}
+                statusOptions={buildAuditStatusItems(auditIsCompleted)}
               />
             ),
           }}

--- a/apps/webapp/app/routes/_layout+/audits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/audits._index.tsx
@@ -1,5 +1,6 @@
 import type { AuditStatus } from "@prisma/client";
 import type { Prisma } from "@prisma/client";
+import { AUDIT_ASSET_STATUS_LABELS } from "@shelf/labels";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { data, useLoaderData } from "react-router";
 import { DescriptionColumn } from "~/components/assets/assets-index/advanced-asset-columns";
@@ -173,7 +174,15 @@ export default function AuditsIndexPage() {
               <Th>Completed</Th>
               <Th className="text-right">Expected</Th>
               <Th className="text-right">Found</Th>
-              <Th className="text-right">Missing</Th>
+              {/* why: this column spans audits in every state, so it cannot be
+                  completion-aware per row. "Not scanned" is true in both states
+                  (a missing asset is one that was never scanned); "Missing" was
+                  not — it claimed a brand-new audit had already lost its assets,
+                  because missingAssetCount is seeded with the full expected
+                  count at creation. */}
+              <Th className="text-right">
+                {AUDIT_ASSET_STATUS_LABELS.PENDING}
+              </Th>
               <Th className="text-right">Unexpected</Th>
             </>
           }

--- a/apps/webapp/app/routes/_layout+/audits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/audits._index.tsx
@@ -1,13 +1,18 @@
 import type { AuditStatus } from "@prisma/client";
 import type { Prisma } from "@prisma/client";
-import { AUDIT_ASSET_STATUS_LABELS } from "@shelf/labels";
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  AUDIT_STATUS_LABELS,
+  auditAssetStatusLabel,
+  isAuditCompleted,
+} from "@shelf/labels";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { data, useLoaderData } from "react-router";
 import { DescriptionColumn } from "~/components/assets/assets-index/advanced-asset-columns";
 import AuditIndexBulkActionsDropdown from "~/components/audit/audit-index-bulk-actions-dropdown";
 import { AuditStatusBadgeWithOverdue } from "~/components/audit/audit-status-badge-with-overdue";
+import { AuditStatusFilter } from "~/components/audit/audit-status-filter";
 import { NewAuditInfoDialog } from "~/components/audit/new-audit-info-dialog";
-import { StatusFilter } from "~/components/booking/status-filter";
 import Header from "~/components/layout/header";
 import type { HeaderData } from "~/components/layout/header/types";
 import { List } from "~/components/list";
@@ -18,6 +23,7 @@ import { SortBy } from "~/components/list/filters/sort-by";
 import { Button } from "~/components/shared/button";
 import { DateS } from "~/components/shared/date";
 import { EmptyTableValue } from "~/components/shared/empty-table-value";
+import { InfoTooltip } from "~/components/shared/info-tooltip";
 import { UserBadge } from "~/components/shared/user-badge";
 import { Td, Th } from "~/components/table";
 import type { AUDIT_LIST_INCLUDE } from "~/modules/audit/service.server";
@@ -138,14 +144,14 @@ export default function AuditsIndexPage() {
         <Filters
           slots={{
             "left-of-search": (
-              <StatusFilter
-                statusItems={{
-                  PENDING: "PENDING",
-                  ACTIVE: "ACTIVE",
-                  COMPLETED: "COMPLETED",
-                  CANCELLED: "CANCELLED",
-                  ARCHIVED: "ARCHIVED",
-                }}
+              // why: AuditStatusFilter, not the booking StatusFilter. Its
+              // key->label contract lets the dropdown read the shared
+              // AUDIT_STATUS_LABELS while the URL keeps the enum names the
+              // loader parses; the booking component renders the raw values,
+              // which is why this list used to sentence-case "PENDING" by CSS.
+              <AuditStatusFilter
+                name="status"
+                statusOptions={AUDIT_STATUS_LABELS}
               />
             ),
             "right-of-search": (
@@ -174,14 +180,28 @@ export default function AuditsIndexPage() {
               <Th>Completed</Th>
               <Th className="text-right">Expected</Th>
               <Th className="text-right">Found</Th>
-              {/* why: this column spans audits in every state, so it cannot be
-                  completion-aware per row. "Not scanned" is true in both states
-                  (a missing asset is one that was never scanned); "Missing" was
-                  not — it claimed a brand-new audit had already lost its assets,
-                  because missingAssetCount is seeded with the full expected
-                  count at creation. */}
+              {/* why: one header spans audits in every state, so it uses the
+                  word that is true in both — "Not scanned". ("Missing" was
+                  not: missingAssetCount is seeded with the full expected count
+                  at creation, so it claimed a brand-new audit had already lost
+                  its assets.) The tooltip reconciles it with the audit detail
+                  page, which calls the same count "Missing" once the audit is
+                  completed; each CELL repeats that per-row in its title. */}
               <Th className="text-right">
-                {AUDIT_ASSET_STATUS_LABELS.PENDING}
+                <span className="inline-flex items-center gap-1">
+                  {AUDIT_ASSET_STATUS_LABELS.PENDING}
+                  <InfoTooltip
+                    iconClassName="size-3.5"
+                    content={
+                      <p className="text-sm text-gray-600">
+                        Expected assets that have not been scanned. Once an
+                        audit is completed these are reported as &ldquo;
+                        {AUDIT_ASSET_STATUS_LABELS.MISSING}&rdquo; on its
+                        overview page.
+                      </p>
+                    }
+                  />
+                </span>
               </Th>
               <Th className="text-right">Unexpected</Th>
             </>
@@ -293,7 +313,16 @@ const ListItemContent = ({ item }: { item: AuditListItem }) => {
         {item.foundAssetCount ?? <EmptyTableValue />}
       </Td>
 
-      <Td className="text-right">
+      {/* why: the header is necessarily state-neutral, but this row is not —
+          `item.completedAt` tells us exactly which word the audit's own
+          overview page uses for this number. Surfacing it here keeps the list
+          and the detail page from naming the same count differently. */}
+      <Td
+        className="text-right"
+        title={`${auditAssetStatusLabel("PENDING", isAuditCompleted(item))}: ${
+          item.missingAssetCount ?? 0
+        }`}
+      >
         {item.missingAssetCount ?? <EmptyTableValue />}
       </Td>
 

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -48,6 +48,18 @@ export declare const AUDIT_STATUS_LABELS: {
 };
 
 /**
+ * Who may act on an audit with no specific assignee, in the three registers the
+ * two apps need: `SHORT` for a card's meta line, `A11Y` for the lowercase
+ * fragment joined into a screen-reader announcement, `DETAIL` for the web's
+ * explanatory tooltip. Kept together so they can never disagree.
+ */
+export declare const AUDIT_UNASSIGNED_LABELS: {
+  readonly SHORT: "Unassigned · admins can scan";
+  readonly A11Y: "unassigned, admins can scan";
+  readonly DETAIL: "Workspace admins and owners can perform this audit because it has no specific assignee.";
+};
+
+/**
  * Per-asset audit outcome (AuditAssetStatus in the Prisma schema).
  *
  * PENDING reads "Not scanned", not "Expected"/"Pending"/"Remaining": all of
@@ -71,13 +83,30 @@ export type AuditAssetStatusLabel =
   (typeof AUDIT_ASSET_STATUS_LABELS)[AuditAssetStatusKey];
 
 /**
+ * The single derivation of the completion flag every audit label depends on.
+ *
+ * Reads `completedAt`, never `status`: archiving a completed audit rewrites the
+ * status to ARCHIVED while keeping the timestamp and the finalised counts, so a
+ * status check relabels genuinely missing assets as "Not scanned" on archive.
+ * An archived-CANCELLED audit was never concluded and correctly stays open.
+ *
+ * Accepts a `Date` (Prisma/web) or an ISO string (the companion's JSON), so
+ * both apps can pass their session object straight in.
+ *
+ * @param audit - anything carrying the audit's `completedAt`
+ * @returns true once the audit has been concluded
+ */
+export declare function isAuditCompleted(
+  audit: { completedAt?: Date | string | null } | null | undefined
+): boolean;
+
+/**
  * Label for a per-asset audit status. An expected asset that has not been
  * scanned only becomes "Missing" once the audit is completed.
  *
  * @param status - the stored AuditAssetStatus
- * @param isAuditCompleted - derive this from the audit's `completedAt`, not its
- *   status: archiving a completed audit rewrites the status to ARCHIVED while
- *   keeping the completion timestamp and the finalised counts.
+ * @param isAuditCompleted - derive this with {@link isAuditCompleted}, never
+ *   from the audit's status
  * @returns the words to show for that status
  */
 export declare function auditAssetStatusLabel(

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -54,8 +54,8 @@ export declare const AUDIT_STATUS_LABELS: {
  * explanatory tooltip. Kept together so they can never disagree.
  */
 export declare const AUDIT_UNASSIGNED_LABELS: {
-  readonly SHORT: "Unassigned · admins can scan";
-  readonly A11Y: "unassigned, admins can scan";
+  readonly SHORT: "Unassigned · admins and owners can scan";
+  readonly A11Y: "unassigned, admins and owners can scan";
   readonly DETAIL: "Workspace admins and owners can perform this audit because it has no specific assignee.";
 };
 

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -33,3 +33,32 @@ export declare const BOOKING_STATUS_LABELS: {
   readonly ARCHIVED: "Archived";
   readonly CANCELLED: "Cancelled";
 };
+
+export declare const AUDIT_STATUS_LABELS: {
+  readonly PENDING: "Pending";
+  readonly ACTIVE: "Active";
+  readonly COMPLETED: "Completed";
+  readonly CANCELLED: "Cancelled";
+  readonly ARCHIVED: "Archived";
+};
+
+export declare const AUDIT_ASSET_STATUS_LABELS: {
+  readonly PENDING: "Not scanned";
+  readonly FOUND: "Found";
+  readonly MISSING: "Missing";
+  readonly UNEXPECTED: "Unexpected";
+};
+
+export type AuditAssetStatusKey = keyof typeof AUDIT_ASSET_STATUS_LABELS;
+
+export type AuditAssetStatusLabel =
+  (typeof AUDIT_ASSET_STATUS_LABELS)[AuditAssetStatusKey];
+
+/**
+ * Label for a per-asset audit status. An expected asset that has not been
+ * scanned only becomes "Missing" once the audit is completed.
+ */
+export declare function auditAssetStatusLabel(
+  status: AuditAssetStatusKey,
+  isAuditCompleted: boolean
+): AuditAssetStatusLabel;

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -34,6 +34,11 @@ export declare const BOOKING_STATUS_LABELS: {
   readonly CANCELLED: "Cancelled";
 };
 
+/**
+ * Audit session lifecycle (AuditStatus in the Prisma schema). Covers ARCHIVED,
+ * which a hand-written status chain on the companion used to fall through to
+ * "Cancelled".
+ */
 export declare const AUDIT_STATUS_LABELS: {
   readonly PENDING: "Pending";
   readonly ACTIVE: "Active";
@@ -42,6 +47,15 @@ export declare const AUDIT_STATUS_LABELS: {
   readonly ARCHIVED: "Archived";
 };
 
+/**
+ * Per-asset audit outcome (AuditAssetStatus in the Prisma schema).
+ *
+ * PENDING reads "Not scanned", not "Expected"/"Pending"/"Remaining": all of
+ * those were live at once for one and the same set of assets, and "Expected"
+ * was already taken by the tile counting EVERY expected asset. Prefer
+ * {@link auditAssetStatusLabel} over indexing this map for PENDING, since only
+ * that helper applies the completion rule.
+ */
 export declare const AUDIT_ASSET_STATUS_LABELS: {
   readonly PENDING: "Not scanned";
   readonly FOUND: "Found";
@@ -49,14 +63,22 @@ export declare const AUDIT_ASSET_STATUS_LABELS: {
   readonly UNEXPECTED: "Unexpected";
 };
 
+/** Enum keys of {@link AUDIT_ASSET_STATUS_LABELS} — the Prisma status values. */
 export type AuditAssetStatusKey = keyof typeof AUDIT_ASSET_STATUS_LABELS;
 
+/** The user-facing strings those keys resolve to. */
 export type AuditAssetStatusLabel =
   (typeof AUDIT_ASSET_STATUS_LABELS)[AuditAssetStatusKey];
 
 /**
  * Label for a per-asset audit status. An expected asset that has not been
  * scanned only becomes "Missing" once the audit is completed.
+ *
+ * @param status - the stored AuditAssetStatus
+ * @param isAuditCompleted - derive this from the audit's `completedAt`, not its
+ *   status: archiving a completed audit rewrites the status to ARCHIVED while
+ *   keeping the completion timestamp and the finalised counts.
+ * @returns the words to show for that status
  */
 export declare function auditAssetStatusLabel(
   status: AuditAssetStatusKey,

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -57,3 +57,52 @@ export const BOOKING_STATUS_LABELS = Object.freeze({
   ARCHIVED: "Archived",
   CANCELLED: "Cancelled",
 });
+
+// Audit session status enum (AuditStatus in the Prisma schema).
+export const AUDIT_STATUS_LABELS = Object.freeze({
+  PENDING: "Pending",
+  ACTIVE: "Active",
+  COMPLETED: "Completed",
+  CANCELLED: "Cancelled",
+  ARCHIVED: "Archived",
+});
+
+// Per-asset audit status (AuditAssetStatus in the Prisma schema).
+//
+// PENDING is deliberately "Not scanned", not "Expected"/"Pending"/"Remaining":
+// all three were in use at once (web rows said "Expected", the web statistics
+// tile said "Missing", mobile said "Pending", the mobile scanner said
+// "Remaining") for one and the same set of assets. "Expected" was already
+// taken by the tile that counts EVERY expected asset, so the not-yet-scanned
+// subset needs a word of its own.
+//
+// MISSING is only true once the audit is completed — that is when the
+// completion flow turns unscanned rows into MISSING. Before completion, use
+// PENDING's label. `auditAssetStatusLabel` below encodes that rule; call it
+// instead of indexing this map directly.
+export const AUDIT_ASSET_STATUS_LABELS = Object.freeze({
+  PENDING: "Not scanned",
+  FOUND: "Found",
+  MISSING: "Missing",
+  UNEXPECTED: "Unexpected",
+});
+
+/**
+ * Resolves the user-facing label for an expected-but-unscanned asset.
+ *
+ * Nothing is "missing" until the audit is closed: while it is still running the
+ * asset simply has not been reached yet. Both apps must apply this rule, so it
+ * lives here next to the strings rather than in either app.
+ *
+ * @param {"PENDING"|"FOUND"|"MISSING"|"UNEXPECTED"} status
+ * @param {boolean} isAuditCompleted
+ * @returns {string}
+ */
+export function auditAssetStatusLabel(status, isAuditCompleted) {
+  if (status === "PENDING") {
+    return isAuditCompleted
+      ? AUDIT_ASSET_STATUS_LABELS.MISSING
+      : AUDIT_ASSET_STATUS_LABELS.PENDING;
+  }
+  return AUDIT_ASSET_STATUS_LABELS[status];
+}

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -67,6 +67,19 @@ export const AUDIT_STATUS_LABELS = Object.freeze({
   ARCHIVED: "Archived",
 });
 
+// Who may act on an audit that has no specific assignee. One idea, three
+// registers — a compact card line, the screen-reader variant that gets joined
+// into a comma-separated announcement, and the prose used where there is room
+// to explain (the web's "Not assigned" tooltip). They live together so the
+// three can never say different things about who is allowed to scan; before
+// this, the sentence was hand-copied to six call sites across both apps.
+export const AUDIT_UNASSIGNED_LABELS = Object.freeze({
+  SHORT: "Unassigned · admins can scan",
+  A11Y: "unassigned, admins can scan",
+  DETAIL:
+    "Workspace admins and owners can perform this audit because it has no specific assignee.",
+});
+
 // Per-asset audit status (AuditAssetStatus in the Prisma schema).
 //
 // PENDING is deliberately "Not scanned", not "Expected"/"Pending"/"Remaining":
@@ -88,6 +101,28 @@ export const AUDIT_ASSET_STATUS_LABELS = Object.freeze({
 });
 
 /**
+ * The ONE derivation of the "is this audit concluded?" flag every audit label
+ * depends on. Read `completedAt`, never `status`.
+ *
+ * why: `completedAt` is the provenance — it is written only by the completion
+ * flow and survives everything that happens afterwards. `status` does not:
+ * archiving a completed audit rewrites it to ARCHIVED while keeping the
+ * timestamp and the finalised counts, so a status check silently relabels
+ * genuinely missing assets as "Not scanned" the moment someone archives. The
+ * inverse holds too — an archived-CANCELLED audit was never concluded, and
+ * `completedAt` correctly keeps it on the open-audit wording.
+ *
+ * Both apps and every surface within them must agree, so the rule lives here
+ * next to the strings it feeds rather than being re-derived per component.
+ *
+ * @param {{ completedAt?: Date | string | null } | null | undefined} audit
+ * @returns {boolean}
+ */
+export function isAuditCompleted(audit) {
+  return audit?.completedAt != null;
+}
+
+/**
  * Resolves the user-facing label for an expected-but-unscanned asset.
  *
  * Nothing is "missing" until the audit is closed: while it is still running the
@@ -95,7 +130,7 @@ export const AUDIT_ASSET_STATUS_LABELS = Object.freeze({
  * lives here next to the strings rather than in either app.
  *
  * @param {"PENDING"|"FOUND"|"MISSING"|"UNEXPECTED"} status
- * @param {boolean} isAuditCompleted
+ * @param {boolean} isAuditCompleted - derive with {@link isAuditCompleted}
  * @returns {string}
  */
 export function auditAssetStatusLabel(status, isAuditCompleted) {

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -73,9 +73,18 @@ export const AUDIT_STATUS_LABELS = Object.freeze({
 // to explain (the web's "Not assigned" tooltip). They live together so the
 // three can never say different things about who is allowed to scan; before
 // this, the sentence was hand-copied to six call sites across both apps.
+//
+// All three name BOTH roles because the server allows both: requireAuditAssignee
+// returns early for any caller that is not BASE/SELF_SERVICE, so ADMIN and OWNER
+// are exactly the set who may scan an unassigned audit. Naming only admins was
+// an earlier reading — that the invite dialog never surfaces OWNER as a role, so
+// users would not recognise the word — but the web tooltip has always said
+// "admins and owners", which meant an owner on the phone was told they could not
+// do a thing the same product told them they could on the web.
+// Pinned by the AUDIT_UNASSIGNED_LABELS tests in the webapp.
 export const AUDIT_UNASSIGNED_LABELS = Object.freeze({
-  SHORT: "Unassigned · admins can scan",
-  A11Y: "unassigned, admins can scan",
+  SHORT: "Unassigned · admins and owners can scan",
+  A11Y: "unassigned, admins and owners can scan",
   DETAIL:
     "Workspace admins and owners can perform this audit because it has no specific assignee.",
 });


### PR DESCRIPTION
Found while walking the same workspace on web and on the companion side by side.

## Problem

**Four names for one thing.** An audit with 14 expected and 3 found described the other 11 as:

| Surface | Word |
| --- | --- |
| Web statistics tile | Missing |
| Web asset rows | Expected |
| Companion audit detail | Pending |
| Companion scanner tab | Remaining |

**And one of them was untrue.** `missingAssetCount` is seeded with the full expected count when an audit is created (`service.server.ts:293`) and only decrements as assets are found. A brand-new, never-started audit therefore reported every asset as *Missing*. Assets only genuinely become MISSING when the completion flow marks the unscanned ones (`service.server.ts:1697`).

Audits were the one domain `@shelf/labels` did not cover. That package exists, in its own words, so terminology "never drifts" — and bookings and asset statuses, which it does cover, have not drifted.

## Fix

- `@shelf/labels` gains `AUDIT_STATUS_LABELS`, `AUDIT_ASSET_STATUS_LABELS` and `auditAssetStatusLabel(status, isAuditCompleted)`, which owns the rule: **Not scanned** until the audit is completed, **Missing** after.
- Web statistics tile is now completion-aware, matching the asset rows, which already were.
- Web audits list column header becomes "Not scanned" — that column spans audits in every state, and "not scanned" is true in both (a missing asset is one that was never scanned), while "Missing" was not.
- Companion filter chips, row badges, hero count and scanner tab all read the shared map.
- The companion also told users an unassigned audit meant "anyone can scan". BASE and SELF_SERVICE users get refused by `requireAuditAssignee`, so it now names admins and owners, and the line wraps instead of truncating mid-word.

## Verified

Rendered, not reasoned about:

- **Web, pending audit:** tile and all three rows read "Not scanned".
- **Web, completed audit:** tile reads "Missing 0", rows read Found / Unexpected. Unchanged.
- **Web audits list:** column header reads "Not scanned"; the two never-started audits no longer claim missing assets.
- **Companion (iPhone 17 simulator, same workspace):** hero "11 not scanned", filter chip and row badge "Not scanned", ownership line "Unassigned · admins and owners can scan" on two lines.

249 audit module tests and 102 layout route tests pass, including a new regression test pinning the completion rule. Webapp and companion typecheck clean, companion lint clean.

The companion half ships with the next companion build; the web half ships on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved audit status labels across web and mobile views.
  * Active audits now show pending assets as “Not scanned”; completed audits show them as “Missing.”
  * Updated filters, dropdowns, progress summaries, empty states, and accessibility text to reflect audit status.
  * Unassigned audits now indicate that only admins can scan them.
  * Ownership text can wrap to two lines for improved readability.

* **Bug Fixes**
  * Standardized status labels and badge behavior across audit screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->