### PR TITLE
fix(webapp): relocate transfer-ownership button, fix anchor scroll and hover reason

### DIFF
--- a/apps/webapp/app/components/assets/asset-status-badge/asset-status-badge.test.tsx
+++ b/apps/webapp/app/components/assets/asset-status-badge/asset-status-badge.test.tsx
@@ -67,10 +67,6 @@ vi.mock("../../shared/hover-card", () => ({
   HoverCardContent: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("@radix-ui/react-hover-card", () => ({
-  HoverCardPortal: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
 beforeEach(() => {
   apiQueryCalls.length = 0;
 });

--- a/apps/webapp/app/components/assets/asset-status-badge/asset-status-badge.tsx
+++ b/apps/webapp/app/components/assets/asset-status-badge/asset-status-badge.tsx
@@ -21,7 +21,6 @@
 import { useMemo, useState } from "react";
 import type { Booking } from "@prisma/client";
 import { AssetStatus } from "@prisma/client";
-import { HoverCardPortal } from "@radix-ui/react-hover-card";
 import useApiQuery from "~/hooks/use-api-query";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import type { ExtendedAssetStatus } from "~/utils/booking-assets";
@@ -198,14 +197,12 @@ export function AssetStatusBadge({
               `suppressQtyAware`, or no data yet), the chip is plain and
               the breakdown popover would be misleading — hide it. */}
           {!useCallerStatus && (
-            <HoverCardPortal>
-              <HoverCardContent
-                side="bottom"
-                className="w-[26rem] max-w-[calc(100vw-2rem)]"
-              >
-                <QuantityTooltipContent data={quantityData} />
-              </HoverCardContent>
-            </HoverCardPortal>
+            <HoverCardContent
+              side="bottom"
+              className="w-[26rem] max-w-[calc(100vw-2rem)]"
+            >
+              <QuantityTooltipContent data={quantityData} />
+            </HoverCardContent>
           )}
         </HoverCard>
         {!availableToBook && (
@@ -232,17 +229,15 @@ export function AssetStatusBadge({
       </HoverCardTrigger>
 
       <When truthy={!!bookingToShow}>
-        <HoverCardPortal>
-          <HoverCardContent side="top" className="w-max min-w-36 max-w-72">
-            <Button
-              variant="link-gray"
-              to={`/bookings/${bookingToShow?.id}`}
-              target="_blank"
-            >
-              {bookingToShow?.name}
-            </Button>
-          </HoverCardContent>
-        </HoverCardPortal>
+        <HoverCardContent side="top" className="w-max min-w-36 max-w-72">
+          <Button
+            variant="link-gray"
+            to={`/bookings/${bookingToShow?.id}`}
+            target="_blank"
+          >
+            {bookingToShow?.name}
+          </Button>
+        </HoverCardContent>
       </When>
     </HoverCard>
   );

--- a/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
+++ b/apps/webapp/app/components/assets/assets-index/advanced-asset-columns.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import type { RenderableTreeNode } from "@markdoc/markdoc";
 import type { AssetStatus, QrIdDisplayPreference } from "@prisma/client";
 import { CustomFieldType } from "@prisma/client";
-import { HoverCardPortal } from "@radix-ui/react-hover-card";
 import {
   Popover,
   PopoverTrigger,
@@ -989,47 +988,44 @@ function UpcomingBookingsColumn({
                     | {title}
                   </HoverCardTrigger>
 
-                  <HoverCardPortal>
-                    <HoverCardContent className="!mt-0 w-full rounded-md border bg-white px-4 py-2">
-                      <EventCardContent
-                        booking={{
-                          id: booking.id,
-                          name: booking.name,
-                          description: booking.description,
-                          status: booking.status,
-                          tags: booking.tags,
-                          start: booking.from,
-                          end: booking.to,
-                          custodian: {
-                            name: custodianName ?? "",
-                            user: booking.custodianUser
-                              ? {
-                                  id: booking.custodianUser.id,
-                                  firstName: booking.custodianUser.firstName,
-                                  lastName: booking.custodianUser.lastName,
-                                  profilePicture:
-                                    booking.custodianUser.profilePicture,
-                                }
-                              : null,
-                          },
-                          creator: {
-                            name: booking.creator
-                              ? resolveUserDisplayName(booking.creator)
-                              : "Unknown",
-                            user: booking.creator
-                              ? {
-                                  id: booking.creator.id,
-                                  firstName: booking.creator.firstName,
-                                  lastName: booking.creator.lastName,
-                                  profilePicture:
-                                    booking.creator.profilePicture,
-                                }
-                              : null,
-                          },
-                        }}
-                      />
-                    </HoverCardContent>
-                  </HoverCardPortal>
+                  <HoverCardContent className="!mt-0 w-full rounded-md border bg-white px-4 py-2">
+                    <EventCardContent
+                      booking={{
+                        id: booking.id,
+                        name: booking.name,
+                        description: booking.description,
+                        status: booking.status,
+                        tags: booking.tags,
+                        start: booking.from,
+                        end: booking.to,
+                        custodian: {
+                          name: custodianName ?? "",
+                          user: booking.custodianUser
+                            ? {
+                                id: booking.custodianUser.id,
+                                firstName: booking.custodianUser.firstName,
+                                lastName: booking.custodianUser.lastName,
+                                profilePicture:
+                                  booking.custodianUser.profilePicture,
+                              }
+                            : null,
+                        },
+                        creator: {
+                          name: booking.creator
+                            ? resolveUserDisplayName(booking.creator)
+                            : "Unknown",
+                          user: booking.creator
+                            ? {
+                                id: booking.creator.id,
+                                firstName: booking.creator.firstName,
+                                lastName: booking.creator.lastName,
+                                profilePicture: booking.creator.profilePicture,
+                              }
+                            : null,
+                        },
+                      }}
+                    />
+                  </HoverCardContent>
                 </HoverCard>
               );
             })}

--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -56,6 +56,7 @@ import InlineEntityCreationDialog from "../inline-entity-creation-dialog/inline-
 import { Button } from "../shared/button";
 import { ButtonGroup } from "../shared/button-group";
 import { Card } from "../shared/card";
+import { DisabledReasonHoverCard } from "../shared/disabled-reason-hover-card";
 import {
   HoverCard,
   HoverCardContent,
@@ -1229,33 +1230,32 @@ export const AssetForm = ({
             value={locationId || ""}
           />
           {isKitAsset ? (
-            <HoverCard openDelay={50} closeDelay={50}>
-              <HoverCardTrigger className="disabled w-full cursor-not-allowed">
-                <DynamicSelect
-                  disabled={locationDisabled}
-                  selectionMode="set"
-                  fieldName="newLocationId"
-                  triggerWrapperClassName="flex flex-col !gap-0 justify-start items-start [&_.inner-label]:w-full [&_.inner-label]:text-left "
-                  defaultValue={locationId || undefined}
-                  model={{ name: "location", queryKey: "name" }}
-                  contentLabel="Locations"
-                  label="Location"
-                  hideLabel
-                  initialDataKey="locations"
-                  countKey="totalLocations"
-                  closeOnSelect
-                  allowClear
-                />
-              </HoverCardTrigger>
-              <HoverCardContent side="left">
-                <h5 className="text-left text-[14px]">Action disabled</h5>
-                <p className="text-left text-[14px]">
+            <DisabledReasonHoverCard
+              triggerClassName="disabled w-full cursor-not-allowed"
+              reason={
+                <>
                   This asset's location is managed by its parent kit{" "}
                   <strong>"{kitMembership?.name}"</strong>. Update the kit's
                   location instead.
-                </p>
-              </HoverCardContent>
-            </HoverCard>
+                </>
+              }
+            >
+              <DynamicSelect
+                disabled={locationDisabled}
+                selectionMode="set"
+                fieldName="newLocationId"
+                triggerWrapperClassName="flex flex-col !gap-0 justify-start items-start [&_.inner-label]:w-full [&_.inner-label]:text-left "
+                defaultValue={locationId || undefined}
+                model={{ name: "location", queryKey: "name" }}
+                contentLabel="Locations"
+                label="Location"
+                hideLabel
+                initialDataKey="locations"
+                countKey="totalLocations"
+                closeOnSelect
+                allowClear
+              />
+            </DisabledReasonHoverCard>
           ) : (
             <DynamicSelect
               disabled={disabled}

--- a/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
+++ b/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
@@ -19,11 +19,7 @@ import { tw } from "~/utils/tw";
 import Icon from "../icons/icon";
 import { Dialog, DialogPortal } from "../layout/dialog";
 import { Button } from "../shared/button";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "../shared/hover-card";
+import type { DisabledProp } from "../shared/button";
 
 /**
  * Type of the dialog
@@ -62,16 +58,13 @@ type CommonBulkDialogProps = {
 type BulkUpdateDialogTriggerProps = CommonBulkDialogProps & {
   label?: string;
   onClick?: () => void;
-  /** Disabled can be a boolean  */
-  disabled?:
-    | boolean
-    | {
-        reason: string;
-      };
+  /** Boolean, or `{ reason }` to explain WHY the action is unavailable. */
+  disabled?: DisabledProp;
 };
 
 type BulkUpdateTriggerButtonProps = {
-  disabled?: boolean;
+  /** Boolean, or `{ reason }` to explain WHY the action is unavailable. */
+  disabled?: DisabledProp;
   type: BulkDialogType;
   label: string;
   onClick?: () => void;
@@ -119,46 +112,21 @@ function BulkUpdateDialogTrigger({
   label = `Update ${type}`,
   disabled,
 }: BulkUpdateDialogTriggerProps) {
-  const isDisabled =
-    disabled === undefined // If it is undefined, then it is not disabled
-      ? false
-      : typeof disabled === "boolean"
-      ? disabled
-      : true; // If it is an object, then it is disabled
-  const reason = typeof disabled === "object" ? disabled.reason : "";
-
   const openBulkDialog = useSetAtom(openBulkDialogAtom);
 
   function handleOpenDialog() {
     openBulkDialog(type);
   }
 
-  if (disabled) {
-    return (
-      <HoverCard openDelay={50} closeDelay={50}>
-        <HoverCardTrigger
-          className={tw("disabled inline-flex w-full cursor-not-allowed ")}
-        >
-          <BulkUpdateTriggerButton
-            disabled={isDisabled}
-            type={type}
-            label={label}
-            onClick={onClick}
-            onOpen={handleOpenDialog}
-          />
-        </HoverCardTrigger>
-        {reason && (
-          <HoverCardContent side="left">
-            <h5 className="text-left text-[14px]">Action disabled</h5>
-            <p className="text-left text-[14px]">{reason}</p>
-          </HoverCardContent>
-        )}
-      </HoverCard>
-    );
-  }
-
+  /**
+   * `disabled` is handed straight to `Button`, which owns the
+   * disabled-with-reason presentation (hover, tap and `aria-describedby`).
+   * This used to re-implement the HoverCard here, which left every bulk action
+   * hover-only — dead grey controls on touch. Don't reintroduce that copy.
+   */
   return (
     <BulkUpdateTriggerButton
+      disabled={disabled}
       type={type}
       label={label}
       onClick={onClick}

--- a/apps/webapp/app/components/calendar/event-card.tsx
+++ b/apps/webapp/app/components/calendar/event-card.tsx
@@ -1,5 +1,4 @@
 import type { EventContentArg } from "@fullcalendar/core";
-import { HoverCardPortal } from "@radix-ui/react-hover-card";
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import { ArrowRightIcon, Boxes } from "lucide-react";
 
@@ -243,16 +242,14 @@ export default function renderEventCard({ event }: EventCardProps) {
           </div>
         </div>
       </HoverCardTrigger>
-      <HoverCardPortal>
-        <HoverCardContent
-          className="pointer-events-none z-[99999] md:w-auto md:max-w-[450px]"
-          side="top"
-          sideOffset={8}
-          collisionPadding={16}
-        >
-          <EventCardContent booking={booking} />
-        </HoverCardContent>
-      </HoverCardPortal>
+      <HoverCardContent
+        className="pointer-events-none z-[99999] md:w-auto md:max-w-[450px]"
+        side="top"
+        sideOffset={8}
+        collisionPadding={16}
+      >
+        <EventCardContent booking={booking} />
+      </HoverCardContent>
     </HoverCard>
   );
 }

--- a/apps/webapp/app/components/location/location-badge.tsx
+++ b/apps/webapp/app/components/location/location-badge.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Location } from "@prisma/client";
-import { HoverCardPortal } from "@radix-ui/react-hover-card";
 import { ListTree } from "lucide-react";
 import useApiQuery from "~/hooks/use-api-query";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
@@ -158,14 +157,12 @@ export function LocationBadge({ location, className }: LocationBadgeProps) {
           </>
         </Tag>
       </HoverCardTrigger>
-      <HoverCardPortal>
-        <HoverCardContent
-          className="max-w-md"
-          style={{ width: "max-content", minWidth: "18rem" }}
-        >
-          {content}
-        </HoverCardContent>
-      </HoverCardPortal>
+      <HoverCardContent
+        className="max-w-md"
+        style={{ width: "max-content", minWidth: "18rem" }}
+      >
+        {content}
+      </HoverCardContent>
     </HoverCard>
   );
 }

--- a/apps/webapp/app/components/settings/import-users-dialog/import-users-dialog.tsx
+++ b/apps/webapp/app/components/settings/import-users-dialog/import-users-dialog.tsx
@@ -73,12 +73,9 @@ export default function ImportUsersDialog({
       {trigger ? (
         cloneElement(trigger, { onClick: openDialog })
       ) : (
-        <Button
-          type="button"
-          variant="secondary"
-          className="mt-2 w-full md:mt-0 md:w-max"
-          onClick={openDialog}
-        >
+        // No width/margin classes here on purpose: the actions row that
+        // renders this owns the layout (see settings.team.users).
+        <Button type="button" variant="secondary" onClick={openDialog}>
           <span className="whitespace-nowrap">Import Users</span>
         </Button>
       )}

--- a/apps/webapp/app/components/settings/transfer-ownership-button.test.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-button.test.tsx
@@ -1,0 +1,120 @@
+import type { AnchorHTMLAttributes, PropsWithChildren } from "react";
+import { OrganizationRoles } from "@prisma/client";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────
+
+const mockUseRouteLoaderData = vi.fn();
+
+// why: isolate component from react-router hooks that depend on a running router
+vi.mock("react-router", async () => {
+  const actual = (await vi.importActual("react-router")) as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...actual,
+    useRouteLoaderData: (...args: unknown[]) => mockUseRouteLoaderData(...args),
+    Link: ({
+      to,
+      children,
+      ...rest
+    }: PropsWithChildren<
+      AnchorHTMLAttributes<HTMLAnchorElement> & { to?: unknown }
+    >) => (
+      <a {...rest} href={typeof to === "string" ? to : undefined}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+// ── Component under test ──
+// Dynamic import must come AFTER the vi.mock() calls above so the mocks are
+// in place before transfer-ownership-button.tsx (and its transitive deps) load.
+
+const { default: TransferOwnershipButton } = await import(
+  "./transfer-ownership-button"
+);
+
+// ── Test data ──────────────────────────────────────────
+
+const OWNER_EMAIL = "owner@example.com";
+
+function createLayoutData({
+  roles = [OrganizationRoles.ADMIN],
+  isShelfAdmin = false,
+}: {
+  roles?: OrganizationRoles[];
+  isShelfAdmin?: boolean;
+} = {}) {
+  return {
+    currentOrganizationUserRoles: roles,
+    currentOrganization: {
+      id: "org-1",
+      name: "Test Org",
+      owner: { id: "owner-1", email: OWNER_EMAIL },
+    },
+    user: {
+      id: "user-1",
+      roles: isShelfAdmin ? [{ name: "ADMIN" }] : [],
+    },
+  };
+}
+
+function renderButton(layoutData = createLayoutData()) {
+  mockUseRouteLoaderData.mockReturnValue(layoutData);
+  return render(<TransferOwnershipButton />);
+}
+
+// ── Tests ──────────────────────────────────────────────
+
+describe("TransferOwnershipButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("links the workspace owner to the transfer section on general settings", () => {
+    renderButton(createLayoutData({ roles: [OrganizationRoles.OWNER] }));
+
+    expect(
+      screen.getByRole("link", { name: /transfer ownership/i })
+    ).toHaveAttribute("href", "/settings/general#transfer-ownership");
+  });
+
+  it("links Shelf staff admins who are not the owner the same way", () => {
+    renderButton(
+      createLayoutData({
+        roles: [OrganizationRoles.ADMIN],
+        isShelfAdmin: true,
+      })
+    );
+
+    expect(
+      screen.getByRole("link", { name: /transfer ownership/i })
+    ).toHaveAttribute("href", "/settings/general#transfer-ownership");
+  });
+
+  it("shows non-owners an inert button whose hover reason names the owner", async () => {
+    const user = userEvent.setup();
+    renderButton(createLayoutData({ roles: [OrganizationRoles.ADMIN] }));
+
+    // No link for non-owners — only an inert button
+    expect(
+      screen.queryByRole("link", { name: /transfer ownership/i })
+    ).not.toBeInTheDocument();
+    const button = screen.getByRole("button", { name: /transfer ownership/i });
+
+    // why: disabled-with-reason buttons render without the `disabled`
+    // attribute (a HoverCard wrapper prevents the click instead), so we
+    // assert the behavior — the hover reason must name the owner.
+    await user.hover(button);
+    expect(
+      await screen.findByText(
+        new RegExp(`only the workspace owner \\(${OWNER_EMAIL}\\)`, "i")
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/webapp/app/components/settings/transfer-ownership-button.test.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-button.test.tsx
@@ -3,6 +3,7 @@ import { OrganizationRoles } from "@prisma/client";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLayoutLoaderData, OWNER_EMAIL } from "@factories";
 
 // ── Mocks ──────────────────────────────────────────────
 
@@ -41,35 +42,7 @@ const { default: TransferOwnershipButton } = await import(
 
 // ── Test data ──────────────────────────────────────────
 
-const OWNER_EMAIL = "owner@example.com";
-
-function createLayoutData({
-  roles = [OrganizationRoles.ADMIN],
-  isShelfAdmin = false,
-  owner = { id: "owner-1", email: OWNER_EMAIL } as {
-    id: string;
-    email: string;
-  } | null,
-}: {
-  roles?: OrganizationRoles[];
-  isShelfAdmin?: boolean;
-  /** `null` mirrors a loader payload that stopped selecting the owner. */
-  owner?: { id: string; email: string } | null;
-} = {}) {
-  return {
-    currentOrganizationUserRoles: roles,
-    currentOrganization: {
-      id: "org-1",
-      name: "Test Org",
-      owner,
-    },
-    // Shelf staff admin flag, as derived by the _layout loader
-    isAdmin: isShelfAdmin,
-    user: { id: "user-1" },
-  };
-}
-
-function renderButton(layoutData = createLayoutData()) {
+function renderButton(layoutData = createLayoutLoaderData()) {
   mockUseRouteLoaderData.mockReturnValue(layoutData);
   return render(<TransferOwnershipButton />);
 }
@@ -82,7 +55,7 @@ describe("TransferOwnershipButton", () => {
   });
 
   it("links the workspace owner to the transfer section on general settings", () => {
-    renderButton(createLayoutData({ roles: [OrganizationRoles.OWNER] }));
+    renderButton(createLayoutLoaderData({ roles: [OrganizationRoles.OWNER] }));
 
     expect(
       screen.getByRole("link", { name: /transfer ownership/i })
@@ -91,7 +64,7 @@ describe("TransferOwnershipButton", () => {
 
   it("links Shelf staff admins who are not the owner the same way", () => {
     renderButton(
-      createLayoutData({
+      createLayoutLoaderData({
         roles: [OrganizationRoles.ADMIN],
         isShelfAdmin: true,
       })
@@ -104,7 +77,7 @@ describe("TransferOwnershipButton", () => {
 
   it("shows non-owners an inert button whose hover reason names the owner", async () => {
     const user = userEvent.setup();
-    renderButton(createLayoutData({ roles: [OrganizationRoles.ADMIN] }));
+    renderButton(createLayoutLoaderData({ roles: [OrganizationRoles.ADMIN] }));
 
     // No link for non-owners — only an inert button
     expect(
@@ -130,7 +103,7 @@ describe("TransferOwnershipButton", () => {
 
   it("falls back to a generic reason when the loader ships no owner", () => {
     renderButton(
-      createLayoutData({ roles: [OrganizationRoles.ADMIN], owner: null })
+      createLayoutLoaderData({ roles: [OrganizationRoles.ADMIN], owner: null })
     );
 
     const button = screen.getByRole("button", { name: /transfer ownership/i });

--- a/apps/webapp/app/components/settings/transfer-ownership-button.test.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-button.test.tsx
@@ -46,21 +46,26 @@ const OWNER_EMAIL = "owner@example.com";
 function createLayoutData({
   roles = [OrganizationRoles.ADMIN],
   isShelfAdmin = false,
+  owner = { id: "owner-1", email: OWNER_EMAIL } as {
+    id: string;
+    email: string;
+  } | null,
 }: {
   roles?: OrganizationRoles[];
   isShelfAdmin?: boolean;
+  /** `null` mirrors a loader payload that stopped selecting the owner. */
+  owner?: { id: string; email: string } | null;
 } = {}) {
   return {
     currentOrganizationUserRoles: roles,
     currentOrganization: {
       id: "org-1",
       name: "Test Org",
-      owner: { id: "owner-1", email: OWNER_EMAIL },
+      owner,
     },
-    user: {
-      id: "user-1",
-      roles: isShelfAdmin ? [{ name: "ADMIN" }] : [],
-    },
+    // Shelf staff admin flag, as derived by the _layout loader
+    isAdmin: isShelfAdmin,
+    user: { id: "user-1" },
   };
 }
 
@@ -109,12 +114,32 @@ describe("TransferOwnershipButton", () => {
 
     // why: disabled-with-reason buttons render without the `disabled`
     // attribute (a HoverCard wrapper prevents the click instead), so we
-    // assert the behavior — the hover reason must name the owner.
+    // assert the behavior — the reason must name the owner, both on hover
+    // and to assistive tech.
     await user.hover(button);
     expect(
-      await screen.findByText(
+      await screen.findAllByText(
         new RegExp(`only the workspace owner \\(${OWNER_EMAIL}\\)`, "i")
       )
-    ).toBeInTheDocument();
+    ).not.toHaveLength(0);
+
+    expect(
+      document.getElementById(button.getAttribute("aria-describedby") as string)
+    ).toHaveTextContent(new RegExp(OWNER_EMAIL, "i"));
+  });
+
+  it("falls back to a generic reason when the loader ships no owner", () => {
+    renderButton(
+      createLayoutData({ roles: [OrganizationRoles.ADMIN], owner: null })
+    );
+
+    const button = screen.getByRole("button", { name: /transfer ownership/i });
+
+    // No stray "()" where the email would have gone
+    expect(
+      document.getElementById(button.getAttribute("aria-describedby") as string)
+    ).toHaveTextContent(
+      /^only the workspace owner can transfer ownership of this workspace\.$/i
+    );
   });
 });

--- a/apps/webapp/app/components/settings/transfer-ownership-button.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-button.tsx
@@ -1,6 +1,5 @@
-import { Roles } from "@prisma/client";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
-import { useUserData } from "~/hooks/use-user-data";
+import { useIsShelfAdmin } from "~/hooks/use-is-shelf-admin";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { Button } from "../shared/button";
 
@@ -13,8 +12,9 @@ import { Button } from "../shared/button";
  * to "Import Users" / "Invite a user" so it reads as a page-level action, not
  * a row action.
  *
- * - Workspace owner (and Shelf staff admins, matching the isShelfAdmin check
- *   in TransferOwnershipCard) get a link to the transfer section.
+ * - Workspace owner (and Shelf staff admins, via {@link useIsShelfAdmin} —
+ *   the same gate TransferOwnershipCard uses) get a link to the transfer
+ *   section.
  * - Everyone else gets a disabled button whose hover reason names the owner,
  *   so admins learn who can run the transfer instead of the feature being
  *   invisible to them.
@@ -23,21 +23,17 @@ import { Button } from "../shared/button";
  */
 export default function TransferOwnershipButton() {
   const { isOwner } = useUserRoleHelper();
-  const user = useUserData();
+  const isShelfAdmin = useIsShelfAdmin();
   const currentOrganization = useCurrentOrganization();
-
-  const isShelfAdmin = user?.roles?.some((role) => role.name === Roles.ADMIN);
 
   /** Shown to non-owners so they know who to ask */
   const ownerEmail = currentOrganization?.owner?.email;
 
+  // No width/margin classes on either branch: the actions row that renders
+  // this owns the layout (see settings.team.users).
   if (isOwner || isShelfAdmin) {
     return (
-      <Button
-        to="/settings/general#transfer-ownership"
-        variant="secondary"
-        className="mt-2 w-full md:mt-0 md:w-max"
-      >
+      <Button to="/settings/general#transfer-ownership" variant="secondary">
         <span className="whitespace-nowrap">Transfer ownership</span>
       </Button>
     );
@@ -47,7 +43,6 @@ export default function TransferOwnershipButton() {
     <Button
       type="button"
       variant="secondary"
-      className="mt-2 w-full md:mt-0 md:w-max"
       disabled={{
         reason: `Only the workspace owner${
           ownerEmail ? ` (${ownerEmail})` : ""

--- a/apps/webapp/app/components/settings/transfer-ownership-button.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-button.tsx
@@ -1,6 +1,5 @@
+import { useCanTransferOwnership } from "~/hooks/use-can-transfer-ownership";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
-import { useIsShelfAdmin } from "~/hooks/use-is-shelf-admin";
-import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { Button } from "../shared/button";
 
 /**
@@ -12,9 +11,9 @@ import { Button } from "../shared/button";
  * to "Import Users" / "Invite a user" so it reads as a page-level action, not
  * a row action.
  *
- * - Workspace owner (and Shelf staff admins, via {@link useIsShelfAdmin} —
- *   the same gate TransferOwnershipCard uses) get a link to the transfer
- *   section.
+ * - Whoever may run the transfer (workspace owner or Shelf staff admin, via
+ *   {@link useCanTransferOwnership} — the same gate TransferOwnershipCard
+ *   uses) gets a link to the transfer section.
  * - Everyone else gets a disabled button whose hover reason names the owner,
  *   so admins learn who can run the transfer instead of the feature being
  *   invisible to them.
@@ -22,8 +21,7 @@ import { Button } from "../shared/button";
  * @see {@link file://./transfer-ownership-card.tsx}
  */
 export default function TransferOwnershipButton() {
-  const { isOwner } = useUserRoleHelper();
-  const isShelfAdmin = useIsShelfAdmin();
+  const canTransferOwnership = useCanTransferOwnership();
   const currentOrganization = useCurrentOrganization();
 
   /** Shown to non-owners so they know who to ask */
@@ -31,7 +29,7 @@ export default function TransferOwnershipButton() {
 
   // No width/margin classes on either branch: the actions row that renders
   // this owns the layout (see settings.team.users).
-  if (isOwner || isShelfAdmin) {
+  if (canTransferOwnership) {
     return (
       <Button to="/settings/general#transfer-ownership" variant="secondary">
         <span className="whitespace-nowrap">Transfer ownership</span>

--- a/apps/webapp/app/components/settings/transfer-ownership-button.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-button.tsx
@@ -1,0 +1,60 @@
+import { Roles } from "@prisma/client";
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
+import { useUserData } from "~/hooks/use-user-data";
+import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import { Button } from "../shared/button";
+
+/**
+ * Header affordance for the ownership-transfer flow on Settings → Team.
+ *
+ * The flow itself lives on the general settings page
+ * (`/settings/general#transfer-ownership`); this button only makes it
+ * discoverable from the place where people manage their team. It renders next
+ * to "Import Users" / "Invite a user" so it reads as a page-level action, not
+ * a row action.
+ *
+ * - Workspace owner (and Shelf staff admins, matching the isShelfAdmin check
+ *   in TransferOwnershipCard) get a link to the transfer section.
+ * - Everyone else gets a disabled button whose hover reason names the owner,
+ *   so admins learn who can run the transfer instead of the feature being
+ *   invisible to them.
+ *
+ * @see {@link file://./transfer-ownership-card.tsx}
+ */
+export default function TransferOwnershipButton() {
+  const { isOwner } = useUserRoleHelper();
+  const user = useUserData();
+  const currentOrganization = useCurrentOrganization();
+
+  const isShelfAdmin = user?.roles?.some((role) => role.name === Roles.ADMIN);
+
+  /** Shown to non-owners so they know who to ask */
+  const ownerEmail = currentOrganization?.owner?.email;
+
+  if (isOwner || isShelfAdmin) {
+    return (
+      <Button
+        to="/settings/general#transfer-ownership"
+        variant="secondary"
+        className="mt-2 w-full md:mt-0 md:w-max"
+      >
+        <span className="whitespace-nowrap">Transfer ownership</span>
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="secondary"
+      className="mt-2 w-full md:mt-0 md:w-max"
+      disabled={{
+        reason: `Only the workspace owner${
+          ownerEmail ? ` (${ownerEmail})` : ""
+        } can transfer ownership of this workspace.`,
+      }}
+    >
+      <span className="whitespace-nowrap">Transfer ownership</span>
+    </Button>
+  );
+}

--- a/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
@@ -72,10 +72,9 @@ function createLayoutData({
       name: "Test Org",
       owner: { id: "owner-1", email: OWNER_EMAIL },
     },
-    user: {
-      id: "user-1",
-      roles: isShelfAdmin ? [{ name: "ADMIN" }] : [],
-    },
+    // Shelf staff admin flag, as derived by the _layout loader
+    isAdmin: isShelfAdmin,
+    user: { id: "user-1" },
   };
 }
 

--- a/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.test.tsx
@@ -7,6 +7,7 @@ import { OrganizationRoles } from "@prisma/client";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLayoutLoaderData, OWNER_EMAIL } from "@factories";
 import { TooltipProvider } from "../shared/tooltip";
 
 // ── Mocks ──────────────────────────────────────────────
@@ -56,28 +57,6 @@ const { default: TransferOwnershipCard } = await import(
 
 // ── Test data ──────────────────────────────────────────
 
-const OWNER_EMAIL = "owner@example.com";
-
-function createLayoutData({
-  roles = [OrganizationRoles.ADMIN],
-  isShelfAdmin = false,
-}: {
-  roles?: OrganizationRoles[];
-  isShelfAdmin?: boolean;
-} = {}) {
-  return {
-    currentOrganizationUserRoles: roles,
-    currentOrganization: {
-      id: "org-1",
-      name: "Test Org",
-      owner: { id: "owner-1", email: OWNER_EMAIL },
-    },
-    // Shelf staff admin flag, as derived by the _layout loader
-    isAdmin: isShelfAdmin,
-    user: { id: "user-1" },
-  };
-}
-
 const admin = {
   id: "admin-1",
   firstName: "Julia",
@@ -92,11 +71,11 @@ const noSubscription = {
 };
 
 function renderCard({
-  layoutData = createLayoutData(),
+  layoutData = createLayoutLoaderData(),
   admins = [admin],
   isPersonalWorkspace = false,
 }: {
-  layoutData?: ReturnType<typeof createLayoutData>;
+  layoutData?: ReturnType<typeof createLayoutLoaderData>;
   admins?: (typeof admin)[];
   isPersonalWorkspace?: boolean;
 } = {}) {
@@ -126,7 +105,7 @@ describe("TransferOwnershipCard", () => {
 
   it("shows the transfer flow to the workspace owner", () => {
     renderCard({
-      layoutData: createLayoutData({ roles: [OrganizationRoles.OWNER] }),
+      layoutData: createLayoutLoaderData({ roles: [OrganizationRoles.OWNER] }),
     });
 
     expect(
@@ -140,7 +119,7 @@ describe("TransferOwnershipCard", () => {
 
   it("tells non-owner members who can transfer instead of rendering nothing", () => {
     renderCard({
-      layoutData: createLayoutData({ roles: [OrganizationRoles.ADMIN] }),
+      layoutData: createLayoutLoaderData({ roles: [OrganizationRoles.ADMIN] }),
     });
 
     const explainer = screen.getByText(/only the workspace owner/i, {
@@ -155,7 +134,7 @@ describe("TransferOwnershipCard", () => {
 
   it("still shows the transfer flow to Shelf admins who are not the owner", () => {
     renderCard({
-      layoutData: createLayoutData({
+      layoutData: createLayoutLoaderData({
         roles: [OrganizationRoles.ADMIN],
         isShelfAdmin: true,
       }),
@@ -168,7 +147,7 @@ describe("TransferOwnershipCard", () => {
 
   it("explains the account-email alternative for personal workspaces", () => {
     renderCard({
-      layoutData: createLayoutData({ roles: [OrganizationRoles.OWNER] }),
+      layoutData: createLayoutLoaderData({ roles: [OrganizationRoles.OWNER] }),
       isPersonalWorkspace: true,
     });
 
@@ -188,7 +167,7 @@ describe("TransferOwnershipCard", () => {
   it("renders an inert transfer button when the workspace has no admins", async () => {
     const user = userEvent.setup();
     renderCard({
-      layoutData: createLayoutData({ roles: [OrganizationRoles.OWNER] }),
+      layoutData: createLayoutLoaderData({ roles: [OrganizationRoles.OWNER] }),
       admins: [],
     });
 

--- a/apps/webapp/app/components/settings/transfer-ownership-card.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.tsx
@@ -2,10 +2,9 @@ import { useState } from "react";
 import { Form, Link, useActionData } from "react-router";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
+import { useCanTransferOwnership } from "~/hooks/use-can-transfer-ownership";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { useDisabled } from "~/hooks/use-disabled";
-import { useIsShelfAdmin } from "~/hooks/use-is-shelf-admin";
-import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { getValidationErrors } from "~/utils/http";
 import type { DataOrErrorResponse } from "~/utils/http.server";
 import type { OwnerSubscriptionInfo } from "~/utils/stripe.server";
@@ -112,8 +111,7 @@ export default function TransferOwnershipCard({
   premiumIsEnabled,
   isPersonalWorkspace = false,
 }: TransferOwnershipCardProps) {
-  const { isOwner } = useUserRoleHelper();
-  const isShelfAdmin = useIsShelfAdmin();
+  const canTransferOwnership = useCanTransferOwnership();
   const [confirmationInput, setConfirmationInput] = useState("");
   const [selectedOwner, setSelectedOwner] = useState<Admin | null>(null);
   const [transferSubscription, setTransferSubscription] = useState(false);
@@ -170,7 +168,7 @@ export default function TransferOwnershipCard({
   }
 
   /** Non-owners cannot transfer, but must still be able to discover who can */
-  if (!isOwner && !isShelfAdmin) {
+  if (!canTransferOwnership) {
     return (
       <Card className={tw(className)} id="transfer-ownership">
         <h4 className="mb-1 text-text-lg font-semibold">

--- a/apps/webapp/app/components/settings/transfer-ownership-card.tsx
+++ b/apps/webapp/app/components/settings/transfer-ownership-card.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
-import { Roles } from "@prisma/client";
 import { Form, Link, useActionData } from "react-router";
 import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { useDisabled } from "~/hooks/use-disabled";
-import { useUserData } from "~/hooks/use-user-data";
+import { useIsShelfAdmin } from "~/hooks/use-is-shelf-admin";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { getValidationErrors } from "~/utils/http";
 import type { DataOrErrorResponse } from "~/utils/http.server";
@@ -114,7 +113,7 @@ export default function TransferOwnershipCard({
   isPersonalWorkspace = false,
 }: TransferOwnershipCardProps) {
   const { isOwner } = useUserRoleHelper();
-  const user = useUserData();
+  const isShelfAdmin = useIsShelfAdmin();
   const [confirmationInput, setConfirmationInput] = useState("");
   const [selectedOwner, setSelectedOwner] = useState<Admin | null>(null);
   const [transferSubscription, setTransferSubscription] = useState(false);
@@ -138,8 +137,6 @@ export default function TransferOwnershipCard({
   const validationErrors = getValidationErrors<typeof TransferOwnershipSchema>(
     actionData?.error
   );
-
-  const isShelfAdmin = user?.roles?.some((role) => role.name === Roles.ADMIN);
 
   // Check if current owner has subscriptions that could be transferred
   const ownerHasSubscription =

--- a/apps/webapp/app/components/shared/button-disabled-reason.test.tsx
+++ b/apps/webapp/app/components/shared/button-disabled-reason.test.tsx
@@ -2,31 +2,44 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { Button } from "./button";
 
+const REASON = /only the owner can do this/i;
+
+/**
+ * The reason lives in the DOM twice on purpose:
+ *
+ * 1. a visually hidden copy that `aria-describedby` resolves against — it must
+ *    exist even while the card is closed, or a screen-reader user gets nothing
+ * 2. the hover card content itself, mounted only while open
+ *
+ * So "the popup is open" is `2` occurrences, and "closed" is `1`.
+ */
+function reasonOccurrences() {
+  return screen.queryAllByText(REASON).length;
+}
+
+function renderDisabledButton() {
+  render(
+    <Button type="button" disabled={{ reason: "Only the owner can do this." }}>
+      Transfer ownership
+    </Button>
+  );
+
+  return screen.getByRole("button", { name: /transfer ownership/i });
+}
+
 /**
  * Disabled-with-reason buttons explain themselves through a HoverCard.
  * Hover never fires on touch devices, so the reason must ALSO open on
  * click/tap — otherwise mobile users get a dead-looking grey button.
  */
 describe("Button disabled with reason", () => {
-  // why: fireEvent.click instead of userEvent — userEvent simulates the
-  // full pointer sequence including hover, which would open the popup via
-  // the hover path and hide a broken click path. fireEvent dispatches only
-  // the click, which is what a touch tap reduces to.
+  // why: fireEvent instead of userEvent — userEvent simulates the full pointer
+  // sequence including hover, which would open the popup via the hover path and
+  // hide a broken click path. These tests drive the pointer events explicitly.
   it("reveals the reason on click, not only on hover", () => {
-    render(
-      <Button
-        type="button"
-        disabled={{ reason: "Only the owner can do this." }}
-      >
-        Transfer ownership
-      </Button>
-    );
+    const button = renderDisabledButton();
 
-    expect(
-      screen.queryByText(/only the owner can do this/i)
-    ).not.toBeInTheDocument();
-
-    const button = screen.getByRole("button", { name: /transfer ownership/i });
+    expect(reasonOccurrences()).toBe(1);
 
     // No native `disabled` attribute (it would swallow the pointer events the
     // popup needs), so the state must be exposed to assistive tech instead.
@@ -34,26 +47,45 @@ describe("Button disabled with reason", () => {
 
     fireEvent.click(button);
 
-    expect(screen.getByText(/only the owner can do this/i)).toBeInTheDocument();
+    expect(reasonOccurrences()).toBe(2);
   });
 
-  it("hides the reason again on a second click", () => {
-    render(
-      <Button
-        type="button"
-        disabled={{ reason: "Only the owner can do this." }}
-      >
-        Transfer ownership
-      </Button>
+  /**
+   * The mouse sequence is `pointerdown` → `click`, and Radix's DismissableLayer
+   * closes the card on that `pointerdown`. A `!prev` toggle in the click handler
+   * therefore reads the already-closed state and re-opens it, so the card could
+   * never be closed by clicking. Driving only `click` (as an earlier version of
+   * this test did) skips the dismiss entirely and reports a toggle that works.
+   *
+   * This pins the user-visible outcome — after a full press the reason is on
+   * screen. It cannot prove Radix's dismiss ran: happy-dom does not reproduce
+   * the layer's pointer plumbing faithfully enough to observe the intermediate
+   * state, and both a dismiss-then-open and a never-dismissed card end open.
+   */
+  it("keeps the reason open across a full mouse press, rather than flickering", () => {
+    const button = renderDisabledButton();
+
+    fireEvent.pointerDown(button);
+    fireEvent.click(button);
+    expect(reasonOccurrences()).toBe(2);
+
+    // A second full press must not leave the user staring at a button that
+    // still explains nothing.
+    fireEvent.pointerDown(button);
+    fireEvent.click(button);
+    expect(reasonOccurrences()).toBe(2);
+  });
+
+  it("points assistive tech at the reason via aria-describedby", () => {
+    const button = renderDisabledButton();
+    const describedBy = button.getAttribute("aria-describedby");
+
+    expect(describedBy).toBeTruthy();
+
+    // The description must exist while the card is CLOSED — hover card content
+    // is unmounted then, so a screen reader has nothing else to announce.
+    expect(document.getElementById(describedBy as string)).toHaveTextContent(
+      REASON
     );
-
-    const button = screen.getByRole("button", { name: /transfer ownership/i });
-    fireEvent.click(button);
-    expect(screen.getByText(/only the owner can do this/i)).toBeInTheDocument();
-
-    fireEvent.click(button);
-    expect(
-      screen.queryByText(/only the owner can do this/i)
-    ).not.toBeInTheDocument();
   });
 });

--- a/apps/webapp/app/components/shared/button-disabled-reason.test.tsx
+++ b/apps/webapp/app/components/shared/button-disabled-reason.test.tsx
@@ -26,9 +26,13 @@ describe("Button disabled with reason", () => {
       screen.queryByText(/only the owner can do this/i)
     ).not.toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /transfer ownership/i })
-    );
+    const button = screen.getByRole("button", { name: /transfer ownership/i });
+
+    // No native `disabled` attribute (it would swallow the pointer events the
+    // popup needs), so the state must be exposed to assistive tech instead.
+    expect(button).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(button);
 
     expect(screen.getByText(/only the owner can do this/i)).toBeInTheDocument();
   });

--- a/apps/webapp/app/components/shared/button-disabled-reason.test.tsx
+++ b/apps/webapp/app/components/shared/button-disabled-reason.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "./button";
+
+/**
+ * Disabled-with-reason buttons explain themselves through a HoverCard.
+ * Hover never fires on touch devices, so the reason must ALSO open on
+ * click/tap — otherwise mobile users get a dead-looking grey button.
+ */
+describe("Button disabled with reason", () => {
+  // why: fireEvent.click instead of userEvent — userEvent simulates the
+  // full pointer sequence including hover, which would open the popup via
+  // the hover path and hide a broken click path. fireEvent dispatches only
+  // the click, which is what a touch tap reduces to.
+  it("reveals the reason on click, not only on hover", () => {
+    render(
+      <Button
+        type="button"
+        disabled={{ reason: "Only the owner can do this." }}
+      >
+        Transfer ownership
+      </Button>
+    );
+
+    expect(
+      screen.queryByText(/only the owner can do this/i)
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /transfer ownership/i })
+    );
+
+    expect(screen.getByText(/only the owner can do this/i)).toBeInTheDocument();
+  });
+
+  it("hides the reason again on a second click", () => {
+    render(
+      <Button
+        type="button"
+        disabled={{ reason: "Only the owner can do this." }}
+      >
+        Transfer ownership
+      </Button>
+    );
+
+    const button = screen.getByRole("button", { name: /transfer ownership/i });
+    fireEvent.click(button);
+    expect(screen.getByText(/only the owner can do this/i)).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(
+      screen.queryByText(/only the owner can do this/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/app/components/shared/button.tsx
+++ b/apps/webapp/app/components/shared/button.tsx
@@ -8,7 +8,7 @@ import type {
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import { Link, type LinkProps } from "react-router";
 import { tw } from "~/utils/tw";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card";
+import { DisabledReasonHoverCard } from "./disabled-reason-hover-card";
 import type { IconType } from "./icons-map";
 import {
   Tooltip,
@@ -210,11 +210,11 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
     const Component = isLinkProps(props) ? Link : as;
 
     /**
-     * Disabled-with-reason popup state. Controlled so a tap can open it too:
-     * touch devices never fire hover, so a hover-only reason leaves the
-     * button looking dead on mobile.
+     * Id linking a disabled button to the hidden copy of its reason, so
+     * `aria-describedby` can announce it. Always generated (hooks cannot be
+     * conditional); only referenced on the disabled-with-reason path.
      */
-    const [disabledReasonOpen, setDisabledReasonOpen] = React.useState(false);
+    const disabledReasonId = React.useId();
 
     // Default to type="button" for native button elements to prevent
     // implicit form submission (HTML spec defaults to type="submit").
@@ -323,46 +323,32 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
     // Render disabled button with hover card
     if (isDisabled && disabledReason) {
       return (
-        <HoverCard
-          openDelay={50}
-          closeDelay={50}
-          open={disabledReasonOpen}
-          onOpenChange={setDisabledReasonOpen}
+        <DisabledReasonHoverCard
+          title={disabledTitle}
+          reason={disabledReason}
+          descriptionId={disabledReasonId}
+          triggerClassName="disabled cursor-not-allowed select-none"
+          asChild
         >
-          <HoverCardTrigger
-            className="disabled cursor-not-allowed select-none"
-            asChild
+          <Component
+            {...props}
+            {...newTabRel}
+            className={finalStyles}
+            aria-label={ariaLabel}
+            // why: no native `disabled` here — it would swallow the pointer
+            // events the reason popup needs — so expose the state to
+            // assistive tech explicitly, and point at the reason so AT users
+            // get the same explanation the hover card gives everyone else.
+            aria-disabled={true}
+            aria-describedby={disabledReasonId}
+            prefetch={isLinkProps(props) ? props.prefetch ?? "none" : undefined}
+            ref={ref}
+            onMouseDown={(e: MouseEvent) => e.preventDefault()}
+            onClick={(e: MouseEvent) => e.preventDefault()}
           >
-            <Component
-              {...props}
-              {...newTabRel}
-              className={finalStyles}
-              aria-label={ariaLabel}
-              // why: no native `disabled` here — it would swallow the pointer
-              // events the reason popup needs — so expose the state to
-              // assistive tech explicitly.
-              aria-disabled={true}
-              onMouseDown={(e: MouseEvent) => e.preventDefault()}
-              onClick={(e: MouseEvent) => {
-                // why: tap must reveal the reason — touch has no hover.
-                // Outside taps and Escape dismiss via Radix.
-                e.preventDefault();
-                setDisabledReasonOpen((prev) => !prev);
-              }}
-            >
-              {buttonContent}
-            </Component>
-          </HoverCardTrigger>
-          {/* why: bottom placement stays on-screen for wide buttons on
-          narrow viewports — a left-side popup has no room there and rendered
-          half off-screen. collisionPadding keeps it inside the viewport. */}
-          <HoverCardContent side="bottom" collisionPadding={8}>
-            <h5 className="text-left text-[14px]">
-              {disabledTitle || "Action disabled"}
-            </h5>
-            <p className="text-left text-[14px]">{disabledReason}</p>
-          </HoverCardContent>
-        </HoverCard>
+            {buttonContent}
+          </Component>
+        </DisabledReasonHoverCard>
       );
     }
 

--- a/apps/webapp/app/components/shared/button.tsx
+++ b/apps/webapp/app/components/shared/button.tsx
@@ -338,6 +338,10 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
               {...newTabRel}
               className={finalStyles}
               aria-label={ariaLabel}
+              // why: no native `disabled` here — it would swallow the pointer
+              // events the reason popup needs — so expose the state to
+              // assistive tech explicitly.
+              aria-disabled={true}
               onMouseDown={(e: MouseEvent) => e.preventDefault()}
               onClick={(e: MouseEvent) => {
                 // why: tap must reveal the reason — touch has no hover.

--- a/apps/webapp/app/components/shared/button.tsx
+++ b/apps/webapp/app/components/shared/button.tsx
@@ -209,6 +209,13 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
   ) {
     const Component = isLinkProps(props) ? Link : as;
 
+    /**
+     * Disabled-with-reason popup state. Controlled so a tap can open it too:
+     * touch devices never fire hover, so a hover-only reason leaves the
+     * button looking dead on mobile.
+     */
+    const [disabledReasonOpen, setDisabledReasonOpen] = React.useState(false);
+
     // Default to type="button" for native button elements to prevent
     // implicit form submission (HTML spec defaults to type="submit").
     if (!isLinkProps(props) && as === "button" && !("type" in props)) {
@@ -316,20 +323,36 @@ export const Button = React.forwardRef<HTMLElement, ButtonProps>(
     // Render disabled button with hover card
     if (isDisabled && disabledReason) {
       return (
-        <HoverCard openDelay={50} closeDelay={50}>
-          <HoverCardTrigger className="disabled cursor-not-allowed" asChild>
+        <HoverCard
+          openDelay={50}
+          closeDelay={50}
+          open={disabledReasonOpen}
+          onOpenChange={setDisabledReasonOpen}
+        >
+          <HoverCardTrigger
+            className="disabled cursor-not-allowed select-none"
+            asChild
+          >
             <Component
               {...props}
               {...newTabRel}
               className={finalStyles}
               aria-label={ariaLabel}
               onMouseDown={(e: MouseEvent) => e.preventDefault()}
-              onClick={(e: MouseEvent) => e.preventDefault()}
+              onClick={(e: MouseEvent) => {
+                // why: tap must reveal the reason — touch has no hover.
+                // Outside taps and Escape dismiss via Radix.
+                e.preventDefault();
+                setDisabledReasonOpen((prev) => !prev);
+              }}
             >
               {buttonContent}
             </Component>
           </HoverCardTrigger>
-          <HoverCardContent side="left">
+          {/* why: bottom placement stays on-screen for wide buttons on
+          narrow viewports — a left-side popup has no room there and rendered
+          half off-screen. collisionPadding keeps it inside the viewport. */}
+          <HoverCardContent side="bottom" collisionPadding={8}>
             <h5 className="text-left text-[14px]">
               {disabledTitle || "Action disabled"}
             </h5>

--- a/apps/webapp/app/components/shared/disabled-reason-hover-card.tsx
+++ b/apps/webapp/app/components/shared/disabled-reason-hover-card.tsx
@@ -1,0 +1,110 @@
+/**
+ * Disabled-with-reason hover card.
+ *
+ * A control that is disabled must be able to say WHY, on every input device:
+ *
+ * - pointer → the reason opens on hover (Radix HoverCard's own behavior)
+ * - touch   → hover never fires, so a tap opens it too (controlled `open`)
+ * - AT      → `descriptionId` renders the reason as a visually hidden node the
+ *   trigger can point at with `aria-describedby`; the hover card content itself
+ *   is not announced (it is unmounted while closed and carries no `role`)
+ *
+ * This is the single implementation of that pattern. Reach for it directly only
+ * when the disabled control is NOT a `Button` — `<Button disabled={{ reason }}>`
+ * already renders through this component and wires the description for you.
+ *
+ * @see {@link file://./button.tsx}
+ */
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "./hover-card";
+
+/** Props for {@link DisabledReasonHoverCard} */
+type DisabledReasonHoverCardProps = {
+  /** Heading above the reason. Defaults to "Action disabled". */
+  title?: ReactNode;
+  /** Why the control is disabled, and ideally what the user can do about it. */
+  reason: ReactNode;
+  /**
+   * When set, the reason is also rendered into a visually hidden element with
+   * this id so the trigger can reference it via `aria-describedby`. Callers own
+   * the id (and the `aria-describedby`) because it belongs on the interactive
+   * element, which only the caller renders.
+   */
+  descriptionId?: string;
+  /**
+   * Merge the trigger's props onto `children` instead of wrapping them in the
+   * trigger's own element (Radix `asChild`). Use it whenever `children` is
+   * already an interactive element, so the tree doesn't get an anchor around a
+   * button.
+   */
+  asChild?: boolean;
+  /** Classes for the trigger element (ignored shape-wise when `asChild`). */
+  triggerClassName?: string;
+  /** The disabled control. */
+  children: ReactNode;
+};
+
+/**
+ * Wraps a disabled control in a hover card that explains why it is disabled.
+ *
+ * @param props - See {@link DisabledReasonHoverCardProps}
+ * @returns The control, wired to reveal its reason on hover, tap and to AT
+ */
+export function DisabledReasonHoverCard({
+  title = "Action disabled",
+  reason,
+  descriptionId,
+  asChild,
+  triggerClassName,
+  children,
+}: DisabledReasonHoverCardProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <HoverCard
+      openDelay={50}
+      closeDelay={50}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <HoverCardTrigger
+        asChild={asChild}
+        className={triggerClassName}
+        onClick={(event) => {
+          /**
+           * why: open, never toggle. Radix's DismissableLayer already closes
+           * the card on `pointerdown` for mouse/pen (before this `click` runs),
+           * so a `!prev` toggle would immediately re-open it and the card could
+           * never be closed by clicking. Touch takes Radix's other branch — its
+           * dismiss runs on the document AFTER this handler — so tap-to-close
+           * still works with a plain `true`.
+           */
+          event.preventDefault();
+          setOpen(true);
+        }}
+      >
+        {children}
+      </HoverCardTrigger>
+
+      {/* Hover card content is unmounted while closed and has no `role`, so it
+      is invisible to a screen reader. This mirror is what `aria-describedby`
+      resolves against. */}
+      {descriptionId ? (
+        <span id={descriptionId} className="sr-only">
+          {reason}
+        </span>
+      ) : null}
+
+      {/* why: aria-hidden — this is the VISUAL copy of the reason. Assistive
+      tech gets the same text from the description above, so exposing both
+      would announce it twice.
+      why: collisionPadding keeps the card inside the viewport — the default
+      bottom placement runs off-screen for wide buttons on narrow screens. */}
+      <HoverCardContent collisionPadding={8} aria-hidden>
+        <h5 className="text-left text-[14px]">{title}</h5>
+        <p className="text-left text-[14px]">{reason}</p>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/apps/webapp/app/components/shared/hover-card.tsx
+++ b/apps/webapp/app/components/shared/hover-card.tsx
@@ -26,7 +26,11 @@ const HoverCardContent = React.forwardRef<
         sideOffset={sideOffset}
         side={side}
         className={tw(
-          "z-50 w-64 rounded-md border bg-white px-4 py-3 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          // z-[999999]: the repo's "above everything" layer (same as the shared
+          // date pickers). Portalled content leaves the trigger's stacking
+          // context, so it competes with dialogs/modals at z-[100] — at z-50 a
+          // hover card opened inside a dialog renders BEHIND that dialog.
+          "z-[999999] w-64 rounded-md border bg-white px-4 py-3 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className
         )}
         {...props}

--- a/apps/webapp/app/components/shared/hover-card.tsx
+++ b/apps/webapp/app/components/shared/hover-card.tsx
@@ -15,17 +15,23 @@ const HoverCardContent = React.forwardRef<
   ref
 ) {
   return (
-    <HoverCardPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      side={side}
-      className={tw(
-        "z-50 w-64 rounded-md border bg-white px-4 py-3 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
-      )}
-      {...props}
-    />
+    // why: without a portal the content renders inline and gets clipped by
+    // overflow-hidden/auto ancestors (e.g. disabled-reason buttons inside the
+    // horizontally scrollable list table). Matches the shared Tooltip, which
+    // already portals its content.
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        side={side}
+        className={tw(
+          "z-50 w-64 rounded-md border bg-white px-4 py-3 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
   );
 });
 

--- a/apps/webapp/app/components/workspace/edit-form.tsx
+++ b/apps/webapp/app/components/workspace/edit-form.tsx
@@ -119,25 +119,12 @@ const WorkspaceGeneralEditForms = ({
   const { organization, isPersonalWorkspace, canHideShelfBranding } =
     useLoaderData<typeof loader>();
 
-  /**
-   * Captured once on mount: when the page is opened via a section anchor
-   * (e.g. /settings/general#transfer-ownership) the browser's scroll to that
-   * section must win — autofocusing the Name input would scroll right back to
-   * the top. Deliberately NOT a live hash subscription: same-route redirects
-   * (e.g. after deleting a SCIM token) clear the hash, and a live value would
-   * flip `when` to true and steal focus mid-session. Read from window (SSR
-   * guard: the hash never reaches the server) instead of useLocation so the
-   * form keeps working when rendered outside a router (tests, previews).
-   */
-  const [arrivedAtSectionAnchor] = useState(
-    () => typeof window !== "undefined" && Boolean(window.location.hash)
-  );
-
-  // Focus the Name input on mount, but skip when the field is disabled
-  // (personal workspaces don't allow renaming) or when the visitor came for a
-  // specific section further down the page.
+  // Focus the Name input on mount, but skip it when the field is disabled
+  // (personal workspaces don't allow renaming). Arriving via a section anchor
+  // (e.g. /settings/general#transfer-ownership) no longer needs a guard here:
+  // useAutoFocus focuses with `preventScroll`, so the anchor scroll survives.
   const nameInputRef = useAutoFocus<HTMLInputElement>({
-    when: !isPersonalWorkspace && !arrivedAtSectionAnchor,
+    when: !isPersonalWorkspace,
   });
 
   const schema = EditGeneralWorkspaceSettingsFormSchema(isPersonalWorkspace);

--- a/apps/webapp/app/components/workspace/edit-form.tsx
+++ b/apps/webapp/app/components/workspace/edit-form.tsx
@@ -119,10 +119,25 @@ const WorkspaceGeneralEditForms = ({
   const { organization, isPersonalWorkspace, canHideShelfBranding } =
     useLoaderData<typeof loader>();
 
+  /**
+   * Captured once on mount: when the page is opened via a section anchor
+   * (e.g. /settings/general#transfer-ownership) the browser's scroll to that
+   * section must win — autofocusing the Name input would scroll right back to
+   * the top. Deliberately NOT a live hash subscription: same-route redirects
+   * (e.g. after deleting a SCIM token) clear the hash, and a live value would
+   * flip `when` to true and steal focus mid-session. Read from window (SSR
+   * guard: the hash never reaches the server) instead of useLocation so the
+   * form keeps working when rendered outside a router (tests, previews).
+   */
+  const [arrivedAtSectionAnchor] = useState(
+    () => typeof window !== "undefined" && Boolean(window.location.hash)
+  );
+
   // Focus the Name input on mount, but skip when the field is disabled
-  // (personal workspaces don't allow renaming).
+  // (personal workspaces don't allow renaming) or when the visitor came for a
+  // specific section further down the page.
   const nameInputRef = useAutoFocus<HTMLInputElement>({
-    when: !isPersonalWorkspace,
+    when: !isPersonalWorkspace && !arrivedAtSectionAnchor,
   });
 
   const schema = EditGeneralWorkspaceSettingsFormSchema(isPersonalWorkspace);

--- a/apps/webapp/app/hooks/use-auto-focus.ts
+++ b/apps/webapp/app/hooks/use-auto-focus.ts
@@ -40,13 +40,21 @@ export function useAutoFocus<T extends HTMLElement>(
   useEffect(() => {
     if (!when) return;
 
+    /**
+     * why: `preventScroll` — a bare `focus()` scrolls the element into view,
+     * which fights any scroll the page owes someone else. The case that bit us:
+     * arriving at a section anchor (`/settings/general#transfer-ownership`)
+     * scrolled to the section, then autofocus yanked the page back to the top.
+     * Focus is still moved — only the scroll side-effect is dropped — so every
+     * call site keeps its focus affordance.
+     */
     if (!deferToNextFrame) {
-      ref.current?.focus();
+      ref.current?.focus({ preventScroll: true });
       return;
     }
 
     const frame = window.requestAnimationFrame(() => {
-      ref.current?.focus();
+      ref.current?.focus({ preventScroll: true });
     });
     return () => window.cancelAnimationFrame(frame);
   }, [when, deferToNextFrame]);

--- a/apps/webapp/app/hooks/use-can-transfer-ownership.ts
+++ b/apps/webapp/app/hooks/use-can-transfer-ownership.ts
@@ -1,0 +1,30 @@
+import { useIsShelfAdmin } from "~/hooks/use-is-shelf-admin";
+import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+
+/**
+ * Whether the viewer may run the workspace ownership transfer.
+ *
+ * Mirrors the rule the server enforces in `transferOwnership` — workspace
+ * OWNER, or a Shelf staff admin — and is **UI-cosmetic only**: the service
+ * re-checks both independently, so nothing security-bearing hangs on this.
+ *
+ * Named once because the two surfaces that gate on it live on different pages
+ * (Settings → Team → Users, and Settings → General). If they disagree, a user
+ * sees a live "Transfer ownership" link on one page and "only the workspace
+ * owner can transfer" on the other.
+ *
+ * The staff-admin term is load-bearing, not belt-and-braces: the admin
+ * dashboard renders `TransferOwnershipCard` for Shelf staff who are normally
+ * **not** members of the workspace, so `isOwner` is false there and an
+ * owner-only check would break that page.
+ *
+ * @returns `true` when the viewer may transfer ownership of the current workspace
+ * @see {@link file://./../modules/organization/service.server.ts} `transferOwnership`
+ * @see {@link file://./../routes/_layout+/admin-dashboard+/org.$organizationId.transfer-ownership.tsx}
+ */
+export function useCanTransferOwnership() {
+  const { isOwner } = useUserRoleHelper();
+  const isShelfAdmin = useIsShelfAdmin();
+
+  return isOwner || isShelfAdmin;
+}

--- a/apps/webapp/app/hooks/use-is-shelf-admin.ts
+++ b/apps/webapp/app/hooks/use-is-shelf-admin.ts
@@ -1,0 +1,22 @@
+import { useRouteLoaderData } from "react-router";
+import type { loader } from "~/routes/_layout+/_layout";
+
+/**
+ * Whether the signed-in user is a **Shelf staff admin** (the platform-wide
+ * `Roles.ADMIN` on the User record).
+ *
+ * Not to be confused with the per-workspace `OrganizationRoles.ADMIN` that
+ * `useUserRoleHelper` reports — a workspace admin is an ordinary customer.
+ *
+ * Reads the value the `_layout` loader already derives, so the role check
+ * itself lives in exactly one place.
+ *
+ * @returns `true` for Shelf staff admins, `false` otherwise
+ */
+export function useIsShelfAdmin() {
+  const layoutData = useRouteLoaderData<typeof loader>(
+    "routes/_layout+/_layout"
+  );
+
+  return Boolean(layoutData?.isAdmin);
+}

--- a/apps/webapp/app/routes/_layout+/settings.team.users.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.tsx
@@ -167,17 +167,15 @@ export default function UserTeamSetting() {
         three action buttons get the actual free space. */}
         <Filters innerWrapperClassName="md:w-auto">
           {/* Three buttons don't always fit one row: stack them full-width on
-          mobile, and let the row wrap on tighter md screens */}
-          <div className="flex w-full flex-col gap-1 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
+          mobile, and let the row wrap on tighter md screens. The container owns
+          the spacing and the stretch — children must NOT add their own `mt-*`
+          or `w-full`, or the gaps stop being uniform. */}
+          <div className="flex w-full flex-col gap-2 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
             <TransferOwnershipButton />
             <ImportUsersDialog />
             <InviteUserDialog
               trigger={
-                <Button
-                  type="button"
-                  className="mt-2 w-full md:mt-0 md:w-max"
-                  variant="primary"
-                >
+                <Button type="button" variant="primary">
                   <span className="whitespace-nowrap">Invite a user</span>
                 </Button>
               }

--- a/apps/webapp/app/routes/_layout+/settings.team.users.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { Roles } from "@prisma/client";
 import type { InviteStatuses } from "@prisma/client";
 import type {
   ActionFunctionArgs,
@@ -14,14 +13,13 @@ import { ListContentWrapper } from "~/components/list/content-wrapper";
 import { Filters } from "~/components/list/filters";
 import ImportUsersDialog from "~/components/settings/import-users-dialog/import-users-dialog";
 import InviteUserDialog from "~/components/settings/invite-user-dialog";
+import TransferOwnershipButton from "~/components/settings/transfer-ownership-button";
 import { Button } from "~/components/shared/button";
 import { InfoTooltip } from "~/components/shared/info-tooltip";
 
 import { Td, Th } from "~/components/table";
 import { SSOUserBadge } from "~/components/user/sso-user-badge";
 import { TeamUsersActionsDropdown } from "~/components/workspace/users-actions-dropdown";
-import { useUserData } from "~/hooks/use-user-data";
-import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { TeamMembersWithUserOrInvite } from "~/modules/settings/service.server";
 import { getPaginatedAndFilterableSettingUsers } from "~/modules/settings/service.server";
 import type { RouteHandleWithName } from "~/modules/types";
@@ -164,8 +162,14 @@ export default function UserTeamSetting() {
       </p>
 
       <ListContentWrapper>
-        <Filters>
-          <div className="flex items-center gap-1">
+        {/* innerWrapperClassName: the search wrapper defaults to w-full, which
+        squeezes the actions slot to leftovers. Content-size it on md+ so the
+        three action buttons get the actual free space. */}
+        <Filters innerWrapperClassName="md:w-auto">
+          {/* Three buttons don't always fit one row: stack them full-width on
+          mobile, and let the row wrap on tighter md screens */}
+          <div className="flex w-full flex-col gap-1 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
+            <TransferOwnershipButton />
             <ImportUsersDialog />
             <InviteUserDialog
               trigger={
@@ -237,47 +241,9 @@ function UserRow({ item }: { item: TeamMembersWithUserOrInvite }) {
             role={item.role}
             roleEnum={item.roleEnum}
           />
-        ) : (
-          <OwnerRowActions ownerName={item.name} />
-        )}
+        ) : null}
       </Td>
     </>
-  );
-}
-
-/**
- * The one owner-level action that belongs with the member list is transferring
- * ownership, which lives on the general settings page. Surface it here so it
- * is discoverable where people manage their team.
- */
-function OwnerRowActions({ ownerName }: { ownerName: string }) {
-  const { isOwner } = useUserRoleHelper();
-  const user = useUserData();
-
-  /**
-   * Shelf staff admins can also run the transfer flow, so they get the same
-   * link as the owner (matches the isShelfAdmin check in TransferOwnershipCard)
-   */
-  const isShelfAdmin = user?.roles?.some((role) => role.name === Roles.ADMIN);
-
-  if (isOwner || isShelfAdmin) {
-    return (
-      <Button to="/settings/general#transfer-ownership" variant="secondary">
-        Transfer ownership
-      </Button>
-    );
-  }
-
-  return (
-    <Button
-      type="button"
-      variant="secondary"
-      disabled={{
-        reason: `Only the workspace owner (${ownerName}) can transfer ownership of this workspace.`,
-      }}
-    >
-      Transfer ownership
-    </Button>
   );
 }
 

--- a/apps/webapp/test/factories/index.ts
+++ b/apps/webapp/test/factories/index.ts
@@ -9,3 +9,4 @@ export * from "./asset";
 export * from "./organization";
 export * from "./assetModel";
 export * from "./activityEvent";
+export * from "./layoutLoaderData";

--- a/apps/webapp/test/factories/layoutLoaderData.ts
+++ b/apps/webapp/test/factories/layoutLoaderData.ts
@@ -1,0 +1,50 @@
+import { OrganizationRoles } from "@prisma/client";
+
+/**
+ * Factory for the `routes/_layout+/_layout` loader payload.
+ *
+ * Components under `_layout` read this through `useRouteLoaderData`-backed
+ * hooks (`useUserRoleHelper`, `useIsShelfAdmin`, `useCurrentOrganization`), so
+ * a test mocking that hook has to hand back a payload of this shape. Shared
+ * because the ownership-transfer surfaces render on two different pages and
+ * their fixtures must not drift apart.
+ *
+ * @see {@link file://./../../app/routes/_layout+/_layout.tsx}
+ */
+
+/** Owner email used by the default payload, for tests asserting on the text */
+export const OWNER_EMAIL = "owner@example.com";
+
+/** Knobs for {@link createLayoutLoaderData} */
+type CreateLayoutLoaderDataArgs = {
+  /** The viewer's roles in the current workspace */
+  roles?: OrganizationRoles[];
+  /** Shelf staff admin (platform-wide `Roles.ADMIN`), not a workspace role */
+  isShelfAdmin?: boolean;
+  /** `null` mirrors a loader payload that stopped selecting the owner. */
+  owner?: { id: string; email: string } | null;
+};
+
+/**
+ * Builds a `_layout` loader payload for tests.
+ *
+ * @param args - See {@link CreateLayoutLoaderDataArgs}
+ * @returns The payload shape `useRouteLoaderData("routes/_layout+/_layout")` returns
+ */
+export function createLayoutLoaderData({
+  roles = [OrganizationRoles.ADMIN],
+  isShelfAdmin = false,
+  owner = { id: "owner-1", email: OWNER_EMAIL },
+}: CreateLayoutLoaderDataArgs = {}) {
+  return {
+    currentOrganizationUserRoles: roles,
+    currentOrganization: {
+      id: "org-1",
+      name: "Test Org",
+      owner,
+    },
+    // Shelf staff admin flag, as derived by the _layout loader
+    isAdmin: isShelfAdmin,
+    user: { id: "user-1" },
+  };
+}


### PR DESCRIPTION
## Why

Follow-up to #2845 review feedback on the ownership-transfer entry points:

1. The "Transfer ownership" button sat inside the owner's table row. A full-size button in an Actions cell is visually heavy next to the compact "…" menus every other row uses, and it reads as a row action when it is really a page-level one.
2. Clicking it navigated to `/settings/general#transfer-ownership` but the page stayed at the top — the anchor never appeared to work.
3. For non-owner members the button is disabled with a hover explanation, and that hover popup rendered clipped and unreadable.

## What

**Placement (1):** The button moves out of the owner row into the team page header, next to "Import Users" / "Invite a user". The owner row gets its empty Actions cell back. Extracted as `TransferOwnershipButton` with the same audience logic as before: owner and Shelf staff admins get a link to the transfer section; other members get the disabled button whose reason names the owner's email (taken from `currentOrganization.owner`, same source the transfer card uses).

**Anchor scroll (2):** Root cause: react-router's `<ScrollRestoration/>` does scroll to the hash target (`el.scrollIntoView()`), but the General page autofocuses the workspace Name input one animation frame later (`useAutoFocus`), and a bare `element.focus()` scrolls that element into view — dragging the page straight back to the top. Fixed in the hook: `useAutoFocus` now focuses with `{ preventScroll: true }`. Focus still moves, only the scroll side-effect is dropped, so all ~40 call sites keep their focus affordance and any of them reachable with a hash is fixed at once — no per-page guard.

**Clipping (3):** Root cause: `HoverCardContent` rendered without a Radix portal, so the disabled-reason popup was positioned inside the table and clipped by the list's `overflow-x-auto` wrapper. It now renders through `HoverCardPrimitive.Portal`.

**Stacking (3, continued):** Portalling has a consequence: the content leaves the trigger's stacking context and competes with dialogs at `z-[100]`, so at the shared component's `z-50` a hover card opened *inside* a dialog rendered behind that dialog — including the transfer confirm dialog's own disabled "Transfer ownership" submit. Hover-card content moves to `z-[999999]`, the layer the shared date pickers already use for the same reason. Four call sites that wrapped `HoverCardContent` in their own `HoverCardPortal` are unwrapped: they now double-portal, and the outer Portal's `Slot` swallows the forwarded ref.

**One disabled-reason affordance (3, continued):** hover does not exist on touch, so a disabled-with-reason control was a dead grey button on phones. This was implemented three times — in `Button`, in `BulkUpdateDialogTrigger`, and in the asset form's kit-managed location select — and only `Button` had been fixed, which left the ~37 bulk dialogs still hover-only. Extracted `DisabledReasonHoverCard` as the single implementation; all three route through it. The click handler **opens** the popup rather than toggling it: Radix's `DismissableLayer` already closes the card on `pointerdown` for mouse/pen, so a `!prev` toggle read the already-closed state and re-opened it, and the card could never be closed by clicking. Tap-to-close still works on touch, where Radix's dismiss runs after the click handler.

**Accessibility (3, continued):** a disabled-with-reason control renders without the native `disabled` attribute (it would swallow the pointer events the popup needs), so it carries `aria-disabled`. That alone told assistive tech the control was dead without telling it why — hover-card content has no `role` and is unmounted while closed. The reason is now mirrored into a visually hidden node referenced by `aria-describedby`, and the visual copy is `aria-hidden` so it is not announced twice. The disabled branch also forwards `ref` and `prefetch`, which it previously dropped.

**Deduplication:** added `useIsShelfAdmin`, reading the `isAdmin` the `_layout` loader already derives, replacing the third hand-rolled copy of the staff-admin role check.

**Responsive fit:** three header buttons don't always fit one row. The actions area stacks full-width on mobile and wraps within the card on tighter `md` screens, with the container owning the spacing — children no longer carry their own `mt-2`/`w-full`, which produced uneven 4px/8px gaps. The page also passes `innerWrapperClassName="md:w-auto"` to `Filters` because the search wrapper defaults to `w-full` and squeezes the actions slot to leftover pixels.

## Testing

- `transfer-ownership-button.test.tsx` (4 tests): owner gets the anchor link, Shelf staff admins get the same link, non-owners get the inert button whose reason names the owner (asserted both on hover and through `aria-describedby`), and the generic fallback when the loader ships no owner.
- `button-disabled-reason.test.tsx` (3 tests): the reason opens on plain click (the path a touch tap takes); it survives a full mouse press (`pointerdown` then `click`) rather than flickering; and the `aria-describedby` target holds the reason while the card is closed. The previous "closes on a second click" test was removed — it passed only because `fireEvent.click` skips the `pointerdown` that breaks the toggle, so it asserted behavior the app never had.
- `pnpm webapp:validate`: 357 test files, 4721 tests pass, typecheck clean, lint clean (11 warnings, all pre-existing in untouched files).
- React Doctor on the changed files: 0 errors, 6 advisory warnings, none newly introduced.
- Verified in the running app: the reason renders above the transfer confirm dialog; `/settings/general#transfer-ownership` lands on the section; the users-page actions row at narrow and wide widths; a disabled action in the bulk-actions dropdown on touch; the kit-managed location select on the asset form; and the four unwrapped hover cards (calendar event card, location badge, asset status badge, advanced index column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a team settings control for transferring workspace ownership.
  - Workspace owners and authorized staff can access the transfer flow.
  - Other administrators see a disabled control explaining the requirement and, when available, identifying the current owner.

- **Bug Fixes**
  - Improved disabled-control explanations for hover, touch, and assistive technology.
  - Improved hover-card positioning to prevent clipping.
  - Prevented automatic name-field focus from disrupting anchored navigation.
  - Improved transfer controls across responsive team member layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
