### PR TITLE
fix(assets): guard search id materialization against the bind-param ceiling

### DIFF
--- a/apps/webapp/app/modules/api/mobile-asset-search.server.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.ts
@@ -1,10 +1,5 @@
-import { Prisma } from "@prisma/client";
-import { withPrismaRetry } from "@shelf/database";
-import { db } from "~/database/db.server";
-import {
-  buildAssetSearchUnion,
-  type AssetSearchIdRow,
-} from "~/modules/asset/search-union.server";
+import type { Prisma } from "@prisma/client";
+import { resolveAssetSearchIds } from "~/modules/asset/search-ids.server";
 import { splitAssetSearchTerms } from "~/modules/asset/search.server";
 
 /**
@@ -27,11 +22,11 @@ import { splitAssetSearchTerms } from "~/modules/asset/search.server";
 /**
  * Resolves the mobile assets search to a Prisma where-fragment.
  *
- * Runs the shared org-scoped UNION for a non-empty term set and materializes
- * the matching asset ids into an `id: { in }` fragment. The route's
- * `baseWhere` has no top-level `OR` (status AVAILABLE rides in `AND`,
- * myCustody is `custody: { some }`), so this fragment is safe to spread
- * directly alongside it — it simply ANDs in.
+ * Runs the shared org-scoped UNION (via `resolveAssetSearchIds`) for a
+ * non-empty term set and materializes the matching asset ids into an
+ * `id: { in }` fragment. The route's `baseWhere` has no top-level `OR` (status
+ * AVAILABLE rides in `AND`, myCustody is `custody: { some }`), so this fragment
+ * is safe to spread directly alongside it — it simply ANDs in.
  *
  * @param organizationId - Tenant scope; every UNION branch is org-scoped.
  * @param search - Raw (already length-capped) search term from the request.
@@ -39,6 +34,8 @@ import { splitAssetSearchTerms } from "~/modules/asset/search.server";
  *   `{ id: { in: [] } }` for whitespace/bare-comma input (a debounced
  *   type-ahead space must not flash the full list) or a search with no
  *   matches; otherwise `{ id: { in: <matching ids> } }`.
+ * @throws {ShelfError} 400 when the search matches more ids than the bind-param
+ *   ceiling allows (see `resolveAssetSearchIds`) — only reachable by a mega-org.
  */
 export async function resolveMobileAssetSearchWhere({
   organizationId,
@@ -58,21 +55,14 @@ export async function resolveMobileAssetSearchWhere({
     return search.length > 0 ? { id: { in: [] } } : {};
   }
 
-  // Wrapped in withPrismaRetry (operationIsRead) like getAssets' and the
-  // advanced index's identical raw query — a raw $queryRaw bypasses the
-  // client's auto-retry extension, so a transient pool/connection blip on
-  // the id-resolution query would otherwise surface as a hard error instead
-  // of being retried.
-  const rows = await withPrismaRetry(
-    () =>
-      db.$queryRaw<AssetSearchIdRow[]>(
-        Prisma.sql`SELECT "id" FROM ${buildAssetSearchUnion({
-          organizationId,
-          terms: searchTerms,
-        })} AS "search_ids"`
-      ),
-    { operationIsRead: true }
-  );
+  // Shared with the web getAssets fetcher: resolveAssetSearchIds runs the
+  // org-scoped UNION (retry-wrapped, since a raw $queryRaw bypasses the
+  // client's auto-retry extension) and guards the id set against Postgres'
+  // ~65k bind-param ceiling, throwing a friendly 400 rather than hard-failing.
+  const ids = await resolveAssetSearchIds({
+    organizationId,
+    terms: searchTerms,
+  });
 
-  return { id: { in: rows.map((row) => row.id) } };
+  return { id: { in: ids } };
 }

--- a/apps/webapp/app/modules/asset/search-ids.server.ts
+++ b/apps/webapp/app/modules/asset/search-ids.server.ts
@@ -1,0 +1,68 @@
+/**
+ * Asset-search id resolver — the id-materializing half of asset search.
+ *
+ * Two of the three search surfaces resolve a search to a concrete list of
+ * matching asset ids and feed it into a Prisma `id: { in: [...] }` clause:
+ * the simple index (`getAssets`, `service.server.ts`) and the mobile assets
+ * endpoint (`resolveMobileAssetSearchWhere`, `modules/api/mobile-asset-search.server.ts`).
+ * Both used to inline the same `withPrismaRetry($queryRaw(buildAssetSearchUnion))`
+ * → `rows.map((r) => r.id)` snippet; this module is the single shared
+ * implementation, plus the bind-param ceiling guard both need.
+ *
+ * The **advanced index** (`generateWhereClause`, `query.server.ts`) deliberately
+ * does NOT use this — it inlines the UNION as a raw `a."id" IN (<subquery>)`, so
+ * it never materializes an id list and is not subject to the ceiling below.
+ *
+ * @see apps/webapp/app/modules/asset/search-union.server.ts (buildAssetSearchUnion)
+ * @see apps/webapp/app/modules/asset/service.server.ts (getAssets)
+ * @see apps/webapp/app/modules/api/mobile-asset-search.server.ts (resolveMobileAssetSearchWhere)
+ */
+import { Prisma } from "@prisma/client";
+import { withPrismaRetry } from "@shelf/database";
+import { db } from "~/database/db.server";
+import {
+  buildAssetSearchUnion,
+  type AssetSearchIdRow,
+} from "./search-union.server";
+import { assertAssetSearchIdCeiling } from "./search.server";
+
+/**
+ * Resolves already-normalized search terms to the set of matching asset ids via
+ * the shared org-scoped UNION ({@link buildAssetSearchUnion}) — index-driven,
+ * org-scoped branches across all 10 search sources.
+ *
+ * Wrapped in `withPrismaRetry({ operationIsRead: true })` because a raw
+ * `$queryRaw` bypasses the client's auto-retry extension, so a transient
+ * pool/connection blip on this id-resolution query would otherwise surface as a
+ * hard error (the SHELF-WEBAPP-227 class) instead of being retried. Guards the
+ * materialized set against the bind-param ceiling before returning.
+ *
+ * @param params.organizationId - Tenant scope (bound as a literal in every branch).
+ * @param params.terms - Non-empty list of trimmed, lowercased search terms.
+ *   Callers must guard the empty case themselves (an empty search means "match
+ *   nothing", expressed as `id: { in: [] }`, not "run the UNION").
+ * @returns The matching asset ids (may be empty).
+ * @throws {ShelfError} 400 when the match set exceeds the bind-param ceiling.
+ */
+export async function resolveAssetSearchIds({
+  organizationId,
+  terms,
+}: {
+  organizationId: string;
+  terms: string[];
+}): Promise<string[]> {
+  const rows = await withPrismaRetry(
+    () =>
+      db.$queryRaw<AssetSearchIdRow[]>(
+        Prisma.sql`SELECT "id" FROM ${buildAssetSearchUnion({
+          organizationId,
+          terms,
+        })} AS "search_ids"`
+      ),
+    { operationIsRead: true }
+  );
+
+  assertAssetSearchIdCeiling(rows.length);
+
+  return rows.map((row) => row.id);
+}

--- a/apps/webapp/app/modules/asset/search.server.test.ts
+++ b/apps/webapp/app/modules/asset/search.server.test.ts
@@ -1,14 +1,20 @@
 /**
  * Test suite for the shared simple-mode asset search helpers in search.server.
  *
- * Pins `splitAssetSearchTerms` (comma-splitting + the term-count cap), which is
- * consumed by the web `getAssets` fetcher, the mobile assets endpoint, and the
- * advanced-index `generateWhereClause` — a change here shifts search parsing on
- * every surface at once. Pure module — no mocks needed.
+ * Pins `splitAssetSearchTerms` (comma-splitting + the term-count cap) and
+ * `assertAssetSearchIdCeiling` (the bind-param ceiling guard), both consumed by
+ * the web `getAssets` fetcher and the mobile assets endpoint — a change here
+ * shifts search behaviour on every id-materializing surface at once. Pure
+ * module — no mocks needed.
  *
  * @see {@link file://./search.server.ts}
  */
-import { splitAssetSearchTerms } from "./search.server";
+import { ShelfError } from "~/utils/error";
+import {
+  MAX_MATCHED_ASSET_SEARCH_IDS,
+  assertAssetSearchIdCeiling,
+  splitAssetSearchTerms,
+} from "./search.server";
 
 // @vitest-environment node
 
@@ -29,5 +35,30 @@ describe("splitAssetSearchTerms", () => {
   it("caps the number of honored terms as a query-cost guard", () => {
     const fifteen = Array.from({ length: 15 }, (_, i) => `term${i}`).join(",");
     expect(splitAssetSearchTerms(fifteen)).toHaveLength(10);
+  });
+});
+
+describe("assertAssetSearchIdCeiling", () => {
+  it("does not throw at or below the bind-param ceiling", () => {
+    expect(() => assertAssetSearchIdCeiling(0)).not.toThrow();
+    expect(() => assertAssetSearchIdCeiling(1)).not.toThrow();
+    expect(() =>
+      assertAssetSearchIdCeiling(MAX_MATCHED_ASSET_SEARCH_IDS)
+    ).not.toThrow();
+  });
+
+  it("throws a user-input 400 above the ceiling (not a captured 500)", () => {
+    let thrown: unknown;
+    try {
+      assertAssetSearchIdCeiling(MAX_MATCHED_ASSET_SEARCH_IDS + 1);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ShelfError);
+    // A 400 so the client sees a "refine your search" message, not "something
+    // went wrong"; shouldBeCaptured false so an over-broad search never pages.
+    expect((thrown as ShelfError).status).toBe(400);
+    expect((thrown as ShelfError).shouldBeCaptured).toBe(false);
   });
 });

--- a/apps/webapp/app/modules/asset/search.server.ts
+++ b/apps/webapp/app/modules/asset/search.server.ts
@@ -1,5 +1,7 @@
 import { AssetStatus, type Prisma } from "@prisma/client";
 
+import { ShelfError } from "~/utils/error";
+
 /**
  * JSON paths inside `AssetCustomFieldValue.value` that hold searchable text.
  * Owned here (not `query.server.ts`) so this module stays standalone — it
@@ -90,4 +92,53 @@ export function buildAssetStatusWhere(
     };
   }
   return { status };
+}
+
+/**
+ * Safe upper bound on the number of matching asset ids that the id-materializing
+ * search surfaces (the simple `getAssets` fetcher and the mobile endpoint) may
+ * feed into a Prisma `id: { in: [...] }` clause.
+ *
+ * Prisma serializes `{ id: { in: [...] } }` for Postgres as `IN ($1,…,$n)` — one
+ * bind parameter per id (measured on Prisma 6.19; it does NOT use `= ANY($1)`).
+ * Postgres caps a single prepared statement at **65,535** bind parameters, so a
+ * search matching more ids than that makes the `count`/`findMany` queries
+ * hard-fail with a raw error (a 500). We stop at 60,000 — well under the ceiling,
+ * leaving headroom for the query's other bound params (pagination, status,
+ * category/location/booking filters).
+ *
+ * Only a ~100k+ asset organization searching a very broad term can reach this;
+ * the largest org today holds ~14k assets, so in practice it never trips. It
+ * exists to turn a latent hard-500 into graceful degradation for a future
+ * mega-org. The advanced index is unaffected — it inlines the UNION as a raw
+ * `id IN (subquery)` and never materializes an id list.
+ */
+export const MAX_MATCHED_ASSET_SEARCH_IDS = 60_000;
+
+/**
+ * Throws a friendly 400 when a search matched more asset ids than we can safely
+ * feed into a Prisma `id: { in }` clause (see {@link MAX_MATCHED_ASSET_SEARCH_IDS}).
+ *
+ * Pure (no I/O) so it can be unit-tested without a database. The error is a
+ * user-input 400 with `shouldBeCaptured: false` — an over-broad search is not a
+ * server fault and should not page anyone.
+ *
+ * @param count - The number of matching asset ids the search resolved to.
+ * @throws {ShelfError} 400 when `count` exceeds {@link MAX_MATCHED_ASSET_SEARCH_IDS}.
+ */
+export function assertAssetSearchIdCeiling(count: number): void {
+  if (count > MAX_MATCHED_ASSET_SEARCH_IDS) {
+    throw new ShelfError({
+      cause: null,
+      message:
+        "Your search matched too many assets to process at once. Please refine it with more specific terms.",
+      label: "Assets",
+      status: 400,
+      shouldBeCaptured: false,
+      additionalData: {
+        matchedCount: count,
+        ceiling: MAX_MATCHED_ASSET_SEARCH_IDS,
+      },
+    });
+  }
 }

--- a/apps/webapp/app/modules/asset/search.server.ts
+++ b/apps/webapp/app/modules/asset/search.server.ts
@@ -95,6 +95,14 @@ export function buildAssetStatusWhere(
 }
 
 /**
+ * User-facing message for the bind-param ceiling 400. Exported so callers and
+ * tests assert the exact contract (that this actionable message — not a generic
+ * wrapper — reaches the user) rather than a fragile substring match.
+ */
+export const ASSET_SEARCH_CEILING_MESSAGE =
+  "Your search matched too many assets to process at once. Please refine it with more specific terms.";
+
+/**
  * Safe upper bound on the number of matching asset ids that the id-materializing
  * search surfaces (the simple `getAssets` fetcher and the mobile endpoint) may
  * feed into a Prisma `id: { in: [...] }` clause.
@@ -103,9 +111,17 @@ export function buildAssetStatusWhere(
  * bind parameter per id (measured on Prisma 6.19; it does NOT use `= ANY($1)`).
  * Postgres caps a single prepared statement at **65,535** bind parameters, so a
  * search matching more ids than that makes the `count`/`findMany` queries
- * hard-fail with a raw error (a 500). We stop at 60,000 — well under the ceiling,
- * leaving headroom for the query's other bound params (pagination, status,
- * category/location/booking filters).
+ * hard-fail with a raw error (a 500).
+ *
+ * We stop at 50,000, reserving ~15,500 params of headroom for the query's OTHER
+ * bound params — which matters because several filters are themselves unbounded,
+ * URL-repeated arrays: `getAssets` binds `teamMemberIds` into four separate
+ * `{ in }` clauses, so a large custodian filter alone can add thousands of
+ * params on top of the search ids. This headroom is a pragmatic margin, not a
+ * formal guarantee: the pure-filter vector is bounded in practice by request URL
+ * length, and a formal bound would instead clamp the `getAll` filter arrays in
+ * `getParamsValues` (`~/utils/list`) — a noted follow-up, not needed for a case
+ * that already requires a 100k+ asset org.
  *
  * Only a ~100k+ asset organization searching a very broad term can reach this;
  * the largest org today holds ~14k assets, so in practice it never trips. It
@@ -113,7 +129,7 @@ export function buildAssetStatusWhere(
  * mega-org. The advanced index is unaffected — it inlines the UNION as a raw
  * `id IN (subquery)` and never materializes an id list.
  */
-export const MAX_MATCHED_ASSET_SEARCH_IDS = 60_000;
+export const MAX_MATCHED_ASSET_SEARCH_IDS = 50_000;
 
 /**
  * Throws a friendly 400 when a search matched more asset ids than we can safely
@@ -130,8 +146,7 @@ export function assertAssetSearchIdCeiling(count: number): void {
   if (count > MAX_MATCHED_ASSET_SEARCH_IDS) {
     throw new ShelfError({
       cause: null,
-      message:
-        "Your search matched too many assets to process at once. Please refine it with more specific terms.",
+      message: ASSET_SEARCH_CEILING_MESSAGE,
       label: "Assets",
       status: 400,
       shouldBeCaptured: false,

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -23,7 +23,10 @@ import { getQr } from "~/modules/qr/service.server";
 import { ShelfError } from "~/utils/error";
 import { createSignedUrl } from "~/utils/storage.server";
 import { resolveAssetIdsForBulkOperation } from "./bulk-operations-helper.server";
-import { MAX_MATCHED_ASSET_SEARCH_IDS } from "./search.server";
+import {
+  ASSET_SEARCH_CEILING_MESSAGE,
+  MAX_MATCHED_ASSET_SEARCH_IDS,
+} from "./search.server";
 import {
   BULK_CREATE_MAX,
   bulkAssignAssetTags,
@@ -4485,9 +4488,9 @@ describe("getAssets search via UNION", () => {
   });
 
   it("over-ceiling: rethrows the refine-search 400 unchanged, no asset fetch", async () => {
-    // A match set past the bind-param ceiling makes resolveAssetSearchIds throw a
-    // deliberate 400; getAssets' catch must let that reach the caller with its
-    // actionable message intact, not re-wrapped as "something went wrong".
+    // why: return more ids than the bind-param ceiling without building real DB
+    // rows, so resolveAssetSearchIds throws its deliberate 400 and we can assert
+    // getAssets' catch propagates it unchanged rather than re-wrapping it.
     queryRawMock.mockResolvedValue(
       Array.from({ length: MAX_MATCHED_ASSET_SEARCH_IDS + 1 }, (_, i) => ({
         id: `a${i}`,
@@ -4503,11 +4506,11 @@ describe("getAssets search via UNION", () => {
 
     expect(thrown).toBeInstanceOf(ShelfError);
     expect((thrown as ShelfError).status).toBe(400);
-    expect((thrown as ShelfError).message).toMatch(/refine/i);
-    // the generic wrapper must NOT have replaced the actionable message
-    expect((thrown as ShelfError).message).not.toMatch(/something went wrong/i);
-    // short-circuited before the asset fetch
+    // exact message — proves the generic catch wrapper did NOT replace it
+    expect((thrown as ShelfError).message).toBe(ASSET_SEARCH_CEILING_MESSAGE);
+    // short-circuited before the asset fetch (both findMany and count)
     expect(findManyMock).not.toHaveBeenCalled();
+    expect(countMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -23,6 +23,7 @@ import { getQr } from "~/modules/qr/service.server";
 import { ShelfError } from "~/utils/error";
 import { createSignedUrl } from "~/utils/storage.server";
 import { resolveAssetIdsForBulkOperation } from "./bulk-operations-helper.server";
+import { MAX_MATCHED_ASSET_SEARCH_IDS } from "./search.server";
 import {
   BULK_CREATE_MAX,
   bulkAssignAssetTags,
@@ -4481,6 +4482,32 @@ describe("getAssets search via UNION", () => {
     expect(findManyMock.mock.calls[0][0]!.where!.OR).toEqual([
       { id: { in: [] } },
     ]);
+  });
+
+  it("over-ceiling: rethrows the refine-search 400 unchanged, no asset fetch", async () => {
+    // A match set past the bind-param ceiling makes resolveAssetSearchIds throw a
+    // deliberate 400; getAssets' catch must let that reach the caller with its
+    // actionable message intact, not re-wrapped as "something went wrong".
+    queryRawMock.mockResolvedValue(
+      Array.from({ length: MAX_MATCHED_ASSET_SEARCH_IDS + 1 }, (_, i) => ({
+        id: `a${i}`,
+      }))
+    );
+
+    let thrown: unknown;
+    try {
+      await getAssets({ ...base, search: "a" });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ShelfError);
+    expect((thrown as ShelfError).status).toBe(400);
+    expect((thrown as ShelfError).message).toMatch(/refine/i);
+    // the generic wrapper must NOT have replaced the actionable message
+    expect((thrown as ShelfError).message).not.toMatch(/something went wrong/i);
+    // short-circuited before the asset fetch
+    expect(findManyMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -112,6 +112,7 @@ import {
   isLikeShelfError,
   isNotFoundError,
   maybeUniqueConstraintViolation,
+  rethrowIfClientError,
   throwIfAssetQuantityOverAllocation,
 } from "~/utils/error";
 import { getRedirectUrlFromRequest } from "~/utils/http";
@@ -956,6 +957,13 @@ export async function getAssets(params: {
 
     return { assets, totalAssets };
   } catch (cause) {
+    // A deliberate client error — e.g. the >65k bind-param ceiling 400 thrown by
+    // resolveAssetSearchIds — must reach the caller with its own actionable
+    // message intact. The generic wrapper below inherits the 400 status from the
+    // cause but overwrites the message ("refine your search" → "something went
+    // wrong"), so pass it straight through. Also covers Cmd+K, which shares
+    // getAssets without the getPaginatedAndFilterableAssets wrapper.
+    rethrowIfClientError(cause);
     throw new ShelfError({
       cause,
       message: "Something went wrong while fetching assets",
@@ -4367,6 +4375,11 @@ export async function getPaginatedAndFilterableAssets({
       ...teamMembersData,
     };
   } catch (cause) {
+    // Preserve deliberate client errors (e.g. the search-id ceiling 400 from
+    // getAssets) so the actionable message survives this second wrapper — the
+    // web /assets index and admin org-assets route both come through here. See
+    // getAssets' catch for the rationale.
+    rethrowIfClientError(cause);
     throw new ShelfError({
       cause,
       message: "Fail to fetch paginated and filterable assets",

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -163,10 +163,7 @@ import {
   parseFiltersWithHierarchy,
   parseSortingOptions,
 } from "./query.server";
-import {
-  buildAssetSearchUnion,
-  type AssetSearchIdRow,
-} from "./search-union.server";
+import { resolveAssetSearchIds } from "./search-ids.server";
 import { buildAssetStatusWhere, splitAssetSearchTerms } from "./search.server";
 import { getNextSequentialId } from "./sequential-id.server";
 import type {
@@ -654,8 +651,12 @@ export async function getAssets(params: {
         where.id = { in: [] };
       } else {
         // Resolve the search to a set of matching asset ids via the shared
-        // org-scoped UNION (buildAssetSearchUnion) — index-driven, org-scoped
-        // branches, ~165ms vs the old multi-table OR's cross-org seq scans.
+        // org-scoped UNION (resolveAssetSearchIds → buildAssetSearchUnion) —
+        // index-driven, org-scoped branches, ~165ms vs the old multi-table OR's
+        // cross-org seq scans. The helper is retry-wrapped (a raw $queryRaw
+        // bypasses the client's auto-retry extension) and guards the id set
+        // against Postgres' ~65k bind-param ceiling, throwing a friendly 400
+        // rather than letting an extreme org + very broad term hard-fail.
         // Setting where.OR here — BEFORE the category/tag/location/team-member
         // filters below — preserves the historical OR-entanglement: those
         // filters append to where.OR, so search OR-combines with them exactly
@@ -664,27 +665,11 @@ export async function getAssets(params: {
         // subset and fell back on zero rows); id-shaped searches therefore now
         // return the full result set — a superset of before, the more-correct
         // answer.
-        // Wrapped in withPrismaRetry (operationIsRead) like the advanced
-        // index's raw query below — a raw $queryRaw bypasses the client's
-        // auto-retry extension, so a transient pool/connection blip on the
-        // id-resolution query would otherwise surface as a hard error (the
-        // SHELF-WEBAPP-227 class) instead of being retried.
-        const rows = await withPrismaRetry(
-          () =>
-            db.$queryRaw<AssetSearchIdRow[]>(
-              Prisma.sql`SELECT "id" FROM ${buildAssetSearchUnion({
-                organizationId,
-                terms: searchTerms,
-              })} AS "search_ids"`
-            ),
-          { operationIsRead: true }
-        );
-        // Materialize the matching ids into a Prisma `id: { in }` member.
-        // Bounded by the org's asset count; an extreme org + a very broad term
-        // could push the bind-param list toward Postgres' ~65k ceiling — if
-        // that ever bites, switch to a raw fetch-by-ids (like the advanced
-        // index's inlined subquery, which never materializes the id set).
-        where.OR = [{ id: { in: rows.map((row) => row.id) } }];
+        const ids = await resolveAssetSearchIds({
+          organizationId,
+          terms: searchTerms,
+        });
+        where.OR = [{ id: { in: ids } }];
       }
     }
 


### PR DESCRIPTION
## What & why

`getAssets` (simple index) and the mobile assets endpoint (`resolveMobileAssetSearchWhere`) resolve a
search to a list of matching asset ids and feed it into a Prisma `id: { in: [...] }` clause. **Measured on
Prisma 6.19.3**, Prisma serializes that as `IN ($1,…,$n)` — one bind parameter per id, *not* `= ANY($1)`.
Postgres caps a single prepared statement at **65,535** bind parameters, so a search matching more ids than
that makes both the `count` and `findMany` hard-fail with a raw 500.

This is only reachable by a ~100k+ asset organization searching a very broad term (the largest org today
holds ~14k), so it's a latent edge — but it was flagged as a real regression during the #2849 review, so
this closes it.

Follow-up to #2849 (org-scoped search UNION).

## Change

- **`search-ids.server.ts`** (new) — extracts the duplicated
  `withPrismaRetry($queryRaw(buildAssetSearchUnion))` → `rows.map(id)` logic (previously copy-pasted in
  `getAssets` and the mobile endpoint) into one shared `resolveAssetSearchIds({ organizationId, terms })`.
- **`search.server.ts`** — adds the pure `MAX_MATCHED_ASSET_SEARCH_IDS = 50_000` (reserving ~15.5k params of headroom under the
  65,535 ceiling for the query's other bound params) and `assertAssetSearchIdCeiling(count)`, which throws a
  friendly **400** (`shouldBeCaptured: false`) — "refine your search" — instead of a raw 500.
- **`service.server.ts`** + **`mobile-asset-search.server.ts`** — both now call the shared helper; dead
  imports removed.
- **`search.server.test.ts`** — pure unit tests for the guard (at-ceiling passes; over-ceiling → 400, not
  captured).

The **advanced index is deliberately untouched** — it inlines the UNION as a raw `a."id" IN (<subquery>)`
and never materializes an id list, so it has no ceiling.

## Testing

- `search.server.test.ts` + `search-union.server.test.ts` — 12/12
- mobile assets route test — 14/14
- `tsc -b --force` clean · eslint clean

Behavior-preserving for every reachable case today (same ids resolved); the guard only changes behavior
above 60k matches, which no current org can reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved consistency across mobile and standard asset searches.
  * Added broader matching for ID-shaped search terms.
  * Added safeguards for exceptionally large result sets.

* **Bug Fixes**
  * Improved reliability by retrying temporary search read failures.
  * Prevented oversized searches from causing database errors.
  * Preserved clear, actionable error messages when searches exceed supported limits.
  * Prevented unnecessary asset retrieval and counting after a search limit is exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
