### PR TITLE
feat(audits): surface the evidence recorded during an audit

### DIFF
--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -1140,6 +1140,10 @@ function AuditDetailContent() {
         images={openEvidenceBucket.images}
         isLoading={evidenceLoading}
         error={evidenceError}
+        onRetry={() => {
+          setEvidenceError(null);
+          void loadEvidence();
+        }}
       />
     </View>
   );

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -149,8 +149,17 @@ function AuditDetailContent() {
   //
   // why a separate fetch: this is the heavy half (image URLs, note bodies,
   // authors) and is only wanted once someone opens a row, so the detail
-  // payload stays cheap. Loaded lazily on first open and then kept, because
-  // a completed audit's evidence cannot change underneath us.
+  // payload stays cheap.
+  //
+  // Re-fetched on every open, NOT cached for the life of the screen. The
+  // first version cached it on the reasoning that "a completed audit's
+  // evidence cannot change" — true of a completed one, but this screen also
+  // serves ACTIVE audits, where the same person adds a photo and reopens the
+  // sheet seconds later. They would have been shown the set from before their
+  // own upload, with the row's count already disagreeing with it.
+  //
+  // Stale-while-revalidate: whatever was loaded stays on screen during the
+  // refetch, so reopening a sheet never flashes empty.
   const [evidence, setEvidence] = useState<AuditEvidenceResponse | null>(null);
   const [evidenceLoading, setEvidenceLoading] = useState(false);
   const [evidenceError, setEvidenceError] = useState<string | null>(null);
@@ -159,15 +168,27 @@ function AuditDetailContent() {
     name: string;
   } | null>(null);
 
+  // Guards concurrent opens without freezing the data, which is what the old
+  // `evidence` guard did. A ref, not state, so it cannot itself trigger a
+  // render or go stale inside the callback.
+  const evidenceInFlight = useRef(false);
+
   const loadEvidence = useCallback(async () => {
-    if (!currentOrg?.id || !id || evidence) return;
-    setEvidenceLoading(true);
+    if (!currentOrg?.id || !id || evidenceInFlight.current) return;
+    evidenceInFlight.current = true;
+    // Only show the spinner when there is nothing to show yet — on a refetch
+    // the previous evidence stays put underneath.
+    setEvidence((current) => {
+      if (!current) setEvidenceLoading(true);
+      return current;
+    });
     setEvidenceError(null);
     const { data, error } = await api.auditEvidence(id, currentOrg.id);
     if (error) setEvidenceError(error);
     else if (data) setEvidence(data);
     setEvidenceLoading(false);
-  }, [currentOrg?.id, id, evidence]);
+    evidenceInFlight.current = false;
+  }, [currentOrg?.id, id]);
 
   /** Opens the viewer for one asset, or for the audit itself (`null`). */
   const onEvidencePress = useCallback(

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -476,8 +476,23 @@ function AuditDetailContent() {
       // why: evidence is the ONE thing on this card worth opening. Everything
       // else (image, name, location, category, custodian, status) is already
       // shown, which is why the card is otherwise inert — see the note below.
-      const evidenceCount = item.notesCount + item.imagesCount;
-      const hasEvidence = evidenceCount > 0 && item.auditAssetId !== null;
+      // why two numbers and not their sum: see scanned-items-list.tsx. The
+      // sum changes for identical evidence depending on whether the auditor
+      // typed a caption, so it cannot be compared between rows.
+      const noteCount = item.notesCount;
+      const photoCount = item.imagesCount;
+      const hasEvidence =
+        (noteCount > 0 || photoCount > 0) && item.auditAssetId !== null;
+      const evidenceLabel = [
+        noteCount > 0
+          ? `${noteCount} ${noteCount === 1 ? "note" : "notes"}`
+          : null,
+        photoCount > 0
+          ? `${photoCount} ${photoCount === 1 ? "photo" : "photos"}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
       const Card = hasEvidence ? TouchableOpacity : View;
 
       return (
@@ -504,11 +519,7 @@ function AuditDetailContent() {
             item.name,
             statusLabel,
             ...metaParts.map((p) => p.text),
-            hasEvidence
-              ? `${evidenceCount} ${
-                  evidenceCount === 1 ? "attachment" : "attachments"
-                }, tap to view`
-              : null,
+            hasEvidence ? `${evidenceLabel}, tap to view` : null,
           ]
             .filter(Boolean)
             .join(", ")}
@@ -573,21 +584,33 @@ function AuditDetailContent() {
             </View>
             {hasEvidence ? (
               <View style={styles.evidenceChip}>
-                <Ionicons name="attach" size={12} color={colors.primaryText} />
-                <Text style={styles.evidenceChipText}>{evidenceCount}</Text>
+                {noteCount > 0 ? (
+                  <>
+                    <Ionicons
+                      name="chatbubble-outline"
+                      size={12}
+                      color={colors.primaryText}
+                    />
+                    <Text style={styles.evidenceChipText}>{noteCount}</Text>
+                  </>
+                ) : null}
+                {photoCount > 0 ? (
+                  <>
+                    <Ionicons
+                      name="image-outline"
+                      size={12}
+                      color={colors.primaryText}
+                    />
+                    <Text style={styles.evidenceChipText}>{photoCount}</Text>
+                  </>
+                ) : null}
               </View>
             ) : null}
           </View>
         </Card>
       );
     },
-    [
-      colors,
-      auditAssetStatusBadge,
-      styles,
-      formatDateTime,
-      onEvidencePress,
-    ]
+    [colors, auditAssetStatusBadge, styles, formatDateTime, onEvidencePress]
   );
 
   // ── Loading / Error states ────────────────────────────

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import {
   View,
   Text,
@@ -168,14 +168,42 @@ function AuditDetailContent() {
     name: string;
   } | null>(null);
 
+  /**
+   * Which audit, in which workspace, the loaded evidence belongs to.
+   *
+   * why this is not optional: evidence is workspace data. Without it, cached
+   * notes and photos survive a switch to another audit or another
+   * organization and are shown under the new one — and a request started
+   * before the switch can land after it and overwrite the new context with
+   * the old one's rows. Both are cross-workspace disclosure, not just a
+   * stale-cache annoyance.
+   */
+  const evidenceContext =
+    currentOrg?.id && id ? `${currentOrg.id}:${id}` : null;
+
   // Guards concurrent opens without freezing the data, which is what the old
-  // `evidence` guard did. A ref, not state, so it cannot itself trigger a
-  // render or go stale inside the callback.
-  const evidenceInFlight = useRef(false);
+  // `evidence` guard did. Holds the context it is fetching FOR, so a reply
+  // from a previous context can be recognised and dropped. A ref, not state,
+  // so it cannot itself trigger a render or go stale inside the callback.
+  const evidenceInFlight = useRef<string | null>(null);
+
+  // Drop everything the moment the context changes, before any render can
+  // show it. Clearing on arrival would be too late: the sheet would paint the
+  // previous workspace's rows for a frame first.
+  useEffect(() => {
+    setEvidence(null);
+    setEvidenceError(null);
+    setEvidenceLoading(false);
+    evidenceInFlight.current = null;
+  }, [evidenceContext]);
 
   const loadEvidence = useCallback(async () => {
-    if (!currentOrg?.id || !id || evidenceInFlight.current) return;
-    evidenceInFlight.current = true;
+    if (!currentOrg?.id || !id || !evidenceContext) return;
+    // Only one fetch per context at a time; a fetch for a DIFFERENT context is
+    // never blocked by an older one still in flight.
+    if (evidenceInFlight.current === evidenceContext) return;
+    const requestFor = evidenceContext;
+    evidenceInFlight.current = requestFor;
     // Only show the spinner when there is nothing to show yet — on a refetch
     // the previous evidence stays put underneath.
     setEvidence((current) => {
@@ -184,11 +212,15 @@ function AuditDetailContent() {
     });
     setEvidenceError(null);
     const { data, error } = await api.auditEvidence(id, currentOrg.id);
+    // The context may have changed while this was in the air. Anything from a
+    // superseded request is discarded, including its in-flight marker, so it
+    // cannot clear a newer fetch's claim.
+    if (evidenceInFlight.current !== requestFor) return;
     if (error) setEvidenceError(error);
     else if (data) setEvidence(data);
     setEvidenceLoading(false);
-    evidenceInFlight.current = false;
-  }, [currentOrg?.id, id]);
+    evidenceInFlight.current = null;
+  }, [currentOrg?.id, id, evidenceContext]);
 
   /** Opens the viewer for one asset, or for the audit itself (`null`). */
   const onEvidencePress = useCallback(

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -197,36 +197,67 @@ function AuditDetailContent() {
     evidenceInFlight.current = null;
   }, [evidenceContext]);
 
-  const loadEvidence = useCallback(async () => {
-    if (!currentOrg?.id || !id || !evidenceContext) return;
-    // Only one fetch per context at a time; a fetch for a DIFFERENT context is
-    // never blocked by an older one still in flight.
-    if (evidenceInFlight.current === evidenceContext) return;
-    const requestFor = evidenceContext;
-    evidenceInFlight.current = requestFor;
-    // Only show the spinner when there is nothing to show yet — on a refetch
-    // the previous evidence stays put underneath.
-    setEvidence((current) => {
-      if (!current) setEvidenceLoading(true);
-      return current;
-    });
-    setEvidenceError(null);
-    const { data, error } = await api.auditEvidence(id, currentOrg.id);
-    // The context may have changed while this was in the air. Anything from a
-    // superseded request is discarded, including its in-flight marker, so it
-    // cannot clear a newer fetch's claim.
-    if (evidenceInFlight.current !== requestFor) return;
-    if (error) setEvidenceError(error);
-    else if (data) setEvidence(data);
-    setEvidenceLoading(false);
-    evidenceInFlight.current = null;
-  }, [currentOrg?.id, id, evidenceContext]);
+  /**
+   * Loads the evidence for ONE target: a single audited asset, or the audit
+   * itself when `auditAssetId` is null.
+   *
+   * Scoped rather than audit-wide because the sheet shows one target at a
+   * time. An audit-wide fetch returns every note and photo in the audit, so a
+   * large audit would move thousands of rows on each open, over whatever
+   * connection a stockroom has.
+   *
+   * Results merge into what is already held rather than replacing it, so
+   * reopening a row keeps the rest of what has been loaded.
+   */
+  const loadEvidence = useCallback(
+    async (auditAssetId: string | null) => {
+      if (!currentOrg?.id || !id || !evidenceContext) return;
+      // One fetch per target at a time. A fetch for a DIFFERENT target, or for
+      // a different context, is never blocked by an older one still in flight.
+      const requestFor = `${evidenceContext}:${auditAssetId ?? "general"}`;
+      if (evidenceInFlight.current === requestFor) return;
+      evidenceInFlight.current = requestFor;
+      // Only show the spinner when there is nothing to show yet — on a refetch
+      // the previous evidence stays put underneath.
+      setEvidence((current) => {
+        if (!current) setEvidenceLoading(true);
+        return current;
+      });
+      setEvidenceError(null);
+      const { data, error } = await api.auditEvidence(
+        id,
+        currentOrg.id,
+        undefined,
+        auditAssetId
+      );
+      // The context may have changed while this was in the air. Anything from
+      // a superseded request is discarded, including its in-flight marker, so
+      // it cannot clear a newer fetch's claim.
+      if (evidenceInFlight.current !== requestFor) return;
+      if (error) setEvidenceError(error);
+      else if (data) {
+        setEvidence((current) => ({
+          general:
+            auditAssetId === null
+              ? data.general
+              : current?.general ?? { notes: [], images: [] },
+          byAuditAsset: {
+            ...(current?.byAuditAsset ?? {}),
+            ...data.byAuditAsset,
+          },
+        }));
+      }
+      setEvidenceLoading(false);
+      evidenceInFlight.current = null;
+    },
+    [currentOrg?.id, id, evidenceContext]
+  );
 
   /** Opens the viewer for one asset, or for the audit itself (`null`). */
   const onEvidencePress = useCallback(
     (target: { auditAssetId: string | null; name: string }) => {
       setOpenEvidence(target);
-      void loadEvidence();
+      void loadEvidence(target.auditAssetId);
     },
     [loadEvidence]
   );
@@ -1142,7 +1173,7 @@ function AuditDetailContent() {
         error={evidenceError}
         onRetry={() => {
           setEvidenceError(null);
-          void loadEvidence();
+          void loadEvidence(openEvidence?.auditAssetId ?? null);
         }}
       />
     </View>

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -21,10 +21,14 @@ import {
   type AuditExpectedAsset,
   type AuditScanData,
   type AuditAssetStatus,
+  type AuditEvidenceResponse,
+  type AuditEvidenceNote,
+  type AuditEvidenceImage,
 } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useDateFormatter } from "@/lib/use-date-formatter";
+import { EvidenceViewer } from "@/components/audit/evidence-viewer";
 import {
   AUDIT_ASSET_STATUS_LABELS,
   AUDIT_STATUS_LABELS,
@@ -114,6 +118,14 @@ type DisplayAsset = {
   locationName: string | null;
   categoryName: string | null;
   custodianName: string | null;
+  /**
+   * The audit-asset row id, present only once the asset has been scanned.
+   * Keys this asset's evidence in the `byAuditAsset` payload.
+   */
+  auditAssetId: string | null;
+  /** Counts from the detail payload — what the row advertises before any fetch. */
+  notesCount: number;
+  imagesCount: number;
 };
 
 const auditAssetKeyExtractor = (item: DisplayAsset) => item.id;
@@ -132,6 +144,53 @@ function AuditDetailContent() {
   const { currentOrg } = useOrg();
   const { colors, auditStatusBadge, auditAssetStatusBadge } = useTheme();
   const { formatDateTime } = useDateFormatter();
+
+  // ── Evidence (notes + photos recorded on this audit) ──
+  //
+  // why a separate fetch: this is the heavy half (image URLs, note bodies,
+  // authors) and is only wanted once someone opens a row, so the detail
+  // payload stays cheap. Loaded lazily on first open and then kept, because
+  // a completed audit's evidence cannot change underneath us.
+  const [evidence, setEvidence] = useState<AuditEvidenceResponse | null>(null);
+  const [evidenceLoading, setEvidenceLoading] = useState(false);
+  const [evidenceError, setEvidenceError] = useState<string | null>(null);
+  const [openEvidence, setOpenEvidence] = useState<{
+    auditAssetId: string | null;
+    name: string;
+  } | null>(null);
+
+  const loadEvidence = useCallback(async () => {
+    if (!currentOrg?.id || !id || evidence) return;
+    setEvidenceLoading(true);
+    setEvidenceError(null);
+    const { data, error } = await api.auditEvidence(id, currentOrg.id);
+    if (error) setEvidenceError(error);
+    else if (data) setEvidence(data);
+    setEvidenceLoading(false);
+  }, [currentOrg?.id, id, evidence]);
+
+  /** Opens the viewer for one asset, or for the audit itself (`null`). */
+  const onEvidencePress = useCallback(
+    (target: { auditAssetId: string | null; name: string }) => {
+      setOpenEvidence(target);
+      void loadEvidence();
+    },
+    [loadEvidence]
+  );
+
+  const openEvidenceBucket: {
+    notes: AuditEvidenceNote[];
+    images: AuditEvidenceImage[];
+  } = (() => {
+    if (!evidence || !openEvidence) return { notes: [], images: [] };
+    if (openEvidence.auditAssetId === null) return evidence.general;
+    return (
+      evidence.byAuditAsset[openEvidence.auditAssetId] ?? {
+        notes: [],
+        images: [],
+      }
+    );
+  })();
   const styles = useStyles();
 
   // ── State ──────────────────────────────────────────────
@@ -336,6 +395,9 @@ function AuditDetailContent() {
         locationName: asset.locationName ?? null,
         categoryName: asset.categoryName ?? null,
         custodianName: asset.custodianName ?? null,
+        auditAssetId: scan?.auditAssetId ?? null,
+        notesCount: scan?.auditNotesCount ?? 0,
+        imagesCount: scan?.auditImagesCount ?? 0,
       });
     }
 
@@ -357,6 +419,9 @@ function AuditDetailContent() {
           locationName: scan.assetLocationName,
           categoryName: null,
           custodianName: null,
+          auditAssetId: scan.auditAssetId,
+          notesCount: scan.auditNotesCount,
+          imagesCount: scan.auditImagesCount,
         });
       }
     }
@@ -408,9 +473,27 @@ function AuditDetailContent() {
         });
       }
 
+      // why: evidence is the ONE thing on this card worth opening. Everything
+      // else (image, name, location, category, custodian, status) is already
+      // shown, which is why the card is otherwise inert — see the note below.
+      const evidenceCount = item.notesCount + item.imagesCount;
+      const hasEvidence = evidenceCount > 0 && item.auditAssetId !== null;
+      const Card = hasEvidence ? TouchableOpacity : View;
+
       return (
-        <View
+        <Card
           style={styles.assetCard}
+          {...(hasEvidence
+            ? {
+                onPress: () =>
+                  onEvidencePress({
+                    auditAssetId: item.auditAssetId as string,
+                    name: item.name,
+                  }),
+                activeOpacity: 0.7,
+                accessibilityRole: "button" as const,
+              }
+            : { accessibilityRole: "summary" as const })}
           // why: React Native 0.81 treats a plain View as a container,
           // so VoiceOver/TalkBack would announce each child Text node
           // separately. `accessible` collapses the subtree into one
@@ -421,8 +504,14 @@ function AuditDetailContent() {
             item.name,
             statusLabel,
             ...metaParts.map((p) => p.text),
-          ].join(", ")}
-          accessibilityRole="summary"
+            hasEvidence
+              ? `${evidenceCount} ${
+                  evidenceCount === 1 ? "attachment" : "attachments"
+                }, tap to view`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(", ")}
         >
           {/*
             why: the previous `router.push('/(tabs)/assets/...)' from
@@ -473,16 +562,32 @@ function AuditDetailContent() {
             )}
           </View>
 
-          <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
-            <View style={[styles.statusDot, { backgroundColor: badge.text }]} />
-            <Text style={[styles.statusText, { color: badge.text }]}>
-              {statusLabel}
-            </Text>
+          <View style={styles.assetRight}>
+            <View style={[styles.statusBadge, { backgroundColor: badge.bg }]}>
+              <View
+                style={[styles.statusDot, { backgroundColor: badge.text }]}
+              />
+              <Text style={[styles.statusText, { color: badge.text }]}>
+                {statusLabel}
+              </Text>
+            </View>
+            {hasEvidence ? (
+              <View style={styles.evidenceChip}>
+                <Ionicons name="attach" size={12} color={colors.primaryText} />
+                <Text style={styles.evidenceChipText}>{evidenceCount}</Text>
+              </View>
+            ) : null}
           </View>
-        </View>
+        </Card>
       );
     },
-    [colors, auditAssetStatusBadge, styles, formatDateTime]
+    [
+      colors,
+      auditAssetStatusBadge,
+      styles,
+      formatDateTime,
+      onEvidencePress,
+    ]
   );
 
   // ── Loading / Error states ────────────────────────────
@@ -731,6 +836,40 @@ function AuditDetailContent() {
                     </Text>
                   </View>
                 )}
+
+                {/*
+                  why: the completion note and any photos attached when the
+                  audit closed are about the audit as a whole, so they belong
+                  with its details rather than on any one asset row. Shown
+                  once completed — before that there is nothing to read.
+                */}
+                {isCompleted && (
+                  <TouchableOpacity
+                    style={styles.auditEvidenceRow}
+                    onPress={() =>
+                      onEvidencePress({
+                        auditAssetId: null,
+                        name: "Completion notes and photos",
+                      })
+                    }
+                    accessibilityRole="button"
+                    accessibilityLabel="View the completion notes and photos for this audit"
+                  >
+                    <Ionicons
+                      name="document-attach-outline"
+                      size={15}
+                      color={colors.primaryText}
+                    />
+                    <Text style={styles.auditEvidenceText}>
+                      Completion notes and photos
+                    </Text>
+                    <Ionicons
+                      name="chevron-forward"
+                      size={15}
+                      color={colors.muted}
+                    />
+                  </TouchableOpacity>
+                )}
               </View>
             </View>
 
@@ -916,6 +1055,16 @@ function AuditDetailContent() {
           </View>
         }
       />
+
+      <EvidenceViewer
+        visible={openEvidence !== null}
+        onClose={() => setOpenEvidence(null)}
+        title={openEvidence?.name ?? ""}
+        notes={openEvidenceBucket.notes}
+        images={openEvidenceBucket.images}
+        isLoading={evidenceLoading}
+        error={evidenceError}
+      />
     </View>
   );
 }
@@ -1013,6 +1162,25 @@ const useStyles = createStyles((colors, shadows) => ({
     fontSize: fontSize.sm,
     fontWeight: "600",
   },
+  assetRight: {
+    alignItems: "flex-end",
+    gap: 4,
+  },
+  auditEvidenceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingTop: spacing.sm,
+    marginTop: spacing.xs,
+    borderTopWidth: 1,
+    borderTopColor: colors.borderLight,
+  },
+  auditEvidenceText: {
+    flex: 1,
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.primaryText,
+  },
   statusBadge: {
     flexDirection: "row",
     alignItems: "center",
@@ -1020,6 +1188,23 @@ const useStyles = createStyles((colors, shadows) => ({
     paddingVertical: 2,
     borderRadius: borderRadius.pill,
     gap: 4,
+  },
+  evidenceChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 3,
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderRadius: borderRadius.pill,
+    backgroundColor: colors.primaryBg,
+  },
+  evidenceChipText: {
+    fontSize: fontSize.xs,
+    fontWeight: "600",
+    // why: `primaryText`, not `primary` — the brand orange is ~3.1:1 on
+    // white and fails the 4.5:1 text bar; `primaryText` is its accessible
+    // twin, the same pairing the rest of the app uses for orange labels.
+    color: colors.primaryText,
   },
   statusDot: {
     width: 6,

--- a/apps/companion/components/audit/evidence-modal.tsx
+++ b/apps/companion/components/audit/evidence-modal.tsx
@@ -132,10 +132,13 @@ export function EvidenceModal({
     const controller = new AbortController();
     setExistingLoading(true);
     void (async () => {
+      // Narrowed to this asset: the sheet shows one row, and the audit-wide
+      // response carries every note and photo in the audit.
       const { data } = await api.auditEvidence(
         auditSessionId,
         currentOrg.id,
-        controller.signal
+        controller.signal,
+        auditAssetId
       );
       if (controller.signal.aborted) return;
       setExisting(

--- a/apps/companion/components/audit/evidence-modal.tsx
+++ b/apps/companion/components/audit/evidence-modal.tsx
@@ -8,7 +8,7 @@
  * @see POST /api/mobile/audits/image - Upload photo with optional note
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   View,
   Text,
@@ -26,6 +26,7 @@ import { Image } from "expo-image";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { api } from "@/lib/api";
+import type { AuditEvidenceImage, AuditEvidenceNote } from "@/lib/api/types";
 import { useOrg } from "@/lib/org-context";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -100,6 +101,52 @@ export function EvidenceModal({
   onEvidenceAdded,
 }: EvidenceModalProps) {
   const { currentOrg } = useOrg();
+
+  /**
+   * The evidence already recorded against this asset.
+   *
+   * why the modal fetches it: this sheet printed "1 note, 1 photo" and then
+   * offered only Add Photo and Save Note. On the SCANNER — where a field
+   * worker actually stands — the counts were a promise the screen did not
+   * keep, which is the same gap the read-only viewer closed on the audit
+   * detail screen. Someone checking whether a scratch was already recorded
+   * had to leave the scan, find the audit, and come back.
+   */
+  const [existing, setExisting] = useState<{
+    notes: AuditEvidenceNote[];
+    images: AuditEvidenceImage[];
+  }>({ notes: [], images: [] });
+  const [existingLoading, setExistingLoading] = useState(false);
+  /** Bumped after each write so the list above refreshes with what was added. */
+  const [savedCount, setSavedCount] = useState(0);
+
+  const auditAssetId = item?.auditAssetId ?? null;
+
+  useEffect(() => {
+    if (!visible || !auditAssetId || !currentOrg?.id) {
+      setExisting({ notes: [], images: [] });
+      return;
+    }
+    // Aborts on close or on switching to another asset, so a slow reply for
+    // the previous row can never paint over the one now open.
+    const controller = new AbortController();
+    setExistingLoading(true);
+    void (async () => {
+      const { data } = await api.auditEvidence(
+        auditSessionId,
+        currentOrg.id,
+        controller.signal
+      );
+      if (controller.signal.aborted) return;
+      setExisting(
+        data?.byAuditAsset?.[auditAssetId] ?? { notes: [], images: [] }
+      );
+      setExistingLoading(false);
+    })();
+    return () => controller.abort();
+    // `savedCount` re-runs this after a note or photo is added, so what the
+    // sheet shows includes what the person just recorded.
+  }, [visible, auditAssetId, currentOrg?.id, auditSessionId, savedCount]);
   const { colors } = useTheme();
   const styles = useStyles();
 
@@ -139,6 +186,7 @@ export function EvidenceModal({
 
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       onEvidenceAdded(item.assetId, "note");
+      setSavedCount((n) => n + 1);
       setNoteText("");
     } catch {
       Alert.alert("Error", "Failed to save note. Please try again.");
@@ -233,9 +281,11 @@ export function EvidenceModal({
 
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       onEvidenceAdded(item.assetId, "image");
+      setSavedCount((n) => n + 1);
       // Server also creates a note when text accompanies the image
       if (noteText.trim()) {
         onEvidenceAdded(item.assetId, "note");
+        setSavedCount((n) => n + 1);
       }
       setSelectedImageUri(null);
       setNoteText("");
@@ -344,6 +394,38 @@ export function EvidenceModal({
                     </Text>
                   </View>
                 </View>
+
+                {/* What is already recorded — the thing the counts point at. */}
+                {existingLoading &&
+                existing.notes.length === 0 &&
+                existing.images.length === 0 ? (
+                  <ActivityIndicator
+                    style={styles.existingLoading}
+                    color={colors.primary}
+                  />
+                ) : null}
+
+                {existing.images.length > 0 ? (
+                  <View style={styles.existingImages}>
+                    {existing.images.map((img) => (
+                      <Image
+                        key={img.id}
+                        source={{ uri: img.thumbnailUrl }}
+                        style={styles.existingThumb}
+                        contentFit="cover"
+                      />
+                    ))}
+                  </View>
+                ) : null}
+
+                {existing.notes.map((note) => (
+                  <View key={note.id} style={styles.existingNote}>
+                    <Text style={styles.existingNoteText}>{note.content}</Text>
+                    <Text style={styles.existingNoteMeta}>
+                      {note.authorName ?? "Unknown"}
+                    </Text>
+                  </View>
+                ))}
 
                 {/* Image preview / picker */}
                 {selectedImageUri ? (
@@ -462,6 +544,36 @@ export function EvidenceModal({
 }
 
 const useStyles = createStyles((colors) => ({
+  existingLoading: { marginBottom: spacing.md },
+  existingImages: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  existingThumb: {
+    width: 72,
+    height: 72,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.borderLight,
+  },
+  existingNote: {
+    backgroundColor: colors.backgroundSecondary,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+    gap: 4,
+  },
+  existingNoteText: {
+    fontSize: fontSize.sm,
+    color: colors.foreground,
+    lineHeight: 20,
+  },
+  existingNoteMeta: {
+    fontSize: fontSize.xs,
+    // why `muted`, not `mutedLight` — the lighter grey misses 4.5:1 at this size.
+    color: colors.muted,
+  },
   overlay: {
     flex: 1,
     justifyContent: "flex-end",

--- a/apps/companion/components/audit/evidence-viewer.tsx
+++ b/apps/companion/components/audit/evidence-viewer.tsx
@@ -1,0 +1,265 @@
+/**
+ * Read-only viewer for evidence already recorded on an audit.
+ *
+ * The sibling {@link file://./evidence-modal.tsx} WRITES evidence during a
+ * live scan. This one only READS, and exists because there was previously no
+ * way to read at all: a field worker photographed a damaged asset, completed
+ * the audit, and every note and photo they had taken became visible only on
+ * the web app. The phone even knew how many there were — the detail payload
+ * carries counts — and still could not show one of them.
+ *
+ * Deliberately has no edit or delete affordance. Removing evidence is a
+ * destructive act that belongs on the surface with room to confirm it; this
+ * is for looking at the record in the field, including long after the audit
+ * closed.
+ *
+ * @see {@link file://./../../lib/api/audits.ts} `auditEvidence`
+ */
+import { useCallback } from "react";
+import {
+  View,
+  Text,
+  Modal,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+} from "react-native";
+import { Image } from "expo-image";
+import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { useDateFormatter } from "@/lib/use-date-formatter";
+import type {
+  AuditEvidenceImage,
+  AuditEvidenceNote,
+} from "@/lib/api/types";
+
+type EvidenceViewerProps = {
+  visible: boolean;
+  onClose: () => void;
+  /** Asset name, or a heading for the audit-wide bucket. */
+  title: string;
+  notes: AuditEvidenceNote[];
+  images: AuditEvidenceImage[];
+  isLoading?: boolean;
+  error?: string | null;
+  /** Opens one photo full-screen. Omitted when there is nothing to open into. */
+  onImagePress?: (image: AuditEvidenceImage) => void;
+};
+
+export function EvidenceViewer({
+  visible,
+  onClose,
+  title,
+  notes,
+  images,
+  isLoading = false,
+  error = null,
+  onImagePress,
+}: EvidenceViewerProps) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+  // why: the workspace's own date format — the same hook every other audit
+  // surface uses, so a completed audit does not suddenly render dates
+  // differently from the screen that opened it.
+  const { formatDateTime } = useDateFormatter();
+
+  const renderNote = useCallback(
+    (note: AuditEvidenceNote) => (
+      <View key={note.id} style={styles.note}>
+        <Text style={styles.noteContent}>{note.content}</Text>
+        <Text style={styles.noteMeta}>
+          {/* why: the account can be deleted while its evidence survives, so
+              the author is nullable. Naming the gap beats an empty gap. */}
+          {note.authorName ?? "Unknown"} · {formatDateTime(note.createdAt)}
+        </Text>
+      </View>
+    ),
+    [styles, formatDateTime]
+  );
+
+  const isEmpty = !isLoading && !error && notes.length === 0 && images.length === 0;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.sheet}>
+          <View style={styles.header}>
+            <Text style={styles.title} numberOfLines={1}>
+              {title}
+            </Text>
+            <TouchableOpacity
+              onPress={onClose}
+              hitSlop={12}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+            >
+              <Ionicons name="close" size={24} color={colors.foreground} />
+            </TouchableOpacity>
+          </View>
+
+          {isLoading ? (
+            <View style={styles.centered}>
+              <ActivityIndicator color={colors.primary} />
+            </View>
+          ) : error ? (
+            <View style={styles.centered}>
+              <Text style={styles.empty}>{error}</Text>
+            </View>
+          ) : isEmpty ? (
+            <View style={styles.centered}>
+              <Text style={styles.empty}>
+                Nothing was recorded against this one.
+              </Text>
+            </View>
+          ) : (
+            <ScrollView
+              style={styles.body}
+              contentContainerStyle={styles.bodyContent}
+            >
+              {images.length > 0 ? (
+                <>
+                  <Text style={styles.sectionLabel}>
+                    {images.length === 1 ? "1 photo" : `${images.length} photos`}
+                  </Text>
+                  <View style={styles.grid}>
+                    {images.map((image) => (
+                      <TouchableOpacity
+                        key={image.id}
+                        activeOpacity={onImagePress ? 0.7 : 1}
+                        onPress={
+                          onImagePress ? () => onImagePress(image) : undefined
+                        }
+                        accessibilityRole={onImagePress ? "button" : "image"}
+                        accessibilityLabel={
+                          image.description
+                            ? `Photo: ${image.description}`
+                            : `Photo by ${image.authorName ?? "Unknown"}`
+                        }
+                      >
+                        <Image
+                          source={{ uri: image.thumbnailUrl }}
+                          style={styles.thumb}
+                          contentFit="cover"
+                        />
+                        {image.description ? (
+                          <Text style={styles.caption} numberOfLines={2}>
+                            {image.description}
+                          </Text>
+                        ) : null}
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                </>
+              ) : null}
+
+              {notes.length > 0 ? (
+                <>
+                  <Text style={styles.sectionLabel}>
+                    {notes.length === 1 ? "1 note" : `${notes.length} notes`}
+                  </Text>
+                  {notes.map(renderNote)}
+                </>
+              ) : null}
+            </ScrollView>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const useStyles = createStyles((colors) => ({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.45)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    backgroundColor: colors.background,
+    borderTopLeftRadius: borderRadius.lg,
+    borderTopRightRadius: borderRadius.lg,
+    maxHeight: "85%",
+    paddingBottom: spacing.lg,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.borderLight,
+  },
+  title: {
+    flex: 1,
+    fontSize: fontSize.md,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  body: { flexGrow: 0 },
+  bodyContent: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.md,
+    gap: spacing.sm,
+  },
+  centered: {
+    padding: spacing.xl,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    fontSize: fontSize.sm,
+    // why: `muted`, not `mutedLight` — the lighter grey is the icon/large-text
+    // token and misses 4.5:1 at this size.
+    color: colors.muted,
+    textAlign: "center",
+  },
+  sectionLabel: {
+    fontSize: fontSize.xs,
+    fontWeight: "600",
+    color: colors.muted,
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginTop: spacing.sm,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  thumb: {
+    width: 104,
+    height: 104,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.borderLight,
+  },
+  caption: {
+    width: 104,
+    marginTop: 4,
+    fontSize: fontSize.xs,
+    color: colors.muted,
+  },
+  note: {
+    backgroundColor: colors.backgroundSecondary,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    gap: 6,
+  },
+  noteContent: {
+    fontSize: fontSize.sm,
+    color: colors.foreground,
+    lineHeight: 20,
+  },
+  noteMeta: {
+    fontSize: fontSize.xs,
+    color: colors.muted,
+  },
+}));

--- a/apps/companion/components/audit/evidence-viewer.tsx
+++ b/apps/companion/components/audit/evidence-viewer.tsx
@@ -30,10 +30,7 @@ import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useDateFormatter } from "@/lib/use-date-formatter";
-import type {
-  AuditEvidenceImage,
-  AuditEvidenceNote,
-} from "@/lib/api/types";
+import type { AuditEvidenceImage, AuditEvidenceNote } from "@/lib/api/types";
 
 type EvidenceViewerProps = {
   visible: boolean;
@@ -46,6 +43,16 @@ type EvidenceViewerProps = {
   error?: string | null;
   /** Opens one photo full-screen. Omitted when there is nothing to open into. */
   onImagePress?: (image: AuditEvidenceImage) => void;
+  /**
+   * Fetches again after a failure.
+   *
+   * why it is needed: the sheet caches per audit, so a failed load left the
+   * error on screen with no way forward — the reader had to close the sheet
+   * and reopen it to get another attempt, which is not a thing anyone guesses.
+   * Audits run in stockrooms and basements, so a request timing out is the
+   * normal case, not the exceptional one.
+   */
+  onRetry?: () => void;
 };
 
 export function EvidenceViewer({
@@ -57,6 +64,7 @@ export function EvidenceViewer({
   isLoading = false,
   error = null,
   onImagePress,
+  onRetry,
 }: EvidenceViewerProps) {
   const { colors } = useTheme();
   const styles = useStyles();
@@ -79,7 +87,8 @@ export function EvidenceViewer({
     [styles, formatDateTime]
   );
 
-  const isEmpty = !isLoading && !error && notes.length === 0 && images.length === 0;
+  const isEmpty =
+    !isLoading && !error && notes.length === 0 && images.length === 0;
 
   return (
     <Modal
@@ -111,6 +120,16 @@ export function EvidenceViewer({
           ) : error ? (
             <View style={styles.centered}>
               <Text style={styles.empty}>{error}</Text>
+              {onRetry ? (
+                <TouchableOpacity
+                  onPress={onRetry}
+                  style={styles.retryButton}
+                  accessibilityRole="button"
+                  accessibilityLabel="Try loading the evidence again"
+                >
+                  <Text style={styles.retryText}>Try again</Text>
+                </TouchableOpacity>
+              ) : null}
             </View>
           ) : isEmpty ? (
             <View style={styles.centered}>
@@ -126,7 +145,9 @@ export function EvidenceViewer({
               {images.length > 0 ? (
                 <>
                   <Text style={styles.sectionLabel}>
-                    {images.length === 1 ? "1 photo" : `${images.length} photos`}
+                    {images.length === 1
+                      ? "1 photo"
+                      : `${images.length} photos`}
                   </Text>
                   <View style={styles.grid}>
                     {images.map((image) => (
@@ -214,6 +235,19 @@ const useStyles = createStyles((colors) => ({
     padding: spacing.xl,
     alignItems: "center",
     justifyContent: "center",
+  },
+  retryButton: {
+    marginTop: spacing.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.primary,
+  },
+  retryText: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.primaryText,
   },
   empty: {
     fontSize: fontSize.sm,

--- a/apps/companion/lib/api/audits.ts
+++ b/apps/companion/lib/api/audits.ts
@@ -81,9 +81,22 @@ export const auditsApi = {
    * @param orgId Active organization id from `useOrg`.
    * @param signal AbortSignal so navigating away mid-flight cancels.
    */
-  auditEvidence: (auditId: string, orgId: string, signal?: AbortSignal) =>
+  auditEvidence: (
+    auditId: string,
+    orgId: string,
+    signal?: AbortSignal,
+    /**
+     * Narrows the response to one audited asset. Pass it whenever the caller
+     * is showing a single row: the audit-wide response carries every note and
+     * photo in the audit, which is the heavy half of this feature.
+     */
+    auditAssetId?: string | null
+  ) =>
     apiFetch<AuditEvidenceResponse>(
-      `/api/mobile/audits/${auditId}/evidence?orgId=${orgId}`,
+      `/api/mobile/audits/${auditId}/evidence?orgId=${orgId}` +
+        (auditAssetId
+          ? `&auditAssetId=${encodeURIComponent(auditAssetId)}`
+          : ""),
       { signal }
     ),
 

--- a/apps/companion/lib/api/audits.ts
+++ b/apps/companion/lib/api/audits.ts
@@ -2,6 +2,7 @@ import { apiFetch, apiUpload } from "./client";
 import type {
   AuditsResponse,
   AuditDetailResponse,
+  AuditEvidenceResponse,
   RecordScanResponse,
   CompleteAuditResponse,
   CreateAuditNoteResponse,
@@ -61,6 +62,29 @@ export const auditsApi = {
   audit: (auditId: string, orgId: string) =>
     apiFetch<AuditDetailResponse>(
       `/api/mobile/audits/${auditId}?orgId=${orgId}`
+    ),
+
+  /**
+   * Get every note and photo recorded on an audit, for READING.
+   *
+   * The write halves (`addAuditNote`, `uploadAuditImage`) have always
+   * existed; this is the read half. Without it the app knew evidence
+   * existed — the detail payload carries counts — but could not show any of
+   * it, so a completed audit surfaced none of the work the field worker had
+   * just done.
+   *
+   * Fetched separately from the detail payload rather than folded into it:
+   * this is heavier (image URLs, note bodies, authors) and only needed when
+   * someone actually opens a row, so the audit list and detail stay cheap.
+   *
+   * @param auditId Audit session id.
+   * @param orgId Active organization id from `useOrg`.
+   * @param signal AbortSignal so navigating away mid-flight cancels.
+   */
+  auditEvidence: (auditId: string, orgId: string, signal?: AbortSignal) =>
+    apiFetch<AuditEvidenceResponse>(
+      `/api/mobile/audits/${auditId}/evidence?orgId=${orgId}`,
+      { signal }
     ),
 
   /** Record a scan during an audit (idempotent) */

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -1053,6 +1053,51 @@ export type AuditDetailResponse = {
   canComplete: boolean;
 };
 
+/**
+ * One note or photo recorded on an audit, as the evidence route serves it.
+ *
+ * `authorName` is null when the account has been removed — the evidence
+ * survives the person, so the UI says "Unknown" rather than hiding the row.
+ */
+export type AuditEvidenceNote = {
+  id: string;
+  content: string;
+  createdAt: string;
+  authorName: string | null;
+  authorImage: string | null;
+};
+
+export type AuditEvidenceImage = {
+  id: string;
+  imageUrl: string;
+  /** Always populated — the server falls back to `imageUrl`. */
+  thumbnailUrl: string;
+  description: string | null;
+  createdAt: string;
+  authorName: string | null;
+  authorImage: string | null;
+};
+
+/**
+ * Everything recorded ON an audit, split the way the schema splits it.
+ *
+ * `general` is the completion note and any photos attached when the audit was
+ * closed. `byAuditAsset` is keyed by the same `auditAssetId` the detail
+ * payload already carries, so a row looks up its own evidence directly.
+ *
+ * @see GET /api/mobile/audits/:auditId/evidence
+ */
+export type AuditEvidenceResponse = {
+  general: {
+    notes: AuditEvidenceNote[];
+    images: AuditEvidenceImage[];
+  };
+  byAuditAsset: Record<
+    string,
+    { notes: AuditEvidenceNote[]; images: AuditEvidenceImage[] }
+  >;
+};
+
 export type RecordScanResponse = {
   success: boolean;
   scanId: string;

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -1096,6 +1096,19 @@ export type AuditEvidenceResponse = {
     string,
     { notes: AuditEvidenceNote[]; images: AuditEvidenceImage[] }
   >;
+  /**
+   * The server clamped the response, so what arrived is the most recent rows
+   * rather than all of them.
+   *
+   * The clamp applies across the WHOLE audit on an audit-wide request, so once
+   * it bites, older per-asset buckets come back short — or empty — while their
+   * count chips still promise the real number. Request a single
+   * `auditAssetId` to get a bucket no unrelated row can clamp.
+   *
+   * Optional so a client built against an older server still type-checks;
+   * absent means the server predates the flag, not that nothing was clamped.
+   */
+  truncated?: boolean;
 };
 
 export type RecordScanResponse = {

--- a/apps/webapp/app/components/audit/audit-asset-list-item.evidence.test.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-list-item.evidence.test.tsx
@@ -1,0 +1,194 @@
+import type { AnchorHTMLAttributes, PropsWithChildren } from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The evidence chip on an audit's asset row.
+ *
+ * why this test exists: the chip is the ONLY thing on the audit overview
+ * that says a row holds condition notes or photos. Without it the one
+ * damaged asset in a 200-row audit is indistinguishable from the 199 clean
+ * ones, and the evidence someone stood there and recorded is reachable only
+ * by scrolling the Activity feed or opening rows on spec.
+ *
+ * @see {@link file://./audit-asset-list-item.tsx}
+ */
+
+const mockUseLoaderData = vi.fn();
+
+// why: the component reads its route's loader data; no router is running here.
+vi.mock("react-router", async () => {
+  const actual = (await vi.importActual("react-router")) as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...actual,
+    useLoaderData: () => mockUseLoaderData(),
+    Link: ({
+      to,
+      children,
+      ...rest
+    }: PropsWithChildren<
+      AnchorHTMLAttributes<HTMLAnchorElement> & { to?: unknown }
+    >) => (
+      <a {...rest} href={typeof to === "string" ? to : undefined}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+// why: these read org/user context from hooks that need a running app; the
+// chip's behaviour does not depend on either.
+vi.mock("~/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => null,
+}));
+vi.mock("~/hooks/user-user-role-helper", () => ({
+  useUserRoleHelper: () => ({ roles: [], isBaseOrSelfService: false }),
+}));
+vi.mock("~/utils/permissions/permission.validator.client", () => ({
+  userHasPermission: () => false,
+}));
+vi.mock("~/hooks/search-params", () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+const { AuditAssetListItem } = await import("./audit-asset-list-item");
+
+const SESSION = { id: "audit-1", status: "COMPLETED", completedAt: new Date() };
+
+function item(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "asset-1",
+    title: "Arri Fresnel 650 Plus",
+    mainImage: null,
+    thumbnailImage: null,
+    category: null,
+    location: null,
+    custody: [],
+    tags: [],
+    qrCodes: [],
+    barcodes: [],
+    auditData: {
+      auditAssetId: "aa-1",
+      expected: true,
+      auditStatus: "FOUND",
+      auditNotesCount: 0,
+      auditImagesCount: 0,
+    },
+    ...overrides,
+  };
+}
+
+function renderRow(itemData: ReturnType<typeof item>) {
+  mockUseLoaderData.mockReturnValue({
+    session: SESSION,
+    canRemoveAssets: false,
+  });
+  return render(
+    <table>
+      <tbody>
+        {/* why: the component renders the row's <td> cells, not the <tr>
+            itself, so the harness supplies the row wrapper. */}
+        <tr>
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+          <AuditAssetListItem item={itemData as any} />
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+describe("AuditAssetListItem — evidence chip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("says nothing when the row holds no evidence", () => {
+    // why: a chip on every row is the same as no chip at all — the point is
+    // that it distinguishes.
+    renderRow(item());
+
+    expect(screen.queryByLabelText(/attachment/i)).toBeNull();
+  });
+
+  it("sums notes and photos into one count", () => {
+    // why: the reader's question is "is there anything here?", not "how many
+    // of each?" — the panel answers the breakdown.
+    renderRow(
+      item({
+        auditData: {
+          auditAssetId: "aa-1",
+          expected: true,
+          auditStatus: "FOUND",
+          auditNotesCount: 2,
+          auditImagesCount: 1,
+        },
+      })
+    );
+
+    expect(
+      screen.getByLabelText("3 attachments on Arri Fresnel 650 Plus")
+    ).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("uses the singular for one attachment", () => {
+    renderRow(
+      item({
+        auditData: {
+          auditAssetId: "aa-1",
+          expected: true,
+          auditStatus: "FOUND",
+          auditNotesCount: 1,
+          auditImagesCount: 0,
+        },
+      })
+    );
+
+    expect(
+      screen.getByLabelText("1 attachment on Arri Fresnel 650 Plus")
+    ).toBeTruthy();
+  });
+
+  it("links into the existing notes-and-images panel", () => {
+    // why: the chip must lead somewhere. Reusing the details panel avoids a
+    // second place to read the same evidence, and that route has no status
+    // gate, so it still opens on a completed audit.
+    renderRow(
+      item({
+        auditData: {
+          auditAssetId: "aa-1",
+          expected: true,
+          auditStatus: "FOUND",
+          auditNotesCount: 1,
+          auditImagesCount: 1,
+        },
+      })
+    );
+
+    const chip = screen.getByLabelText("2 attachments on Arri Fresnel 650 Plus");
+    expect(chip.getAttribute("href")).toBe(
+      "/audits/audit-1/scan/aa-1/details"
+    );
+  });
+
+  it("stays silent when the audit-asset link is missing", () => {
+    // why: without an auditAssetId there is nowhere to send the reader, so a
+    // chip would be a dead control.
+    renderRow(
+      item({
+        auditData: {
+          auditAssetId: null,
+          expected: true,
+          auditStatus: "FOUND",
+          auditNotesCount: 3,
+          auditImagesCount: 0,
+        },
+      })
+    );
+
+    expect(screen.queryByLabelText(/attachment/i)).toBeNull();
+  });
+});

--- a/apps/webapp/app/components/audit/audit-asset-list-item.evidence.test.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-list-item.evidence.test.tsx
@@ -47,9 +47,13 @@ vi.mock("~/hooks/use-current-organization", () => ({
 vi.mock("~/hooks/user-user-role-helper", () => ({
   useUserRoleHelper: () => ({ roles: [], isBaseOrSelfService: false }),
 }));
+// why: the row asks this to decide whether to offer the remove action. False
+// keeps that column out of the way — the evidence chip is what is under test.
 vi.mock("~/utils/permissions/permission.validator.client", () => ({
   userHasPermission: () => false,
 }));
+// why: the real hook needs a router. The chip does not read search params, so
+// a stable empty set keeps the render deterministic.
 vi.mock("~/hooks/search-params", () => ({
   useSearchParams: () => [new URLSearchParams(), vi.fn()],
 }));

--- a/apps/webapp/app/components/audit/audit-asset-list-item.evidence.test.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-list-item.evidence.test.tsx
@@ -110,12 +110,14 @@ describe("AuditAssetListItem — evidence chip", () => {
     // that it distinguishes.
     renderRow(item());
 
-    expect(screen.queryByLabelText(/attachment/i)).toBeNull();
+    expect(screen.queryByLabelText(/note|photo/i)).toBeNull();
   });
 
-  it("sums notes and photos into one count", () => {
-    // why: the reader's question is "is there anything here?", not "how many
-    // of each?" — the panel answers the breakdown.
+  it("keeps notes and photos as two separate counts", () => {
+    // why NOT one summed number: it would not be comparable between rows.
+    // Photos uploaded with a caption store a COMMENT alongside them; the same
+    // photos with no caption store an UPDATE, which is not evidence and is not
+    // counted. A single digit would read differently for identical evidence.
     renderRow(
       item({
         auditData: {
@@ -129,12 +131,16 @@ describe("AuditAssetListItem — evidence chip", () => {
     );
 
     expect(
-      screen.getByLabelText("3 attachments on Arri Fresnel 650 Plus")
+      screen.getByLabelText("2 notes, 1 photo on Arri Fresnel 650 Plus")
     ).toBeTruthy();
-    expect(screen.getByText("3")).toBeTruthy();
+    // both numbers on screen, never their sum
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.queryByText("3")).toBeNull();
   });
 
-  it("uses the singular for one attachment", () => {
+  it("names only the kind that is actually there", () => {
+    // why: "1 note" on a row with no photo, not "1 note, 0 photos".
     renderRow(
       item({
         auditData: {
@@ -148,7 +154,28 @@ describe("AuditAssetListItem — evidence chip", () => {
     );
 
     expect(
-      screen.getByLabelText("1 attachment on Arri Fresnel 650 Plus")
+      screen.getByLabelText("1 note on Arri Fresnel 650 Plus")
+    ).toBeTruthy();
+  });
+
+  it("shows the photo count on a row with photos but no note", () => {
+    // why: uploading photos without a caption writes no COMMENT at all, so
+    // this is the shape of the common field case. A notes-only indicator
+    // would have rendered nothing here.
+    renderRow(
+      item({
+        auditData: {
+          auditAssetId: "aa-1",
+          expected: true,
+          auditStatus: "FOUND",
+          auditNotesCount: 0,
+          auditImagesCount: 2,
+        },
+      })
+    );
+
+    expect(
+      screen.getByLabelText("2 photos on Arri Fresnel 650 Plus")
     ).toBeTruthy();
   });
 
@@ -168,10 +195,10 @@ describe("AuditAssetListItem — evidence chip", () => {
       })
     );
 
-    const chip = screen.getByLabelText("2 attachments on Arri Fresnel 650 Plus");
-    expect(chip.getAttribute("href")).toBe(
-      "/audits/audit-1/scan/aa-1/details"
+    const chip = screen.getByLabelText(
+      "1 note, 1 photo on Arri Fresnel 650 Plus"
     );
+    expect(chip.getAttribute("href")).toBe("/audits/audit-1/scan/aa-1/details");
   });
 
   it("stays silent when the audit-asset link is missing", () => {
@@ -189,6 +216,6 @@ describe("AuditAssetListItem — evidence chip", () => {
       })
     );
 
-    expect(screen.queryByLabelText(/attachment/i)).toBeNull();
+    expect(screen.queryByLabelText(/note|photo/i)).toBeNull();
   });
 });

--- a/apps/webapp/app/components/audit/audit-asset-list-item.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-list-item.tsx
@@ -13,6 +13,7 @@
  */
 
 import { isAuditCompleted } from "@shelf/labels";
+import { Paperclip } from "lucide-react";
 import { useLoaderData } from "react-router";
 
 import { AssetCodeBadge } from "~/components/assets/asset-code-badge";
@@ -56,6 +57,14 @@ type AuditAssetItem = LoaderData["data"]["items"][number];
  */
 export function AuditAssetListItem({ item }: { item: AuditAssetItem }) {
   const { session, canRemoveAssets } = useLoaderData<typeof loader>();
+  /**
+   * Condition notes + photos recorded against this asset during the audit.
+   * One number, because the reader's question is "is there anything here?",
+   * not "how many of each?" — the panel answers that.
+   */
+  const evidenceCount =
+    (item.auditData?.auditNotesCount ?? 0) +
+    (item.auditData?.auditImagesCount ?? 0);
   const { category, location, custody: custodyArray } = item;
   // `custody` is an array on the quantities data model — surface the primary
   // custody row so the existing single-custodian badge keeps working.
@@ -129,9 +138,35 @@ export function AuditAssetListItem({ item }: { item: AuditAssetItem }) {
                 column). Keeps composition consistent across surfaces per
                 `.claude/rules/code-bearing-entity-list-consistency.md`.
               */}
-              {displayCode ? (
+              {displayCode || evidenceCount > 0 ? (
                 <div className="flex flex-wrap items-center gap-2">
-                  <AssetCodeBadge {...displayCode} />
+                  {displayCode ? <AssetCodeBadge {...displayCode} /> : null}
+                  {/*
+                    why: the row is the only place someone looks when asking
+                    "which of these did we find something on?". The notes and
+                    photos were always reachable — through the Activity feed,
+                    or by opening a row on spec — but nothing here said which
+                    rows were worth opening, so on a large audit the one
+                    damaged item read exactly like the clean ones.
+
+                    Links into the existing notes-and-images panel rather than
+                    introducing a second place to read evidence. That panel has
+                    no status gate, so this works on a completed audit, which
+                    is when the record actually gets consulted.
+                  */}
+                  {evidenceCount > 0 && item.auditData?.auditAssetId ? (
+                    <Button
+                      to={`/audits/${session.id}/scan/${item.auditData.auditAssetId}/details`}
+                      variant="link"
+                      className="flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[12px] font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+                      aria-label={`${evidenceCount} ${
+                        evidenceCount === 1 ? "attachment" : "attachments"
+                      } on ${item.title}`}
+                    >
+                      <Paperclip className="size-3" />
+                      <span className="tabular-nums">{evidenceCount}</span>
+                    </Button>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/apps/webapp/app/components/audit/audit-asset-list-item.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-list-item.tsx
@@ -13,7 +13,7 @@
  */
 
 import { isAuditCompleted } from "@shelf/labels";
-import { Paperclip } from "lucide-react";
+import { ImageIcon, MessageSquare } from "lucide-react";
 import { useLoaderData } from "react-router";
 
 import { AssetCodeBadge } from "~/components/assets/asset-code-badge";
@@ -58,13 +58,31 @@ type AuditAssetItem = LoaderData["data"]["items"][number];
 export function AuditAssetListItem({ item }: { item: AuditAssetItem }) {
   const { session, canRemoveAssets } = useLoaderData<typeof loader>();
   /**
-   * Condition notes + photos recorded against this asset during the audit.
-   * One number, because the reader's question is "is there anything here?",
-   * not "how many of each?" — the panel answers that.
+   * What a person recorded against this asset, kept as TWO numbers.
+   *
+   * why not one summed number: it would not be comparable between rows. Two
+   * photos uploaded with a caption store one COMMENT plus two images; the
+   * same two photos with no caption store an UPDATE plus two images, and
+   * UPDATE rows are not evidence and are not counted (helpers.server.ts,
+   * createAuditImageEvidenceNote). A single digit would therefore read 3 or 2
+   * for identical evidence, tracking how the upload happened to be stored
+   * rather than what was found. Every destination keeps them apart too — the
+   * panel this links to has a Notes badge and an Images badge, and the phone
+   * sheet has a notes section and a photo grid.
    */
-  const evidenceCount =
-    (item.auditData?.auditNotesCount ?? 0) +
-    (item.auditData?.auditImagesCount ?? 0);
+  const noteCount = item.auditData?.auditNotesCount ?? 0;
+  const photoCount = item.auditData?.auditImagesCount ?? 0;
+  const hasEvidence = noteCount > 0 || photoCount > 0;
+
+  /** Reads the way a person would say it, for screen readers and the tooltip. */
+  const evidenceLabel = [
+    noteCount > 0 ? `${noteCount} ${noteCount === 1 ? "note" : "notes"}` : null,
+    photoCount > 0
+      ? `${photoCount} ${photoCount === 1 ? "photo" : "photos"}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
   const { category, location, custody: custodyArray } = item;
   // `custody` is an array on the quantities data model — surface the primary
   // custody row so the existing single-custodian badge keeps working.
@@ -138,7 +156,7 @@ export function AuditAssetListItem({ item }: { item: AuditAssetItem }) {
                 column). Keeps composition consistent across surfaces per
                 `.claude/rules/code-bearing-entity-list-consistency.md`.
               */}
-              {displayCode || evidenceCount > 0 ? (
+              {displayCode || hasEvidence ? (
                 <div className="flex flex-wrap items-center gap-2">
                   {displayCode ? <AssetCodeBadge {...displayCode} /> : null}
                   {/*
@@ -154,17 +172,30 @@ export function AuditAssetListItem({ item }: { item: AuditAssetItem }) {
                     no status gate, so this works on a completed audit, which
                     is when the record actually gets consulted.
                   */}
-                  {evidenceCount > 0 && item.auditData?.auditAssetId ? (
+                  {hasEvidence && item.auditData?.auditAssetId ? (
                     <Button
                       to={`/audits/${session.id}/scan/${item.auditData.auditAssetId}/details`}
                       variant="link"
-                      className="flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[12px] font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-                      aria-label={`${evidenceCount} ${
-                        evidenceCount === 1 ? "attachment" : "attachments"
-                      } on ${item.title}`}
+                      className="flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[12px] font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+                      title={`${evidenceLabel} on ${item.title}`}
+                      aria-label={`${evidenceLabel} on ${item.title}`}
                     >
-                      <Paperclip className="size-3" />
-                      <span className="tabular-nums">{evidenceCount}</span>
+                      {/* why these two glyphs: they are the ones the
+                          destination panel already heads its Notes and Images
+                          sections with, so the row and the panel teach one
+                          vocabulary instead of two. */}
+                      {noteCount > 0 ? (
+                        <span className="flex items-center gap-1">
+                          <MessageSquare className="size-3" aria-hidden />
+                          <span className="tabular-nums">{noteCount}</span>
+                        </span>
+                      ) : null}
+                      {photoCount > 0 ? (
+                        <span className="flex items-center gap-1">
+                          <ImageIcon className="size-3" aria-hidden />
+                          <span className="tabular-nums">{photoCount}</span>
+                        </span>
+                      ) : null}
                     </Button>
                   ) : null}
                 </div>

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -168,6 +168,7 @@ const AuditPDFContent = ({
     assetIdToQrCodeMap,
     generalImages,
     assetImages,
+    conditionNotes,
     activityNotes,
   } = pdfMeta;
 
@@ -196,23 +197,59 @@ const AuditPDFContent = ({
           .join(", ")
       : "Not assigned";
 
-  // Group asset-specific images by their associated asset
-  const assetImageGroups = assetImages.reduce(
-    (acc, img) => {
-      const assetId = img.auditAsset?.asset?.id;
-      if (!assetId) return acc;
+  /**
+   * One entry per asset somebody recorded something about, holding BOTH what
+   * they wrote and what they photographed.
+   *
+   * why merged: a note about the Laerdal and a photo of the Laerdal are one
+   * observation. Printing them in two separate sections made the reader join
+   * them up by asset name across pages, which is work the receipt should have
+   * done. Notes led that split badly — they had no section of their own at
+   * all, and arrived mixed into a fifteen-row "Activity Log".
+   */
+  type Finding = {
+    assetName: string;
+    images: typeof assetImages;
+    notes: typeof conditionNotes;
+  };
 
-      if (!acc[assetId]) {
-        acc[assetId] = {
-          assetName: img.auditAsset?.asset?.title || "Unknown",
-          images: [],
-        };
-      }
-      acc[assetId].images.push(img);
-      return acc;
-    },
-    {} as Record<string, { assetName: string; images: typeof assetImages }>
+  const findingGroups: Record<string, Finding> = {};
+
+  const findingFor = (assetId: string, assetName: string) => {
+    if (!findingGroups[assetId]) {
+      findingGroups[assetId] = { assetName, images: [], notes: [] };
+    }
+    return findingGroups[assetId];
+  };
+
+  for (const img of assetImages) {
+    const assetId = img.auditAsset?.asset?.id;
+    if (!assetId) continue;
+    findingFor(assetId, img.auditAsset?.asset?.title || "Unknown").images.push(
+      img
+    );
+  }
+
+  for (const note of conditionNotes) {
+    const assetId = note.auditAsset?.asset?.id;
+    // Audit-wide notes have no asset; they print above, with the general images.
+    if (!assetId) continue;
+    findingFor(assetId, note.auditAsset?.asset?.title || "Unknown").notes.push(
+      note
+    );
+  }
+
+  /** Notes about the audit as a whole — the completion note lives here. */
+  const generalNotes = conditionNotes.filter((n) => !n.auditAsset?.asset?.id);
+
+  const findingEntries = Object.entries(findingGroups).sort((a, b) =>
+    a[1].assetName.localeCompare(b[1].assetName)
   );
+
+  const hasFindings =
+    findingEntries.length > 0 ||
+    generalNotes.length > 0 ||
+    generalImages.length > 0;
 
   return (
     <div
@@ -373,72 +410,96 @@ const AuditPDFContent = ({
         </div>
       </section>
 
-      {/* Images Section - General and asset-specific images */}
-      <When truthy={generalImages.length > 0 || assetImages.length > 0}>
+      {/*
+        Findings — what people RECORDED, grouped by the asset they recorded it
+        about, notes and photographs together.
+
+        why this replaced the old "Images" section: a note and a photo of the
+        same asset are one observation, and printing them apart made the reader
+        rejoin them by name. Notes had it worse — no section at all, folded
+        into a fifteen-row "Activity Log" that the system trail crowded out.
+      */}
+      <When truthy={hasFindings}>
         <section className="mb-5">
-          <h2 className="mb-2 text-lg font-medium">Images</h2>
+          <h2 className="mb-2 text-lg font-medium">Findings</h2>
 
-          {/* General Audit Images - Not linked to specific assets */}
-          <When truthy={generalImages.length > 0}>
+          {/* About the audit as a whole — completion note and its photos. */}
+          <When truthy={generalNotes.length > 0 || generalImages.length > 0}>
             <div className="mb-4">
-              <h3 className="mb-2 text-sm font-medium">
-                General Audit Images ({generalImages.length})
-              </h3>
-              <div className="grid grid-cols-4 gap-2">
-                {generalImages.map((img) => (
-                  <div key={img.id} className="border border-gray-300 p-1">
-                    <img
-                      src={img.thumbnailUrl || img.imageUrl}
-                      alt={img.description || "Audit image"}
-                      className="h-24 w-full object-cover"
-                    />
-                    {img.description && (
-                      <p className="mt-1 text-xs text-gray-600">
-                        {img.description}
-                      </p>
-                    )}
-                  </div>
-                ))}
-              </div>
+              <h3 className="mb-2 text-sm font-medium">About this audit</h3>
+
+              {generalNotes.map((note) => (
+                <div key={note.id} className="mb-2 border border-gray-300 p-2">
+                  <p className="text-xs text-gray-900">{note.content}</p>
+                  <p className="mt-1 text-[10px] text-gray-500">
+                    {note.user
+                      ? resolveUserDisplayName(note.user) || note.user.email
+                      : "System"}{" "}
+                    &middot; <DateS date={note.createdAt} includeTime />
+                  </p>
+                </div>
+              ))}
+
+              <When truthy={generalImages.length > 0}>
+                <div className="grid grid-cols-4 gap-2">
+                  {generalImages.map((img) => (
+                    <div key={img.id} className="border border-gray-300 p-1">
+                      <img
+                        src={img.thumbnailUrl || img.imageUrl}
+                        alt={img.description || "Audit image"}
+                        className="h-24 w-full object-cover"
+                      />
+                      {img.description && (
+                        <p className="mt-1 text-xs text-gray-600">
+                          {img.description}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </When>
             </div>
           </When>
 
-          {/* Asset-Specific Images - Grouped by asset */}
-          <When truthy={assetImages.length > 0}>
-            <div>
-              <h3 className="mb-2 text-sm font-medium">
-                Asset-Specific Images ({assetImages.length})
-              </h3>
-              {Object.entries(assetImageGroups).map(
-                ([assetId, { assetName, images }]) => (
-                  <div key={assetId} className="mb-3">
-                    <h4 className="mb-1 text-xs font-medium text-gray-700">
-                      {assetName}
-                    </h4>
-                    <div className="grid grid-cols-4 gap-2">
-                      {images.map((img) => (
-                        <div
-                          key={img.id}
-                          className="border border-gray-300 p-1"
-                        >
-                          <img
-                            src={img.thumbnailUrl || img.imageUrl}
-                            alt={img.description || "Asset image"}
-                            className="h-24 w-full object-cover"
-                          />
-                          {img.description && (
-                            <p className="mt-1 text-xs text-gray-600">
-                              {img.description}
-                            </p>
-                          )}
-                        </div>
-                      ))}
+          {/* One block per asset somebody recorded something about. */}
+          {findingEntries.map(([assetId, { assetName, images, notes }]) => (
+            <div key={assetId} className="mb-3">
+              <h4 className="mb-1 text-xs font-medium text-gray-700">
+                {assetName}
+              </h4>
+
+              {notes.map((note) => (
+                <div key={note.id} className="mb-2 border border-gray-300 p-2">
+                  <p className="text-xs text-gray-900">{note.content}</p>
+                  <p className="mt-1 text-[10px] text-gray-500">
+                    {note.user
+                      ? resolveUserDisplayName(note.user) || note.user.email
+                      : "System"}{" "}
+                    &middot; <DateS date={note.createdAt} includeTime />
+                  </p>
+                </div>
+              ))}
+
+              <When truthy={images.length > 0}>
+                <div className="grid grid-cols-4 gap-2">
+                  {images.map((img) => (
+                    <div key={img.id} className="border border-gray-300 p-1">
+                      <img
+                        src={img.thumbnailUrl || img.imageUrl}
+                        alt={img.description || `Photo of ${assetName}`}
+                        className="h-24 w-full object-cover"
+                      />
+                      {img.description && (
+                        <p className="mt-1 text-xs text-gray-600">
+                          {img.description}
+                        </p>
+                      )}
                     </div>
-                  </div>
-                )
-              )}
+                  ))}
+                </div>
+              </When>
             </div>
-          </When>
+          ))}
         </section>
       </When>
 

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -430,7 +430,14 @@ const AuditPDFContent = ({
 
               {generalNotes.map((note) => (
                 <div key={note.id} className="mb-2 border border-gray-300 p-2">
-                  <p className="text-xs text-gray-900">{note.content}</p>
+                  {/* why whitespace-pre-wrap: a condition note is typed in a
+                      textarea, so line breaks are part of what the person
+                      wrote. Without this the receipt runs a multi-line
+                      observation together into one paragraph — the Activity
+                      Log above already sets it for the same reason. */}
+                  <p className="whitespace-pre-wrap text-xs text-gray-900">
+                    {note.content}
+                  </p>
                   <p className="mt-1 text-[10px] text-gray-500">
                     {note.user
                       ? resolveUserDisplayName(note.user) || note.user.email
@@ -470,7 +477,14 @@ const AuditPDFContent = ({
 
               {notes.map((note) => (
                 <div key={note.id} className="mb-2 border border-gray-300 p-2">
-                  <p className="text-xs text-gray-900">{note.content}</p>
+                  {/* why whitespace-pre-wrap: a condition note is typed in a
+                      textarea, so line breaks are part of what the person
+                      wrote. Without this the receipt runs a multi-line
+                      observation together into one paragraph — the Activity
+                      Log above already sets it for the same reason. */}
+                  <p className="whitespace-pre-wrap text-xs text-gray-900">
+                    {note.content}
+                  </p>
                   <p className="mt-1 text-[10px] text-gray-500">
                     {note.user
                       ? resolveUserDisplayName(note.user) || note.user.email

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -438,7 +438,7 @@ const AuditPDFContent = ({
                   <p className="whitespace-pre-wrap text-xs text-gray-900">
                     {note.content}
                   </p>
-                  <p className="mt-1 text-[10px] text-gray-500">
+                  <p className="mt-1 text-xs text-gray-500">
                     {note.user
                       ? resolveUserDisplayName(note.user) || note.user.email
                       : "System"}{" "}
@@ -485,7 +485,7 @@ const AuditPDFContent = ({
                   <p className="whitespace-pre-wrap text-xs text-gray-900">
                     {note.content}
                   </p>
-                  <p className="mt-1 text-[10px] text-gray-500">
+                  <p className="mt-1 text-xs text-gray-500">
                     {note.user
                       ? resolveUserDisplayName(note.user) || note.user.email
                       : "System"}{" "}

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -54,14 +54,21 @@ function noteQueryFor(type: "COMMENT" | "UPDATE") {
 }
 
 describe("audit receipt — what it may truncate", () => {
+  /**
+   * why this helper: the same `ReturnType<typeof vi.fn>` shape `noteQueryFor`
+   * already uses one function up. Casting each mock to `any` at the call site
+   * threw away the mock's own typing six times over for no benefit.
+   */
+  const mockOf = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
   beforeEach(async () => {
     vi.clearAllMocks();
-    (db.auditSession.findUnique as any).mockResolvedValue(SESSION);
-    (db.auditAsset.findMany as any).mockResolvedValue([]);
-    (db.auditImage.findMany as any).mockResolvedValue([]);
-    (db.auditNote.findMany as any).mockResolvedValue([]);
-    (db.asset.findMany as any).mockResolvedValue([]);
-    (db.organization.findUnique as any).mockResolvedValue({
+    mockOf(db.auditSession.findUnique).mockResolvedValue(SESSION);
+    mockOf(db.auditAsset.findMany).mockResolvedValue([]);
+    mockOf(db.auditImage.findMany).mockResolvedValue([]);
+    mockOf(db.auditNote.findMany).mockResolvedValue([]);
+    mockOf(db.asset.findMany).mockResolvedValue([]);
+    mockOf(db.organization.findUnique).mockResolvedValue({
       id: "org-1",
       name: "Org",
     });

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -1,0 +1,121 @@
+/**
+ * What the audit receipt is allowed to leave out.
+ *
+ * why this test exists: the receipt is the audit's OUTPUT — the artifact
+ * somebody keeps, attaches to a claim, or hands to a client. It used to read
+ * every `AuditNote` with one query and `take: 15`. `AuditNote` mixes two
+ * unrelated things: the condition notes people typed, and the system trail,
+ * which grows with every scan. So on any audit past a handful of assets the
+ * trail won the fifteen slots and the observations fell off the record with no
+ * warning anywhere.
+ *
+ * Truncating the trail is fine — it is a convenience summary. Truncating what
+ * somebody wrote about a damaged asset is data loss, and it is silent, which
+ * is why it needs a test rather than a comment.
+ *
+ * @see {@link file://./pdf-helpers.ts}
+ * @see {@link file://./../../components/audit/audit-receipt-pdf.tsx}
+ */
+// @vitest-environment node
+
+// why: external database — don't hit the real DB
+vi.mock("~/database/db.server", () => ({
+  db: {
+    auditSession: { findUnique: vi.fn() },
+    auditAsset: { findMany: vi.fn() },
+    auditImage: { findMany: vi.fn() },
+    auditNote: { findMany: vi.fn() },
+    asset: { findMany: vi.fn() },
+    organization: { findUnique: vi.fn() },
+  },
+}));
+
+// why: signing QR images reaches Supabase storage; irrelevant to note queries
+vi.mock("~/modules/qr/service.server", () => ({
+  getQrCodeMaps: vi.fn().mockResolvedValue({}),
+}));
+
+import { db } from "~/database/db.server";
+import { fetchAllAuditPdfRelatedData } from "~/modules/audit/pdf-helpers";
+
+const SESSION = {
+  id: "audit-1",
+  name: "Quarterly check",
+  status: "COMPLETED",
+  organizationId: "org-1",
+  createdBy: { firstName: "Ada", lastName: "L", email: "ada@example.com" },
+  assignments: [],
+};
+
+/** The note query for a given `type`, as it was actually issued. */
+function noteQueryFor(type: "COMMENT" | "UPDATE") {
+  const calls = (db.auditNote.findMany as ReturnType<typeof vi.fn>).mock.calls;
+  return calls.map((c) => c[0]).find((arg) => arg?.where?.type === type);
+}
+
+describe("audit receipt — what it may truncate", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    (db.auditSession.findUnique as any).mockResolvedValue(SESSION);
+    (db.auditAsset.findMany as any).mockResolvedValue([]);
+    (db.auditImage.findMany as any).mockResolvedValue([]);
+    (db.auditNote.findMany as any).mockResolvedValue([]);
+    (db.asset.findMany as any).mockResolvedValue([]);
+    (db.organization.findUnique as any).mockResolvedValue({
+      id: "org-1",
+      name: "Org",
+    });
+
+    await fetchAllAuditPdfRelatedData(
+      "audit-1",
+      "org-1",
+      "user-1",
+      undefined,
+      new Request("http://localhost/x")
+    );
+  });
+
+  it("asks for condition notes and system activity separately", () => {
+    // why: one query for both is what made the loss possible. Two queries is
+    // the structural fix; everything below only holds because of it.
+    expect(db.auditNote.findMany).toHaveBeenCalledTimes(2);
+    expect(noteQueryFor("COMMENT")).toBeTruthy();
+    expect(noteQueryFor("UPDATE")).toBeTruthy();
+  });
+
+  it("never caps the condition notes", () => {
+    // why: this is the whole point. A receipt that quietly drops the
+    // twenty-first observation is worse than one that shows none, because it
+    // looks complete. If a cap is ever added here it must be a deliberate
+    // decision that changes this line, not a default that nobody noticed.
+    const q = noteQueryFor("COMMENT");
+
+    expect(q).not.toHaveProperty("take");
+    expect(q?.where).toMatchObject({
+      auditSessionId: "audit-1",
+      type: "COMMENT",
+    });
+  });
+
+  it("reads condition notes oldest first, so the receipt tells a story", () => {
+    // why: the feed on screen is newest-first because it is a feed. A printed
+    // record is read top to bottom in the order the audit happened.
+    expect(noteQueryFor("COMMENT")?.orderBy).toEqual({ createdAt: "asc" });
+  });
+
+  it("carries each note's asset, so a note prints beside its photos", () => {
+    // why: a note about an asset and a photo of that asset are one
+    // observation. Without the asset on the note the receipt cannot group
+    // them and the reader rejoins them by name across sections.
+    expect(noteQueryFor("COMMENT")?.include).toHaveProperty("auditAsset");
+  });
+
+  it("still caps the system activity, which is a summary and may truncate", () => {
+    // why: the trail grows without bound and nobody needs all of it in a
+    // receipt. Keeping the cap HERE is what lets the notes go uncapped.
+    const q = noteQueryFor("UPDATE");
+
+    expect(q?.take).toBe(15);
+    expect(q?.orderBy).toEqual({ createdAt: "desc" });
+  });
+});

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -1,17 +1,15 @@
 /**
  * What the audit receipt is allowed to leave out.
  *
- * why this test exists: the receipt is the audit's OUTPUT — the artifact
- * somebody keeps, attaches to a claim, or hands to a client. It used to read
- * every `AuditNote` with one query and `take: 15`. `AuditNote` mixes two
- * unrelated things: the condition notes people typed, and the system trail,
- * which grows with every scan. So on any audit past a handful of assets the
- * trail won the fifteen slots and the observations fell off the record with no
- * warning anywhere.
+ * The receipt is the audit's OUTPUT: the artifact somebody keeps, attaches to
+ * a claim, or hands to a client.
  *
- * Truncating the trail is fine — it is a convenience summary. Truncating what
- * somebody wrote about a damaged asset is data loss, and it is silent, which
- * is why it needs a test rather than a comment.
+ * `AuditNote` mixes two unrelated things — the condition notes people typed,
+ * and the system trail, which grows with every scan. They must be read with
+ * separate queries, because only one of them may be truncated. Cutting the
+ * trail short is fine; it is a convenience summary. Cutting off what somebody
+ * wrote about a damaged asset is data loss, and it is silent, which is why the
+ * bound belongs in a test rather than a comment.
  *
  * @see {@link file://./pdf-helpers.ts}
  * @see {@link file://./../../components/audit/audit-receipt-pdf.tsx}

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -80,7 +80,25 @@ export interface AuditPdfDbResult {
       };
     } | null;
   })[];
-  // Recent activity notes (limited to 15)
+  /**
+   * What people OBSERVED — every COMMENT note, uncapped.
+   *
+   * Kept separate from `activityNotes` because they answer different
+   * questions and only one of them is safe to truncate. A condition note is
+   * the reason the audit was worth doing ("scuff on the left arm, still
+   * usable"); dropping one silently removes evidence from the record this
+   * PDF exists to be. Carries its asset so the receipt can group a note with
+   * the photos of the same asset.
+   */
+  conditionNotes: (AuditNote & {
+    user: {
+      firstName: string | null;
+      lastName: string | null;
+      email: string;
+    } | null;
+    auditAsset: { asset: { id: string; title: string } | null } | null;
+  })[];
+  // Recent system activity (UPDATE rows only, limited to 15)
   activityNotes: (AuditNote & {
     user: {
       firstName: string | null;
@@ -217,22 +235,51 @@ export async function fetchAllAuditPdfRelatedData(
     const generalImages = images.filter((img) => img.auditAssetId === null);
     const assetImages = images.filter((img) => img.auditAssetId !== null);
 
-    // Fetch recent activity notes (limit to 15 most recent)
-    const activityNotes = await db.auditNote.findMany({
-      where: { auditSessionId },
-      include: {
-        user: {
-          select: {
-            firstName: true,
-            lastName: true,
-            displayName: true,
-            email: true,
+    // `AuditNote` holds two unrelated things and they must not share a query.
+    //
+    // COMMENT rows are what a person typed about the condition of an asset.
+    // UPDATE rows are the system trail ("X started this audit"), written as
+    // Markdoc source. Reading both with one `take: 15` meant the trail — which
+    // grows with every scan — crowded the observations out of the receipt, and
+    // anything past the fifteenth was dropped without a word. On any audit
+    // larger than a handful of assets the condition notes lost that race.
+    const [conditionNotes, activityNotes] = await Promise.all([
+      // Uncapped, and oldest first: this reads as a report, not a feed.
+      db.auditNote.findMany({
+        where: { auditSessionId, type: "COMMENT" },
+        include: {
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+              displayName: true,
+              email: true,
+            },
+          },
+          // why: lets the receipt put a note and the photos of the same asset
+          // in one place, instead of two sections the reader has to join up.
+          auditAsset: {
+            select: { asset: { select: { id: true, title: true } } },
           },
         },
-      },
-      orderBy: { createdAt: "desc" },
-      take: 15,
-    });
+        orderBy: { createdAt: "asc" },
+      }),
+      db.auditNote.findMany({
+        where: { auditSessionId, type: "UPDATE" },
+        include: {
+          user: {
+            select: {
+              firstName: true,
+              lastName: true,
+              displayName: true,
+              email: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        take: 15,
+      }),
+    ]);
 
     // Fetch assets and organization details in parallel for efficiency
     const [assets, organization] = await Promise.all([
@@ -311,6 +358,7 @@ export async function fetchAllAuditPdfRelatedData(
       assetIdToQrCodeMap,
       generalImages,
       assetImages,
+      conditionNotes,
       activityNotes,
     };
   } catch (cause) {

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -2285,6 +2285,10 @@ export async function requireAuditAssignee({
       additionalData: { auditSessionId, organizationId },
       status: 404,
       label,
+      // An authorization outcome, not a fault: this fires whenever a caller
+      // names an audit outside their workspace, which the read routes hit on
+      // ordinary use. Capturing it turns routine refusals into Sentry volume.
+      shouldBeCaptured: false,
     });
   }
 
@@ -2300,6 +2304,10 @@ export async function requireAuditAssignee({
       additionalData: { auditSessionId, userId },
       status: 403,
       label,
+      // Same reasoning as the 404 above, and it matters more here: the
+      // evidence route runs this on every row tap, so an unassigned user
+      // browsing generates one capture per request.
+      shouldBeCaptured: false,
     });
   }
 }

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -995,6 +995,21 @@ export async function getAssetsForAuditSession({
         assetId: true,
         expected: true,
         status: true,
+        // why: so the overview row can SAY it holds evidence. The notes and
+        // photos were always reachable — via the Activity feed, or by opening
+        // a row on the off-chance — but nothing in the assets table indicated
+        // which rows were worth opening. On a 200-asset audit that makes the
+        // one damaged item indistinguishable from the 199 clean ones.
+        //
+        // COMMENT only, matching `getAuditScans`: system notes are audit
+        // trail, not something a person wrote about the asset's condition,
+        // and counting them would inflate every row to a uniform number.
+        _count: {
+          select: {
+            notes: { where: { type: "COMMENT" } },
+            images: true,
+          },
+        },
       },
     });
 
@@ -1008,6 +1023,8 @@ export async function getAssetsForAuditSession({
           auditAssetId: aa.id,
           expected: aa.expected,
           auditStatus: aa.status,
+          auditNotesCount: aa._count.notes,
+          auditImagesCount: aa._count.images,
         },
       ])
     );

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -119,6 +119,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       }),
     ]);
 
+    // Gate here, not at the end: this is the earliest point `session` exists,
+    // and every query below is work a caller about to be refused never sees.
+    requireAuditAssigneeForBaseSelfService({
+      audit: session,
+      userId,
+      isSelfServiceOrBase,
+      auditId,
+    });
+
     // Split images into general and asset-specific
     const generalImages = allImages.filter((img) => img.auditAssetId === null);
     const assetImages = allImages.filter((img) => img.auditAssetId !== null);
@@ -151,7 +160,6 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
             displayName: true,
             firstName: true,
             lastName: true,
-            profilePicture: true,
           },
         },
         auditAsset: {
@@ -177,13 +185,6 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     const isCreator = session.createdById === userId;
     const canRemoveAssets =
       (isCreator || isAdminOrOwner) && session.status === "PENDING";
-
-    requireAuditAssigneeForBaseSelfService({
-      audit: session,
-      userId,
-      isSelfServiceOrBase,
-      auditId,
-    });
 
     return data(
       payload({

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -21,6 +21,7 @@ import { BulkRemoveAssetsFromAuditSchema } from "~/components/audit/bulk-remove-
 import ImageWithPreview from "~/components/image-with-preview/image-with-preview";
 import { List } from "~/components/list";
 import { Filters } from "~/components/list/filters";
+import { MarkdownViewer } from "~/components/markdown/markdown-viewer";
 import { Button } from "~/components/shared/button";
 import { Card } from "~/components/shared/card";
 import { DateS } from "~/components/shared/date";
@@ -143,6 +144,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         createdAt: true,
         user: {
           select: {
+            // `displayName` first: `resolveUserDisplayName` prefers it, and an
+            // SSO account often carries only that. Selecting just first/last
+            // renders those people as "Unknown" here while the PDF, which uses
+            // the same resolver over a fuller select, names them.
+            displayName: true,
             firstName: true,
             lastName: true,
             profilePicture: true,
@@ -626,14 +632,20 @@ export default function AuditOverview() {
               <Card className="mt-0 md:border">
                 {generalNotes.map((note) => (
                   <div key={note.id} className="mb-3 last:mb-0">
-                    <p className="whitespace-pre-wrap text-sm text-gray-900">
-                      {note.content}
-                    </p>
+                    {/* Audit notes are Markdoc source, not plain text: the
+                        completion note carries `**bold**` stats, a receipt
+                        link, and an `{% audit_images %}` tag. Rendering the
+                        string directly prints that source to the reader.
+                        `allowExternalLinks` stays false here — this bucket is
+                        where the SYSTEM-composed completion note lands, and
+                        only notes a person authored through the editor may
+                        link off-origin. */}
+                    <div className="text-sm text-gray-900">
+                      <MarkdownViewer content={note.content} />
+                    </div>
                     <p className="mt-1 text-xs text-gray-500">
-                      {[note.user?.firstName, note.user?.lastName]
-                        .filter(Boolean)
-                        .join(" ") || "Unknown"}{" "}
-                      &middot; <DateS date={note.createdAt} includeTime />
+                      {resolveUserDisplayName(note.user) || "Unknown"} &middot;{" "}
+                      <DateS date={note.createdAt} includeTime />
                     </p>
                   </div>
                 ))}
@@ -674,13 +686,17 @@ export default function AuditOverview() {
 
                   {notes.map((note) => (
                     <div key={note.id} className="mb-3">
-                      <p className="whitespace-pre-wrap text-sm text-gray-900">
-                        {note.content}
-                      </p>
+                      {/* Condition notes are authored through the editor, so
+                          they may link out — same treatment the details panel
+                          gives these exact rows. */}
+                      <div className="text-sm text-gray-900">
+                        <MarkdownViewer
+                          content={note.content}
+                          allowExternalLinks
+                        />
+                      </div>
                       <p className="mt-1 text-xs text-gray-500">
-                        {[note.user?.firstName, note.user?.lastName]
-                          .filter(Boolean)
-                          .join(" ") || "Unknown"}{" "}
+                        {resolveUserDisplayName(note.user) || "Unknown"}{" "}
                         &middot; <DateS date={note.createdAt} includeTime />
                       </p>
                     </div>

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -122,6 +122,39 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     const generalImages = allImages.filter((img) => img.auditAssetId === null);
     const assetImages = allImages.filter((img) => img.auditAssetId !== null);
 
+    /**
+     * The condition notes people wrote during the audit.
+     *
+     * why this page had none: every photo taken during an audit was already
+     * on this page, grouped and labelled with its asset, while the words
+     * written beside those photos appeared nowhere. Reading them meant
+     * opening rows one at a time, or scrolling the Activity feed where they
+     * sit among system rows. The written observation is the half that says
+     * "already scratched when it went out", so it is the half worth surfacing.
+     *
+     * COMMENT only: UPDATE rows are the system trail, stored as Markdoc
+     * source, and belong to the Activity tab.
+     */
+    const conditionNotes = await db.auditNote.findMany({
+      where: { auditSessionId: auditId, type: "COMMENT" },
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        user: {
+          select: {
+            firstName: true,
+            lastName: true,
+            profilePicture: true,
+          },
+        },
+        auditAsset: {
+          select: { asset: { select: { id: true, title: true } } },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
     const header = { title: `${session.name} · Overview` };
 
     const rolesForOrg = userOrganizations.find(
@@ -155,6 +188,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         header,
         generalImages,
         assetImages,
+        conditionNotes,
         ...assetsData,
         modelName: {
           singular: "asset",
@@ -292,8 +326,63 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
 // react-doctor:no-giant-component — deferred for follow-up refactor
 export default function AuditOverview() {
-  const { session, totalItems, generalImages, assetImages, canRemoveAssets } =
-    useLoaderData<typeof loader>();
+  const {
+    session,
+    totalItems,
+    generalImages,
+    assetImages,
+    conditionNotes,
+    canRemoveAssets,
+  } = useLoaderData<typeof loader>();
+
+  /**
+   * One entry per asset somebody recorded something about, holding BOTH the
+   * words and the photographs.
+   *
+   * why merged: a note about the Laerdal and a photo of the Laerdal are one
+   * observation. Splitting them into a notes list and a photo wall makes the
+   * reader join them up by asset name, which is work this page should do.
+   */
+  const findings = (() => {
+    const groups = new Map<
+      string,
+      {
+        assetName: string;
+        images: typeof assetImages;
+        notes: typeof conditionNotes;
+      }
+    >();
+
+    const groupFor = (assetId: string, assetName: string) => {
+      if (!groups.has(assetId)) {
+        groups.set(assetId, { assetName, images: [], notes: [] });
+      }
+      return groups.get(assetId)!;
+    };
+
+    for (const img of assetImages) {
+      const asset = img.auditAsset?.asset;
+      if (!asset?.id) continue;
+      groupFor(asset.id, asset.title || "Unknown").images.push(img);
+    }
+    for (const note of conditionNotes) {
+      const asset = note.auditAsset?.asset;
+      if (!asset?.id) continue;
+      groupFor(asset.id, asset.title || "Unknown").notes.push(note);
+    }
+
+    return [...groups.entries()].sort((a, b) =>
+      a[1].assetName.localeCompare(b[1].assetName)
+    );
+  })();
+
+  /** Notes about the audit as a whole — the completion note lives here. */
+  const generalNotes = conditionNotes.filter(
+    (note) => !note.auditAsset?.asset?.id
+  );
+
+  const hasFindings =
+    findings.length > 0 || generalNotes.length > 0 || generalImages.length > 0;
   const [searchParams] = useSearchParams();
   const currentFilter = searchParams.get(
     "auditStatus"
@@ -478,100 +567,135 @@ export default function AuditOverview() {
           </Card>
         </div>
 
-        {/* Right Column: Audit Images */}
+        {/*
+          Right column: FINDINGS — what people recorded, grouped by the asset
+          they recorded it about, words and photographs together.
+
+          why this replaced "Audit Images": every photo taken during an audit
+          was already here, grouped and labelled. The notes written beside
+          those photos were on no page at all — reachable only by opening rows
+          one at a time, or by scrolling the Activity feed where they sit among
+          system rows. The written observation is the half that answers "was it
+          already damaged when it went out", so leaving it off the audit's own
+          page was the real gap. A note and a photo of the same asset are one
+          observation and now print as one.
+        */}
         <div className="flex-1">
           <h2 className="mb-4 text-lg font-semibold">
-            Audit Images{" "}
+            Findings{" "}
             <InfoTooltip
               iconClassName="size-4"
               content={
                 <p className="mb-3 text-sm text-gray-600">
-                  Images captured during the audit. General images are
-                  associated with the audit itself, while asset images are
-                  linked to specific assets.
+                  The condition notes and photos people recorded while auditing,
+                  grouped by the asset they were recorded against. Notes about
+                  the audit itself, such as a completion note, appear first.
+                  System activity lives on the Activity tab.
                 </p>
               }
             />
           </h2>
 
-          {/* General Audit Images */}
-          {generalImages.length > 0 && (
+          {/* About the audit as a whole */}
+          {(generalNotes.length > 0 || generalImages.length > 0) && (
             <div className="mb-4">
-              <h3 className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
-                <span className="flex size-5 items-center justify-center rounded bg-primary-50 text-xs text-primary-600">
-                  {generalImages.length}
-                </span>
-                General Audit Images
+              <h3 className="mb-2 text-sm font-medium text-gray-700">
+                About this audit
               </h3>
               <Card className="mt-0 md:border">
-                <div className="flex flex-wrap gap-3">
-                  {generalImages.map((image) => (
-                    <ImageWithPreview
-                      key={image.id}
-                      imageUrl={image.imageUrl}
-                      thumbnailUrl={image.thumbnailUrl}
-                      alt={image.description || "General audit image"}
-                      withPreview
-                      className="size-24 rounded border"
-                      images={generalImages.map((img) => ({
-                        id: img.id,
-                        imageUrl: img.imageUrl,
-                        thumbnailUrl: img.thumbnailUrl,
-                        alt: img.description || "General audit image",
-                      }))}
-                      currentImageId={image.id}
-                    />
-                  ))}
-                </div>
+                {generalNotes.map((note) => (
+                  <div key={note.id} className="mb-3 last:mb-0">
+                    <p className="whitespace-pre-wrap text-sm text-gray-900">
+                      {note.content}
+                    </p>
+                    <p className="mt-1 text-xs text-gray-500">
+                      {[note.user?.firstName, note.user?.lastName]
+                        .filter(Boolean)
+                        .join(" ") || "Unknown"}{" "}
+                      &middot; <DateS date={note.createdAt} includeTime />
+                    </p>
+                  </div>
+                ))}
+
+                {generalImages.length > 0 && (
+                  <div className="flex flex-wrap gap-3">
+                    {generalImages.map((image) => (
+                      <ImageWithPreview
+                        key={image.id}
+                        imageUrl={image.imageUrl}
+                        thumbnailUrl={image.thumbnailUrl}
+                        alt={image.description || "General audit image"}
+                        withPreview
+                        className="size-24 rounded border"
+                        images={generalImages.map((img) => ({
+                          id: img.id,
+                          imageUrl: img.imageUrl,
+                          thumbnailUrl: img.thumbnailUrl,
+                          alt: img.description || "General audit image",
+                        }))}
+                        currentImageId={image.id}
+                      />
+                    ))}
+                  </div>
+                )}
               </Card>
             </div>
           )}
 
-          {/* Asset-Specific Images */}
-          {assetImages.length > 0 && (
-            <div className="mb-4">
-              <h3 className="mb-2 flex items-center gap-2 text-sm font-medium text-gray-700">
-                <span className="flex size-5 items-center justify-center rounded bg-blue-50 text-xs text-blue-600">
-                  {assetImages.length}
-                </span>
-                Asset-Specific Images
-              </h3>
-              <Card className="mt-0 md:border">
-                <div className="flex flex-wrap gap-3">
-                  {assetImages.map((image) => (
-                    <ImageWithPreview
-                      key={image.id}
-                      imageUrl={image.imageUrl}
-                      thumbnailUrl={image.thumbnailUrl}
-                      // Show asset title in the preview header for context.
-                      alt={
-                        image.auditAsset?.asset?.title
-                          ? `Asset: ${image.auditAsset.asset.title}`
-                          : image.description || "Asset image"
-                      }
-                      withPreview
-                      className="size-24 rounded border"
-                      images={assetImages.map((img) => ({
-                        id: img.id,
-                        imageUrl: img.imageUrl,
-                        thumbnailUrl: img.thumbnailUrl,
-                        alt: img.auditAsset?.asset?.title
-                          ? `Asset: ${img.auditAsset.asset.title}`
-                          : img.description || "Asset image",
-                      }))}
-                      currentImageId={image.id}
-                    />
+          {/* One block per asset somebody recorded something about */}
+          {findings.length > 0 && (
+            <div className="mb-4 flex flex-col gap-3">
+              {findings.map(([assetId, { assetName, images, notes }]) => (
+                <Card key={assetId} className="mt-0 md:border">
+                  <h3 className="mb-2 text-sm font-medium text-gray-900">
+                    {assetName}
+                  </h3>
+
+                  {notes.map((note) => (
+                    <div key={note.id} className="mb-3">
+                      <p className="whitespace-pre-wrap text-sm text-gray-900">
+                        {note.content}
+                      </p>
+                      <p className="mt-1 text-xs text-gray-500">
+                        {[note.user?.firstName, note.user?.lastName]
+                          .filter(Boolean)
+                          .join(" ") || "Unknown"}{" "}
+                        &middot; <DateS date={note.createdAt} includeTime />
+                      </p>
+                    </div>
                   ))}
-                </div>
-              </Card>
+
+                  {images.length > 0 && (
+                    <div className="flex flex-wrap gap-3">
+                      {images.map((image) => (
+                        <ImageWithPreview
+                          key={image.id}
+                          imageUrl={image.imageUrl}
+                          thumbnailUrl={image.thumbnailUrl}
+                          alt={`Photo of ${assetName}`}
+                          withPreview
+                          className="size-24 rounded border"
+                          images={images.map((img) => ({
+                            id: img.id,
+                            imageUrl: img.imageUrl,
+                            thumbnailUrl: img.thumbnailUrl,
+                            alt: `Photo of ${assetName}`,
+                          }))}
+                          currentImageId={image.id}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </Card>
+              ))}
             </div>
           )}
 
-          {/* No Images State */}
-          {generalImages.length === 0 && assetImages.length === 0 && (
+          {/* Nothing recorded */}
+          {!hasFindings && (
             <Card className="mt-0 md:border">
               <div className="px-4 py-6 text-center text-sm text-gray-500">
-                No images uploaded
+                Nothing was recorded during this audit
               </div>
             </Card>
           )}

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useSetAtom } from "jotai";
-import { MessageSquare, Paperclip } from "lucide-react";
+import { MessageSquare, ImageIcon } from "lucide-react";
 import type {
   LoaderFunctionArgs,
   ActionFunctionArgs,
@@ -113,11 +113,20 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       auditId,
     });
 
-    // Fetch notes for this audit asset
+    // Fetch the notes a PERSON wrote about this audit asset.
+    //
+    // why the type filter: uploading photos without typing a caption writes an
+    // UPDATE note against this same asset (helpers.server.ts,
+    // createAuditAssetImagesAddedNote), whose body is the Markdoc
+    // `{% audit_images %}` tag. Without the filter this panel counted that row
+    // in its Notes badge and rendered the photos twice — once inside the note,
+    // once in the Images grid below — and it disagreed with the count on the
+    // row that opened it, which asks for COMMENT only.
     const notes = await db.auditNote.findMany({
       where: {
         auditSessionId: auditId,
         auditAssetId: auditAssetId,
+        type: "COMMENT",
       },
       select: {
         id: true,
@@ -895,7 +904,7 @@ export default function AuditAssetDetails() {
       {/* Images section - fixed height at bottom */}
       <div className="h-68 shrink-0 overflow-y-auto  border-gray-200 px-6 py-4">
         <div className="mb-3 flex items-center gap-2">
-          <Paperclip className="size-5 text-gray-600" />
+          <ImageIcon className="size-5 text-gray-600" />
           <h3 className="text-base font-semibold text-gray-900">Images</h3>
           <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
             {localImages.length}

--- a/apps/webapp/app/routes/api+/audits.$auditId.generate-pdf.tsx
+++ b/apps/webapp/app/routes/api+/audits.$auditId.generate-pdf.tsx
@@ -85,7 +85,16 @@ export const loader = async ({
       pdfMeta.to = dateTimeFormat.format(new Date(completedAt));
     }
 
-    // Sanitize activity note content to remove markdoc tags (server-side only)
+    // Sanitize note content to remove markdoc tags (server-side only).
+    //
+    // why BOTH lists: a condition note written alongside photos carries an
+    // embedded `{% audit_images ... /%}` tag (helpers.server.ts,
+    // buildAuditImagesNoteContent). The PDF prints note content as plain text,
+    // so an unsanitised one would put raw tag source in the receipt.
+    pdfMeta.conditionNotes = pdfMeta.conditionNotes.map((note) => ({
+      ...note,
+      content: sanitizeNoteContent(note.content || "", prefs),
+    }));
     pdfMeta.activityNotes = pdfMeta.activityNotes.map((note) => ({
       ...note,
       content: sanitizeNoteContent(note.content || "", prefs),

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
@@ -1,0 +1,182 @@
+import { data, type LoaderFunctionArgs } from "react-router";
+import { z } from "zod";
+import { db } from "~/database/db.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+import { makeShelfError } from "~/utils/error";
+import { getParams } from "~/utils/http.server";
+
+/**
+ * GET /api/mobile/audits/:auditId/evidence
+ *
+ * Everything a person recorded ON an audit, so the phone can READ it back.
+ *
+ * why this route exists: the companion could already WRITE evidence
+ * (`audits.note`, `audits.image`) and its detail payload carries per-asset
+ * COUNTS, but nothing served the content. So a field worker photographed a
+ * scratched lens, completed the audit, and then had no way to see any of it
+ * again — every note and photo they had just taken was visible only on the
+ * web app. Counts without content is the worst of both: the app knows the
+ * evidence exists and still cannot show it.
+ *
+ * Two buckets, because the schema has two:
+ *   - `general` — rows with `auditAssetId: null`. The completion note and the
+ *     photos attached when the audit was closed. About the audit as a whole.
+ *   - `byAuditAsset` — keyed by `auditAsset.id`, matching the `auditAssetId`
+ *     the detail payload already hands the client, so the app can look up a
+ *     row without a second round trip or any id juggling.
+ *
+ * Read-only by design. Editing and deleting evidence stays on the web, where
+ * the confirm affordances live; this is for reviewing in the field.
+ *
+ * Query params:
+ *   - orgId (required): organization ID
+ *
+ * @see {@link file://./audits.$auditId.ts} the detail payload whose
+ *   `auditAssetId` values key `byAuditAsset`
+ * @see {@link file://./audits.note.ts} and {@link file://./audits.image.ts}
+ *   the write halves this completes
+ */
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  try {
+    const { user } = await requireMobileAuth(request);
+    const organizationId = await requireOrganizationAccess(request, user.id);
+    const { canUseAudits } = await getMobileUserContext(user.id, organizationId);
+
+    if (!canUseAudits) {
+      return data(
+        {
+          error: {
+            message:
+              "Audits are not enabled for this workspace. Contact your admin to enable this feature.",
+          },
+        },
+        { status: 403 }
+      );
+    }
+
+    const { auditId } = getParams(
+      params,
+      z.object({ auditId: z.string().min(1) })
+    );
+
+    // Prove the audit is in this workspace before reporting anything about
+    // it, so a guessed id from another org cannot be probed through this
+    // route. Mirrors the guard on the asset-bookings route.
+    const audit = await db.auditSession.findFirst({
+      where: { id: auditId, organizationId },
+      select: { id: true },
+    });
+
+    if (!audit) {
+      return data(
+        { error: { message: "Audit not found in this workspace." } },
+        { status: 404 }
+      );
+    }
+
+    const [notes, images] = await Promise.all([
+      db.auditNote.findMany({
+        where: { auditSessionId: auditId },
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          auditAssetId: true,
+          user: {
+            select: { firstName: true, lastName: true, profilePicture: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+      }),
+      db.auditImage.findMany({
+        where: { auditSessionId: auditId, organizationId },
+        select: {
+          id: true,
+          imageUrl: true,
+          thumbnailUrl: true,
+          description: true,
+          createdAt: true,
+          auditAssetId: true,
+          uploadedBy: {
+            select: { firstName: true, lastName: true, profilePicture: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+      }),
+    ]);
+
+    /** A person's display name, or null when the account is gone. */
+    const actorName = (
+      actor: { firstName: string | null; lastName: string | null } | null
+    ) => {
+      if (!actor) return null;
+      const name = [actor.firstName, actor.lastName]
+        .filter(Boolean)
+        .join(" ")
+        .trim();
+      return name.length > 0 ? name : null;
+    };
+
+    const serialiseNote = (n: (typeof notes)[number]) => ({
+      id: n.id,
+      content: n.content,
+      createdAt: n.createdAt.toISOString(),
+      authorName: actorName(n.user),
+      authorImage: n.user?.profilePicture ?? null,
+    });
+
+    const serialiseImage = (i: (typeof images)[number]) => ({
+      id: i.id,
+      imageUrl: i.imageUrl,
+      // why: fall back to the full image rather than sending null. The app
+      // renders a thumbnail grid, and a missing thumbnail there would show a
+      // gap where a photo plainly exists.
+      thumbnailUrl: i.thumbnailUrl ?? i.imageUrl,
+      description: i.description,
+      createdAt: i.createdAt.toISOString(),
+      authorName: actorName(i.uploadedBy),
+      authorImage: i.uploadedBy?.profilePicture ?? null,
+    });
+
+    /** Per-asset buckets, keyed by the `auditAssetId` the client already has. */
+    const byAuditAsset: Record<
+      string,
+      {
+        notes: ReturnType<typeof serialiseNote>[];
+        images: ReturnType<typeof serialiseImage>[];
+      }
+    > = {};
+
+    const bucket = (auditAssetId: string) => {
+      if (!byAuditAsset[auditAssetId]) {
+        byAuditAsset[auditAssetId] = { notes: [], images: [] };
+      }
+      return byAuditAsset[auditAssetId];
+    };
+
+    for (const n of notes) {
+      if (n.auditAssetId) bucket(n.auditAssetId).notes.push(serialiseNote(n));
+    }
+    for (const i of images) {
+      if (i.auditAssetId) bucket(i.auditAssetId).images.push(serialiseImage(i));
+    }
+
+    return data({
+      general: {
+        notes: notes.filter((n) => !n.auditAssetId).map(serialiseNote),
+        images: images.filter((i) => !i.auditAssetId).map(serialiseImage),
+      },
+      byAuditAsset,
+    });
+  } catch (cause) {
+    const reason = makeShelfError(cause);
+    return data(
+      { error: { message: reason.message } },
+      { status: reason.status }
+    );
+  }
+}

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
@@ -234,12 +234,27 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       if (i.auditAssetId) bucket(i.auditAssetId).images.push(serialiseImage(i));
     }
 
+    /**
+     * Whether the clamp bit, so the client can say "showing the most recent
+     * N" instead of presenting a short list as the whole truth.
+     *
+     * It matters most on the audit-wide call: `MAX_EVIDENCE_ROWS` applies
+     * across the WHOLE audit, newest first, so once it bites the older
+     * per-asset buckets come back short — or empty — while their count chips
+     * still promise the real number. Without this flag "no photos" and
+     * "photos we did not send" look identical. Narrow with `auditAssetId` to
+     * get a bucket that cannot be clamped by unrelated rows.
+     */
+    const truncated =
+      notes.length === MAX_EVIDENCE_ROWS || images.length === MAX_EVIDENCE_ROWS;
+
     return data({
       general: {
         notes: notes.filter((n) => !n.auditAssetId).map(serialiseNote),
         images: images.filter((i) => !i.auditAssetId).map(serialiseImage),
       },
       byAuditAsset,
+      truncated,
     });
   } catch (cause) {
     const reason = makeShelfError(cause);

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
@@ -42,6 +42,15 @@ import { getParams } from "~/utils/http.server";
  * @see {@link file://./audits.note.ts} and {@link file://./audits.image.ts}
  *   the write halves this completes
  */
+/**
+ * Upper bound on rows of each kind in one response.
+ *
+ * Matches the clamp every other mobile list route applies. An audit that
+ * somehow holds more than this is past the point where a phone can usefully
+ * render it, and the caller narrows with `auditAssetId` instead.
+ */
+const MAX_EVIDENCE_ROWS = 200;
+
 export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
@@ -67,6 +76,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       params,
       z.object({ auditId: z.string().min(1) })
     );
+
+    /**
+     * Narrows the response to one audited asset.
+     *
+     * The client opens one row at a time, so this is the shape it actually
+     * wants. Without it a single tap pulls every note and every photo of the
+     * whole audit — on a large audit that is thousands of rows over cellular,
+     * repeated on every open.
+     */
+    const url = new URL(request.url);
+    const auditAssetId = url.searchParams.get("auditAssetId");
 
     // Gate the READ on assignment, exactly as the audit detail route does.
     // This route returns the notes and photos people recorded, which is the
@@ -107,6 +127,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     const [notes, images] = await Promise.all([
       db.auditNote.findMany({
+        take: MAX_EVIDENCE_ROWS,
         // why COMMENT only: `AuditNote` holds two unrelated things. `UPDATE`
         // rows are the system activity trail ("X started this audit") and are
         // written as MARKDOC SOURCE — `{% link to="/settings/team/users/..." /%}`.
@@ -119,7 +140,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         // It also keeps this route agreeing with the COUNTS the client already
         // has — `getAssetsForAuditSession` filters its `_count` the same way,
         // so a row promising 1 attachment opens a sheet holding exactly 1.
-        where: { auditSessionId: auditId, type: "COMMENT" },
+        where: {
+          auditSessionId: auditId,
+          type: "COMMENT",
+          ...(auditAssetId ? { auditAssetId } : {}),
+        },
         select: {
           id: true,
           content: true,
@@ -132,7 +157,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         orderBy: { createdAt: "desc" },
       }),
       db.auditImage.findMany({
-        where: { auditSessionId: auditId, organizationId },
+        take: MAX_EVIDENCE_ROWS,
+        where: {
+          auditSessionId: auditId,
+          organizationId,
+          ...(auditAssetId ? { auditAssetId } : {}),
+        },
         select: {
           id: true,
           imageUrl: true,

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
@@ -6,6 +6,8 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { requireAuditAssignee } from "~/modules/audit/service.server";
+import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
 
@@ -44,7 +46,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
-    const { canUseAudits } = await getMobileUserContext(
+    const { roles, canUseAudits } = await getMobileUserContext(
       user.id,
       organizationId
     );
@@ -66,6 +68,21 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       z.object({ auditId: z.string().min(1) })
     );
 
+    // Gate the READ on assignment, exactly as the audit detail route does.
+    // This route returns the notes and photos people recorded, which is the
+    // same class of data that gate was added to protect: without it an
+    // unassigned BASE or SELF_SERVICE user could read the evidence of any
+    // audit in the workspace by id. The write halves (`audits.note`,
+    // `audits.image`) already require it through
+    // `requireAuditAssetInSession`; reading must not be the loose end.
+    //
+    // Resolved from ALL roles, never from `roles[0]`: `getMobileUserContext`
+    // sets `role = roles[0]`, so a membership ordered [SELF_SERVICE, ADMIN]
+    // would refuse a real admin who is not assigned.
+    const effectiveRole = resolveMostPrivilegedRole(roles);
+    const isSelfServiceOrBase =
+      effectiveRole === "SELF_SERVICE" || effectiveRole === "BASE";
+
     // Prove the audit is in this workspace before reporting anything about
     // it, so a guessed id from another org cannot be probed through this
     // route. Mirrors the guard on the asset-bookings route.
@@ -80,6 +97,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         { status: 404 }
       );
     }
+
+    await requireAuditAssignee({
+      auditSessionId: auditId,
+      organizationId,
+      userId: user.id,
+      isSelfServiceOrBase,
+    });
 
     const [notes, images] = await Promise.all([
       db.auditNote.findMany({

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.evidence.ts
@@ -44,7 +44,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
-    const { canUseAudits } = await getMobileUserContext(user.id, organizationId);
+    const { canUseAudits } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
 
     if (!canUseAudits) {
       return data(
@@ -80,7 +83,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     const [notes, images] = await Promise.all([
       db.auditNote.findMany({
-        where: { auditSessionId: auditId },
+        // why COMMENT only: `AuditNote` holds two unrelated things. `UPDATE`
+        // rows are the system activity trail ("X started this audit") and are
+        // written as MARKDOC SOURCE — `{% link to="/settings/team/users/..." /%}`.
+        // The web feed renders that through `MarkdownViewer`; the phone has no
+        // Markdoc renderer, so an unfiltered query puts raw tag source on
+        // screen. `COMMENT` rows are what a person actually typed, which is
+        // the only thing this route means by evidence. Verified against a real
+        // workspace: 9 UPDATE rows carrying tag source, 1 COMMENT.
+        //
+        // It also keeps this route agreeing with the COUNTS the client already
+        // has — `getAssetsForAuditSession` filters its `_count` the same way,
+        // so a row promising 1 attachment opens a sheet holding exactly 1.
+        where: { auditSessionId: auditId, type: "COMMENT" },
         select: {
           id: true,
           content: true,

--- a/apps/webapp/test/routes-tests/api+/mobile-auth-contract.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile-auth-contract.test.ts
@@ -39,7 +39,24 @@ const AUTH_EXEMPT = new Set<string>([
   "config.ts",
 ]);
 
-const ROUTE_FILES = readdirSync(MOBILE_DIR).filter((f) => f.endsWith(".ts"));
+/**
+ * Every route file under the mobile directory, at any depth and either
+ * extension.
+ *
+ * Recursive and `.tsx`-inclusive on purpose: a flat `.ts`-only listing makes
+ * the exemption set below stop being the only way out of this contract, since
+ * a route in a subdirectory or written as `.tsx` would simply not be
+ * enumerated — unguarded and unreported. Excludes `.test.` files, which are
+ * not routes.
+ */
+const ROUTE_FILES = readdirSync(MOBILE_DIR, { recursive: true })
+  .map((entry) => String(entry))
+  .filter(
+    (f) =>
+      (f.endsWith(".ts") || f.endsWith(".tsx")) &&
+      !f.includes(".test.") &&
+      !f.includes(".spec.")
+  );
 const GUARDED_FILES = ROUTE_FILES.filter((f) => !AUTH_EXEMPT.has(f));
 
 describe("mobile route auth contract", () => {

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
@@ -141,11 +141,17 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
         IMAGE_ASSET,
       ]);
 
-      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+      const res = await loader(
+        createLoaderArgs({ request: request(), ...ARGS })
+      );
       const json = await body(res);
 
-      expect(json.general.notes.map((n: any) => n.id)).toEqual(["note-general"]);
-      expect(json.general.images.map((i: any) => i.id)).toEqual(["img-general"]);
+      expect(json.general.notes.map((n: any) => n.id)).toEqual([
+        "note-general",
+      ]);
+      expect(json.general.images.map((i: any) => i.id)).toEqual([
+        "img-general",
+      ]);
       expect(json.byAuditAsset["aa-1"].notes.map((n: any) => n.id)).toEqual([
         "note-asset",
       ]);
@@ -162,7 +168,9 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
         { ...NOTE_ASSET, id: "note-other", auditAssetId: "aa-2" },
       ]);
 
-      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+      const res = await loader(
+        createLoaderArgs({ request: request(), ...ARGS })
+      );
       const json = await body(res);
 
       expect(Object.keys(json.byAuditAsset).sort()).toEqual(["aa-1", "aa-2"]);
@@ -214,7 +222,9 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
       // why: proves a guessed id from another org cannot be probed here.
       mockDb.auditSession.findFirst.mockResolvedValue(null);
 
-      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+      const res = await loader(
+        createLoaderArgs({ request: request(), ...ARGS })
+      );
 
       expect((res as unknown as Response).status).toBe(404);
       expect(mockDb.auditNote.findMany).not.toHaveBeenCalled();
@@ -227,7 +237,9 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
         canUseAudits: false,
       });
 
-      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+      const res = await loader(
+        createLoaderArgs({ request: request(), ...ARGS })
+      );
 
       expect((res as unknown as Response).status).toBe(403);
       expect(mockDb.auditSession.findFirst).not.toHaveBeenCalled();
@@ -239,6 +251,21 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
       expect(mockDb.auditImage.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { auditSessionId: "audit-1", organizationId: "org-1" },
+        })
+      );
+    });
+
+    it("asks only for COMMENT notes, not the system activity trail", async () => {
+      // why: `AuditNote` mixes human comments with UPDATE rows written as
+      // MARKDOC SOURCE (`{% link to="/settings/team/users/..." /%}`). The web
+      // feed renders those through MarkdownViewer; the phone has no Markdoc
+      // renderer, so an unfiltered query paints raw tag source into the sheet.
+      // Found against a real workspace holding 9 UPDATE rows and 1 COMMENT.
+      await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      expect(mockDb.auditNote.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { auditSessionId: "audit-1", type: "COMMENT" },
         })
       );
     });

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
@@ -23,6 +23,17 @@ vi.mock("react-router", async () => {
 });
 
 // why: external auth — no Supabase in tests
+// why: the assignee gate is a shared guard with its own suite; here it only
+// needs to be callable so the route's own behaviour is what is under test.
+vi.mock("~/modules/audit/service.server", () => ({
+  requireAuditAssignee: vi.fn(),
+}));
+// why: pure role-precedence helper, but importing it pulls in server-only
+// booking authorization; the tests drive the role through getMobileUserContext.
+vi.mock("~/utils/booking-authorization.server", () => ({
+  resolveMostPrivilegedRole: (roles: string[]) =>
+    roles.includes("ADMIN") || roles.includes("OWNER") ? "ADMIN" : roles[0],
+}));
 vi.mock("~/modules/api/mobile-auth.server", () => ({
   requireMobileAuth: vi.fn(),
   requireOrganizationAccess: vi.fn(),
@@ -57,6 +68,7 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { requireAuditAssignee } from "~/modules/audit/service.server";
 
 const mockDb = db as unknown as {
   auditSession: { findFirst: ReturnType<typeof vi.fn> };
@@ -122,6 +134,7 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
     (requireMobileAuth as any).mockResolvedValue({ user: { id: "user-1" } });
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (getMobileUserContext as any).mockResolvedValue({
+      roles: ["ADMIN"],
       role: "ADMIN",
       canUseAudits: true,
     });
@@ -250,6 +263,43 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
         expect.objectContaining({
           where: { auditSessionId: "audit-1", organizationId: "org-1" },
         })
+      );
+    });
+
+    it("gates the read on assignment, like the audit detail route", async () => {
+      // why: this route returns the notes and photos people recorded, the same
+      // class of data #2900 gated on the detail route. Without this an
+      // unassigned BASE or SELF_SERVICE user could read any audit's evidence
+      // in the workspace by id, reopening the hole that PR closed.
+      (getMobileUserContext as any).mockResolvedValue({
+        roles: ["SELF_SERVICE"],
+        canUseAudits: true,
+      });
+
+      await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      expect(requireAuditAssignee).toHaveBeenCalledWith(
+        expect.objectContaining({
+          auditSessionId: "audit-1",
+          organizationId: "org-1",
+          isSelfServiceOrBase: true,
+        })
+      );
+    });
+
+    it("does not treat a privileged member as self-service", async () => {
+      // why: getMobileUserContext sets role = roles[0], so a membership
+      // ordered [SELF_SERVICE, ADMIN] would refuse a real admin. The role must
+      // be resolved from ALL roles.
+      (getMobileUserContext as any).mockResolvedValue({
+        roles: ["SELF_SERVICE", "ADMIN"],
+        canUseAudits: true,
+      });
+
+      await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      expect(requireAuditAssignee).toHaveBeenCalledWith(
+        expect.objectContaining({ isSelfServiceOrBase: false })
       );
     });
 

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
@@ -138,6 +138,7 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
       role: "ADMIN",
       canUseAudits: true,
     });
+    (requireAuditAssignee as any).mockResolvedValue(undefined);
     mockDb.auditSession.findFirst.mockResolvedValue({ id: "audit-1" });
     mockDb.auditNote.findMany.mockResolvedValue([]);
     mockDb.auditImage.findMany.mockResolvedValue([]);
@@ -238,6 +239,35 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
       );
 
       expect((res as unknown as Response).status).toBe(404);
+      expect(mockDb.auditNote.findMany).not.toHaveBeenCalled();
+      expect(mockDb.auditImage.findMany).not.toHaveBeenCalled();
+      // Assert the LOOKUP was org-scoped, not merely that a null lookup 404s.
+      // Without this the case passes with `organizationId` deleted from the
+      // where clause, because the mock returns null regardless of what was
+      // asked — so it would stop testing the guard it is named for.
+      expect(mockDb.auditSession.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "audit-1", organizationId: "org-1" },
+        })
+      );
+    });
+
+    it("reads no evidence when the assignment gate rejects", async () => {
+      // The other cases only ever let this guard resolve, so none of them
+      // notices if it stops blocking — dropping the `await` on the call makes
+      // it fire-and-forget and every one of them still passes. This is the
+      // case that fails when the gate is not awaited.
+      (requireAuditAssignee as any).mockRejectedValue(
+        new Error("not assigned")
+      );
+
+      const res = await loader(
+        createLoaderArgs({ request: request(), ...ARGS })
+      );
+
+      // The route catches and shapes errors, so the observable outcome is a
+      // non-2xx response plus, crucially, no evidence read at all.
+      expect((res as unknown as Response).status).not.toBe(200);
       expect(mockDb.auditNote.findMany).not.toHaveBeenCalled();
       expect(mockDb.auditImage.findMany).not.toHaveBeenCalled();
     });

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
@@ -146,18 +146,16 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
       );
       const json = await body(res);
 
-      expect(json.general.notes.map((n: any) => n.id)).toEqual([
-        "note-general",
-      ]);
-      expect(json.general.images.map((i: any) => i.id)).toEqual([
-        "img-general",
-      ]);
-      expect(json.byAuditAsset["aa-1"].notes.map((n: any) => n.id)).toEqual([
-        "note-asset",
-      ]);
-      expect(json.byAuditAsset["aa-1"].images.map((i: any) => i.id)).toEqual([
-        "img-asset",
-      ]);
+      // why the typed shape rather than `any`: these assertions are about
+      // WHICH bucket each row lands in, so the id is the only field that
+      // matters. Naming it keeps a typo in the property a compile error
+      // instead of a silently-undefined comparison.
+      const ids = (rows: { id: string }[]) => rows.map((r) => r.id);
+
+      expect(ids(json.general.notes)).toEqual(["note-general"]);
+      expect(ids(json.general.images)).toEqual(["img-general"]);
+      expect(ids(json.byAuditAsset["aa-1"].notes)).toEqual(["note-asset"]);
+      expect(ids(json.byAuditAsset["aa-1"].images)).toEqual(["img-asset"]);
       // A general row must never leak into an asset bucket.
       expect(json.byAuditAsset["aa-1"].notes).toHaveLength(1);
     });

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
@@ -1,0 +1,246 @@
+import { loader } from "~/routes/api+/mobile+/audits.$auditId.evidence";
+import { createLoaderArgs } from "@mocks/remix";
+
+// @vitest-environment node
+
+// why: mocking Remix's data() so the loader returns real Response objects
+const createDataMock = vi.hoisted(() => {
+  return () =>
+    vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: {
+          "Content-Type": "application/json",
+          ...(init?.headers || {}),
+        },
+      });
+    });
+});
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+// why: external auth — no Supabase in tests
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+  getMobileUserContext: vi.fn(),
+}));
+
+vi.mock("~/database/db.server", () => ({
+  db: {
+    auditSession: { findFirst: vi.fn() },
+    auditNote: { findMany: vi.fn() },
+    auditImage: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("~/utils/error", () => ({
+  makeShelfError: vi.fn((cause: any) => ({
+    message: cause?.message ?? "error",
+    status: cause?.status ?? 500,
+  })),
+  ShelfError: class ShelfError extends Error {
+    status: number;
+    constructor(opts: any) {
+      super(opts.message);
+      this.status = opts.status || 500;
+    }
+  },
+}));
+
+import { db } from "~/database/db.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+
+const mockDb = db as unknown as {
+  auditSession: { findFirst: ReturnType<typeof vi.fn> };
+  auditNote: { findMany: ReturnType<typeof vi.fn> };
+  auditImage: { findMany: ReturnType<typeof vi.fn> };
+};
+
+function request(qs = "orgId=org-1") {
+  return new Request(
+    `http://localhost/api/mobile/audits/audit-1/evidence?${qs}`,
+    { headers: { Authorization: "Bearer token" } }
+  );
+}
+
+const ARGS = { params: { auditId: "audit-1" } };
+
+/** Parses the loader's mocked Response body. */
+async function body(res: unknown) {
+  return await (res as unknown as Response).json();
+}
+
+const NOTE_GENERAL = {
+  id: "note-general",
+  content: "All three located. Two need follow-up.",
+  createdAt: new Date("2026-08-19T12:42:00.000Z"),
+  auditAssetId: null,
+  user: { firstName: "John", lastName: "Doe", profilePicture: "j.png" },
+};
+
+const NOTE_ASSET = {
+  id: "note-asset",
+  content: "Lens ring stiff when focusing.",
+  createdAt: new Date("2026-08-19T12:33:00.000Z"),
+  auditAssetId: "aa-1",
+  user: { firstName: "John", lastName: "Doe", profilePicture: null },
+};
+
+const IMAGE_GENERAL = {
+  id: "img-general",
+  imageUrl: "https://x/full-rack.jpg",
+  thumbnailUrl: "https://x/thumb-rack.jpg",
+  description: "Rack before the sweep",
+  createdAt: new Date("2026-08-19T12:42:00.000Z"),
+  auditAssetId: null,
+  uploadedBy: { firstName: "John", lastName: "Doe", profilePicture: null },
+};
+
+const IMAGE_ASSET = {
+  id: "img-asset",
+  imageUrl: "https://x/full-arri.jpg",
+  // why: deliberately null — the route must fall back to imageUrl rather
+  // than send null into a thumbnail grid.
+  thumbnailUrl: null,
+  description: null,
+  createdAt: new Date("2026-08-19T12:34:00.000Z"),
+  auditAssetId: "aa-1",
+  uploadedBy: null,
+};
+
+describe("GET /api/mobile/audits/:auditId/evidence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (requireMobileAuth as any).mockResolvedValue({ user: { id: "user-1" } });
+    (requireOrganizationAccess as any).mockResolvedValue("org-1");
+    (getMobileUserContext as any).mockResolvedValue({
+      role: "ADMIN",
+      canUseAudits: true,
+    });
+    mockDb.auditSession.findFirst.mockResolvedValue({ id: "audit-1" });
+    mockDb.auditNote.findMany.mockResolvedValue([]);
+    mockDb.auditImage.findMany.mockResolvedValue([]);
+  });
+
+  describe("splitting the two buckets", () => {
+    it("puts rows with no auditAssetId in `general` and the rest under their asset", async () => {
+      // why: this split is the whole contract. The completion note belongs to
+      // the audit; a condition note belongs to one asset. Merging them would
+      // show a photo of one lens as if it described the whole sweep.
+      mockDb.auditNote.findMany.mockResolvedValue([NOTE_GENERAL, NOTE_ASSET]);
+      mockDb.auditImage.findMany.mockResolvedValue([
+        IMAGE_GENERAL,
+        IMAGE_ASSET,
+      ]);
+
+      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+      const json = await body(res);
+
+      expect(json.general.notes.map((n: any) => n.id)).toEqual(["note-general"]);
+      expect(json.general.images.map((i: any) => i.id)).toEqual(["img-general"]);
+      expect(json.byAuditAsset["aa-1"].notes.map((n: any) => n.id)).toEqual([
+        "note-asset",
+      ]);
+      expect(json.byAuditAsset["aa-1"].images.map((i: any) => i.id)).toEqual([
+        "img-asset",
+      ]);
+      // A general row must never leak into an asset bucket.
+      expect(json.byAuditAsset["aa-1"].notes).toHaveLength(1);
+    });
+
+    it("keys buckets by auditAssetId, which is what the detail payload carries", async () => {
+      mockDb.auditNote.findMany.mockResolvedValue([
+        NOTE_ASSET,
+        { ...NOTE_ASSET, id: "note-other", auditAssetId: "aa-2" },
+      ]);
+
+      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+      const json = await body(res);
+
+      expect(Object.keys(json.byAuditAsset).sort()).toEqual(["aa-1", "aa-2"]);
+    });
+  });
+
+  describe("serialisation", () => {
+    it("falls back to the full image when a thumbnail is missing", async () => {
+      // why: a null thumbnail in a thumbnail grid renders as a gap where a
+      // photo plainly exists.
+      mockDb.auditImage.findMany.mockResolvedValue([IMAGE_ASSET]);
+
+      const json = await body(
+        await loader(createLoaderArgs({ request: request(), ...ARGS }))
+      );
+
+      expect(json.byAuditAsset["aa-1"].images[0].thumbnailUrl).toBe(
+        "https://x/full-arri.jpg"
+      );
+    });
+
+    it("returns a null author when the account is gone, rather than dropping the row", async () => {
+      // why: evidence outlives the person who recorded it. Losing the row
+      // would lose the audit trail.
+      mockDb.auditImage.findMany.mockResolvedValue([IMAGE_ASSET]);
+
+      const json = await body(
+        await loader(createLoaderArgs({ request: request(), ...ARGS }))
+      );
+
+      expect(json.byAuditAsset["aa-1"].images).toHaveLength(1);
+      expect(json.byAuditAsset["aa-1"].images[0].authorName).toBeNull();
+    });
+
+    it("composes the author name and serialises dates as ISO strings", async () => {
+      mockDb.auditNote.findMany.mockResolvedValue([NOTE_GENERAL]);
+
+      const json = await body(
+        await loader(createLoaderArgs({ request: request(), ...ARGS }))
+      );
+
+      expect(json.general.notes[0].authorName).toBe("John Doe");
+      expect(json.general.notes[0].createdAt).toBe("2026-08-19T12:42:00.000Z");
+    });
+  });
+
+  describe("guards", () => {
+    it("404s for an audit outside the caller's workspace, without reading evidence", async () => {
+      // why: proves a guessed id from another org cannot be probed here.
+      mockDb.auditSession.findFirst.mockResolvedValue(null);
+
+      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      expect((res as unknown as Response).status).toBe(404);
+      expect(mockDb.auditNote.findMany).not.toHaveBeenCalled();
+      expect(mockDb.auditImage.findMany).not.toHaveBeenCalled();
+    });
+
+    it("403s when audits are not enabled for the workspace", async () => {
+      (getMobileUserContext as any).mockResolvedValue({
+        role: "ADMIN",
+        canUseAudits: false,
+      });
+
+      const res = await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      expect((res as unknown as Response).status).toBe(403);
+      expect(mockDb.auditSession.findFirst).not.toHaveBeenCalled();
+    });
+
+    it("scopes the image query to the organization", async () => {
+      await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      expect(mockDb.auditImage.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { auditSessionId: "audit-1", organizationId: "org-1" },
+        })
+      );
+    });
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
@@ -303,6 +303,51 @@ describe("GET /api/mobile/audits/:auditId/evidence", () => {
       );
     });
 
+    it("caps how many rows one response can carry", async () => {
+      // why: without a bound, one tap pulls every note and photo in the audit.
+      // Every other mobile list route clamps, and the calendar route added the
+      // same guard for the same reason.
+      await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      expect(mockDb.auditNote.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 200 })
+      );
+      expect(mockDb.auditImage.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: 200 })
+      );
+    });
+
+    it("narrows to one audited asset when the caller asks for one", async () => {
+      // why: the sheet shows a single row, so this is the shape the client
+      // actually wants — the audit-wide response is the heavy half.
+      await loader(
+        createLoaderArgs({
+          request: request("orgId=org-1&auditAssetId=aa-1"),
+          ...ARGS,
+        })
+      );
+
+      expect(mockDb.auditNote.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ auditAssetId: "aa-1" }),
+        })
+      );
+      expect(mockDb.auditImage.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ auditAssetId: "aa-1" }),
+        })
+      );
+    });
+
+    it("returns the whole audit when no asset is named", async () => {
+      // why: the audit-wide shape still has one caller — the completion
+      // notes and photos, which belong to no single asset.
+      await loader(createLoaderArgs({ request: request(), ...ARGS }));
+
+      const noteWhere = mockDb.auditNote.findMany.mock.calls[0][0].where;
+      expect(noteWhere).not.toHaveProperty("auditAssetId");
+    });
+
     it("asks only for COMMENT notes, not the system activity trail", async () => {
       // why: `AuditNote` mixes human comments with UPDATE rows written as
       // MARKDOC SOURCE (`{% link to="/settings/team/users/..." /%}`). The web


### PR DESCRIPTION
## The gap

The companion could **write** audit evidence (`audits.note`, `audits.image`) and its detail payload carried the per-asset **counts** — but nothing ever served the content. A field worker photographed a cracked yoke, completed the audit, and every note and photo they had just taken became visible only on the web.

Counts without content is the worst combination: the app knew the evidence existed and still could not show one item of it.

The web was better but not good: evidence is reachable through the Activity feed, yet the assets table said nothing about which rows held any. On a 200-asset audit that makes the one damaged item indistinguishable from the 199 clean ones.

## What this adds

| | |
| --- | --- |
| `GET /api/mobile/audits/:id/evidence` | new read route — `general` (completion note + closing photos) and `byAuditAsset`, keyed by the `auditAssetId` the detail payload already carries |
| `evidence-viewer.tsx` | read-only sheet: photo grid with captions, notes with author and date |
| Audit detail rows | attachment count, tappable when there is something to open |
| Audit detail header | "Completion notes and photos" for the audit-wide bucket |
| Web assets table | attachment chip linking into the **existing** notes-and-images panel |

Deliberately **read-only**. Deleting evidence is destructive and belongs on the surface with room to confirm it; this is for reviewing in the field, including long after the audit closed.

The web chip costs no extra query — it rides a `_count` on the `auditAsset.findMany` the overview loader already runs. It counts `COMMENT` notes only, matching `getAuditScans`: system notes are audit trail, not condition observations, and counting them would inflate every row.

## Verification

- 8 route tests. **Mutation-tested**: disabling the cross-org guard and leaking `general` rows into asset buckets each fail a test.
- 5 component tests on the chip, also mutation-tested (dropping notes from the count fails 3).
- The filtered `_count` was run against a real database: returns **1** where the DB holds **42** notes, proving the `COMMENT` filter applies.
- Auth-contract suite (63 tests) confirms the new route is not auth-exempt.

## Rollout

The phone half needs this deployed **before** an OTA carrying it, or the viewer calls a 404. Same ordering as #2864.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only audit evidence viewing for notes and photos at audit and asset levels.
  * Added separate note and photo counts, indicators, accessibility labels, and tappable evidence cards with photo previews.
  * Completed audits now display completion evidence.
  * Added Findings sections to audit overviews and PDFs, grouping notes and photos by asset.

* **Bug Fixes**
  * Improved image fallback handling and excluded system-generated updates from condition notes and counts.

* **Tests**
  * Added coverage for evidence access, authorization, formatting, counts, and PDF findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->