### PR TITLE
fix(companion): use the foreground tokens for booking badges and the scan header

### DIFF
--- a/apps/companion/components/audit/progress-header.tsx
+++ b/apps/companion/components/audit/progress-header.tsx
@@ -70,7 +70,10 @@ const useStyles = createStyles((colors) => ({
   },
   progressUnexpected: {
     fontSize: fontSize.xs,
-    color: colors.warning,
+    // why: NOT `warning` — that is the badge FILL token and reads 2.29:1 as
+    // text on this panel. `warningText` is its foreground twin (7.09:1) and
+    // aliases `warning` in dark mode, so dark is unchanged.
+    color: colors.warningText,
     fontWeight: "500",
   },
   progressPercent: {

--- a/apps/companion/lib/theme-colors.ts
+++ b/apps/companion/lib/theme-colors.ts
@@ -190,8 +190,13 @@ function buildBookingStatusBadge(c: Colors) {
     DRAFT: { bg: c.borderLight, text: c.gray700 },
     RESERVED: { bg: c.inCustodyBg, text: c.inCustody },
     ONGOING: { bg: c.checkedOutBg, text: c.checkedOut },
-    OVERDUE: { bg: c.errorBg, text: c.error },
-    COMPLETE: { bg: c.successBg, text: c.success },
+    // why: `error` and `success` are FILL tokens — as badge TEXT they read
+    // 3.46:1 and 2.49:1 on their own backgrounds in light mode, under the
+    // 4.5:1 bar. `errorText` / `successText` are their foreground twins
+    // (6.05:1 and 7.26:1) and alias the base colours in dark mode, so dark is
+    // unchanged. Same fix the audit badges got; these were simply missed.
+    OVERDUE: { bg: c.errorBg, text: c.errorText },
+    COMPLETE: { bg: c.successBg, text: c.successText },
     ARCHIVED: { bg: c.borderLight, text: c.muted },
     CANCELLED: { bg: c.borderLight, text: c.muted },
   } as Record<string, { bg: string; text: string }>;


### PR DESCRIPTION
## What

#2878 switched the audit badges to the `*Text` foreground tokens because the raw fill colours fail WCAG AA when used as text. Three surfaces were missed.

| Surface | Before | After |
| --- | --- | --- |
| Booking `COMPLETE` badge | 2.49:1 | 7.26:1 |
| Booking `OVERDUE` badge | 3.46:1 | 6.05:1 |
| `+N unexpected` scan header | 2.29:1 | 7.09:1 |

Light mode only. `errorText` / `successText` / `warningText` alias their base colours in dark mode, so dark rendering is byte-identical and already passed at 5.18:1, 6.20:1 and 8.03:1.

Backgrounds are unchanged throughout — only the text darkens.

## Why these were missed

`theme-colors.ts` documents that `warning`, `success` and `error` are fill tokens that fail the 4.5:1 text bar. #2878 acted on that for the two audit badge maps and left `buildBookingStatusBadge` on the raw values. The booking badges render on the home screen, the bookings list and the booking detail screen, all at 12px, so the normal-text bar applies with no large-text exemption.

## Ordering

**Based on `fix/audit-status-colour-parity` (#2878), which introduces `successText` and `errorText`. Merge that first**, then this retargets to `main` automatically.

## Still open after this

The scan row's tick icons are 2.49:1 and 2.35:1, under the 3:1 bar for meaningful graphics. They matter more now that #2879 removed the word "Found" and left the icon carrying the state alone. Left out deliberately: the fix needs both #2878 and #2879 merged, since the file belongs to #2879 and the token comes from #2878.

## Verification

- `pnpm --filter @shelf/companion lint` and `typecheck` clean
- Every ratio measured, not estimated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that booking-status badges use accessible text colors for overdue and completed states.
  * Documented that dark-mode color aliases remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->