### PR TITLE
fix(security): redact URL-embedded credentials, escape every CSV cell

### DIFF
--- a/apps/webapp/app/modules/reports/csv-format.test.ts
+++ b/apps/webapp/app/modules/reports/csv-format.test.ts
@@ -32,20 +32,26 @@ describe("formatDateForCsv", () => {
     );
   });
 
-  it("appends the time part for datetime columns, quoted (date/time comma)", () => {
+  it("appends the time part for datetime columns, UNQUOTED", () => {
     // A datetime renders "06/07/2026, 3:30 PM" — the date/time separator is a
-    // comma, so the whole field is quoted to stay one CSV column.
+    // comma, which does need quoting to stay one CSV column. That is now done
+    // once, centrally, by `escapeCsvField` in the export route; doing it here
+    // as well produced a doubly-quoted cell.
     expect(
       formatDateForCsv(new Date(Date.UTC(2026, 6, 6, 15, 30)), ddmm, {
         includeTime: true,
       })
-    ).toBe('"06/07/2026, 3:30 PM"');
+    ).toBe("06/07/2026, 3:30 PM");
   });
 
-  it("quotes a month-name value so its comma doesn't split the CSV column", () => {
+  it("returns a month-name value UNQUOTED, leaving quoting to the caller", () => {
+    // This used to assert the opposite. The function pre-quoted because its
+    // result bypassed the escaper; now the export route runs every cell
+    // through `escapeCsvField`, so pre-quoting was applied twice and a
+    // month-name date came out as `"""Jul 6, 2026"""`.
     expect(
       formatDateForCsv(new Date(Date.UTC(2026, 6, 6, 12)), monthName)
-    ).toBe('"Jul 6, 2026"');
+    ).toBe("Jul 6, 2026");
   });
 
   it("returns an empty string for a null date", () => {

--- a/apps/webapp/app/modules/reports/csv-format.ts
+++ b/apps/webapp/app/modules/reports/csv-format.ts
@@ -23,9 +23,9 @@ import { formatDate, type ResolvedFormatPrefs } from "~/utils/date-format";
  * @param prefs - the acting user's resolved date/time format preferences
  * @param opts - optional flags; `includeTime` appends the time part for datetime
  *   columns (leave unset for date-only columns)
- * @returns the CSV-safe formatted string; empty string for `null`. Month-name
- *   prefs produce a comma (e.g. "Jul 6, 2026"), which would break CSV columns,
- *   so any value containing a comma is wrapped in double quotes.
+ * @returns the formatted string, UNQUOTED; empty string for `null`. Month-name
+ *   prefs produce a comma (e.g. `Jul 6, 2026`) — quoting that is the caller's
+ *   responsibility, and the export route does it centrally for every cell.
  */
 export function formatDateForCsv(
   date: Date | null,
@@ -33,7 +33,13 @@ export function formatDateForCsv(
   opts?: { includeTime?: boolean }
 ): string {
   if (!date) return "";
-  const formatted = formatDate(date, prefs, { includeTime: opts?.includeTime });
-  // Month-name prefs emit a comma ("Jul 6, 2026"); quote so it stays one field.
-  return formatted.includes(",") ? `"${formatted}"` : formatted;
+  // Returned RAW, deliberately. Quoting is the caller's job: the export route
+  // sends every cell through `escapeCsvField` via `buildCsv`, so pre-quoting
+  // here would be quoted a second time — a month-name date came out as
+  // `"""Jul 6, 2026"""` rather than `"Jul 6, 2026"`.
+  //
+  // This function used to quote because its result bypassed the escaper
+  // entirely. Central escaping removed that need and made the pre-quoting a
+  // bug, so the responsibility now lives in exactly one place.
+  return formatDate(date, prefs, { includeTime: opts?.includeTime });
 }

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -318,7 +318,7 @@ function generateBookingComplianceCsv(
 
   const csvRows = rows.map((row) => [
     row.bookingId,
-    escapeCsvField(row.bookingName),
+    row.bookingName,
     formatStatus(row.status),
     row.custodian || "",
     row.assetCount.toString(),
@@ -328,7 +328,7 @@ function generateBookingComplianceCsv(
     formatReturnStatus(row.isOnTime, row.latenessMs),
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -351,7 +351,7 @@ function generateCustodySnapshotCsv(
 
   const csvRows = rows.map((row) => [
     row.assetId,
-    escapeCsvField(row.assetName),
+    row.assetName,
     row.category || "",
     row.location || "",
     row.custodianName,
@@ -361,7 +361,7 @@ function generateCustodySnapshotCsv(
     row.valuation?.toString() || "",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -418,6 +418,30 @@ function formatReturnStatus(
 }
 
 /**
+ * Assembles a CSV document, escaping EVERY cell.
+ *
+ * Escaping used to be applied per field, by hand, at each call site — and was
+ * missed on `custodianName`, `custodian`, `performedBy`, `category` and
+ * `location`, all of which are user-controlled workspace values. A name like
+ * `=cmd|'/c calc'!A1` therefore reached the file as a live formula.
+ *
+ * Escaping here instead means a new column is safe by default: a contributor
+ * adding one cannot forget, because there is no per-field decision left to
+ * make. That is the property the previous approach lacked, not the escaping
+ * itself — `escapeCsvField` was already correct, just unevenly applied.
+ *
+ * @param headers - Column headers, escaped like any other cell
+ * @param rows - Row cells, already stringified and formatted
+ * @returns The complete CSV document
+ */
+function buildCsv(headers: string[], rows: string[][]): string {
+  return [
+    headers.map(escapeCsvField).join(","),
+    ...rows.map((row) => row.map(escapeCsvField).join(",")),
+  ].join("\n");
+}
+
+/**
  * Escape a field for CSV format.
  */
 function escapeCsvField(field: string): string {
@@ -455,7 +479,7 @@ function generateOverdueItemsCsv(
 
   const csvRows = rows.map((row) => [
     row.bookingId,
-    escapeCsvField(row.bookingName),
+    row.bookingName,
     row.custodian || "",
     row.assetCount.toString(),
     // Datetime column: include the time part.
@@ -464,7 +488,7 @@ function generateOverdueItemsCsv(
     row.valueAtRisk?.toString() || "",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -486,7 +510,7 @@ function generateIdleAssetsCsv(
 
   const csvRows = rows.map((row) => [
     row.assetId,
-    escapeCsvField(row.assetName),
+    row.assetName,
     row.category || "",
     row.location || "",
     // Date-only column: no time part.
@@ -495,7 +519,7 @@ function generateIdleAssetsCsv(
     row.valuation?.toString() || "",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -516,7 +540,7 @@ function generateTopBookedAssetsCsv(rows: TopBookedAssetRow[]): string {
   const csvRows = rows.map((row, index) => [
     (index + 1).toString(),
     row.assetId,
-    escapeCsvField(row.assetName),
+    row.assetName,
     row.category || "",
     row.location || "",
     row.bookingCount.toString(),
@@ -526,7 +550,7 @@ function generateTopBookedAssetsCsv(rows: TopBookedAssetRow[]): string {
       : "0",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -546,10 +570,10 @@ function generateTopBookedKitsCsv(rows: TopBookedKitRow[]): string {
 
   const csvRows = rows.map((row, index) => [
     (index + 1).toString(),
-    escapeCsvField(row.kitId),
-    escapeCsvField(row.kitName),
-    escapeCsvField(row.category || ""),
-    escapeCsvField(row.location || ""),
+    row.kitId,
+    row.kitName,
+    row.category || "",
+    row.location || "",
     row.bookingCount.toString(),
     row.totalDaysBooked.toString(),
     row.bookingCount > 0
@@ -557,7 +581,7 @@ function generateTopBookedKitsCsv(rows: TopBookedKitRow[]): string {
       : "0",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -581,7 +605,7 @@ function generateAssetInventoryCsv(
 
   const csvRows = rows.map((row) => [
     row.assetId,
-    escapeCsvField(row.assetName),
+    row.assetName,
     row.category || "",
     row.location || "",
     formatAssetStatus(row.status),
@@ -592,7 +616,7 @@ function generateAssetInventoryCsv(
     row.qrId || "",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -612,7 +636,7 @@ function generateAssetUtilizationCsv(rows: AssetUtilizationRow[]): string {
 
   const csvRows = rows.map((row) => [
     row.assetId,
-    escapeCsvField(row.assetName),
+    row.assetName,
     row.category || "",
     row.location || "",
     row.bookingCount.toString(),
@@ -621,7 +645,7 @@ function generateAssetUtilizationCsv(rows: AssetUtilizationRow[]): string {
     `${row.utilizationRate}%`,
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -644,13 +668,13 @@ function generateAssetActivityCsv(
     // Datetime column ("Date & Time"): include the time part.
     formatDateForCsv(row.occurredAt, prefs, { includeTime: true }),
     row.assetId,
-    escapeCsvField(row.assetName),
+    row.assetName,
     formatActivityType(row.activityType),
-    escapeCsvField(row.description || ""),
+    row.description || "",
     row.performedBy || "System",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }
 
 /**
@@ -704,7 +728,7 @@ function generateDistributionCsv(breakdown: DistributionBreakdown): string {
   ) =>
     rows.map((row) => [
       type,
-      escapeCsvField(row.groupName),
+      row.groupName,
       row.assetCount.toString(),
       `${row.percentage.toFixed(1)}%`,
       row.totalValue?.toString() || "",
@@ -716,7 +740,7 @@ function generateDistributionCsv(breakdown: DistributionBreakdown): string {
     ...formatRows("Status", breakdown.byStatus),
   ];
 
-  return [headers.join(","), ...allRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, allRows);
 }
 
 /**
@@ -743,5 +767,5 @@ function generateMonthlyBookingTrendsCsv(
       : "—",
   ]);
 
-  return [headers.join(","), ...csvRows.map((row) => row.join(","))].join("\n");
+  return buildCsv(headers, csvRows);
 }

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -450,10 +450,15 @@ function escapeCsvField(field: string): string {
   // values with a single quote so the cell is treated as literal text. Applied
   // here in the shared helper so every report export is protected.
   const safeField = /^[=+\-@]/.test(field) ? `'${field}` : field;
+  // `\r` is quoted alongside `\n`: a bare carriage return terminates a record in
+  // consumers that accept CR as a line ending, so an unquoted one lets a
+  // user-controlled value split the row and forge structure — which also puts
+  // the injected content at the start of a "line", back inside formula range.
   if (
     safeField.includes(",") ||
     safeField.includes('"') ||
-    safeField.includes("\n")
+    safeField.includes("\n") ||
+    safeField.includes("\r")
   ) {
     return `"${safeField.replace(/"/g, '""')}"`;
   }

--- a/apps/webapp/app/utils/redact-url.test.ts
+++ b/apps/webapp/app/utils/redact-url.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+/**
+ * Credentials embedded in URL VALUES must not reach the logs.
+ *
+ * `redactSensitive` matches on key names, so `{ url: "..." }` passed straight
+ * through — the key is just `url`, and the secret is inside the value.
+ *
+ * That is reachable, not theoretical: asset CSV import accepts arbitrary image
+ * URLs, and `ssrf.server.ts` puts the URL into `additionalData` on every
+ * failure path. A row pointing at a basic-auth or signed URL therefore wrote a
+ * live credential to the platform logs (CWE-532).
+ *
+ * detail.dev finding D110.
+ *
+ * @see {@link file://./redact.ts}
+ * @see {@link file://./ssrf.server.ts}
+ */
+import { describe, expect, it } from "vitest";
+
+import { redactSensitive, redactUrlCredentials } from "./redact";
+
+describe("redactUrlCredentials", () => {
+  it("strips basic-auth userinfo", () => {
+    const out = redactUrlCredentials(
+      "https://alice:hunter2@example.com/img.jpg"
+    );
+
+    expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("alice");
+    // The rest of the URL survives — the point is a usable log line, not a
+    // blanked one.
+    expect(out).toContain("example.com/img.jpg");
+  });
+
+  it.each([
+    "token",
+    "access_token",
+    "api_key",
+    "signature",
+    "X-Amz-Signature",
+    "X-Amz-Security-Token",
+  ])("redacts the %s query parameter", (param) => {
+    const out = redactUrlCredentials(
+      `https://bucket.example.com/img.jpg?${param}=s3cr3t-value&w=200`
+    );
+
+    expect(out).not.toContain("s3cr3t-value");
+    // Non-sensitive params are untouched, so the URL stays diagnosable.
+    expect(out).toContain("w=200");
+  });
+
+  it("leaves an ordinary URL alone", () => {
+    const url = "https://example.com/img.jpg?w=200&h=100";
+    expect(redactUrlCredentials(url)).toBe(url);
+  });
+
+  it("leaves non-URL strings alone", () => {
+    // Runs over every string in every error payload, so it must not mangle
+    // ordinary prose.
+    const prose = "Failed to fetch image: connection reset by peer";
+    expect(redactUrlCredentials(prose)).toBe(prose);
+  });
+
+  it("returns an unparseable http string unchanged rather than guessing", () => {
+    const broken = "https://";
+    expect(redactUrlCredentials(broken)).toBe(broken);
+  });
+});
+
+describe("redactSensitive — URL values", () => {
+  it("redacts a credential under a NON-sensitive key", () => {
+    // The whole point: `url` is not a sensitive key name, so key-based
+    // redaction could never have caught this.
+    const out = redactSensitive({
+      url: "https://user:pw@host/img.jpg?token=abc123",
+      status: 403,
+    });
+
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("pw@");
+    expect(serialized).not.toContain("abc123");
+    expect(out.status).toBe(403);
+  });
+
+  it("reaches URLs nested inside additionalData", () => {
+    const out = redactSensitive({
+      additionalData: { url: "https://host/i.jpg?signature=deadbeef" },
+    });
+
+    expect(JSON.stringify(out)).not.toContain("deadbeef");
+  });
+
+  it("still redacts by key name", () => {
+    // The pre-existing behaviour must survive the string branch being added.
+    const out = redactSensitive({ password: "hunter2", email: "a@b.c" });
+
+    expect(out.password).not.toBe("hunter2");
+    expect(out.email).toBe("a@b.c");
+  });
+});

--- a/apps/webapp/app/utils/redact-url.test.ts
+++ b/apps/webapp/app/utils/redact-url.test.ts
@@ -86,7 +86,16 @@ describe("redactUrlCredentials", () => {
     expect(redactUrlCredentials(prose)).toBe(prose);
   });
 
-  it("returns an unparseable http string unchanged rather than guessing", () => {
+  it("strips the password from an UNPARSEABLE url", () => {
+    // The case that matters most in practice: a malformed URL is precisely the
+    // one that gets logged, because being malformed is why the import failed.
+    const out = redactUrlCredentials("https://alice:hunter2@");
+
+    expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("alice");
+  });
+
+  it("leaves an unparseable url with no credentials alone", () => {
     const broken = "https://";
     expect(redactUrlCredentials(broken)).toBe(broken);
   });

--- a/apps/webapp/app/utils/redact-url.test.ts
+++ b/apps/webapp/app/utils/redact-url.test.ts
@@ -49,6 +49,26 @@ describe("redactUrlCredentials", () => {
     expect(out).toContain("w=200");
   });
 
+  it("redacts a token in the URL FRAGMENT", () => {
+    // `searchParams` does not see the fragment, and OAuth implicit flows put
+    // the token there. This helper runs from `serializeError`, so it sees every
+    // logged URL — an auth callback logged on failure is the realistic case,
+    // not an imported image.
+    const out = redactUrlCredentials(
+      "https://app.shelf.nu/callback#access_token=abc123&state=xyz"
+    );
+
+    expect(out).not.toContain("abc123");
+    expect(out).toContain("state=xyz");
+  });
+
+  it("leaves a plain (non query-shaped) fragment alone", () => {
+    // `#section-2` is not `key=value`; round-tripping it through
+    // URLSearchParams would rewrite it as `section-2=`.
+    const url = "https://example.com/docs#section-2";
+    expect(redactUrlCredentials(url)).toBe(url);
+  });
+
   it("leaves an ordinary URL alone", () => {
     const url = "https://example.com/img.jpg?w=200&h=100";
     expect(redactUrlCredentials(url)).toBe(url);

--- a/apps/webapp/app/utils/redact-url.test.ts
+++ b/apps/webapp/app/utils/redact-url.test.ts
@@ -54,6 +54,31 @@ describe("redactUrlCredentials", () => {
     expect(redactUrlCredentials(url)).toBe(url);
   });
 
+  it("returns a clean URL BYTE-for-byte, without normalizing it", () => {
+    // The previous version returned `url.toString()` unconditionally, so a
+    // URL with nothing to redact still came back rewritten:
+    // `HTTPS://EXAMPLE.COM:443/a` -> `https://example.com/a`. The earlier test
+    // above missed it by picking a URL that was already normalized.
+    //
+    // A redactor that quietly edits non-secrets is its own debugging problem —
+    // the log line no longer matches what the user submitted.
+    const url = "HTTPS://EXAMPLE.COM:443/a?B=2&a=1";
+    expect(redactUrlCredentials(url)).toBe(url);
+  });
+
+  it.each(["X-Goog-Signature", "X-Goog-Credential"])(
+    "redacts the Google Cloud %s parameter",
+    (param) => {
+      // Signed URLs come in both AWS (`X-Amz-*`) and Google (`X-Goog-*`)
+      // spellings; an imported image URL can point at either bucket.
+      const out = redactUrlCredentials(
+        `https://storage.googleapis.com/b/o.jpg?${param}=deadbeefsig`
+      );
+
+      expect(out).not.toContain("deadbeefsig");
+    }
+  );
+
   it("leaves non-URL strings alone", () => {
     // Runs over every string in every error payload, so it must not mangle
     // ordinary prose.

--- a/apps/webapp/app/utils/redact.ts
+++ b/apps/webapp/app/utils/redact.ts
@@ -34,6 +34,15 @@ const SENSITIVE_KEY =
 export const REDACTED = "[REDACTED]";
 
 /**
+ * Replacement for a credential embedded inside a URL.
+ *
+ * Distinct from {@link REDACTED} because it is written back through
+ * `URL.toString()`, which percent-encodes the brackets and would turn the
+ * marker into noise in the middle of an otherwise readable URL.
+ */
+export const REDACTED_URL_PART = "REDACTED";
+
+/**
  * Replacement for a subtree deeper than {@link MAX_DEPTH}.
  *
  * Returning such a subtree unchanged would defeat the whole function: a
@@ -44,6 +53,66 @@ export const TRUNCATED = "[TRUNCATED]";
 
 /** How deep to walk nested objects before giving up. */
 const MAX_DEPTH = 4;
+
+/**
+ * Query parameters that carry a credential in a URL.
+ *
+ * {@link SENSITIVE_KEY} already covers the obvious names (`token`, `api_key`,
+ * `secret`). These are the signed-URL specific ones it does not — and they are
+ * exactly what an image URL from a private bucket carries.
+ */
+const SENSITIVE_URL_PARAM =
+  /^(?:sig|signature|x-amz-signature|x-amz-credential|x-amz-security-token|access[._-]?token|auth)$/i;
+
+/**
+ * Removes credentials embedded in a URL string.
+ *
+ * A secret does not have to sit under a sensitive key to end up in a log line —
+ * it can be inside the value, where key-based redaction cannot see it because
+ * the key is just `url`.
+ *
+ * This is not hypothetical: asset CSV import accepts arbitrary image URLs and
+ * `ssrf.server.ts` logs the URL on every failure path, so a row pointing at
+ * `https://user:pass@host/img.jpg` or `https://host/img.jpg?token=...` wrote a
+ * live credential to the platform logs (CWE-532).
+ *
+ * Both halves matter: basic-auth userinfo and signed-URL query parameters.
+ *
+ * Deliberately narrow — only strings that parse as http(s) URLs are touched, so
+ * ordinary prose in an error message is never mangled.
+ *
+ * @param value - Any string bound for a log line
+ * @returns The string with embedded credentials replaced, or unchanged
+ */
+export function redactUrlCredentials(value: string): string {
+  // Cheap guard first: this runs over every string in every error payload.
+  if (!/^https?:\/\//i.test(value)) {
+    return value;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    // Unparseable, so there is no structure to reason about. Returning it
+    // unchanged is safe: the guard above proved it is not a bare secret, and
+    // guessing at delimiters would be worse than leaving it alone.
+    return value;
+  }
+
+  if (url.username || url.password) {
+    url.username = REDACTED_URL_PART;
+    url.password = REDACTED_URL_PART;
+  }
+
+  for (const param of Array.from(url.searchParams.keys())) {
+    if (SENSITIVE_KEY.test(param) || SENSITIVE_URL_PARAM.test(param)) {
+      url.searchParams.set(param, REDACTED_URL_PART);
+    }
+  }
+
+  return url.toString();
+}
 
 /**
  * Returns a copy of `value` with any sensitively-named field replaced by
@@ -63,6 +132,12 @@ const MAX_DEPTH = 4;
  * @returns A redacted copy, or the original for primitives
  */
 export function redactSensitive<T>(value: T, depth = 0): T {
+  // Strings are inspected, not waved through: a secret does not have to sit
+  // under a sensitive KEY to reach a log line — it can be inside the value.
+  if (typeof value === "string") {
+    return redactUrlCredentials(value) as unknown as T;
+  }
+
   if (value === null || typeof value !== "object") {
     return value;
   }

--- a/apps/webapp/app/utils/redact.ts
+++ b/apps/webapp/app/utils/redact.ts
@@ -96,10 +96,24 @@ export function redactUrlCredentials(value: string): string {
   try {
     url = new URL(value);
   } catch {
-    // Unparseable, so there is no structure to reason about. Returning it
-    // unchanged is safe: the guard above proved it is not a bare secret, and
-    // guessing at delimiters would be worse than leaving it alone.
-    return value;
+    // Unparseable — and these are exactly the URLs that get logged, because a
+    // malformed one is why the import failed in the first place.
+    //
+    // We can still strip the credential without a parser: the guard above
+    // proved the string starts `http(s)://`, so anything between that and the
+    // last `@` before the first `/`, `?` or `#` IS the userinfo. That is not a
+    // guess, it is where the delimiter has to be. `[^/?#]*` is greedy, so it
+    // binds to the LAST `@` in the authority, matching how a real parser
+    // reads it.
+    //
+    // Only the userinfo is handled here. A secret in a query parameter of an
+    // unparseable URL still gets through; covering that would mean redacting
+    // the whole string, which costs the debuggability this function exists to
+    // preserve. Narrow and useful beats broad and blinding.
+    return value.replace(
+      /^(https?:\/\/)[^/?#]*@/i,
+      `$1${REDACTED_URL_PART}:${REDACTED_URL_PART}@`
+    );
   }
 
   let redacted = false;

--- a/apps/webapp/app/utils/redact.ts
+++ b/apps/webapp/app/utils/redact.ts
@@ -59,10 +59,12 @@ const MAX_DEPTH = 4;
  *
  * {@link SENSITIVE_KEY} already covers the obvious names (`token`, `api_key`,
  * `secret`). These are the signed-URL specific ones it does not — and they are
- * exactly what an image URL from a private bucket carries.
+ * exactly what an image URL from a private bucket carries. Both the AWS
+ * (`X-Amz-*`) and Google Cloud (`X-Goog-*`) V4 spellings, since an imported
+ * image URL can point at either.
  */
 const SENSITIVE_URL_PARAM =
-  /^(?:sig|signature|x-amz-signature|x-amz-credential|x-amz-security-token|access[._-]?token|auth)$/i;
+  /^(?:sig|signature|x-(?:amz|goog)-(?:signature|credential|security-token)|access[._-]?token|auth)$/i;
 
 /**
  * Removes credentials embedded in a URL string.
@@ -100,18 +102,28 @@ export function redactUrlCredentials(value: string): string {
     return value;
   }
 
+  let redacted = false;
+
   if (url.username || url.password) {
     url.username = REDACTED_URL_PART;
     url.password = REDACTED_URL_PART;
+    redacted = true;
   }
 
   for (const param of Array.from(url.searchParams.keys())) {
     if (SENSITIVE_KEY.test(param) || SENSITIVE_URL_PARAM.test(param)) {
       url.searchParams.set(param, REDACTED_URL_PART);
+      redacted = true;
     }
   }
 
-  return url.toString();
+  // Return the ORIGINAL string when there was nothing to redact. `URL.toString()`
+  // normalizes — `HTTPS://EXAMPLE.COM:443/a` comes back as
+  // `https://example.com/a` — so returning it unconditionally would silently
+  // rewrite every clean URL in every log line. The point of this function is a
+  // log entry that still matches what the user submitted; a redactor that
+  // quietly edits non-secrets is a debugging problem of its own.
+  return redacted ? url.toString() : value;
 }
 
 /**

--- a/apps/webapp/app/utils/redact.ts
+++ b/apps/webapp/app/utils/redact.ts
@@ -131,6 +131,30 @@ export function redactUrlCredentials(value: string): string {
     }
   }
 
+  // The fragment is not covered by `searchParams`, and OAuth implicit flows put
+  // the token there: `https://host/#access_token=...`. This helper runs from
+  // `serializeError`, so it sees every logged URL and not only imported image
+  // ones — a callback URL logged on an auth failure is the realistic case.
+  if (url.hash.length > 1) {
+    const fragment = new URLSearchParams(url.hash.slice(1));
+    let fragmentRedacted = false;
+
+    for (const param of Array.from(fragment.keys())) {
+      if (SENSITIVE_KEY.test(param) || SENSITIVE_URL_PARAM.test(param)) {
+        fragment.set(param, REDACTED_URL_PART);
+        fragmentRedacted = true;
+      }
+    }
+
+    // Only rewrite the fragment when a parameter actually matched: a plain
+    // `#section-2` is not query-shaped, and round-tripping it through
+    // URLSearchParams would turn it into `section-2=`.
+    if (fragmentRedacted) {
+      url.hash = fragment.toString();
+      redacted = true;
+    }
+  }
+
   // Return the ORIGINAL string when there was nothing to redact. `URL.toString()`
   // normalizes — `HTTPS://EXAMPLE.COM:443/a` comes back as
   // `https://example.com/a` — so returning it unconditionally would silently


### PR DESCRIPTION
## What

Two findings that share a shape: user-controlled data reaching an output
channel with the sanitizer applied **per site** rather than centrally.

detail.dev **D110** (credentials in logs) and **D002** (CSV formula injection).

## D110 — credentials inside URL *values* were logged

`redactSensitive` matches on **key names**. `{ url: "..." }` passed straight
through, because the key is just `url` and the secret is inside the value.

That is reachable, not theoretical: asset CSV import accepts arbitrary image
URLs, and `ssrf.server.ts` puts the URL into `additionalData` on **every**
failure path. A row pointing at `https://user:pass@host/img.jpg`, or a signed
URL carrying `?token=…`, wrote a live credential to the platform logs
(CWE-532).

Worth stating explicitly because it looks covered and isn't: **#2884's
`serializeError` redaction does not help here.** That work was key-based by
design, and no key name would ever have caught this.

### Fixed in the redactor, not at the call sites

```ts
if (typeof value === "string") {
  return redactUrlCredentials(value) as unknown as T;
}
```

`ssrf.server.ts` has ~9 log sites. Fixing them individually would leave the
tenth to whoever adds it — the same failure mode as D002 below. Doing it in
`redactSensitive` covers every caller, including ones outside this file.

`redactUrlCredentials` strips basic-auth userinfo and redacts signed-URL
parameters (`token`, `signature`, `X-Amz-*`, …) while leaving the rest of the
URL intact — a redacted log line still has to be worth reading.

Deliberately narrow: only strings that parse as `http(s)` URLs are touched, so
ordinary prose in an error message is never mangled. An unparseable `http…`
string is returned unchanged rather than guessed at.

## D002 — report CSV exports were formula-injectable

`escapeCsvField` already neutralized `=`, `+`, `-` and `@`. Its own doc comment
claimed it was *"applied here in the shared helper so every report export is
protected"* — which was not true. It was applied **by hand, per field**, and was
missing from:

| Field | |
| --- | --- |
| `custodianName`, `custodian` | user's own display name |
| `performedBy` | user's own display name |
| `category`, `location` | workspace-defined names |

All user-controlled. A member named `=cmd\|'/c calc'!A1` reached the file as a
live formula.

### Fixing the field list would have left the trap

Escaping moved into a shared `buildCsv(headers, rows)`, used by all 11
generators:

```ts
function buildCsv(headers: string[], rows: string[][]): string {
  return [
    headers.map(escapeCsvField).join(","),
    ...rows.map((row) => row.map(escapeCsvField).join(",")),
  ].join("\n");
}
```

A new column is now safe by default, because there is no per-field decision
left to make. That is the property the previous approach lacked — the escaping
function itself was already correct.

The 14 inline `escapeCsvField` calls are **removed**, not kept: escaping twice
would re-quote an already-quoted cell.

## D002 is wider than reported — and the rest needs a decision

`app/utils/csv.server.ts` has **three asset export builders with no formula
escaping at all**. Not in this PR, on purpose.

Two are mechanical. The third builds an **import-ready** CSV whose stated
purpose is:

> Builds an import-ready CSV (headers = content-importer keys, values
> importer-native) **so the file re-imports into another workspace**.

Prefixing a value with `'` would corrupt that round-trip — the quote becomes
part of the data on re-import — unless the importer learns to strip it. That is
a product decision rather than a mechanical fix, so it is raised rather than
guessed at.

Options, roughly: escape all three and teach the importer to strip a leading
`'`; escape the two non-round-tripping builders and document the third as an
accepted residual; or treat the import-ready file as trusted-by-contract, since
it is produced for re-import rather than for opening in a spreadsheet.

## Tests

`app/utils/redact-url.test.ts` (13):

- basic-auth userinfo stripped, with the rest of the URL still present
- each signed-URL parameter redacted, with non-sensitive params left intact
- an ordinary URL and ordinary prose both returned **unchanged** — this runs
  over every string in every error payload, so not mangling normal text is part
  of the contract
- an unparseable `https://` string returned as-is rather than guessed at
- a credential under a **non-sensitive key** (`url`) is redacted — the case
  key-based redaction could never have caught
- key-based redaction still works, so the new string branch did not regress it

Verified: 37 tests across the redaction and CSV modules, typecheck and ESLint
clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CSV report exports now consistently escape headers and values, including carriage returns, commas, quotes, and newlines.
  - Spreadsheet formula protection remains in place to prevent unsafe values in exported files.
  - Sensitive credentials, signed URL parameters, and fragment tokens in HTTP(S) URLs are redacted.
  - URL sanitization preserves safe content while handling malformed and non-URL values safely.

- **Tests**
  - Added coverage for URL credentials, signed parameters, nested data, and key-based redaction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->