### PR TITLE
fix(bookings): enforce booking-status rules in the service, not per route

### DIFF
--- a/apps/webapp/app/modules/booking/booking-status-guards.test.ts
+++ b/apps/webapp/app/modules/booking/booking-status-guards.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Booking-status immutability guards.
+ *
+ * A closed booking (COMPLETE / ARCHIVED / CANCELLED) is a historical record —
+ * once it is closed, nothing about it may change, or the audit trail stops
+ * describing what actually happened. And a booking that was never checked out
+ * cannot be checked in.
+ *
+ * Both rules existed in the product but were enforced only where someone
+ * remembered to write them: in route actions, in loaders that merely decided
+ * what to render, or not at all. These tests pin the service-layer assertions
+ * that now enforce them for every caller.
+ *
+ * detail.dev findings D055, D084, D097.
+ *
+ * @see {@link file://./utils.server.ts}
+ */
+
+import { BookingStatus } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertBookingIsCheckinable,
+  assertBookingIsOpen,
+  CLOSED_BOOKING_STATUSES,
+  IN_FLIGHT_BOOKING_STATUSES,
+} from "./utils.server";
+
+// @vitest-environment node
+
+const BOOKING_ID = "booking-1";
+
+/** Every status the enum defines, so a new one cannot be silently unhandled. */
+const ALL_STATUSES = Object.values(BookingStatus);
+
+describe("assertBookingIsOpen", () => {
+  it.each(CLOSED_BOOKING_STATUSES)("refuses a %s booking", (status) => {
+    expect(() =>
+      assertBookingIsOpen({
+        status,
+        operation: "change the items on",
+        bookingId: BOOKING_ID,
+      })
+    ).toThrow(/closed records/);
+  });
+
+  it.each(ALL_STATUSES.filter((s) => !CLOSED_BOOKING_STATUSES.includes(s)))(
+    "allows a %s booking",
+    (status) => {
+      expect(() =>
+        assertBookingIsOpen({
+          status,
+          operation: "change the items on",
+          bookingId: BOOKING_ID,
+        })
+      ).not.toThrow();
+    }
+  );
+
+  it("throws a 400 that is not reported as a server fault", () => {
+    // A stale tab whose booking was completed elsewhere lands here
+    // legitimately, so this must not page anyone.
+    try {
+      assertBookingIsOpen({
+        status: BookingStatus.COMPLETE,
+        operation: "check out",
+        bookingId: BOOKING_ID,
+      });
+      throw new Error("expected assertBookingIsOpen to throw");
+    } catch (cause) {
+      const err = cause as { status?: number; shouldBeCaptured?: boolean };
+      expect(err.status).toBe(400);
+      expect(err.shouldBeCaptured).toBe(false);
+    }
+  });
+
+  it("names the operation, so the four call sites do not share one message", () => {
+    const message = (operation: string) => {
+      try {
+        assertBookingIsOpen({
+          status: BookingStatus.CANCELLED,
+          operation,
+          bookingId: BOOKING_ID,
+        });
+        return "";
+      } catch (cause) {
+        return (cause as Error).message;
+      }
+    };
+
+    expect(message("add scanned items to")).toContain("add scanned items to");
+    expect(message("check out")).toContain("check out");
+  });
+});
+
+describe("assertBookingIsCheckinable", () => {
+  it.each(IN_FLIGHT_BOOKING_STATUSES)("allows a %s booking", (status) => {
+    expect(() =>
+      assertBookingIsCheckinable({ status, bookingId: BOOKING_ID })
+    ).not.toThrow();
+  });
+
+  it.each(ALL_STATUSES.filter((s) => !IN_FLIGHT_BOOKING_STATUSES.includes(s)))(
+    "refuses a %s booking",
+    (status) => {
+      expect(() =>
+        assertBookingIsCheckinable({ status, bookingId: BOOKING_ID })
+      ).toThrow(/ongoing or overdue/);
+    }
+  );
+
+  it("refuses DRAFT and RESERVED specifically", () => {
+    // The reported bug: these two marked the booking COMPLETE while checking
+    // in nothing, because the asset filter keeps only CHECKED_OUT assets and
+    // on these statuses there are none.
+    for (const status of [BookingStatus.DRAFT, BookingStatus.RESERVED]) {
+      expect(() =>
+        assertBookingIsCheckinable({ status, bookingId: BOOKING_ID })
+      ).toThrow();
+    }
+  });
+});
+
+describe("the two status sets", () => {
+  it("do not overlap", () => {
+    // A booking cannot be both closed and in flight. If this ever fails, one
+    // of the two guards is contradicting the other.
+    const overlap = CLOSED_BOOKING_STATUSES.filter((s) =>
+      IN_FLIGHT_BOOKING_STATUSES.includes(s)
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it("leave DRAFT and RESERVED open but not checkinable", () => {
+    // The distinction the whole fix rests on: a planned booking may still be
+    // edited, but it may not be completed.
+    for (const status of [BookingStatus.DRAFT, BookingStatus.RESERVED]) {
+      expect(CLOSED_BOOKING_STATUSES).not.toContain(status);
+      expect(IN_FLIGHT_BOOKING_STATUSES).not.toContain(status);
+    }
+  });
+});

--- a/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.partial-checkout.test.ts
@@ -71,6 +71,12 @@ vitest.mock("~/database/db.server", () => {
               (callbackOrArray as (tx: unknown) => unknown)(db as any)
             : Promise.all(callbackOrArray as Promise<unknown>[])
         ),
+      // why: `lockBookingForStatusCheck` takes its row lock through a raw
+      // `SELECT … FOR UPDATE`, which the model-shaped mocks below cannot
+      // express. ONGOING is the one status that satisfies both the open and
+      // the in-flight assertion, so a single default serves every path this
+      // suite exercises. String literal — this factory is hoisted.
+      $queryRaw: vitest.fn().mockResolvedValue([{ status: "ONGOING" }]),
       booking: {
         findUniqueOrThrow: vitest.fn().mockResolvedValue({}),
         // why: computeBookingAssetRemainingToCheckOut's legacy-ONGOING

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -903,6 +903,10 @@ describe("partialCheckinBooking", () => {
     //@ts-expect-error missing vitest type
     db.booking.findUniqueOrThrow.mockResolvedValue({
       ...mockBookingData,
+      // The base fixture is DRAFT, but this scenario checks assets back IN and
+      // mocks them CHECKED_OUT — a combination that cannot exist. Nothing read
+      // the status before, so the mismatch went unnoticed.
+      status: BookingStatus.ONGOING,
       bookingAssets: [
         {
           asset: { id: "asset-1", assetKits: [] },
@@ -952,6 +956,9 @@ describe("partialCheckinBooking", () => {
     //@ts-expect-error missing vitest type
     db.booking.findUniqueOrThrow.mockResolvedValue({
       ...mockBookingData,
+      // Same fixture mismatch as the sibling test: the scenario is a booking
+      // in flight, but the base fixture is DRAFT.
+      status: BookingStatus.ONGOING,
       assets: [
         { id: "asset-1", kitId: null },
         { id: "asset-2", kitId: null },
@@ -1743,6 +1750,39 @@ describe("updateBasicBooking", () => {
 describe("updateBookingAssets", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+  });
+
+  it.each([
+    BookingStatus.COMPLETE,
+    BookingStatus.ARCHIVED,
+    BookingStatus.CANCELLED,
+  ])("refuses to change the items on a %s booking", async (status) => {
+    // All four callers DO check the status — but each in a read of its own,
+    // before calling this function. A booking closed in between was still
+    // written to. The guard now reads the status inside the same transaction
+    // as the write, which closes that window rather than narrowing it.
+    // (detail.dev D055)
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValueOnce({
+      id: "booking-1",
+      name: "Test Booking",
+      status,
+    });
+
+    await expect(
+      updateBookingAssets({
+        id: "booking-1",
+        organizationId: "org-1",
+        assetIds: ["asset-1"],
+        userId: "user-1",
+      })
+    ).rejects.toThrow(/closed records/);
+
+    // The guard bails before anything else in the transaction runs: the asset
+    // validation immediately after it never fires. Asserting on a downstream
+    // effect rather than only on the throw, so this still fails if the guard is
+    // moved somewhere that lets writes happen first.
+    expect(db.asset.findMany).not.toHaveBeenCalled();
   });
 
   /**
@@ -3896,7 +3936,13 @@ describe("fulfilModelRequestsAndCheckout", () => {
     });
     const hydratedBooking = { ...mockBooking, status: BookingStatus.ONGOING };
 
+    // A three-deep queue, in the order the flow reads: the pre-tx load, the
+    // in-tx booking-status guard on the scanned-asset write path (RESERVED, so
+    // it passes), then the post-tx hydrate. Ordering matters — a missing entry
+    // does not fail loudly, it shifts every later read by one and the function
+    // returns whatever the exhausted mock yields.
     (db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce(mockBooking)
       .mockResolvedValueOnce(mockBooking)
       .mockResolvedValueOnce(hydratedBooking);
     // why: scanned asset metadata lookup inside the tx — the service needs
@@ -4599,9 +4645,12 @@ describe("checkinBooking", () => {
     });
   });
 
-  it("should handle checkin for non-ongoing booking", async () => {
-    expect.assertions(1);
-
+  it("refuses checkin of a booking that was never checked out", async () => {
+    // This test used to assert the OPPOSITE — that checking in a DRAFT
+    // booking "works" — and so pinned the defect in place: `checkinBooking`
+    // writes COMPLETE unconditionally, while the asset filter keeps only
+    // CHECKED_OUT assets, of which a DRAFT booking has none. The booking came
+    // out marked finished with nothing checked in. (detail.dev D084)
     const mockBooking = { ...mockBookingData, status: BookingStatus.DRAFT };
     //@ts-expect-error missing vitest type
     db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
@@ -4611,8 +4660,12 @@ describe("checkinBooking", () => {
       status: BookingStatus.COMPLETE,
     });
 
-    const result = await checkinBooking(mockCheckinParams);
-    expect(result).toBeDefined();
+    await expect(checkinBooking(mockCheckinParams)).rejects.toThrow(
+      /ongoing or overdue/
+    );
+    // Assert on the WRITE, not only the throw: the point of the guard is that
+    // the booking is never stamped COMPLETE.
+    expect(db.booking.update).not.toHaveBeenCalled();
   });
 
   it("should schedule auto-archive when enabled", async () => {
@@ -9912,6 +9965,40 @@ describe("bulkCancelBookings", () => {
 describe("addScannedAssetsToBooking", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+  });
+
+  it.each([
+    BookingStatus.COMPLETE,
+    BookingStatus.ARCHIVED,
+    BookingStatus.CANCELLED,
+  ])("refuses to add scanned assets to a %s booking", async (status) => {
+    // This path had no booking-status check anywhere before: the route action
+    // only called requirePermission, and the loader's canUserManageBookingAssets
+    // decided what to RENDER, not what to accept. A direct POST could therefore
+    // append assets to a closed booking. (detail.dev D097)
+    //
+    // Asserting through the public service function rather than the assertion
+    // helper directly, so this fails if the guard is ever unwired from the path.
+    // mockResolvedValueOnce, not mockResolvedValue: `clearAllMocks` in the
+    // beforeEach clears call history but NOT implementations, so a persistent
+    // stub here would answer every later test in this describe with a closed
+    // booking and fail them for the wrong reason.
+    (
+      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce({ status });
+
+    await expect(
+      addScannedAssetsToBooking({
+        assetIds: ["asset-1"],
+        kitIds: [],
+        bookingId: "booking-1",
+        organizationId: "org-1",
+        userId: "user-1",
+      })
+    ).rejects.toThrow(/closed records/);
+
+    // The booking must be untouched — the guard runs before any write.
+    expect(db.booking.update).not.toHaveBeenCalled();
   });
 
   it("rejects when a scanned asset is reserved for an overlapping booking", async () => {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -102,6 +102,14 @@ vitest.mock("~/database/db.server", () => ({
           : Promise.all(callbackOrArray)
       ),
     $executeRaw: vitest.fn().mockResolvedValue(0),
+    // why: `lockBookingForStatusCheck` issues a raw `SELECT … FOR UPDATE`,
+    // which the model-shaped mock below cannot express. Defaults to an OPEN
+    // status so every pre-existing test is unaffected; the status-guard tests
+    // override it. ONGOING specifically: it is the only status that satisfies
+    // BOTH assertions (open for the asset-mutation paths, in-flight for
+    // check-in), so one default serves every caller. A string literal, not
+    // BookingStatus.ONGOING — this factory is hoisted above the imports.
+    $queryRaw: vitest.fn().mockResolvedValue([{ status: "ONGOING" }]),
     booking: {
       create: vitest.fn().mockResolvedValue({}),
       update: vitest.fn().mockResolvedValue({}),
@@ -1762,12 +1770,13 @@ describe("updateBookingAssets", () => {
     // written to. The guard now reads the status inside the same transaction
     // as the write, which closes that window rather than narrowing it.
     // (detail.dev D055)
-    //@ts-expect-error missing vitest type
-    db.booking.findUniqueOrThrow.mockResolvedValueOnce({
-      id: "booking-1",
-      name: "Test Booking",
-      status,
-    });
+    // why: the guard takes a row lock via raw SQL, so this is the read it
+    // asserts on. Once, not persistent: clearAllMocks clears call history but
+    // NOT implementations, and a persistent closed status would fail every
+    // later test in this describe for the wrong reason.
+    (db.$queryRaw as ReturnType<typeof vitest.fn>).mockResolvedValueOnce([
+      { status },
+    ]);
 
     await expect(
       updateBookingAssets({
@@ -3936,13 +3945,14 @@ describe("fulfilModelRequestsAndCheckout", () => {
     });
     const hydratedBooking = { ...mockBooking, status: BookingStatus.ONGOING };
 
-    // A three-deep queue, in the order the flow reads: the pre-tx load, the
-    // in-tx booking-status guard on the scanned-asset write path (RESERVED, so
-    // it passes), then the post-tx hydrate. Ordering matters — a missing entry
-    // does not fail loudly, it shifts every later read by one and the function
-    // returns whatever the exhausted mock yields.
+    // why: no database in unit tests, so every booking read this flow makes
+    // has to be queued here — the pre-tx load, then the post-tx hydrate. The
+    // in-tx status guard does NOT consume an entry: it reads through
+    // `$queryRaw` (row lock), which is stubbed separately in the db mock.
+    // Ordering matters — a missing or surplus entry does not fail loudly, it
+    // shifts every later read by one and the function returns whatever the
+    // exhausted mock yields.
     (db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>)
-      .mockResolvedValueOnce(mockBooking)
       .mockResolvedValueOnce(mockBooking)
       .mockResolvedValueOnce(hydratedBooking);
     // why: scanned asset metadata lookup inside the tx — the service needs
@@ -4643,6 +4653,29 @@ describe("checkinBooking", () => {
       },
       data: { status: AssetStatus.AVAILABLE },
     });
+  });
+
+  it("refuses a checkin whose booking is completed between the read and the write", async () => {
+    // The race the row lock exists for. The pre-transaction read sees ONGOING
+    // and passes the early exit; by the time the write transaction opens, a
+    // concurrent check-in has committed COMPLETE. Modelled by letting the two
+    // reads disagree — which is precisely what a non-locking SELECT permits
+    // under READ COMMITTED.
+    const mockBooking = { ...mockBookingData, status: BookingStatus.ONGOING };
+    // why: the unlocked pre-transaction read — still the old status.
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
+    // why: the locked in-transaction read — the booking has moved on.
+    (db.$queryRaw as ReturnType<typeof vitest.fn>).mockResolvedValueOnce([
+      { status: BookingStatus.COMPLETE },
+    ]);
+
+    await expect(checkinBooking(mockCheckinParams)).rejects.toThrow(
+      /ongoing or overdue/
+    );
+    // Without the locked check the early exit would have waved this through
+    // and the booking would have been written a second time.
+    expect(db.booking.update).not.toHaveBeenCalled();
   });
 
   it("refuses checkin of a booking that was never checked out", async () => {
@@ -9979,13 +10012,13 @@ describe("addScannedAssetsToBooking", () => {
     //
     // Asserting through the public service function rather than the assertion
     // helper directly, so this fails if the guard is ever unwired from the path.
-    // mockResolvedValueOnce, not mockResolvedValue: `clearAllMocks` in the
-    // beforeEach clears call history but NOT implementations, so a persistent
-    // stub here would answer every later test in this describe with a closed
-    // booking and fail them for the wrong reason.
-    (
-      db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>
-    ).mockResolvedValueOnce({ status });
+    // why: the guard takes a row lock via raw SQL, so this is the read it
+    // asserts on. Once, not persistent: clearAllMocks clears call history but
+    // NOT implementations, so a persistent closed status would answer every
+    // later test in this describe and fail them for the wrong reason.
+    (db.$queryRaw as ReturnType<typeof vitest.fn>).mockResolvedValueOnce([
+      { status },
+    ]);
 
     await expect(
       addScannedAssetsToBooking({

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -152,6 +152,7 @@ import {
   assertBookingIsCheckinable,
   assertBookingIsOpen,
   createBookingConflictConditions,
+  lockBookingForStatusCheck,
   getBulkBookingsWhereInput,
   isBookingExpired,
 } from "./utils.server";
@@ -2544,7 +2545,9 @@ export async function checkoutBooking({
       });
 
     // Not a reported finding — the twin of D084 on the check-out side, swept
-    // in because it is the same missing guard. Deliberately rejects only the
+    // in because it is the same missing guard. Unlocked early exit; the
+    // authoritative locked check runs inside the write transaction below.
+    // Deliberately rejects only the
     // CLOSED statuses: an existing pinned test checks out a DRAFT booking, so
     // narrowing this to RESERVED would be a behaviour change rather than a
     // fix. Re-running a FULL checkout on an ONGOING booking is a separate
@@ -2744,6 +2747,19 @@ export async function checkoutBooking({
 
     await db.$transaction(
       async (tx) => {
+        // Authoritative status check. The pre-transaction assert above is a
+        // cheap early exit; THIS one is the one that holds, because it locks
+        // the row and the lock is kept until this transaction commits.
+        //
+        // The race is not theoretical: cancelling a RESERVED booking from
+        // another tab while this checkout is in flight would otherwise leave a
+        // CANCELLED booking whose assets are all CHECKED_OUT.
+        assertBookingIsOpen({
+          status: await lockBookingForStatusCheck(tx, id, organizationId),
+          operation: "check out",
+          bookingId: id,
+        });
+
         await checkoutBookingWritesWithinTx(tx, {
           bookingId: bookingFound.id,
           // SECURITY (cross-org IDOR): the helper scopes the asset/kit
@@ -4302,6 +4318,10 @@ export async function checkinBooking({
     // checking in nothing: the asset filter keeps only CHECKED_OUT assets, and
     // on those statuses there are none. The booking then reads as finished
     // although it never happened. (detail.dev D084)
+    //
+    // This read is NOT locked — `bookingFound` is loaded outside the write
+    // transaction — so treat it as a cheap early exit only. The authoritative,
+    // locked check runs inside the transaction below.
     assertBookingIsCheckinable({ status: bookingFound.status, bookingId: id });
 
     const dataToUpdate: Prisma.BookingUpdateInput = {
@@ -4515,6 +4535,15 @@ export async function checkinBooking({
 
     const updatedBooking = await db.$transaction(
       async (tx) => {
+        // Authoritative status check — the pre-transaction assert above is a
+        // cheap early exit, this is the one that holds. Locking matters here
+        // because two concurrent check-ins would otherwise both read ONGOING
+        // and both run the completion writes.
+        assertBookingIsCheckinable({
+          status: await lockBookingForStatusCheck(tx, id, organizationId),
+          bookingId: id,
+        });
+
         /**
          * Per-qty-tracked-asset disposition work. Runs FIRST so the
          * pool-drain guard can read the current `Asset.quantity` before
@@ -8248,12 +8277,21 @@ export async function updateBookingAssets({
       });
 
       // The four callers each validate the status before getting here, but
-      // every one of them does so in a read of its own — so a booking
-      // completed between their check and this write was still modified.
-      // Re-asserting on the row THIS transaction just read closes that window
-      // by construction. (detail.dev D055)
+      // every one of them does so in a read of its own, so a booking closed in
+      // between was still written to. (detail.dev D055)
+      //
+      // Re-reading inside this transaction is NOT sufficient on its own: under
+      // READ COMMITTED the `findUniqueOrThrow` above takes no lock, so a
+      // concurrent check-in or cancellation can still commit between it and
+      // the writes below. The row lock is what actually closes the window —
+      // it is held until this transaction commits.
+      const lockedStatus = await lockBookingForStatusCheck(
+        tx,
+        id,
+        organizationId
+      );
       assertBookingIsOpen({
-        status: b.status,
+        status: lockedStatus,
         operation: "change the items on",
         bookingId: id,
       });
@@ -12594,12 +12632,16 @@ async function addScannedAssetsToBookingWithinTx(
   // not here. The scan-assets loader computes `canUserManageBookingAssets`,
   // but that only decides what to render, so a direct POST could add assets to
   // a COMPLETE, ARCHIVED or CANCELLED booking. (detail.dev D097)
-  const scanTargetBooking = await tx.booking.findUniqueOrThrow({
-    where: { id: bookingId, organizationId },
-    select: { status: true },
-  });
+  //
+  // Locked rather than merely re-read: this runs inside the caller's
+  // transaction, and a plain SELECT there takes no lock under READ COMMITTED.
+  const scanTargetStatus = await lockBookingForStatusCheck(
+    tx,
+    bookingId,
+    organizationId
+  );
   assertBookingIsOpen({
-    status: scanTargetBooking.status,
+    status: scanTargetStatus,
     operation: "add scanned items to",
     bookingId,
   });

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -149,6 +149,8 @@ import type {
   SchedulerData,
 } from "./types";
 import {
+  assertBookingIsCheckinable,
+  assertBookingIsOpen,
   createBookingConflictConditions,
   getBulkBookingsWhereInput,
   isBookingExpired,
@@ -2541,6 +2543,19 @@ export async function checkoutBooking({
         });
       });
 
+    // Not a reported finding — the twin of D084 on the check-out side, swept
+    // in because it is the same missing guard. Deliberately rejects only the
+    // CLOSED statuses: an existing pinned test checks out a DRAFT booking, so
+    // narrowing this to RESERVED would be a behaviour change rather than a
+    // fix. Re-running a FULL checkout on an ONGOING booking is a separate
+    // integrity problem (it re-processes every asset and duplicates events)
+    // and is left alone here for the same reason.
+    assertBookingIsOpen({
+      status: bookingFound.status,
+      operation: "check out",
+      bookingId: id,
+    });
+
     // SECURITY (defense-in-depth): reject checkout if any attached asset is
     // not in this org BEFORE any asset-derived logic runs. A legacy
     // pre-remediation cross-org link would otherwise (a) leak the foreign
@@ -4281,6 +4296,13 @@ export async function checkinBooking({
           shouldBeCaptured: !isNotFoundError(cause),
         });
       });
+
+    // `dataToUpdate` below sets COMPLETE unconditionally. Without this guard a
+    // direct POST against a DRAFT or RESERVED booking marked it COMPLETE while
+    // checking in nothing: the asset filter keeps only CHECKED_OUT assets, and
+    // on those statuses there are none. The booking then reads as finished
+    // although it never happened. (detail.dev D084)
+    assertBookingIsCheckinable({ status: bookingFound.status, bookingId: id });
 
     const dataToUpdate: Prisma.BookingUpdateInput = {
       status: BookingStatus.COMPLETE,
@@ -8223,6 +8245,17 @@ export async function updateBookingAssets({
           from: true,
           to: true,
         },
+      });
+
+      // The four callers each validate the status before getting here, but
+      // every one of them does so in a read of its own — so a booking
+      // completed between their check and this write was still modified.
+      // Re-asserting on the row THIS transaction just read closes that window
+      // by construction. (detail.dev D055)
+      assertBookingIsOpen({
+        status: b.status,
+        operation: "change the items on",
+        bookingId: id,
       });
 
       const slices = kitSlices ?? [];
@@ -12556,6 +12589,20 @@ async function addScannedAssetsToBookingWithinTx(
     },
     tx
   );
+
+  // This path had NO booking-status check anywhere — not in the route action,
+  // not here. The scan-assets loader computes `canUserManageBookingAssets`,
+  // but that only decides what to render, so a direct POST could add assets to
+  // a COMPLETE, ARCHIVED or CANCELLED booking. (detail.dev D097)
+  const scanTargetBooking = await tx.booking.findUniqueOrThrow({
+    where: { id: bookingId, organizationId },
+    select: { status: true },
+  });
+  assertBookingIsOpen({
+    status: scanTargetBooking.status,
+    operation: "add scanned items to",
+    bookingId,
+  });
 
   /**
    * Conflict guard (mirrors the reserve/checkout guards): reject the add

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2424,7 +2424,6 @@ async function runCheckoutSideEffects({
   bookingFound,
   userId,
   effectiveStatus,
-  effectiveBooking,
   effectiveTo,
   hints,
   organizationId,
@@ -2433,7 +2432,6 @@ async function runCheckoutSideEffects({
   bookingFound: BookingForEmail;
   userId?: string;
   effectiveStatus: BookingStatus;
-  effectiveBooking: BookingForEmail;
   effectiveTo: Date | null | undefined;
   hints: ClientHint;
   organizationId: Booking["organizationId"];
@@ -2452,10 +2450,6 @@ async function runCheckoutSideEffects({
       custodianUserId: bookingFound.custodianUserId || undefined,
     });
   }
-
-  /** Calculate the time difference between the booking.to and the current time */
-  const { hours } = calcTimeDifference(effectiveTo!, new Date());
-  const lessThanOneHourToCheckin = hours < 1;
 
   /** We cancel just in case there is something pending */
   await cancelScheduler(bookingFound);
@@ -2806,22 +2800,13 @@ export async function checkoutBooking({
       { timeout: 15000 }
     );
 
-    /** Build effective post-checkout values by merging bookingFound with any
-     * fields modified by dataToUpdate (adjusted dates, status). This avoids
-     * re-reading from the DB and ensures downstream logic (notes, scheduling)
-     * uses the correct post-checkout values. */
-    const effectiveFrom =
-      (dataToUpdate.from as Date | undefined) ?? bookingFound.from;
+    /** The post-checkout values, taken from `dataToUpdate` where it changed
+     * them and from `bookingFound` otherwise. Avoids re-reading the row, and
+     * keeps downstream logic (notes, scheduling) on post-checkout truth. */
     const effectiveTo =
       (dataToUpdate.to as Date | undefined) ?? bookingFound.to;
     const effectiveStatus =
       (dataToUpdate.status as BookingStatus) ?? bookingFound.status;
-    const effectiveBooking = {
-      ...bookingFound,
-      from: effectiveFrom,
-      to: effectiveTo,
-      status: effectiveStatus,
-    };
 
     // Extracted to a shared helper so `fulfilModelRequestsAndCheckout`
     // can run the same post-commit work (status transition note,
@@ -2835,7 +2820,6 @@ export async function checkoutBooking({
       bookingFound,
       userId,
       effectiveStatus,
-      effectiveBooking,
       effectiveTo,
       hints,
       organizationId,
@@ -3193,27 +3177,18 @@ export async function fulfilModelRequestsAndCheckout({
       userId,
     });
 
-    /** Build an effective snapshot so the status-transition note + email
-     * scheduler see the post-checkout truth without re-reading the row. */
-    const effectiveFrom =
-      (dataToUpdate.from as Date | undefined) ?? bookingFound.from;
+    /** The post-checkout values, so the status-transition note and the email
+     * scheduler see post-checkout truth without re-reading the row. */
     const effectiveTo =
       (dataToUpdate.to as Date | undefined) ?? bookingFound.to;
     const effectiveStatus =
       (dataToUpdate.status as BookingStatus) ?? bookingFound.status;
-    const effectiveBooking = {
-      ...bookingFound,
-      from: effectiveFrom,
-      to: effectiveTo,
-      status: effectiveStatus,
-    };
 
     /** Post-commit checkout side-effects shared with `checkoutBooking` */
     return await runCheckoutSideEffects({
       bookingFound,
       userId,
       effectiveStatus,
-      effectiveBooking,
       effectiveTo,
       hints,
       organizationId,

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -818,3 +818,110 @@ export function normalizeBookingAssets<
     bookingAssetId: ba.id,
   }));
 }
+
+/**
+ * Booking statuses in which the booking is a CLOSED record.
+ *
+ * A closed booking is history: its assets have been returned (COMPLETE), the
+ * reservation was called off (CANCELLED), or it has been filed away
+ * (ARCHIVED). Nothing about it may change afterwards, or the audit trail stops
+ * describing what actually happened.
+ *
+ * This is the same set `canUserRemoveBookingAssets` treats as closed and the
+ * inverse of `ADDABLE_BOOKING_STATUSES` — kept in one place so the server-side
+ * assertions below cannot drift from the client-side affordances.
+ *
+ * @see {@link file://./../../utils/bookings.ts} `canUserRemoveBookingAssets`
+ * @see {@link file://./constants.ts} `ADDABLE_BOOKING_STATUSES`
+ */
+export const CLOSED_BOOKING_STATUSES: BookingStatus[] = [
+  BookingStatus.COMPLETE,
+  BookingStatus.ARCHIVED,
+  BookingStatus.CANCELLED,
+];
+
+/**
+ * Statuses in which a booking is physically in flight — its assets are out
+ * with a custodian right now. Only these can be checked back in.
+ */
+export const IN_FLIGHT_BOOKING_STATUSES: BookingStatus[] = [
+  BookingStatus.ONGOING,
+  BookingStatus.OVERDUE,
+];
+
+/**
+ * Refuses a mutation against a booking that is already closed.
+ *
+ * Call this from the SERVICE layer, inside the same transaction as the write,
+ * reading the status from a row loaded in that transaction. Routes checking
+ * the status themselves is not equivalent, for two reasons:
+ *
+ * 1. A route that forgets is simply unguarded. The scan-assets action had no
+ *    status check of any kind, so a direct POST could add assets to a
+ *    COMPLETE booking; its loader computed `canUserManageBookingAssets`, but
+ *    that only decided what to RENDER.
+ * 2. A route that checks before calling the service leaves a window open. The
+ *    four `updateBookingAssets` callers all validated the status, but each did
+ *    so in a read of its own — so a booking completed in between was still
+ *    written to. Reading inside the write's transaction closes that window by
+ *    construction rather than by narrowing it.
+ *
+ * @param status - The booking's current status, read inside the transaction
+ * @param operation - Verb phrase for the message, e.g. "add items to"
+ * @param bookingId - Included in `additionalData` for debugging
+ * @throws {ShelfError} 400 when the booking is COMPLETE, ARCHIVED or CANCELLED
+ */
+export function assertBookingIsOpen({
+  status,
+  operation,
+  bookingId,
+}: {
+  status: BookingStatus;
+  operation: string;
+  bookingId: Booking["id"];
+}): void {
+  if (CLOSED_BOOKING_STATUSES.includes(status)) {
+    throw new ShelfError({
+      cause: null,
+      message: `You cannot ${operation} a booking that is ${status.toLowerCase()}. Completed, archived and cancelled bookings are closed records and can no longer be changed.`,
+      additionalData: { bookingId, status },
+      label,
+      status: 400,
+      // User-input class, not a server fault: a stale tab whose booking was
+      // completed elsewhere lands here legitimately.
+      shouldBeCaptured: false,
+    });
+  }
+}
+
+/**
+ * Refuses a check-in against a booking that was never checked out.
+ *
+ * `checkinBooking` writes `status: COMPLETE` unconditionally, so without this
+ * a direct POST against a DRAFT or RESERVED booking marked it COMPLETE while
+ * checking in nothing — the asset filter drops every asset that is not
+ * CHECKED_OUT, which for those statuses is all of them. The result is a
+ * booking that reads as finished but never happened.
+ *
+ * @param status - The booking's current status, read inside the transaction
+ * @param bookingId - Included in `additionalData` for debugging
+ * @throws {ShelfError} 400 unless the booking is ONGOING or OVERDUE
+ */
+export function assertBookingIsCheckinable({
+  status,
+  bookingId,
+}: {
+  status: BookingStatus;
+  bookingId: Booking["id"];
+}): void {
+  if (!IN_FLIGHT_BOOKING_STATUSES.includes(status)) {
+    throw new ShelfError({
+      cause: null,
+      message: `You cannot check in a booking that is ${status.toLowerCase()}. Only ongoing or overdue bookings — the ones whose assets are actually out — can be checked in.`,
+      additionalData: { bookingId, status },
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
+}

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -927,6 +927,25 @@ export function assertBookingIsCheckinable({
 }
 
 /**
+ * The only capability {@link lockBookingForStatusCheck} needs from a client.
+ *
+ * Structural rather than `any`: the extended Prisma client has no exported
+ * interactive-transaction type, but the helper does not need one — it issues a
+ * single tagged-template raw query. Naming just that keeps the compiler able to
+ * reject anything that is not a query-capable client, which `any` cannot do.
+ *
+ * `unknown[]` for the interpolated values: they are bound as parameters, so
+ * their static types are irrelevant here, and `unknown` does not silently
+ * accept a value the caller meant to narrow.
+ */
+type RawQueryClient = {
+  $queryRaw<T = unknown>(
+    query: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<T>;
+};
+
+/**
  * Takes a row-level lock on a booking, then returns its status.
  *
  * **Must be called inside a `db.$transaction()` interactive transaction**, and
@@ -952,8 +971,7 @@ export function assertBookingIsCheckinable({
  * @see {@link file://./../consumption-log/quantity-lock.server.ts} the asset equivalent
  */
 export async function lockBookingForStatusCheck(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  tx: any, // Prisma interactive tx client (no clean type for extended clients)
+  tx: RawQueryClient,
   bookingId: Booking["id"],
   organizationId: Booking["organizationId"]
 ): Promise<BookingStatus> {

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -925,3 +925,53 @@ export function assertBookingIsCheckinable({
     });
   }
 }
+
+/**
+ * Takes a row-level lock on a booking, then returns its status.
+ *
+ * **Must be called inside a `db.$transaction()` interactive transaction**, and
+ * before any write that depends on the booking still being in a given status.
+ *
+ * A plain `SELECT` inside a transaction is NOT enough. Under PostgreSQL's
+ * default READ COMMITTED isolation it takes no lock, so a concurrent check-in,
+ * archive or cancellation can commit between the read and the write and this
+ * transaction still succeeds — mutating a booking that is closed by the time
+ * it commits. Reading inside the transaction narrows that window; only the
+ * lock closes it.
+ *
+ * The predicate is **org-scoped**, matching `lockAssetForQuantityUpdate`: a
+ * caller passing a foreign-org booking id matches zero rows, so it takes no
+ * lock and learns nothing about whether the id exists. Locking on `id` alone
+ * would hand an attacker a cross-tenant lock oracle and a contention vector.
+ *
+ * @param tx - Prisma interactive transaction client
+ * @param bookingId - Booking to lock
+ * @param organizationId - Caller's validated organization; scopes the lock
+ * @returns The locked booking's current status
+ * @throws {ShelfError} 404 when the booking is missing or cross-org
+ * @see {@link file://./../consumption-log/quantity-lock.server.ts} the asset equivalent
+ */
+export async function lockBookingForStatusCheck(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tx: any, // Prisma interactive tx client (no clean type for extended clients)
+  bookingId: Booking["id"],
+  organizationId: Booking["organizationId"]
+): Promise<BookingStatus> {
+  // `Booking.status` carries no `@map`, so the Prisma field name IS the column
+  // name here — checked against the schema, per the raw-SQL rule.
+  const rows = await tx.$queryRaw<{ status: BookingStatus }[]>`
+    SELECT status FROM "Booking" WHERE id = ${bookingId} AND "organizationId" = ${organizationId} FOR UPDATE
+  `;
+
+  if (!rows || rows.length === 0) {
+    throw new ShelfError({
+      cause: null,
+      message: "Booking not found",
+      additionalData: { bookingId, organizationId },
+      label,
+      status: 404,
+    });
+  }
+
+  return rows[0].status;
+}


### PR DESCRIPTION
## What

Closed bookings could still be modified, and a booking that was never checked
out could be marked COMPLETE.

Both rules already existed in the product. Both were enforced only where
someone remembered to write them — in a route action, in a loader that merely
decided what to render, or nowhere at all.

Three findings from the detail.dev OSS scan: **D097**, **D084**, **D055**.

## The three findings are one root cause

**D097 — scan-assets had no status check anywhere.** The action called only
`requirePermission`. The loader computed `canUserManageBookingAssets`, but
that decides what to *render*. A direct POST appended assets to a COMPLETE,
ARCHIVED or CANCELLED booking.

**D084 — `checkinBooking` writes `status: COMPLETE` unconditionally.** A direct
POST against a DRAFT or RESERVED booking marked it COMPLETE while checking in
*nothing*: the asset filter keeps only `CHECKED_OUT` assets, and on those
statuses there are none. The booking then read as finished although it never
happened. Reachable from two routes — the check-in scanner and the overview
`checkIn` intent.

**D055 — the `updateBookingAssets` callers check, but too early.** All four
validate the status. Each does so in a read of its own, before calling the
service. A booking closed in between was still written to.

## The fix

Assert in the **service**, **inside the write transaction**, on a row that
transaction has **locked**.

The service-layer placement is what stops a fifth caller from forgetting —
which is exactly how D097 happened.

The lock is what makes D055 a fix rather than a smaller window. The first
revision of this PR only re-read the row inside the transaction and claimed
that closed the race. **It does not.** Under PostgreSQL's default
`READ COMMITTED` isolation a plain `SELECT` takes no lock, so a concurrent
check-in, cancellation or archival can still commit between the read and the
write. Raised by Codex and CodeRabbit independently; corrected in `6bc2b3270`.

`lockBookingForStatusCheck` mirrors the existing `lockAssetForQuantityUpdate`
— `SELECT … FOR UPDATE`, and **org-scoped for the same reason that one is**:
locking on `id` alone would let a caller take a real lock on another tenant's
row, which is both an existence oracle and a contention vector.

Check-out and check-in keep their pre-transaction assert as a cheap early
exit, with the authoritative locked check inside their own write transaction.
An earlier revision argued those two were "state-validity checks, not TOCTOU
ones" and so did not need locking. That was wrong: `CANCELLED` and `ARCHIVED`
are precisely the statuses a concurrent request moves a booking *into*
mid-flight — cancelling a RESERVED booking from another tab during a checkout
would have left a cancelled booking with every asset `CHECKED_OUT`.

Two assertions in `modules/booking/utils.server.ts`, applied to
`updateBookingAssets`, `addScannedAssetsToBookingWithinTx`, `checkinBooking`
and `checkoutBooking`.

Neither invents policy — both reuse sets the codebase already had:

| Assertion | Rule | Already expressed as |
| --- | --- | --- |
| `assertBookingIsOpen` | rejects COMPLETE / ARCHIVED / CANCELLED | `canUserRemoveBookingAssets`; the inverse of `ADDABLE_BOOKING_STATUSES` |
| `assertBookingIsCheckinable` | requires ONGOING / OVERDUE | the setup of every existing `checkinBooking` test |

## Sweep

`checkoutBooking` is **not** a reported finding, but has the identical missing
guard and is the service twin of the route fixed in #2889. Included.

Deliberately limited there to the closed statuses: an existing pinned test
(`"should handle checkout for non-reserved booking"`) checks out a DRAFT
booking, so narrowing to RESERVED would be a behaviour change rather than a
fix.

`archiveBooking` and `cancelBooking` were already guarded — checked, left alone.

## Tests

`booking-status-guards.test.ts` (19) — both assertions across **every** member
of `BookingStatus`, so a new status cannot be silently unhandled; the 400 /
`shouldBeCaptured: false` contract; and that the two status sets do not
overlap.

Service-level, asserting through the public functions so the tests fail if a
guard is ever unwired from its path (6): `addScannedAssetsToBooking` and
`updateBookingAssets` each refuse all three closed statuses, and each asserts a
downstream effect never fired rather than only that something threw.

### Three existing tests changed — worth a look

**One asserted the bug as correct behaviour.** `"should handle checkin for
non-ongoing booking"` set up a DRAFT booking and asserted the check-in
succeeded. Inverted; it now also asserts `db.booking.update` is never called,
so the claim is "the booking is never stamped COMPLETE", not merely "something
threw".

**Two carried an impossible fixture.** They mocked assets as `CHECKED_OUT` on a
booking the base fixture left `DRAFT` — a state that cannot exist. Nothing read
the status, so the contradiction sat there unnoticed until a guard read it. Set
to `ONGOING`, which is what those scenarios describe.

A fourth failure was self-inflicted and is called out in a comment: adding an
in-transaction read shifted a `mockResolvedValueOnce` queue, and the function
silently returned `{}`. That class fails quietly, so the queue now says what
each entry is for.

Plus a regression test for the race itself: it lets the unlocked
pre-transaction read and the locked in-transaction read return **different**
statuses, which is exactly what a non-locking `SELECT` permits, and asserts the
booking is never written.

Verified: 266 booking service tests, 19 new guard tests, partial-checkout (57),
utils (35), and the four booking route suites (44). Typecheck clean.

## Known residual (not a regression)

Re-running a **full** checkout on an ONGOING booking still re-processes every
asset, duplicating check-out events and re-flipping already-returned assets —
the service comments say so explicitly. Real, but a behaviour change beyond
these findings, so it is untouched here and worth its own look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented changes to completed, archived, or cancelled bookings.
  * Restricted check-in to bookings currently in progress or overdue.
  * Added validation for checkout, asset updates, and scanned-asset additions.
  * Improved error messages when booking operations are rejected.
  * Strengthened safeguards against conflicting or outdated booking updates.

* **Tests**
  * Added comprehensive coverage for booking status rules, lifecycle safeguards, invalid operations, and concurrent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->