### PR TITLE
fix(security): mobile select-all expansion and the Sentry tunnel SSRF

### DIFF
--- a/apps/webapp/app/modules/api/mobile-bulk-ids.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-bulk-ids.server.test.ts
@@ -18,7 +18,7 @@
 import { describe, expect, it } from "vitest";
 
 import { ALL_SELECTED_KEY } from "~/utils/list";
-import { mobileBulkIdsSchema } from "./mobile-bulk-ids.server";
+import { mobileBulkIdsSchema, mobileIdSchema } from "./mobile-bulk-ids.server";
 
 // @vitest-environment node
 
@@ -70,5 +70,40 @@ describe("mobileBulkIdsSchema", () => {
     expect(schema.parse(["all-selected-but-not-really"])).toEqual([
       "all-selected-but-not-really",
     ]);
+  });
+});
+
+describe("mobileIdSchema", () => {
+  const single = mobileIdSchema("assetId");
+
+  it("accepts an explicit id", () => {
+    expect(single.parse("a1")).toBe("a1");
+  });
+
+  it("rejects the sentinel", () => {
+    // The scalar case is the one that looks safe and is not: the endpoint wraps
+    // it as `assetIds: [assetId]`, and `["all-selected"]` satisfies
+    // `includes(ALL_SELECTED_KEY)` exactly as a longer list does.
+    expect(single.safeParse(ALL_SELECTED_KEY).success).toBe(false);
+  });
+
+  it("still rejects an empty string", () => {
+    expect(single.safeParse("").success).toBe(false);
+  });
+
+  it("explains itself in the error", () => {
+    const result = single.safeParse(ALL_SELECTED_KEY);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/select all/i);
+      expect(result.error.issues[0].message).toContain("assetId");
+    }
+  });
+
+  it("does not reject an id that merely contains the sentinel as a substring", () => {
+    expect(single.parse("all-selected-but-not-really")).toBe(
+      "all-selected-but-not-really"
+    );
   });
 });

--- a/apps/webapp/app/modules/api/mobile-bulk-ids.server.test.ts
+++ b/apps/webapp/app/modules/api/mobile-bulk-ids.server.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Mobile bulk id lists — select-all sentinel rejection
+ *
+ * Mobile has no select-all control and sends no `currentSearchParams`. If the
+ * `ALL_SELECTED_KEY` sentinel reaches a mobile bulk endpoint it expands against
+ * an EMPTY filter — every matching row in the organization — so the schema has
+ * to refuse it rather than the service having to cope.
+ *
+ * That is reachable by SELF_SERVICE, which holds `asset:custody` and
+ * `kit:custody`, so on the custody endpoints it is a privilege escalation
+ * rather than merely an unbounded write.
+ *
+ * Regression coverage for detail.dev finding D130.
+ *
+ * @see {@link file://./mobile-bulk-ids.server.ts}
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { ALL_SELECTED_KEY } from "~/utils/list";
+import { mobileBulkIdsSchema } from "./mobile-bulk-ids.server";
+
+// @vitest-environment node
+
+const schema = mobileBulkIdsSchema("assetIds");
+
+describe("mobileBulkIdsSchema", () => {
+  it("accepts explicit ids", () => {
+    expect(schema.parse(["a1", "a2"])).toEqual(["a1", "a2"]);
+  });
+
+  it("rejects the select-all sentinel on its own", () => {
+    expect(schema.safeParse([ALL_SELECTED_KEY]).success).toBe(false);
+  });
+
+  it("rejects the sentinel hidden among real ids", () => {
+    // The services check `ids.includes(ALL_SELECTED_KEY)`, so one sentinel
+    // anywhere in the array switches the whole request to select-all.
+    expect(schema.safeParse(["a1", ALL_SELECTED_KEY, "a2"]).success).toBe(
+      false
+    );
+  });
+
+  it("still rejects an empty list", () => {
+    expect(schema.safeParse([]).success).toBe(false);
+  });
+
+  it("explains itself in the error", () => {
+    const result = schema.safeParse([ALL_SELECTED_KEY]);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/select all/i);
+      expect(result.error.issues[0].message).toContain("assetIds");
+    }
+  });
+
+  it("names the field it was built for", () => {
+    const kits = mobileBulkIdsSchema("kitIds").safeParse([ALL_SELECTED_KEY]);
+
+    expect(kits.success).toBe(false);
+    if (!kits.success) {
+      expect(kits.error.issues[0].message).toContain("kitIds");
+    }
+  });
+
+  it("does not reject ids that merely contain the sentinel as a substring", () => {
+    // A real cuid could in principle embed the string; only an exact match is
+    // the sentinel.
+    expect(schema.parse(["all-selected-but-not-really"])).toEqual([
+      "all-selected-but-not-really",
+    ]);
+  });
+});

--- a/apps/webapp/app/modules/api/mobile-bulk-ids.server.ts
+++ b/apps/webapp/app/modules/api/mobile-bulk-ids.server.ts
@@ -1,0 +1,43 @@
+/**
+ * Mobile bulk-action id lists.
+ *
+ * The web list UI can send an `ALL_SELECTED_KEY` sentinel instead of ids,
+ * meaning "everything matching the filters I am looking at". That contract only
+ * works because the web client also submits `currentSearchParams`, so the
+ * server can rebuild the same filtered set.
+ *
+ * The mobile client has no select-all control and sends no filters. If the
+ * sentinel reaches a mobile bulk endpoint it therefore expands against an EMPTY
+ * filter — every matching row in the organization — which is both unbounded and
+ * invisible to the caller. On the custody endpoints that is reachable by
+ * SELF_SERVICE, which holds `asset:custody` and `kit:custody`.
+ *
+ * So mobile rejects the sentinel outright rather than trying to support it. A
+ * mobile client has no way to produce it legitimately; its presence means a
+ * hand-crafted request.
+ *
+ * @see {@link file://./../../utils/list.ts} ALL_SELECTED_KEY
+ */
+
+import { z } from "zod";
+
+import { ALL_SELECTED_KEY } from "~/utils/list";
+
+/**
+ * A non-empty list of explicit entity ids for a mobile bulk action.
+ *
+ * Rejects the select-all sentinel. Use this instead of a bare
+ * `z.array(z.string())` on any mobile endpoint that forwards ids into a service
+ * capable of expanding the sentinel.
+ *
+ * @param field - Field name used in the validation message (e.g. `assetIds`)
+ * @returns A Zod schema for the id array
+ */
+export function mobileBulkIdsSchema(field: string) {
+  return z
+    .array(z.string().min(1))
+    .min(1)
+    .refine((ids) => !ids.includes(ALL_SELECTED_KEY), {
+      message: `${field} must contain explicit ids. "Select all" is not supported on mobile.`,
+    });
+}

--- a/apps/webapp/app/modules/api/mobile-bulk-ids.server.ts
+++ b/apps/webapp/app/modules/api/mobile-bulk-ids.server.ts
@@ -41,3 +41,27 @@ export function mobileBulkIdsSchema(field: string) {
       message: `${field} must contain explicit ids. "Select all" is not supported on mobile.`,
     });
 }
+
+/**
+ * A single explicit entity id for a mobile endpoint that wraps it into an array
+ * before handing it to a sentinel-aware service (e.g. `assetIds: [assetId]`).
+ *
+ * A scalar field looks safe and is not: `["all-selected"]` satisfies
+ * `includes(ALL_SELECTED_KEY)` exactly as a multi-item list does, so a
+ * single-asset endpoint expands to the whole organization just as readily as a
+ * bulk one. `/api/mobile/custody/assign` was reachable this way.
+ *
+ * Use this — not a bare `z.string().min(1)` — for any scalar id that ends up in
+ * an array argument to a service that understands the sentinel.
+ *
+ * @param field - Field name used in the validation message (e.g. `assetId`)
+ * @returns A Zod schema for the single id
+ */
+export function mobileIdSchema(field: string) {
+  return z
+    .string()
+    .min(1)
+    .refine((id) => id !== ALL_SELECTED_KEY, {
+      message: `${field} must be an explicit id. "Select all" is not supported on mobile.`,
+    });
+}

--- a/apps/webapp/app/routes/api+/mobile+/bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-assign-custody.ts
@@ -6,6 +6,7 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { mobileBulkIdsSchema } from "~/modules/api/mobile-bulk-ids.server";
 import { bulkCheckOutAssets } from "~/modules/asset/service.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { getTeamMember } from "~/modules/team-member/service.server";
@@ -46,7 +47,7 @@ export async function action({ request }: ActionFunctionArgs) {
     const body = await request.json();
     const { assetIds, custodianId } = z
       .object({
-        assetIds: z.array(z.string().min(1)).min(1),
+        assetIds: mobileBulkIdsSchema("assetIds"),
         custodianId: z.string().min(1),
       })
       .parse(body);

--- a/apps/webapp/app/routes/api+/mobile+/bulk-assign-custody.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-assign-custody.ts
@@ -44,13 +44,30 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.custody,
     });
 
-    const body = await request.json();
-    const { assetIds, custodianId } = z
+    // safeParse, not parse: a raw ZodError reaches `makeShelfError`'s
+    // unknown branch and surfaces as a captured 500 "Sorry, something went
+    // wrong". A malformed body is a client error, and the select-all
+    // rejection below is an EXPECTED one — reporting it as a server outage
+    // would bury it in Sentry.
+    const parsed = z
       .object({
         assetIds: mobileBulkIdsSchema("assetIds"),
         custodianId: z.string().min(1),
       })
-      .parse(body);
+      .safeParse(await request.json().catch(() => null));
+
+    if (!parsed.success) {
+      throw new ShelfError({
+        cause: parsed.error,
+        message: "Invalid request body",
+        additionalData: { validationErrors: parsed.error.flatten() },
+        label: "Assets",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const { assetIds, custodianId } = parsed.data;
 
     // Get user context (role + barcode access) for asset index settings
     const { role, canUseBarcodes, canSeeAllCustody } =

--- a/apps/webapp/app/routes/api+/mobile+/bulk-release-custody.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-release-custody.ts
@@ -9,7 +9,7 @@ import {
 import { mobileBulkIdsSchema } from "~/modules/api/mobile-bulk-ids.server";
 import { bulkCheckInAssets } from "~/modules/asset/service.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
-import { makeShelfError } from "~/utils/error";
+import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
   PermissionEntity,
@@ -42,12 +42,29 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.custody,
     });
 
-    const body = await request.json();
-    const { assetIds } = z
+    // safeParse, not parse: a raw ZodError reaches `makeShelfError`'s
+    // unknown branch and surfaces as a captured 500 "Sorry, something went
+    // wrong". A malformed body is a client error, and the select-all
+    // rejection below is an EXPECTED one — reporting it as a server outage
+    // would bury it in Sentry.
+    const parsed = z
       .object({
         assetIds: mobileBulkIdsSchema("assetIds"),
       })
-      .parse(body);
+      .safeParse(await request.json().catch(() => null));
+
+    if (!parsed.success) {
+      throw new ShelfError({
+        cause: parsed.error,
+        message: "Invalid request body",
+        additionalData: { validationErrors: parsed.error.flatten() },
+        label: "Assets",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const { assetIds } = parsed.data;
 
     const { role, canUseBarcodes, canSeeAllCustody } =
       await getMobileUserContext(user.id, organizationId);

--- a/apps/webapp/app/routes/api+/mobile+/bulk-release-custody.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-release-custody.ts
@@ -6,6 +6,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { mobileBulkIdsSchema } from "~/modules/api/mobile-bulk-ids.server";
 import { bulkCheckInAssets } from "~/modules/asset/service.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { makeShelfError } from "~/utils/error";
@@ -44,7 +45,7 @@ export async function action({ request }: ActionFunctionArgs) {
     const body = await request.json();
     const { assetIds } = z
       .object({
-        assetIds: z.array(z.string().min(1)).min(1),
+        assetIds: mobileBulkIdsSchema("assetIds"),
       })
       .parse(body);
 

--- a/apps/webapp/app/routes/api+/mobile+/bulk-update-location.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-update-location.ts
@@ -6,6 +6,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { mobileBulkIdsSchema } from "~/modules/api/mobile-bulk-ids.server";
 import { bulkUpdateAssetLocation } from "~/modules/asset/service.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { makeShelfError } from "~/utils/error";
@@ -38,7 +39,7 @@ export async function action({ request }: ActionFunctionArgs) {
     const body = await request.json();
     const { assetIds, locationId } = z
       .object({
-        assetIds: z.array(z.string().min(1)).min(1),
+        assetIds: mobileBulkIdsSchema("assetIds"),
         locationId: z.string().min(1),
       })
       .parse(body);

--- a/apps/webapp/app/routes/api+/mobile+/bulk-update-location.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bulk-update-location.ts
@@ -9,7 +9,7 @@ import {
 import { mobileBulkIdsSchema } from "~/modules/api/mobile-bulk-ids.server";
 import { bulkUpdateAssetLocation } from "~/modules/asset/service.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
-import { makeShelfError } from "~/utils/error";
+import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
   PermissionEntity,
@@ -36,13 +36,30 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.update,
     });
 
-    const body = await request.json();
-    const { assetIds, locationId } = z
+    // safeParse, not parse: a raw ZodError reaches `makeShelfError`'s
+    // unknown branch and surfaces as a captured 500 "Sorry, something went
+    // wrong". A malformed body is a client error, and the select-all
+    // rejection below is an EXPECTED one — reporting it as a server outage
+    // would bury it in Sentry.
+    const parsed = z
       .object({
         assetIds: mobileBulkIdsSchema("assetIds"),
         locationId: z.string().min(1),
       })
-      .parse(body);
+      .safeParse(await request.json().catch(() => null));
+
+    if (!parsed.success) {
+      throw new ShelfError({
+        cause: parsed.error,
+        message: "Invalid request body",
+        additionalData: { validationErrors: parsed.error.flatten() },
+        label: "Assets",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const { assetIds, locationId } = parsed.data;
 
     const { role, canUseBarcodes } = await getMobileUserContext(
       user.id,

--- a/apps/webapp/app/routes/api+/mobile+/custody.assign.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custody.assign.ts
@@ -6,6 +6,7 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { mobileIdSchema } from "~/modules/api/mobile-bulk-ids.server";
 import { bulkCheckOutAssets } from "~/modules/asset/service.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
 import { getTeamMember } from "~/modules/team-member/service.server";
@@ -41,13 +42,30 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.custody,
     });
 
-    const body = await request.json();
-    const { assetId, custodianId } = z
+    // safeParse, not parse: a raw ZodError reaches `makeShelfError`'s unknown
+    // branch and surfaces as a captured 500. A crafted body is a client error.
+    const parsed = z
       .object({
-        assetId: z.string().min(1),
+        // NOT a bare z.string(): this is wrapped as `assetIds: [assetId]` below
+        // and handed to `bulkCheckOutAssets`, which treats `["all-selected"]`
+        // as "every asset matching the filters" — and mobile sends no filters.
+        assetId: mobileIdSchema("assetId"),
         custodianId: z.string().min(1),
       })
-      .parse(body);
+      .safeParse(await request.json().catch(() => null));
+
+    if (!parsed.success) {
+      throw new ShelfError({
+        cause: parsed.error,
+        message: "Invalid request body",
+        additionalData: { validationErrors: parsed.error.flatten() },
+        label: "Assets",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const { assetId, custodianId } = parsed.data;
 
     // Get user context (role + barcode access) for asset index settings
     const { role, canUseBarcodes, canSeeAllCustody } =

--- a/apps/webapp/app/routes/api+/mobile+/kits.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.bulk-actions.ts
@@ -8,6 +8,7 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { mobileBulkIdsSchema } from "~/modules/api/mobile-bulk-ids.server";
 import {
   bulkAssignKitCustody,
   bulkReleaseKitCustody,
@@ -39,16 +40,16 @@ import { enforceUserRateLimit } from "~/utils/rate-limit.server";
 const BodySchema = z.discriminatedUnion("intent", [
   z.object({
     intent: z.literal("assign-custody"),
-    kitIds: z.array(z.string().min(1)).min(1),
+    kitIds: mobileBulkIdsSchema("kitIds"),
     custodianId: z.string().min(1),
   }),
   z.object({
     intent: z.literal("release-custody"),
-    kitIds: z.array(z.string().min(1)).min(1),
+    kitIds: mobileBulkIdsSchema("kitIds"),
   }),
   z.object({
     intent: z.literal("update-location"),
-    kitIds: z.array(z.string().min(1)).min(1),
+    kitIds: mobileBulkIdsSchema("kitIds"),
     newLocationId: z.string().min(1),
   }),
 ]);

--- a/apps/webapp/app/routes/api+/mobile+/kits.bulk-actions.ts
+++ b/apps/webapp/app/routes/api+/mobile+/kits.bulk-actions.ts
@@ -70,7 +70,25 @@ export async function action({ request }: ActionFunctionArgs) {
 
     const organizationId = await requireOrganizationAccess(request, user.id);
 
-    const body = BodySchema.parse(await request.json());
+    // safeParse, not parse — see the asset bulk endpoints: a raw ZodError
+    // becomes a captured 500, and the select-all rejection is an expected
+    // client error.
+    const parsedBody = BodySchema.safeParse(
+      await request.json().catch(() => null)
+    );
+
+    if (!parsedBody.success) {
+      throw new ShelfError({
+        cause: parsedBody.error,
+        message: "Invalid request body",
+        additionalData: { validationErrors: parsedBody.error.flatten() },
+        label: "Kit",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const body = parsedBody.data;
 
     await requireMobilePermission({
       userId: user.id,

--- a/apps/webapp/app/routes/api+/sentry-tunnel.ts
+++ b/apps/webapp/app/routes/api+/sentry-tunnel.ts
@@ -1,3 +1,8 @@
+import {
+  buildSentryEnvelopeUrl,
+  envelopeDsnMatches,
+  getConfiguredSentryTarget,
+} from "~/utils/sentry-tunnel.server";
 import type { Route } from "./+types/sentry-tunnel";
 
 /**
@@ -7,10 +12,27 @@ import type { Route } from "./+types/sentry-tunnel";
  * blocked by ad-blockers or browser tracking protection (e.g. Firefox
  * Enhanced Tracking Protection).
  *
+ * The destination is pinned to the server's own configured Sentry project. The
+ * DSN in the client's envelope is only ever compared against it — it never
+ * builds the URL we fetch. Deriving the host from the envelope made this a
+ * full-read SSRF; see `~/utils/sentry-tunnel.server` for the full account.
+ *
  * @see https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option
+ * @see {@link file://./../../utils/sentry-tunnel.server.ts}
  */
 export async function action({ request }: Route.ActionArgs) {
   try {
+    // Resolved per request rather than at module load so the route stays
+    // testable without reaching into the env module.
+    const target = getConfiguredSentryTarget();
+
+    if (!target) {
+      // No configured Sentry project means there is no legitimate destination.
+      // Refusing is the only safe answer — falling back to the envelope's own
+      // DSN is exactly the behaviour that made this an SSRF.
+      return new Response("Sentry tunnel is not configured", { status: 404 });
+    }
+
     const envelopeBytes = await request.arrayBuffer();
     const envelope = new TextDecoder().decode(envelopeBytes);
 
@@ -22,16 +44,26 @@ export async function action({ request }: Route.ActionArgs) {
       return new Response("Missing DSN in envelope header", { status: 400 });
     }
 
-    const url = new URL(dsn);
-    const projectId = url.pathname.replace("/", "");
-    const sentryUrl = `https://${url.hostname}/api/${projectId}/envelope/`;
+    if (!envelopeDsnMatches(dsn, target)) {
+      // Deliberately does not echo the submitted DSN back: the response would
+      // otherwise confirm what was rejected, and the value is attacker-chosen.
+      return new Response("Envelope DSN does not match this deployment", {
+        status: 403,
+      });
+    }
 
-    const sentryResponse = await fetch(sentryUrl, {
+    const sentryResponse = await fetch(buildSentryEnvelopeUrl(target), {
       method: "POST",
       body: envelopeBytes,
       headers: {
         "Content-Type": "application/x-sentry-envelope",
       },
+      // Never follow redirects. Following them is how the original bug reached
+      // internal-only hosts: an attacker-owned host answered the HTTPS request
+      // with a 302 to `http://169.254.169.254/...` and fetch chased it. The
+      // host is pinned now, but Sentry's ingest does not redirect either, so a
+      // 3xx here is unexpected and is surfaced rather than chased.
+      redirect: "manual",
     });
 
     return new Response(sentryResponse.body, {

--- a/apps/webapp/app/utils/sentry-tunnel.server.test.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.test.ts
@@ -43,6 +43,9 @@ describe("parseSentryDsn", () => {
     ["no project id", "https://pubkey@o123.ingest.sentry.io/"],
     ["a non-http scheme", "file:///etc/passwd"],
     ["a javascript: URL", "javascript:alert(1)"],
+    // The tunnel always egressed over https, so an http DSN never worked.
+    // Refusing it keeps the parser and `buildSentryEnvelopeUrl` in agreement.
+    ["a plaintext http DSN", "http://pubkey@o123.ingest.sentry.io/456"],
   ])("returns null for %s", (_label, input) => {
     expect(parseSentryDsn(input)).toBeNull();
   });

--- a/apps/webapp/app/utils/sentry-tunnel.server.test.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.test.ts
@@ -48,6 +48,18 @@ describe("parseSentryDsn", () => {
     });
   });
 
+  it("accepts a non-numeric project id, which the spec permits", () => {
+    // Sentry's SDK spec calls the project id a string identifier that is
+    // merely "usually an integer". Enforcing numeric would break a valid
+    // deployment and buys nothing: a client-supplied project id is only ever
+    // compared, never used to build a URL.
+    expect(parseSentryDsn("https://pubkey@sentry.example.com/abc123")).toEqual({
+      origin: "https://sentry.example.com",
+      pathPrefix: "",
+      projectId: "abc123",
+    });
+  });
+
   it("keeps a non-default port, which `hostname` would drop", () => {
     expect(
       parseSentryDsn("https://pubkey@sentry.example.com:8443/456")
@@ -69,6 +81,9 @@ describe("parseSentryDsn", () => {
     // The tunnel always egressed over https, so an http DSN never worked.
     // Refusing it keeps the parser and `buildSentryEnvelopeUrl` in agreement.
     ["a plaintext http DSN", "http://pubkey@o123.ingest.sentry.io/456"],
+    // The public key is mandatory per the DSN spec; without it the string is
+    // not a DSN at all.
+    ["a keyless DSN", "https://o123.ingest.sentry.io/456"],
   ])("returns null for %s", (_label, input) => {
     expect(parseSentryDsn(input)).toBeNull();
   });
@@ -101,16 +116,16 @@ describe("envelopeDsnMatches", () => {
   });
 
   it.each([
-    ["an arbitrary attacker host", "https://evil.com/456"],
-    ["the AWS metadata endpoint", "https://169.254.169.254/456"],
-    ["localhost", "https://127.0.0.1/456"],
+    ["an arbitrary attacker host", "https://pubkey@evil.com/456"],
+    ["the AWS metadata endpoint", "https://pubkey@169.254.169.254/456"],
+    ["localhost", "https://pubkey@127.0.0.1/456"],
     [
       "a host that merely ends with ours",
-      "https://evilo123.ingest.sentry.io/456",
+      "https://pubkey@evilo123.ingest.sentry.io/456",
     ],
     [
       "a host that merely contains ours",
-      "https://o123.ingest.sentry.io.evil.com/456",
+      "https://pubkey@o123.ingest.sentry.io.evil.com/456",
     ],
     [
       "ours smuggled into userinfo",
@@ -118,7 +133,7 @@ describe("envelopeDsnMatches", () => {
     ],
     [
       "ours smuggled into the path",
-      "https://evil.com/o123.ingest.sentry.io/456",
+      "https://pubkey@evil.com/o123.ingest.sentry.io/456",
     ],
   ])("rejects %s", (_label, dsn) => {
     expect(envelopeDsnMatches(dsn, TARGET)).toBe(false);

--- a/apps/webapp/app/utils/sentry-tunnel.server.test.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Sentry tunnel destination pinning.
+ *
+ * The tunnel used to build its upstream URL from the DSN in the CLIENT's
+ * envelope, which made the destination host fully attacker-controlled — a
+ * full-read SSRF (detail.dev finding D071). These tests pin the replacement
+ * contract: the envelope's DSN is only ever COMPARED against the server's own
+ * configuration, never used to build a URL.
+ *
+ * @see {@link file://./sentry-tunnel.server.ts}
+ * @see {@link file://./../routes/api+/sentry-tunnel.ts}
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { envelopeDsnMatches, parseSentryDsn } from "./sentry-tunnel.server";
+
+// @vitest-environment node
+
+const TARGET = { host: "o123.ingest.sentry.io", projectId: "456" };
+
+describe("parseSentryDsn", () => {
+  it("pulls the ingest host and project id out of a real DSN", () => {
+    expect(parseSentryDsn("https://pubkey@o123.ingest.sentry.io/456")).toEqual(
+      TARGET
+    );
+  });
+
+  it("takes the LAST path segment as the project id", () => {
+    // A self-hosted Sentry can live under a path prefix. The old code used
+    // `pathname.replace("/", "")`, which strips only the FIRST slash and would
+    // have produced "some/path/456".
+    expect(
+      parseSentryDsn("https://pubkey@sentry.example.com/some/path/456")
+    ).toEqual({ host: "sentry.example.com", projectId: "456" });
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["empty (Sentry not configured)", ""],
+    ["not a URL", "not-a-dsn"],
+    ["no project id", "https://pubkey@o123.ingest.sentry.io/"],
+    ["a non-http scheme", "file:///etc/passwd"],
+    ["a javascript: URL", "javascript:alert(1)"],
+  ])("returns null for %s", (_label, input) => {
+    expect(parseSentryDsn(input)).toBeNull();
+  });
+});
+
+describe("envelopeDsnMatches", () => {
+  it("accepts the envelope the real SDK sends", () => {
+    expect(
+      envelopeDsnMatches("https://pubkey@o123.ingest.sentry.io/456", TARGET)
+    ).toBe(true);
+  });
+
+  it("ignores the public key, which rotates and is not a security boundary", () => {
+    expect(
+      envelopeDsnMatches("https://different@o123.ingest.sentry.io/456", TARGET)
+    ).toBe(true);
+  });
+
+  it("is case-insensitive on the host, as DNS is", () => {
+    expect(
+      envelopeDsnMatches("https://pubkey@O123.INGEST.SENTRY.IO/456", TARGET)
+    ).toBe(true);
+  });
+
+  it("rejects a different project on the same host", () => {
+    // Otherwise the tunnel is a free relay into any Sentry org.
+    expect(
+      envelopeDsnMatches("https://pubkey@o123.ingest.sentry.io/999", TARGET)
+    ).toBe(false);
+  });
+
+  it.each([
+    ["an arbitrary attacker host", "https://evil.com/456"],
+    ["the AWS metadata endpoint", "https://169.254.169.254/456"],
+    ["localhost", "https://127.0.0.1/456"],
+    [
+      "a host that merely ends with ours",
+      "https://evilo123.ingest.sentry.io/456",
+    ],
+    [
+      "a host that merely contains ours",
+      "https://o123.ingest.sentry.io.evil.com/456",
+    ],
+    [
+      "ours smuggled into userinfo",
+      "https://o123.ingest.sentry.io@evil.com/456",
+    ],
+    [
+      "ours smuggled into the path",
+      "https://evil.com/o123.ingest.sentry.io/456",
+    ],
+  ])("rejects %s", (_label, dsn) => {
+    expect(envelopeDsnMatches(dsn, TARGET)).toBe(false);
+  });
+
+  it("rejects garbage rather than throwing", () => {
+    expect(envelopeDsnMatches("", TARGET)).toBe(false);
+    expect(envelopeDsnMatches("not-a-dsn", TARGET)).toBe(false);
+  });
+});

--- a/apps/webapp/app/utils/sentry-tunnel.server.test.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.test.ts
@@ -13,26 +13,49 @@
 
 import { describe, expect, it } from "vitest";
 
-import { envelopeDsnMatches, parseSentryDsn } from "./sentry-tunnel.server";
+import {
+  buildSentryEnvelopeUrl,
+  envelopeDsnMatches,
+  parseSentryDsn,
+} from "./sentry-tunnel.server";
 
 // @vitest-environment node
 
-const TARGET = { host: "o123.ingest.sentry.io", projectId: "456" };
+const TARGET = {
+  origin: "https://o123.ingest.sentry.io",
+  pathPrefix: "",
+  projectId: "456",
+};
 
 describe("parseSentryDsn", () => {
-  it("pulls the ingest host and project id out of a real DSN", () => {
+  it("pulls the ingest origin and project id out of a real DSN", () => {
     expect(parseSentryDsn("https://pubkey@o123.ingest.sentry.io/456")).toEqual(
       TARGET
     );
   });
 
-  it("takes the LAST path segment as the project id", () => {
-    // A self-hosted Sentry can live under a path prefix. The old code used
-    // `pathname.replace("/", "")`, which strips only the FIRST slash and would
-    // have produced "some/path/456".
+  it("keeps the base path a self-hosted instance is mounted under", () => {
+    // The old code used `pathname.replace("/", "")`, which strips only the
+    // FIRST slash and produced "some/path/456" as the project id. Taking the
+    // last segment fixes that, but the prefix still has to be KEPT — the
+    // ingest endpoint lives under it.
     expect(
       parseSentryDsn("https://pubkey@sentry.example.com/some/path/456")
-    ).toEqual({ host: "sentry.example.com", projectId: "456" });
+    ).toEqual({
+      origin: "https://sentry.example.com",
+      pathPrefix: "/some/path",
+      projectId: "456",
+    });
+  });
+
+  it("keeps a non-default port, which `hostname` would drop", () => {
+    expect(
+      parseSentryDsn("https://pubkey@sentry.example.com:8443/456")
+    ).toEqual({
+      origin: "https://sentry.example.com:8443",
+      pathPrefix: "",
+      projectId: "456",
+    });
   });
 
   it.each([
@@ -104,5 +127,30 @@ describe("envelopeDsnMatches", () => {
   it("rejects garbage rather than throwing", () => {
     expect(envelopeDsnMatches("", TARGET)).toBe(false);
     expect(envelopeDsnMatches("not-a-dsn", TARGET)).toBe(false);
+  });
+});
+
+describe("buildSentryEnvelopeUrl", () => {
+  it("builds the endpoint for a root-mounted instance", () => {
+    expect(buildSentryEnvelopeUrl(TARGET)).toBe(
+      "https://o123.ingest.sentry.io/api/456/envelope/"
+    );
+  });
+
+  it("builds the endpoint for a prefixed instance on a non-default port", () => {
+    // Both halves were previously lost: `hostname` dropped :8443, and the
+    // prefix was discarded — forwarding to a URL that does not exist there.
+    const target = parseSentryDsn(
+      "https://pubkey@sentry.example.com:8443/sentry/456"
+    );
+
+    expect(target).not.toBeNull();
+    expect(buildSentryEnvelopeUrl(target!)).toBe(
+      "https://sentry.example.com:8443/sentry/api/456/envelope/"
+    );
+  });
+
+  it("always emits https, because the parser refuses anything else", () => {
+    expect(buildSentryEnvelopeUrl(TARGET).startsWith("https://")).toBe(true);
   });
 });

--- a/apps/webapp/app/utils/sentry-tunnel.server.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.ts
@@ -1,0 +1,139 @@
+/**
+ * Sentry tunnel destination pinning.
+ *
+ * The tunnel (`/api/sentry-tunnel`) exists so error envelopes reach Sentry
+ * through our own domain instead of being blocked by ad-blockers. It is a
+ * server-side proxy, so the question of WHERE it forwards to is a security
+ * boundary, not a detail.
+ *
+ * It originally read the destination host out of the DSN in the client's own
+ * envelope. That made the host fully attacker-controlled: any authenticated
+ * user could make the server POST to an arbitrary address and read the
+ * response back — a full-read SSRF, and one that reached internal-only hosts
+ * (cloud metadata, RFC1918, localhost) via a redirect from an attacker-owned
+ * public host.
+ *
+ * The fix is to stop deriving the destination from input at all. The server
+ * already knows the only Sentry project it may talk to — its own `SENTRY_DSN`.
+ * So the envelope's DSN is now only ever COMPARED against that; the URL the
+ * tunnel fetches is built entirely from server-side configuration.
+ *
+ * This is deliberately stricter than {@link file://./ssrf.server.ts}'s
+ * `safeFetch`, which blocks private/reserved addresses but still permits any
+ * globally-routable host. That is the right boundary for user-supplied image
+ * URLs, where arbitrary public hosts are the feature. Here they are not: the
+ * tunnel has exactly one legitimate destination, so an allow-list of one is
+ * both safer and simpler than filtering the internet.
+ *
+ * @see {@link file://./../routes/api+/sentry-tunnel.ts} — the only consumer
+ * @see {@link file://./ssrf.server.ts} — the general-purpose SSRF guard
+ */
+
+import { SENTRY_DSN } from "~/utils/env";
+
+/** The ingest destination a Sentry DSN points at. */
+export type SentryIngestTarget = {
+  /** Ingest hostname, lower-cased by the URL parser. */
+  host: string;
+  /** Numeric Sentry project id (the DSN's final path segment). */
+  projectId: string;
+};
+
+/**
+ * Parses a Sentry DSN (`https://<publicKey>@<host>/<projectId>`) into the
+ * pieces that identify its ingest endpoint.
+ *
+ * The public key is deliberately ignored: it is not a secret (it ships in the
+ * client bundle), it rotates, and it is not what we are authorizing on. Host
+ * and project id are what decide where bytes go.
+ *
+ * Fails closed — anything unparseable, non-http(s), or missing a project id
+ * returns `null` rather than a partially-trusted result.
+ *
+ * @param dsn - A Sentry DSN, or nullish when Sentry is not configured
+ * @returns The ingest target, or `null` if the DSN is absent or unusable
+ */
+export function parseSentryDsn(
+  dsn: string | undefined | null
+): SentryIngestTarget | null {
+  if (!dsn) {
+    return null;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(dsn);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return null;
+  }
+
+  // The project id is the LAST path segment. Self-hosted Sentry can sit under
+  // a path prefix, and the previous `pathname.replace("/", "")` stripped only
+  // the first slash — which would have yielded "some/path/456".
+  const projectId = url.pathname.split("/").filter(Boolean).pop() ?? "";
+
+  if (!url.hostname || !projectId) {
+    return null;
+  }
+
+  return { host: url.hostname, projectId };
+}
+
+/**
+ * The single destination the tunnel is permitted to forward to, derived from
+ * the server's own `SENTRY_DSN`.
+ *
+ * `SENTRY_DSN` is optional (self-hosters may run without Sentry), so this
+ * returns `null` when the tunnel has no legitimate destination at all — in
+ * which case the route refuses to proxy anything rather than falling back to
+ * whatever the client asked for.
+ *
+ * @returns The configured ingest target, or `null` if Sentry is not configured
+ */
+export function getConfiguredSentryTarget(): SentryIngestTarget | null {
+  return parseSentryDsn(SENTRY_DSN);
+}
+
+/**
+ * Whether an envelope's DSN addresses exactly the configured Sentry project.
+ *
+ * Compares parsed URL components, never substrings. Substring matching on a
+ * host is trivially bypassed from both ends — `evil-o123.ingest.sentry.io`
+ * ends with ours, `o123.ingest.sentry.io.evil.com` contains it, and
+ * `https://o123.ingest.sentry.io@evil.com/` hides ours in the userinfo where a
+ * naive check reads it as the host.
+ *
+ * @param dsn - The DSN taken from the client's envelope header (untrusted)
+ * @param target - The server's configured ingest target
+ * @returns `true` only if both host and project id match exactly
+ */
+export function envelopeDsnMatches(
+  dsn: string,
+  target: SentryIngestTarget
+): boolean {
+  const parsed = parseSentryDsn(dsn);
+
+  return (
+    parsed !== null &&
+    parsed.host === target.host &&
+    parsed.projectId === target.projectId
+  );
+}
+
+/**
+ * Builds the ingest URL for a target.
+ *
+ * Takes a {@link SentryIngestTarget} rather than a string precisely so a raw,
+ * client-supplied DSN cannot be passed here by mistake — the only way to get
+ * one is through {@link getConfiguredSentryTarget}.
+ *
+ * @param target - The configured ingest target
+ * @returns The absolute envelope endpoint URL
+ */
+export function buildSentryEnvelopeUrl(target: SentryIngestTarget): string {
+  return `https://${target.host}/api/${target.projectId}/envelope/`;
+}

--- a/apps/webapp/app/utils/sentry-tunnel.server.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.ts
@@ -31,7 +31,15 @@
 
 import { SENTRY_DSN } from "~/utils/env";
 
-/** The ingest destination a Sentry DSN points at. */
+/**
+ * A validated Sentry ingest destination.
+ *
+ * Only ever produced by {@link parseSentryDsn}, which is what lets
+ * {@link buildSentryEnvelopeUrl} trust the scheme: a value of this type has
+ * already been proven to be an https DSN. Holding it as a type rather than a
+ * raw string is deliberate — it means a client-supplied DSN cannot reach URL
+ * construction by mistake.
+ */
 export type SentryIngestTarget = {
   /**
    * Scheme + host + port, normalised by the URL parser (`https://host:8443`).
@@ -97,7 +105,14 @@ export function parseSentryDsn(
   const projectId = segments.pop() ?? "";
   const pathPrefix = segments.length > 0 ? `/${segments.join("/")}` : "";
 
-  if (!url.hostname || !projectId) {
+  // The public key is mandatory per the DSN spec, so its absence means the
+  // string is not a DSN at all. We still do not COMPARE it (see below) — this
+  // only stops a malformed value being treated as a usable destination.
+  //
+  // The project id is deliberately NOT required to be numeric: Sentry's own
+  // SDK spec calls it a string identifier that is merely "usually an integer",
+  // and it never reaches URL construction from client input anyway.
+  if (!url.username || !url.hostname || !projectId) {
     return null;
   }
 

--- a/apps/webapp/app/utils/sentry-tunnel.server.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.ts
@@ -33,8 +33,20 @@ import { SENTRY_DSN } from "~/utils/env";
 
 /** The ingest destination a Sentry DSN points at. */
 export type SentryIngestTarget = {
-  /** Ingest hostname, lower-cased by the URL parser. */
-  host: string;
+  /**
+   * Scheme + host + port, normalised by the URL parser (`https://host:8443`).
+   *
+   * `origin` rather than `hostname` because a self-hosted Sentry can run on a
+   * non-default port, and `hostname` silently drops it. It also strips
+   * userinfo, so `https://ours@evil.com/` yields `https://evil.com` and cannot
+   * masquerade as us.
+   */
+  origin: string;
+  /**
+   * Base path a self-hosted Sentry is mounted under, without a trailing slash
+   * (`/sentry`), or `""` for a root-mounted instance such as sentry.io.
+   */
+  pathPrefix: string;
   /** Numeric Sentry project id (the DSN's final path segment). */
   projectId: string;
 };
@@ -76,16 +88,20 @@ export function parseSentryDsn(
     return null;
   }
 
-  // The project id is the LAST path segment. Self-hosted Sentry can sit under
-  // a path prefix, and the previous `pathname.replace("/", "")` stripped only
-  // the first slash — which would have yielded "some/path/456".
-  const projectId = url.pathname.split("/").filter(Boolean).pop() ?? "";
+  // The project id is the LAST path segment; anything before it is the base
+  // path a self-hosted instance is mounted under. Both have to be kept: the
+  // ingest endpoint is `<origin><prefix>/api/<projectId>/envelope/`, so
+  // dropping the prefix (or the port, via `hostname`) forwards to a URL that
+  // does not exist on that deployment.
+  const segments = url.pathname.split("/").filter(Boolean);
+  const projectId = segments.pop() ?? "";
+  const pathPrefix = segments.length > 0 ? `/${segments.join("/")}` : "";
 
   if (!url.hostname || !projectId) {
     return null;
   }
 
-  return { host: url.hostname, projectId };
+  return { origin: url.origin, pathPrefix, projectId };
 }
 
 /**
@@ -106,8 +122,8 @@ export function getConfiguredSentryTarget(): SentryIngestTarget | null {
 /**
  * Whether an envelope's DSN addresses exactly the configured Sentry project.
  *
- * Compares parsed URL components, never substrings. Substring matching on a
- * host is trivially bypassed from both ends — `evil-o123.ingest.sentry.io`
+ * Compares parsed URL components (origin, base path, project id), never
+ * substrings. Substring matching on a host is trivially bypassed from both ends — `evil-o123.ingest.sentry.io`
  * ends with ours, `o123.ingest.sentry.io.evil.com` contains it, and
  * `https://o123.ingest.sentry.io@evil.com/` hides ours in the userinfo where a
  * naive check reads it as the host.
@@ -124,7 +140,8 @@ export function envelopeDsnMatches(
 
   return (
     parsed !== null &&
-    parsed.host === target.host &&
+    parsed.origin === target.origin &&
+    parsed.pathPrefix === target.pathPrefix &&
     parsed.projectId === target.projectId
   );
 }
@@ -140,5 +157,7 @@ export function envelopeDsnMatches(
  * @returns The absolute envelope endpoint URL
  */
 export function buildSentryEnvelopeUrl(target: SentryIngestTarget): string {
-  return `https://${target.host}/api/${target.projectId}/envelope/`;
+  // The scheme comes from `origin`, which is safe because `parseSentryDsn` is
+  // the only way to obtain a target and it refuses anything but https.
+  return `${target.origin}${target.pathPrefix}/api/${target.projectId}/envelope/`;
 }

--- a/apps/webapp/app/utils/sentry-tunnel.server.ts
+++ b/apps/webapp/app/utils/sentry-tunnel.server.ts
@@ -67,7 +67,12 @@ export function parseSentryDsn(
     return null;
   }
 
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
+  // https only, deliberately. The tunnel has always egressed over https, so an
+  // http DSN never actually worked — accepting one here would only create an
+  // asymmetry with `buildSentryEnvelopeUrl` (which pins https), and the next
+  // editor to derive the scheme from the parsed target would silently
+  // reintroduce plaintext egress.
+  if (url.protocol !== "https:") {
     return null;
   }
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bulk-assign-custody.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bulk-assign-custody.test.ts
@@ -1,5 +1,6 @@
 import { action } from "~/routes/api+/mobile+/bulk-assign-custody";
 import { createActionArgs } from "@mocks/remix";
+import { ALL_SELECTED_KEY } from "~/utils/list";
 
 // @vitest-environment node
 
@@ -132,7 +133,7 @@ describe("POST /api/mobile/bulk-assign-custody", () => {
     // in the organization. SELF_SERVICE holds `asset:custody`, so this is
     // reachable by a restricted role, not just an admin.
     const request = createBulkAssignRequest({
-      assetIds: ["all-selected"],
+      assetIds: [ALL_SELECTED_KEY],
       custodianId: "custodian-1",
     });
 
@@ -149,7 +150,7 @@ describe("POST /api/mobile/bulk-assign-custody", () => {
     // The service checks `ids.includes(ALL_SELECTED_KEY)`, so one sentinel
     // anywhere switches the whole request to select-all.
     const request = createBulkAssignRequest({
-      assetIds: ["asset-1", "all-selected"],
+      assetIds: ["asset-1", ALL_SELECTED_KEY],
       custodianId: "custodian-1",
     });
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bulk-assign-custody.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bulk-assign-custody.test.ts
@@ -138,7 +138,9 @@ describe("POST /api/mobile/bulk-assign-custody", () => {
 
     const result = await action(createActionArgs({ request }));
 
-    expect((result as unknown as Response).status).not.toBe(200);
+    // 400, not 500: an expected client error must not be reported as a server
+    // outage, or it drowns in Sentry alongside real faults.
+    expect((result as unknown as Response).status).toBe(400);
     // The write must never be reached
     expect(bulkCheckOutAssets).not.toHaveBeenCalled();
   });
@@ -153,7 +155,7 @@ describe("POST /api/mobile/bulk-assign-custody", () => {
 
     const result = await action(createActionArgs({ request }));
 
-    expect((result as unknown as Response).status).not.toBe(200);
+    expect((result as unknown as Response).status).toBe(400);
     expect(bulkCheckOutAssets).not.toHaveBeenCalled();
   });
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bulk-assign-custody.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bulk-assign-custody.test.ts
@@ -126,6 +126,37 @@ describe("POST /api/mobile/bulk-assign-custody", () => {
     });
   });
 
+  it("rejects the select-all sentinel instead of expanding it org-wide", async () => {
+    // Mobile has no select-all control and sends no `currentSearchParams`, so
+    // the sentinel would expand against an empty filter — every AVAILABLE asset
+    // in the organization. SELF_SERVICE holds `asset:custody`, so this is
+    // reachable by a restricted role, not just an admin.
+    const request = createBulkAssignRequest({
+      assetIds: ["all-selected"],
+      custodianId: "custodian-1",
+    });
+
+    const result = await action(createActionArgs({ request }));
+
+    expect((result as unknown as Response).status).not.toBe(200);
+    // The write must never be reached
+    expect(bulkCheckOutAssets).not.toHaveBeenCalled();
+  });
+
+  it("rejects the sentinel even when mixed with real ids", async () => {
+    // The service checks `ids.includes(ALL_SELECTED_KEY)`, so one sentinel
+    // anywhere switches the whole request to select-all.
+    const request = createBulkAssignRequest({
+      assetIds: ["asset-1", "all-selected"],
+      custodianId: "custodian-1",
+    });
+
+    const result = await action(createActionArgs({ request }));
+
+    expect((result as unknown as Response).status).not.toBe(200);
+    expect(bulkCheckOutAssets).not.toHaveBeenCalled();
+  });
+
   it("should bulk assign custody successfully", async () => {
     const request = createBulkAssignRequest({
       assetIds: ["asset-1", "asset-2"],

--- a/apps/webapp/test/routes-tests/api+/mobile.custody.assign.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.custody.assign.test.ts
@@ -162,4 +162,41 @@ describe("POST /api/mobile/custody/assign", () => {
     const body = await (result as unknown as Response).json();
     expect(body.error.message).toContain("Permission denied");
   });
+
+  /**
+   * The SCALAR field is the one that looks safe and is not. The route wraps it
+   * as `assetIds: [assetId]`, and `["all-selected"]` satisfies
+   * `bulkCheckOutAssets`'s `includes(ALL_SELECTED_KEY)` check exactly as a
+   * longer list does. Mobile hardcodes `currentSearchParams: ""`, so it expands
+   * against an EMPTY filter — every available asset in the organization.
+   *
+   * SELF_SERVICE holds `asset:custody`, so a restricted role can reach it.
+   *
+   * The bulk siblings were fixed first; this one was missed because a single-id
+   * field does not read as a bulk operation.
+   */
+  it("rejects the select-all sentinel in the scalar assetId field", async () => {
+    const request = createCustodyAssignRequest({
+      assetId: "all-selected",
+      custodianId: "custodian-1",
+    });
+
+    const result = await action(createActionArgs({ request }));
+
+    expect((result as unknown as Response).status).toBe(400);
+    // The assertion that matters: the org-wide write is never reached.
+    expect(bulkCheckOutAssets).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty assetId", async () => {
+    const request = createCustodyAssignRequest({
+      assetId: "",
+      custodianId: "custodian-1",
+    });
+
+    const result = await action(createActionArgs({ request }));
+
+    expect((result as unknown as Response).status).toBe(400);
+    expect(bulkCheckOutAssets).not.toHaveBeenCalled();
+  });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile.custody.assign.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.custody.assign.test.ts
@@ -1,5 +1,6 @@
 import { action } from "~/routes/api+/mobile+/custody.assign";
 import { createActionArgs } from "@mocks/remix";
+import { ALL_SELECTED_KEY } from "~/utils/list";
 
 // @vitest-environment node
 
@@ -177,7 +178,7 @@ describe("POST /api/mobile/custody/assign", () => {
    */
   it("rejects the select-all sentinel in the scalar assetId field", async () => {
     const request = createCustodyAssignRequest({
-      assetId: "all-selected",
+      assetId: ALL_SELECTED_KEY,
       custodianId: "custodian-1",
     });
 

--- a/apps/webapp/test/routes-tests/api+/sentry-tunnel.test.ts
+++ b/apps/webapp/test/routes-tests/api+/sentry-tunnel.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Sentry tunnel route — SSRF regression coverage.
+ *
+ * The tunnel built its upstream URL from the DSN inside the client's own
+ * envelope, so the destination host was fully attacker-controlled and the
+ * upstream body was handed straight back: a full-read SSRF (detail.dev
+ * finding D071).
+ *
+ * The exploit chain needed only a public host the attacker controls — it
+ * answered the request with a redirect to `http://169.254.169.254/...` and
+ * `fetch` chased it, because the route set no `redirect` option. Verified
+ * against real sockets before writing the fix: the redirect was followed to a
+ * different host and the internal body came back to the caller.
+ *
+ * These tests assert on the URL actually passed to `fetch`, because that is
+ * the sink. A test that only checked the response status would pass even if
+ * the request still went to the attacker's host.
+ *
+ * @see {@link file://./../../../app/routes/api+/sentry-tunnel.ts}
+ * @see {@link file://./../../../app/utils/sentry-tunnel.server.ts}
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: the route reads the deployment's own DSN from the env module, which
+// reads `process.env` at import time. Pinning it here is what makes "the
+// configured project" a fixed, assertable value.
+vi.mock("~/utils/env", () => ({
+  SENTRY_DSN: "https://pubkey@o123.ingest.sentry.io/456",
+}));
+
+import { action } from "~/routes/api+/sentry-tunnel";
+
+// @vitest-environment node
+
+const CONFIGURED_URL = "https://o123.ingest.sentry.io/api/456/envelope/";
+
+/** Builds a Sentry envelope whose header declares `dsn`. */
+function envelope(dsn: string) {
+  return `${JSON.stringify({
+    dsn,
+    sent_at: "2026-01-01T00:00:00.000Z",
+  })}\n{"type":"event"}\n{}`;
+}
+
+/** Invokes the route action with a raw envelope body. */
+function post(body: string) {
+  return action({
+    request: new Request("https://app.shelf.nu/api/sentry-tunnel", {
+      method: "POST",
+      body,
+    }),
+    params: {},
+    context: {},
+  } as unknown as Parameters<typeof action>[0]);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue(
+    new Response('{"id":"abc"}', {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("sentry-tunnel action", () => {
+  it("forwards a genuine envelope to the configured project", () => {
+    return post(envelope("https://pubkey@o123.ingest.sentry.io/456")).then(
+      async (response) => {
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toBe(CONFIGURED_URL);
+        expect(response.status).toBe(200);
+      }
+    );
+  });
+
+  it("never follows redirects", () => {
+    // Redirect-following was half the exploit: a public host the attacker
+    // controls answers with a 302 to an internal address.
+    return post(envelope("https://pubkey@o123.ingest.sentry.io/456")).then(
+      () => {
+        expect(fetchMock.mock.calls[0][1]).toMatchObject({
+          redirect: "manual",
+        });
+      }
+    );
+  });
+
+  it.each([
+    ["an attacker-controlled host", "https://pubkey@evil.com/456"],
+    ["the AWS metadata endpoint", "https://pubkey@169.254.169.254/456"],
+    ["localhost", "https://pubkey@127.0.0.1/456"],
+    ["a suffix look-alike", "https://pubkey@evil-o123.ingest.sentry.io/456"],
+    [
+      "a subdomain look-alike",
+      "https://pubkey@o123.ingest.sentry.io.evil.com/456",
+    ],
+    [
+      "our host hidden in userinfo",
+      "https://o123.ingest.sentry.io@evil.com/456",
+    ],
+  ])("refuses %s without making any request", (_label, dsn) => {
+    return post(envelope(dsn)).then((response) => {
+      expect(response.status).toBe(403);
+      // The assertion that matters: the sink was never reached.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("refuses a different Sentry project on our own host", () => {
+    return post(envelope("https://pubkey@o123.ingest.sentry.io/999")).then(
+      (response) => {
+        expect(response.status).toBe(403);
+        expect(fetchMock).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  it("does not echo the rejected DSN back to the caller", () => {
+    return post(envelope("https://pubkey@evil.com/456")).then(
+      async (response) => {
+        expect(await response.text()).not.toContain("evil.com");
+      }
+    );
+  });
+
+  it("rejects an envelope with no DSN", () => {
+    return post(envelope("")).then((response) => {
+      expect(response.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects a malformed envelope header", () => {
+    return post("not json\n{}").then((response) => {
+      expect(response.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Two unrelated broken-access-control fixes from the detail.dev OSS scan, bundled
at the author's request so they land in one review cycle. They share no code —
read them as two PRs in one.

| | Finding | Reachable by |
| --- | --- | --- |
| 1 | Mobile endpoints expand the `all-selected` sentinel org-wide | **SELF_SERVICE** |
| 2 | Sentry tunnel is a full-read SSRF | any authenticated user |

---

# 1 — Mobile select-all expansion (D130)

A **SELF_SERVICE** user could take custody of **every available asset in the
workspace** in a single mobile API call — and the same for kits.

Found by the detail.dev OSS scan (finding D130). Fourth of the select-all
cluster, after #2867 (tags), #2869 (locations) and #2872 (bookings).

## The bug

The web list can send an `all-selected` sentinel instead of ids, meaning
"everything matching the filters I'm looking at". That contract works because
the web client *also* submits `currentSearchParams`, so the server rebuilds the
same filtered set.

Mobile has no select-all control and sends no filters — it hardcodes an empty
value:

```ts
assetIds: z.array(z.string().min(1)).min(1),   // accepts "all-selected"
…
currentSearchParams: "",                        // nothing to narrow by
```

So a sentinel reaching a mobile bulk endpoint expanded against an **empty
filter** — every matching row in the organization.

**Who can reach it:** `bulk-assign-custody` and `bulk-release-custody` require
`asset:custody`; the kit intents require `kit:custody`. **SELF_SERVICE holds
both.** So this is a restricted role acting workspace-wide, not an admin doing
something merely unbounded.

`bulk-update-location` needs `asset:update`, which restricted roles don't hold —
unbounded, but ADMIN/OWNER only.

## Scope: the finding named one endpoint, there were seven sites

| Endpoint | Sites | Reachable by |
| --- | --- | --- |
| `bulk-assign-custody` | 1 | SELF_SERVICE |
| `bulk-release-custody` | 1 | SELF_SERVICE |
| `bulk-update-location` | 1 | ADMIN / OWNER |
| `kits.bulk-actions` | 3 (assign / release / update-location) | SELF_SERVICE (custody intents) |
| `custody.assign` | 1 — **scalar** `assetId`, wrapped as `assetIds: [assetId]` | SELF_SERVICE |

The scalar one is the trap: `["all-selected"]` satisfies
`includes(ALL_SELECTED_KEY)` exactly as a longer list does, so a *single-asset*
endpoint expands org-wide just as readily as a bulk one. It was found by
parameter.ai on this PR after the first six were fixed — a single-id field
simply does not read as a bulk operation. `mobileIdSchema` now guards that
shape beside `mobileBulkIdsSchema`.

I then swept every route funnelling an id into any of the 21 functions that
read `ALL_SELECTED_KEY`. This was the last one: `custody.release` and the
`-quantity` variants call singular services, and the remaining
`assetIds: [id]` call sites go to `createNotes` / `getBookings`, neither
sentinel-aware.

## The fix

Reject the sentinel at the schema rather than teaching each service to cope.
A mobile client has no way to produce it legitimately — its presence means a
hand-crafted request.

```ts
assetIds: mobileBulkIdsSchema("assetIds"),
```

One shared helper covers all six sites, so a new mobile bulk endpoint can't
reintroduce this by copying a neighbour.

### Why reject rather than support

Making mobile *support* select-all would mean forwarding real filters from the
client and trusting them — a much larger surface, for a feature the mobile UI
doesn't offer. Refusing is the smaller and more honest change.

## Notes from verifying

The kit endpoints already carried comments acknowledging that mobile sends no
filters, and that the resolved set is therefore "every kit in the organization".
The release path had also gained an ownership guard from the earlier
`2f20bbd85` fix. So the shape was known — what was missing is that the sentinel
should never have been accepted in the first place, which closes it for the
`assign` intent too, where no ownership guard applies.

## Not a breaking change for the companion app

The obvious risk in rejecting an input is breaking a client that legitimately
sends it. Checked before and after writing the fix:

- **No occurrence of `all-selected` or `ALL_SELECTED` anywhere in
  `apps/companion/`.**
- **No select-all control** in the companion UI.
- Its API wrappers (`lib/api/custody.ts`, `lib/api/kits.ts`) take explicit
  `assetIds: string[]` / `kitIds: string[]` built from scanner selections.

So the sentinel cannot arise from the shipped app — only from a hand-crafted
request, which is exactly what this refuses. No companion release is needed.

## Tests

- `app/modules/api/mobile-bulk-ids.server.test.ts` (7) — sentinel alone, sentinel
  mixed with real ids, empty list, the message naming its field, and that an id
  merely *containing* the string is still accepted.
- `mobile.bulk-assign-custody.test.ts` (+2) — end-to-end: a crafted select-all
  request is refused and `bulkCheckOutAssets` is never called.
- `mobile.custody.assign.test.ts` (+2) — the same, for the scalar field. Added
  to the existing suite; its two prior tests still pass unchanged.

**Both route tests were confirmed to return `200` and reach the write** with the
guard removed.

11 existing mobile bulk route tests still pass.


---

# 2 — Sentry tunnel SSRF (D071)

`/api/sentry-tunnel` built its upstream URL from the DSN inside the **client's
own envelope**, so the destination host was fully attacker-controlled, and it
returned the upstream response body to the caller. That is a **full-read SSRF**.

Found by the detail.dev OSS scan (finding D071).

### The bug

```ts
const dsn = JSON.parse(header).dsn as string;   // from the request body
const url = new URL(dsn);
const sentryUrl = `https://${url.hostname}/api/${projectId}/envelope/`;

const sentryResponse = await fetch(sentryUrl, { method: "POST", … });
return new Response(sentryResponse.body, { status: sentryResponse.status, … });
```

### The hardcoded `https://` is not a defense

It only constrains the *first* hop, and the route set no `redirect` option, so
`fetch` follows redirects by default:

1. Attacker points the DSN at a public host they control.
2. That host answers with `302 → http://169.254.169.254/latest/meta-data/…`.
3. `fetch` chases it — cross-protocol, into link-local space.
4. The body comes back through the tunnel to the attacker.

**I verified this against real sockets** before writing the fix, rather than
taking the report's word for it:

```
redirect followed to a DIFFERENT host:port : true
status returned to caller                  : 200
BODY returned to caller                    : "INTERNAL-SECRET-CREDENTIALS"
=> full-read SSRF: CONFIRMED
```

**Who can reach it:** any authenticated user — the route is behind the session
middleware but has no further gate. See the D053 note at the bottom.

### The fix

Stop deriving the destination from input at all.

The server already knows the only Sentry project it may talk to — its own
`SENTRY_DSN`. So the envelope's DSN is now only **compared** against that, and
the URL we fetch is built entirely from server-side config:

```ts
const target = getConfiguredSentryTarget();          // from SENTRY_DSN
if (!target) return 404;                             // nothing legitimate to proxy to
if (!envelopeDsnMatches(dsn, target)) return 403;    // compared, never interpolated
await fetch(buildSentryEnvelopeUrl(target), { …, redirect: "manual" });
```

Fails closed throughout: an unparseable DSN yields `null`, and an unset
`SENTRY_DSN` refuses to proxy rather than falling back to the envelope's value —
that fallback *is* the bug.

### Why not `safeFetch`?

The repo already has an SSRF guard (`~/utils/ssrf.server`, from
GHSA-xgrm-8w6v-mvjg). It is the wrong tool here on both counts:

- It is **GET-only** and returns a buffer — shaped for image downloads, not an
  envelope POST.
- More importantly it blocks private/reserved addresses but still permits **any
  globally-routable host**. That is the right boundary for user-supplied image
  URLs, where arbitrary public hosts are the feature. Here they are not — leaving
  it as an open relay that POSTs attacker bytes from our IP.

One legitimate destination means an allow-list of one beats filtering the
internet. `redirect: "manual"` then closes the redirect leg as defense in depth.

### Comparison is on parsed components, never substrings

Host matching by `startsWith`/`endsWith`/`includes` is bypassable from both
ends, so the check compares `URL` components. Covered by tests:

| Attack | Why a naive check fails |
| --- | --- |
| `evil-o123.ingest.sentry.io` | ends with ours |
| `o123.ingest.sentry.io.evil.com` | contains ours |
| `https://o123.ingest.sentry.io@evil.com/` | ours is **userinfo**; the host is `evil.com` |
| same host, project `999` | a free relay into any other Sentry org |

### Self-hosted deployments

The destination is now the full `origin` (scheme + host + **port**) plus the
base path the instance is mounted under. An earlier revision of this PR stored
`hostname` and the last path segment only, which was still wrong for a
self-hosted Sentry: `https://key@sentry.example.com:8443/sentry/456` would have
forwarded to `https://sentry.example.com/api/456/envelope/`.

To be precise about what is and isn't a regression — the port was dropped by
the pre-fix code too (it also read `hostname`), and the prefix was mishandled
differently there (`pathname.replace("/", "")` strips only the *first* slash,
so it produced `/api/sentry/456/envelope/`). Neither version produced the right
URL; this one does. Shelf Cloud is root-mounted on the default port, so this
never surfaced in production.

Caught by CodeRabbit — thanks.

### Sweep

Per the house rule that this class travels in packs, I grepped for other
server-side `fetch` calls with an interpolated host. **This was the only one** —
the CSV `imageUrl` path already goes through `safeFetch`.

### Tests

- `app/utils/sentry-tunnel.server.test.ts` (22) — DSN parsing and the
  host/project comparison, including every look-alike above.
- `test/routes-tests/api+/sentry-tunnel.test.ts` (12) — end-to-end.

The route tests assert on **the URL passed to `fetch`**, because that is the
sink. A test that only checked the response status would pass while the request
still went to the attacker's host.

**All 8 security assertions were confirmed to fail against the pre-fix route**
and pass after — verified by restoring the old file, not by assumption.

### Follow-ups (not in this PR)

- **D053** — the tunnel is missing from `publicPaths`, so anonymous client
  errors are 302'd to `/login` and lost. That fix is now safe to make; **doing it
  before this one would have converted an authenticated SSRF into an
  unauthenticated one.**
- Before D053 lands, consider whether an unauthenticated tunnel wants a body-size
  cap. I deliberately left one out here: Sentry envelopes carrying replays or
  large stack traces can be big, and guessing a limit risks silently dropping
  legitimate error reports — a regression that would be invisible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile bulk actions now reject empty IDs and select-all sentinel values with clear HTTP 400 validation errors.
  * Malformed mobile requests are handled safely without exposing generic server errors.
  * Sentry tunnel requests are restricted to the configured HTTPS destination, blocking unauthorized or attacker-controlled endpoints.
  * Missing or mismatched Sentry configuration now returns appropriate client errors.

* **Tests**
  * Added regression coverage for mobile ID validation and Sentry tunnel security, including malformed inputs, alternate destinations, and redirect prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->