### PR TITLE
ci(build): publish a version-tagged image when a release is tagged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # `latest` is published by exactly one rule below, gated on `main`.
+          # The default `latest=auto` would ALSO emit it for `type=match`, so a
+          # release tag would move `latest` — and tagging an older commit for a
+          # hotfix would drag `latest` backwards with it.
+          flavor: |
+            latest=false
           # `type=ref,event=tag` would emit the git tag verbatim, but a Docker tag
           # cannot contain `@` — `shelf@2.1.2` is sanitised into something that is
           # not the version anyone was told to pull. Match the version out of the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - dev
+    # Release tags are `shelf@X.Y.Z`. Without this the workflow never runs for a
+    # release, so the version-pinned image the release notes tell self-hosted
+    # operators to pull is never built.
+    tags:
+      - "shelf@*"
 
 permissions:
   actions: write
@@ -18,7 +23,7 @@ env:
 jobs:
   build:
     name: 🐳 Build
-    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
+    if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🛑 Cancel Previous Runs
@@ -53,10 +58,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # `type=ref,event=tag` would emit the git tag verbatim, but a Docker tag
+          # cannot contain `@` — `shelf@2.1.2` is sanitised into something that is
+          # not the version anyone was told to pull. Match the version out of the
+          # tag instead, so a release publishes a plain `2.1.2` image alongside
+          # `latest`.
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=ref,enable=${{ github.ref_type != 'tag' }},suffix=-{{sha}},event=branch
-            type=ref,event=tag
+            type=match,pattern=shelf@(.*),group=1
 
       - name: 🛠 Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## What

Release notes tell self-hosted operators to pull a version-pinned image:

```bash
docker pull ghcr.io/shelf-nu/shelf.nu:2.1.1
```

**That image was never built.** Publishing a release creates the git tag and
nothing else — no version-tagged image is pushed to ghcr.

Found while preparing the `2.1.2` security release, where a failed pull is worse
than an inconvenience: an operator following the upgrade steps under time
pressure reads it as "the fix isn't out yet".

## Three separate blockers

1. **The workflow never ran.** `on.push` listed only `main` and `dev`, so a tag
   push triggered nothing.
2. **The job would have skipped anyway.** `if:` allowed only those two branch
   refs.
3. **The tag rule produced the wrong name.** `type=ref,event=tag` emits the git
   tag verbatim, but a Docker tag cannot contain `@` — `shelf@2.1.2` gets
   sanitised into something that is not the version anyone was told to pull.

All three had to be fixed; any one alone leaves it broken.

## The change

```yaml
on:
  push:
    branches: [main, dev]
    tags:
      - "shelf@*"          # was absent
```

```yaml
if: ${{ … || github.ref_type == 'tag' }}   # was branch-only
```

```yaml
flavor: |
  latest=false                             # was absent — see below
tags: |
  type=match,pattern=shelf@(.*),group=1    # was type=ref,event=tag
```

So `shelf@2.1.2` now publishes `ghcr.io/shelf-nu/shelf.nu:2.1.2`.

## What does not change

- **`latest` still tracks `main`** — but not for the reason I first wrote here.
  My original claim was that the existing `enable=` condition was sufficient.
  It was not: `type=match` inherits the default `latest=auto`, which emits
  `latest` for match, semver, pep440 and `type=ref,event=tag` regardless of the
  other rules. As first pushed, this PR would have moved `latest` on every
  release tag — and tagging an older commit for a hotfix would have dragged it
  backwards. `flavor: latest=false` now disables that, leaving the explicit
  main-gated rule as the only thing that publishes `latest`. Caught by
  CodeRabbit; corrected in `fc8a3977e`.
- **No deploy is triggered.** `deploy.yml` fires only on branch pushes, so
  tagging a release does not deploy to production — checked before making the
  change, since that would have been the dangerous side effect.
- Branch builds (`main-<sha>`) are unaffected.

## Verification

I could not confirm the current ghcr tag list — my token lacks `read:packages` —
so the "image was never built" conclusion is read from the workflow rather than
from the registry. If a `2.1.1` image does somehow exist, the mechanism producing
it is not this workflow, and this change is still the one that makes the
documented pull command true.

The workflow YAML parses, and the `tags` input resolves to exactly three
definitions with no comment lines leaking into `metadata-action` — the
explanatory comment sits above the key rather than inside the block scalar,
which would have been passed through as a tag definition.

## Merge order

Worth merging **before** publishing `shelf@2.1.2`, so the release tag builds its
own image. Otherwise `2.1.2` needs a re-tag or the notes need to point at
`:latest` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release builds to run from versioned release tags.
  * Improved Docker image tagging for releases.
  * Limited the `latest` image tag to builds from the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->