### PR TITLE
fix(tags): scope bulk delete to the filters the user was looking at

### DIFF
--- a/apps/webapp/app/modules/tag/bulk-delete-scope.test.ts
+++ b/apps/webapp/app/modules/tag/bulk-delete-scope.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tag bulk delete — "select all" scope
+ *
+ * When the user picks "select all" on a filtered list, the delete must
+ * reproduce that list's filters. Ignoring them deletes every tag in the
+ * workspace while the UI reports the filtered count — permanent data loss the
+ * user was actively told would not happen.
+ *
+ * The filters are built by the same helper the list query uses, so the two
+ * cannot drift. That drift is a real failure mode: the equivalent locations
+ * helper matched on name only while its list matched name + description +
+ * address, so "select all" silently missed rows the user could see.
+ *
+ * Regression coverage for detail.dev finding D088.
+ *
+ * @see {@link file://./service.server.ts}
+ * @see {@link file://./../../routes/api+/tags.bulk-actions.ts}
+ */
+
+import { TagUseFor } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ALL_SELECTED_KEY } from "~/utils/list";
+import { bulkDeleteTags } from "./service.server";
+
+// @vitest-environment node
+
+const dbMock = vi.hoisted(() => ({
+  tag: { deleteMany: vi.fn() },
+}));
+
+// why: asserting the exact where-clause sent to Prisma is the whole point —
+// this bug is a wrong filter, not a wrong result
+vi.mock("~/database/db.server", () => ({ db: dbMock }));
+
+const ORG = "org-1";
+
+describe("bulkDeleteTags — explicit selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.tag.deleteMany.mockResolvedValue({ count: 2 });
+  });
+
+  it("deletes only the given ids, scoped to the organization", async () => {
+    await bulkDeleteTags({
+      tagIds: ["tag-1", "tag-2"],
+      organizationId: ORG,
+    });
+
+    expect(dbMock.tag.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["tag-1", "tag-2"] }, organizationId: ORG },
+    });
+  });
+
+  it("ignores currentSearchParams when ids are explicit", async () => {
+    await bulkDeleteTags({
+      tagIds: ["tag-1"],
+      organizationId: ORG,
+      currentSearchParams: "s=keep",
+    });
+
+    expect(dbMock.tag.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ["tag-1"] }, organizationId: ORG },
+    });
+  });
+});
+
+describe("bulkDeleteTags — select all", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.tag.deleteMany.mockResolvedValue({ count: 3 });
+  });
+
+  it("applies the search filter instead of deleting the whole workspace", async () => {
+    await bulkDeleteTags({
+      tagIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: "s=fragile",
+    });
+
+    expect(dbMock.tag.deleteMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: ORG,
+        name: { contains: "fragile", mode: "insensitive" },
+      },
+    });
+  });
+
+  it("applies the useFor filter", async () => {
+    await bulkDeleteTags({
+      tagIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: `useFor=${TagUseFor.ASSET}`,
+    });
+
+    expect(dbMock.tag.deleteMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: ORG,
+        useFor: { has: TagUseFor.ASSET },
+      },
+    });
+  });
+
+  it("applies search and useFor together", async () => {
+    await bulkDeleteTags({
+      tagIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: `s=fragile&useFor=${TagUseFor.BOOKING}`,
+    });
+
+    expect(dbMock.tag.deleteMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: ORG,
+        name: { contains: "fragile", mode: "insensitive" },
+        useFor: { has: TagUseFor.BOOKING },
+      },
+    });
+  });
+
+  it("deletes every tag in the org only when no filter is active", async () => {
+    // Unfiltered select-all genuinely means everything — that is the one case
+    // where the workspace-wide delete is correct.
+    await bulkDeleteTags({
+      tagIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: "",
+    });
+
+    expect(dbMock.tag.deleteMany).toHaveBeenCalledWith({
+      where: { organizationId: ORG },
+    });
+  });
+
+  it("ignores params that are not list filters", async () => {
+    // Pagination and sorting ride along in the same query string and must not
+    // widen or narrow what gets deleted.
+    await bulkDeleteTags({
+      tagIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: "page=2&per_page=25&orderBy=createdAt",
+    });
+
+    expect(dbMock.tag.deleteMany).toHaveBeenCalledWith({
+      where: { organizationId: ORG },
+    });
+  });
+});

--- a/apps/webapp/app/modules/tag/service.server.ts
+++ b/apps/webapp/app/modules/tag/service.server.ts
@@ -21,6 +21,46 @@ import type { CreateAssetFromContentImportPayload } from "../asset/types";
 
 const label: ErrorLabel = "Tag";
 
+/**
+ * Builds the Prisma filter for a tag list.
+ *
+ * Shared deliberately between {@link getTags}, which renders the list, and
+ * {@link bulkDeleteTags}, which acts on a "select all" over that same list. Two
+ * separate builders is how the equivalent locations helper drifted out of sync
+ * with its list query — the list matched on name, description and address while
+ * "select all" matched on name only, so a bulk action silently missed rows the
+ * user could see. Keeping one function means the two cannot disagree.
+ *
+ * @param args - Organization scope plus the raw filter values from the list
+ * @returns A where-clause always scoped to the organization
+ */
+function buildTagsWhereInput({
+  organizationId,
+  search,
+  useFor,
+}: {
+  organizationId: Organization["id"];
+  search?: string | null;
+  useFor?: string | null;
+}): Prisma.TagWhereInput {
+  /** Default value of where. Takes the items belonging to current user */
+  const where: Prisma.TagWhereInput = { organizationId };
+
+  /** If the search string exists, add it to the where object */
+  if (search) {
+    where.name = {
+      contains: search,
+      mode: "insensitive",
+    };
+  }
+
+  if (useFor) {
+    where.useFor = { has: useFor as TagUseFor };
+  }
+
+  return where;
+}
+
 export async function getTags(params: {
   organizationId: Organization["id"];
   /** Page number. Starts at 1 */
@@ -39,20 +79,7 @@ export async function getTags(params: {
     const skip = page > 1 ? (page - 1) * perPage : 0;
     const take = perPage >= 1 ? perPage : 8; // min 1 and max 25 per page
 
-    /** Default value of where. Takes the items belonging to current user */
-    const where: Prisma.TagWhereInput = { organizationId };
-
-    /** If the search string exists, add it to the where object */
-    if (search) {
-      where.name = {
-        contains: search,
-        mode: "insensitive",
-      };
-    }
-
-    if (useFor) {
-      where.useFor = { has: useFor as TagUseFor };
-    }
+    const where = buildTagsWhereInput({ organizationId, search, useFor });
 
     const [tags, totalTags] = await Promise.all([
       /** Get the items */
@@ -274,18 +301,45 @@ export async function updateTag({
   }
 }
 
+/**
+ * Deletes tags in bulk, either by explicit ids or across a filtered list.
+ *
+ * When `tagIds` carries the `ALL_SELECTED_KEY` sentinel the user picked "select
+ * all" on a list they were looking at, so the delete must reproduce that list's
+ * filters. Ignoring them deletes every tag in the workspace while the UI reports
+ * the filtered count — permanent data loss the user was actively told would not
+ * happen. `currentSearchParams` is what carries those filters over; the bulk
+ * dialog has always submitted it.
+ *
+ * @param args - Ids (or the select-all sentinel), org scope, and the list's
+ *   filters as a raw query string
+ * @returns Prisma's batch payload, whose `count` is the number actually deleted
+ * @throws {ShelfError} If the delete fails
+ */
 export async function bulkDeleteTags({
   tagIds,
   organizationId,
+  currentSearchParams,
 }: {
   tagIds: Tag["id"][];
   organizationId: Organization["id"];
+  currentSearchParams?: string | null;
 }) {
   try {
+    if (!tagIds.includes(ALL_SELECTED_KEY)) {
+      return await db.tag.deleteMany({
+        where: { id: { in: tagIds }, organizationId },
+      });
+    }
+
+    const searchParams = new URLSearchParams(currentSearchParams ?? "");
+
     return await db.tag.deleteMany({
-      where: tagIds.includes(ALL_SELECTED_KEY)
-        ? { organizationId }
-        : { id: { in: tagIds }, organizationId },
+      where: buildTagsWhereInput({
+        organizationId,
+        search: searchParams.get("s"),
+        useFor: searchParams.get("useFor"),
+      }),
     });
   } catch (cause) {
     throw new ShelfError({

--- a/apps/webapp/app/routes/api+/tags.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/tags.bulk-actions.ts
@@ -1,6 +1,7 @@
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
 import { BulkDeleteTagsSchema } from "~/components/tag/bulk-delete-dialog";
+import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { bulkDeleteTags } from "~/modules/tag/service.server";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
@@ -39,13 +40,25 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
     switch (intent) {
       case "bulk-delete": {
-        const { tagIds } = parseData(formData, BulkDeleteTagsSchema);
+        // `currentSearchParams` carries the filters the user was looking at.
+        // Without it a "select all" over a filtered list deletes every tag in
+        // the workspace while the UI reports the filtered count.
+        const { tagIds, currentSearchParams } = parseData(
+          formData,
+          BulkDeleteTagsSchema.and(CurrentSearchParamsSchema)
+        );
 
-        await bulkDeleteTags({ tagIds, organizationId });
+        const { count } = await bulkDeleteTags({
+          tagIds,
+          organizationId,
+          currentSearchParams,
+        });
 
         sendNotification({
-          title: "Tags deleted",
-          message: "Your tags has been deleted successfully",
+          title: count === 1 ? "Tag deleted" : "Tags deleted",
+          message: `${count} ${
+            count === 1 ? "tag has" : "tags have"
+          } been deleted successfully`,
           icon: { name: "trash", variant: "error" },
           senderId: userId,
         });


### PR DESCRIPTION
## What

**"Select all" on a filtered tag list deleted every tag in the workspace** — while
the UI reported the filtered count.

Found by the detail.dev OSS scan (finding D088). First of the select-all cluster;
the same class as the NRM scope bug fixed in #2838.

## The bug

The route never read `currentSearchParams`:

```ts
const { tagIds } = parseData(formData, BulkDeleteTagsSchema);
await bulkDeleteTags({ tagIds, organizationId });
```

so the service mapped the sentinel straight to a workspace-wide delete:

```ts
where: tagIds.includes(ALL_SELECTED_KEY)
  ? { organizationId }            // every tag in the workspace
  : { id: { in: tagIds }, organizationId },
```

Filter tags down to 3, click select-all, delete → all 400 tags gone. Tags are
attached to assets and bookings, so this takes their categorisation with it, and
there is no undo.

**The client was never at fault.** The dialog routes through
`BulkUpdateDialogContent`, which has always submitted `currentSearchParams` as a
hidden field. Only the server ignored it — so this is a server-side fix with no
UI change.

## The fix

The route parses `currentSearchParams` and passes it down; the service applies
the list's filters (`s`, `useFor`) when the sentinel is present.

### One where-builder, shared with the list

`getTags` and `bulkDeleteTags` now use the same `buildTagsWhereInput`, rather
than the delete getting a second builder written next to it.

This is deliberate, and it is the more interesting half of the fix. Writing a
separate builder is exactly how the equivalent **locations** helper drifted:
`getLocations` matches on name, description and address, while
`getLocationsWhereInput` matches on name only — so "select all" there silently
misses rows the user can see (that one is still open, tracked as D075). Two
builders can disagree; one cannot.

## Behaviour

| Selection | Before | After |
| --- | --- | --- |
| Explicit ids | those tags | unchanged |
| Select all, no filter | all org tags | all org tags (correct) |
| **Select all, filtered** | **all org tags** 🔴 | only matching tags ✅ |

Also replaced the fixed `"Your tags has been deleted successfully"` with the
real deleted count, so the message can no longer disagree with what happened.

## Tests

`app/modules/tag/bulk-delete-scope.test.ts` (7) asserts the exact where-clause
sent to Prisma — this bug is a wrong filter, so the query is the thing worth
pinning:

- search filter applied; `useFor` filter applied; both together
- unfiltered select-all still means the whole workspace
- pagination/sorting params ride along in the same query string and must not
  widen or narrow the delete
- explicit-id selection ignores `currentSearchParams` entirely

**The three select-all filter tests were confirmed to fail against the previous
code**, each reporting the workspace-wide `{ organizationId }` clause.

## Sweep

`bulk-delete` is the only intent on this route and `bulkDeleteTags` has exactly
one caller, so tags are fully covered. The remaining select-all findings live in
other modules (bookings, kits, locations, mobile) and are tracked separately —
deliberately not folded in here, since one PR across all of them would be far
harder to review than the bug warrants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk deletion now respects active search and usage filters when selecting all tags.
  * Explicit tag selections remain limited to the current organization.
  * Deletion confirmations now display accurate singular or plural messaging based on the number of tags removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->