### PR TITLE
fix(kits): gate last-scan PII server-side on the kit detail loader

### DIFF
--- a/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.tsx
@@ -47,8 +47,7 @@ import {
 import { createNote } from "~/modules/note/service.server";
 
 import { generateQrObj } from "~/modules/qr/utils.server";
-import { getScanByQrId } from "~/modules/scan/service.server";
-import { parseScanData } from "~/modules/scan/utils.server";
+import { getLastScanForViewer } from "~/modules/scan/service.server";
 import type { RouteHandleWithName } from "~/modules/types";
 import { getUserByID } from "~/modules/user/service.server";
 import dropdownCss from "~/styles/actions-dropdown.css?url";
@@ -176,14 +175,29 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
 
     /**
      * We get the first QR code(for now we can only have 1)
-     * And using the ID of tha qr code, we find the latest scan
+     * And using the ID of tha qr code, we find the latest scan.
+     *
+     * `getLastScanForViewer` applies the `scan:read` gate SERVER-SIDE and
+     * returns null without it. The parsed scan carries the scanner's name and
+     * email, GPS coordinates and user-agent; the component renders
+     * `<ScanDetails>` behind the same check, but a client-side check only
+     * hides the data — BASE and SELF_SERVICE hold `scan: []` and were still
+     * receiving all of it in the page payload.
+     *
+     * The asset route was moved onto this helper in `109d02857`; the kit route
+     * was not, and kept calling `parseScanData` directly.
      */
-    const lastScan = kit.qrCodes[0]?.id
-      ? parseScanData({
-          scan: (await getScanByQrId({ qrId: kit.qrCodes[0].id })) || null,
-          userId,
-        })
-      : null;
+    const lastScan = await getLastScanForViewer({
+      qrId: kit.qrCodes[0]?.id,
+      userId,
+      organizationId,
+      // The caller's FULL role list, mirroring the asset route. Not the single
+      // resolved `role` from requirePermission: passing one role would hand
+      // `hasPermission` a narrower view of the membership than it has, which
+      // is the `roles[0]` trap that bit the mobile audit guards.
+      roles: userOrganizations.find((o) => o.organization.id === organizationId)
+        ?.roles,
+    });
     const currentBooking = getKitCurrentBooking({
       id: kit.id,
       assets: kit.assetKits.map((ak) => ak.asset),

--- a/apps/webapp/test/routes-tests/_layout+/kits.$kitId.last-scan.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/kits.$kitId.last-scan.test.ts
@@ -24,6 +24,15 @@
 
 import { OrganizationRoles } from "@prisma/client";
 
+// why: importing the route pulls in `db.server`, whose non-production
+// initialization calls `db.$connect()`. Without this the test attempts a real
+// PostgreSQL connection and emits an unhandled PrismaClientInitializationError
+// — which vitest reports separately from the assertions, so the suite can go
+// green while still being broken.
+vi.mock("~/database/db.server", () => ({
+  db: { $connect: vi.fn(), $transaction: vi.fn() },
+}));
+
 const { mockRequirePermission } = vi.hoisted(() => ({
   mockRequirePermission: vi.fn(),
 }));
@@ -56,6 +65,11 @@ vi.mock("~/modules/kit/service.server", () => ({
   }),
   deleteKit: vi.fn(),
   deleteKitImage: vi.fn(),
+  // why: called immediately after the scan lookup. Omitting it made the loader
+  // throw a missing-export error right past the assertions, which the removed
+  // `.catch()` then swallowed — so the tests passed without the loader ever
+  // returning a payload.
+  getKitCurrentBooking: vi.fn().mockReturnValue(null),
 }));
 // why: `generateQrObj` lives in qr/utils.server (not service.server) and runs
 // inside the same Promise.all as the kit fetch, so it reaches the DB and
@@ -96,11 +110,16 @@ describe("kit detail loader — last scan", () => {
   it("resolves the last scan through the gated helper", async () => {
     callerHolds([OrganizationRoles.BASE]);
 
-    await loader(loaderArgs()).catch(() => undefined);
+    // Awaited without a catch: if the loader throws, the test fails. A
+    // suppressed rejection here would let these assertions pass while the
+    // loader never actually completed.
+    const result = await loader(loaderArgs());
 
     // The defect was that this route called `parseScanData` directly, skipping
     // the `scan:read` gate the helper applies.
     expect(mockGetLastScanForViewer).toHaveBeenCalledTimes(1);
+    // …and the loader really did produce a payload carrying the gated value.
+    expect(result).toHaveProperty("lastScan", null);
   });
 
   it("forwards the viewer's FULL role list, not a single resolved role", async () => {
@@ -109,7 +128,7 @@ describe("kit detail loader — last scan", () => {
     // `role`, hands `hasPermission` a narrower membership than the caller has.
     callerHolds([OrganizationRoles.SELF_SERVICE, OrganizationRoles.ADMIN]);
 
-    await loader(loaderArgs()).catch(() => undefined);
+    await loader(loaderArgs());
 
     expect(mockGetLastScanForViewer).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/webapp/test/routes-tests/_layout+/kits.$kitId.last-scan.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/kits.$kitId.last-scan.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+/**
+ * Kit detail loader — last-scan PII is gated SERVER-SIDE.
+ *
+ * `parseScanData` returns the scanner's display name and EMAIL, the scan's GPS
+ * COORDINATES and the device user-agent. BASE and SELF_SERVICE hold `scan: []`,
+ * and the page hides `<ScanDetails>` behind a client-side check — which hides
+ * the data without withholding it. It was still in the page payload, readable
+ * from the network response.
+ *
+ * The asset overview loader was moved onto the gated `getLastScanForViewer` in
+ * `109d02857`; the kit loader kept calling `parseScanData` directly and was the
+ * last route doing so.
+ *
+ * This asserts the WIRING — that the loader delegates to the gated helper and
+ * forwards the viewer's full role list. The helper's own gate is pinned
+ * separately, against the live permission matrix, in
+ * `app/modules/scan/last-scan-for-viewer.test.ts`.
+ *
+ * detail.dev finding D060.
+ *
+ * @see {@link file://./../../../app/routes/_layout+/kits.$kitId.tsx}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+const { mockRequirePermission } = vi.hoisted(() => ({
+  mockRequirePermission: vi.fn(),
+}));
+// why: the RBAC gate is not under test — it must PASS, so what the loader does
+// with the scan is what the assertions are about.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: mockRequirePermission,
+}));
+
+const { mockGetLastScanForViewer } = vi.hoisted(() => ({
+  mockGetLastScanForViewer: vi.fn().mockResolvedValue(null),
+}));
+// why: the gated helper is the collaborator under test. Mocking it lets this
+// assert the loader delegates and forwards the right roles, without re-testing
+// the gate itself.
+vi.mock("~/modules/scan/service.server", () => ({
+  getLastScanForViewer: mockGetLastScanForViewer,
+  getScanByQrId: vi.fn(),
+}));
+
+// why: the loader's data fetch; irrelevant to scan gating and would need a DB.
+vi.mock("~/modules/kit/service.server", () => ({
+  getKit: vi.fn().mockResolvedValue({
+    id: "kit-1",
+    name: "Camera kit",
+    qrCodes: [{ id: "qr-1" }],
+    assetKits: [],
+    custody: null,
+    barcodes: [],
+  }),
+  deleteKit: vi.fn(),
+  deleteKitImage: vi.fn(),
+}));
+// why: `generateQrObj` lives in qr/utils.server (not service.server) and runs
+// inside the same Promise.all as the kit fetch, so it reaches the DB and
+// rejects before the loader ever gets to the scan.
+vi.mock("~/modules/qr/utils.server", () => ({
+  generateQrObj: vi.fn().mockResolvedValue({ qr: null }),
+}));
+
+import { loader } from "~/routes/_layout+/kits.$kitId";
+
+const ORG = "org-1";
+
+function loaderArgs() {
+  return {
+    request: new Request("https://app.shelf.nu/kits/kit-1"),
+    params: { kitId: "kit-1" },
+    context: { getSession: () => ({ userId: "user-1", email: "a@b.c" }) },
+  } as unknown as Parameters<typeof loader>[0];
+}
+
+/** Makes `requirePermission` report a caller holding `roles`. */
+function callerHolds(roles: OrganizationRoles[]) {
+  mockRequirePermission.mockResolvedValue({
+    organizationId: ORG,
+    currentOrganization: { id: ORG },
+    canUseBarcodes: false,
+    canSeeAllCustody: true,
+    userOrganizations: [{ organization: { id: ORG }, roles }],
+  });
+}
+
+describe("kit detail loader — last scan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetLastScanForViewer.mockResolvedValue(null);
+  });
+
+  it("resolves the last scan through the gated helper", async () => {
+    callerHolds([OrganizationRoles.BASE]);
+
+    await loader(loaderArgs()).catch(() => undefined);
+
+    // The defect was that this route called `parseScanData` directly, skipping
+    // the `scan:read` gate the helper applies.
+    expect(mockGetLastScanForViewer).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the viewer's FULL role list, not a single resolved role", async () => {
+    // `[SELF_SERVICE, ADMIN]` is the shape that has repeatedly gone wrong in
+    // this codebase: passing only `roles[0]`, or only the single resolved
+    // `role`, hands `hasPermission` a narrower membership than the caller has.
+    callerHolds([OrganizationRoles.SELF_SERVICE, OrganizationRoles.ADMIN]);
+
+    await loader(loaderArgs()).catch(() => undefined);
+
+    expect(mockGetLastScanForViewer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qrId: "qr-1",
+        userId: "user-1",
+        organizationId: ORG,
+        roles: [OrganizationRoles.SELF_SERVICE, OrganizationRoles.ADMIN],
+      })
+    );
+  });
+});


### PR DESCRIPTION
## What

The kit detail loader shipped scan PII to roles that may not read scans.

detail.dev findings **D060** (fixed) and **D037** (verified already fixed — see
below).

## D060 — last-scan PII on the kit detail page

`parseScanData` returns the scanner's display name and **email**, the scan's
**GPS coordinates** and the device user-agent.

BASE and SELF_SERVICE hold `scan: []`. The page hides `<ScanDetails>` behind a
client-side permission check — which hides the data without withholding it. It
was still in the page payload, readable straight out of the network response.

```ts
// before — no gate; the client-side check is the only thing hiding it
const lastScan = kit.qrCodes[0]?.id
  ? parseScanData({ scan: await getScanByQrId({ qrId: kit.qrCodes[0].id }), userId })
  : null;
```

### This was a known bug with an existing fix

`109d02857` introduced `getLastScanForViewer` — which applies the `scan:read`
gate **server-side** and returns `null` for an unauthorized viewer, the same
shape as "never scanned", so callers need no special case — and moved the asset
overview loader onto it.

The kit loader was not moved, and was the **last route in the codebase** still
calling `parseScanData` directly.

```ts
// after
const lastScan = await getLastScanForViewer({
  qrId: kit.qrCodes[0]?.id,
  userId,
  organizationId,
  roles: userOrganizations.find((o) => o.organization.id === organizationId)?.roles,
});
```

### On the roles argument

Passes the caller's **full role list**, derived from `userOrganizations` the way
the asset route does — deliberately not `requirePermission`'s single resolved
`role`.

Handing `hasPermission` a narrower view of a membership than the caller actually
holds is the `roles[0]` trap, which has produced real bugs here twice in the last
week (#2890, and again in the mobile audit guards on #2900). One of the tests
pins that a `[SELF_SERVICE, ADMIN]` membership is forwarded intact.

## D037 — verified, no change needed

Reported that the web asset index ships custody PII (names, emails) to users
without custody permission, while the mobile API filters it server-side.

**True at the scanned commit** (`7e139f5c`, 2026-08-06). **Fixed since**, by
unrelated work:

| | |
| --- | --- |
| `9e46ea6b4` (2026-08-11) | `redactCustodianForViewer` added, for the kits list |
| `af7ba15c4` (2026-08-12) | assets index adopted it |

It is applied in **both** simple and advanced index modes, so the finding's
premise — web exposes, mobile filters — no longer holds.

Its tracker header names a different file from its prose
(`assets.$assetId.ongoing-booking.ts`; that is the 9th mislabelled path in this
scan). Checked that too: it returns a raw, org-scoped `Booking` row carrying
custodian **ids**, no names or emails.

Recorded in the commit message as well, so the reasoning survives the PR.

## Tests

`test/routes-tests/_layout+/kits.$kitId.last-scan.test.ts` (2) — asserts the
**wiring**, because the wiring is what was missing:

- the loader delegates to the gated helper at all
- it forwards the viewer's full role list, pinned with `[SELF_SERVICE, ADMIN]`

The gate itself is already pinned against the **live permission matrix** in
`app/modules/scan/last-scan-for-viewer.test.ts`, which drives the real
`Role2PermissionMap` through the real `hasPermission` rather than restating it.
Duplicating that here would assert the mock, not the rule.

Verified: 12 scan module tests, 2 new route tests, typecheck and ESLint clean.

## Scope

Small on purpose — one finding needed a fix and the other needed verifying.
Splitting them out kept the "already fixed" reasoning attached to something
reviewable rather than dropped in a tracker nobody reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kit details now display scan information only when the viewer has the required permission.
  * Scan retrieval correctly accounts for viewers with multiple organization roles.
  * Unauthorized viewers no longer receive scan data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->