### PR TITLE
fix(security): stop logging OTPs and passwords in plaintext

### DIFF
--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -155,7 +155,10 @@ export async function action({ request, context }: ActionFunctionArgs) {
           throw new ShelfError({
             cause: verifyError,
             message: "Invalid or expired verification code",
-            additionalData: { email, otp },
+            // The OTP is deliberately NOT included. It is a live
+            // account-takeover credential until it expires, and additionalData
+            // is written straight to the log line.
+            additionalData: { email },
             label: "Auth",
             shouldBeCaptured: false,
           });

--- a/apps/webapp/app/utils/http-parse-data-redaction.test.ts
+++ b/apps/webapp/app/utils/http-parse-data-redaction.test.ts
@@ -123,3 +123,47 @@ describe("parseData redaction", () => {
     expect(validationErrors.password.message).toBe("Password is too short.");
   });
 });
+
+describe("logger serialization", () => {
+  it("redacts a hand-written additionalData that carries a secret", async () => {
+    // Defence in depth for the sites parseData does not build. `serializeError`
+    // is the single point where a ShelfError becomes the object pino writes, so
+    // redacting there makes a new `additionalData` safe by default.
+    const { serializeError } = await import("./logger");
+    const { ShelfError } = await import("./error");
+
+    const serialized = serializeError(
+      new ShelfError({
+        cause: null,
+        message: "Invalid or expired verification code",
+        additionalData: { email: "user@example.com", otp: "123456" },
+        label: "Auth",
+        shouldBeCaptured: false,
+      })
+    ) as unknown as { additionalData: Record<string, unknown> };
+
+    expect(serialized.additionalData.otp).toBe(REDACTED);
+    // The useful context survives — redaction must not cost us debuggability.
+    expect(serialized.additionalData.email).toBe("user@example.com");
+  });
+
+  it("redacts through a nested cause chain", async () => {
+    const { serializeError } = await import("./logger");
+    const { ShelfError } = await import("./error");
+
+    const inner = new ShelfError({
+      cause: null,
+      message: "inner",
+      additionalData: { password: "hunter2" },
+      label: "Auth",
+    });
+
+    const serialized = JSON.stringify(
+      serializeError(
+        new ShelfError({ cause: inner, message: "outer", label: "Auth" })
+      )
+    );
+
+    expect(serialized).not.toContain("hunter2");
+  });
+});

--- a/apps/webapp/app/utils/http-parse-data-redaction.test.ts
+++ b/apps/webapp/app/utils/http-parse-data-redaction.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `parseData` must not echo secrets into the error it throws.
+ *
+ * On a validation failure it places the ENTIRE submitted payload into
+ * `additionalData`, and the logger writes `additionalData` verbatim. The
+ * password-reset form submits `{ email, otp, password, confirmPassword }`, so
+ * the most ordinary user mistake — mistyping the confirmation — wrote a live
+ * OTP and the user's chosen password to the server log in plaintext.
+ *
+ * `shouldBeCaptured: false` does not help: it suppresses the Sentry hop, not
+ * the log line. The password-reset route passes exactly that option, which is
+ * why the leak survived review.
+ *
+ * detail.dev finding D042.
+ *
+ * @see {@link file://./http.server.ts} `parseData`
+ * @see {@link file://./redact.ts}
+ */
+
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { REDACTED } from "./redact";
+
+// @vitest-environment node
+
+/** Mirrors the real `OtpSchema` on the password-reset route. */
+const OtpSchema = z.object({
+  otp: z.string().min(6, "OTP is required."),
+  email: z.string(),
+  password: z.string().min(8, "Password is too short."),
+  confirmPassword: z.string().min(8, "Password is too short."),
+});
+
+/** The payload a user submits when they mistype the confirmation. */
+function passwordResetPayload() {
+  return new URLSearchParams({
+    otp: "123456",
+    email: "user@example.com",
+    // Under the 8-char minimum so validation actually fails, and distinctive
+    // so a substring check cannot collide with the validation MESSAGE (which
+    // itself contains the word "short").
+    password: "Zx9Qw",
+    confirmPassword: "Zx9Qw",
+  });
+}
+
+describe("parseData redaction", () => {
+  it("does not put the OTP or password in additionalData", async () => {
+    const { parseData } = await import("./http.server");
+
+    let thrown: unknown;
+    try {
+      parseData(passwordResetPayload(), OtpSchema, {
+        // Exactly what the real route passes — and exactly why this was missed.
+        shouldBeCaptured: false,
+      });
+    } catch (cause) {
+      thrown = cause;
+    }
+
+    const additionalData = (thrown as { additionalData: { data: any } })
+      .additionalData;
+
+    expect(additionalData.data.otp).toBe(REDACTED);
+    expect(additionalData.data.password).toBe(REDACTED);
+    expect(additionalData.data.confirmPassword).toBe(REDACTED);
+  });
+
+  it("keeps the non-sensitive fields that make the log useful", async () => {
+    const { parseData } = await import("./http.server");
+
+    let thrown: unknown;
+    try {
+      parseData(passwordResetPayload(), OtpSchema, {});
+    } catch (cause) {
+      thrown = cause;
+    }
+
+    const additionalData = (thrown as { additionalData: { data: any } })
+      .additionalData;
+
+    expect(additionalData.data.email).toBe("user@example.com");
+  });
+
+  it("leaves no secret anywhere in the serialized error", async () => {
+    // The assertion that actually matters: whatever the shape, the plaintext
+    // secret must not survive into anything a logger would write.
+    const { parseData } = await import("./http.server");
+
+    let thrown: unknown;
+    try {
+      parseData(passwordResetPayload(), OtpSchema, {
+        shouldBeCaptured: false,
+      });
+    } catch (cause) {
+      thrown = cause;
+    }
+
+    const serialized = JSON.stringify(
+      (thrown as { additionalData: unknown }).additionalData
+    );
+
+    expect(serialized).not.toContain("123456");
+    expect(serialized).not.toContain("Zx9Qw");
+  });
+
+  it("still reports which field failed validation", async () => {
+    // Redaction must not cost the user a usable error.
+    const { parseData } = await import("./http.server");
+
+    let thrown: unknown;
+    try {
+      parseData(passwordResetPayload(), OtpSchema, {});
+    } catch (cause) {
+      thrown = cause;
+    }
+
+    const { validationErrors } = (
+      thrown as { additionalData: { validationErrors: any } }
+    ).additionalData;
+
+    expect(validationErrors.password.message).toBe("Password is too short.");
+  });
+});

--- a/apps/webapp/app/utils/http-parse-data-redaction.test.ts
+++ b/apps/webapp/app/utils/http-parse-data-redaction.test.ts
@@ -59,8 +59,9 @@ describe("parseData redaction", () => {
       thrown = cause;
     }
 
-    const additionalData = (thrown as { additionalData: { data: any } })
-      .additionalData;
+    const { additionalData } = thrown as {
+      additionalData: { data: Record<string, unknown> };
+    };
 
     expect(additionalData.data.otp).toBe(REDACTED);
     expect(additionalData.data.password).toBe(REDACTED);
@@ -77,8 +78,9 @@ describe("parseData redaction", () => {
       thrown = cause;
     }
 
-    const additionalData = (thrown as { additionalData: { data: any } })
-      .additionalData;
+    const { additionalData } = thrown as {
+      additionalData: { data: Record<string, unknown> };
+    };
 
     expect(additionalData.data.email).toBe("user@example.com");
   });
@@ -117,7 +119,11 @@ describe("parseData redaction", () => {
     }
 
     const { validationErrors } = (
-      thrown as { additionalData: { validationErrors: any } }
+      thrown as {
+        additionalData: {
+          validationErrors: Record<string, { message: string }>;
+        };
+      }
     ).additionalData;
 
     expect(validationErrors.password.message).toBe("Password is too short.");

--- a/apps/webapp/app/utils/http.server.ts
+++ b/apps/webapp/app/utils/http.server.ts
@@ -12,6 +12,7 @@ import {
 } from "./error";
 import type { ValidationError } from "./http";
 import { Logger } from "./logger";
+import { redactSensitive } from "./redact";
 
 export function getCurrentPath(request: Request) {
   return new URL(request.url).pathname;
@@ -172,7 +173,12 @@ export function parseData<Schema extends ZodType<any, any, any>>(
       ...options,
       additionalData: {
         ...options?.additionalData,
-        data,
+        // Redacted: this is the WHOLE submitted payload, and additionalData is
+        // written to the log line verbatim (and to Sentry `extra` when
+        // captured). On the password-reset form the payload carries the OTP and
+        // the user's new password, so an ordinary mistyped confirmation logged
+        // both in plaintext. See ~/utils/redact.
+        data: redactSensitive(data),
         validationErrors,
       },
     });

--- a/apps/webapp/app/utils/logger.ts
+++ b/apps/webapp/app/utils/logger.ts
@@ -3,6 +3,7 @@ import pino from "pino";
 
 import { SENTRY_DSN, env } from "./env";
 import { ShelfError } from "./error";
+import { redactSensitive } from "./redact";
 
 /**
  * Fraction of handled 4xx errors to record in the Sentry log trail. Defaults
@@ -28,19 +29,32 @@ const HANDLED_4XX_SAMPLE_RATE = (() => {
   return Number.isFinite(raw) && raw >= 0 && raw <= 1 ? raw : 1;
 })();
 
-function serializeError<E extends Error>(error: E): Error {
+/**
+ * Flattens an error (and its `cause` chain) into the plain object pino writes.
+ *
+ * The spread pulls in every enumerable own property, which for a `ShelfError`
+ * includes `additionalData` — so this function is the single point where
+ * caller-supplied debug context becomes a durable log line. Redacting here
+ * rather than at each call site means a hand-written `additionalData` carrying
+ * a secret is safe by default; `parseData` sanitizes its payload separately,
+ * before the value ever reaches an error.
+ *
+ * @param error - The error to serialize
+ * @returns A plain object safe to write to the log
+ */
+export function serializeError<E extends Error>(error: E): Error {
   if (!(error.cause instanceof Error)) {
-    return {
+    return redactSensitive({
       ...error,
       stack: error.stack,
-    };
+    });
   }
 
-  return {
+  return redactSensitive({
     ...error,
     cause: serializeError(error.cause),
     stack: error.stack,
-  };
+  });
 }
 
 const logger = pino({

--- a/apps/webapp/app/utils/redact.test.ts
+++ b/apps/webapp/app/utils/redact.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Redaction of log-bound values.
+ *
+ * `parseData` puts the whole submitted payload into `ShelfError.additionalData`
+ * on a validation failure, and the logger emits `additionalData` verbatim. On
+ * the password-reset form that payload is `{ email, otp, password,
+ * confirmPassword }` — so mistyping the confirmation logged a valid OTP and the
+ * user's chosen password in plaintext.
+ *
+ * detail.dev finding D042 (reported for one `additionalData` site; `parseData`
+ * is the generic sink behind it).
+ *
+ * @see {@link file://./redact.ts}
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { REDACTED, redactSensitive } from "./redact";
+
+// @vitest-environment node
+
+describe("redactSensitive", () => {
+  it("redacts the password-reset payload that caused this", () => {
+    expect(
+      redactSensitive({
+        email: "user@example.com",
+        otp: "123456",
+        password: "hunter2",
+        confirmPassword: "hunter2",
+      })
+    ).toEqual({
+      email: "user@example.com",
+      otp: REDACTED,
+      password: REDACTED,
+      confirmPassword: REDACTED,
+    });
+  });
+
+  it("keeps non-sensitive fields, which are the point of logging at all", () => {
+    expect(redactSensitive({ email: "a@b.c", name: "Ada", count: 3 })).toEqual({
+      email: "a@b.c",
+      name: "Ada",
+      count: 3,
+    });
+  });
+
+  it.each([
+    "password",
+    "newPassword",
+    "confirmPassword",
+    "currentPassword",
+    "password_confirmation",
+    "otp",
+    "token",
+    "refreshToken",
+    "accessToken",
+    "apiKey",
+    "api_key",
+    "clientSecret",
+    "authorization",
+    "sessionId",
+    "privateKey",
+  ])("redacts %s", (key) => {
+    expect(redactSensitive({ [key]: "sensitive" })[key]).toBe(REDACTED);
+  });
+
+  it("does not mutate the input — callers still need the real values", () => {
+    // A validation failure still has to tell the user which field was wrong.
+    const input = { otp: "123456", email: "a@b.c" };
+
+    redactSensitive(input);
+
+    expect(input.otp).toBe("123456");
+  });
+
+  it("walks nested objects and arrays", () => {
+    expect(
+      redactSensitive({
+        user: { email: "a@b.c", password: "hunter2" },
+        attempts: [{ otp: "111111" }, { otp: "222222" }],
+      })
+    ).toEqual({
+      user: { email: "a@b.c", password: REDACTED },
+      attempts: [{ otp: REDACTED }, { otp: REDACTED }],
+    });
+  });
+
+  it("passes primitives and null through untouched", () => {
+    expect(redactSensitive("plain")).toBe("plain");
+    expect(redactSensitive(42)).toBe(42);
+    expect(redactSensitive(null)).toBeNull();
+    expect(redactSensitive(undefined)).toBeUndefined();
+  });
+
+  it("leaves non-plain objects alone rather than flattening them", () => {
+    // Spreading a Date into a plain object would turn it into `{}` and lose
+    // the value entirely — worse than not redacting it.
+    const date = new Date("2026-01-01");
+
+    expect(redactSensitive({ when: date }).when).toBe(date);
+  });
+
+  it("terminates on deeply nested input instead of recursing forever", () => {
+    let deep: Record<string, unknown> = { password: "hunter2" };
+    for (let i = 0; i < 50; i++) {
+      deep = { nested: deep };
+    }
+
+    expect(() => redactSensitive(deep)).not.toThrow();
+  });
+});

--- a/apps/webapp/app/utils/redact.test.ts
+++ b/apps/webapp/app/utils/redact.test.ts
@@ -15,7 +15,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { REDACTED, redactSensitive } from "./redact";
+import { REDACTED, TRUNCATED, redactSensitive } from "./redact";
 
 // @vitest-environment node
 
@@ -107,5 +107,22 @@ describe("redactSensitive", () => {
     }
 
     expect(() => redactSensitive(deep)).not.toThrow();
+  });
+
+  it("truncates past the depth limit rather than passing the subtree through", () => {
+    // Failing OPEN here would defeat the function: returning an unwalked
+    // subtree means returning an unredacted one.
+    let deep: Record<string, unknown> = { password: "hunter2" };
+    for (let i = 0; i < 50; i++) {
+      deep = { nested: deep };
+    }
+
+    expect(JSON.stringify(redactSensitive(deep))).not.toContain("hunter2");
+  });
+
+  it("marks what it truncated so the gap is visible in the log", () => {
+    const deep = { a: { b: { c: { d: { e: { secretless: "value" } } } } } };
+
+    expect(JSON.stringify(redactSensitive(deep))).toContain(TRUNCATED);
   });
 });

--- a/apps/webapp/app/utils/redact.ts
+++ b/apps/webapp/app/utils/redact.ts
@@ -33,6 +33,15 @@ const SENSITIVE_KEY =
 /** Replacement written in place of a redacted value. */
 export const REDACTED = "[REDACTED]";
 
+/**
+ * Replacement for a subtree deeper than {@link MAX_DEPTH}.
+ *
+ * Returning such a subtree unchanged would defeat the whole function: a
+ * `password` nested five levels down would be written in plaintext. A redactor
+ * has to fail closed, so the depth limit truncates rather than waves through.
+ */
+export const TRUNCATED = "[TRUNCATED]";
+
 /** How deep to walk nested objects before giving up. */
 const MAX_DEPTH = 4;
 
@@ -45,16 +54,23 @@ const MAX_DEPTH = 4;
  *
  * Walks nested objects and arrays to a bounded depth so a payload shaped
  * `{ user: { password } }` is covered without risking a cycle or a pathological
- * structure. Anything deeper is returned as-is; the alternative (dropping it)
- * would silently lose debugging context that is usually not sensitive.
+ * structure. Anything deeper is replaced by {@link TRUNCATED} rather than
+ * returned as-is — an unwalked subtree is an unredacted one, and losing some
+ * debugging context is the right trade against writing a credential.
  *
  * @param value - Any value destined for `additionalData` or a log line
  * @param depth - Internal recursion counter; callers should omit it
  * @returns A redacted copy, or the original for primitives
  */
 export function redactSensitive<T>(value: T, depth = 0): T {
-  if (value === null || typeof value !== "object" || depth > MAX_DEPTH) {
+  if (value === null || typeof value !== "object") {
     return value;
+  }
+
+  // Past the limit we can no longer inspect what is in there, so we must not
+  // pass it through.
+  if (depth > MAX_DEPTH) {
+    return TRUNCATED as unknown as T;
   }
 
   if (Array.isArray(value)) {

--- a/apps/webapp/app/utils/redact.ts
+++ b/apps/webapp/app/utils/redact.ts
@@ -1,0 +1,81 @@
+/**
+ * Redaction for values that reach logs.
+ *
+ * `ShelfError.additionalData` is emitted by the pino logger and spread into
+ * Sentry's `extra`, so anything placed there is written to durable storage in
+ * plaintext. `shouldBeCaptured: false` only suppresses the Sentry hop — the log
+ * line is still written.
+ *
+ * That matters most for `parseData`, which puts the ENTIRE submitted payload
+ * into `additionalData` on a validation failure. On the password-reset form
+ * that payload is `{ email, otp, password, confirmPassword }`, so the most
+ * ordinary user mistake — mistyping the confirmation — logged a valid OTP and
+ * the user's chosen password. No attacker required.
+ *
+ * Redaction is by KEY NAME rather than by value, because the sensitive thing is
+ * identified by what the field is for, not by what it looks like.
+ *
+ * @see {@link file://./http.server.ts} `parseData`
+ * @see {@link file://./error.ts} `ShelfError.additionalData`
+ */
+
+/**
+ * Field names whose values must never be logged.
+ *
+ * Matched case-insensitively against the whole key, allowing a `camelCase`,
+ * `snake_case`, `kebab-case` or dotted prefix/suffix around the sensitive word
+ * — so `newPassword`, `password_confirmation` and `x-api-key` all match, while
+ * a merely adjacent field like `passwordUpdatedAt` does not need to.
+ */
+const SENSITIVE_KEY =
+  /(?:^|[._-]|(?<=[a-z0-9]))(otp|passwd|password|pwd|secret|token|api[._-]?key|credential|authorization|cookie|session[._-]?id|private[._-]?key)(?:$|[._-]|(?=[A-Z]))/i;
+
+/** Replacement written in place of a redacted value. */
+export const REDACTED = "[REDACTED]";
+
+/** How deep to walk nested objects before giving up. */
+const MAX_DEPTH = 4;
+
+/**
+ * Returns a copy of `value` with any sensitively-named field replaced by
+ * {@link REDACTED}.
+ *
+ * Never mutates the input — the caller usually still needs the real values (a
+ * validation failure still has to tell the user which field was wrong).
+ *
+ * Walks nested objects and arrays to a bounded depth so a payload shaped
+ * `{ user: { password } }` is covered without risking a cycle or a pathological
+ * structure. Anything deeper is returned as-is; the alternative (dropping it)
+ * would silently lose debugging context that is usually not sensitive.
+ *
+ * @param value - Any value destined for `additionalData` or a log line
+ * @param depth - Internal recursion counter; callers should omit it
+ * @returns A redacted copy, or the original for primitives
+ */
+export function redactSensitive<T>(value: T, depth = 0): T {
+  if (value === null || typeof value !== "object" || depth > MAX_DEPTH) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      redactSensitive(item, depth + 1)
+    ) as unknown as T;
+  }
+
+  // Dates, FormData, and other non-plain objects are returned untouched rather
+  // than being flattened into a plain object by the spread below.
+  if (Object.getPrototypeOf(value) !== Object.prototype) {
+    return value;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    result[key] = SENSITIVE_KEY.test(key)
+      ? REDACTED
+      : redactSensitive(item, depth + 1);
+  }
+
+  return result as T;
+}


### PR DESCRIPTION
## What

The server wrote **live password-reset OTPs and users' chosen passwords to the
logs in plaintext** — on an ordinary user mistake, not an attack.

Found by the detail.dev OSS scan (finding D042). Independent of #2882/#2883;
can merge in any order.

## The reported bug

```ts
throw new ShelfError({
  message: "Invalid or expired verification code",
  additionalData: { email, otp },   // <- written to the log line
  shouldBeCaptured: false,
});
```

`shouldBeCaptured: false` does **not** help. It suppresses the Sentry hop, not
the pino log line — `additionalData` is serialized either way.

## The bigger one behind it

The scan named that single site. The generic sink is `parseData`, which on a
validation failure puts the **entire submitted payload** into `additionalData`:

```ts
additionalData: { ...options?.additionalData, data, validationErrors }
```

The password-reset form submits `{ email, otp, password, confirmPassword }`.
So the most **ordinary user mistake** — mistyping the confirmation — logged a
valid OTP *and* the user's chosen new password. No attacker involved, and it
applies to every form in the app carrying a secret field.

That route passes `shouldBeCaptured: false`, which is probably why this survived
review: it reads as "this one is handled".

## The fix — two layers

**1. Sanitize the payload.** `redactSensitive` (`~/utils/redact`) replaces
sensitively-*named* keys and is applied to what `parseData` echoes. Redaction is
by key name because what makes a field sensitive is its purpose, not the shape
of its contents. Non-sensitive fields survive — they are why the payload is
logged at all — and `validationErrors` is untouched, so users still get a usable
message.

**2. Redact at the chokepoint.** `serializeError` is the single point where a
`ShelfError` becomes the object pino writes; its spread pulls in every
enumerable own property, `additionalData` included. Redacting there makes a
*hand-written* `additionalData` safe by default rather than safe-if-remembered.

Layer 2 came from the pre-commit security reviewer, which pointed out that
fixing individual call sites leaves the class open. It was right.

The reported site also drops `otp` directly — defence in depth, since it is
hand-written rather than built by `parseData`.

## Tests

- `redact.test.ts` (22) — the exact password-reset payload; 15 key spellings
  (`newPassword`, `password_confirmation`, `api_key`, …); non-mutation; nested
  objects and arrays; primitives; non-plain objects left alone rather than
  flattened to `{}`; deep input terminates.
- `http-parse-data-redaction.test.ts` (6) — a real `parseData` failure, asserting
  no secret survives into the serialized error, that the *useful* fields and the
  validation message do survive, and that a nested `cause` chain is covered too.

Confirmed failing against the unredacted `parseData`. Full `app/utils` (1163)
and route-test (601) suites pass, so nothing depended on reading the raw payload
back out of the error.

## Two mistakes worth naming

- A first assertion checked the payload did not contain `"short"` — which also
  appears in the message *"Password is too short."* False positive; replaced with
  a value that cannot collide.
- A first version of the chokepoint test captured `process.stdout.write`, which
  pino bypasses (it writes to its own destination). It passed against **empty
  output**. Replaced with a direct assertion on `serializeError`, which is now
  exported for that reason.

## Not covered

`Sentry.captureException` still receives the original error object, so Sentry's
own serialization of enumerable properties is unaffected. After the `parseData`
fix no secret reaches `additionalData` on that path in the first place, but a
central Sentry-side redaction is worth doing separately.

## Worth considering separately

Any OTP or password already written to logs while this was live is still in
whatever log retention we have. That is an ops question this PR cannot answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive password-reset details, including one-time codes and passwords, are now removed from error logs and monitoring data.
  * Non-sensitive information, such as email addresses and validation details, remains available for troubleshooting.
  * Subscription and add-on purchases now reject invalid, inactive, mismatched, or incorrectly categorized prices before processing.

* **Tests**
  * Added coverage for sensitive-data redaction and billing-price validation across subscription and checkout flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->