### PR TITLE
fix(security): make add-on trials and purchases owner-only on the server

### DIFF
--- a/apps/webapp/app/routes/_layout+/audits.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.tsx
@@ -25,7 +25,10 @@ import {
   PermissionAction,
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
-import { requirePermission } from "~/utils/roles.server";
+import {
+  assertIsOrganizationOwner,
+  requirePermission,
+} from "~/utils/roles.server";
 import {
   customerHasPaymentMethod,
   getDomainUrl,
@@ -137,8 +140,19 @@ export async function action({ context, request }: ActionFunctionArgs) {
       })
     );
 
-    const { organizationId, currentOrganization } =
+    const { organizationId, currentOrganization, userOrganizations } =
       await getSelectedOrganization({ userId, request });
+
+    // `subscription:update` is not enough here. ADMIN short-circuits to
+    // allow-all in `hasPermission`, so it clears that gate -- but this spends
+    // money on the owner's card and burns the workspace's ONE free trial, an
+    // irreversible flag. The purchase UI is owner-only; this makes the action
+    // agree with it.
+    assertIsOrganizationOwner({
+      userOrganizations,
+      organizationId,
+      action: "start or buy the audits add-on",
+    });
 
     const user = await getUserByID(userId, {
       select: {

--- a/apps/webapp/app/routes/api+/barcode-addon.ts
+++ b/apps/webapp/app/routes/api+/barcode-addon.ts
@@ -16,7 +16,10 @@ import {
   PermissionAction,
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
-import { requirePermission } from "~/utils/roles.server";
+import {
+  assertIsOrganizationOwner,
+  requirePermission,
+} from "~/utils/roles.server";
 import {
   customerHasPaymentMethod,
   getDomainUrl,
@@ -49,8 +52,19 @@ export async function action({ context, request }: ActionFunctionArgs) {
       })
     );
 
-    const { organizationId, currentOrganization } =
+    const { organizationId, currentOrganization, userOrganizations } =
       await getSelectedOrganization({ userId, request });
+
+    // `subscription:update` is not enough here. ADMIN short-circuits to
+    // allow-all in `hasPermission`, so it clears that gate -- but this spends
+    // money on the owner's card and burns the workspace's ONE free trial, an
+    // irreversible flag. The purchase UI is owner-only; this makes the action
+    // agree with it.
+    assertIsOrganizationOwner({
+      userOrganizations,
+      organizationId,
+      action: "start or buy the barcodes add-on",
+    });
 
     const user = await getUserByID(userId, {
       select: {

--- a/apps/webapp/app/utils/roles-owner.server.test.ts
+++ b/apps/webapp/app/utils/roles-owner.server.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Workspace-owner assertion.
+ *
+ * `requirePermission(subscription, update)` is not a sufficient gate for
+ * anything that spends money or burns a one-time entitlement: ADMIN
+ * short-circuits to allow-all in `hasPermission`, so it clears that check.
+ * The add-on purchase UI is owner-only (`if (!isOwner) return null`), but the
+ * actions behind it were not — so an ADMIN could burn the workspace's single
+ * free trial, an irreversible flag, and commit the workspace to a charge on the
+ * owner's card.
+ *
+ * detail.dev finding D102.
+ *
+ * @see {@link file://./roles.server.ts}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+// why: roles.server imports the Prisma client and Sentry at module load
+vi.mock("~/database/db.server", () => ({ db: {} }));
+vi.mock("@sentry/react-router", () => ({ setUser: vi.fn(), setTag: vi.fn() }));
+
+import { assertIsOrganizationOwner, isOrganizationOwner } from "./roles.server";
+
+// @vitest-environment node
+
+const ORG = "org-1";
+
+/** Builds a membership list granting `roles` in ORG. */
+function memberships(roles: OrganizationRoles[]) {
+  return [
+    { organization: { id: "other-org" }, roles: [OrganizationRoles.OWNER] },
+    { organization: { id: ORG }, roles },
+  ];
+}
+
+describe("isOrganizationOwner", () => {
+  it("recognises the owner", () => {
+    expect(
+      isOrganizationOwner({
+        userOrganizations: memberships([OrganizationRoles.OWNER]),
+        organizationId: ORG,
+      })
+    ).toBe(true);
+  });
+
+  it("does not treat ADMIN as owner", () => {
+    expect(
+      isOrganizationOwner({
+        userOrganizations: memberships([OrganizationRoles.ADMIN]),
+        organizationId: ORG,
+      })
+    ).toBe(false);
+  });
+
+  it("finds OWNER anywhere in the roles array, not just first", () => {
+    // `resolveEffectiveRole` returns roles[0], so a check built on it would
+    // miss an owner who also carries another role.
+    expect(
+      isOrganizationOwner({
+        userOrganizations: memberships([
+          OrganizationRoles.ADMIN,
+          OrganizationRoles.OWNER,
+        ]),
+        organizationId: ORG,
+      })
+    ).toBe(true);
+  });
+
+  it("does not leak ownership of a DIFFERENT workspace", () => {
+    // The fixture makes the caller OWNER of "other-org"; that must not count.
+    expect(
+      isOrganizationOwner({
+        userOrganizations: memberships([OrganizationRoles.ADMIN]),
+        organizationId: ORG,
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when the caller has no membership at all", () => {
+    expect(
+      isOrganizationOwner({ userOrganizations: [], organizationId: ORG })
+    ).toBe(false);
+  });
+});
+
+describe("assertIsOrganizationOwner", () => {
+  it("passes for the owner", () => {
+    expect(() =>
+      assertIsOrganizationOwner({
+        userOrganizations: memberships([OrganizationRoles.OWNER]),
+        organizationId: ORG,
+        action: "start the trial",
+      })
+    ).not.toThrow();
+  });
+
+  it("throws 403 for an ADMIN", () => {
+    expect(() =>
+      assertIsOrganizationOwner({
+        userOrganizations: memberships([OrganizationRoles.ADMIN]),
+        organizationId: ORG,
+        action: "start the trial",
+      })
+    ).toThrow(expect.objectContaining({ status: 403 }) as unknown as Error);
+  });
+
+  it("names the action in the message", () => {
+    try {
+      assertIsOrganizationOwner({
+        userOrganizations: memberships([OrganizationRoles.BASE]),
+        organizationId: ORG,
+        action: "start or buy the audits add-on",
+      });
+      expect.unreachable("should have thrown");
+    } catch (cause) {
+      expect((cause as Error).message).toBe(
+        "Only the workspace owner can start or buy the audits add-on."
+      );
+    }
+  });
+});

--- a/apps/webapp/app/utils/roles.server.ts
+++ b/apps/webapp/app/utils/roles.server.ts
@@ -251,6 +251,76 @@ export async function requirePermission({
 }
 
 /**
+ * Whether the user holds OWNER in the given organization.
+ *
+ * Checks membership of the roles ARRAY rather than `resolveEffectiveRole`,
+ * which returns `roles[0]` — a user carrying more than one role could be the
+ * owner without OWNER being first. This mirrors the check the loaders already
+ * use to decide whether to render the purchase UI, so the server gate and the
+ * UI gate cannot disagree.
+ *
+ * @param userOrganizations - The caller's memberships, as returned by `requirePermission`
+ * @param organizationId - The active organization
+ * @returns `true` if the caller owns this workspace
+ */
+export function isOrganizationOwner({
+  userOrganizations,
+  organizationId,
+}: {
+  userOrganizations: Array<{
+    organization: { id: string };
+    roles: OrganizationRoles[];
+  }>;
+  organizationId: string;
+}): boolean {
+  return (
+    userOrganizations
+      .find((o) => o.organization.id === organizationId)
+      ?.roles.includes(OrganizationRoles.OWNER) ?? false
+  );
+}
+
+/**
+ * Asserts the caller owns the workspace.
+ *
+ * `requirePermission(subscription, update)` is NOT sufficient for anything that
+ * spends money or burns a one-time entitlement: ADMIN short-circuits to
+ * allow-all in `hasPermission`, so it passes that gate. The add-on purchase UI
+ * is owner-only, but the actions behind it were not — letting an ADMIN burn the
+ * workspace's single free trial (an irreversible flag) and commit the workspace
+ * to a charge on the owner's card.
+ *
+ * @param userOrganizations - The caller's memberships, as returned by `requirePermission`
+ * @param organizationId - The active organization
+ * @param action - Verb phrase completing "Only the workspace owner can …"
+ * @throws {ShelfError} 403 if the caller is not the owner
+ */
+export function assertIsOrganizationOwner({
+  userOrganizations,
+  organizationId,
+  action,
+}: {
+  userOrganizations: Array<{
+    organization: { id: string };
+    roles: OrganizationRoles[];
+  }>;
+  organizationId: string;
+  action: string;
+}): void {
+  if (!isOrganizationOwner({ userOrganizations, organizationId })) {
+    throw new ShelfError({
+      cause: null,
+      title: "Owner only",
+      message: `Only the workspace owner can ${action}.`,
+      additionalData: { organizationId },
+      label: "Subscription",
+      status: 403,
+      shouldBeCaptured: false,
+    });
+  }
+}
+
+/**
  * Splits a comma-separated `SsoDetails` group-id field into a normalized list of
  * lower-cased, trimmed, non-empty ids. Mirrors the comma-separated convention
  * already used by `SsoDetails.domain`, so one role can map to several IdP groups

--- a/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
+++ b/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Barcode add-on purchase route — owner-only enforcement.
+ *
+ * The action gated on `requirePermission(subscription, update)` alone. ADMIN
+ * short-circuits to allow-all in `hasPermission`, so it cleared that gate — but
+ * starting the trial writes `usedBarcodeTrial: true`, an IRREVERSIBLE flag that
+ * spends the workspace's single free trial, and creates a Stripe subscription
+ * that auto-charges the owner's card when the trial ends.
+ *
+ * The UI was already owner-only (`if (!isOwner) return null` in
+ * unlock-barcodes-banner), so only a direct POST reached this.
+ *
+ * detail.dev finding D102.
+ *
+ * @see {@link file://./../../../app/routes/api+/barcode-addon.ts}
+ * @see {@link file://./../../../app/utils/roles.server.ts} `assertIsOrganizationOwner`
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+// why: mocking Remix's data() so the action's error path returns a Response
+// whose status we can assert (React Router v7 single fetch)
+const createDataMock = vi.hoisted(() => {
+  return () =>
+    vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+});
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+// why: preventing Prisma from connecting to a real database
+const { mockOrgUpdate } = vi.hoisted(() => ({ mockOrgUpdate: vi.fn() }));
+vi.mock("~/database/db.server", () => ({
+  db: { organization: { update: mockOrgUpdate } },
+}));
+
+// why: the permission gate is not what's under test — we want it to PASS so
+// the assertion proves the owner check is what refuses, not the RBAC check.
+vi.mock("~/utils/roles.server", async () => {
+  const actual = await vi.importActual<typeof import("~/utils/roles.server")>(
+    "~/utils/roles.server"
+  );
+  return { ...actual, requirePermission: vi.fn().mockResolvedValue({}) };
+});
+
+// why: external Stripe/billing calls — also the sinks we assert are unreached
+vi.mock("~/modules/barcode/addon.server", () => ({
+  createBarcodeAddonTrialSubscription: vi
+    .fn()
+    .mockResolvedValue({ hasPaymentMethod: true }),
+  createBarcodeAddonCheckoutSession: vi
+    .fn()
+    .mockResolvedValue("https://stripe.example/checkout"),
+}));
+
+const { mockGetSelectedOrganization } = vi.hoisted(() => ({
+  mockGetSelectedOrganization: vi.fn(),
+}));
+vi.mock("~/modules/organization/context.server", () => ({
+  getSelectedOrganization: mockGetSelectedOrganization,
+}));
+
+vi.mock("~/modules/user/service.server", () => ({
+  getUserByID: vi.fn().mockResolvedValue({
+    customerId: "cus_1",
+    firstName: "Ada",
+    lastName: "L",
+    displayName: "Ada",
+  }),
+}));
+
+vi.mock("~/utils/stripe.server", () => ({
+  getOrCreateCustomerId: vi.fn().mockResolvedValue("cus_1"),
+  customerHasPaymentMethod: vi.fn().mockResolvedValue(false),
+  getDomainUrl: vi.fn().mockReturnValue("https://app.shelf.nu"),
+}));
+
+vi.mock("~/emails/stripe/barcode-trial-welcome", () => ({
+  sendBarcodeTrialWelcomeEmail: vi.fn(),
+}));
+
+import {
+  createBarcodeAddonCheckoutSession,
+  createBarcodeAddonTrialSubscription,
+} from "~/modules/barcode/addon.server";
+import { action } from "~/routes/api+/barcode-addon";
+
+// @vitest-environment node
+
+const ORG = "org-1";
+
+/** Makes `getSelectedOrganization` report the caller as holding `roles`. */
+function callerHolds(roles: OrganizationRoles[]) {
+  mockGetSelectedOrganization.mockResolvedValue({
+    organizationId: ORG,
+    currentOrganization: { id: ORG, usedBarcodeTrial: false },
+    userOrganizations: [{ organization: { id: ORG }, roles }],
+  });
+}
+
+/** POSTs to the add-on route with the given intent. */
+function post(intent: "trial" | "subscribe") {
+  return action({
+    request: new Request("https://app.shelf.nu/api/barcode-addon", {
+      method: "POST",
+      body: new URLSearchParams({
+        priceId: "price_1",
+        intent,
+        consentAcknowledged: "true",
+      }),
+    }),
+    params: {},
+    context: { getSession: () => ({ userId: "user-1", email: "a@b.c" }) },
+  } as unknown as Parameters<typeof action>[0]);
+}
+
+describe("POST /api/barcode-addon", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOrgUpdate.mockResolvedValue({ id: ORG });
+  });
+
+  it("refuses an ADMIN starting the trial, and never burns the flag", async () => {
+    callerHolds([OrganizationRoles.ADMIN]);
+
+    const result = await post("trial");
+
+    expect((result as unknown as Response).status).toBe(403);
+    // The two assertions that matter: no Stripe subscription, and above all
+    // `usedBarcodeTrial` is never set — that flag cannot be undone.
+    expect(createBarcodeAddonTrialSubscription).not.toHaveBeenCalled();
+    expect(mockOrgUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refuses an ADMIN subscribing", async () => {
+    callerHolds([OrganizationRoles.ADMIN]);
+
+    const result = await post("subscribe");
+
+    expect((result as unknown as Response).status).toBe(403);
+    expect(createBarcodeAddonCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("still lets the OWNER start the trial", async () => {
+    callerHolds([OrganizationRoles.OWNER]);
+
+    await post("trial");
+
+    expect(createBarcodeAddonTrialSubscription).toHaveBeenCalledTimes(1);
+    expect(mockOrgUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
+++ b/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
@@ -30,6 +30,8 @@ const createDataMock = vi.hoisted(() => {
     });
 });
 
+// why: React Router v7 single fetch — `data()` must return a real Response
+// so the action's error path has an assertable status.
 vi.mock("react-router", async () => {
   const actual = await vi.importActual("react-router");
   return { ...actual, data: createDataMock() };
@@ -63,10 +65,15 @@ vi.mock("~/modules/barcode/addon.server", () => ({
 const { mockGetSelectedOrganization } = vi.hoisted(() => ({
   mockGetSelectedOrganization: vi.fn(),
 }));
+// why: resolves the caller's memberships from the session and DB. Mocking it
+// is how this test chooses whether the caller is ADMIN or OWNER, which is the
+// entire variable under test.
 vi.mock("~/modules/organization/context.server", () => ({
   getSelectedOrganization: mockGetSelectedOrganization,
 }));
 
+// why: a DB read for the Stripe customer name fields; irrelevant to the owner
+// check and would otherwise need a database.
 vi.mock("~/modules/user/service.server", () => ({
   getUserByID: vi.fn().mockResolvedValue({
     customerId: "cus_1",
@@ -76,12 +83,15 @@ vi.mock("~/modules/user/service.server", () => ({
   }),
 }));
 
+// why: real Stripe calls. `customerHasPaymentMethod` returning false also
+// keeps the consent branch out of the way of the assertion.
 vi.mock("~/utils/stripe.server", () => ({
   getOrCreateCustomerId: vi.fn().mockResolvedValue("cus_1"),
   customerHasPaymentMethod: vi.fn().mockResolvedValue(false),
   getDomainUrl: vi.fn().mockReturnValue("https://app.shelf.nu"),
 }));
 
+// why: sends a real email on the success path.
 vi.mock("~/emails/stripe/barcode-trial-welcome", () => ({
   sendBarcodeTrialWelcomeEmail: vi.fn(),
 }));


### PR DESCRIPTION
> **Stacked on #2882** — based on `fix/addon-price-entitlement-bypass` so the
> diff here is only this fix. GitHub will retarget it to `main` automatically
> once #2882 merges. Merge #2882 first.

## What

A workspace **ADMIN** could burn the workspace's one-time free add-on trial and
commit the workspace to a charge on the **owner's** card.

Found by the detail.dev OSS scan (finding D102).

## The bug

Both add-on purchase actions gated on this alone:

```ts
await requirePermission({ entity: PermissionEntity.subscription,
                          action: PermissionAction.update });
```

ADMIN short-circuits to allow-all in `hasPermission`, so it clears that gate.

The intent was already owner-only — it was just never enforced server-side:

```tsx
// unlock-barcodes-banner.tsx
if (!isOwner) { return null; }

// audits.tsx loader
const canStartTrial = isOwner && !currentOrganization.usedAuditTrial && !hasAccess;
```

`isOwner` was computed in the loaders **for the UI only**, so a direct POST
reached the action regardless.

## Impact

- `usedBarcodeTrial` / `usedAuditTrial` are set to `true` — **irreversible**,
  and they exist precisely to stop the trial being used twice. An ADMIN could
  spend it, and the owner can never get it back.
- A Stripe subscription is created that auto-charges the owner's card when the
  trial ends.

## The fix

`assertIsOrganizationOwner` in `roles.server`, applied to both actions — for the
`subscribe` intent as well as `trial`, because the UI hides the whole purchase
surface from non-owners, not just the trial button.

```ts
assertIsOrganizationOwner({ userOrganizations, organizationId,
                            action: "start or buy the barcodes add-on" });
```

It reads the roles **array**, not `resolveEffectiveRole` — that returns
`roles[0]`, so a user carrying more than one role could own the workspace
without `OWNER` being first. That also makes the check textually identical to
the loaders' own `roles.includes("OWNER")`, so the server gate and the UI gate
cannot drift.

## Tests

- `roles-owner.server.test.ts` (8) — ADMIN is not owner; OWNER found anywhere in
  the array; ownership of a *different* workspace does not count; empty
  membership fails closed.
- `barcode-addon.test.ts` (3) — end-to-end. For an ADMIN the response is 403 and
  **neither the Stripe call nor the `organization.update` that writes the trial
  flag happens**. The RBAC gate is mocked to PASS, so the test proves the owner
  check is what refuses.

Confirmed failing against the unguarded action.

## Sweep

Checked the rest of the billing surface for the same class:

- `account-details.subscription.tsx` writes `user.tierId` — tier lives on
  **User**, so that is self-service on the caller's own account, not a workspace
  entitlement. No owner gate belongs there.
- `_welcome+/welcome.tsx` queries `where: { owner: { is: { id: userId } } }`, so
  the caller owns it by construction.
- No add-on cancel/reactivate routes exist.

## One reviewer suggestion deliberately not taken

The pre-commit reviewer suggested sourcing `userOrganizations` from
`requirePermission`'s return rather than the `getSelectedOrganization` call
below it, on the grounds the two could drift. They cannot — `requirePermission`
calls `getSelectedOrganization` internally, so it is the same query — and the
routes need that call anyway for `currentOrganization`, so it removes nothing.
Tried it: it broke `audits.tsx`, whose loader legitimately uses that destructure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Restricted audit and barcode add-on trials and purchases to organization owners.
  * Admins and other non-owners now receive a permission error, with no billing or subscription changes initiated.

* **Bug Fixes**
  * Improved authorization checks across add-on purchase workflows.

* **Tests**
  * Added coverage for owner, admin, unrelated membership, and missing membership scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->