### PR TITLE
fix(tooling): stop the security-review debug flag crashing on an empty match

### DIFF
--- a/scripts/security-review-staged.sh
+++ b/scripts/security-review-staged.sh
@@ -271,8 +271,12 @@ done
 
 if [[ "$VERBOSE" == "1" ]]; then
   echo "[shelf-security-reviewer] filter trace:"
-  for f in "${RELEVANT[@]}"; do echo "  ✓ $f"; done
-  for f in "${DROPPED[@]}"; do echo "  · $f"; done
+  # why the `+` guards: macOS ships bash 3.2, where `"${arr[@]}"` on an EMPTY
+  # array is an unbound-variable error under `set -u`. That made the debug flag
+  # abort exactly when it was most useful - when nothing matched the filter and
+  # you wanted to know why.
+  for f in ${RELEVANT[@]+"${RELEVANT[@]}"}; do echo "  ✓ $f"; done
+  for f in ${DROPPED[@]+"${DROPPED[@]}"}; do echo "  · $f"; done
 fi
 
 if [[ "$FORCE" == "1" && ${#RELEVANT[@]} -eq 0 ]]; then


### PR DESCRIPTION
## What

`SHELF_SEC_REVIEW_VERBOSE=1` crashes when no staged file matches the sensitivity filter:

```
[shelf-security-reviewer] filter trace:
./scripts/security-review-staged.sh: line 276: RELEVANT[@]: unbound variable
```

## Why

macOS ships bash 3.2, where expanding `"${arr[@]}"` on an **empty** array is an unbound-variable error under `set -u`. The trace loop runs before the `${#RELEVANT[@]} -eq 0` early return, so it dies first.

The flag therefore fails in exactly the situation you reach for it: you want to know why a file you expected to be reviewed got skipped, and the script exits without telling you.

## Fix

Both trace loops use the `${arr[@]+"${arr[@]}"}` guard, which expands to nothing when the array is unset or empty.

## Verified on bash 3.2

| Case | Before | After |
| --- | --- | --- |
| `VERBOSE=1` with a non-sensitive file | `unbound variable`, aborts | prints `· README.md (denied)`, exits 0 |
| `VERBOSE=1` with a sensitive file | traced correctly | traced correctly (`✓ …/bookings.reserve.ts`) |
| `pnpm test:tooling` | 208 passed | 208 passed |

## How it was found

Running the reviewer by hand over PRs where the pre-commit hook had been skipped. Worth noting separately: the automated reviewer needs an authenticated `claude` CLI, so it cannot run in a non-interactive session at all — it exits with `Invalid API key` and the script correctly treats that as advisory and allows the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where security review checks could terminate unexpectedly in debug mode when no files matched the relevant or dropped file filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->