### PR TITLE
fix(audits,mobile): keep the real audit start time; show model and SAM ID on mobile

### DIFF
--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -642,6 +642,23 @@ export default function AssetDetailScreen() {
                 )}
               />
             )}
+            {asset.assetModel?.name ? (
+              <InfoRow
+                icon="cube-outline"
+                label="Asset Model"
+                value={asset.assetModel.name}
+              />
+            ) : null}
+            {asset.sequentialId ? (
+              // why: the scanner's manual entry accepts a SAM ID, so the app
+              // has to be able to tell you what an asset's SAM ID is. Web has
+              // always shown it as "Asset ID".
+              <InfoRow
+                icon="pricetag-outline"
+                label="Asset ID"
+                value={asset.sequentialId}
+              />
+            ) : null}
             <InfoRow
               icon="calendar-outline"
               label="Created"

--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -654,7 +654,10 @@ export default function AssetDetailScreen() {
               // has to be able to tell you what an asset's SAM ID is. Web has
               // always shown it as "Asset ID".
               <InfoRow
-                icon="pricetag-outline"
+                // `barcode-outline` rather than `pricetag-outline`: the Category
+                // row above already owns the pricetag, and it also matches the
+                // scanner affordance this row exists for.
+                icon="barcode-outline"
                 label="Asset ID"
                 value={asset.sequentialId}
               />

--- a/apps/companion/app/(tabs)/assets/index.tsx
+++ b/apps/companion/app/(tabs)/assets/index.tsx
@@ -253,10 +253,10 @@ function AssetsListContent() {
           onPress={() => router.push(`/(tabs)/assets/${item.id}`)}
           activeOpacity={0.6}
           accessibilityLabel={`${item.title}, ${formatStatus(item.status)}${
-            quantityLabel ? `, quantity ${quantityLabel}` : ""
-          }${item.category ? `, ${item.category.name}` : ""}${
-            item.location ? `, ${item.location.name}` : ""
-          }`}
+            item.sequentialId ? `, ${item.sequentialId}` : ""
+          }${quantityLabel ? `, quantity ${quantityLabel}` : ""}${
+            item.category ? `, ${item.category.name}` : ""
+          }${item.location ? `, ${item.location.name}` : ""}`}
           accessibilityRole="button"
         >
           {item.thumbnailImage || item.mainImage ? (
@@ -276,6 +276,15 @@ function AssetsListContent() {
               {item.title}
             </Text>
             <View style={styles.assetMeta}>
+              {/* Search accepts a SAM ID, so a hit has to be able to show WHICH
+                  id it is — otherwise the row identifies itself by title only
+                  and the user has to open it to find out. Absent on older
+                  servers, where the row renders exactly as before. */}
+              {item.sequentialId ? (
+                <Text style={styles.assetSequentialId} numberOfLines={1}>
+                  {item.sequentialId}
+                </Text>
+              ) : null}
               {item.category && (
                 <Text style={styles.assetCategory} numberOfLines={1}>
                   {item.category.name}
@@ -653,6 +662,12 @@ const useStyles = createStyles((colors, shadows) => ({
   assetLocation: {
     fontSize: fontSize.xs,
     color: colors.mutedLight,
+  },
+  assetSequentialId: {
+    fontSize: fontSize.xs,
+    color: colors.mutedLight,
+    // Tabular so a column of SAM ids lines up while scanning the list.
+    fontVariant: ["tabular-nums"],
   },
 
   // Status badge — pill shape like webapp

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -118,6 +118,12 @@ export type AssetQuantityFields = {
 export type AssetListItem = {
   id: string;
   title: string;
+  /**
+   * Workspace-scoped human ID ("SAM-0017"). Lets a row show WHICH id matched a
+   * SAM-ID search instead of identifying itself by title alone. Absent on older
+   * servers.
+   */
+  sequentialId?: string | null;
   status: string;
   mainImage: string | null;
   thumbnailImage: string | null;
@@ -177,8 +183,12 @@ export type AssetQuantityBreakdown = {
 export type AssetDetail = {
   id: string;
   title: string;
-  /** Workspace-scoped human ID ("SAM-0017"); what the scanner accepts as a SAM ID. */
-  sequentialId: string | null;
+  /**
+   * Workspace-scoped human ID ("SAM-0017"); what the scanner accepts as a SAM
+   * ID. Absent on older servers — this app build ships before the webapp half
+   * reaches every self-hosted deployment.
+   */
+  sequentialId?: string | null;
   description: string | null;
   status: string;
   mainImage: string | null;
@@ -189,8 +199,13 @@ export type AssetDetail = {
   updatedAt: string;
   organizationId: string;
   category: { id: string; name: string; color: string } | null;
-  /** Identity only — cover images arrive pre-resolved in mainImage/thumbnailImage. */
-  assetModel: { id: string; name: string } | null;
+  /**
+   * Name only — cover images arrive pre-resolved in mainImage/thumbnailImage,
+   * and there is no mobile asset-model screen to navigate to. Absent on older
+   * servers, and on the quantity-custody / adjust-quantity responses, which are
+   * shaped from the canonical mobile asset select rather than the detail one.
+   */
+  assetModel?: { name: string } | null;
   location: { id: string; name: string } | null;
   custody: {
     createdAt: string;

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -177,6 +177,8 @@ export type AssetQuantityBreakdown = {
 export type AssetDetail = {
   id: string;
   title: string;
+  /** Workspace-scoped human ID ("SAM-0017"); what the scanner accepts as a SAM ID. */
+  sequentialId: string | null;
   description: string | null;
   status: string;
   mainImage: string | null;
@@ -187,6 +189,8 @@ export type AssetDetail = {
   updatedAt: string;
   organizationId: string;
   category: { id: string; name: string; color: string } | null;
+  /** Identity only — cover images arrive pre-resolved in mainImage/thumbnailImage. */
+  assetModel: { id: string; name: string } | null;
   location: { id: string; name: string } | null;
   custody: {
     createdAt: string;

--- a/apps/webapp/app/modules/activity-event/types.ts
+++ b/apps/webapp/app/modules/activity-event/types.ts
@@ -40,6 +40,13 @@ export type FieldChangeAction =
   | "BOOKING_STATUS_CHANGED"
   | "BOOKING_DATES_CHANGED"
   | "AUDIT_DUE_DATE_CHANGED"
+  // Not named `*_CHANGED`, but shaped like one on purpose: this is a per-field
+  // audit change (today only `status`, when a scan resumes a PENDING audit that
+  // already has a `startedAt`). Listing it here rather than in
+  // `GenericEventInput` is what stops it becoming the umbrella "audit was
+  // updated somehow" event that `record-event-payload-shapes` forbids —
+  // `count(action, field)` has to stay answerable without parsing JSON.
+  | "AUDIT_UPDATED"
   | "ORGANIZATION_QR_ID_DISPLAY_PREFERENCE_CHANGED";
 
 /** Fields shared by every event input. */

--- a/apps/webapp/app/modules/api/mobile-auth.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.test.ts
@@ -51,6 +51,7 @@ const baseAsset = {
   id: "asset-123",
   title: "Test Asset",
   status: "AVAILABLE",
+  sequentialId: "SAM-0123" as string | null,
   mainImage: null,
   thumbnailImage: null,
   assetModel: null as {

--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -338,6 +338,10 @@ export const MOBILE_ASSET_SELECT = {
   id: true,
   title: true,
   status: true,
+  // The workspace-visible identifier ("SAM-0017"). Web shows it on the asset
+  // overview and the scanner invites you to type one, so every mobile surface
+  // that names an asset needs to be able to show WHICH id it is.
+  sequentialId: true,
   mainImage: true,
   thumbnailImage: true,
   // Cover image of the asset's model. `shapeMobileAssetResponse` resolves the
@@ -487,6 +491,8 @@ export type MobileAssetResponse = {
   id: string;
   title: string;
   status: string;
+  /** Workspace-visible identifier, e.g. "SAM-0017". Null until one is assigned. */
+  sequentialId: string | null;
   /** Model this asset belongs to, or null. Drives fulfil-scan matching. */
   assetModelId?: string | null;
   /**
@@ -559,6 +565,7 @@ export function shapeMobileAssetResponse(asset: {
   id: string;
   title: string;
   status: string;
+  sequentialId: string | null;
   mainImage: string | null;
   thumbnailImage: string | null;
   assetModel: { image: string | null; thumbnailImage: string | null } | null;

--- a/apps/webapp/app/modules/audit/helpers.server.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.ts
@@ -222,6 +222,65 @@ export async function createAuditStartedNote({
 }
 
 /**
+ * Creates an automatic note when a previously-started audit is brought back to
+ * ACTIVE by a scan.
+ *
+ * Distinct from {@link createAuditStartedNote}: the audit already has a
+ * `startedAt` and that moment is never rewritten, so the feed must say the
+ * audit was resumed rather than claim a second start.
+ *
+ * @param auditSessionId - The audit being resumed
+ * @param userId - The user whose scan resumed it
+ * @param tx - Prisma transaction client, so the note commits with the status change
+ * @param prefetchedUser - Optional user record fetched outside the transaction
+ */
+export async function createAuditResumedNote({
+  auditSessionId,
+  userId,
+  tx,
+  prefetchedUser,
+}: {
+  auditSessionId: string;
+  userId: string;
+  tx: any; // Prisma transaction client
+  prefetchedUser?: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+  } | null;
+}) {
+  // Use pre-fetched data if available, otherwise fetch inside the transaction
+  const resumer =
+    prefetchedUser ??
+    (await tx.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        displayName: true,
+      },
+    }));
+
+  if (!resumer) {
+    return; // Skip note creation if user not found
+  }
+
+  await tx.auditNote.create({
+    data: {
+      auditSessionId,
+      userId: resumer.id,
+      type: "UPDATE",
+      content: `${wrapUserLinkForNote({
+        id: resumer.id,
+        firstName: resumer.firstName,
+        lastName: resumer.lastName,
+      })} resumed the audit.`,
+    },
+  });
+}
+
+/**
  * Creates a COMMENT note when an audit is completed.
  * The note includes completion stats, receipt link, and any user-provided note/images.
  * Using COMMENT type for better layout (header with user info, content below without indentation).

--- a/apps/webapp/app/modules/audit/helpers.server.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.ts
@@ -1,3 +1,5 @@
+import type { ITXClientDenyList } from "@prisma/client/runtime/library";
+import type { ExtendedPrismaClient } from "~/database/db.server";
 import { stripMarkdocDelimiters } from "~/utils/markdoc-sanitize";
 import {
   wrapAssetsWithDataForNote,
@@ -171,6 +173,74 @@ export async function createAssetScanRemovedNote({
   });
 }
 
+/** The actor fields a lifecycle note needs, when fetched outside the transaction. */
+type PrefetchedNoteActor = {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+} | null;
+
+/**
+ * Writes one audit-lifecycle UPDATE note attributed to the acting user.
+ *
+ * Shared by the start / resume wrappers below: they differ only in the sentence
+ * that follows the user link, so the user lookup, the missing-user early return
+ * and the note write live here once.
+ *
+ * @param auditSessionId - The audit the note belongs to
+ * @param userId - The user who performed the action
+ * @param sentence - Predicate appended after the user link, e.g. "started the audit."
+ * @param tx - Prisma transaction client, so the note commits with the status change
+ * @param prefetchedUser - Optional actor fetched outside the transaction
+ */
+async function createAuditLifecycleNote({
+  auditSessionId,
+  userId,
+  sentence,
+  tx,
+  prefetchedUser,
+}: {
+  auditSessionId: string;
+  userId: string;
+  sentence: string;
+  // why: narrowed to the transaction-client shape (mirrors the precedent in
+  // modules/user/service.server.ts) rather than the `tx: any` this file's older
+  // exports use. The exported wrappers keep `any` to match their siblings;
+  // migrating all of them is a file-wide change, not this one's business.
+  tx: Omit<ExtendedPrismaClient, ITXClientDenyList>;
+  prefetchedUser?: PrefetchedNoteActor;
+}) {
+  // Use pre-fetched data if available, otherwise fetch inside the transaction
+  const actor =
+    prefetchedUser ??
+    (await tx.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        displayName: true,
+      },
+    }));
+
+  if (!actor) {
+    return; // Skip note creation if user not found
+  }
+
+  await tx.auditNote.create({
+    data: {
+      auditSessionId,
+      userId: actor.id,
+      type: "UPDATE",
+      content: `${wrapUserLinkForNote({
+        id: actor.id,
+        firstName: actor.firstName,
+        lastName: actor.lastName,
+      })} ${sentence}`,
+    },
+  });
+}
+
 /**
  * Creates an automatic note when an audit is started (activated from PENDING status).
  * This note records who performed the first scan that activated the audit.
@@ -184,40 +254,14 @@ export async function createAuditStartedNote({
   auditSessionId: string;
   userId: string;
   tx: any; // Prisma transaction client
-  prefetchedUser?: {
-    id: string;
-    firstName: string | null;
-    lastName: string | null;
-  } | null;
+  prefetchedUser?: PrefetchedNoteActor;
 }) {
-  // Use pre-fetched data if available, otherwise fetch inside the transaction
-  const starter =
-    prefetchedUser ??
-    (await tx.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        displayName: true,
-      },
-    }));
-
-  if (!starter) {
-    return; // Skip note creation if user not found
-  }
-
-  await tx.auditNote.create({
-    data: {
-      auditSessionId,
-      userId: starter.id,
-      type: "UPDATE",
-      content: `${wrapUserLinkForNote({
-        id: starter.id,
-        firstName: starter.firstName,
-        lastName: starter.lastName,
-      })} started the audit.`,
-    },
+  await createAuditLifecycleNote({
+    auditSessionId,
+    userId,
+    sentence: "started the audit.",
+    tx,
+    prefetchedUser,
   });
 }
 
@@ -243,40 +287,14 @@ export async function createAuditResumedNote({
   auditSessionId: string;
   userId: string;
   tx: any; // Prisma transaction client
-  prefetchedUser?: {
-    id: string;
-    firstName: string | null;
-    lastName: string | null;
-  } | null;
+  prefetchedUser?: PrefetchedNoteActor;
 }) {
-  // Use pre-fetched data if available, otherwise fetch inside the transaction
-  const resumer =
-    prefetchedUser ??
-    (await tx.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        displayName: true,
-      },
-    }));
-
-  if (!resumer) {
-    return; // Skip note creation if user not found
-  }
-
-  await tx.auditNote.create({
-    data: {
-      auditSessionId,
-      userId: resumer.id,
-      type: "UPDATE",
-      content: `${wrapUserLinkForNote({
-        id: resumer.id,
-        firstName: resumer.firstName,
-        lastName: resumer.lastName,
-      })} resumed the audit.`,
-    },
+  await createAuditLifecycleNote({
+    auditSessionId,
+    userId,
+    sentence: "resumed the audit.",
+    tx,
+    prefetchedUser,
   });
 }
 

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -2,10 +2,14 @@ import { AuditStatus } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "~/database/db.server";
+import { recordEvent } from "~/modules/activity-event/service.server";
 import { ShelfError } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
 import { sendAuditCancelledEmails } from "./email-helpers";
-import { createAuditStartedNote } from "./helpers.server";
+import {
+  createAuditResumedNote,
+  createAuditStartedNote,
+} from "./helpers.server";
 import {
   createAuditSession,
   addAssetsToAudit,
@@ -32,6 +36,7 @@ vi.mock("~/utils/storage.server", () => ({
 vi.mock("./helpers.server", () => ({
   createAuditCreationNote: vi.fn(),
   createAuditStartedNote: vi.fn(),
+  createAuditResumedNote: vi.fn(),
   createAssetScanNote: vi.fn(),
   createAssetsAddedToAuditNote: vi.fn(),
   createAssetRemovedFromAuditNote: vi.fn(),
@@ -75,13 +80,15 @@ vi.mock("~/database/db.server", () => {
   const mockDb = {
     auditSession: {
       create: vi.fn(),
-      // why: the first-start claim is a guarded updateMany inside the tx.
       findUnique: vi.fn(),
       findUniqueOrThrow: vi.fn(),
       findFirst: vi.fn(),
       findFirstOrThrow: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
+      // why: recordAuditScan claims the audit's first start with a guarded
+      // updateMany inside the tx, and reactivates a previously-started audit
+      // with a second one. Both tests below assert on these calls.
       updateMany: vi.fn(),
       delete: vi.fn(),
       deleteMany: vi.fn(),
@@ -101,12 +108,14 @@ vi.mock("~/database/db.server", () => {
     auditAsset: {
       createMany: vi.fn(),
       findMany: vi.fn(),
+      // why: recordAuditScan reads the (auditSessionId, assetId) row to decide
+      // whether the asset was expected, then marks it FOUND. Without these the
+      // transaction rejects partway, and a test that only inspects earlier
+      // calls would still pass.
       findUnique: vi.fn(),
-      // why: recordAuditScan marks the expected asset FOUND and then reads it
-      // back. Without these the transaction rejects partway, and a test that
-      // only inspects earlier calls would still pass.
       findFirst: vi.fn(),
       create: vi.fn(),
+      update: vi.fn(),
       updateMany: vi.fn(),
       delete: vi.fn(),
       deleteMany: vi.fn(),
@@ -159,6 +168,7 @@ const mockDb = db as unknown as {
     createMany: ReturnType<typeof vi.fn>;
     findFirst: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
     updateMany: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
@@ -2193,7 +2203,6 @@ describe("audit service", () => {
       auditSessionId: "audit-1",
       qrId: "qr-1",
       assetId: "asset-1",
-      isExpected: true,
       userId: "user-1",
       organizationId: "org-1",
     };
@@ -2203,15 +2212,29 @@ describe("audit service", () => {
      * a rejected call and asserting on writes that happened before the failure
      * would let these tests pass on a broken scan.
      *
-     * @param claimWins - whether the guarded first-start updateMany matches a
-     *   row, i.e. whether this scan is the audit's genuine first start
+     * The two session `updateMany` calls are stubbed per-call, in the order the
+     * service issues them, because that ORDER is what the tests distinguish:
+     * a lost first-start claim followed by a won reactivation is a resume, and
+     * two lost claims mean another scanner got there first.
+     *
+     * @param claims - `first` = does the guarded first-start claim match a row;
+     *   `resume` = does the follow-up PENDING -> ACTIVE update match one
+     * @param startedAt - the audit's existing start time, if it has one
      */
-    function mockPendingSession(claimWins: boolean) {
+    function mockPendingSession({
+      first,
+      resume = 0,
+      startedAt = null,
+    }: {
+      first: 0 | 1;
+      resume?: 0 | 1;
+      startedAt?: Date | null;
+    }) {
       mockDb.auditSession.findFirst.mockResolvedValue({
         id: "audit-1",
         organizationId: "org-1",
         status: AuditStatus.PENDING,
-        startedAt: claimWins ? null : new Date("2026-06-15T09:19:00.000Z"),
+        startedAt,
         foundAssetCount: 0,
         unexpectedAssetCount: 0,
         missingAssetCount: 0,
@@ -2228,25 +2251,46 @@ describe("audit service", () => {
         title: "Camera",
         organizationId: "org-1",
       });
-      // The claim itself: count 1 only when this scan really is the first.
-      mockDb.auditSession.updateMany.mockResolvedValue({
-        count: claimWins ? 1 : 0,
-      });
+      // why: `vi.clearAllMocks()` clears recorded calls but NOT queued
+      // `mockResolvedValueOnce` values, so an unconsumed one from the previous
+      // test would answer this test's first claim. Reset drains the queue.
+      mockDb.auditSession.updateMany.mockReset();
+      mockDb.auditSession.updateMany
+        .mockResolvedValueOnce({ count: first })
+        .mockResolvedValueOnce({ count: resume });
       mockDb.auditScan.create.mockResolvedValue({ id: "scan-1" });
+      // The asset IS expected in this audit — the service derives that from
+      // this row rather than from the request body.
+      mockDb.auditAsset.findUnique.mockResolvedValue({
+        id: "audit-asset-1",
+        expected: true,
+        status: "PENDING",
+      });
       mockDb.auditAsset.updateMany.mockResolvedValue({ count: 1 });
-      mockDb.auditAsset.findFirst.mockResolvedValue({ id: "audit-asset-1" });
       mockDb.auditSession.update.mockResolvedValue({
         foundAssetCount: 1,
         unexpectedAssetCount: 0,
       });
     }
 
-    /** The guarded claim — the update that decides the first start. */
+    /** The guarded claim — the update that stamps the first start. */
     function firstStartClaim() {
       return (
         mockDb.auditSession.updateMany.mock
           .calls as AuditSessionUpdateManyCall[]
-      ).find((call) => call[0]?.data?.status === AuditStatus.ACTIVE);
+      ).find((call) => call[0]?.data?.startedAt !== undefined);
+    }
+
+    /** The follow-up update that brings a started audit back to ACTIVE. */
+    function reactivation() {
+      return (
+        mockDb.auditSession.updateMany.mock
+          .calls as AuditSessionUpdateManyCall[]
+      ).find(
+        (call) =>
+          call[0]?.data?.status === AuditStatus.ACTIVE &&
+          call[0]?.data?.startedAt === undefined
+      );
     }
 
     beforeEach(() => {
@@ -2257,7 +2301,7 @@ describe("audit service", () => {
     });
 
     it("stamps startedAt and records the start once, on a genuine first scan", async () => {
-      mockPendingSession(true);
+      mockPendingSession({ first: 1 });
 
       // Not caught: a rejection here must fail the test.
       const result = await recordAuditScan(scanInput);
@@ -2272,40 +2316,195 @@ describe("audit service", () => {
         organizationId: "org-1",
       });
       expect(createAuditStartedNote).toHaveBeenCalledTimes(1);
+      // A first start is not also a resume.
+      expect(createAuditResumedNote).not.toHaveBeenCalled();
     });
 
     it("keeps the original startedAt when a started audit is scanned again", async () => {
       // why: production data showed one audit with three "started the audit"
       // entries, its Started field moving to the latest each time. The moment
       // an audit actually began must not be rewritten.
-      mockPendingSession(false);
+      mockPendingSession({
+        first: 0,
+        resume: 1,
+        startedAt: new Date("2026-06-15T09:19:00.000Z"),
+      });
 
       const result = await recordAuditScan(scanInput);
 
       expect(result.scanId).toBe("scan-1");
-      // It is still re-activated, but without a timestamp or a start record.
-      const reactivation = (
-        mockDb.auditSession.updateMany.mock
-          .calls as AuditSessionUpdateManyCall[]
-      ).find(
-        (call) =>
-          call[0]?.data?.status === AuditStatus.ACTIVE &&
-          call[0]?.data?.startedAt === undefined
-      );
-      expect(reactivation).toBeDefined();
+      // It is still re-activated, but without a timestamp...
+      expect(reactivation()).toBeDefined();
+      expect(reactivation()?.[0].data?.startedAt).toBeUndefined();
+      // ...and it reads as a resume, not a second start.
       expect(createAuditStartedNote).not.toHaveBeenCalled();
+      expect(createAuditResumedNote).toHaveBeenCalledTimes(1);
+      // A PENDING -> ACTIVE transition is tracked state, so it leaves an event.
+      expect(recordEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "AUDIT_UPDATED",
+          field: "status",
+          fromValue: AuditStatus.PENDING,
+          toValue: AuditStatus.ACTIVE,
+        }),
+        expect.anything()
+      );
     });
 
-    it("does not record a first start when another scanner won the claim", async () => {
-      // why: two scanners hitting a fresh audit at once both saw PENDING in the
-      // pre-transaction snapshot. Only the one whose guarded update matches a
-      // row may write the note and the AUDIT_STARTED event.
-      mockPendingSession(true);
-      mockDb.auditSession.updateMany.mockResolvedValue({ count: 0 });
+    it("records neither a start nor a resume when another scanner won the claim", async () => {
+      // why: two scanners hitting the same audit at once both saw PENDING in
+      // their pre-transaction snapshot. The loser's first-start claim AND its
+      // reactivation both match zero rows — the audit is already ACTIVE — so it
+      // must stay silent rather than add a duplicate feed entry.
+      mockPendingSession({ first: 0, resume: 0 });
 
       await recordAuditScan(scanInput);
 
       expect(createAuditStartedNote).not.toHaveBeenCalled();
+      expect(createAuditResumedNote).not.toHaveBeenCalled();
+    });
+
+    it("issues no session-status writes at all for an already-ACTIVE audit", async () => {
+      // why: the activation block is gated on the snapshot status. Ungated,
+      // both updates match zero rows on EVERY scan after the first, so a
+      // 500-asset audit paid 1000 wasted round-trips inside a 15s transaction.
+      mockPendingSession({ first: 0, resume: 0 });
+      mockDb.auditSession.findFirst.mockResolvedValue({
+        id: "audit-1",
+        organizationId: "org-1",
+        status: AuditStatus.ACTIVE,
+        startedAt: new Date("2026-06-15T09:19:00.000Z"),
+        foundAssetCount: 0,
+        unexpectedAssetCount: 0,
+        missingAssetCount: 0,
+      });
+
+      await recordAuditScan(scanInput);
+
+      expect(mockDb.auditSession.updateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordAuditScan expectedness and counts", () => {
+    /** Runs the callback straight against the mock db, as $transaction would. */
+    type TransactionCallback = (tx: typeof mockDb) => unknown;
+
+    const scanInput = {
+      auditSessionId: "audit-1",
+      qrId: "qr-1",
+      assetId: "asset-1",
+      userId: "user-1",
+      organizationId: "org-1",
+    };
+
+    /** The count-moving update on the session (increments only). */
+    function countUpdateData() {
+      return mockDb.auditSession.update.mock.calls[0]?.[0]?.data;
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockDb.$transaction.mockImplementation((cb: TransactionCallback) =>
+        cb(mockDb)
+      );
+      // An ACTIVE audit mid-scan, with counts already moved by earlier scans —
+      // the snapshot values that used to be written back verbatim.
+      mockDb.auditSession.findFirst.mockResolvedValue({
+        id: "audit-1",
+        organizationId: "org-1",
+        status: AuditStatus.ACTIVE,
+        startedAt: new Date("2026-06-15T09:19:00.000Z"),
+        expectedAssetCount: 10,
+        foundAssetCount: 4,
+        missingAssetCount: 6,
+        unexpectedAssetCount: 3,
+      });
+      mockDb.auditScan.findFirst.mockResolvedValue(null);
+      mockDb.user.findUnique.mockResolvedValue({
+        id: "user-1",
+        firstName: "Scan",
+        lastName: "User",
+        displayName: "Scan User",
+      });
+      mockDb.asset.findUnique.mockResolvedValue({
+        id: "asset-1",
+        title: "Camera",
+        organizationId: "org-1",
+      });
+      mockDb.auditScan.create.mockResolvedValue({ id: "scan-1" });
+      mockDb.auditSession.update.mockResolvedValue({
+        foundAssetCount: 5,
+        unexpectedAssetCount: 3,
+      });
+    });
+
+    it("never writes a snapshot count back — every field is a relative increment", async () => {
+      // why: `session` is read OUTSIDE the transaction, so writing its absolute
+      // values back for the fields this scan does not move let two concurrent
+      // scanners clobber each other: an unexpected scan's committed
+      // `unexpectedAssetCount` 3 -> 4 was undone by an expected scan writing
+      // its own stale 3 back.
+      mockDb.auditAsset.findUnique.mockResolvedValue({
+        id: "audit-asset-1",
+        expected: true,
+        status: "PENDING",
+      });
+      mockDb.auditAsset.updateMany.mockResolvedValue({ count: 1 });
+
+      await recordAuditScan(scanInput);
+
+      expect(countUpdateData()).toEqual({
+        foundAssetCount: { increment: 1 },
+        missingAssetCount: { increment: -1 },
+        // The untouched field is a no-op increment, NOT the stale literal 3.
+        unexpectedAssetCount: { increment: 0 },
+      });
+    });
+
+    it("treats an asset with no audit row as unexpected, whatever the client believed", async () => {
+      // why: an admin can remove an asset from a still-PENDING audit after a
+      // device cached the expected list. The device then posts isExpected:true,
+      // which used to match zero rows — the scan got no AuditAsset row while
+      // the counts still moved, driving missingAssetCount negative.
+      mockDb.auditAsset.findUnique.mockResolvedValue(null);
+      mockDb.auditAsset.create.mockResolvedValue({ id: "audit-asset-new" });
+
+      const result = await recordAuditScan(scanInput);
+
+      // It becomes a real unexpected row, so notes and photos can attach.
+      expect(mockDb.auditAsset.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ expected: false }),
+        })
+      );
+      expect(result.auditAssetId).toBe("audit-asset-new");
+      expect(countUpdateData()).toEqual({
+        foundAssetCount: { increment: 0 },
+        // Crucially NOT decremented — the asset is not missing, it is not part
+        // of the audit at all.
+        missingAssetCount: { increment: 0 },
+        unexpectedAssetCount: { increment: 1 },
+      });
+    });
+
+    it("does not move the counts twice when a concurrent scan already marked the asset FOUND", async () => {
+      // why: the duplicate-scan short-circuit runs OUTSIDE the transaction, so
+      // two scanners can both reach the FOUND update for the same asset. The
+      // status-guarded updateMany matches for only one of them.
+      mockDb.auditAsset.findUnique.mockResolvedValue({
+        id: "audit-asset-1",
+        expected: true,
+        status: "PENDING",
+      });
+      mockDb.auditAsset.updateMany.mockResolvedValue({ count: 0 });
+
+      await recordAuditScan(scanInput);
+
+      expect(countUpdateData()).toEqual({
+        foundAssetCount: { increment: 0 },
+        missingAssetCount: { increment: 0 },
+        unexpectedAssetCount: { increment: 0 },
+      });
     });
   });
 

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -5,6 +5,7 @@ import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
 import { sendAuditCancelledEmails } from "./email-helpers";
+import { createAuditStartedNote } from "./helpers.server";
 import {
   createAuditSession,
   addAssetsToAudit,
@@ -29,6 +30,7 @@ vi.mock("~/utils/storage.server", () => ({
 // why: Mock the helper functions that create automatic notes to avoid database dependencies in unit tests
 vi.mock("./helpers.server", () => ({
   createAuditCreationNote: vi.fn(),
+  createAuditStartedNote: vi.fn(),
   createAssetScanNote: vi.fn(),
   createAssetsAddedToAuditNote: vi.fn(),
   createAssetRemovedFromAuditNote: vi.fn(),
@@ -2157,6 +2159,79 @@ describe("audit service", () => {
         status: 404,
         shouldBeCaptured: false,
       });
+    });
+  });
+
+  describe("recordAuditScan start stamping", () => {
+    const scanInput = {
+      auditSessionId: "audit-1",
+      qrId: "qr-1",
+      assetId: "asset-1",
+      isExpected: true,
+      userId: "user-1",
+      organizationId: "org-1",
+    };
+
+    /** A PENDING session whose startedAt is whatever the test needs. */
+    function mockPendingSession(startedAt: Date | null) {
+      mockDb.auditSession.findFirst.mockResolvedValue({
+        id: "audit-1",
+        organizationId: "org-1",
+        status: AuditStatus.PENDING,
+        startedAt,
+        foundAssetCount: 0,
+        unexpectedAssetCount: 0,
+        missingAssetCount: 0,
+      });
+      mockDb.auditScan.findFirst.mockResolvedValue(null);
+      mockDb.user.findUnique.mockResolvedValue({
+        id: "user-1",
+        firstName: "Scan",
+        lastName: "User",
+        displayName: "Scan User",
+      });
+      mockDb.asset.findUnique.mockResolvedValue({
+        id: "asset-1",
+        title: "Camera",
+        organizationId: "org-1",
+      });
+      mockDb.auditScan.create.mockResolvedValue({ id: "scan-1" });
+      mockDb.auditAsset.findUnique.mockResolvedValue({ id: "audit-asset-1" });
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockDb.$transaction.mockImplementation((cb: any) => cb(mockDb));
+    });
+
+    it("stamps startedAt on the genuine first start", async () => {
+      mockPendingSession(null);
+
+      await recordAuditScan(scanInput).catch(() => {});
+
+      const update = mockDb.auditSession.update.mock.calls.find(
+        (c: any) => c[0]?.data?.status === AuditStatus.ACTIVE
+      );
+      expect(update).toBeDefined();
+      expect(update?.[0].data.startedAt).toBeInstanceOf(Date);
+      expect(createAuditStartedNote).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the original startedAt when a started audit is scanned again", async () => {
+      // why: production data showed one audit with three "started the audit"
+      // entries, its Started field moving to the latest each time. The moment
+      // an audit actually began must not be rewritten.
+      const original = new Date("2026-06-15T09:19:00.000Z");
+      mockPendingSession(original);
+
+      await recordAuditScan(scanInput).catch(() => {});
+
+      const update = mockDb.auditSession.update.mock.calls.find(
+        (c: any) => c[0]?.data?.status === AuditStatus.ACTIVE
+      );
+      expect(update).toBeDefined();
+      expect(update?.[0].data).not.toHaveProperty("startedAt");
+      expect(createAuditStartedNote).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -2173,6 +2173,21 @@ describe("audit service", () => {
   });
 
   describe("recordAuditScan start stamping", () => {
+    /** The shape of an `auditSession.updateMany` call this block asserts on. */
+    type AuditSessionUpdateManyCall = [
+      {
+        where?: {
+          status?: AuditStatus;
+          startedAt?: Date | null;
+          organizationId?: string;
+        };
+        data?: { status?: AuditStatus; startedAt?: Date };
+      },
+    ];
+
+    /** Runs the callback straight against the mock db, as $transaction would. */
+    type TransactionCallback = (tx: typeof mockDb) => unknown;
+
     const scanInput = {
       auditSessionId: "audit-1",
       qrId: "qr-1",
@@ -2227,14 +2242,17 @@ describe("audit service", () => {
 
     /** The guarded claim — the update that decides the first start. */
     function firstStartClaim() {
-      return mockDb.auditSession.updateMany.mock.calls.find(
-        (call: any) => call[0]?.data?.status === AuditStatus.ACTIVE
-      );
+      return (
+        mockDb.auditSession.updateMany.mock
+          .calls as AuditSessionUpdateManyCall[]
+      ).find((call) => call[0]?.data?.status === AuditStatus.ACTIVE);
     }
 
     beforeEach(() => {
       vi.clearAllMocks();
-      mockDb.$transaction.mockImplementation((cb: any) => cb(mockDb));
+      mockDb.$transaction.mockImplementation((cb: TransactionCallback) =>
+        cb(mockDb)
+      );
     });
 
     it("stamps startedAt and records the start once, on a genuine first scan", async () => {
@@ -2245,7 +2263,7 @@ describe("audit service", () => {
 
       expect(result.scanId).toBe("scan-1");
       const claim = firstStartClaim();
-      expect(claim?.[0].data.startedAt).toBeInstanceOf(Date);
+      expect(claim?.[0].data?.startedAt).toBeInstanceOf(Date);
       // The claim can only match an audit that has never been started.
       expect(claim?.[0].where).toMatchObject({
         status: AuditStatus.PENDING,
@@ -2265,8 +2283,11 @@ describe("audit service", () => {
 
       expect(result.scanId).toBe("scan-1");
       // It is still re-activated, but without a timestamp or a start record.
-      const reactivation = mockDb.auditSession.updateMany.mock.calls.find(
-        (call: any) =>
+      const reactivation = (
+        mockDb.auditSession.updateMany.mock
+          .calls as AuditSessionUpdateManyCall[]
+      ).find(
+        (call) =>
           call[0]?.data?.status === AuditStatus.ACTIVE &&
           call[0]?.data?.startedAt === undefined
       );

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -113,6 +113,9 @@ vi.mock("~/database/db.server", () => {
       // transaction rejects partway, and a test that only inspects earlier
       // calls would still pass.
       findUnique: vi.fn(),
+      // why: the unexpected-asset insert is idempotent — createMany with
+      // skipDuplicates, then a re-read — so both are on the scan hot path.
+      findUniqueOrThrow: vi.fn(),
       findFirst: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
@@ -166,6 +169,7 @@ const mockDb = db as unknown as {
   };
   auditAsset: {
     createMany: ReturnType<typeof vi.fn>;
+    findUniqueOrThrow: ReturnType<typeof vi.fn>;
     findFirst: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
@@ -2467,14 +2471,22 @@ describe("audit service", () => {
       // which used to match zero rows — the scan got no AuditAsset row while
       // the counts still moved, driving missingAssetCount negative.
       mockDb.auditAsset.findUnique.mockResolvedValue(null);
-      mockDb.auditAsset.create.mockResolvedValue({ id: "audit-asset-new" });
+      // why: the insert is idempotent (ON CONFLICT DO NOTHING) and the row is
+      // re-read afterwards, so both mocks are needed. count 1 = we inserted it.
+      mockDb.auditAsset.createMany.mockResolvedValue({ count: 1 });
+      mockDb.auditAsset.findUniqueOrThrow.mockResolvedValue({
+        id: "audit-asset-new",
+        expected: false,
+        status: "UNEXPECTED",
+      });
 
       const result = await recordAuditScan(scanInput);
 
       // It becomes a real unexpected row, so notes and photos can attach.
-      expect(mockDb.auditAsset.create).toHaveBeenCalledWith(
+      expect(mockDb.auditAsset.createMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ expected: false }),
+          data: [expect.objectContaining({ expected: false })],
+          skipDuplicates: true,
         })
       );
       expect(result.auditAssetId).toBe("audit-asset-new");
@@ -2484,6 +2496,114 @@ describe("audit service", () => {
         // of the audit at all.
         missingAssetCount: { increment: 0 },
         unexpectedAssetCount: { increment: 1 },
+      });
+    });
+
+    it("records the scan instead of a 500 when a concurrent scanner inserted the row first", async () => {
+      // why: the read and the insert are not atomic and the duplicate-scan
+      // short-circuit runs outside the transaction, so two scanners can both
+      // find no row. A plain create made the loser fail with Prisma P2002,
+      // which neither isLikeShelfError nor isAuditAssetFkViolation (P2003 only)
+      // recognises — a captured 500 that rolled the loser's whole scan back.
+      mockDb.auditAsset.findUnique.mockResolvedValue(null);
+      // count 0 = ON CONFLICT DO NOTHING skipped our row; the winner's persisted.
+      mockDb.auditAsset.createMany.mockResolvedValue({ count: 0 });
+      mockDb.auditAsset.findUniqueOrThrow.mockResolvedValue({
+        id: "audit-asset-winner",
+        expected: false,
+        status: "UNEXPECTED",
+      });
+
+      const result = await recordAuditScan(scanInput);
+
+      // The loser's scan still lands, attached to the winner's row...
+      expect(result.scanId).toBe("scan-1");
+      expect(result.auditAssetId).toBe("audit-asset-winner");
+      expect(mockDb.auditScan.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { auditAssetId: "audit-asset-winner" },
+        })
+      );
+      // ...and contributes NO count movement: the winner already counted it.
+      expect(countUpdateData()).toEqual({
+        foundAssetCount: { increment: 0 },
+        missingAssetCount: { increment: 0 },
+        unexpectedAssetCount: { increment: 0 },
+      });
+    });
+
+    it("marks the asset FOUND when the insert lost to an admin adding it as expected", async () => {
+      // why: addAssetsToAudit inserts expected rows and only requires the audit
+      // to be PENDING, so it can commit between this scan's read and its insert.
+      // The scanned asset must not be left PENDING — completion would then
+      // report an asset that was physically scanned as missing.
+      mockDb.auditAsset.findUnique.mockResolvedValue(null);
+      mockDb.auditAsset.createMany.mockResolvedValue({ count: 0 });
+      mockDb.auditAsset.findUniqueOrThrow.mockResolvedValue({
+        id: "audit-asset-expected",
+        expected: true,
+        status: "PENDING",
+      });
+      mockDb.auditAsset.updateMany.mockResolvedValue({ count: 1 });
+
+      await recordAuditScan(scanInput);
+
+      expect(mockDb.auditAsset.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: "FOUND" }),
+        })
+      );
+      expect(countUpdateData()).toEqual({
+        foundAssetCount: { increment: 1 },
+        missingAssetCount: { increment: -1 },
+        unexpectedAssetCount: { increment: 0 },
+      });
+    });
+
+    it("refreshes a surviving unexpected row and counts it when its status drifted", async () => {
+      // why: removing a scan can leave the AuditAsset row behind. Re-scanning
+      // must reuse that row (the unique constraint rules out a second one) and
+      // re-count it, because the recompute on scan removal only counts rows
+      // whose status is still UNEXPECTED.
+      mockDb.auditAsset.findUnique.mockResolvedValue({
+        id: "audit-asset-stale",
+        expected: false,
+        status: "PENDING",
+      });
+
+      const result = await recordAuditScan(scanInput);
+
+      expect(mockDb.auditAsset.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "audit-asset-stale" },
+          data: expect.objectContaining({ status: "UNEXPECTED" }),
+        })
+      );
+      expect(result.auditAssetId).toBe("audit-asset-stale");
+      expect(countUpdateData()).toEqual({
+        foundAssetCount: { increment: 0 },
+        missingAssetCount: { increment: 0 },
+        unexpectedAssetCount: { increment: 1 },
+      });
+    });
+
+    it("does not re-count an unexpected asset that is already UNEXPECTED", async () => {
+      // why: the counterpart to the test above. A rescan of an already-counted
+      // unexpected asset refreshes its scan metadata but must not inflate
+      // unexpectedAssetCount a second time.
+      mockDb.auditAsset.findUnique.mockResolvedValue({
+        id: "audit-asset-unexpected",
+        expected: false,
+        status: "UNEXPECTED",
+      });
+
+      await recordAuditScan(scanInput);
+
+      expect(mockDb.auditAsset.update).toHaveBeenCalledTimes(1);
+      expect(countUpdateData()).toEqual({
+        foundAssetCount: { increment: 0 },
+        missingAssetCount: { increment: 0 },
+        unexpectedAssetCount: { increment: 0 },
       });
     });
 

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -74,6 +74,7 @@ vi.mock("~/database/db.server", () => {
   const mockDb = {
     auditSession: {
       create: vi.fn(),
+      // why: the first-start claim is a guarded updateMany inside the tx.
       findUnique: vi.fn(),
       findUniqueOrThrow: vi.fn(),
       findFirst: vi.fn(),
@@ -100,6 +101,12 @@ vi.mock("~/database/db.server", () => {
       createMany: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
+      // why: recordAuditScan marks the expected asset FOUND and then reads it
+      // back. Without these the transaction rejects partway, and a test that
+      // only inspects earlier calls would still pass.
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      updateMany: vi.fn(),
       delete: vi.fn(),
       deleteMany: vi.fn(),
     },
@@ -149,6 +156,9 @@ const mockDb = db as unknown as {
   };
   auditAsset: {
     createMany: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
@@ -2172,13 +2182,20 @@ describe("audit service", () => {
       organizationId: "org-1",
     };
 
-    /** A PENDING session whose startedAt is whatever the test needs. */
-    function mockPendingSession(startedAt: Date | null) {
+    /**
+     * Wires the FULL transaction path so `recordAuditScan` resolves. Awaiting
+     * a rejected call and asserting on writes that happened before the failure
+     * would let these tests pass on a broken scan.
+     *
+     * @param claimWins - whether the guarded first-start updateMany matches a
+     *   row, i.e. whether this scan is the audit's genuine first start
+     */
+    function mockPendingSession(claimWins: boolean) {
       mockDb.auditSession.findFirst.mockResolvedValue({
         id: "audit-1",
         organizationId: "org-1",
         status: AuditStatus.PENDING,
-        startedAt,
+        startedAt: claimWins ? null : new Date("2026-06-15T09:19:00.000Z"),
         foundAssetCount: 0,
         unexpectedAssetCount: 0,
         missingAssetCount: 0,
@@ -2195,8 +2212,24 @@ describe("audit service", () => {
         title: "Camera",
         organizationId: "org-1",
       });
+      // The claim itself: count 1 only when this scan really is the first.
+      mockDb.auditSession.updateMany.mockResolvedValue({
+        count: claimWins ? 1 : 0,
+      });
       mockDb.auditScan.create.mockResolvedValue({ id: "scan-1" });
-      mockDb.auditAsset.findUnique.mockResolvedValue({ id: "audit-asset-1" });
+      mockDb.auditAsset.updateMany.mockResolvedValue({ count: 1 });
+      mockDb.auditAsset.findFirst.mockResolvedValue({ id: "audit-asset-1" });
+      mockDb.auditSession.update.mockResolvedValue({
+        foundAssetCount: 1,
+        unexpectedAssetCount: 0,
+      });
+    }
+
+    /** The guarded claim — the update that decides the first start. */
+    function firstStartClaim() {
+      return mockDb.auditSession.updateMany.mock.calls.find(
+        (call: any) => call[0]?.data?.status === AuditStatus.ACTIVE
+      );
     }
 
     beforeEach(() => {
@@ -2204,16 +2237,21 @@ describe("audit service", () => {
       mockDb.$transaction.mockImplementation((cb: any) => cb(mockDb));
     });
 
-    it("stamps startedAt on the genuine first start", async () => {
-      mockPendingSession(null);
+    it("stamps startedAt and records the start once, on a genuine first scan", async () => {
+      mockPendingSession(true);
 
-      await recordAuditScan(scanInput).catch(() => {});
+      // Not caught: a rejection here must fail the test.
+      const result = await recordAuditScan(scanInput);
 
-      const update = mockDb.auditSession.update.mock.calls.find(
-        (c: any) => c[0]?.data?.status === AuditStatus.ACTIVE
-      );
-      expect(update).toBeDefined();
-      expect(update?.[0].data.startedAt).toBeInstanceOf(Date);
+      expect(result.scanId).toBe("scan-1");
+      const claim = firstStartClaim();
+      expect(claim?.[0].data.startedAt).toBeInstanceOf(Date);
+      // The claim can only match an audit that has never been started.
+      expect(claim?.[0].where).toMatchObject({
+        status: AuditStatus.PENDING,
+        startedAt: null,
+        organizationId: "org-1",
+      });
       expect(createAuditStartedNote).toHaveBeenCalledTimes(1);
     });
 
@@ -2221,16 +2259,30 @@ describe("audit service", () => {
       // why: production data showed one audit with three "started the audit"
       // entries, its Started field moving to the latest each time. The moment
       // an audit actually began must not be rewritten.
-      const original = new Date("2026-06-15T09:19:00.000Z");
-      mockPendingSession(original);
+      mockPendingSession(false);
 
-      await recordAuditScan(scanInput).catch(() => {});
+      const result = await recordAuditScan(scanInput);
 
-      const update = mockDb.auditSession.update.mock.calls.find(
-        (c: any) => c[0]?.data?.status === AuditStatus.ACTIVE
+      expect(result.scanId).toBe("scan-1");
+      // It is still re-activated, but without a timestamp or a start record.
+      const reactivation = mockDb.auditSession.updateMany.mock.calls.find(
+        (call: any) =>
+          call[0]?.data?.status === AuditStatus.ACTIVE &&
+          call[0]?.data?.startedAt === undefined
       );
-      expect(update).toBeDefined();
-      expect(update?.[0].data).not.toHaveProperty("startedAt");
+      expect(reactivation).toBeDefined();
+      expect(createAuditStartedNote).not.toHaveBeenCalled();
+    });
+
+    it("does not record a first start when another scanner won the claim", async () => {
+      // why: two scanners hitting a fresh audit at once both saw PENDING in the
+      // pre-transaction snapshot. Only the one whose guarded update matches a
+      // row may write the note and the AUDIT_STARTED event.
+      mockPendingSession(true);
+      mockDb.auditSession.updateMany.mockResolvedValue({ count: 0 });
+
+      await recordAuditScan(scanInput);
+
       expect(createAuditStartedNote).not.toHaveBeenCalled();
     });
   });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1448,13 +1448,10 @@ export async function recordAuditScan(
         //
         // AuditAsset is unique on (auditSessionId, assetId), so that one row is
         // the authority on whether this asset belongs to the audit.
-        const existingAuditAsset = await tx.auditAsset.findUnique({
+        let auditAssetRow = await tx.auditAsset.findUnique({
           where: { auditSessionId_assetId: { auditSessionId, assetId } },
           select: { id: true, expected: true, status: true },
         });
-        const isExpected = existingAuditAsset?.expected === true;
-
-        let auditAssetId: string | null = null;
 
         // Session-count movements for this scan, applied as relative
         // increments below. 0 means "this scan does not move that count".
@@ -1462,23 +1459,65 @@ export async function recordAuditScan(
         let missingDelta = 0;
         let unexpectedDelta = 0;
 
-        // Update or create the audit asset record
-        if (!existingAuditAsset) {
-          // Genuinely unexpected asset - create a new audit asset record
-          const auditAsset = await tx.auditAsset.create({
-            data: {
-              auditSessionId,
-              assetId,
-              expected: false,
-              status: AuditAssetStatus.UNEXPECTED,
-              scannedAt: new Date(),
-              scannedById: userId,
-            },
+        // Tracks whether THIS scan is the one that inserted the row, which is
+        // what decides who owns the unexpected count.
+        let insertedUnexpectedRow = false;
+
+        if (!auditAssetRow) {
+          // The asset is not part of the audit yet — add it as unexpected,
+          // idempotently.
+          //
+          // The read above and this write are not atomic, and the
+          // duplicate-scan short-circuit runs OUTSIDE the transaction, so the
+          // row can appear in between: another scanner recording the same
+          // unexpected asset, or an admin adding it to the still-PENDING audit
+          // as expected (`addAssetsToAudit`). A plain `create` then raises
+          // Prisma P2002 on the (auditSessionId, assetId) unique — which
+          // neither `isLikeShelfError` nor `isAuditAssetFkViolation` (P2003
+          // only) recognises, so it surfaced as a captured 500 and rolled the
+          // whole scan back.
+          //
+          // `skipDuplicates` compiles to ON CONFLICT DO NOTHING, which does not
+          // abort the transaction, and its `count` is exactly the "did WE
+          // insert it" signal the count below needs.
+          const created = await tx.auditAsset.createMany({
+            data: [
+              {
+                auditSessionId,
+                assetId,
+                expected: false,
+                status: AuditAssetStatus.UNEXPECTED,
+                scannedAt: new Date(),
+                scannedById: userId,
+              },
+            ],
+            skipDuplicates: true,
           });
-          auditAssetId = auditAsset.id;
+          insertedUnexpectedRow = created.count === 1;
+
+          // Re-read rather than trust what we tried to write: on a conflict the
+          // winner's row is what persisted, and it may be an EXPECTED row.
+          // ON CONFLICT DO NOTHING waits for the conflicting transaction, so by
+          // now that row is committed and visible to this statement.
+          auditAssetRow = await tx.auditAsset.findUniqueOrThrow({
+            where: { auditSessionId_assetId: { auditSessionId, assetId } },
+            select: { id: true, expected: true, status: true },
+          });
+        }
+
+        const isExpected = auditAssetRow.expected;
+        const auditAssetId = auditAssetRow.id;
+
+        if (insertedUnexpectedRow) {
+          // We created the row, already UNEXPECTED and stamped with this scan.
           unexpectedDelta = 1;
-        } else if (existingAuditAsset.expected) {
+        } else if (auditAssetRow.expected) {
           // Expected asset - update its status to FOUND.
+          //
+          // Reached either normally, or when the insert above lost to an admin
+          // adding this asset to the audit as expected mid-transaction. Both
+          // want the same outcome: a scanned asset must not be left PENDING, or
+          // completion would report it missing.
           //
           // Scoped to a row that is not already FOUND so the counts move
           // exactly once: the duplicate-scan short-circuit above runs outside
@@ -1499,18 +1538,17 @@ export async function recordAuditScan(
             },
           });
 
-          auditAssetId = existingAuditAsset.id;
-
           if (foundClaim.count === 1) {
             foundDelta = 1;
             missingDelta = -1;
           }
         } else {
           // An unexpected row already exists for this asset — its scan was
-          // removed but the row survived. The unique constraint rules out a
-          // second row, so reuse this one and refresh its scan metadata.
+          // removed but the row survived, or a concurrent scanner just inserted
+          // it. The unique constraint rules out a second row, so reuse this one
+          // and refresh its scan metadata.
           await tx.auditAsset.update({
-            where: { id: existingAuditAsset.id },
+            where: { id: auditAssetRow.id },
             data: {
               status: AuditAssetStatus.UNEXPECTED,
               scannedAt: new Date(),
@@ -1518,21 +1556,20 @@ export async function recordAuditScan(
             },
           });
 
-          auditAssetId = existingAuditAsset.id;
-
-          // Only count it if it was not already counted as unexpected.
-          if (existingAuditAsset.status !== AuditAssetStatus.UNEXPECTED) {
+          // Only count it if it was not already counted as unexpected. A row a
+          // concurrent scanner just inserted is already UNEXPECTED and already
+          // counted by them, so this correctly contributes nothing.
+          if (auditAssetRow.status !== AuditAssetStatus.UNEXPECTED) {
             unexpectedDelta = 1;
           }
         }
 
-        // Link the scan to the audit asset so we can query it later
-        if (auditAssetId) {
-          await tx.auditScan.update({
-            where: { id: scan.id },
-            data: { auditAssetId },
-          });
-        }
+        // Link the scan to the audit asset so we can query it later. Always
+        // resolvable now: every branch above either found or created the row.
+        await tx.auditScan.update({
+          where: { id: scan.id },
+          data: { auditAssetId },
+        });
 
         // Update the audit session counts.
         //
@@ -1572,7 +1609,7 @@ export async function recordAuditScan(
             entityType: "AUDIT",
             entityId: auditSessionId,
             auditSessionId,
-            auditAssetId: auditAssetId ?? undefined,
+            auditAssetId,
             assetId,
             meta: { isExpected },
           },

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1304,37 +1304,47 @@ export async function recordAuditScan(
     // Record the scan in a transaction
     const result = await db.$transaction(
       async (tx) => {
-        // If this is the first scan and audit is still PENDING, activate it
+        // If this is the first scan and audit is still PENDING, activate it.
+        // `startedAt` is only stamped the FIRST time: an audit that returns to
+        // PENDING and is scanned again must keep the moment it actually began,
+        // otherwise the audit's own history moves. Seen in production data as
+        // three "started the audit" entries on one audit, with both the web and
+        // the companion "Started" field showing only the latest.
+        const isFirstStart = session.startedAt === null;
         if (session.status === AuditStatus.PENDING) {
           await tx.auditSession.update({
             // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: auditSessionId proven org-owned by the db.auditSession.findFirst({ where: { id: auditSessionId, organizationId } }) guard earlier in this fn (throws 404 otherwise); update() requires a unique-only where.
             where: { id: auditSessionId },
             data: {
               status: AuditStatus.ACTIVE,
-              startedAt: new Date(),
+              ...(isFirstStart ? { startedAt: new Date() } : {}),
             },
           });
 
-          // Create automatic note for audit being started
-          await createAuditStartedNote({
-            auditSessionId,
-            userId,
-            tx,
-            prefetchedUser: scannerUser,
-          });
-
-          // Activity event — AUDIT_STARTED.
-          await recordEvent(
-            {
-              organizationId,
-              actorUserId: userId,
-              action: "AUDIT_STARTED",
-              entityType: "AUDIT",
-              entityId: auditSessionId,
+          // Create automatic note for audit being started — only on the real
+          // first start, so the activity feed cannot claim one audit began
+          // several times.
+          if (isFirstStart) {
+            await createAuditStartedNote({
               auditSessionId,
-            },
-            tx
-          );
+              userId,
+              tx,
+              prefetchedUser: scannerUser,
+            });
+
+            // Activity event — AUDIT_STARTED.
+            await recordEvent(
+              {
+                organizationId,
+                actorUserId: userId,
+                action: "AUDIT_STARTED",
+                entityType: "AUDIT",
+                entityId: auditSessionId,
+                auditSessionId,
+              },
+              tx
+            );
+          }
         }
 
         // Create the scan record

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -38,6 +38,7 @@ import {
   createAssetScanNote,
   createAuditCreationNote,
   createAuditStartedNote,
+  createAuditResumedNote,
   createAuditCompletedNote,
   createAuditUpdateNote,
   createDueDateChangedNote,
@@ -180,8 +181,13 @@ export type RecordAuditScanInput = {
   qrId: string;
   /** The ID of the asset that was scanned */
   assetId: string;
-  /** Whether this asset was expected in the audit (true) or unexpected (false) */
-  isExpected: boolean;
+  /**
+   * Deliberately absent: whether the asset was expected is NOT an input.
+   * A scanning device's copy of the expected list goes stale, so
+   * `recordAuditScan` derives it from the audit's own AuditAsset row inside
+   * the transaction. Callers may still accept an `isExpected` flag on the
+   * wire for older clients, but must not forward it.
+   */
   /** The ID of the user who performed the scan */
   userId: string;
   /** The organization ID for security validation */
@@ -1202,8 +1208,7 @@ function isAuditAssetFkViolation(cause: unknown): boolean {
 export async function recordAuditScan(
   input: RecordAuditScanInput
 ): Promise<RecordAuditScanResult> {
-  const { auditSessionId, qrId, assetId, isExpected, userId, organizationId } =
-    input;
+  const { auditSessionId, qrId, assetId, userId, organizationId } = input;
 
   try {
     // Verify the audit session exists and belongs to the organization
@@ -1306,67 +1311,116 @@ export async function recordAuditScan(
       async (tx) => {
         // Activate a PENDING audit on its first scan.
         //
-        // The claim is a guarded updateMany INSIDE the transaction, not a read
-        // from the pre-transaction `session` snapshot: two scanners hitting a
-        // fresh audit at the same moment would both see PENDING/startedAt null
-        // and both write a start note and an AUDIT_STARTED event. Only the row
-        // that actually matches `startedAt: null` can win, so exactly one of
-        // them records the first start.
+        // Gated on the pre-transaction snapshot so an already-ACTIVE audit —
+        // i.e. every scan after the first — issues no session-status writes at
+        // all. Ungated, both updates below match zero rows on every one of
+        // them, so auditing several hundred assets paid two wasted round-trips
+        // per scan inside this 15s transaction.
         //
-        // Scoping the update to `status: PENDING` also stops a scan in flight
-        // from resurrecting an audit someone cancelled or completed a moment
-        // earlier — an unconditional update would have overwritten that.
-        //
-        // `startedAt` is stamped only by this claim, so an audit that returns
-        // to PENDING and is scanned again keeps the moment it truly began.
-        // Production data showed one audit carrying three "started the audit"
-        // entries, with both surfaces reporting only the latest as "Started".
-        const firstStartClaim = await tx.auditSession.updateMany({
-          where: {
-            id: auditSessionId,
-            organizationId,
-            status: AuditStatus.PENDING,
-            startedAt: null,
-          },
-          data: {
-            status: AuditStatus.ACTIVE,
-            startedAt: new Date(),
-          },
-        });
-
-        if (firstStartClaim.count === 1) {
-          // Automatic note for the audit being started. Guarded by the claim,
-          // so the activity feed cannot show one audit starting several times.
-          await createAuditStartedNote({
-            auditSessionId,
-            userId,
-            tx,
-            prefetchedUser: scannerUser,
-          });
-
-          // Activity event — AUDIT_STARTED.
-          await recordEvent(
-            {
-              organizationId,
-              actorUserId: userId,
-              action: "AUDIT_STARTED",
-              entityType: "AUDIT",
-              entityId: auditSessionId,
-              auditSessionId,
-            },
-            tx
-          );
-        } else {
-          // Still PENDING but already carrying a startedAt: it was started
-          // before. Bring it back to ACTIVE without restamping or re-noting.
-          await tx.auditSession.updateMany({
+        // The concurrency case the claim exists for is *both* scanners seeing
+        // PENDING in their own snapshot, so gating on the snapshot does not
+        // weaken it: whoever sees PENDING still has to win the claim.
+        if (session.status === AuditStatus.PENDING) {
+          // The claim is a guarded updateMany INSIDE the transaction, not a
+          // read from the pre-transaction `session` snapshot: two scanners
+          // hitting a fresh audit at the same moment would both see
+          // PENDING/startedAt null and both write a start note and an
+          // AUDIT_STARTED event. Only the row that actually matches
+          // `startedAt: null` can win, so exactly one of them records the
+          // first start.
+          //
+          // Scoping the update to `status: PENDING` also stops a scan in
+          // flight from resurrecting an audit someone cancelled or completed a
+          // moment earlier — an unconditional update would have overwritten
+          // that.
+          //
+          // `startedAt` is stamped only by this claim, so an audit that returns
+          // to PENDING and is scanned again keeps the moment it truly began.
+          // Production data showed one audit carrying three "started the audit"
+          // entries, with both surfaces reporting only the latest as "Started".
+          const firstStartClaim = await tx.auditSession.updateMany({
             where: {
               id: auditSessionId,
               organizationId,
               status: AuditStatus.PENDING,
+              startedAt: null,
             },
-            data: { status: AuditStatus.ACTIVE },
+            data: {
+              status: AuditStatus.ACTIVE,
+              startedAt: new Date(),
+            },
           });
+
+          if (firstStartClaim.count === 1) {
+            // Automatic note for the audit being started. Guarded by the
+            // claim, so the activity feed cannot show one audit starting
+            // several times.
+            await createAuditStartedNote({
+              auditSessionId,
+              userId,
+              tx,
+              prefetchedUser: scannerUser,
+            });
+
+            // Activity event — AUDIT_STARTED.
+            await recordEvent(
+              {
+                organizationId,
+                actorUserId: userId,
+                action: "AUDIT_STARTED",
+                entityType: "AUDIT",
+                entityId: auditSessionId,
+                auditSessionId,
+              },
+              tx
+            );
+          } else {
+            // Still PENDING but already carrying a startedAt: it was started
+            // before. Bring it back to ACTIVE without restamping the original
+            // start or re-noting it.
+            const resumeClaim = await tx.auditSession.updateMany({
+              where: {
+                id: auditSessionId,
+                organizationId,
+                status: AuditStatus.PENDING,
+              },
+              data: { status: AuditStatus.ACTIVE },
+            });
+
+            // PENDING -> ACTIVE is a tracked status transition, so it needs a
+            // trail of its own: without one the audit silently reappears as
+            // ACTIVE with nothing in the feed or the event stream explaining
+            // it. Reported as a status change rather than a second
+            // AUDIT_STARTED, which stays reserved for the genuine first start
+            // so reports can still count how many audits ever began.
+            //
+            // Guarded on the claim so the scanner that lost this race — the
+            // audit was flipped to ACTIVE a moment ago by someone else — does
+            // not add a duplicate entry.
+            if (resumeClaim.count === 1) {
+              await createAuditResumedNote({
+                auditSessionId,
+                userId,
+                tx,
+                prefetchedUser: scannerUser,
+              });
+
+              await recordEvent(
+                {
+                  organizationId,
+                  actorUserId: userId,
+                  action: "AUDIT_UPDATED",
+                  entityType: "AUDIT",
+                  entityId: auditSessionId,
+                  auditSessionId,
+                  field: "status",
+                  fromValue: AuditStatus.PENDING,
+                  toValue: AuditStatus.ACTIVE,
+                },
+                tx
+              );
+            }
+          }
         }
 
         // Create the scan record
@@ -1380,37 +1434,37 @@ export async function recordAuditScan(
           },
         });
 
+        // Whether this asset was expected is derived from the audit's own
+        // rows, never taken from the request body.
+        //
+        // A scanning device sends the flag from the expected list it cached at
+        // audit start, and that copy goes stale: an admin can remove an asset
+        // from a still-PENDING audit (`removeAssetFromAudit`) after the device
+        // loaded it. Trusting the flag then matched zero rows on the
+        // expected-asset update, so the scan got no AuditAsset row at all —
+        // notes and photos could never attach to it — while the session counts
+        // still moved, driving `missingAssetCount` negative and reporting a
+        // found asset that is no longer part of the audit.
+        //
+        // AuditAsset is unique on (auditSessionId, assetId), so that one row is
+        // the authority on whether this asset belongs to the audit.
+        const existingAuditAsset = await tx.auditAsset.findUnique({
+          where: { auditSessionId_assetId: { auditSessionId, assetId } },
+          select: { id: true, expected: true, status: true },
+        });
+        const isExpected = existingAuditAsset?.expected === true;
+
         let auditAssetId: string | null = null;
 
+        // Session-count movements for this scan, applied as relative
+        // increments below. 0 means "this scan does not move that count".
+        let foundDelta = 0;
+        let missingDelta = 0;
+        let unexpectedDelta = 0;
+
         // Update or create the audit asset record
-        if (isExpected) {
-          // Expected asset - update its status to FOUND
-          await tx.auditAsset.updateMany({
-            where: {
-              auditSessionId,
-              assetId,
-              expected: true,
-            },
-            data: {
-              status: AuditAssetStatus.FOUND,
-              scannedAt: new Date(),
-              scannedById: userId,
-            },
-          });
-
-          // Get the audit asset ID for return
-          const updatedAsset = await tx.auditAsset.findFirst({
-            where: {
-              auditSessionId,
-              assetId,
-              expected: true,
-            },
-            select: { id: true },
-          });
-
-          auditAssetId = updatedAsset?.id ?? null;
-        } else {
-          // Unexpected asset - create a new audit asset record
+        if (!existingAuditAsset) {
+          // Genuinely unexpected asset - create a new audit asset record
           const auditAsset = await tx.auditAsset.create({
             data: {
               auditSessionId,
@@ -1422,6 +1476,54 @@ export async function recordAuditScan(
             },
           });
           auditAssetId = auditAsset.id;
+          unexpectedDelta = 1;
+        } else if (existingAuditAsset.expected) {
+          // Expected asset - update its status to FOUND.
+          //
+          // Scoped to a row that is not already FOUND so the counts move
+          // exactly once: the duplicate-scan short-circuit above runs outside
+          // the transaction, so two scanners can both reach this point for the
+          // same asset. Without the status guard the second one decrements
+          // `missingAssetCount` again and it goes negative.
+          const foundClaim = await tx.auditAsset.updateMany({
+            where: {
+              auditSessionId,
+              assetId,
+              expected: true,
+              status: { not: AuditAssetStatus.FOUND },
+            },
+            data: {
+              status: AuditAssetStatus.FOUND,
+              scannedAt: new Date(),
+              scannedById: userId,
+            },
+          });
+
+          auditAssetId = existingAuditAsset.id;
+
+          if (foundClaim.count === 1) {
+            foundDelta = 1;
+            missingDelta = -1;
+          }
+        } else {
+          // An unexpected row already exists for this asset — its scan was
+          // removed but the row survived. The unique constraint rules out a
+          // second row, so reuse this one and refresh its scan metadata.
+          await tx.auditAsset.update({
+            where: { id: existingAuditAsset.id },
+            data: {
+              status: AuditAssetStatus.UNEXPECTED,
+              scannedAt: new Date(),
+              scannedById: userId,
+            },
+          });
+
+          auditAssetId = existingAuditAsset.id;
+
+          // Only count it if it was not already counted as unexpected.
+          if (existingAuditAsset.status !== AuditAssetStatus.UNEXPECTED) {
+            unexpectedDelta = 1;
+          }
         }
 
         // Link the scan to the audit asset so we can query it later
@@ -1432,20 +1534,21 @@ export async function recordAuditScan(
           });
         }
 
-        // Update the audit session counts
+        // Update the audit session counts.
+        //
+        // Every field is written as a RELATIVE increment, 0 for the ones this
+        // scan does not move. `session` is a pre-transaction snapshot, so
+        // writing its absolute values back for the untouched fields let two
+        // concurrent scanners clobber each other: an unexpected scan committing
+        // `unexpectedAssetCount` 0 -> 1 was immediately undone by an expected
+        // scan writing its own stale `unexpectedAssetCount: 0` back.
         const updatedSession = await tx.auditSession.update({
           // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: auditSessionId proven org-owned by the db.auditSession.findFirst({ where: { id: auditSessionId, organizationId } }) guard earlier in this fn (throws 404 otherwise); update() requires a unique-only where.
           where: { id: auditSessionId },
           data: {
-            foundAssetCount: isExpected
-              ? { increment: 1 }
-              : session.foundAssetCount,
-            missingAssetCount: isExpected
-              ? { decrement: 1 }
-              : session.missingAssetCount,
-            unexpectedAssetCount: !isExpected
-              ? { increment: 1 }
-              : session.unexpectedAssetCount,
+            foundAssetCount: { increment: foundDelta },
+            missingAssetCount: { increment: missingDelta },
+            unexpectedAssetCount: { increment: unexpectedDelta },
           },
         });
 

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1304,47 +1304,69 @@ export async function recordAuditScan(
     // Record the scan in a transaction
     const result = await db.$transaction(
       async (tx) => {
-        // If this is the first scan and audit is still PENDING, activate it.
-        // `startedAt` is only stamped the FIRST time: an audit that returns to
-        // PENDING and is scanned again must keep the moment it actually began,
-        // otherwise the audit's own history moves. Seen in production data as
-        // three "started the audit" entries on one audit, with both the web and
-        // the companion "Started" field showing only the latest.
-        const isFirstStart = session.startedAt === null;
-        if (session.status === AuditStatus.PENDING) {
-          await tx.auditSession.update({
-            // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: auditSessionId proven org-owned by the db.auditSession.findFirst({ where: { id: auditSessionId, organizationId } }) guard earlier in this fn (throws 404 otherwise); update() requires a unique-only where.
-            where: { id: auditSessionId },
-            data: {
-              status: AuditStatus.ACTIVE,
-              ...(isFirstStart ? { startedAt: new Date() } : {}),
-            },
+        // Activate a PENDING audit on its first scan.
+        //
+        // The claim is a guarded updateMany INSIDE the transaction, not a read
+        // from the pre-transaction `session` snapshot: two scanners hitting a
+        // fresh audit at the same moment would both see PENDING/startedAt null
+        // and both write a start note and an AUDIT_STARTED event. Only the row
+        // that actually matches `startedAt: null` can win, so exactly one of
+        // them records the first start.
+        //
+        // Scoping the update to `status: PENDING` also stops a scan in flight
+        // from resurrecting an audit someone cancelled or completed a moment
+        // earlier — an unconditional update would have overwritten that.
+        //
+        // `startedAt` is stamped only by this claim, so an audit that returns
+        // to PENDING and is scanned again keeps the moment it truly began.
+        // Production data showed one audit carrying three "started the audit"
+        // entries, with both surfaces reporting only the latest as "Started".
+        const firstStartClaim = await tx.auditSession.updateMany({
+          where: {
+            id: auditSessionId,
+            organizationId,
+            status: AuditStatus.PENDING,
+            startedAt: null,
+          },
+          data: {
+            status: AuditStatus.ACTIVE,
+            startedAt: new Date(),
+          },
+        });
+
+        if (firstStartClaim.count === 1) {
+          // Automatic note for the audit being started. Guarded by the claim,
+          // so the activity feed cannot show one audit starting several times.
+          await createAuditStartedNote({
+            auditSessionId,
+            userId,
+            tx,
+            prefetchedUser: scannerUser,
           });
 
-          // Create automatic note for audit being started — only on the real
-          // first start, so the activity feed cannot claim one audit began
-          // several times.
-          if (isFirstStart) {
-            await createAuditStartedNote({
+          // Activity event — AUDIT_STARTED.
+          await recordEvent(
+            {
+              organizationId,
+              actorUserId: userId,
+              action: "AUDIT_STARTED",
+              entityType: "AUDIT",
+              entityId: auditSessionId,
               auditSessionId,
-              userId,
-              tx,
-              prefetchedUser: scannerUser,
-            });
-
-            // Activity event — AUDIT_STARTED.
-            await recordEvent(
-              {
-                organizationId,
-                actorUserId: userId,
-                action: "AUDIT_STARTED",
-                entityType: "AUDIT",
-                entityId: auditSessionId,
-                auditSessionId,
-              },
-              tx
-            );
-          }
+            },
+            tx
+          );
+        } else {
+          // Still PENDING but already carrying a startedAt: it was started
+          // before. Bring it back to ACTIVE without restamping or re-noting.
+          await tx.auditSession.updateMany({
+            where: {
+              id: auditSessionId,
+              organizationId,
+              status: AuditStatus.PENDING,
+            },
+            data: { status: AuditStatus.ACTIVE },
+          });
         }
 
         // Create the scan record

--- a/apps/webapp/app/routes/api+/audits.record-scan.ts
+++ b/apps/webapp/app/routes/api+/audits.record-scan.ts
@@ -2,7 +2,10 @@ import type { ActionFunctionArgs } from "react-router";
 import { data } from "react-router";
 import { z } from "zod";
 
-import { recordAuditScan } from "~/modules/audit/service.server";
+import {
+  recordAuditScan,
+  requireAuditAssignee,
+} from "~/modules/audit/service.server";
 import { makeShelfError } from "~/utils/error";
 import { error, parseData, payload } from "~/utils/http.server";
 import {
@@ -15,10 +18,10 @@ const RecordScanSchema = z.object({
   auditSessionId: z.string(),
   qrId: z.string(),
   assetId: z.string(),
-  isExpected: z
-    .string()
-    .transform((val) => val === "true" || val === "1")
-    .pipe(z.boolean()),
+  // Accepted for wire compatibility with clients that still send it, but never
+  // forwarded: `recordAuditScan` derives expectedness from the audit's own
+  // AuditAsset row, because a client's cached expected list goes stale.
+  isExpected: z.string().optional(),
 });
 
 /**
@@ -30,24 +33,37 @@ export async function action({ context, request }: ActionFunctionArgs) {
   const { userId } = context.getSession();
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, isSelfServiceOrBase } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.audit,
       action: PermissionAction.update,
     });
 
-    const { auditSessionId, qrId, assetId, isExpected } = parseData(
+    const { auditSessionId, qrId, assetId } = parseData(
       await request.formData(),
       RecordScanSchema,
       { additionalData: { userId } }
     );
 
+    // Scanning writes audit data, so it is gated exactly like note, photo and
+    // complete: ADMIN/OWNER act on any audit, BASE/SELF_SERVICE must be
+    // assignees. `audit: update` alone is not enough — BASE and SELF_SERVICE
+    // both hold it, so without this gate any member could record a scan on any
+    // audit in the workspace and win its permanent first-start claim, stamping
+    // the wrong actor and time on an AUDIT_STARTED that is never rewritten.
+    // Mirrors the mobile sibling at api+/mobile+/audits.record-scan.ts.
+    await requireAuditAssignee({
+      auditSessionId,
+      organizationId,
+      userId,
+      isSelfServiceOrBase,
+    });
+
     const result = await recordAuditScan({
       auditSessionId,
       qrId,
       assetId,
-      isExpected,
       userId,
       organizationId,
     });

--- a/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
@@ -12,7 +12,6 @@ import {
   filterMobileCustodyListForViewer,
   viewerCanSeeLegacyCustody,
 } from "~/modules/api/mobile-custody-visibility.server";
-import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getAssetQuantityRows } from "~/modules/asset/quantity-breakdown.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import { makeShelfError } from "~/utils/error";
@@ -55,8 +54,22 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         description: true,
         status: true,
         mainImage: true,
-        // Model cover image; the shaper resolves the cascade
-        ...ASSET_MODEL_IMAGE_SELECT,
+        // The web asset overview shows "Asset ID SAM-0017"; the companion
+        // scanner even invites you to type a SAM ID ("Enter QR, barcode, or
+        // SAM ID"), but no mobile screen could show you one because this
+        // payload never carried it.
+        sequentialId: true,
+        // Superset of ASSET_MODEL_IMAGE_SELECT: the shaper resolves the cover
+        // image cascade from image/thumbnailImage, and the detail screen shows
+        // the model NAME, which web has always shown and mobile never did.
+        assetModel: {
+          select: {
+            id: true,
+            name: true,
+            image: true,
+            thumbnailImage: true,
+          },
+        },
         mainImageExpiration: true,
         thumbnailImage: true,
         availableToBook: true,
@@ -250,10 +263,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       userId: _,
       assetLocations: __,
       assetKits: ___,
-      // Dropped from the response: the helper already resolved the cascade
-      // into flat image fields, and shipping the nested relation alongside
-      // them would give the client two sources of truth for one decision.
-      assetModel: ____,
+      // The image fields are dropped here on purpose — the helper already
+      // resolved the cover-image cascade into flat fields, and shipping the
+      // nested relation alongside them would give the client two sources of
+      // truth for one decision. The model's identity is re-attached below as
+      // `assetModel` so the detail screen can show it, the way web does.
+      assetModel: detailAssetModel,
       custody: detailCustody,
       category: detailCategory,
       ...assetData
@@ -264,6 +279,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // `custodyList` to their OWN entries and report how many holders were
     // hidden — mirroring the web's QuantityCustodyList filter + hidden-count
     // (quantity-custody-list.tsx:121-126).
+    const assetModel = detailAssetModel
+      ? { id: detailAssetModel.id, name: detailAssetModel.name }
+      : null;
+
     const { custodyList, custodyListOthersCount } =
       filterMobileCustodyListForViewer({
         custodyList: flattened.custodyList,
@@ -301,6 +320,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         kit: flattened.kit,
         kitId: flattened.kitId,
         location: flattened.location,
+        // Identity only (no image fields — see the destructure above).
+        assetModel,
         // why: re-attach the detail-shape custody (with createdAt +
         // custodian.user) — the helper's narrower shape drops both.
         // Nulled when the caller lacks custody-view permission (see above).

--- a/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
@@ -12,6 +12,7 @@ import {
   filterMobileCustodyListForViewer,
   viewerCanSeeLegacyCustody,
 } from "~/modules/api/mobile-custody-visibility.server";
+import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getAssetQuantityRows } from "~/modules/asset/quantity-breakdown.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import { makeShelfError } from "~/utils/error";
@@ -59,15 +60,21 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         // SAM ID"), but no mobile screen could show you one because this
         // payload never carried it.
         sequentialId: true,
-        // Superset of ASSET_MODEL_IMAGE_SELECT: the shaper resolves the cover
-        // image cascade from image/thumbnailImage, and the detail screen shows
-        // the model NAME, which web has always shown and mobile never did.
+        /**
+         * `name` drives the detail screen's Model row, which web has always
+         * shown and mobile never did; the image columns feed the shaper's
+         * cover-image cascade.
+         *
+         * Merged into ONE key with a spread of the shared constant rather than
+         * re-listing the image columns — same reasoning as
+         * `modules/asset/fields.ts`. Hardcoding them here would silently drop a
+         * future third image column on this surface only, while every other
+         * surface kept resolving the cascade.
+         */
         assetModel: {
           select: {
-            id: true,
             name: true,
-            image: true,
-            thumbnailImage: true,
+            ...ASSET_MODEL_IMAGE_SELECT.assetModel.select,
           },
         },
         mainImageExpiration: true,
@@ -183,6 +190,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       id: asset.id,
       title: asset.title,
       status: asset.status,
+      // Part of the helper's param shape. This route serves its own copy from
+      // `assetData` below, so the helper's is unused here.
+      sequentialId: asset.sequentialId,
       mainImage: asset.mainImage,
       // Passed through so the helper can resolve the model-image cascade —
       // the detail screen renders the model's cover image for an asset that
@@ -274,15 +284,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       ...assetData
     } = asset;
 
+    // The model's name only. The detail screen renders it as read-only text —
+    // unlike web, mobile has no asset-model screen to link to — so shipping an
+    // id nothing navigates to would work against the single-source-of-truth
+    // narrowing the destructure above exists for.
+    const assetModel = detailAssetModel
+      ? { name: detailAssetModel.name }
+      : null;
+
     // Custody visibility parity (server-side, since mobile clients are
     // untrusted): when the caller lacks custody-view permission, filter
     // `custodyList` to their OWN entries and report how many holders were
     // hidden — mirroring the web's QuantityCustodyList filter + hidden-count
     // (quantity-custody-list.tsx:121-126).
-    const assetModel = detailAssetModel
-      ? { id: detailAssetModel.id, name: detailAssetModel.name }
-      : null;
-
     const { custodyList, custodyListOthersCount } =
       filterMobileCustodyListForViewer({
         custodyList: flattened.custodyList,
@@ -320,7 +334,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         kit: flattened.kit,
         kitId: flattened.kitId,
         location: flattened.location,
-        // Identity only (no image fields — see the destructure above).
+        // Name only (no id, no image fields — see the destructure above).
         assetModel,
         // why: re-attach the detail-shape custody (with createdAt +
         // custodian.user) — the helper's narrower shape drops both.

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -137,6 +137,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
             title: true,
             status: true,
             mainImage: true,
+            // The scanner invites you to "Enter QR, barcode, or SAM ID", and
+            // this list is where that search lands — so each row has to be able
+            // to show WHICH SAM ID matched. Without it the user gets hits
+            // identified by title only and has to open each one to find out.
+            sequentialId: true,
             // Model cover image; `shapeMobileAssetResponse` resolves the cascade
             // into the flat image fields the companion already reads.
             ...ASSET_MODEL_IMAGE_SELECT,

--- a/apps/webapp/app/routes/api+/mobile+/audits.record-scan.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.record-scan.ts
@@ -30,7 +30,8 @@ import {
  *   - auditSessionId: string — the audit session being scanned
  *   - qrId: string — the QR code or barcode value that was scanned
  *   - assetId: string — the resolved asset ID
- *   - isExpected: boolean — whether the asset was expected in the audit
+ *   - isExpected: boolean (optional, ignored) — accepted so shipped builds keep
+ *     working; the server derives expectedness from the audit's own rows
  */
 export async function action({ request }: ActionFunctionArgs) {
   try {
@@ -60,12 +61,16 @@ export async function action({ request }: ActionFunctionArgs) {
     });
 
     const body = await request.json();
-    const { auditSessionId, qrId, assetId, isExpected } = z
+    const { auditSessionId, qrId, assetId } = z
       .object({
         auditSessionId: z.string().min(1),
         qrId: z.string().min(1),
         assetId: z.string().min(1),
-        isExpected: z.boolean(),
+        // Accepted for wire compatibility with shipped app builds, but never
+        // forwarded: `recordAuditScan` derives expectedness from the audit's
+        // own AuditAsset row. A device queues scans offline, so its cached
+        // expected list can be hours out of date by the time they land.
+        isExpected: z.boolean().optional(),
       })
       .parse(body);
 
@@ -85,7 +90,6 @@ export async function action({ request }: ActionFunctionArgs) {
         auditSessionId,
         qrId,
         assetId,
-        isExpected,
         userId: user.id,
         organizationId,
       });

--- a/apps/webapp/test/routes-tests/api+/audits.record-scan.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.record-scan.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+/**
+ * Authorization tests for the WEB audit record-scan endpoint.
+ *
+ * `audit: update` alone does not identify who may scan into an audit: BASE and
+ * SELF_SERVICE both hold that permission (packages/permissions matrix), so this
+ * route has to apply the same assignee gate its mobile sibling does. It
+ * previously stopped at `requirePermission`, which let any workspace member
+ * record a scan on any audit — and since a scan claims the audit's write-once
+ * `startedAt`, the wrong actor and time became permanent.
+ *
+ * Also pins that the body's `isExpected` is NOT forwarded to the service: the
+ * server derives expectedness from the audit's own rows.
+ *
+ * @see {@link file://../../../app/routes/api+/audits.record-scan.ts}
+ * @see {@link file://../../../app/routes/api+/mobile+/audits.record-scan.ts} the sibling
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { action } from "~/routes/api+/audits.record-scan";
+import { ShelfError } from "~/utils/error";
+
+const { recordAuditScan, requireAuditAssignee, requirePermission } = vi.hoisted(
+  () => ({
+    recordAuditScan: vi.fn(),
+    requireAuditAssignee: vi.fn(),
+    requirePermission: vi.fn(),
+  })
+);
+
+// why: the gate under test consumes `isSelfServiceOrBase` from here; mocking
+// lets each test act as a different role without touching auth or the DB.
+vi.mock("~/utils/roles.server", () => ({ requirePermission }));
+
+// why: the service is the boundary we assert against — these tests are about
+// which calls the route makes, not what scanning does.
+vi.mock("~/modules/audit/service.server", () => ({
+  recordAuditScan,
+  requireAuditAssignee,
+}));
+
+/**
+ * Builds the form-encoded request the web scanner posts.
+ *
+ * why: a URLSearchParams body, not FormData — happy-dom drops empty fields on
+ * the Request round-trip (see reference notes on FormData in route tests).
+ */
+function createRecordScanRequest(
+  fields: Record<string, string> = {
+    auditSessionId: "audit-1",
+    qrId: "qr-abc",
+    assetId: "asset-1",
+    isExpected: "true",
+  }
+) {
+  return new Request("http://localhost/api/audits/record-scan", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(fields).toString(),
+  });
+}
+
+/**
+ * Minimal `context` stub — the action reads only `getSession().userId`.
+ */
+function callAction(request = createRecordScanRequest()) {
+  return action({
+    request,
+    context: { getSession: () => ({ userId: "user-1" }) },
+    params: {},
+  } as never);
+}
+
+describe("POST /api/audits/record-scan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireAuditAssignee.mockResolvedValue(undefined);
+    recordAuditScan.mockResolvedValue({
+      scanId: "scan-1",
+      auditAssetId: "audit-asset-1",
+      foundAssetCount: 5,
+      unexpectedAssetCount: 1,
+    });
+  });
+
+  it("requires assignee status for a BASE caller before recording anything", async () => {
+    requirePermission.mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: true,
+      role: "BASE",
+    });
+
+    await callAction();
+
+    expect(requireAuditAssignee).toHaveBeenCalledWith({
+      auditSessionId: "audit-1",
+      organizationId: "org-1",
+      userId: expect.any(String),
+      isSelfServiceOrBase: true,
+    });
+  });
+
+  it("does not record the scan when the assignee gate rejects", async () => {
+    // why: without this the caller still wins the audit's write-once first-start
+    // claim, stamping the wrong actor and time on an AUDIT_STARTED that no later
+    // real start can correct.
+    requirePermission.mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: true,
+      role: "BASE",
+    });
+    // why: a real ShelfError, not a plain Error with a `status` property —
+    // `makeShelfError` only preserves the status of a ShelfError, so a plain
+    // one would surface as 500 and the test would prove nothing about the gate.
+    requireAuditAssignee.mockRejectedValue(
+      new ShelfError({
+        cause: null,
+        message: "Only users assigned to this audit can perform this action.",
+        status: 403,
+        label: "Audit",
+      })
+    );
+
+    const result = await callAction();
+
+    expect(recordAuditScan).not.toHaveBeenCalled();
+    expect((result as { init?: ResponseInit | null }).init?.status).toBe(403);
+  });
+
+  it("lets an ADMIN scan any audit in the workspace", async () => {
+    requirePermission.mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: false,
+      role: "ADMIN",
+    });
+
+    await callAction();
+
+    // The gate short-circuits to allow-all for ADMIN/OWNER, mirroring the
+    // permissions resolver — but it must still be CALLED with the right flag.
+    expect(requireAuditAssignee).toHaveBeenCalledWith(
+      expect.objectContaining({ isSelfServiceOrBase: false })
+    );
+    expect(recordAuditScan).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not forward the client's isExpected flag to the service", async () => {
+    // why: a device's cached expected list goes stale (an admin can remove an
+    // asset from a still-PENDING audit), so the flag is accepted for wire
+    // compatibility and ignored — the service reads the AuditAsset row instead.
+    requirePermission.mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: false,
+      role: "ADMIN",
+    });
+
+    await callAction();
+
+    expect(recordAuditScan).toHaveBeenCalledWith({
+      auditSessionId: "audit-1",
+      qrId: "qr-abc",
+      assetId: "asset-1",
+      userId: expect.any(String),
+      organizationId: "org-1",
+    });
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/mobile.assets.assetId.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.assets.assetId.test.ts
@@ -128,8 +128,16 @@ function buildAsset() {
   return {
     id: "asset-1",
     title: "Bolts",
+    sequentialId: "SAM-0017",
     description: null,
     status: "IN_CUSTODY",
+    // Selected with the image columns so the shaper can resolve the cover-image
+    // cascade; the response must expose the NAME only.
+    assetModel: {
+      name: "M8 Hex Bolt",
+      image: "https://example.test/model.jpg",
+      thumbnailImage: "https://example.test/model-thumb.jpg",
+    },
     mainImage: null,
     mainImageExpiration: null,
     thumbnailImage: null,
@@ -309,5 +317,77 @@ describe("GET /api/mobile/assets/:assetId — custody visibility", () => {
     expect(body.asset.custodyListOthersCount).toBe(0);
     // Legacy custody stays the primary (oldest) record
     expect(body.asset.custody.custodian.id).toBe("tm-alice");
+  });
+});
+
+/**
+ * The response is assembled by destructuring fields OFF the row and re-attaching
+ * narrowed copies — the projection shape this repo gets wrong most often, and
+ * one typecheck cannot see: dropping a key from the destructure or the return
+ * literal leaves `validate` green and the field simply gone from the wire.
+ */
+describe("GET /api/mobile/assets/:assetId — payload projection", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+
+    (requireMobileAuth as any).mockResolvedValue({
+      user: mockUser,
+      authUser: { id: "auth-user-1", email: mockUser.email },
+    });
+    (requireOrganizationAccess as any).mockResolvedValue("org-1");
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      canUseBarcodes: false,
+      canUseAudits: false,
+      canSeeAllCustody: true,
+    });
+    (db.asset.findUnique as any).mockResolvedValue(buildAsset());
+  });
+
+  it("sends the SAM ID, which the scanner's manual entry accepts", async () => {
+    const result = await loader(
+      createLoaderArgs({
+        request: createDetailRequest(),
+        params: { assetId: "asset-1" },
+      })
+    );
+
+    const body = await (result as unknown as Response).json();
+
+    expect(body.asset.sequentialId).toBe("SAM-0017");
+  });
+
+  it("sends the model NAME only — no id, no image columns", async () => {
+    const result = await loader(
+      createLoaderArgs({
+        request: createDetailRequest(),
+        params: { assetId: "asset-1" },
+      })
+    );
+
+    const body = await (result as unknown as Response).json();
+
+    // Exactly `{ name }`: an id has nothing to navigate to on mobile, and the
+    // image columns would be a second source of truth for a cascade the shaper
+    // has already resolved into mainImage/thumbnailImage.
+    expect(body.asset.assetModel).toEqual({ name: "M8 Hex Bolt" });
+  });
+
+  it("returns a null model rather than omitting the field when the asset has none", async () => {
+    (db.asset.findUnique as any).mockResolvedValue({
+      ...buildAsset(),
+      assetModel: null,
+    });
+
+    const result = await loader(
+      createLoaderArgs({
+        request: createDetailRequest(),
+        params: { assetId: "asset-1" },
+      })
+    );
+
+    const body = await (result as unknown as Response).json();
+
+    expect(body.asset.assetModel).toBeNull();
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.record-scan.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.record-scan.test.ts
@@ -135,11 +135,14 @@ describe("POST /api/mobile/audits/record-scan", () => {
     expect(body.foundAssetCount).toBe(5);
     expect(body.unexpectedAssetCount).toBe(1);
 
+    // why: the body's `isExpected` is accepted for wire compatibility with
+    // shipped app builds but must NOT be forwarded — the service derives
+    // expectedness from the audit's own AuditAsset row, because a device that
+    // queues scans offline can hold an hours-stale expected list.
     expect(recordAuditScan).toHaveBeenCalledWith({
       auditSessionId: "session-1",
       qrId: "qr-abc",
       assetId: "asset-1",
-      isExpected: true,
       userId: "user-1",
       organizationId: "org-1",
     });


### PR DESCRIPTION
Three gaps found walking web and the companion side by side on one workspace.

## 1. An audit's start time moved

`recordAuditScan` stamped `startedAt: new Date()` on **every** PENDING to ACTIVE transition (`service.server.ts:1309`), with no guard preserving an existing value.

Observed on a real audit: its activity feed shows **"started the audit" three times** (15/06 10:30, 15/06 11:19, 13/08 15:37), while both web and the companion show only the last one as "Started". The moment the audit actually began is gone, and the feed reads as if one audit began three times.

`startedAt` is now written once. The started note and the `AUDIT_STARTED` event only fire on the genuine first start, so the feed cannot claim an audit began more than once.

Honest scope: I could not find a current code path that returns an ACTIVE audit to PENDING, so those repeat transitions may come from older code or manual QA data. The overwrite is in current code either way, and this is the guard that makes it safe.

## 2. The companion never showed an asset's model

Web shows **Asset Model** on the asset overview, and asset models are a shipped mobile feature (live since 1.2.0). The mobile detail payload selected the model **only** to resolve the cover-image cascade, then deliberately dropped it before responding, so no mobile screen could ever show it.

It now carries the model's identity (id and name, deliberately **not** the image fields, so the client still has exactly one source of truth for the image decision) and the detail screen renders it.

## 3. The companion never showed an asset's SAM ID

The mobile scanner's manual entry is labelled "Enter QR, barcode, or SAM ID" and the app parses sequential IDs, but `sequentialId` was not in either mobile asset payload. A user could type a SAM ID into the app and never learn one from it. Web has always shown it as "Asset ID SAM-0017".

## Verified

- **Companion, pointed at a local server running this branch:** the asset detail now shows `Asset Model: New Asset Model` and `Asset ID: SAM-0017`, matching the same asset on web exactly.
- **Start-time guard:** two new tests, each confirmed to actually execute (not silently skipped) — a first start still stamps `startedAt` and writes one started note; a second start on an already-started audit writes neither.
- 631 audit module and mobile API tests pass. Webapp and companion typecheck clean, companion lint clean.

## Not included, and why

I also reported that mobile formatted currency differently from web (`US$ 699,00` vs `US$699.00`). That was my error. Web formats with the viewer's `Accept-Language` and the companion with the device locale, which is the same rule; my simulator was set to `en_NL`. Nothing to fix, so nothing changed.

The companion half ships with the next companion build; the server half ships on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Asset lists and details now display the sequential asset ID when available.
  - Mobile asset information includes asset model names and sequential IDs.
  - Audit resumptions are recorded as activity updates.

- **Bug Fixes**
  - Audit scans now determine expected status from saved audit data.
  - Concurrent scans prevent duplicate counts, findings, and start records.
  - Audit scanning is restricted to authorized assignees.
  - Audit start times remain accurate when audits are resumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->