### PR TITLE
docs(working-hours): state that hours are the physical location's local time

### DIFF
--- a/.claude/rules/working-hours-are-location-local.md
+++ b/.claude/rules/working-hours-are-location-local.md
@@ -1,0 +1,52 @@
+# Working Hours Are Local To The Physical Location
+
+Working hours describe when a **physical place** is open. Both halves are
+absolute and location-local — never relative to whoever is looking:
+
+| Part                               | Meaning                   | Never                                                  |
+| ---------------------------------- | ------------------------- | ------------------------------------------------------ |
+| `weeklySchedule` times (`"09:00"`) | wall-clock **on site**    | convert through a viewer's timezone                    |
+| `WorkingHoursOverride.date`        | an absolute calendar date | format the stored UTC-midnight instant in a local zone |
+
+"Open 9–5" means 9–5 where the assets physically are. It does not become 2–10
+because the person reading it is in another country. The schema says so at
+`packages/database/prisma/schema.prisma` on `WorkingHours.weeklySchedule`:
+_"no timezone conversion … interpreted as local wall time, not UTC"_.
+
+**The dates half is already enforced.** Use `getOverrideDateKey()`
+(`~/modules/working-hours/utils`) to read an override's day — it reads from UTC,
+because the DB column is `@db.Date` and Prisma hydrates it as UTC midnight.
+Formatting that instant in a local zone shifts it a day west of UTC, which made
+a "closed on the 24th" override match bookings on the 23rd.
+
+```ts
+// ❌ Bad — UTC-midnight instant read in the viewer's zone; off by one for America/*
+const key = format(override.date, "yyyy-MM-dd");
+
+// ✅ Good
+const key = getOverrideDateKey(override.date);
+```
+
+**The times half is NOT enforced, deliberately.** `validateWorkingHours`
+(`~/components/booking/forms/forms-schema`) and `getBookingDefaultStartEndTimes`
+convert the booking instant into the **acting user's** preference zone before
+comparing `HH:mm` against the window. Strictly that contradicts the rule: a user
+in Tokyo booking an Amsterdam-located asset has Amsterdam's 9–5 judged against
+Tokyo wall time.
+
+This is an **accepted risk, decided 2026-08-20**: there is no
+`Organization.timeZone` / `WorkingHours.timeZone` to evaluate against, and in
+practice the people constrained by an org's working hours are at or near that
+location. Fixing it properly means storing the location's zone (migration +
+settings UI + backfill), which is not worth it for the ~0.1% case.
+
+So: **do not "fix" this by threading more user-zone logic through working
+hours, and do not file it as a bug.** If it ever does need solving, the answer
+is a stored location zone, not a different user-side zone. The UI states the
+semantics at the two places users meet them — the Weekly Schedule settings form
+and the booking form's working-hours info box.
+
+When you touch working-hours code, ask which half you are in: a **date** must
+stay absolute (use the helper), a **time** is on-site wall clock and needs no
+conversion at all. See [[quantity-semantics-per-surface]] for the same
+"name what this value means before reaching for a helper" discipline.

--- a/apps/webapp/app/components/booking/forms/fields/dates.tsx
+++ b/apps/webapp/app/components/booking/forms/fields/dates.tsx
@@ -276,6 +276,9 @@ export function WorkingHoursInfo({
               Special dates and holidays are also considered
             </p>
           )}
+          <p className="mt-1 text-xs text-gray-500">
+            Local hours of the physical location
+          </p>
           <div className="shrink-0">
             <WorkingHoursPreviewDialog workingHoursData={workingHoursData} />
           </div>

--- a/apps/webapp/app/components/working-hours/weekly-schedule-form.tsx
+++ b/apps/webapp/app/components/working-hours/weekly-schedule-form.tsx
@@ -168,8 +168,10 @@ export const WeeklyScheduleForm = ({
         <div className="mb-4 border-b pb-4">
           <h3 className="text-text-lg font-semibold">Weekly Schedule</h3>
           <p className="text-sm text-gray-600">
-            Set your working hours for each day of the week. Times will be
-            displayed in your local format.
+            Set your working hours for each day of the week. These are the{" "}
+            <strong>local hours of your physical location</strong> — they are
+            not converted to anyone&apos;s timezone, so 9:00 means 9:00 on site
+            for everyone.
           </p>
 
           {validationErrors.general && (

--- a/apps/webapp/app/utils/date-format.server.ts
+++ b/apps/webapp/app/utils/date-format.server.ts
@@ -104,16 +104,20 @@ export async function resolveUserFormatPrefsById(
  * passed by accident.
  *
  * ACCEPTED RISK — the declared zone is fully client-controlled, and the booking
- * schema evaluates working-hours / booking-window rules in it. A caller can
- * therefore choose a zone whose 09:00 lands on an out-of-hours instant and still
- * satisfy the org's rules. This is pre-existing behaviour on `main` (the mobile
- * routes have always validated in `body.timeZone`), confined to the caller's own
- * organization and their own permitted booking action — policy evasion, not an
- * IDOR. The durable fix is to evaluate working-hours against the ORGANIZATION's
- * zone and keep the declared zone strictly for decoding the offset-less wire
- * string; that is a product decision affecting web equally, so it is deliberately
- * deferred rather than solved here. Do not widen this helper's use without
- * revisiting it.
+ * schema evaluates working-hours rules in it. A caller can therefore choose a
+ * zone whose 09:00 lands on an out-of-hours instant and still satisfy the org's
+ * rules. Pre-existing on `main` (the mobile routes have always validated in
+ * `body.timeZone`), confined to the caller's own organization and their own
+ * permitted booking action — policy evasion, not an IDOR.
+ *
+ * Note this is the SAME gap as the one described in
+ * `.claude/rules/working-hours-are-location-local.md`, reached from the client
+ * side: working hours are the physical location's local wall clock and should
+ * not be judged against ANY user-supplied zone. The durable fix is a stored
+ * location zone, not a different user-side one. Deliberately accepted on
+ * 2026-08-20 — the people constrained by an org's hours are at that location in
+ * practice, and there is no `Organization.timeZone` to evaluate against. Read
+ * that rule before widening this helper's use.
  *
  * @param timeZone - The IANA zone the client declared, already validated by the
  *   route's Zod schema (`isValidTimeZone`). Callers MUST validate before calling.


### PR DESCRIPTION
Working hours describe when a **physical place** is open, so both the weekly times and the date overrides are absolute and location-local — never relative to whoever is looking. "Open 9–5" means 9–5 where the assets are; it does not become 2–10 because the person reading it is in another country.

The schema already says this on `WorkingHours.weeklySchedule` — *"no timezone conversion … interpreted as local wall time, not UTC"* — but nothing surfaced it to users or contributors, and it has caused confusion more than once.

## The settings copy said the opposite

> Set your working hours for each day of the week. **Times will be displayed in your local format.**

That reads as though hours are viewer-relative. Replaced with a statement that they are the location's local hours and are not converted for anyone. The booking form's working-hours info box gets the same note, since that is where the constraint is actually felt.

## The rule

`.claude/rules/working-hours-are-location-local.md` records the semantics and — more usefully — **which half is enforced and which isn't**:

- **Dates: enforced.** `getOverrideDateKey()` reads an override's day from UTC, because the column is `@db.Date` and Prisma hydrates it at UTC midnight. Formatting that instant in a local zone shifted it a day west of UTC, which made a "closed on the 24th" override match bookings on the 23rd.
- **Times: not enforced, knowingly.** `validateWorkingHours` and `getBookingDefaultStartEndTimes` compare against the acting user's preference zone, so an Amsterdam org's 9–5 is judged in Tokyo wall time for a Tokyo user.

## Why the second one is accepted rather than fixed

There is no `Organization.timeZone` / `WorkingHours.timeZone` to evaluate against, and in practice the people constrained by an org's working hours are at or near that location. Fixing it properly means storing the location's zone — migration, settings UI, backfill decision — which isn't worth it for the ~0.1% case of someone booking from another timezone.

The rule states that plainly so nobody re-files it as a bug or "fixes" it by threading more user-zone logic through working hours. If it ever does need solving, the answer is a stored location zone, **not** a different user-side zone.

Also corrects the note at `prefsForDeclaredZone` (added in #2896), which framed the same gap as a deferred product decision. It's the same rule reached from the client side, and now points at the rule file.

## Scope

Copy and documentation only — no behaviour change. Typecheck clean; 127 tests pass across the booking, working-hours and date-fns suites.

Related: #2896 (decode direction), #2905 (produce direction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that working-hour dates use the physical location’s local calendar.
  - Documented that schedule times are based on the location’s wall-clock time and are not converted to the viewer’s timezone.
  - Added guidance explaining how working hours are represented during booking.
  - Updated internal documentation regarding timezone handling and future improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->