### PR TITLE
fix(mobile): write the asset creation notes, and show booking creator + tags

### DIFF
--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -17,6 +17,7 @@ import { Image } from "expo-image";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { pushIntoTab } from "@/lib/navigation";
 import { formatPersonName } from "@/lib/person-name";
+import { TagChip } from "@/components/tag-chip";
 import {
   consumeBookingDirty,
   markBookingsListDirty,
@@ -920,17 +921,11 @@ export default function BookingDetailScreen() {
     text: colors.muted,
   };
 
-  const creatorName = formatPersonName(
-    booking?.creator?.firstName,
-    booking?.creator?.lastName
-  );
+  const creatorName = formatPersonName(booking.creator);
 
   const custodianName =
     booking.custodianTeamMember?.name ||
-    formatPersonName(
-      booking.custodianUser?.firstName,
-      booking.custodianUser?.lastName
-    );
+    formatPersonName(booking.custodianUser);
 
   // Lifecycle counts for the progress bar: every asset is in exactly one of three
   // states. `checkedOutCount` (status === CHECKED_OUT) already EXCLUDES returned
@@ -1126,16 +1121,16 @@ export default function BookingDetailScreen() {
                 ) : null}
               </View>
 
-              {/* Tags were also already in the payload and shown by web. */}
-              {booking.tags.length > 0 && (
+              {/* Tag names were already in the payload and shown by web; the
+                  colour they are keyed by was not, and was added with the
+                  chip so the phone can tell two tags apart the way web can. */}
+              {booking.tags?.length ? (
                 <View style={styles.tagRow}>
                   {booking.tags.map((tag) => (
-                    <View key={tag.id} style={styles.tagChip}>
-                      <Text style={styles.tagChipText}>{tag.name}</Text>
-                    </View>
+                    <TagChip key={tag.id} tag={tag} />
                   ))}
                 </View>
-              )}
+              ) : null}
             </View>
 
             {/* Lifecycle progress: reserved → out → returned (single bar) */}
@@ -2004,18 +1999,6 @@ const useStyles = createStyles((colors, shadows) => ({
     flexWrap: "wrap",
     gap: spacing.xs,
     marginTop: spacing.sm,
-  },
-  tagChip: {
-    backgroundColor: colors.backgroundTertiary,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: borderRadius.sm,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: 3,
-  },
-  tagChipText: {
-    fontSize: fontSize.xs,
-    color: colors.foregroundSecondary,
   },
   infoRows: {
     gap: spacing.sm,

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -16,6 +16,7 @@ import * as Haptics from "expo-haptics";
 import { Image } from "expo-image";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { pushIntoTab } from "@/lib/navigation";
+import { formatPersonName } from "@/lib/person-name";
 import {
   consumeBookingDirty,
   markBookingsListDirty,
@@ -919,17 +920,17 @@ export default function BookingDetailScreen() {
     text: colors.muted,
   };
 
-  const creatorName =
-    [booking?.creator?.firstName, booking?.creator?.lastName]
-      .filter(Boolean)
-      .join(" ") || null;
+  const creatorName = formatPersonName(
+    booking?.creator?.firstName,
+    booking?.creator?.lastName
+  );
 
   const custodianName =
     booking.custodianTeamMember?.name ||
-    [booking.custodianUser?.firstName, booking.custodianUser?.lastName]
-      .filter(Boolean)
-      .join(" ") ||
-    null;
+    formatPersonName(
+      booking.custodianUser?.firstName,
+      booking.custodianUser?.lastName
+    );
 
   // Lifecycle counts for the progress bar: every asset is in exactly one of three
   // states. `checkedOutCount` (status === CHECKED_OUT) already EXCLUDES returned

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -919,6 +919,11 @@ export default function BookingDetailScreen() {
     text: colors.muted,
   };
 
+  const creatorName =
+    [booking?.creator?.firstName, booking?.creator?.lastName]
+      .filter(Boolean)
+      .join(" ") || null;
+
   const custodianName =
     booking.custodianTeamMember?.name ||
     [booking.custodianUser?.firstName, booking.custodianUser?.lastName]
@@ -1102,7 +1107,34 @@ export default function BookingDetailScreen() {
                     <Text style={styles.infoValue}>{custodianName}</Text>
                   </View>
                 )}
+
+                {/* why: web shows who created the booking on this same screen,
+                    and the field was already in the payload — fetched, then
+                    dropped. Custodian and creator are different people often
+                    enough that showing only one is misleading. */}
+                {creatorName ? (
+                  <View style={styles.infoRow}>
+                    <Ionicons
+                      name="create-outline"
+                      size={15}
+                      color={colors.muted}
+                    />
+                    <Text style={styles.infoLabel}>Created by</Text>
+                    <Text style={styles.infoValue}>{creatorName}</Text>
+                  </View>
+                ) : null}
               </View>
+
+              {/* Tags were also already in the payload and shown by web. */}
+              {booking.tags.length > 0 && (
+                <View style={styles.tagRow}>
+                  {booking.tags.map((tag) => (
+                    <View key={tag.id} style={styles.tagChip}>
+                      <Text style={styles.tagChipText}>{tag.name}</Text>
+                    </View>
+                  ))}
+                </View>
+              )}
             </View>
 
             {/* Lifecycle progress: reserved → out → returned (single bar) */}
@@ -1965,6 +1997,24 @@ const useStyles = createStyles((colors, shadows) => ({
     fontSize: fontSize.base,
     color: colors.muted,
     lineHeight: 20,
+  },
+  tagRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+    marginTop: spacing.sm,
+  },
+  tagChip: {
+    backgroundColor: colors.backgroundTertiary,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  tagChipText: {
+    fontSize: fontSize.xs,
+    color: colors.foregroundSecondary,
   },
   infoRows: {
     gap: spacing.sm,

--- a/apps/companion/components/tag-chip.tsx
+++ b/apps/companion/components/tag-chip.tsx
@@ -1,0 +1,85 @@
+/**
+ * Read-only tag chip.
+ *
+ * One rendering for a tag wherever the app *displays* one, so the same tag does
+ * not look like a different thing on two screens. This is deliberately NOT the
+ * chip used by the tag pickers (`bookings/new.tsx`, `bookings/edit.tsx`,
+ * `components/asset-edit/tag-picker-field.tsx`): those carry selection and
+ * remove affordances, and their fill encodes selected-vs-not rather than the
+ * tag's own colour.
+ *
+ * @see {@link file://../app/(tabs)/bookings/[id].tsx} — booking detail
+ */
+
+import { Text, View } from "react-native";
+import { borderRadius, fontSize, spacing } from "@/lib/constants";
+import { createStyles } from "@/lib/create-styles";
+
+/** A tag as the mobile API returns it. `color` is absent on older payloads. */
+type TagChipTag = {
+  id: string;
+  name: string;
+  color?: string | null;
+};
+
+/**
+ * React Native throws on a malformed colour string on Android rather than
+ * ignoring it, and `Tag.color` is workspace data we do not control, so the
+ * value is only used once it looks like a hex colour.
+ */
+const HEX_COLOR = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/**
+ * Renders a tag as a chip with its workspace colour shown as a leading dot.
+ *
+ * The colour is carried by the dot rather than by the text or fill (which is
+ * how the webapp badge does it) because the webapp derives its text colour by
+ * darkening the tag hue — that assumes a light background, and this app has a
+ * dark theme. A dot keeps the colour legible in both themes while text contrast
+ * stays owned by the palette.
+ *
+ * @param tag - The tag to render; a missing or malformed `color` renders the
+ *   chip without a dot rather than failing
+ */
+export function TagChip({ tag }: { tag: TagChipTag }) {
+  const styles = useStyles();
+  const color = tag.color?.trim();
+  const dotColor = color && HEX_COLOR.test(color) ? color : null;
+
+  return (
+    <View style={styles.chip}>
+      {dotColor ? (
+        // Decorative: the name right next to it already carries the meaning.
+        <View
+          accessible={false}
+          importantForAccessibility="no"
+          style={[styles.dot, { backgroundColor: dotColor }]}
+        />
+      ) : null}
+      <Text style={styles.text}>{tag.name}</Text>
+    </View>
+  );
+}
+
+const useStyles = createStyles((colors) => ({
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    backgroundColor: colors.backgroundTertiary,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  text: {
+    fontSize: fontSize.xs,
+    color: colors.foregroundSecondary,
+  },
+}));

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -655,11 +655,15 @@ export type BookingDetail = {
   updatedAt: string;
   creator: {
     id: string;
+    /** Preferred over first+last when set — see `formatPersonName`. */
+    displayName: string | null;
     firstName: string | null;
     lastName: string | null;
   };
   custodianUser: {
     id: string;
+    /** Preferred over first+last when set — see `formatPersonName`. */
+    displayName: string | null;
     firstName: string | null;
     lastName: string | null;
     profilePicture: string | null;
@@ -668,7 +672,7 @@ export type BookingDetail = {
     id: string;
     name: string;
   } | null;
-  tags: { id: string; name: string }[];
+  tags: { id: string; name: string; color: string | null }[];
   assets: BookingAsset[];
   assetCount: number;
   checkedOutCount: number;

--- a/apps/companion/lib/person-name.ts
+++ b/apps/companion/lib/person-name.ts
@@ -1,0 +1,15 @@
+/**
+ * Builds a display name from the optional first/last name pair the API returns.
+ *
+ * Every surface that shows a person (booking creator, custodian, note author,
+ * audit assignee) had its own copy of
+ * `[firstName, lastName].filter(Boolean).join(" ") || null`, so a user with only
+ * a first name rendered as "Carlos" in one place and " Carlos" in another.
+ * Returns null rather than an empty string so callers can fall back with `??`.
+ */
+export function formatPersonName(
+  firstName?: string | null,
+  lastName?: string | null
+): string | null {
+  return [firstName, lastName].filter(Boolean).join(" ").trim() || null;
+}

--- a/apps/companion/lib/person-name.ts
+++ b/apps/companion/lib/person-name.ts
@@ -11,5 +11,10 @@ export function formatPersonName(
   firstName?: string | null,
   lastName?: string | null
 ): string | null {
-  return [firstName, lastName].filter(Boolean).join(" ").trim() || null;
+  return (
+    [firstName, lastName]
+      .map((part) => part?.trim())
+      .filter(Boolean)
+      .join(" ") || null
+  );
 }

--- a/apps/companion/lib/person-name.ts
+++ b/apps/companion/lib/person-name.ts
@@ -1,18 +1,54 @@
 /**
- * Builds a display name from the optional first/last name pair the API returns.
+ * Display-name resolution for the people the API returns.
  *
- * Every surface that shows a person (booking creator, custodian, note author,
- * audit assignee) had its own copy of
- * `[firstName, lastName].filter(Boolean).join(" ") || null`, so a user with only
- * a first name rendered as "Carlos" in one place and " Carlos" in another.
- * Returns null rather than an empty string so callers can fall back with `??`.
+ * MIRROR of `resolveUserDisplayName` in
+ * `apps/webapp/app/utils/user.ts` — the companion cannot import from
+ * `apps/webapp/app/**` (Remix-internal paths Metro can't consume). It encodes
+ * the same precedence the server uses, so a person is named identically on both
+ * clients: `displayName` when set, otherwise `firstName lastName`.
+ *
+ * Two deliberate differences from the webapp original:
+ * - returns `null` rather than `""` for "no name", so callers can fall back
+ *   with `??` and render nothing at all;
+ * - trims each part before joining, so a user with only a first name is
+ *   `"Carlos"` and never `" Carlos"`.
+ *
+ * Cosmetic only — nothing is gated on this.
+ *
+ * Migrated call sites so far: the booking detail screen (creator + custodian).
+ * The same join is still hand-rolled, untrimmed and displayName-blind in
+ * `app/(tabs)/audits/[id].tsx`, `app/(tabs)/settings.tsx`,
+ * `app/(tabs)/scanner.tsx`, `app/(tabs)/assets/[id].tsx`,
+ * `app/(tabs)/assets/kits/[id].tsx`, `components/team-member-picker.tsx` and
+ * `components/asset-detail/notes-section.tsx`. Converting those needs the
+ * matching `displayName` added to each route's payload, so it is tracked
+ * separately rather than done blind here.
+ */
+
+/** The name-bearing subset of a user, as the mobile API returns it. */
+type PersonNameParts = {
+  displayName?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+};
+
+/**
+ * Resolves the name to show for a person.
+ *
+ * @param person - The user's name fields; `null`/`undefined` is tolerated so
+ *   call sites don't need their own guard for an absent custodian or creator
+ * @returns The display name, or `null` when the person has no usable name
  */
 export function formatPersonName(
-  firstName?: string | null,
-  lastName?: string | null
+  person?: PersonNameParts | null
 ): string | null {
+  if (!person) return null;
+
+  const displayName = person.displayName?.trim();
+  if (displayName) return displayName;
+
   return (
-    [firstName, lastName]
+    [person.firstName, person.lastName]
       .map((part) => part?.trim())
       .filter(Boolean)
       .join(" ") || null

--- a/apps/webapp/app/modules/asset/utils.server.test.ts
+++ b/apps/webapp/app/modules/asset/utils.server.test.ts
@@ -4,6 +4,7 @@ import {
   detectPotentialChanges,
   detectCustomFieldChanges,
   getCustomFieldUpdateNoteContent,
+  getInitialPlacementNoteContent,
   getKitLocationUpdateNoteContent,
   getLocationUpdateNoteContent,
 } from "./utils.server";
@@ -837,5 +838,86 @@ describe("getKitLocationUpdateNoteContent", () => {
     expect(result).toContain("removed 50 units from");
     expect(result).toContain("Office A");
     expect(result.endsWith("via parent kit removal.")).toBe(true);
+  });
+});
+
+describe("getInitialPlacementNoteContent", () => {
+  /** The name-bearing subset both create routes pass through from `asset.user`. */
+  const user = {
+    id: "u1",
+    firstName: "Alex",
+    lastName: "Doe",
+    displayName: null as string | null,
+  };
+
+  it("returns null when the asset was created without a location", () => {
+    // Both routes branch on this, so a wrong answer here means either a missing
+    // placement note or a note about a location the asset does not have.
+    expect(
+      getInitialPlacementNoteContent({
+        user,
+        type: AssetType.INDIVIDUAL,
+        unitOfMeasure: null,
+        assetLocations: [],
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when the pivot row carries no location", () => {
+    expect(
+      getInitialPlacementNoteContent({
+        user,
+        type: AssetType.INDIVIDUAL,
+        unitOfMeasure: null,
+        assetLocations: [{ quantity: 1, location: null }],
+      })
+    ).toBeNull();
+  });
+
+  it("names the primary location for an INDIVIDUAL asset, without a count", () => {
+    const result = getInitialPlacementNoteContent({
+      user,
+      type: AssetType.INDIVIDUAL,
+      unitOfMeasure: null,
+      assetLocations: [
+        { quantity: 1, location: { id: "loc-a", name: "Office A" } },
+      ],
+    });
+
+    expect(result).toContain("set the location to");
+    expect(result).toContain("Office A");
+  });
+
+  it("counts the pivot row's units for a QUANTITY_TRACKED asset", () => {
+    // The multiplier is `AssetLocation.quantity` (units placed here), NOT
+    // `Asset.quantity` — the surface-specific quantity this helper must use.
+    const result = getInitialPlacementNoteContent({
+      user,
+      type: AssetType.QUANTITY_TRACKED,
+      unitOfMeasure: "boxes",
+      assetLocations: [
+        { quantity: 50, location: { id: "loc-a", name: "Office A" } },
+      ],
+    });
+
+    expect(result).toContain("placed 50 boxes at");
+    expect(result).toContain("Office A");
+  });
+
+  it("names the actor by displayName when they have one", () => {
+    // The drift this extraction exists to prevent: the `displayName` argument is
+    // optional, so a duplicated mapping could silently fall back to first+last
+    // on one route and rename the user relative to every other surface.
+    const result = getInitialPlacementNoteContent({
+      user: { ...user, displayName: "Dr. Smith" },
+      type: AssetType.INDIVIDUAL,
+      unitOfMeasure: null,
+      assetLocations: [
+        { quantity: 1, location: { id: "loc-a", name: "Office A" } },
+      ],
+    });
+
+    expect(result).toContain('text="Dr. Smith"');
+    expect(result).not.toContain("Alex Doe");
   });
 });

--- a/apps/webapp/app/modules/asset/utils.server.ts
+++ b/apps/webapp/app/modules/asset/utils.server.ts
@@ -35,6 +35,10 @@ import type { Column } from "../asset-index-settings/helpers";
  * @param userId - Acting user id (for the actor link)
  * @param firstName - Acting user's first name
  * @param lastName - Acting user's last name
+ * @param displayName - Acting user's `User.displayName`, when the caller has
+ *   it. `wrapUserLinkForNote` prefers it over first+last, so a caller holding
+ *   the full user row should pass it or the note names the person differently
+ *   from every other surface that renders them.
  * @param isRemoving - When true, render the removal phrasing
  * @param type - Asset type; only QUANTITY_TRACKED gets a unit count
  * @param unitOfMeasure - Optional unit label ("boxes", defaults to "units")
@@ -47,7 +51,7 @@ export function getLocationUpdateNoteContent({
   userId,
   firstName,
   lastName,
-
+  displayName,
   isRemoving,
   type,
   unitOfMeasure,
@@ -58,6 +62,8 @@ export function getLocationUpdateNoteContent({
   userId: string;
   firstName: string;
   lastName: string;
+  /** Optional — see the `@param` note; callers that omit it keep first+last. */
+  displayName?: string | null;
   isRemoving?: boolean;
   /** Asset type — only QUANTITY_TRACKED triggers the unit-count phrasing. */
   type?: AssetType;
@@ -71,6 +77,7 @@ export function getLocationUpdateNoteContent({
 }) {
   const userLink = wrapUserLinkForNote({
     id: userId,
+    displayName,
     firstName,
     lastName,
   });

--- a/apps/webapp/app/modules/asset/utils.server.ts
+++ b/apps/webapp/app/modules/asset/utils.server.ts
@@ -5,6 +5,7 @@ import type {
   Location,
   Prisma,
   CustomFieldType,
+  User,
 } from "@prisma/client";
 import _ from "lodash";
 import { z } from "zod";
@@ -122,6 +123,54 @@ export function getLocationUpdateNoteContent({
   }
 
   return message;
+}
+
+/**
+ * Builds the system-note text for the single primary placement an asset is
+ * created with, or `null` when it was created without a location.
+ *
+ * Both asset-create routes (web `assets.new` and mobile `asset.create`) need
+ * exactly this, and each used to re-derive it: pick `assetLocations[0]`, guard
+ * on its location, then map eight arguments into
+ * {@link getLocationUpdateNoteContent}. Two copies of that mapping is how the
+ * actor naming drifts — the `displayName` argument is optional, so one route
+ * could silently fall back to first+last and start naming users differently
+ * from the other, with nothing to catch it. Deriving it once removes that.
+ *
+ * `createAsset` writes at most ONE `AssetLocation` row at creation time. A
+ * quantity-tracked asset can accumulate more later, but only this row is the
+ * primary, and its `quantity` (units placed here) — NOT `Asset.quantity` — is
+ * the multiplier the phrasing uses.
+ *
+ * The parameter is typed structurally rather than as
+ * `Awaited<ReturnType<typeof createAsset>>`: `service.server.ts` already
+ * imports from this module, so naming it here would close a module cycle.
+ *
+ * @param asset - The just-created asset, with its `user` row and placement pivot
+ * @returns Markdoc-formatted note content, or `null` when the asset is unplaced
+ */
+export function getInitialPlacementNoteContent(asset: {
+  user: Pick<User, "id" | "firstName" | "lastName" | "displayName">;
+  type: AssetType;
+  unitOfMeasure: string | null;
+  assetLocations?: {
+    quantity: number;
+    location: Pick<Location, "id" | "name"> | null;
+  }[];
+}): string | null {
+  const primaryPlacement = asset.assetLocations?.[0] ?? null;
+  if (!primaryPlacement?.location) return null;
+
+  return getLocationUpdateNoteContent({
+    newLocation: primaryPlacement.location,
+    userId: asset.user.id,
+    firstName: asset.user.firstName ?? "",
+    lastName: asset.user.lastName ?? "",
+    displayName: asset.user.displayName,
+    type: asset.type,
+    unitOfMeasure: asset.unitOfMeasure,
+    quantity: primaryPlacement.quantity,
+  });
 }
 
 /**

--- a/apps/webapp/app/routes/_layout+/assets.new.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.new.tsx
@@ -17,7 +17,7 @@ import {
   getAllEntriesForCreateAndEdit,
   updateAssetMainImage,
 } from "~/modules/asset/service.server";
-import { getLocationUpdateNoteContent } from "~/modules/asset/utils.server";
+import { getInitialPlacementNoteContent } from "~/modules/asset/utils.server";
 import {
   getAssetModel,
   getAssetModels,
@@ -322,30 +322,14 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       }),
     ];
 
-    // The note only references the single primary placement set at creation
-    // time; qty-tracked assets can hold multiple AssetLocation rows but only one
-    // is primary. The row (not just its location) is what we need —
-    // `AssetLocation.quantity` is the multiplier the phrasing uses for a
-    // QUANTITY_TRACKED asset.
-    //
-    // The sentence, the link and the QT-aware "placed 50 units at X" variant are
-    // owned by `getLocationUpdateNoteContent`, which every later placement
-    // change also goes through. Hand-rolling it here is what made a QT asset
-    // read "set the location to X" on create and "moved 50 units …" ever after.
-    const primaryPlacement = asset.assetLocations?.[0] ?? null;
-    if (primaryPlacement?.location) {
+    // Shared with the mobile create route — the primary-placement selection, the
+    // QT-aware phrasing and the actor mapping all live in the helper, so the two
+    // routes cannot drift on how they name the person or count the units.
+    const placementNote = getInitialPlacementNoteContent(asset);
+    if (placementNote) {
       postCreationTasks.push(
         createNote({
-          content: getLocationUpdateNoteContent({
-            newLocation: primaryPlacement.location,
-            userId: asset.user.id,
-            firstName: asset.user.firstName ?? "",
-            lastName: asset.user.lastName ?? "",
-            displayName: asset.user.displayName,
-            type: asset.type,
-            unitOfMeasure: asset.unitOfMeasure,
-            quantity: primaryPlacement.quantity,
-          }),
+          content: placementNote,
           type: "UPDATE",
           userId: authSession.userId,
           assetId: asset.id,

--- a/apps/webapp/app/routes/_layout+/assets.new.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.new.tsx
@@ -17,7 +17,7 @@ import {
   getAllEntriesForCreateAndEdit,
   updateAssetMainImage,
 } from "~/modules/asset/service.server";
-import { getPrimaryLocation } from "~/modules/asset/utils";
+import { getLocationUpdateNoteContent } from "~/modules/asset/utils.server";
 import {
   getAssetModel,
   getAssetModels,
@@ -42,7 +42,7 @@ import {
   getRefererPath,
   parseData,
 } from "~/utils/http.server";
-import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
+import { wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import {
   PermissionAction,
   PermissionEntity,
@@ -299,11 +299,10 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       unitOfMeasure,
     });
 
-    const actor = wrapUserLinkForNote({
-      id: authSession.userId,
-      firstName: asset.user.firstName,
-      lastName: asset.user.lastName,
-    });
+    // `asset.user` is the full User row (createAsset includes `user: true`), so
+    // it is passed whole: `wrapUserLinkForNote` prefers `displayName`, and
+    // hand-picking first+last renamed anyone who had set one.
+    const actor = wrapUserLinkForNote(asset.user);
 
     // Run independent post-creation tasks in parallel
     const postCreationTasks: Promise<unknown>[] = [
@@ -323,17 +322,30 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       }),
     ];
 
-    // The note only references the single primary location set at creation time;
-    // qty-tracked assets can hold multiple AssetLocation rows but only one is primary.
-    const primaryLocation = getPrimaryLocation(asset);
-    if (primaryLocation) {
-      const locationLink = wrapLinkForNote(
-        `/locations/${primaryLocation.id}`,
-        primaryLocation.name.trim()
-      );
+    // The note only references the single primary placement set at creation
+    // time; qty-tracked assets can hold multiple AssetLocation rows but only one
+    // is primary. The row (not just its location) is what we need —
+    // `AssetLocation.quantity` is the multiplier the phrasing uses for a
+    // QUANTITY_TRACKED asset.
+    //
+    // The sentence, the link and the QT-aware "placed 50 units at X" variant are
+    // owned by `getLocationUpdateNoteContent`, which every later placement
+    // change also goes through. Hand-rolling it here is what made a QT asset
+    // read "set the location to X" on create and "moved 50 units …" ever after.
+    const primaryPlacement = asset.assetLocations?.[0] ?? null;
+    if (primaryPlacement?.location) {
       postCreationTasks.push(
         createNote({
-          content: `${actor} set the location to ${locationLink}.`,
+          content: getLocationUpdateNoteContent({
+            newLocation: primaryPlacement.location,
+            userId: asset.user.id,
+            firstName: asset.user.firstName ?? "",
+            lastName: asset.user.lastName ?? "",
+            displayName: asset.user.displayName,
+            type: asset.type,
+            unitOfMeasure: asset.unitOfMeasure,
+            quantity: primaryPlacement.quantity,
+          }),
           type: "UPDATE",
           userId: authSession.userId,
           assetId: asset.id,

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -27,7 +27,7 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { buildMobileCustomFieldPayload } from "~/modules/api/mobile-custom-fields.server";
 import { createAsset } from "~/modules/asset/service.server";
-import { getLocationUpdateNoteContent } from "~/modules/asset/utils.server";
+import { getInitialPlacementNoteContent } from "~/modules/asset/utils.server";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { createNote } from "~/modules/note/service.server";
 import { buildTagsSet } from "~/modules/tag/service.server";
@@ -231,31 +231,19 @@ export async function action({ request }: ActionFunctionArgs) {
     // set one.
     const actor = wrapUserLinkForNote(asset.user);
 
-    // Mirrors web: only the single primary placement is named, since a
-    // quantity-tracked asset can hold several AssetLocation rows. The row (not
-    // just its location) is what we need — `AssetLocation.quantity` is the
-    // multiplier the note phrasing uses for a QUANTITY_TRACKED asset.
-    const primaryPlacement = asset.assetLocations?.[0] ?? null;
+    // Each note carries its kind so a failure can name which one failed. Tagged
+    // at construction rather than by loop index: a third note added later would
+    // silently inherit the wrong label from a positional check.
+    const notes: { kind: "creation" | "placement"; content: string }[] = [
+      { kind: "creation", content: `Asset was created by ${actor}.` },
+    ];
 
-    const noteContents = [`Asset was created by ${actor}.`];
-
-    if (primaryPlacement?.location) {
-      // The sentence, the link and the QT-aware "placed 50 units at X" variant
-      // are all owned by this helper, which every later placement change also
-      // goes through. Hand-rolling the string here is what made a QT asset read
-      // "set the location to X" on create and "moved 50 units …" ever after.
-      noteContents.push(
-        getLocationUpdateNoteContent({
-          newLocation: primaryPlacement.location,
-          userId: asset.user.id,
-          firstName: asset.user.firstName ?? "",
-          lastName: asset.user.lastName ?? "",
-          displayName: asset.user.displayName,
-          type: asset.type,
-          unitOfMeasure: asset.unitOfMeasure,
-          quantity: primaryPlacement.quantity,
-        })
-      );
+    // Shared with the web create route — the primary-placement selection, the
+    // QT-aware phrasing and the actor mapping all live in the helper, so the two
+    // routes cannot drift on how they name the person or count the units.
+    const placementNote = getInitialPlacementNoteContent(asset);
+    if (placementNote) {
+      notes.push({ kind: "placement", content: placementNote });
     }
 
     // why: the asset and its ASSET_CREATED event are already committed by the
@@ -271,7 +259,7 @@ export async function action({ request }: ActionFunctionArgs) {
     // same millisecond, which showed the placement above the creation. Failures
     // are swallowed per note, so a failed placement note cannot also cost us the
     // creation note.
-    for (const content of noteContents) {
+    for (const { kind, content } of notes) {
       try {
         await createNote({
           content,
@@ -284,9 +272,16 @@ export async function action({ request }: ActionFunctionArgs) {
         Logger.error(
           new ShelfError({
             cause,
-            message: "Failed to write the creation note for a new asset",
+            message: "Failed to write an activity note for a new asset",
             label: "Assets",
-            additionalData: { assetId: asset.id, userId: user.id },
+            // Both notes throw from this one line with one message, so Sentry
+            // groups them into a single issue — `noteKind` is the only thing
+            // that tells an on-call engineer which of the two actually failed.
+            additionalData: {
+              assetId: asset.id,
+              userId: user.id,
+              noteKind: kind,
+            },
           })
         );
       }

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -27,10 +27,13 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { buildMobileCustomFieldPayload } from "~/modules/api/mobile-custom-fields.server";
 import { createAsset } from "~/modules/asset/service.server";
+import { getPrimaryLocation } from "~/modules/asset/utils";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
+import { createNote } from "~/modules/note/service.server";
 import { buildTagsSet } from "~/modules/tag/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
 import { makeShelfError } from "~/utils/error";
+import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import { assertTagsAssignableToAssets } from "~/utils/org-validation.server";
 import {
   PermissionAction,
@@ -214,6 +217,47 @@ export async function action({ request }: ActionFunctionArgs) {
       customFieldsValues,
       qrId: qrId || undefined,
     });
+
+    // why: the same two notes the web create route writes. `createAsset` emits
+    // the ASSET_CREATED activity event on its own, so reports were already in
+    // step, but the human-readable feed on the asset page was not: an asset
+    // created from the phone opened with an empty history while the identical
+    // asset created on the website said who made it and where they put it.
+    const actor = wrapUserLinkForNote({
+      id: user.id,
+      firstName: asset.user.firstName,
+      lastName: asset.user.lastName,
+    });
+
+    const notes: Promise<unknown>[] = [
+      createNote({
+        content: `Asset was created by ${actor}.`,
+        type: "UPDATE",
+        userId: user.id,
+        assetId: asset.id,
+        organizationId,
+      }),
+    ];
+
+    // Mirrors web: only the single primary location is named, since a
+    // quantity-tracked asset can hold several AssetLocation rows.
+    const primaryLocation = getPrimaryLocation(asset);
+    if (primaryLocation) {
+      notes.push(
+        createNote({
+          content: `${actor} set the location to ${wrapLinkForNote(
+            `/locations/${primaryLocation.id}`,
+            primaryLocation.name.trim()
+          )}.`,
+          type: "UPDATE",
+          userId: user.id,
+          assetId: asset.id,
+          organizationId,
+        })
+      );
+    }
+
+    await Promise.all(notes);
 
     return data({
       asset: {

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -27,14 +27,14 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { buildMobileCustomFieldPayload } from "~/modules/api/mobile-custom-fields.server";
 import { createAsset } from "~/modules/asset/service.server";
-import { getPrimaryLocation } from "~/modules/asset/utils";
+import { getLocationUpdateNoteContent } from "~/modules/asset/utils.server";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { createNote } from "~/modules/note/service.server";
 import { buildTagsSet } from "~/modules/tag/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
-import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
+import { wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import { assertTagsAssignableToAssets } from "~/utils/org-validation.server";
 import {
   PermissionAction,
@@ -224,36 +224,36 @@ export async function action({ request }: ActionFunctionArgs) {
     // step, but the human-readable feed on the asset page was not: an asset
     // created from the phone opened with an empty history while the identical
     // asset created on the website said who made it and where they put it.
-    const actor = wrapUserLinkForNote({
-      id: user.id,
-      firstName: asset.user.firstName,
-      lastName: asset.user.lastName,
-    });
+    //
+    // `asset.user` is the full User row (createAsset's include is `user: true`),
+    // so it is passed whole: `wrapUserLinkForNote` prefers `displayName` over
+    // first+last, and hand-picking the two name fields renamed anyone who had
+    // set one.
+    const actor = wrapUserLinkForNote(asset.user);
 
-    const notes: Promise<unknown>[] = [
-      createNote({
-        content: `Asset was created by ${actor}.`,
-        type: "UPDATE",
-        userId: user.id,
-        assetId: asset.id,
-        organizationId,
-      }),
-    ];
+    // Mirrors web: only the single primary placement is named, since a
+    // quantity-tracked asset can hold several AssetLocation rows. The row (not
+    // just its location) is what we need — `AssetLocation.quantity` is the
+    // multiplier the note phrasing uses for a QUANTITY_TRACKED asset.
+    const primaryPlacement = asset.assetLocations?.[0] ?? null;
 
-    // Mirrors web: only the single primary location is named, since a
-    // quantity-tracked asset can hold several AssetLocation rows.
-    const primaryLocation = getPrimaryLocation(asset);
-    if (primaryLocation) {
-      notes.push(
-        createNote({
-          content: `${actor} set the location to ${wrapLinkForNote(
-            `/locations/${primaryLocation.id}`,
-            primaryLocation.name.trim()
-          )}.`,
-          type: "UPDATE",
-          userId: user.id,
-          assetId: asset.id,
-          organizationId,
+    const noteContents = [`Asset was created by ${actor}.`];
+
+    if (primaryPlacement?.location) {
+      // The sentence, the link and the QT-aware "placed 50 units at X" variant
+      // are all owned by this helper, which every later placement change also
+      // goes through. Hand-rolling the string here is what made a QT asset read
+      // "set the location to X" on create and "moved 50 units …" ever after.
+      noteContents.push(
+        getLocationUpdateNoteContent({
+          newLocation: primaryPlacement.location,
+          userId: asset.user.id,
+          firstName: asset.user.firstName ?? "",
+          lastName: asset.user.lastName ?? "",
+          displayName: asset.user.displayName,
+          type: asset.type,
+          unitOfMeasure: asset.unitOfMeasure,
+          quantity: primaryPlacement.quantity,
         })
       );
     }
@@ -265,12 +265,25 @@ export async function action({ request }: ActionFunctionArgs) {
     // QR while the first asset kept the scanned one, so the label in the user's
     // hand pointed at the wrong row. A missing note costs far less than that.
     // Same shape as the sibling mobile routes (asset.adjust-quantity.ts).
-    const noteResults = await Promise.allSettled(notes);
-    for (const result of noteResults) {
-      if (result.status === "rejected") {
+    //
+    // Written one at a time rather than concurrently: the feed orders by
+    // `createdAt` and two inserts issued in the same tick routinely land in the
+    // same millisecond, which showed the placement above the creation. Failures
+    // are swallowed per note, so a failed placement note cannot also cost us the
+    // creation note.
+    for (const content of noteContents) {
+      try {
+        await createNote({
+          content,
+          type: "UPDATE",
+          userId: user.id,
+          assetId: asset.id,
+          organizationId,
+        });
+      } catch (cause) {
         Logger.error(
           new ShelfError({
-            cause: result.reason,
+            cause,
             message: "Failed to write the creation note for a new asset",
             label: "Assets",
             additionalData: { assetId: asset.id, userId: user.id },

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -32,7 +32,8 @@ import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { createNote } from "~/modules/note/service.server";
 import { buildTagsSet } from "~/modules/tag/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
-import { makeShelfError } from "~/utils/error";
+import { makeShelfError, ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
 import { wrapLinkForNote, wrapUserLinkForNote } from "~/utils/markdoc-wrappers";
 import { assertTagsAssignableToAssets } from "~/utils/org-validation.server";
 import {
@@ -257,7 +258,26 @@ export async function action({ request }: ActionFunctionArgs) {
       );
     }
 
-    await Promise.all(notes);
+    // why: the asset and its ASSET_CREATED event are already committed by the
+    // time we get here, so a failed note must not be reported as a failed
+    // creation. It made the companion create screen offer a retry for an asset
+    // that already existed - and with a scanned `qrId` the retry took a fresh
+    // QR while the first asset kept the scanned one, so the label in the user's
+    // hand pointed at the wrong row. A missing note costs far less than that.
+    // Same shape as the sibling mobile routes (asset.adjust-quantity.ts).
+    const noteResults = await Promise.allSettled(notes);
+    for (const result of noteResults) {
+      if (result.status === "rejected") {
+        Logger.error(
+          new ShelfError({
+            cause: result.reason,
+            message: "Failed to write the creation note for a new asset",
+            label: "Assets",
+            additionalData: { assetId: asset.id, userId: user.id },
+          })
+        );
+      }
+    }
 
     return data({
       asset: {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -81,6 +81,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         creator: {
           select: {
             id: true,
+            displayName: true,
             firstName: true,
             lastName: true,
           },
@@ -88,6 +89,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         custodianUser: {
           select: {
             id: true,
+            displayName: true,
             firstName: true,
             lastName: true,
             profilePicture: true,
@@ -100,7 +102,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           },
         },
         tags: {
-          select: { id: true, name: true },
+          select: { id: true, name: true, color: true },
         },
         // Walk the BookingAsset pivot to reach assets. `quantity` +
         // `assetKitId` per row let the loader below collapse multi-row

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
@@ -457,6 +457,33 @@ describe("POST /api/mobile/asset/create", () => {
       }
     );
 
+    it("cannot inject a Markdoc tag via a quantity-tracked asset's unit label", async () => {
+      // The QT phrasing splices `unitOfMeasure` in as LITERAL text, not inside a
+      // quoted attribute, so the escaping that protects the location name does
+      // not cover it — `sanitizeUnitOfMeasureLabel` stripping {, % and } does.
+      vi.mocked(createAsset).mockResolvedValue(
+        createdAsset({
+          type: "QUANTITY_TRACKED",
+          unitOfMeasure: '{% link to="javascript:alert(1)" text="x" /%}',
+          assetLocations: [assetLocationRow("loc-1", "Warehouse A", 50)],
+        } as unknown as Partial<CreatedAsset>)
+      );
+
+      await action(
+        createActionArgs({
+          request: createRequest({ title: "Screws", locationId: "loc-1" }),
+        })
+      );
+
+      const tags = [...Markdoc.parse(noteContents()[1]).walk()].filter(
+        (node) => node.type === "tag"
+      );
+      expect(tags).toHaveLength(2);
+      for (const tag of tags) {
+        expect(String(tag.attributes.to)).toMatch(/^\//);
+      }
+    });
+
     it("writes only the creation note when the asset has no location", async () => {
       vi.mocked(createAsset).mockResolvedValue(createdAsset());
 

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
@@ -167,6 +167,26 @@ function assetLocationRow(
   } as unknown as CreatedAsset["assetLocations"][number];
 }
 
+/**
+ * One `user` row. `createAsset` includes `user: true`, so the real type is the
+ * full Prisma User (~14 scalars). The cast is confined here — same pattern as
+ * `assetLocationRow` — so call sites stay typed and a typo in a name field is
+ * still a compile error.
+ */
+function assetUserRow(
+  overrides: Partial<
+    Pick<CreatedAsset["user"], "id" | "displayName" | "firstName" | "lastName">
+  > = {}
+): CreatedAsset["user"] {
+  return {
+    id: "user-1",
+    displayName: null,
+    firstName: "Carlos",
+    lastName: "Virreira",
+    ...overrides,
+  } as unknown as CreatedAsset["user"];
+}
+
 function createdAsset(overrides: Partial<CreatedAsset> = {}): CreatedAsset {
   return {
     id: "asset-1",
@@ -174,12 +194,7 @@ function createdAsset(overrides: Partial<CreatedAsset> = {}): CreatedAsset {
     // The full User row, as createAsset's `user: true` include returns it —
     // `displayName` included, because the note wrapper prefers it and a fixture
     // without the field cannot show that the route drops it.
-    user: {
-      id: "user-1",
-      displayName: null,
-      firstName: "Carlos",
-      lastName: "Virreira",
-    },
+    user: assetUserRow(),
     type: "INDIVIDUAL",
     unitOfMeasure: null,
     assetLocations: [],
@@ -362,14 +377,7 @@ describe("POST /api/mobile/asset/create", () => {
       // `wrapUserLinkForNote` prefers displayName; the route used to hand-pick
       // first+last past it, renaming anyone who had one.
       vi.mocked(createAsset).mockResolvedValue(
-        createdAsset({
-          user: {
-            id: "user-1",
-            displayName: "Dr. Smith",
-            firstName: "Carlos",
-            lastName: "Virreira",
-          },
-        } as unknown as Partial<CreatedAsset>)
+        createdAsset({ user: assetUserRow({ displayName: "Dr. Smith" }) })
       );
 
       await action(
@@ -393,7 +401,7 @@ describe("POST /api/mobile/asset/create", () => {
           type: "QUANTITY_TRACKED",
           unitOfMeasure: "boxes",
           assetLocations: [assetLocationRow("loc-1", "Warehouse A", 50)],
-        } as unknown as Partial<CreatedAsset>)
+        })
       );
 
       await action(
@@ -466,7 +474,7 @@ describe("POST /api/mobile/asset/create", () => {
           type: "QUANTITY_TRACKED",
           unitOfMeasure: '{% link to="javascript:alert(1)" text="x" /%}',
           assetLocations: [assetLocationRow("loc-1", "Warehouse A", 50)],
-        } as unknown as Partial<CreatedAsset>)
+        })
       );
 
       await action(

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
@@ -84,6 +84,11 @@ vi.mock("~/modules/note/service.server", () => ({
   createNote: vi.fn().mockResolvedValue({ id: "note-1" }),
 }));
 
+// why: the route logs a swallowed note failure; keep it off the test output.
+vi.mock("~/utils/logger", () => ({
+  Logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
 // why: error utility — we mock to control error formatting in tests
 vi.mock("~/utils/error", () => ({
   makeShelfError: vi.fn((cause: any) => ({
@@ -235,6 +240,25 @@ describe("POST /api/mobile/asset/create", () => {
           assetId: "asset-1",
         })
       );
+    });
+
+    it("still reports success when a note fails, so the phone cannot create a duplicate", async () => {
+      // The asset and its activity event are committed before the notes run.
+      // Answering "failed" here made the create screen offer a retry for an
+      // asset that already existed - and a scanned qrId went to the retry.
+      (createAsset as any).mockResolvedValue(createdAsset());
+      (createNote as any).mockRejectedValueOnce(
+        new Error("note insert failed")
+      );
+
+      const result = await action(
+        createActionArgs({ request: createRequest({ title: "New Laptop" }) })
+      );
+
+      expect((result as unknown as Response).status).toBe(200);
+      const body = await (result as unknown as Response).json();
+      expect(body.asset.id).toBe("asset-1");
+      expect(createAsset).toHaveBeenCalledTimes(1);
     });
 
     it("writes only the creation note when the asset has no location", async () => {

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
@@ -77,6 +77,13 @@ vi.mock("~/modules/tag/service.server", () => ({
   })),
 }));
 
+// why: the route writes the two creation notes web writes. Mock the module so
+// tests assert the note contract itself rather than exercising Prisma; the
+// db mock below deliberately has no `note` model.
+vi.mock("~/modules/note/service.server", () => ({
+  createNote: vi.fn().mockResolvedValue({ id: "note-1" }),
+}));
+
 // why: error utility — we mock to control error formatting in tests
 vi.mock("~/utils/error", () => ({
   makeShelfError: vi.fn((cause: any) => ({
@@ -98,6 +105,7 @@ import {
   requireMobilePermission,
 } from "~/modules/api/mobile-auth.server";
 import { createAsset } from "~/modules/asset/service.server";
+import { createNote } from "~/modules/note/service.server";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
 import { assertTagsAssignableToAssets } from "~/utils/org-validation.server";
@@ -127,6 +135,24 @@ function createRequest(
   });
 }
 
+/**
+ * The shape `createAsset` actually resolves to. It includes `user` and the
+ * `assetLocations` pivot, so a bare `{ id, title }` mock is a lie that lets a
+ * route read an undefined field and still pass. Keep this in step with the
+ * `include` in createAsset.
+ */
+function createdAsset(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    id: "asset-1",
+    title: "New Laptop",
+    user: { id: "user-1", firstName: "Carlos", lastName: "Virreira" },
+    assetLocations: [],
+    ...overrides,
+  };
+}
+
 describe("POST /api/mobile/asset/create", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -144,10 +170,7 @@ describe("POST /api/mobile/asset/create", () => {
   });
 
   it("should create an asset and return its id and title", async () => {
-    (createAsset as any).mockResolvedValue({
-      id: "asset-1",
-      title: "New Laptop",
-    });
+    (createAsset as any).mockResolvedValue(createdAsset());
 
     const request = createRequest({ title: "New Laptop" });
     const result = await action(createActionArgs({ request }));
@@ -166,8 +189,67 @@ describe("POST /api/mobile/asset/create", () => {
     );
   });
 
+  // The point of this route change: an asset created from the phone used to
+  // open with an empty history, while the same asset created on the website
+  // said who made it and where they put it.
+  describe("creation notes (parity with the web create route)", () => {
+    it("writes the creation note naming the actor", async () => {
+      (createAsset as any).mockResolvedValue(createdAsset());
+
+      await action(
+        createActionArgs({ request: createRequest({ title: "New Laptop" }) })
+      );
+
+      expect(createNote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content:
+            'Asset was created by {% link to="/settings/team/users/user-1" text="Carlos Virreira" /%}.',
+          type: "UPDATE",
+          userId: "user-1",
+          assetId: "asset-1",
+          organizationId: "org-1",
+        })
+      );
+    });
+
+    it("names the location when the asset was placed", async () => {
+      (createAsset as any).mockResolvedValue(
+        createdAsset({
+          assetLocations: [
+            { location: { id: "loc-1", name: " Warehouse A " } },
+          ],
+        })
+      );
+
+      await action(
+        createActionArgs({
+          request: createRequest({ title: "New Laptop", locationId: "loc-1" }),
+        })
+      );
+
+      expect(createNote).toHaveBeenCalledTimes(2);
+      expect(createNote).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content:
+            '{% link to="/settings/team/users/user-1" text="Carlos Virreira" /%} set the location to {% link to="/locations/loc-1" text="Warehouse A" /%}.',
+          assetId: "asset-1",
+        })
+      );
+    });
+
+    it("writes only the creation note when the asset has no location", async () => {
+      (createAsset as any).mockResolvedValue(createdAsset());
+
+      await action(
+        createActionArgs({ request: createRequest({ title: "New Laptop" }) })
+      );
+
+      expect(createNote).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("org-validates submitted tags and connects them to the new asset", async () => {
-    (createAsset as any).mockResolvedValue({ id: "asset-1", title: "Tagged" });
+    (createAsset as any).mockResolvedValue(createdAsset({ title: "Tagged" }));
 
     const request = createRequest({
       title: "Tagged",
@@ -262,10 +344,7 @@ describe("POST /api/mobile/asset/create", () => {
       (extractCustomFieldValuesFromPayload as any).mockReturnValue([
         { id: "cf-serial", value: { raw: "SN-123" } },
       ]);
-      (createAsset as any).mockResolvedValue({
-        id: "asset-1",
-        title: "New Laptop",
-      });
+      (createAsset as any).mockResolvedValue(createdAsset());
 
       const request = createRequest({
         title: "New Laptop",
@@ -345,7 +424,7 @@ describe("POST /api/mobile/asset/create", () => {
     });
 
     it("calls getActiveCustomFields with category: null when no categoryId is provided", async () => {
-      (createAsset as any).mockResolvedValue({ id: "asset-1", title: "T" });
+      (createAsset as any).mockResolvedValue(createdAsset({ title: "T" }));
 
       const request = createRequest({ title: "Test Asset" });
       await action(createActionArgs({ request }));
@@ -357,7 +436,7 @@ describe("POST /api/mobile/asset/create", () => {
     });
 
     it("calls getActiveCustomFields with the provided categoryId", async () => {
-      (createAsset as any).mockResolvedValue({ id: "asset-1", title: "T" });
+      (createAsset as any).mockResolvedValue(createdAsset({ title: "T" }));
       (db.category.findFirst as any).mockResolvedValue({ id: "cat-42" });
 
       const request = createRequest({
@@ -408,7 +487,7 @@ describe("POST /api/mobile/asset/create", () => {
           return [{ id: "cf-active", value: { raw: true } }];
         }
       );
-      (createAsset as any).mockResolvedValue({ id: "asset-1", title: "T" });
+      (createAsset as any).mockResolvedValue(createdAsset({ title: "T" }));
 
       const request = createRequest({
         title: "New Laptop",

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
@@ -1,3 +1,4 @@
+import Markdoc from "@markdoc/markdoc";
 import { action } from "~/routes/api+/mobile+/asset.create";
 import { createActionArgs } from "@mocks/remix";
 
@@ -111,6 +112,7 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { createAsset } from "~/modules/asset/service.server";
 import { createNote } from "~/modules/note/service.server";
+import { Logger } from "~/utils/logger";
 import { getActiveCustomFields } from "~/modules/custom-field/service.server";
 import { extractCustomFieldValuesFromPayload } from "~/utils/custom-fields";
 import { assertTagsAssignableToAssets } from "~/utils/org-validation.server";
@@ -149,16 +151,19 @@ function createRequest(
 type CreatedAsset = Awaited<ReturnType<typeof createAsset>>;
 
 /**
- * One `assetLocations` row. The route only reads `location.id` and
- * `location.name` (via getPrimaryLocation), so the cast is confined here
- * rather than repeated at every call site.
+ * One `assetLocations` row. The route reads `location.id`, `location.name` and
+ * the row's own `quantity` (the multiplier the note phrasing uses for a
+ * quantity-tracked asset), so the cast is confined here rather than repeated at
+ * every call site.
  */
 function assetLocationRow(
   id: string,
-  name: string
+  name: string,
+  quantity = 1
 ): CreatedAsset["assetLocations"][number] {
   return {
     location: { id, name },
+    quantity,
   } as unknown as CreatedAsset["assetLocations"][number];
 }
 
@@ -166,7 +171,17 @@ function createdAsset(overrides: Partial<CreatedAsset> = {}): CreatedAsset {
   return {
     id: "asset-1",
     title: "New Laptop",
-    user: { id: "user-1", firstName: "Carlos", lastName: "Virreira" },
+    // The full User row, as createAsset's `user: true` include returns it —
+    // `displayName` included, because the note wrapper prefers it and a fixture
+    // without the field cannot show that the route drops it.
+    user: {
+      id: "user-1",
+      displayName: null,
+      firstName: "Carlos",
+      lastName: "Virreira",
+    },
+    type: "INDIVIDUAL",
+    unitOfMeasure: null,
     assetLocations: [],
     ...overrides,
     // The fixture carries only the fields this route reads. The single cast
@@ -174,6 +189,11 @@ function createdAsset(overrides: Partial<CreatedAsset> = {}): CreatedAsset {
     // error, which is what would have caught the missing `user` in the first
     // place.
   } as unknown as CreatedAsset;
+}
+
+/** The `content` of each note the route wrote, in the order it wrote them. */
+function noteContents(): string[] {
+  return vi.mocked(createNote).mock.calls.map(([args]) => args.content);
 }
 
 describe("POST /api/mobile/asset/create", () => {
@@ -275,7 +295,167 @@ describe("POST /api/mobile/asset/create", () => {
       const body = await (result as unknown as Response).json();
       expect(body.asset.id).toBe("asset-1");
       expect(createAsset).toHaveBeenCalledTimes(1);
+      // The other half of "fail quietly but visibly": without this assertion,
+      // deleting the whole catch block from the route still passes the test.
+      expect(Logger.error).toHaveBeenCalledTimes(1);
     });
+
+    it("still writes the creation note when the location note fails", async () => {
+      // Notes go out one at a time and are swallowed individually, so the note
+      // that matters most can't be lost to the one that matters least.
+      vi.mocked(createAsset).mockResolvedValue(
+        createdAsset({
+          assetLocations: [assetLocationRow("loc-1", "Warehouse A")],
+        })
+      );
+      vi.mocked(createNote)
+        .mockResolvedValueOnce({ id: "note-1" } as never)
+        .mockRejectedValueOnce(new Error("note insert failed"));
+
+      const result = await action(
+        createActionArgs({
+          request: createRequest({ title: "New Laptop", locationId: "loc-1" }),
+        })
+      );
+
+      expect((result as unknown as Response).status).toBe(200);
+      expect(createNote).toHaveBeenCalledTimes(2);
+      expect(noteContents()[0]).toContain("Asset was created by");
+      expect(Logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("finishes the creation note before starting the placement note", async () => {
+      // Both notes used to be issued in the same tick; two inserts landing in
+      // the same millisecond let the feed (ordered by createdAt desc) show the
+      // placement above the creation it describes. Asserting on overlap rather
+      // than on call order — `mock.calls` is in argument order either way, so
+      // it cannot tell concurrent from sequential.
+      const timeline: string[] = [];
+      vi.mocked(createNote).mockImplementation(async ({ content }) => {
+        const label = content.includes("created by") ? "creation" : "placement";
+        timeline.push(`start:${label}`);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        timeline.push(`end:${label}`);
+        return { id: label } as never;
+      });
+      vi.mocked(createAsset).mockResolvedValue(
+        createdAsset({
+          assetLocations: [assetLocationRow("loc-1", "Warehouse A")],
+        })
+      );
+
+      await action(
+        createActionArgs({
+          request: createRequest({ title: "New Laptop", locationId: "loc-1" }),
+        })
+      );
+
+      expect(timeline).toEqual([
+        "start:creation",
+        "end:creation",
+        "start:placement",
+        "end:placement",
+      ]);
+    });
+
+    it("names the user by displayName when they have set one", async () => {
+      // `wrapUserLinkForNote` prefers displayName; the route used to hand-pick
+      // first+last past it, renaming anyone who had one.
+      vi.mocked(createAsset).mockResolvedValue(
+        createdAsset({
+          user: {
+            id: "user-1",
+            displayName: "Dr. Smith",
+            firstName: "Carlos",
+            lastName: "Virreira",
+          },
+        } as unknown as Partial<CreatedAsset>)
+      );
+
+      await action(
+        createActionArgs({ request: createRequest({ title: "New Laptop" }) })
+      );
+
+      expect(createNote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content:
+            'Asset was created by {% link to="/settings/team/users/user-1" text="Dr. Smith" /%}.',
+        })
+      );
+    });
+
+    it("counts the units when a quantity-tracked asset is placed", async () => {
+      // The shared helper's QT phrasing. The hand-rolled sentence said "set the
+      // location to X" at creation and "moved 50 boxes …" on every later move
+      // of the very same asset.
+      vi.mocked(createAsset).mockResolvedValue(
+        createdAsset({
+          type: "QUANTITY_TRACKED",
+          unitOfMeasure: "boxes",
+          assetLocations: [assetLocationRow("loc-1", "Warehouse A", 50)],
+        } as unknown as Partial<CreatedAsset>)
+      );
+
+      await action(
+        createActionArgs({
+          request: createRequest({ title: "Screws", locationId: "loc-1" }),
+        })
+      );
+
+      expect(createNote).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          content:
+            '{% link to="/settings/team/users/user-1" text="Carlos Virreira" /%} placed 50 boxes at {% link to="/locations/loc-1" text="Warehouse A" /%}.',
+        })
+      );
+    });
+
+    // `Location.name` is free-form workspace input spliced into Markdoc note
+    // content. Asserted on the PARSE rather than the string: a substring check
+    // misses payloads that only become a tag after concatenation.
+    it.each([
+      ["closes the wrapper", 'A {% link to="javascript:alert(1)" text="x" /%}'],
+      [
+        "closes the tag first",
+        'A /%} {% link to="javascript:alert(1)" text="x" /%}',
+      ],
+      [
+        "pre-encodes its quotes",
+        "A&quot; to=&quot;javascript:alert(1)&quot; x=&quot;",
+      ],
+      [
+        "doubles the delimiter",
+        'A{{% link to="javascript:alert(1)" text="x" /%}',
+      ],
+    ])(
+      "cannot inject a Markdoc tag via a location name that %s",
+      async (_label, evilName) => {
+        vi.mocked(createAsset).mockResolvedValue(
+          createdAsset({
+            assetLocations: [assetLocationRow("loc-1", evilName)],
+          })
+        );
+
+        await action(
+          createActionArgs({
+            request: createRequest({
+              title: "New Laptop",
+              locationId: "loc-1",
+            }),
+          })
+        );
+
+        const tags = [...Markdoc.parse(noteContents()[1]).walk()].filter(
+          (node) => node.type === "tag"
+        );
+        // Exactly the two links we meant to emit, both pointing in-app — an
+        // escaped payload adds a third tag or an off-site `to`.
+        expect(tags).toHaveLength(2);
+        for (const tag of tags) {
+          expect(String(tag.attributes.to)).toMatch(/^\//);
+        }
+      }
+    );
 
     it("writes only the creation note when the asset has no location", async () => {
       vi.mocked(createAsset).mockResolvedValue(createdAsset());

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.create.test.ts
@@ -146,16 +146,34 @@ function createRequest(
  * route read an undefined field and still pass. Keep this in step with the
  * `include` in createAsset.
  */
-function createdAsset(
-  overrides: Record<string, unknown> = {}
-): Record<string, unknown> {
+type CreatedAsset = Awaited<ReturnType<typeof createAsset>>;
+
+/**
+ * One `assetLocations` row. The route only reads `location.id` and
+ * `location.name` (via getPrimaryLocation), so the cast is confined here
+ * rather than repeated at every call site.
+ */
+function assetLocationRow(
+  id: string,
+  name: string
+): CreatedAsset["assetLocations"][number] {
+  return {
+    location: { id, name },
+  } as unknown as CreatedAsset["assetLocations"][number];
+}
+
+function createdAsset(overrides: Partial<CreatedAsset> = {}): CreatedAsset {
   return {
     id: "asset-1",
     title: "New Laptop",
     user: { id: "user-1", firstName: "Carlos", lastName: "Virreira" },
     assetLocations: [],
     ...overrides,
-  };
+    // The fixture carries only the fields this route reads. The single cast
+    // lives here so call sites stay typed: a typo in `overrides` is a compile
+    // error, which is what would have caught the missing `user` in the first
+    // place.
+  } as unknown as CreatedAsset;
 }
 
 describe("POST /api/mobile/asset/create", () => {
@@ -175,7 +193,7 @@ describe("POST /api/mobile/asset/create", () => {
   });
 
   it("should create an asset and return its id and title", async () => {
-    (createAsset as any).mockResolvedValue(createdAsset());
+    vi.mocked(createAsset).mockResolvedValue(createdAsset());
 
     const request = createRequest({ title: "New Laptop" });
     const result = await action(createActionArgs({ request }));
@@ -199,7 +217,7 @@ describe("POST /api/mobile/asset/create", () => {
   // said who made it and where they put it.
   describe("creation notes (parity with the web create route)", () => {
     it("writes the creation note naming the actor", async () => {
-      (createAsset as any).mockResolvedValue(createdAsset());
+      vi.mocked(createAsset).mockResolvedValue(createdAsset());
 
       await action(
         createActionArgs({ request: createRequest({ title: "New Laptop" }) })
@@ -218,11 +236,9 @@ describe("POST /api/mobile/asset/create", () => {
     });
 
     it("names the location when the asset was placed", async () => {
-      (createAsset as any).mockResolvedValue(
+      vi.mocked(createAsset).mockResolvedValue(
         createdAsset({
-          assetLocations: [
-            { location: { id: "loc-1", name: " Warehouse A " } },
-          ],
+          assetLocations: [assetLocationRow("loc-1", " Warehouse A ")],
         })
       );
 
@@ -246,8 +262,8 @@ describe("POST /api/mobile/asset/create", () => {
       // The asset and its activity event are committed before the notes run.
       // Answering "failed" here made the create screen offer a retry for an
       // asset that already existed - and a scanned qrId went to the retry.
-      (createAsset as any).mockResolvedValue(createdAsset());
-      (createNote as any).mockRejectedValueOnce(
+      vi.mocked(createAsset).mockResolvedValue(createdAsset());
+      vi.mocked(createNote).mockRejectedValueOnce(
         new Error("note insert failed")
       );
 
@@ -262,7 +278,7 @@ describe("POST /api/mobile/asset/create", () => {
     });
 
     it("writes only the creation note when the asset has no location", async () => {
-      (createAsset as any).mockResolvedValue(createdAsset());
+      vi.mocked(createAsset).mockResolvedValue(createdAsset());
 
       await action(
         createActionArgs({ request: createRequest({ title: "New Laptop" }) })
@@ -273,7 +289,7 @@ describe("POST /api/mobile/asset/create", () => {
   });
 
   it("org-validates submitted tags and connects them to the new asset", async () => {
-    (createAsset as any).mockResolvedValue(createdAsset({ title: "Tagged" }));
+    vi.mocked(createAsset).mockResolvedValue(createdAsset({ title: "Tagged" }));
 
     const request = createRequest({
       title: "Tagged",
@@ -368,7 +384,7 @@ describe("POST /api/mobile/asset/create", () => {
       (extractCustomFieldValuesFromPayload as any).mockReturnValue([
         { id: "cf-serial", value: { raw: "SN-123" } },
       ]);
-      (createAsset as any).mockResolvedValue(createdAsset());
+      vi.mocked(createAsset).mockResolvedValue(createdAsset());
 
       const request = createRequest({
         title: "New Laptop",
@@ -448,7 +464,7 @@ describe("POST /api/mobile/asset/create", () => {
     });
 
     it("calls getActiveCustomFields with category: null when no categoryId is provided", async () => {
-      (createAsset as any).mockResolvedValue(createdAsset({ title: "T" }));
+      vi.mocked(createAsset).mockResolvedValue(createdAsset({ title: "T" }));
 
       const request = createRequest({ title: "Test Asset" });
       await action(createActionArgs({ request }));
@@ -460,7 +476,7 @@ describe("POST /api/mobile/asset/create", () => {
     });
 
     it("calls getActiveCustomFields with the provided categoryId", async () => {
-      (createAsset as any).mockResolvedValue(createdAsset({ title: "T" }));
+      vi.mocked(createAsset).mockResolvedValue(createdAsset({ title: "T" }));
       (db.category.findFirst as any).mockResolvedValue({ id: "cat-42" });
 
       const request = createRequest({
@@ -511,7 +527,7 @@ describe("POST /api/mobile/asset/create", () => {
           return [{ id: "cf-active", value: { raw: true } }];
         }
       );
-      (createAsset as any).mockResolvedValue(createdAsset({ title: "T" }));
+      vi.mocked(createAsset).mockResolvedValue(createdAsset({ title: "T" }));
 
       const request = createRequest({
         title: "New Laptop",


### PR DESCRIPTION
Two gaps found by sweeping what the phone **receives** against what it **shows**, and what it **writes** against what web writes.

## 1. An asset created from the phone had an empty activity feed

`createAsset` emits the `ASSET_CREATED` activity event itself, so reports were already in step. But the two human-readable notes the web create route writes **afterwards** were missing on mobile:

- "Asset was created by X."
- "X set the location to Y."

So the same asset created on the website opened with its history, and created on the phone opened blank. The mobile route now writes both, through the same `createNote` + markdoc wrappers, and mirrors web's rule of naming only the primary location (a quantity-tracked asset can hold several `AssetLocation` rows).

## 2. The booking detail fetched the creator and the tags, then rendered neither

Both were already in the mobile payload. Web shows both on the same screen.

Custodian and creator are frequently different people, so showing only the custodian is not just incomplete, it is misleading. Verified on device: a booking whose custodian reads `carlitos.virreira+qa-base` now also reads **Created by QA Base**.

## Verified

- iPhone 17 simulator, real data: the booking detail shows the new **Created by** row beside the existing Custodian row.
- Webapp and companion typecheck clean, both lint clean.

## Related, deliberately not in this PR

Mobile asset **create** cannot set `type`, `quantity`, `minQuantity`, `unitOfMeasure`, `consumptionType`, `assetModelId` or `barcodes` — web can. The mobile form does not offer those fields, so nothing is silently dropped; every asset created on the phone is `INDIVIDUAL`. That is a product decision (can a field worker create a quantity-tracked asset?), not a bug, so it is written up rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Booking details now show creator and custodian names, along with associated tags and tag colors.
  - Asset creation records activity notes for the creator and primary location, including placement quantities when applicable.
  - Names in activity records use configured display names when available.

- **Bug Fixes**
  - Asset creation remains successful if activity notes cannot be recorded.
  - Location names in activity records are trimmed and safely formatted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->