### PR TITLE
fix(companion): don't red-box a timeout we are about to retry

### DIFF
--- a/apps/companion/lib/api/client.ts
+++ b/apps/companion/lib/api/client.ts
@@ -232,8 +232,6 @@ export async function apiFetch<T>(
       return { data: null, error: null };
     }
 
-    if (__DEV__) console.error("[API] Fetch error:", err);
-
     // Auto-retry on timeout or network errors (not on auth/permission
     // errors). Requests sent with `retry: false` are exempt: a timed-out
     // POST may have landed server-side, and re-sending a non-idempotent
@@ -241,7 +239,21 @@ export async function apiFetch<T>(
     const isRetryable =
       (err instanceof Error && err.name === "AbortError" && timedOut) ||
       err instanceof TypeError; // TypeError = network failure
-    if (isRetryable && options.retry !== false && _retryCount < MAX_RETRIES) {
+    const willRetry =
+      isRetryable && options.retry !== false && _retryCount < MAX_RETRIES;
+
+    // why warn, not error, when a retry follows: in development React
+    // Native's LogBox promotes every console.error into a full-screen red
+    // overlay. A timeout we are about to retry — and usually recover from —
+    // is not worth stopping the app for, and on a slow or flaky connection
+    // it made the app unusable for testing while nothing was actually
+    // broken. Reserve the red box for the request that has given up.
+    if (__DEV__) {
+      const log = willRetry ? console.warn : console.error;
+      log("[API] Fetch failed:", path, err);
+    }
+
+    if (willRetry) {
       if (__DEV__) console.log("[API] Retrying…", path);
       return apiFetch<T>(path, options, _retryCount + 1);
     }


### PR DESCRIPTION
## What

In development React Native's LogBox turns every `console.error` into a full-screen overlay. The API client logged one for **any** timeout or network failure, including the ones it immediately retries and usually recovers from.

The result, from a real session on a slow connection:

```
[API] Fetch error: AbortError: Aborted
```

full screen, blocking the app, while the retry underneath succeeded a second later. On a flaky connection it repeated and made the app unusable for testing when nothing was actually broken.

## Change

`apps/companion/lib/api/client.ts` decides whether it will retry **before** it logs, then:

- `console.warn` when a retry follows — visible in the Metro log, no overlay
- `console.error` only when the request has given up, which is the case worth stopping for
- the path is now in the message, so the line says which endpoint stalled

## Who this affects

Developers only. The whole block is behind `__DEV__`, so it never runs in a store or OTA build and no user has ever seen it. Retry behaviour, timeouts and the returned error strings are all unchanged — this only moves which console method is called.

## How it was found

`/api/mobile/me` stalled behind a `getaddrinfo ENOTFOUND` on the database host during a local test session: 12s → 500, then 17s → 200, against a client timeout of 20s. The client retried correctly and recovered. The overlay still stopped the session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API requests now reliably use the currently active server and authentication session.
  * Authentication listeners reconnect automatically after switching servers.
  * Requests are blocked when the selected server and authentication project do not match.
  * Improved request error logging during automatic retries.
  * Retryable timeout and network failures now log warnings while additional attempts remain, with final failures logged as errors.
  * Retry settings and retry limits continue to be respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->