### PR TITLE
fix(audits): scope audit-asset lookups to their session (cross-tenant IDOR)

### DIFF
--- a/apps/webapp/app/modules/audit/audit-asset-scope.test.ts
+++ b/apps/webapp/app/modules/audit/audit-asset-scope.test.ts
@@ -14,8 +14,8 @@
  * @see {@link file://./service.server.ts} `removeAssetFromAudit`, `removeAssetsFromAudit`
  */
 
-import { AuditStatus } from "@prisma/client";
 import { beforeEach, describe, expect, it, vitest } from "vitest";
+import { createAuditAsset, createAuditSession } from "@factories";
 import type * as noteService from "~/modules/note/service.server";
 
 // why: no database in unit tests. The callback form of $transaction hands the
@@ -75,19 +75,24 @@ const ORG_ID = "org-mine";
 /** The victim's row: a real AuditAsset, belonging to a DIFFERENT audit. */
 const FOREIGN_AUDIT_ASSET_ID = "auditasset-belonging-to-another-org";
 
+/**
+ * The caller's own audit — genuinely theirs, genuinely PENDING. That is what
+ * made the bug reachable: every check that DID exist passed.
+ */
+const myAudit = () =>
+  createAuditSession({
+    id: AUDIT_ID,
+    name: "My Audit",
+    organizationId: ORG_ID,
+  });
+
 describe("removeAssetFromAudit", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
     mockDb.$transaction.mockImplementation((cb: (tx: unknown) => unknown) =>
       cb(mockDb)
     );
-    // The caller's own audit — genuinely theirs, genuinely PENDING. This is
-    // what made the bug reachable: every check that DID exist passed.
-    mockDb.auditSession.findUnique.mockResolvedValue({
-      id: AUDIT_ID,
-      name: "My Audit",
-      status: AuditStatus.PENDING,
-    });
+    mockDb.auditSession.findUnique.mockResolvedValue(myAudit());
   });
 
   it("refuses an audit asset that belongs to a different audit", async () => {
@@ -161,11 +166,7 @@ describe("concurrent removal", () => {
     mockDb.$transaction.mockImplementation((cb: (tx: unknown) => unknown) =>
       cb(mockDb)
     );
-    mockDb.auditSession.findUnique.mockResolvedValue({
-      id: AUDIT_ID,
-      name: "My Audit",
-      status: AuditStatus.PENDING,
-    });
+    mockDb.auditSession.findUnique.mockResolvedValue(myAudit());
   });
 
   it("does not decrement counts when the row was already deleted", async () => {
@@ -174,10 +175,9 @@ describe("concurrent removal", () => {
     // rather than throwing the way `delete` did, so without an explicit check
     // the second request would still decrement the counters and write a
     // second note — double-counting a single removal.
-    mockDb.auditAsset.findFirst.mockResolvedValue({
-      assetId: "asset-1",
-      expected: true,
-    });
+    mockDb.auditAsset.findFirst.mockResolvedValue(
+      createAuditAsset({ auditSessionId: AUDIT_ID })
+    );
     mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 0 });
 
     await expect(
@@ -197,8 +197,11 @@ describe("concurrent removal", () => {
     // make the decrement overshoot — and the `expected` flag needed to choose
     // the counter cannot be recovered from a row that is already gone.
     mockDb.auditAsset.findMany.mockResolvedValue([
-      { id: "auditasset-1", assetId: "asset-1", expected: true },
-      { id: "auditasset-2", assetId: "asset-2", expected: true },
+      createAuditAsset({ auditSessionId: AUDIT_ID }, { id: "auditasset-1" }),
+      createAuditAsset(
+        { auditSessionId: AUDIT_ID },
+        { id: "auditasset-2", assetId: "asset-2" }
+      ),
     ]);
     mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 1 });
 
@@ -221,18 +224,14 @@ describe("removeAssetsFromAudit (bulk)", () => {
     mockDb.$transaction.mockImplementation((cb: (tx: unknown) => unknown) =>
       cb(mockDb)
     );
-    mockDb.auditSession.findUnique.mockResolvedValue({
-      id: AUDIT_ID,
-      name: "My Audit",
-      status: AuditStatus.PENDING,
-    });
+    mockDb.auditSession.findUnique.mockResolvedValue(myAudit());
   });
 
   it("deletes only the ids proven to be in this audit", async () => {
     // One id is genuinely in this audit; the other belongs elsewhere and so
     // does not come back from the scoped read.
     mockDb.auditAsset.findMany.mockResolvedValue([
-      { id: "auditasset-mine", assetId: "asset-1", expected: true },
+      createAuditAsset({ auditSessionId: AUDIT_ID }, { id: "auditasset-mine" }),
     ]);
     // why: the delete-count guard compares this against the proven-id count.
     mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 1 });

--- a/apps/webapp/app/modules/audit/audit-asset-scope.test.ts
+++ b/apps/webapp/app/modules/audit/audit-asset-scope.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Audit-asset removal must not reach outside its own audit.
+ *
+ * `AuditAsset` carries no `organizationId`. It inherits its tenant purely
+ * through `auditSession`, so `auditSessionId` is the ONLY thing that can scope
+ * it — an id-only lookup matches every row in the table, in every workspace.
+ *
+ * The removal paths proved the AUDIT was org-owned and PENDING, then looked up
+ * the audit asset by id alone, with the id taken straight from the request
+ * body. Nothing tied the two together.
+ *
+ * detail.dev finding D125.
+ *
+ * @see {@link file://./service.server.ts} `removeAssetFromAudit`, `removeAssetsFromAudit`
+ */
+
+import { AuditStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vitest } from "vitest";
+import type * as noteService from "~/modules/note/service.server";
+
+// why: no database in unit tests. The callback form of $transaction hands the
+// same stub back as `tx`, which is what these functions write through.
+const { mockDb } = vitest.hoisted(() => ({
+  mockDb: {
+    $transaction: vitest.fn(),
+    auditSession: {
+      findUnique: vitest.fn(),
+      update: vitest.fn().mockResolvedValue({}),
+    },
+    auditAsset: {
+      findFirst: vitest.fn(),
+      findMany: vitest.fn(),
+      delete: vitest.fn().mockResolvedValue({}),
+      deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
+    },
+    asset: {
+      updateMany: vitest.fn().mockResolvedValue({ count: 0 }),
+      findMany: vitest.fn().mockResolvedValue([]),
+    },
+    // why: the SUCCESS path writes a removal note, which reads the actor and
+    // the removed assets through the same tx. Not the subject of these tests,
+    // but the bulk happy-path traverses it.
+    user: {
+      findUnique: vitest
+        .fn()
+        .mockResolvedValue({ id: "user-1", firstName: "A", lastName: "B" }),
+    },
+    note: { createMany: vitest.fn().mockResolvedValue({ count: 0 }) },
+    // why: removal emits one activity event per removed asset through the same
+    // tx (the bulk-event-parity rule). Stubbed so the happy path completes.
+    activityEvent: { createMany: vitest.fn().mockResolvedValue({ count: 0 }) },
+  },
+}));
+vitest.mock("~/database/db.server", () => ({ db: mockDb }));
+
+// why: note writing is a side effect of removal, not the subject of this test,
+// and it pulls in Markdoc wrappers and user lookups we do not need here.
+vitest.mock("~/modules/note/service.server", async (importOriginal) => {
+  const actual = await importOriginal<typeof noteService>();
+  return {
+    ...actual,
+    createNotes: vitest.fn().mockResolvedValue({}),
+    createNote: vitest.fn().mockResolvedValue({}),
+    createAssetNotesForAuditRemoval: vitest.fn().mockResolvedValue({}),
+  };
+});
+
+import { removeAssetFromAudit, removeAssetsFromAudit } from "./service.server";
+
+// @vitest-environment node
+
+const AUDIT_ID = "audit-mine";
+const ORG_ID = "org-mine";
+
+/** The victim's row: a real AuditAsset, belonging to a DIFFERENT audit. */
+const FOREIGN_AUDIT_ASSET_ID = "auditasset-belonging-to-another-org";
+
+describe("removeAssetFromAudit", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    mockDb.$transaction.mockImplementation((cb: (tx: unknown) => unknown) =>
+      cb(mockDb)
+    );
+    // The caller's own audit — genuinely theirs, genuinely PENDING. This is
+    // what made the bug reachable: every check that DID exist passed.
+    mockDb.auditSession.findUnique.mockResolvedValue({
+      id: AUDIT_ID,
+      name: "My Audit",
+      status: AuditStatus.PENDING,
+    });
+  });
+
+  it("refuses an audit asset that belongs to a different audit", async () => {
+    // The scoped lookup finds nothing, because the row is not in this audit.
+    mockDb.auditAsset.findFirst.mockResolvedValue(null);
+
+    await expect(
+      removeAssetFromAudit({
+        auditId: AUDIT_ID,
+        auditAssetId: FOREIGN_AUDIT_ASSET_ID,
+        organizationId: ORG_ID,
+        userId: "user-1",
+      })
+    ).rejects.toThrow(/not found in this audit/);
+
+    // The assertion that matters: nothing was deleted. A test that only
+    // checked the throw would still pass if the delete ran first.
+    expect(mockDb.auditAsset.delete).not.toHaveBeenCalled();
+    expect(mockDb.auditAsset.deleteMany).not.toHaveBeenCalled();
+    // …and the caller's own audit counts are untouched. The old code
+    // decremented them off a row from someone else's audit.
+    expect(mockDb.auditSession.update).not.toHaveBeenCalled();
+  });
+
+  it("scopes the lookup by auditSessionId, not by id alone", async () => {
+    mockDb.auditAsset.findFirst.mockResolvedValue(null);
+
+    await expect(
+      removeAssetFromAudit({
+        auditId: AUDIT_ID,
+        auditAssetId: FOREIGN_AUDIT_ASSET_ID,
+        organizationId: ORG_ID,
+        userId: "user-1",
+      })
+    ).rejects.toThrow();
+
+    // Asserting the WHERE clause directly. `AuditAsset` has no organizationId
+    // column, so this predicate is the entire tenant boundary — if a refactor
+    // drops it, the row becomes globally addressable again.
+    expect(mockDb.auditAsset.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: FOREIGN_AUDIT_ASSET_ID,
+          auditSessionId: AUDIT_ID,
+        }),
+      })
+    );
+  });
+
+  it("does not reveal whether the id exists elsewhere", async () => {
+    mockDb.auditAsset.findFirst.mockResolvedValue(null);
+
+    const cause = await removeAssetFromAudit({
+      auditId: AUDIT_ID,
+      auditAssetId: FOREIGN_AUDIT_ASSET_ID,
+      organizationId: ORG_ID,
+      userId: "user-1",
+    }).catch((e: unknown) => e);
+
+    // Same 404 either way — a distinct "belongs to another audit" message
+    // would confirm the id is real, which is an existence oracle.
+    const err = cause as { status?: number; message?: string };
+    expect(err.status).toBe(404);
+    expect(err.message).not.toMatch(/another|other audit|different/i);
+  });
+});
+
+describe("removeAssetsFromAudit (bulk)", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    mockDb.$transaction.mockImplementation((cb: (tx: unknown) => unknown) =>
+      cb(mockDb)
+    );
+    mockDb.auditSession.findUnique.mockResolvedValue({
+      id: AUDIT_ID,
+      name: "My Audit",
+      status: AuditStatus.PENDING,
+    });
+  });
+
+  it("deletes only the ids proven to be in this audit", async () => {
+    // One id is genuinely in this audit; the other belongs elsewhere and so
+    // does not come back from the scoped read.
+    mockDb.auditAsset.findMany.mockResolvedValue([
+      { id: "auditasset-mine", assetId: "asset-1", expected: true },
+    ]);
+
+    await removeAssetsFromAudit({
+      auditId: AUDIT_ID,
+      auditAssetIds: ["auditasset-mine", FOREIGN_AUDIT_ASSET_ID],
+      organizationId: ORG_ID,
+      userId: "user-1",
+    });
+
+    // The delete must use the PROVEN ids, not the caller's original list —
+    // passing the input list through would delete the foreign row even though
+    // it was correctly excluded from the counts.
+    expect(mockDb.auditAsset.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ["auditasset-mine"] },
+          auditSessionId: AUDIT_ID,
+        }),
+      })
+    );
+  });
+
+  it("scopes the bulk read by auditSessionId", async () => {
+    mockDb.auditAsset.findMany.mockResolvedValue([]);
+
+    await removeAssetsFromAudit({
+      auditId: AUDIT_ID,
+      auditAssetIds: [FOREIGN_AUDIT_ASSET_ID],
+      organizationId: ORG_ID,
+      userId: "user-1",
+    });
+
+    expect(mockDb.auditAsset.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ auditSessionId: AUDIT_ID }),
+      })
+    );
+    // Nothing matched, so nothing is deleted at all.
+    expect(mockDb.auditAsset.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/audit/audit-asset-scope.test.ts
+++ b/apps/webapp/app/modules/audit/audit-asset-scope.test.ts
@@ -155,6 +155,66 @@ describe("removeAssetFromAudit", () => {
   });
 });
 
+describe("concurrent removal", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    mockDb.$transaction.mockImplementation((cb: (tx: unknown) => unknown) =>
+      cb(mockDb)
+    );
+    mockDb.auditSession.findUnique.mockResolvedValue({
+      id: AUDIT_ID,
+      name: "My Audit",
+      status: AuditStatus.PENDING,
+    });
+  });
+
+  it("does not decrement counts when the row was already deleted", async () => {
+    // Two simultaneous removals of the same asset. Both pass the read; the
+    // second deletes nothing. `deleteMany` reports that as `{ count: 0 }`
+    // rather than throwing the way `delete` did, so without an explicit check
+    // the second request would still decrement the counters and write a
+    // second note — double-counting a single removal.
+    mockDb.auditAsset.findFirst.mockResolvedValue({
+      assetId: "asset-1",
+      expected: true,
+    });
+    mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      removeAssetFromAudit({
+        auditId: AUDIT_ID,
+        auditAssetId: "auditasset-mine",
+        organizationId: ORG_ID,
+        userId: "user-1",
+      })
+    ).rejects.toThrow(/not found in this audit/);
+
+    expect(mockDb.auditSession.update).not.toHaveBeenCalled();
+  });
+
+  it("aborts a bulk removal when fewer rows were deleted than proven", async () => {
+    // `expectedCount` is derived from the READ, so a concurrent removal would
+    // make the decrement overshoot — and the `expected` flag needed to choose
+    // the counter cannot be recovered from a row that is already gone.
+    mockDb.auditAsset.findMany.mockResolvedValue([
+      { id: "auditasset-1", assetId: "asset-1", expected: true },
+      { id: "auditasset-2", assetId: "asset-2", expected: true },
+    ]);
+    mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      removeAssetsFromAudit({
+        auditId: AUDIT_ID,
+        auditAssetIds: ["auditasset-1", "auditasset-2"],
+        organizationId: ORG_ID,
+        userId: "user-1",
+      })
+    ).rejects.toThrow(/removed by someone else/);
+
+    expect(mockDb.auditSession.update).not.toHaveBeenCalled();
+  });
+});
+
 describe("removeAssetsFromAudit (bulk)", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
@@ -174,6 +234,8 @@ describe("removeAssetsFromAudit (bulk)", () => {
     mockDb.auditAsset.findMany.mockResolvedValue([
       { id: "auditasset-mine", assetId: "asset-1", expected: true },
     ]);
+    // why: the delete-count guard compares this against the proven-id count.
+    mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 1 });
 
     await removeAssetsFromAudit({
       auditId: AUDIT_ID,

--- a/apps/webapp/app/modules/audit/helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.test.ts
@@ -792,7 +792,7 @@ describe("audit helpers", () => {
           findUnique: vi.fn(),
         },
         auditAsset: {
-          findUnique: vi.fn(),
+          findFirst: vi.fn(),
         },
         auditNote: {
           create: vi.fn(),
@@ -807,7 +807,7 @@ describe("audit helpers", () => {
         lastName: "Doe",
       });
 
-      mockTx.auditAsset.findUnique.mockResolvedValue({
+      mockTx.auditAsset.findFirst.mockResolvedValue({
         id: "audit-asset-1",
         asset: {
           id: "asset-1",
@@ -833,8 +833,10 @@ describe("audit helpers", () => {
         },
       });
 
-      expect(mockTx.auditAsset.findUnique).toHaveBeenCalledWith({
-        where: { id: "audit-asset-1" },
+      // `auditSessionId` is the whole tenant boundary here: AuditAsset has no
+      // organizationId column, so an id-only lookup reaches every workspace.
+      expect(mockTx.auditAsset.findFirst).toHaveBeenCalledWith({
+        where: { id: "audit-asset-1", auditSessionId: "audit-1" },
         include: {
           asset: {
             select: { id: true, title: true },
@@ -866,7 +868,7 @@ describe("audit helpers", () => {
         lastName: "Smith",
       });
 
-      mockTx.auditAsset.findUnique.mockResolvedValue({
+      mockTx.auditAsset.findFirst.mockResolvedValue({
         id: "audit-asset-2",
         asset: {
           id: "asset-2",
@@ -906,7 +908,7 @@ describe("audit helpers", () => {
         lastName: "Johnson",
       });
 
-      mockTx.auditAsset.findUnique.mockResolvedValue({
+      mockTx.auditAsset.findFirst.mockResolvedValue({
         id: "audit-asset-3",
         asset: {
           id: "asset-3",
@@ -929,7 +931,7 @@ describe("audit helpers", () => {
 
     it("skips note creation when user not found", async () => {
       mockTx.user.findUnique.mockResolvedValue(null);
-      mockTx.auditAsset.findUnique.mockResolvedValue({
+      mockTx.auditAsset.findFirst.mockResolvedValue({
         id: "audit-asset-4",
         asset: { id: "asset-4", title: "Test Asset" },
       });
@@ -951,7 +953,7 @@ describe("audit helpers", () => {
         firstName: "Bob",
         lastName: "Williams",
       });
-      mockTx.auditAsset.findUnique.mockResolvedValue(null);
+      mockTx.auditAsset.findFirst.mockResolvedValue(null);
 
       await createAuditAssetImagesAddedNote({
         auditSessionId: "audit-5",
@@ -1499,7 +1501,7 @@ describe("audit helpers", () => {
           }),
         },
         auditAsset: {
-          findUnique: vi.fn().mockResolvedValue({
+          findFirst: vi.fn().mockResolvedValue({
             id: "audit-asset-1",
             asset: { id: "asset-1", title: "Drill" },
           }),

--- a/apps/webapp/app/modules/audit/helpers.server.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.ts
@@ -458,8 +458,15 @@ export async function createAuditAssetImagesAddedNote({
         displayName: true,
       },
     }),
-    tx.auditAsset.findUnique({
-      where: { id: auditAssetId },
+    // SECURITY (cross-audit IDOR): scoped to the session the note is being
+    // written for. `auditSessionId` was already a parameter here and simply
+    // went unused, so an id-only lookup matched any `AuditAsset` in the table
+    // — including another organization's, since `AuditAsset` inherits its
+    // tenant through `auditSession` and carries no `organizationId` of its
+    // own. The result was a note in one audit naming an asset from another,
+    // which then flows into the PDF report. (detail.dev D050)
+    tx.auditAsset.findFirst({
+      where: { id: auditAssetId, auditSessionId },
       include: {
         asset: {
           select: { id: true, title: true },

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -563,6 +563,11 @@ describe("audit service", () => {
   describe("removeAssetFromAudit", () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      // why: the removal paths now check the affected-row count, because
+      // `deleteMany` reports a vanished row as `{ count: 0 }` where the old
+      // unique `delete` threw. `clearAllMocks` wipes implementations set in an
+      // earlier describe, so this has to be re-established per test.
+      mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 1 });
     });
 
     it("removes expected asset from pending audit", async () => {
@@ -571,7 +576,7 @@ describe("audit service", () => {
         name: "Test Audit",
         status: "PENDING",
       });
-      mockDb.auditAsset.findUnique.mockResolvedValue({
+      mockDb.auditAsset.findFirst.mockResolvedValue({
         assetId: "asset-1",
         expected: true,
       });
@@ -588,8 +593,11 @@ describe("audit service", () => {
         select: { id: true, name: true, status: true },
       });
 
-      expect(mockDb.auditAsset.delete).toHaveBeenCalledWith({
-        where: { id: "audit-asset-1" },
+      // Scoped delete: `auditSessionId` is the tenant boundary, since
+      // AuditAsset has no organizationId of its own. `deleteMany` rather than
+      // `delete` because Prisma's unique-where cannot carry the extra filter.
+      expect(mockDb.auditAsset.deleteMany).toHaveBeenCalledWith({
+        where: { id: "audit-asset-1", auditSessionId: "audit-1" },
       });
 
       expect(mockDb.auditSession.update).toHaveBeenCalledWith({
@@ -607,7 +615,7 @@ describe("audit service", () => {
         name: "Test Audit",
         status: "PENDING",
       });
-      mockDb.auditAsset.findUnique.mockResolvedValue({
+      mockDb.auditAsset.findFirst.mockResolvedValue({
         assetId: "asset-1",
         expected: false,
       });
@@ -619,7 +627,7 @@ describe("audit service", () => {
         userId: "user-1",
       });
 
-      expect(mockDb.auditAsset.delete).toHaveBeenCalled();
+      expect(mockDb.auditAsset.deleteMany).toHaveBeenCalled();
       expect(mockDb.auditSession.update).not.toHaveBeenCalled();
     });
 
@@ -655,7 +663,7 @@ describe("audit service", () => {
       mockDb.auditSession.findUnique.mockResolvedValue({
         status: "PENDING",
       });
-      mockDb.auditAsset.findUnique.mockResolvedValue(null);
+      mockDb.auditAsset.findFirst.mockResolvedValue(null);
 
       await expect(
         removeAssetFromAudit({
@@ -671,6 +679,9 @@ describe("audit service", () => {
   describe("removeAssetsFromAudit", () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      // why: see the singular describe — the bulk path aborts unless the
+      // delete count matches the ids it just proved were in this audit.
+      mockDb.auditAsset.deleteMany.mockResolvedValue({ count: 3 });
     });
 
     it("removes multiple assets from pending audit", async () => {
@@ -692,9 +703,12 @@ describe("audit service", () => {
         userId: "user-1",
       });
 
+      // `auditSessionId` is the tenant boundary: AuditAsset has no
+      // organizationId column, so an id-only delete reaches every workspace.
       expect(mockDb.auditAsset.deleteMany).toHaveBeenCalledWith({
         where: {
           id: { in: ["audit-asset-1", "audit-asset-2", "audit-asset-3"] },
+          auditSessionId: "audit-1",
         },
       });
 

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2871,9 +2871,26 @@ export async function removeAssetFromAudit({
       // Delete the audit asset (cascade will delete related scans). Scoped
       // again rather than by id alone: defence in depth, so the write cannot
       // outlive a future refactor of the check above.
-      await tx.auditAsset.deleteMany({
+      const removed = await tx.auditAsset.deleteMany({
         where: { id: auditAssetId, auditSessionId: auditId },
       });
+
+      // `deleteMany` reports zero rows where `delete` would have thrown
+      // P2025, so the count has to be checked explicitly or the scoping change
+      // above would have quietly cost us a concurrency guard: two simultaneous
+      // removals of the same asset would both pass the read, the second would
+      // delete nothing, and it would still decrement the counters and write a
+      // second note. Throwing here rolls the whole transaction back.
+      if (removed.count !== 1) {
+        throw new ShelfError({
+          cause: null,
+          message: "Audit asset not found in this audit",
+          additionalData: { auditAssetId, auditId },
+          label,
+          status: 404,
+          shouldBeCaptured: false,
+        });
+      }
 
       // Update audit session counts
       // If it was an expected asset, decrement expectedAssetCount
@@ -2991,9 +3008,32 @@ export async function removeAssetsFromAudit({
       // the caller's original id list — a foreign id in the input must not
       // reach the delete even though it was filtered out of the counts above.
       const provenAuditAssetIds = auditAssets.map((aa) => aa.id);
-      await tx.auditAsset.deleteMany({
+      const removed = await tx.auditAsset.deleteMany({
         where: { id: { in: provenAuditAssetIds }, auditSessionId: auditId },
       });
+
+      // Same reasoning as the singular path. `expectedCount` was derived from
+      // the READ, so if a concurrent removal took some of these rows first,
+      // decrementing by it would overshoot — and the `expected` flag needed to
+      // pick the right counter cannot be recovered from a row that is already
+      // gone. Aborting and letting the caller retry keeps the counters honest;
+      // silently proceeding would corrupt audit totals, which is the thing
+      // this whole path exists to keep accurate.
+      if (removed.count !== provenAuditAssetIds.length) {
+        throw new ShelfError({
+          cause: null,
+          message:
+            "Some of those assets were removed by someone else while this request was running. Nothing was changed — please reload the audit and try again.",
+          additionalData: {
+            auditId,
+            expected: provenAuditAssetIds.length,
+            removed: removed.count,
+          },
+          label,
+          status: 409,
+          shouldBeCaptured: false,
+        });
+      }
 
       // Update audit session counts
       if (expectedCount > 0) {

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2839,25 +2839,40 @@ export async function removeAssetFromAudit({
         });
       }
 
-      // Fetch the audit asset to get the actual asset ID
-      const auditAsset = await tx.auditAsset.findUnique({
-        where: { id: auditAssetId },
+      // SECURITY (cross-tenant IDOR): scope the lookup to THIS audit.
+      //
+      // `auditAssetId` arrives from the request body. `AuditAsset` carries no
+      // `organizationId` of its own — it inherits the tenant purely through
+      // `auditSession` — so `auditSessionId` is the only thing that can scope
+      // it, and an id-only `findUnique` matched any row in the table. Proving
+      // the AUDIT is org-owned above does not help: nothing tied the audit
+      // asset to that audit. A caller could delete another organization's
+      // audit rows (cascading to their scans), and the count decrement below
+      // would then corrupt their OWN audit's totals as well.
+      const auditAsset = await tx.auditAsset.findFirst({
+        where: { id: auditAssetId, auditSessionId: auditId },
         select: { assetId: true, expected: true },
       });
 
       if (!auditAsset) {
         throw new ShelfError({
           cause: null,
-          message: "Audit asset not found",
-          additionalData: { auditAssetId },
+          // Deliberately does not distinguish "no such row" from "belongs to
+          // another audit" — the id is caller-supplied and the difference is
+          // an existence oracle.
+          message: "Audit asset not found in this audit",
+          additionalData: { auditAssetId, auditId },
           label,
           status: 404,
+          shouldBeCaptured: false,
         });
       }
 
-      // Delete the audit asset (cascade will delete related scans)
-      await tx.auditAsset.delete({
-        where: { id: auditAssetId },
+      // Delete the audit asset (cascade will delete related scans). Scoped
+      // again rather than by id alone: defence in depth, so the write cannot
+      // outlive a future refactor of the check above.
+      await tx.auditAsset.deleteMany({
+        where: { id: auditAssetId, auditSessionId: auditId },
       });
 
       // Update audit session counts
@@ -2955,9 +2970,13 @@ export async function removeAssetsFromAudit({
         });
       }
 
-      // Fetch the audit assets to get the actual asset IDs
+      // SECURITY (cross-tenant IDOR): same unscoped lookup as the singular
+      // path — see the comment there. The current web caller happens to
+      // resolve these ids itself from `auditSessionId`, so it is safe by
+      // construction, but that is the CALLER's property and not this
+      // function's. Scoping here is what makes it true for every caller.
       const auditAssets = await tx.auditAsset.findMany({
-        where: { id: { in: auditAssetIds } },
+        where: { id: { in: auditAssetIds }, auditSessionId: auditId },
         select: { id: true, assetId: true, expected: true },
       });
 
@@ -2968,9 +2987,12 @@ export async function removeAssetsFromAudit({
       const assetIds = auditAssets.map((aa) => aa.assetId);
       const expectedCount = auditAssets.filter((aa) => aa.expected).length;
 
-      // Delete the audit assets (cascade will delete related scans)
+      // Delete only the rows just PROVEN to belong to this audit, rather than
+      // the caller's original id list — a foreign id in the input must not
+      // reach the delete even though it was filtered out of the counts above.
+      const provenAuditAssetIds = auditAssets.map((aa) => aa.id);
       await tx.auditAsset.deleteMany({
-        where: { id: { in: auditAssetIds } },
+        where: { id: { in: provenAuditAssetIds }, auditSessionId: auditId },
       });
 
       // Update audit session counts

--- a/apps/webapp/test/factories/audit.ts
+++ b/apps/webapp/test/factories/audit.ts
@@ -1,0 +1,78 @@
+/**
+ * Factories for audit test data.
+ *
+ * `AuditAsset` deserves particular care: it carries **no `organizationId`**.
+ * It inherits its tenant purely through `auditSession`, so `auditSessionId` is
+ * the only field that scopes it — which is why the factory requires one rather
+ * than defaulting it silently. A fixture that omits the link models a row that
+ * cannot exist, and would let a scoping regression pass unnoticed.
+ *
+ * @see {@link file://./../../app/modules/audit/service.server.ts}
+ */
+
+import type { AuditAsset, AuditSession } from "@prisma/client";
+import { AuditAssetStatus, AuditStatus } from "@prisma/client";
+
+/** Default ids, exported so tests can assert against the same constants. */
+export const AUDIT_SESSION_ID = "audit-session-1";
+export const AUDIT_ORGANIZATION_ID = "org-1";
+
+/**
+ * Builds an AuditSession row.
+ *
+ * Defaults to PENDING — the only status from which assets may be added or
+ * removed, so it is the state most removal tests need.
+ *
+ * @param overrides - Fields to replace on the default row
+ */
+export function createAuditSession(
+  overrides: Partial<AuditSession> = {}
+): Partial<AuditSession> {
+  return {
+    id: AUDIT_SESSION_ID,
+    name: "Test Audit",
+    description: null,
+    status: AuditStatus.PENDING,
+    organizationId: AUDIT_ORGANIZATION_ID,
+    createdById: "user-1",
+    expectedAssetCount: 0,
+    foundAssetCount: 0,
+    missingAssetCount: 0,
+    unexpectedAssetCount: 0,
+    startedAt: null,
+    dueDate: null,
+    completedAt: null,
+    cancelledAt: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+/**
+ * Builds an AuditAsset row.
+ *
+ * `auditSessionId` is REQUIRED, not defaulted. It is the entire tenant
+ * boundary for this model, and a fixture that leaves it implicit is exactly
+ * the shape that lets an unscoped query look correct in a test.
+ *
+ * @param args.auditSessionId - The session this row belongs to
+ * @param overrides - Fields to replace on the default row
+ */
+export function createAuditAsset(
+  { auditSessionId }: { auditSessionId: string },
+  overrides: Partial<AuditAsset> = {}
+): Partial<AuditAsset> {
+  return {
+    id: "audit-asset-1",
+    auditSessionId,
+    assetId: "asset-1",
+    expected: true,
+    status: AuditAssetStatus.PENDING,
+    scannedById: null,
+    scannedAt: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}

--- a/apps/webapp/test/factories/index.ts
+++ b/apps/webapp/test/factories/index.ts
@@ -9,4 +9,5 @@ export * from "./asset";
 export * from "./organization";
 export * from "./assetModel";
 export * from "./activityEvent";
+export * from "./audit";
 export * from "./stripePrice";

--- a/apps/webapp/test/factories/index.ts
+++ b/apps/webapp/test/factories/index.ts
@@ -9,6 +9,8 @@ export * from "./asset";
 export * from "./organization";
 export * from "./assetModel";
 export * from "./activityEvent";
+/** Audit session + audit asset factories. `createAuditAsset` requires an
+ * `auditSessionId`: that link is the model's entire tenant boundary. */
 export * from "./audit";
 export * from "./layoutLoaderData";
 export * from "./stripePrice";

--- a/apps/webapp/test/factories/index.ts
+++ b/apps/webapp/test/factories/index.ts
@@ -1,16 +1,29 @@
 /**
  * Centralized exports for all test factories
  * Use these to generate consistent test data across all tests
+ *
+ * Each line below is a pointer, not a substitute: the factories carry their
+ * own file-level JSDoc explaining the shape they build and why it exists.
  */
 
+/** `createUser` — a User row, plus the shared USER id/email constants. */
 export * from "./user";
+/** `createTeamMember` — a TeamMember row (the non-registered-member shape). */
 export * from "./teamMember";
+/** `createAsset`, and `createAssetSearchResult` for the joined index rows. */
 export * from "./asset";
+/** `createOrganization`, plus the shared ORGANIZATION id constant. */
 export * from "./organization";
+/** `createAssetModel` — an AssetModel row. */
 export * from "./assetModel";
+/** `createActivityEventInput` — one `recordEvent` payload. */
 export * from "./activityEvent";
 /** Audit session + audit asset factories. `createAuditAsset` requires an
  * `auditSessionId`: that link is the model's entire tenant boundary. */
 export * from "./audit";
+/** `createLayoutLoaderData` — the `_layout` loader payload that
+ * `useUserRoleHelper` and friends read through `useRouteLoaderData`. */
 export * from "./layoutLoaderData";
+/** `stripePriceFactory` + `tierMetadata`/`addonMetadata` — resolved Stripe
+ * prices, whose four entitlement-relevant properties must all be set. */
 export * from "./stripePrice";


### PR DESCRIPTION
## What

Audit-asset removal could delete **another organization's** rows.

detail.dev findings **D125** and **D050**. D125 is filed as an audit-scope
issue; it is actually a cross-tenant IDOR.

## The bug

`AuditAsset` has **no `organizationId` column**. It inherits its tenant purely
through `auditSession`:

```prisma
model AuditAsset {
  id             String @id @default(cuid())
  auditSession   AuditSession @relation(fields: [auditSessionId], ...)
  auditSessionId String
  asset          Asset @relation(fields: [assetId], ...)
  assetId        String
}
```

So `auditSessionId` is the **only** thing that can scope one. `removeAssetFromAudit`
had neither that nor an org filter:

```ts
// The audit IS verified — org-owned and PENDING.
const audit = await tx.auditSession.findUnique({
  where: { id: auditId, organizationId },
});
// …and then the audit asset is looked up by id alone.
const auditAsset = await tx.auditAsset.findUnique({
  where: { id: auditAssetId },        // ← formData.get("auditAssetId")
});
await tx.auditAsset.delete({ where: { id: auditAssetId } });
```

Nothing tied the audit asset to the audit. `auditAssetId` comes straight from
the request body, so any caller holding `audit:update` in **any** workspace
could delete an audit asset belonging to **any** audit in **any**
organization — cascading to its scans.

The permission gate does not help. It authorizes the verb, never the object.

### The tell nobody would recognise

The count decrement afterwards is applied to `auditId` — the **caller's** audit:

```ts
await tx.auditSession.update({
  where: { id: auditId },
  data: { expectedAssetCount: { decrement: 1 } },
});
```

So an attacker corrupts their own totals in the same request. In practice this
reaches support as *"my audit counts are wrong"* long before anyone suspects a
tenant boundary was crossed — which is a plausible reason it has gone unnoticed.

## The fix

Scope the read **and** the write, on all three paths.

```ts
const auditAsset = await tx.auditAsset.findFirst({
  where: { id: auditAssetId, auditSessionId: auditId },
});
await tx.auditAsset.deleteMany({
  where: { id: auditAssetId, auditSessionId: auditId },
});
```

The bulk path deletes only the ids **just proven** to belong to the audit,
rather than replaying the caller's list — a foreign id must not reach the
delete merely because it was filtered out of the counts:

```ts
const provenAuditAssetIds = auditAssets.map((aa) => aa.id);
await tx.auditAsset.deleteMany({
  where: { id: { in: provenAuditAssetIds }, auditSessionId: auditId },
});
```

The 404 deliberately does not distinguish "no such row" from "belongs to
another audit". The id is caller-supplied, so the difference is an existence
oracle.

> The bulk path's current web caller resolves its ids itself from
> `auditSessionId`, so it was safe *by construction*. That is the caller's
> property, not the function's — scoping here is what makes it true for every
> caller, including the next one.

## Sweep

**D050 is the same bug** and is fixed here rather than deferred to the planned
assignee sweep. `createAuditAssetImagesAddedNote` already **received**
`auditSessionId` and simply never used it, so an uploaded image could attach a
note naming an asset from a different audit — which then flows into the PDF
report.

Every other `auditAsset` lookup was checked and is already scoped, by
`auditSessionId` or through `auditSession.organizationId`:

| Site | Scoped by |
| --- | --- |
| `mobile-evidence.server.ts` | `auditSessionId` (via `requireAuditAssetInSession`) |
| `get-scanned-barcode.$value.ts` | `auditSessionId` |
| `get-scanned-item.$qrId.ts` | `auditSessionId` (×2) |
| `audits.$auditId.scan.$auditAssetId.details.tsx` | `auditSession.organizationId` |
| `pdf-helpers.ts` | `auditSessionId` |
| `service.server.ts` scan claim | `auditSessionId_assetId` compound unique |

## Tests

`audit-asset-scope.test.ts` (5 new):

- a foreign audit's asset is refused — asserting **nothing was deleted** and
  the caller's own audit counts are **untouched**, not merely that it threw
- the `where` clause is asserted directly, because that predicate *is* the
  tenant boundary; if a refactor drops it the row becomes globally addressable
  again and no behavioural test would notice
- the 404 does not reveal whether the id exists elsewhere
- bulk: the delete uses the **proven** ids, not the caller's input list
- bulk: the read is session-scoped, and a fully-foreign list deletes nothing

Existing `helpers.server.test.ts` moved from `findUnique` to `findFirst`, and
its where-clause assertion now carries `auditSessionId`.

Verified: 57 tests across the touched audit modules, plus the audit route
suites (`delete-audit`, `scan.details.injection`, `asset-details`). Typecheck
and ESLint clean.

## Disclosure

This crosses an organization boundary, so it warrants a GHSA on the same path
as the earlier booking IDORs. Happy to draft it — flagging rather than
assuming, since the release timing is yours.

## Still open in this cluster

D101, D043 and D054 — the assignee guard (`requireAuditAssetInSession` has
**zero** call sites in any web route, though the mobile API uses it). Separate
PR; they are an authorization gap, not a tenant-boundary one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audit asset removal to ensure assets can only be removed from the audit session they belong to.
  - Bulk removal now deletes only assets verified as part of the current audit session.
  - Requests for missing or inaccessible assets return a consistent not-found response without revealing whether the asset exists elsewhere.
  - Audit image activity notes now reference assets only when they belong to the associated audit session.
  - Improved handling of concurrent removals to prevent audit counters and totals from becoming inaccurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->