### PR TITLE
feat(feedback): let in-app feedback reach more than one inbox (needs 1 Fly command at merge)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,11 @@ ADMIN_EMAIL="admin@shelf.nu"
 # Email for contact the internal support.
 SUPPORT_EMAIL="support@shelf.nu"
 
+# Optional. Who receives in-app feedback (issues, ideas and error reports
+# submitted from the feedback modal). Comma separated, so several inboxes can
+# be notified. Defaults to SUPPORT_EMAIL when unset.
+# FEEDBACK_EMAIL="support@shelf.nu,product@shelf.nu"
+
 FULL_CALENDAR_LICENSE_KEY="full-calendar-license-key"
 
 # ── Companion app deep linking (iOS Universal Links / Android App Links) ──

--- a/apps/webapp/app/emails/email.worker.server.test.ts
+++ b/apps/webapp/app/emails/email.worker.server.test.ts
@@ -76,6 +76,19 @@ describe("triggerEmail", () => {
     );
   });
 
+  it("skips soft-deleted addresses whatever the domain casing", async () => {
+    vi.mocked(transporter.sendMail).mockClear();
+
+    await triggerEmail({
+      ...basePayload,
+      to: "support@shelf.nu, deleted+abc123@DELETED.SHELF.NU",
+    });
+
+    expect(transporter.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "support@shelf.nu" })
+    );
+  });
+
   it("skips sending when every address in a list is soft-deleted", async () => {
     vi.mocked(transporter.sendMail).mockClear();
 

--- a/apps/webapp/app/emails/email.worker.server.test.ts
+++ b/apps/webapp/app/emails/email.worker.server.test.ts
@@ -48,4 +48,42 @@ describe("triggerEmail", () => {
       expect.objectContaining({ to: "user@example.com" })
     );
   });
+
+  it("sends to every address of a comma separated list", async () => {
+    vi.mocked(transporter.sendMail).mockClear();
+
+    await triggerEmail({
+      ...basePayload,
+      to: "support@shelf.nu, product@shelf.nu",
+    });
+
+    expect(transporter.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "support@shelf.nu, product@shelf.nu" })
+    );
+  });
+
+  it("drops only the soft-deleted address from a list", async () => {
+    vi.mocked(transporter.sendMail).mockClear();
+
+    await triggerEmail({
+      ...basePayload,
+      to: "support@shelf.nu, deleted+abc123@deleted.shelf.nu",
+    });
+
+    // The live inbox must still get the email
+    expect(transporter.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "support@shelf.nu" })
+    );
+  });
+
+  it("skips sending when every address in a list is soft-deleted", async () => {
+    vi.mocked(transporter.sendMail).mockClear();
+
+    await triggerEmail({
+      ...basePayload,
+      to: "a@deleted.shelf.nu, b@deleted.shelf.nu",
+    });
+
+    expect(transporter.sendMail).not.toHaveBeenCalled();
+  });
 });

--- a/apps/webapp/app/emails/email.worker.server.test.ts
+++ b/apps/webapp/app/emails/email.worker.server.test.ts
@@ -70,7 +70,9 @@ describe("triggerEmail", () => {
       to: "support@shelf.nu, deleted+abc123@deleted.shelf.nu",
     });
 
-    // The live inbox must still get the email
+    // The live inbox must still get the email, and the soft-deleted one must
+    // not: a second call would mean the guard only rewrote the first header
+    expect(transporter.sendMail).toHaveBeenCalledOnce();
     expect(transporter.sendMail).toHaveBeenCalledWith(
       expect.objectContaining({ to: "support@shelf.nu" })
     );
@@ -84,6 +86,7 @@ describe("triggerEmail", () => {
       to: "support@shelf.nu, deleted+abc123@DELETED.SHELF.NU",
     });
 
+    expect(transporter.sendMail).toHaveBeenCalledOnce();
     expect(transporter.sendMail).toHaveBeenCalledWith(
       expect.objectContaining({ to: "support@shelf.nu" })
     );

--- a/apps/webapp/app/emails/email.worker.server.ts
+++ b/apps/webapp/app/emails/email.worker.server.ts
@@ -88,7 +88,9 @@ export const triggerEmail = async ({
     .map((address) => address.trim())
     .filter(Boolean);
   const deliverableRecipients = recipients.filter(
-    (address) => !address.endsWith(SOFT_DELETED_EMAIL_DOMAIN)
+    // Lower-cased first: domains are case-insensitive, so an address stored
+    // as "@DELETED.SHELF.NU" is the same dead inbox and must not be mailed
+    (address) => !address.toLowerCase().endsWith(SOFT_DELETED_EMAIL_DOMAIN)
   );
 
   if (recipients.length > 0 && deliverableRecipients.length === 0) {

--- a/apps/webapp/app/emails/email.worker.server.ts
+++ b/apps/webapp/app/emails/email.worker.server.ts
@@ -74,19 +74,40 @@ export const triggerEmail = async ({
   from,
   replyTo,
 }: EmailPayloadType) => {
-  if (to.endsWith(SOFT_DELETED_EMAIL_DOMAIN)) {
+  /**
+   * `to` can carry a comma separated list of addresses (in-app feedback goes
+   * to every inbox in FEEDBACK_EMAIL), so the soft-deleted check runs per
+   * address instead of on the whole string. Two things this fixes for lists:
+   * one soft-deleted recipient no longer drops the email for everybody else,
+   * and the outcome no longer depends on which address happens to be last.
+   * An empty/unparseable `to` is passed through untouched so it still fails
+   * loudly in nodemailer rather than being silently swallowed here.
+   */
+  const recipients = to
+    .split(",")
+    .map((address) => address.trim())
+    .filter(Boolean);
+  const deliverableRecipients = recipients.filter(
+    (address) => !address.endsWith(SOFT_DELETED_EMAIL_DOMAIN)
+  );
+
+  if (recipients.length > 0 && deliverableRecipients.length === 0) {
     Logger.warn(
       `Skipping email to soft-deleted user: ${to} (subject: ${subject})`
     );
     return;
   }
 
+  const toHeader = deliverableRecipients.length
+    ? deliverableRecipients.join(", ")
+    : to;
+
   try {
     // send mail with defined transport object
     await transporter.sendMail({
       from: from || SMTP_FROM || `"Shelf" <hello@example.com>`, // sender address
       replyTo: replyTo || SUPPORT_EMAIL, // reply to
-      to, // list of receivers
+      to: toHeader, // list of receivers
       subject, // Subject line
       text, // plain text body
       html: html || "", // html body

--- a/apps/webapp/app/emails/feedback/feedback-email.test.tsx
+++ b/apps/webapp/app/emails/feedback/feedback-email.test.tsx
@@ -27,6 +27,7 @@ vi.mock("~/utils/logger", () => ({
 vi.mock("~/utils/env", () => ({
   SERVER_URL: "https://app.shelf.nu",
   SUPPORT_EMAIL: "support@shelf.nu",
+  FEEDBACK_EMAIL: undefined,
   SEND_ONBOARDING_EMAIL: false,
   ENABLE_PREMIUM_FEATURES: false,
   FREE_TRIAL_DAYS: "7",
@@ -41,6 +42,7 @@ vi.mock("~/utils/env", () => ({
 import {
   feedbackEmailText,
   feedbackEmailHtml,
+  resolveFeedbackRecipients,
   sendFeedbackEmail,
 } from "./feedback-email";
 
@@ -203,5 +205,52 @@ describe("sendFeedbackEmail", () => {
         subject: expect.stringContaining("New feedback [Error report]:"),
       })
     );
+  });
+});
+
+describe("resolveFeedbackRecipients", () => {
+  it("falls back to the support inbox when FEEDBACK_EMAIL is not set", () => {
+    expect(resolveFeedbackRecipients(undefined, "support@shelf.nu")).toBe(
+      "support@shelf.nu"
+    );
+    expect(resolveFeedbackRecipients("", "support@shelf.nu")).toBe(
+      "support@shelf.nu"
+    );
+    // A variable set to whitespace is a misconfiguration, not an override
+    expect(resolveFeedbackRecipients("   ", "support@shelf.nu")).toBe(
+      "support@shelf.nu"
+    );
+  });
+
+  it("delivers to every address of a comma separated list", () => {
+    expect(
+      resolveFeedbackRecipients(
+        "support@shelf.nu, product@shelf.nu",
+        "support@shelf.nu"
+      )
+    ).toBe("support@shelf.nu, product@shelf.nu");
+  });
+
+  it("trims addresses and drops empty entries", () => {
+    expect(
+      resolveFeedbackRecipients(
+        "  support@shelf.nu ,, product@shelf.nu ,",
+        "support@shelf.nu"
+      )
+    ).toBe("support@shelf.nu, product@shelf.nu");
+  });
+
+  it("de-duplicates repeated addresses regardless of case", () => {
+    // Otherwise the same person gets the same report twice
+    expect(
+      resolveFeedbackRecipients(
+        "support@shelf.nu,Support@Shelf.nu,product@shelf.nu",
+        "support@shelf.nu"
+      )
+    ).toBe("support@shelf.nu, product@shelf.nu");
+  });
+
+  it("returns an empty string when nothing is configured", () => {
+    expect(resolveFeedbackRecipients(undefined, undefined)).toBe("");
   });
 });

--- a/apps/webapp/app/emails/feedback/feedback-email.tsx
+++ b/apps/webapp/app/emails/feedback/feedback-email.tsx
@@ -8,7 +8,7 @@ import {
 } from "@react-email/components";
 import parser from "ua-parser-js";
 import type { FeedbackErrorContext } from "~/modules/feedback/schema";
-import { SERVER_URL, SUPPORT_EMAIL } from "~/utils/env";
+import { FEEDBACK_EMAIL, SERVER_URL, SUPPORT_EMAIL } from "~/utils/env";
 import { ShelfError } from "~/utils/error";
 import { Logger } from "~/utils/logger";
 import { LogoForEmail } from "../logo";
@@ -41,9 +41,46 @@ interface FeedbackEmailProps {
 type DetailRow = { label: string; value: string; href?: string };
 
 /**
- * Emails a user-submitted feedback entry (issue/idea/error report) to
- * SUPPORT_EMAIL with reply-to set to the submitter. Fire-and-forget:
- * failures are logged, never surfaced to the user.
+ * Resolves the internal recipients of the feedback email.
+ *
+ * `FEEDBACK_EMAIL` accepts a comma separated list so a report can land in
+ * more than one inbox; when it is not set we fall back to `SUPPORT_EMAIL`,
+ * which is where every deployment sent feedback before. Addresses are
+ * trimmed and de-duplicated (case-insensitively) because nodemailer happily
+ * delivers the same message twice when an address is repeated.
+ *
+ * Pure and exported so the resolution can be tested without re-mocking the
+ * env module for every case.
+ */
+export function resolveFeedbackRecipients(
+  feedbackEmail: string | undefined,
+  supportEmail: string | undefined
+) {
+  const configured = feedbackEmail?.trim() ? feedbackEmail : supportEmail;
+  const seen = new Set<string>();
+
+  return (configured ?? "")
+    .split(",")
+    .map((address) => address.trim())
+    .filter((address) => {
+      if (!address) {
+        return false;
+      }
+      const key = address.toLowerCase();
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .join(", ");
+}
+
+/**
+ * Emails a user-submitted feedback entry (issue/idea/error report) to the
+ * internal feedback recipients (see {@link resolveFeedbackRecipients}) with
+ * reply-to set to the submitter. Fire-and-forget: failures are logged, never
+ * surfaced to the user.
  */
 export const sendFeedbackEmail = async (props: FeedbackEmailProps) => {
   try {
@@ -54,11 +91,23 @@ export const sendFeedbackEmail = async (props: FeedbackEmailProps) => {
       sanitized.length > 50 ? `${sanitized.slice(0, 50)}...` : sanitized;
     const subject = `New feedback [${typeLabel}]: ${subjectPreview}`;
 
+    const to = resolveFeedbackRecipients(FEEDBACK_EMAIL, SUPPORT_EMAIL);
+    if (!to) {
+      /* Neither variable is set: sending would fail inside nodemailer and
+       * burn 15 queue retries on a config problem, so say so once instead. */
+      throw new ShelfError({
+        cause: null,
+        message:
+          "No feedback recipient configured. Set SUPPORT_EMAIL or FEEDBACK_EMAIL.",
+        label: "Email",
+      });
+    }
+
     const html = await feedbackEmailHtml(props);
     const text = feedbackEmailText(props);
 
     void sendEmail({
-      to: SUPPORT_EMAIL,
+      to,
       subject,
       html,
       text,

--- a/apps/webapp/app/emails/types.ts
+++ b/apps/webapp/app/emails/types.ts
@@ -6,7 +6,11 @@ export type BookingForEmail = Prisma.BookingGetPayload<{
 }>;
 
 export type EmailPayloadType = {
-  /** Email address of recipient */
+  /**
+   * Email address of the recipient. A comma separated list is allowed for
+   * internal emails that go to several inboxes (see FEEDBACK_EMAIL); every
+   * address in it is checked against the soft-deleted domain individually.
+   */
   to: string;
 
   /** Subject of email */

--- a/apps/webapp/app/utils/env.ts
+++ b/apps/webapp/app/utils/env.ts
@@ -67,6 +67,7 @@ declare global {
       /** Auto-injected on Fly machines; used as a fallback for SENTRY_RELEASE. */
       FLY_RELEASE_VERSION: string;
       ADMIN_EMAIL: string;
+      FEEDBACK_EMAIL: string;
       CHROME_EXECUTABLE_PATH: string;
       FINGERPRINT: string;
       FREE_TRIAL_DAYS: string;
@@ -207,6 +208,20 @@ export const SENTRY_RELEASE =
   "";
 
 export const ADMIN_EMAIL = getEnv("ADMIN_EMAIL", {
+  isRequired: false,
+});
+
+/**
+ * Internal inbox(es) that receive in-app feedback: issues, ideas and error
+ * reports. Accepts a comma separated list so more than one person gets
+ * notified (e.g. the support inbox plus whoever triages product feedback).
+ * Optional: when it is unset the feedback email goes to SUPPORT_EMAIL alone,
+ * which is what every deployment did before this variable existed.
+ *
+ * Server side only, and deliberately absent from `getBrowserEnv()`: unlike
+ * SUPPORT_EMAIL it is never shown to users, it only routes internal mail.
+ */
+export const FEEDBACK_EMAIL = getEnv("FEEDBACK_EMAIL", {
   isRequired: false,
 });
 


### PR DESCRIPTION
> [!IMPORTANT]
> ## Merging this is not enough. Run one command after merge.
>
> ```
> fly secrets set FEEDBACK_EMAIL="support@shelf.nu,nikolay@shelf.nu" --app shelf-webapp
> ```
>
> Without it nothing changes: feedback keeps going to support@shelf.nu only, and Nikolay still gets nothing.
> It cannot be done inside this PR. The deploy job runs `flyctl deploy` from the repo root with no `--config`, so `apps/webapp/fly.toml` `[env]` is not what production reads. The value has to be set on the Fly app itself.
>
> No migration, no schema change, nothing else to do.

## What

In-app feedback (issues, ideas and error reports from the feedback modal) is mailed to `SUPPORT_EMAIL` and nowhere else, so anyone else who triages product feedback has to be forwarded every report by hand.

This adds an optional `FEEDBACK_EMAIL` variable: a comma separated list of internal inboxes that receive the feedback email.

- Unset: the email goes to `SUPPORT_EMAIL` alone, exactly as before. Nothing changes for existing deployments or self-hosters.
- Set: every address in the list receives the same email, with reply-to still pointing at the submitter.

Addresses are trimmed and de-duplicated case-insensitively, so `support@…,Support@…` does not deliver the same report twice. A whitespace-only value counts as "not set" and falls back to `SUPPORT_EMAIL`. If neither variable is set, the send is refused with a clear error instead of failing inside nodemailer and burning 15 queue retries on a config problem.

`FEEDBACK_EMAIL` is server-side only and deliberately absent from `getBrowserEnv()`: unlike `SUPPORT_EMAIL` it is never shown to users, it only routes internal mail.

## Soft-deleted-user guard, now per address

`triggerEmail` skipped any email whose `to` ended with the soft-deleted domain. That check ran on the whole string, which was fine while `to` was always a single address. Now that it can hold a list, it is applied per address:

- one soft-deleted recipient no longer drops the email for everybody else on the list;
- the outcome no longer depends on which address happens to be last in the string.

An empty or unparseable `to` is passed through untouched, so it still fails loudly in nodemailer rather than being swallowed here.

## Verification

- `pnpm webapp:validate` green: 388 test files, 5152 tests, plus lint and typecheck.
- 9 new tests: recipient resolution (fallback, whitespace-only, list, trimming, case-insensitive dedupe, nothing configured) and the worker guard (list delivery, one soft-deleted address dropped from a list, all-soft-deleted skipped).
- Sent a real message through our SMTP transport with two addresses in one `to` header to confirm the provider accepts the list rather than the first entry only: both came back in `info.accepted`, `rejected` empty, `250` response.
