### PR TITLE
fix(security): guard mobile booking check-out and check-in against cross-user use

### DIFF
--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -242,6 +242,14 @@ export async function getMobileUserContext(
   organizationId: string
 ): Promise<{
   role: OrganizationRoles;
+  /**
+   * Every role on this membership. `role` is `roles[0]`, which is wrong for
+   * any authorization decision: a membership ordered `[SELF_SERVICE, ADMIN]`
+   * resolves to SELF_SERVICE and an actual admin gets treated as restricted.
+   * Callers making a privilege decision should use this with
+   * `resolveMostPrivilegedRole`.
+   */
+  roles: OrganizationRoles[];
   canUseBarcodes: boolean;
   canUseAudits: boolean;
   canSeeAllCustody: boolean;
@@ -280,6 +288,7 @@ export async function getMobileUserContext(
 
   return {
     role,
+    roles: userOrg.roles,
     canUseBarcodes: canUseBarcodes(userOrg.organization),
     canUseAudits: canUseAudits(userOrg.organization),
     canSeeAllCustody: computeCanSeeAllCustody({

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
@@ -11,7 +11,10 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { checkinBooking } from "~/modules/booking/service.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
-import { validateBookingOwnership } from "~/utils/booking-authorization.server";
+import {
+  resolveMostPrivilegedRole,
+  validateBookingOwnership,
+} from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
@@ -47,7 +50,7 @@ export async function action({ request }: ActionFunctionArgs) {
     // scan / select the assets (the partial-checkin path). The mobile app must
     // NEVER be more permissive than the web / a workspace's settings, so we
     // enforce the same policy server-side here.
-    const { role } = await getMobileUserContext(user.id, organizationId);
+    const { role, roles } = await getMobileUserContext(user.id, organizationId);
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
     const explicitCheckinRequired =
@@ -105,7 +108,7 @@ export async function action({ request }: ActionFunctionArgs) {
     validateBookingOwnership({
       booking: existingBooking,
       userId: user.id,
-      role,
+      role: resolveMostPrivilegedRole(roles),
       action: "check in",
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
@@ -1,6 +1,7 @@
 import { OrganizationRoles } from "@prisma/client";
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
   requireMobileAuth,
   requireMobilePermission,
@@ -10,6 +11,7 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { checkinBooking } from "~/modules/booking/service.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
+import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
@@ -81,6 +83,31 @@ export async function action({ request }: ActionFunctionArgs) {
       ...getClientHint(request),
       ...(timeZone ? { timeZone } : {}),
     };
+
+    // Org-scoped, so a foreign-org id 404s before ownership is evaluated.
+    const existingBooking = await db.booking.findFirst({
+      where: { id: bookingId, organizationId },
+      select: { creatorId: true, custodianUserId: true },
+    });
+
+    if (!existingBooking) {
+      return data(
+        { error: { message: "Booking not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+
+    // Cross-user IDOR guard, mirroring the checkout routes: SELF_SERVICE holds
+    // `booking:checkin`, so the role gate above passes for ANY booking id in
+    // the organization, and `checkinBooking` does not check ownership itself.
+    // No-op for ADMIN/OWNER. `role` is already resolved above for the
+    // explicit-checkin policy.
+    validateBookingOwnership({
+      booking: existingBooking,
+      userId: user.id,
+      role,
+      action: "check in",
+    });
 
     const booking = await checkinBooking({
       id: bookingId,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
@@ -2,12 +2,14 @@ import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireMobilePermission,
   requireOrganizationAccess,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import { checkoutBooking } from "~/modules/booking/service.server";
+import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -56,7 +58,13 @@ export async function action({ request }: ActionFunctionArgs) {
     // foreign-org id 404s.
     const existingBooking = await db.booking.findFirst({
       where: { id: bookingId, organizationId },
-      select: { from: true, to: true },
+      // creatorId/custodianUserId feed the ownership guard below.
+      select: {
+        from: true,
+        to: true,
+        creatorId: true,
+        custodianUserId: true,
+      },
     });
 
     if (!existingBooking) {
@@ -65,6 +73,20 @@ export async function action({ request }: ActionFunctionArgs) {
         { status: 404 }
       );
     }
+
+    // Cross-user IDOR guard: SELF_SERVICE holds `booking:checkout` in the
+    // permission map, so the role gate above passes for ANY booking id in the
+    // organization — they may only check out bookings they created or are
+    // custodian of. No-op for ADMIN/OWNER. `checkoutBooking` does not check
+    // ownership itself, so without this the route is more permissive than web.
+    // Mirrors the guard added to bookings.fulfil-and-checkout.ts in 918d53d51.
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    validateBookingOwnership({
+      booking: existingBooking,
+      userId: user.id,
+      role,
+      action: "check out",
+    });
 
     // Derive hints the standard way: locale from the request's Accept-Language
     // header and timeZone from the CH-time-zone cookie (UTC fallback). Native

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
@@ -9,7 +9,10 @@ import {
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import { checkoutBooking } from "~/modules/booking/service.server";
-import { validateBookingOwnership } from "~/utils/booking-authorization.server";
+import {
+  resolveMostPrivilegedRole,
+  validateBookingOwnership,
+} from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -80,11 +83,11 @@ export async function action({ request }: ActionFunctionArgs) {
     // custodian of. No-op for ADMIN/OWNER. `checkoutBooking` does not check
     // ownership itself, so without this the route is more permissive than web.
     // Mirrors the guard added to bookings.fulfil-and-checkout.ts in 918d53d51.
-    const { role } = await getMobileUserContext(user.id, organizationId);
+    const { roles } = await getMobileUserContext(user.id, organizationId);
     validateBookingOwnership({
       booking: existingBooking,
       userId: user.id,
-      role,
+      role: resolveMostPrivilegedRole(roles),
       action: "check out",
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.fulfil-and-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.fulfil-and-checkout.ts
@@ -9,7 +9,10 @@ import {
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
 import { fulfilModelRequestsAndCheckout } from "~/modules/booking/service.server";
-import { validateBookingOwnership } from "~/utils/booking-authorization.server";
+import {
+  resolveMostPrivilegedRole,
+  validateBookingOwnership,
+} from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -104,11 +107,11 @@ export async function action({ request }: ActionFunctionArgs) {
     // `fulfilModelRequestsAndCheckout` does NOT check ownership itself (unlike
     // the scan-add path, whose guard lives in `processBooking`), so without
     // this the mobile route would be more permissive than web.
-    const { role } = await getMobileUserContext(user.id, organizationId);
+    const { roles } = await getMobileUserContext(user.id, organizationId);
     validateBookingOwnership({
       booking: existingBooking,
       userId: user.id,
-      role,
+      role: resolveMostPrivilegedRole(roles),
       action: "check out",
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
@@ -1,12 +1,15 @@
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
+  getMobileUserContext,
   requireMobileAuth,
   requireMobilePermission,
   requireOrganizationAccess,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import { partialCheckoutBooking } from "~/modules/booking/service.server";
+import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -85,6 +88,33 @@ export async function action({ request }: ActionFunctionArgs) {
       ...getClientHint(request),
       ...(timeZone ? { timeZone } : {}),
     };
+
+    // Org-scoped, so a foreign-org id 404s before the ownership check runs.
+    const existingBooking = await db.booking.findFirst({
+      where: { id: bookingId, organizationId },
+      select: { creatorId: true, custodianUserId: true },
+    });
+
+    if (!existingBooking) {
+      return data(
+        { error: { message: "Booking not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+
+    // Cross-user IDOR guard: SELF_SERVICE holds `booking:checkout` in the
+    // permission map, so the role gate above passes for ANY booking id in the
+    // organization — they may only check out bookings they created or are
+    // custodian of. No-op for ADMIN/OWNER. `partialCheckoutBooking` does not check
+    // ownership itself, so without this the route is more permissive than web.
+    // Mirrors the guard added to bookings.fulfil-and-checkout.ts in 918d53d51.
+    const { role } = await getMobileUserContext(user.id, organizationId);
+    validateBookingOwnership({
+      booking: existingBooking,
+      userId: user.id,
+      role,
+      action: "check out",
+    });
 
     const result = await partialCheckoutBooking({
       id: bookingId,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
@@ -9,7 +9,10 @@ import {
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import { partialCheckoutBooking } from "~/modules/booking/service.server";
-import { validateBookingOwnership } from "~/utils/booking-authorization.server";
+import {
+  resolveMostPrivilegedRole,
+  validateBookingOwnership,
+} from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -108,11 +111,11 @@ export async function action({ request }: ActionFunctionArgs) {
     // custodian of. No-op for ADMIN/OWNER. `partialCheckoutBooking` does not check
     // ownership itself, so without this the route is more permissive than web.
     // Mirrors the guard added to bookings.fulfil-and-checkout.ts in 918d53d51.
-    const { role } = await getMobileUserContext(user.id, organizationId);
+    const { roles } = await getMobileUserContext(user.id, organizationId);
     validateBookingOwnership({
       booking: existingBooking,
       userId: user.id,
-      role,
+      role: resolveMostPrivilegedRole(roles),
       action: "check out",
     });
 

--- a/apps/webapp/app/utils/booking-authorization.server.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.ts
@@ -146,6 +146,33 @@ interface ValidateBookingOwnershipParams {
  *
  * @throws {ShelfError} 403 if user is not authorized
  */
+/**
+ * Picks the most privileged role from a membership's role array.
+ *
+ * `roles` is an array and the codebase conventionally reads `roles[0]`, which
+ * is fine for display and wrong for authorization: a membership ordered
+ * `[SELF_SERVICE, ADMIN]` resolves to SELF_SERVICE, so an actual admin is
+ * treated as restricted and refused. {@link validateBookingOwnership} only
+ * distinguishes privileged (ADMIN/OWNER, allowed through) from restricted
+ * (SELF_SERVICE/BASE, owner-only), so it needs the privileged answer.
+ *
+ * @param roles - Every role on the membership
+ * @returns OWNER or ADMIN when present, otherwise `roles[0]`, defaulting to BASE
+ */
+export function resolveMostPrivilegedRole(
+  roles: OrganizationRoles[]
+): OrganizationRoles {
+  if (roles.includes(OrganizationRoles.OWNER)) {
+    return OrganizationRoles.OWNER;
+  }
+
+  if (roles.includes(OrganizationRoles.ADMIN)) {
+    return OrganizationRoles.ADMIN;
+  }
+
+  return roles[0] ?? OrganizationRoles.BASE;
+}
+
 export function validateBookingOwnership({
   booking,
   userId,

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.model-requests.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.model-requests.test.ts
@@ -100,6 +100,8 @@ function makeArgs(method: "POST" | "DELETE", body: Record<string, unknown>) {
 function withRole(role: OrganizationRoles) {
   getMobileUserContextMock.mockResolvedValue({
     role,
+    // The guard reads the full array, not roles[0].
+    roles: [role],
     canUseBarcodes: true,
     canUseAudits: true,
     canSeeAllCustody: true,

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.serialization.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.serialization.test.ts
@@ -75,6 +75,7 @@ beforeEach(() => {
   requireOrganizationAccessMock.mockResolvedValue("org-1");
   getMobileUserContextMock.mockResolvedValue({
     role: OrganizationRoles.ADMIN,
+    roles: [OrganizationRoles.ADMIN],
     canUseBarcodes: true,
     canUseAudits: true,
     canSeeAllCustody: true,

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.slices.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.slices.test.ts
@@ -109,6 +109,7 @@ beforeEach(() => {
   requireOrganizationAccessMock.mockResolvedValue("org-1");
   getMobileUserContextMock.mockResolvedValue({
     role: OrganizationRoles.ADMIN,
+    roles: [OrganizationRoles.ADMIN],
     canUseBarcodes: true,
     canUseAudits: true,
     canSeeAllCustody: true,

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
@@ -68,6 +68,8 @@ const BOOKING_ID = "booking-1";
 function withRole(role: OrganizationRoles) {
   getMobileUserContextMock.mockResolvedValue({
     role,
+    // The guard reads the full array, not roles[0].
+    roles: [role],
     canUseBarcodes: true,
     canUseAudits: true,
     canSeeAllCustody: true,

--- a/apps/webapp/test/routes-tests/api+/mobile+/dashboard.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/dashboard.test.ts
@@ -106,6 +106,8 @@ function actAs(role: OrganizationRoles) {
   requireOrganizationAccessMock.mockResolvedValue(ORG_ID);
   getMobileUserContextMock.mockResolvedValue({
     role,
+    // The guard reads the full array, not roles[0].
+    roles: [role],
     canUseBarcodes: true,
     canUseAudits: true,
     canSeeAllCustody: role !== OrganizationRoles.SELF_SERVICE,

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.checkin.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.checkin.test.ts
@@ -114,7 +114,10 @@ describe("POST /api/mobile/bookings/checkin", () => {
     });
     (assertMobileCanUseBookings as any).mockResolvedValue(undefined);
     // Default: admin role + explicit check-in NOT required (quick check-in OK).
-    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      roles: ["ADMIN"],
+    });
     (getBookingSettingsForOrganization as any).mockResolvedValue({
       requireExplicitCheckinForAdmin: false,
       requireExplicitCheckinForSelfService: false,
@@ -171,7 +174,10 @@ describe("POST /api/mobile/bookings/checkin", () => {
   it("blocks quick check-in (403) when the workspace requires explicit check-in for the role", async () => {
     // Admin in a workspace that mandates explicit (scan/select) check-in for
     // admins — quick "check in all" must be refused, mirroring the web policy.
-    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      roles: ["ADMIN"],
+    });
     (getBookingSettingsForOrganization as any).mockResolvedValue({
       requireExplicitCheckinForAdmin: true,
       requireExplicitCheckinForSelfService: false,
@@ -193,7 +199,10 @@ describe("POST /api/mobile/bookings/checkin", () => {
     // SELF_SERVICE holds `booking:checkin`, so the role gate above passes for
     // ANY booking id in the organization, and `checkinBooking` does not check
     // ownership itself. Only the ownership guard stops this.
-    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      roles: ["SELF_SERVICE"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       creatorId: "someone-else",
       custodianUserId: "someone-else",
@@ -207,7 +216,29 @@ describe("POST /api/mobile/bookings/checkin", () => {
   });
 
   it("still lets ADMIN check in a booking they do not own", async () => {
-    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      roles: ["ADMIN"],
+    });
+    (db.booking.findFirst as any).mockResolvedValue({
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createCheckinRequest({ bookingId: "booking-1" });
+    await action(createActionArgs({ request }));
+
+    expect(checkinBooking).toHaveBeenCalled();
+  });
+
+  it("does not block a real ADMIN whose roles array starts with SELF_SERVICE", async () => {
+    // `getMobileUserContext.role` is roles[0], so a membership ordered
+    // [SELF_SERVICE, ADMIN] resolves to SELF_SERVICE — the guard would refuse
+    // an actual admin. The guard reads the whole array instead.
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      roles: ["SELF_SERVICE", "ADMIN"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       creatorId: "someone-else",
       custodianUserId: "someone-else",

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.checkin.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.checkin.test.ts
@@ -35,6 +35,12 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
 }));
 
 // why: external service — we mock the booking checkin to avoid database calls
+// why: the route now loads creatorId/custodianUserId for the ownership guard;
+// mock the org-scoped lookup rather than hitting a database.
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
 vi.mock("~/modules/booking/service.server", () => ({
   checkinBooking: vi.fn(),
 }));
@@ -63,6 +69,7 @@ import {
   assertMobileCanUseBookings,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { db } from "~/database/db.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import { checkinBooking } from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
@@ -99,6 +106,12 @@ describe("POST /api/mobile/bookings/checkin", () => {
 
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    // Default: the caller owns the booking, so the ownership guard is a
+    // no-op and the pre-existing cases still test what they were written for.
+    (db.booking.findFirst as any).mockResolvedValue({
+      creatorId: "user-1",
+      custodianUserId: null,
+    });
     (assertMobileCanUseBookings as any).mockResolvedValue(undefined);
     // Default: admin role + explicit check-in NOT required (quick check-in OK).
     (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
@@ -174,5 +187,35 @@ describe("POST /api/mobile/bookings/checkin", () => {
     expect((result as unknown as Response).status).toBe(403);
     // The quick check-in must NOT run — the user is forced to scan/select.
     expect(checkinBooking).not.toHaveBeenCalled();
+  });
+
+  it("refuses a SELF_SERVICE user checking in someone else's booking", async () => {
+    // SELF_SERVICE holds `booking:checkin`, so the role gate above passes for
+    // ANY booking id in the organization, and `checkinBooking` does not check
+    // ownership itself. Only the ownership guard stops this.
+    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createCheckinRequest({ bookingId: "booking-1" });
+    await action(createActionArgs({ request }));
+
+    // The assertion that matters: the check-in never happens.
+    expect(checkinBooking).not.toHaveBeenCalled();
+  });
+
+  it("still lets ADMIN check in a booking they do not own", async () => {
+    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createCheckinRequest({ bookingId: "booking-1" });
+    await action(createActionArgs({ request }));
+
+    expect(checkinBooking).toHaveBeenCalled();
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
@@ -108,7 +108,10 @@ describe("POST /api/mobile/bookings/checkout", () => {
     (requireMobilePermission as any).mockResolvedValue(undefined);
     // Default: the caller owns the booking, so the ownership guard is a
     // no-op and the pre-existing cases still test what they were written for.
-    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      roles: ["SELF_SERVICE"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       from: BOOKING_FROM,
       to: BOOKING_TO,
@@ -184,7 +187,10 @@ describe("POST /api/mobile/bookings/checkout", () => {
   it("refuses a SELF_SERVICE user checking out someone else's booking", async () => {
     // SELF_SERVICE holds `booking:checkout`, so the role gate above passes for
     // ANY booking id in the organization. Only the ownership guard stops this.
-    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      roles: ["SELF_SERVICE"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       from: BOOKING_FROM,
       to: BOOKING_TO,
@@ -201,10 +207,32 @@ describe("POST /api/mobile/bookings/checkout", () => {
 
   it("still lets ADMIN check out a booking they do not own", async () => {
     // The guard is a no-op for ADMIN/OWNER — it must not break admin workflows.
-    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      roles: ["ADMIN"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       from: BOOKING_FROM,
       to: BOOKING_TO,
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createCheckoutRequest({ bookingId: "booking-1" });
+    await action(createActionArgs({ request }));
+
+    expect(checkoutBooking).toHaveBeenCalled();
+  });
+
+  it("does not block a real ADMIN whose roles array starts with SELF_SERVICE", async () => {
+    // `getMobileUserContext.role` is roles[0], so a membership ordered
+    // [SELF_SERVICE, ADMIN] resolves to SELF_SERVICE — the guard would refuse
+    // an actual admin. The guard reads the whole array instead.
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      roles: ["SELF_SERVICE", "ADMIN"],
+    });
+    (db.booking.findFirst as any).mockResolvedValue({
       creatorId: "someone-else",
       custodianUserId: "someone-else",
     });

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.checkout.test.ts
@@ -31,6 +31,9 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
   requireOrganizationAccess: vi.fn(),
   requireMobilePermission: vi.fn(),
   assertMobileCanUseBookings: vi.fn(),
+  // why: the cross-user ownership guard resolves the caller's role through
+  // this; mocking it is how each test picks SELF_SERVICE vs ADMIN.
+  getMobileUserContext: vi.fn(),
 }));
 
 // why: external service — we mock the booking checkout to avoid database calls
@@ -61,6 +64,7 @@ import {
   requireOrganizationAccess,
   requireMobilePermission,
   assertMobileCanUseBookings,
+  getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
 import { db } from "~/database/db.server";
 import { checkoutBooking } from "~/modules/booking/service.server";
@@ -102,9 +106,15 @@ describe("POST /api/mobile/bookings/checkout", () => {
 
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    // Default: the caller owns the booking, so the ownership guard is a
+    // no-op and the pre-existing cases still test what they were written for.
+    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
     (db.booking.findFirst as any).mockResolvedValue({
       from: BOOKING_FROM,
       to: BOOKING_TO,
+      // Owned by the caller so the ownership guard is a no-op here.
+      creatorId: "user-1",
+      custodianUserId: null,
     });
     (assertMobileCanUseBookings as any).mockResolvedValue(undefined);
   });
@@ -169,5 +179,39 @@ describe("POST /api/mobile/bookings/checkout", () => {
     expect(body.error.message).toContain("Permission denied");
 
     expect(checkoutBooking).not.toHaveBeenCalled();
+  });
+
+  it("refuses a SELF_SERVICE user checking out someone else's booking", async () => {
+    // SELF_SERVICE holds `booking:checkout`, so the role gate above passes for
+    // ANY booking id in the organization. Only the ownership guard stops this.
+    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      from: BOOKING_FROM,
+      to: BOOKING_TO,
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createCheckoutRequest({ bookingId: "booking-1" });
+    await action(createActionArgs({ request }));
+
+    // The assertion that matters: the checkout never happens.
+    expect(checkoutBooking).not.toHaveBeenCalled();
+  });
+
+  it("still lets ADMIN check out a booking they do not own", async () => {
+    // The guard is a no-op for ADMIN/OWNER — it must not break admin workflows.
+    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      from: BOOKING_FROM,
+      to: BOOKING_TO,
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createCheckoutRequest({ bookingId: "booking-1" });
+    await action(createActionArgs({ request }));
+
+    expect(checkoutBooking).toHaveBeenCalled();
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.partial-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.partial-checkout.test.ts
@@ -33,9 +33,18 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
   // why: the route premium-gates with assertMobileCanUseBookings; mock it so
   // the gate is a no-op in these tests (mirrors the sibling booking tests).
   assertMobileCanUseBookings: vi.fn(),
+  // why: the cross-user ownership guard resolves the caller's role through
+  // this; mocking it is how each test picks SELF_SERVICE vs ADMIN.
+  getMobileUserContext: vi.fn(),
 }));
 
 // why: external service — we mock the partial checkout to avoid database calls
+// why: the route now loads creatorId/custodianUserId for the ownership guard;
+// mock the org-scoped lookup rather than hitting a database.
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
 vi.mock("~/modules/booking/service.server", () => ({
   partialCheckoutBooking: vi.fn(),
 }));
@@ -56,7 +65,9 @@ import {
   requireMobileAuth,
   requireOrganizationAccess,
   requireMobilePermission,
+  getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { db } from "~/database/db.server";
 import { partialCheckoutBooking } from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
 
@@ -99,6 +110,13 @@ describe("POST /api/mobile/bookings/partial-checkout", () => {
 
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
+    // Default: the caller owns the booking, so the ownership guard is a
+    // no-op and the pre-existing cases still test what they were written for.
+    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      creatorId: "user-1",
+      custodianUserId: null,
+    });
   });
 
   it("accepts legacy { bookingId, assetIds } payload with INDIVIDUAL semantics", async () => {
@@ -227,5 +245,43 @@ describe("POST /api/mobile/bookings/partial-checkout", () => {
     expect((result as unknown as Response).status).toBe(404);
     const body = await (result as unknown as Response).json();
     expect(body.error.message).toContain("Booking not found");
+  });
+
+  it("refuses a SELF_SERVICE user checking out someone else's booking", async () => {
+    // SELF_SERVICE holds `booking:checkout`, so the role gate above passes for
+    // ANY booking id in the organization. Only the ownership guard stops this.
+    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createPartialCheckoutRequest({
+      bookingId: "booking-1",
+      // cuid: the schema validates assetIds with z.string().cuid()
+      assetIds: ["clx1a2b3c0000d4e5f6g7h8i9"],
+    });
+    await action(createActionArgs({ request }));
+
+    // The assertion that matters: the checkout never happens.
+    expect(partialCheckoutBooking).not.toHaveBeenCalled();
+  });
+
+  it("still lets ADMIN check out a booking they do not own", async () => {
+    // The guard is a no-op for ADMIN/OWNER — it must not break admin workflows.
+    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (db.booking.findFirst as any).mockResolvedValue({
+      creatorId: "someone-else",
+      custodianUserId: "someone-else",
+    });
+
+    const request = createPartialCheckoutRequest({
+      bookingId: "booking-1",
+      // cuid: the schema validates assetIds with z.string().cuid()
+      assetIds: ["clx1a2b3c0000d4e5f6g7h8i9"],
+    });
+    await action(createActionArgs({ request }));
+
+    expect(partialCheckoutBooking).toHaveBeenCalled();
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.partial-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.partial-checkout.test.ts
@@ -112,7 +112,10 @@ describe("POST /api/mobile/bookings/partial-checkout", () => {
     (requireMobilePermission as any).mockResolvedValue(undefined);
     // Default: the caller owns the booking, so the ownership guard is a
     // no-op and the pre-existing cases still test what they were written for.
-    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      roles: ["SELF_SERVICE"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       creatorId: "user-1",
       custodianUserId: null,
@@ -250,7 +253,10 @@ describe("POST /api/mobile/bookings/partial-checkout", () => {
   it("refuses a SELF_SERVICE user checking out someone else's booking", async () => {
     // SELF_SERVICE holds `booking:checkout`, so the role gate above passes for
     // ANY booking id in the organization. Only the ownership guard stops this.
-    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "SELF_SERVICE",
+      roles: ["SELF_SERVICE"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       creatorId: "someone-else",
       custodianUserId: "someone-else",
@@ -269,7 +275,10 @@ describe("POST /api/mobile/bookings/partial-checkout", () => {
 
   it("still lets ADMIN check out a booking they do not own", async () => {
     // The guard is a no-op for ADMIN/OWNER — it must not break admin workflows.
-    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      roles: ["ADMIN"],
+    });
     (db.booking.findFirst as any).mockResolvedValue({
       creatorId: "someone-else",
       custodianUserId: "someone-else",


### PR DESCRIPTION
## What

A **SELF_SERVICE** user could check out — and check in — **any other member's
booking** in their workspace, via the mobile API.

detail.dev finding **D005**, plus two sibling routes the scan never named.

## The bug

SELF_SERVICE holds both `booking:checkout` and `booking:checkin` in the
permission matrix, so the role gate on these endpoints passes for **any**
booking id in the organization. Nothing else stood between the caller and the
mutation:

- the routes never read `creatorId` / `custodianUserId`;
- and the services don't check either — `checkoutBooking`,
  `partialCheckoutBooking` and `checkinBooking` all have **zero** ownership
  references.

`918d53d51` fixed exactly this on one route in July. The rest were never swept:

| Route | Before this PR |
| --- | --- |
| `bookings.fulfil-and-checkout.ts` | guarded by `918d53d51` |
| `bookings.partial-checkout.ts` | ❌ **D005** |
| `bookings.checkout.ts` | ❌ **not in the scan** |
| `bookings.checkin.ts` | ❌ **not in the scan** — never loaded the booking at all |

## The fix

The same guard `918d53d51` introduced, applied to the remaining three:

```ts
validateBookingOwnership({
  booking: existingBooking,
  userId: user.id,
  role,
  action: "check out",
});
```

`bookings.checkout.ts` already loaded the booking for its conflict window, so
only its `select` widened. `partial-checkout` and `checkin` loaded nothing and
gain an org-scoped fetch — a foreign-org id still 404s **before** ownership is
evaluated, so there's no cross-org existence oracle.

The guard is a **no-op for ADMIN/OWNER**, pinned by a test on each route so it
can't regress into blocking admin workflows.

## Two corrections to my own sweep

I first reported `bookings.partial-checkin.ts` and
`bookings.add-scanned-assets.ts` as unguarded. **They aren't.** They use
`canUserManageBookingAssets` and inline `custodianUserId` comparisons rather
than `validateBookingOwnership`, and I had grepped for only one of the two
guard shapes this codebase uses. The corrected sweep counts both, and both
routes come back clean.

Worth recording because the same one-shape grep is what would have missed
`bookings.checkout.ts` in the other direction.

## Still unguarded, deliberately not here

`bookings.update.ts` and `bookings.$bookingId.model-requests.ts` have no
route-level ownership guard, both gated on `booking:update`. `updateBasicBooking`
appears to guard internally, so these need their own verification rather than a
reflexive fix. Flagged rather than silently swept in.

## Tests

18 pass across the four mobile booking suites. Each new guard was confirmed
**failing when removed** — the SELF_SERVICE case asserts the service is never
called, not merely that the status changed.

Updating the existing suites' mocks was unavoidable: the guard resolves the
caller's role via `getMobileUserContext` and loads the booking. That those
suites broke is the evidence the guard sits on the live path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Mobile check-in, checkout, partial checkout, and fulfilment now verify booking ownership and organization access.
  * Self-service users can only process their own bookings.
  * Administrators and owners retain access to bookings they do not own, including when multiple roles are assigned.
  * Unknown or unauthorized bookings return an appropriate not-found response.

* **Tests**
  * Added coverage for ownership restrictions, role resolution, and administrator access across mobile booking workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->