### PR TITLE
fix(tooling): answer Parameter findings, and correct QR link docs #2844 falsified

### DIFF
--- a/apps/companion/app/(tabs)/assets/link-qr.tsx
+++ b/apps/companion/app/(tabs)/assets/link-qr.tsx
@@ -1,9 +1,10 @@
 /**
  * Link-QR asset picker screen.
  *
- * Reached from the scanner after an unclaimed QR code is claimed into the
- * current workspace (or directly for a code the org already claimed but never
- * linked). Presents a searchable, paginated list of the workspace's assets;
+ * Reached from the scanner for a code the org already claimed but never
+ * linked, and directly for an UNCLAIMED code — the link endpoint claims those
+ * inline, so there is no separate claim step before this screen.
+ * Presents a searchable, paginated list of the workspace's assets;
  * selecting one links the scanned QR to it via `POST /api/mobile/qr/link-asset`
  * and navigates to the asset's detail.
  *
@@ -102,9 +103,15 @@ function LinkQrContent() {
   /**
    * Workspace-switch guard (mirrors the scanner's originOrgId pin): the
    * scanned `qrId` belongs to the workspace that was active when the picker
-   * opened. If the user switches workspaces mid-flow, the list would show
-   * the NEW org's assets while the link targets the OLD org's code — the
-   * server would 403 on confirm, a confusing dead end. Leave instead.
+   * opened. If the user switches workspaces mid-flow, the list would show the
+   * NEW org's assets while the link targets the OLD org's code.
+   *
+   * why this guard is load-bearing, not cosmetic: do NOT justify it with "the
+   * server would 403 anyway". For a code the previous org already OWNS that is
+   * true, but for an UNCLAIMED code it is not — `relinkAssetQrCode` claims
+   * inline into whichever org is active, so confirming after a switch would
+   * silently claim the label into the WRONG workspace. There is no unclaim.
+   * This guard is the only thing preventing that; removing it is not safe.
    */
   const originOrgIdRef = useRef(currentOrg?.id);
   useEffect(() => {

--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -752,10 +752,12 @@ function ScannerContent() {
                 : null;
 
             if (unclaimedQrId && canManageQrCodes) {
-              // Admin/owner: native takeover of the web claim flow. Both
-              // actions claim the code into the CURRENT workspace first,
-              // then continue in-app (create form links on submit; the
-              // picker links an existing asset).
+              // Admin/owner: native takeover of the web claim flow. The two
+              // actions claim at DIFFERENT points, deliberately: "Create New
+              // Asset" claims up front (the create form needs an owned code),
+              // while "Link Existing Asset" does not claim at all here — the
+              // link endpoint claims inline, so abandoning the picker leaves
+              // the label unclaimed for anyone. See each action below.
               setScanResult({
                 type: "not_found",
                 title: "Unclaimed Code",

--- a/apps/companion/lib/api/assets.ts
+++ b/apps/companion/lib/api/assets.ts
@@ -130,9 +130,11 @@ export const assetsApi = {
    * deliberately offers no org picker (web does).
    *
    * Admin/owner only: the server gates on `qr:update`, which no role below
-   * ADMIN holds. A 403 also covers the already-claimed race (the server wraps
-   * it with a generic "Failed to claim qr code"), so callers should re-resolve
-   * the code on failure instead of trusting the message text.
+   * ADMIN holds. A 403 also covers the already-claimed race. The server now
+   * rethrows its own guard errors instead of re-wrapping them, so that 403
+   * carries a specific message ("already belongs to an organization") rather
+   * than the old generic "Failed to claim qr code" — but still branch on
+   * status, not message text.
    *
    * @param orgId - Caller's current workspace id (the claim target).
    * @param qrId - The unclaimed QR id (echoed by the resolve error payload).
@@ -149,17 +151,22 @@ export const assetsApi = {
     }),
 
   /**
-   * Link a claimed-but-unlinked QR code to an existing asset
-   * (`POST /api/mobile/qr/link-asset`). Replaces the asset's current QR codes
-   * (web parity — the web confirm dialog carries the same warning), so the
-   * picker's confirm step must warn about that. A 400 whose
-   * `errorDetails.reason === "unclaimed"` means the claim didn't stick —
-   * re-run {@link claimQr} and retry.
+   * Link a QR code to an existing asset (`POST /api/mobile/qr/link-asset`).
+   * Replaces the asset's current QR codes (web parity — the web confirm dialog
+   * carries the same warning), so the picker's confirm step must warn about
+   * that.
+   *
+   * The code does NOT need to be claimed first: the route delegates to
+   * `relinkAssetQrCode`, which claims an UNCLAIMED code into the caller's org
+   * inline as part of the link. There is consequently no
+   * `errorDetails.reason === "unclaimed"` response from this endpoint any more
+   * — do not write recovery paths against one.
    *
    * Admin/owner only (server gates on `qr:update`, same as the web link flow).
    *
-   * @param orgId - Caller's current workspace id (must own the QR).
-   * @param qrId - The claimed, unlinked QR id.
+   * @param orgId - Caller's current workspace id (must own the QR, or the
+   *   code must be unclaimed — it is then claimed into this org).
+   * @param qrId - The QR id to link; claimed by this org, or unclaimed.
    * @param assetId - The asset (in the caller's org) to link the code to.
    * @returns `{ qr }` summary on success (assetId set) or `{ error }`.
    */
@@ -167,8 +174,12 @@ export const assetsApi = {
     apiFetch<QrMutationResponse>(`/api/mobile/qr/link-asset?orgId=${orgId}`, {
       method: "POST",
       body: JSON.stringify({ qrId, assetId }),
-      // why: not retried — a timed-out-but-landed link would 403 on the
-      // retry ("already linked"), reporting failure for a landed success.
+      // why: not retried. The 403-on-retry rationale no longer applies —
+      // relinking the same {qrId, assetId} is idempotent, since the service
+      // only rejects `qr.assetId && qr.assetId !== assetId`. But a retry can
+      // still LOSE a concurrent race and 403, and it would write a second
+      // "changed QR code" note; the caller's re-resolve fallback is the
+      // honest recovery.
       retry: false,
     }),
 

--- a/apps/companion/lib/api/client.ts
+++ b/apps/companion/lib/api/client.ts
@@ -84,7 +84,8 @@ export type ApiFetchOptions = RequestInit & { retry?: boolean };
  * Structured error payload from the mobile API's `{ error: { … } }` envelope.
  * `message` mirrors the flat `error` string consumers already display.
  * `reason` is an additive machine-readable discriminator some endpoints emit
- * (today: `"unclaimed"` on the QR resolve / link routes), with `qrId` echoing
+ * (today: `"unclaimed"` on the QR RESOLVE routes only — the link route claims
+ * unclaimed codes inline and no longer emits it), with `qrId` echoing
  * the scanned code id whenever `reason` is present. Branch on `reason`, never
  * on `message` text — messages are human copy and can change; the reason
  * field is the wire contract.

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -275,14 +275,15 @@ export type QrResponse = {
 };
 
 /**
- * Machine-readable failure discriminator carried by the QR resolve / link
- * error payloads (`{ error: { message, reason?, qrId? } }`), surfaced client
+ * Machine-readable failure discriminator carried by the QR RESOLVE error
+ * payloads (`{ error: { message, reason?, qrId? } }`), surfaced client
  * side via `apiFetch`'s `errorDetails`. Mirrors the server's
  * `ResolveMobileCodeFailureReason`.
  *
  * `"unclaimed"` — the QR row exists, has no organization yet (a printed
  * Shelf code nobody claimed) and is not linked to an asset or kit. The
- * scanner offers the native claim → create / link flow for it. Absence of a
+ * scanner offers the native claim → create / link flow for it. (The link
+ * route does not emit this: it claims an unclaimed code inline.) Absence of a
  * reason (plain not-found 404, wrong-org 403, or an orgless-but-linked
  * corrupted row the web claim flow refuses) MUST keep the existing dead-end /
  * web-bridge behaviour — never offer claim for those.

--- a/scripts/__tests__/pr-review.test.sh
+++ b/scripts/__tests__/pr-review.test.sh
@@ -96,8 +96,25 @@ assert_eq "bot" "$r" "codex is a bot"
 is_bot "copilot-pull-request-reviewer[bot]" && r=bot || r=human
 assert_eq "bot" "$r" "copilot is a bot"
 
+is_bot "parameterai[bot]"           && r=bot || r=human
+assert_eq "bot" "$r" "parameterai is a bot (REST spelling)"
+
+is_bot "parameterai"                && r=bot || r=human
+assert_eq "bot" "$r" "parameterai is a bot (GraphQL spelling)"
+
 is_bot "DonKoko"                    && r=bot || r=human
 assert_eq "human" "$r" "DonKoko is not a bot"
+
+# why: parameterai is a BOT for classification but is deliberately not awaited
+# for quiescence — see the note at REVIEW_BOT_LOGINS. Pinned so the split is a
+# recorded decision rather than something that reads like an omission (which is
+# exactly how the BOT_LOGINS gap went unnoticed).
+case " $REVIEW_BOT_LOGINS " in
+  *" parameterai "*) r=present ;;
+  *) r=missing ;;
+esac
+assert_eq "missing" "$r" \
+  "parameterai is classified as a bot but not yet awaited for quiescence"
 
 describe "pr-review-watch: fingerprinting"
 

--- a/scripts/pr-review-watch.sh
+++ b/scripts/pr-review-watch.sh
@@ -45,13 +45,28 @@ COLLECT_THREADS_MAX_PAGES="${PR_REVIEW_MAX_THREAD_PAGES:-20}"
 # suffix that REST's user.login includes ("coderabbitai" vs
 # "coderabbitai[bot]") — verified against PR #2770. Normalize before matching
 # or every bot thread is misclassified as a human comment.
-BOT_LOGINS="coderabbitai chatgpt-codex-connector copilot-pull-request-reviewer github-actions"
+#
+# `parameterai` was missing until 2026-08-13, so every Parameter finding was
+# classified `kind: "human"` — which the loop never triages, replies to, or
+# resolves. They accumulated unanswered on every PR (seen on #2844, where it
+# filed a correct cross-tenant finding that sat untouched). Its login is
+# `parameterai[bot]`; note the product was formerly branded "hex sentinel" and
+# its finding bodies STILL carry a `<!-- hex-sentinel-finding-head:… -->`
+# marker, so matching on body text rather than login will mislead you.
+BOT_LOGINS="coderabbitai chatgpt-codex-connector copilot-pull-request-reviewer parameterai github-actions"
 
 # The subset of BOT_LOGINS that actually posts a PR REVIEW (as opposed to a
 # thread comment or, for github-actions, React Doctor's sticky ISSUE
 # comment). Quiescence condition #1 needs to know which bots to wait on for
 # `.reviewedHead` — including github-actions there would make that condition
 # permanently unsatisfiable, since it never appears in the reviews endpoint.
+# NOTE: `parameterai` is deliberately NOT here yet, though it does post real
+# reviews. Adding it makes quiescence wait on it, which is arguably more
+# correct — but the QUIESCENT integration test runs against a real captured
+# fixture from PR #2770, which predates the bot, so it would sit blocked until
+# the 20-minute stale-bot waiver. That needs a fresh fixture, not a doctored
+# one. Leaving it out only costs an occasional early "clean" announcement: its
+# findings are still triaged and still block condition #2 once they arrive.
 REVIEW_BOT_LOGINS="coderabbitai chatgpt-codex-connector copilot-pull-request-reviewer"
 
 # --- state -----------------------------------------------------------------


### PR DESCRIPTION
## Need

Two loose ends from the #2757 / #2844 review cycle. Unrelated to each other, so they're separate commits — read whichever concerns you.

## 1. `docs(companion)` — comments that #2844 made untrue

#2844 routed the mobile link-asset endpoint through `relinkAssetQrCode`, which claims an unclaimed code **inline**. That deleted the `400 { reason: "unclaimed" }` response — but the docs describing it shipped unchanged, so `main` currently documents a contract that no longer exists.

Corrected, comments only, no behaviour change:

| Site | Was | Now |
| --- | --- | --- |
| `lib/api/assets.ts` — `linkQrToAsset` | "a `reason === "unclaimed"` 400 means re-run `claimQr` and retry" | that response no longer exists; the code needn't be claimed first |
| `lib/api/assets.ts` — link `retry: false` | "a landed retry would 403 already-linked" | false — same `qrId`+`assetId` is idempotent; the real risk is losing a race and writing a second note |
| `lib/api/assets.ts` — `claimQr` | "the server wraps it with a generic 'Failed to claim qr code'" | #2844 made `claimQrCode` rethrow its own errors, so the 403 is specific |
| `lib/api/client.ts`, `lib/api/types.ts` | `"unclaimed"` on the "resolve / **link**" routes | resolve routes only |
| `scanner.tsx` | "**Both** actions claim the code into the CURRENT workspace first" | only "Create New Asset" does — and this was contradicted by the comment 16 lines below it |

### ⚠️ The one that mattered

`link-qr.tsx`'s workspace-switch guard — **added by #2844** — justified itself with *"the server would 403 on confirm"*.

That is true for a code the previous org already owns, and **false for an unclaimed one**, which `relinkAssetQrCode` now claims into whichever workspace is active. So a maintainer who checked the rationale would have found it untrue and could reasonably have deleted the guard — at which point confirming after a workspace switch silently claims the physical label into the **wrong workspace**, and there is no unclaim.

The comment now states that the guard is load-bearing and why removing it is unsafe. This is the only part of the PR with a path to user harm.

## 2. `fix(tooling)` — Parameter findings were never answered

`BOT_LOGINS` in `scripts/pr-review-watch.sh` was missing `parameterai`, so every Parameter finding was classified `kind: "human"`. The `/pr-review-loop` never triages, replies to, or resolves human threads by design — so those findings accumulated **unanswered on every PR the loop ran**. Seen on #2844, where Parameter filed a correct cross-tenant finding that sat untouched while both other bots' findings were handled.

Verified against the GitHub API rather than assumed: `parameterai[bot]` is the only Parameter login appearing on recent PRs, in both the reviews and review-comments endpoints, and no `hex-*` login appears anywhere — the rename is already complete on GitHub's side. Its finding bodies do still carry a `<!-- hex-sentinel-finding-head:… -->` marker, which is now recorded in a comment so nobody tries to match on body text instead of login.

### Known follow-up: Parameter is still not awaited for quiescence

I deliberately did **not** add it to `REVIEW_BOT_LOGINS`, though it does post real reviews. Doing so blocks the QUIESCENT integration test, which runs against a **real captured API fixture from PR #2770** that predates the bot — the only way to make it pass would be editing a genuine capture to contain a review that never happened, which isn't a fix.

Cost of leaving it out is an occasional early "clean" announcement; its findings are still triaged and still block quiescence condition #2 once they arrive. A test pins the split so it reads as a decision rather than the same class of omission being fixed here. Doing it properly needs a fresh fixture.

## Test plan

- `pnpm test:tooling` — **212 passed, 0 failed** (4 new assertions: both `parameterai` login spellings, plus the `REVIEW_BOT_LOGINS` split)
- `pnpm --filter @shelf/companion typecheck` — 0 errors
- eslint clean on all five companion files
- The docs commit changes no executable code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linking an existing asset from an unclaimed QR code now completes claiming automatically.
  - Creating a new asset continues to claim the QR code during that flow.

- **Bug Fixes**
  - Prevented abandoned QR labels from being claimed prematurely.
  - Improved QR linking retry and concurrent-use recovery.
  - Added safeguards against claiming codes in the wrong workspace when switching workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->