### PR TITLE
fix(calendar): show an overdue booking in red, like everywhere else

### DIFF
--- a/apps/webapp/app/utils/calendar-status-colors.test.ts
+++ b/apps/webapp/app/utils/calendar-status-colors.test.ts
@@ -1,6 +1,7 @@
 import { BookingStatus } from "@prisma/client";
+import { BADGE_COLORS } from "~/utils/badge-colors";
 import { bookingStatusColorMap } from "~/utils/bookings";
-import { getStatusClasses, statusClassesOnHover } from "~/utils/calendar";
+import { getStatusClasses } from "~/utils/calendar";
 
 // @vitest-environment node
 
@@ -13,25 +14,47 @@ import { getStatusClasses, statusClassesOnHover } from "~/utils/calendar";
  * Tailwind class names and the badge wants hex, so the two are kept in step by
  * hand. That is exactly the kind of pairing that drifts silently: OVERDUE was
  * amber here and red everywhere else, and nothing failed.
+ *
+ * So the expectations are DERIVED from the canonical map rather than restated.
+ * A hardcoded second list would pass happily while the two sources diverged,
+ * which is the failure this suite exists to prevent.
  */
 
-/** Canonical colour family per status, named as the badge map assigns it. */
-const EXPECTED_FAMILY: Record<BookingStatus, string> = {
-  DRAFT: "gray",
-  ARCHIVED: "gray",
-  CANCELLED: "gray",
-  RESERVED: "blue",
-  ONGOING: "purple",
-  OVERDUE: "error",
-  COMPLETE: "success",
-};
+/**
+ * The one translation this file is allowed to hardcode: a badge colour to the
+ * Tailwind family that renders it. Everything else is looked up.
+ *
+ * Keyed by the shared `BADGE_COLORS` objects themselves, so a status pointed at
+ * a colour with no calendar equivalent resolves to undefined and fails loudly
+ * rather than silently skipping.
+ */
+const FAMILY_BY_BADGE_COLOR = new Map<unknown, string>([
+  [BADGE_COLORS.gray, "gray"],
+  [BADGE_COLORS.blue, "blue"],
+  [BADGE_COLORS.violet, "purple"],
+  [BADGE_COLORS.red, "error"],
+  [BADGE_COLORS.green, "success"],
+]);
+
+/** The Tailwind family the canonical map says this status should wear. */
+function expectedFamily(status: BookingStatus): string {
+  const family = FAMILY_BY_BADGE_COLOR.get(bookingStatusColorMap[status]);
+  if (!family) {
+    throw new Error(
+      `bookingStatusColorMap.${status} uses a badge colour with no calendar ` +
+        `equivalent. Add the family to FAMILY_BY_BADGE_COLOR and give the ` +
+        `calendar a matching case, or the two surfaces will disagree.`
+    );
+  }
+  return family;
+}
 
 describe("calendar event colours match the rest of the product", () => {
   it.each(Object.values(BookingStatus))(
-    "colours %s from a single family",
+    "colours %s from the family the badge map assigns",
     (status) => {
       const classes = getStatusClasses(status, false, "dayGridMonth").join(" ");
-      const family = EXPECTED_FAMILY[status];
+      const family = expectedFamily(status);
 
       expect(classes).toContain(`text-${family}-700`);
       expect(classes).toContain(`bg-${family}-50`);
@@ -39,35 +62,45 @@ describe("calendar event colours match the rest of the product", () => {
     }
   );
 
-  it("uses the same family on hover", () => {
-    for (const status of Object.values(BookingStatus)) {
-      expect(statusClassesOnHover[status]).toContain(
-        `bg-${EXPECTED_FAMILY[status]}-100`
-      );
+  it.each(Object.values(BookingStatus))(
+    "uses the same family for %s on the hover-capable views",
+    (status) => {
+      // Through getStatusClasses, not the lookup table it reads, so a
+      // regression where the hover class stops being appended is caught.
+      //
+      // Compared as a whole class token rather than a substring: the base set
+      // already carries `md:focus:!bg-<family>-100`, so `toContain` matched it
+      // and passed even with the hover class gone.
+      const classes = getStatusClasses(status, false, "timeGridWeek");
+
+      expect(classes).toContain(`md:!bg-${expectedFamily(status)}-100`);
     }
-  });
+  );
 
   it("shows an overdue booking as an error, not a warning", () => {
     // The regression this exists for. Amber reads as "heads up"; every other
     // surface in the product calls an overdue booking red, and a calendar is
     // where someone scans for exactly that.
-    const classes = getStatusClasses(
-      BookingStatus.OVERDUE,
-      false,
-      "dayGridMonth"
-    ).join(" ");
+    expect(expectedFamily(BookingStatus.OVERDUE)).toBe("error");
 
-    expect(classes).not.toContain("warning");
-    expect(statusClassesOnHover.OVERDUE).not.toContain("warning");
+    for (const view of ["dayGridMonth", "timeGridWeek"] as const) {
+      const classes = getStatusClasses(
+        BookingStatus.OVERDUE,
+        false,
+        view
+      ).join(" ");
+      expect(classes).not.toContain("warning");
+    }
   });
 
-  it("keeps every status the badge map knows about", () => {
-    // A new BookingStatus must get a deliberate colour here, not fall through
-    // the switch's default and render unstyled.
-    for (const status of Object.keys(
-      bookingStatusColorMap
-    ) as BookingStatus[]) {
-      expect(EXPECTED_FAMILY[status]).toBeDefined();
+  it("gives every booking status a calendar colour", () => {
+    // A new BookingStatus must get a deliberate colour, not fall through the
+    // switch's default and render unstyled.
+    for (const status of Object.values(BookingStatus)) {
+      expect(() => expectedFamily(status)).not.toThrow();
+      expect(getStatusClasses(status, false, "dayGridMonth").join(" ")).toMatch(
+        /text-\w+-700/
+      );
     }
   });
 });

--- a/apps/webapp/app/utils/calendar-status-colors.test.ts
+++ b/apps/webapp/app/utils/calendar-status-colors.test.ts
@@ -84,11 +84,9 @@ describe("calendar event colours match the rest of the product", () => {
     expect(expectedFamily(BookingStatus.OVERDUE)).toBe("error");
 
     for (const view of ["dayGridMonth", "timeGridWeek"] as const) {
-      const classes = getStatusClasses(
-        BookingStatus.OVERDUE,
-        false,
-        view
-      ).join(" ");
+      const classes = getStatusClasses(BookingStatus.OVERDUE, false, view).join(
+        " "
+      );
       expect(classes).not.toContain("warning");
     }
   });

--- a/apps/webapp/app/utils/calendar-status-colors.test.ts
+++ b/apps/webapp/app/utils/calendar-status-colors.test.ts
@@ -1,0 +1,73 @@
+import { BookingStatus } from "@prisma/client";
+import { bookingStatusColorMap } from "~/utils/bookings";
+import { getStatusClasses, statusClassesOnHover } from "~/utils/calendar";
+
+// @vitest-environment node
+
+/**
+ * The calendar must colour a booking the same way the rest of the product does.
+ *
+ * `bookingStatusColorMap` is the canonical answer — the badge on the bookings
+ * index, the booking detail, the asset page and the companion app all resolve
+ * through it. The calendar cannot share it directly, because FullCalendar wants
+ * Tailwind class names and the badge wants hex, so the two are kept in step by
+ * hand. That is exactly the kind of pairing that drifts silently: OVERDUE was
+ * amber here and red everywhere else, and nothing failed.
+ */
+
+/** Canonical colour family per status, named as the badge map assigns it. */
+const EXPECTED_FAMILY: Record<BookingStatus, string> = {
+  DRAFT: "gray",
+  ARCHIVED: "gray",
+  CANCELLED: "gray",
+  RESERVED: "blue",
+  ONGOING: "purple",
+  OVERDUE: "error",
+  COMPLETE: "success",
+};
+
+describe("calendar event colours match the rest of the product", () => {
+  it.each(Object.values(BookingStatus))(
+    "colours %s from a single family",
+    (status) => {
+      const classes = getStatusClasses(status, false, "dayGridMonth").join(" ");
+      const family = EXPECTED_FAMILY[status];
+
+      expect(classes).toContain(`text-${family}-700`);
+      expect(classes).toContain(`bg-${family}-50`);
+      expect(classes).toContain(`border-${family}-200`);
+    }
+  );
+
+  it("uses the same family on hover", () => {
+    for (const status of Object.values(BookingStatus)) {
+      expect(statusClassesOnHover[status]).toContain(
+        `bg-${EXPECTED_FAMILY[status]}-100`
+      );
+    }
+  });
+
+  it("shows an overdue booking as an error, not a warning", () => {
+    // The regression this exists for. Amber reads as "heads up"; every other
+    // surface in the product calls an overdue booking red, and a calendar is
+    // where someone scans for exactly that.
+    const classes = getStatusClasses(
+      BookingStatus.OVERDUE,
+      false,
+      "dayGridMonth"
+    ).join(" ");
+
+    expect(classes).not.toContain("warning");
+    expect(statusClassesOnHover.OVERDUE).not.toContain("warning");
+  });
+
+  it("keeps every status the badge map knows about", () => {
+    // A new BookingStatus must get a deliberate colour here, not fall through
+    // the switch's default and render unstyled.
+    for (const status of Object.keys(
+      bookingStatusColorMap
+    ) as BookingStatus[]) {
+      expect(EXPECTED_FAMILY[status]).toBeDefined();
+    }
+  });
+});

--- a/apps/webapp/app/utils/calendar.ts
+++ b/apps/webapp/app/utils/calendar.ts
@@ -59,14 +59,18 @@ export function getStatusClasses(
         "md:focus:!bg-purple-100",
       ];
       break;
+    // Red, not amber. `bookingStatusColorMap` maps OVERDUE to red and every
+    // other place a booking status is shown reads from it - the badge on the
+    // bookings index, the booking detail, the asset page, the companion app.
+    // The calendar was the only surface calling an overdue booking a warning.
     case "OVERDUE":
       statusClasses = [
-        "md:!text-warning-700",
-        "md:bg-warning-50",
-        "md:border-warning-200",
-        "[&_.fc-daygrid-event-dot]:!border-warning-700",
-        "[&_.fc-list-event-dot]:!border-warning-700",
-        "md:focus:!bg-warning-100",
+        "md:!text-error-700",
+        "md:bg-error-50",
+        "md:border-error-200",
+        "[&_.fc-daygrid-event-dot]:!border-error-700",
+        "[&_.fc-list-event-dot]:!border-error-700",
+        "md:focus:!bg-error-100",
       ];
       break;
     case "COMPLETE":
@@ -97,7 +101,7 @@ export const statusClassesOnHover: Record<BookingStatus, string> = {
   CANCELLED: "md:!bg-gray-100",
   RESERVED: "md:!bg-blue-100",
   ONGOING: "md:!bg-purple-100",
-  OVERDUE: "md:!bg-warning-100",
+  OVERDUE: "md:!bg-error-100",
   COMPLETE: "md:!bg-success-100",
 };
 


### PR DESCRIPTION
## What

The calendar painted an overdue booking **amber**. Everywhere else in the product an overdue booking is **red**.

## Why red is the correct one

`bookingStatusColorMap` (`app/utils/bookings.ts`) is where the product decides what colour a booking status is, and it maps `OVERDUE` to red. Everything that shows a booking status resolves through it:

- the badge on the bookings index
- the booking detail page
- the asset page's bookings
- the companion app

The calendar was the only surface that disagreed. So the same booking was a warning in one view and an error in every other, and a calendar is precisely where someone scans for what has gone wrong.

## Why it drifted

The calendar cannot use the map directly: FullCalendar wants Tailwind class names, the badge wants hex. The two are kept in step by hand, and nothing failed when they came apart.

This adds `calendar-status-colors.test.ts`, which pins every status to its expected colour family for both the event classes and the hover classes, and asserts a new `BookingStatus` cannot fall through the switch unstyled. Reverting the fix fails two of its tests.

## Scope

One `case` in `getStatusClasses`, one entry in `statusClassesOnHover`, plus the test. No behaviour beyond colour.

Found while checking web/mobile parity for the companion booking calendar (#2864). Mobile already matched the canonical map, so nothing changes there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated overdue calendar bookings to use the error/red color palette instead of warning/amber styling.
  * Corrected hover styling for overdue bookings to match the updated color treatment.

* **Tests**
  * Added coverage to verify calendar colors and hover states for all booking statuses.
  * Added safeguards to prevent overdue bookings from receiving warning styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->