### PR TITLE
fix(security): accept only the invite the accept-invite page displayed

### DIFF
--- a/apps/webapp/app/routes/_auth+/accept-invite.$inviteId.tsx
+++ b/apps/webapp/app/routes/_auth+/accept-invite.$inviteId.tsx
@@ -98,8 +98,12 @@ export async function loader({ context, params }: LoaderFunctionArgs) {
 
 export const meta = () => [{ title: appendToMetaTitle("Accept team invite") }];
 
-export async function action({ context, request }: LoaderFunctionArgs) {
+export async function action({ context, params, request }: LoaderFunctionArgs) {
   try {
+    const { inviteId } = getParams(params, z.object({ inviteId: z.string() }), {
+      additionalData: { inviteId: params.inviteId },
+    });
+
     const { token } = parseData(
       await request.formData(),
       z.object({ token: z.string() }),
@@ -112,6 +116,34 @@ export async function action({ context, request }: LoaderFunctionArgs) {
     const decodedInvite = jwt.verify(token, INVITE_TOKEN_SECRET) as {
       id: string;
     };
+
+    /**
+     * The loader renders the organization name from the URL's `inviteId`, but
+     * acceptance acts on the invite named by the TOKEN. Nothing tied the two
+     * together, so a crafted link could display one workspace and join another
+     * — and because `updateInviteStatus` performs no session check and the
+     * route then signs the browser in as the accepted invite's `inviteeEmail`,
+     * an unauthenticated victim could land in the ATTACKER's account rather
+     * than merely the wrong organization.
+     *
+     * Requiring the two to agree cannot break a real invite: `inviteUser`
+     * signs `{ id: invite.id }` and both link builders put that same
+     * `invite.id` in the path.
+     */
+    if (decodedInvite.id !== inviteId) {
+      throw new ShelfError({
+        cause: null,
+        title: "Invalid invite token",
+        // Deliberately does not name the invite the token pointed at — the
+        // value is attacker-chosen and echoing it confirms what was rejected.
+        message:
+          "This invitation link is invalid. Please click the link in your email again or request a new invite. If the issue persists, feel free to contact support",
+        additionalData: { inviteId },
+        label: "Invite",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
     const password = generateRandomCode(10);
     // Detect the accepter's prefs from browser hints so their brand-new user
     // row is stamped at creation. timeZone is left null when the CH-time-zone

--- a/apps/webapp/test/routes-tests/_auth+/accept-invite.$inviteId.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/accept-invite.$inviteId.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Accept-invite route — the displayed invite must be the accepted invite.
+ *
+ * The loader renders the organization name from the URL's `inviteId`. The
+ * action used to accept whatever invite the JWT in the form body named, and
+ * nothing tied the two together. So a crafted link could show one workspace
+ * and join another:
+ *
+ *   /accept-invite/<invite-the-victim-trusts>?token=<attacker's own invite>
+ *
+ * `updateInviteStatus` performs no session check — it acts purely on the id it
+ * is given, then the route signs the browser in as that invite's
+ * `inviteeEmail`. So an unauthenticated victim accepting a swapped token lands
+ * in the ATTACKER's account, not merely the wrong organization.
+ *
+ * Every legitimately-generated link signs the same id it puts in the path
+ * (`jwt.sign({ id: invite.id })` alongside `/accept-invite/${invite.id}` in
+ * both `invite-template.tsx` and `helpers.ts`), so requiring equality cannot
+ * break a real invite — pinned by the happy-path test below.
+ *
+ * detail.dev finding D070.
+ *
+ * @see {@link file://./../../../app/routes/_auth+/accept-invite.$inviteId.tsx}
+ */
+
+// why: preventing Prisma from trying to connect to a real database during tests
+vi.mock("~/database/db.server", () => ({ db: {} }));
+
+// why: mocking Remix's data() so the action's error path returns a readable
+// Response rather than an internal payload object
+const createDataMock = vi.hoisted(() => {
+  return () =>
+    vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+});
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+// why: acceptance is the sink under test — assert it is never reached, and
+// never actually mutate an invite
+vi.mock("~/modules/invite/service.server", () => ({
+  updateInviteStatus: vi.fn(),
+  checkUserAndInviteMatch: vi.fn(),
+}));
+
+// why: external auth — no Supabase in tests. Returning null takes the
+// "already registered" branch, which redirects without touching a session.
+vi.mock("~/modules/auth/service.server", () => ({
+  signInWithEmail: vi.fn().mockResolvedValue(null),
+}));
+
+// why: only sets a cookie header on the success path
+vi.mock("~/modules/organization/context.server", () => ({
+  setSelectedOrganizationIdCookie: vi.fn().mockResolvedValue("org-cookie"),
+}));
+
+import { updateInviteStatus } from "~/modules/invite/service.server";
+import { action } from "~/routes/_auth+/accept-invite.$inviteId";
+// The real secret, stubbed by test/setup-test-env.ts — signing with the same
+// value the route verifies with keeps this a test of the id check, not of JWT.
+import { INVITE_TOKEN_SECRET } from "~/utils/env";
+import jwt from "~/utils/jsonwebtoken.server";
+
+// @vitest-environment node
+
+/** Signs a token naming `inviteId`, exactly as `inviteUser` does. */
+function tokenFor(inviteId: string, secret: string = INVITE_TOKEN_SECRET) {
+  return jwt.sign({ id: inviteId }, secret, { expiresIn: "7d" });
+}
+
+/** Invokes the action for `/accept-invite/:inviteId` with a token in the body. */
+function accept({ inviteId, token }: { inviteId: string; token: string }) {
+  return action({
+    request: new Request(`https://app.shelf.nu/accept-invite/${inviteId}`, {
+      method: "POST",
+      body: new URLSearchParams({ token }),
+    }),
+    params: { inviteId },
+    context: {
+      isAuthenticated: false,
+      getSession: () => ({ userId: "user-1" }),
+      setSession: vi.fn(),
+    },
+  } as unknown as Parameters<typeof action>[0]);
+}
+
+describe("accept-invite action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (updateInviteStatus as any).mockResolvedValue({
+      status: "ACCEPTED",
+      organizationId: "org-1",
+      inviteeEmail: "invitee@example.com",
+    });
+  });
+
+  it("refuses a token naming a different invite than the URL", async () => {
+    // The victim sees the organization behind `trusted-invite`; the token
+    // would have joined them to the attacker's.
+    await accept({
+      inviteId: "trusted-invite",
+      token: tokenFor("attacker-invite"),
+    });
+
+    // The assertion that matters: acceptance never happens.
+    expect(updateInviteStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not echo the invite the token named", async () => {
+    const result = await accept({
+      inviteId: "trusted-invite",
+      token: tokenFor("attacker-invite"),
+    });
+
+    expect(await (result as unknown as Response).text()).not.toContain(
+      "attacker-invite"
+    );
+  });
+
+  it("accepts when the token names the invite in the URL", async () => {
+    // Every real link signs the same id it puts in the path, so this is the
+    // shape all genuine invites take.
+    await accept({ inviteId: "real-invite", token: tokenFor("real-invite") });
+
+    expect(updateInviteStatus).toHaveBeenCalledTimes(1);
+    expect((updateInviteStatus as any).mock.calls[0][0]).toMatchObject({
+      id: "real-invite",
+    });
+  });
+
+  it("still rejects a token signed with the wrong secret", async () => {
+    await accept({
+      inviteId: "real-invite",
+      token: tokenFor("real-invite", "not-the-secret"),
+    });
+
+    expect(updateInviteStatus).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

The accept-invite page displayed one organization and could accept an invite to
a different one. Worse, the victim could end up signed in as the **attacker's
user**.

Found by the detail.dev OSS scan (finding D070). First P0 after #2874.

## The bug

The loader renders the workspace name from the URL's `inviteId`. The action
accepted whatever invite the JWT in the form body named. Nothing compared them.

```ts
// loader — what the user SEES
const invite = await db.invite.findFirstOrThrow({ where: { id: inviteId } });  // URL
return payload({ workspace: invite.organization.name });

// action — what actually HAPPENS
const decodedInvite = jwt.verify(token, INVITE_TOKEN_SECRET) as { id: string };
await updateInviteStatus({ id: decodedInvite.id, ... });                       // token
```

So a crafted link:

```
/accept-invite/<invite-the-victim-trusts>?token=<attacker's own invite>
```

renders *"Alice invites you to join BigCorp's workspace"* and joins something
else on click.

### It is not just the wrong organization

`updateInviteStatus` performs **no session check** — it acts purely on the id it
is given. The route then does:

```ts
const authSession = await signInWithEmail(updatedInvite.inviteeEmail, password);
```

with a password it generated moments earlier. An attacker only needs a valid
token for an invite **they** control (invite their own address to their own
workspace), so an unauthenticated victim following the swapped link is signed
in as the attacker's user — and everything they do next happens inside the
attacker's account.

For an **authenticated** victim, the loader's `checkUserAndInviteMatch`
validates the URL's invite against the session. The action then ignored that
invite entirely, so the check was guarding something that was never accepted.

## The fix

Require the token to name the invite the page displayed.

```ts
if (decodedInvite.id !== inviteId) {
  throw new ShelfError({ title: "Invalid invite token", status: 400, ... });
}
```

Placed **after** `jwt.verify` (a forged token never reaches it) and **before**
`updateInviteStatus` and session creation.

The rejection deliberately does not name the invite the token pointed at — that
value is attacker-chosen, and echoing it confirms what was rejected.

## Why this cannot break a real invite

`inviteUser` signs `{ id: invite.id }` and both link builders put that same
`invite.id` in the path, so genuine links always satisfy the check. Pinned by a
happy-path test.

The pre-commit reviewer asked whether a **legacy link shape** might already be
sitting in inboxes and would now be rejected. Checked rather than assumed:

- `git log -L` on both builders shows the URL has been
  `${SERVER_URL}/accept-invite/${invite.id}?token=${token}` since each was first
  written — there has never been a different shape.
- `INVITE_EXPIRY_TTL_DAYS = 5`, so the oldest live link is five days old.

No deliverability impact.

## Sweep

Two complementary passes, both clean:

- **`jwt.verify` appears in exactly one route** in the whole app — this one. The
  bearer-token-vs-URL decoupling has no siblings.
- **No route reads a path param's id back out of the request body.** (My first
  attempt at this grep was too loose and matched `getParams(params, …)`, which
  is the *correct* pattern; the refined query looks only at schemas attached to
  a `formData()`/`json()` read.)

## Tests

`test/routes-tests/_auth+/accept-invite.$inviteId.test.ts` (4):

- a token naming a different invite is refused, and `updateInviteStatus` is
  **never called** — asserting on the sink, not just the status
- the rejection does not echo the token's invite id
- a token naming the URL's invite still accepts (the shape every real link has)
- a token signed with the wrong secret is still rejected, i.e. the new check did
  not displace signature verification

Confirmed failing against the unfixed route before the fix landed.

## Known residual (unchanged by this PR, not a regression)

Invite acceptance is intentionally **pre-auth and bearer-token based**: holding
a validly-signed token is the authorization. This PR does not add an assertion
that a logged-in accepter's session email equals `invite.inviteeEmail` — the
action can still be POSTed directly, bypassing the loader's
`checkUserAndInviteMatch`. That was true before and is the pre-existing model;
flagging it explicitly rather than leaving it implied. Worth a separate look if
we want acceptance to be identity-bound rather than bearer-bound.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation acceptance now verifies that the invitation in the URL matches the invitation token.
  * Mismatched or invalid tokens are rejected without exposing invitation details.
  * Valid matching invitations continue to be accepted successfully.

* **Tests**
  * Added coverage for matching, mismatched, and incorrectly signed invitation tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->