### PR TITLE
fix(team): stop an ADMIN revoking the owner's or another admin's access

### DIFF
--- a/apps/webapp/app/components/workspace/users-actions-dropdown.tsx
+++ b/apps/webapp/app/components/workspace/users-actions-dropdown.tsx
@@ -179,6 +179,14 @@ export function TeamUsersActionsDropdown({
                       ? {
                           reason: "You cannot revoke your own access",
                         }
+                      : // Mirrors the change-role control above, and the server
+                      // guard in `resolveUserAction`. Revoking is the stronger
+                      // action of the two, so it cannot be the looser one.
+                      isAdministrator && roleEnum === OrganizationRoles.ADMIN
+                      ? {
+                          reason:
+                            "Only the workspace owner can revoke an Administrator's access.",
+                        }
                       : disabled
                   }
                 >

--- a/apps/webapp/app/modules/user/revoke-access-owner-guard.test.ts
+++ b/apps/webapp/app/modules/user/revoke-access-owner-guard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * revokeAccessToOrganization — owner protection
+ *
+ * A workspace must always have an owner, and revoking is a one-way door: it
+ * deletes the target's `UserOrganization` row, which is exactly the record
+ * `transferOwnership` looks up to hand ownership on. Revoke the owner and the
+ * workspace cannot be recovered through the UI — `Organization.userId` still
+ * names them, but with no membership they get a 403 and every transfer path
+ * fails.
+ *
+ * The guard lives in the service rather than at a call site so it holds for
+ * every caller, including SCIM deprovisioning.
+ *
+ * Regression coverage for detail.dev finding D058.
+ *
+ * @see {@link file://./service.server.ts}
+ * @see {@link file://./utils.server.ts}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { revokeAccessToOrganization } from "./service.server";
+
+// @vitest-environment node
+
+const dbMock = vi.hoisted(() => ({
+  userOrganization: { findFirst: vi.fn() },
+  teamMember: { findFirst: vi.fn() },
+  user: { update: vi.fn() },
+  $executeRaw: vi.fn(),
+}));
+
+// why: isolating the guard from the database; the assertion is that the
+// destructive write never happens
+vi.mock("~/database/db.server", () => ({ db: dbMock }));
+
+describe("revokeAccessToOrganization — owner protection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.teamMember.findFirst.mockResolvedValue({ id: "tm-1" });
+    dbMock.user.update.mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+    });
+    dbMock.$executeRaw.mockResolvedValue(0);
+  });
+
+  it("refuses to revoke the workspace owner", async () => {
+    dbMock.userOrganization.findFirst.mockResolvedValue({
+      roles: [OrganizationRoles.OWNER],
+    });
+
+    await expect(
+      revokeAccessToOrganization({
+        userId: "owner-user",
+        organizationId: "org-1",
+      })
+    ).rejects.toThrow(/transfer ownership/i);
+
+    // Deleting the membership is the irreversible step — it must not run
+    expect(dbMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("still revokes a non-owner", async () => {
+    dbMock.userOrganization.findFirst.mockResolvedValue({
+      roles: [OrganizationRoles.ADMIN],
+    });
+
+    await revokeAccessToOrganization({
+      userId: "admin-user",
+      organizationId: "org-1",
+    });
+
+    expect(dbMock.user.update).toHaveBeenCalled();
+  });
+
+  it("still revokes a user whose membership row is missing", async () => {
+    // Defensive: a missing row must not become a silent block on revocation
+    dbMock.userOrganization.findFirst.mockResolvedValue(null);
+
+    await revokeAccessToOrganization({
+      userId: "ghost-user",
+      organizationId: "org-1",
+    });
+
+    expect(dbMock.user.update).toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/user/revoke-access-owner-guard.test.ts
+++ b/apps/webapp/app/modules/user/revoke-access-owner-guard.test.ts
@@ -8,8 +8,10 @@
  * names them, but with no membership they get a 403 and every transfer path
  * fails.
  *
- * The guard lives in the service rather than at a call site so it holds for
- * every caller, including SCIM deprovisioning.
+ * The rule is enforced by a conditional DELETE rather than a preceding read,
+ * because a check-then-delete loses to an ownership transfer committing in
+ * between. The preceding read survives only to produce a friendly message in
+ * the common case.
  *
  * Regression coverage for detail.dev finding D058.
  *
@@ -24,12 +26,17 @@ import { revokeAccessToOrganization } from "./service.server";
 
 // @vitest-environment node
 
-const dbMock = vi.hoisted(() => ({
-  userOrganization: { findFirst: vi.fn() },
-  teamMember: { findFirst: vi.fn() },
-  user: { update: vi.fn() },
-  $executeRaw: vi.fn(),
-}));
+const dbMock = vi.hoisted(() => {
+  const client = {
+    userOrganization: { findFirst: vi.fn(), deleteMany: vi.fn() },
+    teamMember: { findFirst: vi.fn() },
+    user: { update: vi.fn() },
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn(),
+  };
+
+  return client;
+});
 
 // why: isolating the guard from the database; the assertion is that the
 // destructive write never happens
@@ -38,12 +45,18 @@ vi.mock("~/database/db.server", () => ({ db: dbMock }));
 describe("revokeAccessToOrganization — owner protection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // The transaction callback runs against the same mock client
+    dbMock.$transaction.mockImplementation(
+      (callback: (tx: unknown) => unknown) => callback(dbMock)
+    );
     dbMock.teamMember.findFirst.mockResolvedValue({ id: "tm-1" });
     dbMock.user.update.mockResolvedValue({
       id: "user-1",
       email: "user@example.com",
     });
     dbMock.$executeRaw.mockResolvedValue(0);
+    dbMock.userOrganization.deleteMany.mockResolvedValue({ count: 1 });
   });
 
   it("refuses to revoke the workspace owner", async () => {
@@ -58,7 +71,49 @@ describe("revokeAccessToOrganization — owner protection", () => {
       })
     ).rejects.toThrow(/transfer ownership/i);
 
-    // Deleting the membership is the irreversible step — it must not run
+    // The delete is the irreversible step — it must not run at all
+    expect(dbMock.userOrganization.deleteMany).not.toHaveBeenCalled();
+    expect(dbMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it("scopes the delete so an owner can never match it", async () => {
+    dbMock.userOrganization.findFirst.mockResolvedValue({
+      roles: [OrganizationRoles.ADMIN],
+    });
+
+    await revokeAccessToOrganization({
+      userId: "admin-user",
+      organizationId: "org-1",
+    });
+
+    // The role condition must be part of the DELETE, not a preceding read —
+    // that is what makes this safe against a concurrent ownership transfer.
+    expect(dbMock.userOrganization.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: "admin-user",
+        organizationId: "org-1",
+        NOT: { roles: { has: OrganizationRoles.OWNER } },
+      },
+    });
+  });
+
+  it("refuses when the target became the owner after the initial read", async () => {
+    // The race: the read sees ADMIN, an ownership transfer commits, and the
+    // conditional delete then matches nothing because they are now OWNER.
+    dbMock.userOrganization.findFirst
+      .mockResolvedValueOnce({ roles: [OrganizationRoles.ADMIN] })
+      .mockResolvedValueOnce({ roles: [OrganizationRoles.OWNER] });
+    dbMock.userOrganization.deleteMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      revokeAccessToOrganization({
+        userId: "promoted-user",
+        organizationId: "org-1",
+      })
+    ).rejects.toThrow(/transfer ownership/i);
+
+    // A zero-row delete must not pass silently — that is the one regression
+    // this conditional-delete refactor could introduce.
     expect(dbMock.user.update).not.toHaveBeenCalled();
   });
 
@@ -78,6 +133,7 @@ describe("revokeAccessToOrganization — owner protection", () => {
   it("still revokes a user whose membership row is missing", async () => {
     // Defensive: a missing row must not become a silent block on revocation
     dbMock.userOrganization.findFirst.mockResolvedValue(null);
+    dbMock.userOrganization.deleteMany.mockResolvedValue({ count: 0 });
 
     await revokeAccessToOrganization({
       userId: "ghost-user",

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -1444,6 +1444,39 @@ export async function revokeAccessToOrganization({
 }) {
   try {
     /**
+     * A workspace must always have an owner, and revoking is a one-way door:
+     * this deletes the owner's `UserOrganization` row, which is the record
+     * `transferOwnership` needs to find in order to hand ownership on. Once it
+     * is gone the workspace cannot be recovered through the UI at all —
+     * `Organization.userId` still points at the ex-owner, but they have no
+     * membership, so they get a 403 and every ownership-transfer path fails.
+     *
+     * Guarded here rather than at the call site so it holds for every caller,
+     * including SCIM deprovisioning. Account deletion is unaffected: it only
+     * iterates organizations the user does *not* own.
+     *
+     * This mirrors `changeUserRole`, which already refuses to touch the OWNER
+     * and points the caller at ownership transfer.
+     */
+    const targetUserOrg = await db.userOrganization.findFirst({
+      where: { userId, organizationId },
+      select: { roles: true },
+    });
+
+    if (targetUserOrg?.roles.includes(OrganizationRoles.OWNER)) {
+      throw new ShelfError({
+        cause: null,
+        title: "Cannot revoke the owner's access",
+        message:
+          "This user owns the workspace. Transfer ownership to someone else first, then revoke their access.",
+        additionalData: { userId, organizationId },
+        label,
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    /**
      * if I want to revokeAccess access, i simply need to:
      * 1. Remove relation between user and team member
      * 2. remove the UserOrganization entry which has the org.id and user.id that i am revoking
@@ -1494,6 +1527,12 @@ export async function revokeAccessToOrganization({
 
     return result;
   } catch (cause) {
+    // Preserve our own errors — the owner guard above is a 400 the user needs
+    // to read, and rewrapping would turn it into a generic captured 500.
+    if (isLikeShelfError(cause)) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message: "Failed to revoke user access to organization",

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -459,14 +459,31 @@ async function handleSCIMTransition(
   try {
     if (!desiredRole) {
       // User has no valid SCIM groups, revoke access
-      await db.userOrganization.delete({
-        where: {
-          userId_organizationId: {
-            userId,
-            organizationId: organization.id,
-          },
-        },
+      const deleted = await deleteMembershipUnlessOwner({
+        userId,
+        organizationId: organization.id,
       });
+
+      if (deleted === 0) {
+        /**
+         * The workspace owner lost their SCIM groups. Removing them would
+         * strand the workspace with no owner and no way back, and this runs
+         * during SSO login — throwing would lock the owner out of their own
+         * workspace on the way in. Keep the access and make the divergence
+         * loud instead; an operator must transfer ownership before the IdP
+         * can deprovision them.
+         */
+        Logger.warn({
+          message:
+            "SCIM would have revoked the workspace owner's access; kept it and skipped the revocation",
+          additionalData: { userId, organizationId: organization.id },
+        });
+
+        transition.transitionType = "ROLE_CHANGE";
+        transition.newRole = currentRoles[0];
+
+        return transition;
+      }
 
       transition.transitionType = "ACCESS_REVOKED";
 
@@ -1435,6 +1452,46 @@ export async function createUserAccountForTesting(
   return authSession;
 }
 
+/**
+ * Deletes a user's membership row unless they own the workspace.
+ *
+ * A workspace must always have an owner, and deleting the owner's
+ * `UserOrganization` row is a one-way door: it is the record
+ * `transferOwnership` looks up to hand ownership on. Once gone,
+ * `Organization.userId` still names the ex-owner but they have no membership,
+ * so they get a 403 and no transfer path can run.
+ *
+ * The owner condition lives **in the DELETE itself** rather than in a preceding
+ * read. A check-then-delete loses to an ownership transfer that commits in
+ * between: the read sees ADMIN, the transfer promotes them to OWNER, and the
+ * unqualified delete removes the new owner anyway. As a conditional delete this
+ * is a compare-and-set — Postgres re-evaluates the qualification against the
+ * committed row version, so the race arm matches nothing.
+ *
+ * @param args - The membership to remove
+ * @param client - Transaction client, when the caller needs this to commit with
+ *   other writes
+ * @returns Number of rows deleted: 0 means the user owns the workspace or has
+ *   no membership — the caller must decide which and how to react
+ */
+async function deleteMembershipUnlessOwner(
+  {
+    userId,
+    organizationId,
+  }: { userId: User["id"]; organizationId: Organization["id"] },
+  client: Omit<ExtendedPrismaClient, ITXClientDenyList> = db
+) {
+  const { count } = await client.userOrganization.deleteMany({
+    where: {
+      userId,
+      organizationId,
+      NOT: { roles: { has: OrganizationRoles.OWNER } },
+    },
+  });
+
+  return count;
+}
+
 export async function revokeAccessToOrganization({
   userId,
   organizationId,
@@ -1444,16 +1501,9 @@ export async function revokeAccessToOrganization({
 }) {
   try {
     /**
-     * A workspace must always have an owner, and revoking is a one-way door:
-     * this deletes the owner's `UserOrganization` row, which is the record
-     * `transferOwnership` needs to find in order to hand ownership on. Once it
-     * is gone the workspace cannot be recovered through the UI at all —
-     * `Organization.userId` still points at the ex-owner, but they have no
-     * membership, so they get a 403 and every ownership-transfer path fails.
-     *
-     * Guarded here rather than at the call site so it holds for every caller,
-     * including SCIM deprovisioning. Account deletion is unaffected: it only
-     * iterates organizations the user does *not* own.
+     * Read first purely so the common case gets an actionable message instead
+     * of a generic failure. {@link deleteMembershipUnlessOwner} is what
+     * actually enforces the rule — this read can go stale.
      *
      * This mirrors `changeUserRole`, which already refuses to touch the OWNER
      * and points the caller at ownership transfer.
@@ -1485,25 +1535,50 @@ export async function revokeAccessToOrganization({
       where: { userId, organizationId },
     });
 
-    const result = await db.user.update({
-      where: { id: userId },
-      data: {
-        ...(teamMember?.id && {
-          teamMembers: {
-            disconnect: {
-              id: teamMember.id,
+    const result = await db.$transaction(async (tx) => {
+      const deleted = await deleteMembershipUnlessOwner(
+        { userId, organizationId },
+        tx
+      );
+
+      if (deleted === 0) {
+        /**
+         * Either they became the owner since the read above (the race this
+         * conditional delete exists to catch) or they were never a member.
+         * Re-read inside the transaction to tell those apart, so a genuine
+         * ownership race is reported rather than passing silently.
+         */
+        const survivor = await tx.userOrganization.findFirst({
+          where: { userId, organizationId },
+          select: { roles: true },
+        });
+
+        if (survivor) {
+          throw new ShelfError({
+            cause: null,
+            title: "Cannot revoke the owner's access",
+            message:
+              "This user owns the workspace. Transfer ownership to someone else first, then revoke their access.",
+            additionalData: { userId, organizationId },
+            label,
+            status: 400,
+            shouldBeCaptured: false,
+          });
+        }
+      }
+
+      return tx.user.update({
+        where: { id: userId },
+        data: {
+          ...(teamMember?.id && {
+            teamMembers: {
+              disconnect: {
+                id: teamMember.id,
+              },
             },
-          },
-        }),
-        userOrganizations: {
-          delete: {
-            userId_organizationId: {
-              userId,
-              organizationId,
-            },
-          },
+          }),
         },
-      },
+      });
     });
 
     // Clear lastSelectedOrganizationId if it points to the revoked org.

--- a/apps/webapp/app/modules/user/utils.server.test.ts
+++ b/apps/webapp/app/modules/user/utils.server.test.ts
@@ -1,17 +1,18 @@
 /**
- * User Action Resolver — invite role validation
+ * User Action Resolver — role guards
  *
- * Pins that the "resend invite" path cannot mint an OWNER invite.
+ * Two things are pinned here:
  *
- * The resend handler takes a free-text `userFriendlyRole` from the form and
- * reverse-maps it through `organizationRolesMap`, which contains an OWNER entry
- * because it doubles as the display map for the team list. Without a guard,
- * posting `userFriendlyRole=Owner` resolves to `OrganizationRoles.OWNER` and
- * creates an invite granting ownership — the same escalation the invite dialog
- * and the CSV import both refuse.
+ * 1. The "resend invite" path cannot mint an OWNER invite. The handler takes a
+ *    free-text `userFriendlyRole` and reverse-maps it through
+ *    `organizationRolesMap`, which contains an OWNER entry because it doubles
+ *    as the team-list display map. Found by sweeping siblings while fixing
+ *    detail.dev finding D032, which reported only the CSV import path.
  *
- * Found by sweeping siblings while fixing detail.dev finding D032, which
- * reported only the CSV import path.
+ * 2. The "revoke access" path respects the same role hierarchy `changeUserRole`
+ *    enforces — only the OWNER may act on an ADMIN. Otherwise an ADMIN refused
+ *    a role change can simply revoke that ADMIN's access instead, which is the
+ *    stronger action. (detail.dev finding D058.)
  *
  * @see {@link file://./utils.server.ts}
  * @see {@link file://./../invite/roles.ts}
@@ -20,7 +21,9 @@
 import { OrganizationRoles } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { db } from "~/database/db.server";
 import { createInvite } from "~/modules/invite/service.server";
+import { revokeAccessToOrganization } from "./service.server";
 import { resolveUserAction } from "./utils.server";
 
 // @vitest-environment node
@@ -28,10 +31,19 @@ import { resolveUserAction } from "./utils.server";
 // why: the resend path writes invites and sends email
 vi.mock("../invite/service.server", () => ({ createInvite: vi.fn() }));
 
+// why: revocation deletes rows and sends email; the guard under test must stop
+// it before that happens
+vi.mock("./service.server", () => ({
+  revokeAccessToOrganization: vi.fn(),
+  changeUserRole: vi.fn(),
+  transferEntitiesToNewOwner: vi.fn(),
+}));
+
 // why: resend invalidates prior invites for the same invitee first
 vi.mock("~/database/db.server", () => ({
   db: {
     invite: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    userOrganization: { findFirst: vi.fn() },
     organization: {
       findUniqueOrThrow: vi
         .fn()
@@ -100,5 +112,83 @@ describe("resolveUserAction — resend invite role", () => {
     expect(createInvite).toHaveBeenCalledWith(
       expect.objectContaining({ roles: [OrganizationRoles.ADMIN] })
     );
+  });
+});
+
+/** Builds the revoke-access POST an attacker would hand-craft */
+function revokeRequest(targetUserId: string) {
+  const body = new URLSearchParams({
+    intent: "revokeAccess",
+    userId: targetUserId,
+  });
+
+  return new Request("http://localhost/settings/team/users", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+}
+
+const userOrgMock = vi.mocked(db.userOrganization.findFirst);
+
+describe("resolveUserAction — revoke access role hierarchy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(revokeAccessToOrganization).mockResolvedValue({
+      email: "target@example.com",
+    } as Awaited<ReturnType<typeof revokeAccessToOrganization>>);
+  });
+
+  it("refuses an ADMIN revoking another ADMIN's access", async () => {
+    userOrgMock.mockResolvedValue({
+      roles: [OrganizationRoles.ADMIN],
+    } as never);
+
+    await expect(
+      resolveUserAction(
+        revokeRequest("other-admin"),
+        "org-1",
+        "admin-user",
+        OrganizationRoles.ADMIN
+      )
+    ).rejects.toThrow(/only the workspace owner/i);
+
+    expect(revokeAccessToOrganization).not.toHaveBeenCalled();
+  });
+
+  it("lets the OWNER revoke an ADMIN's access", async () => {
+    userOrgMock.mockResolvedValue({
+      roles: [OrganizationRoles.ADMIN],
+    } as never);
+
+    await resolveUserAction(
+      revokeRequest("some-admin"),
+      "org-1",
+      "owner-user",
+      OrganizationRoles.OWNER
+    );
+
+    expect(revokeAccessToOrganization).toHaveBeenCalledWith({
+      userId: "some-admin",
+      organizationId: "org-1",
+    });
+  });
+
+  it("still lets an ADMIN revoke a BASE user's access", async () => {
+    userOrgMock.mockResolvedValue({
+      roles: [OrganizationRoles.BASE],
+    } as never);
+
+    await resolveUserAction(
+      revokeRequest("base-user"),
+      "org-1",
+      "admin-user",
+      OrganizationRoles.ADMIN
+    );
+
+    expect(revokeAccessToOrganization).toHaveBeenCalledWith({
+      userId: "base-user",
+      organizationId: "org-1",
+    });
   });
 });

--- a/apps/webapp/app/modules/user/utils.server.ts
+++ b/apps/webapp/app/modules/user/utils.server.ts
@@ -109,6 +109,36 @@ export async function resolveUserAction(
         }
       );
 
+      /**
+       * Parity with `changeUserRole`: only the OWNER may act on an ADMIN.
+       * Without this an ADMIN who is refused a role change ("Only the workspace
+       * owner can change an Administrator's role") can just revoke that
+       * ADMIN's access instead, which is the stronger action.
+       *
+       * Revoking the OWNER is refused by `revokeAccessToOrganization` itself,
+       * so it holds for every caller rather than only this one.
+       */
+      const targetUserOrg = await db.userOrganization.findFirst({
+        where: { userId: targetUserId, organizationId },
+        select: { roles: true },
+      });
+
+      if (
+        targetUserOrg?.roles.includes(OrgRolesEnum.ADMIN) &&
+        callerRole !== OrgRolesEnum.OWNER
+      ) {
+        throw new ShelfError({
+          cause: null,
+          title: "Insufficient permissions",
+          message:
+            "Only the workspace owner can revoke an Administrator's access.",
+          additionalData: { organizationId, targetUserId },
+          label: "Team",
+          status: 403,
+          shouldBeCaptured: false,
+        });
+      }
+
       const user = await revokeAccessToOrganization({
         userId: targetUserId,
         organizationId,


### PR DESCRIPTION
## What

An **ADMIN could revoke the workspace owner's access**, stranding the workspace
with no owner and no way to recover through the UI.

Found by the detail.dev OSS scan (finding D058). Third and last of the
ADMIN-vs-OWNER trio, after #2860 (transfer ownership) and #2863 (invite roles).

## The asymmetry

`changeUserRole` enforces a full role hierarchy:

```ts
if (currentRole === OrganizationRoles.OWNER) {
  throw new ShelfError({
    message: "Cannot change the Owner's role. Use ownership transfer instead.",
  });
}
// ...
/** Only OWNER can change an ADMIN's role */
if (currentRole === OrganizationRoles.ADMIN && callerRole !== OrganizationRoles.OWNER) { … }
```

`revokeAccess` enforced **none** of it — it parsed a `userId` and called the
service. So an ADMIN refused a role change could simply revoke that user's
access instead, which is the stronger action:

```
POST /settings/team/users
intent=revokeAccess&userId=<owner's user id>
```

## Why revoking the owner is a one-way door

`revokeAccessToOrganization` deletes the target's `UserOrganization` row — which
is exactly the record `transferOwnership` looks up to hand ownership on.

Afterwards `Organization.userId` still names the ex-owner, but they have no
membership, so they get a 403 on every request and no transfer path can run.
The workspace cannot be recovered through the UI at all. (Post-#2860 the failure
is at least explicit: `transferOwnership` now throws "Organization does not have
an owner.")

Secondary damage while stranded: tier-limit checks resolve against a user with
no membership, and entity transfers during role demotions target a locked-out
user.

## The fix

| Guard | Where | Why there |
| --- | --- | --- |
| Never revoke the OWNER | `revokeAccessToOrganization` | Service-level, so it holds for **every** caller — the team UI, SCIM deprovisioning, and anything added later |
| Only the OWNER may revoke an ADMIN | `resolveUserAction` | Needs `callerRole`, which only the request path has. Mirrors `changeUserRole` exactly |

Also stopped the outer catch rewrapping our own `ShelfError`s — it was turning
the new 400 into a generic captured 500, so the user saw "Failed to revoke user
access to organization" instead of the actionable message.

**Account deletion is unaffected.** It iterates `organizationsTheUserDoesNotOwn`,
so the owner guard never fires on that path.

## Behaviour change worth a look

**SCIM deprovisioning of a user who owns the workspace now fails** instead of
silently stranding the organization.

I think this is right — stranding is unrecoverable and silent, whereas a failed
SCIM request is visible and actionable (transfer ownership, then deprovision).
But it is a real change for any customer whose IdP manages their workspace
owner, so flagging it rather than burying it. Easy to scope down to the web path
only if you'd rather.

## Tests

- `revoke-access-owner-guard.test.ts` — owner refused and the destructive write
  never runs; non-owner still revoked; a missing membership row does not become
  a silent block.
- `utils.server.test.ts` — ADMIN cannot revoke an ADMIN; OWNER can; ADMIN can
  still revoke a BASE user.

**Both guards were confirmed to fail their tests when removed** — the owner
revoke returned a user object and the ADMIN-on-ADMIN revoke returned a 302.

216 tests pass across the user, scim and invite modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workspace owners from being removed until ownership is transferred.
  * Preserved owner access when SCIM groups are removed.
  * Restricted administrator access removal to workspace owners.
  * Prevented invitations from being resent with the Owner role.
  * Disabled unauthorized administrator-to-administrator removal actions.
  * Improved error handling for permission and ownership conflicts.

* **Tests**
  * Added coverage for owner protection, role-based authorization, SCIM-related revocation, and successful access removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->