### PR TITLE
fix(working-hours): do closed-day math in the preference zone

### DIFF
--- a/apps/webapp/app/components/booking/forms/forms-schema.ts
+++ b/apps/webapp/app/components/booking/forms/forms-schema.ts
@@ -355,7 +355,8 @@ function buildBookingDateSchemas({
         durationInHours = calculateBusinessHoursDuration(
           startDate,
           endDate,
-          workingHours
+          workingHours,
+          prefs.timeZone
         );
       } else {
         // Standard calendar hours calculation
@@ -646,7 +647,8 @@ export function ExtendBookingSchema({
           durationInHours = calculateBusinessHoursDuration(
             startDate,
             endDate,
-            workingHours
+            workingHours,
+            timeZone
           );
         } else {
           // Standard calendar hours calculation

--- a/apps/webapp/app/modules/working-hours/utils.test.ts
+++ b/apps/webapp/app/modules/working-hours/utils.test.ts
@@ -142,7 +142,8 @@ describe("calculateEffectiveEndDate", () => {
       startDate,
       endDate,
       mockWorkingHours,
-      false // skipClosedDays = false
+      false, // skipClosedDays = false
+      "UTC"
     );
 
     expect(result).toBe(endDate);
@@ -159,7 +160,8 @@ describe("calculateEffectiveEndDate", () => {
       startDate,
       endDate,
       disabledWorkingHours,
-      true // skipClosedDays = true, but working hours disabled
+      true, // skipClosedDays = true, but working hours disabled
+      "UTC"
     );
 
     expect(result).toBe(endDate);
@@ -175,7 +177,8 @@ describe("calculateEffectiveEndDate", () => {
       startDate,
       endDate,
       null, // no working hours
-      true
+      true,
+      "UTC"
     );
 
     expect(result).toBe(endDate);
@@ -191,7 +194,8 @@ describe("calculateEffectiveEndDate", () => {
       startDate,
       endDate,
       mockWorkingHours,
-      true
+      true,
+      "UTC"
     );
 
     // Should extend by 2 days (Saturday + Sunday)
@@ -226,7 +230,8 @@ describe("calculateEffectiveEndDate", () => {
       startDate,
       endDate,
       workingHoursWithOverride,
-      true
+      true,
+      "UTC"
     );
 
     // Should extend by 3 days (Saturday + Sunday + Monday holiday)
@@ -261,7 +266,8 @@ describe("calculateEffectiveEndDate", () => {
       startDate,
       endDate,
       workingHoursWithOverride,
-      true
+      true,
+      "UTC"
     );
 
     // Should extend by 1 day (only Sunday, Saturday is now open)
@@ -279,7 +285,8 @@ describe("calculateEffectiveEndDate", () => {
       startDate,
       endDate,
       mockWorkingHours,
-      true
+      true,
+      "UTC"
     );
 
     // No closed days in between, should return original
@@ -311,7 +318,8 @@ describe("calculateBusinessHoursDuration", () => {
     const result = calculateBusinessHoursDuration(
       startDate,
       endDate,
-      mockWorkingHours
+      mockWorkingHours,
+      "UTC"
     );
 
     // Total: 74 hours, Closed: 48 hours (Sat + Sun), Effective: 26 hours
@@ -327,7 +335,8 @@ describe("calculateBusinessHoursDuration", () => {
     const result = calculateBusinessHoursDuration(
       startDate,
       endDate,
-      mockWorkingHours
+      mockWorkingHours,
+      "UTC"
     );
 
     // 5 hours on an open day
@@ -343,7 +352,8 @@ describe("calculateBusinessHoursDuration", () => {
     const result = calculateBusinessHoursDuration(
       startDate,
       endDate,
-      mockWorkingHours
+      mockWorkingHours,
+      "UTC"
     );
 
     // Total: 29 hours, All closed: 29 hours, Effective: 0 hours
@@ -359,7 +369,8 @@ describe("calculateBusinessHoursDuration", () => {
     const result = calculateBusinessHoursDuration(
       startDate,
       endDate,
-      mockWorkingHours
+      mockWorkingHours,
+      "UTC"
     );
 
     // Total: 170 hours, Closed: 48 hours (1 weekend: Sat + Sun), Effective: 122 hours
@@ -392,7 +403,8 @@ describe("calculateBusinessHoursDuration", () => {
     const result = calculateBusinessHoursDuration(
       startDate,
       endDate,
-      workingHoursWithHoliday
+      workingHoursWithHoliday,
+      "UTC"
     );
 
     // Total: 98 hours, Closed: 72 hours (Sat + Sun + Mon holiday), Effective: 26 hours
@@ -409,7 +421,8 @@ describe("calculateBusinessHoursDuration", () => {
     const result = calculateBusinessHoursDuration(
       startDate,
       endDate,
-      mockWorkingHours
+      mockWorkingHours,
+      "UTC"
     );
 
     // Total: 71 hours, Closed: 48 hours (full weekend), Effective: 23 hours
@@ -773,5 +786,72 @@ describe("getOverrideDateKey", () => {
     expect(getOverrideDateKey(new Date("2026-04-24T23:30:00-05:00"))).toBe(
       "2026-04-25"
     );
+  });
+});
+
+/**
+ * Closed-day math must be done in the zone the caller supplies.
+ *
+ * Both of these walk day-by-day and ask "is this day open?", so the answer turns
+ * entirely on which calendar day an instant falls in. They previously read that
+ * off the DEVICE clock, which is what made two cases in this file fail under
+ * `TZ=Asia/Tokyo` while passing on UTC CI — green in CI, wrong in production for
+ * anyone whose device differed from their preference zone.
+ *
+ * Each case passes the SAME instants through two zones and asserts different
+ * results, so a build that ignores the zone cannot pass.
+ */
+describe("closed-day math is zone-driven", () => {
+  const weekdaysOpen: WorkingHoursData = {
+    enabled: true,
+    weeklySchedule: {
+      "0": { isOpen: false }, // Sunday
+      "1": { isOpen: true, openTime: "09:00", closeTime: "17:00" },
+      "2": { isOpen: true, openTime: "09:00", closeTime: "17:00" },
+      "3": { isOpen: true, openTime: "09:00", closeTime: "17:00" },
+      "4": { isOpen: true, openTime: "09:00", closeTime: "17:00" },
+      "5": { isOpen: true, openTime: "09:00", closeTime: "17:00" },
+      "6": { isOpen: false }, // Saturday
+    } as WeeklyScheduleJson,
+    overrides: [],
+  };
+
+  it("calculateBusinessHoursDuration attributes closed hours per zone", () => {
+    expect.assertions(2);
+
+    // 8 calendar hours spanning the UTC Friday→Saturday midnight boundary.
+    const start = new Date("2025-07-25T20:00:00Z");
+    const end = new Date("2025-07-26T04:00:00Z");
+
+    // UTC: 20:00-24:00 is Friday (open), 00:00-04:00 is Saturday (closed).
+    // 8 total - 4 closed = 4.
+    expect(calculateBusinessHoursDuration(start, end, weekdaysOpen, "UTC")).toBe(
+      4
+    );
+
+    // Asia/Tokyo (+9): the window is Sat 05:00 → Sat 13:00 local, entirely
+    // inside a closed Saturday. 8 total - 8 closed = 0.
+    expect(
+      calculateBusinessHoursDuration(start, end, weekdaysOpen, "Asia/Tokyo")
+    ).toBe(0);
+  });
+
+  it("calculateEffectiveEndDate counts closed days per zone", () => {
+    expect.assertions(2);
+
+    const start = new Date("2025-07-25T20:00:00Z");
+    const end = new Date("2025-07-27T20:00:00Z");
+
+    // UTC: the walk sees Friday (open) then Saturday (closed) → 1 closed day,
+    // so the end shifts out by one.
+    expect(
+      calculateEffectiveEndDate(start, end, weekdaysOpen, true, "UTC")
+    ).toEqual(new Date("2025-07-28T20:00:00Z"));
+
+    // Asia/Tokyo: the same instants are Sat 05:00 → Mon 05:00 local, so the
+    // walk sees Saturday AND Sunday closed → 2 closed days.
+    expect(
+      calculateEffectiveEndDate(start, end, weekdaysOpen, true, "Asia/Tokyo")
+    ).toEqual(new Date("2025-07-29T20:00:00Z"));
   });
 });

--- a/apps/webapp/app/modules/working-hours/utils.ts
+++ b/apps/webapp/app/modules/working-hours/utils.ts
@@ -1,4 +1,4 @@
-import { addDays, format, differenceInHours } from "date-fns";
+import { differenceInHours } from "date-fns";
 import { DateTime } from "luxon";
 import { dateForDateTimeInputValue } from "~/utils/date-fns";
 import type { ResolvedFormatPrefs } from "~/utils/date-format";
@@ -436,7 +436,8 @@ export function calculateEffectiveEndDate(
   startDate: Date,
   endDate: Date,
   workingHoursData: WorkingHoursData | null | undefined,
-  skipClosedDays: boolean
+  skipClosedDays: boolean,
+  timeZone: string
 ): Date {
   // If not skipping closed days or no working hours data, use original endDate
   if (!skipClosedDays || !workingHoursData?.enabled) {
@@ -444,41 +445,29 @@ export function calculateEffectiveEndDate(
   }
 
   let closedDaysCount = 0;
-  const currentDate = new Date(startDate);
-  const originalEndDate = new Date(endDate);
+  let cursor = DateTime.fromJSDate(startDate).setZone(timeZone);
+  const end = DateTime.fromJSDate(endDate).setZone(timeZone);
 
   // Count closed days between start and original end date
-  while (currentDate < originalEndDate) {
-    const dateString = format(currentDate, "yyyy-MM-dd");
-    const dayOfWeek = currentDate.getDay().toString();
+  while (cursor < end) {
+    // Which day this is, and whether it is open, are decided in `timeZone` —
+    // see the shared resolver. Reading them off a device-local Date put the
+    // count on the wrong days whenever the device and preference zones
+    // straddled midnight.
+    const isOpen =
+      resolveDaySchedule(cursor, workingHoursData)?.isOpen ?? false;
 
-    // Check for date-specific override first
-    const override = workingHoursData.overrides.find(
-      (override) => getOverrideDateKey(override.date) === dateString
-    );
-
-    let isOpen: boolean;
-
-    if (override) {
-      isOpen = override.isOpen;
-    } else {
-      const daySchedule = workingHoursData.weeklySchedule[dayOfWeek];
-      isOpen = daySchedule?.isOpen || false;
-    }
-
-    // If this day is closed, count it
     if (!isOpen) {
       closedDaysCount++;
     }
 
-    // Move to next day
-    currentDate.setTime(addDays(currentDate, 1).getTime());
+    // Move to next day. `plus({ days })` steps by calendar day in `timeZone`,
+    // so the walk stays correct across a DST boundary.
+    cursor = cursor.plus({ days: 1 });
   }
 
   // Extend the end date by the number of closed days
-  const finalEndDate = addDays(originalEndDate, closedDaysCount);
-
-  return finalEndDate;
+  return end.plus({ days: closedDaysCount }).toJSDate();
 }
 
 /**
@@ -495,51 +484,43 @@ export function calculateEffectiveEndDate(
 export function calculateBusinessHoursDuration(
   startDate: Date,
   endDate: Date,
-  workingHoursData: WorkingHoursData
+  workingHoursData: WorkingHoursData,
+  timeZone: string
 ): number {
-  // Start with total calendar hours
+  // Total calendar hours is pure instant arithmetic — no zone involved.
   const totalCalendarHours = differenceInHours(endDate, startDate);
   let closedDaysHours = 0;
 
-  const currentDate = new Date(startDate);
+  let cursor = DateTime.fromJSDate(startDate).setZone(timeZone);
+  const end = DateTime.fromJSDate(endDate).setZone(timeZone);
 
   // Process each day from start to end to count closed days
-  while (currentDate < endDate) {
-    const nextDay = addDays(currentDate, 1);
-    nextDay.setHours(0, 0, 0, 0); // Start of next day
+  while (cursor < end) {
+    // Midnight is a WALL-CLOCK boundary, so it has to be taken in `timeZone`.
+    // `setHours(0,0,0,0)` cut the day on the device clock, which sliced the
+    // window on the wrong boundary for anyone whose device differed from their
+    // preference zone — and shifted how many hours got attributed to a closed
+    // day.
+    const nextDay = cursor.plus({ days: 1 }).startOf("day");
 
-    // Get the actual time window for this day (intersection of booking with day)
-    const windowStart = currentDate;
-    const windowEnd = nextDay > endDate ? endDate : nextDay;
+    // Intersection of the booking with this day
+    const windowEnd = nextDay > end ? end : nextDay;
 
-    // Check if this day is closed
-    const dateString = format(windowStart, "yyyy-MM-dd");
-    const dayOfWeek = windowStart.getDay().toString();
-
-    // Check for date-specific override first
-    const override = workingHoursData.overrides.find(
-      (override) => getOverrideDateKey(override.date) === dateString
-    );
-
-    let isOpen: boolean;
-    if (override) {
-      isOpen = override.isOpen;
-    } else {
-      const daySchedule = workingHoursData.weeklySchedule[dayOfWeek];
-      isOpen = daySchedule?.isOpen || false;
-    }
+    const isOpen =
+      resolveDaySchedule(cursor, workingHoursData)?.isOpen ?? false;
 
     if (!isOpen) {
-      // This day is closed, subtract its hours from the total
-      const hoursInThisDay = differenceInHours(windowEnd, windowStart);
-      closedDaysHours += hoursInThisDay;
+      // This day is closed, subtract its hours from the total. Kept on
+      // `differenceInHours` so the truncation matches the calendar-hours total
+      // it is subtracted from.
+      closedDaysHours += differenceInHours(
+        windowEnd.toJSDate(),
+        cursor.toJSDate()
+      );
     }
 
-    // Move to next day
-    currentDate.setTime(nextDay.getTime());
+    cursor = nextDay;
   }
 
-  const effectiveHours = totalCalendarHours - closedDaysHours;
-
-  return effectiveHours;
+  return totalCalendarHours - closedDaysHours;
 }

--- a/apps/webapp/app/modules/working-hours/utils.ts
+++ b/apps/webapp/app/modules/working-hours/utils.ts
@@ -430,6 +430,8 @@ function getOriginalDefaultTimes(
  * @param endDate - The end date of the booking
  * @param workingHoursData - Working hours configuration with schedules and overrides
  * @param skipClosedDays - Whether to skip closed days in the calculation
+ * @param timeZone - IANA zone that decides which calendar day the walk is on.
+ *   Same contract as {@link calculateBusinessHoursDuration}.
  * @returns Effective end date for validation (or original endDate if not skipping)
  */
 export function calculateEffectiveEndDate(
@@ -479,6 +481,11 @@ export function calculateEffectiveEndDate(
  * @param startDate - The start date of the booking
  * @param endDate - The end date of the booking
  * @param workingHoursData - Working hours configuration with schedules and overrides
+ * @param timeZone - IANA zone that decides which calendar day each hour belongs
+ *   to, and where midnight falls. Pass the acting user's resolved preference
+ *   zone — see `.claude/rules/working-hours-are-location-local.md` for why that
+ *   is the accepted proxy, and why leaving it to the ambient clock is worse
+ *   (it differs between the browser and the server for the same submission).
  * @returns Calendar hours minus closed days hours
  */
 export function calculateBusinessHoursDuration(


### PR DESCRIPTION
The last device-zone leak on web, and the one `.claude/rules/working-hours-are-location-local.md` (#2907) points at.

`calculateBusinessHoursDuration` and `calculateEffectiveEndDate` walk a booking day by day asking *"is this day open?"* — but read the calendar day and weekday off the **device** clock via `format(…, "yyyy-MM-dd")` and `.getDay()`, and cut each day at `setHours(0, 0, 0, 0)`, i.e. device midnight.

`calculateBusinessHoursDuration` is **live**: it feeds max-booking-length validation when `maxBookingLengthSkipClosedDays` is enabled. So a user whose device differs from their preference zone had closed hours attributed to the wrong days and the wrong limit enforced against them.

Both now take the zone and resolve days through the shared `resolveDaySchedule`, with `startOf("day")` treating midnight as the wall-clock boundary it actually is.

## The CI blind spot this closes

Two cases in `working-hours/utils.test.ts` **failed under `TZ=Asia/Tokyo` and passed under UTC**. CI runs UTC, so the suite stayed green while the code was wrong for anyone east of it — which is exactly how this survived three prior timezone PRs.

The suite now passes identically under **UTC, Asia/Tokyo and America/Chicago**.

## Tests that can't pass by accident

Both new cases push the *same instants* through two zones and assert *different* results, so a build that ignores the zone parameter cannot satisfy them:

- 8 hours spanning UTC's Friday→Saturday midnight is **4** business hours in UTC (half lands on an open Friday) but **0** in `Asia/Tokyo`, where the whole window is a closed Saturday.
- The same span counts **1** closed day in UTC and **2** in `Asia/Tokyo`, so the extended end date differs by a day.

Verified by **mutation**, not just by passing: forcing both walks to `setZone("utc")` while keeping the parameter fails both cases. That is the check the earlier zone tests in this file lacked, per the #2905 review.

`addDays` and `format` are now unused here — the file has no device-local date arithmetic left.

## One thing to decide

`calculateEffectiveEndDate` has **no production callers**. It is exported, has 7 tests, and is used nowhere in `apps/` or `packages/`. I fixed it so the file stays coherent and its tests keep passing, rather than delete a public export unilaterally — but it is a strong candidate for removal. Happy to drop it and its tests in a follow-up commit here if you'd rather.

## Verification

- Typecheck clean across all 5 packages.
- 125 working-hours + booking tests pass under three machine zones.
- 91 route-test files / 663 tests, exit 0.

## Out of scope

The **companion** picker/display split (device-local picker, preference-zone detail view) is deliberately not here — it needs picker, display and serialisation changed together and ships on the native release train *after* a webapp deploy, so bundling it would couple two things that deploy at different times.

Completes the series: #2896 (decode) → #2905 (produce) → #2907 (the rule) → this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed booking duration calculations to respect the acting user’s selected time zone.
  - Corrected closed-day handling when bookings cross midnight or span multiple time zones.
  - Improved date calculations for extending, duplicating, and validating bookings across working-hours boundaries.
  - Ensured working-hours schedules are evaluated consistently across different local times and time-zone offsets.
  - Added coverage for time-zone-sensitive booking scenarios, including transitions across midnight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->