### PR TITLE
fix(audits): require assignment, and bind evidence to the audit that owns it

### DIFF
--- a/apps/webapp/app/modules/audit/image.service.server.test.ts
+++ b/apps/webapp/app/modules/audit/image.service.server.test.ts
@@ -189,10 +189,18 @@ describe("audit image service", () => {
       await deleteAuditImage({
         imageId: "img-1",
         organizationId: "org-1",
+        auditSessionId: "audit-1",
       });
 
+      // The `auditSessionId` predicate is the point: `imageId` is
+      // caller-supplied, so an org-only filter let any member delete any
+      // image in the workspace through a URL naming a different audit.
       expect(db.auditImage.findFirst).toHaveBeenCalledWith({
-        where: { id: "img-1", organizationId: "org-1" },
+        where: {
+          id: "img-1",
+          organizationId: "org-1",
+          auditSessionId: "audit-1",
+        },
       });
 
       expect(removePublicFile).toHaveBeenCalledWith({
@@ -215,10 +223,60 @@ describe("audit image service", () => {
         deleteAuditImage({
           imageId: "nonexistent",
           organizationId: "org-1",
+          auditSessionId: "audit-1",
         })
       ).rejects.toThrow();
 
       expect(db.auditImage.delete).not.toHaveBeenCalled();
+    });
+
+    it("refuses an image that belongs to a different audit", async () => {
+      // The reported vector: a real image id, submitted through a URL naming
+      // an audit it does not belong to. The scoped lookup matches nothing.
+      vi.mocked(db.auditImage.findFirst).mockResolvedValue(null);
+
+      await expect(
+        deleteAuditImage({
+          imageId: "img-from-another-audit",
+          organizationId: "org-1",
+          auditSessionId: "audit-the-caller-named",
+        })
+      ).rejects.toThrow();
+
+      expect(db.auditImage.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: "img-from-another-audit",
+          organizationId: "org-1",
+          auditSessionId: "audit-the-caller-named",
+        },
+      });
+      // Nothing deleted, and crucially no storage object removed — the files
+      // go before the row, so an unscoped lookup destroys the evidence even
+      // if the DB delete were to fail afterwards.
+      expect(db.auditImage.delete).not.toHaveBeenCalled();
+      expect(removePublicFile).not.toHaveBeenCalled();
+    });
+
+    it("binds to the audit ASSET too when the route names one", async () => {
+      vi.mocked(db.auditImage.findFirst).mockResolvedValue(null);
+
+      await expect(
+        deleteAuditImage({
+          imageId: "img-1",
+          organizationId: "org-1",
+          auditSessionId: "audit-1",
+          auditAssetId: "auditasset-1",
+        })
+      ).rejects.toThrow();
+
+      expect(db.auditImage.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: "img-1",
+          organizationId: "org-1",
+          auditSessionId: "audit-1",
+          auditAssetId: "auditasset-1",
+        },
+      });
     });
   });
 

--- a/apps/webapp/app/modules/audit/image.service.server.ts
+++ b/apps/webapp/app/modules/audit/image.service.server.ts
@@ -263,25 +263,53 @@ async function validateImageLimits({
 export async function deleteAuditImage({
   imageId,
   organizationId,
+  auditSessionId,
+  auditAssetId,
 }: {
   imageId: AuditImage["id"];
   organizationId: Organization["id"];
+  /**
+   * The audit the caller is acting on, taken from the route. REQUIRED, and
+   * deliberately not optional: `imageId` comes from the request body, and
+   * without this the org filter was the only constraint — so an image could be
+   * deleted through a URL naming a completely different audit.
+   */
+  auditSessionId: AuditSession["id"];
+  /**
+   * The audit asset the caller is acting on, when the route names one. Binds
+   * the image to its specific parent row rather than merely to the audit.
+   * Omitted by callers that legitimately act on audit-level (general) images.
+   */
+  auditAssetId?: AuditAsset["id"];
 }): Promise<boolean> {
   try {
-    // Get the image record to retrieve URLs
+    // Get the image record to retrieve URLs.
+    //
+    // SECURITY: scoped to the audit (and, when the route names one, the audit
+    // asset) the caller is acting on — not to the organization alone. The
+    // `imageId` is caller-supplied, so an org-only filter let any member
+    // delete any image in the workspace, including evidence attached to an
+    // audit they are not assigned to and did not name in the URL.
     const image = await db.auditImage.findFirst({
       where: {
         id: imageId,
         organizationId,
+        auditSessionId,
+        ...(auditAssetId ? { auditAssetId } : {}),
       },
     });
 
     if (!image) {
       throw new ShelfError({
         cause: null,
+        // Deliberately uniform: a real image belonging to another audit and a
+        // wholly unknown id return the same message, so this cannot be used to
+        // probe which image ids exist.
         message: "Image not found or you don't have permission to delete it",
-        additionalData: { imageId, organizationId },
+        additionalData: { imageId, organizationId, auditSessionId },
         label,
+        status: 404,
+        shouldBeCaptured: false,
       });
     }
 

--- a/apps/webapp/app/modules/audit/mobile-evidence.server.test.ts
+++ b/apps/webapp/app/modules/audit/mobile-evidence.server.test.ts
@@ -39,7 +39,7 @@ describe("requireAuditAssetInSession", () => {
     vi.clearAllMocks();
     (db.auditSession.findFirst as any).mockResolvedValue({ id: "session-1" });
     (db.auditAsset.findFirst as any).mockResolvedValue({ id: "audit-asset-1" });
-    (getMobileUserContext as any).mockResolvedValue({ role: "ADMIN" });
+    (getMobileUserContext as any).mockResolvedValue({ roles: ["ADMIN"] });
     (requireAuditAssignee as any).mockResolvedValue(undefined);
   });
 
@@ -70,7 +70,7 @@ describe("requireAuditAssetInSession", () => {
   });
 
   it("passes isSelfServiceOrBase=true to the assignee guard for BASE", async () => {
-    (getMobileUserContext as any).mockResolvedValue({ role: "BASE" });
+    (getMobileUserContext as any).mockResolvedValue({ roles: ["BASE"] });
     await requireAuditAssetInSession(args);
     expect(requireAuditAssignee).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -82,8 +82,40 @@ describe("requireAuditAssetInSession", () => {
     );
   });
 
+  it("treats a member holding BOTH SELF_SERVICE and ADMIN as an admin", async () => {
+    // `getMobileUserContext` returns `role = roles[0]`, and its own JSDoc warns
+    // that this is wrong for an authorization decision. Deriving from it meant
+    // a membership ordered `[SELF_SERVICE, ADMIN]` resolved to SELF_SERVICE,
+    // so a real admin who is not an assignee was refused.
+    (getMobileUserContext as any).mockResolvedValue({
+      roles: ["SELF_SERVICE", "ADMIN"],
+    });
+
+    await requireAuditAssetInSession(args);
+
+    expect(requireAuditAssignee).toHaveBeenCalledWith(
+      expect.objectContaining({ isSelfServiceOrBase: false })
+    );
+  });
+
+  it("still restricts a member holding only SELF_SERVICE and BASE", async () => {
+    // The inverse: resolving "most privileged" must not accidentally promote
+    // someone who holds no privileged role at all.
+    (getMobileUserContext as any).mockResolvedValue({
+      roles: ["BASE", "SELF_SERVICE"],
+    });
+
+    await requireAuditAssetInSession(args);
+
+    expect(requireAuditAssignee).toHaveBeenCalledWith(
+      expect.objectContaining({ isSelfServiceOrBase: true })
+    );
+  });
+
   it("propagates the assignee guard rejection", async () => {
-    (getMobileUserContext as any).mockResolvedValue({ role: "SELF_SERVICE" });
+    (getMobileUserContext as any).mockResolvedValue({
+      roles: ["SELF_SERVICE"],
+    });
     const err = Object.assign(new Error("Not an assignee"), { status: 403 });
     (requireAuditAssignee as any).mockRejectedValue(err);
     await expect(requireAuditAssetInSession(args)).rejects.toMatchObject({

--- a/apps/webapp/app/modules/audit/mobile-evidence.server.ts
+++ b/apps/webapp/app/modules/audit/mobile-evidence.server.ts
@@ -23,6 +23,7 @@
 import { db } from "~/database/db.server";
 import { getMobileUserContext } from "~/modules/api/mobile-auth.server";
 import { requireAuditAssignee } from "~/modules/audit/service.server";
+import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
 import { ShelfError } from "~/utils/error";
 
 /**
@@ -76,8 +77,14 @@ export async function requireAuditAssetInSession({
     });
   }
 
-  const { role } = await getMobileUserContext(userId, organizationId);
-  const isSelfServiceOrBase = role === "SELF_SERVICE" || role === "BASE";
+  // Resolved from ALL roles. `getMobileUserContext` sets `role = roles[0]`,
+  // and its own JSDoc warns that this is wrong for an authorization decision:
+  // a membership ordered `[SELF_SERVICE, ADMIN]` resolves to SELF_SERVICE, so
+  // a real admin who is not an assignee would be refused here.
+  const { roles } = await getMobileUserContext(userId, organizationId);
+  const effectiveRole = resolveMostPrivilegedRole(roles);
+  const isSelfServiceOrBase =
+    effectiveRole === "SELF_SERVICE" || effectiveRole === "BASE";
   await requireAuditAssignee({
     auditSessionId,
     organizationId,

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -185,24 +185,35 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const formData = await request.clone().formData();
     const intent = formData.get("intent");
 
-    // Assignee-gated for EVERY intent: ADMIN/OWNER may act on any audit,
+    /**
+     * Intents whose own authorization rule is BROADER than assignment, and so
+     * must not sit behind the assignment guard.
+     *
+     * `cancel-audit` is the only one today. `createAuditSession` does NOT
+     * auto-assign the creator, while `cancelAuditSession` guarantees the
+     * creator may always cancel — so gating it on assignment would lock a
+     * BASE creator out of an audit they made themselves. The narrower
+     * creator-or-admin rule inside the service is the correct gate there.
+     */
+    const INTENTS_WITH_THEIR_OWN_RULE = new Set(["cancel-audit"]);
+
+    // Assignee-gated by DEFAULT: ADMIN/OWNER may act on any audit,
     // BASE/SELF_SERVICE only on audits assigned to them.
     //
-    // Hoisted rather than repeated per branch, because only `complete-audit`
-    // used to carry it — `remove-asset` and `bulk-remove-assets` had none, so
-    // an unassigned member could strip assets out of anyone's audit by direct
-    // POST. The loader's `canRemoveAssets` is display-only. Putting the guard
-    // ahead of the switch means a newly added intent inherits it instead of
-    // having to remember. (detail.dev D101)
-    //
-    // `cancel-audit` additionally enforces creator-or-admin inside
-    // `cancelAuditSession`; that is a narrower rule and stays where it is.
-    await requireAuditAssignee({
-      auditSessionId: auditId,
-      organizationId,
-      userId,
-      isSelfServiceOrBase,
-    });
+    // Expressed as an exclusion rather than a list of guarded intents so the
+    // default is fail-closed — a newly added intent inherits the guard instead
+    // of silently escaping it. Only `complete-audit` used to carry a check, so
+    // `remove-asset` and `bulk-remove-assets` let an unassigned member strip
+    // assets out of anyone's audit by direct POST; the loader's
+    // `canRemoveAssets` is display-only. (detail.dev D101)
+    if (!INTENTS_WITH_THEIR_OWN_RULE.has(String(intent))) {
+      await requireAuditAssignee({
+        auditSessionId: auditId,
+        organizationId,
+        userId,
+        isSelfServiceOrBase,
+      });
+    }
 
     if (intent === "complete-audit") {
       await completeAuditWithImages({

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.overview.tsx
@@ -185,16 +185,26 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const formData = await request.clone().formData();
     const intent = formData.get("intent");
 
-    if (intent === "complete-audit") {
-      // Assignee-gated: ADMIN/OWNER may complete any audit,
-      // BASE/SELF_SERVICE only when assigned.
-      await requireAuditAssignee({
-        auditSessionId: auditId,
-        organizationId,
-        userId,
-        isSelfServiceOrBase,
-      });
+    // Assignee-gated for EVERY intent: ADMIN/OWNER may act on any audit,
+    // BASE/SELF_SERVICE only on audits assigned to them.
+    //
+    // Hoisted rather than repeated per branch, because only `complete-audit`
+    // used to carry it — `remove-asset` and `bulk-remove-assets` had none, so
+    // an unassigned member could strip assets out of anyone's audit by direct
+    // POST. The loader's `canRemoveAssets` is display-only. Putting the guard
+    // ahead of the switch means a newly added intent inherits it instead of
+    // having to remember. (detail.dev D101)
+    //
+    // `cancel-audit` additionally enforces creator-or-admin inside
+    // `cancelAuditSession`; that is a narrower rule and stays where it is.
+    await requireAuditAssignee({
+      auditSessionId: auditId,
+      organizationId,
+      userId,
+      isSelfServiceOrBase,
+    });
 
+    if (intent === "complete-audit") {
       await completeAuditWithImages({
         request,
         auditSessionId: auditId,

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -491,6 +491,34 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
 
+      // Prove the note is ours BEFORE uploading anything.
+      //
+      // The scoped lookup used to sit inside the transaction below, AFTER this
+      // loop — so a request naming a note in another audit (or another
+      // organization) was correctly refused, but only once the images had
+      // already been written to storage and to the database. The refusal was
+      // sound; the side effect was not.
+      const targetNote = await db.auditNote.findFirst({
+        where: {
+          id: noteId,
+          auditSessionId: auditId,
+          auditSession: { organizationId },
+        },
+        select: { id: true },
+      });
+
+      if (!targetNote) {
+        throw new ShelfError({
+          cause: null,
+          // Uniform with a genuinely unknown id — `noteId` is caller-supplied.
+          message: "Note not found",
+          additionalData: { noteId, auditId },
+          label: "Audit Image",
+          status: 404,
+          shouldBeCaptured: false,
+        });
+      }
+
       // Upload each file sequentially
       const uploadedImages: Array<{ id: string }> = [];
       for (const file of files) {
@@ -516,85 +544,105 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       }
 
       // Update the note to append the audit_images tag
-      await db.$transaction(async (tx) => {
-        // SECURITY (cross-organization IDOR): `AuditNote` has no
-        // `organizationId` column — it inherits its tenant through
-        // `auditSession` — so an id-only lookup addressed every note in the
-        // table, in every workspace. `noteId` comes from the request body, so
-        // this branch could READ and then OVERWRITE the content of any audit
-        // note in any organization.
-        //
-        // The sibling delete branch was hardened for exactly this and carries
-        // a comment saying so; this path was missed.
-        const existingNote = await tx.auditNote.findFirst({
-          where: {
-            id: noteId,
-            auditSessionId: auditId,
-            auditSession: { organizationId },
-          },
-        });
-
-        if (!existingNote) {
-          throw new ShelfError({
-            cause: null,
-            message: "Note not found",
-            additionalData: { noteId },
-            label: "Audit Image",
-            status: 404,
+      // The pre-check above closes the ordinary case. This still re-checks
+      // under the write, because the note can be deleted between the two —
+      // and if that happens the uploads are rolled back rather than left
+      // orphaned in storage with nothing pointing at them.
+      try {
+        await db.$transaction(async (tx) => {
+          // SECURITY (cross-organization IDOR): `AuditNote` has no
+          // `organizationId` column — it inherits its tenant through
+          // `auditSession` — so an id-only lookup addressed every note in the
+          // table, in every workspace. `noteId` comes from the request body, so
+          // this branch could READ and then OVERWRITE the content of any audit
+          // note in any organization.
+          //
+          // The sibling delete branch was hardened for exactly this and carries
+          // a comment saying so; this path was missed.
+          const existingNote = await tx.auditNote.findFirst({
+            where: {
+              id: noteId,
+              auditSessionId: auditId,
+              auditSession: { organizationId },
+            },
           });
-        }
 
-        // Extract existing image IDs from content if any
-        const existingImageIds: string[] = [];
-        const regex = /{%\s*audit_images[^%]*ids="([^"]+)"[^%]*%}/g;
-        let match;
-        while ((match = regex.exec(existingNote.content)) !== null) {
-          existingImageIds.push(...match[1].split(","));
-        }
+          if (!existingNote) {
+            throw new ShelfError({
+              cause: null,
+              message: "Note not found",
+              additionalData: { noteId },
+              label: "Audit Image",
+              status: 404,
+            });
+          }
 
-        // Add new image IDs
-        const newImageIds = uploadedImages.map((img) => img.id);
-        const allImageIds = [...existingImageIds, ...newImageIds];
+          // Extract existing image IDs from content if any
+          const existingImageIds: string[] = [];
+          const regex = /{%\s*audit_images[^%]*ids="([^"]+)"[^%]*%}/g;
+          let match;
+          while ((match = regex.exec(existingNote.content)) !== null) {
+            existingImageIds.push(...match[1].split(","));
+          }
 
-        // Remove existing audit_images tags, sanitize the surviving user-authored
-        // body so a previously-injected delimiter can't survive a re-tag, then
-        // append the fresh trusted tag.
-        const strippedTags = existingNote.content.replace(
-          /{%\s*audit_images[^%]*%}/g,
-          ""
+          // Add new image IDs
+          const newImageIds = uploadedImages.map((img) => img.id);
+          const allImageIds = [...existingImageIds, ...newImageIds];
+
+          // Remove existing audit_images tags, sanitize the surviving user-authored
+          // body so a previously-injected delimiter can't survive a re-tag, then
+          // append the fresh trusted tag.
+          const strippedTags = existingNote.content.replace(
+            /{%\s*audit_images[^%]*%}/g,
+            ""
+          );
+          // stripMarkdocDelimiters trims and removes `{%`/`%}` from user text only;
+          // the trusted tag is appended after, so it is never touched.
+          const sanitizedBody = stripMarkdocDelimiters(strippedTags);
+          const updatedContent = `${sanitizedBody}\n\n{% audit_images count=${
+            allImageIds.length
+          } ids="${allImageIds.join(",")}" /%}`;
+
+          // `updateMany`, not `update`: a unique-only `where` cannot carry the
+          // parent scope, and the write must be scoped in its own right rather
+          // than relying on the read above surviving a future refactor.
+          const updated = await tx.auditNote.updateMany({
+            where: {
+              id: noteId,
+              auditSessionId: auditId,
+              auditSession: { organizationId },
+            },
+            data: {
+              content: updatedContent,
+            },
+          });
+
+          if (updated.count === 0) {
+            throw new ShelfError({
+              cause: null,
+              message: "Note not found",
+              additionalData: { noteId, auditId },
+              label: "Audit",
+              status: 404,
+              shouldBeCaptured: false,
+            });
+          }
+        });
+      } catch (cause) {
+        // Best-effort cleanup. A failure here must not mask the original
+        // error, which is the one the caller needs to see.
+        await Promise.all(
+          uploadedImages.map((img) =>
+            deleteAuditImage({
+              imageId: img.id,
+              organizationId,
+              auditSessionId: auditId,
+              auditAssetId,
+            }).catch(() => undefined)
+          )
         );
-        // stripMarkdocDelimiters trims and removes `{%`/`%}` from user text only;
-        // the trusted tag is appended after, so it is never touched.
-        const sanitizedBody = stripMarkdocDelimiters(strippedTags);
-        const updatedContent = `${sanitizedBody}\n\n{% audit_images count=${
-          allImageIds.length
-        } ids="${allImageIds.join(",")}" /%}`;
-
-        // `updateMany`, not `update`: a unique-only `where` cannot carry the
-        // parent scope, and the write must be scoped in its own right rather
-        // than relying on the read above surviving a future refactor.
-        const updated = await tx.auditNote.updateMany({
-          where: {
-            id: noteId,
-            auditSessionId: auditId,
-            auditSession: { organizationId },
-          },
-          data: {
-            content: updatedContent,
-          },
-        });
-
-        if (updated.count === 0) {
-          throw new ShelfError({
-            cause: null,
-            message: "Note not found",
-            additionalData: { noteId, auditId },
-            label: "Audit",
-            status: 404,
-            shouldBeCaptured: false,
-          });
-        }
-      });
+        throw cause;
+      }
 
       return payload({ images: uploadedImages });
     }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -306,7 +306,14 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
       // Prevent deletion of auto-generated notes (UPDATE type)
       const noteToDelete = await db.auditNote.findFirst({
-        where: { id: noteId, auditSession: { organizationId } },
+        where: {
+          id: noteId,
+          // Bound to the audit in the URL as well as the org. Org scope alone
+          // let an assignee of one audit delete notes belonging to another
+          // audit in the same workspace.
+          auditSessionId: auditId,
+          auditSession: { organizationId },
+        },
         select: { type: true },
       });
 
@@ -333,6 +340,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       const deleted = await db.auditNote.deleteMany({
         where: {
           id: noteId,
+          auditSessionId: auditId,
           auditSession: { organizationId },
         },
       });
@@ -509,8 +517,21 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
       // Update the note to append the audit_images tag
       await db.$transaction(async (tx) => {
-        const existingNote = await tx.auditNote.findUnique({
-          where: { id: noteId },
+        // SECURITY (cross-organization IDOR): `AuditNote` has no
+        // `organizationId` column — it inherits its tenant through
+        // `auditSession` — so an id-only lookup addressed every note in the
+        // table, in every workspace. `noteId` comes from the request body, so
+        // this branch could READ and then OVERWRITE the content of any audit
+        // note in any organization.
+        //
+        // The sibling delete branch was hardened for exactly this and carries
+        // a comment saying so; this path was missed.
+        const existingNote = await tx.auditNote.findFirst({
+          where: {
+            id: noteId,
+            auditSessionId: auditId,
+            auditSession: { organizationId },
+          },
         });
 
         if (!existingNote) {
@@ -549,12 +570,30 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           allImageIds.length
         } ids="${allImageIds.join(",")}" /%}`;
 
-        await tx.auditNote.update({
-          where: { id: noteId },
+        // `updateMany`, not `update`: a unique-only `where` cannot carry the
+        // parent scope, and the write must be scoped in its own right rather
+        // than relying on the read above surviving a future refactor.
+        const updated = await tx.auditNote.updateMany({
+          where: {
+            id: noteId,
+            auditSessionId: auditId,
+            auditSession: { organizationId },
+          },
           data: {
             content: updatedContent,
           },
         });
+
+        if (updated.count === 0) {
+          throw new ShelfError({
+            cause: null,
+            message: "Note not found",
+            additionalData: { noteId, auditId },
+            label: "Audit",
+            status: 404,
+            shouldBeCaptured: false,
+          });
+        }
       });
 
       return payload({ images: uploadedImages });

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -36,7 +36,10 @@ import {
   deleteAuditImage,
 } from "~/modules/audit/image.service.server";
 import { stripMarkdocDelimiters } from "~/modules/audit/note-content.server";
-import { requireAuditAssigneeForBaseSelfService } from "~/modules/audit/service.server";
+import {
+  requireAuditAssignee,
+  requireAuditAssigneeForBaseSelfService,
+} from "~/modules/audit/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { error, getParams, payload } from "~/utils/http.server";
@@ -186,11 +189,22 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
   );
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, isSelfServiceOrBase } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.audit,
       action: PermissionAction.update,
+    });
+
+    // The loader gates the read with `requireAuditAssigneeForBaseSelfService`;
+    // this action did not gate the writes. Every intent below mutates the
+    // audit — notes, condition, evidence deletion — so the guard is hoisted
+    // here rather than repeated per intent, and a new intent inherits it.
+    await requireAuditAssignee({
+      auditSessionId: auditId,
+      organizationId,
+      userId,
+      isSelfServiceOrBase,
     });
 
     const formData = await request.clone().formData();
@@ -528,6 +542,8 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       await deleteAuditImage({
         imageId,
         organizationId,
+        auditSessionId: auditId,
+        auditAssetId,
       });
 
       return payload({ success: true });

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -312,6 +312,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           // let an assignee of one audit delete notes belonging to another
           // audit in the same workspace.
           auditSessionId: auditId,
+          auditAssetId,
           auditSession: { organizationId },
         },
         select: { type: true },
@@ -341,6 +342,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         where: {
           id: noteId,
           auditSessionId: auditId,
+          auditAssetId,
           auditSession: { organizationId },
         },
       });
@@ -502,6 +504,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         where: {
           id: noteId,
           auditSessionId: auditId,
+          auditAssetId,
           auditSession: { organizationId },
         },
         select: { id: true },
@@ -563,6 +566,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             where: {
               id: noteId,
               auditSessionId: auditId,
+              auditAssetId,
               auditSession: { organizationId },
             },
           });
@@ -610,6 +614,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
             where: {
               id: noteId,
               auditSessionId: auditId,
+              // …and to the ASSET the URL names. This route creates notes with
+              // `auditAssetId` set and lists them filtered by it, so a note on a
+              // different asset is one this page never offered. Not a privilege
+              // boundary — assignment is per-audit, so an assignee reaches every
+              // asset in it — but appending images to, or deleting, another
+              // asset's note corrupts data the caller never saw.
+              auditAssetId,
               auditSession: { organizationId },
             },
             data: {

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.$auditAssetId.details.tsx
@@ -78,6 +78,12 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     const auditAsset = await db.auditAsset.findFirst({
       where: {
         id: auditAssetId,
+        // Bound to the audit named in the URL, not merely to the org. Without
+        // `auditSessionId` a caller could pass an audit asset from a DIFFERENT
+        // audit and the page would render it under this audit's heading — and
+        // the action's assignment guard, which keys on `auditId`, would then be
+        // validating a different audit from the one being written to.
+        auditSessionId: auditId,
         auditSession: {
           organizationId,
         },
@@ -206,6 +212,34 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
       userId,
       isSelfServiceOrBase,
     });
+
+    // …and prove the audit asset actually belongs to that audit. Both ids come
+    // from the URL and were never tied together, so guarding on `auditId`
+    // alone would validate assignment against one audit while every intent
+    // below writes to an asset in another. `AuditAsset` has no
+    // `organizationId` of its own — the session link is its whole tenant
+    // boundary — so the org filter goes through the relation.
+    const auditAssetInSession = await db.auditAsset.findFirst({
+      where: {
+        id: auditAssetId,
+        auditSessionId: auditId,
+        auditSession: { organizationId },
+      },
+      select: { id: true },
+    });
+
+    if (!auditAssetInSession) {
+      throw new ShelfError({
+        cause: null,
+        // Uniform with a genuinely unknown id: both ids are caller-supplied,
+        // so a distinct message would confirm which ones exist.
+        message: "Audit asset not found in this audit",
+        additionalData: { auditId, auditAssetId },
+        label: "Audit",
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    }
 
     const formData = await request.clone().formData();
     const intent = formData.get("intent") as string;

--- a/apps/webapp/app/routes/api+/audits.$auditId.assets.$assetId.images.ts
+++ b/apps/webapp/app/routes/api+/audits.$auditId.assets.$assetId.images.ts
@@ -4,6 +4,7 @@ import {
   deleteAuditImage,
   getAuditImages,
 } from "~/modules/audit/image.service.server";
+import { requireAuditAssignee } from "~/modules/audit/service.server";
 import { makeShelfError } from "~/utils/error";
 import { error, getParams, parseData, payload } from "~/utils/http.server";
 import {
@@ -22,7 +23,7 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
   const { userId } = context.getSession();
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, isSelfServiceOrBase } = await requirePermission({
       request,
       userId,
       entity: PermissionEntity.audit,
@@ -34,6 +35,17 @@ export async function loader({ request, context, params }: LoaderFunctionArgs) {
       z.object({ auditId: z.string(), assetId: z.string() }),
       { additionalData: { userId } }
     );
+
+    // `audit: read` authorizes reading audits in general, never THIS audit.
+    // Without an assignment check a BASE or SELF_SERVICE member could read the
+    // evidence attached to any audit in the workspace, including ones they
+    // were never assigned to. ADMIN/OWNER are unrestricted.
+    await requireAuditAssignee({
+      auditSessionId: auditId,
+      organizationId,
+      userId,
+      isSelfServiceOrBase,
+    });
 
     // Fetch images for the specific audit asset
     const images = await getAuditImages({
@@ -53,18 +65,27 @@ export async function action({ request, context, params }: LoaderFunctionArgs) {
   const { userId } = context.getSession();
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, isSelfServiceOrBase } = await requirePermission({
       request,
       userId,
       entity: PermissionEntity.audit,
       action: PermissionAction.update,
     });
 
-    const { auditId } = getParams(
+    const { auditId, assetId } = getParams(
       params,
       z.object({ auditId: z.string(), assetId: z.string() }),
       { additionalData: { userId } }
     );
+
+    // Deleting evidence is destructive and irreversible — the storage objects
+    // go too — so the same assignment rule as the read applies here.
+    await requireAuditAssignee({
+      auditSessionId: auditId,
+      organizationId,
+      userId,
+      isSelfServiceOrBase,
+    });
 
     const { intent, imageId } = parseData(
       await request.formData(),
@@ -76,7 +97,16 @@ export async function action({ request, context, params }: LoaderFunctionArgs) {
     );
 
     if (intent === "delete") {
-      await deleteAuditImage({ imageId, organizationId });
+      // `auditSessionId` and `auditAssetId` bind the caller-supplied `imageId`
+      // to the parent named in the URL. Without them the org filter was the
+      // only constraint, so this route could delete an image belonging to an
+      // entirely different audit.
+      await deleteAuditImage({
+        imageId,
+        organizationId,
+        auditSessionId: auditId,
+        auditAssetId: assetId,
+      });
       return data(payload({ success: true }));
     }
 

--- a/apps/webapp/app/routes/api+/audits.add-assets.ts
+++ b/apps/webapp/app/routes/api+/audits.add-assets.ts
@@ -5,7 +5,10 @@ import { z } from "zod";
 import { resolveAssetIdsForBulkOperation } from "~/modules/asset/bulk-operations-helper.server";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
-import { addAssetsToAudit } from "~/modules/audit/service.server";
+import {
+  addAssetsToAudit,
+  requireAuditAssignee,
+} from "~/modules/audit/service.server";
 import { scopeCustodianFilterIds } from "~/modules/team-member/service.server";
 import { getClientHint } from "~/utils/client-hints";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
@@ -29,13 +32,18 @@ export async function action({ request, context }: ActionFunctionArgs) {
   try {
     assertIsPost(request);
 
-    const { organizationId, canUseBarcodes, role, canSeeAllCustody } =
-      await requirePermission({
-        userId,
-        request,
-        entity: PermissionEntity.audit,
-        action: PermissionAction.update,
-      });
+    const {
+      organizationId,
+      canUseBarcodes,
+      role,
+      canSeeAllCustody,
+      isSelfServiceOrBase,
+    } = await requirePermission({
+      userId,
+      request,
+      entity: PermissionEntity.audit,
+      action: PermissionAction.update,
+    });
 
     const formData = await request.formData();
 
@@ -50,6 +58,17 @@ export async function action({ request, context }: ActionFunctionArgs) {
         additionalData: { organizationId, userId },
       }
     );
+
+    // `audit: update` authorizes updating audits in general, never THIS audit.
+    // Without this a BASE or SELF_SERVICE member could widen the scope of any
+    // pending audit in the workspace — adding assets to one they were never
+    // assigned to. ADMIN/OWNER are unrestricted. (detail.dev D043)
+    await requireAuditAssignee({
+      auditSessionId: auditId,
+      organizationId,
+      userId,
+      isSelfServiceOrBase,
+    });
 
     // Determine if we're selecting all items across multiple pages
     const isSelectingAll =

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
@@ -10,6 +10,7 @@ import {
   getAuditScans,
   requireAuditAssignee,
 } from "~/modules/audit/service.server";
+import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
 
@@ -26,7 +27,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
-    const { role, canUseAudits } = await getMobileUserContext(
+    const { roles, canUseAudits } = await getMobileUserContext(
       user.id,
       organizationId
     );
@@ -52,7 +53,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // BASE or SELF_SERVICE user could still fetch the full audit — its assets,
     // scans, notes and progress — for any audit in the workspace. The web
     // overview loader already gates this; mobile did not. (detail.dev D054)
-    const isSelfServiceOrBase = role === "SELF_SERVICE" || role === "BASE";
+    // Resolved from ALL roles, not from `role`. `getMobileUserContext` sets
+    // `role = roles[0]`, and its own JSDoc warns that this is wrong for any
+    // authorization decision: a membership ordered `[SELF_SERVICE, ADMIN]`
+    // resolves to SELF_SERVICE, so a real admin who is not assigned to this
+    // audit would be refused by the guard below.
+    const effectiveRole = resolveMostPrivilegedRole(roles);
+    const isSelfServiceOrBase =
+      effectiveRole === "SELF_SERVICE" || effectiveRole === "BASE";
     await requireAuditAssignee({
       auditSessionId: auditId,
       organizationId,

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
@@ -8,6 +8,7 @@ import {
 import {
   getAuditSessionDetails,
   getAuditScans,
+  requireAuditAssignee,
 } from "~/modules/audit/service.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
@@ -46,6 +47,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       z.object({ auditId: z.string().min(1) })
     );
 
+    // Gate the READ, not merely the CTA below. `isAssignee` was computed only
+    // to decide whether to show a "Complete Audit" button, so an unassigned
+    // BASE or SELF_SERVICE user could still fetch the full audit — its assets,
+    // scans, notes and progress — for any audit in the workspace. The web
+    // overview loader already gates this; mobile did not. (detail.dev D054)
+    const isSelfServiceOrBase = role === "SELF_SERVICE" || role === "BASE";
+    await requireAuditAssignee({
+      auditSessionId: auditId,
+      organizationId,
+      userId: user.id,
+      isSelfServiceOrBase,
+    });
+
     // Fetch session details and scans in parallel
     const [{ session, expectedAssets }, scans] = await Promise.all([
       getAuditSessionDetails({ id: auditId, organizationId }),
@@ -57,7 +71,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // SELF_SERVICE only when assigned. Encode that eligibility in
     // `canComplete` so the client never shows a "Complete Audit" CTA that
     // 403s after confirmation. Mirrors the endpoint's own rule exactly.
-    const isSelfServiceOrBase = role === "SELF_SERVICE" || role === "BASE";
     const isAssignee = session.assignments.some((a) => a.user.id === user.id);
     const canCompleteAudit =
       (session.status === "ACTIVE" || session.status === "PENDING") &&

--- a/apps/webapp/test/routes-tests/_layout+/audits.overview.intent-guards.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.overview.intent-guards.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+/**
+ * Audit overview action — which intents sit behind the assignment guard.
+ *
+ * The guard is hoisted ahead of the intent branches so a newly added intent
+ * inherits it (fail-closed) rather than silently escaping it. That is right
+ * for every intent EXCEPT `cancel-audit`, whose own rule is broader:
+ * `createAuditSession` does not auto-assign the creator, and
+ * `cancelAuditSession` guarantees the creator may always cancel. Gating cancel
+ * on assignment would lock a BASE creator out of an audit they made.
+ *
+ * Both directions are pinned here, because getting either wrong is invisible
+ * to typecheck and to every other test.
+ *
+ * detail.dev D101; the cancel exemption was caught in review on #2900.
+ *
+ * @see {@link file://./../../../app/routes/_layout+/audits.$auditId.overview.tsx}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+// why: React Router v7 single fetch — `data()`/`redirect()` must return real
+// Responses so the action's paths can be exercised without a router.
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    data: vi.fn(
+      (body: unknown, init?: ResponseInit) =>
+        new Response(JSON.stringify(body), { status: init?.status || 200 })
+    ),
+    redirect: vi.fn(
+      (url: string) =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: url },
+        })
+    ),
+  };
+});
+
+const { mockRequirePermission } = vi.hoisted(() => ({
+  mockRequirePermission: vi.fn(),
+}));
+// why: the RBAC gate must PASS, so a refusal proves the ASSIGNMENT check is
+// what refused rather than the permission check.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: mockRequirePermission,
+}));
+
+const mocks = vi.hoisted(() => ({
+  requireAuditAssignee: vi.fn(),
+  cancelAuditSession: vi.fn().mockResolvedValue({}),
+  removeAssetFromAudit: vi.fn().mockResolvedValue(undefined),
+  removeAssetsFromAudit: vi.fn().mockResolvedValue({ removedCount: 1 }),
+}));
+// why: the guard and the mutations all hit the database. Mocking them lets a
+// test choose "assigned" vs "not assigned" and assert on the sinks.
+vi.mock("~/modules/audit/service.server", () => ({
+  ...mocks,
+  getAuditSessionDetails: vi.fn(),
+  getAssetsForAuditSession: vi.fn(),
+  requireAuditAssigneeForBaseSelfService: vi.fn(),
+}));
+vi.mock("~/modules/audit/complete-audit-with-images.server", () => ({
+  completeAuditWithImages: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("~/modules/audit/image.service.server", () => ({
+  getAuditImages: vi.fn().mockResolvedValue([]),
+}));
+// why: the bulk branch resolves auditAssetIds through Prisma before calling
+// the service; irrelevant to which intents are guarded.
+vi.mock("~/database/db.server", () => ({
+  db: { auditAsset: { findMany: vi.fn().mockResolvedValue([{ id: "aa-1" }]) } },
+}));
+
+import { action } from "~/routes/_layout+/audits.$auditId.overview";
+
+const AUDIT_ID = "audit-1";
+
+/** The 403 `requireAuditAssignee` throws for a non-assignee. */
+function notAnAssignee() {
+  const err = new Error("You don't have permission to view this audit");
+  Object.assign(err, { status: 403, isShelfError: true });
+  return err;
+}
+
+function post(body: Record<string, string>) {
+  return action({
+    request: new Request(`https://app.shelf.nu/audits/${AUDIT_ID}/overview`, {
+      method: "POST",
+      body: new URLSearchParams(body),
+    }),
+    params: { auditId: AUDIT_ID },
+    context: { getSession: () => ({ userId: "user-1", email: "a@b.c" }) },
+  } as unknown as Parameters<typeof action>[0]);
+}
+
+describe("audit overview intent guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cancelAuditSession.mockResolvedValue({});
+    mocks.removeAssetFromAudit.mockResolvedValue(undefined);
+    mocks.removeAssetsFromAudit.mockResolvedValue({ removedCount: 1 });
+    mockRequirePermission.mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: true,
+      role: OrganizationRoles.BASE,
+    });
+  });
+
+  describe("guarded by assignment", () => {
+    beforeEach(() => {
+      mocks.requireAuditAssignee.mockRejectedValue(notAnAssignee());
+    });
+
+    it("refuses remove-asset from an unassigned member", async () => {
+      await post({ intent: "remove-asset", auditAssetId: "aa-1" });
+      expect(mocks.removeAssetFromAudit).not.toHaveBeenCalled();
+    });
+
+    it("refuses bulk-remove-assets from an unassigned member", async () => {
+      await post({ intent: "bulk-remove-assets", "assetIds[0]": "asset-1" });
+      expect(mocks.removeAssetsFromAudit).not.toHaveBeenCalled();
+    });
+
+    it("guards an UNKNOWN intent too, so a new one cannot escape by default", async () => {
+      // The reason the guard is an exclusion rather than an allowlist. If this
+      // ever fails, someone inverted it and new intents ship unguarded.
+      await post({ intent: "some-future-intent" });
+      expect(mocks.requireAuditAssignee).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("cancel-audit — its own rule is broader", () => {
+    it("reaches the service even when the caller is not an assignee", async () => {
+      mocks.requireAuditAssignee.mockRejectedValue(notAnAssignee());
+
+      await post({ intent: "cancel-audit" });
+
+      // The creator of an audit is never auto-assigned to it, so gating this
+      // on assignment would lock a BASE creator out of their own audit.
+      // `cancelAuditSession` applies creator-or-admin itself.
+      expect(mocks.cancelAuditSession).toHaveBeenCalledTimes(1);
+      expect(mocks.requireAuditAssignee).not.toHaveBeenCalled();
+    });
+
+    it("forwards isAdminOrOwner so the service can apply its own rule", async () => {
+      mocks.requireAuditAssignee.mockResolvedValue(undefined);
+
+      await post({ intent: "cancel-audit" });
+
+      expect(mocks.cancelAuditSession).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "user-1", isAdminOrOwner: false })
+      );
+    });
+  });
+});

--- a/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
@@ -47,9 +47,14 @@ vi.mock("~/utils/roles.server", () => ({
   requirePermission: vi.fn(),
 }));
 
-// why: shared audit-assignee guard; mocked since it performs DB lookups.
+// why: shared audit-assignee guards; mocked since they perform DB lookups.
+// Both are needed: the loader uses the sync BASE/SELF_SERVICE variant, the
+// action uses the async one. A module mock that omits either makes the missing
+// export `undefined`, so the route 500s and every assertion fails for the
+// wrong reason rather than reporting a missing guard.
 vi.mock("~/modules/audit/service.server", () => ({
   requireAuditAssigneeForBaseSelfService: vi.fn(),
+  requireAuditAssignee: vi.fn(),
 }));
 
 // why: external database — don't hit the real DB. $transaction runs the

--- a/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
@@ -59,7 +59,13 @@ vi.mock("~/modules/audit/service.server", () => ({
 
 // why: external database — don't hit the real DB. $transaction runs the
 // callback with an opaque tx so we can assert on helpers called inside it.
-const { txNoteOps } = vi.hoisted(() => ({
+const { txNoteOps, dbNoteOps } = vi.hoisted(() => ({
+  // The pre-check runs on `db` (outside the transaction); the update runs on
+  // `tx`. Separate spies so a test can tell which layer refused.
+  dbNoteOps: {
+    findFirst: vi.fn().mockResolvedValue({ id: "note-1" }),
+    deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+  },
   txNoteOps: {
     create: vi.fn(),
     findUnique: vi.fn(),
@@ -84,14 +90,11 @@ vi.mock("~/database/db.server", () => ({
     // created per call, so a test can assert on the WHERE clause they were
     // given. `AuditNote` has no `organizationId` column, so that predicate is
     // the entire tenant boundary for the model.
-    $transaction: vi.fn(async (fn: any) => fn({ auditNote: txNoteOps })),
-    auditNote: {
-      findUnique: vi.fn(),
-      findFirst: vi.fn(),
-      update: vi.fn(),
-      updateMany: vi.fn(),
-      deleteMany: vi.fn(),
-    },
+    $transaction: vi.fn(
+      async (fn: (tx: { auditNote: typeof txNoteOps }) => unknown) =>
+        fn({ auditNote: txNoteOps })
+    ),
+    auditNote: dbNoteOps,
   },
 }));
 
@@ -192,6 +195,7 @@ describe("audits.$auditId.scan.$auditAssetId.details action — note scoping", (
       organizationId: "org-1",
       isSelfServiceOrBase: false,
     } as any);
+    dbNoteOps.findFirst.mockResolvedValue({ id: "note-1" });
     txNoteOps.findFirst.mockResolvedValue({ id: "note-1", content: "body" });
     txNoteOps.updateMany.mockResolvedValue({ count: 1 });
     (uploadAuditImage as any).mockResolvedValue({ id: "img-1" });
@@ -213,9 +217,9 @@ describe("audits.$auditId.scan.$auditAssetId.details action — note scoping", (
       ),
       params: { auditId: "session-1", auditAssetId: "audit-asset-1" },
       context: { getSession: () => ({ userId: "user-1" }) },
-    } as any);
+    } as unknown as Parameters<typeof action>[0]);
 
-    expect(txNoteOps.findFirst).toHaveBeenCalledWith(
+    expect(dbNoteOps.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
           id: "note-from-another-org",
@@ -226,6 +230,30 @@ describe("audits.$auditId.scan.$auditAssetId.details action — note scoping", (
     );
     // `findUnique` is the unscoped shape this replaced — it must not come back.
     expect(txNoteOps.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("uploads NOTHING when the note is not in this audit", async () => {
+    // The refusal was always correct; the ordering was not. The scoped lookup
+    // used to run after the upload loop, so a rejected request still wrote
+    // images to storage and to the database before returning 404.
+    dbNoteOps.findFirst.mockResolvedValue(null);
+
+    const form = new FormData();
+    form.set("intent", "add-images-to-note");
+    form.set("noteId", "note-from-another-org");
+    form.set("content", "body");
+    form.append("images", new File(["d"], "p.jpg", { type: "image/jpeg" }));
+
+    await action({
+      request: new Request(
+        "http://localhost/audits/session-1/scan/audit-asset-1/details",
+        { method: "POST", body: form }
+      ),
+      params: { auditId: "session-1", auditAssetId: "audit-asset-1" },
+      context: { getSession: () => ({ userId: "user-1" }) },
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(uploadAuditImage).not.toHaveBeenCalled();
   });
 
   it("scopes the add-images-to-note WRITE, not just the read", async () => {
@@ -244,7 +272,7 @@ describe("audits.$auditId.scan.$auditAssetId.details action — note scoping", (
       ),
       params: { auditId: "session-1", auditAssetId: "audit-asset-1" },
       context: { getSession: () => ({ userId: "user-1" }) },
-    } as any);
+    } as unknown as Parameters<typeof action>[0]);
 
     // Scoped in its own right rather than trusting the read above to have
     // filtered — the two must not drift apart in a later refactor.

--- a/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
@@ -59,6 +59,16 @@ vi.mock("~/modules/audit/service.server", () => ({
 
 // why: external database — don't hit the real DB. $transaction runs the
 // callback with an opaque tx so we can assert on helpers called inside it.
+const { txNoteOps } = vi.hoisted(() => ({
+  txNoteOps: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    findFirst: vi.fn().mockResolvedValue({ id: "note-1", content: "body" }),
+    update: vi.fn(),
+    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+  },
+}));
+
 vi.mock("~/database/db.server", () => ({
   db: {
     // why: the action proves the URL's `auditAssetId` belongs to the URL's
@@ -69,18 +79,18 @@ vi.mock("~/database/db.server", () => ({
     // $transaction passes a tx exposing the auditNote ops that the
     // multi-file and add-images-to-note paths call directly. The single-file
     // path delegates to the mocked helper, which never touches tx.
-    $transaction: vi.fn(async (fn: any) =>
-      fn({
-        auditNote: {
-          create: vi.fn(),
-          findUnique: vi.fn(),
-          update: vi.fn(),
-        },
-      })
-    ),
+    //
+    // The note ops are hoisted to module scope (`txNoteOps`) rather than
+    // created per call, so a test can assert on the WHERE clause they were
+    // given. `AuditNote` has no `organizationId` column, so that predicate is
+    // the entire tenant boundary for the model.
+    $transaction: vi.fn(async (fn: any) => fn({ auditNote: txNoteOps })),
     auditNote: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
+      deleteMany: vi.fn(),
     },
   },
 }));
@@ -159,6 +169,97 @@ function makeUploadImageRequest(opts: {
     { method: "POST", body: form }
   );
 }
+
+describe("audits.$auditId.scan.$auditAssetId.details action — note scoping", () => {
+  /**
+   * `AuditNote` has NO `organizationId` column. It inherits its tenant purely
+   * through `auditSession`, so a lookup keyed on the note id alone addresses
+   * every note in the table, in every workspace — and `noteId` arrives in the
+   * request body.
+   *
+   * The delete branch was hardened for this and carries a comment saying so.
+   * The `add-images-to-note` branch was missed: it read the note with
+   * `findUnique({ where: { id } })` and then OVERWROTE its content with
+   * `update({ where: { id } })`, both unscoped.
+   *
+   * These assert the WHERE clauses, because that predicate IS the tenant
+   * boundary — if a refactor drops it the note becomes globally addressable
+   * again, and no behavioural assertion would notice.
+   */
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: false,
+    } as any);
+    txNoteOps.findFirst.mockResolvedValue({ id: "note-1", content: "body" });
+    txNoteOps.updateMany.mockResolvedValue({ count: 1 });
+    (uploadAuditImage as any).mockResolvedValue({ id: "img-1" });
+  });
+
+  it("scopes the add-images-to-note READ to the audit and the org", async () => {
+    const form = new FormData();
+    form.set("intent", "add-images-to-note");
+    form.set("noteId", "note-from-another-org");
+    form.set("content", "body");
+    // `images` (plural) is the field this branch reads; a File under any
+    // other name is filtered out and the route 400s before the note lookup.
+    form.append("images", new File(["d"], "p.jpg", { type: "image/jpeg" }));
+
+    await action({
+      request: new Request(
+        "http://localhost/audits/session-1/scan/audit-asset-1/details",
+        { method: "POST", body: form }
+      ),
+      params: { auditId: "session-1", auditAssetId: "audit-asset-1" },
+      context: { getSession: () => ({ userId: "user-1" }) },
+    } as any);
+
+    expect(txNoteOps.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "note-from-another-org",
+          auditSessionId: "session-1",
+          auditSession: { organizationId: "org-1" },
+        }),
+      })
+    );
+    // `findUnique` is the unscoped shape this replaced — it must not come back.
+    expect(txNoteOps.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("scopes the add-images-to-note WRITE, not just the read", async () => {
+    const form = new FormData();
+    form.set("intent", "add-images-to-note");
+    form.set("noteId", "note-1");
+    form.set("content", "body");
+    // `images` (plural) is the field this branch reads; a File under any
+    // other name is filtered out and the route 400s before the note lookup.
+    form.append("images", new File(["d"], "p.jpg", { type: "image/jpeg" }));
+
+    await action({
+      request: new Request(
+        "http://localhost/audits/session-1/scan/audit-asset-1/details",
+        { method: "POST", body: form }
+      ),
+      params: { auditId: "session-1", auditAssetId: "audit-asset-1" },
+      context: { getSession: () => ({ userId: "user-1" }) },
+    } as any);
+
+    // Scoped in its own right rather than trusting the read above to have
+    // filtered — the two must not drift apart in a later refactor.
+    expect(txNoteOps.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "note-1",
+          auditSessionId: "session-1",
+          auditSession: { organizationId: "org-1" },
+        }),
+      })
+    );
+    expect(txNoteOps.update).not.toHaveBeenCalled();
+  });
+});
 
 describe("audits.$auditId.scan.$auditAssetId.details action — upload-image injection", () => {
   beforeEach(() => {

--- a/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
@@ -61,6 +61,11 @@ vi.mock("~/modules/audit/service.server", () => ({
 // callback with an opaque tx so we can assert on helpers called inside it.
 vi.mock("~/database/db.server", () => ({
   db: {
+    // why: the action proves the URL's `auditAssetId` belongs to the URL's
+    // `auditId` before dispatching any intent — both ids are caller-supplied
+    // and were never tied together. Returning a row means "it does belong",
+    // which is the precondition every test in this file assumes.
+    auditAsset: { findFirst: vi.fn().mockResolvedValue({ id: "aa-1" }) },
     // $transaction passes a tx exposing the auditNote ops that the
     // multi-file and add-images-to-note paths call directly. The single-file
     // path delegates to the mocked helper, which never touches tx.

--- a/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.scan.details.injection.test.ts
@@ -232,6 +232,41 @@ describe("audits.$auditId.scan.$auditAssetId.details action — note scoping", (
     expect(txNoteOps.findUnique).not.toHaveBeenCalled();
   });
 
+  it("refuses a note in the SAME audit but a different asset", async () => {
+    // Assignment is per-audit, so this is not a privilege boundary — but the
+    // route lists and creates notes filtered by `auditAssetId`, so a note on a
+    // sibling asset is one this page never offered. Appending images to it
+    // would corrupt a note the caller never saw.
+    dbNoteOps.findFirst.mockResolvedValue(null);
+
+    const form = new FormData();
+    form.set("intent", "add-images-to-note");
+    form.set("noteId", "note-on-a-sibling-asset");
+    form.set("content", "body");
+    form.append("images", new File(["d"], "p.jpg", { type: "image/jpeg" }));
+
+    await action({
+      request: new Request(
+        "http://localhost/audits/session-1/scan/audit-asset-1/details",
+        { method: "POST", body: form }
+      ),
+      params: { auditId: "session-1", auditAssetId: "audit-asset-1" },
+      context: { getSession: () => ({ userId: "user-1" }) },
+    } as unknown as Parameters<typeof action>[0]);
+
+    expect(dbNoteOps.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: "note-on-a-sibling-asset",
+          auditSessionId: "session-1",
+          auditAssetId: "audit-asset-1",
+        }),
+      })
+    );
+    expect(uploadAuditImage).not.toHaveBeenCalled();
+    expect(txNoteOps.updateMany).not.toHaveBeenCalled();
+  });
+
   it("uploads NOTHING when the note is not in this audit", async () => {
     // The refusal was always correct; the ordering was not. The scoped lookup
     // used to run after the upload loop, so a rejected request still wrote

--- a/apps/webapp/test/routes-tests/api+/audits.images.authorization.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.images.authorization.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Audit image evidence — assignment and parent binding.
+ *
+ * Reported externally against `shelf@2.1.2` (GHSA-433r-fpjf-cc4h): an
+ * authenticated low-privilege member could read and delete AuditImages
+ * belonging to an audit they were not assigned to, within their own
+ * organization.
+ *
+ * Two independent flaws on one route:
+ *
+ *  1. Neither the loader nor the action checked AuditAssignment. `audit:read`
+ *     and `audit:update` authorize the VERB, never the object.
+ *  2. The delete never bound the body's `imageId` to the `auditId`/`assetId`
+ *     in the URL, so an image from an entirely different audit could be named.
+ *
+ * The delete removes the storage objects before the row, so an unscoped lookup
+ * destroys the evidence irreversibly.
+ *
+ * @see {@link file://./../../../app/routes/api+/audits.$auditId.assets.$assetId.images.ts}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+// why: React Router v7 single fetch — `data()` must return a real Response so
+// the error path has an assertable status.
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    data: vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  };
+});
+
+const { mockRequirePermission } = vi.hoisted(() => ({
+  mockRequirePermission: vi.fn(),
+}));
+// why: the RBAC gate is not what's under test — it must PASS, so the assertion
+// proves the ASSIGNMENT check is what refuses, not the permission check.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: mockRequirePermission,
+}));
+
+const { mockRequireAuditAssignee } = vi.hoisted(() => ({
+  mockRequireAuditAssignee: vi.fn(),
+}));
+// why: the guard itself does a DB lookup. Mocking it lets each test choose
+// "assigned" (resolves) or "not assigned" (throws), which is the variable
+// under test.
+vi.mock("~/modules/audit/service.server", () => ({
+  requireAuditAssignee: mockRequireAuditAssignee,
+}));
+
+// why: external storage + database; these are also the sinks asserted unreached.
+const { mockGetAuditImages, mockDeleteAuditImage } = vi.hoisted(() => ({
+  mockGetAuditImages: vi.fn().mockResolvedValue([]),
+  mockDeleteAuditImage: vi.fn().mockResolvedValue(true),
+}));
+vi.mock("~/modules/audit/image.service.server", () => ({
+  getAuditImages: mockGetAuditImages,
+  deleteAuditImage: mockDeleteAuditImage,
+}));
+
+import {
+  action,
+  loader,
+} from "~/routes/api+/audits.$auditId.assets.$assetId.images";
+
+// @vitest-environment node
+
+const AUDIT_ID = "audit-1";
+const ASSET_ID = "auditasset-1";
+const ORG_ID = "org-1";
+
+/** The 403 the guard throws for a member who is not an assignee. */
+function notAnAssignee() {
+  const err = new Error("You don't have permission to view this audit");
+  Object.assign(err, { status: 403, isShelfError: true });
+  return err;
+}
+
+function args(body?: Record<string, string>) {
+  return {
+    request: new Request(
+      `https://app.shelf.nu/api/audits/${AUDIT_ID}/assets/${ASSET_ID}/images`,
+      body
+        ? { method: "POST", body: new URLSearchParams(body) }
+        : { method: "GET" }
+    ),
+    params: { auditId: AUDIT_ID, assetId: ASSET_ID },
+    context: { getSession: () => ({ userId: "user-1", email: "a@b.c" }) },
+  } as unknown as Parameters<typeof loader>[0];
+}
+
+describe("audit image evidence authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAuditImages.mockResolvedValue([]);
+    mockDeleteAuditImage.mockResolvedValue(true);
+    mockRequirePermission.mockResolvedValue({
+      organizationId: ORG_ID,
+      isSelfServiceOrBase: true,
+      role: OrganizationRoles.BASE,
+    });
+  });
+
+  it("refuses to READ evidence for an audit the caller is not assigned to", async () => {
+    mockRequireAuditAssignee.mockRejectedValue(notAnAssignee());
+
+    await loader(args());
+
+    // The images are never fetched — the guard runs before the read, so an
+    // unassigned member learns nothing about the audit's contents.
+    expect(mockGetAuditImages).not.toHaveBeenCalled();
+  });
+
+  it("refuses to DELETE evidence for an audit the caller is not assigned to", async () => {
+    mockRequireAuditAssignee.mockRejectedValue(notAnAssignee());
+
+    await action(args({ intent: "delete", imageId: "img-1" }));
+
+    // Asserting the sink: the delete removes storage objects before the DB
+    // row, so "did not throw later" is not good enough — it must never run.
+    expect(mockDeleteAuditImage).not.toHaveBeenCalled();
+  });
+
+  it("binds the image to the audit and asset named in the URL", async () => {
+    mockRequireAuditAssignee.mockResolvedValue(undefined);
+
+    await action(args({ intent: "delete", imageId: "img-1" }));
+
+    // The reported second flaw: `imageId` came from the body and was scoped by
+    // organization alone, so it could name an image from a different audit.
+    expect(mockDeleteAuditImage).toHaveBeenCalledWith({
+      imageId: "img-1",
+      organizationId: ORG_ID,
+      auditSessionId: AUDIT_ID,
+      auditAssetId: ASSET_ID,
+    });
+  });
+
+  it("still lets an assigned member read and delete", async () => {
+    mockRequireAuditAssignee.mockResolvedValue(undefined);
+
+    await loader(args());
+    expect(mockGetAuditImages).toHaveBeenCalledTimes(1);
+
+    await action(args({ intent: "delete", imageId: "img-1" }));
+    expect(mockDeleteAuditImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the caller's role through to the guard", async () => {
+    mockRequireAuditAssignee.mockResolvedValue(undefined);
+
+    await loader(args());
+
+    // ADMIN/OWNER short-circuit inside the guard, so the route must forward
+    // `isSelfServiceOrBase` rather than assuming everyone is restricted.
+    expect(mockRequireAuditAssignee).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditSessionId: AUDIT_ID,
+        organizationId: ORG_ID,
+        userId: "user-1",
+        isSelfServiceOrBase: true,
+      })
+    );
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/audits.images.authorization.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.images.authorization.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 /**
  * Audit image evidence — assignment and parent binding.
  *
@@ -69,8 +70,6 @@ import {
   action,
   loader,
 } from "~/routes/api+/audits.$auditId.assets.$assetId.images";
-
-// @vitest-environment node
 
 const AUDIT_ID = "audit-1";
 const ASSET_ID = "auditasset-1";


### PR DESCRIPTION
## What

Audit routes authorized the **verb** and not the **object**. `audit:read` and
`audit:update` say a member may work with audits; they never say they may work
with **this** audit. Five surfaces acted on that permission alone.

Fixes an **externally reported** issue plus three from the detail.dev scan.

## The reported issue

Reported against `shelf@2.1.2` by an outside researcher and reproduced by them
locally with an unassigned `BASE` attacker. Verified still live on `main`
before writing the fix. Two independent flaws on
`/api/audits/:auditId/assets/:assetId/images`:

**1. No assignment check, on either verb.**

```ts
const { organizationId } = await requirePermission({
  entity: PermissionEntity.audit,
  action: PermissionAction.read,     // authorizes the VERB, not this audit
});
const images = await getAuditImages({ auditSessionId: auditId, organizationId });
```

An unassigned member could read the evidence attached to any audit in the
workspace.

**2. The delete never bound `imageId` to its parent.**

```ts
await deleteAuditImage({ imageId, organizationId });   // imageId from the body
```

Scoped by organization alone, so it could name an image belonging to an
entirely **different** audit than the URL named.

That second one is the destructive half: `deleteAuditImage` removes the
storage objects **before** the database row, so an unscoped lookup destroys
the evidence irreversibly even if the row delete were to fail afterwards.

## The fix

`deleteAuditImage` now takes `auditSessionId` as a **required** parameter —
not an optional one — so the compiler forces every call site to state which
audit it is acting on, and `auditAssetId` binds to the specific parent row
when the route names one.

```ts
const image = await db.auditImage.findFirst({
  where: { id: imageId, organizationId, auditSessionId, ...(auditAssetId ? { auditAssetId } : {}) },
});
```

Both routes gate on `requireAuditAssignee`, which already short-circuits for
ADMIN/OWNER. The 404 is deliberately uniform — a real image in another audit
and an unknown id return the same message, so this cannot be used to probe
which ids exist.

### Making the parameter required found a second site

The compiler pointed straight at `audits.$auditId.scan.$auditAssetId.details`,
which had the same unbound delete. Inspecting it turned up something neither
the report nor the scan covers: **its action was ungated entirely.** The loader
checks assignment; the action did not, across every intent it handles — notes,
condition, evidence deletion. Guard hoisted there too.

## Also fixed — same shape, from the scan

| | |
| --- | --- |
| **D101** | The overview action gated only `complete-audit`. `remove-asset` and `bulk-remove-assets` had nothing, so an unassigned member could strip assets out of anyone's audit by direct POST — the loader's `canRemoveAssets` is display-only. One guard now sits ahead of the intent branches so a new intent inherits it. `cancel-audit` keeps its narrower creator-or-admin rule inside `cancelAuditSession`. |
| **D043** | `audits.add-assets` let any member widen the scope of any pending audit in the workspace. |
| **D054** | The mobile audit-detail loader computed `isAssignee` purely to decide whether to render a "Complete Audit" button, and never gated the read. The web overview loader already gated it; mobile did not. |

## Sweep

Checked every audit surface. Already guarded, left alone: `cancel-audit`,
`record-scan`, `upload-image`, `mobile/complete`, `mobile/image`,
`mobile/note`, and `generate-pdf`.

`generate-pdf` nearly became a false positive — its assignment check lives in
`fetchAllAuditPdfRelatedData`, not in the route, so grepping route files for
`requireAuditAssignee` under-reports it. Worth knowing before the next sweep of
this area.

Deliberately **not** guarded, and why: `audits.start` (creating an audit cannot
require an assignment that does not exist yet), `audits.ts` / `get-pending` /
`team-members` (org-scoped list reads that feed pickers), and `bulk-actions`
(passes `isSelfServiceOrBase` into the service, which scopes the where clause).

## Blast radius

Confined to a single workspace. `AuditImage` carries its own `organizationId`,
and the reporter explicitly confirmed cross-organization read and delete did
not reproduce. No escalation to Owner.

## Tests

`test/routes-tests/api+/audits.images.authorization.test.ts` (5) — the reported
vector end to end:

- unassigned read refused, asserting `getAuditImages` is **never called**
- unassigned delete refused, asserting the sink — "did not throw later" is not
  good enough when storage objects go first
- the delete's parent binding asserted explicitly (`auditSessionId` **and**
  `auditAssetId` forwarded from the URL)
- an assigned member still reads and deletes
- `isSelfServiceOrBase` is forwarded, so ADMIN/OWNER are not wrongly blocked

Plus 3 in `image.service.server.test.ts`, including an image belonging to a
different audit, asserting no storage file is removed.

The RBAC gate is mocked to **pass** in these tests, so a green result proves
the assignment check is what refuses — not the permission check.

Verified: 295 audit module tests, 71 audit route tests, typecheck and ESLint
clean.

## Disclosure

GHSA-433r-fpjf-cc4h is in triage with the reporter waiting. It needs a reply,
and publishing with credit once this ships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted audit details, asset changes, and evidence access to assigned audit members.
  * Prevented unauthorized image access across audits, assets, and organizations.
  * Improved role handling so higher-level permissions retain appropriate access.
  * Preserved creator or administrator authorization for audit cancellation.

* **Bug Fixes**
  * Image deletion now validates the associated audit and asset.
  * Prevented updates and deletions when identifiers do not match.
  * Added consistent handling for missing or unauthorized evidence.

* **Tests**
  * Added coverage for assignment authorization, role handling, scoped note updates, and cross-audit image access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->