### PR TITLE
fix(bookings): compute booking date defaults in the preference zone

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
+++ b/apps/webapp/app/components/assets/assets-index/create-booking-for-selected-assets-dialog.tsx
@@ -56,7 +56,8 @@ export default function CreateBookingForSelectedAssetsDialog() {
     getBookingDefaultStartEndTimes(
       workingHours,
       bookingSettings.bufferStartTime,
-      isAdministratorOrOwner
+      isAdministratorOrOwner,
+      prefs
     );
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(defaultEndDate);

--- a/apps/webapp/app/components/booking/actions-dropdown.tsx
+++ b/apps/webapp/app/components/booking/actions-dropdown.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuTrigger,
 } from "~/components/shared/dropdown";
 import { useBookingStatusHelpers } from "~/hooks/use-booking-status";
+import { useFormatPrefs } from "~/hooks/use-format-prefs";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { isBookingArchivable } from "~/modules/booking/helpers";
 import type { loader } from "~/routes/_layout+/bookings.$bookingId.overview";
@@ -36,6 +37,10 @@ interface Props {
 
 export const ActionsDropdown = ({ fullWidth }: Props) => {
   const { booking } = useLoaderData<typeof loader>();
+  // Seed the extend dialog in the RESOLVED preference zone — the same zone this
+  // page displays the booking in and the extend action parses the submission in.
+  // Seeding from the device clock showed a different end date than the page.
+  const prefs = useFormatPrefs();
   const {
     isCompleted,
     isOngoing,
@@ -100,7 +105,10 @@ export const ActionsDropdown = ({ fullWidth }: Props) => {
           </When>
           <When truthy={canExtendBooking}>
             <ExtendBookingDialog
-              currentEndDate={dateForDateTimeInputValue(new Date(booking.to))}
+              currentEndDate={dateForDateTimeInputValue(
+                new Date(booking.to),
+                prefs.timeZone
+              )}
             />
           </When>
           <When

--- a/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/edit-booking-form.tsx
@@ -60,8 +60,6 @@ type BookingFormData = {
   booking: {
     id: string;
     name: string;
-    startDate: string;
-    endDate: string;
     custodianRef: string; // This is a stringified value for custodianRef. It can be either a team member id or a user id
     bookingFlags: BookingFlags;
     description: string | null;

--- a/apps/webapp/app/components/booking/forms/fields/dates.tsx
+++ b/apps/webapp/app/components/booking/forms/fields/dates.tsx
@@ -1,4 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
+import { DateTime } from "luxon";
 import FormRow from "~/components/forms/form-row";
 import { DateTimePicker } from "~/components/shared/date-time-picker";
 import { InfoBox } from "~/components/shared/info-box";
@@ -11,7 +12,7 @@ import type {
   useWorkingHours,
   UseWorkingHoursResult,
 } from "~/hooks/use-working-hours";
-import { dateForDateTimeInputValue } from "~/utils/date-fns";
+import { DATE_TIME_FORMAT } from "~/utils/constants";
 import { tw } from "~/utils/tw";
 
 export function DatesFields({
@@ -82,22 +83,36 @@ export function DatesFields({
             const inputValue = wire;
             if (isNewBooking && endDate && inputValue) {
               try {
-                // Safari-friendly date parsing: datetime-local format is YYYY-MM-DDTHH:mm
-                const newStartDate = new Date(inputValue);
-                const currentEndDate = new Date(endDate);
+                // Both values are NAIVE wall-clock strings in the user's
+                // preference zone — that is what the field displays and what the
+                // server parses. So this comparison and the 6 PM adjustment stay
+                // entirely in wall-clock space: parse both in a single fixed
+                // zone, do the arithmetic, format straight back. Never convert to
+                // an absolute instant, or the device zone leaks in. UTC is used
+                // purely as a neutral reference so no DST transition can shift a
+                // wall clock that is not meant to move.
+                const newStartDate = DateTime.fromISO(inputValue, {
+                  zone: "utc",
+                });
+                const currentEndDate = DateTime.fromISO(endDate, {
+                  zone: "utc",
+                });
 
                 // Check if dates are valid before comparing
                 if (
-                  !isNaN(newStartDate.getTime()) &&
-                  !isNaN(currentEndDate.getTime()) &&
+                  newStartDate.isValid &&
+                  currentEndDate.isValid &&
                   newStartDate > currentEndDate
                 ) {
                   // Create new end date at 6 PM on the same day as start date
-                  const endDateTime = new Date(newStartDate);
-                  endDateTime.setHours(18, 0, 0, 0);
+                  const endDateTime = newStartDate.set({
+                    hour: 18,
+                    minute: 0,
+                    second: 0,
+                    millisecond: 0,
+                  });
 
-                  const newEndDate = dateForDateTimeInputValue(endDateTime);
-                  setEndDate(newEndDate.substring(0, newEndDate.length - 3));
+                  setEndDate(endDateTime.toFormat(DATE_TIME_FORMAT));
                 }
               } catch (error) {
                 // If date parsing fails, just update the start date without affecting end date

--- a/apps/webapp/app/components/booking/forms/new-booking-form.tsx
+++ b/apps/webapp/app/components/booking/forms/new-booking-form.tsx
@@ -78,7 +78,8 @@ export function NewBookingForm({ booking, action }: NewBookingFormData) {
     getBookingDefaultStartEndTimes(
       workingHours,
       bookingSettings.bufferStartTime,
-      isAdministratorOrOwner
+      isAdministratorOrOwner,
+      prefs
     );
 
   const [startDate, setStartDate] = useState(defaultStartDate);

--- a/apps/webapp/app/components/booking/page-content.tsx
+++ b/apps/webapp/app/components/booking/page-content.tsx
@@ -6,7 +6,6 @@ import {
   canAssignModelUnits,
   countUnassignedModelUnits,
 } from "~/utils/booking-model-requests";
-import { dateForDateTimeInputValue } from "~/utils/date-fns";
 import { BookingAssetsColumn } from "./booking-assets-column";
 import { BookingStatistics } from "./booking-statistics";
 import { EditBookingForm } from "./forms/edit-booking-form";
@@ -52,8 +51,6 @@ export function BookingPageContent() {
               name: booking.name,
               description: booking.description,
               bookingFlags,
-              startDate: dateForDateTimeInputValue(new Date(booking.from)),
-              endDate: dateForDateTimeInputValue(new Date(booking.to)),
               custodianRef: custodian?.id || "", // We have an old bug that some users dont have a teamMember attached to them. This is a safety just so the UI doesnt break until we solve the data
               tags: booking.tags,
             }}

--- a/apps/webapp/app/modules/working-hours/utils.test.ts
+++ b/apps/webapp/app/modules/working-hours/utils.test.ts
@@ -1,3 +1,5 @@
+import type { ResolvedFormatPrefs } from "~/utils/date-format";
+import { HARDCODED_DEFAULT_PREFS } from "~/utils/date-format";
 import type { WorkingHoursData, WeeklyScheduleJson } from "./types";
 import {
   calculateBusinessHoursDuration,
@@ -10,12 +12,19 @@ import {
 // @vitest-environment node
 // 👋 see https://vitest.dev/guide/environment.html#environments-for-specific-files
 
-// Mock date-fns to control time in tests
-vitest.mock("~/utils/date-fns", () => ({
-  dateForDateTimeInputValue: vitest.fn(
-    (date: Date) => date.toISOString().slice(0, 16) // YYYY-MM-DDTHH:mm format
-  ),
-}));
+/**
+ * Resolved prefs carrying a specific zone.
+ *
+ * `~/utils/date-fns` is deliberately NOT mocked here. It used to be, with a
+ * `toISOString().slice(0,16)` stand-in that formatted in UTC while production
+ * formatted in the device zone — so these cases agreed with production only
+ * because the suite also forced `process.env.TZ = "UTC"` (which V8 does not
+ * reliably honour after start). Both crutches are gone: every case now states
+ * the zone it means, and the assertions exercise the real conversion.
+ */
+function prefsFor(timeZone: string): ResolvedFormatPrefs {
+  return { ...HARDCODED_DEFAULT_PREFS, timeZone };
+}
 
 describe("normalizeWorkingHoursForValidation", () => {
   it("should normalize valid working hours data", () => {
@@ -409,13 +418,10 @@ describe("calculateBusinessHoursDuration", () => {
 });
 
 describe("getBookingDefaultStartEndTimes", () => {
-  const originalTZ = process.env.TZ;
-
-  beforeAll(() => {
-    // Force tests to run in UTC for consistent behavior across environments
-    process.env.TZ = "UTC";
-  });
-
+  // why: the defaults are computed relative to "now", so pinning the clock is
+  // what makes the expected wall-clocks assertable instead of drifting. The
+  // suite no longer touches process.env.TZ — each case passes the zone it means,
+  // so the machine's own timezone cannot affect the result.
   beforeEach(() => {
     // Mock current time to Friday, July 25, 2025 at 2 PM UTC
     vitest.useFakeTimers();
@@ -424,15 +430,6 @@ describe("getBookingDefaultStartEndTimes", () => {
 
   afterEach(() => {
     vitest.useRealTimers();
-  });
-
-  afterAll(() => {
-    // Restore original timezone
-    if (originalTZ !== undefined) {
-      process.env.TZ = originalTZ;
-    } else {
-      delete process.env.TZ;
-    }
   });
 
   const mockWorkingHours: WorkingHoursData = {
@@ -457,40 +454,56 @@ describe("getBookingDefaultStartEndTimes", () => {
     const result = getBookingDefaultStartEndTimes(
       disabledWorkingHours,
       2,
-      false
+      false,
+      prefsFor("UTC")
     );
 
     // Should use original logic with 2-hour buffer
-    expect(result.startDate).toBe("2025-07-25T16:00"); // Current + 2 hours
+    expect(result.startDate).toBe("2025-07-25T16:00:00"); // Current + 2 hours
   });
 
   it("should use fallback logic when no working hours data", () => {
     expect.assertions(1);
 
-    const result = getBookingDefaultStartEndTimes(null, 1, false);
+    const result = getBookingDefaultStartEndTimes(
+      null,
+      1,
+      false,
+      prefsFor("UTC")
+    );
 
     // Should use original logic with 1-hour buffer
-    expect(result.startDate).toBe("2025-07-25T15:00"); // Current + 1 hour
+    expect(result.startDate).toBe("2025-07-25T15:00:00"); // Current + 1 hour
   });
 
   it("should handle current time within working hours", () => {
     expect.assertions(2);
 
-    const result = getBookingDefaultStartEndTimes(mockWorkingHours, 0, false);
+    const result = getBookingDefaultStartEndTimes(
+      mockWorkingHours,
+      0,
+      false,
+      prefsFor("UTC")
+    );
 
     // Since we're within working hours (2 PM on Friday), use 10-minute buffer
-    expect(result.startDate).toBe("2025-07-25T14:10"); // Current time + 10 minutes
-    expect(result.endDate).toBe("2025-07-25T17:00"); // End of current working day
+    expect(result.startDate).toBe("2025-07-25T14:10:00"); // Current time + 10 minutes
+    expect(result.endDate).toBe("2025-07-25T17:00:00"); // End of current working day
   });
 
   it("should handle buffer time within working hours", () => {
     expect.assertions(2);
 
-    const result = getBookingDefaultStartEndTimes(mockWorkingHours, 2, false);
+    const result = getBookingDefaultStartEndTimes(
+      mockWorkingHours,
+      2,
+      false,
+      prefsFor("UTC")
+    );
 
     // Since we're within working hours and buffer doesn't exceed closing time
-    expect(result.startDate).toBe("2025-07-25T16:00"); // Current time + 2 hours buffer
-    expect(result.endDate).toBe("2025-07-25T17:00"); // End of current working day
+    expect(result.startDate).toBe("2025-07-25T16:00:00"); // Current time + 2 hours buffer
+    expect(result.endDate).toBe("2025-07-25T17:00:00"); // End of current working day
   });
 
   it("should find next working day when outside hours", () => {
@@ -499,10 +512,15 @@ describe("getBookingDefaultStartEndTimes", () => {
     // Mock time to Saturday (closed day)
     vitest.setSystemTime(new Date("2025-07-26T14:00:00Z"));
 
-    const result = getBookingDefaultStartEndTimes(mockWorkingHours, 0, false);
+    const result = getBookingDefaultStartEndTimes(
+      mockWorkingHours,
+      0,
+      false,
+      prefsFor("UTC")
+    );
 
-    expect(result.startDate).toBe("2025-07-28T09:00"); // Next Monday 9 AM UTC
-    expect(result.endDate).toBe("2025-07-28T17:00"); // Next Monday 5 PM UTC
+    expect(result.startDate).toBe("2025-07-28T09:00:00"); // Next Monday 9 AM UTC
+    expect(result.endDate).toBe("2025-07-28T17:00:00"); // Next Monday 5 PM UTC
   });
 
   it("should handle buffer time that extends past working hours", () => {
@@ -511,11 +529,16 @@ describe("getBookingDefaultStartEndTimes", () => {
     // Mock time to late Friday afternoon
     vitest.setSystemTime(new Date("2025-07-25T16:30:00Z"));
 
-    const result = getBookingDefaultStartEndTimes(mockWorkingHours, 2, false);
+    const result = getBookingDefaultStartEndTimes(
+      mockWorkingHours,
+      2,
+      false,
+      prefsFor("UTC")
+    );
 
     // Buffer would put us at 6:30 PM, past closing, so use next working day
-    expect(result.startDate).toBe("2025-07-28T09:00"); // Next Monday 9 AM UTC
-    expect(result.endDate).toBe("2025-07-28T17:00"); // Next Monday 5 PM UTC
+    expect(result.startDate).toBe("2025-07-28T09:00:00"); // Next Monday 9 AM UTC
+    expect(result.endDate).toBe("2025-07-28T17:00:00"); // Next Monday 5 PM UTC
   });
 
   it("should handle date-specific overrides", () => {
@@ -541,11 +564,12 @@ describe("getBookingDefaultStartEndTimes", () => {
     const result = getBookingDefaultStartEndTimes(
       workingHoursWithOverride,
       0,
-      false
+      false,
+      prefsFor("UTC")
     );
 
-    expect(result.startDate).toBe("2025-07-28T09:00"); // Next Monday 9 AM UTC
-    expect(result.endDate).toBe("2025-07-28T17:00"); // Next Monday 5 PM UTC
+    expect(result.startDate).toBe("2025-07-28T09:00:00"); // Next Monday 9 AM UTC
+    expect(result.endDate).toBe("2025-07-28T17:00:00"); // Next Monday 5 PM UTC
   });
 
   it("should bypass buffer time for admin/owner users", () => {
@@ -555,17 +579,19 @@ describe("getBookingDefaultStartEndTimes", () => {
     const baseUserResult = getBookingDefaultStartEndTimes(
       mockWorkingHours,
       24,
-      false
+      false,
+      prefsFor("UTC")
     );
-    expect(baseUserResult.startDate).toBe("2025-07-28T09:00"); // Next working day (buffer pushes to Monday)
+    expect(baseUserResult.startDate).toBe("2025-07-28T09:00:00"); // Next working day (buffer pushes to Monday)
 
     // Admin user with same 24-hour buffer should get time ~10 minutes from now
     const adminUserResult = getBookingDefaultStartEndTimes(
       mockWorkingHours,
       24,
-      true
+      true,
+      prefsFor("UTC")
     );
-    expect(adminUserResult.startDate).toBe("2025-07-25T14:10"); // Current time + 10 minutes (buffer bypassed)
+    expect(adminUserResult.startDate).toBe("2025-07-25T14:10:00"); // Current time + 10 minutes (buffer bypassed)
   });
 
   it("should bypass buffer time for admin/owner when working hours disabled", () => {
@@ -577,17 +603,125 @@ describe("getBookingDefaultStartEndTimes", () => {
     const baseUserResult = getBookingDefaultStartEndTimes(
       disabledWorkingHours,
       10,
-      false
+      false,
+      prefsFor("UTC")
     );
-    expect(baseUserResult.startDate).toBe("2025-07-26T00:00"); // Current + 10 hours = next day midnight
+    expect(baseUserResult.startDate).toBe("2025-07-26T00:00:00"); // Current + 10 hours = next day midnight
 
     // Admin user with same 10-hour buffer should get 10 minutes from now
     const adminUserResult = getBookingDefaultStartEndTimes(
       disabledWorkingHours,
       10,
-      true
+      true,
+      prefsFor("UTC")
     );
-    expect(adminUserResult.startDate).toBe("2025-07-25T14:10"); // Current time + 10 minutes (buffer bypassed)
+    expect(adminUserResult.startDate).toBe("2025-07-25T14:10:00"); // Current time + 10 minutes (buffer bypassed)
+  });
+
+  /**
+   * The bug this parameter exists for: defaults used to be computed on the
+   * DEVICE clock while the form field displays and submits in the user's
+   * PREFERENCE zone. Reported from the field as a "Create booking" dialog
+   * prefilling ~10 hours late.
+   *
+   * These cases pin the zone-correct behaviour. They pass the same instant with
+   * different prefs, so they assert the zone actually drives the result rather
+   * than the machine the suite happens to run on.
+   */
+  describe("preference zone drives the result", () => {
+    it("returns the wall-clock of the preference zone, not UTC", () => {
+      expect.assertions(2);
+
+      // 14:00Z with working hours disabled → start is "now + 10 minutes",
+      // expressed in whichever zone the user prefers.
+      const utc = getBookingDefaultStartEndTimes(
+        null,
+        0,
+        false,
+        prefsFor("UTC")
+      );
+      const losAngeles = getBookingDefaultStartEndTimes(
+        null,
+        0,
+        false,
+        prefsFor("America/Los_Angeles")
+      );
+
+      expect(utc.startDate).toBe("2025-07-25T14:10:00");
+      // Same instant, PDT (UTC-7) → 07:10 local, and still the 25th.
+      expect(losAngeles.startDate).toBe("2025-07-25T07:10:00");
+    });
+
+    it("picks the working day of the preference zone when zones straddle midnight", () => {
+      expect.assertions(2);
+
+      // 2025-07-25T23:30Z is still FRIDAY in UTC but already SATURDAY in Tokyo
+      // (UTC+9, 08:30 on the 26th). Saturday is closed in this schedule, so the
+      // two zones must resolve to different next-working-day answers.
+      vitest.setSystemTime(new Date("2025-07-25T23:30:00Z"));
+
+      const utc = getBookingDefaultStartEndTimes(
+        mockWorkingHours,
+        0,
+        false,
+        prefsFor("UTC")
+      );
+      const tokyo = getBookingDefaultStartEndTimes(
+        mockWorkingHours,
+        0,
+        false,
+        prefsFor("Asia/Tokyo")
+      );
+
+      // UTC: Friday 23:30 is past Friday's 17:00 close → next working day is Monday.
+      expect(utc.startDate).toBe("2025-07-28T09:00:00");
+      // Tokyo: already Saturday 08:30 → Saturday is closed, so also Monday, but
+      // Monday 09:00 TOKYO — a different absolute instant and a different string.
+      expect(tokyo.startDate).toBe("2025-07-28T09:00:00");
+    });
+
+    it("resolves a date override against the preference zone's calendar day", () => {
+      expect.assertions(2);
+
+      // Friday the 25th is overridden closed. At 23:30Z it is still the 25th in
+      // UTC (override applies) but already the 26th in Tokyo (it does not).
+      vitest.setSystemTime(new Date("2025-07-25T23:30:00Z"));
+
+      const workingHoursWithOverride: WorkingHoursData = {
+        ...mockWorkingHours,
+        overrides: [
+          {
+            id: "friday-closed",
+            date: new Date("2025-07-25"),
+            isOpen: false,
+            openTime: null,
+            closeTime: null,
+            reason: "Company event",
+            createdAt: new Date("2025-01-01T00:00:00.000Z"),
+            updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+            workingHoursId: "working-hours-1",
+          },
+        ],
+      };
+
+      const utc = getBookingDefaultStartEndTimes(
+        workingHoursWithOverride,
+        0,
+        false,
+        prefsFor("UTC")
+      );
+      const tokyo = getBookingDefaultStartEndTimes(
+        workingHoursWithOverride,
+        0,
+        false,
+        prefsFor("Asia/Tokyo")
+      );
+
+      // Both land on Monday here; what matters is that each resolved the
+      // override against its OWN calendar day without throwing or skipping a week.
+      expect(utc.startDate).toBe("2025-07-28T09:00:00");
+      expect(tokyo.startDate).toBe("2025-07-28T09:00:00");
+    });
   });
 });
 

--- a/apps/webapp/app/modules/working-hours/utils.test.ts
+++ b/apps/webapp/app/modules/working-hours/utils.test.ts
@@ -656,47 +656,68 @@ describe("getBookingDefaultStartEndTimes", () => {
       expect.assertions(2);
 
       // 2025-07-25T23:30Z is still FRIDAY in UTC but already SATURDAY in Tokyo
-      // (UTC+9, 08:30 on the 26th). Saturday is closed in this schedule, so the
-      // two zones must resolve to different next-working-day answers.
+      // (UTC+9, 08:30 on the 26th).
+      //
+      // Saturday is opened on DIFFERENT hours from the weekday schedule so the
+      // two zones cannot produce the same answer. With Saturday closed (as the
+      // shared fixture has it) both zones funnel to Monday 09:00 and the case
+      // proves nothing — a build reading the calendar day off UTC while still
+      // formatting in the preference zone would pass it.
       vitest.setSystemTime(new Date("2025-07-25T23:30:00Z"));
 
+      const saturdayOpen: WorkingHoursData = {
+        ...mockWorkingHours,
+        weeklySchedule: {
+          ...mockWorkingHours.weeklySchedule,
+          "6": { isOpen: true, openTime: "10:00", closeTime: "14:00" },
+        } as WeeklyScheduleJson,
+      };
+
       const utc = getBookingDefaultStartEndTimes(
-        mockWorkingHours,
+        saturdayOpen,
         0,
         false,
         prefsFor("UTC")
       );
       const tokyo = getBookingDefaultStartEndTimes(
-        mockWorkingHours,
+        saturdayOpen,
         0,
         false,
         prefsFor("Asia/Tokyo")
       );
 
-      // UTC: Friday 23:30 is past Friday's 17:00 close → next working day is Monday.
-      expect(utc.startDate).toBe("2025-07-28T09:00:00");
-      // Tokyo: already Saturday 08:30 → Saturday is closed, so also Monday, but
-      // Monday 09:00 TOKYO — a different absolute instant and a different string.
+      // UTC: Friday 23:30, past Friday's 17:00 close → next open day is
+      // Saturday, which now opens at 10:00.
+      expect(utc.startDate).toBe("2025-07-26T10:00:00");
+      // Tokyo: already Saturday 08:30, and the search only ever starts from
+      // TOMORROW → Sunday (closed), then Monday 09:00 Tokyo. Different calendar
+      // day and different wall clock from UTC.
       expect(tokyo.startDate).toBe("2025-07-28T09:00:00");
     });
 
     it("resolves a date override against the preference zone's calendar day", () => {
       expect.assertions(2);
 
-      // Friday the 25th is overridden closed. At 23:30Z it is still the 25th in
-      // UTC (override applies) but already the 26th in Tokyo (it does not).
+      // Friday the 25th carries an override. At 23:30Z it is still the 25th in
+      // UTC, so the override applies there; in Tokyo it is already the 26th, so
+      // it does not.
+      //
+      // The override OPENS Friday late rather than closing it. A closed-Friday
+      // override is inert at this instant — 23:30 is past the normal 17:00 close
+      // either way — so it could be deleted without changing either assertion.
+      // Opening late makes the override the only thing that separates the zones.
       vitest.setSystemTime(new Date("2025-07-25T23:30:00Z"));
 
       const workingHoursWithOverride: WorkingHoursData = {
         ...mockWorkingHours,
         overrides: [
           {
-            id: "friday-closed",
+            id: "friday-late",
             date: new Date("2025-07-25"),
-            isOpen: false,
-            openTime: null,
-            closeTime: null,
-            reason: "Company event",
+            isOpen: true,
+            openTime: "20:00",
+            closeTime: "23:59",
+            reason: "Late event",
             createdAt: new Date("2025-01-01T00:00:00.000Z"),
             updatedAt: new Date("2025-01-01T00:00:00.000Z"),
             workingHoursId: "working-hours-1",
@@ -717,9 +738,11 @@ describe("getBookingDefaultStartEndTimes", () => {
         prefsFor("Asia/Tokyo")
       );
 
-      // Both land on Monday here; what matters is that each resolved the
-      // override against its OWN calendar day without throwing or skipping a week.
-      expect(utc.startDate).toBe("2025-07-28T09:00:00");
+      // UTC: still the 25th → override applies, and 23:30 sits inside
+      // 20:00-23:59 → the in-hours branch, i.e. now + 10 minutes.
+      expect(utc.startDate).toBe("2025-07-25T23:40:00");
+      // Tokyo: already the 26th → the override does not apply. Saturday and
+      // Sunday are closed, so the next open day is Monday.
       expect(tokyo.startDate).toBe("2025-07-28T09:00:00");
     });
   });

--- a/apps/webapp/app/modules/working-hours/utils.ts
+++ b/apps/webapp/app/modules/working-hours/utils.ts
@@ -1,4 +1,4 @@
-import { addHours, addDays, format, differenceInHours } from "date-fns";
+import { addDays, format, differenceInHours } from "date-fns";
 import { DateTime } from "luxon";
 import { dateForDateTimeInputValue } from "~/utils/date-fns";
 import type { ResolvedFormatPrefs } from "~/utils/date-format";

--- a/apps/webapp/app/modules/working-hours/utils.ts
+++ b/apps/webapp/app/modules/working-hours/utils.ts
@@ -1,10 +1,64 @@
 import { addHours, addDays, format, differenceInHours } from "date-fns";
+import { DateTime } from "luxon";
 import { dateForDateTimeInputValue } from "~/utils/date-fns";
+import type { ResolvedFormatPrefs } from "~/utils/date-format";
 import type {
   DaySchedule,
   WeeklyScheduleJson,
   WorkingHoursData,
 } from "./types";
+
+/**
+ * The day schedule that applies on a given zoned calendar date.
+ *
+ * A date-specific override wins over the weekly schedule, matching how
+ * `validateWorkingHours` resolves the same data
+ * (`~/components/booking/forms/forms-schema.ts`). Both the override key and the
+ * weekday are read from `zoned`, so the caller's zone decides which day this is
+ * — reading them from a device-local `Date` is what let a user whose preference
+ * zone differs from their device get another day's hours.
+ *
+ * @param zoned - The instant, already converted to the zone that defines "day".
+ * @param workingHours - The org's weekly schedule plus date overrides.
+ * @returns The applicable schedule, or null when the day has none.
+ */
+function resolveDaySchedule(
+  zoned: DateTime,
+  workingHours: WorkingHoursData
+): DaySchedule | null {
+  const dateString = zoned.toFormat("yyyy-MM-dd");
+  const override = workingHours.overrides.find(
+    (o) => getOverrideDateKey(o.date) === dateString
+  );
+
+  if (override) {
+    return {
+      isOpen: override.isOpen,
+      openTime: override.openTime || undefined,
+      closeTime: override.closeTime || undefined,
+    };
+  }
+
+  // Luxon weekday is 1=Mon..7=Sun; the schedule is keyed 0=Sun..6=Sat.
+  const dayOfWeek = (zoned.weekday % 7).toString();
+  return workingHours.weeklySchedule[dayOfWeek] || null;
+}
+
+/**
+ * The same calendar day as `zoned`, at an `"HH:mm"` wall-clock time in its zone.
+ *
+ * Used to materialise the org's open/close times on a specific day. Doing this
+ * with Luxon's `set` keeps the result in the target zone; the previous
+ * `Date.setHours` equivalent placed it on the DEVICE clock instead.
+ *
+ * @param zoned - The day to place the time on, in the target zone.
+ * @param time - Wall-clock time as `"HH:mm"`.
+ * @returns A DateTime on the same calendar day at that wall-clock time.
+ */
+function atWallClock(zoned: DateTime, time: string): DateTime {
+  const [hour, minute] = time.split(":").map(Number);
+  return zoned.set({ hour, minute, second: 0, millisecond: 0 });
+}
 
 /**
  * Returns the YYYY-MM-DD key that identifies an override's calendar date.
@@ -124,132 +178,86 @@ interface NextWorkingDayResult {
  * Finds the next working day based on the current date and provided working hours.
  * It checks for date-specific overrides first, then falls back to the weekly schedule.
  * If no working day is found within 14 days, it defaults to tomorrow's 9 AM - 6 PM.
+ * All calendar-day and wall-clock reasoning happens in `timeZone`, so "tomorrow"
+ * and "9 AM" mean what the user means. Reading them off a device-local `Date`
+ * put the search on the wrong day whenever the device and preference zones
+ * straddled midnight.
+ *
  * @param currentDate - The date from which to start searching for the next working day.
  * @param workingHours - The working hours data containing weekly schedules and overrides.
  * @param bufferStartTime - Buffer time in hours from current time.
+ * @param timeZone - IANA zone that defines calendar days and wall-clock times.
  * @returns An object containing the start and end times of the next working day.
  */
 function findNextWorkingDay(
   currentDate: Date,
   workingHours: WorkingHoursData,
-  bufferStartTime: number
+  bufferStartTime: number,
+  timeZone: string
 ): NextWorkingDayResult {
-  // Calculate buffer expiry time (current time + buffer hours)
-  const bufferExpiryTime =
-    bufferStartTime > 0 ? addHours(currentDate, bufferStartTime) : currentDate;
-  // Remove seconds and milliseconds
-  bufferExpiryTime.setSeconds(0, 0);
+  const now = DateTime.fromJSDate(currentDate).setZone(timeZone);
 
-  // Start checking from tomorrow
-  const searchDate = new Date(currentDate);
-  searchDate.setDate(searchDate.getDate() + 1);
+  // Buffer expiry (current time + buffer hours), seconds stripped. Luxon values
+  // are immutable, so unlike the previous `setSeconds` this cannot mutate the
+  // caller's Date when the buffer is 0.
+  const bufferExpiry = (
+    bufferStartTime > 0 ? now.plus({ hours: bufferStartTime }) : now
+  ).set({ second: 0, millisecond: 0 });
 
-  // Check up to 14 days to find next working day
-  for (let i = 0; i < 14; i++) {
-    const checkDate = new Date(searchDate);
-    checkDate.setDate(searchDate.getDate() + i);
+  // Check up to 14 days ahead, starting tomorrow. `plus({ days })` steps by
+  // calendar day in `timeZone`, so it stays correct across a DST boundary.
+  for (let dayOffset = 1; dayOffset <= 14; dayOffset++) {
+    const checkDay = now.plus({ days: dayOffset });
+    const daySchedule = resolveDaySchedule(checkDay, workingHours);
 
-    const dateString = format(checkDate, "yyyy-MM-dd"); // local calendar date
-    const dayOfWeek = checkDate.getDay().toString();
-
-    // Check for date-specific override first
-    const override = workingHours.overrides.find(
-      (override) => getOverrideDateKey(override.date) === dateString
-    );
-
-    let daySchedule: DaySchedule | null = null;
-
-    if (override) {
-      // Use override schedule
-      daySchedule = {
-        isOpen: override.isOpen,
-        openTime: override.openTime || undefined,
-        closeTime: override.closeTime || undefined,
-      };
-    } else {
-      // Use regular weekly schedule
-      daySchedule = workingHours.weeklySchedule[dayOfWeek] || null;
+    if (
+      !daySchedule?.isOpen ||
+      !daySchedule.openTime ||
+      !daySchedule.closeTime
+    ) {
+      continue;
     }
 
-    if (daySchedule?.isOpen && daySchedule.openTime && daySchedule.closeTime) {
-      const [openHours, openMinutes] = daySchedule.openTime
-        .split(":")
-        .map(Number);
-      const [closeHours, closeMinutes] = daySchedule.closeTime
-        .split(":")
-        .map(Number);
+    const workingDayStart = atWallClock(checkDay, daySchedule.openTime);
+    const workingDayEnd = atWallClock(checkDay, daySchedule.closeTime);
 
-      const workingDayStart = new Date(checkDate);
-      workingDayStart.setHours(openHours, openMinutes, 0, 0);
+    // Use whichever is later: buffer expiry time or working day start
+    const startTime =
+      bufferExpiry > workingDayStart ? bufferExpiry : workingDayStart;
 
-      const workingDayEnd = new Date(checkDate);
-      workingDayEnd.setHours(closeHours, closeMinutes, 0, 0);
-
-      // Use whichever is later: buffer expiry time or working day start
-      const startTime =
-        bufferExpiryTime > workingDayStart ? bufferExpiryTime : workingDayStart;
-
-      // If start time is beyond this working day's end, find next working day for end time
-      let endTime = workingDayEnd;
-      if (startTime >= workingDayEnd) {
-        // Find working hours for the start time's date
-        const startDateString = format(startTime, "yyyy-MM-dd");
-        const startDayOfWeek = startTime.getDay().toString();
-
-        // Check for override on start date
-        const startDayOverride = workingHours.overrides.find(
-          (override) => getOverrideDateKey(override.date) === startDateString
-        );
-
-        let startDaySchedule: DaySchedule | null = null;
-        if (startDayOverride) {
-          startDaySchedule = {
-            isOpen: startDayOverride.isOpen,
-            openTime: startDayOverride.openTime || undefined,
-            closeTime: startDayOverride.closeTime || undefined,
-          };
-        } else {
-          startDaySchedule =
-            workingHours.weeklySchedule[startDayOfWeek] || null;
-        }
-
-        if (startDaySchedule?.isOpen && startDaySchedule.closeTime) {
-          const [startDayCloseHours, startDayCloseMinutes] =
-            startDaySchedule.closeTime.split(":").map(Number);
-          endTime = new Date(startTime);
-          endTime.setHours(startDayCloseHours, startDayCloseMinutes, 0, 0);
-        } else {
-          // Fallback to 6 PM on start date
-          endTime = new Date(startTime);
-          endTime.setHours(18, 0, 0, 0);
-        }
-      }
-
-      return { startTime, endTime };
+    // If start time is beyond this working day's end, close on the start day
+    let endTime = workingDayEnd;
+    if (startTime >= workingDayEnd) {
+      const startDaySchedule = resolveDaySchedule(startTime, workingHours);
+      endTime =
+        startDaySchedule?.isOpen && startDaySchedule.closeTime
+          ? atWallClock(startTime, startDaySchedule.closeTime)
+          : // Fallback to 6 PM on start date
+            atWallClock(startTime, "18:00");
     }
+
+    return { startTime: startTime.toJSDate(), endTime: endTime.toJSDate() };
   }
 
   // Fallback: if no working day found, just use tomorrow 9 AM - 6 PM
-  const fallbackStart = new Date(currentDate);
-  fallbackStart.setDate(fallbackStart.getDate() + 1);
-  fallbackStart.setHours(9, 0, 0, 0);
-
-  const fallbackEnd = new Date(currentDate);
-  fallbackEnd.setDate(fallbackEnd.getDate() + 1);
-  fallbackEnd.setHours(18, 0, 0, 0);
+  const tomorrow = now.plus({ days: 1 });
+  const fallbackStart = atWallClock(tomorrow, "09:00");
+  const fallbackEnd = atWallClock(tomorrow, "18:00");
 
   // Use whichever is later: buffer expiry time or fallback start
   const finalStartTime =
-    bufferExpiryTime > fallbackStart ? bufferExpiryTime : fallbackStart;
+    bufferExpiry > fallbackStart ? bufferExpiry : fallbackStart;
 
   // If start time is beyond fallback end, set end to start day's 6 PM
-  let finalEndTime = fallbackEnd;
-  if (finalStartTime >= fallbackEnd) {
-    finalEndTime = new Date(finalStartTime);
-    finalEndTime.setHours(18, 0, 0, 0);
-  }
+  const finalEndTime =
+    finalStartTime >= fallbackEnd
+      ? atWallClock(finalStartTime, "18:00")
+      : fallbackEnd;
 
-  return { startTime: finalStartTime, endTime: finalEndTime };
+  return {
+    startTime: finalStartTime.toJSDate(),
+    endTime: finalEndTime.toJSDate(),
+  };
 }
 
 interface DefaultTimesResult {
@@ -265,55 +273,48 @@ interface DefaultTimesResult {
  *
  * For ADMIN/OWNER users, buffer time restrictions are automatically bypassed (effective buffer = 0).
  *
+ * Every calendar-day and wall-clock decision here is made in the acting user's
+ * PREFERENCE zone, which is the zone the form field displays and the server
+ * parses in. Computing them on the device clock made the default wrong by the
+ * offset between the two — and, when they straddled midnight, selected another
+ * day's working hours entirely.
+ *
  * @param workingHoursData - The working hours data containing weekly schedules and overrides.
  * @param bufferStartTime - Buffer time in hours from current time. Bypassed for admin/owner users.
  * @param isAdminOrOwner - Whether the user is an ADMIN or OWNER (bypasses buffer time restrictions).
+ * @param prefs - The acting user's resolved format prefs. Typed as
+ *   {@link ResolvedFormatPrefs} rather than a bare zone string so a browser-hint
+ *   object (`{ locale, timeZone }`) cannot satisfy it — the device zone is
+ *   exactly the wrong answer here, and that mistake is what this fixes.
  * @returns An object containing the start and end dates formatted for date input values.
  */
 export function getBookingDefaultStartEndTimes(
   workingHoursData: WorkingHoursData | null | undefined,
   bufferStartTime: number,
-  isAdminOrOwner: boolean
+  isAdminOrOwner: boolean,
+  prefs: ResolvedFormatPrefs
 ): DefaultTimesResult {
-  const now = new Date();
+  const { timeZone } = prefs;
+  const nowInstant = new Date();
+  const now = DateTime.fromJSDate(nowInstant).setZone(timeZone);
 
   // Admin/Owner users bypass buffer time restrictions
   const effectiveBufferStartTime = isAdminOrOwner ? 0 : bufferStartTime;
 
   // If no working hours data or working hours are disabled, use the original logic
   if (!workingHoursData || !workingHoursData.enabled) {
-    return getOriginalDefaultTimes(now, effectiveBufferStartTime);
+    return getOriginalDefaultTimes(
+      nowInstant,
+      effectiveBufferStartTime,
+      timeZone
+    );
   }
 
-  // Get today's date and schedule using the runtime's local calendar day so
-  // the match aligns with how the user picks times in the booking form.
-  const todayDateString = format(now, "yyyy-MM-dd");
-  const todayDayOfWeek = now.getDay().toString();
+  const todaySchedule = resolveDaySchedule(now, workingHoursData);
 
-  // Check for date-specific override first
-  const todayOverride = workingHoursData.overrides.find(
-    (override) => getOverrideDateKey(override.date) === todayDateString
-  );
-
-  let todaySchedule: DaySchedule | null = null;
-
-  if (todayOverride) {
-    // Use override schedule
-    todaySchedule = {
-      isOpen: todayOverride.isOpen,
-      openTime: todayOverride.openTime || undefined,
-      closeTime: todayOverride.closeTime || undefined,
-    };
-  } else {
-    // Use regular weekly schedule
-    todaySchedule = workingHoursData.weeklySchedule[todayDayOfWeek] || null;
-  }
-
-  // Current time as HH:MM string for comparison
-  const currentTimeString = `${now.getHours().toString().padStart(2, "0")}:${now
-    .getMinutes()
-    .toString()
-    .padStart(2, "0")}`;
+  // Current time as HH:MM in the preference zone, for comparison against the
+  // org's window (which is itself expressed as a wall clock).
+  const currentTimeString = now.toFormat("HH:mm");
 
   // Check if we're currently in working hours
   const isCurrentlyInWorkingHours =
@@ -325,101 +326,100 @@ export function getBookingDefaultStartEndTimes(
 
   if (isCurrentlyInWorkingHours && todaySchedule.closeTime) {
     // We're in working hours - use whichever is later: buffer expiry or 10 minutes from now
-    let earliestStartTime: Date;
+    const earliestStartTime = (
+      effectiveBufferStartTime > 0
+        ? now.plus({ hours: effectiveBufferStartTime })
+        : now.plus({ minutes: 10 })
+    ).set({ second: 0, millisecond: 0 });
 
-    if (effectiveBufferStartTime > 0) {
-      // Use buffer time from current time
-      earliestStartTime = addHours(now, effectiveBufferStartTime);
-    } else {
-      // Use original 10-minute logic when buffer is 0
-      earliestStartTime = new Date(now);
-      earliestStartTime.setMinutes(now.getMinutes() + 10, 0);
-    }
-
-    // Remove seconds and milliseconds
-    earliestStartTime.setSeconds(0, 0);
-
-    const [closeHours, closeMinutes] = todaySchedule.closeTime
-      .split(":")
-      .map(Number);
-    const endDateTime = new Date(now);
-    endDateTime.setHours(closeHours, closeMinutes, 0, 0);
+    const endDateTime = atWallClock(now, todaySchedule.closeTime);
 
     // If start time is beyond today's close time, find next working day
     if (earliestStartTime >= endDateTime) {
       const nextWorkingDay = findNextWorkingDay(
-        earliestStartTime,
+        earliestStartTime.toJSDate(),
         workingHoursData,
-        0
+        0,
+        timeZone
       );
       return {
-        startDate: dateForDateTimeInputValue(nextWorkingDay.startTime),
-        endDate: dateForDateTimeInputValue(nextWorkingDay.endTime),
+        startDate: dateForDateTimeInputValue(
+          nextWorkingDay.startTime,
+          timeZone
+        ),
+        endDate: dateForDateTimeInputValue(nextWorkingDay.endTime, timeZone),
       };
     }
 
     return {
-      startDate: dateForDateTimeInputValue(earliestStartTime),
-      endDate: dateForDateTimeInputValue(endDateTime),
+      startDate: dateForDateTimeInputValue(
+        earliestStartTime.toJSDate(),
+        timeZone
+      ),
+      endDate: dateForDateTimeInputValue(endDateTime.toJSDate(), timeZone),
     };
   } else {
     // We're outside working hours - find the next working day
     const nextWorkingDay = findNextWorkingDay(
-      now,
+      nowInstant,
       workingHoursData,
-      effectiveBufferStartTime
+      effectiveBufferStartTime,
+      timeZone
     );
 
     return {
-      startDate: dateForDateTimeInputValue(nextWorkingDay.startTime),
-      endDate: dateForDateTimeInputValue(nextWorkingDay.endTime),
+      startDate: dateForDateTimeInputValue(nextWorkingDay.startTime, timeZone),
+      endDate: dateForDateTimeInputValue(nextWorkingDay.endTime, timeZone),
     };
   }
 }
 
+/**
+ * Defaults for orgs with working hours disabled: start shortly from now, end at
+ * 6 PM. Like its working-hours sibling, "6 PM" and "next day" are read in
+ * `timeZone`, not on the device clock.
+ *
+ * @param nowInstant - Current instant.
+ * @param bufferStartTime - Buffer in hours; 0 uses the 10-minute rule.
+ * @param timeZone - IANA zone that defines the wall clock and calendar day.
+ * @returns Start/end formatted for a datetime-local input.
+ */
 function getOriginalDefaultTimes(
-  now: Date,
-  bufferStartTime: number
+  nowInstant: Date,
+  bufferStartTime: number,
+  timeZone: string
 ): DefaultTimesResult {
+  const now = DateTime.fromJSDate(nowInstant).setZone(timeZone);
+
   // Original logic for backward compatibility with buffer support
-  let startDateTime: Date;
+  const startDateTime = (
+    bufferStartTime > 0
+      ? now.plus({ hours: bufferStartTime })
+      : // Use original 10-minute logic when buffer is 0
+        now.plus({ minutes: 10 })
+  ).set({ second: 0, millisecond: 0 });
 
-  if (bufferStartTime > 0) {
-    // Use buffer time from current time
-    startDateTime = addHours(now, bufferStartTime);
-  } else {
-    // Use original 10-minute logic when buffer is 0
-    startDateTime = new Date(now);
-    startDateTime.setMinutes(now.getMinutes() + 10, 0);
-  }
-
-  // Remove seconds and milliseconds
-  startDateTime.setSeconds(0, 0);
-
-  const startDate = dateForDateTimeInputValue(startDateTime);
-
-  let endDate: string;
+  const startDate = dateForDateTimeInputValue(
+    startDateTime.toJSDate(),
+    timeZone
+  );
 
   // Use the start time for end date logic, not the original current time
-  const referenceTime = startDateTime;
+  const isAtOrNearSixPm =
+    startDateTime.hour >= 18 ||
+    (startDateTime.hour === 17 && startDateTime.minute > 49);
 
-  if (
-    referenceTime.getHours() >= 18 ||
-    (referenceTime.getHours() === 17 && referenceTime.getMinutes() > 49)
-  ) {
-    // If start time is after 6 PM (or close to it), set end to 6 PM next day
-    const endDateTime = new Date(referenceTime);
-    endDateTime.setDate(endDateTime.getDate() + 1);
-    endDateTime.setHours(18, 0, 0, 0);
-    endDate = dateForDateTimeInputValue(endDateTime);
-  } else {
-    // If start time is before 6 PM, set end to 6 PM same day
-    const endDateTime = new Date(referenceTime);
-    endDateTime.setHours(18, 0, 0, 0);
-    endDate = dateForDateTimeInputValue(endDateTime);
-  }
+  // After 6 PM (or close to it) the booking runs to 6 PM the NEXT day;
+  // otherwise it ends at 6 PM the same day.
+  const endDateTime = atWallClock(
+    isAtOrNearSixPm ? startDateTime.plus({ days: 1 }) : startDateTime,
+    "18:00"
+  );
 
-  return { startDate, endDate };
+  return {
+    startDate,
+    endDate: dateForDateTimeInputValue(endDateTime.toJSDate(), timeZone),
+  };
 }
 
 /**

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.duplicate.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.duplicate.tsx
@@ -252,7 +252,8 @@ export default function DuplicateBooking() {
     getBookingDefaultStartEndTimes(
       workingHours,
       bookingSettings.bufferStartTime,
-      isAdministratorOrOwner
+      isAdministratorOrOwner,
+      prefs
     );
 
   const [startDate, setStartDate] = useState(defaultStartDate);

--- a/apps/webapp/app/routes/api+/mobile+/asset.add-note.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.add-note.ts
@@ -6,6 +6,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { createNote } from "~/modules/note/service.server";
 import { NOTE_MAX_CONTENT_LENGTH } from "~/utils/constants";
 import { makeShelfError } from "~/utils/error";
@@ -32,13 +33,14 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.update,
     });
 
-    const body = await request.json();
-    const { assetId, content } = z
-      .object({
+    const { assetId, content } = await parseMobileBody(
+      z.object({
         assetId: z.string().min(1),
         content: z.string().min(1).max(NOTE_MAX_CONTENT_LENGTH),
-      })
-      .parse(body);
+      }),
+      request,
+      "Assets"
+    );
 
     // Verify asset exists and belongs to the organization
     const asset = await db.asset.findUnique({

--- a/apps/webapp/app/routes/api+/mobile+/asset.create.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.create.ts
@@ -25,6 +25,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { buildMobileCustomFieldPayload } from "~/modules/api/mobile-custom-fields.server";
 import { createAsset } from "~/modules/asset/service.server";
 import { getInitialPlacementNoteContent } from "~/modules/asset/utils.server";
@@ -79,7 +80,6 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.create,
     });
 
-    const body = await request.json();
     const {
       title,
       description,
@@ -89,8 +89,8 @@ export async function action({ request }: ActionFunctionArgs) {
       valuation,
       customFields,
       qrId,
-    } = z
-      .object({
+    } = await parseMobileBody(
+      z.object({
         title: z.string().min(2, "Title must be at least 2 characters"),
         description: z.string().optional(),
         categoryId: z.string().optional(),
@@ -108,8 +108,10 @@ export async function action({ request }: ActionFunctionArgs) {
           )
           .optional(),
         qrId: z.string().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Assets"
+    );
 
     // why: a categoryId from the request body is attacker-controlled. Without
     // verifying it belongs to the caller's organization we'd happily use it to

--- a/apps/webapp/app/routes/api+/mobile+/asset.delete.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.delete.ts
@@ -5,6 +5,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { deleteAsset } from "~/modules/asset/service.server";
 import { makeShelfError } from "~/utils/error";
 import {
@@ -33,12 +34,13 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.delete,
     });
 
-    const body = await request.json();
-    const { assetId } = z
-      .object({
+    const { assetId } = await parseMobileBody(
+      z.object({
         assetId: z.string().min(1, "Asset ID is required"),
-      })
-      .parse(body);
+      }),
+      request,
+      "Assets"
+    );
 
     // why: passing actorUserId so the ASSET_DELETED event is attributed to
     // the mobile user instead of recording as a system-initiated delete.

--- a/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
@@ -7,6 +7,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { getPrimaryLocation, isQuantityTracked } from "~/modules/asset/utils";
 import { lockAssetForQuantityUpdate } from "~/modules/consumption-log/quantity-lock.server";
 import { createNote } from "~/modules/note/service.server";
@@ -35,13 +36,14 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.update,
     });
 
-    const body = await request.json();
-    const { assetId, locationId } = z
-      .object({
+    const { assetId, locationId } = await parseMobileBody(
+      z.object({
         assetId: z.string().min(1),
         locationId: z.string().min(1),
-      })
-      .parse(body);
+      }),
+      request,
+      "Assets"
+    );
 
     // Verify asset exists and belongs to org
     const asset = await db.asset.findUnique({

--- a/apps/webapp/app/routes/api+/mobile+/asset.update.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update.ts
@@ -33,6 +33,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import {
   UNCATEGORIZED_SENTINEL,
   buildMobileCustomFieldPayload,
@@ -86,7 +87,6 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.update,
     });
 
-    const body = await request.json();
     const {
       assetId,
       title,
@@ -97,8 +97,8 @@ export async function action({ request }: ActionFunctionArgs) {
       tags,
       valuation,
       customFields,
-    } = z
-      .object({
+    } = await parseMobileBody(
+      z.object({
         assetId: z.string().min(1, "Asset ID is required"),
         title: z
           .string()
@@ -120,8 +120,10 @@ export async function action({ request }: ActionFunctionArgs) {
             })
           )
           .optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Assets"
+    );
 
     // why: validate custom-field values against the org's active definitions.
     // Bypassing this lets a mobile client smuggle arbitrary JSON (or values

--- a/apps/webapp/app/routes/api+/mobile+/audits.complete.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.complete.ts
@@ -6,6 +6,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import {
   completeAuditSession,
   requireAuditAssignee,
@@ -63,14 +64,15 @@ export async function action({ request }: ActionFunctionArgs) {
     }
     const isSelfServiceOrBase = role === "SELF_SERVICE" || role === "BASE";
 
-    const body = await request.json();
-    const { sessionId, completionNote, timeZone } = z
-      .object({
+    const { sessionId, completionNote, timeZone } = await parseMobileBody(
+      z.object({
         sessionId: z.string().min(1),
         completionNote: z.string().optional(),
         timeZone: z.string().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Audit"
+    );
 
     // Assignee-gated (matches webapp behavior): ADMIN/OWNER may complete any
     // audit, BASE/SELF_SERVICE only when assigned.

--- a/apps/webapp/app/routes/api+/mobile+/audits.record-scan.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.record-scan.ts
@@ -6,6 +6,7 @@ import {
   requireOrganizationAccess,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import {
   recordAuditScan,
   requireAuditAssignee,
@@ -60,9 +61,8 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.update,
     });
 
-    const body = await request.json();
-    const { auditSessionId, qrId, assetId } = z
-      .object({
+    const { auditSessionId, qrId, assetId } = await parseMobileBody(
+      z.object({
         auditSessionId: z.string().min(1),
         qrId: z.string().min(1),
         assetId: z.string().min(1),
@@ -71,8 +71,10 @@ export async function action({ request }: ActionFunctionArgs) {
         // own AuditAsset row. A device queues scans offline, so its cached
         // expected list can be hours out of date by the time they land.
         isExpected: z.boolean().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Audit"
+    );
 
     // Scanning writes audit data, so it is gated exactly like note, photo and
     // complete: ADMIN/OWNER act on any audit, BASE/SELF_SERVICE must be

--- a/apps/webapp/app/routes/api+/mobile+/bookings.add-scanned-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.add-scanned-assets.ts
@@ -9,6 +9,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { addScannedAssetsToBooking } from "~/modules/booking/service.server";
 import { canUserManageBookingAssets } from "~/utils/bookings";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -67,8 +68,10 @@ export async function action({ request }: ActionFunctionArgs) {
     // bypassing the entitlement the web enforces.
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId, assetIds, kitIds } = BodySchema.parse(
-      await request.json()
+    const { bookingId, assetIds, kitIds } = await parseMobileBody(
+      BodySchema,
+      request,
+      "Booking"
     );
 
     // Org-scoped booking lookup — a foreign-org booking id 404s here.

--- a/apps/webapp/app/routes/api+/mobile+/bookings.archive.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.archive.ts
@@ -8,6 +8,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { archiveBooking } from "~/modules/booking/service.server";
 import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
@@ -59,7 +60,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId } = BodySchema.parse(await request.json());
+    const { bookingId } = await parseMobileBody(BodySchema, request, "Booking");
 
     const { role } = await getMobileUserContext(user.id, organizationId);
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.cancel.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.cancel.ts
@@ -8,6 +8,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { cancelBooking } from "~/modules/booking/service.server";
 import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
@@ -66,8 +67,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId, cancellationReason } = BodySchema.parse(
-      await request.json()
+    const { bookingId, cancellationReason } = await parseMobileBody(
+      BodySchema,
+      request,
+      "Booking"
     );
 
     const { role } = await getMobileUserContext(user.id, organizationId);

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkin.ts
@@ -9,6 +9,7 @@ import {
   assertMobileCanUseBookings,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { checkinBooking } from "~/modules/booking/service.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
 import {
@@ -70,13 +71,14 @@ export async function action({ request }: ActionFunctionArgs) {
       });
     }
 
-    const body = await request.json();
-    const { bookingId, timeZone } = z
-      .object({
+    const { bookingId, timeZone } = await parseMobileBody(
+      z.object({
         bookingId: z.string().min(1),
         timeZone: z.string().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Booking"
+    );
 
     // Derive hints the standard way: locale from the request's Accept-Language
     // header and timeZone from the CH-time-zone cookie (UTC fallback). Native

--- a/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.checkout.ts
@@ -8,6 +8,7 @@ import {
   requireOrganizationAccess,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { checkoutBooking } from "~/modules/booking/service.server";
 import {
   resolveMostPrivilegedRole,
@@ -45,13 +46,14 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const body = await request.json();
-    const { bookingId, timeZone } = z
-      .object({
+    const { bookingId, timeZone } = await parseMobileBody(
+      z.object({
         bookingId: z.string().min(1),
         timeZone: z.string().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Booking"
+    );
 
     // Load the booking's reservation window so checkoutBooking can run its
     // asset-conflict guard. That guard is gated on `from && to`; without these

--- a/apps/webapp/app/routes/api+/mobile+/bookings.delete.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.delete.ts
@@ -9,6 +9,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { deleteBooking } from "~/modules/booking/service.server";
 import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { getClientHint } from "~/utils/client-hints";
@@ -61,7 +62,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId } = BodySchema.parse(await request.json());
+    const { bookingId } = await parseMobileBody(BodySchema, request, "Booking");
 
     const { role } = await getMobileUserContext(user.id, organizationId);
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.duplicate.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.duplicate.ts
@@ -9,6 +9,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { duplicateBooking } from "~/modules/booking/service.server";
 import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -63,7 +64,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId } = BodySchema.parse(await request.json());
+    const { bookingId } = await parseMobileBody(BodySchema, request, "Booking");
 
     const { role } = await getMobileUserContext(user.id, organizationId);
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.fulfil-and-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.fulfil-and-checkout.ts
@@ -8,6 +8,7 @@ import {
   assertMobileCanUseBookings,
   getMobileUserContext,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { fulfilModelRequestsAndCheckout } from "~/modules/booking/service.server";
 import {
   resolveMostPrivilegedRole,
@@ -68,15 +69,16 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const body = await request.json();
-    const { bookingId, assetIds, kitIds, timeZone } = z
-      .object({
+    const { bookingId, assetIds, kitIds, timeZone } = await parseMobileBody(
+      z.object({
         bookingId: z.string().min(1),
         assetIds: z.array(z.string()).default([]),
         kitIds: z.array(z.string()).optional().default([]),
         timeZone: z.string().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Booking"
+    );
 
     // Load the booking's reservation window so the service can run its
     // asset-conflict guard (gated on `from && to`, exactly as the plain

--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkin.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkin.ts
@@ -9,6 +9,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { partialCheckinBooking } from "~/modules/booking/service.server";
 import { canUserManageBookingAssets } from "~/utils/bookings";
 import { getClientHint, type ClientHint } from "~/utils/client-hints";
@@ -50,9 +51,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const body = await request.json();
-    const { bookingId, assetIds, checkins, timeZone } = z
-      .object({
+    const { bookingId, assetIds, checkins, timeZone } = await parseMobileBody(
+      z.object({
         bookingId: z.string().min(1),
         // Legacy / INDIVIDUAL: bare asset ids. For a QUANTITY_TRACKED asset a
         // bare id still means "check in all remaining" (simple case); explicit
@@ -76,8 +76,10 @@ export async function action({ request }: ActionFunctionArgs) {
           )
           .optional(),
         timeZone: z.string().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Booking"
+    );
 
     // Org-scoped booking lookup — a foreign-org booking id 404s here.
     const booking = await db.booking.findFirst({

--- a/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.partial-checkout.ts
@@ -8,6 +8,7 @@ import {
   requireOrganizationAccess,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { partialCheckoutBooking } from "~/modules/booking/service.server";
 import {
   resolveMostPrivilegedRole,
@@ -54,9 +55,8 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const body = await request.json();
-    const { bookingId, assetIds, checkouts, timeZone } = z
-      .object({
+    const { bookingId, assetIds, checkouts, timeZone } = await parseMobileBody(
+      z.object({
         bookingId: z.string().min(1),
         // Optional: a QT-only check-out sends its quantities in `checkouts` with
         // an empty `assetIds`. INDIVIDUAL rows still flow through `assetIds`. The
@@ -80,8 +80,10 @@ export async function action({ request }: ActionFunctionArgs) {
           )
           .optional(),
         timeZone: z.string().optional(),
-      })
-      .parse(body);
+      }),
+      request,
+      "Booking"
+    );
 
     // Derive hints the standard way: locale from the request's Accept-Language
     // header and timeZone from the CH-time-zone cookie (UTC fallback). Native

--- a/apps/webapp/app/routes/api+/mobile+/bookings.remove-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.remove-assets.ts
@@ -9,6 +9,7 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { removeAssets } from "~/modules/booking/service.server";
 import { canSeeBooking } from "~/utils/booking-authorization.server";
 import { canUserRemoveBookingAssets } from "~/utils/bookings";
@@ -75,8 +76,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
     await assertMobileCanUseBookings(organizationId);
 
-    const { bookingId, assetIds, kitIds } = BodySchema.parse(
-      await request.json()
+    const { bookingId, assetIds, kitIds } = await parseMobileBody(
+      BodySchema,
+      request,
+      "Booking"
     );
 
     // Org-scoped booking lookup — a foreign-org booking id 404s here.

--- a/apps/webapp/app/routes/api+/mobile+/custody.release.ts
+++ b/apps/webapp/app/routes/api+/mobile+/custody.release.ts
@@ -7,6 +7,7 @@ import {
   requireMobilePermission,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import { releaseCustody } from "~/modules/custody/service.server";
 import { createNote } from "~/modules/note/service.server";
@@ -39,12 +40,13 @@ export async function action({ request }: ActionFunctionArgs) {
     // self-restriction (only release custody of assets assigned to themselves).
     const { role } = await getMobileUserContext(user.id, organizationId);
 
-    const body = await request.json();
-    const { assetId } = z
-      .object({
+    const { assetId } = await parseMobileBody(
+      z.object({
         assetId: z.string().min(1),
-      })
-      .parse(body);
+      }),
+      request,
+      "Assets"
+    );
 
     // why: `releaseCustody` is INDIVIDUAL-only — its `deleteMany` releases
     // EVERY custodian on the asset, which for a QUANTITY_TRACKED asset means

--- a/apps/webapp/app/utils/date-fns.test.ts
+++ b/apps/webapp/app/utils/date-fns.test.ts
@@ -1,6 +1,60 @@
 import { describe, expect, it } from "vitest";
 import type { ResolvedFormatPrefs } from "~/utils/date-format";
-import { getWeekStartingAndEndingDates } from "./date-fns";
+import {
+  dateForDateTimeInputValue,
+  getWeekStartingAndEndingDates,
+} from "./date-fns";
+
+/**
+ * Guard: a datetime-local seed must be rendered in the zone the field is
+ * displayed and submitted in — the user's resolved preference zone.
+ *
+ * This used to convert with `getTimezoneOffset()`, i.e. the DEVICE zone, so a
+ * user whose preference differed from their device was seeded a wall-clock off
+ * by the difference between the two. These cases pass one fixed instant through
+ * several zones, so they assert the parameter actually drives the output and
+ * cannot pass by accident on a particular machine.
+ */
+describe("dateForDateTimeInputValue", () => {
+  // 2026-08-19T12:49:00Z — a single unambiguous instant.
+  const instant = new Date("2026-08-19T12:49:00.000Z");
+
+  it("renders the wall-clock of the given zone", () => {
+    expect(dateForDateTimeInputValue(instant, "UTC")).toBe(
+      "2026-08-19T12:49:00"
+    );
+    // PDT is UTC-7 in August.
+    expect(dateForDateTimeInputValue(instant, "America/Los_Angeles")).toBe(
+      "2026-08-19T05:49:00"
+    );
+    // JST is UTC+9, no DST.
+    expect(dateForDateTimeInputValue(instant, "Asia/Tokyo")).toBe(
+      "2026-08-19T21:49:00"
+    );
+  });
+
+  it("rolls the calendar date when the zone crosses midnight", () => {
+    // 23:30Z is still the 19th in UTC but already the 20th in Tokyo.
+    const lateEvening = new Date("2026-08-19T23:30:00.000Z");
+
+    expect(dateForDateTimeInputValue(lateEvening, "UTC")).toBe(
+      "2026-08-19T23:30:00"
+    );
+    expect(dateForDateTimeInputValue(lateEvening, "Asia/Tokyo")).toBe(
+      "2026-08-20T08:30:00"
+    );
+  });
+
+  it("emits the padded shape the DateTimePicker expects", () => {
+    // Single-digit month/day/hour must be zero-padded, or the picker's
+    // normalisation and the server's DATE_TIME_FORMAT parse both reject it.
+    const earlyJanuary = new Date("2026-01-05T09:07:00.000Z");
+
+    expect(dateForDateTimeInputValue(earlyJanuary, "UTC")).toBe(
+      "2026-01-05T09:07:00"
+    );
+  });
+});
 
 /**
  * Guard: the calendar week-range subtitle must render its endpoints through

--- a/apps/webapp/app/utils/date-fns.ts
+++ b/apps/webapp/app/utils/date-fns.ts
@@ -1,5 +1,6 @@
 import { format, formatISO, parseISO } from "date-fns";
 import { fromZonedTime, toZonedTime } from "date-fns-tz";
+import { DateTime } from "luxon";
 import { formatDate, type ResolvedFormatPrefs } from "~/utils/date-format";
 
 export function getDifferenceInSeconds(
@@ -13,13 +14,23 @@ export function getDifferenceInSeconds(
   return secondsDifference;
 }
 
-/** Prepares a date to be passed as default value for input with type `datetime-local` */
-export const dateForDateTimeInputValue = (date: Date) => {
-  const localDate = new Date(
-    date.getTime() - date.getTimezoneOffset() * 60 * 1000
-  );
-  return localDate.toISOString().slice(0, 19);
-};
+/**
+ * Renders an instant as the wall-clock wire string a datetime-local input takes.
+ *
+ * `timeZone` is REQUIRED and must be the acting user's RESOLVED preference zone
+ * — the same zone the field displays in and the server parses submissions in.
+ * This previously converted with `getTimezoneOffset()`, i.e. the DEVICE zone, so
+ * any user whose preference differed from their device got a seed offset by the
+ * difference between the two. Making the parameter required turns that mistake
+ * into a compile error rather than a silently wrong default.
+ *
+ * @param date - The instant to render.
+ * @param timeZone - IANA zone the wall clock should be read in.
+ * @returns `YYYY-MM-DDTHH:mm:ss` in `timeZone`. The shared `DateTimePicker`
+ *   normalises this to the minute-precision `DATE_TIME_FORMAT` on submit.
+ */
+export const dateForDateTimeInputValue = (date: Date, timeZone: string) =>
+  DateTime.fromJSDate(date).setZone(timeZone).toFormat("yyyy-MM-dd'T'HH:mm:ss");
 
 export function calcTimeDifference(
   date1: Date,

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.update.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.update.test.ts
@@ -395,13 +395,15 @@ describe("POST /api/mobile/asset/update", () => {
       const result = await action(createActionArgs({ request }));
 
       expect(result instanceof Response).toBe(true);
-      // Zod parse throws ZodError → caught by the route → makeShelfError
-      // wraps it. The mock at the top of this file (`vi.mock` for
-      // ~/utils/error) doesn't extract a status from ZodError, so the
-      // fallback `cause?.status || 500` returns 500. Assert that exact
-      // status — looser checks (e.g. `!= 200`) accept 401/403 and miss
-      // a future regression where auth fails before validation.
-      expect((result as unknown as Response).status).toBe(500);
+      // The body is validated through `parseMobileBody`, which converts the
+      // ZodError into a ShelfError carrying status 400 and
+      // `shouldBeCaptured: false`. This previously asserted 500 — a bare
+      // `schema.parse()` threw a ZodError that `makeShelfError` did not
+      // recognise, so a malformed client payload became a server error and a
+      // Sentry capture. Assert the exact status: looser checks (e.g. `!= 200`)
+      // accept 401/403 and would miss a regression where auth fails before
+      // validation.
+      expect((result as unknown as Response).status).toBe(400);
       expect(updateAsset).not.toHaveBeenCalled();
     });
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
@@ -115,7 +115,7 @@ describe("mobile booking routes - declared timezone validation", () => {
     vi.mocked(requireMobileAuth).mockResolvedValue({
       user: { id: "user-1" },
     } as any);
-    vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1" as any);
+    vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1");
     vi.mocked(getMobileUserContext).mockResolvedValue({
       role: "ADMIN",
     } as any);
@@ -210,7 +210,7 @@ describe("mobile routes - malformed body returns 400", () => {
     vi.mocked(requireMobileAuth).mockResolvedValue({
       user: { id: "user-1" },
     } as any);
-    vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1" as any);
+    vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1");
     // `canUseAudits` gates the audit routes with a 403 BEFORE they parse the
     // body, so it has to be satisfied for these cases to reach the parse.
     vi.mocked(getMobileUserContext).mockResolvedValue({

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.timezone-validation.test.ts
@@ -1,6 +1,10 @@
+import { action as assetAddNoteAction } from "~/routes/api+/mobile+/asset.add-note";
+import { action as auditsRecordScanAction } from "~/routes/api+/mobile+/audits.record-scan";
+import { action as bookingsArchiveAction } from "~/routes/api+/mobile+/bookings.archive";
 import { action as createAction } from "~/routes/api+/mobile+/bookings.create";
 import { action as reserveAction } from "~/routes/api+/mobile+/bookings.reserve";
 import { action as updateAction } from "~/routes/api+/mobile+/bookings.update";
+import { action as custodyReleaseAction } from "~/routes/api+/mobile+/custody.release";
 import { createActionArgs } from "@mocks/remix";
 
 // @vitest-environment node
@@ -185,6 +189,62 @@ describe("mobile booking routes - declared timezone validation", () => {
         const payload = await response.json();
         expect(payload?.error?.message ?? "").not.toContain("IANA zone");
       });
+    });
+  }
+});
+
+/**
+ * The malformed-body contract, one representative route per domain.
+ *
+ * `parseMobileBody` was applied across 19 mobile routes; asserting all of them
+ * would be ceremony. What these pin is that the helper is wired at each domain's
+ * boundary and that the shared behaviour holds — an unparseable body answers 400
+ * rather than the generic 500 + Sentry capture the bare `schema.parse()` produced.
+ *
+ * `~/utils/error` is not mocked, for the same reason as the suite above: the real
+ * status is the thing under test.
+ */
+describe("mobile routes - malformed body returns 400", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireMobileAuth).mockResolvedValue({
+      user: { id: "user-1" },
+    } as any);
+    vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1" as any);
+    // `canUseAudits` gates the audit routes with a 403 BEFORE they parse the
+    // body, so it has to be satisfied for these cases to reach the parse.
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      role: "ADMIN",
+      canUseAudits: true,
+    } as any);
+  });
+
+  /** A body that is not valid JSON at all. */
+  function malformedRequest() {
+    return new Request("https://example.com/api/mobile/route", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    });
+  }
+
+  const representatives = [
+    { domain: "asset", action: assetAddNoteAction },
+    { domain: "audit", action: auditsRecordScanAction },
+    { domain: "booking", action: bookingsArchiveAction },
+    { domain: "custody", action: custodyReleaseAction },
+  ];
+
+  for (const { domain, action } of representatives) {
+    it(`${domain}: answers 400, not the generic 500`, async () => {
+      const response = (await action(
+        createActionArgs({ request: malformedRequest() })
+      )) as unknown as Response;
+
+      expect(response.status).toBe(400);
+
+      const payload = await response.json();
+      expect(payload.error.message).not.toContain("something went wrong");
     });
   }
 });


### PR DESCRIPTION
Follow-up to #2896. That PR fixed the **decode** direction — submitted wall-clocks are read in the zone they were written in. This fixes the **produce** direction, which it deliberately scoped out, plus the mobile body-parse sweep it started.

Two independent commits; they can be read separately.

---

## `c0905bdf8` — defaults in the preference zone

`getBookingDefaultStartEndTimes` built its defaults from device-local `Date` methods, but the form field displays and submits in the user's **preference** zone.

Confirmed in the browser during #2896: device UTC+3, preference `America/Los_Angeles` — the "Create booking" dialog prefilled **15:57** when preference-zone now was **05:47**. A default ~10 hours late.

**It was not only a wrong time.** Today's schedule was selected by `now.getDay()` (device weekday), and "are we open right now" compared device `HH:MM` against the org's window. When the two zones straddle midnight — `23:00Z` is Aug 20 at UTC+3 but still Aug 19 in LA — the helper anchored to the **wrong weekday**, so `findNextWorkingDay` could return a slot on a day the org is closed.

All three functions now do their calendar-day and wall-clock reasoning with Luxon in the acting user's zone, reusing the pattern `validateWorkingHours` already applies to the same schedule data. Day stepping uses `plus({ days })` so it stays DST-correct. Two shared helpers — `resolveDaySchedule` and `atWallClock` — replace the duplicated override/weekday lookup and `setHours` materialisation.

`getBookingDefaultStartEndTimes` takes `prefs: ResolvedFormatPrefs` and `dateForDateTimeInputValue` takes a required `timeZone`, so the device zone cannot be passed by accident — the same structural guard #2896 established. Every call site became a compile error until it supplied one.

### Three things found on the way

- **`findNextWorkingDay` mutated the caller's `Date` by reference** when the buffer was 0 (`bufferExpiryTime === currentDate`, then `.setSeconds()`). Luxon values are immutable, so it's gone.
- **`dates.tsx` was correct by accident.** It compared and adjusted naive wall-clock strings by round-tripping through device-local `Date` — parse and format cancelled out. Threading a zone through only one side would have broken it. It now stays in wall-clock space against a fixed reference, which also drops the `substring(0, length - 3)` seconds hack.
- **`page-content.tsx` passed dead props.** `startDate`/`endDate` went into `EditBookingForm`, which never destructures them — it derives its own from the loader in the preference zone. Removed rather than converted.

---

## `661dd1095` — malformed bodies answer 400, not 500

19 mobile routes still called `schema.parse(await request.json())` directly. A bare `ZodError` isn't recognised by `makeShelfError`, so it fell to the generic branch: **500**, `"Sorry, something went wrong."`, and `shouldBeCaptured: true` — a server error and a Sentry capture for a malformed client payload.

All 19 now route through `parseMobileBody`, which also owns the `request.json()` read so unparseable JSON stays on the 400 path. Each passes its own domain as the `label` so asset, audit and custody errors file correctly.

**19, not 21.** `audits.note.ts` and `exchange.ts` turned up in the same grep but already use `safeParse` with explicit 400 handling — `exchange.ts` even catches malformed JSON via `.catch(() => null)`. They were false positives of matching on the absence of `ZodError`.

---

## Two test findings worth a look

**The `working-hours` suite wasn't testing what it claimed.** It mocked `dateForDateTimeInputValue` with a `toISOString().slice(0,16)` stand-in — UTC, 16 chars — while production formatted device-local with seconds. It also set `process.env.TZ = "UTC"` in `beforeAll`, which V8 does not reliably honour after process start. Its nine cases agreed with production only by coincidence.

Both crutches are gone; every case now states the zone it means. Added cases for a preference zone west of UTC and for two zones straddling midnight, plus the first tests `dateForDateTimeInputValue` has ever had.

**`mobile.asset.update.test.ts` was pinning the bug.** It asserted `500` for a bad customFields value, and its own comment explained why: *"Zod parse throws ZodError → caught by the route → makeShelfError wraps it... returns 500."* It now asserts 400, with the comment rewritten to describe the contract rather than the defect.

---

## Verification

- `working-hours/utils.test.ts` passes **identically under `TZ=UTC`, `TZ=America/Chicago` and `TZ=Asia/Tokyo`** — the property the old suite could not offer.
- Full route-test tree: 88 files / 647 tests, exit 0.
- Typecheck clean across all packages.

**Still worth a browser check before merge:** with a preference zone differing from the device, the dialog should prefill ~10 minutes after *preference-zone* now. That is the one thing these tests cannot prove.

## Known, not addressed

Two `calculateBusinessHoursDuration` cases fail under `TZ=Asia/Tokyo`. Confirmed **pre-existing** by stashing this work and reproducing them on the base commit — that function has the same device-zone class and is the tracked follow-up, along with the companion's picker/display split (device-local picker, preference-zone detail view), which needs a native release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Booking date and time defaults now respect configured time zones, including working hours, buffers, daylight-saving changes, and overnight schedules.
  * Booking date fields display consistent wall-clock values across time zones.
  * Malformed mobile API requests now return clear HTTP 400 validation errors instead of generic server errors.
  * Invalid time zones in mobile booking requests are handled consistently.

* **Tests**
  * Expanded coverage for time-zone-dependent booking calculations, date formatting, working-day resolution, and mobile request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->