### PR TITLE
fix(bookings): validate booking dates in the resolved preference timezone

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
@@ -15,6 +15,7 @@ import { Button } from "~/components/shared/button";
 import { Card } from "~/components/shared/card";
 import { TagsAutocomplete } from "~/components/tag/tags-autocomplete";
 import { useBookingSettings } from "~/hooks/use-booking-settings";
+import { useFormatPrefs } from "~/hooks/use-format-prefs";
 import { useUserData } from "~/hooks/use-user-data";
 import { useWorkingHours } from "~/hooks/use-working-hours";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
@@ -36,10 +37,14 @@ export default function CreateBookingForSelectedAssetsDialog() {
   const bookingSettings = useBookingSettings();
   const { isBaseOrSelfService, roles, isAdministratorOrOwner } =
     useUserRoleHelper();
+  // TIMEZONE FIX: client-side date validation uses the RESOLVED pref zone
+  // (matches display + the server parse), not the browser hint.
+  const prefs = useFormatPrefs();
 
   const zo = useZorm(
     "CreateBookingWithAssets",
     BookingFormSchema({
+      prefs,
       action: "new",
       workingHours,
       bookingSettings,

--- a/apps/webapp/app/components/booking/extend-booking-dialog.tsx
+++ b/apps/webapp/app/components/booking/extend-booking-dialog.tsx
@@ -5,10 +5,10 @@ import { useZorm } from "react-zorm";
 import { useBookingSettings } from "~/hooks/use-booking-settings";
 import { useDisabled } from "~/hooks/use-disabled";
 import useFetcherWithReset from "~/hooks/use-fetcher-with-reset";
+import { useFormatPrefs } from "~/hooks/use-format-prefs";
 import { useWorkingHours } from "~/hooks/use-working-hours";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { BookingPageLoaderData } from "~/routes/_layout+/bookings.$bookingId.overview";
-import { useHints } from "~/utils/client-hints";
 import { getValidationErrors } from "~/utils/http";
 import type { DataOrErrorResponse } from "~/utils/http.server";
 import { tw } from "~/utils/tw";
@@ -34,7 +34,11 @@ export default function ExtendBookingDialog({
   const [open, setOpen] = useState(false);
   const fetcher = useFetcherWithReset<DataOrErrorResponse>();
   const disabled = useDisabled(fetcher);
-  const hints = useHints();
+  // TIMEZONE FIX: validate the new end date in the user's RESOLVED pref zone.
+  // The server action parses the submitted value with that same zone, so using
+  // the browser hint here made the two disagree for anyone with an explicit
+  // timezone preference.
+  const prefs = useFormatPrefs();
   const { booking } = useLoaderData<BookingPageLoaderData>();
   const workingHoursData = useWorkingHours();
   const bookingSettings = useBookingSettings();
@@ -45,7 +49,7 @@ export default function ExtendBookingDialog({
   const zo = useZorm(
     "ExtendBooking",
     ExtendBookingSchema({
-      timeZone: hints.timeZone,
+      prefs,
       workingHours: workingHoursData.workingHours,
       bookingSettings,
       isAdminOrOwner: isAdministratorOrOwner,

--- a/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
@@ -15,7 +15,6 @@ import type {
   BookingPageActionData,
   BookingPageLoaderData,
 } from "~/routes/_layout+/bookings.$bookingId.overview";
-import { useHints } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { toIsoDateTimeToUserTimezone } from "~/utils/date-fns";
 import { isFormProcessing } from "~/utils/form";
@@ -111,13 +110,12 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
   const hasItemsToCheckOut = (lifecycleProgress?.bookedCount ?? 0) > 0;
 
   const isProcessing = isFormProcessing(navigation.state);
-  const hints = useHints();
   // TIMEZONE FIX: seed the datetime-local inputs with the wall-clock in the
   // user's RESOLVED timezone preference (the same one date DISPLAY uses), so
   // the edit form shows the same wall-clock the display shows. Seeding from
   // the raw stored UTC instant via `dateForDateTimeInputValue` (browser/runtime
   // zone) produced a different wall-clock whenever the browser zone differed
-  // from the pref zone. Locale still comes from `hints`.
+  // from the pref zone.
   const prefs = useFormatPrefs();
   const incomingStartDate = toIsoDateTimeToUserTimezone(
     loaderBooking.from,
@@ -178,7 +176,7 @@ export function EditBookingForm({ booking, action }: BookingFormData) {
     BookingFormSchema({
       // TIMEZONE FIX: client-side date validation uses the RESOLVED pref zone
       // (matches display + the server parse), not the browser hint.
-      hints: { ...hints, timeZone: prefs.timeZone },
+      prefs,
       action: "save", // NOTE: in the front-end the action save basically handles the schema for reserve which is the same, the full schema
       status,
       workingHours: workingHours,

--- a/apps/webapp/app/components/booking/forms/forms-schema.test.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.test.ts
@@ -1211,6 +1211,10 @@ describe("BookingFormSchema - near-future start, user west of UTC", () => {
   const NOW = new Date("2026-08-18T18:00:00.000Z");
   const CHICAGO = "America/Chicago";
 
+  // why: `validateFutureDate` compares the parsed start against the real clock.
+  // Pinning "now" to a known instant is what makes the offset-sized rejection
+  // cliff below assertable at all — against a live clock the boundary cases
+  // would drift and flake.
   beforeAll(() => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);

--- a/apps/webapp/app/components/booking/forms/forms-schema.test.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.test.ts
@@ -1,6 +1,8 @@
 import { addHours, addDays, subDays, addMinutes } from "date-fns";
-import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
 import { toIsoDateTimeToUserTimezone } from "~/utils/date-fns";
+import type { ResolvedFormatPrefs } from "~/utils/date-format";
+import { HARDCODED_DEFAULT_PREFS } from "~/utils/date-format";
 import {
   BookingFormSchema,
   DuplicateBookingSchema,
@@ -13,6 +15,27 @@ import {
  *
  * See issue: Bug: Booking time restrictions affect OWNER and ADMIN users and they shouldn't
  */
+
+/**
+ * Resolved prefs carrying a specific zone. The schemas read only `timeZone`,
+ * but they take the whole `ResolvedFormatPrefs` on purpose — that is what makes
+ * a browser-hints object (`{ locale, timeZone }`) a compile error at every call
+ * site, so validation can never silently run in the hint zone while display and
+ * storage use the preference zone.
+ */
+function prefsFor(timeZone: string): ResolvedFormatPrefs {
+  return { ...HARDCODED_DEFAULT_PREFS, timeZone };
+}
+
+/**
+ * Prefs for the cases below that are not about timezones. These suites build
+ * their dates with `date-fns` relative to `new Date()`, i.e. in the RUNTIME
+ * zone, so they need the schema to read the wire string back in that same zone
+ * or every assertion shifts by the machine's offset.
+ */
+const RUNTIME_ZONE_PREFS = prefsFor(
+  Intl.DateTimeFormat().resolvedOptions().timeZone
+);
 
 describe("BookingFormSchema - time restrictions", () => {
   const baseBookingSettings = {
@@ -31,6 +54,7 @@ describe("BookingFormSchema - time restrictions", () => {
   describe("bufferStartTime restriction", () => {
     it("should enforce buffer time for BASE/SELF_SERVICE users", () => {
       const schema = BookingFormSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -63,6 +87,7 @@ describe("BookingFormSchema - time restrictions", () => {
 
     it("should bypass buffer time for ADMIN/OWNER users", () => {
       const schema = BookingFormSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -91,6 +116,7 @@ describe("BookingFormSchema - time restrictions", () => {
   describe("maxBookingLength restriction", () => {
     it("should enforce max booking length for BASE/SELF_SERVICE users", () => {
       const schema = BookingFormSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -125,6 +151,7 @@ describe("BookingFormSchema - time restrictions", () => {
 
     it("should bypass max booking length for ADMIN/OWNER users", () => {
       const schema = BookingFormSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -154,6 +181,7 @@ describe("BookingFormSchema - time restrictions", () => {
     it("should still enforce end date after start date for all users", () => {
       // This validation should apply to everyone
       const schema = BookingFormSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -189,6 +217,7 @@ describe("BookingFormSchema - time restrictions", () => {
   describe("default isAdminOrOwner behavior", () => {
     it("should default to false (enforce restrictions) when isAdminOrOwner is not provided", () => {
       const schema = BookingFormSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         action: "new",
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
@@ -232,6 +261,7 @@ describe("ExtendBookingSchema - time restrictions", () => {
   describe("maxBookingLength restriction", () => {
     it("should enforce max booking length for BASE/SELF_SERVICE users", () => {
       const schema = ExtendBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: false, // BASE/SELF_SERVICE user
@@ -260,6 +290,7 @@ describe("ExtendBookingSchema - time restrictions", () => {
 
     it("should bypass max booking length for ADMIN/OWNER users", () => {
       const schema = ExtendBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: true, // ADMIN/OWNER user
@@ -282,6 +313,7 @@ describe("ExtendBookingSchema - time restrictions", () => {
   describe("default isAdminOrOwner behavior", () => {
     it("should default to false (enforce restrictions) when isAdminOrOwner is not provided", () => {
       const schema = ExtendBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         // isAdminOrOwner not provided - should default to false
@@ -371,7 +403,7 @@ describe("BookingFormSchema - override timezone handling", () => {
 
   it("does not flag a 4/23 booking as closed when the override is for 4/24", () => {
     const schema = BookingFormSchema({
-      hints: { timeZone: "America/Chicago" } as any,
+      prefs: prefsFor("America/Chicago"),
       action: "new",
       workingHours: workingHoursWith424Closed,
       bookingSettings: baseBookingSettings,
@@ -401,7 +433,7 @@ describe("BookingFormSchema - override timezone handling", () => {
 
   it("still flags a 4/24 booking as closed when the override is for 4/24", () => {
     const schema = BookingFormSchema({
-      hints: { timeZone: "America/Chicago" } as any,
+      prefs: prefsFor("America/Chicago"),
       action: "new",
       workingHours: workingHoursWith424Closed,
       bookingSettings: baseBookingSettings,
@@ -440,7 +472,7 @@ describe("BookingFormSchema - override timezone handling", () => {
  * `z.coerce.date()`, which is interpreted in the server's local zone (UTC in
  * production). For users west of UTC, valid future bookings were rejected as
  * "Start date must be in the future". The fix parses the wire string with
- * Luxon using `hints.timeZone`.
+ * Luxon using `prefs.timeZone`.
  */
 describe("BookingFormSchema - datetime-local wire string (1HC regression)", () => {
   const baseBookingSettings = {
@@ -486,9 +518,9 @@ describe("BookingFormSchema - datetime-local wire string (1HC regression)", () =
   }
 
   it("accepts a future-but-soon booking when the user is west of UTC (NY)", () => {
-    const hints = { timeZone: "America/New_York" } as any;
+    const prefs = prefsFor("America/New_York");
     const schema = BookingFormSchema({
-      hints,
+      prefs,
       action: "new",
       workingHours: disabledWorkingHours,
       bookingSettings: baseBookingSettings,
@@ -518,9 +550,9 @@ describe("BookingFormSchema - datetime-local wire string (1HC regression)", () =
   });
 
   it("still rejects a past wire-string startDate", () => {
-    const hints = { timeZone: "America/New_York" } as any;
+    const prefs = prefsFor("America/New_York");
     const schema = BookingFormSchema({
-      hints,
+      prefs,
       action: "new",
       workingHours: disabledWorkingHours,
       bookingSettings: baseBookingSettings,
@@ -553,9 +585,9 @@ describe("BookingFormSchema - datetime-local wire string (1HC regression)", () =
   });
 
   it("rejects an invalid wire-string format", () => {
-    const hints = { timeZone: "America/New_York" } as any;
+    const prefs = prefsFor("America/New_York");
     const schema = BookingFormSchema({
-      hints,
+      prefs,
       action: "new",
       workingHours: disabledWorkingHours,
       bookingSettings: baseBookingSettings,
@@ -591,7 +623,7 @@ describe("BookingFormSchema - datetime-local wire string (1HC regression)", () =
    * UTC on the server and gets rejected by a 9–17 working-hours window.
    */
   it("accepts a working-hours-window booking from a non-UTC user (LA)", () => {
-    const hints = { timeZone: "America/Los_Angeles" } as any;
+    const prefs = prefsFor("America/Los_Angeles");
     // 9–17 every day so the test exercises a narrow window — pre-fix, the
     // server would format the parsed instant as 19:00 PDT-equivalent and
     // reject. Post-fix, components are read in the user's zone.
@@ -609,7 +641,7 @@ describe("BookingFormSchema - datetime-local wire string (1HC regression)", () =
       overrides: [],
     };
     const schema = BookingFormSchema({
-      hints,
+      prefs,
       action: "new",
       workingHours: enabledWorkingHours,
       bookingSettings: baseBookingSettings,
@@ -639,7 +671,7 @@ describe("BookingFormSchema - datetime-local wire string (1HC regression)", () =
   });
 
   it("rejects a working-hours-window booking outside the LA local window", () => {
-    const hints = { timeZone: "America/Los_Angeles" } as any;
+    const prefs = prefsFor("America/Los_Angeles");
     const enabledWorkingHours = {
       enabled: true,
       weeklySchedule: {
@@ -654,7 +686,7 @@ describe("BookingFormSchema - datetime-local wire string (1HC regression)", () =
       overrides: [],
     };
     const schema = BookingFormSchema({
-      hints,
+      prefs,
       action: "new",
       workingHours: enabledWorkingHours,
       bookingSettings: baseBookingSettings,
@@ -761,6 +793,7 @@ describe("DuplicateBookingSchema - date validation", () => {
   describe("bufferStartTime restriction", () => {
     it("enforces buffer time for BASE/SELF_SERVICE users", () => {
       const schema = DuplicateBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: false, // BASE/SELF_SERVICE user
@@ -783,6 +816,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
     it("bypasses buffer time for ADMIN/OWNER users", () => {
       const schema = DuplicateBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: true, // ADMIN/OWNER user
@@ -801,7 +835,7 @@ describe("DuplicateBookingSchema - date validation", () => {
   describe("working hours restrictions", () => {
     it("rejects a closed-day override with the real closed message", () => {
       const schema = DuplicateBookingSchema({
-        hints: { timeZone: "America/Chicago" } as any,
+        prefs: prefsFor("America/Chicago"),
         workingHours: workingHoursWith424Closed,
         bookingSettings: {
           ...baseBookingSettings,
@@ -828,7 +862,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
     it("rejects a non-working weekday", () => {
       const schema = DuplicateBookingSchema({
-        hints: { timeZone: "America/Chicago" } as any,
+        prefs: prefsFor("America/Chicago"),
         workingHours: weekdaysOnlyWorkingHours,
         bookingSettings: {
           ...baseBookingSettings,
@@ -855,7 +889,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
     it("accepts any future date when working hours are disabled", () => {
       const schema = DuplicateBookingSchema({
-        hints: { timeZone: "America/Chicago" } as any,
+        prefs: prefsFor("America/Chicago"),
         workingHours: disabledWorkingHours,
         bookingSettings: {
           ...baseBookingSettings,
@@ -879,6 +913,7 @@ describe("DuplicateBookingSchema - date validation", () => {
   describe("cross-field date validation", () => {
     it("rejects endDate <= startDate with the exact cross-field message on the endDate path", () => {
       const schema = DuplicateBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: {
           ...baseBookingSettings,
@@ -908,6 +943,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
     it("rejects bookings exceeding max length for BASE users but bypasses for ADMIN/OWNER", () => {
       const baseSchema = DuplicateBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: false,
@@ -931,6 +967,7 @@ describe("DuplicateBookingSchema - date validation", () => {
 
       // Same 72h window passes for an admin (buffer + max-length bypassed).
       const adminSchema = DuplicateBookingSchema({
+        prefs: RUNTIME_ZONE_PREFS,
         workingHours: disabledWorkingHours,
         bookingSettings: baseBookingSettings,
         isAdminOrOwner: true,
@@ -956,11 +993,13 @@ describe("DuplicateBookingSchema - date validation", () => {
   describe("parity with BookingFormSchema (action: new)", () => {
     const sharedSettings = baseBookingSettings;
     const dupSchema = DuplicateBookingSchema({
+      prefs: RUNTIME_ZONE_PREFS,
       workingHours: disabledWorkingHours,
       bookingSettings: sharedSettings,
       isAdminOrOwner: true,
     });
     const formSchema = BookingFormSchema({
+      prefs: RUNTIME_ZONE_PREFS,
       action: "new",
       workingHours: disabledWorkingHours,
       bookingSettings: sharedSettings,
@@ -1018,8 +1057,8 @@ describe("DuplicateBookingSchema - date validation", () => {
  * zone and the stored UTC instant is offset wrong.
  *
  * FIX: every booking action feeds `BookingFormSchema`/`coerceLocalDate` the
- * acting user's RESOLVED pref timezone (via a hints-like object whose
- * `timeZone` is overridden), and the edit form seeds its datetime-local inputs
+ * acting user's RESOLVED pref timezone (the `prefs` param, which only a
+ * `ResolvedFormatPrefs` satisfies), and the edit form seeds its datetime-local inputs
  * with `toIsoDateTimeToUserTimezone(utc, prefTimeZone).slice(0, 16)` — the SAME
  * zone display uses — instead of the browser-zone `dateForDateTimeInputValue`.
  *
@@ -1058,7 +1097,7 @@ describe("BookingFormSchema - pref timezone drives the stored UTC (config date f
 
   function parseStart(timeZone: string): Date {
     const schema = BookingFormSchema({
-      hints: { timeZone },
+      prefs: prefsFor(timeZone),
       action: "new",
       workingHours: disabledWorkingHours,
       bookingSettings: baseBookingSettings,
@@ -1111,7 +1150,7 @@ describe("BookingFormSchema - pref timezone drives the stored UTC (config date f
 
     // 2. Submit that wall-clock and parse it back with the pref zone.
     const schema = BookingFormSchema({
-      hints: { timeZone: PREF_ZONE },
+      prefs: prefsFor(PREF_ZONE),
       action: "new",
       workingHours: disabledWorkingHours,
       bookingSettings: baseBookingSettings,
@@ -1128,5 +1167,170 @@ describe("BookingFormSchema - pref timezone drives the stored UTC (config date f
       // Round-trip is lossless: back to the exact stored instant.
       expect((result.data.startDate as Date).toISOString()).toBe(storedUtc);
     }
+  });
+});
+
+/**
+ * Regression: a booking that starts SOON, for a user WEST of UTC.
+ *
+ * A caller that omitted the zone used to fall through to `coerceLocalDate`'s UTC
+ * default, so the typed wall-clock was read as UTC. For America/Chicago (UTC-5
+ * in summer) that shifts the instant 5 hours into the past, and the plain
+ * future-date check rejects it with "Start date must be in the future". The
+ * user therefore could not book anything less than their UTC offset ahead —
+ * reported from the field as "unable to create a booking unless the time is
+ * 5 hours in advance".
+ *
+ * `prefs` is now required AND typed as `ResolvedFormatPrefs`, so both omitting
+ * the zone and passing the browser hint are compile errors. These cases pin the
+ * runtime behaviour that made a wrong zone harmful, so the guarantee survives
+ * any future refactor of the parse.
+ */
+describe("BookingFormSchema - near-future start, user west of UTC", () => {
+  const disabledWorkingHours = {
+    enabled: false,
+    weeklySchedule: {},
+    overrides: [],
+  };
+
+  /** No advance-notice requirement, so only the plain future check applies. */
+  const noBufferSettings = {
+    bufferStartTime: 0,
+    tagsRequired: false,
+    maxBookingLength: null,
+    maxBookingLengthSkipClosedDays: false,
+  };
+
+  const validCustodian = JSON.stringify({
+    id: "tm-1",
+    name: "Test User",
+    userId: "user-1",
+  });
+
+  /** 2026-08-18 13:00 in America/Chicago (CDT, UTC-5) is 18:00Z. */
+  const NOW = new Date("2026-08-18T18:00:00.000Z");
+  const CHICAGO = "America/Chicago";
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  /** Builds the form payload for a start/end typed as local wall-clock. */
+  function parseWith(timeZone: string, startDate: string, endDate: string) {
+    return BookingFormSchema({
+      prefs: prefsFor(timeZone),
+      action: "new",
+      workingHours: disabledWorkingHours,
+      bookingSettings: noBufferSettings,
+      isAdminOrOwner: false,
+    }).safeParse({
+      name: "Book a printer this afternoon",
+      startDate,
+      endDate,
+      custodian: validCustodian,
+    });
+  }
+
+  /** Messages for a failed parse, or [] when it succeeded. */
+  function messages(result: ReturnType<typeof parseWith>) {
+    return result.success ? [] : result.error.errors.map((e) => e.message);
+  }
+
+  it("accepts a start 2 hours ahead when the user's own zone is used", () => {
+    // 13:00 Chicago now, booking 15:00-17:00 Chicago the same afternoon.
+    const result = parseWith(CHICAGO, "2026-08-18T15:00", "2026-08-18T17:00");
+    expect(messages(result)).toEqual([]);
+    expect(result.success).toBe(true);
+  });
+
+  it("reads that start as the correct absolute instant", () => {
+    const result = parseWith(CHICAGO, "2026-08-18T15:00", "2026-08-18T17:00");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // 15:00 CDT is 20:00Z, not 15:00Z.
+      expect((result.data.startDate as Date).toISOString()).toBe(
+        "2026-08-18T20:00:00.000Z"
+      );
+    }
+  });
+
+  it("rejects that same start when the zone is lost to UTC", () => {
+    // This is the shipped bug, reproduced by passing the fallback zone that an
+    // omitted zone used to produce. 15:00 read as UTC is 10:00 Chicago,
+    // three hours BEFORE the current 13:00, so it looks like the past.
+    const result = parseWith("UTC", "2026-08-18T15:00", "2026-08-18T17:00");
+    expect(result.success).toBe(false);
+    expect(messages(result)).toContain("Start date must be in the future");
+  });
+
+  it("shows the rejection window equals the user's UTC offset", () => {
+    // Under the bug the cliff sits exactly 5 hours out for UTC-5: everything
+    // earlier reads as past, 18:01 onwards reads as future.
+    const verdicts = ["14:00", "17:00", "18:00", "19:00"].map((time) => ({
+      time,
+      accepted: parseWith("UTC", `2026-08-18T${time}`, "2026-08-19T09:00")
+        .success,
+    }));
+
+    expect(verdicts).toEqual([
+      { time: "14:00", accepted: false }, // 1h ahead locally
+      { time: "17:00", accepted: false }, // 4h ahead locally
+      { time: "18:00", accepted: false }, // 5h ahead locally, still the cliff
+      { time: "19:00", accepted: true }, // 6h ahead locally, finally allowed
+    ]);
+  });
+});
+
+/**
+ * Pins the type-level guarantee that motivated the `prefs: ResolvedFormatPrefs`
+ * param.
+ *
+ * The runtime cases above prove that the WRONG zone rejects valid bookings, but
+ * nothing at runtime can stop a future caller from handing the schema a browser
+ * hint instead of the user's preference — the two are both "a timezone", and a
+ * bare `timeZone: string` param accepts either. `ResolvedFormatPrefs` makes that
+ * mistake a compile error, because a `ClientHint` (`{ locale, timeZone }`) is
+ * missing `dateFormat`, `timeFormat` and `weekStartsOn`.
+ *
+ * `@ts-expect-error` is the assertion here: this suite FAILS TO COMPILE — and so
+ * fails `typecheck` — if the param is ever loosened back to something a hints
+ * object satisfies. There is no runtime expectation to make; reaching the
+ * `expect` below at all means the guard still holds.
+ */
+describe("BookingFormSchema - prefs param rejects a browser-hints object", () => {
+  const disabledWorkingHours = {
+    enabled: false,
+    weeklySchedule: {},
+    overrides: [],
+  };
+
+  const baseBookingSettings = {
+    bufferStartTime: 0,
+    tagsRequired: false,
+    maxBookingLength: null,
+    maxBookingLengthSkipClosedDays: false,
+  };
+
+  it("does not accept ClientHint where ResolvedFormatPrefs is required", () => {
+    /** Exactly the shape `useHints()` / `getClientHint()` return. */
+    const browserHints = { locale: "en-US", timeZone: "America/Chicago" };
+
+    const build = () =>
+      BookingFormSchema({
+        // @ts-expect-error - a browser hint must NOT satisfy `prefs`; if this
+        // stops erroring, the compile-time guard is gone and the hint zone can
+        // silently diverge from the preference zone again.
+        prefs: browserHints,
+        action: "new",
+        workingHours: disabledWorkingHours,
+        bookingSettings: baseBookingSettings,
+        isAdminOrOwner: true,
+      });
+
+    expect(build).toBeTypeOf("function");
   });
 });

--- a/apps/webapp/app/components/booking/forms/forms-schema.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.ts
@@ -9,7 +9,7 @@ import {
   getOverrideDateKey,
   normalizeWorkingHoursForValidation,
 } from "~/modules/working-hours/utils";
-import type { getHints } from "~/utils/client-hints";
+import type { ResolvedFormatPrefs } from "~/utils/date-format";
 
 /**
  * Parses a `datetime-local` wire string (e.g. `"2026-05-01T16:10"`) in the
@@ -19,8 +19,11 @@ import type { getHints } from "~/utils/client-hints";
  *
  * Returns a Zod string schema whose `.transform()` yields a correct Date.
  *
- * @param timeZone - IANA zone (from `getHints(request).timeZone`). Falls back
- *   to UTC if missing.
+ * @param timeZone - IANA zone, always the acting user's RESOLVED preference
+ *   zone (`ResolvedFormatPrefs.timeZone`, which is non-optional). The `?? "UTC"`
+ *   is a defensive backstop for a hand-built prefs object, not a supported path
+ *   — see the docblock on {@link BookingFormSchemaParams} for why an implicit
+ *   UTC here is dangerous.
  */
 function coerceLocalDate(timeZone?: string) {
   const zone = timeZone ?? "UTC";
@@ -180,7 +183,36 @@ function validateFutureDate(
 }
 
 interface BookingFormSchemaParams {
-  hints?: ReturnType<typeof getHints>;
+  /**
+   * The acting user's fully-resolved formatting preferences. Only `timeZone` is
+   * read, but the whole object is taken deliberately — see below.
+   *
+   * REQUIRED, and typed as `ResolvedFormatPrefs` rather than a bare zone string
+   * or a browser-hints object, because BOTH weaker shapes have already shipped
+   * bugs:
+   *
+   * 1. OMITTING the zone. `coerceLocalDate` falls back to UTC, so every typed
+   *    wall-clock time is read as UTC. For a user west of UTC that makes
+   *    near-future starts look like the past, and "Start date must be in the
+   *    future" blocks them for the length of their UTC offset (5 hours in US
+   *    Central, 7 in US Pacific). That shipped for three months while this
+   *    param was optional and one caller omitted it.
+   *
+   * 2. Passing the BROWSER hint zone instead of the preference zone. Date
+   *    DISPLAY resolves through `resolveFormatPrefs`, where a stored user
+   *    preference WINS over the browser hint. Validating in the hint zone while
+   *    displaying and storing in the preference zone makes the form reject
+   *    times the server would accept (and vice-versa) for any user who set an
+   *    explicit timezone.
+   *
+   * `ResolvedFormatPrefs` closes (2) structurally: a `ClientHint` is only
+   * `{ locale, timeZone }`, so it does not satisfy this type and passing raw
+   * hints is a compile error rather than a silent wrong answer.
+   *
+   * Build it from `useFormatPrefs()` on the client, or
+   * `resolveUserFormatPrefsById(userId, getClientHint(request))` on the server.
+   */
+  prefs: ResolvedFormatPrefs;
   action: "new" | "save" | "reserve";
   status?: BookingStatus;
   workingHours: any; // Accept any type, normalize internally
@@ -209,7 +241,7 @@ interface BookingFormSchemaParams {
  */
 export type BookingDateSchemaParams = Pick<
   BookingFormSchemaParams,
-  "hints" | "workingHours" | "bookingSettings" | "isAdminOrOwner"
+  "prefs" | "workingHours" | "bookingSettings" | "isAdminOrOwner"
 >;
 
 /**
@@ -226,13 +258,13 @@ export type BookingDateSchemaParams = Pick<
  * restrictions are bypassed; working-hours restrictions still apply when
  * enabled.
  *
- * @param params - The hints, raw working hours, booking settings, and
- *   admin/owner flag. See {@link BookingDateSchemaParams}.
+ * @param params - The resolved format prefs, raw working hours, booking
+ *   settings, and admin/owner flag. See {@link BookingDateSchemaParams}.
  * @returns The `startDateSchema`, `endDateSchema`, and `crossFieldDateValidation`
  *   refinement, ready to compose into a `z.object(...).superRefine(...)`.
  */
 function buildBookingDateSchemas({
-  hints,
+  prefs,
   workingHours: rawWorkingHours,
   bookingSettings,
   isAdminOrOwner = false,
@@ -249,13 +281,13 @@ function buildBookingDateSchemas({
   const workingHours = normalizeWorkingHoursForValidation(rawWorkingHours);
 
   // Create enhanced date schemas with working hours and buffer validation
-  const startDateSchema = coerceLocalDate(hints?.timeZone).superRefine(
+  const startDateSchema = coerceLocalDate(prefs.timeZone).superRefine(
     (data, ctx) => {
       // 1. Validate future date with buffer (skipped for ADMIN/OWNER when effectiveBufferStartTime is 0)
       const futureValidation = validateFutureDate(
         data,
         effectiveBufferStartTime,
-        hints?.timeZone
+        prefs.timeZone
       );
       if (!futureValidation.isValid) {
         ctx.addIssue({
@@ -265,12 +297,13 @@ function buildBookingDateSchemas({
         return;
       }
 
-      // 2. Validate working hours if available
-      if (workingHours && hints?.timeZone) {
+      // 2. Validate working hours if available. `prefs.timeZone` is a
+      // non-optional resolved zone, so only the working-hours data can be absent.
+      if (workingHours) {
         const workingHoursValidation = validateWorkingHours(
           data,
           workingHours,
-          hints.timeZone
+          prefs.timeZone
         );
         if (!workingHoursValidation.isValid) {
           ctx.addIssue({
@@ -282,14 +315,14 @@ function buildBookingDateSchemas({
     }
   );
 
-  const endDateSchema = coerceLocalDate(hints?.timeZone).superRefine(
+  const endDateSchema = coerceLocalDate(prefs.timeZone).superRefine(
     (data, ctx) => {
       // Only validate working hours for end date (no future date requirement)
-      if (workingHours && hints?.timeZone) {
+      if (workingHours) {
         const validation = validateWorkingHours(
           data,
           workingHours,
-          hints.timeZone
+          prefs.timeZone
         );
         if (!validation.isValid) {
           ctx.addIssue({
@@ -364,7 +397,8 @@ function buildBookingDateSchemas({
  *   - Only base-level validation applies.
  *
  * @param params - The form schema inputs. See {@link BookingFormSchemaParams}.
- * @param params.hints - Client hints (timezone) used to coerce/validate dates.
+ * @param params.prefs - The acting user's resolved format prefs; its `timeZone`
+ *   is the zone every typed wall-clock date is coerced and validated in.
  * @param params.action - The form action ("new" | "save" | "reserve"); selects
  *   which field set and refinements apply.
  * @param params.status - The current booking status (drives the "save" branch).
@@ -377,7 +411,7 @@ function buildBookingDateSchemas({
  *   shaped per the given `action`/`status`.
  */
 export function BookingFormSchema({
-  hints,
+  prefs,
   action,
   status,
   workingHours: rawWorkingHours,
@@ -390,7 +424,7 @@ export function BookingFormSchema({
   // exactly the same rules as the duplicate dialog (single source of truth).
   const { startDateSchema, endDateSchema, crossFieldDateValidation } =
     buildBookingDateSchemas({
-      hints,
+      prefs,
       workingHours: rawWorkingHours,
       bookingSettings,
       isAdminOrOwner,
@@ -420,8 +454,8 @@ export function BookingFormSchema({
           userId: z.string().optional().nullable(),
         })
       ),
-    startDate: coerceLocalDate(hints?.timeZone).optional(),
-    endDate: coerceLocalDate(hints?.timeZone).optional(),
+    startDate: coerceLocalDate(prefs.timeZone).optional(),
+    endDate: coerceLocalDate(prefs.timeZone).optional(),
     tags: tagsRequired
       ? z.string().min(1, "At least one tag is required")
       : z.string().optional(),
@@ -489,20 +523,20 @@ export type BookingFormSchemaType = ReturnType<typeof BookingFormSchema>;
  * working-hours check, end-after-start check, and max-booking-length check all
  * produce identical messages and error paths (`startDate` / `endDate`).
  *
- * @param params - The hints, raw working hours, booking settings, and
- *   admin/owner flag. See {@link BookingDateSchemaParams}.
+ * @param params - The resolved format prefs, raw working hours, booking
+ *   settings, and admin/owner flag. See {@link BookingDateSchemaParams}.
  * @returns A `z.object({ startDate, endDate })` schema with the cross-field
  *   refinement applied via `superRefine`.
  */
 export function DuplicateBookingSchema({
-  hints,
+  prefs,
   workingHours,
   bookingSettings,
   isAdminOrOwner = false,
 }: BookingDateSchemaParams) {
   const { startDateSchema, endDateSchema, crossFieldDateValidation } =
     buildBookingDateSchemas({
-      hints,
+      prefs,
       workingHours,
       bookingSettings,
       isAdminOrOwner,
@@ -523,7 +557,15 @@ export type DuplicateBookingSchemaType = ReturnType<
 
 interface ExtendBookingSchemaParams {
   workingHours?: any;
-  timeZone?: string;
+  /**
+   * The acting user's fully-resolved formatting preferences. Same contract, and
+   * the same reasoning, as {@link BookingFormSchemaParams.prefs} — read that
+   * docblock before changing this type. This was previously an optional
+   * `timeZone?: string`, which let the extend dialog validate in the BROWSER
+   * zone while the server action parsed the submitted date in the PREFERENCE
+   * zone; the two disagreed for every user who had set an explicit timezone.
+   */
+  prefs: ResolvedFormatPrefs;
   bookingSettings: Pick<
     BookingSettings,
     "bufferStartTime" | "maxBookingLength" | "maxBookingLengthSkipClosedDays"
@@ -538,10 +580,11 @@ interface ExtendBookingSchemaParams {
 
 export function ExtendBookingSchema({
   workingHours: rawWorkingHours,
-  timeZone,
+  prefs,
   bookingSettings,
   isAdminOrOwner = false,
 }: ExtendBookingSchemaParams) {
+  const { timeZone } = prefs;
   const { bufferStartTime, maxBookingLength, maxBookingLengthSkipClosedDays } =
     bookingSettings;
 

--- a/apps/webapp/app/components/booking/forms/new-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/new-booking-form.tsx
@@ -14,7 +14,6 @@ import type {
   NewBookingActionReturnType,
   NewBookingLoaderReturnType,
 } from "~/routes/_layout+/bookings.new";
-import { useHints } from "~/utils/client-hints";
 
 import { getValidationErrors } from "~/utils/http";
 import { userCanViewSpecificCustody } from "~/utils/permissions/custody-and-bookings-permissions.validator.client";
@@ -62,10 +61,9 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
   const [, updateName] = useAtom(updateDynamicTitleAtom);
 
   const disabled = useDisabled(fetcher);
-  const hints = useHints();
   // TIMEZONE FIX: client-side date validation must use the user's RESOLVED
   // timezone preference (the same one display uses), not the browser hint, so
-  // it agrees with the server parse. Locale still comes from `hints`.
+  // it agrees with the server parse.
   const prefs = useFormatPrefs();
 
   // Fetch working hours for validation
@@ -89,7 +87,7 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
   const zo = useZorm(
     "NewQuestionWizardScreen",
     BookingFormSchema({
-      hints: { ...hints, timeZone: prefs.timeZone },
+      prefs,
       action: "new",
       workingHours: workingHours,
       bookingSettings,

--- a/apps/webapp/app/modules/api/mobile-body.server.ts
+++ b/apps/webapp/app/modules/api/mobile-body.server.ts
@@ -17,22 +17,46 @@
  * @see {@link file://../../utils/http.server.ts} parseData — the FormData equivalent for web routes
  */
 import { z } from "zod";
+import type { ErrorLabel } from "~/utils/error";
 import { ShelfError } from "~/utils/error";
 
 /**
- * Parse a mobile JSON body against a Zod schema, surfacing validation failures
- * as a 400 rather than an uncaptured 500.
+ * Read and validate a mobile JSON body, surfacing client-input failures as a
+ * 400 rather than an uncaptured 500.
+ *
+ * Takes the `Request` rather than an already-parsed body on purpose: a body that
+ * is not valid JSON makes `request.json()` throw a `SyntaxError`, which reaches
+ * the same generic 500 + Sentry branch this helper exists to avoid. Parsing here
+ * keeps both failure modes — unparseable JSON and schema-invalid JSON — on the
+ * 400 path.
  *
  * @param schema - The Zod schema describing the expected body.
- * @param body - The parsed JSON from `await request.json()`.
+ * @param request - The incoming request whose JSON body to read.
+ * @param label - `ShelfError` label for the thrown error. Defaults to "Booking"
+ *   since the booking actions are the current callers; pass the owning domain
+ *   when reusing this from another mobile route.
  * @returns The validated, typed body.
- * @throws {ShelfError} 400 (not captured) when validation fails; rethrows
- *   anything that is not a `ZodError` untouched.
+ * @throws {ShelfError} 400 (not captured) for unparseable JSON or schema
+ *   violations; rethrows anything else untouched.
  */
-export function parseMobileBody<Schema extends z.ZodTypeAny>(
+export async function parseMobileBody<Schema extends z.ZodTypeAny>(
   schema: Schema,
-  body: unknown
-): z.infer<Schema> {
+  request: Request,
+  label: ErrorLabel = "Booking"
+): Promise<z.infer<Schema>> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Request body must be valid JSON.",
+      label,
+      status: 400,
+      shouldBeCaptured: false,
+    });
+  }
+
   try {
     return schema.parse(body);
   } catch (cause) {
@@ -42,7 +66,7 @@ export function parseMobileBody<Schema extends z.ZodTypeAny>(
         // Name the offending field so "Time zone must be a valid IANA zone"
         // reaches the client instead of a generic failure.
         message: cause.errors[0]?.message ?? "Invalid request body.",
-        label: "Booking",
+        label,
         status: 400,
         shouldBeCaptured: false,
       });

--- a/apps/webapp/app/modules/api/mobile-body.server.ts
+++ b/apps/webapp/app/modules/api/mobile-body.server.ts
@@ -1,0 +1,52 @@
+/**
+ * Mobile API request-body validation.
+ *
+ * The `api+/mobile+/*` actions validate their JSON body with a Zod schema and
+ * then let the route's outer `catch` turn anything thrown into a response. A
+ * bare `schema.parse()` throws a `ZodError`, which `makeShelfError` does not
+ * recognise — it falls through to the generic branch and becomes a **500** with
+ * the message "Sorry, something went wrong.", captured to Sentry. That is the
+ * wrong answer for a malformed client payload twice over: the caller gets a
+ * server-error status for their own bad input, and the noise reaches Sentry.
+ *
+ * This helper converts the `ZodError` into the same shape the routes already use
+ * for their `BookingFormSchema` validation — a 400 carrying the first
+ * user-facing message, with `shouldBeCaptured: false`.
+ *
+ * @see {@link file://../../utils/error.ts} makeShelfError — the generic branch this avoids
+ * @see {@link file://../../utils/http.server.ts} parseData — the FormData equivalent for web routes
+ */
+import { z } from "zod";
+import { ShelfError } from "~/utils/error";
+
+/**
+ * Parse a mobile JSON body against a Zod schema, surfacing validation failures
+ * as a 400 rather than an uncaptured 500.
+ *
+ * @param schema - The Zod schema describing the expected body.
+ * @param body - The parsed JSON from `await request.json()`.
+ * @returns The validated, typed body.
+ * @throws {ShelfError} 400 (not captured) when validation fails; rethrows
+ *   anything that is not a `ZodError` untouched.
+ */
+export function parseMobileBody<Schema extends z.ZodTypeAny>(
+  schema: Schema,
+  body: unknown
+): z.infer<Schema> {
+  try {
+    return schema.parse(body);
+  } catch (cause) {
+    if (cause instanceof z.ZodError) {
+      throw new ShelfError({
+        cause,
+        // Name the offending field so "Time zone must be a valid IANA zone"
+        // reaches the client instead of a generic failure.
+        message: cause.errors[0]?.message ?? "Invalid request body.",
+        label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+    throw cause;
+  }
+}

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.duplicate.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.duplicate.tsx
@@ -50,7 +50,7 @@ import { getBookingSettingsForOrganization } from "~/modules/booking-settings/se
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getBookingDefaultStartEndTimes } from "~/modules/working-hours/utils";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
-import { getClientHint, getHints, useHints } from "~/utils/client-hints";
+import { getClientHint } from "~/utils/client-hints";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
@@ -143,13 +143,12 @@ export async function action({ request, context, params }: ActionFunctionArgs) {
     });
 
     const formData = await request.formData();
-    const hints = getHints(request);
     // TIMEZONE FIX: parse the submitted wall-clock dates in the acting user's
     // RESOLVED pref timezone (matches display), not the browser hint.
-    const prefTimeZone = (
-      await resolveUserFormatPrefsById(userId, getClientHint(request))
-    ).timeZone;
-    const hintsWithPrefTz = { ...hints, timeZone: prefTimeZone };
+    const prefs = await resolveUserFormatPrefsById(
+      userId,
+      getClientHint(request)
+    );
     const workingHours = await getWorkingHoursForOrganization(organizationId);
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
@@ -166,7 +165,7 @@ export async function action({ request, context, params }: ActionFunctionArgs) {
     const { startDate: from, endDate: to } = parseData(
       formData,
       DuplicateBookingSchema({
-        hints: hintsWithPrefTz,
+        prefs,
         workingHours,
         bookingSettings,
         isAdminOrOwner,
@@ -234,10 +233,9 @@ export default function DuplicateBooking() {
   const actionData = useActionData<DataOrErrorResponse>();
 
   const disabled = useDisabled();
-  const hints = useHints();
   // TIMEZONE FIX: client-side date validation must use the user's RESOLVED
   // timezone preference (the same one display uses), not the browser hint, so
-  // it agrees with the server parse. Locale still comes from `hints`.
+  // it agrees with the server parse.
   const prefs = useFormatPrefs();
 
   // Working hours + booking settings drive the date defaults and validation,
@@ -272,7 +270,7 @@ export default function DuplicateBooking() {
   const zo = useZorm(
     "DuplicateBooking",
     DuplicateBookingSchema({
-      hints: { ...hints, timeZone: prefs.timeZone },
+      prefs,
       workingHours,
       bookingSettings,
       isAdminOrOwner: isAdministratorOrOwner,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -91,7 +91,7 @@ import {
   canUserRemoveBookingAssets,
 } from "~/utils/bookings";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
-import { getClientHint, getHints } from "~/utils/client-hints";
+import { getClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import {
   setCookie,
@@ -1576,20 +1576,19 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     switch (intent) {
       case "save": {
-        const hints = getHints(request);
         // TIMEZONE FIX: parse submitted wall-clock dates in the acting user's
         // RESOLVED timezone preference (the same one date DISPLAY uses), not the
         // browser hint. Resolved lazily — only this date-parsing branch needs it.
-        const prefTimeZone = (
-          await resolveUserFormatPrefsById(userId, getClientHint(request))
-        ).timeZone;
-        const hintsWithPrefTz = { ...hints, timeZone: prefTimeZone };
+        const prefs = await resolveUserFormatPrefsById(
+          userId,
+          getClientHint(request)
+        );
         const parsedData = parseData(
           formData,
           BookingFormSchema({
             action: "save",
             status: basicBookingInfo.status,
-            hints: hintsWithPrefTz,
+            prefs,
             workingHours,
             bookingSettings,
             isAdminOrOwner,
@@ -1604,13 +1603,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
         const formattedFrom = from
           ? DateTime.fromFormat(from.toString(), DATE_TIME_FORMAT, {
-              zone: prefTimeZone,
+              zone: prefs.timeZone,
             }).toJSDate()
           : undefined;
 
         const formattedTo = to
           ? DateTime.fromFormat(to.toString(), DATE_TIME_FORMAT, {
-              zone: prefTimeZone,
+              zone: prefs.timeZone,
             }).toJSDate()
           : undefined;
 
@@ -1642,19 +1641,18 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
       case "reserve": {
-        const hints = getHints(request);
         // TIMEZONE FIX: parse submitted wall-clock dates in the acting user's
         // RESOLVED timezone preference (the same one date DISPLAY uses), not the
         // browser hint. Resolved lazily — only this date-parsing branch needs it.
-        const prefTimeZone = (
-          await resolveUserFormatPrefsById(userId, getClientHint(request))
-        ).timeZone;
-        const hintsWithPrefTz = { ...hints, timeZone: prefTimeZone };
+        const prefs = await resolveUserFormatPrefsById(
+          userId,
+          getClientHint(request)
+        );
 
         const parsedData = parseData(
           formData,
           BookingFormSchema({
-            hints: hintsWithPrefTz,
+            prefs,
             action: "reserve",
             status: basicBookingInfo.status,
             workingHours,
@@ -1672,13 +1670,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
         const formattedFrom = from
           ? DateTime.fromFormat(from.toString(), DATE_TIME_FORMAT, {
-              zone: prefTimeZone,
+              zone: prefs.timeZone,
             }).toJSDate()
           : undefined;
 
         const formattedTo = to
           ? DateTime.fromFormat(to.toString(), DATE_TIME_FORMAT, {
-              zone: prefTimeZone,
+              zone: prefs.timeZone,
             }).toJSDate()
           : undefined;
 
@@ -2055,14 +2053,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         // TIMEZONE FIX: parse the submitted wall-clock end date in the acting
         // user's RESOLVED pref timezone (matches display), not the browser
         // hint. Resolved lazily — only this date-parsing branch needs it.
-        const prefTimeZone = (await resolveUserFormatPrefsById(userId, hints))
-          .timeZone;
+        const prefs = await resolveUserFormatPrefsById(userId, hints);
 
         const { endDate } = parseData(
           formData,
           ExtendBookingSchema({
             workingHours,
-            timeZone: prefTimeZone,
+            prefs,
             bookingSettings,
             isAdminOrOwner,
           }),

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -5,7 +5,6 @@ import {
   OrganizationRoles,
   type Prisma,
 } from "@prisma/client";
-import { DateTime } from "luxon";
 import type {
   ActionFunctionArgs,
   LinksFunction,
@@ -92,7 +91,6 @@ import {
 } from "~/utils/bookings";
 import { checkExhaustiveSwitch } from "~/utils/check-exhaustive-switch";
 import { getClientHint } from "~/utils/client-hints";
-import { DATE_TIME_FORMAT } from "~/utils/constants";
 import {
   setCookie,
   updateCookieWithPerPage,
@@ -1598,20 +1596,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           }
         );
 
-        const from = formData.get("startDate");
-        const to = formData.get("endDate");
-
-        const formattedFrom = from
-          ? DateTime.fromFormat(from.toString(), DATE_TIME_FORMAT, {
-              zone: prefs.timeZone,
-            }).toJSDate()
-          : undefined;
-
-        const formattedTo = to
-          ? DateTime.fromFormat(to.toString(), DATE_TIME_FORMAT, {
-              zone: prefs.timeZone,
-            }).toJSDate()
-          : undefined;
+        // Use the schema-coerced instants rather than re-parsing the raw form
+        // fields: `coerceLocalDate` accepts second precision via `fromISO`,
+        // while DATE_TIME_FORMAT is minute-only, so a value the schema accepted
+        // could re-parse to an Invalid Date and reach the service. Same
+        // reasoning as the duplicate dialog and the extend branch below.
+        const formattedFrom = parsedData.startDate;
+        const formattedTo = parsedData.endDate;
 
         const tags = buildTagsSet(parsedData.tags).set;
 
@@ -1664,21 +1655,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           }
         );
 
-        const from = formData.get("startDate");
-        const to = formData.get("endDate");
         const tags = buildTagsSet(parsedData.tags).set;
 
-        const formattedFrom = from
-          ? DateTime.fromFormat(from.toString(), DATE_TIME_FORMAT, {
-              zone: prefs.timeZone,
-            }).toJSDate()
-          : undefined;
-
-        const formattedTo = to
-          ? DateTime.fromFormat(to.toString(), DATE_TIME_FORMAT, {
-              zone: prefs.timeZone,
-            }).toJSDate()
-          : undefined;
+        // Schema-coerced instants, not a re-parse of the raw form fields — see
+        // the "save" branch above for why the minute-only DATE_TIME_FORMAT
+        // cannot be used on a value `coerceLocalDate` already accepted.
+        const formattedFrom = parsedData.startDate;
+        const formattedTo = parsedData.endDate;
 
         const booking = await reserveBooking({
           id,

--- a/apps/webapp/app/routes/_layout+/bookings.new.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.new.tsx
@@ -36,7 +36,7 @@ import {
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import styles from "~/styles/layout/bookings.new.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
-import { getClientHint, getHints } from "~/utils/client-hints";
+import { getClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { setCookie } from "~/utils/cookies.server";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
@@ -170,16 +170,15 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     const formData = await request.formData();
     const intent = formData.get("intent") as string;
-    const hints = getHints(request);
     // TIMEZONE FIX: parse the submitted wall-clock date in the acting user's
     // RESOLVED timezone preference (the same one date DISPLAY uses), not the
     // browser hint. When the two differ (e.g. pref Europe/London, browser
     // UTC+3) the browser hint interprets the typed wall-clock in the wrong
-    // zone and stores the wrong UTC instant. Locale still comes from `hints`.
-    const prefTimeZone = (
-      await resolveUserFormatPrefsById(userId, getClientHint(request))
-    ).timeZone;
-    const hintsWithPrefTz = { ...hints, timeZone: prefTimeZone };
+    // zone and stores the wrong UTC instant.
+    const prefs = await resolveUserFormatPrefsById(
+      userId,
+      getClientHint(request)
+    );
     const workingHours = await getWorkingHoursForOrganization(organizationId);
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
@@ -190,7 +189,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
     const payload = parseData(
       formData,
       BookingFormSchema({
-        hints: hintsWithPrefTz,
+        prefs,
         action: "new",
         workingHours,
         bookingSettings,
@@ -245,7 +244,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
       formData.get("startDate")!.toString()!,
       DATE_TIME_FORMAT,
       {
-        zone: prefTimeZone,
+        zone: prefs.timeZone,
       }
     ).toJSDate();
 
@@ -253,7 +252,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
       formData.get("endDate")!.toString()!,
       DATE_TIME_FORMAT,
       {
-        zone: prefTimeZone,
+        zone: prefs.timeZone,
       }
     ).toJSDate();
 

--- a/apps/webapp/app/routes/_layout+/bookings.new.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.new.tsx
@@ -1,5 +1,4 @@
 import { useAtomValue } from "jotai";
-import { DateTime } from "luxon";
 import type {
   ActionFunctionArgs,
   LinksFunction,
@@ -37,7 +36,6 @@ import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.
 import styles from "~/styles/layout/bookings.new.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { getClientHint } from "~/utils/client-hints";
-import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { setCookie } from "~/utils/cookies.server";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
@@ -210,6 +208,13 @@ export async function action({ context, request }: ActionFunctionArgs) {
       assetIds,
       description,
       tags: commaSeparatedTags,
+      // Use the schema-coerced instants rather than re-parsing the raw form
+      // field: `coerceLocalDate` accepts second precision via `fromISO`, while
+      // DATE_TIME_FORMAT is minute-only, so a value the schema accepted could
+      // re-parse to an Invalid Date and reach the service. Same reasoning as
+      // the duplicate dialog and the extend branch.
+      startDate: from,
+      endDate: to,
     } = payload;
 
     // Validate that the custodian belongs to the same organization
@@ -240,21 +245,20 @@ export async function action({ context, request }: ActionFunctionArgs) {
       });
     }
 
-    const from = DateTime.fromFormat(
-      formData.get("startDate")!.toString()!,
-      DATE_TIME_FORMAT,
-      {
-        zone: prefs.timeZone,
-      }
-    ).toJSDate();
-
-    const to = DateTime.fromFormat(
-      formData.get("endDate")!.toString()!,
-      DATE_TIME_FORMAT,
-      {
-        zone: prefs.timeZone,
-      }
-    ).toJSDate();
+    // `BookingFormSchema` returns a union across its action branches, so the
+    // coerced dates widen to `Date | undefined` even though the "new" branch
+    // makes both required. Assert that at runtime rather than with `!`: a
+    // missing date is a 400, never an Invalid Date handed to `createBooking`.
+    if (!from || !to) {
+      throw new ShelfError({
+        cause: null,
+        message: "Booking start and end dates are required.",
+        additionalData: { userId, organizationId },
+        label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
 
     const tags = buildTagsSet(commaSeparatedTags).set;
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
@@ -16,6 +16,7 @@ import { getTeamMember } from "~/modules/team-member/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -139,6 +140,15 @@ export async function action({ request }: ActionFunctionArgs) {
       timeZone: body.timeZone,
     };
 
+    // TIMEZONE FIX: read the typed wall-clock in the acting user's RESOLVED
+    // preference zone, exactly as the web action does. A stored preference wins;
+    // when the user has none, this resolves to the device zone above, so the
+    // behaviour is unchanged for everyone who never set one. Without this, a
+    // user with an explicit preference got mobile validation and storage in the
+    // device zone while the companion DISPLAYED the same booking in the
+    // preference zone.
+    const prefs = await resolveUserFormatPrefsById(userId, hints);
+
     // Business-rule validation via the shared web schema. We shape the JSON body
     // into the form-data shape the schema expects (custodian as a JSON string,
     // tags as a comma-separated string) so the rules stay byte-identical to web.
@@ -148,7 +158,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     try {
       BookingFormSchema({
-        hints,
+        prefs,
         action: "new",
         workingHours,
         bookingSettings,
@@ -185,11 +195,13 @@ export async function action({ request }: ActionFunctionArgs) {
     // so a value can pass validation yet not match DATE_TIME_FORMAT here and
     // become an Invalid Date. Guard explicitly before handing dates to the
     // service (otherwise `Invalid Date` would silently flow into createBooking).
+    // Same zone the schema validated in, so the stored instant matches the
+    // wall-clock that just passed validation.
     const fromDt = DateTime.fromFormat(body.startDate, DATE_TIME_FORMAT, {
-      zone: body.timeZone,
+      zone: prefs.timeZone,
     });
     const toDt = DateTime.fromFormat(body.endDate, DATE_TIME_FORMAT, {
-      zone: body.timeZone,
+      zone: prefs.timeZone,
     });
     if (!fromDt.isValid || !toDt.isValid) {
       throw new ShelfError({

--- a/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
@@ -9,6 +9,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { createBooking } from "~/modules/booking/service.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import { getTeamMember } from "~/modules/team-member/service.server";
@@ -99,7 +100,7 @@ export async function action({ request }: ActionFunctionArgs) {
     // of the web route-layer gate).
     await assertMobileCanUseBookings(organizationId);
 
-    const body = BodySchema.parse(await request.json());
+    const body = parseMobileBody(BodySchema, await request.json());
 
     // Resolve the caller's role to branch self-service rules + admin bypass.
     const { role } = await getMobileUserContext(user.id, organizationId);

--- a/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
@@ -100,7 +100,7 @@ export async function action({ request }: ActionFunctionArgs) {
     // of the web route-layer gate).
     await assertMobileCanUseBookings(organizationId);
 
-    const body = parseMobileBody(BodySchema, await request.json());
+    const body = await parseMobileBody(BodySchema, request);
 
     // Resolve the caller's role to branch self-service rules + admin bypass.
     const { role } = await getMobileUserContext(user.id, organizationId);

--- a/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
@@ -1,5 +1,4 @@
 import { OrganizationRoles } from "@prisma/client";
-import { DateTime } from "luxon";
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
 import { BookingFormSchema } from "~/components/booking/forms/forms-schema";
@@ -15,7 +14,6 @@ import { getBookingSettingsForOrganization } from "~/modules/booking-settings/se
 import { getTeamMember } from "~/modules/team-member/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
-import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { isValidTimeZone } from "~/utils/date-format";
 import { prefsForDeclaredZone } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -161,8 +159,9 @@ export async function action({ request }: ActionFunctionArgs) {
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
 
+    let parsedBooking;
     try {
-      BookingFormSchema({
+      parsedBooking = BookingFormSchema({
         prefs,
         action: "new",
         workingHours,
@@ -196,19 +195,14 @@ export async function action({ request }: ActionFunctionArgs) {
       throw cause;
     }
 
-    // BookingFormSchema validates the dates with the broader `coerceLocalDate`,
-    // so a value can pass validation yet not match DATE_TIME_FORMAT here and
-    // become an Invalid Date. Guard explicitly before handing dates to the
-    // service (otherwise `Invalid Date` would silently flow into createBooking).
-    // Same zone the schema validated in, so the stored instant matches the
-    // wall-clock that just passed validation.
-    const fromDt = DateTime.fromFormat(body.startDate, DATE_TIME_FORMAT, {
-      zone: prefs.timeZone,
-    });
-    const toDt = DateTime.fromFormat(body.endDate, DATE_TIME_FORMAT, {
-      zone: prefs.timeZone,
-    });
-    if (!fromDt.isValid || !toDt.isValid) {
+    // Use the instants the schema already produced rather than re-parsing the
+    // raw body: `coerceLocalDate` accepts second precision via `fromISO`, while
+    // DATE_TIME_FORMAT is minute-only, so re-parsing could reject a payload the
+    // schema had just accepted. Reusing the result also guarantees the stored
+    // instant is the one that was validated, in the same declared zone.
+    const from = parsedBooking.startDate;
+    const to = parsedBooking.endDate;
+    if (!from || !to) {
       throw new ShelfError({
         cause: null,
         message: "Invalid booking start or end date.",
@@ -217,8 +211,6 @@ export async function action({ request }: ActionFunctionArgs) {
         shouldBeCaptured: false,
       });
     }
-    const from = fromDt.toJSDate();
-    const to = toDt.toJSDate();
 
     const booking = await createBooking({
       booking: {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
@@ -17,7 +17,7 @@ import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { isValidTimeZone } from "~/utils/date-format";
-import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
+import { prefsForDeclaredZone } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -68,10 +68,10 @@ const BodySchema = z.object({
   custodianTeamMemberId: z.string().min(1, "Please select a custodian"),
   startDate: z.string().min(1, "Start date is required"),
   endDate: z.string().min(1, "End date is required"),
-  // Must be a real IANA zone: an unrecognised string is discarded by
-  // `resolveFormatPrefs`, which then falls back to UTC for any user without a
-  // stored timezone preference — silently reintroducing the wrong-zone bug this
-  // route was fixed for. Reject it at the boundary instead.
+  // Must be a real IANA zone. The declared zone is what every date on this
+  // request is decoded in, so an unrecognised one makes Luxon yield an invalid
+  // DateTime and surfaces as a vague "Invalid date format" against the date
+  // fields. Reject it here instead, naming the field that is actually wrong.
   timeZone: z
     .string()
     .min(1, "Time zone is required")
@@ -148,14 +148,11 @@ export async function action({ request }: ActionFunctionArgs) {
       timeZone: body.timeZone,
     };
 
-    // TIMEZONE FIX: read the typed wall-clock in the acting user's RESOLVED
-    // preference zone, exactly as the web action does. A stored preference wins;
-    // when the user has none, this resolves to the device zone above, so the
-    // behaviour is unchanged for everyone who never set one. Without this, a
-    // user with an explicit preference got mobile validation and storage in the
-    // device zone while the companion DISPLAYED the same booking in the
-    // preference zone.
-    const prefs = await resolveUserFormatPrefsById(userId, hints);
+    // Decode the wall-clock in the zone the client DECLARED it in, not the
+    // user's preference zone: the companion builds `startDate`/`endDate` from
+    // device-local components and sends the matching zone, so any other zone
+    // yields a different instant than the picker showed.
+    const prefs = prefsForDeclaredZone(body.timeZone);
 
     // Business-rule validation via the shared web schema. We shape the JSON body
     // into the form-data shape the schema expects (custodian as a JSON string,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.create.ts
@@ -16,6 +16,7 @@ import { getTeamMember } from "~/modules/team-member/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { isValidTimeZone } from "~/utils/date-format";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
@@ -67,7 +68,14 @@ const BodySchema = z.object({
   custodianTeamMemberId: z.string().min(1, "Please select a custodian"),
   startDate: z.string().min(1, "Start date is required"),
   endDate: z.string().min(1, "End date is required"),
-  timeZone: z.string().min(1, "Time zone is required"),
+  // Must be a real IANA zone: an unrecognised string is discarded by
+  // `resolveFormatPrefs`, which then falls back to UTC for any user without a
+  // stored timezone preference — silently reintroducing the wrong-zone bug this
+  // route was fixed for. Reject it at the boundary instead.
+  timeZone: z
+    .string()
+    .min(1, "Time zone is required")
+    .refine(isValidTimeZone, "Time zone must be a valid IANA zone"),
   tags: z.array(z.string()).optional().default([]),
   assetIds: z.array(z.string()).optional().default([]),
 });

--- a/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
@@ -12,6 +12,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import {
   getBookingFlags,
   reserveBooking,
@@ -83,7 +84,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId, timeZone } = BodySchema.parse(await request.json());
+    const { bookingId, timeZone } = parseMobileBody(
+      BodySchema,
+      await request.json()
+    );
 
     const { role } = await getMobileUserContext(user.id, organizationId);
     const isSelfServiceOrBase =

--- a/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
@@ -20,6 +20,7 @@ import { getBookingSettingsForOrganization } from "~/modules/booking-settings/se
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { isValidTimeZone } from "~/utils/date-format";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
@@ -55,7 +56,11 @@ import { enforceUserRateLimit } from "~/utils/rate-limit.server";
 
 const BodySchema = z.object({
   bookingId: z.string().min(1),
-  timeZone: z.string().min(1, "Time zone is required"),
+  // See `bookings.create.ts` — an unrecognised zone silently resolves to UTC.
+  timeZone: z
+    .string()
+    .min(1, "Time zone is required")
+    .refine(isValidTimeZone, "Time zone must be a valid IANA zone"),
 });
 
 export async function action({ request }: ActionFunctionArgs) {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
@@ -84,10 +84,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId, timeZone } = parseMobileBody(
-      BodySchema,
-      await request.json()
-    );
+    const { bookingId, timeZone } = await parseMobileBody(BodySchema, request);
 
     const { role } = await getMobileUserContext(user.id, organizationId);
     const isSelfServiceOrBase =

--- a/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
@@ -20,6 +20,7 @@ import { getBookingSettingsForOrganization } from "~/modules/booking-settings/se
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -222,6 +223,11 @@ export async function action({ request }: ActionFunctionArgs) {
       timeZone,
     };
 
+    // TIMEZONE FIX: evaluate the booking's wall-clock in the acting user's
+    // RESOLVED preference zone, matching the web reserve action. Falls back to
+    // the device zone above when no preference is stored. See `bookings.create.ts`.
+    const prefs = await resolveUserFormatPrefsById(userId, hints);
+
     // Full validation parity with the web reserve action. The stored dates are
     // round-tripped to the form's local-string shape so the shared schema's
     // working-hours / buffer / max-length rules apply.
@@ -229,16 +235,18 @@ export async function action({ request }: ActionFunctionArgs) {
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
 
+    // Format and re-parse in the SAME zone the schema validates in, otherwise
+    // this round-trip would shift the instant it is meant to preserve.
     const startDate = DateTime.fromJSDate(booking.from)
-      .setZone(timeZone)
+      .setZone(prefs.timeZone)
       .toFormat(DATE_TIME_FORMAT);
     const endDate = DateTime.fromJSDate(booking.to)
-      .setZone(timeZone)
+      .setZone(prefs.timeZone)
       .toFormat(DATE_TIME_FORMAT);
 
     try {
       BookingFormSchema({
-        hints,
+        prefs,
         action: "reserve",
         status: booking.status,
         workingHours,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.reserve.ts
@@ -56,7 +56,7 @@ import { enforceUserRateLimit } from "~/utils/rate-limit.server";
 
 const BodySchema = z.object({
   bookingId: z.string().min(1),
-  // See `bookings.create.ts` — an unrecognised zone silently resolves to UTC.
+  // Must be a real IANA zone — see `bookings.create.ts`.
   timeZone: z
     .string()
     .min(1, "Time zone is required")

--- a/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
@@ -17,6 +17,7 @@ import { getTeamMember } from "~/modules/team-member/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -151,6 +152,11 @@ export async function action({ request }: ActionFunctionArgs) {
       timeZone: body.timeZone,
     };
 
+    // TIMEZONE FIX: read the typed wall-clock in the acting user's RESOLVED
+    // preference zone, matching the web action. Falls back to the device zone
+    // above when the user has no stored preference. See `bookings.create.ts`.
+    const prefs = await resolveUserFormatPrefsById(userId, hints);
+
     // Business-rule validation via the shared web schema. The "save" action +
     // current status picks the right rule set (active bookings skip the date
     // rules; DRAFTs validate future/buffer/working-hours/max-length).
@@ -160,7 +166,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     try {
       BookingFormSchema({
-        hints,
+        prefs,
         action: "save",
         status: existing.status,
         workingHours,
@@ -195,14 +201,16 @@ export async function action({ request }: ActionFunctionArgs) {
     // Dates + custodian only apply to DRAFT bookings (updateBasicBooking
     // re-gates this internally); parse the dates only when they will be used.
     const isDraft = existing.status === BookingStatus.DRAFT;
+    // Same zone the schema validated in, so the stored instant matches the
+    // wall-clock that just passed validation.
     const from = isDraft
       ? DateTime.fromFormat(body.startDate, DATE_TIME_FORMAT, {
-          zone: body.timeZone,
+          zone: prefs.timeZone,
         }).toJSDate()
       : undefined;
     const to = isDraft
       ? DateTime.fromFormat(body.endDate, DATE_TIME_FORMAT, {
-          zone: body.timeZone,
+          zone: prefs.timeZone,
         }).toJSDate()
       : undefined;
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
@@ -17,6 +17,7 @@ import { getTeamMember } from "~/modules/team-member/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
+import { isValidTimeZone } from "~/utils/date-format";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
@@ -61,7 +62,11 @@ const BodySchema = z.object({
   custodianTeamMemberId: z.string().min(1, "Please select a custodian"),
   startDate: z.string().min(1, "Start date is required"),
   endDate: z.string().min(1, "End date is required"),
-  timeZone: z.string().min(1, "Time zone is required"),
+  // See `bookings.create.ts` — an unrecognised zone silently resolves to UTC.
+  timeZone: z
+    .string()
+    .min(1, "Time zone is required")
+    .refine(isValidTimeZone, "Time zone must be a valid IANA zone"),
   tags: z.array(z.string()).optional().default([]),
 });
 
@@ -203,16 +208,33 @@ export async function action({ request }: ActionFunctionArgs) {
     const isDraft = existing.status === BookingStatus.DRAFT;
     // Same zone the schema validated in, so the stored instant matches the
     // wall-clock that just passed validation.
-    const from = isDraft
+    const fromDt = isDraft
       ? DateTime.fromFormat(body.startDate, DATE_TIME_FORMAT, {
           zone: prefs.timeZone,
-        }).toJSDate()
+        })
       : undefined;
-    const to = isDraft
+    const toDt = isDraft
       ? DateTime.fromFormat(body.endDate, DATE_TIME_FORMAT, {
           zone: prefs.timeZone,
-        }).toJSDate()
+        })
       : undefined;
+
+    // BookingFormSchema validates the dates with the broader `coerceLocalDate`,
+    // so a value can pass validation yet not match DATE_TIME_FORMAT here and
+    // become an Invalid Date. Guard before handing dates to the service, as the
+    // create path does — otherwise `Invalid Date` flows into updateBasicBooking.
+    if ((fromDt && !fromDt.isValid) || (toDt && !toDt.isValid)) {
+      throw new ShelfError({
+        cause: null,
+        message: "Invalid booking start or end date.",
+        label: "Booking",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const from = fromDt?.toJSDate();
+    const to = toDt?.toJSDate();
 
     const booking = await updateBasicBooking({
       id: body.bookingId,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
@@ -88,7 +88,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const body = parseMobileBody(BodySchema, await request.json());
+    const body = await parseMobileBody(BodySchema, request);
 
     const { role } = await getMobileUserContext(user.id, organizationId);
     const isSelfServiceOrBase =

--- a/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
@@ -10,6 +10,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { updateBasicBooking } from "~/modules/booking/service.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import { getTeamMember } from "~/modules/team-member/service.server";
@@ -87,7 +88,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const body = BodySchema.parse(await request.json());
+    const body = parseMobileBody(BodySchema, await request.json());
 
     const { role } = await getMobileUserContext(user.id, organizationId);
     const isSelfServiceOrBase =

--- a/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
@@ -1,5 +1,4 @@
 import { BookingStatus, OrganizationRoles } from "@prisma/client";
-import { DateTime } from "luxon";
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
 import { BookingFormSchema } from "~/components/booking/forms/forms-schema";
@@ -16,7 +15,6 @@ import { getBookingSettingsForOrganization } from "~/modules/booking-settings/se
 import { getTeamMember } from "~/modules/team-member/service.server";
 import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
-import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { isValidTimeZone } from "~/utils/date-format";
 import { prefsForDeclaredZone } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -170,8 +168,9 @@ export async function action({ request }: ActionFunctionArgs) {
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
 
+    let parsedBooking;
     try {
-      BookingFormSchema({
+      parsedBooking = BookingFormSchema({
         prefs,
         action: "save",
         status: existing.status,
@@ -205,26 +204,20 @@ export async function action({ request }: ActionFunctionArgs) {
     }
 
     // Dates + custodian only apply to DRAFT bookings (updateBasicBooking
-    // re-gates this internally); parse the dates only when they will be used.
+    // re-gates this internally), so only carry them through for a draft.
+    //
+    // Use the instants the schema already produced rather than re-parsing the
+    // raw body: `coerceLocalDate` accepts second precision via `fromISO`, while
+    // DATE_TIME_FORMAT is minute-only, so re-parsing could reject a payload the
+    // schema had just accepted. Reusing the result also guarantees the stored
+    // instant is the one that was validated, in the same declared zone.
     const isDraft = existing.status === BookingStatus.DRAFT;
-    // Same zone the schema validated in, so the stored instant matches the
-    // wall-clock that just passed validation.
-    const fromDt = isDraft
-      ? DateTime.fromFormat(body.startDate, DATE_TIME_FORMAT, {
-          zone: prefs.timeZone,
-        })
-      : undefined;
-    const toDt = isDraft
-      ? DateTime.fromFormat(body.endDate, DATE_TIME_FORMAT, {
-          zone: prefs.timeZone,
-        })
-      : undefined;
+    const from = isDraft ? parsedBooking.startDate : undefined;
+    const to = isDraft ? parsedBooking.endDate : undefined;
 
-    // BookingFormSchema validates the dates with the broader `coerceLocalDate`,
-    // so a value can pass validation yet not match DATE_TIME_FORMAT here and
-    // become an Invalid Date. Guard before handing dates to the service, as the
-    // create path does — otherwise `Invalid Date` flows into updateBasicBooking.
-    if ((fromDt && !fromDt.isValid) || (toDt && !toDt.isValid)) {
+    // A DRAFT validates through the full schema, so both dates are present;
+    // assert it rather than handing `undefined` to the service as "unchanged".
+    if (isDraft && (!from || !to)) {
       throw new ShelfError({
         cause: null,
         message: "Invalid booking start or end date.",
@@ -233,9 +226,6 @@ export async function action({ request }: ActionFunctionArgs) {
         shouldBeCaptured: false,
       });
     }
-
-    const from = fromDt?.toJSDate();
-    const to = toDt?.toJSDate();
 
     const booking = await updateBasicBooking({
       id: body.bookingId,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.update.ts
@@ -18,7 +18,7 @@ import { getWorkingHoursForOrganization } from "~/modules/working-hours/service.
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
 import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { isValidTimeZone } from "~/utils/date-format";
-import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
+import { prefsForDeclaredZone } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -62,7 +62,7 @@ const BodySchema = z.object({
   custodianTeamMemberId: z.string().min(1, "Please select a custodian"),
   startDate: z.string().min(1, "Start date is required"),
   endDate: z.string().min(1, "End date is required"),
-  // See `bookings.create.ts` — an unrecognised zone silently resolves to UTC.
+  // Must be a real IANA zone — see `bookings.create.ts`.
   timeZone: z
     .string()
     .min(1, "Time zone is required")
@@ -157,10 +157,11 @@ export async function action({ request }: ActionFunctionArgs) {
       timeZone: body.timeZone,
     };
 
-    // TIMEZONE FIX: read the typed wall-clock in the acting user's RESOLVED
-    // preference zone, matching the web action. Falls back to the device zone
-    // above when the user has no stored preference. See `bookings.create.ts`.
-    const prefs = await resolveUserFormatPrefsById(userId, hints);
+    // Decode the wall-clock in the zone the client DECLARED it in, not the
+    // user's preference zone. See `bookings.create.ts` — and note the edit
+    // screen re-submits the value it rendered device-local, so a preference-zone
+    // decode here would shift the booking again on every save.
+    const prefs = prefsForDeclaredZone(body.timeZone);
 
     // Business-rule validation via the shared web schema. The "save" action +
     // current status picks the right rule set (active bookings skip the date

--- a/apps/webapp/app/utils/date-format.server.ts
+++ b/apps/webapp/app/utils/date-format.server.ts
@@ -14,7 +14,10 @@
 import { db } from "~/database/db.server";
 import type { ClientHint } from "~/utils/client-hints";
 import type { RawFormatPrefs, ResolvedFormatPrefs } from "~/utils/date-format";
-import { resolveFormatPrefs } from "~/utils/date-format";
+import {
+  HARDCODED_DEFAULT_PREFS,
+  resolveFormatPrefs,
+} from "~/utils/date-format";
 
 /**
  * Minimal Prisma surface `resolveUserFormatPrefsById` needs. Both the extended
@@ -70,4 +73,40 @@ export async function resolveUserFormatPrefsById(
   });
 
   return resolveFormatPrefs(userPrefs, hints);
+}
+
+/**
+ * Prefs whose zone is the one a client DECLARED it encoded its wall-clock in.
+ *
+ * A `datetime-local`-style wire string (`"2026-08-20T09:00"`) carries no offset,
+ * so it only means something paired with the zone it was written in. Decoding it
+ * in any other zone yields a different instant — an encoding error, not a
+ * preference disagreement.
+ *
+ * The companion serialises picked dates from DEVICE-local components
+ * (`toLocalWire` in `apps/companion/app/(tabs)/bookings/new.tsx`) and declares
+ * that zone in the request body, deliberately rendering its picker device-local
+ * to match. So the mobile booking routes must decode in the declared zone, NOT
+ * in the user's stored preference zone. Doing otherwise shifts the stored
+ * instant, and — because the edit screen re-submits what it rendered — shifts it
+ * again on every save.
+ *
+ * Web needs no equivalent: its forms seed the input from the preference zone
+ * (`toIsoDateTimeToUserTimezone(booking.from, prefs.timeZone)`), so there the
+ * declared zone and the preference zone are the same thing, and
+ * {@link resolveUserFormatPrefsById} is the right source.
+ *
+ * Only `timeZone` is read by the booking schemas; the remaining fields come from
+ * {@link HARDCODED_DEFAULT_PREFS} and are never used for parsing. This exists as
+ * a named helper rather than an inline object so the exception is greppable and
+ * explained once — `BookingFormSchemaParams.prefs` is typed
+ * {@link ResolvedFormatPrefs} precisely to stop a non-preference zone being
+ * passed by accident.
+ *
+ * @param timeZone - The IANA zone the client declared, already validated by the
+ *   route's Zod schema (`isValidTimeZone`).
+ * @returns Concrete prefs carrying the declared zone.
+ */
+export function prefsForDeclaredZone(timeZone: string): ResolvedFormatPrefs {
+  return { ...HARDCODED_DEFAULT_PREFS, timeZone };
 }

--- a/apps/webapp/app/utils/date-format.server.ts
+++ b/apps/webapp/app/utils/date-format.server.ts
@@ -103,8 +103,20 @@ export async function resolveUserFormatPrefsById(
  * {@link ResolvedFormatPrefs} precisely to stop a non-preference zone being
  * passed by accident.
  *
+ * ACCEPTED RISK — the declared zone is fully client-controlled, and the booking
+ * schema evaluates working-hours / booking-window rules in it. A caller can
+ * therefore choose a zone whose 09:00 lands on an out-of-hours instant and still
+ * satisfy the org's rules. This is pre-existing behaviour on `main` (the mobile
+ * routes have always validated in `body.timeZone`), confined to the caller's own
+ * organization and their own permitted booking action — policy evasion, not an
+ * IDOR. The durable fix is to evaluate working-hours against the ORGANIZATION's
+ * zone and keep the declared zone strictly for decoding the offset-less wire
+ * string; that is a product decision affecting web equally, so it is deliberately
+ * deferred rather than solved here. Do not widen this helper's use without
+ * revisiting it.
+ *
  * @param timeZone - The IANA zone the client declared, already validated by the
- *   route's Zod schema (`isValidTimeZone`).
+ *   route's Zod schema (`isValidTimeZone`). Callers MUST validate before calling.
  * @returns Concrete prefs carrying the declared zone.
  */
 export function prefsForDeclaredZone(timeZone: string): ResolvedFormatPrefs {

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
@@ -1,0 +1,165 @@
+import { action as createAction } from "~/routes/api+/mobile+/bookings.create";
+import { action as updateAction } from "~/routes/api+/mobile+/bookings.update";
+import { createActionArgs } from "@mocks/remix";
+
+// @vitest-environment node
+
+/**
+ * The mobile booking routes accept the IANA zone their caller declares and
+ * decode every submitted wall-clock in it, so an unrecognised zone has to be
+ * rejected at the boundary.
+ *
+ * These cases pin the OBSERVABLE contract: HTTP 400 plus a message naming the
+ * timezone field. That matters because the failure mode being guarded against
+ * is a 500 — a bare `schema.parse()` throws a `ZodError`, which `makeShelfError`
+ * does not recognise, so it becomes "Sorry, something went wrong." with a Sentry
+ * capture. `~/utils/error` is deliberately NOT mocked here: the real
+ * `ShelfError` / `makeShelfError` are the behaviour under test.
+ */
+
+// why: Remix's data() returns a plain object in tests; wrap it in a Response so
+// the assertions can read the real HTTP status the route produced.
+const createDataMock = vi.hoisted(() => {
+  return () =>
+    vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+});
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+// why: external auth — these gates run before body validation and would
+// otherwise hit Supabase.
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+  requireMobilePermission: vi.fn(),
+  assertMobileCanUseBookings: vi.fn(),
+  getMobileUserContext: vi.fn(),
+}));
+
+// why: rate limiting runs before validation and talks to its backing store.
+vi.mock("~/utils/rate-limit.server", () => ({
+  enforceUserRateLimit: vi.fn(),
+}));
+
+// why: `db.server` runs `void db.$connect()` at module load, which throws an
+// unhandled P1001 in the node environment when nothing mocks it.
+vi.mock("~/database/db.server", () => ({
+  db: { booking: { findFirst: vi.fn() } },
+}));
+
+// why: imported at module load by the routes under test; never reached here,
+// but they pull in the database client if left real.
+vi.mock("~/modules/booking/service.server", () => ({
+  createBooking: vi.fn(),
+  updateBasicBooking: vi.fn(),
+}));
+vi.mock("~/modules/booking-settings/service.server", () => ({
+  getBookingSettingsForOrganization: vi.fn(),
+}));
+vi.mock("~/modules/working-hours/service.server", () => ({
+  getWorkingHoursForOrganization: vi.fn(),
+}));
+vi.mock("~/modules/team-member/service.server", () => ({
+  getTeamMember: vi.fn(),
+}));
+
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+
+/** Builds a POST request carrying `body` as JSON. */
+function jsonRequest(body: Record<string, unknown>) {
+  return new Request("https://example.com/api/mobile/bookings", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** A body that is valid apart from whatever `overrides` changes. */
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    bookingId: "booking-1",
+    name: "Some booking",
+    custodianTeamMemberId: "tm-1",
+    startDate: "2026-08-20T09:00",
+    endDate: "2026-08-20T17:00",
+    timeZone: "America/Chicago",
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("mobile booking routes - declared timezone validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireMobileAuth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as any);
+    vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1" as any);
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      role: "ADMIN",
+    } as any);
+  });
+
+  const routes = [
+    { name: "create", action: createAction },
+    { name: "update", action: updateAction },
+  ];
+
+  for (const route of routes) {
+    describe(route.name, () => {
+      it("rejects an unrecognised IANA zone with 400, not 500", async () => {
+        const response = (await route.action(
+          createActionArgs({
+            request: jsonRequest(validBody({ timeZone: "Not/AZone" })),
+          })
+        )) as unknown as Response;
+
+        expect(response.status).toBe(400);
+
+        const payload = await response.json();
+        expect(payload.error.message).toContain("valid IANA zone");
+        // The generic message is what a 500 would have produced.
+        expect(payload.error.message).not.toContain("something went wrong");
+      });
+
+      it("rejects an empty zone with 400", async () => {
+        const response = (await route.action(
+          createActionArgs({
+            request: jsonRequest(validBody({ timeZone: "" })),
+          })
+        )) as unknown as Response;
+
+        expect(response.status).toBe(400);
+
+        const payload = await response.json();
+        expect(payload.error.message).toContain("Time zone");
+      });
+
+      it("accepts a real IANA zone past body validation", async () => {
+        // Not asserting a 2xx — the request goes on to hit collaborators this
+        // suite deliberately does not set up. What matters is that a valid zone
+        // does NOT produce the timezone 400 the cases above assert.
+        const response = (await route.action(
+          createActionArgs({
+            request: jsonRequest(validBody({ timeZone: "Europe/Amsterdam" })),
+          })
+        )) as unknown as Response;
+
+        const payload = await response.json();
+        expect(payload?.error?.message ?? "").not.toContain("IANA zone");
+      });
+    });
+  }
+});

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
@@ -1,4 +1,5 @@
 import { action as createAction } from "~/routes/api+/mobile+/bookings.create";
+import { action as reserveAction } from "~/routes/api+/mobile+/bookings.reserve";
 import { action as updateAction } from "~/routes/api+/mobile+/bookings.update";
 import { createActionArgs } from "@mocks/remix";
 
@@ -60,6 +61,10 @@ vi.mock("~/database/db.server", () => ({
 vi.mock("~/modules/booking/service.server", () => ({
   createBooking: vi.fn(),
   updateBasicBooking: vi.fn(),
+  // reserve's imports — unreachable in these cases (validation or the booking
+  // lookup answers first), but declared so the mock mirrors the real module.
+  reserveBooking: vi.fn(),
+  getBookingFlags: vi.fn(),
 }));
 vi.mock("~/modules/booking-settings/service.server", () => ({
   getBookingSettingsForOrganization: vi.fn(),
@@ -114,6 +119,7 @@ describe("mobile booking routes - declared timezone validation", () => {
 
   const routes = [
     { name: "create", action: createAction },
+    { name: "reserve", action: reserveAction },
     { name: "update", action: updateAction },
   ];
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
@@ -147,6 +147,25 @@ describe("mobile booking routes - declared timezone validation", () => {
         expect(payload.error.message).toContain("Time zone");
       });
 
+      it("rejects an unparseable JSON body with 400", async () => {
+        // `request.json()` throws a SyntaxError, which reaches the same generic
+        // 500 branch as an unhandled ZodError unless the helper owns the parse.
+        const request = new Request("https://example.com/api/mobile/bookings", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{not json",
+        });
+
+        const response = (await route.action(
+          createActionArgs({ request })
+        )) as unknown as Response;
+
+        expect(response.status).toBe(400);
+
+        const payload = await response.json();
+        expect(payload.error.message).not.toContain("something went wrong");
+      });
+
       it("accepts a real IANA zone past body validation", async () => {
         // Not asserting a 2xx — the request goes on to hit collaborators this
         // suite deliberately does not set up. What matters is that a valid zone

--- a/apps/webapp/test/routes-tests/bookings.new.test.tsx
+++ b/apps/webapp/test/routes-tests/bookings.new.test.tsx
@@ -63,17 +63,29 @@ vi.mock("~/utils/emitter/send-notification.server", () => ({
 }));
 
 // why: controlling form data parsing and response formatting for predictable test behavior
+// why: stands in for parseData + BookingFormSchema so these cases can exercise
+// the action's org-scoping and redirect behaviour without building a payload
+// that satisfies the real future-date / working-hours rules (the fixture dates
+// are deliberately in the past).
 vi.mock("~/utils/http.server", () => ({
   assertIsPost: vi.fn(),
   parseData: vi.fn().mockImplementation((formData) => {
     const name = formData.get("name");
     const custodian = JSON.parse(formData.get("custodian") || "{}");
+    // The real parseData runs the schema, whose `coerceLocalDate` yields Date
+    // instances on `startDate`/`endDate`; the action consumes those directly
+    // rather than re-reading the raw form fields. Mirror that here — returning
+    // them undefined makes the action's "dates are required" guard fire.
+    const startDate = formData.get("startDate");
+    const endDate = formData.get("endDate");
     return {
       name,
       custodian,
       assetIds: [],
       description: null,
       tags: "",
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
     };
   }),
   data: vi.fn((x) => ({ success: true, ...x })),


### PR DESCRIPTION
Replaces #2893.

Builds on @carlosvirreira's diagnosis and regression suite — the root cause and the Chicago repro tests are his. This version changes the **fix**: instead of passing a corrected hints object, the schemas take the resolved prefs, so the wrong zone is a compile error rather than a silent wrong answer.

## The original bug

The assets-index "Create booking" dialog called `BookingFormSchema` without a timezone. `hints` was optional and `coerceLocalDate` defaults to UTC, so that dialog read every typed wall-clock time as UTC. For a user west of UTC the start shifts backwards by their offset, looks like the past, and the browser-side check blocks the submit with "Start date must be in the future" — for the length of the offset, 5 hours in US Central. The form pre-fills "now + 10 minutes", so its own default failed its own validation.

Live since 2026-05-14, when the schema moved from `z.coerce.date()` to `coerceLocalDate`. **No data was stored wrong** — the server already re-parsed in the resolved preference zone, so this only blocked people. Nothing to repair.

## Why the param changed

Making `hints` required would have caught that one omission, but not the likelier mistake. The schemas only ever read `hints.timeZone`, and every caller overwrote it with `prefs.timeZone`, so the spread was inert. Worse, the param type was just `{ timeZone: string }` — which is exactly what a browser-hints object is. This typechecked cleanly while validating in a zone the server never used:

```ts
BookingFormSchema({ hints, action: "new", ... })  // raw browser zone, compiles fine
```

`prefs: ResolvedFormatPrefs` closes that structurally. A `ClientHint` is only `{ locale, timeZone }`, so it no longer satisfies the param. Both producers already return the right type: `useFormatPrefs()` on the client, `resolveUserFormatPrefsById()` on the server.

## Two more live mismatches this surfaced

- **Extend booking.** The dialog validated in the BROWSER zone while the server action parsed the submitted date in the PREFERENCE zone. The two disagreed for anyone with an explicit timezone, rejecting valid end dates in the same direction as the original bug. `ExtendBookingSchemaParams.timeZone` was still optional; it is now the same required `prefs`.
- **Mobile create / update / reserve.** These validated and stored in the device zone sent by the native client, while the companion DISPLAYS bookings in the preference zone. They now resolve prefs with the device zone as the fallback. The `DateTime.fromFormat` conversions move to the same zone, so the stored instant always matches the wall-clock that just passed validation.

## Second commit: mobile input boundary

Raised by the pre-commit security review. An unrecognised `timeZone` in the request body is discarded by `resolveFormatPrefs`, which falls back to `HARDCODED_DEFAULT_PREFS` — UTC. So for a user without a stored preference, a malformed zone silently reproduced the exact bug this PR fixes, arriving through the body instead of a missing param. `.refine(isValidTimeZone)` now rejects it with a 400.

Also mirrors the create path's `Invalid Date` guard into the update path, which called `.toJSDate()` straight through.

## Behavior changes

⚠️ **Mobile bookings for users who have set an explicit timezone preference are now read in that zone instead of the device zone.** Users who never set one are unaffected — the device zone remains the fallback.

⚠️ **The mobile booking APIs now return 400 for a non-IANA `timeZone`.** Not a compatibility risk: every companion call site sources it from `Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"`, so installed versions can only send valid zones.

## Verification

- Typecheck clean. Lint 0 errors (9 warnings, all pre-existing in untouched files). Prettier clean.
- Full suite: 5091 pass. The only failures were the known `activity[.csv]` hook-timeout flakes, confirmed passing at `--hookTimeout=30000` and unrelated to booking schemas.
- Schema suite runs green under a non-UTC machine zone (`TZ=Asia/Tokyo`), so the assertions aren't accidentally machine-zone-dependent.
- New `@ts-expect-error` test pins that a `ClientHint` cannot satisfy `prefs` — it fails typecheck if the param is ever loosened back.
- Five `as any` casts dropped from the test fixtures.

## Known gap

The invalid-timezone rejection has **no test**. Those three mobile routes have no route-test files at all, so covering it means standing up a new harness. Happy to add a focused suite for the three body schemas if wanted.

## Not addressed

Working-hours rules still evaluate in the acting user's zone rather than the organization's. Deliberate — web behaves the same way, so changing it is a product decision affecting both surfaces, not a cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Booking creation, editing, extending, duplicating, and reserving now validate dates consistently using resolved timezone preferences.
  * Improved date handling for users with explicit timezone settings or no configured preference.
  * Mobile booking requests now interpret submitted times in the declared timezone and reject invalid timezones or dates.
  * Fixed discrepancies between client-side and server-side validation, including support for date values with second-level precision.
  * Malformed or invalid mobile booking requests now return clear 400-level errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->