### PR TITLE
fix(invites): stop invites from granting the OWNER role

### DIFF
--- a/apps/webapp/app/components/settings/invite-user-dialog.tsx
+++ b/apps/webapp/app/components/settings/invite-user-dialog.tsx
@@ -6,6 +6,7 @@ import { useZorm } from "react-zorm";
 import { z } from "zod";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import useFetcherWithReset from "~/hooks/use-fetcher-with-reset";
+import { INVITABLE_ROLES } from "~/modules/invite/roles";
 import type { UserFriendlyRoles } from "~/routes/_layout+/settings.team";
 import { isFormProcessing } from "~/utils/form";
 import { getValidationErrors } from "~/utils/http";
@@ -42,16 +43,11 @@ export const InviteUserFormSchema = z.object({
       message: "Please enter a valid email",
     })),
   teamMemberId: z.string().optional(),
+  // INVITABLE_ROLES is shared with the CSV import path so the two cannot drift.
+  // OWNER is excluded there, and that exclusion is a security control.
   role: z.preprocess(
     (value) => String(value).trim().toUpperCase(),
-    z.enum(
-      [
-        OrganizationRoles.ADMIN,
-        OrganizationRoles.BASE,
-        OrganizationRoles.SELF_SERVICE,
-      ],
-      { message: "Please select a role" }
-    )
+    z.enum(INVITABLE_ROLES, { message: "Please select a role" })
   ),
   inviteMessage: z.string().max(1000).optional(),
 });

--- a/apps/webapp/app/modules/invite/roles.test.ts
+++ b/apps/webapp/app/modules/invite/roles.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Invite Roles
+ *
+ * Pins that OWNER can never be granted by an invite. Both the invite dialog's
+ * Zod enum and the CSV import's runtime check read this list, so this test is
+ * the single place that failure mode is caught for both paths.
+ *
+ * @see {@link file://./roles.ts}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { INVITABLE_ROLES, isInvitableRole } from "./roles";
+
+// @vitest-environment node
+
+describe("INVITABLE_ROLES", () => {
+  it("never includes OWNER", () => {
+    expect(INVITABLE_ROLES).not.toContain(OrganizationRoles.OWNER);
+  });
+
+  it("covers every non-OWNER organization role", () => {
+    // If a new role is added to the schema, this fails so someone has to decide
+    // whether it is invitable rather than silently leaving it out.
+    const nonOwnerRoles = Object.values(OrganizationRoles).filter(
+      (role) => role !== OrganizationRoles.OWNER
+    );
+
+    expect([...INVITABLE_ROLES].sort()).toEqual(nonOwnerRoles.sort());
+  });
+});
+
+describe("isInvitableRole", () => {
+  it("rejects OWNER", () => {
+    expect(isInvitableRole(OrganizationRoles.OWNER)).toBe(false);
+  });
+
+  it.each(INVITABLE_ROLES)("accepts %s", (role) => {
+    expect(isInvitableRole(role)).toBe(true);
+  });
+
+  it.each([
+    ["unknown role", "SUPERUSER"],
+    ["lowercase owner", "owner"],
+    ["empty string", ""],
+    ["undefined", undefined],
+    ["null", null],
+  ])("rejects %s", (_label, value) => {
+    expect(isInvitableRole(value)).toBe(false);
+  });
+});

--- a/apps/webapp/app/modules/invite/roles.ts
+++ b/apps/webapp/app/modules/invite/roles.ts
@@ -1,0 +1,49 @@
+/**
+ * Invite Roles
+ *
+ * Single source of truth for which organization roles an invite may grant.
+ *
+ * This lives in its own dependency-free module (no `.server` suffix, no React)
+ * so that both the client invite form and the server-side CSV import can import
+ * it. Duplicating the list in either place would let the two drift, and the
+ * whole point of this constant is that they cannot.
+ *
+ * @see {@link file://./../../components/settings/invite-user-dialog.tsx}
+ * @see {@link file://./../../routes/api+/settings.import-users.ts}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+/**
+ * Roles that may be granted through an invite.
+ *
+ * `OWNER` is deliberately absent. There is exactly one supported way to move
+ * ownership — `transferOwnership`, which demotes the outgoing owner, moves the
+ * subscription and notifies both parties. `changeUserRole` refuses `OWNER` for
+ * the same reason. An invite that granted `OWNER` would bypass all of that and
+ * leave `Organization.owner` pointing at the previous owner while the invitee
+ * held every OWNER privilege, because permissions resolve from
+ * `UserOrganization.roles`, never from `Organization.owner`.
+ */
+export const INVITABLE_ROLES = [
+  OrganizationRoles.ADMIN,
+  OrganizationRoles.BASE,
+  OrganizationRoles.SELF_SERVICE,
+] as const;
+
+/** A role that may be granted through an invite. */
+export type InvitableRole = (typeof INVITABLE_ROLES)[number];
+
+/**
+ * Whether a value is a role an invite is allowed to grant.
+ *
+ * Accepts `unknown` on purpose: the CSV import path receives arbitrary strings
+ * from an uploaded file, so the check has to be a runtime narrowing rather than
+ * a type assertion.
+ *
+ * @param value - Candidate role, typically straight from user input
+ * @returns True when the value is one of {@link INVITABLE_ROLES}
+ */
+export function isInvitableRole(value: unknown): value is InvitableRole {
+  return INVITABLE_ROLES.includes(value as InvitableRole);
+}

--- a/apps/webapp/app/modules/invite/service.server.test.ts
+++ b/apps/webapp/app/modules/invite/service.server.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Invite Service — role validation at acceptance
+ *
+ * Creation-time guards cannot protect an invite that already exists. A row
+ * written before those guards landed still carries its stored roles, and
+ * `updateInviteStatus` hands them to `createUserOrAttachOrg` verbatim, which
+ * writes them into `UserOrganization.roles`. This pins that an invite granting
+ * a non-invitable role is refused at acceptance instead.
+ *
+ * @see {@link file://./service.server.ts}
+ * @see {@link file://./roles.ts}
+ */
+
+import { InviteStatuses, OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { updateInviteStatus } from "./service.server";
+import { createUserOrAttachOrg } from "../user/service.server";
+
+// @vitest-environment node
+
+const dbMock = vi.hoisted(() => ({
+  invite: {
+    findFirst: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  teamMember: { update: vi.fn() },
+}));
+
+// why: isolating the acceptance branch from the database
+vi.mock("~/database/db.server", () => ({ db: dbMock }));
+
+// why: acceptance creates the user and the org association — the write this
+// test is asserting must NOT happen
+vi.mock("../user/service.server", () => ({
+  createUserOrAttachOrg: vi.fn(),
+}));
+
+// why: acceptance sends a welcome email
+vi.mock("~/emails/mail.server", () => ({ sendEmail: vi.fn() }));
+
+/** Builds a PENDING invite row as `db.invite.findFirst` would return it */
+function pendingInvite(roles: OrganizationRoles[]) {
+  return {
+    id: "invite-1",
+    inviteeEmail: "invitee@example.com",
+    organizationId: "org-1",
+    roles,
+    status: InviteStatuses.PENDING,
+    expiresAt: new Date(Date.now() + 86_400_000),
+    inviteeTeamMember: { id: "tm-1", name: "Invitee Person" },
+  };
+}
+
+describe("updateInviteStatus — stored role validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.invite.update.mockResolvedValue({ id: "invite-1" });
+    dbMock.invite.updateMany.mockResolvedValue({ count: 0 });
+    dbMock.teamMember.update.mockResolvedValue({ id: "tm-1" });
+    vi.mocked(createUserOrAttachOrg).mockResolvedValue({
+      id: "user-1",
+    } as Awaited<ReturnType<typeof createUserOrAttachOrg>>);
+  });
+
+  it("refuses an invite that grants OWNER", async () => {
+    // A row that could only have been written before the creation-time guards
+    dbMock.invite.findFirst.mockResolvedValue(
+      pendingInvite([OrganizationRoles.OWNER])
+    );
+
+    await expect(
+      updateInviteStatus({
+        id: "invite-1",
+        status: InviteStatuses.ACCEPTED,
+        password: "hunter2hunter2",
+      })
+    ).rejects.toThrow(/no longer be assigned/i);
+
+    // The org association is the escalation — it must never be written
+    expect(createUserOrAttachOrg).not.toHaveBeenCalled();
+  });
+
+  it("refuses an invite mixing OWNER with an allowed role", async () => {
+    dbMock.invite.findFirst.mockResolvedValue(
+      pendingInvite([OrganizationRoles.ADMIN, OrganizationRoles.OWNER])
+    );
+
+    await expect(
+      updateInviteStatus({
+        id: "invite-1",
+        status: InviteStatuses.ACCEPTED,
+        password: "hunter2hunter2",
+      })
+    ).rejects.toThrow(/no longer be assigned/i);
+
+    expect(createUserOrAttachOrg).not.toHaveBeenCalled();
+  });
+
+  it("still accepts an invite for an invitable role", async () => {
+    dbMock.invite.findFirst.mockResolvedValue(
+      pendingInvite([OrganizationRoles.ADMIN])
+    );
+
+    await updateInviteStatus({
+      id: "invite-1",
+      status: InviteStatuses.ACCEPTED,
+      password: "hunter2hunter2",
+    });
+
+    expect(createUserOrAttachOrg).toHaveBeenCalledWith(
+      expect.objectContaining({ roles: [OrganizationRoles.ADMIN] })
+    );
+  });
+});

--- a/apps/webapp/app/modules/invite/service.server.ts
+++ b/apps/webapp/app/modules/invite/service.server.ts
@@ -29,6 +29,7 @@ import { getParamsValues } from "~/utils/list";
 import { checkDomainSSOStatus, doesSSOUserExist } from "~/utils/sso.server";
 import { generateRandomCode, inviteEmailText, splitName } from "./helpers";
 import { processInvitationMessage } from "./message-validator.server";
+import { isInvitableRole } from "./roles";
 import { createTeamMember } from "../team-member/service.server";
 import { createUserOrAttachOrg } from "../user/service.server";
 
@@ -634,6 +635,31 @@ export async function bulkInviteUsers({
         user.email.trim() !== "" &&
         user.role.trim() !== ""
     );
+
+    /**
+     * Defense in depth: `users` is typed as `InviteUserSchema[]`, but that type
+     * comes from `z.infer` and is never enforced at runtime — the CSV import
+     * hands over raw strings parsed out of an uploaded file. The route
+     * validates them, and so must this, because `payload.role` is written
+     * straight into `Invite.roles` below and permissions resolve from
+     * `UserOrganization.roles` after acceptance.
+     */
+    const disallowedRoles = validUsers
+      .map((user) => user.role)
+      .filter((role) => !isInvitableRole(role));
+
+    if (disallowedRoles.length > 0) {
+      throw new ShelfError({
+        cause: null,
+        message: `Invites cannot grant these roles: ${[
+          ...new Set(disallowedRoles),
+        ].join(", ")}. Ownership moves only through ownership transfer.`,
+        additionalData: { organizationId, disallowedRoles },
+        label,
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
 
     // Filter out duplicate emails
     const uniquePayloads = lodash.uniqBy(validUsers, (user) => user.email);

--- a/apps/webapp/app/modules/invite/service.server.ts
+++ b/apps/webapp/app/modules/invite/service.server.ts
@@ -370,6 +370,32 @@ export async function updateInviteStatus({
     const data = { status };
 
     if (status === "ACCEPTED") {
+      /**
+       * The creation-time guards cannot protect an invite that already exists.
+       * Rows written before those guards landed — or by any future path that
+       * forgets to validate — still carry their stored roles, and they are
+       * handed to `createUserOrAttachOrg` verbatim below, which writes them
+       * straight into `UserOrganization.roles`.
+       *
+       * An invite granting OWNER can only have come from that gap, so it is
+       * refused outright rather than silently downgraded: honouring it in any
+       * form would hand out access the workspace owner never approved through a
+       * supported flow, and quietly rewriting the role would hide that
+       * something anomalous happened.
+       */
+      if (!invite.roles.every(isInvitableRole)) {
+        throw new ShelfError({
+          cause: null,
+          title: "Invite is no longer valid",
+          message:
+            "This invite grants a role that can no longer be assigned. Please ask your administrator to send you a new invite.",
+          additionalData: { inviteId: invite.id, roles: invite.roles },
+          label,
+          status: 400,
+          shouldBeCaptured: false,
+        });
+      }
+
       const { firstName, lastName } = splitName(invite.inviteeTeamMember.name);
 
       const user = await createUserOrAttachOrg({

--- a/apps/webapp/app/modules/user/utils.server.test.ts
+++ b/apps/webapp/app/modules/user/utils.server.test.ts
@@ -68,7 +68,11 @@ function resendRequest(userFriendlyRole: string) {
 describe("resolveUserAction — resend invite role", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(createInvite).mockResolvedValue({ id: "invite-1" } as any);
+    // Only the fact that it resolved matters here; the assertions are on the
+    // arguments createInvite was called with, not on its return value.
+    vi.mocked(createInvite).mockResolvedValue({ id: "invite-1" } as Awaited<
+      ReturnType<typeof createInvite>
+    >);
   });
 
   it("refuses to resend an invite as Owner", async () => {

--- a/apps/webapp/app/modules/user/utils.server.test.ts
+++ b/apps/webapp/app/modules/user/utils.server.test.ts
@@ -1,0 +1,100 @@
+/**
+ * User Action Resolver — invite role validation
+ *
+ * Pins that the "resend invite" path cannot mint an OWNER invite.
+ *
+ * The resend handler takes a free-text `userFriendlyRole` from the form and
+ * reverse-maps it through `organizationRolesMap`, which contains an OWNER entry
+ * because it doubles as the display map for the team list. Without a guard,
+ * posting `userFriendlyRole=Owner` resolves to `OrganizationRoles.OWNER` and
+ * creates an invite granting ownership — the same escalation the invite dialog
+ * and the CSV import both refuse.
+ *
+ * Found by sweeping siblings while fixing detail.dev finding D032, which
+ * reported only the CSV import path.
+ *
+ * @see {@link file://./utils.server.ts}
+ * @see {@link file://./../invite/roles.ts}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createInvite } from "~/modules/invite/service.server";
+import { resolveUserAction } from "./utils.server";
+
+// @vitest-environment node
+
+// why: the resend path writes invites and sends email
+vi.mock("../invite/service.server", () => ({ createInvite: vi.fn() }));
+
+// why: resend invalidates prior invites for the same invitee first
+vi.mock("~/database/db.server", () => ({
+  db: {
+    invite: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    organization: {
+      findUniqueOrThrow: vi
+        .fn()
+        .mockResolvedValue({ name: "Org", customEmailFooter: null }),
+    },
+  },
+}));
+
+// why: success notifications are a side effect, not part of the contract
+vi.mock("~/utils/emitter/send-notification.server", () => ({
+  sendNotification: vi.fn(),
+}));
+
+// why: avoids a real mail transport
+vi.mock("~/emails/mail.server", () => ({ sendEmail: vi.fn() }));
+
+/** Builds the resend POST an attacker would hand-craft */
+function resendRequest(userFriendlyRole: string) {
+  const body = new URLSearchParams({
+    intent: "resend",
+    email: "invitee@example.com",
+    name: "Invitee",
+    teamMemberId: "tm-1",
+    userFriendlyRole,
+  });
+
+  return new Request("http://localhost/settings/team/invites", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+}
+
+describe("resolveUserAction — resend invite role", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createInvite).mockResolvedValue({ id: "invite-1" } as any);
+  });
+
+  it("refuses to resend an invite as Owner", async () => {
+    await expect(
+      resolveUserAction(
+        resendRequest("Owner"),
+        "org-1",
+        "admin-user",
+        OrganizationRoles.ADMIN
+      )
+    ).rejects.toThrow(/invalid role/i);
+
+    // The invite must never be created — that write is the escalation
+    expect(createInvite).not.toHaveBeenCalled();
+  });
+
+  it("still resends an invite for an invitable role", async () => {
+    await resolveUserAction(
+      resendRequest("Administrator"),
+      "org-1",
+      "admin-user",
+      OrganizationRoles.ADMIN
+    );
+
+    expect(createInvite).toHaveBeenCalledWith(
+      expect.objectContaining({ roles: [OrganizationRoles.ADMIN] })
+    );
+  });
+});

--- a/apps/webapp/app/modules/user/utils.server.ts
+++ b/apps/webapp/app/modules/user/utils.server.ts
@@ -25,6 +25,7 @@ import {
   transferEntitiesToNewOwner,
 } from "./service.server";
 import { revokeAccessEmailText, roleChangeEmailText } from "../invite/helpers";
+import { isInvitableRole } from "../invite/roles";
 import { createInvite } from "../invite/service.server";
 
 /**
@@ -220,12 +221,21 @@ export async function resolveUserAction(
         (key) => organizationRolesMap[key] === userFriendlyRole
       ) as OrganizationRoles | undefined;
 
-      if (!role) {
+      /**
+       * `userFriendlyRole` is free text from the form and `organizationRolesMap`
+       * contains an OWNER entry (it doubles as the display map for the team
+       * list), so "Owner" would resolve here and mint an OWNER invite —
+       * the same escalation the invite dialog and CSV import both refuse.
+       * Ownership moves only through `transferOwnership`.
+       */
+      if (!role || !isInvitableRole(role)) {
         throw new ShelfError({
           cause: null,
           message: "Invalid role",
           additionalData: { userFriendlyRole },
           label: "Team",
+          status: 400,
+          shouldBeCaptured: false,
         });
       }
 

--- a/apps/webapp/app/routes/api+/settings.import-users.ts
+++ b/apps/webapp/app/routes/api+/settings.import-users.ts
@@ -1,4 +1,5 @@
 import { data, type ActionFunctionArgs } from "react-router";
+import { INVITABLE_ROLES, isInvitableRole } from "~/modules/invite/roles";
 import { bulkInviteUsers } from "~/modules/invite/service.server";
 import { IMPORT_USERS_CSV_HEADERS } from "~/modules/invite/utils.server";
 import { csvDataFromRequest } from "~/utils/csv.server";
@@ -45,6 +46,40 @@ export async function action({ context, request }: ActionFunctionArgs) {
       csvData,
       IMPORT_USERS_CSV_HEADERS
     );
+
+    /**
+     * The CSV is untrusted input and its `role` column reaches the invite
+     * verbatim. The single-invite endpoint validates against the same list via
+     * `InviteUserFormSchema`; without this, an ADMIN could upload a row with
+     * `role=OWNER` and mint an OWNER invite — which `changeUserRole` and the
+     * invite dialog both refuse.
+     *
+     * Rows are reported rather than silently dropped: an admin who lists ten
+     * users and is told "invited 9" has no way to tell which row was ignored.
+     * Fully blank rows never get here — `csvDataFromRequest` strips them.
+     */
+    const invalidRoleRows = users
+      .map((user, index) => ({ user, index }))
+      .filter(({ user }) => !isInvitableRole(user.role))
+      // +2 converts a 0-based data index to the spreadsheet row the user sees
+      // (1 for the header row, 1 because spreadsheets are 1-based).
+      .map(({ user, index }) => `row ${index + 2} ("${user.role ?? ""}")`);
+
+    if (invalidRoleRows.length > 0) {
+      throw new ShelfError({
+        cause: null,
+        title: "Invalid role in CSV",
+        message: `Roles must be one of ${INVITABLE_ROLES.join(
+          ", "
+        )}. Ownership cannot be granted by invite — use ownership transfer instead. Problem rows: ${invalidRoleRows.join(
+          ", "
+        )}.`,
+        additionalData: { userId, organizationId },
+        label: "Team Member",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
 
     const response = await bulkInviteUsers({
       organizationId,

--- a/apps/webapp/test/routes-tests/api+/settings.import-users.test.ts
+++ b/apps/webapp/test/routes-tests/api+/settings.import-users.test.ts
@@ -13,11 +13,13 @@
  */
 
 import { OrganizationRoles } from "@prisma/client";
+import type { AppLoadContext } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createActionArgs } from "@mocks/remix";
 
 import { bulkInviteUsers } from "~/modules/invite/service.server";
 import { action } from "~/routes/api+/settings.import-users";
+import type { CSVData } from "~/utils/csv.server";
 import { csvDataFromRequest } from "~/utils/csv.server";
 import { requirePermission } from "~/utils/roles.server";
 import { assertUserCanInviteUsersToWorkspace } from "~/utils/subscription.server";
@@ -47,15 +49,25 @@ const mockContext = {
   commitSession: vi.fn(),
   isAuthenticated: true,
   appVersion: "test",
-} as any;
+} as unknown as AppLoadContext;
+
+/** One CSV row: role, email, teamMemberId — matching IMPORT_USERS_CSV_HEADERS */
+type CsvRow = [string, string, string];
 
 /** Builds the raw CSV grid `csvDataFromRequest` would return */
-function csvRows(rows: Array<[string, string, string]>) {
+function csvRows(rows: CsvRow[]): CSVData {
   return [["role", "email", "teamMemberId"], ...rows];
 }
 
-async function runImport(rows: Array<[string, string, string]>) {
-  vi.mocked(csvDataFromRequest).mockResolvedValue(csvRows(rows) as any);
+/**
+ * The action funnels thrown ShelfErrors through `data(error(reason), { status })`,
+ * which returns a DataWithResponseInit rather than a Response. `data` stays
+ * `unknown` because its shape differs between the success and error branches.
+ */
+type ActionResult = { init?: { status?: number }; data?: unknown };
+
+async function runImport(rows: CsvRow[]): Promise<ActionResult> {
+  vi.mocked(csvDataFromRequest).mockResolvedValue(csvRows(rows));
 
   const request = new Request("http://localhost/api/settings/import-users", {
     method: "POST",
@@ -65,20 +77,23 @@ async function runImport(rows: Array<[string, string, string]>) {
 
   return (await action(
     createActionArgs({ context: mockContext, request, params: {} })
-  )) as { init?: { status?: number }; data?: any };
+  )) as ActionResult;
 }
 
 describe("settings.import-users role validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    // The route destructures only organizationId; the rest of the permission
+    // payload is irrelevant here, so it is cast to the real return type rather
+    // than reconstructed field by field.
     vi.mocked(requirePermission).mockResolvedValue({
       organizationId: "org-1",
-    } as any);
-    vi.mocked(assertUserCanInviteUsersToWorkspace).mockResolvedValue(
-      undefined as any
+    } as Awaited<ReturnType<typeof requirePermission>>);
+    vi.mocked(assertUserCanInviteUsersToWorkspace).mockResolvedValue(undefined);
+    vi.mocked(bulkInviteUsers).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof bulkInviteUsers>>
     );
-    vi.mocked(bulkInviteUsers).mockResolvedValue({} as any);
   });
 
   it("rejects a CSV row granting OWNER", async () => {

--- a/apps/webapp/test/routes-tests/api+/settings.import-users.test.ts
+++ b/apps/webapp/test/routes-tests/api+/settings.import-users.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Bulk user invite (CSV import) — role validation
+ *
+ * Pins that the CSV import cannot grant a role the invite dialog refuses. The
+ * `role` column is raw text from an uploaded file and flows into `Invite.roles`
+ * verbatim; after acceptance, permissions resolve from `UserOrganization.roles`,
+ * so an unvalidated `OWNER` there is a full privilege escalation.
+ *
+ * Regression coverage for detail.dev finding D032.
+ *
+ * @see {@link file://./../../../app/routes/api+/settings.import-users.ts}
+ * @see {@link file://./../../../app/modules/invite/roles.ts}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createActionArgs } from "@mocks/remix";
+
+import { bulkInviteUsers } from "~/modules/invite/service.server";
+import { action } from "~/routes/api+/settings.import-users";
+import { csvDataFromRequest } from "~/utils/csv.server";
+import { requirePermission } from "~/utils/roles.server";
+import { assertUserCanInviteUsersToWorkspace } from "~/utils/subscription.server";
+
+// @vitest-environment node
+
+// why: the route parses an uploaded file; we drive rows in directly instead
+vi.mock("~/utils/csv.server", () => ({ csvDataFromRequest: vi.fn() }));
+
+// why: authorization is not under test here — the role gate is
+vi.mock("~/utils/roles.server", () => ({ requirePermission: vi.fn() }));
+
+// why: subscription seat limits are a separate concern from role validation
+vi.mock("~/utils/subscription.server", () => ({
+  assertUserCanInviteUsersToWorkspace: vi.fn(),
+}));
+
+// why: the invite service sends email and writes to the database
+vi.mock("~/modules/invite/service.server", () => ({
+  bulkInviteUsers: vi.fn(),
+}));
+
+const mockContext = {
+  getSession: () => ({ userId: "user-1" }),
+  setSession: vi.fn(),
+  destroySession: vi.fn(),
+  commitSession: vi.fn(),
+  isAuthenticated: true,
+  appVersion: "test",
+} as any;
+
+/** Builds the raw CSV grid `csvDataFromRequest` would return */
+function csvRows(rows: Array<[string, string, string]>) {
+  return [["role", "email", "teamMemberId"], ...rows];
+}
+
+async function runImport(rows: Array<[string, string, string]>) {
+  vi.mocked(csvDataFromRequest).mockResolvedValue(csvRows(rows) as any);
+
+  const request = new Request("http://localhost/api/settings/import-users", {
+    method: "POST",
+    body: new URLSearchParams({ message: "" }),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+
+  return (await action(
+    createActionArgs({ context: mockContext, request, params: {} })
+  )) as { init?: { status?: number }; data?: any };
+}
+
+describe("settings.import-users role validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+    } as any);
+    vi.mocked(assertUserCanInviteUsersToWorkspace).mockResolvedValue(
+      undefined as any
+    );
+    vi.mocked(bulkInviteUsers).mockResolvedValue({} as any);
+  });
+
+  it("rejects a CSV row granting OWNER", async () => {
+    const response = await runImport([
+      [OrganizationRoles.OWNER, "attacker@example.com", ""],
+    ]);
+
+    expect(response.init?.status).toBe(400);
+    // The invite must never be created — this is the escalation itself
+    expect(bulkInviteUsers).not.toHaveBeenCalled();
+  });
+
+  it("names the offending spreadsheet row so the admin can fix it", async () => {
+    const response = await runImport([
+      [OrganizationRoles.ADMIN, "fine@example.com", ""],
+      [OrganizationRoles.OWNER, "attacker@example.com", ""],
+    ]);
+
+    // Data row 2 is spreadsheet row 3 (header + 1-based)
+    expect(JSON.stringify(response.data)).toContain("row 3");
+  });
+
+  it("rejects an unknown role rather than passing it to Prisma", async () => {
+    const response = await runImport([["SUPERUSER", "x@example.com", ""]]);
+
+    expect(response.init?.status).toBe(400);
+    expect(bulkInviteUsers).not.toHaveBeenCalled();
+  });
+
+  it("still accepts the three invitable roles", async () => {
+    const response = await runImport([
+      [OrganizationRoles.ADMIN, "a@example.com", ""],
+      [OrganizationRoles.BASE, "b@example.com", ""],
+      [OrganizationRoles.SELF_SERVICE, "c@example.com", ""],
+    ]);
+
+    expect(response.init?.status).toBeUndefined();
+    expect(bulkInviteUsers).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

An **ADMIN could mint an OWNER invite** through two paths, bypassing the control
that makes ownership transfer the only way to change owner.

Found by the detail.dev OSS scan (finding D032) — which reported the CSV import.
The second path was found by sweeping siblings and is **not** in that report.

## The control being bypassed

`changeUserRole` refuses OWNER outright:

```ts
if (newRole === OrganizationRoles.OWNER) {
  throw new ShelfError({
    message: "Cannot assign Owner role directly. Use ownership transfer instead.",
  });
}
```

Ownership is supposed to move only through `transferOwnership`, which demotes the
outgoing owner, moves the subscription and emails both parties.

## Path 1 — CSV bulk import

`role` is raw text from an uploaded file, written straight into `Invite.roles`:

```ts
roles: [payload.role],   // no validation anywhere upstream
```

The single-invite endpoint validates the same field with
`parseData(formData, InviteUserFormSchema)`, whose enum is
`[ADMIN, BASE, SELF_SERVICE]`. The import route never validated at all.

What made it easy to miss: `bulkInviteUsers` types its input as
`z.infer<typeof InviteUserFormSchema>`, so the signature reads as though the rows
were already validated. That type is erased at runtime.

## Path 2 — Resend invite (not in the original report)

```ts
const role = Object.keys(organizationRolesMap).find(
  (key) => organizationRolesMap[key] === userFriendlyRole
);
```

`userFriendlyRole` is free text from the form, and `organizationRolesMap`
contains `[OrganizationRoles.OWNER]: "Owner"` because it doubles as the team
list's display map. So:

```
POST /settings/team/invites
intent=resend&email=…&name=…&teamMemberId=…&userFriendlyRole=Owner
```

resolved to `OWNER` and created an owner invite. Gated only by
`teamMember:update`, which ADMIN has.

## Why it escalates

On acceptance, `updateInviteStatus` → `createUserOrAttachOrg({ roles: invite.roles })`
writes the roles to `UserOrganization.roles` verbatim. Permissions resolve from
there via `resolveEffectiveRole` (`roles[0]`) — never from `Organization.owner`,
which would still point at the previous owner. The result is a second full owner
and a stale ownership record.

## The fix

`INVITABLE_ROLES` is now the single source of truth for what an invite may grant,
in a dependency-free module both the client form and the server paths import — so
the list cannot drift. Then:

| Path | Guard |
| --- | --- |
| Invite dialog | Zod enum now reads `INVITABLE_ROLES` |
| CSV import route | Validates every row, 400 naming the offending spreadsheet rows |
| `bulkInviteUsers` | Defense in depth — it is exported and its type enforces nothing at runtime |
| Resend invite | Rejects a non-invitable resolved role |

Invalid rows are **reported, not dropped**: an admin who lists ten users and is
told "invited 9" has no way to tell which row was ignored. Fully blank rows never
reach the check — `csvDataFromRequest` already strips them — so trailing-newline
CSVs are unaffected.

## Tests

- `app/modules/invite/roles.test.ts` — OWNER is never invitable; a new schema role
  fails the test rather than being silently omitted.
- `test/routes-tests/api+/settings.import-users.test.ts` — OWNER row rejected 400
  and `bulkInviteUsers` never called; unknown role rejected; offending row named;
  the three valid roles still import.
- `app/modules/user/utils.server.test.ts` — `userFriendlyRole=Owner` rejected and
  no invite created.

**Every test was confirmed to fail with its guard removed** — the OWNER import
returned `{"success":true}` and the OWNER resend resolved cleanly before the fix.

## Before merging — please run an audit

The pre-commit security reviewer flagged this and it's a fair point: the fix
closes the hole but says nothing about rows created while it was open.

```sql
-- Pending invites granting OWNER
SELECT id, "inviteeEmail", "organizationId", "inviterId", status, "createdAt"
FROM "Invite"
WHERE 'OWNER' = ANY(roles) AND status = 'PENDING';

-- Members holding OWNER who are not the recorded organization owner
SELECT uo."userId", uo."organizationId", uo.roles, o."userId" AS recorded_owner
FROM "UserOrganization" uo
JOIN "Organization" o ON o.id = uo."organizationId"
WHERE 'OWNER' = ANY(uo.roles) AND uo."userId" <> o."userId";
```

The second query is the one that matters — a non-empty result means someone
already holds owner privileges without being the recorded owner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation, invite acceptance, and resend-invitation flows now consistently reject ineligible roles, including Owner.
  * CSV user imports provide clear errors identifying invalid roles and spreadsheet rows.
  * Valid invitation roles remain supported: Administrator, Base, and Self-Service.

* **Tests**
  * Added coverage for role validation across invitations, invite acceptance, resending invitations, and CSV imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->