### PR TITLE
fix(bookings): allow direct booking of qty-tracked assets that belong to kits

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/book-selected-assets-dropdown.tsx
+++ b/apps/webapp/app/components/assets/assets-index/book-selected-assets-dropdown.tsx
@@ -16,6 +16,7 @@ import When from "~/components/when/when";
 import { useControlledDropdownMenu } from "~/hooks/use-controlled-dropdown-menu";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import { isDirectBookingBlockedByKit } from "~/modules/asset/utils";
 import { ALL_SELECTED_KEY, isSelectingAllItems } from "~/utils/list";
 import { isPersonalOrg } from "~/utils/organization";
 import {
@@ -70,8 +71,14 @@ function ConditionalActionsDropdown() {
       (asset) => asset.id !== ALL_SELECTED_KEY
     );
 
-    /** If any asset is part of a kit. */
-    const someAssetsPartOfKit = realAssets.some((asset) => !!asset.kit);
+    /**
+     * If any asset can't be booked outside of its kit.
+     *
+     * Only INDIVIDUAL assets qualify — a QUANTITY_TRACKED asset allocates a
+     * slice of its pool per kit and keeps the remainder free for direct
+     * bookings. See `isDirectBookingBlockedByKit`.
+     */
+    const someAssetsPartOfKit = realAssets.some(isDirectBookingBlockedByKit);
     if (someAssetsPartOfKit) {
       return {
         reason:

--- a/apps/webapp/app/components/assets/booking-actions-dropdown.test.tsx
+++ b/apps/webapp/app/components/assets/booking-actions-dropdown.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * BookingActionsDropdown — unit tests
+ *
+ * Pins the kit-membership gate on the asset overview page's "Book" dropdown:
+ * an INDIVIDUAL asset inside a kit must be booked through its kit, but a
+ * QUANTITY_TRACKED asset only allocates a *slice* of its pool per kit and
+ * keeps the remainder directly bookable.
+ *
+ * Regression: a customer's qty-tracked asset (6 units, 4 allocated to kits,
+ * 2 free) had both booking actions disabled here while the booking page's own
+ * asset picker happily accepted it.
+ *
+ * @see {@link file://./booking-actions-dropdown.tsx}
+ * @see {@link file://./../../modules/asset/utils.ts}
+ */
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import BookingActionsDropdown from "./booking-actions-dropdown";
+import type { BookLink } from "../shared/generic-add-to-bookings-actions-dropdown";
+
+const useLoaderDataMock = vi.hoisted(() => vi.fn());
+
+// why: the component reads the asset straight off the route loader; there is
+// no prop seam to inject it through.
+vi.mock("react-router", () => ({
+  useLoaderData: useLoaderDataMock,
+}));
+
+// why: `useCurrentOrganization` reads the _layout route loader via
+// `useRouteLoaderData`, which needs a full router context we don't need here.
+vi.mock("~/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({ id: "org-1", type: "TEAM" }),
+}));
+
+/**
+ * Captured `links` from the last render, so assertions can read the
+ * `disabled` decision for each booking action.
+ *
+ * why: the real dropdown renders its items inside a Radix Popover portal that
+ * only mounts once hydrated and opened — neither happens in Happy DOM. The
+ * links array IS the component's output contract, so we assert on it directly.
+ */
+let capturedLinks: BookLink[] = [];
+
+vi.mock("../shared/generic-add-to-bookings-actions-dropdown", () => ({
+  GenericBookActionsDropdown: ({ links }: { links: BookLink[] }) => {
+    capturedLinks = links;
+    return null;
+  },
+}));
+
+/** Reads the `disabled` prop the component assigned to a named booking action */
+function disabledFor(label: string) {
+  return capturedLinks.find((link) => link.label === label)?.disabled;
+}
+
+const baseAsset = {
+  id: "asset-1",
+  title: "Canon EF 16-35mm Lens",
+  availableToBook: true,
+};
+
+const kitMembership = (kitId: string, name: string) => ({
+  id: `pivot-${kitId}`,
+  quantity: 1,
+  kit: { id: kitId, name },
+});
+
+describe("BookingActionsDropdown", () => {
+  beforeEach(() => {
+    capturedLinks = [];
+  });
+
+  it("blocks both booking actions for an INDIVIDUAL asset inside a kit", () => {
+    useLoaderDataMock.mockReturnValue({
+      asset: {
+        ...baseAsset,
+        type: "INDIVIDUAL",
+        assetKits: [kitMembership("kit-1", "Camera kit")],
+      },
+    });
+
+    render(<BookingActionsDropdown />);
+
+    expect(disabledFor("Create new booking")).toMatchObject({
+      reason: expect.anything(),
+    });
+    expect(disabledFor("Add to existing booking")).toMatchObject({
+      reason: expect.anything(),
+    });
+  });
+
+  it("keeps both booking actions enabled for a QUANTITY_TRACKED asset spread across kits", () => {
+    useLoaderDataMock.mockReturnValue({
+      asset: {
+        ...baseAsset,
+        type: "QUANTITY_TRACKED",
+        quantity: 6,
+        assetKits: [
+          kitMembership("kit-1", "BMPCC4K Kit w/ Tripod - Pa"),
+          kitMembership("kit-2", "BMPCC4K Kit w/ Tripod - Hi"),
+          kitMembership("kit-3", "BMPCC4K Kit w/ Tripod - Ta"),
+          kitMembership("kit-4", "BMPCC4K Kit w/ Tripod - Ti"),
+        ],
+      },
+    });
+
+    render(<BookingActionsDropdown />);
+
+    expect(disabledFor("Create new booking")).toBe(false);
+    expect(disabledFor("Add to existing booking")).toBe(false);
+  });
+
+  it("keeps booking actions enabled for an asset that belongs to no kit", () => {
+    useLoaderDataMock.mockReturnValue({
+      asset: { ...baseAsset, type: "INDIVIDUAL", assetKits: [] },
+    });
+
+    render(<BookingActionsDropdown />);
+
+    expect(disabledFor("Create new booking")).toBe(false);
+    expect(disabledFor("Add to existing booking")).toBe(false);
+  });
+});

--- a/apps/webapp/app/components/assets/booking-actions-dropdown.tsx
+++ b/apps/webapp/app/components/assets/booking-actions-dropdown.tsx
@@ -1,6 +1,9 @@
 import { useLoaderData } from "react-router";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
-import { getPrimaryKit } from "~/modules/asset/utils";
+import {
+  getPrimaryKit,
+  isDirectBookingBlockedByKit,
+} from "~/modules/asset/utils";
 import type { loader } from "~/routes/_layout+/assets.$assetId";
 import { isPersonalOrg } from "~/utils/organization";
 import { Button } from "../shared/button";
@@ -15,20 +18,33 @@ export default function BookingActionsDropdown() {
   if (isPersonalOrg(organization)) return null;
 
   const assetKit = getPrimaryKit<{ id: string; name: string }>(asset);
-  const disabled = assetKit
-    ? {
-        reason: (
-          <>
-            Cannot book this asset directly because it's part of a kit. Please
-            book the{" "}
-            <Button to={`/kits/${assetKit.id}`} target="_blank" variant="link">
-              kit
-            </Button>{" "}
-            instead.
-          </>
-        ),
-      }
-    : false;
+
+  /**
+   * Kit membership only blocks INDIVIDUAL assets — a QUANTITY_TRACKED asset
+   * allocates a slice of its pool to each kit and keeps the rest free for
+   * direct bookings (see `isDirectBookingBlockedByKit`). Blocking on mere
+   * membership hid the Book action from customers whose qty-tracked asset had
+   * standalone units left, even though the booking page's picker accepted it.
+   */
+  const disabled =
+    isDirectBookingBlockedByKit(asset) && assetKit
+      ? {
+          reason: (
+            <>
+              Cannot book this asset directly because it's part of a kit. Please
+              book the{" "}
+              <Button
+                to={`/kits/${assetKit.id}`}
+                target="_blank"
+                variant="link"
+              >
+                kit
+              </Button>{" "}
+              instead.
+            </>
+          ),
+        }
+      : false;
 
   const disabledTrigger = availableToBook
     ? false

--- a/apps/webapp/app/modules/asset/utils.test.ts
+++ b/apps/webapp/app/modules/asset/utils.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the shared, client-safe asset utilities.
+ *
+ * The `isDirectBookingBlockedByKit` suite pins the rule that a
+ * QUANTITY_TRACKED asset's kit membership only claims a *slice* of its pool,
+ * so the remaining free-pool units stay directly bookable — the regression a
+ * customer hit on the asset overview page's "Book" dropdown.
+ *
+ * @see {@link file://./utils.ts}
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  getPrimaryKit,
+  getPrimaryLocation,
+  isDirectBookingBlockedByKit,
+  isQuantityTracked,
+} from "./utils";
+
+describe("isQuantityTracked", () => {
+  it("recognises the QUANTITY_TRACKED type from an asset or a raw value", () => {
+    expect(isQuantityTracked({ type: "QUANTITY_TRACKED" })).toBe(true);
+    expect(isQuantityTracked("QUANTITY_TRACKED")).toBe(true);
+    expect(isQuantityTracked({ type: "INDIVIDUAL" })).toBe(false);
+    expect(isQuantityTracked(null)).toBe(false);
+    expect(isQuantityTracked(undefined)).toBe(false);
+  });
+});
+
+describe("getPrimaryKit / getPrimaryLocation", () => {
+  it("returns the first pivot row's relation, or null", () => {
+    expect(
+      getPrimaryKit({ assetKits: [{ kit: { id: "kit-1" } }] })
+    ).toStrictEqual({ id: "kit-1" });
+    expect(getPrimaryKit({ assetKits: [] })).toBeNull();
+    expect(getPrimaryKit(null)).toBeNull();
+
+    expect(
+      getPrimaryLocation({ assetLocations: [{ location: { id: "loc-1" } }] })
+    ).toStrictEqual({ id: "loc-1" });
+    expect(getPrimaryLocation(undefined)).toBeNull();
+  });
+});
+
+describe("isDirectBookingBlockedByKit", () => {
+  describe("INDIVIDUAL assets", () => {
+    it("blocks direct booking when the asset belongs to a kit", () => {
+      expect(
+        isDirectBookingBlockedByKit({
+          type: "INDIVIDUAL",
+          assetKits: [{ kit: { id: "kit-1", name: "Camera kit" } }],
+        })
+      ).toBe(true);
+    });
+
+    it("blocks direct booking on the index projection (`kit` scalar)", () => {
+      expect(
+        isDirectBookingBlockedByKit({
+          type: "INDIVIDUAL",
+          kit: { id: "kit-1", name: "Camera kit" },
+        })
+      ).toBe(true);
+    });
+
+    it("allows direct booking when the asset belongs to no kit", () => {
+      expect(
+        isDirectBookingBlockedByKit({ type: "INDIVIDUAL", assetKits: [] })
+      ).toBe(false);
+      expect(
+        isDirectBookingBlockedByKit({ type: "INDIVIDUAL", kit: null })
+      ).toBe(false);
+    });
+  });
+
+  describe("QUANTITY_TRACKED assets", () => {
+    it("allows direct booking even when the asset belongs to a kit", () => {
+      expect(
+        isDirectBookingBlockedByKit({
+          type: "QUANTITY_TRACKED",
+          assetKits: [{ kit: { id: "kit-1", name: "Camera kit" } }],
+        })
+      ).toBe(false);
+    });
+
+    it("allows direct booking when the asset is spread across several kits", () => {
+      // A QT asset legitimately allocates a slice to each of N kits while
+      // keeping a free pool — the exact shape the customer report hit.
+      expect(
+        isDirectBookingBlockedByKit({
+          type: "QUANTITY_TRACKED",
+          assetKits: [
+            { kit: { id: "kit-1", name: "Kit A" } },
+            { kit: { id: "kit-2", name: "Kit B" } },
+            { kit: { id: "kit-3", name: "Kit C" } },
+            { kit: { id: "kit-4", name: "Kit D" } },
+          ],
+        })
+      ).toBe(false);
+    });
+
+    it("allows direct booking on the index projection (`kit` scalar)", () => {
+      expect(
+        isDirectBookingBlockedByKit({
+          type: "QUANTITY_TRACKED",
+          kit: { id: "kit-1", name: "Camera kit" },
+        })
+      ).toBe(false);
+    });
+  });
+
+  it("never blocks when there is no asset to inspect", () => {
+    expect(isDirectBookingBlockedByKit(null)).toBe(false);
+    expect(isDirectBookingBlockedByKit(undefined)).toBe(false);
+  });
+});

--- a/apps/webapp/app/modules/asset/utils.ts
+++ b/apps/webapp/app/modules/asset/utils.ts
@@ -47,6 +47,48 @@ export function getPrimaryKit<TKit>(
 }
 
 /**
+ * Returns true when the asset's kit membership should block booking it
+ * directly (outside of its kit).
+ *
+ * Only `INDIVIDUAL` assets are blocked. An INDIVIDUAL asset lives entirely
+ * inside its kit — the `enforce_individual_asset_single_kit` trigger caps it
+ * at one membership — so booking it standalone would double-book the very
+ * same physical unit.
+ *
+ * `QUANTITY_TRACKED` assets are NOT blocked: each `AssetKit` row claims only a
+ * *slice* of the pool (`AssetKit.quantity`), and a QT asset may belong to
+ * several kits at once while still keeping free-pool units. Those free units
+ * are legitimately bookable on their own — which is exactly what the booking
+ * page's asset picker already allows. Over-allocation is caught server-side by
+ * the windowed availability guards in `createBooking` / `updateBookingAssets`,
+ * so this client-side check stays purely advisory.
+ *
+ * Accepts either projection of kit membership we load today: the `assetKits`
+ * pivot rows (asset detail, scanner drawers) or the flattened `kit` scalar
+ * (assets index rows).
+ *
+ * @param asset - An asset-like object carrying `type` plus `assetKits` and/or `kit`
+ * @returns true when direct booking must be disabled because of a kit
+ */
+export function isDirectBookingBlockedByKit(
+  asset?: {
+    type?: AssetType | string | null;
+    assetKits?: Array<unknown> | null;
+    kit?: unknown;
+    // Index signature so loosely-typed list rows (`ListItemData`, which is
+    // `{ id: string; [x: string]: any }`) are assignable — without it TS's
+    // weak-type check rejects them for having "no properties in common".
+    [key: string]: unknown;
+  } | null
+): boolean {
+  if (!asset) return false;
+
+  const isPartOfKit = (asset.assetKits?.length ?? 0) > 0 || !!asset.kit;
+
+  return isPartOfKit && !isQuantityTracked(asset);
+}
+
+/**
  * Returns the asset's primary location (or null) from the
  * `AssetLocation` pivot.
  *

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -9755,7 +9755,28 @@ describe("getAvailableAssetsIdsForBooking", () => {
     ).resolves.toEqual(["asset-1", "asset-2"]);
   });
 
-  it("rejects a kit-member asset as a handled 400, not a captured 500 (SHELF-WEBAPP-21Y)", async () => {
+  it("returns a QUANTITY_TRACKED kit member — its free pool stays directly bookable", async () => {
+    // A QT asset allocates only a slice of its pool per kit (and may sit in
+    // several kits at once), so the remaining units are legitimately bookable
+    // on their own. Rejecting on mere membership 400'd the "Book" actions on
+    // the asset overview page for a customer with free standalone units.
+    // why: stub the org-scoped lookup to return one QT asset that IS a kit
+    // member — the branch that must NOT reject.
+    (db.asset.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([
+      {
+        id: "asset-1",
+        status: AssetStatus.AVAILABLE,
+        type: AssetType.QUANTITY_TRACKED,
+        assetKits: [{ kitId: "kit-1" }, { kitId: "kit-2" }],
+      },
+    ]);
+
+    await expect(
+      getAvailableAssetsIdsForBooking(["asset-1"], "org-1")
+    ).resolves.toEqual(["asset-1"]);
+  });
+
+  it("rejects an INDIVIDUAL kit-member asset as a handled 400, not a captured 500 (SHELF-WEBAPP-21Y)", async () => {
     // A selected asset that belongs to a kit is user-input validation, not a
     // server fault, so it must be a 400 kept out of the Sentry error pipeline.
     // why: stub the org-scoped lookup to return one asset that IS a kit member
@@ -9764,6 +9785,7 @@ describe("getAvailableAssetsIdsForBooking", () => {
       {
         id: "asset-1",
         status: AssetStatus.AVAILABLE,
+        type: AssetType.INDIVIDUAL,
         assetKits: [{ kitId: "kit-1" }],
       },
     ]);

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -36,7 +36,10 @@ import {
   getAssetAvailability,
 } from "~/modules/asset/availability.server";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
-import { isQuantityTracked } from "~/modules/asset/utils";
+import {
+  isDirectBookingBlockedByKit,
+  isQuantityTracked,
+} from "~/modules/asset/utils";
 import { stripMarkdocDelimiters } from "~/modules/audit/note-content.server";
 import { fulfilModelRequestsForAssets } from "~/modules/booking-model-request/service.server";
 import { checkAndNotifyLowStock } from "~/modules/consumption-log/low-stock.server";
@@ -12872,8 +12875,15 @@ export async function getExistingBookingDetails(
 /**
  * Resolves the subset of the given asset IDs that can be added to a booking.
  *
- * Assets that belong to a kit are rejected (kits are added as a unit, not as
- * loose assets).
+ * INDIVIDUAL assets that belong to a kit are rejected — they live entirely
+ * inside their kit, so kits are added as a unit rather than as loose assets.
+ *
+ * QUANTITY_TRACKED kit members are ACCEPTED: each `AssetKit` row claims only a
+ * slice of the pool (`AssetKit.quantity`) and a QT asset may sit in several
+ * kits at once while keeping free-pool units, which are legitimately bookable
+ * on their own. That's the same rule the booking page's asset picker already
+ * applies. Over-allocation is caught downstream by the windowed availability
+ * guard in `updateBookingAssets`. See `isDirectBookingBlockedByKit`.
  *
  * @param assetIds - Asset IDs sourced from request/form input
  * @param organizationId - The caller's validated organization ID. Scopes the
@@ -12881,8 +12891,8 @@ export async function getExistingBookingDetails(
  *   be returned), preventing a cross-org IDOR where an attacker in Org A could
  *   add Org B's assets to a booking.
  * @returns The IDs of the assets that exist in `organizationId` and are not
- *   part of a kit
- * @throws {ShelfError} If any selected asset belongs to a kit
+ *   blocked by kit membership
+ * @throws {ShelfError} If any selected INDIVIDUAL asset belongs to a kit
  */
 export async function getAvailableAssetsIdsForBooking(
   assetIds: Asset["id"][],
@@ -12896,15 +12906,18 @@ export async function getAvailableAssetsIdsForBooking(
       select: {
         status: true,
         id: true,
+        // `type` decides whether kit membership actually blocks the add —
+        // only INDIVIDUAL members are exclusive to their kit.
+        type: true,
         assetKits: { select: { kitId: true } },
       },
     });
 
-    if (selectedAssets.some((asset) => asset.assetKits.length > 0)) {
-      // User-input validation, not a server fault: adding kit-member assets
-      // directly is disallowed (kits are added as a unit). A 400 keeps this out
-      // of the Sentry error pipeline (handled client error). The outer catch
-      // re-wraps but inherits status/shouldBeCaptured from this cause. See
+    if (selectedAssets.some(isDirectBookingBlockedByKit)) {
+      // User-input validation, not a server fault: adding INDIVIDUAL kit-member
+      // assets directly is disallowed (kits are added as a unit). A 400 keeps
+      // this out of the Sentry error pipeline (handled client error). The outer
+      // catch re-wraps but inherits status/shouldBeCaptured from this cause. See
       // SHELF-WEBAPP-21Y.
       throw new ShelfError({
         cause: null,


### PR DESCRIPTION
## The report

> I have an asset with a total quantity of 6. After correcting the location/inventory allocation, there are 2 units available for standalone booking. However, from the Asset Overview page, clicking **Book → Create new booking** is disabled and shows *"Cannot book this asset directly because it's part of a kit. Please book the kit instead."* The important part is that I can successfully book the same asset from the Booking page.

Accurate, and there were **two** layers of it — the UI gate the customer saw, plus a server guard behind it that would have returned a 400 even with the button enabled.

## Root cause

Both gates treated *any* kit membership as disqualifying, ignoring `Asset.type`:

- `booking-actions-dropdown.tsx` — `getPrimaryKit(asset) ? disabled : false`
- `getAvailableAssetsIdsForBooking` (`booking/service.server.ts`) — `selectedAssets.some((a) => a.assetKits.length > 0)` → `400 "Cannot add assets that belong to a kit."`

That rule is only correct for `INDIVIDUAL` assets, which the `enforce_individual_asset_single_kit` trigger caps at one kit and which live entirely inside it — booking one standalone would double-book the same physical unit.

A `QUANTITY_TRACKED` asset is different: each `AssetKit` row claims only a **slice** of the pool (`AssetKit.quantity`), and a QT asset may sit in several kits at once while keeping free-pool units. Those units are legitimately bookable on their own.

The booking page's own asset picker already encodes exactly this (`manage-assets.tsx` skips QT when computing disabled rows), which is why booking from *there* worked. The asset page and the server guard had drifted from it.

Side effect for this customer's 4-kit asset: `getPrimaryKit` picked one arbitrary kit, so the tooltip's "book the **kit**" link pointed at one of four.

## Changes

| File | Change |
|---|---|
| `modules/asset/utils.ts` | New `isDirectBookingBlockedByKit()` — single source of truth. Accepts both projections we load: the `assetKits` pivot rows and the flattened `kit` scalar on index rows. |
| `booking/service.server.ts` | `getAvailableAssetsIdsForBooking` now selects `type` and rejects only INDIVIDUAL kit members. Covers both `add-to-existing-booking` paths (asset overview + `api+/assets.add-to-booking`). |
| `assets/booking-actions-dropdown.tsx` | Asset overview "Book" dropdown uses the helper. Also guards `Button to=` against a nullish kit id per `.claude/rules/resolve-nullish-button-to.md`. |
| `assets-index/book-selected-assets-dropdown.tsx` | Same fix on the bulk "Book selection" dropdown, which carried the identical `!!asset.kit` check. |

The predicate **fails closed**: an asset whose `type` is missing or unrecognised is still blocked, which is why the pre-existing kit-member test (stubbing no `type`) passes unchanged.

Over-allocation remains covered server-side by the windowed availability guard in `updateBookingAssets`.

## Testing

`pnpm webapp:validate` — **4701 passed**, typecheck clean, lint 0 errors. (The `bookings.$bookingId.activity[.csv]` suite hits its known 10s `hookTimeout` flake; confirmed passing on its own with `--hookTimeout=30000`, unrelated to these files.)

12 new tests across `modules/asset/utils.test.ts`, `components/assets/booking-actions-dropdown.test.tsx` and the `getAvailableAssetsIdsForBooking` suite. Both key cases were verified to genuinely fail without the fix (stashed the change, re-ran, watched them go red).

Manually verified: QT asset in kits is bookable from the asset page and the index; INDIVIDUAL kit members are still blocked on every surface, with a working kit link.

## Deliberately not in scope

- Adding standalone units to a booking that **already** holds the same asset via a kit still hits the `"already contains the asset"` dedupe guard in `add-to-existing-booking.tsx`. The schema explicitly supports a standalone row coexisting with kit rows, so this guard is over-broad for QT — but narrowing it changes dedupe semantics for the bulk API path too, so it's a separate call.
- `apps/companion/lib/batch-blockers.ts` carries the same type-blind `i.kitId !== null` check on add-to-booking and both custody actions. Out of scope per the cross-app rule, and it needs a native build — flagged for that team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quantity-tracked assets in kits can now be booked directly when standalone availability exists.
  * Individual assets in kits remain blocked from direct booking.
  * Booking controls and validation now apply consistent kit eligibility rules across the app.

* **Tests**
  * Added coverage for booking eligibility across kit membership, asset types, quantities, and availability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->