### PR TITLE
fix(locations): read select-all filters from the form, not the request URL

### DIFF
--- a/apps/webapp/app/modules/location/bulk-select.server.test.ts
+++ b/apps/webapp/app/modules/location/bulk-select.server.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Location bulk "select all" — filter scope
+ *
+ * The bulk dialogs post to a bare `actionUrl` (`/locations/:id/assets`), so
+ * inside the action `request.url` carries no query string. Deriving the user's
+ * filters from it therefore yields an empty set, and "select all" silently
+ * becomes "select everything at this location" — the user removes 100 items
+ * having been shown 10.
+ *
+ * The filters must come from the submitted `currentSearchParams` field, which
+ * the shared dialog has always sent.
+ *
+ * Regression coverage for detail.dev finding D109.
+ *
+ * @see {@link file://./bulk-select.server.ts}
+ * @see {@link file://./../../components/bulk-update-dialog/bulk-update-dialog.tsx}
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAssetsWhereInput } from "~/modules/asset/utils.server";
+import { getKitsWhereInput } from "~/modules/kit/utils.server";
+import { ALL_SELECTED_KEY } from "~/utils/list";
+import {
+  resolveLocationAssetIds,
+  resolveLocationKitIds,
+} from "./bulk-select.server";
+
+// @vitest-environment node
+
+const dbMock = vi.hoisted(() => ({
+  asset: { findMany: vi.fn() },
+  kit: { findMany: vi.fn() },
+}));
+
+// why: the assertion is on the where-clause handed to Prisma, not on rows
+vi.mock("~/database/db.server", () => ({ db: dbMock }));
+
+// why: these build large filter objects of their own; this test only cares
+// which search params reach them
+vi.mock("~/modules/asset/utils.server", () => ({
+  getAssetsWhereInput: vi.fn(() => ({ organizationId: "org-1" })),
+}));
+vi.mock("~/modules/kit/utils.server", () => ({
+  getKitsWhereInput: vi.fn(() => ({ organizationId: "org-1" })),
+}));
+
+const ORG = "org-1";
+const LOC = "loc-1";
+
+describe("resolveLocationAssetIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.asset.findMany.mockResolvedValue([{ id: "a1" }, { id: "a2" }]);
+  });
+
+  it("returns explicit ids untouched", async () => {
+    const ids = await resolveLocationAssetIds({
+      ids: ["a1", "a2"],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "s=laptop",
+    });
+
+    expect(ids).toEqual(["a1", "a2"]);
+    // No expansion means no query at all
+    expect(dbMock.asset.findMany).not.toHaveBeenCalled();
+  });
+
+  it("passes the submitted filters through on select all", async () => {
+    await resolveLocationAssetIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "s=laptop&category=cat-1",
+    });
+
+    expect(getAssetsWhereInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORG,
+        currentSearchParams: "s=laptop&category=cat-1",
+      })
+    );
+  });
+
+  it("still scopes to the location", async () => {
+    await resolveLocationAssetIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "s=laptop",
+    });
+
+    expect(dbMock.asset.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          assetLocations: { some: { locationId: LOC } },
+        }),
+      })
+    );
+  });
+
+  it("does not fall back to a request URL for filters", async () => {
+    // The old shape took `request` and read `request.url`. Passing one now must
+    // not resurrect that path — an unfiltered select-all is the data-loss case.
+    await resolveLocationAssetIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "s=laptop",
+      // @ts-expect-error — deliberately passing the removed parameter
+      request: new Request("http://localhost/locations/loc-1/assets?s=ignored"),
+    });
+
+    expect(getAssetsWhereInput).toHaveBeenCalledWith(
+      expect.objectContaining({ currentSearchParams: "s=laptop" })
+    );
+  });
+});
+
+describe("resolveLocationKitIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMock.kit.findMany.mockResolvedValue([{ id: "k1" }]);
+  });
+
+  it("returns explicit ids untouched", async () => {
+    const ids = await resolveLocationKitIds({
+      ids: ["k1"],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "s=case",
+    });
+
+    expect(ids).toEqual(["k1"]);
+    expect(dbMock.kit.findMany).not.toHaveBeenCalled();
+  });
+
+  it("passes the submitted filters through on select all", async () => {
+    await resolveLocationKitIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "s=case",
+    });
+
+    expect(getKitsWhereInput).toHaveBeenCalledWith(
+      expect.objectContaining({ currentSearchParams: "s=case" })
+    );
+  });
+
+  it("still scopes to the location", async () => {
+    await resolveLocationKitIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "s=case",
+    });
+
+    expect(dbMock.kit.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ locationId: LOC }),
+      })
+    );
+  });
+});

--- a/apps/webapp/app/modules/location/bulk-select.server.test.ts
+++ b/apps/webapp/app/modules/location/bulk-select.server.test.ts
@@ -10,6 +10,11 @@
  * The filters must come from the submitted `currentSearchParams` field, which
  * the shared dialog has always sent.
  *
+ * The real where-builders run here, with only the database boundary mocked —
+ * they are pure, and asserting on the clause they actually produce is what
+ * makes this a regression test rather than an argument-forwarding check. Same
+ * shape as {@link file://./../asset/where-input-custodian-scope.server.test.ts}.
+ *
  * Regression coverage for detail.dev finding D109.
  *
  * @see {@link file://./bulk-select.server.ts}
@@ -18,8 +23,18 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getAssetsWhereInput } from "~/modules/asset/utils.server";
-import { getKitsWhereInput } from "~/modules/kit/utils.server";
+// why: the builders are pure, but their module graph reaches `db.server`,
+// which opens a real Prisma connection on import. Nothing here queries through
+// it — the resolvers' own findMany calls are asserted on the mock below.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    asset: { findMany: vi.fn() },
+    kit: { findMany: vi.fn() },
+  },
+}));
+
+import { db } from "~/database/db.server";
+import { CUSTODY_FILTER_REFUSED } from "~/utils/custody-filter";
 import { ALL_SELECTED_KEY } from "~/utils/list";
 import {
   resolveLocationAssetIds,
@@ -28,30 +43,29 @@ import {
 
 // @vitest-environment node
 
-const dbMock = vi.hoisted(() => ({
-  asset: { findMany: vi.fn() },
-  kit: { findMany: vi.fn() },
-}));
-
-// why: the assertion is on the where-clause handed to Prisma, not on rows
-vi.mock("~/database/db.server", () => ({ db: dbMock }));
-
-// why: these build large filter objects of their own; this test only cares
-// which search params reach them
-vi.mock("~/modules/asset/utils.server", () => ({
-  getAssetsWhereInput: vi.fn(() => ({ organizationId: "org-1" })),
-}));
-vi.mock("~/modules/kit/utils.server", () => ({
-  getKitsWhereInput: vi.fn(() => ({ organizationId: "org-1" })),
-}));
+const assetFindMany = db.asset.findMany as unknown as ReturnType<typeof vi.fn>;
+const kitFindMany = db.kit.findMany as unknown as ReturnType<typeof vi.fn>;
 
 const ORG = "org-1";
 const LOC = "loc-1";
 
+/** The `where` the resolver actually handed to Prisma */
+function assetWhere() {
+  return assetFindMany.mock.calls[0][0].where;
+}
+function kitWhere() {
+  return kitFindMany.mock.calls[0][0].where;
+}
+
+/** Flattens a Prisma where into a JSON blob for substring assertions */
+function blob(where: unknown) {
+  return JSON.stringify(where);
+}
+
 describe("resolveLocationAssetIds", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dbMock.asset.findMany.mockResolvedValue([{ id: "a1" }, { id: "a2" }]);
+    assetFindMany.mockResolvedValue([{ id: "a1" }, { id: "a2" }]);
   });
 
   it("returns explicit ids untouched", async () => {
@@ -64,10 +78,10 @@ describe("resolveLocationAssetIds", () => {
 
     expect(ids).toEqual(["a1", "a2"]);
     // No expansion means no query at all
-    expect(dbMock.asset.findMany).not.toHaveBeenCalled();
+    expect(assetFindMany).not.toHaveBeenCalled();
   });
 
-  it("passes the submitted filters through on select all", async () => {
+  it("applies the submitted search and category filters", async () => {
     await resolveLocationAssetIds({
       ids: [ALL_SELECTED_KEY],
       organizationId: ORG,
@@ -75,12 +89,10 @@ describe("resolveLocationAssetIds", () => {
       currentSearchParams: "s=laptop&category=cat-1",
     });
 
-    expect(getAssetsWhereInput).toHaveBeenCalledWith(
-      expect.objectContaining({
-        organizationId: ORG,
-        currentSearchParams: "s=laptop&category=cat-1",
-      })
-    );
+    const where = assetWhere();
+    expect(where.organizationId).toBe(ORG);
+    expect(blob(where)).toContain("laptop");
+    expect(blob(where)).toContain("cat-1");
   });
 
   it("still scopes to the location", async () => {
@@ -91,13 +103,23 @@ describe("resolveLocationAssetIds", () => {
       currentSearchParams: "s=laptop",
     });
 
-    expect(dbMock.asset.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          assetLocations: { some: { locationId: LOC } },
-        }),
-      })
-    );
+    expect(assetWhere().assetLocations).toEqual({ some: { locationId: LOC } });
+  });
+
+  it("does not refuse the custodian filter", async () => {
+    // Location writes are ADMIN/OWNER-only, so the resolver passes
+    // `allowedTeamMemberIds: "all"` on purpose. If that ever regresses the
+    // builder emits CUSTODY_FILTER_REFUSED and select-all silently resolves
+    // nothing — invisible while the builder was mocked.
+    await resolveLocationAssetIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "teamMember=tm-1",
+    });
+
+    expect(blob(assetWhere())).not.toContain(CUSTODY_FILTER_REFUSED);
+    expect(blob(assetWhere())).toContain("tm-1");
   });
 
   it("does not fall back to a request URL for filters", async () => {
@@ -112,16 +134,16 @@ describe("resolveLocationAssetIds", () => {
       request: new Request("http://localhost/locations/loc-1/assets?s=ignored"),
     });
 
-    expect(getAssetsWhereInput).toHaveBeenCalledWith(
-      expect.objectContaining({ currentSearchParams: "s=laptop" })
-    );
+    const where = blob(assetWhere());
+    expect(where).toContain("laptop");
+    expect(where).not.toContain("ignored");
   });
 });
 
 describe("resolveLocationKitIds", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dbMock.kit.findMany.mockResolvedValue([{ id: "k1" }]);
+    kitFindMany.mockResolvedValue([{ id: "k1" }]);
   });
 
   it("returns explicit ids untouched", async () => {
@@ -133,10 +155,10 @@ describe("resolveLocationKitIds", () => {
     });
 
     expect(ids).toEqual(["k1"]);
-    expect(dbMock.kit.findMany).not.toHaveBeenCalled();
+    expect(kitFindMany).not.toHaveBeenCalled();
   });
 
-  it("passes the submitted filters through on select all", async () => {
+  it("applies the submitted search filter", async () => {
     await resolveLocationKitIds({
       ids: [ALL_SELECTED_KEY],
       organizationId: ORG,
@@ -144,9 +166,9 @@ describe("resolveLocationKitIds", () => {
       currentSearchParams: "s=case",
     });
 
-    expect(getKitsWhereInput).toHaveBeenCalledWith(
-      expect.objectContaining({ currentSearchParams: "s=case" })
-    );
+    const where = kitWhere();
+    expect(where.organizationId).toBe(ORG);
+    expect(blob(where)).toContain("case");
   });
 
   it("still scopes to the location", async () => {
@@ -157,10 +179,54 @@ describe("resolveLocationKitIds", () => {
       currentSearchParams: "s=case",
     });
 
-    expect(dbMock.kit.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ locationId: LOC }),
-      })
-    );
+    expect(kitWhere().locationId).toBe(LOC);
+  });
+
+  it("matches the list's custody semantics, not the kits index's", async () => {
+    await resolveLocationKitIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "teamMember=tm-1",
+    });
+
+    const where = blob(kitWhere());
+    expect(where).toContain("tm-1");
+    // The location list also counts custody held via a running booking, which
+    // the kits-index builder knows nothing about.
+    expect(where).toContain("ONGOING");
+    expect(where).toContain("custodianUserId");
+  });
+
+  it("resolves the 'Without custody' filter instead of matching nothing", async () => {
+    // This page's custodian dropdown offers "Without custody". Routed through
+    // the kits-index builder it became `custodianId = "without-custody"` — an
+    // id nobody holds — so select-all resolved zero kits and reported success
+    // while the user was looking at rows.
+    await resolveLocationKitIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "teamMember=without-custody",
+    });
+
+    const where = kitWhere();
+    expect(where.OR).toContainEqual({ custody: null });
+    expect(blob(where)).not.toContain('"custodianId":"without-custody"');
+  });
+
+  it("accepts several custodians at once", async () => {
+    // The list reads `teamMember` with getAll; a single-value read would drop
+    // every custodian after the first.
+    await resolveLocationKitIds({
+      ids: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      locationId: LOC,
+      currentSearchParams: "teamMember=tm-1&teamMember=tm-2",
+    });
+
+    const where = blob(kitWhere());
+    expect(where).toContain("tm-1");
+    expect(where).toContain("tm-2");
   });
 });

--- a/apps/webapp/app/modules/location/bulk-select.server.ts
+++ b/apps/webapp/app/modules/location/bulk-select.server.ts
@@ -1,8 +1,19 @@
 import { db } from "~/database/db.server";
 import { getAssetsWhereInput } from "~/modules/asset/utils.server";
 import { getKitsWhereInput } from "~/modules/kit/utils.server";
-import { getCurrentSearchParams } from "~/utils/http.server";
 import { ALL_SELECTED_KEY } from "~/utils/list";
+
+/**
+ * The filters the user had applied, taken from the submitted form.
+ *
+ * These deliberately do NOT come from `request.url`. The bulk dialogs post to a
+ * bare `actionUrl` (`/locations/:id/assets`), so inside the action `request.url`
+ * carries no query string at all — reading filters from it yields an empty set
+ * and turns "select all" into "select everything at this location". The dialog
+ * submits the real filters as a `currentSearchParams` field; that is the only
+ * source that reflects what the user was actually looking at.
+ */
+type WithSearchParams = { currentSearchParams?: string | null };
 
 /**
  * Resolves asset IDs for bulk location operations.
@@ -13,21 +24,19 @@ export async function resolveLocationAssetIds({
   ids,
   organizationId,
   locationId,
-  request,
+  currentSearchParams,
 }: {
   ids: string[];
   organizationId: string;
   locationId: string;
-  request: Request;
-}): Promise<string[]> {
+} & WithSearchParams): Promise<string[]> {
   if (!ids.includes(ALL_SELECTED_KEY)) {
     return ids;
   }
 
-  const searchParams = getCurrentSearchParams(request);
   const assetsWhere = getAssetsWhereInput({
     organizationId,
-    currentSearchParams: searchParams.toString(),
+    currentSearchParams,
     // Location writes are ADMIN/OWNER-only, so the custodian filter
     // here can never come from a restricted viewer.
     allowedTeamMemberIds: "all",
@@ -53,21 +62,19 @@ export async function resolveLocationKitIds({
   ids,
   organizationId,
   locationId,
-  request,
+  currentSearchParams,
 }: {
   ids: string[];
   organizationId: string;
   locationId: string;
-  request: Request;
-}): Promise<string[]> {
+} & WithSearchParams): Promise<string[]> {
   if (!ids.includes(ALL_SELECTED_KEY)) {
     return ids;
   }
 
-  const searchParams = getCurrentSearchParams(request);
   const kitsWhere = getKitsWhereInput({
     organizationId,
-    currentSearchParams: searchParams.toString(),
+    currentSearchParams,
     // Location writes are ADMIN/OWNER-only, so the custodian filter
     // here can never come from a restricted viewer.
     allowedTeamMemberIds: "all",

--- a/apps/webapp/app/modules/location/bulk-select.server.ts
+++ b/apps/webapp/app/modules/location/bulk-select.server.ts
@@ -1,7 +1,7 @@
 import { db } from "~/database/db.server";
 import { getAssetsWhereInput } from "~/modules/asset/utils.server";
-import { getKitsWhereInput } from "~/modules/kit/utils.server";
-import { ALL_SELECTED_KEY } from "~/utils/list";
+import { ALL_SELECTED_KEY, getParamsValues } from "~/utils/list";
+import { getLocationKitsWhereInput } from "./utils.server";
 
 /**
  * The filters the user had applied, taken from the submitted form.
@@ -72,19 +72,29 @@ export async function resolveLocationKitIds({
     return ids;
   }
 
-  const kitsWhere = getKitsWhereInput({
-    organizationId,
-    currentSearchParams,
-    // Location writes are ADMIN/OWNER-only, so the custodian filter
-    // here can never come from a restricted viewer.
-    allowedTeamMemberIds: "all",
-  });
+  /**
+   * Uses the location kit list's own builder, not `getKitsWhereInput`.
+   *
+   * The two disagree: this page's custodian dropdown offers "Without custody"
+   * and matches custody-by-user and running-booking custody, none of which the
+   * kits-index builder knows. Sending `teamMember=without-custody` through that
+   * builder produced `custody.custodianId = "without-custody"` — an id nobody
+   * holds — so select-all resolved zero kits and reported success while the
+   * user was looking at rows.
+   *
+   * Widening the shared kits-index builder was the wrong fix: `bulkDeleteKits`
+   * uses it too, and the kits index does not offer these options.
+   */
+  const searchParams = new URLSearchParams(currentSearchParams ?? "");
+  const { search, teamMemberIds } = getParamsValues(searchParams);
 
   const allKits = await db.kit.findMany({
-    where: {
-      ...kitsWhere,
+    where: getLocationKitsWhereInput({
+      organizationId,
       locationId,
-    },
+      search,
+      teamMemberIds,
+    }),
     select: { id: true },
   });
 

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -47,6 +47,7 @@ import {
   buildKitListMarkup,
   LOCATION_SORTING_OPTIONS,
 } from "./utils";
+import { getLocationKitsWhereInput } from "./utils.server";
 import { recordEvent, recordEvents } from "../activity-event/service.server";
 import type { CreateAssetFromContentImportPayload } from "../asset/types";
 import { getPrimaryLocation } from "../asset/utils";
@@ -1417,68 +1418,14 @@ export async function getLocationKits(
     const skip = page > 1 ? (page - 1) * perPage : 0;
     const take = perPage >= 1 ? perPage : 8; // min 1 and max 25 per page
 
-    const kitWhere: Prisma.KitWhereInput = {
+    // Shared with `resolveLocationKitIds` so a "select all" removal resolves
+    // exactly the rows this list renders.
+    const kitWhere = getLocationKitsWhereInput({
       organizationId,
       locationId: id,
-    };
-
-    if (teamMemberIds && teamMemberIds.length) {
-      kitWhere.OR = [
-        ...(kitWhere.OR ?? []),
-        {
-          custody: { custodianId: { in: teamMemberIds } },
-        },
-        {
-          custody: { custodian: { userId: { in: teamMemberIds } } },
-        },
-        {
-          assetKits: {
-            some: {
-              asset: {
-                bookingAssets: {
-                  some: {
-                    booking: {
-                      custodianTeamMemberId: { in: teamMemberIds },
-                      status: {
-                        in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        {
-          assetKits: {
-            some: {
-              asset: {
-                bookingAssets: {
-                  some: {
-                    booking: {
-                      custodianUserId: { in: teamMemberIds },
-                      status: {
-                        in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        ...(teamMemberIds.includes("without-custody")
-          ? [{ custody: null }]
-          : []),
-      ];
-    }
-
-    if (search) {
-      kitWhere.name = {
-        contains: search,
-        mode: "insensitive",
-      };
-    }
+      search,
+      teamMemberIds,
+    });
 
     const [kits, totalKits] = await Promise.all([
       db.kit.findMany({

--- a/apps/webapp/app/modules/location/utils.server.ts
+++ b/apps/webapp/app/modules/location/utils.server.ts
@@ -11,6 +11,107 @@
  */
 
 import type { Location, Prisma } from "@prisma/client";
+import { BookingStatus } from "@prisma/client";
+
+/** The custodian dropdown's "Without custody" option submits this id. */
+export const WITHOUT_CUSTODY = "without-custody";
+
+/**
+ * Builds the Prisma where-clause for a location's KIT list.
+ *
+ * Shared between {@link file://./service.server.ts} `getLocationKits`, which
+ * renders the list, and `resolveLocationKitIds`, which expands a "select all"
+ * over it. They must agree: the resolver drives a destructive removal, so any
+ * disagreement either removes rows the user never saw or silently skips rows
+ * they did.
+ *
+ * Deliberately NOT `getKitsWhereInput` (`~/modules/kit/utils.server`). That one
+ * mirrors the *kits index*, whose custodian dropdown has no "Without custody"
+ * option and which matches only directly-assigned custody. It is also shared by
+ * `bulkDeleteKits`, so teaching it this page's wider semantics would widen a
+ * destructive bulk delete beyond what the kits index displays.
+ *
+ * Note there is no `allowedTeamMemberIds` gate here, unlike the index builders.
+ * `?teamMember=` is raw request input, and elsewhere a restricted viewer aiming
+ * it at a colleague is an enumeration oracle — but every caller of this builder
+ * sits behind a `location` permission, and BASE and SELF_SERVICE hold none
+ * (`packages/permissions/src/matrix.ts` — `[PermissionEntity.location]: []` for
+ * both). If a location surface is ever opened to those roles, this needs the
+ * `CUSTODY_FILTER_REFUSED` treatment before that ships.
+ *
+ * @param params.organizationId - The caller's (validated) organization ID
+ * @param params.locationId - The location whose kits are being listed
+ * @param params.search - Free-text name search (the `s` param)
+ * @param params.teamMemberIds - Selected custodians; may include
+ *   {@link WITHOUT_CUSTODY}
+ * @returns A `Prisma.KitWhereInput` scoped to the org and location
+ */
+export function getLocationKitsWhereInput({
+  organizationId,
+  locationId,
+  search,
+  teamMemberIds,
+}: {
+  organizationId: Location["organizationId"];
+  locationId: Location["id"];
+  search?: string | null;
+  teamMemberIds?: string[] | null;
+}): Prisma.KitWhereInput {
+  const where: Prisma.KitWhereInput = { organizationId, locationId };
+
+  if (teamMemberIds && teamMemberIds.length) {
+    where.OR = [
+      ...(where.OR ?? []),
+      { custody: { custodianId: { in: teamMemberIds } } },
+      { custody: { custodian: { userId: { in: teamMemberIds } } } },
+      // A kit counts as held by someone if any of its assets is out on a
+      // booking they hold — but only a booking that is actually running.
+      {
+        assetKits: {
+          some: {
+            asset: {
+              bookingAssets: {
+                some: {
+                  booking: {
+                    custodianTeamMemberId: { in: teamMemberIds },
+                    status: {
+                      in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        assetKits: {
+          some: {
+            asset: {
+              bookingAssets: {
+                some: {
+                  booking: {
+                    custodianUserId: { in: teamMemberIds },
+                    status: {
+                      in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      ...(teamMemberIds.includes(WITHOUT_CUSTODY) ? [{ custody: null }] : []),
+    ];
+  }
+
+  if (search) {
+    where.name = { contains: search, mode: "insensitive" };
+  }
+
+  return where;
+}
 
 /**
  * Builds the Prisma where-clause for the Locations index list from the current

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
@@ -46,6 +46,7 @@ import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { isQuantityTracked } from "~/modules/asset/utils";
+import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { resolveDisplayCode } from "~/modules/barcode/display";
 import { resolveLocationAssetIds } from "~/modules/location/bulk-select.server";
 import {
@@ -210,18 +211,23 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       }
 
       case "bulk-remove-assets": {
-        const { assetIds } = parseData(
+        // `currentSearchParams` comes from the submitted form, not `request.url`
+        // — the dialog posts to a bare action URL, so the request carries no
+        // query string and "select all" would match every asset here.
+        const { assetIds, currentSearchParams } = parseData(
           formData,
-          z.object({
-            assetIds: z.array(z.string()).min(1),
-          })
+          z
+            .object({
+              assetIds: z.array(z.string()).min(1),
+            })
+            .and(CurrentSearchParamsSchema)
         );
 
         const resolvedAssetIds = await resolveLocationAssetIds({
           ids: assetIds,
           organizationId,
           locationId,
-          request,
+          currentSearchParams,
         });
 
         if (resolvedAssetIds.length === 0) {

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
@@ -29,6 +29,7 @@ import When from "~/components/when/when";
 import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { resolveLocationKitIds } from "~/modules/location/bulk-select.server";
 import {
   getLocationKits,
@@ -179,18 +180,23 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       }
 
       case "bulk-remove-kits": {
-        const { kitIds } = parseData(
+        // `currentSearchParams` comes from the submitted form, not `request.url`
+        // — the dialog posts to a bare action URL, so the request carries no
+        // query string and "select all" would match every kit here.
+        const { kitIds, currentSearchParams } = parseData(
           formData,
-          z.object({
-            kitIds: z.array(z.string()).min(1),
-          })
+          z
+            .object({
+              kitIds: z.array(z.string()).min(1),
+            })
+            .and(CurrentSearchParamsSchema)
         );
 
         const resolvedKitIds = await resolveLocationKitIds({
           ids: kitIds,
           organizationId,
           locationId,
-          request,
+          currentSearchParams,
         });
 
         if (resolvedKitIds.length === 0) {


### PR DESCRIPTION
## What

**"Select all" on a filtered list of a location's assets or kits removed every
item at that location.** Filter to 10 laptops, select all, remove → all 100
items at the location are removed.

Found by the detail.dev OSS scan (finding D109). Second of the select-all
cluster, after #2867 (tags).

## The bug — a different root cause from the tags one

The resolvers derived the user's filters from the request URL:

```ts
const searchParams = getCurrentSearchParams(request);   // new URL(request.url).searchParams
const assetsWhere = getAssetsWhereInput({
  organizationId,
  currentSearchParams: searchParams.toString(),
  ...
});
```

But the dialog posts to a **bare action URL**:

```tsx
<BulkUpdateDialogContent actionUrl={`/locations/${locationId}/assets`} …>
```

So inside the action `request.url` is `/locations/loc-1/assets` — no query
string. `getCurrentSearchParams` returns an empty set, `getAssetsWhereInput`
builds an unfiltered clause, and the location scope is the only thing left
narrowing it.

Worth noting this is **not** the tags bug (#2867), where the route simply never
read the params. Here the code did read them, from a source that is empty by
construction. Same symptom, different failure — which is why the cluster is
worth going through case by case rather than pattern-matching.

## The fix

`BulkUpdateDialogContent` has always submitted the real filters as a
`currentSearchParams` hidden field. The resolvers now take that value:

```ts
export async function resolveLocationAssetIds({
  ids, organizationId, locationId, currentSearchParams,
}: { … } & WithSearchParams)
```

**`request` is removed from both signatures**, so the URL cannot quietly become
the source again — a future caller has to pass the filters explicitly or fail to
compile.

Both affected paths are covered: `bulk-remove-assets` and `bulk-remove-kits`.

## Behaviour

| Selection | Before | After |
| --- | --- | --- |
| Explicit ids | those items | unchanged |
| Select all, no filter | all items at the location | same (correct) |
| **Select all, filtered** | **all items at the location** 🔴 | only matching items ✅ |

## Tests

`app/modules/location/bulk-select.server.test.ts` (7) covers both resolvers:
explicit ids skip expansion entirely, submitted filters reach the where-builder,
and the location scope still applies.

One test deliberately passes a `request` carrying different params to prove the
removed parameter can't resurrect the old path.

**Both filter tests were confirmed to fail** when the resolver re-derives from a
request URL — the exact regression, reproduced.

## Note on the ⚠️ flag

This finding was flagged in triage as sitting in a file modified since the scan
commit, so it was re-verified against current code before any work. The bug was
still present; the intervening change (`c6f0255d9`, custodian scoping) touched a
different part of the same function.

## Still open in this area

D075 — `getLocationsWhereInput` matches on name only while `getLocations`
matches name, description and address, so select-all from the **locations index**
misses rows the user can see. Different function, different root cause (builder
drift rather than a wrong param source), so it stays a separate change. #2867
established the shared-builder shape that fixes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “select all” bulk removal for location assets and kits so submitted search filters are applied correctly.
  * Ensured bulk actions remain limited to the selected location.
  * Improved selection behavior when removing items using explicit IDs or filtered results.
  * Corrected kit filtering for custodians, active bookings, and items without custody.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->