### PR TITLE
feat(kits): show the code chip on every kit-listing surface

### DIFF
--- a/.claude/rules/code-bearing-entity-list-consistency.md
+++ b/.claude/rules/code-bearing-entity-list-consistency.md
@@ -39,10 +39,22 @@ of the surface grid:
 
 **When you surface a new attribute or code on ANY surface, in order:**
 
-1. Use the shared **resolver** — `resolveDisplayCode({ entity, organization })`
-   from `~/modules/barcode/display`. The `EntityForCodeResolution` type
-   accepts both Asset and Kit shapes (kit-specific fields are optional).
-   Don't re-implement.
+1. Use the shared **resolver** —
+   `resolveDisplayCode({ entity, organization, entityKind })` from
+   `~/modules/barcode/display`. The `EntityForCodeResolution` type accepts both
+   Asset and Kit shapes (kit-specific fields are optional). Don't re-implement.
+
+   **`entityKind` is required, and it is not on the row.** It is a fact the
+   call site knows, so no loader payload carries it and no default can infer
+   it. It never changes WHICH code is chosen — only the fallback help text —
+   which is exactly why it is required rather than defaulted: pass the wrong
+   one and the chip still renders, still shows the right code, and only the
+   advice turns impossible ("add a SAM ID" to a kit, which has no
+   `sequentialId` column and no UI to set one). Nothing observable breaks, so
+   the compiler is the only thing that can catch it. Pinned by a
+   `@ts-expect-error` case in `display.test.ts` — if that directive ever goes
+   unused, someone has made the argument optional again.
+
 2. Use the shared **rendering primitive** — `<AssetCodeBadge>` from
    `~/components/assets/asset-code-badge`. Same chip everywhere. Use the
    `interactive` prop when the chip opens a code preview, so the trailing
@@ -76,7 +88,13 @@ deciding what to render:
 
 ```tsx
 const displayCode = currentOrganization
-  ? resolveDisplayCode({ entity: item, organization: currentOrganization })
+  ? resolveDisplayCode({
+      entity: item,
+      organization: currentOrganization,
+      // "kit" on a kit surface — see rule 1; the compiler will not let you
+      // omit it, but it cannot tell you which one is right.
+      entityKind: "asset",
+    })
   : null;
 
 // ...

--- a/.claude/rules/code-bearing-entity-list-consistency.md
+++ b/.claude/rules/code-bearing-entity-list-consistency.md
@@ -87,13 +87,23 @@ of the surface grid:
 deciding what to render:
 
 ```tsx
+// On an ASSET surface:
 const displayCode = currentOrganization
   ? resolveDisplayCode({
       entity: item,
       organization: currentOrganization,
-      // "kit" on a kit surface — see rule 1; the compiler will not let you
-      // omit it, but it cannot tell you which one is right.
       entityKind: "asset",
+    })
+  : null;
+
+// On a KIT surface, the same call with the one word that changes. The compiler
+// will not let you omit it — but it cannot tell you which one is right, so
+// this is the line to check when you copy a row component between surfaces.
+const kitDisplayCode = currentOrganization
+  ? resolveDisplayCode({
+      entity: kit,
+      organization: currentOrganization,
+      entityKind: "kit",
     })
   : null;
 

--- a/apps/webapp/app/components/assets/asset-code-badge.test.tsx
+++ b/apps/webapp/app/components/assets/asset-code-badge.test.tsx
@@ -80,6 +80,43 @@ describe("AssetCodeBadge", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not tell a kit to add a SAM ID it cannot have", () => {
+    // why: `Kit` has no `sequentialId` column and no UI to set one, so the
+    // generic fallback body — "this item has no SAM ID. Add one … to fix" —
+    // is an instruction nobody can follow. An impossible instruction reads as
+    // the reader's fault rather than a product gap.
+    renderWithTooltip(
+      <AssetCodeBadge
+        value="kit-qr-1"
+        type="QR_ID"
+        isFallback={true}
+        workspacePreference="SAM_ID"
+        entityKind="kit"
+      />
+    );
+
+    expect(
+      screen.getByLabelText(/which kits do not have/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Add one/i)).toBeNull();
+  });
+
+  it("still tells an ASSET to add the missing code", () => {
+    // why: an asset genuinely can be given a SAM ID, so the actionable
+    // wording must survive for it. This is the pair that stops the kit
+    // branch swallowing the useful case.
+    renderWithTooltip(
+      <AssetCodeBadge
+        value="asset-qr-1"
+        type="QR_ID"
+        isFallback={true}
+        workspacePreference="SAM_ID"
+      />
+    );
+
+    expect(screen.getByLabelText(/Add one/i)).toBeInTheDocument();
+  });
+
   it("collapses tooltip to type:value form when explicit=true", () => {
     renderWithTooltip(
       <AssetCodeBadge

--- a/apps/webapp/app/components/assets/asset-code-badge.tsx
+++ b/apps/webapp/app/components/assets/asset-code-badge.tsx
@@ -8,7 +8,9 @@
  * Pairs with `resolveDisplayCode` from `~/modules/barcode/display`; the
  * `ResolvedDisplayCode` shape can be spread directly onto the badge:
  *
- *   <AssetCodeBadge {...resolveDisplayCode({ asset, organization })} />
+ *   <AssetCodeBadge
+ *     {...resolveDisplayCode({ entity, organization, entityKind: "asset" })}
+ *   />
  *
  * Renders nothing when `value` is empty (defensive — should not normally
  * happen because every asset has a QR fallback, but the loader could omit
@@ -26,11 +28,23 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/shared/tooltip";
-import type { ResolvedDisplayCode } from "~/modules/barcode/display";
+import type {
+  CodeEntityKind,
+  ResolvedDisplayCode,
+} from "~/modules/barcode/display";
 import { labelForPreference } from "~/modules/barcode/display";
 import { tw } from "~/utils/tw";
 
-type AssetCodeBadgeProps = ResolvedDisplayCode & {
+type AssetCodeBadgeProps = Omit<ResolvedDisplayCode, "entityKind"> & {
+  /**
+   * Optional here, unlike on {@link ResolvedDisplayCode}, where the resolver
+   * always sets it. Preview chips in the workspace and per-asset preference
+   * pickers hand-build these props with `isFallback={false}`, and the kind is
+   * only ever read on the fallback path — so demanding it there would be
+   * ceremony with no safety to show for it.
+   */
+  entityKind?: CodeEntityKind;
+
   className?: string;
   /**
    * Set true when the chip is wrapped in a click target (e.g., opens a code
@@ -71,7 +85,7 @@ function buildTooltipContent(
   type: ResolvedDisplayCode["type"],
   isFallback: boolean,
   workspacePreference: ResolvedDisplayCode["workspacePreference"],
-  entityKind: NonNullable<ResolvedDisplayCode["entityKind"]> = "asset"
+  entityKind: CodeEntityKind = "asset"
 ): { title: string; body?: string } {
   const typeLabel = labelForPreference(type);
   const wsLabel = labelForPreference(workspacePreference);

--- a/apps/webapp/app/components/assets/asset-code-badge.tsx
+++ b/apps/webapp/app/components/assets/asset-code-badge.tsx
@@ -70,12 +70,26 @@ function buildTooltipContent(
   value: string,
   type: ResolvedDisplayCode["type"],
   isFallback: boolean,
-  workspacePreference: ResolvedDisplayCode["workspacePreference"]
+  workspacePreference: ResolvedDisplayCode["workspacePreference"],
+  entityKind: NonNullable<ResolvedDisplayCode["entityKind"]> = "asset"
 ): { title: string; body?: string } {
   const typeLabel = labelForPreference(type);
   const wsLabel = labelForPreference(workspacePreference);
 
   if (isFallback) {
+    // why a kit gets different words: the generic body tells the reader to
+    // "add one", and for a kit on a SAM ID workspace that is impossible —
+    // `Kit` has no `sequentialId` column and there is no UI to set one. An
+    // instruction nobody can follow reads as the reader's fault rather than a
+    // product gap, so name the gap instead. Only SAM_ID can reach this for a
+    // kit; kits carry their own QR and barcodes, so every other preference
+    // resolves normally.
+    if (entityKind === "kit" && workspacePreference === "SAM_ID") {
+      return {
+        title: `${typeLabel}: ${value} (fallback)`,
+        body: `Your workspace prefers ${wsLabel}, which kits do not have. Showing the ${typeLabel} instead.`,
+      };
+    }
     return {
       title: `${typeLabel}: ${value} (fallback)`,
       body: `Your workspace prefers ${wsLabel} but this item has no ${wsLabel}. Add one (or change the workspace setting) to fix.`,
@@ -115,6 +129,7 @@ export function AssetCodeBadge({
   type,
   isFallback,
   workspacePreference,
+  entityKind = "asset",
   className,
   interactive = false,
   explicit = false,
@@ -133,7 +148,13 @@ export function AssetCodeBadge({
   // tooltip.
   const { title, body } = explicit
     ? { title: `${labelForPreference(type)}: ${value}`, body: undefined }
-    : buildTooltipContent(value, type, isFallback, workspacePreference);
+    : buildTooltipContent(
+        value,
+        type,
+        isFallback,
+        workspacePreference,
+        entityKind
+      );
 
   // aria-label concatenates title + body so screen-reader users get the full
   // explanation even without the tooltip mounting. Single string keeps SR

--- a/apps/webapp/app/components/assets/assets-index/assets-list.tsx
+++ b/apps/webapp/app/components/assets/assets-index/assets-list.tsx
@@ -160,6 +160,7 @@ export const AssetsList = ({
                           barcodes: resource.extendedProps?.barcodes,
                         },
                         organization: currentOrganization,
+                        entityKind: "asset",
                       })
                     : null;
                   return (
@@ -253,7 +254,11 @@ export const ListAssetContent = ({
   } = formatCustodyList(custodyArray);
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: item, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: item,
+        organization: currentOrganization,
+        entityKind: "asset",
+      })
     : null;
   return (
     <>

--- a/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
+++ b/apps/webapp/app/components/assets/assets-index/use-kit-availability-data.ts
@@ -33,6 +33,15 @@ export function useKitAvailabilityData(items: Items) {
         mainImage: item.image,
         thumbnailImage: item.imageExpiration,
         status: item.status,
+        // Passed through to `resourceLabelContent` so the calendar shows the
+        // same code chip as the list view. The kits loader already carries
+        // these (KITS_INCLUDE_FIELDS); they were simply not forwarded, which
+        // is why the calendar was the one kit surface with no chip despite
+        // having the data. Mirrors use-asset-availability-data.ts.
+        // Kit has no sequentialId / preferredBarcodeId — the resolver treats
+        // both as absent and falls back to the QR id.
+        qrCodes: item.qrCodes ?? [],
+        barcodes: item.barcodes ?? [],
         // why: match the list view's semantic in kits._index.tsx — a kit is
         // bookable only when ALL slices are bookable (booking reserves the
         // whole kit). Undefined assetKits is treated as not-bookable since we

--- a/apps/webapp/app/components/audit/audit-asset-list-item.tsx
+++ b/apps/webapp/app/components/audit/audit-asset-list-item.tsx
@@ -68,7 +68,11 @@ export function AuditAssetListItem({ item }: { item: AuditAssetItem }) {
   // is the strongest case for the badge — the field worker matches the label
   // on their hand to a row on screen.
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: item, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: item,
+        organization: currentOrganization,
+        entityKind: "asset",
+      })
     : null;
 
   // Show audit status column when "ALL" or "EXPECTED" filter is active

--- a/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
@@ -345,7 +345,11 @@ function AssetTitleAndStatus({
   // QR when the org has lost the barcode add-on, so this read is always safe.
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: asset, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: asset,
+        organization: currentOrganization,
+        entityKind: "asset",
+      })
     : null;
   const qtyBooked = asset.bookedQuantity ?? 0;
   const qtyDispositioned = dispositionedByAsset?.[asset.id] ?? 0;

--- a/apps/webapp/app/components/booking/kit-row.tsx
+++ b/apps/webapp/app/components/booking/kit-row.tsx
@@ -83,8 +83,9 @@ export default function KitRow({
   // is SAM.
   const displayCode = currentOrganization
     ? resolveDisplayCode({
-        entity: { ...kit, entityKind: "kit" },
+        entity: kit,
         organization: currentOrganization,
+        entityKind: "kit",
       })
     : null;
 

--- a/apps/webapp/app/components/booking/kit-row.tsx
+++ b/apps/webapp/app/components/booking/kit-row.tsx
@@ -82,7 +82,10 @@ export default function KitRow({
   // optional fields tolerate that and fall back to QR when workspace pref
   // is SAM.
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: kit, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: { ...kit, entityKind: "kit" },
+        organization: currentOrganization,
+      })
     : null;
 
   // Create booking asset IDs set for context-aware status calculation

--- a/apps/webapp/app/components/booking/list-asset-content.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.tsx
@@ -100,6 +100,7 @@ export default function ListAssetContent({
     ? resolveDisplayCode({
         entity: item,
         organization: currentOrganization,
+        entityKind: "asset",
       })
     : null;
   const { isReserved, isDraft, isFinished } = useBookingStatusHelpers(

--- a/apps/webapp/app/modules/barcode/display.test.ts
+++ b/apps/webapp/app/modules/barcode/display.test.ts
@@ -50,6 +50,7 @@ describe("resolveDisplayCode — workspace preference QR_ID", () => {
       type: "QR_ID",
       isFallback: false,
       workspacePreference: "QR_ID",
+      entityKind: "asset",
     });
   });
 
@@ -78,6 +79,7 @@ describe("resolveDisplayCode — workspace preference SAM_ID", () => {
       type: "SAM_ID",
       isFallback: false,
       workspacePreference: "SAM_ID",
+      entityKind: "asset",
     });
   });
 
@@ -96,6 +98,7 @@ describe("resolveDisplayCode — workspace preference SAM_ID", () => {
       type: "QR_ID",
       isFallback: true,
       workspacePreference: "SAM_ID",
+      entityKind: "asset",
     });
   });
 });
@@ -114,6 +117,7 @@ describe("resolveDisplayCode — workspace preference is a BarcodeType", () => {
       type: "Code128",
       isFallback: false,
       workspacePreference: "Code128",
+      entityKind: "asset",
     });
   });
 
@@ -164,6 +168,7 @@ describe("resolveDisplayCode — workspace preference is a BarcodeType", () => {
       type: "QR_ID",
       isFallback: true,
       workspacePreference: "Code128",
+      entityKind: "asset",
     });
   });
 
@@ -206,6 +211,7 @@ describe("resolveDisplayCode — per-asset preferredBarcodeId override", () => {
       type: "Code39",
       isFallback: false,
       workspacePreference: "Code128",
+      entityKind: "asset",
     });
   });
 
@@ -265,6 +271,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
       type: "QR_ID",
       isFallback: false,
       workspacePreference: "QR_ID",
+      entityKind: "asset",
     });
   });
 
@@ -301,6 +308,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
       type: "QR_ID",
       isFallback: true,
       workspacePreference: "Code128",
+      entityKind: "asset",
     });
   });
 
@@ -332,6 +340,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
       type: "QR_ID",
       isFallback: true,
       workspacePreference: "Code128",
+      entityKind: "asset",
     });
   });
 
@@ -359,6 +368,35 @@ describe("resolveDisplayCode — non-addon organizations", () => {
       type: "QR_ID",
       isFallback: true,
       workspacePreference: "Code128",
+      entityKind: "asset",
     });
+  });
+
+  it("carries entityKind through so callers can word help text honestly", () => {
+    // why: the resolver picks the same code for a kit as for an asset — this
+    // field never changes WHICH code wins. It exists so the badge can avoid
+    // telling a kit to add a SAM ID, which kits cannot have.
+    const result = resolveDisplayCode({
+      entity: { qrCodes: [{ id: "kit-qr" }], entityKind: "kit" },
+      organization: {
+        qrIdDisplayPreference: "SAM_ID",
+        barcodesEnabled: false,
+      },
+    });
+
+    expect(result.entityKind).toBe("kit");
+    expect(result.value).toBe("kit-qr");
+    expect(result.isFallback).toBe(true);
+  });
+
+  it("treats an unmarked entity as an asset", () => {
+    // why: every existing call site omits entityKind; none of them may change
+    // meaning because this field was added.
+    const result = resolveDisplayCode({
+      entity: { qrCodes: [{ id: "qr" }] },
+      organization: { qrIdDisplayPreference: "QR_ID", barcodesEnabled: false },
+    });
+
+    expect(result.entityKind).toBe("asset");
   });
 });

--- a/apps/webapp/app/modules/barcode/display.test.ts
+++ b/apps/webapp/app/modules/barcode/display.test.ts
@@ -43,6 +43,7 @@ describe("resolveDisplayCode — workspace preference QR_ID", () => {
     const result = resolveDisplayCode({
       entity: asset({ qrCodes: [{ id: "qr-abc" }] }),
       organization: org({ qrIdDisplayPreference: "QR_ID" }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -60,6 +61,7 @@ describe("resolveDisplayCode — workspace preference QR_ID", () => {
     const result = resolveDisplayCode({
       entity: asset({ qrCodes: [] }),
       organization: org({ qrIdDisplayPreference: "QR_ID" }),
+      entityKind: "asset",
     });
 
     expect(result.value).toBe("");
@@ -72,6 +74,7 @@ describe("resolveDisplayCode — workspace preference SAM_ID", () => {
     const result = resolveDisplayCode({
       entity: asset({ sequentialId: "SAM-0042" }),
       organization: org({ qrIdDisplayPreference: "SAM_ID" }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -91,6 +94,7 @@ describe("resolveDisplayCode — workspace preference SAM_ID", () => {
         qrCodes: [{ id: "qr-fallback" }],
       }),
       organization: org({ qrIdDisplayPreference: "SAM_ID" }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -110,6 +114,7 @@ describe("resolveDisplayCode — workspace preference is a BarcodeType", () => {
         barcodes: [{ id: "bc-1", type: BarcodeType.Code128, value: "ABC-123" }],
       }),
       organization: org({ qrIdDisplayPreference: "Code128" }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -132,6 +137,7 @@ describe("resolveDisplayCode — workspace preference is a BarcodeType", () => {
         ],
       }),
       organization: org({ qrIdDisplayPreference: "Code128" }),
+      entityKind: "asset",
     });
 
     expect(result.value).toBe("A-FIRST");
@@ -148,6 +154,7 @@ describe("resolveDisplayCode — workspace preference is a BarcodeType", () => {
         ],
       }),
       organization: org({ qrIdDisplayPreference: "Code128" }),
+      entityKind: "asset",
     });
 
     expect(result.value).toBe("C128-1");
@@ -161,6 +168,7 @@ describe("resolveDisplayCode — workspace preference is a BarcodeType", () => {
         barcodes: [{ id: "bc-1", type: BarcodeType.Code39, value: "C39-1" }],
       }),
       organization: org({ qrIdDisplayPreference: "Code128" }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -184,6 +192,7 @@ describe("resolveDisplayCode — workspace preference is a BarcodeType", () => {
         barcodes: [{ id: "bc-x", type: preferred, value: `${preferred}-val` }],
       }),
       organization: org({ qrIdDisplayPreference: preferred }),
+      entityKind: "asset",
     });
 
     expect(result.value).toBe(`${preferred}-val`);
@@ -204,6 +213,7 @@ describe("resolveDisplayCode — per-asset preferredBarcodeId override", () => {
       }),
       // Workspace prefers Code128, but the override forces Code39 for this asset
       organization: org({ qrIdDisplayPreference: "Code128" }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -227,6 +237,7 @@ describe("resolveDisplayCode — per-asset preferredBarcodeId override", () => {
         ],
       }),
       organization: org({ qrIdDisplayPreference: "Code128" }),
+      entityKind: "asset",
     });
 
     // Falls through to workspace pref → picks bc-present
@@ -248,6 +259,7 @@ describe("resolveDisplayCode — per-asset preferredBarcodeId override", () => {
         ],
       }),
       organization: org({ qrIdDisplayPreference: "QR_ID" }),
+      entityKind: "asset",
     });
 
     expect(result.value).toBe("https://x.example");
@@ -264,6 +276,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
         barcodesEnabled: false,
         qrIdDisplayPreference: "QR_ID",
       }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -283,6 +296,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
         barcodesEnabled: false,
         qrIdDisplayPreference: "SAM_ID",
       }),
+      entityKind: "asset",
     });
 
     expect(result.value).toBe("SAM-0001");
@@ -301,6 +315,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
         barcodesEnabled: false,
         qrIdDisplayPreference: "Code128",
       }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -333,6 +348,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
         barcodesEnabled: false,
         qrIdDisplayPreference: "Code128",
       }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -361,6 +377,7 @@ describe("resolveDisplayCode — non-addon organizations", () => {
         barcodesEnabled: false,
         qrIdDisplayPreference: "Code128",
       }),
+      entityKind: "asset",
     });
 
     expect(result).toEqual({
@@ -377,11 +394,12 @@ describe("resolveDisplayCode — non-addon organizations", () => {
     // field never changes WHICH code wins. It exists so the badge can avoid
     // telling a kit to add a SAM ID, which kits cannot have.
     const result = resolveDisplayCode({
-      entity: { qrCodes: [{ id: "kit-qr" }], entityKind: "kit" },
+      entity: { qrCodes: [{ id: "kit-qr" }] },
       organization: {
         qrIdDisplayPreference: "SAM_ID",
         barcodesEnabled: false,
       },
+      entityKind: "kit",
     });
 
     expect(result.entityKind).toBe("kit");
@@ -389,14 +407,25 @@ describe("resolveDisplayCode — non-addon organizations", () => {
     expect(result.isFallback).toBe(true);
   });
 
-  it("treats an unmarked entity as an asset", () => {
-    // why: every existing call site omits entityKind; none of them may change
-    // meaning because this field was added.
+  it("refuses to resolve without an entityKind", () => {
+    // The failure this guards is invisible at runtime: an entity resolved as
+    // the wrong kind still renders, still shows the RIGHT code, and only the
+    // fallback advice becomes impossible to follow ("add a SAM ID" to a kit).
+    // Nothing observable is wrong, so no ordinary assertion can catch it and
+    // the compiler has to be the guard.
+    //
+    // The directive below IS that guard: make `entityKind` optional again and
+    // it stops suppressing anything, so `tsc` fails the build on an unused
+    // directive. Deleting this case removes the only enforcement there is.
+    // (Keep any mention of the directive off the start of a comment line —
+    // TypeScript reads one there as real, wherever it appears.)
+    // @ts-expect-error - entityKind is deliberately required
     const result = resolveDisplayCode({
       entity: { qrCodes: [{ id: "qr" }] },
       organization: { qrIdDisplayPreference: "QR_ID", barcodesEnabled: false },
     });
 
-    expect(result.entityKind).toBe("asset");
+    // Still resolves at runtime — which is exactly why the type must object.
+    expect(result.value).toBe("qr");
   });
 });

--- a/apps/webapp/app/modules/barcode/display.ts
+++ b/apps/webapp/app/modules/barcode/display.ts
@@ -76,6 +76,20 @@ export type EntityForCodeResolution = {
   qrCodes?: Pick<Qr, "id">[];
   barcodes?: Pick<Barcode, "id" | "type" | "value">[];
   preferredBarcodeId?: string | null;
+  /**
+   * What kind of thing this is. Only affects the fallback HELP TEXT, never
+   * which code is chosen.
+   *
+   * why it exists: the fallback tooltip tells the reader how to fix the
+   * fallback — "this item has no SAM ID, add one". For a KIT that sentence is
+   * an instruction nobody can follow: `Kit` has no `sequentialId` column and
+   * no UI to set one, so the reader is told to do something impossible and
+   * then blames themselves. Kits still resolve normally on the other six
+   * preference values, so this is help text, not behaviour.
+   *
+   * Defaults to "asset" so no existing call site changes meaning.
+   */
+  entityKind?: "asset" | "kit";
 };
 
 /**
@@ -123,6 +137,15 @@ export type ResolvedDisplayCode = {
   /** True when the workspace-preferred type was unavailable and we fell back to QR. */
   isFallback: boolean;
   /**
+   * Carried through so the badge can word the fallback honestly. A kit
+   * cannot be given a SAM ID, so it must not be told to add one.
+   *
+   * Optional, and the badge treats absence as "asset": several call sites
+   * hand-build this object for an explicit column where the entity kind is
+   * already obvious from the surface.
+   */
+  entityKind?: "asset" | "kit";
+  /**
    * What the workspace ASKED FOR — included so callers can craft good
    * help/tooltip copy when `isFallback` is true (so the badge can say
    * "workspace prefers Code 128 but this asset has none" instead of just
@@ -150,6 +173,8 @@ export function resolveDisplayCode({
   // value rather than a runtime crash.
   const qrCodes = entity.qrCodes ?? [];
   const barcodes = entity.barcodes ?? [];
+  // Only ever affects help text — see EntityForCodeResolution.entityKind.
+  const entityKind = entity.entityKind ?? "asset";
 
   // Universal fallback: every code-bearing entity has at least one active
   // QR. If the QR relation isn't included in the query, value is "" —
@@ -159,6 +184,7 @@ export function resolveDisplayCode({
     type: "QR_ID",
     isFallback,
     workspacePreference: organization.qrIdDisplayPreference,
+    entityKind,
   });
 
   // 1. Per-entity override wins when present and resolvable — but ONLY if
@@ -175,6 +201,7 @@ export function resolveDisplayCode({
         type: preferred.type,
         isFallback: false,
         workspacePreference: organization.qrIdDisplayPreference,
+        entityKind,
       };
     }
     // Stale FK — fall through to workspace preference.
@@ -198,6 +225,7 @@ export function resolveDisplayCode({
             type: "SAM_ID",
             isFallback: false,
             workspacePreference: organization.qrIdDisplayPreference,
+            entityKind,
           }
         : qrFallback(true);
 
@@ -226,6 +254,7 @@ export function resolveDisplayCode({
             type: matching[0].type,
             isFallback: false,
             workspacePreference: organization.qrIdDisplayPreference,
+            entityKind,
           }
         : qrFallback(true);
     }

--- a/apps/webapp/app/modules/barcode/display.ts
+++ b/apps/webapp/app/modules/barcode/display.ts
@@ -76,21 +76,19 @@ export type EntityForCodeResolution = {
   qrCodes?: Pick<Qr, "id">[];
   barcodes?: Pick<Barcode, "id" | "type" | "value">[];
   preferredBarcodeId?: string | null;
-  /**
-   * What kind of thing this is. Only affects the fallback HELP TEXT, never
-   * which code is chosen.
-   *
-   * why it exists: the fallback tooltip tells the reader how to fix the
-   * fallback — "this item has no SAM ID, add one". For a KIT that sentence is
-   * an instruction nobody can follow: `Kit` has no `sequentialId` column and
-   * no UI to set one, so the reader is told to do something impossible and
-   * then blames themselves. Kits still resolve normally on the other six
-   * preference values, so this is help text, not behaviour.
-   *
-   * Defaults to "asset" so no existing call site changes meaning.
-   */
-  entityKind?: "asset" | "kit";
 };
+
+/**
+ * Which kind of code-bearing entity a row is.
+ *
+ * Deliberately NOT part of {@link EntityForCodeResolution}: it is a fact the
+ * CALL SITE knows, not a column on the row, and no loader payload carries it.
+ * It is a required argument to {@link resolveDisplayCode} so a new surface
+ * cannot silently inherit the wrong one — the failure it guards against is
+ * invisible at runtime (wrong tooltip wording, right code) and so would never
+ * be caught by a test nobody thought to write.
+ */
+export type CodeEntityKind = "asset" | "kit";
 
 /**
  * Back-compat alias. New code should use `EntityForCodeResolution`.
@@ -137,14 +135,14 @@ export type ResolvedDisplayCode = {
   /** True when the workspace-preferred type was unavailable and we fell back to QR. */
   isFallback: boolean;
   /**
-   * Carried through so the badge can word the fallback honestly. A kit
-   * cannot be given a SAM ID, so it must not be told to add one.
+   * Carried through so the badge can word the fallback honestly. A kit cannot
+   * be given a SAM ID, so it must not be told to add one.
    *
-   * Optional, and the badge treats absence as "asset": several call sites
-   * hand-build this object for an explicit column where the entity kind is
-   * already obvious from the surface.
+   * Always set here, because {@link resolveDisplayCode} requires it. The badge
+   * accepts it optionally, for preview chips that are hand-built rather than
+   * resolved — see `AssetCodeBadgeProps`.
    */
-  entityKind?: "asset" | "kit";
+  entityKind: CodeEntityKind;
   /**
    * What the workspace ASKED FOR — included so callers can craft good
    * help/tooltip copy when `isFallback` is true (so the badge can say
@@ -155,17 +153,26 @@ export type ResolvedDisplayCode = {
 };
 
 /**
- * Resolves the display code for one asset given its workspace's preference.
+ * Resolves the display code for one code-bearing entity given its workspace's
+ * preference.
  *
- * @param input - The asset + organization slices needed to resolve
- * @returns A `ResolvedDisplayCode` ready to pass into `<AssetCodeBadge>`
+ * @param input - The entity + organization slices needed to resolve, plus the
+ *   kind of entity being resolved
+ * @param input.entityKind - Required. Only ever affects the fallback HELP TEXT,
+ *   never which code is chosen — but getting it wrong tells a kit's reader to
+ *   "add a SAM ID", which kits cannot have. Required rather than defaulted
+ *   precisely because the wrong value is invisible: the badge still renders,
+ *   still shows the right code, and only the advice is impossible to follow.
+ * @returns A `ResolvedDisplayCode` ready to spread into `<AssetCodeBadge>`
  */
 export function resolveDisplayCode({
   entity,
   organization,
+  entityKind,
 }: {
   entity: EntityForCodeResolution;
   organization: OrganizationForCodeResolution;
+  entityKind: CodeEntityKind;
 }): ResolvedDisplayCode {
   // Defensive: if the loader didn't include these relations (e.g. older
   // call site, partial select, or a test fixture), treat them as empty.
@@ -173,8 +180,6 @@ export function resolveDisplayCode({
   // value rather than a runtime crash.
   const qrCodes = entity.qrCodes ?? [];
   const barcodes = entity.barcodes ?? [];
-  // Only ever affects help text — see EntityForCodeResolution.entityKind.
-  const entityKind = entity.entityKind ?? "asset";
 
   // Universal fallback: every code-bearing entity has at least one active
   // QR. If the QR relation isn't included in the query, value is "" —

--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -276,6 +276,14 @@ export const BOOKING_WITH_ASSETS_INCLUDE = {
                   id: true,
                   name: true,
                   image: true,
+                  // Kit-code resolution, mirroring the asset select above.
+                  // Kits carry Qr and Barcode rows too, and the sidebar's kit
+                  // group header is a kit-listing surface — without these it
+                  // is the only row in that sidebar with no code chip.
+                  // Kit has no sequentialId / preferredBarcodeId; the resolver
+                  // tolerates their absence and falls back to QR.
+                  qrCodes: { take: 1, select: { id: true } },
+                  barcodes: { select: { id: true, type: true, value: true } },
                   location: {
                     select: { id: true, name: true },
                   },

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -1432,6 +1432,13 @@ export async function getLocationKits(
         where: kitWhere,
         include: {
           category: true,
+          // Code-resolution relations for AssetCodeBadge / resolveDisplayCode.
+          // Kits are code-bearing entities (Qr.kitId and Barcode.kitId exist),
+          // so a kit-listing surface that omits these can never render the
+          // chip — see `.claude/rules/code-bearing-entity-list-consistency.md`.
+          // Same tight shape as KITS_INCLUDE_FIELDS in `~/modules/kit/types`.
+          qrCodes: { take: 1, select: { id: true } },
+          barcodes: { select: { id: true, type: true, value: true } },
           custody: {
             select: {
               custodian: {

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -1612,6 +1612,7 @@ const RowComponent = ({
                     {...resolveDisplayCode({
                       entity: item,
                       organization: currentOrganization,
+                      entityKind: "asset",
                     })}
                   />
                 ) : null}

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -997,8 +997,9 @@ function Row({ item: kit }: { item: KitForBooking }) {
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
     ? resolveDisplayCode({
-        entity: { ...kit, entityKind: "kit" },
+        entity: kit,
         organization: currentOrganization,
+        entityKind: "kit",
       })
     : null;
 

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-kits.tsx
@@ -996,7 +996,10 @@ function Row({ item: kit }: { item: KitForBooking }) {
   const { isCheckedOut } = getKitAvailabilityStatus(kit, booking.id);
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: kit, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: { ...kit, entityKind: "kit" },
+        organization: currentOrganization,
+      })
     : null;
 
   // For Case 1: Check if kit is checked out in current booking

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.tsx
@@ -268,7 +268,11 @@ function ListContent({ item }: { item: ListItemForKitPage }) {
   const { roles } = useUserRoleHelper();
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: item, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: item,
+        organization: currentOrganization,
+        entityKind: "asset",
+      })
     : null;
   return (
     <>

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -405,13 +405,29 @@ export default function KitsIndexPage() {
                       to={`/kits/${resource.id}/assets`}
                       title={resource.title}
                     />
-                    <div className="flex items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                       <KitStatusBadge
                         status={resource.extendedProps?.status}
                         availableToBook={
                           resource.extendedProps?.availableToBook
                         }
                       />
+                      {/* why: the list view of this same page shows the code
+                          chip, so switching to the calendar used to lose it.
+                          Same resolver, same primitive — see
+                          `.claude/rules/code-bearing-entity-list-consistency.md`. */}
+                      {(() => {
+                        if (!organization) return null;
+                        const code = resolveDisplayCode({
+                          entity: {
+                            qrCodes: resource.extendedProps?.qrCodes,
+                            barcodes: resource.extendedProps?.barcodes,
+                            entityKind: "kit",
+                          },
+                          organization,
+                        });
+                        return code ? <AssetCodeBadge {...code} /> : null;
+                      })()}
                     </div>
                   </div>
                 </div>
@@ -498,7 +514,10 @@ function ListContent({
   // back to QR when the workspace prefers SAM.
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: item, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: { ...item, entityKind: "kit" },
+        organization: currentOrganization,
+      })
     : null;
 
   return (

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -39,6 +39,7 @@ import { useIsAvailabilityView } from "~/hooks/use-is-availability-view";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { LOCATION_WITH_HIERARCHY } from "~/modules/asset/fields";
 import { getLocationsForCreateAndEdit } from "~/modules/asset/service.server";
+import type { EntityForCodeResolution } from "~/modules/barcode/display";
 import { resolveDisplayCode } from "~/modules/barcode/display";
 import {
   getPaginatedAndFilterableKits,
@@ -412,22 +413,10 @@ export default function KitsIndexPage() {
                           resource.extendedProps?.availableToBook
                         }
                       />
-                      {/* The list view of this page shows the code chip, and the calendar
-                          view of the same rows must show it too — same resolver, same
-                          primitive. See
-                          `.claude/rules/code-bearing-entity-list-consistency.md`. */}
-                      {(() => {
-                        if (!organization) return null;
-                        const code = resolveDisplayCode({
-                          entity: {
-                            qrCodes: resource.extendedProps?.qrCodes,
-                            barcodes: resource.extendedProps?.barcodes,
-                            entityKind: "kit",
-                          },
-                          organization,
-                        });
-                        return code ? <AssetCodeBadge {...code} /> : null;
-                      })()}
+                      <KitCalendarCodeBadge
+                        qrCodes={resource.extendedProps?.qrCodes}
+                        barcodes={resource.extendedProps?.barcodes}
+                      />
                     </div>
                   </div>
                 </div>
@@ -482,6 +471,42 @@ export default function KitsIndexPage() {
   );
 }
 
+/**
+ * The code chip for one kit row in the availability CALENDAR view.
+ *
+ * The list and calendar views of this page render the same kits, so they must
+ * render the same chip through the same resolver — see
+ * `.claude/rules/code-bearing-entity-list-consistency.md`. The calendar builds
+ * its rows from `extendedProps` rather than the loader payload, hence the two
+ * explicit props instead of a whole entity.
+ *
+ * A component rather than an inline block because it needs
+ * `useCurrentOrganization`, and the calendar renders rows inside a callback
+ * where a hook cannot go.
+ *
+ * @param qrCodes - QR rows forwarded by `useKitAvailabilityData`
+ * @param barcodes - Barcode rows forwarded by `useKitAvailabilityData`
+ * @returns The shared chip, or `null` before the organization resolves
+ */
+function KitCalendarCodeBadge({
+  qrCodes,
+  barcodes,
+}: {
+  qrCodes?: EntityForCodeResolution["qrCodes"];
+  barcodes?: EntityForCodeResolution["barcodes"];
+}) {
+  const organization = useCurrentOrganization();
+  if (!organization) return null;
+
+  const code = resolveDisplayCode({
+    entity: { qrCodes, barcodes },
+    organization,
+    entityKind: "kit",
+  });
+
+  return code ? <AssetCodeBadge {...code} /> : null;
+}
+
 function ListContent({
   item,
   bulkActions,
@@ -515,8 +540,9 @@ function ListContent({
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
     ? resolveDisplayCode({
-        entity: { ...item, entityKind: "kit" },
+        entity: item,
         organization: currentOrganization,
+        entityKind: "kit",
       })
     : null;
 

--- a/apps/webapp/app/routes/_layout+/kits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/kits._index.tsx
@@ -412,9 +412,9 @@ export default function KitsIndexPage() {
                           resource.extendedProps?.availableToBook
                         }
                       />
-                      {/* why: the list view of this same page shows the code
-                          chip, so switching to the calendar used to lose it.
-                          Same resolver, same primitive — see
+                      {/* The list view of this page shows the code chip, and the calendar
+                          view of the same rows must show it too — same resolver, same
+                          primitive. See
                           `.claude/rules/code-bearing-entity-list-consistency.md`. */}
                       {(() => {
                         if (!organization) return null;

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
@@ -446,7 +446,11 @@ const ListAssetContent = ({
   const { locationId } = useParams<{ locationId: string }>();
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
-    ? resolveDisplayCode({ entity: item, organization: currentOrganization })
+    ? resolveDisplayCode({
+        entity: item,
+        organization: currentOrganization,
+        entityKind: "asset",
+      })
     : null;
   return (
     <>

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.kits.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.kits.manage-kits.tsx
@@ -445,8 +445,9 @@ const RowComponent = ({
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
     ? resolveDisplayCode({
-        entity: { ...item, entityKind: "kit" },
+        entity: item,
         organization: currentOrganization,
+        entityKind: "kit",
       })
     : null;
 

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.kits.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.kits.manage-kits.tsx
@@ -58,6 +58,7 @@ import { resolveDisplayCode } from "~/modules/barcode/display";
 import { getPaginatedAndFilterableKits } from "~/modules/kit/service.server";
 import { updateLocationKits } from "~/modules/location/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { redactCustodianForViewer } from "~/utils/custody-visibility.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
 import { payload, error, getParams, parseData } from "~/utils/http.server";
@@ -133,7 +134,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       },
       showSidebar: true,
       noScroll: true,
-      items: kits,
+      // The custodian's name and user.email are on every row regardless of
+      // whether the UI draws them, so a viewer without custody visibility can
+      // read them straight out of the route's data payload. Redact here, not
+      // in the component.
+      items: redactCustodianForViewer(kits, { canSeeAllCustody, userId }),
       page,
       search,
       totalItems: totalKits,

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.kits.manage-kits.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.kits.manage-kits.tsx
@@ -23,6 +23,7 @@ import {
   setSelectedBulkItemAtom,
   setSelectedBulkItemsAtom,
 } from "~/atoms/list";
+import { AssetCodeBadge } from "~/components/assets/asset-code-badge";
 import { CategoryBadge } from "~/components/assets/category-badge";
 import { StatusFilter } from "~/components/booking/status-filter";
 import { Form } from "~/components/custom-form";
@@ -51,7 +52,9 @@ import {
 import { Td, Th } from "~/components/table";
 import UnsavedChangesAlert from "~/components/unsaved-changes-alert";
 import { db } from "~/database/db.server";
+import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { LOCATION_WITH_HIERARCHY } from "~/modules/asset/fields";
+import { resolveDisplayCode } from "~/modules/barcode/display";
 import { getPaginatedAndFilterableKits } from "~/modules/kit/service.server";
 import { updateLocationKits } from "~/modules/location/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
@@ -420,11 +423,27 @@ export default function ManageLocationKits() {
 const RowComponent = ({
   item,
 }: {
+  // why the code relations are declared here: the loader calls
+  // `getPaginatedAndFilterableKits`, which merges KITS_INCLUDE_FIELDS, so
+  // every row already carries them at runtime — this type simply had not
+  // said so, which is why the chip could not be rendered without a cast.
   item: Prisma.KitGetPayload<{
-    include: { category: true; location: typeof LOCATION_WITH_HIERARCHY };
+    include: {
+      category: true;
+      location: typeof LOCATION_WITH_HIERARCHY;
+      qrCodes: { take: 1; select: { id: true } };
+      barcodes: { select: { id: true; type: true; value: true } };
+    };
   }>;
 }) => {
   const { category } = item;
+  const currentOrganization = useCurrentOrganization();
+  const displayCode = currentOrganization
+    ? resolveDisplayCode({
+        entity: { ...item, entityKind: "kit" },
+        organization: currentOrganization,
+      })
+    : null;
 
   return (
     <>
@@ -448,7 +467,15 @@ const RowComponent = ({
               <p className="word-break whitespace-break-spaces font-medium">
                 {item.name}
               </p>
-              <KitStatusBadge status={item.status} availableToBook />
+              <div className="flex flex-wrap items-center gap-2">
+                <KitStatusBadge status={item.status} availableToBook />
+                {/* why: this modal is where someone matches a physical label
+                    to a row, which is exactly when the code matters most. The
+                    data was already on every row (getPaginatedAndFilterableKits
+                    merges KITS_INCLUDE_FIELDS); only the chip was missing. The
+                    equivalent booking modal has rendered it all along. */}
+                {displayCode ? <AssetCodeBadge {...displayCode} /> : null}
+              </div>
             </div>
           </div>
         </div>

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
@@ -6,6 +6,7 @@ import type {
 } from "react-router";
 import { data, useParams } from "react-router";
 import z from "zod";
+import { AssetCodeBadge } from "~/components/assets/asset-code-badge";
 import { CategoryBadge } from "~/components/assets/category-badge";
 import DynamicDropdown from "~/components/dynamic-dropdown/dynamic-dropdown";
 import { ChevronRight } from "~/components/icons/library";
@@ -30,6 +31,7 @@ import { useCurrentOrganization } from "~/hooks/use-current-organization";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
+import { resolveDisplayCode } from "~/modules/barcode/display";
 import { resolveLocationKitIds } from "~/modules/location/bulk-select.server";
 import {
   getLocationKits,
@@ -370,6 +372,8 @@ const Row = ({
   item: Prisma.KitGetPayload<{
     include: {
       category: true;
+      qrCodes: { take: 1; select: { id: true } };
+      barcodes: { select: { id: true; type: true; value: true } };
       custody: {
         select: {
           custodian: {
@@ -382,6 +386,17 @@ const Row = ({
   extraProps: { canReadCustody: boolean; userRoleCanManageKits: boolean };
 }) => {
   const { category, custody } = item;
+  // why: this is a kit-listing surface, and kits are code-bearing entities.
+  // It was the only one whose query did not even fetch the relations, so the
+  // chip could not be rendered here at all. See
+  // `.claude/rules/code-bearing-entity-list-consistency.md`.
+  const currentOrganization = useCurrentOrganization();
+  const displayCode = currentOrganization
+    ? resolveDisplayCode({
+        entity: { ...item, entityKind: "kit" },
+        organization: currentOrganization,
+      })
+    : null;
 
   return (
     <>
@@ -414,6 +429,7 @@ const Row = ({
                 </Button>
               </span>
               <KitStatusBadge status={item.status} availableToBook />
+              {displayCode ? <AssetCodeBadge {...displayCode} /> : null}
             </div>
           </div>
         </div>

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
@@ -40,6 +40,7 @@ import {
 import { getTeamMemberForCustodianFilter } from "~/modules/team-member/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { updateCookieWithPerPage } from "~/utils/cookies.server";
+import { redactCustodianForViewer } from "~/utils/custody-visibility.server";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -128,7 +129,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
 
     return payload({
       modelName,
-      items: kits,
+      // The custodian's name and user.email are on every row regardless of
+      // whether the UI draws them, so a viewer without custody visibility can
+      // read them straight out of the route's data payload. Redact here, not
+      // in the component.
+      items: redactCustodianForViewer(kits, { canSeeAllCustody, userId }),
       page,
       totalItems: totalKits,
       perPage,

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.kits.tsx
@@ -398,8 +398,9 @@ const Row = ({
   const currentOrganization = useCurrentOrganization();
   const displayCode = currentOrganization
     ? resolveDisplayCode({
-        entity: { ...item, entityKind: "kit" },
+        entity: item,
         organization: currentOrganization,
+        entityKind: "kit",
       })
     : null;
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
@@ -123,7 +123,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
       assets: assets.map((asset) => {
         const codeEntity = codeByAssetId.get(asset.id);
         const resolved = codeEntity
-          ? resolveDisplayCode({ entity: codeEntity, organization: org })
+          ? resolveDisplayCode({
+              entity: codeEntity,
+              organization: org,
+              entityKind: "asset",
+            })
           : null;
         return {
           id: asset.id,


### PR DESCRIPTION
## Why

Kits are code-bearing entities — `Qr.kitId` and `Barcode.kitId` both exist — and `.claude/rules/code-bearing-entity-list-consistency.md` says any surface listing one should render the shared `<AssetCodeBadge>` via `resolveDisplayCode`. The `/kits` index already did. **Five other kit surfaces did not**, so whether you could match a physical label to a row depended on which page you happened to be on.

## The five, split by what was actually wrong

**Missing the data, not the markup** — these could not have rendered a chip:

| Surface | What the query said |
| --- | --- |
| Location detail → Kits tab | `getLocationKits` included only `category` and `custody` |
| Booking sidebar, kit group header | the nested kit select omitted both relations, while the sibling **asset** select 200 lines above has all four code fields. `kit-row.tsx` was already rendering the chip against data that never arrived |

**Had the data, didn't render it** — no query changes:

| Surface | What was wrong |
| --- | --- |
| Kits availability calendar | `extendedProps` dropped the fields its asset twin passes through |
| Add-kits-to-location modal | imported neither the resolver nor the badge; the equivalent booking modal has rendered it all along |
| Calendar resource label | same |

## An instruction nobody could follow

On a workspace preferring **SAM ID**, a kit falls back to its QR and the tooltip read:

> Your workspace prefers SAM ID but this item has no SAM ID. **Add one** (or change the workspace setting) to fix.

`Kit` has no `sequentialId` column and no UI to set one. That sentence made a product gap look like the reader's mistake. It now names the gap:

> Your workspace prefers SAM ID, which kits do not have. Showing the QR Code ID instead.

`resolveDisplayCode` carries an optional `entityKind` for this. It is **help text only** — it never changes which code is chosen, and an unmarked entity resolves exactly as before (pinned by a test).

## Deliberately NOT done: `Kit.sequentialId`

The rule flags it as a deferred gap, and it should stay deferred:

- the sequence generator is asset-scoped end to end — `create_asset_sequence_for_org`, and `reset_asset_sequence_for_org` reads `FROM "Asset"`
- `preferredBarcodeId`'s ownership invariant is enforced by a deferrable `CONSTRAINT TRIGGER`
- it forces an unmade product decision: does `SAM-0042` identify an asset or a kit? Support would have to ask which every time

That is a migration plus trigger work plus a picker UI, to change one chip variant on one of seven preference values. Worth a product decision, not a drive-by.

## Verification

- `display.test.ts` 22 passing, `asset-code-badge.test.tsx` 7 passing
- New tests cover the kit fallback wording, the asset wording surviving, `entityKind` round-tripping, and an unmarked entity defaulting to `asset`
- Mutation-tested: disabling the kit branch fails the kit test and nothing else
- Checked on a real workspace — the location Kits tab went from no code to `QR Code ID: kitqab10ck`, rendered by the shared badge with its full tooltip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Kit display codes now appear consistently in kit lists, management views, booking screens, location views, and availability calendars.
  - QR codes and barcodes are supported when resolving kit display identifiers.
  - Kit-specific tooltip messaging clarifies when no preferred identifier is available.

- **Bug Fixes**
  - Improved QR and barcode fallback behavior for kits.
  - Preserved actionable guidance for assets while avoiding misleading instructions for kits.

- **Tests**
  - Added coverage for kit and asset identifier resolution and tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->