### PR TITLE
fix(security): gate booking archive, cancel and checkout on their own permissions

### DIFF
--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.tsx
@@ -156,6 +156,21 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       request,
     });
 
+    // `canUserManageBookingAssets` takes only (status, from, to) plus an
+    // is-self-service flag — it never sees `userId`, so it cannot answer "is
+    // this MY booking". Without this, a SELF_SERVICE user could load another
+    // member's booking, its model requests and its asset data through this
+    // screen, even though the action would refuse the checkout. Read access is
+    // the leak; the write guard does not cover it.
+    if (isSelfService) {
+      validateBookingOwnership({
+        booking,
+        userId,
+        role,
+        action: "check out",
+      });
+    }
+
     const canManageAssets = canUserManageBookingAssets(booking, isSelfService);
 
     if (!canManageAssets) {

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.tsx
@@ -55,6 +55,7 @@ import {
 } from "~/modules/booking/service.server";
 import scannerCss from "~/styles/scanner.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { canUserManageBookingAssets } from "~/utils/bookings";
 import { getClientHint } from "~/utils/client-hints";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
@@ -131,15 +132,21 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   });
 
   try {
+    // Matches the action's gate: this screen exists only to check out, so a
+    // role without `booking:checkout` should not reach it at all.
     const { organizationId, role, userOrganizations } = await requirePermission(
       {
         userId,
         request,
         entity: PermissionEntity.booking,
-        action: PermissionAction.update,
+        action: PermissionAction.checkout,
       }
     );
 
+    // NOTE: BASE is deliberately not folded in here. `canUserManageBookingAssets`
+    // takes an is-self-service flag, and BASE reaching this loader would get the
+    // permissive branch — but BASE does not hold `booking:checkout`, so the gate
+    // above now stops it before this matters.
     const isSelfService = role === OrganizationRoles.SELF_SERVICE;
 
     const booking = await getBooking({
@@ -262,12 +269,16 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
 
-    const { organizationId } = await requirePermission({
-      userId,
-      request,
-      entity: PermissionEntity.booking,
-      action: PermissionAction.update,
-    });
+    // `checkout`, not `update`: BASE holds `update` and deliberately does NOT
+    // hold `checkout`, so gating on `update` let a BASE user check out through
+    // this route. The dedicated action exists precisely to withhold this.
+    const { organizationId, role, isSelfServiceOrBase } =
+      await requirePermission({
+        userId,
+        request,
+        entity: PermissionEntity.booking,
+        action: PermissionAction.checkout,
+      });
 
     const formData = await request.formData();
 
@@ -283,8 +294,28 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
      */
     const basicBookingInfo = await db.booking.findUniqueOrThrow({
       where: { id: bookingId, organizationId },
-      select: { from: true, to: true },
+      // creatorId/custodianUserId feed the ownership guard below.
+      select: {
+        from: true,
+        to: true,
+        creatorId: true,
+        custodianUserId: true,
+      },
     });
+
+    // The loader restricts via `canUserManageBookingAssets`, but the ACTION had
+    // no equivalent — a direct POST skipped it entirely. SELF_SERVICE holds
+    // `booking:checkout`, and `fulfilModelRequestsAndCheckout` does not check
+    // ownership itself, so this is what stops a cross-user checkout. No-op for
+    // ADMIN/OWNER. Mirrors api+/mobile+/bookings.fulfil-and-checkout.ts.
+    if (isSelfServiceOrBase) {
+      validateBookingOwnership({
+        booking: basicBookingInfo,
+        userId,
+        role,
+        action: "check out",
+      });
+    }
 
     await fulfilModelRequestsAndCheckout({
       bookingId,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -1500,7 +1500,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       [
         db.booking.findFirstOrThrow({
           where: { id, organizationId },
-          select: { id: true, status: true, from: true, to: true },
+          // creatorId/custodianUserId feed the ownership guard below.
+          select: {
+            id: true,
+            status: true,
+            from: true,
+            to: true,
+            creatorId: true,
+            custodianUserId: true,
+          },
         }),
         getWorkingHoursForOrganization(organizationId),
         getBookingSettingsForOrganization(organizationId),
@@ -1537,6 +1545,32 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         label: "Booking",
         status: 403,
         shouldBeCaptured: false,
+      });
+    }
+
+    /**
+     * Cross-user guard for every mutating intent.
+     *
+     * Hoisted rather than repeated per case, deliberately: the route had one
+     * ownership check (inside `delete`) and fifteen intents, so each new intent
+     * silently arrived unguarded. SELF_SERVICE legitimately holds
+     * `booking:checkout`, `checkin`, `archive`, `cancel` and `extend`, and none
+     * of the services behind them checks ownership -- `checkoutBooking`,
+     * `checkinBooking`, `archiveBooking` and `cancelBooking` all have zero
+     * ownership references -- so this is the only thing standing between a
+     * restricted role and someone else's booking.
+     *
+     * No-op for ADMIN/OWNER. `delete` is not reachable here -- it returns
+     * before this point, with its own check, because it must not fetch the
+     * booking first. The compiler confirms it: `intent` has already narrowed to
+     * exclude it.
+     */
+    if (isSelfServiceOrBase) {
+      validateBookingOwnership({
+        booking: basicBookingInfo,
+        userId,
+        role,
+        action: intent,
       });
     }
 
@@ -1889,20 +1923,6 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
       case "archive": {
-        // Cross-user guard, mirroring api+/mobile+/bookings.archive.ts. The
-        // permission gate alone is not enough: SELF_SERVICE legitimately holds
-        // `booking:archive`, so without this they can archive anyone's booking.
-        // `archiveBooking` does not check ownership itself. No-op for
-        // ADMIN/OWNER.
-        if (isSelfServiceOrBase) {
-          validateBookingOwnership({
-            booking: await getBooking({ id, organizationId, request }),
-            userId,
-            role,
-            action: "archive",
-          });
-        }
-
         await archiveBooking({ id, organizationId, userId: user.id });
 
         sendNotification({
@@ -1922,17 +1942,6 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             additionalData: { userId, id, organizationId, role },
           }
         );
-        // Same guard as archive above — `cancelBooking` does not check
-        // ownership, and SELF_SERVICE holds `booking:cancel`.
-        if (isSelfServiceOrBase) {
-          validateBookingOwnership({
-            booking: await getBooking({ id, organizationId, request }),
-            userId,
-            role,
-            action: "cancel",
-          });
-        }
-
         const cancelledBooking = await cancelBooking({
           id,
           organizationId,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -1380,8 +1380,11 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       checkOut: PermissionAction.checkout,
       checkOutRemaining: PermissionAction.checkout,
       checkIn: PermissionAction.checkin,
-      archive: PermissionAction.update,
-      cancel: PermissionAction.update,
+      // archive/cancel have dedicated permissions, and BASE deliberately holds
+      // neither. Mapping them to `update` -- which BASE does hold -- let a BASE
+      // user archive or cancel bookings the role was never granted.
+      archive: PermissionAction.archive,
+      cancel: PermissionAction.cancel,
       removeKit: PermissionAction.update,
       "revert-to-draft": PermissionAction.update,
       "extend-booking": PermissionAction.extend,
@@ -1886,6 +1889,20 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
       case "archive": {
+        // Cross-user guard, mirroring api+/mobile+/bookings.archive.ts. The
+        // permission gate alone is not enough: SELF_SERVICE legitimately holds
+        // `booking:archive`, so without this they can archive anyone's booking.
+        // `archiveBooking` does not check ownership itself. No-op for
+        // ADMIN/OWNER.
+        if (isSelfServiceOrBase) {
+          validateBookingOwnership({
+            booking: await getBooking({ id, organizationId, request }),
+            userId,
+            role,
+            action: "archive",
+          });
+        }
+
         await archiveBooking({ id, organizationId, userId: user.id });
 
         sendNotification({
@@ -1905,6 +1922,17 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             additionalData: { userId, id, organizationId, role },
           }
         );
+        // Same guard as archive above — `cancelBooking` does not check
+        // ownership, and SELF_SERVICE holds `booking:cancel`.
+        if (isSelfServiceOrBase) {
+          validateBookingOwnership({
+            booking: await getBooking({ id, organizationId, request }),
+            userId,
+            role,
+            action: "cancel",
+          });
+        }
+
         const cancelledBooking = await cancelBooking({
           id,
           organizationId,

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.test.ts
@@ -130,16 +130,32 @@ describe("fulfil-and-checkout action", () => {
   });
 
   it("refuses a SELF_SERVICE user checking out someone else's booking", async () => {
-    await post({ roles: [OrganizationRoles.SELF_SERVICE] });
+    const result = await post({ roles: [OrganizationRoles.SELF_SERVICE] });
 
-    // The assertion that matters: the checkout never happens.
+    // Assert the STATUS, not merely that the sink went uncalled: a refusal test
+    // that only checks "not called" passes for any earlier failure — a bad
+    // payload, a thrown mock — and would keep passing if the guard vanished but
+    // something else broke first.
+    expect((result as unknown as Response).status).toBe(403);
     expect(fulfilMock).not.toHaveBeenCalled();
   });
 
-  it("allows a SELF_SERVICE user to check out their own booking", async () => {
+  it("allows a SELF_SERVICE user who CREATED the booking", async () => {
+    // Split from the custodian case: setting both fields to the caller tests
+    // neither path on its own, so a guard checking only one would still pass.
     await post({
       roles: [OrganizationRoles.SELF_SERVICE],
       creatorId: "user-1",
+      custodianUserId: "someone-else",
+    });
+
+    expect(fulfilMock).toHaveBeenCalled();
+  });
+
+  it("allows a SELF_SERVICE user who is the CUSTODIAN of the booking", async () => {
+    await post({
+      roles: [OrganizationRoles.SELF_SERVICE],
+      creatorId: "someone-else",
       custodianUserId: "user-1",
     });
 

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.test.ts
@@ -30,6 +30,8 @@ const createDataMock = vi.hoisted(() => {
     });
 });
 
+// why: React Router v7 single fetch — `data()` must return a real Response so
+// the action's error path has an assertable status.
 vi.mock("react-router", async () => {
   const actual = await vi.importActual("react-router");
   return { ...actual, data: createDataMock() };
@@ -59,6 +61,9 @@ vi.mock("~/modules/booking/service.server", () => ({
   getBooking: vi.fn(),
 }));
 
+// why: the emitter pushes to a live SSE stream keyed to a real session; there
+// is none in a route-level test, and the notification is a side effect of the
+// success path rather than anything these assertions inspect.
 vi.mock("~/utils/emitter/send-notification.server", () => ({
   sendNotification: vi.fn(),
 }));

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Web fulfil-and-checkout — permission mapping and cross-user guard.
+ *
+ * Two defects, both reachable by a direct POST that skips the loader:
+ *
+ *  1. The action gated on `PermissionAction.update`. BASE holds `update` and
+ *     deliberately does NOT hold `checkout`, so a BASE user could check out
+ *     through this route despite the role being denied that capability.
+ *  2. The action had no ownership check at all — `canUserManageBookingAssets`
+ *     runs only in the loader, and `fulfilModelRequestsAndCheckout` does not
+ *     check ownership itself. So SELF_SERVICE, who legitimately holds
+ *     `booking:checkout`, could check out anyone else's booking.
+ *
+ * detail.dev finding D017 — the web twin of D005.
+ *
+ * @see {@link file://./../../../app/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout.tsx}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+// why: mocking Remix's data() so the action's error path returns a Response
+// whose status is assertable (React Router v7 single fetch).
+const createDataMock = vi.hoisted(() => {
+  return () =>
+    vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+});
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+// why: the permission gate is the first defect under test — mocking it lets
+// each case choose the caller's role, and asserts which action was demanded.
+const { requirePermissionMock } = vi.hoisted(() => ({
+  requirePermissionMock: vi.fn(),
+}));
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: requirePermissionMock,
+}));
+
+// why: the booking lookup feeding the ownership guard; avoids a database.
+const { bookingFindUniqueOrThrow } = vi.hoisted(() => ({
+  bookingFindUniqueOrThrow: vi.fn(),
+}));
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findUniqueOrThrow: bookingFindUniqueOrThrow } },
+}));
+
+// why: the sink we assert is never reached on a refused request.
+const { fulfilMock } = vi.hoisted(() => ({ fulfilMock: vi.fn() }));
+vi.mock("~/modules/booking/service.server", () => ({
+  fulfilModelRequestsAndCheckout: fulfilMock,
+  getBooking: vi.fn(),
+}));
+
+vi.mock("~/utils/emitter/send-notification.server", () => ({
+  sendNotification: vi.fn(),
+}));
+
+import { action } from "~/routes/_layout+/bookings.$bookingId.overview.fulfil-and-checkout";
+
+// @vitest-environment node
+
+/** POSTs to the action as a caller holding `roles`. */
+function post({
+  roles,
+  creatorId = "someone-else",
+  custodianUserId = "someone-else",
+}: {
+  roles: OrganizationRoles[];
+  creatorId?: string;
+  custodianUserId?: string;
+}) {
+  const role = roles[0];
+  requirePermissionMock.mockResolvedValue({
+    organizationId: "org-1",
+    role,
+    isSelfServiceOrBase:
+      role === OrganizationRoles.SELF_SERVICE ||
+      role === OrganizationRoles.BASE,
+  });
+  bookingFindUniqueOrThrow.mockResolvedValue({
+    from: new Date("2026-01-01T09:00:00Z"),
+    to: new Date("2026-01-02T09:00:00Z"),
+    creatorId,
+    custodianUserId,
+  });
+
+  return action({
+    request: new Request(
+      "https://app.shelf.nu/bookings/booking-1/overview/fulfil-and-checkout",
+      {
+        method: "POST",
+        // react-zorm's parseFormAny wants bracket-index keys for arrays; a
+        // repeated plain key collapses to a string and the schema 400s BEFORE
+        // the guard, which would make the refusal assertions pass for the wrong
+        // reason.
+        body: new URLSearchParams({ "assetIds[0]": "asset-1" }),
+      }
+    ),
+    params: { bookingId: "booking-1" },
+    context: { getSession: () => ({ userId: "user-1" }) },
+  } as unknown as Parameters<typeof action>[0]);
+}
+
+describe("fulfil-and-checkout action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("demands booking:checkout, not booking:update", async () => {
+    await post({ roles: [OrganizationRoles.ADMIN] });
+
+    // BASE holds `update` and not `checkout`; gating on `update` is exactly
+    // what let a BASE user check out here.
+    expect(requirePermissionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "checkout" })
+    );
+  });
+
+  it("refuses a SELF_SERVICE user checking out someone else's booking", async () => {
+    await post({ roles: [OrganizationRoles.SELF_SERVICE] });
+
+    // The assertion that matters: the checkout never happens.
+    expect(fulfilMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a SELF_SERVICE user to check out their own booking", async () => {
+    await post({
+      roles: [OrganizationRoles.SELF_SERVICE],
+      creatorId: "user-1",
+      custodianUserId: "user-1",
+    });
+
+    expect(fulfilMock).toHaveBeenCalled();
+  });
+
+  it("leaves ADMIN able to check out a booking they do not own", async () => {
+    await post({ roles: [OrganizationRoles.ADMIN] });
+
+    expect(fulfilMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Three booking actions demanded `booking:update` where a dedicated permission
exists — and **BASE holds `update` but is deliberately denied all three**:

| Intent | Gated on | Should be |
| --- | --- | --- |
| `archive` | `update` | `archive` |
| `cancel` | `update` | `cancel` |
| fulfil-and-checkout | `update` | `checkout` |

detail.dev findings **D057** and **D017**.

## ⚠️ Behaviour change worth a decision

**BASE users lose the ability to archive, cancel and check out bookings.**

They could only do it because the broader permission stood in for the specific
ones. `PermissionAction.archive`, `.cancel` and `.checkout` all exist, and the
role matrix withholds every one of them from BASE — so this restores the
intent that was already written down. But if a customer relies on BASE doing
these things today, that is a product call, not a regression, and it should be
made knowingly.

SELF_SERVICE is unaffected: it holds all three.

## The mapping was only half of it

None of these actions had an ownership check either, and none of the services
carries one:

```
archiveBooking, cancelBooking, checkoutBooking, checkinBooking,
fulfilModelRequestsAndCheckout   -> 0 ownership references each
```

So correcting the mapping alone would have blocked BASE and **left
SELF_SERVICE able to archive, cancel or check out other people's bookings** —
a fix that looks complete and isn't.

### And the gap was wider than the two findings

Investigating that turned up the real shape of it. The overview action had
**one** ownership check — inside the `delete` intent — and **fifteen** intents
in its switch. Nothing downstream compensated:

- **`getBooking` does not scope by user.** Its `writableBy` option belongs to
  the *list* function `getBookings` and has **zero call sites** anywhere in the
  codebase.
- the services, as above, check nothing.

So a SELF_SERVICE user could check out, check in, extend or modify **any
booking in the organization** through this route — not just archive and cancel.

The guard is therefore **hoisted above the switch** rather than repeated per
case, so a newly-added intent inherits it instead of silently arriving
unguarded, which is exactly how one check ended up covering fifteen intents. It
reuses the `basicBookingInfo` fetch already made there, so it costs no extra
query.

`delete` is untouched — it returns earlier with its own check because it must
not fetch the booking first. The compiler confirmed it: an `intent !== "delete"`
clause was rejected as unreachable, the union having already narrowed.

## Mobile was already correct

`api+/mobile+/bookings.archive.ts` and `bookings.cancel.ts` gate on the
dedicated action **and** call `validateBookingOwnership`. Web was the looser
surface, not mobile — worth stating, since the usual direction of drift is the
opposite.

## Tests

New suite for the fulfil-and-checkout action (4): the permission demanded, the
cross-user refusal, the owner-allowed case, and ADMIN unaffected. All four
confirmed **failing against the pre-fix route**.

Full route-test suite: 630/630 (with `--hookTimeout=30000`; the `activity[.csv]`
files hit a known 10s hook flake otherwise).

## One trap worth recording

My first version of the test posted `assetIds` as a plain string. `react-zorm`'s
`parseFormAny` needs bracket-index keys for arrays, so the schema 400'd **before**
the guard — and the two refusal assertions passed for the wrong reason. They
only became meaningful once the payload used `assetIds[0]`.

## Follow-up, not in this PR

`removeKit` and `revert-to-draft` still map to `update`. Unlike archive/cancel
there is no dedicated action for either, so whether BASE should hold them is a
product question rather than a mis-mapping. Flagged rather than silently
changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Access Control**
  - Checkout, archive, and cancel actions now require their dedicated permissions.
  - Self-service users can only modify or complete bookings they own.
  - Administrators can complete bookings regardless of ownership.
- **Validation**
  - Asset or kit removal is prevented when the booking status does not allow it.
- **Tests**
  - Added coverage for checkout permissions, ownership validation, and administrator access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->