### PR TITLE
fix(bookings): pass the user's timezone to the assets-index booking dialog

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
@@ -15,11 +15,13 @@ import { Button } from "~/components/shared/button";
 import { Card } from "~/components/shared/card";
 import { TagsAutocomplete } from "~/components/tag/tags-autocomplete";
 import { useBookingSettings } from "~/hooks/use-booking-settings";
+import { useFormatPrefs } from "~/hooks/use-format-prefs";
 import { useUserData } from "~/hooks/use-user-data";
 import { useWorkingHours } from "~/hooks/use-working-hours";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { getBookingDefaultStartEndTimes } from "~/modules/working-hours/utils";
 import type { AssetIndexLoaderData } from "~/routes/_layout+/assets._index";
+import { useHints } from "~/utils/client-hints";
 import { getValidationErrors } from "~/utils/http";
 import { userCanViewSpecificCustody } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
 
@@ -36,10 +38,15 @@ export default function CreateBookingForSelectedAssetsDialog() {
   const bookingSettings = useBookingSettings();
   const { isBaseOrSelfService, roles, isAdministratorOrOwner } =
     useUserRoleHelper();
+  const hints = useHints();
+  // TIMEZONE FIX: client-side date validation uses the RESOLVED pref zone
+  // (matches display + the server parse), not the browser hint.
+  const prefs = useFormatPrefs();
 
   const zo = useZorm(
     "CreateBookingWithAssets",
     BookingFormSchema({
+      hints: { ...hints, timeZone: prefs.timeZone },
       action: "new",
       workingHours,
       bookingSettings,

--- a/apps/webapp/app/components/booking/forms/forms-schema.test.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.test.ts
@@ -1,5 +1,5 @@
 import { addHours, addDays, subDays, addMinutes } from "date-fns";
-import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
 import { toIsoDateTimeToUserTimezone } from "~/utils/date-fns";
 import {
   BookingFormSchema,
@@ -13,6 +13,20 @@ import {
  *
  * See issue: Bug: Booking time restrictions affect OWNER and ADMIN users and they shouldn't
  */
+
+/**
+ * Zone + locale for the cases below that are not about timezones. These suites
+ * build their dates with `date-fns` relative to `new Date()`, i.e. in the
+ * RUNTIME zone, so they need the schema to read the wire string back in that
+ * same zone or every assertion shifts by the machine's offset.
+ *
+ * `hints` is required precisely so a caller can never fall through to an
+ * implicit UTC (see the docblock on `BookingFormSchemaParams`). Spelling it out
+ * here keeps that guarantee visible in the tests too.
+ */
+const RUNTIME_ZONE_HINTS = {
+  timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+};
 
 describe("BookingFormSchema - time restrictions", () => {
   const baseBookingSettings = {
@@ -31,6 +45,7 @@ describe("BookingFormSchema - time restrictions", () => {
   describe("bufferStartTime restriction", () => {
     it("should enforce buffer time for BASE/SELF_SERVICE users", () => {
       const schema = BookingFormSchema({
+        hints: RUNTIME_ZONE_HINTS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -63,6 +78,7 @@ describe("BookingFormSchema - time restrictions", () => {
 
     it("should bypass buffer time for ADMIN/OWNER users", () => {
       const schema = BookingFormSchema({
+        hints: RUNTIME_ZONE_HINTS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -91,6 +107,7 @@ describe("BookingFormSchema - time restrictions", () => {
   describe("maxBookingLength restriction", () => {
     it("should enforce max booking length for BASE/SELF_SERVICE users", () => {
       const schema = BookingFormSchema({
+        hints: RUNTIME_ZONE_HINTS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -125,6 +142,7 @@ describe("BookingFormSchema - time restrictions", () => {
 
     it("should bypass max booking length for ADMIN/OWNER users", () => {
       const schema = BookingFormSchema({
+        hints: RUNTIME_ZONE_HINTS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -154,6 +172,7 @@ describe("BookingFormSchema - time restrictions", () => {
     it("should still enforce end date after start date for all users", () => {
       // This validation should apply to everyone
       const schema = BookingFormSchema({
+        hints: RUNTIME_ZONE_HINTS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -189,6 +208,7 @@ describe("BookingFormSchema - time restrictions", () => {
   describe("default isAdminOrOwner behavior", () => {
     it("should default to false (enforce restrictions) when isAdminOrOwner is not provided", () => {
       const schema = BookingFormSchema({
+        hints: RUNTIME_ZONE_HINTS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -761,6 +781,7 @@ describe("DuplicateBookingSchema - date validation", () => {
   describe("bufferStartTime restriction", () => {
     it("enforces buffer time for BASE/SELF_SERVICE users", () => {
       const schema = DuplicateBookingSchema({
+        hints: RUNTIME_ZONE_HINTS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: false, // BASE/SELF_SERVICE user
@@ -783,6 +804,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
     it("bypasses buffer time for ADMIN/OWNER users", () => {
       const schema = DuplicateBookingSchema({
+        hints: RUNTIME_ZONE_HINTS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: true, // ADMIN/OWNER user
@@ -879,6 +901,7 @@ describe("DuplicateBookingSchema - date validation", () => {
   describe("cross-field date validation", () => {
     it("rejects endDate <= startDate with the exact cross-field message on the endDate path", () => {
       const schema = DuplicateBookingSchema({
+        hints: RUNTIME_ZONE_HINTS,
         workingHours: disabledWorkingHours,
         bookingSettings: {
           ...baseBookingSettings,
@@ -908,6 +931,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
     it("rejects bookings exceeding max length for BASE users but bypasses for ADMIN/OWNER", () => {
       const baseSchema = DuplicateBookingSchema({
+        hints: RUNTIME_ZONE_HINTS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: false,
@@ -931,6 +955,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
       // Same 72h window passes for an admin (buffer + max-length bypassed).
       const adminSchema = DuplicateBookingSchema({
+        hints: RUNTIME_ZONE_HINTS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: true,
@@ -956,11 +981,13 @@ describe("DuplicateBookingSchema - date validation", () => {
   describe("parity with BookingFormSchema (action: new)", () => {
     const sharedSettings = baseBookingSettings;
     const dupSchema = DuplicateBookingSchema({
+      hints: RUNTIME_ZONE_HINTS,
       workingHours: disabledWorkingHours,
       bookingSettings: sharedSettings,
       isAdminOrOwner: true,
     });
     const formSchema = BookingFormSchema({
+      hints: RUNTIME_ZONE_HINTS,
       action: "new",
       workingHours: disabledWorkingHours,
       bookingSettings: sharedSettings,
@@ -1128,5 +1155,119 @@ describe("BookingFormSchema - pref timezone drives the stored UTC (config date f
       // Round-trip is lossless: back to the exact stored instant.
       expect((result.data.startDate as Date).toISOString()).toBe(storedUtc);
     }
+  });
+});
+
+/**
+ * Regression: a booking that starts SOON, for a user WEST of UTC.
+ *
+ * A caller that omitted `hints` used to fall through to `coerceLocalDate`'s UTC
+ * default, so the typed wall-clock was read as UTC. For America/Chicago (UTC-5
+ * in summer) that shifts the instant 5 hours into the past, and the plain
+ * future-date check rejects it with "Start date must be in the future". The
+ * user therefore could not book anything less than their UTC offset ahead —
+ * reported from the field as "unable to create a booking unless the time is
+ * 5 hours in advance".
+ *
+ * `hints` is now required, so the omission is a compile error. These cases pin
+ * the runtime behaviour that made the omission harmful, so the guarantee
+ * survives any future refactor of the parse.
+ */
+describe("BookingFormSchema - near-future start, user west of UTC", () => {
+  const disabledWorkingHours = {
+    enabled: false,
+    weeklySchedule: {},
+    overrides: [],
+  };
+
+  /** No advance-notice requirement, so only the plain future check applies. */
+  const noBufferSettings = {
+    bufferStartTime: 0,
+    tagsRequired: false,
+    maxBookingLength: null,
+    maxBookingLengthSkipClosedDays: false,
+  };
+
+  const validCustodian = JSON.stringify({
+    id: "tm-1",
+    name: "Test User",
+    userId: "user-1",
+  });
+
+  /** 2026-08-18 13:00 in America/Chicago (CDT, UTC-5) is 18:00Z. */
+  const NOW = new Date("2026-08-18T18:00:00.000Z");
+  const CHICAGO = "America/Chicago";
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  /** Builds the form payload for a start/end typed as local wall-clock. */
+  function parseWith(timeZone: string, startDate: string, endDate: string) {
+    return BookingFormSchema({
+      hints: { timeZone },
+      action: "new",
+      workingHours: disabledWorkingHours,
+      bookingSettings: noBufferSettings,
+      isAdminOrOwner: false,
+    }).safeParse({
+      name: "Book a printer this afternoon",
+      startDate,
+      endDate,
+      custodian: validCustodian,
+    });
+  }
+
+  /** Messages for a failed parse, or [] when it succeeded. */
+  function messages(result: ReturnType<typeof parseWith>) {
+    return result.success ? [] : result.error.errors.map((e) => e.message);
+  }
+
+  it("accepts a start 2 hours ahead when the user's own zone is used", () => {
+    // 13:00 Chicago now, booking 15:00-17:00 Chicago the same afternoon.
+    const result = parseWith(CHICAGO, "2026-08-18T15:00", "2026-08-18T17:00");
+    expect(messages(result)).toEqual([]);
+    expect(result.success).toBe(true);
+  });
+
+  it("reads that start as the correct absolute instant", () => {
+    const result = parseWith(CHICAGO, "2026-08-18T15:00", "2026-08-18T17:00");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // 15:00 CDT is 20:00Z, not 15:00Z.
+      expect((result.data.startDate as Date).toISOString()).toBe(
+        "2026-08-18T20:00:00.000Z"
+      );
+    }
+  });
+
+  it("rejects that same start when the zone is lost to UTC", () => {
+    // This is the shipped bug, reproduced by passing the fallback zone that an
+    // omitted `hints` used to produce. 15:00 read as UTC is 10:00 Chicago,
+    // three hours BEFORE the current 13:00, so it looks like the past.
+    const result = parseWith("UTC", "2026-08-18T15:00", "2026-08-18T17:00");
+    expect(result.success).toBe(false);
+    expect(messages(result)).toContain("Start date must be in the future");
+  });
+
+  it("shows the rejection window equals the user's UTC offset", () => {
+    // Under the bug the cliff sits exactly 5 hours out for UTC-5: everything
+    // earlier reads as past, 18:01 onwards reads as future.
+    const verdicts = ["14:00", "17:00", "18:00", "19:00"].map((time) => ({
+      time,
+      accepted: parseWith("UTC", `2026-08-18T${time}`, "2026-08-19T09:00")
+        .success,
+    }));
+
+    expect(verdicts).toEqual([
+      { time: "14:00", accepted: false }, // 1h ahead locally
+      { time: "17:00", accepted: false }, // 4h ahead locally
+      { time: "18:00", accepted: false }, // 5h ahead locally, still the cliff
+      { time: "19:00", accepted: true }, // 6h ahead locally, finally allowed
+    ]);
   });
 });

--- a/apps/webapp/app/components/booking/forms/forms-schema.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.ts
@@ -180,7 +180,22 @@ function validateFutureDate(
 }
 
 interface BookingFormSchemaParams {
-  hints?: ReturnType<typeof getHints>;
+  /**
+   * Timezone + locale for the acting user. REQUIRED, and deliberately not
+   * optional: `coerceLocalDate` falls back to UTC when it has no zone, so a
+   * caller that forgets this silently reads every typed wall-clock time as UTC.
+   * For a user west of UTC that makes near-future starts look like the past and
+   * "Start date must be in the future" blocks them for the length of their UTC
+   * offset (5 hours in US Central, 7 in US Pacific). That shipped for three
+   * months because `hints` was optional and one caller omitted it.
+   *
+   * Pass the RESOLVED preference zone, not the raw browser hint:
+   * `{ ...hints, timeZone: prefs.timeZone }` on the client (`useFormatPrefs`),
+   * or `resolveUserFormatPrefsById(userId, getClientHint(request)).timeZone` on
+   * the server. That is the same zone date DISPLAY uses, so the check the user
+   * sees agrees with the instant we store.
+   */
+  hints: ReturnType<typeof getHints>;
   action: "new" | "save" | "reserve";
   status?: BookingStatus;
   workingHours: any; // Accept any type, normalize internally
@@ -249,13 +264,13 @@ function buildBookingDateSchemas({
   const workingHours = normalizeWorkingHoursForValidation(rawWorkingHours);
 
   // Create enhanced date schemas with working hours and buffer validation
-  const startDateSchema = coerceLocalDate(hints?.timeZone).superRefine(
+  const startDateSchema = coerceLocalDate(hints.timeZone).superRefine(
     (data, ctx) => {
       // 1. Validate future date with buffer (skipped for ADMIN/OWNER when effectiveBufferStartTime is 0)
       const futureValidation = validateFutureDate(
         data,
         effectiveBufferStartTime,
-        hints?.timeZone
+        hints.timeZone
       );
       if (!futureValidation.isValid) {
         ctx.addIssue({
@@ -266,7 +281,7 @@ function buildBookingDateSchemas({
       }
 
       // 2. Validate working hours if available
-      if (workingHours && hints?.timeZone) {
+      if (workingHours && hints.timeZone) {
         const workingHoursValidation = validateWorkingHours(
           data,
           workingHours,
@@ -282,10 +297,10 @@ function buildBookingDateSchemas({
     }
   );
 
-  const endDateSchema = coerceLocalDate(hints?.timeZone).superRefine(
+  const endDateSchema = coerceLocalDate(hints.timeZone).superRefine(
     (data, ctx) => {
       // Only validate working hours for end date (no future date requirement)
-      if (workingHours && hints?.timeZone) {
+      if (workingHours && hints.timeZone) {
         const validation = validateWorkingHours(
           data,
           workingHours,
@@ -420,8 +435,8 @@ export function BookingFormSchema({
           userId: z.string().optional().nullable(),
         })
       ),
-    startDate: coerceLocalDate(hints?.timeZone).optional(),
-    endDate: coerceLocalDate(hints?.timeZone).optional(),
+    startDate: coerceLocalDate(hints.timeZone).optional(),
+    endDate: coerceLocalDate(hints.timeZone).optional(),
     tags: tagsRequired
       ? z.string().min(1, "At least one tag is required")
       : z.string().optional(),


### PR DESCRIPTION
## The bug

On the assets index, **Book selection → Create new booking** refuses to create a booking that starts soon, for any user **west of UTC**, with:

> Start date must be in the future

The form pre-fills the start time with **now + 10 minutes**, so its own default value fails its own validation. The user types nothing and is blocked on the first click. They then have to push the start time out by the length of their UTC offset before it is accepted.

## Cause

`CreateBookingForSelectedAssetsDialog` built its schema without `hints`:

```tsx
BookingFormSchema({
  action: "new",
  workingHours,
  bookingSettings,
  isAdminOrOwner: isAdministratorOrOwner,
})
```

`hints` was optional, and `coerceLocalDate` falls back to UTC when it has no zone:

```ts
const zone = timeZone ?? "UTC";
```

So that dialog read the typed wall-clock as UTC. For a user at UTC-5, a typed 15:00 became 15:00Z, which is 10:00 their time, which is in the past.

`validateFutureDate` compares against a real `new Date()`, so the rejection window is exactly the user's UTC offset.

## Blast radius

| Zone | Blocked window (summer) |
|---|---|
| America/Sao_Paulo (UTC-3) | 3 hours |
| America/New_York (UTC-4) | 4 hours |
| America/Chicago (UTC-5) | 5 hours |
| America/Denver (UTC-6) | 6 hours |
| America/Los_Angeles (UTC-7) | 7 hours |

Each gets one hour worse in winter. Users east of UTC are not blocked by the future check, but with working hours enabled they can get spurious "Time must be between X and Y" errors from the same dialog.

Every other booking entry point is correct: the new-booking page, the edit form, the duplicate dialog, and the three mobile API routes all pass the resolved zone.

**No data was stored wrong.** The server re-parses in the resolved preference zone (`resolveUserFormatPrefsById`), so this only ever blocked people. Nothing to repair, no migration.

## When it started

`00f675b78` (2026-05-14) moved the schema from `z.coerce.date()` to `coerceLocalDate`. A browser reads `new Date("2026-08-18T15:00")` as **local** time, so this dialog was correct before that commit and wrong after it.

`3ca4ef1a6` (2026-07-17) routed the new-booking page, the edit form and the duplicate dialog through the resolved preference zone. This caller was missed because `hints` was optional, so nothing failed at build time.

## The fix

1. The dialog now passes `{ ...hints, timeZone: prefs.timeZone }`, identical to the new-booking and edit forms.
2. **`hints` is now required** on `BookingFormSchemaParams`. An omitted zone is a compile error instead of a silent UTC fallback.

Verified the guardrail bites: reverting only the dialog change makes `tsc` fail on the exact line that shipped the bug.

```
create-booking-for-selected-assets-dialog.tsx(42,23): error TS2345:
  Property 'hints' is missing in type '{ action: "new"; ... }'
  but required in type 'BookingFormSchemaParams'.
```

3. The 18 test call sites that were relying on the implicit UTC now state their zone explicitly.

## Tests

New regression suite in `forms-schema.test.ts`, clock pinned to 13:00 America/Chicago:

- a 15:00 start is accepted when the user's own zone is passed
- it resolves to `2026-08-18T20:00:00.000Z`, not `15:00Z`
- the same start is rejected when the zone is lost to UTC
- the rejection window is exactly the UTC offset (14:00/17:00/18:00 rejected, 19:00 accepted)

`pnpm webapp:validate`: 380 files, 5063 tests pass, 0 lint errors, typecheck clean.

## Verification note

The diagnosis and the cliff were reproduced on production before the fix: with the account time zone set to `America/Chicago`, the same start time was **accepted** by Bookings → New booking and **rejected** by this dialog, and the dialog only started accepting once the start was more than 5 hours out.

The fixed dialog was **not** clicked through in a local browser: the shared dev database is currently drifted from `main` (`column a.stockStatus does not exist`) so the assets index does not load, and it carries migrations from several in-flight branches, so I did not want to migrate it. The change makes this dialog use the exact expression already proven correct on the new-booking page in the same render context, and the guardrail is enforced by the compiler. Worth one click on staging before merge.

## Reproduce (2 minutes, any location)

1. Account details → General → Language & region → Time zone → `America/Chicago`. Save. Note the "Dates will look like" clock, call it T.
2. Assets → tick one asset → Book selection → Create new booking.
3. Start = today at T + 1 hour, End = today at T + 3 hours, any custodian → Confirm.
4. Before: "Start date must be in the future". After: the booking is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking date validation across time zones.
  * Corrected handling of near-future bookings in regions west of UTC.
  * Added clearer validation when timezone information is unavailable.
  * Preserved working-hours checks and timezone-aware date parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->