### PR TITLE
fix(bookings): scope bulk delete, archive and cancel to the caller's own

### DIFF
--- a/apps/webapp/app/modules/booking/bulk-ownership-scope.test.ts
+++ b/apps/webapp/app/modules/booking/bulk-ownership-scope.test.ts
@@ -59,6 +59,28 @@ describe("getBookingOwnershipScope", () => {
       getBookingOwnershipScope({ role: OrganizationRoles.BASE })
     ).toThrow();
   });
+
+  it("restricts an unrecognised role rather than waving it through", () => {
+    // The check allow-lists ADMIN/OWNER, so a role added to the enum later
+    // lands in the RESTRICTED branch by default. A deny-list would hand it
+    // org-wide delete on the day it was introduced.
+    const futureRole = "AUDITOR" as OrganizationRoles;
+
+    expect(getBookingOwnershipScope({ role: futureRole, userId: ME })).toEqual({
+      OR: [{ creatorId: ME }, { custodianUserId: ME }],
+    });
+  });
+
+  it("covers every role in the enum, so a new one cannot slip past unreviewed", () => {
+    // Fails the moment `OrganizationRoles` grows a member: whoever adds it has
+    // to decide which side of this clause it belongs on.
+    expect(Object.values(OrganizationRoles).sort()).toEqual([
+      OrganizationRoles.ADMIN,
+      OrganizationRoles.BASE,
+      OrganizationRoles.OWNER,
+      OrganizationRoles.SELF_SERVICE,
+    ]);
+  });
 });
 
 describe("getBulkBookingsWhereInput — select all", () => {

--- a/apps/webapp/app/modules/booking/bulk-ownership-scope.test.ts
+++ b/apps/webapp/app/modules/booking/bulk-ownership-scope.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Bulk booking actions — ownership scope
+ *
+ * The bookings list scopes a BASE / SELF_SERVICE user to their own bookings,
+ * but the bulk where-builder applied only `organizationId` and an optional
+ * status. So `bookingIds=["all-selected"]` deleted, archived or cancelled every
+ * matching booking in the workspace — other people's included — from a list
+ * that had only ever shown the caller their own.
+ *
+ * The explicit-id branch was equally unscoped, so posting a guessed id worked
+ * too. Both branches are covered here.
+ *
+ * Regression coverage for detail.dev finding D031.
+ *
+ * @see {@link file://./utils.server.ts}
+ * @see {@link file://./../../utils/booking-authorization.server.ts} validateBookingOwnership — the singular gate this mirrors
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { ALL_SELECTED_KEY } from "~/utils/list";
+import {
+  getBookingOwnershipScope,
+  getBulkBookingsWhereInput,
+} from "./utils.server";
+
+// @vitest-environment node
+
+const ORG = "org-1";
+const ME = "user-me";
+
+const RESTRICTED = [OrganizationRoles.BASE, OrganizationRoles.SELF_SERVICE];
+const UNRESTRICTED = [OrganizationRoles.ADMIN, OrganizationRoles.OWNER];
+
+/** Every ownership predicate the clause ended up matching on */
+function ownershipBranches(
+  where: ReturnType<typeof getBulkBookingsWhereInput>
+) {
+  const and = (where.AND ?? []) as Array<{ OR?: unknown[] }>;
+  const scope = [and].flat().find((clause) => clause?.OR);
+  return (scope?.OR ?? []) as Array<Record<string, string>>;
+}
+
+describe("getBookingOwnershipScope", () => {
+  it.each(UNRESTRICTED)("does not restrict %s", (role) => {
+    expect(getBookingOwnershipScope({ role, userId: ME })).toBeNull();
+  });
+
+  it.each(RESTRICTED)("restricts %s to their own bookings", (role) => {
+    expect(getBookingOwnershipScope({ role, userId: ME })).toEqual({
+      OR: [{ creatorId: ME }, { custodianUserId: ME }],
+    });
+  });
+
+  it("fails closed when a restricted role has no user to scope to", () => {
+    // Returning null here would silently widen to the whole workspace
+    expect(() =>
+      getBookingOwnershipScope({ role: OrganizationRoles.BASE })
+    ).toThrow();
+  });
+});
+
+describe("getBulkBookingsWhereInput — select all", () => {
+  it.each(RESTRICTED)("scopes %s to their own bookings", (role) => {
+    const where = getBulkBookingsWhereInput({
+      bookingIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: "status=DRAFT",
+      role,
+      userId: ME,
+    });
+
+    expect(ownershipBranches(where)).toEqual([
+      { creatorId: ME },
+      { custodianUserId: ME },
+    ]);
+    // The list filter still applies — this narrows, it does not replace
+    expect(JSON.stringify(where)).toContain("DRAFT");
+  });
+
+  it.each(UNRESTRICTED)("leaves %s unscoped", (role) => {
+    const where = getBulkBookingsWhereInput({
+      bookingIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: "status=DRAFT",
+      role,
+      userId: ME,
+    });
+
+    expect(where.AND).toBeUndefined();
+    expect(where.organizationId).toBe(ORG);
+  });
+});
+
+describe("getBulkBookingsWhereInput — explicit ids", () => {
+  it.each(RESTRICTED)("scopes %s even when ids are posted directly", (role) => {
+    // Guessing another user's booking id must not be enough — the list never
+    // showed it, but the id alone used to be sufficient.
+    const where = getBulkBookingsWhereInput({
+      bookingIds: ["someone-elses-booking"],
+      organizationId: ORG,
+      role,
+      userId: ME,
+    });
+
+    expect(ownershipBranches(where)).toEqual([
+      { creatorId: ME },
+      { custodianUserId: ME },
+    ]);
+    expect(JSON.stringify(where)).toContain("someone-elses-booking");
+  });
+
+  it.each(UNRESTRICTED)("leaves %s unscoped", (role) => {
+    const where = getBulkBookingsWhereInput({
+      bookingIds: ["bk-1", "bk-2"],
+      organizationId: ORG,
+      role,
+      userId: ME,
+    });
+
+    expect(where).toEqual({
+      id: { in: ["bk-1", "bk-2"] },
+      organizationId: ORG,
+    });
+  });
+});
+
+describe("getBulkBookingsWhereInput — composition", () => {
+  it("intersects rather than unions the ownership clause", () => {
+    // A spread-merge would put ownership into the same OR as the filters,
+    // widening a destructive query instead of narrowing it.
+    const where = getBulkBookingsWhereInput({
+      bookingIds: [ALL_SELECTED_KEY],
+      organizationId: ORG,
+      currentSearchParams: "status=DRAFT",
+      role: OrganizationRoles.SELF_SERVICE,
+      userId: ME,
+    });
+
+    expect(Array.isArray(where.AND)).toBe(true);
+    expect(where.OR).toBeUndefined();
+  });
+});

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -9229,6 +9229,7 @@ describe("bulkArchiveBookings", () => {
       bookingIds: ["bk-arch-1", "bk-arch-2"],
       organizationId: "org-1",
       userId: "user-1",
+      role: OrganizationRoles.OWNER,
     });
 
     // Service no longer wraps the updateMany + notes in an interactive
@@ -9275,6 +9276,7 @@ describe("bulkArchiveBookings", () => {
       bookingIds: ["b1", "b2"],
       organizationId: "org-1",
       userId: "user-1",
+      role: OrganizationRoles.OWNER,
     });
 
     expect(db.booking.updateMany).toHaveBeenCalledWith({
@@ -9318,6 +9320,7 @@ describe("bulkArchiveBookings", () => {
         bookingIds: ["b1"],
         organizationId: "org-1",
         userId: "user-1",
+        role: OrganizationRoles.OWNER,
       })
     ).rejects.toThrow(ShelfError);
   });
@@ -9339,6 +9342,7 @@ describe("bulkArchiveBookings", () => {
       bookingIds: ["r1"],
       organizationId: "org-1",
       userId: "user-1",
+      role: OrganizationRoles.OWNER,
     });
 
     expect(db.booking.updateMany).toHaveBeenCalledWith({
@@ -9372,6 +9376,7 @@ describe("bulkArchiveBookings", () => {
         bookingIds: ["r1"],
         organizationId: "org-1",
         userId: "user-1",
+        role: OrganizationRoles.OWNER,
       })
     ).rejects.toThrow(ShelfError);
     expect(db.booking.updateMany).not.toHaveBeenCalled();
@@ -9395,6 +9400,7 @@ describe("bulkArchiveBookings", () => {
         bookingIds: ["o1"],
         organizationId: "org-1",
         userId: "user-1",
+        role: OrganizationRoles.OWNER,
       })
     ).rejects.toThrow(ShelfError);
   });
@@ -9423,6 +9429,7 @@ describe("bulkArchiveBookings", () => {
       bookingIds: ["c1", "r1"],
       organizationId: "org-1",
       userId: "user-1",
+      role: OrganizationRoles.OWNER,
     });
 
     // COMPLETE rows archive without the flag…
@@ -9472,6 +9479,7 @@ describe("bulkArchiveBookings", () => {
       bookingIds: ["b1", "b2"],
       organizationId: "org-1",
       userId: "user-1",
+      role: OrganizationRoles.OWNER,
     });
 
     expect(activityEventService.recordEvents).toHaveBeenCalledWith(
@@ -9532,6 +9540,7 @@ describe("bulkArchiveBookings", () => {
       bookingIds: ["b1", "r1"],
       organizationId: "org-1",
       userId: "user-1",
+      role: OrganizationRoles.OWNER,
     });
 
     // Exactly one BOOKING_ARCHIVED event, for the archived booking only.
@@ -9595,6 +9604,7 @@ describe("bulkCancelBookings", () => {
       bookingIds: ["bk-canc-1", "bk-canc-2"],
       organizationId: "org-1",
       userId: "user-1",
+      role: OrganizationRoles.OWNER,
       hints: mockClientHints,
     });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -79,7 +79,7 @@ import {
   getCurrentSearchParams,
   parseData,
 } from "~/utils/http.server";
-import { ALL_SELECTED_KEY, getParamsValues } from "~/utils/list";
+import { getParamsValues } from "~/utils/list";
 import { Logger } from "~/utils/logger";
 import {
   wrapAssetWithCountForNote,
@@ -146,7 +146,7 @@ import type {
 } from "./types";
 import {
   createBookingConflictConditions,
-  getBookingWhereInput,
+  getBulkBookingsWhereInput,
   isBookingExpired,
 } from "./utils.server";
 import { recordEvent, recordEvents } from "../activity-event/service.server";
@@ -11494,20 +11494,29 @@ export async function bulkDeleteBookings({
   userId,
   hints,
   currentSearchParams,
+  role,
 }: {
   bookingIds: Booking["id"][];
   organizationId: Organization["id"];
   userId: User["id"];
   hints: ClientHint;
   currentSearchParams?: string | null;
+  /** Caller's effective role — decides whether ownership scoping applies */
+  role: OrganizationRoles;
 }) {
   try {
-    /** If all are selected in the list, then we have to consider filter */
-    const where: Prisma.BookingWhereInput = bookingIds.includes(
-      ALL_SELECTED_KEY
-    )
-      ? getBookingWhereInput({ currentSearchParams, organizationId })
-      : { id: { in: bookingIds }, organizationId };
+    /**
+     * Scopes to the filters the user had applied AND to the bookings they are
+     * allowed to act on. Without the ownership half, a restricted caller could
+     * delete every booking in the workspace with one request.
+     */
+    const where = getBulkBookingsWhereInput({
+      bookingIds,
+      organizationId,
+      currentSearchParams,
+      role,
+      userId,
+    });
 
     const [bookings, user] = await Promise.all([
       db.booking.findMany({
@@ -11660,6 +11669,7 @@ export async function bulkArchiveBookings({
   organizationId,
   userId,
   currentSearchParams,
+  role,
 }: {
   bookingIds: Booking["id"][];
   organizationId: Organization["id"];
@@ -11671,14 +11681,22 @@ export async function bulkArchiveBookings({
    */
   userId?: User["id"];
   currentSearchParams?: string | null;
+  /** Caller's effective role — decides whether ownership scoping applies */
+  role: OrganizationRoles;
 }) {
   try {
-    /** If all are selected in the list, then we have to consider filter */
-    const where: Prisma.BookingWhereInput = bookingIds.includes(
-      ALL_SELECTED_KEY
-    )
-      ? getBookingWhereInput({ currentSearchParams, organizationId })
-      : { id: { in: bookingIds }, organizationId };
+    /**
+     * Scopes to the filters the user had applied AND to the bookings they are
+     * allowed to act on. Without the ownership half, a restricted caller could
+     * delete every booking in the workspace with one request.
+     */
+    const where = getBulkBookingsWhereInput({
+      bookingIds,
+      organizationId,
+      currentSearchParams,
+      role,
+      userId,
+    });
 
     const bookings = await db.booking.findMany({
       where,
@@ -11857,20 +11875,29 @@ export async function bulkCancelBookings({
   userId,
   hints,
   currentSearchParams,
+  role,
 }: {
   bookingIds: Booking["id"][];
   organizationId: Organization["id"];
   userId: User["id"];
   hints: ClientHint;
   currentSearchParams?: string | null;
+  /** Caller's effective role — decides whether ownership scoping applies */
+  role: OrganizationRoles;
 }) {
   try {
-    /** If all are selected in the list, then we have to consider filter */
-    const where: Prisma.BookingWhereInput = bookingIds.includes(
-      ALL_SELECTED_KEY
-    )
-      ? getBookingWhereInput({ currentSearchParams, organizationId })
-      : { id: { in: bookingIds }, organizationId };
+    /**
+     * Scopes to the filters the user had applied AND to the bookings they are
+     * allowed to act on. Without the ownership half, a restricted caller could
+     * delete every booking in the workspace with one request.
+     */
+    const where = getBulkBookingsWhereInput({
+      bookingIds,
+      organizationId,
+      currentSearchParams,
+      role,
+      userId,
+    });
 
     const [bookings, user] = await Promise.all([
       db.booking.findMany({

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -1,11 +1,127 @@
-import { AssetStatus, AssetType, BookingStatus } from "@prisma/client";
-import type { Asset, Booking, Organization, Prisma } from "@prisma/client";
+import {
+  AssetStatus,
+  AssetType,
+  BookingStatus,
+  OrganizationRoles,
+} from "@prisma/client";
+import type {
+  Asset,
+  Booking,
+  Organization,
+  Prisma,
+  User,
+} from "@prisma/client";
 import { DateTime } from "luxon";
 import { redirect } from "react-router";
 import type { ErrorLabel } from "~/utils/error";
 import { ShelfError } from "~/utils/error";
+import { ALL_SELECTED_KEY } from "~/utils/list";
 
 const label: ErrorLabel = "Booking";
+
+/**
+ * Restricts a bulk booking query to the rows the caller is allowed to act on.
+ *
+ * Mirrors `validateBookingOwnership`, the gate the SINGULAR write paths use:
+ * a BASE or SELF_SERVICE caller may only act on bookings they created or hold
+ * custody of. ADMIN and OWNER are unrestricted.
+ *
+ * Deliberately keyed on the ROLE, not on `canSeeAllBookings`. Those differ:
+ * `selfServiceCanSeeBookings` / `baseUserCanSeeBookings` make the *list* show a
+ * restricted user every booking in the workspace, but they do not grant write
+ * access — singular delete still refuses. Scoping a destructive bulk action by
+ * what the user can SEE would hand those workspaces org-wide deletion.
+ *
+ * Team-member custody links are intentionally absent, matching
+ * `validateBookingOwnership`. The read path is wider (it also matches
+ * `custodianTeamMemberId`), and that asymmetry is a known, separately tracked
+ * inconsistency — widening it here would be a silent authorization change
+ * bundled into a security fix.
+ *
+ * @param role - The caller's effective role in this organization
+ * @param userId - The caller
+ * @returns An ownership predicate, or `null` when the role is unrestricted
+ */
+export function getBookingOwnershipScope({
+  role,
+  userId,
+}: {
+  role: OrganizationRoles;
+  /** Absent for system-initiated calls, which have no acting user */
+  userId?: User["id"];
+}): Prisma.BookingWhereInput | null {
+  const isRestricted =
+    role === OrganizationRoles.SELF_SERVICE || role === OrganizationRoles.BASE;
+
+  if (!isRestricted) {
+    return null;
+  }
+
+  if (!userId) {
+    /**
+     * A restricted role with nobody to scope to. Returning `null` here would
+     * silently hand the caller every booking in the workspace, so fail closed:
+     * this can only be a wiring mistake, and it must not degrade into an
+     * org-wide destructive query.
+     */
+    throw new ShelfError({
+      cause: null,
+      message:
+        "Cannot resolve which bookings this user may act on. Please contact support.",
+      additionalData: { role },
+      label,
+    });
+  }
+
+  return { OR: [{ creatorId: userId }, { custodianUserId: userId }] };
+}
+
+/**
+ * Builds the complete `where` for a bulk booking action.
+ *
+ * Shared by `bulkDeleteBookings`, `bulkArchiveBookings` and
+ * `bulkCancelBookings` so the three cannot drift — and so the ownership scope
+ * cannot be forgotten on one of them.
+ *
+ * The ownership predicate is AND-ed onto BOTH branches on purpose. Applying it
+ * only to "select all" would still let a restricted caller act on someone
+ * else's booking by posting its id directly.
+ *
+ * @param bookingIds - Explicit ids, or `[ALL_SELECTED_KEY]` for select-all
+ * @param organizationId - The caller's (validated) organization
+ * @param currentSearchParams - The list filters, for the select-all branch
+ * @param role - The caller's effective role
+ * @param userId - The caller
+ * @returns A `Prisma.BookingWhereInput` scoped to org, filters and ownership
+ */
+export function getBulkBookingsWhereInput({
+  bookingIds,
+  organizationId,
+  currentSearchParams,
+  role,
+  userId,
+}: {
+  bookingIds: Booking["id"][];
+  organizationId: Organization["id"];
+  currentSearchParams?: string | null;
+  role: OrganizationRoles;
+  /** Absent for system-initiated calls, which have no acting user */
+  userId?: User["id"];
+}): Prisma.BookingWhereInput {
+  const base: Prisma.BookingWhereInput = bookingIds.includes(ALL_SELECTED_KEY)
+    ? getBookingWhereInput({ currentSearchParams, organizationId })
+    : { id: { in: bookingIds }, organizationId };
+
+  const ownership = getBookingOwnershipScope({ role, userId });
+
+  if (!ownership) {
+    return base;
+  }
+
+  // AND rather than a spread: `base` may carry its own OR, and merging the two
+  // would union them — widening a destructive action instead of narrowing it.
+  return { AND: [base, ownership] };
+}
 
 export function getBookingWhereInput({
   organizationId,

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -50,10 +50,18 @@ export function getBookingOwnershipScope({
   /** Absent for system-initiated calls, which have no acting user */
   userId?: User["id"];
 }): Prisma.BookingWhereInput | null {
-  const isRestricted =
-    role === OrganizationRoles.SELF_SERVICE || role === OrganizationRoles.BASE;
+  /**
+   * ALLOW-list, not a deny-list on SELF_SERVICE/BASE. A role added to
+   * `OrganizationRoles` later lands in the RESTRICTED branch by default, so it
+   * gets scoped to its own rows rather than silently inheriting org-wide
+   * delete. Matches `bookingWriteScopeClause`, which is the other query-side
+   * clause and documents the same reasoning; the submit-time gate
+   * (`validateBookingOwnership`) deny-lists by deliberate, separate design.
+   */
+  const canActOnEveryBooking =
+    role === OrganizationRoles.ADMIN || role === OrganizationRoles.OWNER;
 
-  if (!isRestricted) {
+  if (canActOnEveryBooking) {
     return null;
   }
 

--- a/apps/webapp/app/routes/api+/bookings.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/bookings.bulk-actions.ts
@@ -44,7 +44,9 @@ export async function action({ request, context }: ActionFunctionArgs) {
       "bulk-cancel": PermissionAction.update,
     };
 
-    const { organizationId } = await requirePermission({
+    // `role` decides whether the bulk query is scoped to the caller's own
+    // bookings. It is the same authority the singular write paths use.
+    const { organizationId, role } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.booking,
@@ -59,6 +61,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           bookingIds,
           organizationId,
           userId,
+          role,
           hints: getClientHint(request),
           currentSearchParams,
         });
@@ -80,6 +83,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           bookingIds,
           organizationId,
           userId,
+          role,
           currentSearchParams,
         });
 
@@ -100,6 +104,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
           bookingIds,
           organizationId,
           userId,
+          role,
           hints: getClientHint(request),
           currentSearchParams,
         });


### PR DESCRIPTION
## What

**A BASE or SELF_SERVICE user could delete, archive or cancel every booking in
the workspace** — including other people's — from a list that had only ever
shown them their own.

Found by the detail.dev OSS scan (finding D031). Third of the select-all
cluster, after #2867 (tags) and #2869 (locations).

## The bug

The bookings list scopes restricted users to their own bookings:

```ts
// getBookingsFilterData — applied when !canSeeAllBookings
selfServiceData = { custodianScope };   // their user link + team-member links
```

The bulk where-builder applied none of it:

```ts
const where = bookingIds.includes(ALL_SELECTED_KEY)
  ? getBookingWhereInput({ currentSearchParams, organizationId })  // org + status only
  : { id: { in: bookingIds }, organizationId };                    // also unscoped
```

Both roles hold the permissions these intents map to — the matrix even documents
the intent: `delete` is *"for the user to delete their own bookings only when
they are draft."*

Note the **explicit-id branch was unscoped too**, so this did not need
select-all: posting a guessed booking id was enough.

### A third distinct root cause

Worth recording, because it argues against pattern-matching the rest of this
cluster:

| | Failure |
| --- | --- |
| #2867 tags | route never read `currentSearchParams` |
| #2869 locations | read them from `request.url`, which is empty in an action |
| **#this bookings** | **params read and applied correctly — the builder omits the *ownership* scoping, not the filters** |

This one is not about filters at all.

## The fix

One shared `getBulkBookingsWhereInput`, used by all three services, so the scope
cannot be forgotten on one of them. The ownership predicate is applied to **both**
branches.

### Two decisions worth reviewing

**It keys on the ROLE, not on `canSeeAllBookings`.** Those genuinely differ:
`selfServiceCanSeeBookings` / `baseUserCanSeeBookings` make the *list* show a
restricted user every booking in the workspace, but they do not grant write
access — singular delete still refuses via `validateBookingOwnership`. Scoping a
destructive bulk action by what the user can **see** would hand exactly those
workspaces org-wide deletion. The role check mirrors the singular write gate.

**The predicate is AND-ed, never spread.** `getBookingWhereInput` can carry its
own `OR`, and merging the two would *union* them — widening a destructive query
instead of narrowing it. There is a test pinning that.

`role` is a **required** parameter, so the compiler rejects any call site that
forgets it — that is what caught the ten existing test call sites. And a
restricted role arriving with no user to scope to throws rather than silently
degrading to an unscoped query.

## Behaviour

| Caller | Select all | Explicit ids |
| --- | --- | --- |
| ADMIN / OWNER | all matching (unchanged) | those ids (unchanged) |
| **BASE / SELF_SERVICE** | **all matching org-wide** 🔴 → own only ✅ | **any id** 🔴 → own only ✅ |

## Tests

`app/modules/booking/bulk-ownership-scope.test.ts` (14) covers both roles ×
both branches, the unrestricted roles staying unscoped, the AND-not-union
composition, and the fail-closed path.

**Five tests were confirmed to fail** with the ownership scope removed.

607 tests pass across the booking module.

## Deliberately not included

Team-member custody links (`custodianTeamMemberId`) are absent from the
ownership predicate, matching `validateBookingOwnership`. The read path is wider,
and that asymmetry is a known separately-tracked inconsistency (D076) — widening
it here would be a silent authorization change bundled into a security fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk booking actions now respect role-based ownership restrictions.
  * Restricted users can only archive, cancel, or delete bookings they created or currently manage.
  * Select-all and explicitly selected bookings now apply the same access safeguards.
  * Missing ownership information fails safely without affecting unrestricted roles.
* **Tests**
  * Added regression coverage for ownership filtering across bulk actions and selection modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->