### PR TITLE
fix(audits): share the status colour decision so the apps stop drifting

### DIFF
--- a/.claude/rules/comments-describe-code-not-history.md
+++ b/.claude/rules/comments-describe-code-not-history.md
@@ -1,0 +1,69 @@
+---
+description: Comments and JSDoc must describe what the code is and how to use it — never the bug, PR, or drift that prompted them
+globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
+---
+
+# Comments Describe The Code, Not Its History
+
+Every comment is read by someone who never saw the PR that introduced it —
+usually months later, usually an agent or a colleague with no context at all.
+Write for that reader: **what this thing is, what it is for, and what a caller
+has to know to use it correctly.** In the present tense, as if the code had
+always looked this way.
+
+Do not narrate the fix. "Before this…", "used to…", "and duly drifted", "which
+is the bug this exists to prevent", "was inverted between the apps", "this file
+used to carry a copy", any phase / sprint / PR name — all of it is archaeology.
+It ages instantly, it buries the sentence the reader actually needed, and it is
+already recorded in the commit and the PR description.
+
+**The test:** would this sentence still be worth reading if the bug had never
+happened? If it only makes sense as an account of a fix, cut it.
+
+| Keep — a standing constraint                                        | Cut — an incident report                                   |
+| ------------------------------------------------------------------- | ---------------------------------------------------------- |
+| "Read `completedAt`, never `status`: archiving rewrites the status" | "this used to read `status`, which broke on archive"       |
+| "Both maps must stay visually equivalent — change one, change both" | "the two duplicated maps drifted, so we extracted this"    |
+| "MISSING outranks UNEXPECTED: a missing asset may be stolen"        | "MISSING and UNEXPECTED had opposite colours between apps" |
+
+Rationale is not the enemy — history is. Phrase a reason as a rule the next
+editor must not break, not as something that once went wrong. `// why:` comments
+follow the same standard: they state a standing reason, not a past incident.
+
+```js
+// ❌ Bad — a changelog entry pretending to be documentation
+/**
+ * Tone per audit status.
+ *
+ * This is the same fix already applied to the words above. Those were pulled in
+ * here so the apps "can never show a different one", but the colours were left
+ * duplicated and duly drifted: Pending and Active disagreed too.
+ */
+
+// ✅ Good — what it is, and the constraint on changing it
+/**
+ * Tone for each audit session status.
+ *
+ * Only a running audit (info) and a finished one (success) carry a signal; an
+ * audit nobody has started yet is neutral. Audits that need chasing get a
+ * separate "Overdue" badge, which is what the warning tone is reserved for.
+ */
+```
+
+**Rare exception:** a comment may name a specific past failure when the code
+would otherwise look wrong and be "corrected" back — a deliberate no-op, an
+unusual ordering, a workaround for an upstream bug. Name the trap and why it
+must stay, not the story of finding it (see
+[[resolve-nullish-button-to]] for that shape done well). This is the exception,
+not a licence.
+
+**Fix the docs on code you touch.** When you edit a file and see a JSDoc or
+inline comment that narrates history, restates the code, or describes behaviour
+the code no longer has, rewrite it in the same change. "It was already like
+that" is not a reason to leave it — every pass that ignores it makes the file
+harder for the next reader. Keep the constraint, delete the archaeology, correct
+anything stale.
+
+The history still matters — it just lives in the commit message body, the PR
+description, or a rule in `.claude/rules/` when it is a lesson worth enforcing
+repo-wide. See [[self-improve-rules]].

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,6 +413,13 @@ All code must include inline documentation and JSDoc comments. This applies to e
 - Especially important: when a variable name could be confused (e.g., `userId` referring to different users in different contexts), add a clarifying comment
 - Explain "why" rather than "what" — the code shows what, comments explain why
 
+**Timeless, not historical:**
+
+- Write comments in the present tense, for a reader who never saw the PR that introduced them — describe what the thing is and how to use it, not the bug that prompted it
+- Phrase a reason as a standing constraint ("read `completedAt`, never `status`, because archiving rewrites the status"), never as an incident report ("this used to read `status`, which broke on archive")
+- When you edit a file, rewrite any JSDoc/inline comment there that narrates history or describes behaviour the code no longer has — in the same change
+- 📖 Full rule: [.claude/rules/comments-describe-code-not-history.md](./.claude/rules/comments-describe-code-not-history.md)
+
 **Example:**
 
 ```typescript

--- a/apps/companion/lib/theme-colors.ts
+++ b/apps/companion/lib/theme-colors.ts
@@ -191,8 +191,8 @@ function buildBookingStatusBadge(c: Colors) {
     DRAFT: { bg: c.borderLight, text: c.gray700 },
     RESERVED: { bg: c.inCustodyBg, text: c.inCustody },
     ONGOING: { bg: c.checkedOutBg, text: c.checkedOut },
-    OVERDUE: { bg: c.errorBg, text: c.error },
-    COMPLETE: { bg: c.successBg, text: c.success },
+    OVERDUE: { bg: c.errorBg, text: c.errorText },
+    COMPLETE: { bg: c.successBg, text: c.successText },
     ARCHIVED: { bg: c.borderLight, text: c.muted },
     CANCELLED: { bg: c.borderLight, text: c.muted },
   } as Record<string, { bg: string; text: string }>;

--- a/apps/companion/lib/theme-colors.ts
+++ b/apps/companion/lib/theme-colors.ts
@@ -59,7 +59,14 @@ export const lightColors = {
   // text bar and the 3:1 non-text bar), so small amber labels/icons (e.g.
   // the low-stock indicator) must use this deeper shade instead. Mirrors
   // `primaryText`'s relationship to `primary`. WCAG AA 7.1:1 on white.
-  warningText: "#92400E",
+  warningText: "#92400E", // amber-800 — 6.79:1 on warningBg (AA)
+  // why: `success` (#12B76A) and `error` (#F04438) are 2.49:1 and 3.46:1 on
+  // their own badge backgrounds, both below the 4.5:1 the repo requires. They
+  // stay as-is for icons and bars, where AA does not apply the same way; badge
+  // TEXT uses these darker foregrounds instead. errorText is the same hex the
+  // webapp already uses for red badge text, so the two apps also match visually.
+  successText: "#05603A", // green-800 — 7.26:1 on successBg (AA)
+  errorText: "#B42318", // red-700 — 6.05:1 on errorBg (AA)
   success: "#12B76A",
   successBg: "#ECFDF3",
 
@@ -136,6 +143,10 @@ export const darkColors: Colors = {
   // #161B22), so the text token matches `warning` here — same pattern as
   // dark `primaryText` matching `primary`.
   warningText: "#F0A020",
+  // Dark mode already clears AA on its own backgrounds (6.20:1 and 5.18:1), so
+  // these alias the base colours rather than darkening them further.
+  successText: "#3FB950",
+  errorText: "#F85149",
   success: "#3FB950",
   successBg: "#0D2818",
 
@@ -209,9 +220,9 @@ function buildToneBadge(
   return {
     neutral: { bg: c.borderLight, text: c.muted },
     info: { bg: c.inCustodyBg, text: c.inCustody },
-    success: { bg: c.successBg, text: c.success },
-    warning: { bg: c.warningBg, text: c.warning },
-    danger: { bg: c.errorBg, text: c.error },
+    success: { bg: c.successBg, text: c.successText },
+    warning: { bg: c.warningBg, text: c.warningText },
+    danger: { bg: c.errorBg, text: c.errorText },
   };
 }
 

--- a/apps/companion/lib/theme-colors.ts
+++ b/apps/companion/lib/theme-colors.ts
@@ -5,6 +5,11 @@
  * via the ThemeProvider. Status-badge and shadow maps are also duplicated
  * per theme for convenience.
  */
+import {
+  AUDIT_ASSET_STATUS_TONES,
+  AUDIT_STATUS_TONES,
+  type StatusTone,
+} from "@shelf/labels";
 
 // ────────────────────────────── Light palette ──────────────────────────────
 
@@ -187,22 +192,44 @@ export const darkStatusBadge = buildStatusBadge(darkColors);
 export const lightBookingStatusBadge = buildBookingStatusBadge(lightColors);
 export const darkBookingStatusBadge = buildBookingStatusBadge(darkColors);
 
-function buildAuditStatusBadge(c: Colors) {
+/**
+ * Resolves a shared {@link StatusTone} against this theme's palette.
+ *
+ * The tone-per-status decision lives in `@shelf/labels` next to the words, so
+ * this app and the webapp cannot disagree about which status carries which
+ * weight. Only the colour VALUES are app-owned, because the companion resolves
+ * every tone twice (light and dark) while the webapp has one fixed palette.
+ *
+ * Keep this visually equivalent to the webapp's `toneBadgeColors`
+ * (`apps/webapp/app/utils/status-tone-colors.ts`).
+ */
+function buildToneBadge(
+  c: Colors
+): Record<StatusTone, { bg: string; text: string }> {
   return {
-    PENDING: { bg: c.warningBg, text: c.warning },
-    ACTIVE: { bg: c.inCustodyBg, text: c.inCustody },
-    COMPLETED: { bg: c.successBg, text: c.success },
-    CANCELLED: { bg: c.borderLight, text: c.muted },
-  } as Record<string, { bg: string; text: string }>;
+    neutral: { bg: c.borderLight, text: c.muted },
+    info: { bg: c.inCustodyBg, text: c.inCustody },
+    success: { bg: c.successBg, text: c.success },
+    warning: { bg: c.warningBg, text: c.warning },
+    danger: { bg: c.errorBg, text: c.error },
+  };
+}
+
+function buildAuditStatusBadge(c: Colors) {
+  const tone = buildToneBadge(c);
+  return Object.fromEntries(
+    Object.entries(AUDIT_STATUS_TONES).map(([status, t]) => [status, tone[t]])
+  ) as Record<string, { bg: string; text: string }>;
 }
 
 function buildAuditAssetStatusBadge(c: Colors) {
-  return {
-    PENDING: { bg: c.borderLight, text: c.muted },
-    FOUND: { bg: c.successBg, text: c.success },
-    MISSING: { bg: c.errorBg, text: c.error },
-    UNEXPECTED: { bg: c.warningBg, text: c.warning },
-  } as Record<string, { bg: string; text: string }>;
+  const tone = buildToneBadge(c);
+  return Object.fromEntries(
+    Object.entries(AUDIT_ASSET_STATUS_TONES).map(([status, t]) => [
+      status,
+      tone[t],
+    ])
+  ) as Record<string, { bg: string; text: string }>;
 }
 
 export const lightAuditStatusBadge = buildAuditStatusBadge(lightColors);

--- a/apps/companion/lib/theme-colors.ts
+++ b/apps/companion/lib/theme-colors.ts
@@ -60,11 +60,11 @@ export const lightColors = {
   // the low-stock indicator) must use this deeper shade instead. Mirrors
   // `primaryText`'s relationship to `primary`. WCAG AA 7.1:1 on white.
   warningText: "#92400E", // amber-800 — 6.79:1 on warningBg (AA)
-  // why: `success` (#12B76A) and `error` (#F04438) are 2.49:1 and 3.46:1 on
-  // their own badge backgrounds, both below the 4.5:1 the repo requires. They
-  // stay as-is for icons and bars, where AA does not apply the same way; badge
-  // TEXT uses these darker foregrounds instead. errorText is the same hex the
-  // webapp already uses for red badge text, so the two apps also match visually.
+  // Text-safe foregrounds: use these for any WORDS drawn on `successBg` /
+  // `errorBg`. The `success` and `error` values below are tuned for icons and
+  // bars; as text on those backgrounds they measure 2.49:1 and 3.46:1, under
+  // the 4.5:1 WCAG AA requires. `errorText` is the hex the webapp uses for red
+  // badge text, so both apps also match.
   successText: "#05603A", // green-800 — 7.26:1 on successBg (AA)
   errorText: "#B42318", // red-700 — 6.05:1 on errorBg (AA)
   success: "#12B76A",
@@ -143,8 +143,9 @@ export const darkColors: Colors = {
   // #161B22), so the text token matches `warning` here — same pattern as
   // dark `primaryText` matching `primary`.
   warningText: "#F0A020",
-  // Dark mode already clears AA on its own backgrounds (6.20:1 and 5.18:1), so
-  // these alias the base colours rather than darkening them further.
+  // Dark-mode counterparts of the light palette's text-safe foregrounds. Here
+  // the base colours already clear AA on their own backgrounds (6.20:1 and
+  // 5.18:1), so these alias them rather than darkening them further.
   successText: "#3FB950",
   errorText: "#F85149",
   success: "#3FB950",
@@ -204,15 +205,17 @@ export const lightBookingStatusBadge = buildBookingStatusBadge(lightColors);
 export const darkBookingStatusBadge = buildBookingStatusBadge(darkColors);
 
 /**
- * Resolves a shared {@link StatusTone} against this theme's palette.
+ * Resolves a shared {@link StatusTone} against one theme's palette.
  *
  * The tone-per-status decision lives in `@shelf/labels` next to the words, so
  * this app and the webapp cannot disagree about which status carries which
  * weight. Only the colour VALUES are app-owned, because the companion resolves
- * every tone twice (light and dark) while the webapp has one fixed palette.
+ * every tone twice — once for light, once for dark — while the webapp has one
+ * fixed palette.
  *
- * Keep this visually equivalent to the webapp's `toneBadgeColors`
- * (`apps/webapp/app/utils/status-tone-colors.ts`).
+ * This map and the webapp's `toneBadgeColors`
+ * (`apps/webapp/app/utils/status-tone-colors.ts`) are what make a tone mean the
+ * same thing in both apps — change one and you must change the other.
  */
 function buildToneBadge(
   c: Colors

--- a/apps/webapp/app/components/audit/audit-asset-status-badge.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-status-badge.tsx
@@ -1,23 +1,30 @@
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  AUDIT_ASSET_STATUS_TONES,
+} from "@shelf/labels";
 import type { AuditStatusLabel } from "~/modules/audit/audit-filter-utils";
 
-import { BADGE_COLORS, type BadgeColorScheme } from "~/utils/badge-colors";
+import { toneBadgeColors } from "~/utils/status-tone-colors";
 import { Badge } from "../shared/badge";
 
 interface AuditAssetStatusBadgeProps {
   status: AuditStatusLabel;
 }
 
-const auditStatusColorMap = (status: AuditStatusLabel): BadgeColorScheme => {
-  switch (status) {
-    case "Not scanned":
-      return BADGE_COLORS.gray;
-    case "Found":
-      return BADGE_COLORS.green;
-    case "Missing":
-      return BADGE_COLORS.amber;
-    case "Unexpected":
-      return BADGE_COLORS.red;
-  }
+/**
+ * Maps the displayed words back to the stored status so the shared tone map is
+ * the single source of colour. `AuditStatusLabel` is the label, not the enum —
+ * "Not scanned" and "Missing" are the same PENDING row before and after the
+ * audit closes.
+ */
+const STATUS_BY_LABEL: Record<
+  AuditStatusLabel,
+  keyof typeof AUDIT_ASSET_STATUS_TONES
+> = {
+  [AUDIT_ASSET_STATUS_LABELS.PENDING]: "PENDING",
+  [AUDIT_ASSET_STATUS_LABELS.FOUND]: "FOUND",
+  [AUDIT_ASSET_STATUS_LABELS.MISSING]: "MISSING",
+  [AUDIT_ASSET_STATUS_LABELS.UNEXPECTED]: "UNEXPECTED",
 };
 
 /**
@@ -25,7 +32,9 @@ const auditStatusColorMap = (status: AuditStatusLabel): BadgeColorScheme => {
  * Shown when viewing "ALL" filter to indicate which category each asset belongs to.
  */
 export function AuditAssetStatusBadge({ status }: AuditAssetStatusBadgeProps) {
-  const colors = auditStatusColorMap(status);
+  const colors = toneBadgeColors(
+    AUDIT_ASSET_STATUS_TONES[STATUS_BY_LABEL[status]]
+  );
 
   return (
     <Badge color={colors.bg} textColor={colors.text} withDot={false}>

--- a/apps/webapp/app/components/audit/audit-asset-status-badge.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-status-badge.tsx
@@ -12,10 +12,10 @@ interface AuditAssetStatusBadgeProps {
 }
 
 /**
- * Maps the displayed words back to the stored status so the shared tone map is
- * the single source of colour. `AuditStatusLabel` is the label, not the enum —
- * "Not scanned" and "Missing" are the same PENDING row before and after the
- * audit closes.
+ * Maps the displayed words back to the stored status, so the badge can look up
+ * the shared tone. The component receives an `AuditStatusLabel` — the label,
+ * not the enum — and "Not scanned" and "Missing" are the same PENDING row
+ * before and after the audit closes.
  */
 const STATUS_BY_LABEL: Record<
   AuditStatusLabel,
@@ -28,8 +28,11 @@ const STATUS_BY_LABEL: Record<
 };
 
 /**
- * Badge component to display the audit status of an asset.
- * Shown when viewing "ALL" filter to indicate which category each asset belongs to.
+ * Badge showing one asset's outcome within an audit.
+ *
+ * Shown under the "ALL" filter, where rows of every outcome are mixed together.
+ * The colour comes from the tone `@shelf/labels` assigns the status, so the
+ * companion app's scan list ranks the same outcomes the same way.
  */
 export function AuditAssetStatusBadge({ status }: AuditAssetStatusBadgeProps) {
   const colors = toneBadgeColors(

--- a/apps/webapp/app/components/audit/audit-status-badge.tsx
+++ b/apps/webapp/app/components/audit/audit-status-badge.tsx
@@ -4,11 +4,12 @@ import { toneBadgeColors } from "~/utils/status-tone-colors";
 import { Badge } from "../shared/badge";
 
 /**
- * Badge component for displaying audit status with appropriate colors.
- * Colors are sourced from the platform's consistent BADGE_COLORS palette;
- * the words come from `@shelf/labels` so the companion app's audit cards can
- * never show a different one. This file used to carry a byte-identical local
- * copy of that map.
+ * Badge showing an audit session's status.
+ *
+ * Both halves come from `@shelf/labels`: the words from `AUDIT_STATUS_LABELS`
+ * and the semantic weight from `AUDIT_STATUS_TONES`, so the companion app's
+ * audit cards read the same. `toneBadgeColors` turns that tone into this app's
+ * `BADGE_COLORS` hexes.
  *
  * @param status - The audit status from Prisma enum
  */

--- a/apps/webapp/app/components/audit/audit-status-badge.tsx
+++ b/apps/webapp/app/components/audit/audit-status-badge.tsx
@@ -1,15 +1,7 @@
 import type { AuditStatus } from "@prisma/client";
-import { AUDIT_STATUS_LABELS } from "@shelf/labels";
-import { BADGE_COLORS, type BadgeColorScheme } from "~/utils/badge-colors";
+import { AUDIT_STATUS_LABELS, AUDIT_STATUS_TONES } from "@shelf/labels";
+import { toneBadgeColors } from "~/utils/status-tone-colors";
 import { Badge } from "../shared/badge";
-
-const auditStatusColorMap: Record<AuditStatus, BadgeColorScheme> = {
-  PENDING: BADGE_COLORS.gray,
-  ACTIVE: BADGE_COLORS.violet,
-  COMPLETED: BADGE_COLORS.green,
-  CANCELLED: BADGE_COLORS.gray,
-  ARCHIVED: BADGE_COLORS.gray,
-};
 
 /**
  * Badge component for displaying audit status with appropriate colors.
@@ -21,7 +13,7 @@ const auditStatusColorMap: Record<AuditStatus, BadgeColorScheme> = {
  * @param status - The audit status from Prisma enum
  */
 export function AuditStatusBadge({ status }: { status: AuditStatus }) {
-  const colors = auditStatusColorMap[status];
+  const colors = toneBadgeColors(AUDIT_STATUS_TONES[status]);
 
   return (
     <Badge color={colors.bg} textColor={colors.text} withDot={false}>

--- a/apps/webapp/app/utils/status-tone-colors.test.ts
+++ b/apps/webapp/app/utils/status-tone-colors.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guards the webapp half of the shared-tone contract.
+ *
+ * `@shelf/labels` decides which tone a status carries; this app decides what
+ * each tone looks like. A tone the resolver does not know about returns
+ * `undefined`, which renders as an unstyled badge rather than throwing — so
+ * "every tone and every status resolves to a real colour pair" is asserted
+ * here rather than left to the type checker.
+ *
+ * @see {@link file://./status-tone-colors.ts}
+ */
+import {
+  AUDIT_ASSET_STATUS_TONES,
+  AUDIT_STATUS_TONES,
+  type StatusTone,
+} from "@shelf/labels";
+import { describe, expect, it } from "vitest";
+
+import { BADGE_COLORS } from "./badge-colors";
+import { toneBadgeColors } from "./status-tone-colors";
+
+/** Every tone the shared package can hand this app. */
+const ALL_TONES: StatusTone[] = [
+  "neutral",
+  "info",
+  "success",
+  "warning",
+  "danger",
+];
+
+describe("toneBadgeColors", () => {
+  it.each(ALL_TONES)(
+    "resolves %s to a background and a text colour",
+    (tone) => {
+      const colors = toneBadgeColors(tone);
+
+      expect(colors?.bg).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      expect(colors?.text).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  );
+
+  it("resolves every audit status the shared package knows about", () => {
+    const tones = [
+      ...Object.values(AUDIT_STATUS_TONES),
+      ...Object.values(AUDIT_ASSET_STATUS_TONES),
+    ];
+
+    for (const tone of tones) {
+      expect(toneBadgeColors(tone)).toBeDefined();
+    }
+  });
+
+  it("paints a missing asset red and an unexpected one amber", () => {
+    // The pairing users read as "act on this" vs "file this correctly". It is
+    // the decision the shared tones exist to hold still, so it is pinned on
+    // this side of the mapping too.
+    expect(toneBadgeColors(AUDIT_ASSET_STATUS_TONES.MISSING)).toEqual(
+      BADGE_COLORS.red
+    );
+    expect(toneBadgeColors(AUDIT_ASSET_STATUS_TONES.UNEXPECTED)).toEqual(
+      BADGE_COLORS.amber
+    );
+  });
+});

--- a/apps/webapp/app/utils/status-tone-colors.ts
+++ b/apps/webapp/app/utils/status-tone-colors.ts
@@ -1,0 +1,34 @@
+/**
+ * Maps a shared {@link StatusTone} onto this app's badge palette.
+ *
+ * The tone itself lives in `@shelf/labels` alongside the words, so the webapp
+ * and the companion app cannot disagree about which status deserves which
+ * weight. Only the concrete colours are app-owned: the webapp has one fixed
+ * palette, the companion resolves each tone twice for light and dark mode.
+ *
+ * Keep this visually equivalent to the companion's `buildToneBadge`
+ * (`apps/companion/lib/theme-colors.ts`) — if one side changes what "danger"
+ * looks like, the two apps drift again, which is the bug this indirection
+ * exists to prevent.
+ *
+ * @see {@link file://./badge-colors.ts}
+ */
+import type { StatusTone } from "@shelf/labels";
+
+import { BADGE_COLORS, type BadgeColorScheme } from "./badge-colors";
+
+const TONE_COLORS: Record<StatusTone, BadgeColorScheme> = {
+  neutral: BADGE_COLORS.gray,
+  info: BADGE_COLORS.blue,
+  success: BADGE_COLORS.green,
+  warning: BADGE_COLORS.amber,
+  danger: BADGE_COLORS.red,
+};
+
+/**
+ * @param tone - the shared semantic weight for a status
+ * @returns the badge background/text pair for that tone
+ */
+export function toneBadgeColors(tone: StatusTone): BadgeColorScheme {
+  return TONE_COLORS[tone];
+}

--- a/apps/webapp/app/utils/status-tone-colors.ts
+++ b/apps/webapp/app/utils/status-tone-colors.ts
@@ -1,15 +1,14 @@
 /**
- * Maps a shared {@link StatusTone} onto this app's badge palette.
+ * Resolves a shared {@link StatusTone} against this app's badge palette.
  *
  * The tone itself lives in `@shelf/labels` alongside the words, so the webapp
  * and the companion app cannot disagree about which status deserves which
  * weight. Only the concrete colours are app-owned: the webapp has one fixed
  * palette, the companion resolves each tone twice for light and dark mode.
  *
- * Keep this visually equivalent to the companion's `buildToneBadge`
- * (`apps/companion/lib/theme-colors.ts`) — if one side changes what "danger"
- * looks like, the two apps drift again, which is the bug this indirection
- * exists to prevent.
+ * This map and the companion's `buildToneBadge`
+ * (`apps/companion/lib/theme-colors.ts`) are what make a tone mean the same
+ * thing in both apps — change one and you must change the other.
  *
  * @see {@link file://./badge-colors.ts}
  */

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -78,6 +78,9 @@ export declare const AUDIT_ASSET_STATUS_LABELS: {
 /** Enum keys of {@link AUDIT_ASSET_STATUS_LABELS} — the Prisma status values. */
 export type AuditAssetStatusKey = keyof typeof AUDIT_ASSET_STATUS_LABELS;
 
+/** Enum keys of {@link AUDIT_STATUS_LABELS} — the Prisma AuditStatus values. */
+export type AuditStatusKey = keyof typeof AUDIT_STATUS_LABELS;
+
 /** The user-facing strings those keys resolve to. */
 export type AuditAssetStatusLabel =
   (typeof AUDIT_ASSET_STATUS_LABELS)[AuditAssetStatusKey];
@@ -139,3 +142,20 @@ export declare const BOOKING_RESERVE_BLOCKED_LABELS: {
  * a checked-out asset can still be pulled off a live booking.
  */
 export declare const BOOKING_EMPTY_RESERVED_MESSAGE: "A reserved booking must keep at least one asset or model reservation. Cancel the booking instead, or add a replacement first.";
+
+ * Semantic colour weight shared by both apps. Each app maps a tone onto its own
+ * palette (the webapp's fixed hex `BADGE_COLORS`, the companion's light/dark
+ * theme), so the colour VALUES stay app-owned while the DECISION is shared.
+ *
+ * neutral → grey · info → blue · success → green · warning → amber · danger → red
+ */
+export type StatusTone = "neutral" | "info" | "success" | "warning" | "danger";
+
+/** Tone per audit status. PENDING is neutral; "Overdue" is a separate badge. */
+export declare const AUDIT_STATUS_TONES: Record<AuditStatusKey, StatusTone>;
+
+/** Tone per per-asset audit status. MISSING is danger; UNEXPECTED is warning. */
+export declare const AUDIT_ASSET_STATUS_TONES: Record<
+  AuditAssetStatusKey,
+  StatusTone
+>;

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -143,6 +143,7 @@ export declare const BOOKING_RESERVE_BLOCKED_LABELS: {
  */
 export declare const BOOKING_EMPTY_RESERVED_MESSAGE: "A reserved booking must keep at least one asset or model reservation. Cancel the booking instead, or add a replacement first.";
 
+/**
  * Semantic colour weight shared by both apps. Each app maps a tone onto its own
  * palette (the webapp's fixed hex `BADGE_COLORS`, the companion's light/dark
  * theme), so the colour VALUES stay app-owned while the DECISION is shared.

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -34,11 +34,7 @@ export declare const BOOKING_STATUS_LABELS: {
   readonly CANCELLED: "Cancelled";
 };
 
-/**
- * Audit session lifecycle (AuditStatus in the Prisma schema). Covers ARCHIVED,
- * which a hand-written status chain on the companion used to fall through to
- * "Cancelled".
- */
+/** Audit session lifecycle (AuditStatus in the Prisma schema). */
 export declare const AUDIT_STATUS_LABELS: {
   readonly PENDING: "Pending";
   readonly ACTIVE: "Active";
@@ -62,9 +58,8 @@ export declare const AUDIT_UNASSIGNED_LABELS: {
 /**
  * Per-asset audit outcome (AuditAssetStatus in the Prisma schema).
  *
- * PENDING reads "Not scanned", not "Expected"/"Pending"/"Remaining": all of
- * those were live at once for one and the same set of assets, and "Expected"
- * was already taken by the tile counting EVERY expected asset. Prefer
+ * PENDING reads "Not scanned" rather than "Expected", which is the name of the
+ * tile counting EVERY asset the audit covers. Prefer
  * {@link auditAssetStatusLabel} over indexing this map for PENDING, since only
  * that helper applies the completion rule.
  */
@@ -144,18 +139,19 @@ export declare const BOOKING_RESERVE_BLOCKED_LABELS: {
 export declare const BOOKING_EMPTY_RESERVED_MESSAGE: "A reserved booking must keep at least one asset or model reservation. Cancel the booking instead, or add a replacement first.";
 
 /**
- * Semantic colour weight shared by both apps. Each app maps a tone onto its own
- * palette (the webapp's fixed hex `BADGE_COLORS`, the companion's light/dark
- * theme), so the colour VALUES stay app-owned while the DECISION is shared.
+ * The semantic weight a status badge carries, independent of any palette. Each
+ * app maps a tone onto its own colours (the webapp's fixed hex `BADGE_COLORS`,
+ * the companion's light/dark theme), so the VALUES stay app-owned while the
+ * DECISION is shared.
  *
  * neutral → grey · info → blue · success → green · warning → amber · danger → red
  */
 export type StatusTone = "neutral" | "info" | "success" | "warning" | "danger";
 
-/** Tone per audit status. PENDING is neutral; "Overdue" is a separate badge. */
+/** Tone for each audit session status. */
 export declare const AUDIT_STATUS_TONES: Record<AuditStatusKey, StatusTone>;
 
-/** Tone per per-asset audit status. MISSING is danger; UNEXPECTED is warning. */
+/** Tone for each per-asset audit outcome, escalating neutral → danger. */
 export declare const AUDIT_ASSET_STATUS_TONES: Record<
   AuditAssetStatusKey,
   StatusTone

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -149,10 +149,11 @@ export declare const BOOKING_EMPTY_RESERVED_MESSAGE: "A reserved booking must ke
 export type StatusTone = "neutral" | "info" | "success" | "warning" | "danger";
 
 /** Tone for each audit session status. */
-export declare const AUDIT_STATUS_TONES: Record<AuditStatusKey, StatusTone>;
+export declare const AUDIT_STATUS_TONES: Readonly<
+  Record<AuditStatusKey, StatusTone>
+>;
 
 /** Tone for each per-asset audit outcome, escalating neutral → danger. */
-export declare const AUDIT_ASSET_STATUS_TONES: Record<
-  AuditAssetStatusKey,
-  StatusTone
+export declare const AUDIT_ASSET_STATUS_TONES: Readonly<
+  Record<AuditAssetStatusKey, StatusTone>
 >;

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -185,3 +185,61 @@ export const BOOKING_RESERVE_BLOCKED_LABELS = Object.freeze({
 // reconciles the asset's status when it happens).
 export const BOOKING_EMPTY_RESERVED_MESSAGE =
   "A reserved booking must keep at least one asset or model reservation. Cancel the booking instead, or add a replacement first.";
+
+/**
+ * Semantic colour TONE for each audit status, and for each per-asset status.
+ *
+ * Why tones and not colours: the two apps cannot share colour values. The
+ * webapp uses one fixed hex palette (`BADGE_COLORS`); the companion resolves
+ * every colour twice, once for light mode and once for dark. What they CAN
+ * share — and what actually drifted — is the decision about which status
+ * deserves which weight.
+ *
+ * This is the same fix already applied to the words above. Those were pulled
+ * in here so the two apps "can never show a different one", but the colours
+ * were left duplicated in `apps/webapp/.../audit-status-badge.tsx` and
+ * `apps/companion/lib/theme-colors.ts`, and duly drifted: Missing and
+ * Unexpected had opposite alarm colours, and Pending and Active disagreed too.
+ *
+ * Each app maps a tone to its own palette. They must stay visually equivalent:
+ *   neutral → grey      (no signal; nothing has happened yet)
+ *   info    → blue      (in progress, nothing wrong)
+ *   success → green     (the good outcome)
+ *   warning → amber     (worth attention, nothing lost)
+ *   danger  → red       (something is wrong and costs money)
+ */
+
+/** @typedef {"neutral"|"info"|"success"|"warning"|"danger"} StatusTone */
+
+/**
+ * Tone per audit status.
+ *
+ * PENDING is neutral, NOT amber: an audit nobody has started yet is not a
+ * problem, and both apps render a separate "Overdue" badge for the case that
+ * actually needs chasing. Colouring every pending audit amber spends the
+ * warning colour on the normal case and leaves nothing for the abnormal one.
+ */
+export const AUDIT_STATUS_TONES = {
+  PENDING: "neutral",
+  ACTIVE: "info",
+  COMPLETED: "success",
+  CANCELLED: "neutral",
+  ARCHIVED: "neutral",
+};
+
+/**
+ * Tone per per-asset audit status.
+ *
+ * MISSING outranks UNEXPECTED, which is the pairing that was inverted between
+ * the apps. An asset that should be here and is not may be lost or stolen and
+ * someone must act — that is danger. An unexpected asset is a surprise, but it
+ * is physically in the auditor's hands and merely filed wrong — that is a
+ * warning. The four together read as one escalating scale: neutral, success,
+ * warning, danger.
+ */
+export const AUDIT_ASSET_STATUS_TONES = {
+  PENDING: "neutral",
+  FOUND: "success",
+  MISSING: "danger",
+  UNEXPECTED: "warning",
+};

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -14,8 +14,7 @@
  * Rule: never hard-code a status label string in either app. Import it here.
  * Web `userFriendlyAssetStatus` / `getQuantityBadgeLabelAndColor` and companion
  * `formatStatus` all read from these maps, so the phone can never show a
- * different word than the website (the 1.1.x "In custody" vs "Partial custody"
- * drift class).
+ * different word than the website.
  */
 
 // Base asset status enum (AssetStatus in the Prisma schema).
@@ -71,16 +70,11 @@ export const AUDIT_STATUS_LABELS = Object.freeze({
 // registers — a compact card line, the screen-reader variant that gets joined
 // into a comma-separated announcement, and the prose used where there is room
 // to explain (the web's "Not assigned" tooltip). They live together so the
-// three can never say different things about who is allowed to scan; before
-// this, the sentence was hand-copied to six call sites across both apps.
+// three can never say different things about who is allowed to scan.
 //
 // All three name BOTH roles because the server allows both: requireAuditAssignee
 // returns early for any caller that is not BASE/SELF_SERVICE, so ADMIN and OWNER
-// are exactly the set who may scan an unassigned audit. Naming only admins was
-// an earlier reading — that the invite dialog never surfaces OWNER as a role, so
-// users would not recognise the word — but the web tooltip has always said
-// "admins and owners", which meant an owner on the phone was told they could not
-// do a thing the same product told them they could on the web.
+// are exactly the set who may scan an unassigned audit.
 // Pinned by the AUDIT_UNASSIGNED_LABELS tests in the webapp.
 export const AUDIT_UNASSIGNED_LABELS = Object.freeze({
   SHORT: "Unassigned · admins and owners can scan",
@@ -91,12 +85,9 @@ export const AUDIT_UNASSIGNED_LABELS = Object.freeze({
 
 // Per-asset audit status (AuditAssetStatus in the Prisma schema).
 //
-// PENDING is deliberately "Not scanned", not "Expected"/"Pending"/"Remaining":
-// all three were in use at once (web rows said "Expected", the web statistics
-// tile said "Missing", mobile said "Pending", the mobile scanner said
-// "Remaining") for one and the same set of assets. "Expected" was already
-// taken by the tile that counts EVERY expected asset, so the not-yet-scanned
-// subset needs a word of its own.
+// PENDING reads "Not scanned" rather than "Expected": "Expected" is the name of
+// the statistics tile that counts EVERY asset the audit covers, so the
+// not-yet-scanned subset needs a word of its own.
 //
 // MISSING is only true once the audit is completed — that is when the
 // completion flow turns unscanned rows into MISSING. Before completion, use
@@ -152,14 +143,9 @@ export function auditAssetStatusLabel(status, isAuditCompleted) {
 }
 
 // Why a booking cannot be reserved yet — the three rules web's Reserve button
-// disables on, in one register for every surface that states them.
-//
-// Before this there were FOUR wordings for the same two rules: the web tooltip
-// (which also carried an "unavailble" typo), the mobile route's 400, the
-// in-transaction guard's 400, and the companion's client-side note. A wording
-// change fixed at most one of them, and the phone told users something the
-// website did not. `ALREADY_BOOKED` is the rule the companion could not state
-// at all until the booking detail payload started carrying the flag.
+// disables on, in one register for every surface that states them: the web
+// tooltip, the mobile route's 400, the in-transaction guard's 400 and the
+// companion's client-side note.
 //
 // These are the *reasons the button is blocked*, not the outcome of a failed
 // write: `reserveBooking`'s race-safe conflict check names the specific
@@ -187,37 +173,35 @@ export const BOOKING_EMPTY_RESERVED_MESSAGE =
   "A reserved booking must keep at least one asset or model reservation. Cancel the booking instead, or add a replacement first.";
 
 /**
- * Semantic colour TONE for each audit status, and for each per-asset status.
+ * The semantic weight a status badge carries, independent of any palette.
  *
- * Why tones and not colours: the two apps cannot share colour values. The
- * webapp uses one fixed hex palette (`BADGE_COLORS`); the companion resolves
- * every colour twice, once for light mode and once for dark. What they CAN
- * share — and what actually drifted — is the decision about which status
- * deserves which weight.
+ * The two apps cannot share colour VALUES — the webapp has one fixed hex
+ * palette (`BADGE_COLORS`), the companion resolves every colour twice, once for
+ * light mode and once for dark — so they share the DECISION instead: which
+ * status deserves which weight. Each app resolves a tone against its own
+ * palette, and the two resolvers must stay visually equivalent:
  *
- * This is the same fix already applied to the words above. Those were pulled
- * in here so the two apps "can never show a different one", but the colours
- * were left duplicated in `apps/webapp/.../audit-status-badge.tsx` and
- * `apps/companion/lib/theme-colors.ts`, and duly drifted: Missing and
- * Unexpected had opposite alarm colours, and Pending and Active disagreed too.
+ *   neutral → grey      no signal; nothing has happened yet
+ *   info    → blue      in progress, nothing wrong
+ *   success → green     the good outcome
+ *   warning → amber     worth attention, nothing lost
+ *   danger  → red       something is wrong and someone must act
  *
- * Each app maps a tone to its own palette. They must stay visually equivalent:
- *   neutral → grey      (no signal; nothing has happened yet)
- *   info    → blue      (in progress, nothing wrong)
- *   success → green     (the good outcome)
- *   warning → amber     (worth attention, nothing lost)
- *   danger  → red       (something is wrong and costs money)
+ * Resolvers: `toneBadgeColors` (`apps/webapp/app/utils/status-tone-colors.ts`)
+ * and `buildToneBadge` (`apps/companion/lib/theme-colors.ts`).
  */
 
 /** @typedef {"neutral"|"info"|"success"|"warning"|"danger"} StatusTone */
 
 /**
- * Tone per audit status.
+ * Tone for each audit session status.
  *
- * PENDING is neutral, NOT amber: an audit nobody has started yet is not a
- * problem, and both apps render a separate "Overdue" badge for the case that
- * actually needs chasing. Colouring every pending audit amber spends the
- * warning colour on the normal case and leaves nothing for the abnormal one.
+ * Only a running audit (info) and a finished one (success) carry a signal; an
+ * audit nobody has started yet, or one that ended without running, is neutral.
+ * Urgency is not encoded here at all — both apps signal a late audit through
+ * the due date beside the badge (the web adds an "Overdue" badge, the companion
+ * reddens the due line), so the status badge itself stays a plain statement of
+ * where the audit is.
  */
 export const AUDIT_STATUS_TONES = {
   PENDING: "neutral",
@@ -228,14 +212,12 @@ export const AUDIT_STATUS_TONES = {
 };
 
 /**
- * Tone per per-asset audit status.
+ * Tone for each per-asset audit outcome, read as one escalating scale: neutral
+ * (not reached yet) → success (found) → warning → danger.
  *
- * MISSING outranks UNEXPECTED, which is the pairing that was inverted between
- * the apps. An asset that should be here and is not may be lost or stolen and
- * someone must act — that is danger. An unexpected asset is a surprise, but it
- * is physically in the auditor's hands and merely filed wrong — that is a
- * warning. The four together read as one escalating scale: neutral, success,
- * warning, danger.
+ * MISSING outranks UNEXPECTED. An asset that should be here and is not may be
+ * lost or stolen and someone has to act on it; an unexpected asset is a
+ * surprise, but it is physically in the auditor's hands and merely filed wrong.
  */
 export const AUDIT_ASSET_STATUS_TONES = {
   PENDING: "neutral",

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -203,13 +203,13 @@ export const BOOKING_EMPTY_RESERVED_MESSAGE =
  * reddens the due line), so the status badge itself stays a plain statement of
  * where the audit is.
  */
-export const AUDIT_STATUS_TONES = {
+export const AUDIT_STATUS_TONES = Object.freeze({
   PENDING: "neutral",
   ACTIVE: "info",
   COMPLETED: "success",
   CANCELLED: "neutral",
   ARCHIVED: "neutral",
-};
+});
 
 /**
  * Tone for each per-asset audit outcome, read as one escalating scale: neutral
@@ -219,9 +219,9 @@ export const AUDIT_STATUS_TONES = {
  * lost or stolen and someone has to act on it; an unexpected asset is a
  * surprise, but it is physically in the auditor's hands and merely filed wrong.
  */
-export const AUDIT_ASSET_STATUS_TONES = {
+export const AUDIT_ASSET_STATUS_TONES = Object.freeze({
   PENDING: "neutral",
   FOUND: "success",
   MISSING: "danger",
   UNEXPECTED: "warning",
-};
+});

--- a/packages/labels/index.test.js
+++ b/packages/labels/index.test.js
@@ -1,0 +1,162 @@
+/**
+ * Drift guards for the shared label and tone maps.
+ *
+ * The package exists so the webapp and the companion app cannot say — or now
+ * colour — the same status differently. Nothing in either app fails to compile
+ * when a status is missing from a map here: the companion resolves its badge
+ * maps through a `Record<string, …>` cast, so a gap surfaces as an
+ * `undefined` colour pair on a phone, not as a build error. These tests are
+ * what turns that into a failure at commit time.
+ *
+ * The enum lists on the right-hand side are copied by hand from
+ * `packages/database/prisma/schema.prisma`, following the same convention as
+ * `@shelf/quantity-control`'s enum-parity guard — the package takes no
+ * dependency on Prisma so that Metro can bundle it.
+ *
+ * @see {@link file://../database/prisma/schema.prisma}
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  AUDIT_ASSET_STATUS_LABELS,
+  AUDIT_ASSET_STATUS_TONES,
+  AUDIT_STATUS_LABELS,
+  AUDIT_STATUS_TONES,
+  auditAssetStatusLabel,
+  isAuditCompleted,
+} from "./index.js";
+
+/** The tones both apps know how to resolve. Adding one means touching both. */
+const STATUS_TONES = ["neutral", "info", "success", "warning", "danger"];
+
+/** Compares two key lists as sets, so declaration order is free to change. */
+function assertSameKeys(actual, expected) {
+  assert.deepEqual(Object.keys(actual).sort(), [...expected].sort());
+}
+
+// ---------------------------------------------------------------------------
+// Label maps vs the database enums
+// ---------------------------------------------------------------------------
+
+test("AUDIT_STATUS_LABELS covers the AuditStatus enum", () => {
+  // enum AuditStatus { PENDING, ACTIVE, COMPLETED, CANCELLED, ARCHIVED }
+  assertSameKeys(AUDIT_STATUS_LABELS, [
+    "PENDING",
+    "ACTIVE",
+    "COMPLETED",
+    "CANCELLED",
+    "ARCHIVED",
+  ]);
+});
+
+test("AUDIT_ASSET_STATUS_LABELS covers the AuditAssetStatus enum", () => {
+  // enum AuditAssetStatus { PENDING, FOUND, MISSING, UNEXPECTED }
+  assertSameKeys(AUDIT_ASSET_STATUS_LABELS, [
+    "PENDING",
+    "FOUND",
+    "MISSING",
+    "UNEXPECTED",
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// Tone maps
+// ---------------------------------------------------------------------------
+
+test("every audit status has a tone", () => {
+  assertSameKeys(AUDIT_STATUS_TONES, Object.keys(AUDIT_STATUS_LABELS));
+});
+
+test("every per-asset audit status has a tone", () => {
+  assertSameKeys(
+    AUDIT_ASSET_STATUS_TONES,
+    Object.keys(AUDIT_ASSET_STATUS_LABELS)
+  );
+});
+
+test("every tone is one both apps can resolve", () => {
+  for (const [status, tone] of [
+    ...Object.entries(AUDIT_STATUS_TONES),
+    ...Object.entries(AUDIT_ASSET_STATUS_TONES),
+  ]) {
+    assert.ok(
+      STATUS_TONES.includes(tone),
+      `${status} has tone "${tone}", which no app maps to a colour`
+    );
+  }
+});
+
+test("a missing asset outranks an unexpected one", () => {
+  // The two apps painted these the opposite way round for a release. The
+  // ranking is the whole reason the tones are shared, so it gets pinned:
+  // absent equipment needs action, a surprise find is only filed wrong.
+  assert.equal(AUDIT_ASSET_STATUS_TONES.MISSING, "danger");
+  assert.equal(AUDIT_ASSET_STATUS_TONES.UNEXPECTED, "warning");
+});
+
+test("a not-yet-started audit is not an alarm", () => {
+  // Urgency belongs to the due date beside the badge, not to PENDING itself.
+  assert.equal(AUDIT_STATUS_TONES.PENDING, "neutral");
+});
+
+// ---------------------------------------------------------------------------
+// Completion rule
+// ---------------------------------------------------------------------------
+
+test("an unscanned asset is only missing once the audit is closed", () => {
+  assert.equal(auditAssetStatusLabel("PENDING", false), "Not scanned");
+  assert.equal(auditAssetStatusLabel("PENDING", true), "Missing");
+});
+
+test("every other status reads the same either side of completion", () => {
+  for (const status of ["FOUND", "MISSING", "UNEXPECTED"]) {
+    assert.equal(
+      auditAssetStatusLabel(status, false),
+      AUDIT_ASSET_STATUS_LABELS[status]
+    );
+    assert.equal(
+      auditAssetStatusLabel(status, true),
+      AUDIT_ASSET_STATUS_LABELS[status]
+    );
+  }
+});
+
+test("completion is read from completedAt, in either apps' shape", () => {
+  // The webapp passes a Date, the companion an ISO string over JSON.
+  assert.equal(isAuditCompleted({ completedAt: new Date() }), true);
+  assert.equal(isAuditCompleted({ completedAt: "2026-08-20T10:00:00Z" }), true);
+  assert.equal(isAuditCompleted({ completedAt: null }), false);
+  assert.equal(isAuditCompleted({}), false);
+  assert.equal(isAuditCompleted(null), false);
+  assert.equal(isAuditCompleted(undefined), false);
+});
+
+test("an archived audit that was completed stays completed", () => {
+  // Archiving rewrites `status` but keeps the timestamp, which is why the
+  // helper never looks at `status`.
+  assert.equal(
+    isAuditCompleted({ status: "ARCHIVED", completedAt: new Date() }),
+    true
+  );
+  assert.equal(
+    isAuditCompleted({ status: "ARCHIVED", completedAt: null }),
+    false
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The maps are shared state
+// ---------------------------------------------------------------------------
+
+test("the exported maps cannot be mutated by a consumer", () => {
+  for (const map of [
+    AUDIT_STATUS_LABELS,
+    AUDIT_ASSET_STATUS_LABELS,
+    AUDIT_STATUS_TONES,
+    AUDIT_ASSET_STATUS_TONES,
+  ]) {
+    assert.ok(Object.isFrozen(map));
+  }
+});

--- a/packages/labels/package.json
+++ b/packages/labels/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
+  "scripts": {
+    "test": "node --test"
+  },
   "exports": {
     ".": {
       "types": "./index.d.ts",


### PR DESCRIPTION
## The problem

The audit badges disagreed between web and the companion app on **four of nine statuses**, and two were **exactly inverted**:

| | Web (before) | Mobile (before) |
|---|---|---|
| Audit · Pending | grey | amber |
| Audit · **Active** | violet | blue |
| Asset · **Missing** | amber | **red** |
| Asset · **Unexpected** | red | **amber** |

So on a completed audit the web painted **genuinely absent equipment in mild amber**, while flagging an asset that was **physically present in alarm red**. Anyone moving between the two surfaces read one of them backwards.

## Why not just fix the four values

The words were already centralised in `@shelf/labels` for precisely this reason — `audit-status-badge.tsx` says so in its own comment:

> *"the words come from @shelf/labels so the companion app's audit cards can never show a different one. This file used to carry a byte-identical local copy of that map."*

Someone hit this bug, extracted the labels, and left the colours duplicated in two files. Patching values would leave that mechanism intact and we would find the fifth mismatch next month.

## What this does instead

Moves the **decision** into the shared package, next to the words it already owns:

- `AUDIT_STATUS_TONES` and `AUDIT_ASSET_STATUS_TONES` map each status to a semantic tone: `neutral · info · success · warning · danger`.
- Each app maps tones onto **its own** palette, because the values genuinely cannot be shared — the webapp has one fixed hex palette, the companion resolves every tone twice for light and dark mode.
- Webapp: new `app/utils/status-tone-colors.ts`; both audit badge components read through it.
- Companion: `theme-colors.ts` builds both badge maps from the tones instead of hardcoding them.

The apps can no longer disagree about which status carries which weight, while each keeps control of how its colours look.

## The resolutions, decided per status — not by app precedence

- **Missing → danger, Unexpected → warning.** Missing outranks Unexpected: the asset may be lost and someone must act, whereas an unexpected asset is in the auditor's hands and merely filed wrong. Mobile was right; web changes.
- **Pending → neutral, not amber.** Both apps already render a separate **Overdue** badge, so colouring every pending audit amber spends the warning colour on the normal case and leaves nothing for the abnormal one. Web was right; mobile changes.
- **Active → info (blue, not violet).** The companion already uses blue for *In custody*, so in-progress reads consistently. **This one is a design call, not a correctness one** — if you prefer violet it is now a one-line change in a single file instead of two.

## Verification

- Both apps typecheck and lint clean.
- Rendered on the iOS simulator against production: Pending is now grey while *Overdue 12d* keeps its red, and Active is blue on both surfaces.
- Grey/Not-scanned and green/Found already agreed and are untouched.

## Note for reviewers

This touches a `packages/*` workspace dependency surface, so **run `pnpm install` after pulling** or the `@shelf/labels` import will not resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Standardized audit and audit-asset status badge colors across light and dark themes.
  * Added consistent semantic tones for pending, active, completed, cancelled, archived, found, missing, and unexpected statuses.
  * Improved status-label consistency and visual clarity throughout audit views.
  * Added clearer visual distinctions between status types.
  * Improved accessibility with more readable success and error text colors.
  * Ensured status indicators remain consistent across related audit screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->