### PR TITLE
chore(assets): remove the now-unused Prisma-OR search builders

### DIFF
--- a/apps/webapp/app/modules/asset/search-union.server.test.ts
+++ b/apps/webapp/app/modules/asset/search-union.server.test.ts
@@ -5,7 +5,7 @@
  * The webapp vitest harness has no real DB, so these assert the generated SQL
  * STRING and bound params (the @map-column guard from
  * .claude/rules/raw-sql-respects-prisma-map.md), not row-level results.
- * Row-level parity (UNION id-set == the old buildFullAssetSearchOr id-set) is
+ * Row-level parity (UNION id-set == the old Prisma OR clause's id-set) is
  * verified out-of-harness against a staging copy of a large org, plus the
  * post-deploy EXPLAIN ANALYZE — see the PR's verification notes.
  */

--- a/apps/webapp/app/modules/asset/search-union.server.ts
+++ b/apps/webapp/app/modules/asset/search-union.server.ts
@@ -32,7 +32,7 @@ import { Prisma } from "@prisma/client";
 import { ShelfError } from "~/utils/error";
 // CUSTOM_FIELD_SEARCH_PATHS is owned by ./search.server (the pure, db-free
 // search module). Import it here so the UNION searches the SAME custom-field
-// paths as the Prisma buildFullAssetSearchOr — one list, no drift — and
+// paths as the old Prisma OR clause — one list, no drift — and
 // re-export for this module's existing importers/tests.
 import { CUSTOM_FIELD_SEARCH_PATHS } from "./search.server";
 

--- a/apps/webapp/app/modules/asset/search.server.test.ts
+++ b/apps/webapp/app/modules/asset/search.server.test.ts
@@ -1,19 +1,14 @@
 /**
- * Test suite for the shared simple-mode asset search clause builders.
+ * Test suite for the shared simple-mode asset search helpers in search.server.
  *
- * These builders are consumed by BOTH the web `getAssets` fetcher and the
- * mobile assets endpoint, so this suite pins the searchable field set — a
- * field silently dropped here would degrade search on every surface at once.
- * Pure module — no mocks needed.
+ * Pins `splitAssetSearchTerms` (comma-splitting + the term-count cap), which is
+ * consumed by the web `getAssets` fetcher, the mobile assets endpoint, and the
+ * advanced-index `generateWhereClause` — a change here shifts search parsing on
+ * every surface at once. Pure module — no mocks needed.
  *
  * @see {@link file://./search.server.ts}
  */
-import {
-  buildFullAssetSearchOr,
-  buildNarrowAssetSearchOr,
-  looksLikeAssetId,
-  splitAssetSearchTerms,
-} from "./search.server";
+import { splitAssetSearchTerms } from "./search.server";
 
 // @vitest-environment node
 
@@ -34,132 +29,5 @@ describe("splitAssetSearchTerms", () => {
   it("caps the number of honored terms as a query-cost guard", () => {
     const fifteen = Array.from({ length: 15 }, (_, i) => `term${i}`).join(",");
     expect(splitAssetSearchTerms(fifteen)).toHaveLength(10);
-  });
-});
-
-describe("looksLikeAssetId", () => {
-  it("matches bare numerics and canonical sequential ids", () => {
-    expect(looksLikeAssetId("21035")).toBe(true);
-    expect(looksLikeAssetId("123456789012")).toBe(true);
-    expect(looksLikeAssetId("sam-0001")).toBe(true);
-    expect(looksLikeAssetId("SAM-0001")).toBe(true);
-  });
-
-  it("rejects loose word-like terms", () => {
-    expect(looksLikeAssetId("lab-12")).toBe(false); // fewer than 4 digits
-    expect(looksLikeAssetId("AS1000")).toBe(false); // no dash
-    expect(looksLikeAssetId("tripod")).toBe(false);
-    expect(looksLikeAssetId("sam-0001x")).toBe(false);
-  });
-});
-
-describe("buildFullAssetSearchOr", () => {
-  it("builds one OR-group per term", () => {
-    expect(buildFullAssetSearchOr(["a", "b"])).toHaveLength(2);
-  });
-
-  it("covers every searchable field, case-insensitively", () => {
-    const [group] = buildFullAssetSearchOr(["tripod"]);
-    const branches = group.OR ?? [];
-
-    // 10 branches: title, sequentialId, description, category, location,
-    // tags, custodian names, QR id, barcode value, custom fields.
-    expect(branches).toHaveLength(10);
-
-    // Walk the clause and collect EVERY substring filter — asserting the
-    // exact count and per-filter mode means losing case-insensitivity on
-    // any single branch fails, unlike a >= floor.
-    const containsFilters: Array<Record<string, unknown>> = [];
-    const walk = (node: unknown): void => {
-      if (Array.isArray(node)) {
-        node.forEach(walk);
-        return;
-      }
-      if (node && typeof node === "object") {
-        const record = node as Record<string, unknown>;
-        if ("contains" in record || "string_contains" in record) {
-          containsFilters.push(record);
-        }
-        Object.values(record).forEach(walk);
-      }
-    };
-    walk(branches);
-
-    // title, sequentialId, description, category.name, location.name,
-    // tag.name, custodian (name + firstName + lastName), qr id, barcode
-    // value, 6 custom-field JSON paths = 17 substring filters.
-    expect(containsFilters).toHaveLength(17);
-    for (const filter of containsFilters) {
-      expect(filter.mode).toBe("insensitive");
-      expect(filter.contains ?? filter.string_contains).toBe("tripod");
-    }
-
-    // Pin the matched COLUMNS structurally, not via substring presence.
-    /* eslint-disable @typescript-eslint/no-explicit-any -- why: intentional
-       deep-path probing of a where-clause literal; per-node types add noise
-       without safety here. */
-    const [
-      title,
-      sequentialId,
-      description,
-      category,
-      location,
-      tags,
-      custody,
-      qrCodes,
-      barcodes,
-      customFields,
-    ] = branches as Array<any>;
-    expect(title.title.contains).toBe("tripod");
-    expect(sequentialId.sequentialId.contains).toBe("tripod");
-    expect(description.description.contains).toBe("tripod");
-    expect(category.category.name.contains).toBe("tripod");
-    expect(location.assetLocations.some.location.name.contains).toBe("tripod");
-    expect(tags.tags.some.name.contains).toBe("tripod");
-    const custodianOr = custody.custody.some.custodian.OR;
-    expect(custodianOr[0].name.contains).toBe("tripod");
-    expect(custodianOr[1].user.OR[0].firstName.contains).toBe("tripod");
-    expect(custodianOr[1].user.OR[1].lastName.contains).toBe("tripod");
-    expect(qrCodes.qrCodes.some.id.contains).toBe("tripod");
-    expect(barcodes.barcodes.some.value.contains).toBe("tripod");
-    expect(customFields.customFields.some.OR).toHaveLength(6);
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-  });
-
-  it("searches every custom-field value shape", () => {
-    const [group] = buildFullAssetSearchOr(["x"]);
-    const serialized = JSON.stringify(group);
-    for (const jsonPath of [
-      "valueText",
-      "valueMultiLineText",
-      "valueOption",
-      "valueDate",
-      "valueBoolean",
-      "raw",
-    ]) {
-      expect(serialized).toContain(jsonPath);
-    }
-  });
-});
-
-describe("buildNarrowAssetSearchOr", () => {
-  it("builds a flat 5-branch clause per term over the indexed columns", () => {
-    const clauses = buildNarrowAssetSearchOr(["sam-0001", "21035"]);
-    expect(clauses).toHaveLength(10);
-
-    const serialized = JSON.stringify(clauses);
-    for (const fieldPath of [
-      '"sequentialId"',
-      '"barcodes"',
-      '"qrCodes"',
-      '"title"',
-      '"description"',
-    ]) {
-      expect(serialized).toContain(fieldPath);
-    }
-    // The slow paths must NOT be in the narrow clause.
-    for (const heavy of ['"custody"', '"customFields"', '"tags"']) {
-      expect(serialized).not.toContain(heavy);
-    }
   });
 });

--- a/apps/webapp/app/modules/asset/search.server.ts
+++ b/apps/webapp/app/modules/asset/search.server.ts
@@ -18,25 +18,26 @@ export const CUSTOM_FIELD_SEARCH_PATHS = [
 ] as const;
 
 /**
- * Single source of truth for the simple-mode asset search clauses.
+ * Shared asset-search helpers used across every search surface: the web
+ * `getAssets` fetcher (`service.server.ts`), the mobile assets endpoint
+ * (`modules/api/mobile-asset-search.server.ts`), and the advanced-index
+ * `generateWhereClause` (`query.server.ts`). Holds the term parser
+ * (`splitAssetSearchTerms`), the QT-aware status fragment
+ * (`buildAssetStatusWhere`), and the searchable custom-field JSON paths
+ * (`CUSTOM_FIELD_SEARCH_PATHS`).
  *
- * Consumed by BOTH:
- * - the web `getAssets` fetcher (assets index simple mode + every picker that
- *   goes through it) — see `service.server.ts`, and
- * - the mobile assets endpoint (`routes/api+/mobile+/assets.ts` via
- *   `modules/api/mobile-asset-search.server.ts`).
- *
- * Change a field here and BOTH surfaces change together — that is the point:
- * web and mobile search can no longer drift apart field-by-field. The
- * advanced-mode index searches via raw SQL instead (`query.server.ts`,
- * `generateWhereClause`) and is deliberately not covered by this module.
+ * The actual matching is one org-scoped `UNION` of ids (`buildAssetSearchUnion`
+ * in `search-union.server.ts`), shared by all three surfaces. The old
+ * per-surface Prisma OR clause builders that lived here — buildFullAssetSearchOr
+ * / buildNarrowAssetSearchOr / isIdShapedSearch / looksLikeAssetId — were
+ * removed once every surface moved to the UNION.
  */
 
 /**
  * Upper bound on comma-separated terms honored per search. Each term adds a
- * full 10-branch OR group (including the unindexed custom-fields JSON ILIKE),
- * so an unbounded paste could fan a single request into an arbitrarily
- * expensive query. Ten is far beyond any real search-box usage.
+ * full 10-source group to the search UNION, so an unbounded paste could fan a
+ * single request into an arbitrarily expensive query. Ten is far beyond any
+ * real search-box usage.
  */
 export const MAX_ASSET_SEARCH_TERMS = 10;
 
@@ -58,20 +59,6 @@ export function splitAssetSearchTerms(search: string): string[] {
     .map((term) => term.trim())
     .filter(Boolean)
     .slice(0, MAX_ASSET_SEARCH_TERMS);
-}
-
-/**
- * The shared narrow-vs-full policy: a search takes the narrow indexed fast
- * path only when every term is ID-shaped. Both `getAssets` and the mobile
- * assets endpoint make this decision through here so the policy cannot
- * drift between surfaces.
- *
- * @param searchTerms - Normalized terms from {@link splitAssetSearchTerms}
- * @returns true when the caller should query the narrow clause first and
- *   fall back to the full clause on zero rows
- */
-export function isIdShapedSearch(searchTerms: string[]): boolean {
-  return searchTerms.length > 0 && searchTerms.every(looksLikeAssetId);
 }
 
 /**
@@ -103,187 +90,4 @@ export function buildAssetStatusWhere(
     };
   }
   return { status };
-}
-
-/**
- * Matches the shape of an asset identifier or barcode / QR id. Two forms:
- *   - bare numeric ("21035", or a 12-digit UPC) — users commonly drop the
- *     prefix when scanning or typing an ID
- *   - canonical sequential ID ("SAM-0001") — letter prefix + dash + 4+
- *     digits, matching the format produced by getNextSequentialId
- *
- * Used to run ID-shaped queries against the narrow OR clause
- * ({@link buildNarrowAssetSearchOr}) first, instead of the full 10-branch
- * chain. The narrow clause skips the slow paths — custodian name traversal
- * and the unindexed customFields JSON ILIKE — while still covering every
- * place an ID-shaped value is *most likely* to live.
- *
- * Because a bare number can equally be a real barcode OR a value embedded in
- * a title / description / custom field (indistinguishable by shape), callers
- * fall back to the full search when the narrow clause returns zero rows — so
- * nothing is ever silently missed. See the fallback re-query in `getAssets`
- * and the mobile route's mirror of it.
- *
- * Loose terms like "lab-12" or "AS1000" don't match here and go straight to
- * the full search, since they're more likely substrings of titles, custom
- * fields, etc.
- *
- * @param term - A single normalized search term
- * @returns true when the term should take the narrow indexed fast path
- */
-export function looksLikeAssetId(term: string): boolean {
-  return /^\d+$/.test(term) || /^[a-z]+-\d{4,}$/i.test(term);
-}
-
-/**
- * Full multi-column search clause: matches a term anywhere it can
- * legitimately live — title, sequentialId, description, category, location,
- * tags, custodian names, QR/barcode, and custom fields.
- *
- * This is the slow path (custodian relation traversal + an unindexed
- * customFields JSON ILIKE), so for ID-shaped searches callers run
- * {@link buildNarrowAssetSearchOr} first and only use this when it finds
- * nothing.
- *
- * Returns one `{ OR: [...] }` entry per term; assigning the array to a
- * where's `OR` makes the terms match-any (comma semantics).
- *
- * @param searchTerms - Normalized terms from {@link splitAssetSearchTerms}
- * @returns One OR-group per term, ready to assign to `where.OR`
- */
-export function buildFullAssetSearchOr(
-  searchTerms: string[]
-): Prisma.AssetWhereInput[] {
-  return searchTerms.map((term) => ({
-    OR: [
-      // Search in asset fields
-      { title: { contains: term, mode: "insensitive" } },
-      // Search in asset sequential id
-      { sequentialId: { contains: term, mode: "insensitive" } },
-      // Search in asset description
-      { description: { contains: term, mode: "insensitive" } },
-      // Search in related category
-      { category: { name: { contains: term, mode: "insensitive" } } },
-      // Search in related location — traverses the AssetLocation pivot
-      // since an asset can be placed at multiple locations.
-      {
-        assetLocations: {
-          some: {
-            location: {
-              name: { contains: term, mode: "insensitive" },
-            },
-          },
-        },
-      },
-      // Search in related tags
-      {
-        tags: {
-          some: { name: { contains: term, mode: "insensitive" } },
-        },
-      },
-      // Search in custodian names — custody is a list relation, so
-      // traverse it with `some`.
-      {
-        custody: {
-          some: {
-            custodian: {
-              OR: [
-                { name: { contains: term, mode: "insensitive" } },
-                {
-                  user: {
-                    OR: [
-                      {
-                        firstName: {
-                          contains: term,
-                          mode: "insensitive",
-                        },
-                      },
-                      {
-                        lastName: {
-                          contains: term,
-                          mode: "insensitive",
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        },
-      },
-      // Search qr code id
-      {
-        qrCodes: {
-          some: { id: { contains: term, mode: "insensitive" } },
-        },
-      },
-      // Search barcode values
-      {
-        barcodes: {
-          some: { value: { contains: term, mode: "insensitive" } },
-        },
-      },
-      // Search in custom fields
-      {
-        customFields: {
-          some: {
-            OR: CUSTOM_FIELD_SEARCH_PATHS.map((jsonPath) => ({
-              value: {
-                path: [jsonPath],
-                string_contains: term,
-                mode: "insensitive",
-              },
-            })),
-          },
-        },
-      },
-    ],
-  }));
-}
-
-/**
- * Narrow indexed fast path for ID-shaped searches: the columns where an
- * ID-shaped value can legitimately live — sequentialId, barcode value, QR id,
- * plus title and description. The ID columns are covered by trigram GIN
- * indexes added in migration 20260525110348, and title/description are
- * covered by the composite trigram GIN index Asset_title_description_idx —
- * so the planner stays on indexed scans and a real ID lookup (the common
- * case) returns immediately.
- *
- * title + description are included here (not deferred to the fallback)
- * because a bare-numeric term often lives ONLY inside a title — e.g.
- * searching "451" must match "KCI-451 Kids Resources Box". Without these
- * branches the narrow query can still return rows (some OTHER asset matches
- * "451" in an ID column), which suppresses the zero-row fallback and
- * silently drops the title-only match.
- *
- * Callers must still fall back to {@link buildFullAssetSearchOr} on zero
- * rows so the remaining slow-path columns (custodian names,
- * category/location/tags, custom-field JSON ILIKE) stay covered.
- *
- * @param searchTerms - Normalized terms from {@link splitAssetSearchTerms}
- * @returns A flat OR list covering every term, ready to assign to `where.OR`
- */
-export function buildNarrowAssetSearchOr(
-  searchTerms: string[]
-): Prisma.AssetWhereInput[] {
-  return searchTerms.flatMap((term) => [
-    { sequentialId: { contains: term, mode: "insensitive" } },
-    {
-      barcodes: {
-        some: { value: { contains: term, mode: "insensitive" } },
-      },
-    },
-    {
-      qrCodes: {
-        some: { id: { contains: term, mode: "insensitive" } },
-      },
-    },
-    // Trigram-indexed (Asset_title_description_idx) — matches a
-    // bare-numeric substring embedded in a title/description directly
-    // in the fast path, without relying on the zero-row fallback.
-    { title: { contains: term, mode: "insensitive" } },
-    { description: { contains: term, mode: "insensitive" } },
-  ]);
 }

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -659,7 +659,7 @@ export async function getAssets(params: {
         // Setting where.OR here — BEFORE the category/tag/location/team-member
         // filters below — preserves the historical OR-entanglement: those
         // filters append to where.OR, so search OR-combines with them exactly
-        // as the previous buildFullAssetSearchOr clause did. The UNION always
+        // as the previous Prisma OR clause did. The UNION always
         // searches all 10 sources (the old id-shaped fast path searched a
         // subset and fell back on zero rows); id-shaped searches therefore now
         // return the full result set — a superset of before, the more-correct


### PR DESCRIPTION
## What

Removes the now-unused Prisma-OR asset-search builders from `search.server.ts`:
`buildFullAssetSearchOr`, `buildNarrowAssetSearchOr`, `isIdShapedSearch`, `looksLikeAssetId`.

## Why

These were kept through #2849 as a parity reference + rollback path while the web (`getAssets`) and mobile
(`resolveMobileAssetSearchWhere`) search paths migrated to the shared org-scoped `UNION`
(`buildAssetSearchUnion`). Both surfaces now bypass them entirely, so they have **zero code consumers** —
this removes the dead code and its three test suites.

## What's kept

The still-shared helpers in the same module: `splitAssetSearchTerms` (+ `MAX_ASSET_SEARCH_TERMS`),
`buildAssetStatusWhere`, and `CUSTOM_FIELD_SEARCH_PATHS`. The module + test doc comments and three stale
comment references were refreshed so the removed names don't linger (one intentional historical note in the
module doc records that the builders were removed).

## Verification

- `grep` confirms no code references the four functions anywhere in `app/` or `test/`.
- `search.server.test.ts` + `search-union.server.test.ts` + `service.server.test.ts` +
  `mobile-asset-search.server.test.ts` all pass; `tsc -b` clean.

Net: **+25 / −353**. First of the #2849 follow-ups (each its own PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated search-related documentation to reflect the current search behavior and implementation.
  * Clarified that search terms are normalized, limited, and handled through a unified search process.

* **Tests**
  * Simplified search test coverage to focus on term splitting, normalization, empty-term removal, and term limits.
  * No runtime behavior or test assertions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->