### PR TITLE
refactor(roles): declare role precedence once, and resolve it from all roles

### DIFF
--- a/apps/webapp/app/utils/booking-authorization.server.test.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.test.ts
@@ -20,8 +20,13 @@ import { describe, expect, it } from "vitest";
 import {
   bookingWriteScopeClause,
   canSeeBooking,
+  resolveMostPrivilegedRole,
   validateBookingOwnership,
 } from "./booking-authorization.server";
+import {
+  ROLE_PRECEDENCE,
+  SSO_ASSIGNABLE_ROLE_PRECEDENCE,
+} from "./role-precedence";
 
 const ME = "user-me";
 const SOMEONE_ELSE = "user-victim";
@@ -292,5 +297,51 @@ describe("bookingWriteScopeClause", () => {
       OrganizationRoles.OWNER,
       OrganizationRoles.SELF_SERVICE,
     ]);
+  });
+});
+
+describe("resolveMostPrivilegedRole", () => {
+  it("prefers OWNER over anything else", () => {
+    expect(
+      resolveMostPrivilegedRole([
+        OrganizationRoles.SELF_SERVICE,
+        OrganizationRoles.OWNER,
+        OrganizationRoles.ADMIN,
+      ])
+    ).toBe(OrganizationRoles.OWNER);
+  });
+
+  it("prefers ADMIN when it is not first in the array", () => {
+    // The bug this exists for: `roles[0]` on a [SELF_SERVICE, ADMIN]
+    // membership resolves to SELF_SERVICE, and the ownership guard then
+    // refuses an actual admin.
+    expect(
+      resolveMostPrivilegedRole([
+        OrganizationRoles.SELF_SERVICE,
+        OrganizationRoles.ADMIN,
+      ])
+    ).toBe(OrganizationRoles.ADMIN);
+  });
+
+  it("returns the single role when there is only one", () => {
+    expect(resolveMostPrivilegedRole([OrganizationRoles.BASE])).toBe(
+      OrganizationRoles.BASE
+    );
+  });
+
+  it("falls back to BASE for an empty membership rather than undefined", () => {
+    expect(resolveMostPrivilegedRole([])).toBe(OrganizationRoles.BASE);
+  });
+
+  it("shares its order with SSO, minus OWNER", () => {
+    // SSO must never confer ownership — pinned so the exclusion cannot be
+    // "tidied away" when someone edits the shared order.
+    expect(ROLE_PRECEDENCE[0]).toBe(OrganizationRoles.OWNER);
+    expect(SSO_ASSIGNABLE_ROLE_PRECEDENCE).not.toContain(
+      OrganizationRoles.OWNER
+    );
+    expect([...SSO_ASSIGNABLE_ROLE_PRECEDENCE]).toEqual(
+      ROLE_PRECEDENCE.filter((r) => r !== OrganizationRoles.OWNER)
+    );
   });
 });

--- a/apps/webapp/app/utils/booking-authorization.server.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from "@prisma/client";
 import { OrganizationRoles } from "@prisma/client";
 import { ShelfError } from "./error";
+import { ROLE_PRECEDENCE } from "./role-precedence";
 
 /**
  * The minimal booking projection needed to decide whether a requester is the
@@ -162,15 +163,11 @@ interface ValidateBookingOwnershipParams {
 export function resolveMostPrivilegedRole(
   roles: OrganizationRoles[]
 ): OrganizationRoles {
-  if (roles.includes(OrganizationRoles.OWNER)) {
-    return OrganizationRoles.OWNER;
-  }
-
-  if (roles.includes(OrganizationRoles.ADMIN)) {
-    return OrganizationRoles.ADMIN;
-  }
-
-  return roles[0] ?? OrganizationRoles.BASE;
+  return (
+    ROLE_PRECEDENCE.find((candidate) => roles.includes(candidate)) ??
+    roles[0] ??
+    OrganizationRoles.BASE
+  );
 }
 
 export function validateBookingOwnership({

--- a/apps/webapp/app/utils/role-precedence.ts
+++ b/apps/webapp/app/utils/role-precedence.ts
@@ -1,0 +1,43 @@
+/**
+ * Organization role precedence, in one place.
+ *
+ * Two unrelated features need "which of these roles wins": SSO resolves a role
+ * from a user's IdP group claims (a user can be in several groups), and the
+ * booking ownership guard resolves how privileged a membership is (`roles` is
+ * an array). Both were stating the order independently, which is how they
+ * silently drift.
+ *
+ * The order is deliberately declared once and consumed, rather than each site
+ * writing its own if/else chain.
+ *
+ * @see {@link file://./roles.server.ts} `getRoleFromGroupId` — SSO group claims
+ * @see {@link file://./booking-authorization.server.ts} `resolveMostPrivilegedRole`
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+/**
+ * Every organization role, most privileged first.
+ *
+ * "Most privileged" means: if a membership carries several roles, this is the
+ * order in which one of them should be treated as the effective role for an
+ * authorization decision.
+ */
+export const ROLE_PRECEDENCE = [
+  OrganizationRoles.OWNER,
+  OrganizationRoles.ADMIN,
+  OrganizationRoles.SELF_SERVICE,
+  OrganizationRoles.BASE,
+] as const;
+
+/**
+ * The subset assignable via SSO group mapping, most privileged first.
+ *
+ * OWNER is deliberately absent: ownership is a property of who created or was
+ * transferred the workspace, never something an IdP group can confer. Deriving
+ * this from {@link ROLE_PRECEDENCE} keeps the shared ordering while making that
+ * exclusion explicit rather than an omission someone might "fix".
+ */
+export const SSO_ASSIGNABLE_ROLE_PRECEDENCE = ROLE_PRECEDENCE.filter(
+  (role) => role !== OrganizationRoles.OWNER
+);

--- a/apps/webapp/app/utils/roles.server.test.ts
+++ b/apps/webapp/app/utils/roles.server.test.ts
@@ -12,7 +12,11 @@
 import type { SsoDetails } from "@prisma/client";
 import { OrganizationRoles } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
-import { getRoleFromGroupId, resolveCanSeeAllCustody } from "./roles.server";
+import {
+  getRoleFromGroupId,
+  resolveCanSeeAllCustody,
+  resolveEffectiveRole,
+} from "./roles.server";
 
 // why: roles.server.ts imports ~/database/db.server, whose non-production branch
 // eagerly runs `void db.$connect()` at import time. With the placeholder test
@@ -189,5 +193,48 @@ describe("resolveCanSeeAllCustody", () => {
         currentOrganization: org({ baseUserCanSeeCustody: true }),
       })
     ).toBe(false);
+  });
+});
+
+describe("resolveEffectiveRole", () => {
+  const membership = (roles: OrganizationRoles[]) => [
+    { organization: { id: "org-1" }, roles },
+  ];
+
+  it("returns the most privileged role, not roles[0]", () => {
+    // Both callers use this to decide how much a user may SEE — the custodian
+    // picker's scope and booking visibility. Taking roles[0] handed an actual
+    // admin the restricted view.
+    expect(
+      resolveEffectiveRole({
+        userOrganizations: membership([
+          OrganizationRoles.SELF_SERVICE,
+          OrganizationRoles.ADMIN,
+        ]),
+        organizationId: "org-1",
+      })
+    ).toBe(OrganizationRoles.ADMIN);
+  });
+
+  it("prefers OWNER above all", () => {
+    expect(
+      resolveEffectiveRole({
+        userOrganizations: membership([
+          OrganizationRoles.BASE,
+          OrganizationRoles.OWNER,
+        ]),
+        organizationId: "org-1",
+      })
+    ).toBe(OrganizationRoles.OWNER);
+  });
+
+  it("falls back to BASE when the user has no membership in that org", () => {
+    // Fails closed: an unknown membership gets the narrowest role.
+    expect(
+      resolveEffectiveRole({
+        userOrganizations: membership([OrganizationRoles.ADMIN]),
+        organizationId: "another-org",
+      })
+    ).toBe(OrganizationRoles.BASE);
   });
 });

--- a/apps/webapp/app/utils/roles.server.ts
+++ b/apps/webapp/app/utils/roles.server.ts
@@ -9,7 +9,10 @@ import type {
   PermissionEntity,
 } from "./permissions/permission.data";
 import { validatePermission } from "./permissions/permission.validator.server";
-import { SSO_ASSIGNABLE_ROLE_PRECEDENCE } from "./role-precedence";
+import {
+  ROLE_PRECEDENCE,
+  SSO_ASSIGNABLE_ROLE_PRECEDENCE,
+} from "./role-precedence";
 
 export async function requireUserWithPermission(name: Roles, userId: string) {
   try {
@@ -70,11 +73,18 @@ export function resolveEffectiveRole({
   }>;
   organizationId: string;
 }): OrganizationRoles {
-  const roles = userOrganizations.find(
-    (o) => o.organization.id === organizationId
-  )?.roles;
+  const roles =
+    userOrganizations.find((o) => o.organization.id === organizationId)
+      ?.roles ?? [];
 
-  return roles?.[0] ?? OrganizationRoles.BASE;
+  // Most privileged, not roles[0]. Both callers use this to decide how much a
+  // user may see — the custodian picker's scope and booking visibility — so a
+  // membership ordered [SELF_SERVICE, ADMIN] would otherwise hand an actual
+  // admin the restricted view. Shares its ordering with SSO group resolution.
+  return (
+    ROLE_PRECEDENCE.find((candidate) => roles.includes(candidate)) ??
+    OrganizationRoles.BASE
+  );
 }
 
 /**

--- a/apps/webapp/app/utils/roles.server.ts
+++ b/apps/webapp/app/utils/roles.server.ts
@@ -9,6 +9,7 @@ import type {
   PermissionEntity,
 } from "./permissions/permission.data";
 import { validatePermission } from "./permissions/permission.validator.server";
+import { SSO_ASSIGNABLE_ROLE_PRECEDENCE } from "./role-precedence";
 
 export async function requireUserWithPermission(name: Roles, userId: string) {
   try {
@@ -388,14 +389,22 @@ export function getRoleFromGroupId(
   ssoDetails: SsoDetails,
   groupIds: string[]
 ): OrganizationRoles | null {
-  // We prioritize the admin group. If the user is in several, the highest role wins.
-  if (groupClaimMatches(ssoDetails.adminGroupId, groupIds)) {
-    return OrganizationRoles.ADMIN;
-  } else if (groupClaimMatches(ssoDetails.selfServiceGroupId, groupIds)) {
-    return OrganizationRoles.SELF_SERVICE;
-  } else if (groupClaimMatches(ssoDetails.baseUserGroupId, groupIds)) {
-    return OrganizationRoles.BASE;
-  } else {
-    return null;
-  }
+  // Which SsoDetails field configures the group for each role.
+  const groupField: Record<
+    (typeof SSO_ASSIGNABLE_ROLE_PRECEDENCE)[number],
+    string | null
+  > = {
+    [OrganizationRoles.ADMIN]: ssoDetails.adminGroupId,
+    [OrganizationRoles.SELF_SERVICE]: ssoDetails.selfServiceGroupId,
+    [OrganizationRoles.BASE]: ssoDetails.baseUserGroupId,
+  };
+
+  // Walk in precedence order so the highest matching role wins. The order is
+  // shared with the booking ownership guard (see role-precedence.ts) rather
+  // than restated here, so the two cannot drift.
+  return (
+    SSO_ASSIGNABLE_ROLE_PRECEDENCE.find((role) =>
+      groupClaimMatches(groupField[role], groupIds)
+    ) ?? null
+  );
 }


### PR DESCRIPTION
## What

`roles` is an array, and three separate places answered "which of these roles
wins?" — two of them wrongly, by taking `roles[0]`.

**Merge this before #2889.** Its new booking-ownership guards read `role` from
`requirePermission`, which resolves through `resolveEffectiveRole` — so without
this fix #2889 would reject every booking mutation for a multi-role admin.

## The two bugs

### `resolveEffectiveRole` returned `roles[0]`

Both callers — the custodian picker's scope and booking visibility in
`api+/model-filters.ts` — use the result to decide **how much a user may see**.
A membership ordered `[SELF_SERVICE, ADMIN]` therefore handed an actual admin
the *restricted* view: too few names in the picker, too few bookings in search.

It fails closed, so this was never over-exposure. It was a plain "the app is
broken for me" for anyone holding more than one role.

`requirePermission` returns this same value as its `role` and derives
`isSelfServiceOrBase` from it, so the blast radius is wider than those two call
sites — which is exactly why #2889 depends on it.

### `resolveMostPrivilegedRole` duplicated the ordering

The booking guard added in #2886 wrote out its own OWNER → ADMIN chain. SSO had
already encoded the same idea in `getRoleFromGroupId`:

> *"Precedence is ADMIN > SELF_SERVICE > BASE: if the user is in groups for
> multiple roles, the highest wins."*

Two files, neither of which would ever be edited together, each stating the
order independently.

## The fix

`ROLE_PRECEDENCE` declares it once; all three derive from it.

The two functions are **not** merged, deliberately. They answer different
questions — "which IdP group won" versus "how privileged is this membership" —
take different inputs (`SsoDetails` + claim strings vs `OrganizationRoles[]`),
and differ on OWNER. Coupling them would let an SSO change quietly move an
authorization guard.

`SSO_ASSIGNABLE_ROLE_PRECEDENCE` is derived by excluding OWNER, so that
exclusion reads as a decision rather than an omission someone might "fix":
ownership comes from creating or being transferred a workspace, never from an
IdP group. A test pins it.

## Behaviour

`getRoleFromGroupId` is unchanged — its existing precedence test
("prioritizes ADMIN when the user is in both admin and self-service groups")
passes untouched, along with the other 15 in that suite.

`resolveEffectiveRole` changes only for multi-role memberships, and only ever
in the direction of granting the view the user's highest role already entitles
them to.

## Tests

`resolveEffectiveRole`: most-privileged wins, OWNER beats everything, and an
unknown membership still falls back to BASE (fails closed). Both new cases
confirmed **failing against the `roles[0]` behaviour**.

`resolveMostPrivilegedRole`: OWNER precedence, ADMIN when not first, single
role, empty membership, and that SSO's list is this one minus OWNER.

## Context

This was the fifth sighting of the `roles[0]` pattern in this scan's work —
#2883's owner check, #2886's booking guard, and the two here. The convention is
fine for display and wrong for authorization; after this there are no remaining
uses in an authorization path.

Credit for spotting the duplication: the repo owner, who asked whether SSO had
already solved role priority. It had.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role resolution to consistently select the highest-privilege role when multiple memberships or group assignments exist.
  * Added reliable fallback to the base role when no applicable membership or assignment is found.
  * Standardized SSO role handling while preventing owner-level access from being assigned through SSO.

* **Tests**
  * Expanded coverage for role prioritization, fallback behavior, owner precedence, and SSO role assignment rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->