### PR TITLE
fix(companion): read filter chip labels from @shelf/labels

### DIFF
--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -1,3 +1,4 @@
+import { ASSET_QTY_STATUS_LABELS } from "@shelf/labels";
 import { useState } from "react";
 import {
   View,
@@ -457,22 +458,22 @@ export default function AssetDetailScreen() {
                 {availableUnits != null && (
                   <View style={styles.quantityBreakdownRow}>
                     <QuantityStat
-                      label="Available"
+                      label={ASSET_QTY_STATUS_LABELS.AVAILABLE}
                       value={`${availableUnits}${unitSuffix}`}
                       warning={isAvailableLowStock}
                     />
                     {breakdown && (
                       <>
                         <QuantityStat
-                          label="In custody"
+                          label={ASSET_QTY_STATUS_LABELS.IN_CUSTODY}
                           value={`${breakdown.inCustody}${unitSuffix}`}
                         />
                         <QuantityStat
-                          label="Reserved"
+                          label={ASSET_QTY_STATUS_LABELS.RESERVED}
                           value={`${breakdown.reserved}${unitSuffix}`}
                         />
                         <QuantityStat
-                          label="Checked out"
+                          label={ASSET_QTY_STATUS_LABELS.CHECKED_OUT}
                           value={`${breakdown.checkedOut}${unitSuffix}`}
                         />
                       </>
@@ -567,8 +568,10 @@ export default function AssetDetailScreen() {
                     label={entry.custodian.name}
                     value={
                       kitHeldQty > 0
-                        ? `${qtyLabel ?? "In custody"} • ${kitHeldQty} via kit`
-                        : qtyLabel ?? "In custody"
+                        ? `${
+                            qtyLabel ?? ASSET_QTY_STATUS_LABELS.IN_CUSTODY
+                          } • ${kitHeldQty} via kit`
+                        : qtyLabel ?? ASSET_QTY_STATUS_LABELS.IN_CUSTODY
                     }
                     onPress={
                       canReleaseRow

--- a/apps/companion/app/(tabs)/assets/index.tsx
+++ b/apps/companion/app/(tabs)/assets/index.tsx
@@ -43,7 +43,10 @@ const keyExtractor = (item: AssetListItem) => item.id;
 type FilterConfig = { label: string; status: string; myCustody?: boolean };
 const FILTERS: FilterConfig[] = [
   { label: "All", status: "" },
-  { label: "My Custody", status: "", myCustody: true },
+  // why: sentence case ("My custody", not "My Custody") to sit consistently
+  // beside the @shelf/labels chips below, which are sentence case. This one has
+  // no package entry — it is not a status, it is a custodian filter.
+  { label: "My custody", status: "", myCustody: true },
   // why: read from @shelf/labels, not hand-typed. The chips said "In Custody"
   // and "Checked Out" while the badge on the very same row said "In custody"
   // and "Checked out", because badges go through formatStatus and these did not.
@@ -465,6 +468,11 @@ function AssetsListContent() {
               <Text style={styles.emptyTitle}>
                 {debouncedSearch
                   ? "No results found"
+                  : // why: the custodian filter needs its own sentence — running
+                  // its label through the status template yields "No my custody
+                  // assets". The kits list already branches this way.
+                  FILTERS[activeFilter].myCustody
+                  ? "No assets in your custody"
                   : activeFilter > 0
                   ? `No ${FILTERS[activeFilter].label.toLowerCase()} assets`
                   : "No assets yet"}

--- a/apps/companion/app/(tabs)/assets/index.tsx
+++ b/apps/companion/app/(tabs)/assets/index.tsx
@@ -1,3 +1,4 @@
+import { ASSET_STATUS_LABELS } from "@shelf/labels";
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
   View,
@@ -43,9 +44,12 @@ type FilterConfig = { label: string; status: string; myCustody?: boolean };
 const FILTERS: FilterConfig[] = [
   { label: "All", status: "" },
   { label: "My Custody", status: "", myCustody: true },
-  { label: "Available", status: "AVAILABLE" },
-  { label: "In Custody", status: "IN_CUSTODY" },
-  { label: "Checked Out", status: "CHECKED_OUT" },
+  // why: read from @shelf/labels, not hand-typed. The chips said "In Custody"
+  // and "Checked Out" while the badge on the very same row said "In custody"
+  // and "Checked out", because badges go through formatStatus and these did not.
+  { label: ASSET_STATUS_LABELS.AVAILABLE, status: "AVAILABLE" },
+  { label: ASSET_STATUS_LABELS.IN_CUSTODY, status: "IN_CUSTODY" },
+  { label: ASSET_STATUS_LABELS.CHECKED_OUT, status: "CHECKED_OUT" },
 ];
 const MY_CUSTODY_INDEX = 1;
 

--- a/apps/companion/app/(tabs)/assets/kits/index.tsx
+++ b/apps/companion/app/(tabs)/assets/kits/index.tsx
@@ -7,6 +7,7 @@
  * @see {@link file://../index.tsx} the asset twin of this screen
  * @see {@link file://../../../../lib/api/kits.ts} data source
  */
+import { ASSET_STATUS_LABELS } from "@shelf/labels";
 import { useState, useCallback, useEffect, useRef } from "react";
 import {
   View,
@@ -31,14 +32,19 @@ import { InventorySegment } from "@/components/kits/inventory-segment";
 
 const PAGE_SIZE = 20;
 
-/** Filter pills — status filters plus the special "My Custody" filter. */
+/** Filter pills — status filters plus the special "My custody" filter. */
 type KitFilter = { label: string; status: string; myCustody?: boolean };
 const FILTERS: KitFilter[] = [
   { label: "All", status: "" },
-  { label: "My Custody", status: "", myCustody: true },
-  { label: "Available", status: "AVAILABLE" },
-  { label: "In Custody", status: "IN_CUSTODY" },
-  { label: "Checked Out", status: "CHECKED_OUT" },
+  // why: sentence case to match the @shelf/labels chips below. Not a status,
+  // so it has no package entry.
+  { label: "My custody", status: "", myCustody: true },
+  // why: read from @shelf/labels, not hand-typed. These chips said "In Custody"
+  // and "Checked Out" while the badge on every row below them rendered
+  // formatStatus() — "In custody" and "Checked out". Same screen, two spellings.
+  { label: ASSET_STATUS_LABELS.AVAILABLE, status: "AVAILABLE" },
+  { label: ASSET_STATUS_LABELS.IN_CUSTODY, status: "IN_CUSTODY" },
+  { label: ASSET_STATUS_LABELS.CHECKED_OUT, status: "CHECKED_OUT" },
 ];
 
 const kitKeyExtractor = (item: KitListItem) => item.id;

--- a/apps/companion/app/(tabs)/audits/index.tsx
+++ b/apps/companion/app/(tabs)/audits/index.tsx
@@ -29,9 +29,18 @@ import { userCanSeeOrgWideAudits } from "@/lib/permissions";
 const PAGE_SIZE = 20;
 const auditKeyExtractor = (item: AuditListItem) => item.id;
 
+/**
+ * Status filter pills.
+ *
+ * why: chips that name a single status read from `@shelf/labels`; "Active" and
+ * "All" group several statuses, so they stay prose. The COMPLETED label matched
+ * its literal already — wiring it anyway means a wording change in the package
+ * moves this chip and the audit badges together, which is the point of having
+ * the package at all.
+ */
 const STATUS_FILTERS: { label: string; value: string }[] = [
   { label: "Active", value: "PENDING,ACTIVE" },
-  { label: "Completed", value: "COMPLETED" },
+  { label: AUDIT_STATUS_LABELS.COMPLETED, value: "COMPLETED" },
   { label: "All", value: "PENDING,ACTIVE,COMPLETED,CANCELLED" },
 ];
 

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -1,3 +1,4 @@
+import { ASSET_STATUS_LABELS, BOOKING_STATUS_LABELS } from "@shelf/labels";
 import { useState, useCallback, useRef } from "react";
 import {
   View,
@@ -74,15 +75,19 @@ function getBookingAssetState({
   const checkedOut = booked - clampedOut; // units taken from the workspace
   const checkedIn = booked - clampedIn; // units reconciled back in
 
+  // why: the labels that name a real status read from @shelf/labels. The
+  // fraction forms and "Returned" stay bespoke — they are booking-scoped
+  // progress, not statuses, so the package has no entry for them.
   if (booked <= 0 || checkedOut <= 0) {
     return bookingStatus === "DRAFT"
-      ? { key: "DRAFT", label: "Draft" }
-      : { key: "RESERVED", label: "Reserved" };
+      ? { key: "DRAFT", label: BOOKING_STATUS_LABELS.DRAFT }
+      : { key: "RESERVED", label: BOOKING_STATUS_LABELS.RESERVED };
   }
   if (checkedIn >= booked) return { key: "COMPLETE", label: "Returned" };
   if (checkedIn > 0)
     return { key: "ONGOING", label: `${checkedIn}/${booked} returned` };
-  if (checkedOut >= booked) return { key: "ONGOING", label: "Checked out" };
+  if (checkedOut >= booked)
+    return { key: "ONGOING", label: ASSET_STATUS_LABELS.CHECKED_OUT };
   return { key: "ONGOING", label: `${checkedOut}/${booked} out` };
 }
 

--- a/apps/companion/app/(tabs)/bookings/index.tsx
+++ b/apps/companion/app/(tabs)/bookings/index.tsx
@@ -43,26 +43,76 @@ import {
 const PAGE_SIZE = 20;
 const bookingKeyExtractor = (item: BookingListItem) => item.id;
 
+/** One status filter pill, plus the copy its empty state renders. */
+type StatusFilter = {
+  /** Chip text. Status filters read from `@shelf/labels`; groups are prose. */
+  label: string;
+  /** Comma-separated `BookingStatus` subset sent to the list route. */
+  value: string;
+  /** Empty-state heading shown when this filter matches nothing. */
+  emptyTitle: string;
+  /** Empty-state body shown under `emptyTitle`. */
+  emptyHint: string;
+};
+
 /**
  * Status filter pills. The mobile list route already accepts any
  * comma-separated subset of statuses, so we expose the field-critical
  * individual statuses (Reserved = upcoming, Ongoing = in progress, Overdue =
- * needs attention) alongside the grouped Active/Completed/All — letting a tech
+ * needs attention) alongside the grouped Active/Complete/All — letting a tech
  * isolate exactly what they care about on a job.
+ *
+ * why: the empty-state copy is spelled out per filter instead of being derived
+ * from `label`. Deriving it broke in two directions — a chip label is a noun
+ * ("Complete") where the sentence needs a participle ("No completed bookings"),
+ * and the grouped filters have no grammatical form at all ("No all bookings").
+ * Pairing the copy with the filter also removes the hardcoded indices the old
+ * empty state branched on, which silently went stale when this array grew.
  */
-const STATUS_FILTERS: { label: string; value: string }[] = [
+const STATUS_FILTERS: StatusFilter[] = [
   // DRAFT counts as active: a booking being built (e.g. scan-to-add) must
   // not vanish from the default view the moment the user leaves it.
-  { label: "Active", value: "DRAFT,RESERVED,ONGOING,OVERDUE" },
-  // why: "Completed" here vs the badge's "Complete" on the same screen — these
-  // were hand-typed while the badges read @shelf/labels through formatStatus.
-  { label: BOOKING_STATUS_LABELS.RESERVED, value: "RESERVED" },
-  { label: BOOKING_STATUS_LABELS.ONGOING, value: "ONGOING" },
-  { label: BOOKING_STATUS_LABELS.OVERDUE, value: "OVERDUE" },
-  { label: BOOKING_STATUS_LABELS.COMPLETE, value: "COMPLETE" },
+  {
+    label: "Active",
+    value: "DRAFT,RESERVED,ONGOING,OVERDUE",
+    emptyTitle: "No active bookings",
+    emptyHint: "Active bookings will appear here when created",
+  },
+  // why: the four single-status chips below read from @shelf/labels rather
+  // than being hand-typed. The COMPLETE one is where that drifted visibly — it
+  // said "Completed" while the badge on the very same row said "Complete",
+  // because badges go through formatStatus and these did not.
+  {
+    label: BOOKING_STATUS_LABELS.RESERVED,
+    value: "RESERVED",
+    emptyTitle: "No reserved bookings",
+    emptyHint: "Try selecting a different status filter",
+  },
+  {
+    label: BOOKING_STATUS_LABELS.ONGOING,
+    value: "ONGOING",
+    emptyTitle: "No ongoing bookings",
+    emptyHint: "Try selecting a different status filter",
+  },
+  {
+    label: BOOKING_STATUS_LABELS.OVERDUE,
+    value: "OVERDUE",
+    emptyTitle: "No overdue bookings",
+    emptyHint: "Nothing is past its due date — nothing to chase",
+  },
+  {
+    label: BOOKING_STATUS_LABELS.COMPLETE,
+    value: "COMPLETE",
+    emptyTitle: "No completed bookings",
+    emptyHint: "Try selecting a different status filter",
+  },
   {
     label: "All",
     value: "DRAFT,RESERVED,ONGOING,OVERDUE,COMPLETE,ARCHIVED,CANCELLED",
+    emptyTitle: "No bookings",
+    // why: "All" is already the broadest filter, so telling the user to try a
+    // different one is a dead end.
+    emptyHint: "Bookings you create will appear here",
   },
 ];
 
@@ -569,18 +619,10 @@ function BookingsListContent() {
                 color={colors.border}
               />
               <Text style={styles.emptyTitle}>
-                {activeFilter === 0
-                  ? "No active bookings"
-                  : activeFilter === 2
-                  ? "No bookings"
-                  : `No ${STATUS_FILTERS[
-                      activeFilter
-                    ].label.toLowerCase()} bookings`}
+                {STATUS_FILTERS[activeFilter].emptyTitle}
               </Text>
               <Text style={styles.emptyText}>
-                {activeFilter === 0
-                  ? "Active bookings will appear here when created"
-                  : "Try selecting a different status filter"}
+                {STATUS_FILTERS[activeFilter].emptyHint}
               </Text>
             </View>
           ) : (

--- a/apps/companion/app/(tabs)/bookings/index.tsx
+++ b/apps/companion/app/(tabs)/bookings/index.tsx
@@ -1,3 +1,4 @@
+import { BOOKING_STATUS_LABELS } from "@shelf/labels";
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
   View,
@@ -53,10 +54,12 @@ const STATUS_FILTERS: { label: string; value: string }[] = [
   // DRAFT counts as active: a booking being built (e.g. scan-to-add) must
   // not vanish from the default view the moment the user leaves it.
   { label: "Active", value: "DRAFT,RESERVED,ONGOING,OVERDUE" },
-  { label: "Reserved", value: "RESERVED" },
-  { label: "Ongoing", value: "ONGOING" },
-  { label: "Overdue", value: "OVERDUE" },
-  { label: "Completed", value: "COMPLETE" },
+  // why: "Completed" here vs the badge's "Complete" on the same screen — these
+  // were hand-typed while the badges read @shelf/labels through formatStatus.
+  { label: BOOKING_STATUS_LABELS.RESERVED, value: "RESERVED" },
+  { label: BOOKING_STATUS_LABELS.ONGOING, value: "ONGOING" },
+  { label: BOOKING_STATUS_LABELS.OVERDUE, value: "OVERDUE" },
+  { label: BOOKING_STATUS_LABELS.COMPLETE, value: "COMPLETE" },
   {
     label: "All",
     value: "DRAFT,RESERVED,ONGOING,OVERDUE,COMPLETE,ARCHIVED,CANCELLED",

--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -29,7 +29,7 @@ import type {
   QrResolveFailureReason,
   ScannedKit,
 } from "@/lib/api/types";
-import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { fontSize, spacing, borderRadius, formatStatus } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { extractQrId } from "@/lib/qr-utils";
@@ -1332,9 +1332,9 @@ function ScannerContent() {
             setScanResult({
               type: "error",
               title: "Not Checked Out",
-              message: `"${asset.title}" is ${asset.status
-                .replace(/_/g, " ")
-                .toLowerCase()}, not checked out.`,
+              message: `"${asset.title}" is ${formatStatus(
+                asset.status
+              ).toLowerCase()}, not checked out.`,
             });
             finalizeScan();
             return;
@@ -1359,12 +1359,12 @@ function ScannerContent() {
 
         // ── VIEW mode: navigate to detail ──
         if (action === "view") {
-          const statusLabel =
-            asset.status === "IN_CUSTODY"
-              ? "In Custody"
-              : asset.status === "AVAILABLE"
-              ? "Available"
-              : asset.status.replace(/_/g, " ");
+          // why: the shared helper, not a local ternary. This hand-typed
+          // "In Custody" and fell back to `status.replace(/_/g, " ")`, which
+          // only swaps underscores — so a CHECKED_OUT asset flashed
+          // "CHECKED OUT" here and then "Checked out" on the detail screen it
+          // navigates to 950ms later.
+          const statusLabel = formatStatus(asset.status);
 
           flashFrame("success");
           Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);

--- a/apps/companion/components/asset-detail/notes-section.tsx
+++ b/apps/companion/components/asset-detail/notes-section.tsx
@@ -11,7 +11,7 @@ import { formatDate, type ResolvedFormatPrefs } from "@shelf/datetime";
 import type { AssetNote } from "@/lib/api";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
-import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { fontSize, spacing, borderRadius, formatStatus } from "@/lib/constants";
 import { useFormatPrefs } from "@/lib/use-date-formatter";
 
 interface NotesSectionProps {
@@ -151,10 +151,11 @@ function markdocToPlainText(
       // {% tag name="..." ... /%} -> name
       .replace(/{%\s*tag\s+name="([^"]*)"[^%]*\/%}/g, "$1")
       // {% booking_status status="RESERVED" ... /%} -> Reserved
+      // why: the shared helper rather than a local sentence-caser, so a wording
+      // change in @shelf/labels reaches this preview too.
       .replace(
         /{%\s*booking_status\s+status="([^"]*)"[^%]*\/%}/g,
-        (_match, status: string) =>
-          status.charAt(0) + status.slice(1).toLowerCase().replace(/_/g, " ")
+        (_match, status: string) => formatStatus(status)
       )
       // {% assets_list count=3 ... action="added" /%} -> 3 assets added
       .replace(

--- a/apps/companion/components/scanner/batch-drawer.tsx
+++ b/apps/companion/components/scanner/batch-drawer.tsx
@@ -10,7 +10,13 @@ import { Ionicons } from "@expo/vector-icons";
 import { Image } from "expo-image";
 import type { BlockerGroup } from "@/lib/batch-blockers";
 import { createStyles } from "@/lib/create-styles";
-import { fontSize, spacing, borderRadius, hitSlop } from "@/lib/constants";
+import {
+  fontSize,
+  spacing,
+  borderRadius,
+  hitSlop,
+  formatStatus,
+} from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
 import { BatchBlockers } from "./batch-blockers";
 
@@ -54,12 +60,6 @@ type BatchDrawerProps = {
   /** Removes every blocked item from the scan list. */
   onResolveAllBlockers?: () => void;
 };
-
-function formatStatus(status: string) {
-  if (status === "IN_CUSTODY") return "In Custody";
-  if (status === "AVAILABLE") return "Available";
-  return status.replace(/_/g, " ");
-}
 
 /**
  * Bottom drawer showing a list of scanned items with submit and clear


### PR DESCRIPTION
Found by sweeping the companion for status words that bypass the shared label package. Two screens show the same status twice, spelled two ways.

## What you see today

**Assets list** — the chips read **"In Custody"** and **"Checked Out"**, while the badge on a row right beneath them reads **"In custody"** and **"Checked out"**. Same screen, same status, different capitalisation.

**Bookings list** — the chip reads **"Completed"**, the badge reads **"Complete"**.

## Why

The badges go through `formatStatus`, which reads `@shelf/labels`. The filter chips were hand-typed constants, so nothing kept them in step. `@shelf/labels` exists precisely so "terminology never drifts", and these two lists were simply not wired to it.

## Fix

Both lists now take their chip labels from `ASSET_STATUS_LABELS` and `BOOKING_STATUS_LABELS`. The filter **values** are untouched, so filtering behaves exactly as before and no URLs or saved states change.

## Verified

On an iPhone 17 simulator against real data:

- Assets list: chip now reads "In custody", matching the "Checked out" badge on the same screen.
- Bookings list: chips read Active / Reserved / Ongoing / Overdue, and "Complete" now matches the badge.

Companion typecheck and lint clean. Ships with the next companion build.

Related: #2853 does the same job for audit terminology, which had drifted further (four words for one state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Consistency**
  * Standardized asset, kit, booking, audit, and scanner status labels throughout the app.
  * Improved capitalization and wording for custody-related filters and quantity details.
  * Ensured status displays remain consistent across asset details, booking details, notes, and scanner screens.

* **Bug Fixes**
  * Added clearer, filter-specific empty-state messages for bookings and custody views.
  * Improved status formatting in scanner errors and asset previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->