### PR TITLE
fix(security): validate Stripe price ids against the product they claim to be

### DIFF
--- a/apps/webapp/app/modules/audit/addon.server.test.ts
+++ b/apps/webapp/app/modules/audit/addon.server.test.ts
@@ -61,9 +61,11 @@ beforeEach(() => {
   mockStripe.prices.retrieve.mockResolvedValue({
     id: "price_123",
     active: true,
+    type: "recurring",
     product: {
       id: "prod_1",
       deleted: false,
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     },
   });
@@ -239,6 +241,7 @@ describe("getAuditAddonPrices", () => {
       id: "price_month",
       recurring: { interval: "month" },
       product: {
+        active: true,
         metadata: { product_type: "addon", addon_type: "audits" },
       },
     };
@@ -246,6 +249,7 @@ describe("getAuditAddonPrices", () => {
       id: "price_year",
       recurring: { interval: "year" },
       product: {
+        active: true,
         metadata: { product_type: "addon", addon_type: "audits" },
       },
     };
@@ -253,6 +257,7 @@ describe("getAuditAddonPrices", () => {
       id: "price_other",
       recurring: { interval: "month" },
       product: {
+        active: true,
         metadata: { product_type: "addon", addon_type: "barcodes" },
       },
     };
@@ -271,6 +276,7 @@ describe("getAuditAddonPrices", () => {
       id: "price_month",
       recurring: { interval: "month" },
       product: {
+        active: true,
         metadata: { product_type: "addon", addon_type: "audits" },
       },
     };
@@ -310,6 +316,7 @@ describe("linkAuditAddonToOrganization", () => {
     const sub = makeSubscription("active");
     mockStripe.subscriptions.list.mockResolvedValue({ data: [sub] });
     mockStripe.products.retrieve.mockResolvedValue({
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     });
     mockStripe.subscriptions.update.mockResolvedValue({});
@@ -326,6 +333,7 @@ describe("linkAuditAddonToOrganization", () => {
     const sub = makeSubscription("active");
     mockStripe.subscriptions.list.mockResolvedValue({ data: [sub] });
     mockStripe.products.retrieve.mockResolvedValue({
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     });
     mockStripe.subscriptions.update.mockResolvedValue({});
@@ -348,6 +356,7 @@ describe("linkAuditAddonToOrganization", () => {
     const sub = makeSubscription("trialing");
     mockStripe.subscriptions.list.mockResolvedValue({ data: [sub] });
     mockStripe.products.retrieve.mockResolvedValue({
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     });
     mockStripe.subscriptions.update.mockResolvedValue({});
@@ -368,6 +377,7 @@ describe("linkAuditAddonToOrganization", () => {
     const sub = makeSubscription("active");
     mockStripe.subscriptions.list.mockResolvedValue({ data: [sub] });
     mockStripe.products.retrieve.mockResolvedValue({
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     });
     mockStripe.subscriptions.update.mockResolvedValue({});
@@ -396,6 +406,7 @@ describe("linkAuditAddonToOrganization", () => {
       data: [linkedSub, unlinkedSub],
     });
     mockStripe.products.retrieve.mockResolvedValue({
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     });
     mockStripe.subscriptions.update.mockResolvedValue({});
@@ -420,6 +431,7 @@ describe("linkAuditAddonToOrganization", () => {
     };
     mockStripe.subscriptions.list.mockResolvedValue({ data: [sub] });
     mockStripe.products.retrieve.mockResolvedValue({
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     });
     mockStripe.subscriptions.update.mockResolvedValue({});
@@ -487,6 +499,7 @@ describe("getAuditSubscriptionInfo", () => {
       ],
     });
     mockStripe.products.retrieve.mockResolvedValue({
+      active: true,
       metadata: { product_type: "addon", addon_type: "audits" },
     });
 
@@ -680,9 +693,11 @@ describe("add-on price validation (entitlement bypass)", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_tier",
       active: true,
+      type: "recurring",
       product: {
         id: "prod_tier",
         deleted: false,
+        active: true,
         metadata: { shelf_tier: "tier_2" },
       },
     });
@@ -703,9 +718,11 @@ describe("add-on price validation (entitlement bypass)", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_tier",
       active: true,
+      type: "recurring",
       product: {
         id: "prod_tier",
         deleted: false,
+        active: true,
         metadata: { shelf_tier: "tier_2" },
       },
     });

--- a/apps/webapp/app/modules/audit/addon.server.test.ts
+++ b/apps/webapp/app/modules/audit/addon.server.test.ts
@@ -689,6 +689,35 @@ describe("add-on price validation (entitlement bypass)", () => {
    *
    * detail.dev finding D094.
    */
+  it("surfaces the price-validation message, not the generic wrapper text", async () => {
+    // The wrapping catch used to rewrite every failure to "Please try again
+    // later", handing back a 400 that asks the user to retry a request which
+    // can never succeed.
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_tier",
+      active: true,
+      type: "recurring",
+      product: {
+        id: "prod_tier",
+        deleted: false,
+        active: true,
+        metadata: { shelf_tier: "tier_2" },
+      },
+    });
+
+    await expect(
+      createAuditAddonTrialSubscription({
+        customerId: "cus_123",
+        priceId: "price_tier",
+        userId: "user_1",
+        organizationId: "org_1",
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "The selected plan is not available for this add-on.",
+    });
+  });
+
   it("refuses a tier price and never creates a subscription", async () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_tier",

--- a/apps/webapp/app/modules/audit/addon.server.test.ts
+++ b/apps/webapp/app/modules/audit/addon.server.test.ts
@@ -5,7 +5,7 @@ const { mockStripe } = vi.hoisted(() => ({
   mockStripe: {
     checkout: { sessions: { create: vi.fn() } },
     subscriptions: { create: vi.fn(), list: vi.fn(), update: vi.fn() },
-    prices: { list: vi.fn() },
+    prices: { list: vi.fn(), retrieve: vi.fn() },
     products: { retrieve: vi.fn() },
     paymentMethods: { list: vi.fn() },
   },
@@ -56,6 +56,17 @@ const baseParams = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // why: `assertPriceIsForAddon` resolves the price server-side before any
+  // subscription is created, so every path here needs a valid add-on price.
+  mockStripe.prices.retrieve.mockResolvedValue({
+    id: "price_123",
+    active: true,
+    product: {
+      id: "prod_1",
+      deleted: false,
+      metadata: { product_type: "addon", addon_type: "audits" },
+    },
+  });
   mockPremiumIsEnabled.value = true;
 });
 
@@ -652,5 +663,63 @@ describe("handleAuditAddonWebhook", () => {
     });
 
     expect(mockOrgUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("add-on price validation (entitlement bypass)", () => {
+  /**
+   * A TIER price is an ordinary active recurring price, so before this guard
+   * it was accepted here. The route enables the feature flag eagerly, and the
+   * resulting subscription carries a tierId — which makes `isAddonSubscription`
+   * return false, so the add-on webhook that would clear the flag never runs.
+   * Net effect: a one-time 7-day trial granted the paid feature permanently.
+   *
+   * detail.dev finding D094.
+   */
+  it("refuses a tier price and never creates a subscription", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_tier",
+      active: true,
+      product: {
+        id: "prod_tier",
+        deleted: false,
+        metadata: { shelf_tier: "tier_2" },
+      },
+    });
+
+    await expect(
+      createAuditAddonTrialSubscription({
+        customerId: "cus_123",
+        priceId: "price_tier",
+        userId: "user_1",
+        organizationId: "org_1",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+
+    expect(mockStripe.subscriptions.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a tier price on the checkout path too", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_tier",
+      active: true,
+      product: {
+        id: "prod_tier",
+        deleted: false,
+        metadata: { shelf_tier: "tier_2" },
+      },
+    });
+
+    await expect(
+      createAuditAddonCheckoutSession({
+        priceId: "price_tier",
+        userId: "user_1",
+        domainUrl: "https://app.shelf.nu",
+        customerId: "cus_123",
+        organizationId: "org_1",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/audit/addon.server.ts
+++ b/apps/webapp/app/modules/audit/addon.server.ts
@@ -65,6 +65,15 @@ export async function createAuditAddonCheckoutSession({
     }
     return url;
   } catch (cause) {
+    // A CLIENT-error ShelfError (e.g. the price validation above) already
+    // carries a message the user can act on; rewriting it to "try again later"
+    // would hand back a 400 telling them to retry a request that can never
+    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
+    // found in stripe checkout session" is not something a user can act on.
+    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message:
@@ -131,6 +140,15 @@ export async function createAuditAddonTrialSubscription({
 
     return { subscription, hasPaymentMethod: !!defaultPaymentMethod };
   } catch (cause) {
+    // A CLIENT-error ShelfError (e.g. the price validation above) already
+    // carries a message the user can act on; rewriting it to "try again later"
+    // would hand back a 400 telling them to retry a request that can never
+    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
+    // found in stripe checkout session" is not something a user can act on.
+    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message:

--- a/apps/webapp/app/modules/audit/addon.server.ts
+++ b/apps/webapp/app/modules/audit/addon.server.ts
@@ -2,6 +2,10 @@ import type { User } from "@prisma/client";
 import type Stripe from "stripe";
 import type { PriceWithProduct } from "~/components/subscription/prices";
 import { db } from "~/database/db.server";
+import {
+  assertPriceIsForAddon,
+  isAddonProduct,
+} from "~/modules/billing/price-validation.server";
 import type { ErrorLabel } from "~/utils/error";
 import { ShelfError } from "~/utils/error";
 import { premiumIsEnabled, stripe } from "~/utils/stripe.server";
@@ -23,6 +27,12 @@ export async function createAuditAddonCheckoutSession({
   organizationId: string;
 }): Promise<string> {
   try {
+    // The caller supplies `priceId` from the request, and an add-on price is
+    // distinguishable from a TIER price only by its product metadata. Without
+    // this, any active recurring price bought the add-on -- see
+    // ~/modules/billing/price-validation.server for why that granted it permanently.
+    await assertPriceIsForAddon({ priceId, addonType: "audits" });
+
     if (!stripe) {
       throw new ShelfError({
         cause: null,
@@ -78,6 +88,12 @@ export async function createAuditAddonTrialSubscription({
   organizationId: string;
 }) {
   try {
+    // The caller supplies `priceId` from the request, and an add-on price is
+    // distinguishable from a TIER price only by its product metadata. Without
+    // this, any active recurring price bought the add-on -- see
+    // ~/modules/billing/price-validation.server for why that granted it permanently.
+    await assertPriceIsForAddon({ priceId, addonType: "audits" });
+
     if (!stripe) {
       throw new ShelfError({
         cause: null,
@@ -139,13 +155,9 @@ export async function getAuditAddonPrices() {
       limit: 100,
     });
 
-    const auditPrices = pricesResponse.data.filter((p) => {
-      const product = p.product as Stripe.Product;
-      return (
-        product?.metadata?.product_type === "addon" &&
-        product?.metadata?.addon_type === "audits"
-      );
-    }) as PriceWithProduct[];
+    const auditPrices = pricesResponse.data.filter((p) =>
+      isAddonProduct(p.product, "audits")
+    ) as PriceWithProduct[];
 
     const monthlyPrice =
       auditPrices.find((p) => p.recurring?.interval === "month") || null;
@@ -215,10 +227,7 @@ export async function linkAuditAddonToOrganization({
         if (!productId) continue;
 
         const product = await stripe.products.retrieve(productId);
-        if (
-          product.metadata?.product_type === "addon" &&
-          product.metadata?.addon_type === "audits"
-        ) {
+        if (isAddonProduct(product, "audits")) {
           auditSubscription = sub;
           break;
         }
@@ -299,10 +308,7 @@ export async function getAuditSubscriptionInfo({
         if (!productId) continue;
 
         const product = await stripe.products.retrieve(productId);
-        if (
-          product.metadata?.product_type === "addon" &&
-          product.metadata?.addon_type === "audits"
-        ) {
+        if (isAddonProduct(product, "audits")) {
           return {
             interval:
               (item.price.recurring?.interval as "month" | "year") || "year",

--- a/apps/webapp/app/modules/audit/addon.server.ts
+++ b/apps/webapp/app/modules/audit/addon.server.ts
@@ -7,7 +7,7 @@ import {
   isAddonProduct,
 } from "~/modules/billing/price-validation.server";
 import type { ErrorLabel } from "~/utils/error";
-import { ShelfError } from "~/utils/error";
+import { ShelfError, rethrowIfClientError } from "~/utils/error";
 import { premiumIsEnabled, stripe } from "~/utils/stripe.server";
 
 const label: ErrorLabel = "Stripe";
@@ -65,14 +65,7 @@ export async function createAuditAddonCheckoutSession({
     }
     return url;
   } catch (cause) {
-    // A CLIENT-error ShelfError (e.g. the price validation above) already
-    // carries a message the user can act on; rewriting it to "try again later"
-    // would hand back a 400 telling them to retry a request that can never
-    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
-    // found in stripe checkout session" is not something a user can act on.
-    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
-      throw cause;
-    }
+    rethrowIfClientError(cause);
 
     throw new ShelfError({
       cause,
@@ -140,14 +133,7 @@ export async function createAuditAddonTrialSubscription({
 
     return { subscription, hasPaymentMethod: !!defaultPaymentMethod };
   } catch (cause) {
-    // A CLIENT-error ShelfError (e.g. the price validation above) already
-    // carries a message the user can act on; rewriting it to "try again later"
-    // would hand back a 400 telling them to retry a request that can never
-    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
-    // found in stripe checkout session" is not something a user can act on.
-    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
-      throw cause;
-    }
+    rethrowIfClientError(cause);
 
     throw new ShelfError({
       cause,

--- a/apps/webapp/app/modules/barcode/addon.server.test.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.test.ts
@@ -54,9 +54,11 @@ beforeEach(() => {
   mockStripe.prices.retrieve.mockResolvedValue({
     id: "price_123",
     active: true,
+    type: "recurring",
     product: {
       id: "prod_1",
       deleted: false,
+      active: true,
       metadata: { product_type: "addon", addon_type: "barcodes" },
     },
   });
@@ -82,6 +84,7 @@ const baseTrialParams = {
 function makeBarcodeProduct(overrides: Partial<Stripe.Product> = {}) {
   return {
     id: "prod_barcode",
+    active: true,
     metadata: { product_type: "addon", addon_type: "barcodes" },
     ...overrides,
   };
@@ -90,6 +93,7 @@ function makeBarcodeProduct(overrides: Partial<Stripe.Product> = {}) {
 function makeNonBarcodeProduct() {
   return {
     id: "prod_other",
+    active: true,
     metadata: { product_type: "plan", addon_type: undefined },
   };
 }
@@ -662,9 +666,11 @@ describe("add-on price validation (entitlement bypass)", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_tier",
       active: true,
+      type: "recurring",
       product: {
         id: "prod_tier",
         deleted: false,
+        active: true,
         metadata: { shelf_tier: "tier_2" },
       },
     });
@@ -683,9 +689,11 @@ describe("add-on price validation (entitlement bypass)", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_tier",
       active: true,
+      type: "recurring",
       product: {
         id: "prod_tier",
         deleted: false,
+        active: true,
         metadata: { shelf_tier: "tier_2" },
       },
     });

--- a/apps/webapp/app/modules/barcode/addon.server.test.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.test.ts
@@ -7,7 +7,7 @@ const { mockStripe } = vi.hoisted(() => ({
   mockStripe: {
     checkout: { sessions: { create: vi.fn() } },
     subscriptions: { create: vi.fn(), list: vi.fn(), update: vi.fn() },
-    prices: { list: vi.fn() },
+    prices: { list: vi.fn(), retrieve: vi.fn() },
     products: { retrieve: vi.fn() },
     paymentMethods: { list: vi.fn() },
   },
@@ -49,6 +49,17 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // why: `assertPriceIsForAddon` resolves the price server-side before any
+  // subscription is created, so every path here needs a valid add-on price.
+  mockStripe.prices.retrieve.mockResolvedValue({
+    id: "price_123",
+    active: true,
+    product: {
+      id: "prod_1",
+      deleted: false,
+      metadata: { product_type: "addon", addon_type: "barcodes" },
+    },
+  });
   mockPremiumIsEnabled.value = true;
   mockOrgUpdate.mockResolvedValue({ id: "org_1" });
 });
@@ -634,5 +645,58 @@ describe("handleBarcodeAddonWebhook", () => {
     });
 
     expect(mockOrgUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("add-on price validation (entitlement bypass)", () => {
+  /**
+   * A TIER price is an ordinary active recurring price, so before this guard
+   * it was accepted here. The route enables the feature flag eagerly, and the
+   * resulting subscription carries a tierId — which makes `isAddonSubscription`
+   * return false, so the add-on webhook that would clear the flag never runs.
+   * Net effect: a one-time 7-day trial granted the paid feature permanently.
+   *
+   * detail.dev finding D094.
+   */
+  it("refuses a tier price and never creates a subscription", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_tier",
+      active: true,
+      product: {
+        id: "prod_tier",
+        deleted: false,
+        metadata: { shelf_tier: "tier_2" },
+      },
+    });
+
+    await expect(
+      createBarcodeAddonTrialSubscription({
+        ...baseTrialParams,
+        priceId: "price_tier",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+
+    expect(mockStripe.subscriptions.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a tier price on the checkout path too", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_tier",
+      active: true,
+      product: {
+        id: "prod_tier",
+        deleted: false,
+        metadata: { shelf_tier: "tier_2" },
+      },
+    });
+
+    await expect(
+      createBarcodeAddonCheckoutSession({
+        ...baseCheckoutParams,
+        priceId: "price_tier",
+      })
+    ).rejects.toBeInstanceOf(ShelfError);
+
+    expect(mockStripe.checkout.sessions.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/barcode/addon.server.test.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.test.ts
@@ -662,6 +662,35 @@ describe("add-on price validation (entitlement bypass)", () => {
    *
    * detail.dev finding D094.
    */
+  it("surfaces the price-validation message, not the generic wrapper text", async () => {
+    // The wrapping catch used to rewrite every failure to "Please try again
+    // later", handing back a 400 that asks the user to retry a request which
+    // can never succeed.
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_tier",
+      active: true,
+      type: "recurring",
+      product: {
+        id: "prod_tier",
+        deleted: false,
+        active: true,
+        metadata: { shelf_tier: "tier_2" },
+      },
+    });
+
+    await expect(
+      createBarcodeAddonTrialSubscription({
+        customerId: "cus_123",
+        priceId: "price_tier",
+        userId: "user_1",
+        organizationId: "org_1",
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "The selected plan is not available for this add-on.",
+    });
+  });
+
   it("refuses a tier price and never creates a subscription", async () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_tier",

--- a/apps/webapp/app/modules/barcode/addon.server.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.ts
@@ -7,7 +7,7 @@ import {
   isAddonProduct,
 } from "~/modules/billing/price-validation.server";
 import type { ErrorLabel } from "~/utils/error";
-import { ShelfError } from "~/utils/error";
+import { ShelfError, rethrowIfClientError } from "~/utils/error";
 import { premiumIsEnabled, stripe } from "~/utils/stripe.server";
 
 const label: ErrorLabel = "Stripe";
@@ -65,14 +65,7 @@ export async function createBarcodeAddonCheckoutSession({
     }
     return url;
   } catch (cause) {
-    // A CLIENT-error ShelfError (e.g. the price validation above) already
-    // carries a message the user can act on; rewriting it to "try again later"
-    // would hand back a 400 telling them to retry a request that can never
-    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
-    // found in stripe checkout session" is not something a user can act on.
-    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
-      throw cause;
-    }
+    rethrowIfClientError(cause);
 
     throw new ShelfError({
       cause,
@@ -140,14 +133,7 @@ export async function createBarcodeAddonTrialSubscription({
 
     return { subscription, hasPaymentMethod: !!defaultPaymentMethod };
   } catch (cause) {
-    // A CLIENT-error ShelfError (e.g. the price validation above) already
-    // carries a message the user can act on; rewriting it to "try again later"
-    // would hand back a 400 telling them to retry a request that can never
-    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
-    // found in stripe checkout session" is not something a user can act on.
-    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
-      throw cause;
-    }
+    rethrowIfClientError(cause);
 
     throw new ShelfError({
       cause,

--- a/apps/webapp/app/modules/barcode/addon.server.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.ts
@@ -65,6 +65,15 @@ export async function createBarcodeAddonCheckoutSession({
     }
     return url;
   } catch (cause) {
+    // A CLIENT-error ShelfError (e.g. the price validation above) already
+    // carries a message the user can act on; rewriting it to "try again later"
+    // would hand back a 400 telling them to retry a request that can never
+    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
+    // found in stripe checkout session" is not something a user can act on.
+    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message:
@@ -131,6 +140,15 @@ export async function createBarcodeAddonTrialSubscription({
 
     return { subscription, hasPaymentMethod: !!defaultPaymentMethod };
   } catch (cause) {
+    // A CLIENT-error ShelfError (e.g. the price validation above) already
+    // carries a message the user can act on; rewriting it to "try again later"
+    // would hand back a 400 telling them to retry a request that can never
+    // succeed. Internal 5xx ShelfErrors keep the friendly wrapper -- "No url
+    // found in stripe checkout session" is not something a user can act on.
+    if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message:

--- a/apps/webapp/app/modules/barcode/addon.server.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.ts
@@ -2,6 +2,10 @@ import type { User } from "@prisma/client";
 import type Stripe from "stripe";
 import type { PriceWithProduct } from "~/components/subscription/prices";
 import { db } from "~/database/db.server";
+import {
+  assertPriceIsForAddon,
+  isAddonProduct,
+} from "~/modules/billing/price-validation.server";
 import type { ErrorLabel } from "~/utils/error";
 import { ShelfError } from "~/utils/error";
 import { premiumIsEnabled, stripe } from "~/utils/stripe.server";
@@ -23,6 +27,12 @@ export async function createBarcodeAddonCheckoutSession({
   organizationId: string;
 }): Promise<string> {
   try {
+    // The caller supplies `priceId` from the request, and an add-on price is
+    // distinguishable from a TIER price only by its product metadata. Without
+    // this, any active recurring price bought the add-on -- see
+    // ~/modules/billing/price-validation.server for why that granted it permanently.
+    await assertPriceIsForAddon({ priceId, addonType: "barcodes" });
+
     if (!stripe) {
       throw new ShelfError({
         cause: null,
@@ -78,6 +88,12 @@ export async function createBarcodeAddonTrialSubscription({
   organizationId: string;
 }) {
   try {
+    // The caller supplies `priceId` from the request, and an add-on price is
+    // distinguishable from a TIER price only by its product metadata. Without
+    // this, any active recurring price bought the add-on -- see
+    // ~/modules/billing/price-validation.server for why that granted it permanently.
+    await assertPriceIsForAddon({ priceId, addonType: "barcodes" });
+
     if (!stripe) {
       throw new ShelfError({
         cause: null,
@@ -139,13 +155,9 @@ export async function getBarcodeAddonPrices() {
       limit: 100,
     });
 
-    const barcodePrices = pricesResponse.data.filter((p) => {
-      const product = p.product as Stripe.Product;
-      return (
-        product?.metadata?.product_type === "addon" &&
-        product?.metadata?.addon_type === "barcodes"
-      );
-    }) as PriceWithProduct[];
+    const barcodePrices = pricesResponse.data.filter((p) =>
+      isAddonProduct(p.product, "barcodes")
+    ) as PriceWithProduct[];
 
     const monthlyPrice =
       barcodePrices.find((p) => p.recurring?.interval === "month") || null;
@@ -215,10 +227,7 @@ export async function linkBarcodeAddonToOrganization({
         if (!productId) continue;
 
         const product = await stripe.products.retrieve(productId);
-        if (
-          product.metadata?.product_type === "addon" &&
-          product.metadata?.addon_type === "barcodes"
-        ) {
+        if (isAddonProduct(product, "barcodes")) {
           barcodeSubscription = sub;
           break;
         }
@@ -299,10 +308,7 @@ export async function getBarcodeSubscriptionInfo({
         if (!productId) continue;
 
         const product = await stripe.products.retrieve(productId);
-        if (
-          product.metadata?.product_type === "addon" &&
-          product.metadata?.addon_type === "barcodes"
-        ) {
+        if (isAddonProduct(product, "barcodes")) {
           return {
             interval:
               (item.price.recurring?.interval as "month" | "year") || "year",

--- a/apps/webapp/app/modules/billing/price-validation.server.test.ts
+++ b/apps/webapp/app/modules/billing/price-validation.server.test.ts
@@ -42,10 +42,11 @@ function missingResourceError() {
 }
 
 /** A Stripe product carrying the given metadata. */
-function product(metadata: Record<string, string>) {
+function product(metadata: Record<string, string>, active = true) {
   return {
     id: "prod_1",
     deleted: false,
+    active,
     metadata,
   } as unknown as Stripe.Product;
 }
@@ -106,6 +107,7 @@ describe("assertPriceIsForAddon", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_1",
       active: true,
+      type: "recurring",
       product: BARCODE_PRODUCT,
     });
 
@@ -125,6 +127,7 @@ describe("assertPriceIsForAddon", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_tier",
       active: true,
+      type: "recurring",
       product: TIER_PRODUCT,
     });
 
@@ -137,6 +140,7 @@ describe("assertPriceIsForAddon", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_audits",
       active: true,
+      type: "recurring",
       product: AUDIT_PRODUCT,
     });
 
@@ -149,6 +153,7 @@ describe("assertPriceIsForAddon", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_old",
       active: false,
+      type: "recurring",
       product: BARCODE_PRODUCT,
     });
 
@@ -201,6 +206,7 @@ describe("assertPriceMatchesTier", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_t2",
       active: true,
+      type: "recurring",
       product: TIER_PRODUCT,
     });
 
@@ -213,6 +219,7 @@ describe("assertPriceMatchesTier", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_t1",
       active: true,
+      type: "recurring",
       product: product({ shelf_tier: "tier_1" }),
     });
 
@@ -228,6 +235,7 @@ describe("assertPriceMatchesTier", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_barcodes",
       active: true,
+      type: "recurring",
       product: BARCODE_PRODUCT,
     });
 
@@ -240,6 +248,7 @@ describe("assertPriceMatchesTier", () => {
     mockStripe.prices.retrieve.mockResolvedValue({
       id: "price_old",
       active: false,
+      type: "recurring",
       product: TIER_PRODUCT,
     });
 
@@ -271,5 +280,62 @@ describe("assertPriceMatchesTier — Stripe failure classification", () => {
     await expect(
       assertPriceMatchesTier({ priceId: "price_t2", shelfTier: "tier_2" })
     ).rejects.toBe(outage);
+  });
+});
+
+describe("inactive products and non-recurring prices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects an ARCHIVED add-on product", () => {
+    // The metadata still matches; only `active` says it is retired. Selling it
+    // would create a subscription against a product the operator withdrew.
+    expect(
+      isAddonProduct(
+        product({ product_type: "addon", addon_type: "barcodes" }, false),
+        "barcodes"
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a one-time add-on price", async () => {
+    // Every caller creates a SUBSCRIPTION.
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_once",
+      active: true,
+      type: "one_time",
+      product: BARCODE_PRODUCT,
+    });
+
+    await expect(
+      assertPriceIsForAddon({ priceId: "price_once", addonType: "barcodes" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects a one-time tier price", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_once",
+      active: true,
+      type: "one_time",
+      product: TIER_PRODUCT,
+    });
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "price_once", shelfTier: "tier_2" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects an archived tier product", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_t2",
+      active: true,
+      type: "recurring",
+      product: product({ shelf_tier: "tier_2" }, false),
+    });
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "price_t2", shelfTier: "tier_2" })
+    ).rejects.toMatchObject({ status: 400 });
   });
 });

--- a/apps/webapp/app/modules/billing/price-validation.server.test.ts
+++ b/apps/webapp/app/modules/billing/price-validation.server.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Stripe add-on product identity — entitlement-bypass regression coverage.
+ *
+ * The add-on routes took `priceId: z.string()` from the request and handed it
+ * to Stripe unvalidated. Any active recurring price was accepted, including a
+ * TIER price — which granted the paid feature permanently, because the route
+ * enables the flag eagerly while the resulting tier subscription never reaches
+ * the add-on webhook handler that would clear it.
+ *
+ * detail.dev finding D094 (reported for barcodes; audits was identical).
+ *
+ * @see {@link file://./price-validation.server.ts}
+ */
+
+import type Stripe from "stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: Stripe SDK makes external API calls
+const { mockStripe } = vi.hoisted(() => ({
+  mockStripe: { prices: { retrieve: vi.fn() } },
+}));
+
+vi.mock("~/utils/stripe.server", () => ({
+  stripe: mockStripe,
+  premiumIsEnabled: true,
+}));
+
+import {
+  assertPriceIsForAddon,
+  assertPriceMatchesTier,
+  isAddonProduct,
+} from "./price-validation.server";
+
+// @vitest-environment node
+
+/** A Stripe product carrying the given metadata. */
+function product(metadata: Record<string, string>) {
+  return {
+    id: "prod_1",
+    deleted: false,
+    metadata,
+  } as unknown as Stripe.Product;
+}
+
+const BARCODE_PRODUCT = product({
+  product_type: "addon",
+  addon_type: "barcodes",
+});
+const AUDIT_PRODUCT = product({ product_type: "addon", addon_type: "audits" });
+// What a tier subscription price points at — the payload that caused the bug.
+const TIER_PRODUCT = product({ shelf_tier: "tier_2" });
+
+describe("isAddonProduct", () => {
+  it("accepts the matching add-on product", () => {
+    expect(isAddonProduct(BARCODE_PRODUCT, "barcodes")).toBe(true);
+    expect(isAddonProduct(AUDIT_PRODUCT, "audits")).toBe(true);
+  });
+
+  it("rejects the OTHER add-on", () => {
+    // `product_type === "addon"` alone would let a barcode purchase enable
+    // audits, so both halves of the metadata pair are required.
+    expect(isAddonProduct(AUDIT_PRODUCT, "barcodes")).toBe(false);
+    expect(isAddonProduct(BARCODE_PRODUCT, "audits")).toBe(false);
+  });
+
+  it("rejects a tier product", () => {
+    expect(isAddonProduct(TIER_PRODUCT, "barcodes")).toBe(false);
+  });
+
+  it("rejects a product tagged addon_type without product_type", () => {
+    expect(
+      isAddonProduct(product({ addon_type: "barcodes" }), "barcodes")
+    ).toBe(false);
+  });
+
+  it("fails closed on an unexpanded, deleted, or absent product", () => {
+    // An unexpanded product is a bare id string — reaching for `.metadata` on
+    // it would silently yield undefined and read as "not an addon" by luck
+    // rather than by decision.
+    expect(isAddonProduct("prod_1", "barcodes")).toBe(false);
+    expect(
+      isAddonProduct(
+        { id: "prod_1", deleted: true } as unknown as Stripe.DeletedProduct,
+        "barcodes"
+      )
+    ).toBe(false);
+    expect(isAddonProduct(null, "barcodes")).toBe(false);
+    expect(isAddonProduct(undefined, "barcodes")).toBe(false);
+  });
+});
+
+describe("assertPriceIsForAddon", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the price when it belongs to the add-on", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_1",
+      active: true,
+      product: BARCODE_PRODUCT,
+    });
+
+    const price = await assertPriceIsForAddon({
+      priceId: "price_1",
+      addonType: "barcodes",
+    });
+
+    expect(price.id).toBe("price_1");
+    // The product must be resolved server-side; the caller only sent an id.
+    expect(mockStripe.prices.retrieve).toHaveBeenCalledWith("price_1", {
+      expand: ["product"],
+    });
+  });
+
+  it("rejects a tier price — the entitlement bypass", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_tier",
+      active: true,
+      product: TIER_PRODUCT,
+    });
+
+    await expect(
+      assertPriceIsForAddon({ priceId: "price_tier", addonType: "barcodes" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects the other add-on's price", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_audits",
+      active: true,
+      product: AUDIT_PRODUCT,
+    });
+
+    await expect(
+      assertPriceIsForAddon({ priceId: "price_audits", addonType: "barcodes" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects an inactive price", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_old",
+      active: false,
+      product: BARCODE_PRODUCT,
+    });
+
+    await expect(
+      assertPriceIsForAddon({ priceId: "price_old", addonType: "barcodes" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("turns an unknown price into a 400, not a 500", async () => {
+    // A bad id is caller error. Letting Stripe's own throw escape would make
+    // it a captured 500 and page someone for a crafted request.
+    mockStripe.prices.retrieve.mockRejectedValue(new Error("No such price"));
+
+    await expect(
+      assertPriceIsForAddon({ priceId: "nope", addonType: "barcodes" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("assertPriceMatchesTier", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts the price whose product carries that tier", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_t2",
+      active: true,
+      product: TIER_PRODUCT,
+    });
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "price_t2", shelfTier: "tier_2" })
+    ).resolves.toMatchObject({ id: "price_t2" });
+  });
+
+  it("refuses a cheaper tier's price claimed as a higher tier", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_t1",
+      active: true,
+      product: product({ shelf_tier: "tier_1" }),
+    });
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "price_t1", shelfTier: "tier_2" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("refuses an ADD-ON price claimed as a tier — the worst case", async () => {
+    // Worst because the resulting subscription is an add-on product, so
+    // `isAddonSubscription` early-returns and the webhook never corrects the
+    // tier the route already wrote.
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_barcodes",
+      active: true,
+      product: BARCODE_PRODUCT,
+    });
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "price_barcodes", shelfTier: "tier_2" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("refuses an inactive tier price", async () => {
+    mockStripe.prices.retrieve.mockResolvedValue({
+      id: "price_old",
+      active: false,
+      product: TIER_PRODUCT,
+    });
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "price_old", shelfTier: "tier_2" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/webapp/app/modules/billing/price-validation.server.test.ts
+++ b/apps/webapp/app/modules/billing/price-validation.server.test.ts
@@ -12,7 +12,7 @@
  * @see {@link file://./price-validation.server.ts}
  */
 
-import type Stripe from "stripe";
+import Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // why: Stripe SDK makes external API calls
@@ -32,6 +32,14 @@ import {
 } from "./price-validation.server";
 
 // @vitest-environment node
+
+/** The error Stripe raises for an id that does not exist. */
+function missingResourceError() {
+  return new Stripe.errors.StripeInvalidRequestError({
+    message: "No such price",
+    code: "resource_missing",
+  });
+}
 
 /** A Stripe product carrying the given metadata. */
 function product(metadata: Record<string, string>) {
@@ -152,11 +160,35 @@ describe("assertPriceIsForAddon", () => {
   it("turns an unknown price into a 400, not a 500", async () => {
     // A bad id is caller error. Letting Stripe's own throw escape would make
     // it a captured 500 and page someone for a crafted request.
-    mockStripe.prices.retrieve.mockRejectedValue(new Error("No such price"));
+    mockStripe.prices.retrieve.mockRejectedValue(missingResourceError());
 
     await expect(
       assertPriceIsForAddon({ priceId: "nope", addonType: "barcodes" })
     ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it.each([
+    [
+      "a rate limit",
+      new Stripe.errors.StripeRateLimitError({ message: "slow down" }),
+    ],
+    [
+      "bad server credentials",
+      new Stripe.errors.StripeAuthenticationError({ message: "bad key" }),
+    ],
+    [
+      "an outage",
+      new Stripe.errors.StripeConnectionError({ message: "unreachable" }),
+    ],
+  ])("does NOT disguise %s as a client error", async (_label, stripeError) => {
+    // These are our problem, not the caller's. Converting them to an uncaptured
+    // 400 "plan not found" would hide a billing outage from error monitoring
+    // and tell users their plan does not exist.
+    mockStripe.prices.retrieve.mockRejectedValue(stripeError);
+
+    await expect(
+      assertPriceIsForAddon({ priceId: "price_1", addonType: "barcodes" })
+    ).rejects.toBe(stripeError);
   });
 });
 
@@ -214,5 +246,30 @@ describe("assertPriceMatchesTier", () => {
     await expect(
       assertPriceMatchesTier({ priceId: "price_old", shelfTier: "tier_2" })
     ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("assertPriceMatchesTier — Stripe failure classification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("turns an unknown price into a 400", async () => {
+    mockStripe.prices.retrieve.mockRejectedValue(missingResourceError());
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "nope", shelfTier: "tier_2" })
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("lets a Stripe outage propagate so it is captured", async () => {
+    const outage = new Stripe.errors.StripeConnectionError({
+      message: "unreachable",
+    });
+    mockStripe.prices.retrieve.mockRejectedValue(outage);
+
+    await expect(
+      assertPriceMatchesTier({ priceId: "price_t2", shelfTier: "tier_2" })
+    ).rejects.toBe(outage);
   });
 });

--- a/apps/webapp/app/modules/billing/price-validation.server.test.ts
+++ b/apps/webapp/app/modules/billing/price-validation.server.test.ts
@@ -13,7 +13,9 @@
  */
 
 import Stripe from "stripe";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addonMetadata, stripePriceFactory, tierMetadata } from "@factories";
 
 // why: Stripe SDK makes external API calls
 const { mockStripe } = vi.hoisted(() => ({
@@ -104,12 +106,7 @@ describe("assertPriceIsForAddon", () => {
   });
 
   it("returns the price when it belongs to the add-on", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_1",
-      active: true,
-      type: "recurring",
-      product: BARCODE_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(stripePriceFactory());
 
     const price = await assertPriceIsForAddon({
       priceId: "price_1",
@@ -124,12 +121,9 @@ describe("assertPriceIsForAddon", () => {
   });
 
   it("rejects a tier price — the entitlement bypass", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_tier",
-      active: true,
-      type: "recurring",
-      product: TIER_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({ id: "price_tier", metadata: tierMetadata() })
+    );
 
     await expect(
       assertPriceIsForAddon({ priceId: "price_tier", addonType: "barcodes" })
@@ -137,12 +131,12 @@ describe("assertPriceIsForAddon", () => {
   });
 
   it("rejects the other add-on's price", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_audits",
-      active: true,
-      type: "recurring",
-      product: AUDIT_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({
+        id: "price_audits",
+        metadata: addonMetadata("audits"),
+      })
+    );
 
     await expect(
       assertPriceIsForAddon({ priceId: "price_audits", addonType: "barcodes" })
@@ -150,12 +144,9 @@ describe("assertPriceIsForAddon", () => {
   });
 
   it("rejects an inactive price", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_old",
-      active: false,
-      type: "recurring",
-      product: BARCODE_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({ id: "price_old", active: false })
+    );
 
     await expect(
       assertPriceIsForAddon({ priceId: "price_old", addonType: "barcodes" })
@@ -203,12 +194,9 @@ describe("assertPriceMatchesTier", () => {
   });
 
   it("accepts the price whose product carries that tier", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_t2",
-      active: true,
-      type: "recurring",
-      product: TIER_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({ id: "price_t2", metadata: tierMetadata() })
+    );
 
     await expect(
       assertPriceMatchesTier({ priceId: "price_t2", shelfTier: "tier_2" })
@@ -216,12 +204,9 @@ describe("assertPriceMatchesTier", () => {
   });
 
   it("refuses a cheaper tier's price claimed as a higher tier", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_t1",
-      active: true,
-      type: "recurring",
-      product: product({ shelf_tier: "tier_1" }),
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({ id: "price_t1", metadata: tierMetadata("tier_1") })
+    );
 
     await expect(
       assertPriceMatchesTier({ priceId: "price_t1", shelfTier: "tier_2" })
@@ -232,12 +217,9 @@ describe("assertPriceMatchesTier", () => {
     // Worst because the resulting subscription is an add-on product, so
     // `isAddonSubscription` early-returns and the webhook never corrects the
     // tier the route already wrote.
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_barcodes",
-      active: true,
-      type: "recurring",
-      product: BARCODE_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({ id: "price_barcodes" })
+    );
 
     await expect(
       assertPriceMatchesTier({ priceId: "price_barcodes", shelfTier: "tier_2" })
@@ -301,12 +283,9 @@ describe("inactive products and non-recurring prices", () => {
 
   it("rejects a one-time add-on price", async () => {
     // Every caller creates a SUBSCRIPTION.
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_once",
-      active: true,
-      type: "one_time",
-      product: BARCODE_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({ id: "price_once", type: "one_time" })
+    );
 
     await expect(
       assertPriceIsForAddon({ priceId: "price_once", addonType: "barcodes" })
@@ -314,12 +293,13 @@ describe("inactive products and non-recurring prices", () => {
   });
 
   it("rejects a one-time tier price", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_once",
-      active: true,
-      type: "one_time",
-      product: TIER_PRODUCT,
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({
+        id: "price_once",
+        type: "one_time",
+        metadata: tierMetadata(),
+      })
+    );
 
     await expect(
       assertPriceMatchesTier({ priceId: "price_once", shelfTier: "tier_2" })
@@ -327,12 +307,13 @@ describe("inactive products and non-recurring prices", () => {
   });
 
   it("rejects an archived tier product", async () => {
-    mockStripe.prices.retrieve.mockResolvedValue({
-      id: "price_t2",
-      active: true,
-      type: "recurring",
-      product: product({ shelf_tier: "tier_2" }, false),
-    });
+    mockStripe.prices.retrieve.mockResolvedValue(
+      stripePriceFactory({
+        id: "price_t2",
+        metadata: tierMetadata(),
+        productActive: false,
+      })
+    );
 
     await expect(
       assertPriceMatchesTier({ priceId: "price_t2", shelfTier: "tier_2" })

--- a/apps/webapp/app/modules/billing/price-validation.server.ts
+++ b/apps/webapp/app/modules/billing/price-validation.server.ts
@@ -1,0 +1,196 @@
+/**
+ * Stripe price validation.
+ *
+ * Shelf sells two add-ons — barcodes and audits — as Stripe products carrying
+ * `metadata.product_type === "addon"` and an `addon_type`. That metadata pair
+ * is the ONLY thing distinguishing an add-on price from a tier subscription
+ * price; both are ordinary recurring prices on the same Stripe account.
+ *
+ * The add-on purchase routes accepted a client-supplied `priceId` as a bare
+ * string and handed it straight to Stripe, so any active recurring price was
+ * accepted — including a TIER price. That turned a 7-day add-on trial into
+ * permanent free access to the paid feature: the route enables the flag
+ * eagerly, but the resulting subscription is a tier subscription, so
+ * `isAddonSubscription` returns false for it and the add-on webhook handler
+ * that would later clear the flag never runs.
+ *
+ * Validating at the entry point is what closes it: a mismatched subscription
+ * is never created in the first place, so no webhook has to reason about one.
+ *
+ * The same class applies to TIER prices: the subscription route writes the
+ * user's `tierId` from a client-supplied `shelfTier` without checking that
+ * the price paid actually is that tier's price. Both live here so the two
+ * halves of the billing surface validate the same way.
+ *
+ * @see {@link file://./../barcode/addon.server.ts}
+ * @see {@link file://./../audit/addon.server.ts}
+ * @see {@link file://./../stripe-webhook/helpers.server.ts} `isAddonSubscription`
+ */
+
+import type Stripe from "stripe";
+
+import { ShelfError } from "~/utils/error";
+import { stripe } from "~/utils/stripe.server";
+
+const label = "Stripe" as const;
+
+/** The add-ons Shelf sells, as written in Stripe product metadata. */
+export type AddonType = "barcodes" | "audits";
+
+/**
+ * Whether a Stripe product is the add-on product for `addonType`.
+ *
+ * Both halves matter. `product_type === "addon"` alone would accept the other
+ * add-on's price (buying barcodes would enable audits), and `addon_type` alone
+ * would match anything an operator happened to tag.
+ *
+ * @param product - The expanded Stripe product, or a bare id / deleted product
+ * @param addonType - Which add-on the caller expects
+ * @returns `true` only if the product carries both metadata values
+ */
+export function isAddonProduct(
+  product: Stripe.Product | Stripe.DeletedProduct | string | null | undefined,
+  addonType: AddonType
+): boolean {
+  // A string means the caller did not expand the product, and a deleted
+  // product carries no usable metadata. Fail closed for both rather than
+  // reaching into a shape that isn't there.
+  if (!product || typeof product === "string" || product.deleted) {
+    return false;
+  }
+
+  return (
+    product.metadata?.product_type === "addon" &&
+    product.metadata?.addon_type === addonType
+  );
+}
+
+/**
+ * Asserts that a client-supplied price id really is a price for `addonType`.
+ *
+ * Call this before creating any subscription or checkout session from a
+ * `priceId` that came from a request. Resolving the price server-side is the
+ * point: the caller sends only an id, so the product metadata we check is
+ * Stripe's answer, not the caller's claim.
+ *
+ * @param priceId - The price id supplied by the client
+ * @param addonType - Which add-on the route is selling
+ * @returns The resolved Stripe price
+ * @throws {ShelfError} 400 if the price is unknown, inactive, or belongs to
+ *   any product other than the expected add-on
+ */
+export async function assertPriceIsForAddon({
+  priceId,
+  addonType,
+}: {
+  priceId: string;
+  addonType: AddonType;
+}): Promise<Stripe.Price> {
+  if (!stripe) {
+    throw new ShelfError({
+      cause: null,
+      message: "Stripe not initialized",
+      additionalData: { priceId, addonType },
+      label,
+    });
+  }
+
+  const price = await stripe.prices
+    .retrieve(priceId, { expand: ["product"] })
+    .catch((cause) => {
+      throw new ShelfError({
+        cause,
+        message: "The selected plan could not be found.",
+        additionalData: { priceId, addonType },
+        label,
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    });
+
+  // An inactive price is not purchasable; accepting one would create a
+  // subscription against a price the operator has retired.
+  if (!price.active || !isAddonProduct(price.product, addonType)) {
+    throw new ShelfError({
+      cause: null,
+      // Deliberately does not describe what was wrong with the price — the
+      // value is caller-supplied and the distinction between "not an add-on"
+      // and "inactive" is not the caller's business.
+      message: "The selected plan is not available for this add-on.",
+      additionalData: { priceId, addonType },
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
+
+  return price;
+}
+
+/**
+ * Asserts that a client-supplied price id really is the price for `shelfTier`.
+ *
+ * The subscription route takes BOTH `priceId` and `shelfTier` from the form and
+ * writes `user.tierId = shelfTier` directly, without checking that the price
+ * being paid is that tier's price. So `shelfTier: "tier_2"` could be paired
+ * with any cheaper active price — including an add-on price, which is the worst
+ * case: `isAddonSubscription` sees an add-on product, returns early, and the
+ * webhook never corrects the tier the route already wrote.
+ *
+ * A tier price is identified the same way an add-on price is — by its product
+ * metadata (`shelf_tier`), which only Stripe can vouch for.
+ *
+ * @param priceId - The price id supplied by the client
+ * @param shelfTier - The tier the client claims that price buys
+ * @returns The resolved Stripe price
+ * @throws {ShelfError} 400 if the price is unknown, inactive, or is not the
+ *   price for that tier
+ */
+export async function assertPriceMatchesTier({
+  priceId,
+  shelfTier,
+}: {
+  priceId: string;
+  shelfTier: string;
+}): Promise<Stripe.Price> {
+  if (!stripe) {
+    throw new ShelfError({
+      cause: null,
+      message: "Stripe not initialized",
+      additionalData: { priceId, shelfTier },
+      label,
+    });
+  }
+
+  const price = await stripe.prices
+    .retrieve(priceId, { expand: ["product"] })
+    .catch((cause) => {
+      throw new ShelfError({
+        cause,
+        message: "The selected plan could not be found.",
+        additionalData: { priceId, shelfTier },
+        label,
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    });
+
+  const product = price.product;
+  const priceTier =
+    !product || typeof product === "string" || product.deleted
+      ? undefined
+      : product.metadata?.shelf_tier;
+
+  if (!price.active || priceTier !== shelfTier) {
+    throw new ShelfError({
+      cause: null,
+      message: "The selected plan is not available.",
+      additionalData: { priceId, shelfTier, priceTier },
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
+
+  return price;
+}

--- a/apps/webapp/app/modules/billing/price-validation.server.ts
+++ b/apps/webapp/app/modules/billing/price-validation.server.ts
@@ -105,7 +105,11 @@ export function isAddonProduct(
     return false;
   }
 
+  // `active` matters as much as the metadata: an archived add-on product must
+  // not be sellable, and this predicate also filters the price lists the UI
+  // offers.
   return (
+    product.active === true &&
     product.metadata?.product_type === "addon" &&
     product.metadata?.addon_type === addonType
   );
@@ -147,8 +151,14 @@ export async function assertPriceIsForAddon({
   });
 
   // An inactive price is not purchasable; accepting one would create a
-  // subscription against a price the operator has retired.
-  if (!price.active || !isAddonProduct(price.product, addonType)) {
+  // subscription against a price the operator has retired. `recurring` because
+  // every caller creates a SUBSCRIPTION -- a one-time price would either fail
+  // at Stripe or produce a subscription that never renews.
+  if (
+    !price.active ||
+    price.type !== "recurring" ||
+    !isAddonProduct(price.product, addonType)
+  ) {
     throw new ShelfError({
       cause: null,
       // Deliberately does not describe what was wrong with the price — the
@@ -206,12 +216,14 @@ export async function assertPriceMatchesTier({
   });
 
   const product = price.product;
-  const priceTier =
-    !product || typeof product === "string" || product.deleted
-      ? undefined
-      : product.metadata?.shelf_tier;
+  const isUsableProduct =
+    !!product &&
+    typeof product !== "string" &&
+    !product.deleted &&
+    product.active === true;
+  const priceTier = isUsableProduct ? product.metadata?.shelf_tier : undefined;
 
-  if (!price.active || priceTier !== shelfTier) {
+  if (!price.active || price.type !== "recurring" || priceTier !== shelfTier) {
     throw new ShelfError({
       cause: null,
       message: "The selected plan is not available.",

--- a/apps/webapp/app/modules/billing/price-validation.server.ts
+++ b/apps/webapp/app/modules/billing/price-validation.server.ts
@@ -27,8 +27,9 @@
  * @see {@link file://./../stripe-webhook/helpers.server.ts} `isAddonSubscription`
  */
 
-import type Stripe from "stripe";
+import Stripe from "stripe";
 
+import type { AdditionalData } from "~/utils/error";
 import { ShelfError } from "~/utils/error";
 import { stripe } from "~/utils/stripe.server";
 
@@ -36,6 +37,51 @@ const label = "Stripe" as const;
 
 /** The add-ons Shelf sells, as written in Stripe product metadata. */
 export type AddonType = "barcodes" | "audits";
+
+/**
+ * Retrieves a price with its product expanded, mapping ONLY a genuine
+ * unknown-id response to a client error.
+ *
+ * The distinction matters operationally. An unconditional catch here would turn
+ * a Stripe outage, a rate-limit, or rejected server credentials into an
+ * uncaptured 400 telling the user their plan does not exist — hiding a billing
+ * failure from error monitoring and misclassifying a retryable server fault as
+ * the caller's mistake. Anything that is not "no such price" is rethrown so the
+ * surrounding handler reports it as a captured 500.
+ *
+ * Mirrors the existing detection in `~/utils/stripe.server`.
+ *
+ * @param priceId - The price id supplied by the client
+ * @param additionalData - Context attached to the 400, for debugging
+ * @returns The resolved Stripe price, product expanded
+ * @throws {ShelfError} 400 when Stripe reports no such price
+ * @throws The original error for every other Stripe failure
+ */
+async function retrievePriceWithProduct(
+  priceId: string,
+  additionalData: AdditionalData
+): Promise<Stripe.Price> {
+  try {
+    return await stripe!.prices.retrieve(priceId, { expand: ["product"] });
+  } catch (cause) {
+    const isUnknownPrice =
+      cause instanceof Stripe.errors.StripeInvalidRequestError &&
+      (cause.code === "resource_missing" || cause.statusCode === 404);
+
+    if (!isUnknownPrice) {
+      throw cause;
+    }
+
+    throw new ShelfError({
+      cause,
+      message: "The selected plan could not be found.",
+      additionalData,
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
+}
 
 /**
  * Whether a Stripe product is the add-on product for `addonType`.
@@ -95,18 +141,10 @@ export async function assertPriceIsForAddon({
     });
   }
 
-  const price = await stripe.prices
-    .retrieve(priceId, { expand: ["product"] })
-    .catch((cause) => {
-      throw new ShelfError({
-        cause,
-        message: "The selected plan could not be found.",
-        additionalData: { priceId, addonType },
-        label,
-        status: 400,
-        shouldBeCaptured: false,
-      });
-    });
+  const price = await retrievePriceWithProduct(priceId, {
+    priceId,
+    addonType,
+  });
 
   // An inactive price is not purchasable; accepting one would create a
   // subscription against a price the operator has retired.
@@ -162,18 +200,10 @@ export async function assertPriceMatchesTier({
     });
   }
 
-  const price = await stripe.prices
-    .retrieve(priceId, { expand: ["product"] })
-    .catch((cause) => {
-      throw new ShelfError({
-        cause,
-        message: "The selected plan could not be found.",
-        additionalData: { priceId, shelfTier },
-        label,
-        status: 400,
-        shouldBeCaptured: false,
-      });
-    });
+  const price = await retrievePriceWithProduct(priceId, {
+    priceId,
+    shelfTier,
+  });
 
   const product = price.product;
   const priceTier =

--- a/apps/webapp/app/routes/_layout+/account-details.subscription.tsx
+++ b/apps/webapp/app/routes/_layout+/account-details.subscription.tsx
@@ -22,6 +22,10 @@ import { SubscriptionsOverview } from "~/components/subscription/subscriptions-o
 import SuccessfulSubscriptionModal from "~/components/subscription/successful-subscription-modal";
 import { db } from "~/database/db.server";
 import { useUserData } from "~/hooks/use-user-data";
+import {
+  assertPriceIsForAddon,
+  assertPriceMatchesTier,
+} from "~/modules/billing/price-validation.server";
 import { getUserTierLimit } from "~/modules/tier/service.server";
 
 import { getUserByID } from "~/modules/user/service.server";
@@ -185,6 +189,26 @@ export async function action({ context, request }: ActionFunctionArgs) {
           barcodePriceId: z.string().optional(),
         })
       );
+
+    // `shelfTier` and every price id here come from the form. The tier is
+    // written straight to `user.tierId` below and the add-on ids become raw
+    // Stripe line items, so without resolving each price server-side a caller
+    // could pair tier_2 with any cheaper active price -- and if that price is
+    // an add-on price, `isAddonSubscription` makes the webhook early-return and
+    // the tier is never corrected. See ~/modules/billing/price-validation.server.
+    await assertPriceMatchesTier({ priceId, shelfTier });
+    if (auditPriceId) {
+      await assertPriceIsForAddon({
+        priceId: auditPriceId,
+        addonType: "audits",
+      });
+    }
+    if (barcodePriceId) {
+      await assertPriceIsForAddon({
+        priceId: barcodePriceId,
+        addonType: "barcodes",
+      });
+    }
 
     const user = await getUserByID(userId, {
       select: {

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -204,6 +204,26 @@ export class ShelfError extends Error {
 }
 
 /**
+ * Re-throws `cause` unchanged when it is a deliberate CLIENT-error ShelfError.
+ *
+ * Service wrappers typically catch everything and re-throw with a friendly
+ * "something went wrong, try again later" message. That is right for an
+ * internal fault, and wrong for a 4xx someone chose deliberately: it hands the
+ * user a 400 telling them to retry a request that can never succeed.
+ *
+ * 4xx means a human wrote that message for a user; 5xx means something broke.
+ * `status` is optional on ShelfError, so an unset status is treated as 500.
+ *
+ * @param cause - The caught value
+ * @throws The original error when it is a client-error ShelfError
+ */
+export function rethrowIfClientError(cause: unknown): void {
+  if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
+    throw cause;
+  }
+}
+
+/**
  * This helper function is used to check if an error is an instance of `ShelfError` or an object that looks like an `ShelfError`.
  */
 export function isLikeShelfError(cause: unknown): cause is ShelfError {

--- a/apps/webapp/test/factories/index.ts
+++ b/apps/webapp/test/factories/index.ts
@@ -9,3 +9,4 @@ export * from "./asset";
 export * from "./organization";
 export * from "./assetModel";
 export * from "./activityEvent";
+export * from "./stripePrice";

--- a/apps/webapp/test/factories/stripePrice.ts
+++ b/apps/webapp/test/factories/stripePrice.ts
@@ -1,0 +1,72 @@
+/**
+ * Stripe price/product fixtures.
+ *
+ * `assertPriceIsForAddon` and `assertPriceMatchesTier` decide on FOUR
+ * properties of a resolved price — `active`, `type`, and the product's `active`
+ * plus its metadata. A literal repeated per test has to spell all four out, and
+ * every test that omits one starts passing or failing for the wrong reason.
+ *
+ * That is not hypothetical: adding the `product.active` requirement broke 13
+ * hand-written fixtures at once, each needing the same edit. A factory makes
+ * the default correct and lets a test override only the property it is about.
+ *
+ * @see {@link file://./../../app/modules/billing/price-validation.server.ts}
+ */
+
+import type Stripe from "stripe";
+
+/** Overrides for {@link stripePriceFactory}. */
+export type StripePriceOverrides = {
+  id?: string;
+  active?: boolean;
+  type?: Stripe.Price.Type;
+  /** Product metadata — `{ product_type, addon_type }` or `{ shelf_tier }`. */
+  metadata?: Record<string, string>;
+  /** Whether the PRODUCT is active, as distinct from the price. */
+  productActive?: boolean;
+  productDeleted?: boolean;
+};
+
+/**
+ * Builds a price that passes validation by default, product expanded.
+ *
+ * Defaults to the barcode add-on because that is the common case; pass
+ * `metadata` for a tier or the other add-on.
+ *
+ * @param overrides - Only the properties the test is actually about
+ * @returns A Stripe price shaped as `prices.retrieve(..., { expand: ["product"] })` returns it
+ */
+export function stripePriceFactory(
+  overrides: StripePriceOverrides = {}
+): Stripe.Price {
+  const {
+    id = "price_1",
+    active = true,
+    type = "recurring",
+    metadata = { product_type: "addon", addon_type: "barcodes" },
+    productActive = true,
+    productDeleted = false,
+  } = overrides;
+
+  return {
+    id,
+    active,
+    type,
+    product: {
+      id: "prod_1",
+      active: productActive,
+      deleted: productDeleted,
+      metadata,
+    },
+  } as unknown as Stripe.Price;
+}
+
+/** The metadata a tier product carries. */
+export function tierMetadata(tier = "tier_2") {
+  return { shelf_tier: tier };
+}
+
+/** The metadata an add-on product carries. */
+export function addonMetadata(addonType: "barcodes" | "audits" = "barcodes") {
+  return { product_type: "addon", addon_type: addonType };
+}


### PR DESCRIPTION
## What

Any authenticated user with `subscription:update` could get a **paid add-on
permanently, for free**, by starting its 7-day trial with a *tier* price id.

Found by the detail.dev OSS scan (finding D094).

## The bug

An add-on price and a tier price are both ordinary active recurring prices on
the same Stripe account. The only thing distinguishing them is product
metadata. The routes took the id as a bare string:

```ts
priceId: z.string(),   // any active recurring price
```

and handed it straight to Stripe.

### Why it was *permanent*, not just a free trial

The route enables the flag eagerly:

```ts
data: { barcodesEnabled: true, usedBarcodeTrial: true, ... }
```

but a tier price produces a subscription carrying a `tierId`, and:

```ts
export function isAddonSubscription({ tierId, ... }) {
  if (tierId) return false;   // -> caller treats it as a tier subscription
```

so the add-on webhook handler never runs and **nothing ever clears the flag**.
The trial ends, the subscription pauses, the feature stays on.

## Scope: the scan named one endpoint

Sweeping for client-supplied price ids found **4 route files / 8 fields**:

| Route | Fields |
| --- | --- |
| `api+/barcode-addon.ts` | `priceId` |
| `_layout+/audits.tsx` | `priceId` |
| `_welcome+/welcome.tsx` | `auditPriceId`, `barcodePriceId` |
| `_layout+/account-details.subscription.tsx` | `priceId`, `shelfTier`, `auditPriceId`, `barcodePriceId` |

**My first sweep missed two of these** — I grepped case-sensitively for
`priceId`, which does not match `auditPriceId`. Re-run case-insensitively for
the corrected list above. The companion app has no billing surface at all.

### One of them is worse than the reported bug

`account-details.subscription.tsx` writes the user's tier straight from the
form:

```ts
data: { tierId: shelfTier, usedFreeTrial: true }
```

with no check that `priceId` is that tier's price. Pairing `tier_2` with an
add-on price is the worst case — the subscription is an add-on product, so
`isAddonSubscription` early-returns and the tier the route already wrote is
never corrected.

## The fix

`~/modules/billing/price-validation.server` resolves every client-supplied
price through Stripe and checks the product metadata — the server's answer, not
the caller's claim:

```ts
assertPriceIsForAddon({ priceId, addonType })   // product_type + addon_type
assertPriceMatchesTier({ priceId, shelfTier })  // shelf_tier
```

Both metadata halves are required for add-ons: `product_type === "addon"` alone
would let a barcode purchase enable audits.

**Placement is deliberate.** The add-on guards live inside the four service
functions rather than in the routes, which is why `welcome.tsx` — a caller I had
not enumerated when I wrote them — is covered for free. The tier guard lives in
the route instead, because putting it in `stripe.server` would create an import
cycle.

Also replaces six copies of the add-on metadata predicate with a shared
`isAddonProduct` that fails closed on an unexpanded, deleted or absent product.
The inline copies read `.metadata` off a value that can be a bare string.

## Tests

- `price-validation.server.test.ts` (14) — tier price, the *other* add-on's
  price, inactive price, unknown price → 400 not 500, and fail-closed on
  unexpanded/deleted/null products.
- `barcode/addon.server.test.ts`, `audit/addon.server.test.ts` (+2 each) — a
  tier price is refused and **no subscription is created**.

Confirmed failing against the unguarded services. That the existing add-on
suites broke when the guard landed (they had no `prices.retrieve` stub) is the
evidence every path now goes through it.

## Deliberately not enforcing a numeric project id

Considered and rejected: Sentry's own SDK spec calls a project id a string
identifier that is merely "usually an integer", so requiring digits would reject
a spec-valid deployment.

## Ops follow-up — this does not revoke what was already granted

Blocking new bypasses leaves existing entitlements in place. `superpowers/d094-reconciliation.sql`
lists workspaces with an add-on flag set, plus the owner's Stripe customer id and
the `*EnabledAt` timestamps. SQL cannot see Stripe, so each row needs a check for
a real add-on subscription; rows without one should be revoked.

**Two live-Stripe checks before deploy**, which I cannot make from the repo:

- every active **tier** product must carry `metadata.shelf_tier`, or
  `assertPriceMatchesTier` will 400 real purchases (the app already derives tier
  from that key elsewhere, so this is very likely fine — but it is a revenue path);
- a `$0` or legacy price sitting on an add-on product would still be accepted
  (correct entitlement, possibly wrong amount).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened billing validation so subscription prices must match the selected tier.
  * Prevented invalid, inactive, unknown, non-recurring, or mismatched audit and barcode add-on prices from creating subscriptions or checkout sessions.
  * Preserved clear validation messages while continuing to surface payment-provider failures appropriately.
  * Ensured only valid audit and barcode add-on products are identified and linked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->