### PR TITLE
fix(dialogs): stop bulk dialogs from clipping their own footer

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
@@ -88,6 +88,10 @@ export default function CreateBookingForSelectedAssetsDialog() {
       description={`Create a new booking with selected(${selectedAssets.length}) assets`}
       actionUrl="/bookings/new"
       className="lg:w-[600px]"
+      // No `allowBodyOverflow` despite the TagsAutocomplete below: this dialog
+      // scrolls its own content in the `max-h`/`overflow-auto` wrapper, which
+      // already clips the suggestion listbox before the dialog body ever could.
+      // Opting in would not un-clip it — it would only cost the body its scroll.
     >
       {({ disabled, handleCloseDialog, fetcherError, fetcherData }) => {
         /** This handles server side errors in case client side validation fails */

--- a/apps/webapp/app/components/assets/bulk-assign-tags-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-assign-tags-dialog.tsx
@@ -77,6 +77,10 @@ export default function BulkAssignTagsDialog() {
       description="Assign tags to selected assets. Assets that already have any of the selected tags, will be skipped."
       actionUrl="/api/assets/bulk-assign-tags"
       arrayFieldId="assetIds"
+      // TagsAutocomplete's suggestion listbox is absolutely positioned inside
+      // its own field, so the dialog body must not clip it. Safe here because
+      // this dialog is short enough to never need the body to scroll.
+      allowBodyOverflow
     >
       {({ disabled, handleCloseDialog, fetcherError }) => (
         <div className="modal-content-wrapper">

--- a/apps/webapp/app/components/assets/bulk-remove-tags-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-remove-tags-dialog.tsx
@@ -58,6 +58,10 @@ export default function BulkRemoveTagsDialog() {
       description="Remove tags to selected assets. Assets that don't have any of the selected tags, will be skipped."
       actionUrl="/api/assets/bulk-assign-tags?remove=true"
       arrayFieldId="assetIds"
+      // TagsAutocomplete's suggestion listbox is absolutely positioned inside
+      // its own field, so the dialog body must not clip it. Safe here because
+      // this dialog is short enough to never need the body to scroll.
+      allowBodyOverflow
     >
       {({ disabled, handleCloseDialog, fetcherError }) => (
         <div className="modal-content-wrapper">

--- a/apps/webapp/app/components/booking/bulk-partial-checkin-dialog.tsx
+++ b/apps/webapp/app/components/booking/bulk-partial-checkin-dialog.tsx
@@ -186,7 +186,7 @@ export default function BulkPartialCheckinDialog({
       <Dialog
         open={open}
         onClose={handleCloseDialog}
-        className={tw("bulk-tagging-dialog lg:w-[400px]")}
+        className="lg:w-[400px]"
         title={
           <div className="w-full">
             <div className={tw("mb-2")}>

--- a/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.tsx
+++ b/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.tsx
@@ -523,7 +523,7 @@ export default function BulkPartialCheckoutDialog({
       <Dialog
         open={open}
         onClose={handleCloseDialog}
-        className={tw("bulk-tagging-dialog lg:w-[400px]")}
+        className="lg:w-[400px]"
         title={
           <div className="w-full">
             <div className={tw("mb-2")}>

--- a/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.test.tsx
+++ b/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.test.tsx
@@ -85,6 +85,7 @@ type DialogTestProps = {
   keepSelectionOnSuccess?: boolean;
   skipCloseOnSuccess?: boolean;
   allowBodyOverflow?: boolean;
+  className?: string;
 };
 
 /**
@@ -237,9 +238,26 @@ describe("BulkUpdateDialogContent — body overflow opt-in", () => {
   });
 
   it("keeps the caller's own className alongside the opt-in", async () => {
+    // `test-caller-class` is a deliberate non-Tailwind sentinel: `tw()` is
+    // `twMerge`, which would collapse a second width utility into the first and
+    // hide a regression that dropped the caller's classes.
+    await open("tag-add", {
+      allowBodyOverflow: true,
+      className: "md:w-[600px] test-caller-class",
+    });
+
+    const el = dialogEl();
+    expect(el?.classList.contains("dialog-allows-overflow")).toBe(true);
+    expect(el?.classList.contains("test-caller-class")).toBe(true);
+    expect(el?.className).toContain("md:w-[600px]");
+    // The two width sources are `className || "lg:w-[400px]"` — mutually
+    // exclusive, so a caller class REPLACES the default rather than joining it.
+    expect(el?.className).not.toContain("lg:w-[400px]");
+  });
+
+  it("falls back to the default width when no className is passed", async () => {
     await open("tag-add", { allowBodyOverflow: true });
 
-    // The default `lg:w-[400px]` still applies when no className is passed.
     expect(dialogEl()?.className).toContain("lg:w-[400px]");
   });
 });

--- a/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.test.tsx
+++ b/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.test.tsx
@@ -78,19 +78,23 @@ const SELECTION = [
 ] as unknown as ListItemData[];
 
 /**
+ * The `BulkUpdateDialogContent` props these tests drive. Kept as one alias so
+ * the render helper, the rerender helper and `open` cannot drift apart.
+ */
+type DialogTestProps = {
+  keepSelectionOnSuccess?: boolean;
+  skipCloseOnSuccess?: boolean;
+  allowBodyOverflow?: boolean;
+};
+
+/**
  * Renders the dialog for a given `type` under a dedicated jotai store, then
  * seeds the dialog-open + selection atoms. Seeding happens AFTER the first
  * render (inside `act`) on purpose: both atoms reset themselves via `onMount`
  * when first subscribed, so seeding before render would be clobbered. Returns
  * the store so tests can read the resulting atom state.
  */
-async function renderDialog(
-  type: BulkDialogType,
-  props: {
-    keepSelectionOnSuccess?: boolean;
-    skipCloseOnSuccess?: boolean;
-  } = {}
-) {
+async function renderDialog(type: BulkDialogType, props: DialogTestProps = {}) {
   const store = createStore();
 
   const utils = render(
@@ -136,16 +140,10 @@ async function resolveFetcher(
 
 // Remember the last render config so `resolveFetcher` can rerender identically.
 let lastType: BulkDialogType;
-let lastProps: {
-  keepSelectionOnSuccess?: boolean;
-  skipCloseOnSuccess?: boolean;
-};
+let lastProps: DialogTestProps;
 
 /** Wraps `renderDialog` capturing config for the rerender helper. */
-function open(
-  type: BulkDialogType,
-  props: { keepSelectionOnSuccess?: boolean; skipCloseOnSuccess?: boolean } = {}
-) {
+function open(type: BulkDialogType, props: DialogTestProps = {}) {
   lastType = type;
   lastProps = props;
   return renderDialog(type, props);
@@ -205,5 +203,43 @@ describe("BulkUpdateDialogContent — post-success selection handling", () => {
 
     expect(utils.store.get(selectedBulkItemsAtom)).toEqual(SELECTION);
     expect(utils.store.get(bulkDialogAtom).location).toBe(true);
+  });
+});
+
+/**
+ * `.dialog-allows-overflow` switches `.dialog-body` to `overflow: visible`,
+ * which removes the ONLY scroll container a dialog has. It used to be applied
+ * to every bulk dialog, so any dialog taller than the panel's
+ * `md:max-h-[calc(100vh-4rem)]` cap pushed its footer past the viewport with no
+ * way to reach it — the bulk "Create audit" dialog lost its submit button on
+ * short windows that way (#2894).
+ *
+ * happy-dom applies no real stylesheet, so these assert on the class contract
+ * rather than computed overflow: the class must be opt-in per dialog.
+ */
+describe("BulkUpdateDialogContent — body overflow opt-in", () => {
+  /** The portaled `<dialog>` element the Dialog renders into `document.body`. */
+  const dialogEl = () => document.querySelector("dialog.dialog");
+
+  it("does not make the body overflow-visible by default", async () => {
+    await open("start-audit");
+
+    expect(dialogEl()).not.toBeNull();
+    expect(dialogEl()?.classList.contains("dialog-allows-overflow")).toBe(
+      false
+    );
+  });
+
+  it("makes the body overflow-visible when allowBodyOverflow is set", async () => {
+    await open("tag-add", { allowBodyOverflow: true });
+
+    expect(dialogEl()?.classList.contains("dialog-allows-overflow")).toBe(true);
+  });
+
+  it("keeps the caller's own className alongside the opt-in", async () => {
+    await open("tag-add", { allowBodyOverflow: true });
+
+    // The default `lg:w-[400px]` still applies when no className is passed.
+    expect(dialogEl()?.className).toContain("lg:w-[400px]");
   });
 });

--- a/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
+++ b/apps/webapp/app/components/bulk-update-dialog/bulk-update-dialog.tsx
@@ -195,6 +195,25 @@ type BulkUpdateDialogContentProps = CommonBulkDialogProps & {
    * Additional className to form
    */
   formClassName?: string;
+
+  /**
+   * Opt in to a non-clipping, non-scrolling dialog body (`overflow: visible`).
+   *
+   * Set this ONLY when the dialog renders an inline, non-portaled floating
+   * element that must escape the body box — today that means `TagsAutocomplete`,
+   * whose `.react-tags__listbox` is absolutely positioned inside its own field.
+   * Radix popovers/selects wrapped in `PopoverPortal` render outside the dialog
+   * entirely and need nothing here.
+   *
+   * The cost is real: `.dialog-body` is the only scroll container a dialog has,
+   * so opting in means a dialog taller than `md:max-h-[calc(100vh-4rem)]` pushes
+   * its footer past the viewport with no way to reach it. This used to be on for
+   * every bulk dialog, which is what hid the "Create audit" submit button on
+   * short windows (#2894). A dialog that opts in must stay short.
+   *
+   * @default false
+   */
+  allowBodyOverflow?: boolean;
 };
 
 /** This component is basically the body of the Dialog */
@@ -214,6 +233,7 @@ const BulkUpdateDialogContent = forwardRef<
     skipCloseOnSuccess = false,
     keepSelectionOnSuccess = false,
     formClassName = "",
+    allowBodyOverflow = false,
   },
   ref
 ) {
@@ -284,7 +304,10 @@ const BulkUpdateDialogContent = forwardRef<
       <Dialog
         open={isDialogOpen}
         onClose={handleCloseDialog}
-        className={tw("bulk-tagging-dialog", className || "lg:w-[400px]")}
+        className={tw(
+          allowBodyOverflow && "dialog-allows-overflow",
+          className || "lg:w-[400px]"
+        )}
         title={
           <div className="w-full">
             {type !== "cancel" ? (

--- a/apps/webapp/app/styles/global.css
+++ b/apps/webapp/app/styles/global.css
@@ -269,11 +269,29 @@ dialog {
   }
 }
 
-.bulk-tagging-dialog .react-tags__listbox {
+/*
+ * Opt-in escape hatch for dialogs holding an inline (non-portaled) autocomplete.
+ * `.react-tags__listbox` is absolutely positioned inside its own field, so a
+ * dialog body that clips or scrolls would cut the suggestions off.
+ *
+ * Apply it ONLY to those dialogs — never by default. `.dialog-body` is the sole
+ * scroll container a dialog has: `.dialog-backdrop` is `fixed`, and `<dialog>`
+ * is opened via the `open` attribute rather than `showModal()`, so it is not
+ * `:modal` and gets no UA `overflow: auto` either. Switching the body to
+ * `visible` therefore removes the LAST place a tall dialog can scroll: anything
+ * exceeding the panel's `md:max-h-[calc(100vh-4rem)]` cap spills past the
+ * viewport with no way to reach it. That is how the bulk "Create audit" dialog
+ * lost its submit button on short windows (#2894) — the class used to be
+ * applied unconditionally to every bulk dialog.
+ *
+ * @see {@link file://./../components/bulk-update-dialog/bulk-update-dialog.tsx} `allowBodyOverflow`
+ * @see {@link file://./../components/layout/dialog.tsx} the panel cap this defeats
+ */
+.dialog-allows-overflow .react-tags__listbox {
   z-index: 1000;
 }
 
-.bulk-tagging-dialog .dialog-body {
+.dialog-allows-overflow .dialog-body {
   @apply overflow-visible;
 }
 


### PR DESCRIPTION
Fixes #2894.

## The report

In the "Start an audit" dialog, the team-member list pushes the **Create audit**
button out of view. Reported on Safari (browser and web app).

## It is not a Safari bug

It reproduces in Chrome at the same viewport height. The trigger is viewport
*height*, not the engine — Safari surfaced it first only because its chrome is
taller, and the reporter's second screenshot also has Safari's "Open in web app"
banner eating ~44px.

Their own two screenshots show it. Same browser, same page, same dialog:

| | Viewport height | Dialog needs | Result |
|---|---|---|---|
| Safari **web app** (no URL bar) | ~966px | ~902px | button visible |
| Safari **browser** + banner | ~905px | ~902px | footer cut off |

## Root cause

`.bulk-tagging-dialog .dialog-body { overflow: visible }` (added in 8e3588800,
Sept 2024, so the react-tags listbox could escape the dialog) outranks the
`overflow-auto` utility on `.dialog-body` — two classes vs one. And
`BulkUpdateDialogContent` applied `bulk-tagging-dialog` to **every** bulk dialog,
not just the tag ones.

`.dialog-body` is the only scroll container a dialog has: `.dialog-backdrop` is
`fixed`, and `<dialog>` is opened via the `open` attribute rather than
`showModal()`, so it is not `:modal` and gets no UA `overflow: auto` either.
Switching the body to `visible` therefore means anything past the panel's
`md:max-h-[calc(100vh-4rem)]` cap renders outside the panel, unreachable.

That cap (d79996c58) explicitly assumed the opposite — "a cap on the flex column
makes the `dialog-body` (grow overflow-auto) shrink and scroll". True for the
scanner dialogs it was written for, false for every bulk dialog.

The audit dialog is simply the first one tall enough to expose it: a two-column
body whose assignee list is a fixed `md:max-h-[470px]` block. Measured minimum
viewport height:

- Assets → Actions → Create audit: **847px** with 5 team members, **~899px** once the list hits its cap
- Kits variant: **~990px** (extra scope row + info banner)

For scale, Chrome gives ~760px of viewport on a 13" MacBook Air, ~840px on a 14"
MBP and ~930px on a 1080p monitor — so this broke for most laptop users in every
browser.

## The fix

- Rename the class to `.dialog-allows-overflow` and document what it costs.
- New `allowBodyOverflow` prop on `BulkUpdateDialogContent`, default `false`.
- **Opt in (2)** — `bulk-assign-tags-dialog`, `bulk-remove-tags-dialog`. They render
  `TagsAutocomplete`, whose listbox is absolutely positioned inside its own field,
  and both are short enough never to need the body to scroll.
- **Deliberately not opted in** — `create-booking-for-selected-assets-dialog`, despite
  having a `TagsAutocomplete`. Its own `max-h`/`overflow-auto` wrapper already clips
  the listbox before the body could, so opting in would buy nothing and only cost the
  body its scroll. Commented in place so it does not get "fixed" back.
- **Removed (2)** — `bulk-partial-checkin-dialog` and `bulk-partial-checkout-dialog`
  hardcoded the class on `Dialog` with no autocomplete anywhere.

Every other floating element inside a bulk dialog (`DynamicSelect`, the audit scope
popovers, add-to-existing-booking) is wrapped in `PopoverPortal` and renders outside
the dialog, so regaining `overflow: auto` cannot clip it.

## Verification

Three cases added to `bulk-update-dialog.test.tsx`. The main one was confirmed to
genuinely fail against the old code (restoring the unconditional class →
`expected true to be false`), so it is a real guard, not a tautology.

`pnpm webapp:validate` green: 5088 tests, lint 0 errors, typecheck exit 0.

Checked live on a dev server at a **677px viewport** — a genuinely short window,
not a simulation:

```
Create audit   vh 677, content needs 799  → 122px over the cap
  dialogClass "dialog md:w-[800px]"   hasOverflowOptIn false
  bodyOverflow "auto"                 bodyCanScroll true (647 > 461)
  after a real wheel scroll: btnFullyInsidePanel true, btnClickableAtCenter true

Assign tags    dialogClass "dialog dialog-allows-overflow lg:w-[400px]"
  bodyOverflow "visible"   listboxEscapesPanel true (632 vs panel 522)
  listboxTopOptionHitTestable true
```

## How to review

You do **not** need Safari, and you do not need a large team — the assignee list
only makes the dialog taller. Shrink the viewport instead: `Cmd +` a couple of
times on `/assets` is easiest, since zoom shrinks the CSS viewport. The rule is
`viewport < contentHeight + 64`, which is about 620px with a single team member.

Then: Assets → select a row → Actions → Create audit. The body should scroll and
the footer should stay reachable. Repeat on the **Kits** index (the taller variant,
and the one in the reporter's screenshots), and confirm Assign tags / Remove tags
still pop their suggestions past the dialog edge.

## Not verified

The same mechanism should have been breaking these dialogs on mobile web too (the
panel takes a definite `100dvh` height and the body still could not shrink). The
fix covers that path, but I have no on-device confirmation either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tag autocomplete menus in bulk assignment and removal dialogs so suggestions are no longer clipped.
  - Fixed booking date validation to consistently respect selected date and time zone preferences.
  - Preserved appropriate scrolling and overflow behavior across booking and asset dialogs.
  - Standardized dialog sizing and styling for bulk check-in and checkout flows.

- **Tests**
  - Added coverage for default and opt-in overflow behavior, including dialog styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->