### PR TITLE
fix(bookings): stop the phone reserving what the website refuses

### DIFF
--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -1223,6 +1223,16 @@ export default function BookingDetailScreen() {
                 </View>
               </View>
             )}
+            {/* why visible rather than only in an alert: the disabled Reserve
+                  button was a dead control - tapping it produced nothing on
+                  device, so the one thing a user needs (what to fix) was
+                  unreachable. Stating it here does not depend on a tap firing,
+                  and it is readable before you even reach for the button. */}
+            {booking.status === "DRAFT" && reserveBlockedReason ? (
+              <Text style={styles.reserveBlockedNote}>
+                {reserveBlockedReason}
+              </Text>
+            ) : null}
 
             {/* Action buttons */}
             {!["COMPLETE", "ARCHIVED", "CANCELLED"].includes(
@@ -2098,6 +2108,13 @@ const useStyles = createStyles((colors, shadows) => ({
   manageRow: {
     flexDirection: "row",
     gap: spacing.sm,
+  },
+  reserveBlockedNote: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
+    paddingHorizontal: spacing.xs,
+    paddingTop: spacing.xs,
+    lineHeight: 16,
   },
   actionButtonDisabled: {
     opacity: 0.45,

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -919,6 +919,21 @@ export default function BookingDetailScreen() {
     text: colors.muted,
   };
 
+  /**
+   * Why Reserve is unavailable, or null when it is fine. Mirrors the web
+   * form's disable rules so the app never offers a tap the server refuses:
+   * a booking with neither assets nor model reservations reserves nothing,
+   * and an asset flagged unavailable is unavailable on either surface.
+   * Enforced server-side too, in `bookings.reserve.ts`.
+   */
+  const reserveBlockedReason: string | null = !booking
+    ? null
+    : booking.assetCount === 0 && (booking.modelRequestCount ?? 0) === 0
+    ? "Add assets or reserve at least one model on this booking before you reserve it."
+    : booking.assets.some((a) => a.availableToBook === false)
+    ? "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving."
+    : null;
+
   const custodianName =
     booking.custodianTeamMember?.name ||
     [booking.custodianUser?.firstName, booking.custodianUser?.lastName]
@@ -1232,9 +1247,20 @@ export default function BookingDetailScreen() {
 
                 {booking.status === "DRAFT" && (
                   <TouchableOpacity
-                    style={[styles.actionButton, styles.manageRowItem]}
-                    onPress={handleReserve}
+                    style={[
+                      styles.actionButton,
+                      styles.manageRowItem,
+                      reserveBlockedReason ? styles.actionButtonDisabled : null,
+                    ]}
+                    onPress={
+                      reserveBlockedReason
+                        ? () =>
+                            Alert.alert("Cannot reserve", reserveBlockedReason)
+                        : handleReserve
+                    }
                     accessibilityLabel="Reserve this booking"
+                    accessibilityState={{ disabled: !!reserveBlockedReason }}
+                    accessibilityHint={reserveBlockedReason ?? undefined}
                     accessibilityRole="button"
                   >
                     <Ionicons
@@ -2072,6 +2098,9 @@ const useStyles = createStyles((colors, shadows) => ({
   manageRow: {
     flexDirection: "row",
     gap: spacing.sm,
+  },
+  actionButtonDisabled: {
+    opacity: 0.45,
   },
   manageRowItem: {
     flex: 1,

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -1,4 +1,8 @@
-import { ASSET_STATUS_LABELS, BOOKING_STATUS_LABELS } from "@shelf/labels";
+import {
+  ASSET_STATUS_LABELS,
+  BOOKING_RESERVE_BLOCKED_LABELS,
+  BOOKING_STATUS_LABELS,
+} from "@shelf/labels";
 import { useState, useCallback, useRef } from "react";
 import {
   View,
@@ -927,19 +931,31 @@ export default function BookingDetailScreen() {
   };
 
   /**
-   * Why Reserve is unavailable, or null when it is fine. Mirrors the web
-   * form's disable rules so the app never offers a tap the server refuses:
-   * a booking with neither assets nor model reservations reserves nothing,
-   * and an asset flagged unavailable is unavailable on either surface.
-   * Enforced server-side too, in `bookings.reserve.ts`.
+   * Why Reserve is unavailable, or null when it is fine. Mirrors all THREE of
+   * the web form's disable rules so the app never offers a tap the server
+   * refuses: a booking with neither assets nor model reservations reserves
+   * nothing, an asset flagged unavailable is unavailable on either surface,
+   * and an asset already booked for this window conflicts on either surface.
+   *
+   * The first two are decided from rows this screen already holds. The third
+   * cannot be — it needs the overlapping-booking query — so the server sends
+   * it as a flag. `?? false` keeps a not-yet-updated server (rolling deploy,
+   * field absent) on the old behavior rather than blocking Reserve outright.
+   *
+   * All three are enforced server-side too: the first two in
+   * `bookings.reserve.ts`, the third by `reserveBooking`'s race-safe conflict
+   * check, which names the offending assets.
+   *
+   * `booking` is non-null here — the early return above already handled it.
    */
-  const reserveBlockedReason: string | null = !booking
-    ? null
-    : booking.assetCount === 0 && (booking.modelRequestCount ?? 0) === 0
-    ? "Add assets or reserve at least one model on this booking before you reserve it."
-    : booking.assets.some((a) => a.availableToBook === false)
-    ? "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving."
-    : null;
+  const reserveBlockedReason: string | null =
+    booking.assetCount === 0 && (booking.modelRequestCount ?? 0) === 0
+      ? BOOKING_RESERVE_BLOCKED_LABELS.NOTHING_TO_RESERVE
+      : booking.assets.some((a) => a.availableToBook === false)
+      ? BOOKING_RESERVE_BLOCKED_LABELS.UNAVAILABLE_ASSETS
+      : booking.hasAlreadyBookedAssets ?? false
+      ? BOOKING_RESERVE_BLOCKED_LABELS.ALREADY_BOOKED
+      : null;
 
   const creatorName = formatPersonName(booking.creator);
 
@@ -1295,14 +1311,16 @@ export default function BookingDetailScreen() {
                       styles.manageRowItem,
                       reserveBlockedReason ? styles.actionButtonDisabled : null,
                     ]}
-                    onPress={
-                      reserveBlockedReason
-                        ? () =>
-                            Alert.alert("Cannot reserve", reserveBlockedReason)
-                        : handleReserve
-                    }
+                    // why: `disabled` is the real prop. Setting only
+                    // `accessibilityState={{ disabled }}` ALSO disables the
+                    // touchable — RN's `_createPressabilityConfig` falls back
+                    // to it — which silently made an onPress fallback here
+                    // unreachable. RN copies this prop back into
+                    // `accessibilityState`, so screen readers still announce
+                    // the disabled state without setting it by hand.
+                    disabled={!!reserveBlockedReason}
+                    onPress={handleReserve}
                     accessibilityLabel="Reserve this booking"
-                    accessibilityState={{ disabled: !!reserveBlockedReason }}
                     accessibilityHint={reserveBlockedReason ?? undefined}
                     accessibilityRole="button"
                   >
@@ -2148,11 +2166,20 @@ const useStyles = createStyles((colors, shadows) => ({
     flexDirection: "row",
     gap: spacing.sm,
   },
+  // The blocking reason is the ONLY thing that tells the user why Reserve is
+  // greyed out, so it is styled as a warning callout rather than as incidental
+  // metadata. `warningText` is the token picked for WCAG AA contrast on light
+  // surfaces (see theme-colors.ts); `muted` at xs read as a caption nobody
+  // looked at.
   reserveBlockedNote: {
-    fontSize: fontSize.xs,
-    color: colors.muted,
-    paddingHorizontal: spacing.xs,
-    paddingTop: spacing.xs,
+    fontSize: fontSize.sm,
+    color: colors.warningText,
+    backgroundColor: colors.warningBg,
+    borderRadius: 8,
+    padding: spacing.sm,
+    marginTop: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingTop: spacing.sm,
     lineHeight: 16,
   },
   actionButtonDisabled: {

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -583,6 +583,8 @@ export type BookingAsset = {
   id: string;
   title: string;
   status: string;
+  /** False when the asset is flagged unavailable for bookings. */
+  availableToBook?: boolean;
   mainImage: string | null;
   kitId: string | null;
   category: { id: string; name: string; color: string } | null;

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -704,6 +704,16 @@ export type BookingDetail = {
   /** Total units still to assign across all model requests. */
   outstandingModelUnitCount: number;
   /**
+   * True when any asset on this booking is already booked for the same window
+   * — the third rule web's Reserve button disables on, and the one the client
+   * cannot derive from `assets` (it needs the overlapping-booking query).
+   *
+   * Sent for DRAFT bookings only, since Reserve is its sole consumer. Optional
+   * because a not-yet-updated server (rolling deploy) omits it; treat absent
+   * as `false` rather than blocking Reserve.
+   */
+  hasAlreadyBookedAssets?: boolean;
+  /**
    * Segmented lifecycle progress (Booked / Partial / Fully out / Returned),
    * computed server-side by the SAME shared helper the web booking overview
    * uses, so the mobile progress bar shows identical numbers to web. `null` /

--- a/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { BookingStatus, Tag } from "@prisma/client";
+import { BOOKING_RESERVE_BLOCKED_LABELS } from "@shelf/labels";
 import { useAtom } from "jotai";
 import { DateTime } from "luxon";
 import { useActionData, useLoaderData, useNavigation } from "react-router";
@@ -335,13 +336,18 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
                   bookingFlags?.hasAlreadyBookedAssets ||
                   bookingFlags?.hasUnavailableAssets
                     ? {
+                        // Wording lives in @shelf/labels so the tooltip, the
+                        // mobile route's 400, the in-transaction guard and the
+                        // companion's inline note can never say four different
+                        // things about the same rule (they did, and this copy
+                        // carried an "unavailble" typo).
                         reason: bookingFlags?.hasUnavailableAssets
-                          ? "You have some assets in your booking that are marked as unavailble. Either remove the assets from this booking or make them available again"
+                          ? BOOKING_RESERVE_BLOCKED_LABELS.UNAVAILABLE_ASSETS
                           : bookingFlags?.hasAlreadyBookedAssets
-                          ? "Your booking has assets that are already booked for the desired period. You need to resolve that before you can reserve"
+                          ? BOOKING_RESERVE_BLOCKED_LABELS.ALREADY_BOOKED
                           : isProcessing || isLoadingWorkingHours
                           ? undefined
-                          : "You need to add assets or reserve at least one model on your booking before you can reserve it",
+                          : BOOKING_RESERVE_BLOCKED_LABELS.NOTHING_TO_RESERVE,
                       }
                     : false
                 }

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -7,6 +7,10 @@ import {
   OrganizationRoles,
   ConsumptionType,
 } from "@prisma/client";
+import {
+  BOOKING_EMPTY_RESERVED_MESSAGE,
+  BOOKING_RESERVE_BLOCKED_LABELS,
+} from "@shelf/labels";
 
 import { db } from "~/database/db.server";
 import * as activityEventService from "~/modules/activity-event/service.server";
@@ -243,12 +247,18 @@ vitest.mock("~/database/db.server", () => ({
       // why: Phase 3c qty-tracked flows call tx.bookingAsset.count when
       // deciding whether a shared pool can flip back to AVAILABLE.
       count: vitest.fn().mockResolvedValue(0),
+      // why: reserveBooking's in-transaction eligibility probe looks for a
+      // single slice whose asset is flagged unavailable.
+      findFirst: vitest.fn().mockResolvedValue(null),
     },
     // why: Phase 3d checkoutBooking queries tx.bookingModelRequest.findMany
     // to block RESERVED → ONGOING when model-level reservations haven't
     // been materialised into concrete BookingAsset rows yet.
     bookingModelRequest: {
       findMany: vitest.fn().mockResolvedValue([]),
+      // why: reserveBooking's eligibility probe falls back to counting model
+      // reservations when a booking holds no concrete assets.
+      count: vitest.fn().mockResolvedValue(0),
     },
     consumptionLog: {
       create: vitest.fn().mockResolvedValue({}),
@@ -2566,7 +2576,72 @@ describe("buildKitSlicesForBooking", () => {
 describe("reserveBooking", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+    // Healthy eligibility on the OUTER client. The tests below hand the
+    // transaction a client that disagrees, so a guard reading through `db`
+    // instead of `tx` sees a booking that is fine and fails to refuse.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.count.mockResolvedValue(1);
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findFirst.mockResolvedValue(null);
+    //@ts-expect-error missing vitest type
+    db.bookingModelRequest.count.mockResolvedValue(1);
   });
+
+  afterEach(() => {
+    // Restore the module-level defaults: implementations set with
+    // `mockResolvedValue` survive `clearAllMocks`, so without this the
+    // reserve-friendly values above leak into every later describe.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.count.mockResolvedValue(0);
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findFirst.mockResolvedValue(null);
+    //@ts-expect-error missing vitest type
+    db.bookingModelRequest.count.mockResolvedValue(0);
+    //@ts-expect-error missing vitest type
+    db.$transaction.mockImplementation((callbackOrArray) =>
+      typeof callbackOrArray === "function"
+        ? callbackOrArray(db)
+        : Promise.all(callbackOrArray)
+    );
+  });
+
+  /**
+   * Hands the transaction callback a client whose eligibility answers differ
+   * from the outer `db` mock.
+   *
+   * This is what makes the tests below able to tell an IN-transaction guard
+   * from a pre-transaction one. With the default `$transaction` mock the
+   * callback receives `db` itself, so `tx.x` IS `db.x` and relocating the
+   * guard out of the transaction — the exact regression this describe exists
+   * to prevent — would leave every assertion green.
+   */
+  function installTxEligibility(eligibility: {
+    sliceCount: number;
+    unavailableSlice: { id: string } | null;
+    modelRequestCount: number;
+  }) {
+    const tx = {
+      ...db,
+      bookingAsset: {
+        ...db.bookingAsset,
+        count: vitest.fn().mockResolvedValue(eligibility.sliceCount),
+        findFirst: vitest.fn().mockResolvedValue(eligibility.unavailableSlice),
+      },
+      bookingModelRequest: {
+        ...db.bookingModelRequest,
+        count: vitest.fn().mockResolvedValue(eligibility.modelRequestCount),
+      },
+    };
+
+    //@ts-expect-error missing vitest type
+    db.$transaction.mockImplementation((callbackOrArray) =>
+      typeof callbackOrArray === "function"
+        ? callbackOrArray(tx)
+        : Promise.all(callbackOrArray)
+    );
+
+    return tx;
+  }
 
   const mockReserveParams = {
     id: "booking-1",
@@ -2587,23 +2662,50 @@ describe("reserveBooking", () => {
    * its Reserve button from loader flags and the mobile route checks before it
    * reads working hours and settings, so both leave a window in which a
    * concurrent edit can empty the booking or mark an asset unavailable.
+   *
+   * Every test here states the healthy answer on the outer `db` mock and the
+   * concurrently-edited answer on the transaction client, so they fail both
+   * ways: deleting the guard drops the refusal, and moving it back OUT of the
+   * transaction makes it read the stale outer values and also drop it.
    */
   describe("eligibility re-check on the read immediately before the write", () => {
+    /** The booking as the outer read still sees it: one healthy asset. */
+    const healthyOuterRead = {
+      ...mockBookingData,
+      status: BookingStatus.DRAFT,
+      from: mockReserveParams.from,
+      to: mockReserveParams.to,
+      modelRequests: [],
+      bookingAssets: [
+        {
+          asset: {
+            id: "asset-1",
+            title: "Asset 1",
+            status: "AVAILABLE",
+            availableToBook: true,
+            bookingAssets: [],
+          },
+          assetId: "asset-1",
+          quantity: 1,
+          id: "ba-1",
+        },
+      ],
+    };
+
     it("refuses a booking that lost its last asset and holds no model request", async () => {
       expect.assertions(1);
 
       //@ts-expect-error missing vitest type
-      db.booking.findUniqueOrThrow.mockResolvedValue({
-        ...mockBookingData,
-        status: BookingStatus.DRAFT,
-        from: mockReserveParams.from,
-        to: mockReserveParams.to,
-        bookingAssets: [],
-        modelRequests: [],
+      db.booking.findUniqueOrThrow.mockResolvedValue(healthyOuterRead);
+      // Emptied by a concurrent request after the outer read.
+      installTxEligibility({
+        sliceCount: 0,
+        unavailableSlice: null,
+        modelRequestCount: 0,
       });
 
       await expect(reserveBooking(mockReserveParams)).rejects.toThrow(
-        "Add assets or reserve at least one model on this booking before you reserve it."
+        BOOKING_RESERVE_BLOCKED_LABELS.NOTHING_TO_RESERVE
       );
     });
 
@@ -2624,6 +2726,11 @@ describe("reserveBooking", () => {
         bookingAssets: [],
         modelRequests: [],
       });
+      installTxEligibility({
+        sliceCount: 0,
+        unavailableSlice: null,
+        modelRequestCount: 1,
+      });
 
       await expect(reserveBooking(mockReserveParams)).resolves.toBeDefined();
     });
@@ -2632,32 +2739,50 @@ describe("reserveBooking", () => {
       expect.assertions(1);
 
       //@ts-expect-error missing vitest type
-      db.booking.findUniqueOrThrow.mockResolvedValue({
-        ...mockBookingData,
-        status: BookingStatus.DRAFT,
-        from: mockReserveParams.from,
-        to: mockReserveParams.to,
-        modelRequests: [],
-        bookingAssets: [
-          {
-            asset: {
-              id: "asset-1",
-              title: "Asset 1",
-              status: "AVAILABLE",
-              // flipped by another request between the caller's read and here
-              availableToBook: false,
-              bookingAssets: [],
-            },
-            assetId: "asset-1",
-            quantity: 1,
-            id: "ba-unavail-1",
-          },
-        ],
+      db.booking.findUniqueOrThrow.mockResolvedValue(healthyOuterRead);
+      // Flipped to unavailable by another request between the two reads.
+      installTxEligibility({
+        sliceCount: 1,
+        unavailableSlice: { id: "ba-1" },
+        modelRequestCount: 0,
       });
 
       await expect(reserveBooking(mockReserveParams)).rejects.toThrow(
-        "This booking holds assets marked as unavailable."
+        BOOKING_RESERVE_BLOCKED_LABELS.UNAVAILABLE_ASSETS
       );
+    });
+
+    it("reads eligibility through the transaction client, not the outer one", async () => {
+      expect.assertions(3);
+
+      //@ts-expect-error missing vitest type
+      db.booking.findUniqueOrThrow.mockResolvedValue(healthyOuterRead);
+      const tx = installTxEligibility({
+        sliceCount: 1,
+        unavailableSlice: null,
+        modelRequestCount: 0,
+      });
+      //@ts-expect-error missing vitest type
+      db.booking.update.mockResolvedValue({
+        ...healthyOuterRead,
+        status: BookingStatus.RESERVED,
+      });
+
+      await reserveBooking(mockReserveParams);
+
+      // The probes ran on the transaction client...
+      expect(tx.bookingAsset.count).toHaveBeenCalledWith({
+        where: { bookingId: mockReserveParams.id },
+      });
+      expect(tx.bookingAsset.findFirst).toHaveBeenCalledWith({
+        where: {
+          bookingId: mockReserveParams.id,
+          asset: { availableToBook: false },
+        },
+        select: { id: true },
+      });
+      // ...and not on the outer one.
+      expect(db.bookingAsset.count).not.toHaveBeenCalled();
     });
   });
 
@@ -7095,6 +7220,84 @@ describe("extendBooking", () => {
 describe("removeAssets", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+  });
+
+  /**
+   * The zero-asset invariant, approached from the removal side.
+   *
+   * `reserveBooking` refuses to take an empty booking into RESERVED, but that
+   * only guards the transition: emptying the booking afterwards reached the
+   * same state — a booking that reserves nothing — from the other direction.
+   */
+  describe("refuses to leave a stock-holding booking empty", () => {
+    const emptyingBooking = { id: "booking-1", assetIds: ["asset-1"] };
+
+    /** Nothing left on the booking after the delete. */
+    function nothingRemains(status: BookingStatus) {
+      //@ts-expect-error missing vitest type
+      db.bookingAsset.deleteMany.mockResolvedValue({ count: 1 });
+      //@ts-expect-error missing vitest type
+      db.booking.findUniqueOrThrow.mockResolvedValue({
+        ...emptyingBooking,
+        name: "Test Booking",
+        status,
+      });
+      //@ts-expect-error missing vitest type
+      db.bookingAsset.count.mockResolvedValue(0);
+      //@ts-expect-error missing vitest type
+      db.bookingModelRequest.count.mockResolvedValue(0);
+    }
+
+    const baseArgs = {
+      firstName: "Test",
+      lastName: "User",
+      userId: "user-1",
+      organizationId: "org-1",
+    };
+
+    it("refuses when the booking is RESERVED", async () => {
+      expect.assertions(1);
+      nothingRemains(BookingStatus.RESERVED);
+
+      await expect(
+        removeAssets({ booking: emptyingBooking, ...baseArgs })
+      ).rejects.toThrow(BOOKING_EMPTY_RESERVED_MESSAGE);
+    });
+
+    // The guard is RESERVED-only on purpose. DRAFT is work-in-progress, and a
+    // live booking must stay emptiable so a checked-out asset can be pulled
+    // off it — the bug #99 describe below covers that reconciliation.
+    it.each([
+      BookingStatus.DRAFT,
+      BookingStatus.ONGOING,
+      BookingStatus.OVERDUE,
+    ])("allows a %s booking to be emptied", async (status) => {
+      nothingRemains(status);
+
+      await expect(
+        removeAssets({ booking: emptyingBooking, ...baseArgs })
+      ).resolves.not.toThrow();
+    });
+
+    it("allows emptying the assets while a model reservation still holds the booking", async () => {
+      nothingRemains(BookingStatus.RESERVED);
+      // Model reservations survive asset removal, so the booking still holds
+      // something and the guard must not fire.
+      //@ts-expect-error missing vitest type
+      db.bookingModelRequest.count.mockResolvedValue(1);
+
+      await expect(
+        removeAssets({ booking: emptyingBooking, ...baseArgs })
+      ).resolves.not.toThrow();
+    });
+
+    afterEach(() => {
+      // Restore the module-level defaults for the sibling tests below.
+      //@ts-expect-error missing vitest type
+      db.bookingAsset.count.mockResolvedValue(0);
+      //@ts-expect-error missing vitest type
+      db.bookingModelRequest.count.mockResolvedValue(0);
+    });
   });
 
   it("should remove assets from booking successfully", async () => {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -2574,6 +2574,85 @@ describe("reserveBooking", () => {
     tags: [],
   };
 
+  /**
+   * Race-safe twin of the caller-side checks. The web overview only disables
+   * its Reserve button from loader flags and the mobile route checks before it
+   * reads working hours and settings, so both leave a window in which a
+   * concurrent edit can empty the booking or mark an asset unavailable.
+   */
+  describe("eligibility re-check on the read immediately before the write", () => {
+    it("refuses a booking that lost its last asset and holds no model request", async () => {
+      expect.assertions(1);
+
+      //@ts-expect-error missing vitest type
+      db.booking.findUniqueOrThrow.mockResolvedValue({
+        ...mockBookingData,
+        status: BookingStatus.DRAFT,
+        from: mockReserveParams.from,
+        to: mockReserveParams.to,
+        bookingAssets: [],
+        modelRequests: [],
+      });
+
+      await expect(reserveBooking(mockReserveParams)).rejects.toThrow(
+        "Add assets or reserve at least one model on this booking before you reserve it."
+      );
+    });
+
+    it("reserves a booking that holds only a model request", async () => {
+      //@ts-expect-error missing vitest type
+      db.booking.findUniqueOrThrow.mockResolvedValue({
+        ...mockBookingData,
+        status: BookingStatus.DRAFT,
+        from: mockReserveParams.from,
+        to: mockReserveParams.to,
+        bookingAssets: [],
+        modelRequests: [{ id: "mr-1", assetModelId: "model-1", quantity: 2 }],
+      });
+      //@ts-expect-error missing vitest type
+      db.booking.update.mockResolvedValue({
+        ...mockBookingData,
+        status: BookingStatus.RESERVED,
+        bookingAssets: [],
+        modelRequests: [],
+      });
+
+      await expect(reserveBooking(mockReserveParams)).resolves.toBeDefined();
+    });
+
+    it("refuses when an asset was marked unavailable after the caller checked", async () => {
+      expect.assertions(1);
+
+      //@ts-expect-error missing vitest type
+      db.booking.findUniqueOrThrow.mockResolvedValue({
+        ...mockBookingData,
+        status: BookingStatus.DRAFT,
+        from: mockReserveParams.from,
+        to: mockReserveParams.to,
+        modelRequests: [],
+        bookingAssets: [
+          {
+            asset: {
+              id: "asset-1",
+              title: "Asset 1",
+              status: "AVAILABLE",
+              // flipped by another request between the caller's read and here
+              availableToBook: false,
+              bookingAssets: [],
+            },
+            assetId: "asset-1",
+            quantity: 1,
+            id: "ba-unavail-1",
+          },
+        ],
+      });
+
+      await expect(reserveBooking(mockReserveParams)).rejects.toThrow(
+        "This booking holds assets marked as unavailable."
+      );
+    });
+  });
+
   it("should reserve booking successfully with no conflicts", async () => {
     expect.assertions(2);
 
@@ -2588,6 +2667,7 @@ describe("reserveBooking", () => {
             id: "asset-1",
             title: "Asset 1",
             status: "AVAILABLE",
+            availableToBook: true,
             bookingAssets: [], // No conflicting bookings
           },
           assetId: "asset-1",
@@ -2599,6 +2679,7 @@ describe("reserveBooking", () => {
             id: "asset-2",
             title: "Asset 2",
             status: "AVAILABLE",
+            availableToBook: true,
             bookingAssets: [], // No conflicting bookings
           },
           assetId: "asset-2",
@@ -2645,6 +2726,7 @@ describe("reserveBooking", () => {
             id: "asset-1",
             title: "Asset 1",
             status: "CHECKED_OUT",
+            availableToBook: true,
             bookingAssets: [
               {
                 booking: {
@@ -2725,6 +2807,7 @@ describe("reserveBooking", () => {
               id: QT_ASSET_ID,
               title: "Folding Chairs",
               type: AssetType.QUANTITY_TRACKED,
+              availableToBook: true,
               status: "AVAILABLE",
               unitOfMeasure: "chairs",
               // QUANTITY_TRACKED assets are exempt from the whole-asset
@@ -2959,7 +3042,6 @@ describe("reserveBooking", () => {
     });
   });
 });
-
 describe("checkoutBooking", () => {
   beforeEach(() => {
     vitest.clearAllMocks();

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1551,6 +1551,11 @@ export async function reserveBooking({
                   ...BOOKING_INCLUDE_FOR_RESERVATION_EMAIL.bookingAssets.include
                     .asset.select,
                   status: true,
+                  // Needed by the race-safe availability guard below: the
+                  // route-level check happens before the working-hours and
+                  // settings reads, so an asset can be marked unavailable in
+                  // between. This read is the one immediately before the write.
+                  availableToBook: true,
                   // Needed for the QUANTITY_TRACKED windowed-availability
                   // guard's shortfall message (see the DRAFT → RESERVED
                   // transaction below).
@@ -1627,6 +1632,45 @@ export async function reserveBooking({
           shouldBeCaptured: false,
         });
       }
+    }
+
+    /**
+     * Race-safe twin of the checks the callers make before they get here: the
+     * web overview disables its Reserve button from loader flags, and the
+     * mobile route refuses up front with a friendlier message. Both read the
+     * booking earlier in the request, so a concurrent edit that empties the
+     * booking or marks an asset unavailable would still land in RESERVED.
+     * This re-read is the last one before the write, so the window closes here.
+     */
+    if (
+      bookingFound.bookingAssets.length === 0 &&
+      bookingFound.modelRequests.length === 0
+    ) {
+      throw new ShelfError({
+        cause: null,
+        label,
+        title: "Nothing to reserve",
+        message:
+          "Add assets or reserve at least one model on this booking before you reserve it.",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const unavailableAssets = bookingFound.bookingAssets
+      .map((ba) => ba.asset)
+      .filter((asset) => !asset.availableToBook);
+
+    if (unavailableAssets.length > 0) {
+      throw new ShelfError({
+        cause: null,
+        label,
+        title: "Unavailable assets",
+        message:
+          "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.",
+        status: 400,
+        shouldBeCaptured: false,
+      });
     }
 
     /** Validate the booking dates */

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -1634,45 +1634,6 @@ export async function reserveBooking({
       }
     }
 
-    /**
-     * Race-safe twin of the checks the callers make before they get here: the
-     * web overview disables its Reserve button from loader flags, and the
-     * mobile route refuses up front with a friendlier message. Both read the
-     * booking earlier in the request, so a concurrent edit that empties the
-     * booking or marks an asset unavailable would still land in RESERVED.
-     * This re-read is the last one before the write, so the window closes here.
-     */
-    if (
-      bookingFound.bookingAssets.length === 0 &&
-      bookingFound.modelRequests.length === 0
-    ) {
-      throw new ShelfError({
-        cause: null,
-        label,
-        title: "Nothing to reserve",
-        message:
-          "Add assets or reserve at least one model on this booking before you reserve it.",
-        status: 400,
-        shouldBeCaptured: false,
-      });
-    }
-
-    const unavailableAssets = bookingFound.bookingAssets
-      .map((ba) => ba.asset)
-      .filter((asset) => !asset.availableToBook);
-
-    if (unavailableAssets.length > 0) {
-      throw new ShelfError({
-        cause: null,
-        label,
-        title: "Unavailable assets",
-        message:
-          "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.",
-        status: 400,
-        shouldBeCaptured: false,
-      });
-    }
-
     /** Validate the booking dates */
     if (!from || !to) {
       throw new ShelfError({
@@ -1821,6 +1782,58 @@ export async function reserveBooking({
     );
 
     const updatedBooking = await db.$transaction(async (tx) => {
+      /**
+       * Eligibility, re-read through `tx` immediately before the status write.
+       *
+       * The callers check this earlier - the web overview disables its Reserve
+       * button from loader flags, the mobile route refuses up front with a
+       * better message - but both read the booking before the working-hours and
+       * settings queries, so a concurrent edit could still land in RESERVED.
+       * `availableToBook` is the one that really moves: it is an asset-level
+       * flag toggled from the asset page, with nothing to do with this booking.
+       *
+       * This does not make the transition serializable on its own. Closing the
+       * window completely would mean locking every asset in the booking, which
+       * the QT path below already does for the assets whose pool is contested.
+       * This narrows it to the width of the transaction.
+       */
+      const eligibility = await tx.booking.findUniqueOrThrow({
+        where: { id, organizationId },
+        select: {
+          bookingAssets: {
+            select: { asset: { select: { id: true, availableToBook: true } } },
+          },
+          modelRequests: { select: { id: true } },
+        },
+      });
+
+      if (
+        eligibility.bookingAssets.length === 0 &&
+        eligibility.modelRequests.length === 0
+      ) {
+        throw new ShelfError({
+          cause: null,
+          label,
+          title: "Nothing to reserve",
+          message:
+            "Add assets or reserve at least one model on this booking before you reserve it.",
+          status: 400,
+          shouldBeCaptured: false,
+        });
+      }
+
+      if (eligibility.bookingAssets.some((ba) => !ba.asset.availableToBook)) {
+        throw new ShelfError({
+          cause: null,
+          label,
+          title: "Unavailable assets",
+          message:
+            "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.",
+          status: 400,
+          shouldBeCaptured: false,
+        });
+      }
+
       if (uniqueQtyTrackedAssetIds.length > 0) {
         const assetById = new Map(
           qtyTrackedBookingAssets.map((ba) => [ba.asset.id, ba.asset])

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -15,6 +15,10 @@ import type {
   Tag,
   OrganizationRoles,
 } from "@prisma/client";
+import {
+  BOOKING_EMPTY_RESERVED_MESSAGE,
+  BOOKING_RESERVE_BLOCKED_LABELS,
+} from "@shelf/labels";
 import { isBefore } from "date-fns";
 import { DateTime } from "luxon";
 import { redirect } from "react-router";
@@ -1558,11 +1562,12 @@ export async function reserveBooking({
                   ...BOOKING_INCLUDE_FOR_RESERVATION_EMAIL.bookingAssets.include
                     .asset.select,
                   status: true,
-                  // Needed by the race-safe availability guard below: the
-                  // route-level check happens before the working-hours and
-                  // settings reads, so an asset can be marked unavailable in
-                  // between. This read is the one immediately before the write.
-                  availableToBook: true,
+                  // why: `availableToBook` is deliberately NOT selected here.
+                  // The availability guard reads it through `tx` immediately
+                  // before the status write (see the transaction below); this
+                  // outer read happens before the working-hours and settings
+                  // queries, so its copy would be stale at exactly the moment
+                  // it mattered.
                   // Needed for the QUANTITY_TRACKED windowed-availability
                   // guard's shortfall message (see the DRAFT → RESERVED
                   // transaction below).
@@ -1804,41 +1809,48 @@ export async function reserveBooking({
        * the QT path below already does for the assets whose pool is contested.
        * This narrows it to the width of the transaction.
        */
-      const eligibility = await tx.booking.findUniqueOrThrow({
-        where: { id, organizationId },
-        select: {
-          bookingAssets: {
-            select: { asset: { select: { id: true, availableToBook: true } } },
-          },
-          modelRequests: { select: { id: true } },
-        },
+      // Constant-cost probes, not a materialised list. Both questions are
+      // existence questions, and this runs inside the transaction that goes on
+      // to take a per-asset advisory lock for every QT asset below — loading N
+      // slices and their assets here would widen that lock window for nothing.
+      const sliceCount = await tx.bookingAsset.count({
+        where: { bookingId: id },
       });
 
-      if (
-        eligibility.bookingAssets.length === 0 &&
-        eligibility.modelRequests.length === 0
-      ) {
-        throw new ShelfError({
-          cause: null,
-          label,
-          title: "Nothing to reserve",
-          message:
-            "Add assets or reserve at least one model on this booking before you reserve it.",
-          status: 400,
-          shouldBeCaptured: false,
+      if (sliceCount === 0) {
+        const modelRequestCount = await tx.bookingModelRequest.count({
+          where: { bookingId: id },
         });
+
+        if (modelRequestCount === 0) {
+          throw new ShelfError({
+            cause: null,
+            label,
+            title: "Nothing to reserve",
+            message: BOOKING_RESERVE_BLOCKED_LABELS.NOTHING_TO_RESERVE,
+            status: 400,
+            shouldBeCaptured: false,
+          });
+        }
       }
 
-      if (eligibility.bookingAssets.some((ba) => !ba.asset.availableToBook)) {
-        throw new ShelfError({
-          cause: null,
-          label,
-          title: "Unavailable assets",
-          message:
-            "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.",
-          status: 400,
-          shouldBeCaptured: false,
+      // Only worth asking when the booking actually holds assets.
+      if (sliceCount > 0) {
+        const unavailableSlice = await tx.bookingAsset.findFirst({
+          where: { bookingId: id, asset: { availableToBook: false } },
+          select: { id: true },
         });
+
+        if (unavailableSlice) {
+          throw new ShelfError({
+            cause: null,
+            label,
+            title: "Unavailable assets",
+            message: BOOKING_RESERVE_BLOCKED_LABELS.UNAVAILABLE_ASSETS,
+            status: 400,
+            shouldBeCaptured: false,
+          });
+        }
       }
 
       if (uniqueQtyTrackedAssetIds.length > 0) {
@@ -10404,6 +10416,53 @@ export async function removeAssets({
       await tx.bookingAsset.deleteMany({ where: rowsToDeleteWhere });
 
       /**
+       * The zero-asset invariant, defended from the removal side.
+       *
+       * `reserveBooking` refuses to take a booking into RESERVED with nothing
+       * in it, but that only guards the transition — emptying the booking
+       * afterwards reached exactly the same state from the other direction,
+       * leaving a booking that reserves nothing and cannot be checked out.
+       * Enforced here, in the shared service, rather than at the six call
+       * sites (web overview bulk + single, manage-assets, manage-kits, the
+       * mobile endpoint), so no future caller can miss it.
+       *
+       * RESERVED only, deliberately. An empty DRAFT is normal
+       * work-in-progress; COMPLETE / ARCHIVED / CANCELLED hold nothing any
+       * more; and ONGOING / OVERDUE must stay emptiable, because pulling a
+       * checked-out asset off a live booking is a real correction flow that
+       * this service already reconciles asset status for (bug #99 coverage).
+       *
+       * Throwing inside the tx rolls the delete back, so the booking is never
+       * observably empty.
+       */
+      if (sourceBooking.status === BookingStatus.RESERVED) {
+        const remainingSlices = await tx.bookingAsset.count({
+          where: { bookingId: id },
+        });
+
+        if (remainingSlices === 0) {
+          // Model reservations survive asset removal (the rollback below only
+          // decrements `fulfilledQuantity`), so a booking held purely by
+          // outstanding model requests is still holding something.
+          const remainingModelRequests = await tx.bookingModelRequest.count({
+            where: { bookingId: id },
+          });
+
+          if (remainingModelRequests === 0) {
+            throw new ShelfError({
+              cause: null,
+              label,
+              title: "Booking would be left empty",
+              message: BOOKING_EMPTY_RESERVED_MESSAGE,
+              status: 400,
+              shouldBeCaptured: false,
+              additionalData: { bookingId: id, organizationId },
+            });
+          }
+        }
+      }
+
+      /**
        * Re-open reservations that the removed rows had discharged.
        *
        * Counted from `bookingModelRequestId` — the row's own record of which
@@ -11428,9 +11487,16 @@ export async function getBookingFlags(
       id: { in: booking.assetIds },
       organizationId: booking.organizationId,
     },
-    include: {
-      category: true,
-      custody: true,
+    // why: `select`, not `include`. This function returns only booleans, so the
+    // row shape is private to it — and the previous `include` fetched every
+    // Asset scalar plus `category` and `custody` relations that no flag below
+    // reads (`hasAssetsInCustody` is derived from `status`, not the relation).
+    // On a large booking that payload is paid on every Reserve tap.
+    select: {
+      id: true,
+      type: true,
+      status: true,
+      availableToBook: true,
       assetKits: { select: { kitId: true } },
       bookingAssets: {
         where: {
@@ -11472,7 +11538,7 @@ export async function getBookingFlags(
               : { id: { not: booking.id } }),
           },
         },
-        include: {
+        select: {
           booking: {
             select: { id: true, status: true },
           },

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -116,6 +116,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 id: true,
                 title: true,
                 status: true,
+                // why: lets the app grey out Reserve for the same reason web
+                // does, instead of offering a tap the server will refuse.
+                availableToBook: true,
                 // Quantity-tracked metadata so the app can render the
                 // check-in / check-out quantity + disposition pickers: `type`
                 // gates the picker to QT assets, `consumptionType` decides
@@ -465,6 +468,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           id: a.id,
           kitId: a.kitId,
           status: a.status,
+          availableToBook: a.availableToBook,
           assetType: a.type,
           bookedQuantity: isQty ? booked : undefined,
           // checked-out = booked − still-to-check-out; dispositioned =

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -1,4 +1,9 @@
-import { AssetStatus, AssetType, OrganizationRoles } from "@prisma/client";
+import {
+  AssetStatus,
+  AssetType,
+  BookingStatus,
+  OrganizationRoles,
+} from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
@@ -14,6 +19,7 @@ import {
   bookingDraftVisibilityClause,
   computeBookingAssetRemaining,
   computeBookingAssetRemainingToCheckOut,
+  getBookingFlags,
   getPartiallyCheckedInAssetIds,
 } from "~/modules/booking/service.server";
 import { calculateBookingLifecycleProgress } from "~/modules/booking/utils.server";
@@ -120,6 +126,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
                 status: true,
                 // why: lets the app grey out Reserve for the same reason web
                 // does, instead of offering a tap the server will refuse.
+                // It reaches the client through the `serializeAssetImage(rest)`
+                // spread that builds each row — there is no explicit mapping to
+                // grep for, so do not assume it is unused.
                 availableToBook: true,
                 // Quantity-tracked metadata so the app can render the
                 // check-in / check-out quantity + disposition pickers: `type`
@@ -470,7 +479,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           id: a.id,
           kitId: a.kitId,
           status: a.status,
-          availableToBook: a.availableToBook,
           assetType: a.type,
           bookedQuantity: isQty ? booked : undefined,
           // checked-out = booked − still-to-check-out; dispositioned =
@@ -488,6 +496,31 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       bookingStatus: booking.status,
       countKitsAsSingleUnit: bookingSettings.countKitsAsSingleUnit ?? false,
     });
+
+    /**
+     * The third rule web's Reserve button disables on, which the companion had
+     * no way to evaluate: whether any asset is already booked for this window.
+     * Unlike "no assets" and "unavailable asset", it cannot be derived from the
+     * rows in this response — it needs the overlapping-booking query — so
+     * without this flag the phone showed an enabled Reserve, the user tapped,
+     * confirmed, and only then got a 400 from `reserveBooking`'s conflict check.
+     *
+     * Computed for DRAFT bookings only: Reserve is the sole consumer and it is
+     * the only status that renders it, so no other request pays for the query.
+     */
+    const hasAlreadyBookedAssets =
+      booking.status === BookingStatus.DRAFT && booking.from && booking.to
+        ? (
+            await getBookingFlags({
+              id: booking.id,
+              organizationId,
+              assetIds: assetsForResponse.map((a) => a.id),
+              modelRequestCount,
+              from: booking.from,
+              to: booking.to,
+            })
+          ).hasAlreadyBookedAssets
+        : false;
 
     return data({
       booking: {
@@ -510,6 +543,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         modelRequestCount,
         outstandingModelUnitCount,
         lifecycleProgress,
+        hasAlreadyBookedAssets,
       },
       checkedInAssetIds,
       canCheckout,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
@@ -11,7 +11,10 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
-import { reserveBooking } from "~/modules/booking/service.server";
+import {
+  getBookingFlags,
+  reserveBooking,
+} from "~/modules/booking/service.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
@@ -96,6 +99,9 @@ export async function action({ request }: ActionFunctionArgs) {
         custodianTeamMemberId: true,
         custodianTeamMember: { select: { id: true, name: true, userId: true } },
         tags: { select: { id: true } },
+        // Needed for the same Reserve eligibility check the web form runs.
+        bookingAssets: { select: { assetId: true } },
+        modelRequests: { select: { id: true } },
       },
     });
 
@@ -131,6 +137,57 @@ export async function action({ request }: ActionFunctionArgs) {
       throw new ShelfError({
         cause: null,
         message: "Booking has no custodian. Add a custodian before reserving.",
+        label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    /**
+     * Reserve eligibility, matching the web form exactly.
+     *
+     * Web disables its Reserve button when a booking has neither assets nor
+     * model requests, or when it holds an asset marked unavailable. Those
+     * checks lived only in the web UI, so the phone could reserve a booking
+     * the website refuses — an empty reservation reserves nothing, and an
+     * unavailable asset is unavailable on either surface. The repo's own rule
+     * (see `bookings.checkin.ts`) is that the app must never be more
+     * permissive than the web, so this is enforced server-side where no client
+     * can skip it.
+     *
+     * Already-booked assets are NOT re-checked here: `reserveBooking` runs its
+     * own conflict validation inside the transaction, which is the race-safe
+     * place for it.
+     */
+    const flags = await getBookingFlags({
+      id: booking.id,
+      organizationId,
+      assetIds: booking.bookingAssets.map((ba) => ba.assetId),
+      // A booking with no concrete assets but a model-level reservation is
+      // still a valid thing to reserve — same door web leaves open.
+      modelRequestCount: booking.modelRequests.length,
+      from: booking.from,
+      to: booking.to,
+    });
+
+    if (!flags.hasAssets && !flags.hasModelRequests) {
+      throw new ShelfError({
+        cause: null,
+        title: "Nothing to reserve",
+        message:
+          "Add assets or reserve at least one model on this booking before you reserve it.",
+        label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (flags.hasUnavailableAssets) {
+      throw new ShelfError({
+        cause: null,
+        title: "Unavailable assets",
+        message:
+          "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.",
         label: "Booking",
         status: 400,
         shouldBeCaptured: false,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
@@ -1,4 +1,5 @@
-import { OrganizationRoles } from "@prisma/client";
+import { BookingStatus, OrganizationRoles } from "@prisma/client";
+import { BOOKING_RESERVE_BLOCKED_LABELS } from "@shelf/labels";
 import { DateTime } from "luxon";
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
@@ -144,6 +145,28 @@ export async function action({ request }: ActionFunctionArgs) {
     }
 
     /**
+     * Status first, eligibility second.
+     *
+     * `reserveBooking` refuses anything that is not DRAFT anyway, but it does
+     * so AFTER this route's eligibility block. Two devices on one booking is
+     * the ordinary case: A reserves it, B's stale detail screen still shows
+     * DRAFT and B taps Reserve. If that booking also holds an unavailable
+     * asset, checking eligibility first sends B hunting for an asset to fix
+     * when the real answer is "someone already reserved this". Answering with
+     * the status also skips the eligibility queries on a request that cannot
+     * succeed.
+     */
+    if (booking.status !== BookingStatus.DRAFT) {
+      throw new ShelfError({
+        cause: null,
+        message: `This booking is already ${booking.status.toLowerCase()}. Only DRAFT bookings can be reserved.`,
+        label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    /**
      * Reserve eligibility, matching the web form exactly.
      *
      * Web disables its Reserve button when a booking has neither assets nor
@@ -156,8 +179,12 @@ export async function action({ request }: ActionFunctionArgs) {
      * can skip it.
      *
      * Already-booked assets are NOT re-checked here: `reserveBooking` runs its
-     * own conflict validation inside the transaction, which is the race-safe
-     * place for it.
+     * own conflict validation inside the transaction, which is both the
+     * race-safe place for it and the one that can name the offending assets.
+     * The companion greys Reserve out for that case from the
+     * `hasAlreadyBookedAssets` flag on the booking detail payload, so this
+     * route refusing it a second time would only trade a precise message for
+     * a vague one.
      */
     const flags = await getBookingFlags({
       id: booking.id,
@@ -173,9 +200,7 @@ export async function action({ request }: ActionFunctionArgs) {
     if (!flags.hasAssets && !flags.hasModelRequests) {
       throw new ShelfError({
         cause: null,
-        title: "Nothing to reserve",
-        message:
-          "Add assets or reserve at least one model on this booking before you reserve it.",
+        message: BOOKING_RESERVE_BLOCKED_LABELS.NOTHING_TO_RESERVE,
         label: "Booking",
         status: 400,
         shouldBeCaptured: false,
@@ -185,9 +210,7 @@ export async function action({ request }: ActionFunctionArgs) {
     if (flags.hasUnavailableAssets) {
       throw new ShelfError({
         cause: null,
-        title: "Unavailable assets",
-        message:
-          "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.",
+        message: BOOKING_RESERVE_BLOCKED_LABELS.UNAVAILABLE_ASSETS,
         label: "Booking",
         status: 400,
         shouldBeCaptured: false,
@@ -272,6 +295,11 @@ export async function action({ request }: ActionFunctionArgs) {
     });
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
+    // why: message-only by contract. The companion's shared API client
+    // flattens every response to `json.error.message` (lib/api/client.ts) and
+    // supplies its own alert heading, so a `title` on the errors above would
+    // never reach a user. Keep refusal messages self-contained sentences
+    // rather than relying on a heading to complete them.
     return data(
       { error: { message: reason.message } },
       { status: reason.status }

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -113,3 +113,29 @@ export declare function auditAssetStatusLabel(
   status: AuditAssetStatusKey,
   isAuditCompleted: boolean
 ): AuditAssetStatusLabel;
+
+/**
+ * Why a booking cannot be reserved yet — the three rules web's Reserve button
+ * disables on, in one register for every surface that states them (web
+ * tooltip, mobile route 400, in-transaction guard, companion client note).
+ *
+ * These are the *reasons the button is blocked*. They are not the outcome of a
+ * failed write: `reserveBooking`'s race-safe conflict check names the specific
+ * offending assets and keeps its own richer message.
+ */
+export declare const BOOKING_RESERVE_BLOCKED_LABELS: {
+  readonly NOTHING_TO_RESERVE: "Add assets or reserve at least one model on this booking before you reserve it.";
+  readonly UNAVAILABLE_ASSETS: "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.";
+  readonly ALREADY_BOOKED: "This booking holds assets already booked for that period. Remove them, or change the dates, before reserving.";
+};
+
+/**
+ * Refusal shown when emptying a RESERVED booking — the same zero-asset
+ * invariant the Reserve guards defend, enforced on the removal side so it
+ * cannot be reached from the other direction.
+ *
+ * RESERVED only: an empty DRAFT is normal work-in-progress, the terminal
+ * statuses hold nothing, and ONGOING / OVERDUE bookings must stay emptiable so
+ * a checked-out asset can still be pulled off a live booking.
+ */
+export declare const BOOKING_EMPTY_RESERVED_MESSAGE: "A reserved booking must keep at least one asset or model reservation. Cancel the booking instead, or add a replacement first.";

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -150,3 +150,38 @@ export function auditAssetStatusLabel(status, isAuditCompleted) {
   }
   return AUDIT_ASSET_STATUS_LABELS[status];
 }
+
+// Why a booking cannot be reserved yet — the three rules web's Reserve button
+// disables on, in one register for every surface that states them.
+//
+// Before this there were FOUR wordings for the same two rules: the web tooltip
+// (which also carried an "unavailble" typo), the mobile route's 400, the
+// in-transaction guard's 400, and the companion's client-side note. A wording
+// change fixed at most one of them, and the phone told users something the
+// website did not. `ALREADY_BOOKED` is the rule the companion could not state
+// at all until the booking detail payload started carrying the flag.
+//
+// These are the *reasons the button is blocked*, not the outcome of a failed
+// write: `reserveBooking`'s race-safe conflict check names the specific
+// offending assets and deliberately keeps its own richer message.
+export const BOOKING_RESERVE_BLOCKED_LABELS = Object.freeze({
+  NOTHING_TO_RESERVE:
+    "Add assets or reserve at least one model on this booking before you reserve it.",
+  UNAVAILABLE_ASSETS:
+    "This booking holds assets marked as unavailable. Remove them, or make them available again, before reserving.",
+  ALREADY_BOOKED:
+    "This booking holds assets already booked for that period. Remove them, or change the dates, before reserving.",
+});
+
+// Refusal shown when emptying a RESERVED booking. Such a booking with nothing
+// in it reserves nothing — the very state the Reserve guards exist to prevent —
+// so the removal paths defend the same invariant rather than letting users
+// reach it from the other side.
+//
+// RESERVED only, deliberately. An empty DRAFT is normal work-in-progress; a
+// COMPLETE / ARCHIVED / CANCELLED booking is not holding anything any more; and
+// ONGOING / OVERDUE bookings must stay emptiable, because pulling a
+// checked-out asset off a live booking is a real correction flow (the service
+// reconciles the asset's status when it happens).
+export const BOOKING_EMPTY_RESERVED_MESSAGE =
+  "A reserved booking must keep at least one asset or model reservation. Cancel the booking instead, or add a replacement first.";


### PR DESCRIPTION
Noticed while asking a simple product question: why is there a RESERVED booking with zero assets? Because the phone allows it and the website does not.

## The gap

Web disables its Reserve button when a booking has **neither assets nor model reservations**, and when it holds an **asset flagged unavailable**. Its tooltip even says so: *"You need to add assets or reserve at least one model on your booking before you can reserve it."*

Both checks lived **only in the web UI**. The mobile Reserve button had no disabled condition at all beyond `status === "DRAFT"`, and `bookings.reserve.ts` checked only that the booking exists, that a self-service user owns it, and that it has dates and a custodian.

So the phone could reserve a booking the website refuses — including an empty one, which reserves nothing.

This repo already states the rule, in `bookings.checkin.ts`:

> The mobile app must NEVER be more permissive than the web / a workspace's settings

Explicit check-in got that treatment. Reserve never did.

## Fix

- Both guards enforced **server-side** in `bookings.reserve.ts`, through the same shared `getBookingFlags` the web loader uses, so no client can skip them.
- The model-request door stays open: assets **or** model requests is enough, exactly as on web.
- Already-booked assets are deliberately **not** re-checked here. `reserveBooking` runs its own conflict validation inside the transaction, which is the race-safe place for it — and that check already protected mobile, so double-booking was never possible.
- The mobile button now greys out with web's wording, and `availableToBook` rides in the booking payload so the app can tell the two cases apart instead of guessing.

Existing empty reservations are untouched; this only governs new transitions.

## Verified

Webapp and companion typecheck clean, companion lint clean, 389 mobile API route tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added booking eligibility validation before reservations can be submitted.
  * Reservations are blocked when a booking has no assets or model requests, or includes unavailable assets.
  * Booking details now show whether assets are available for booking.

* **Bug Fixes**
  * Prevented invalid reservations from reaching the reservation process.
  * Added clear alerts, disabled button styling, and accessibility states when reservations cannot be submitted.
  * Added final eligibility checks to prevent availability changes from creating invalid reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->