### PR TITLE
fix(organization): stop workspace ADMINs from transferring ownership

### DIFF
--- a/apps/webapp/app/modules/organization/service.server.test.ts
+++ b/apps/webapp/app/modules/organization/service.server.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Organization Service — ownership transfer authorization
+ *
+ * Pins the authorization contract of {@link transferOwnership}: only the
+ * workspace's current OWNER, or a Shelf platform admin, may transfer
+ * ownership. A workspace ADMIN must not.
+ *
+ * Regression coverage for detail.dev finding D000: the owner check compared
+ * the *organization owner's* role against itself (`currentOwnerUserOrg` was
+ * selected by `roles.includes(OWNER)`, so `!roles.includes(OWNER)` could never
+ * be true) and never compared the requesting `userId` to anyone, letting any
+ * workspace ADMIN take over the workspace.
+ *
+ * @see {@link file://./service.server.ts}
+ * @see {@link file://./../../routes/_layout+/settings.general.tsx}
+ */
+
+import { OrganizationRoles, OrganizationType, Roles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { transferOwnership } from "./service.server";
+
+// @vitest-environment node
+
+const ORG_ID = "org-1";
+const OWNER_ID = "user-owner";
+const ADMIN_ID = "user-admin";
+const NEW_OWNER_ID = "user-new-owner";
+const SHELF_ADMIN_ID = "user-shelf-admin";
+
+type MockDb = {
+  $transaction: <T>(callback: (tx: MockDb) => Promise<T>) => Promise<T>;
+  user: { findUniqueOrThrow: ReturnType<typeof vi.fn> };
+  userOrganization: {
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  organization: { update: ReturnType<typeof vi.fn> };
+};
+
+const dbMock = vi.hoisted<MockDb>(() => ({
+  $transaction: vi.fn(
+    <T>(callback: (tx: MockDb) => Promise<T>): Promise<T> =>
+      callback(dbMock as MockDb)
+  ) as <T>(callback: (tx: MockDb) => Promise<T>) => Promise<T>,
+  user: { findUniqueOrThrow: vi.fn() },
+  userOrganization: { findMany: vi.fn(), update: vi.fn() },
+  organization: { update: vi.fn() },
+}));
+
+// why: isolating database calls so the authorization branch can be unit tested
+vi.mock("~/database/db.server", () => ({ db: dbMock }));
+
+// why: ownership transfer sends notification emails as a side effect
+vi.mock("~/emails/mail.server", () => ({ sendEmail: vi.fn() }));
+
+// why: premium/Stripe paths are irrelevant to the authorization contract and
+// would otherwise require a full Stripe client
+vi.mock("~/utils/stripe.server", () => ({
+  premiumIsEnabled: false,
+  getUserActiveSubscription: vi.fn(),
+  getUserActiveSubscriptions: vi.fn(),
+  transferSubscriptionToCustomer: vi.fn(),
+  createStripeCustomer: vi.fn(),
+  customerHasPaymentMethod: vi.fn(),
+}));
+
+vi.mock("../tier/service.server", () => ({ updateUserTierId: vi.fn() }));
+
+const currentOrganization = {
+  id: ORG_ID,
+  name: "Test Org",
+  type: OrganizationType.TEAM,
+};
+
+/** Builds a UserOrganization row shaped like the service's `select` clause */
+function userOrg(userId: string, roles: OrganizationRoles[]) {
+  return {
+    id: `uo-${userId}`,
+    user: {
+      id: userId,
+      firstName: "Test",
+      lastName: "User",
+      displayName: null,
+      email: `${userId}@example.com`,
+      roles: [],
+      customerId: null,
+      tierId: "free",
+      usedFreeTrial: false,
+    },
+    roles,
+  };
+}
+
+describe("transferOwnership authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (dbMock.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      <T>(callback: (tx: MockDb) => Promise<T>): Promise<T> => callback(dbMock)
+    );
+
+    // Default: the requesting user is NOT a Shelf platform admin
+    dbMock.user.findUniqueOrThrow.mockResolvedValue({
+      id: ADMIN_ID,
+      roles: [],
+    });
+
+    // The service's findMany returns the org OWNER plus the new-owner candidate
+    dbMock.userOrganization.findMany.mockResolvedValue([
+      userOrg(OWNER_ID, [OrganizationRoles.OWNER]),
+      userOrg(NEW_OWNER_ID, [OrganizationRoles.ADMIN]),
+    ]);
+
+    dbMock.userOrganization.update.mockResolvedValue({});
+    dbMock.organization.update.mockResolvedValue({});
+  });
+
+  it("rejects a workspace ADMIN who is not the owner", async () => {
+    await expect(
+      transferOwnership({
+        currentOrganization,
+        newOwnerId: NEW_OWNER_ID,
+        // The caller is a workspace ADMIN, not the OWNER
+        userId: ADMIN_ID,
+      })
+    ).rejects.toThrow(/not the owner/i);
+
+    // Nothing may be written when authorization fails
+    expect(dbMock.organization.update).not.toHaveBeenCalled();
+    expect(dbMock.userOrganization.update).not.toHaveBeenCalled();
+  });
+
+  it("allows the current OWNER to transfer ownership", async () => {
+    dbMock.user.findUniqueOrThrow.mockResolvedValue({
+      id: OWNER_ID,
+      roles: [],
+    });
+
+    const { newOwner } = await transferOwnership({
+      currentOrganization,
+      newOwnerId: NEW_OWNER_ID,
+      userId: OWNER_ID,
+    });
+
+    expect(newOwner.id).toBe(NEW_OWNER_ID);
+    expect(dbMock.organization.update).toHaveBeenCalled();
+  });
+
+  it("allows a Shelf platform admin who is not an organization member", async () => {
+    // Shelf admins act from the admin dashboard and are not org members, so
+    // they never appear in the userOrganization rows.
+    dbMock.user.findUniqueOrThrow.mockResolvedValue({
+      id: SHELF_ADMIN_ID,
+      roles: [{ name: Roles.ADMIN }],
+    });
+
+    const { newOwner } = await transferOwnership({
+      currentOrganization,
+      newOwnerId: NEW_OWNER_ID,
+      userId: SHELF_ADMIN_ID,
+    });
+
+    expect(newOwner.id).toBe(NEW_OWNER_ID);
+    expect(dbMock.organization.update).toHaveBeenCalled();
+  });
+
+  it("demotes the real outgoing owner, not the requesting Shelf admin", async () => {
+    dbMock.user.findUniqueOrThrow.mockResolvedValue({
+      id: SHELF_ADMIN_ID,
+      roles: [{ name: Roles.ADMIN }],
+    });
+
+    await transferOwnership({
+      currentOrganization,
+      newOwnerId: NEW_OWNER_ID,
+      userId: SHELF_ADMIN_ID,
+    });
+
+    // The row demoted to ADMIN must be the previous OWNER's row. This is what
+    // breaks if `currentOwnerUserOrg` is repointed at the requesting user.
+    expect(dbMock.userOrganization.update).toHaveBeenCalledWith({
+      where: { id: `uo-${OWNER_ID}` },
+      data: { roles: { set: [OrganizationRoles.ADMIN] } },
+    });
+  });
+});

--- a/apps/webapp/app/modules/organization/service.server.test.ts
+++ b/apps/webapp/app/modules/organization/service.server.test.ts
@@ -65,6 +65,8 @@ vi.mock("~/utils/stripe.server", () => ({
   customerHasPaymentMethod: vi.fn(),
 }));
 
+// why: tier writes are a subscription-transfer side effect, and these tests run
+// with premiumIsEnabled false to assert only the authorization branch
 vi.mock("../tier/service.server", () => ({ updateUserTierId: vi.fn() }));
 
 const currentOrganization = {

--- a/apps/webapp/app/modules/organization/service.server.ts
+++ b/apps/webapp/app/modules/organization/service.server.ts
@@ -810,26 +810,37 @@ export async function transferOwnership({
       },
     });
 
+    /**
+     * The organization's CURRENT owner — i.e. the user losing ownership.
+     *
+     * This is deliberately NOT the requesting user: it is the record that gets
+     * demoted to ADMIN below, whose subscription is optionally transferred, and
+     * who receives the "you are no longer the owner" email. A Shelf platform
+     * admin can drive this flow without being a member of the organization at
+     * all, so the two identities must stay separate.
+     */
     const currentOwnerUserOrg = userOrganization.find((userOrg) =>
       userOrg.roles.includes(OrganizationRoles.OWNER)
     );
-    /** Validate if the current user is a member of the organization */
     if (!currentOwnerUserOrg) {
       throw new ShelfError({
         cause: null,
-        message: "Current user is not a member of the organization.",
+        message: "Organization does not have an owner.",
         label,
       });
     }
 
     /**
-     * Validate if the current user is the owner of organization
-     * or is a Shelf admin
+     * Validate that the REQUESTING user may transfer ownership: either they are
+     * the current owner, or they are a Shelf platform admin.
+     *
+     * Comparing identities is the entire check. A workspace ADMIN passes
+     * `requirePermission` on the settings route because ADMIN and OWNER share
+     * every permission, so this is the only place the two are distinguished —
+     * previously this compared the owner's role against itself, which is always
+     * true, and let any ADMIN take over the workspace.
      */
-    if (
-      !currentOwnerUserOrg.roles.includes(OrganizationRoles.OWNER) &&
-      !isCurrentUserShelfAdmin
-    ) {
+    if (currentOwnerUserOrg.user.id !== userId && !isCurrentUserShelfAdmin) {
       throw new ShelfError({
         cause: null,
         message: "Current user is not the owner of the organization.",

--- a/apps/webapp/app/routes/_layout+/settings.general.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.general.tsx
@@ -439,6 +439,23 @@ export async function action({ context, request }: ActionFunctionArgs) {
         return redirect("/settings/general");
       }
       case "transfer-ownership": {
+        // Defense in depth: the transfer card is hidden from non-owners, but a
+        // hand-crafted POST must not be able to transfer the workspace either.
+        // `requirePermission` above cannot catch this — ADMIN and OWNER share
+        // every permission, so the role has to be checked explicitly.
+        if (role !== OrganizationRoles.OWNER) {
+          throw new ShelfError({
+            cause: null,
+            title: "Permission denied",
+            message: "Only the workspace owner can transfer ownership.",
+            label: "Settings",
+            status: 403,
+            // why: a blocked privilege escalation attempt is a client error, not
+            // a server fault — it should not page anyone via Sentry
+            shouldBeCaptured: false,
+          });
+        }
+
         const parsedData = parseData(formData, TransferOwnershipSchema, {
           additionalData: { userId, organizationId },
         });

--- a/apps/webapp/test/routes-tests/_layout+/settings.general.test.tsx
+++ b/apps/webapp/test/routes-tests/_layout+/settings.general.test.tsx
@@ -5,6 +5,7 @@ import { createLoaderArgs, createActionArgs } from "@mocks/remix";
 import { db } from "~/database/db.server";
 import {
   getOrganizationAdmins,
+  transferOwnership,
   updateOrganization,
 } from "~/modules/organization/service.server";
 import { getOrganizationTierLimit } from "~/modules/tier/service.server";
@@ -566,6 +567,92 @@ describe("settings.general action", () => {
     // Should allow hiding branding (Plus tier on personal workspace)
     expect(updateOrganizationMock).toHaveBeenCalledWith(
       expect.objectContaining({ showShelfBranding: false })
+    );
+  });
+});
+
+describe("settings.general transfer-ownership authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    getOrganizationTierLimitMock.mockResolvedValue({
+      id: "tier_2",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      canImportAssets: true,
+      canExportAssets: true,
+      canImportNRM: true,
+      canHideShelfBranding: true,
+      maxCustomFields: 0,
+      maxOrganizations: 1,
+    } as any);
+    canHideShelfBrandingMock.mockReturnValue(true);
+    dbMock.user.findUniqueOrThrow.mockResolvedValue({ tierId: "tier_2" });
+  });
+
+  /** Builds the POST body an attacker would hand-craft */
+  function transferRequest() {
+    const body = new URLSearchParams();
+    body.append("intent", "transfer-ownership");
+    body.append("newOwner", "user-2");
+    body.append("agreeConditions", "on");
+
+    return new Request("http://localhost/settings/general", {
+      method: "POST",
+      body,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+  }
+
+  function mockRole(role: OrganizationRoles) {
+    requirePermissionMock.mockResolvedValue({
+      organizationId: "org-1",
+      currentOrganization: baseOrganization(),
+      role,
+      organizations: [baseOrganization()],
+      isSelfServiceOrBase: false,
+      userOrganizations: [],
+      canSeeAllBookings: true,
+      canSeeAllCustody: true,
+      canUseBarcodes: false,
+    } as any);
+  }
+
+  it("rejects a direct POST from a workspace ADMIN", async () => {
+    // ADMIN passes requirePermission — ADMIN and OWNER share every permission —
+    // so only the explicit role check in the action can stop this.
+    mockRole(OrganizationRoles.ADMIN);
+
+    const response = (await action(
+      createActionArgs({
+        context: mockContext,
+        request: transferRequest(),
+        params: {},
+      })
+      // The action funnels thrown ShelfErrors through `data(error(reason), {
+      // status })`, which returns a DataWithResponseInit rather than a Response.
+    )) as { init?: { status?: number } };
+
+    expect(response.init?.status).toBe(403);
+    expect(transferOwnership).not.toHaveBeenCalled();
+  });
+
+  it("allows the OWNER to transfer ownership", async () => {
+    mockRole(OrganizationRoles.OWNER);
+    vi.mocked(transferOwnership).mockResolvedValue({
+      newOwner: { id: "user-2", email: "new@example.com" },
+    } as any);
+
+    await action(
+      createActionArgs({
+        context: mockContext,
+        request: transferRequest(),
+        params: {},
+      })
+    );
+
+    expect(transferOwnership).toHaveBeenCalledWith(
+      expect.objectContaining({ newOwnerId: "user-2" })
     );
   });
 });


### PR DESCRIPTION
## What

Any workspace **ADMIN** could take over the workspace by transferring ownership to themselves.

Found by the free detail.dev OSS scan (finding D000, scanned at `7e139f5c`).

## The bug

`transferOwnership` compared a record against itself:

```ts
// currentOwnerUserOrg is SELECTED BY having the OWNER role...
const currentOwnerUserOrg = userOrganization.find((userOrg) =>
  userOrg.roles.includes(OrganizationRoles.OWNER)
);

// ...so this can never be true. The requesting `userId` is never compared.
if (
  !currentOwnerUserOrg.roles.includes(OrganizationRoles.OWNER) &&
  !isCurrentUserShelfAdmin
) {
  throw new ShelfError({ message: "Current user is not the owner..." });
}
```

The route couldn't catch it either. ADMIN and OWNER share every permission, so
`requirePermission` passes for both, and the `transfer-ownership` intent had no
role check — unlike the `sso` and `scim` intents in the same `switch`.

**Exploit** — an ADMIN POSTs directly, bypassing the UI that hides the card:

```
POST /settings/general
intent=transfer-ownership&newOwner=<their-own-user-id>&agreeConditions=on
```

Introduced in `707644315`, which changed the query from `{ userId }` to
`{ roles: { has: OWNER } }` to add Shelf-admin support without updating the
validation to match.

## The fix

**Service** — compare identities instead of re-checking the owner's own role:

```ts
if (currentOwnerUserOrg.user.id !== userId && !isCurrentUserShelfAdmin) {
```

**Route** — add the `role !== OWNER` guard as defense in depth, matching the
`sso`/`scim` siblings, with `status: 403` and `shouldBeCaptured: false` so a
blocked escalation attempt isn't logged as a 5xx and doesn't page anyone.

### Why `currentOwnerUserOrg` still points at the current owner

Worth flagging for review, because the obvious fix is wrong here.

That variable is also the row demoted to ADMIN, the tier/subscription source,
and the recipient of the previous-owner email. Repointing it at the *requesting*
user (the intuitive fix, and the one the scanner recommended) leaves it
`undefined` on the Shelf-admin path — admins aren't org members — and crashes
the admin-dashboard transfer at `currentOwnerUserOrg.user.tierId`.

Keeping it as the real owner and adding a *separate* identity check is smaller
and correct on all three paths. There's a test pinning that the outgoing
owner's row is the one demoted, so this can't silently regress.

## Behaviour

| Caller | Before | After |
| --- | --- | --- |
| Workspace OWNER | allowed | allowed |
| Shelf platform admin (admin dashboard) | allowed | allowed |
| **Workspace ADMIN** | **allowed** 🔴 | **403** ✅ |

## Tests

`apps/webapp/app/modules/organization/service.server.test.ts` (new, 4 tests) —
ADMIN rejected, OWNER allowed, Shelf admin allowed, and the correct row demoted.

`settings.general.test.tsx` (+2) — ADMIN direct POST returns 403 and never
reaches the service; OWNER still passes through.

The ADMIN test was confirmed to fail against the unfixed code before the fix
was applied, so the vulnerability is genuinely reproduced rather than assumed.

## Sweep

- The `roles: { has: OWNER }`-as-authorization pattern appears nowhere else.
- All four owner-only intents in `settings.general` are now guarded.

## Follow-ups (deliberately not in this PR)

- `transferOwnership` emits **no `recordEvent`** — the highest-privilege state
  change in the product leaves no activity-trail entry. Violates
  `.claude/rules/use-record-event.md`.
- The `sso`/`scim` role guards in the same file throw without `status`, so they
  surface as captured 500s rather than 403s.

## Disclosure

Privilege escalation reachable by any workspace ADMIN. Flagging for a GHSA
decision before release — no action taken here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted workspace ownership transfers to the current workspace owner.
  * Allowed authorized platform administrators to perform ownership transfers.
  * Prevented non-owner workspace administrators from initiating transfers or changing ownership records.
  * Ensured rejected requests return a permission error before any changes are made.
* **Tests**
  * Added coverage for authorized and unauthorized ownership-transfer scenarios, including correct ownership demotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->