### PR TITLE
feat(reports): populate booking compliance report filters from args

### DIFF
--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -49,6 +49,7 @@ import type {
   IdleAssetRow,
   MonthlyBookingTrendRow,
   OverdueItemRow,
+  ReportFilter,
   ReportKpi,
   ReportPayload,
   ResolvedTimeframe,
@@ -241,7 +242,33 @@ export async function bookingComplianceReport(
       },
       filters: {
         timeframe,
-        filters: [], // TODO: Populate from args
+        filters: [
+          ...(statusFilter?.map(
+            (status): ReportFilter => ({
+              type: "status" as const,
+              value: status,
+              label: formatStatusLabel(status),
+            })
+          ) ?? []),
+          ...(custodianId
+            ? [
+                {
+                  type: "team_member" as const,
+                  value: custodianId,
+                  label: custodianId,
+                },
+              ]
+            : []),
+          ...(locationId
+            ? [
+                {
+                  type: "location" as const,
+                  value: locationId,
+                  label: locationId,
+                },
+              ]
+            : []),
+        ],
       },
       kpis,
       rows: rowsResult.rows,


### PR DESCRIPTION
## Summary
The Booking Compliance report returned a hardcoded empty filters array in its payload, with a TODO: Populate from args marker. This change populates it from the report's input arguments so applied filters are echoed back for URL state sync, as the ReportPayload.filters contract specifies.