### PR TITLE
fix(security): org-scope every note and override deletion

### DIFF
--- a/apps/webapp/app/modules/audit/asset-details.service.server.test.ts
+++ b/apps/webapp/app/modules/audit/asset-details.service.server.test.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the database
@@ -130,13 +131,30 @@ describe("audit asset details service", () => {
         updatedAt: new Date(),
       };
 
-      const updatedNote = {
+      // Typed against the query rather than `as any`: the re-read selects
+      // `displayName`, and a loose fixture silently omitted it.
+      const updatedNote: Prisma.AuditNoteGetPayload<{
+        include: {
+          user: {
+            select: {
+              id: true;
+              firstName: true;
+              lastName: true;
+              displayName: true;
+              email: true;
+              profilePicture: true;
+            };
+          };
+        };
+      }> = {
         ...existingNote,
+        type: "COMMENT",
         content: "Updated content",
         user: {
           id: "user-1",
           firstName: "John",
           lastName: "Doe",
+          displayName: "John Doe",
           email: "john@example.com",
           profilePicture: null,
         },
@@ -144,9 +162,7 @@ describe("audit asset details service", () => {
 
       vi.mocked(db.auditNote.findFirst).mockResolvedValue(existingNote as any);
       vi.mocked(db.auditNote.updateMany).mockResolvedValue({ count: 1 });
-      vi.mocked(db.auditNote.findFirstOrThrow).mockResolvedValue(
-        updatedNote as any
-      );
+      vi.mocked(db.auditNote.findFirstOrThrow).mockResolvedValue(updatedNote);
 
       const result = await updateAuditAssetNote({
         noteId: "note-1",
@@ -188,6 +204,28 @@ describe("audit asset details service", () => {
       );
 
       expect(result.content).toBe("Updated content");
+    });
+
+    it("throws 404 when the scoped update matches nothing", async () => {
+      // The lookup can pass and the mutation still match zero rows — that is
+      // the whole point of moving the predicate onto the write. Nothing had
+      // covered this path.
+      vi.mocked(db.auditNote.findFirst).mockResolvedValue({
+        id: "note-1",
+        userId: "user-1",
+      } as never);
+      vi.mocked(db.auditNote.updateMany).mockResolvedValue({ count: 0 });
+
+      await expect(
+        updateAuditAssetNote({
+          noteId: "note-1",
+          content: "Updated content",
+          userId: "user-1",
+          organizationId: "org-1",
+        })
+      ).rejects.toMatchObject({ status: 404 });
+
+      expect(db.auditNote.findFirstOrThrow).not.toHaveBeenCalled();
     });
 
     it("throws 404 error when note is not found", async () => {
@@ -304,6 +342,24 @@ describe("audit asset details service", () => {
       // deleteMany reports a count; the row itself is gone, so echoing it back
       // would be inventing a value.
       expect(result).toEqual({ count: 1 });
+    });
+
+    it("throws 404 when the scoped delete matches nothing", async () => {
+      // The lookup can pass and the mutation still match zero rows — that is
+      // the point of moving the predicate onto the write. Nothing covered it.
+      vi.mocked(db.auditNote.findFirst).mockResolvedValue({
+        id: "note-1",
+        userId: "user-1",
+      } as never);
+      vi.mocked(db.auditNote.deleteMany).mockResolvedValue({ count: 0 });
+
+      await expect(
+        deleteAuditAssetNote({
+          noteId: "note-1",
+          userId: "user-1",
+          organizationId: "org-1",
+        })
+      ).rejects.toMatchObject({ status: 404 });
     });
 
     it("throws 404 error when note is not found", async () => {

--- a/apps/webapp/app/modules/audit/asset-details.service.server.test.ts
+++ b/apps/webapp/app/modules/audit/asset-details.service.server.test.ts
@@ -146,6 +146,7 @@ describe("audit asset details service", () => {
         noteId: "note-1",
         content: "Updated content",
         userId: "user-1",
+        organizationId: "org-1",
       });
 
       expect(db.auditNote.findFirst).toHaveBeenCalledWith({
@@ -153,6 +154,7 @@ describe("audit asset details service", () => {
           id: "note-1",
           userId: "user-1",
           auditAssetId: { not: null },
+          auditSession: { organizationId: "org-1" },
         },
       });
 
@@ -184,6 +186,7 @@ describe("audit asset details service", () => {
           noteId: "nonexistent-note",
           content: "Updated content",
           userId: "user-1",
+          organizationId: "org-1",
         })
       ).rejects.toThrow(ShelfError);
 
@@ -199,6 +202,7 @@ describe("audit asset details service", () => {
           noteId: "note-1",
           content: "Updated content",
           userId: "wrong-user",
+          organizationId: "org-1",
         })
       ).rejects.toThrow(ShelfError);
 
@@ -214,6 +218,7 @@ describe("audit asset details service", () => {
           noteId: "note-1",
           content: "Updated content",
           userId: "user-1",
+          organizationId: "org-1",
         })
       ).rejects.toThrow();
 
@@ -228,6 +233,23 @@ describe("audit asset details service", () => {
   });
 
   describe("deleteAuditAssetNote", () => {
+    it("refuses a note belonging to another organization", async () => {
+      // The lookup is scoped through auditSession, so a note in org-2 simply
+      // is not found for a caller in org-1 -- previously `userId` alone let an
+      // author reach a note in an organization they had since left.
+      vi.mocked(db.auditNote.findFirst).mockResolvedValue(null);
+
+      await expect(
+        deleteAuditAssetNote({
+          noteId: "note-in-another-org",
+          userId: "user-1",
+          organizationId: "org-1",
+        })
+      ).rejects.toMatchObject({ status: 404 });
+
+      expect(db.auditNote.delete).not.toHaveBeenCalled();
+    });
+
     it("successfully deletes a note owned by the user", async () => {
       const existingNote = {
         id: "note-1",
@@ -246,6 +268,7 @@ describe("audit asset details service", () => {
       const result = await deleteAuditAssetNote({
         noteId: "note-1",
         userId: "user-1",
+        organizationId: "org-1",
       });
 
       expect(db.auditNote.findFirst).toHaveBeenCalledWith({
@@ -253,6 +276,7 @@ describe("audit asset details service", () => {
           id: "note-1",
           userId: "user-1",
           auditAssetId: { not: null },
+          auditSession: { organizationId: "org-1" },
         },
       });
 
@@ -270,6 +294,7 @@ describe("audit asset details service", () => {
         deleteAuditAssetNote({
           noteId: "nonexistent-note",
           userId: "user-1",
+          organizationId: "org-1",
         })
       ).rejects.toThrow(ShelfError);
 
@@ -283,6 +308,7 @@ describe("audit asset details service", () => {
         deleteAuditAssetNote({
           noteId: "note-1",
           userId: "wrong-user",
+          organizationId: "org-1",
         })
       ).rejects.toThrow(ShelfError);
 

--- a/apps/webapp/app/modules/audit/asset-details.service.server.test.ts
+++ b/apps/webapp/app/modules/audit/asset-details.service.server.test.ts
@@ -7,8 +7,11 @@ vi.mock("~/database/db.server", () => ({
     auditNote: {
       create: vi.fn(),
       findFirst: vi.fn(),
+      findFirstOrThrow: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
       delete: vi.fn(),
+      deleteMany: vi.fn(),
       findMany: vi.fn(),
       count: vi.fn(),
     },
@@ -140,7 +143,10 @@ describe("audit asset details service", () => {
       };
 
       vi.mocked(db.auditNote.findFirst).mockResolvedValue(existingNote as any);
-      vi.mocked(db.auditNote.update).mockResolvedValue(updatedNote as any);
+      vi.mocked(db.auditNote.updateMany).mockResolvedValue({ count: 1 });
+      vi.mocked(db.auditNote.findFirstOrThrow).mockResolvedValue(
+        updatedNote as any
+      );
 
       const result = await updateAuditAssetNote({
         noteId: "note-1",
@@ -158,22 +164,28 @@ describe("audit asset details service", () => {
         },
       });
 
-      expect(db.auditNote.update).toHaveBeenCalledWith({
-        where: { id: "note-1" },
-        data: { content: "Updated content" },
-        include: {
-          user: {
-            select: {
-              id: true,
-              firstName: true,
-              lastName: true,
-              displayName: true,
-              email: true,
-              profilePicture: true,
-            },
-          },
+      // The predicate rides on the mutation, not just the lookup before it.
+      expect(db.auditNote.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: "note-1",
+          userId: "user-1",
+          auditAssetId: { not: null },
+          auditSession: { organizationId: "org-1" },
         },
+        data: { content: "Updated content" },
       });
+
+      // The author comes from a re-read carrying the same scope, since
+      // updateMany cannot `include` a relation.
+      expect(db.auditNote.findFirstOrThrow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: "note-1",
+            userId: "user-1",
+            auditSession: { organizationId: "org-1" },
+          },
+        })
+      );
 
       expect(result.content).toBe("Updated content");
     });
@@ -190,7 +202,7 @@ describe("audit asset details service", () => {
         })
       ).rejects.toThrow(ShelfError);
 
-      expect(db.auditNote.update).not.toHaveBeenCalled();
+      expect(db.auditNote.updateMany).not.toHaveBeenCalled();
     });
 
     it("throws 404 error when user doesn't own the note", async () => {
@@ -206,7 +218,7 @@ describe("audit asset details service", () => {
         })
       ).rejects.toThrow(ShelfError);
 
-      expect(db.auditNote.update).not.toHaveBeenCalled();
+      expect(db.auditNote.updateMany).not.toHaveBeenCalled();
     });
 
     it("only allows updating asset-specific notes (auditAssetId not null)", async () => {
@@ -247,7 +259,7 @@ describe("audit asset details service", () => {
         })
       ).rejects.toMatchObject({ status: 404 });
 
-      expect(db.auditNote.delete).not.toHaveBeenCalled();
+      expect(db.auditNote.deleteMany).not.toHaveBeenCalled();
     });
 
     it("successfully deletes a note owned by the user", async () => {
@@ -263,7 +275,7 @@ describe("audit asset details service", () => {
       };
 
       vi.mocked(db.auditNote.findFirst).mockResolvedValue(existingNote as any);
-      vi.mocked(db.auditNote.delete).mockResolvedValue(existingNote as any);
+      vi.mocked(db.auditNote.deleteMany).mockResolvedValue({ count: 1 });
 
       const result = await deleteAuditAssetNote({
         noteId: "note-1",
@@ -280,11 +292,18 @@ describe("audit asset details service", () => {
         },
       });
 
-      expect(db.auditNote.delete).toHaveBeenCalledWith({
-        where: { id: "note-1" },
+      expect(db.auditNote.deleteMany).toHaveBeenCalledWith({
+        where: {
+          id: "note-1",
+          userId: "user-1",
+          auditAssetId: { not: null },
+          auditSession: { organizationId: "org-1" },
+        },
       });
 
-      expect(result).toEqual(existingNote);
+      // deleteMany reports a count; the row itself is gone, so echoing it back
+      // would be inventing a value.
+      expect(result).toEqual({ count: 1 });
     });
 
     it("throws 404 error when note is not found", async () => {
@@ -298,7 +317,7 @@ describe("audit asset details service", () => {
         })
       ).rejects.toThrow(ShelfError);
 
-      expect(db.auditNote.delete).not.toHaveBeenCalled();
+      expect(db.auditNote.deleteMany).not.toHaveBeenCalled();
     });
 
     it("throws 404 error when user doesn't own the note", async () => {
@@ -312,7 +331,7 @@ describe("audit asset details service", () => {
         })
       ).rejects.toThrow(ShelfError);
 
-      expect(db.auditNote.delete).not.toHaveBeenCalled();
+      expect(db.auditNote.deleteMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/app/modules/audit/asset-details.service.server.ts
+++ b/apps/webapp/app/modules/audit/asset-details.service.server.ts
@@ -102,9 +102,37 @@ export async function updateAuditAssetNote({
       });
     }
 
-    return await db.auditNote.update({
-      where: { id: noteId },
+    // The lookup above authorizes a PAST state; writing by id alone would act
+    // on whatever the row is now. updateMany carries the same predicate into
+    // the mutation, so authorization and write are one statement.
+    const updated = await db.auditNote.updateMany({
+      where: {
+        id: noteId,
+        userId,
+        auditAssetId: { not: null },
+        auditSession: { organizationId },
+      },
       data: { content },
+    });
+
+    if (updated.count === 0) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Asset note not found or you don't have permission to update it",
+        additionalData: { noteId, userId, organizationId },
+        label,
+        status: 404,
+      });
+    }
+
+    // Re-read with the same scope — the caller needs the note with its author.
+    return await db.auditNote.findFirstOrThrow({
+      where: {
+        id: noteId,
+        userId,
+        auditSession: { organizationId },
+      },
       include: {
         user: {
           select: {
@@ -174,9 +202,29 @@ export async function deleteAuditAssetNote({
       });
     }
 
-    return await db.auditNote.delete({
-      where: { id: noteId },
+    // Same as the update path: the predicate belongs on the mutation, not only
+    // on the lookup that precedes it.
+    const deleted = await db.auditNote.deleteMany({
+      where: {
+        id: noteId,
+        userId,
+        auditAssetId: { not: null },
+        auditSession: { organizationId },
+      },
     });
+
+    if (deleted.count === 0) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Asset note not found or you don't have permission to delete it",
+        additionalData: { noteId, userId, organizationId },
+        label,
+        status: 404,
+      });
+    }
+
+    return deleted;
   } catch (cause) {
     if (cause instanceof ShelfError) {
       throw cause;

--- a/apps/webapp/app/modules/audit/asset-details.service.server.ts
+++ b/apps/webapp/app/modules/audit/asset-details.service.server.ts
@@ -1,4 +1,4 @@
-import type { AuditNote, AuditAsset, User } from "@prisma/client";
+import type { AuditNote, AuditAsset, User, Organization } from "@prisma/client";
 import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 
@@ -68,10 +68,17 @@ export async function updateAuditAssetNote({
   noteId,
   content,
   userId,
+  organizationId,
 }: {
   noteId: AuditNote["id"];
   content: string;
   userId: User["id"];
+  /**
+   * Required: AuditNote has no organizationId column, so without scoping
+   * through the parent audit session an author could reach their note in an
+   * organization they had since left.
+   */
+  organizationId: Organization["id"];
 }) {
   try {
     // First verify the note exists and user owns it
@@ -80,6 +87,7 @@ export async function updateAuditAssetNote({
         id: noteId,
         userId,
         auditAssetId: { not: null }, // Ensure it's an asset-specific note
+        auditSession: { organizationId },
       },
     });
 
@@ -133,9 +141,16 @@ export async function updateAuditAssetNote({
 export async function deleteAuditAssetNote({
   noteId,
   userId,
+  organizationId,
 }: {
   noteId: AuditNote["id"];
   userId: User["id"];
+  /**
+   * Required: AuditNote has no organizationId column, so without scoping
+   * through the parent audit session an author could reach their note in an
+   * organization they had since left.
+   */
+  organizationId: Organization["id"];
 }) {
   try {
     // First verify the note exists and user owns it
@@ -144,6 +159,7 @@ export async function deleteAuditAssetNote({
         id: noteId,
         userId,
         auditAssetId: { not: null }, // Ensure it's an asset-specific note
+        auditSession: { organizationId },
       },
     });
 

--- a/apps/webapp/app/modules/location-note/service.server.test.ts
+++ b/apps/webapp/app/modules/location-note/service.server.test.ts
@@ -190,18 +190,36 @@ describe("location note service", () => {
   });
 
   describe("deleteLocationNote", () => {
-    it("only deletes notes authored by the user", async () => {
+    it("scopes the delete to the caller's organization, via the location", async () => {
       locationNoteDeleteManyMock.mockResolvedValue({ count: 1 });
 
-      const result = await deleteLocationNote({
+      await deleteLocationNote({
         id: "lnote-1",
         userId: "user-1",
+        organizationId: "org-1",
       });
 
+      // LocationNote has no organizationId column, so the scope comes through
+      // the parent location.
       expect(locationNoteDeleteManyMock).toHaveBeenCalledWith({
-        where: { id: "lnote-1", userId: "user-1" },
+        where: {
+          id: "lnote-1",
+          userId: "user-1",
+          location: { organizationId: "org-1" },
+        },
       });
-      expect(result).toEqual({ count: 1 });
+    });
+
+    it("throws 403 rather than silently reporting nothing deleted", async () => {
+      locationNoteDeleteManyMock.mockResolvedValue({ count: 0 });
+
+      await expect(
+        deleteLocationNote({
+          id: "someone-elses-note",
+          userId: "user-1",
+          organizationId: "org-1",
+        })
+      ).rejects.toMatchObject({ status: 403 });
     });
   });
 });

--- a/apps/webapp/app/modules/location-note/service.server.ts
+++ b/apps/webapp/app/modules/location-note/service.server.ts
@@ -1,4 +1,10 @@
-import type { Location, LocationNote, Prisma, User } from "@prisma/client";
+import type {
+  Location,
+  LocationNote,
+  Prisma,
+  User,
+  Organization,
+} from "@prisma/client";
 
 import { db } from "~/database/db.server";
 import type { ErrorLabel } from "~/utils/error";
@@ -129,16 +135,46 @@ export async function getLocationNotes({
 export async function deleteLocationNote({
   id,
   userId,
-}: Pick<LocationNote, "id"> & { userId: User["id"] }) {
+  organizationId,
+}: Pick<LocationNote, "id"> & {
+  userId: User["id"];
+  /**
+   * Required, not optional: LocationNote has no organizationId column, so the only
+   * scoping was `userId` -- which let an author delete a location note belonging to
+   * an organization they are no longer part of. Making it required means the
+   * compiler, not a grep, finds every call site.
+   */
+  organizationId: Organization["id"];
+}) {
   try {
-    return await db.locationNote.deleteMany({
-      where: { id, userId },
+    // Scoped through the parent location, which is where organizationId lives.
+    // Still one query -- a relation filter, not an extra round trip.
+    const result = await db.locationNote.deleteMany({
+      where: { id, userId, location: { organizationId } },
     });
+
+    if (result.count === 0) {
+      throw new ShelfError({
+        cause: null,
+        message: "Note not found or you don't have permission to delete it.",
+        additionalData: { id, userId, organizationId },
+        label,
+        status: 403,
+      });
+    }
+
+    return result;
   } catch (cause) {
+    // The 403 above is deliberate and user-facing; re-wrapping it would hide
+    // a refused cross-org delete behind a generic 500.
+    if (cause instanceof ShelfError) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message: "Something went wrong while deleting the location note.",
-      additionalData: { id, userId },
+      additionalData: { id, userId, organizationId },
       label,
     });
   }

--- a/apps/webapp/app/modules/note/service.server.test.ts
+++ b/apps/webapp/app/modules/note/service.server.test.ts
@@ -293,33 +293,41 @@ describe("note service", () => {
   });
 
   describe("deleteNote", () => {
-    it("deletes a note for a specific user", async () => {
+    it("scopes the delete to the caller's organization, via the asset", async () => {
       vi.mocked(db.note.deleteMany).mockResolvedValue({ count: 1 });
 
       const result = await deleteNote({
         id: "note-1",
         userId: "user-1",
+        organizationId: "org-1",
       });
 
+      // Note has no organizationId column, so the scope comes through the
+      // parent asset. `userId` alone let an author delete a note in an
+      // organization they had since left.
       expect(db.note.deleteMany).toHaveBeenCalledWith({
         where: {
           id: "note-1",
           userId: "user-1",
+          asset: { organizationId: "org-1" },
         },
       });
 
       expect(result.count).toBe(1);
     });
 
-    it("returns count of 0 when note doesn't exist or user doesn't own it", async () => {
+    it("throws 403 rather than silently reporting nothing deleted", async () => {
+      // A miss now means "not yours" -- wrong author or wrong organization.
+      // Returning count 0 let a refused cross-org delete read as a no-op.
       vi.mocked(db.note.deleteMany).mockResolvedValue({ count: 0 });
 
-      const result = await deleteNote({
-        id: "nonexistent-note",
-        userId: "user-1",
-      });
-
-      expect(result.count).toBe(0);
+      await expect(
+        deleteNote({
+          id: "someone-elses-note",
+          userId: "user-1",
+          organizationId: "org-1",
+        })
+      ).rejects.toMatchObject({ status: 403 });
     });
 
     it("throws ShelfError when database operation fails", async () => {
@@ -331,6 +339,7 @@ describe("note service", () => {
         deleteNote({
           id: "note-1",
           userId: "user-1",
+          organizationId: "org-1",
         })
       ).rejects.toThrow(ShelfError);
 
@@ -338,6 +347,7 @@ describe("note service", () => {
         deleteNote({
           id: "note-1",
           userId: "user-1",
+          organizationId: "org-1",
         })
       ).rejects.toThrow("Something went wrong while deleting the note");
     });

--- a/apps/webapp/app/modules/note/service.server.ts
+++ b/apps/webapp/app/modules/note/service.server.ts
@@ -7,6 +7,7 @@ import type {
   Note,
   Prisma,
   Tag,
+  Organization,
   User,
 } from "@prisma/client";
 import type { AssetType, ConsumptionType } from "@prisma/client";
@@ -184,12 +185,40 @@ export async function createNotes(
 export async function deleteNote({
   id,
   userId,
-}: Pick<Note, "id"> & { userId: User["id"] }) {
+  organizationId,
+}: Pick<Note, "id"> & {
+  userId: User["id"];
+  /**
+   * Required, not optional: Note has no organizationId column, so the only
+   * scoping was `userId` -- which let an author delete a asset note belonging to
+   * an organization they are no longer part of. Making it required means the
+   * compiler, not a grep, finds every call site.
+   */
+  organizationId: Organization["id"];
+}) {
   try {
-    return await db.note.deleteMany({
-      where: { id, userId },
+    // Scoped through the parent asset, which is where organizationId lives.
+    // Still one query -- a relation filter, not an extra round trip.
+    const result = await db.note.deleteMany({
+      where: { id, userId, asset: { organizationId } },
     });
+
+    if (result.count === 0) {
+      throw new ShelfError({
+        cause: null,
+        message: "Note not found or you don't have permission to delete it.",
+        additionalData: { id, userId, organizationId },
+        label,
+        status: 403,
+      });
+    }
+
+    return result;
   } catch (cause) {
+    if (cause instanceof ShelfError) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message: "Something went wrong while deleting the note",

--- a/apps/webapp/app/modules/working-hours/service.server.ts
+++ b/apps/webapp/app/modules/working-hours/service.server.ts
@@ -218,6 +218,7 @@ export async function createWorkingHoursOverride({
 
 export async function updateWorkingHoursOverride({
   overrideId,
+  organizationId,
   date,
   isOpen,
   openTime,
@@ -225,6 +226,12 @@ export async function updateWorkingHoursOverride({
   reason,
 }: {
   overrideId: string;
+  /**
+   * Required for the same reason as on the delete path: the override carries
+   * no organizationId, so without scoping through its parent WorkingHours row
+   * any authenticated caller could edit another organization's override by id.
+   */
+  organizationId: string;
   date?: string; // YYYY-MM-DD format
   isOpen: boolean;
   openTime?: string; // HH:MM format
@@ -247,13 +254,33 @@ export async function updateWorkingHoursOverride({
       updateData.reason = reason;
     }
 
-    const updatedOverride = await db.workingHoursOverride.update({
-      where: { id: overrideId },
+    // updateMany, not update: `update` needs a unique where, and the scope
+    // comes through the parent WorkingHours row.
+    const updated = await db.workingHoursOverride.updateMany({
+      where: { id: overrideId, workingHours: { organizationId } },
       data: updateData,
     });
 
-    return updatedOverride;
+    if (updated.count === 0) {
+      throw new ShelfError({
+        cause: null,
+        message: "Override not found or you don't have permission to edit it.",
+        additionalData: { overrideId, organizationId },
+        label,
+        status: 403,
+      });
+    }
+
+    return await db.workingHoursOverride.findFirstOrThrow({
+      where: { id: overrideId, workingHours: { organizationId } },
+    });
   } catch (cause) {
+    // The 403 above is deliberate and user-facing; re-wrapping it would hide a
+    // refused cross-org write behind a generic 500.
+    if (cause instanceof ShelfError) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message: "Failed to update working hours override",
@@ -290,6 +317,12 @@ export async function deleteWorkingHoursOverride(
       });
     }
   } catch (cause) {
+    // The 403 above is deliberate and user-facing; re-wrapping it would hide a
+    // refused cross-org write behind a generic 500.
+    if (cause instanceof ShelfError) {
+      throw cause;
+    }
+
     throw new ShelfError({
       cause,
       message: "Failed to delete working hours override",

--- a/apps/webapp/app/modules/working-hours/service.server.ts
+++ b/apps/webapp/app/modules/working-hours/service.server.ts
@@ -263,11 +263,32 @@ export async function updateWorkingHoursOverride({
   }
 }
 
-export async function deleteWorkingHoursOverride(overrideId: string) {
+export async function deleteWorkingHoursOverride(
+  overrideId: string,
+  /**
+   * Required: WorkingHoursOverride has no organizationId column, so without
+   * scoping through the parent WorkingHours row any authenticated caller could
+   * delete another organization's override by id.
+   */
+  organizationId: string
+) {
   try {
-    await db.workingHoursOverride.delete({
-      where: { id: overrideId },
+    // deleteMany, not delete: `delete` needs a unique where, and the scope
+    // comes through the parent WorkingHours row.
+    const deleted = await db.workingHoursOverride.deleteMany({
+      where: { id: overrideId, workingHours: { organizationId } },
     });
+
+    if (deleted.count === 0) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "Override not found or you don't have permission to delete it.",
+        additionalData: { overrideId, organizationId },
+        label,
+        status: 403,
+      });
+    }
   } catch (cause) {
     throw new ShelfError({
       cause,

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.note.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.note.tsx
@@ -109,6 +109,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         await deleteNote({
           id: noteId,
           userId,
+          organizationId,
         });
 
         return payload(null);

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.note.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.note.tsx
@@ -99,17 +99,20 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           }
         );
 
+        await deleteNote({
+          id: noteId,
+          userId,
+          organizationId,
+        });
+
+        // After the delete, not before: it is org-scoped now and throws 403 on
+        // a refused cross-org attempt, so announcing success first would tell
+        // the user it worked while the response says otherwise.
         sendNotification({
           title: "Note deleted",
           message: "Your note has been deleted successfully",
           icon: { name: "trash", variant: "error" },
           senderId: authSession.userId,
-        });
-
-        await deleteNote({
-          id: noteId,
-          userId,
-          organizationId,
         });
 
         return payload(null);

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.note.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.note.tsx
@@ -107,13 +107,6 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           }
         );
 
-        sendNotification({
-          title: "Note deleted",
-          message: "Your audit note has been deleted successfully",
-          icon: { name: "trash", variant: "error" },
-          senderId: authSession.userId,
-        });
-
         // deleteMany, not delete: `delete` needs a unique where, and the
         // organization scope has to come through the parent audit session
         // (AuditNote has no organizationId column).
@@ -135,6 +128,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             status: 403,
           });
         }
+
+        // After the zero-count check, not before: a refused cross-org delete
+        // would otherwise report success while returning 403.
+        sendNotification({
+          title: "Note deleted",
+          message: "Your audit note has been deleted successfully",
+          icon: { name: "trash", variant: "error" },
+          senderId: authSession.userId,
+        });
 
         return data(payload(null));
       }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.note.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.note.tsx
@@ -114,12 +114,27 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           senderId: authSession.userId,
         });
 
-        await db.auditNote.delete({
+        // deleteMany, not delete: `delete` needs a unique where, and the
+        // organization scope has to come through the parent audit session
+        // (AuditNote has no organizationId column).
+        const deleted = await db.auditNote.deleteMany({
           where: {
             id: noteId,
             userId, // Ensure user can only delete their own notes
+            auditSession: { organizationId },
           },
         });
+
+        if (deleted.count === 0) {
+          throw new ShelfError({
+            cause: null,
+            message:
+              "Note not found or you don't have permission to delete it.",
+            additionalData: { noteId, organizationId },
+            label: "Audit",
+            status: 403,
+          });
+        }
 
         return data(payload(null));
       }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -277,6 +277,11 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       // (AuditNote has no organizationId column). Before this, the delete was
       // keyed on the note id ALONE -- any authenticated user who could reach
       // this route could delete any audit note in any organization.
+      // why: scoped by organization but deliberately NOT by userId, unlike
+      // audits.$auditId.note.tsx. Audit note deletion here is a role-gated,
+      // org-wide capability -- an auditor tidying a session should not be
+      // blocked by who typed the note. Cross-ORG deletion is what was wrong,
+      // and that is what the auditSession filter closes.
       const deleted = await db.auditNote.deleteMany({
         where: {
           id: noteId,

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -257,8 +257,8 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       }
 
       // Prevent deletion of auto-generated notes (UPDATE type)
-      const noteToDelete = await db.auditNote.findUnique({
-        where: { id: noteId },
+      const noteToDelete = await db.auditNote.findFirst({
+        where: { id: noteId, auditSession: { organizationId } },
         select: { type: true },
       });
 
@@ -272,11 +272,27 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
 
-      await db.auditNote.delete({
+      // deleteMany, not delete: `delete` requires a unique where, and the
+      // organization scope has to come through the parent audit session
+      // (AuditNote has no organizationId column). Before this, the delete was
+      // keyed on the note id ALONE -- any authenticated user who could reach
+      // this route could delete any audit note in any organization.
+      const deleted = await db.auditNote.deleteMany({
         where: {
           id: noteId,
+          auditSession: { organizationId },
         },
       });
+
+      if (deleted.count === 0) {
+        throw new ShelfError({
+          cause: null,
+          message: "Note not found or you don't have permission to delete it.",
+          additionalData: { noteId, organizationId },
+          label: "Audit",
+          status: 403,
+        });
+      }
 
       return payload({ success: true });
     }

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.note.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.note.tsx
@@ -101,6 +101,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         await deleteLocationNote({
           id: noteId,
           userId,
+          organizationId,
         });
 
         sendNotification({

--- a/apps/webapp/app/routes/_layout+/settings.bookings.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.bookings.tsx
@@ -432,7 +432,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
           });
         }
 
-        await deleteWorkingHoursOverride(overrideId);
+        await deleteWorkingHoursOverride(overrideId, organizationId);
 
         sendNotification({
           title: "Override deleted",


### PR DESCRIPTION
## What

Four cross-organization IDOR findings with one root cause: a delete keyed on an
id the caller supplies, with no organization in the `where` clause.

detail.dev findings **D019, D062, D074, D079**. Independent of #2882/#2883/#2884
— different files entirely, so it can merge in any order relative to them.

## The pack

None of these models has an `organizationId` column, so each has to be scoped
through its parent:

| Model | Scoped through | Finding |
| --- | --- | --- |
| `Note` (asset) | `asset.organizationId` | D019 |
| `LocationNote` | `location.organizationId` | D062 |
| `AuditNote` | `auditSession.organizationId` | D074 |
| `WorkingHoursOverride` | `workingHours.organizationId` | D079 |

`deleteBookingNote` and `deleteTeamMemberNote` already scoped correctly, so this
makes the family consistent rather than inventing a shape.

## Severity is not uniform — and one was understated

Three scoped by `userId`, so the exposure was an author reaching their own note
in an organization they had since **left**.

The audit scan-details route scoped by **neither** user nor organization:

```ts
await db.auditNote.delete({ where: { id: noteId } });
```

Any authenticated user who could reach that route could delete **any** audit
note in **any** organization. Its type-check lookup (`findUnique({ where: { id }})`)
was equally unscoped.

## What the required param found that the findings didn't

`organizationId` is a **required typed param**, per
`.claude/rules/org-scope-user-supplied-ids.md`, so the compiler enumerated the
call sites instead of a grep. That surfaced two extra holes:

- **`updateAuditAssetNote`** has the identical unscoped lookup — the same bug on
  the *update* path. Fixed here.
- The sibling sweep found **`updateWorkingHoursOverride` with no scoping at
  all** — not even a preceding lookup. Any authenticated caller could edit
  another organization's override by id. Never reported by the scan.

## Implementation notes

Prisma's `delete`/`update` require a unique `where`, so relation-scoped
mutations become `deleteMany`/`updateMany` plus a count check. Still one query —
a relation filter, not an extra round trip.

A miss now throws **403** rather than returning `count: 0`. Silently reporting
"nothing deleted" let a refused cross-org delete read as an ordinary no-op. The
wrapping catches re-throw `ShelfError` so that 403 is not repackaged as a
generic 500 — one of those (`deleteWorkingHoursOverride`) I had missed and the
pre-commit reviewer caught.

## Checked rather than assumed

- **Parent FKs are all non-nullable** (`Note.assetId`, `LocationNote.locationId`,
  `WorkingHoursOverride.workingHoursId` are `String`, not `String?`), so scoping
  through the parent cannot strand a row as permanently undeletable.
- **`updateAuditAssetNote`, `deleteAuditAssetNote` and both working-hours
  override functions currently have no callers.** The fixes are still correct as
  exported API surface, but it means D074's *live* exposure was the two route
  handlers, not the service. Worth knowing before weighting the severity.

## Left deliberate

The audit scan-details delete is scoped by organization but **not** by author,
unlike its sibling route `audits.$auditId.note.tsx`. Deleting an audit note
there reads as a role-gated, org-wide capability — an auditor tidying a session
shouldn't be blocked by who typed the note. Cross-**org** deletion was the bug,
and the `auditSession` filter closes it. There's a `// why:` at the call site so
the asymmetry reads as a decision rather than an oversight.

## Tests

145 pass across the four modules. New coverage pins the actual vulnerability:
the delete is asserted to carry the relation filter (`asset: { organizationId }`
etc.), a cross-org note is refused with the sink never reached, and a miss
raises 403 instead of a silent zero-count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Note updates and deletions are now securely restricted to the correct organization.
  * Prevented cross-organization access to audit, asset, location, and general notes.
  * Working-hours override updates and deletions now enforce organization-level permissions.
  * Unauthorized or unavailable records return clear permission errors.
  * Success notifications appear only after deletions complete successfully.
  * Improved error handling preserves meaningful access-denied responses instead of generic failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->