### PR TITLE
fix(list-filters): debounce list search so typing stops tripping the rate limiter

### DIFF
--- a/apps/webapp/app/components/list/filters/search-form.test.tsx
+++ b/apps/webapp/app/components/list/filters/search-form.test.tsx
@@ -1,12 +1,11 @@
 /**
  * Regression tests for the list search field's debounce.
  *
- * The behaviour under test is a production incident, not a nicety: every
- * change to `?s=` is a router navigation, and each navigation issues one
- * single-fetch `*.data` request. Undebounced, typing produced one server-side
- * loader run per CHARACTER, which tripped `appLoaderRateLimit` (60 `.data`
- * requests per 60s per `(userId, path)`) and dropped users on the "Too many
- * requests" error boundary mid-task.
+ * Every change to `?s=` is a router navigation, and each navigation issues one
+ * single-fetch `*.data` request. Undebounced, typing costs one server-side
+ * loader run per character, which exhausts `appLoaderRateLimit`'s budget (60
+ * `.data` requests per 60s per `(userId, path)`) and drops the user on the
+ * "Too many requests" error boundary mid-task.
  *
  * These tests assert the observable contract — how many navigations a burst of
  * typing causes — rather than the timer plumbing.
@@ -93,8 +92,8 @@ describe("SearchForm debounce", () => {
     render(<SearchForm />);
     const input = screen.getByLabelText("Search kits");
 
-    // Simulate a user typing "broadcast" — the exact shape that produced nine
-    // `.data` requests in production.
+    // A nine-character search: one `.data` request per character without the
+    // debounce.
     const term = "broadcast";
     for (let i = 1; i <= term.length; i++) {
       fireEvent.change(input, { target: { value: term.slice(0, i) } });
@@ -113,9 +112,8 @@ describe("SearchForm debounce", () => {
     render(<SearchForm />);
     const input = screen.getByLabelText("Search kits");
 
-    // Four separate searches, 16 characters each = 64 characters. Undebounced
-    // this was 64 requests to one bucket — past the limiter's 60 and straight
-    // into a 429.
+    // Four separate searches, ~16 characters each. Undebounced that is 64
+    // requests against one bucket, past the limiter's 60 and into a 429.
     for (const term of [
       "alpha equipment 1",
       "beta equipment 22",
@@ -174,8 +172,8 @@ describe("SearchForm debounce", () => {
   });
 
   it("shows the busy indicator from the FIRST keystroke, not after the debounce", () => {
-    // why: a 100ms debounce was removed in a1f6cd734 precisely because it left
-    // the field looking idle while the user typed. Pin the fix.
+    // why: a debounce that only shows the spinner once the navigation starts
+    // leaves the field looking idle while the user types.
     render(<SearchForm />);
     const input = screen.getByLabelText("Search kits");
 

--- a/apps/webapp/app/components/list/filters/search-form.test.tsx
+++ b/apps/webapp/app/components/list/filters/search-form.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Regression tests for the list search field's debounce.
+ *
+ * The behaviour under test is a production incident, not a nicety: every
+ * change to `?s=` is a router navigation, and each navigation issues one
+ * single-fetch `*.data` request. Undebounced, typing produced one server-side
+ * loader run per CHARACTER, which tripped `appLoaderRateLimit` (60 `.data`
+ * requests per 60s per `(userId, path)`) and dropped users on the "Too many
+ * requests" error boundary mid-task.
+ *
+ * These tests assert the observable contract — how many navigations a burst of
+ * typing causes — rather than the timer plumbing.
+ *
+ * @see {@link file://./search-form.tsx}
+ * @see {@link file://./../../../../server/rate-limit.ts}
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SearchForm } from "./search-form";
+
+const mockNavigation = vi.hoisted(() => ({
+  value: {} as { location?: unknown },
+}));
+const mockSearchParams = vi.hoisted(() => new URLSearchParams());
+const mockSetSearchParams = vi.hoisted(() => vi.fn());
+const mockLoaderData = vi.hoisted(() => ({
+  value: {
+    search: null as string | null,
+    modelName: { singular: "asset", plural: "assets" },
+    searchFieldLabel: "Search kits",
+  },
+}));
+
+// why: drive navigation state and loader data directly — the component reads
+// both through router hooks that need a real router otherwise.
+vi.mock("react-router", async () => {
+  const actual = (await vi.importActual("react-router")) as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    ...actual,
+    useNavigation: () => mockNavigation.value,
+    useLoaderData: () => mockLoaderData.value,
+  };
+});
+
+// why: capture the setter so the test can count navigations without routing.
+vi.mock("~/hooks/search-params", () => ({
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams] as const,
+}));
+
+// why: this hook reads asset-index-only route data that isn't present here.
+vi.mock("~/hooks/use-asset-index-view-state", () => ({
+  useAssetIndexViewState: () => ({ modeIsAdvanced: false }),
+}));
+
+/** Resolve the `?s=` value a recorded setSearchParams call would produce. */
+function resolveSearchTerm(callIndex: number) {
+  const setter = mockSetSearchParams.mock.calls[callIndex][0] as (
+    prev: URLSearchParams
+  ) => URLSearchParams;
+  return setter(new URLSearchParams()).get("s");
+}
+
+/**
+ * Advance past the debounce window inside `act()` so React flushes the state
+ * update the timer callback performs (otherwise every test logs an act warning).
+ */
+function advancePastDebounce() {
+  act(() => {
+    vi.advanceTimersByTime(400);
+  });
+}
+
+describe("SearchForm debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // why: clearAllMocks does not drain queued *Once implementations, so reset
+    // the call history explicitly between tests.
+    mockSetSearchParams.mockReset();
+    mockNavigation.value = {};
+    mockLoaderData.value.search = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("issues ONE navigation for a burst of typing, not one per character", () => {
+    render(<SearchForm />);
+    const input = screen.getByLabelText("Search kits");
+
+    // Simulate a user typing "broadcast" — the exact shape that produced nine
+    // `.data` requests in production.
+    const term = "broadcast";
+    for (let i = 1; i <= term.length; i++) {
+      fireEvent.change(input, { target: { value: term.slice(0, i) } });
+    }
+
+    // Nothing dispatched while the user is still typing.
+    expect(mockSetSearchParams).not.toHaveBeenCalled();
+
+    advancePastDebounce();
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    expect(resolveSearchTerm(0)).toBe("broadcast");
+  });
+
+  it("keeps 60+ characters of typing under the rate limiter's per-minute budget", () => {
+    render(<SearchForm />);
+    const input = screen.getByLabelText("Search kits");
+
+    // Four separate searches, 16 characters each = 64 characters. Undebounced
+    // this was 64 requests to one bucket — past the limiter's 60 and straight
+    // into a 429.
+    for (const term of [
+      "alpha equipment 1",
+      "beta equipment 22",
+      "gamma kit 333333",
+      "delta kit 4444444",
+    ]) {
+      for (let i = 1; i <= term.length; i++) {
+        fireEvent.change(input, { target: { value: term.slice(0, i) } });
+      }
+      advancePastDebounce();
+    }
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(4);
+  });
+
+  it("replaces history entries so Back does not walk through the query letter by letter", () => {
+    render(<SearchForm />);
+    const input = screen.getByLabelText("Search kits");
+
+    fireEvent.change(input, { target: { value: "kit" } });
+    advancePastDebounce();
+
+    expect(mockSetSearchParams).toHaveBeenCalledWith(expect.any(Function), {
+      replace: true,
+    });
+  });
+
+  it("resets pagination when the search term changes", () => {
+    render(<SearchForm />);
+    const input = screen.getByLabelText("Search kits");
+
+    fireEvent.change(input, { target: { value: "kit" } });
+    advancePastDebounce();
+
+    const setter = mockSetSearchParams.mock.calls[0][0] as (
+      prev: URLSearchParams
+    ) => URLSearchParams;
+    const next = setter(new URLSearchParams("page=3"));
+
+    expect(next.get("page")).toBeNull();
+  });
+
+  it("clears the search term when the field is emptied", () => {
+    mockLoaderData.value.search = "kit";
+    render(<SearchForm />);
+    const input = screen.getByLabelText("Search kits");
+
+    fireEvent.change(input, { target: { value: "" } });
+    advancePastDebounce();
+
+    expect(mockSetSearchParams).toHaveBeenCalledTimes(1);
+    const setter = mockSetSearchParams.mock.calls[0][0] as (
+      prev: URLSearchParams
+    ) => URLSearchParams;
+    expect(setter(new URLSearchParams("s=kit&page=2")).get("s")).toBeNull();
+  });
+
+  it("shows the busy indicator from the FIRST keystroke, not after the debounce", () => {
+    // why: a 100ms debounce was removed in a1f6cd734 precisely because it left
+    // the field looking idle while the user typed. Pin the fix.
+    render(<SearchForm />);
+    const input = screen.getByLabelText("Search kits");
+
+    fireEvent.change(input, { target: { value: "b" } });
+
+    // Still inside the debounce window — no navigation yet, but the clear
+    // button must already be showing its spinner.
+    expect(mockSetSearchParams).not.toHaveBeenCalled();
+    expect(screen.getByTitle("Clear search")).toBeDisabled();
+  });
+
+  it("does not dispatch a scheduled search after the field unmounts", () => {
+    // why: these modals close while a debounce can still be in flight.
+    const { unmount } = render(<SearchForm />);
+    const input = screen.getByLabelText("Search kits");
+
+    fireEvent.change(input, { target: { value: "kit" } });
+    unmount();
+    advancePastDebounce();
+
+    expect(mockSetSearchParams).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/components/list/filters/search-form.tsx
+++ b/apps/webapp/app/components/list/filters/search-form.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from "react";
-import { useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLoaderData, useNavigation } from "react-router";
 
 import Input from "~/components/forms/input";
@@ -11,6 +11,31 @@ import { isSearching } from "~/utils/form";
 import { tw } from "~/utils/tw";
 import { SearchFieldTooltip } from "./search-field-tooltip";
 
+/**
+ * How long to wait after the last keystroke before pushing the search term
+ * into the URL.
+ *
+ * Every change to `?s=` is a router navigation, and each navigation issues one
+ * single-fetch `*.data` request. Without a delay that is literally one
+ * server-side loader run PER CHARACTER — which both hammers the database and
+ * trips `appLoaderRateLimit` (`server/rate-limit.ts`: 60 `.data` requests per
+ * 60s per `(userId, path)`, with the query string deliberately excluded from
+ * the bucket key, so every `?s=` variant shares one budget). Typing ~60
+ * characters into a list search within a minute was enough to earn a 429 and
+ * the "Too many requests" error boundary, which is what customers hit on the
+ * booking manage-kits/manage-assets modals.
+ *
+ * 400ms is the usual search-as-you-type range: long enough to collapse a
+ * word into a single request, short enough to still feel live.
+ *
+ * NOTE: a 100ms debounce previously existed here and was removed in
+ * `a1f6cd734` because it broke the loading indicator. That regression is
+ * avoided below by driving the spinner off `isBusy` (pending debounce OR
+ * in-flight navigation) rather than off navigation state alone — do not
+ * "simplify" it back to `isSearching(navigation)`.
+ */
+const SEARCH_DEBOUNCE_MS = 400;
+
 export const SearchForm = ({ className }: { className?: string }) => {
   const [_searchParams, setSearchParams] = useSearchParams();
   const { search, modelName, searchFieldLabel } =
@@ -19,43 +44,106 @@ export const SearchForm = ({ className }: { className?: string }) => {
   const { modeIsAdvanced } = useAssetIndexViewState();
 
   const navigation = useNavigation();
-  const disabled = isSearching(navigation);
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  /** Pending debounce timer, or `null` when nothing is scheduled. */
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /**
+   * True between the keystroke and the debounced navigation firing. Exists so
+   * the search field can show its spinner immediately — see
+   * {@link SEARCH_DEBOUNCE_MS}.
+   */
+  const [isDebouncePending, setIsDebouncePending] = useState(false);
+
+  /** Cancel any scheduled search navigation and clear the pending flag. */
+  const cancelPendingSearch = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setIsDebouncePending(false);
+  }, []);
+
+  // Don't fire a navigation (or set state) after the field has unmounted —
+  // these modals close while a debounce can still be in flight.
+  useEffect(
+    () => () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    },
+    []
+  );
 
   const label = searchFieldLabel ? searchFieldLabel : `Search by ${singular}`;
 
   /**
    * Clears the search parameter and page parameter from the URL
-   * to ensure we start from the first page of results
+   * to ensure we start from the first page of results.
+   *
+   * Runs immediately (no debounce) — clearing is an explicit, single action,
+   * and any keystroke-scheduled navigation is cancelled first so a stale term
+   * can't land after the field has been emptied.
    */
-  function clearSearch() {
-    setSearchParams((prev) => {
-      prev.delete("s");
-      prev.delete("page"); // Reset page when clearing search
-      return prev;
-    });
+  const clearSearch = useCallback(() => {
+    cancelPendingSearch();
+    setSearchParams(
+      (prev) => {
+        prev.delete("s");
+        prev.delete("page"); // Reset page when clearing search
+        return prev;
+      },
+      { replace: true }
+    );
     if (searchInputRef.current) {
       searchInputRef.current.value = "";
     }
-  }
+  }, [cancelPendingSearch, setSearchParams]);
+
   /**
-   * Handles search input changes with debouncing
-   * Resets page to 1 whenever search query changes
+   * Handles search input changes, debounced so a burst of typing produces ONE
+   * navigation instead of one per character.
+   *
+   * `replace: true` keeps search-as-you-type out of the history stack — before
+   * this, every character pushed an entry, so Back walked the user backwards
+   * through their own query one letter at a time.
    */
-  const debouncedHandleChange = (
+  const handleSearchChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     const searchQuery = e.target.value;
-    if (!searchQuery) {
-      clearSearch();
-    } else {
-      setSearchParams((prev) => {
-        prev.set("s", searchQuery);
-        prev.delete("page"); // Reset to page 1 when search query changes
-        return prev;
-      });
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
     }
+    setIsDebouncePending(true);
+
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      setIsDebouncePending(false);
+
+      if (!searchQuery) {
+        clearSearch();
+        return;
+      }
+
+      setSearchParams(
+        (prev) => {
+          prev.set("s", searchQuery);
+          prev.delete("page"); // Reset to page 1 when search query changes
+          return prev;
+        },
+        { replace: true }
+      );
+    }, SEARCH_DEBOUNCE_MS);
   };
+
+  /**
+   * Busy from the first keystroke through to the navigation settling, so the
+   * debounce window is never a dead, unresponsive gap.
+   */
+  const isBusy = isDebouncePending || isSearching(navigation);
 
   return (
     <div className={tw("flex w-full md:w-auto", className)}>
@@ -71,14 +159,14 @@ export const SearchForm = ({ className }: { className?: string }) => {
           className="w-full md:w-auto"
           inputClassName={tw(modeIsAdvanced ? "py-2 text-sm" : "", "pr-9")}
           ref={searchInputRef}
-          onChange={debouncedHandleChange}
+          onChange={handleSearchChange}
         />
-        {search || disabled ? (
+        {search || isBusy ? (
           <Button
             type="button"
-            icon={disabled ? "spinner" : "x"}
+            icon={isBusy ? "spinner" : "x"}
             variant="tertiary"
-            disabled={disabled}
+            disabled={isBusy}
             title="Clear search"
             className="absolute right-3.5 top-1/2 !w-auto -translate-y-1/2 cursor-pointer border-0 p-0 text-gray-400 hover:text-gray-700"
             onClick={clearSearch}

--- a/apps/webapp/app/components/list/filters/search-form.tsx
+++ b/apps/webapp/app/components/list/filters/search-form.tsx
@@ -16,23 +16,22 @@ import { SearchFieldTooltip } from "./search-field-tooltip";
  * into the URL.
  *
  * Every change to `?s=` is a router navigation, and each navigation issues one
- * single-fetch `*.data` request. Without a delay that is literally one
- * server-side loader run PER CHARACTER — which both hammers the database and
- * trips `appLoaderRateLimit` (`server/rate-limit.ts`: 60 `.data` requests per
- * 60s per `(userId, path)`, with the query string deliberately excluded from
- * the bucket key, so every `?s=` variant shares one budget). Typing ~60
- * characters into a list search within a minute was enough to earn a 429 and
- * the "Too many requests" error boundary, which is what customers hit on the
- * booking manage-kits/manage-assets modals.
+ * single-fetch `*.data` request. Undebounced that is one server-side loader run
+ * per character, which both hammers the database and exhausts
+ * `appLoaderRateLimit`'s budget (`server/rate-limit.ts`: 60 `.data` requests
+ * per 60s per `(userId, path)`, with the query string deliberately excluded
+ * from the bucket key, so every `?s=` variant shares one budget). Roughly 60
+ * characters of typing inside one minute is enough to spend it and land the
+ * user on the "Too many requests" error boundary, losing whatever modal they
+ * were working in.
  *
  * 400ms is the usual search-as-you-type range: long enough to collapse a
  * word into a single request, short enough to still feel live.
  *
- * NOTE: a 100ms debounce previously existed here and was removed in
- * `a1f6cd734` because it broke the loading indicator. That regression is
- * avoided below by driving the spinner off `isBusy` (pending debounce OR
- * in-flight navigation) rather than off navigation state alone — do not
- * "simplify" it back to `isSearching(navigation)`.
+ * The busy indicator must stay driven by `isBusy` (pending debounce OR
+ * in-flight navigation). Deriving it from `isSearching(navigation)` alone
+ * leaves the field looking idle for the whole debounce window, so do not
+ * "simplify" it back.
  */
 const SEARCH_DEBOUNCE_MS = 400;
 
@@ -105,9 +104,9 @@ export const SearchForm = ({ className }: { className?: string }) => {
    * Handles search input changes, debounced so a burst of typing produces ONE
    * navigation instead of one per character.
    *
-   * `replace: true` keeps search-as-you-type out of the history stack — before
-   * this, every character pushed an entry, so Back walked the user backwards
-   * through their own query one letter at a time.
+   * `replace: true` keeps search-as-you-type out of the history stack; without
+   * it every burst pushes an entry and Back walks the user backwards through
+   * their own query.
    */
   const handleSearchChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>

--- a/apps/webapp/app/components/list/filters/search-form.tsx
+++ b/apps/webapp/app/components/list/filters/search-form.tsx
@@ -167,6 +167,13 @@ export const SearchForm = ({ className }: { className?: string }) => {
             icon={isBusy ? "spinner" : "x"}
             variant="tertiary"
             disabled={isBusy}
+            // `title` alone is only the last-resort fallback in the accessible
+            // -name computation, and the shared Button treats an icon-only
+            // control without aria-label/label/tooltip as unnamed (it warns in
+            // dev). Keep `title` for the visual tooltip, name it explicitly for
+            // assistive tech. Static on purpose — the control is still "clear
+            // search" while it spins.
+            aria-label="Clear search"
             title="Clear search"
             className="absolute right-3.5 top-1/2 !w-auto -translate-y-1/2 cursor-pointer border-0 p-0 text-gray-400 hover:text-gray-700"
             onClick={clearSearch}

--- a/apps/webapp/app/utils/error.ts
+++ b/apps/webapp/app/utils/error.ts
@@ -95,6 +95,7 @@ export type FailureReason = {
     | "DB"
     | "Request validation"
     | "Request aborted"
+    | "Rate limit" // A server-side rate limiter rejected the request (429)
     | "DB constrain violation"
     | "Dev error" // Error that should never happen in production because it's a developer mistake
     | "Environment" // Related to the environment setup

--- a/apps/webapp/server/rate-limit.test.ts
+++ b/apps/webapp/server/rate-limit.test.ts
@@ -155,6 +155,33 @@ describe("appLoaderRateLimit middleware", () => {
       );
     });
 
+    it("emits at most once per bucket per window, however long the flood runs", async () => {
+      // why: hono-rate-limiter runs the 429 handler for EVERY request once a
+      // bucket is over its limit, so an unthrottled emit would let a runaway
+      // client (or, via the pre-auth mobile limiter, an attacker) flood the
+      // logs quota and bury the very trail this telemetry exists to keep.
+      const app = makeApp(1);
+
+      for (let i = 0; i < 50; i++) {
+        await request(app, "/assets.data", "10.2.0.1");
+      }
+
+      expect(mockHandledClientError).toHaveBeenCalledTimes(1);
+    });
+
+    it("still logs separately for distinct buckets", async () => {
+      // The throttle must not collapse unrelated incidents into one entry —
+      // two different users hitting the same surface are two incidents.
+      const app = makeApp(1);
+
+      for (const ip of ["10.3.0.1", "10.3.0.2", "10.3.0.3"]) {
+        await request(app, "/assets.data", ip);
+        await request(app, "/assets.data", ip);
+      }
+
+      expect(mockHandledClientError).toHaveBeenCalledTimes(3);
+    });
+
     it("does not log the client IP for anonymous requests", async () => {
       const app = makeApp(1);
 

--- a/apps/webapp/server/rate-limit.test.ts
+++ b/apps/webapp/server/rate-limit.test.ts
@@ -113,11 +113,9 @@ describe("appLoaderRateLimit middleware", () => {
 
   /**
    * The limiter short-circuits in Hono middleware, so no `ShelfError` is built
-   * and `error()`/`logException()` never run. Combined with the client
-   * boundary deliberately not capturing 429s, that made rate limiting
-   * invisible in every Sentry dataset — a customer report of "too many
-   * requests" could not be confirmed after the fact. These tests pin the
-   * replacement trail.
+   * and `error()`/`logException()` never run. With the client boundary also
+   * skipping 429 by design, this trail is the only thing that makes a rate
+   * limit visible in Sentry and attributable to a user. These tests pin it.
    */
   describe("observability", () => {
     beforeEach(() => {
@@ -238,10 +236,9 @@ describe("telemetry throttle saturation", () => {
   }
 
   it("keeps a bucket suppressed even after the tracker fills with other buckets", async () => {
-    // why: the first version evicted the least-recently-emitted entry to make
-    // room, so rotating past the cap could evict a live suppressor and let its
-    // bucket emit again inside its own window — degrading the throttle to
-    // roughly one entry per request, which is what it exists to prevent.
+    // why: evicting a live suppressor to make room lets its bucket emit again
+    // inside its own window, degrading the throttle to roughly one entry per
+    // request — exactly what it exists to prevent.
     const { shouldEmitTelemetry } = await freshModule();
     const now = 1_000_000;
 
@@ -304,7 +301,9 @@ describe("telemetry throttle saturation", () => {
     }
 
     const saturationLogs = mockHandledClientError.mock.calls.filter(
-      (call) => typeof call[0]?.message === "string" && call[0].message.includes("saturated")
+      (call) =>
+        typeof call[0]?.message === "string" &&
+        call[0].message.includes("saturated")
     );
     expect(saturationLogs).toHaveLength(1);
     expect(saturationLogs[0][0].label).toBe("Rate limit");

--- a/apps/webapp/server/rate-limit.test.ts
+++ b/apps/webapp/server/rate-limit.test.ts
@@ -217,3 +217,96 @@ describe("appLoaderRateLimit middleware", () => {
     });
   });
 });
+
+/**
+ * Direct unit tests for the telemetry throttle.
+ *
+ * Driven through the exported `shouldEmitTelemetry` with an injected clock
+ * rather than over HTTP: saturating the tracker takes thousands of distinct
+ * buckets, which would mean tens of thousands of requests through Hono.
+ *
+ * Each test re-imports the module so the module-scope tracker starts empty —
+ * a shared tracker would let one test's buckets suppress the next test's.
+ */
+describe("telemetry throttle saturation", () => {
+  const MAX = 5_000;
+  const WINDOW = 60_000;
+
+  async function freshModule() {
+    vi.resetModules();
+    return import("./rate-limit");
+  }
+
+  it("keeps a bucket suppressed even after the tracker fills with other buckets", async () => {
+    // why: the first version evicted the least-recently-emitted entry to make
+    // room, so rotating past the cap could evict a live suppressor and let its
+    // bucket emit again inside its own window — degrading the throttle to
+    // roughly one entry per request, which is what it exists to prevent.
+    const { shouldEmitTelemetry } = await freshModule();
+    const now = 1_000_000;
+
+    expect(shouldEmitTelemetry("victim", now)).toBe(true);
+
+    // Fill well past the cap, all inside the victim's window.
+    for (let i = 0; i < MAX + 500; i++) {
+      shouldEmitTelemetry(`filler-${i}`, now + 1);
+    }
+
+    expect(shouldEmitTelemetry("victim", now + WINDOW - 1)).toBe(false);
+  });
+
+  it("never grows past the cap", async () => {
+    const { shouldEmitTelemetry } = await freshModule();
+    const now = 2_000_000;
+
+    for (let i = 0; i < MAX + 1_000; i++) {
+      shouldEmitTelemetry(`bucket-${i}`, now);
+    }
+
+    // Every survivor is live, so the tracker refuses new buckets rather than
+    // evicting — and the map cannot exceed its ceiling.
+    expect(shouldEmitTelemetry("one-more", now)).toBe(false);
+  });
+
+  it("lets a bucket emit again once its own window has expired", async () => {
+    const { shouldEmitTelemetry } = await freshModule();
+    const now = 3_000_000;
+
+    expect(shouldEmitTelemetry("recurring", now)).toBe(true);
+    expect(shouldEmitTelemetry("recurring", now + WINDOW - 1)).toBe(false);
+    expect(shouldEmitTelemetry("recurring", now + WINDOW)).toBe(true);
+  });
+
+  it("recovers once the saturating buckets age out", async () => {
+    // Fail-closed silence must self-heal — otherwise one flood would mute
+    // telemetry permanently on that machine.
+    const { shouldEmitTelemetry } = await freshModule();
+    const now = 4_000_000;
+
+    for (let i = 0; i < MAX + 100; i++) {
+      shouldEmitTelemetry(`flood-${i}`, now);
+    }
+    expect(shouldEmitTelemetry("after-flood", now)).toBe(false);
+
+    // A full window later the flood's entries can no longer suppress anything.
+    expect(shouldEmitTelemetry("after-flood", now + WINDOW)).toBe(true);
+  });
+
+  it("reports saturation once per window instead of silently dropping", async () => {
+    // why: a fail-closed branch that logs nothing is indistinguishable from
+    // "no rate limiting happened" — a silent empty result that looks healthy.
+    const { shouldEmitTelemetry } = await freshModule();
+    mockHandledClientError.mockReset();
+    const now = 5_000_000;
+
+    for (let i = 0; i < MAX + 200; i++) {
+      shouldEmitTelemetry(`sat-${i}`, now);
+    }
+
+    const saturationLogs = mockHandledClientError.mock.calls.filter(
+      (call) => typeof call[0]?.message === "string" && call[0].message.includes("saturated")
+    );
+    expect(saturationLogs).toHaveLength(1);
+    expect(saturationLogs[0][0].label).toBe("Rate limit");
+  });
+});

--- a/apps/webapp/server/rate-limit.test.ts
+++ b/apps/webapp/server/rate-limit.test.ts
@@ -1,9 +1,22 @@
 import { Hono } from "hono";
 import { session } from "remix-hono/session";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { appLoaderRateLimit } from "./rate-limit";
+import { appLoaderRateLimit, calendarFeedRateLimit } from "./rate-limit";
 import { createSessionStorage } from "./session";
+
+const mockHandledClientError = vi.hoisted(() => vi.fn());
+
+// why: the limiters emit their 429 trail through Logger.handledClientError,
+// which talks to Sentry's structured-log API — capture the call instead.
+vi.mock("~/utils/logger", () => ({
+  Logger: {
+    handledClientError: mockHandledClientError,
+    error: vi.fn(),
+    warn: vi.fn(),
+    log: vi.fn(),
+  },
+}));
 
 describe("appLoaderRateLimit middleware", () => {
   /**
@@ -96,5 +109,84 @@ describe("appLoaderRateLimit middleware", () => {
       const res = await request(app, "/api/sse/notification", "10.0.0.4");
       expect(res.status).toBe(200);
     }
+  });
+
+  /**
+   * The limiter short-circuits in Hono middleware, so no `ShelfError` is built
+   * and `error()`/`logException()` never run. Combined with the client
+   * boundary deliberately not capturing 429s, that made rate limiting
+   * invisible in every Sentry dataset — a customer report of "too many
+   * requests" could not be confirmed after the fact. These tests pin the
+   * replacement trail.
+   */
+  describe("observability", () => {
+    beforeEach(() => {
+      mockHandledClientError.mockReset();
+    });
+
+    it("records a rate-limited request on the handled-4xx log trail", async () => {
+      const app = makeApp(1);
+
+      await request(
+        app,
+        "/bookings/abc123/overview/manage-kits.data",
+        "10.1.0.1"
+      );
+      expect(mockHandledClientError).not.toHaveBeenCalled();
+
+      const overLimit = await request(
+        app,
+        "/bookings/abc123/overview/manage-kits.data",
+        "10.1.0.1"
+      );
+      expect(overLimit.status).toBe(429);
+
+      expect(mockHandledClientError).toHaveBeenCalledTimes(1);
+      const logged = mockHandledClientError.mock.calls[0][0];
+      expect(logged.status).toBe(429);
+      expect(logged.label).toBe("Rate limit");
+      // Never an error event — this is an expected, transient condition.
+      expect(logged.shouldBeCaptured).toBe(false);
+      // The path names the surface the user was on, which is what makes a
+      // customer report actionable.
+      expect(logged.message).toContain("app-loader");
+      expect(logged.message).toContain(
+        "/bookings/abc123/overview/manage-kits.data"
+      );
+    });
+
+    it("does not log the client IP for anonymous requests", async () => {
+      const app = makeApp(1);
+
+      await request(app, "/assets.data", "203.0.113.77");
+      await request(app, "/assets.data", "203.0.113.77");
+
+      const logged = mockHandledClientError.mock.calls[0][0];
+      expect(JSON.stringify(logged.additionalData ?? {})).not.toContain(
+        "203.0.113.77"
+      );
+      expect(logged.message).not.toContain("203.0.113.77");
+    });
+
+    it("never puts the calendar feed's secret token in the log trail", async () => {
+      // why: calendarFeedRateLimit keys on the request PATH, which embeds the
+      // feed's secret token. Logging that path verbatim would leak the secret
+      // into Sentry.
+      const secret = "s3cr3t-feed-token-do-not-log";
+      const app = new Hono();
+      const limiter = calendarFeedRateLimit();
+      app.use("*", limiter);
+      app.all("*", (c) => c.text("ok"));
+
+      // The limiter's default budget is 60/min; exhaust it, then trip it.
+      for (let i = 0; i <= 60; i++) {
+        await app.request(`https://app.shelf.nu/api/calendar/feed/${secret}`);
+      }
+
+      expect(mockHandledClientError).toHaveBeenCalled();
+      const logged = mockHandledClientError.mock.calls[0][0];
+      expect(logged.message).not.toContain(secret);
+      expect(logged.message).toContain("redacted");
+    });
   });
 });

--- a/apps/webapp/server/rate-limit.ts
+++ b/apps/webapp/server/rate-limit.ts
@@ -46,9 +46,8 @@ let saturationNoticeAt = 0;
  * Emit at most one notice per window that telemetry is being dropped because
  * the tracker is saturated.
  *
- * Without this, the fail-closed branch is indistinguishable from "no rate
- * limiting happened" — a silent empty result that looks perfectly healthy,
- * which is the failure mode this repo has been bitten by before.
+ * Without it the fail-closed branch is indistinguishable from "no rate
+ * limiting happened": a silent empty result that looks perfectly healthy.
  *
  * @param now - Current epoch ms
  */
@@ -142,17 +141,15 @@ export function shouldEmitTelemetry(bucket: string, now: number): boolean {
  * Emit a searchable, low-severity trail entry when a rate limiter rejects a
  * request.
  *
- * Rate limiters short-circuit inside Hono middleware: they return
- * `c.json(..., 429)` BEFORE `refreshSession()`, `protect()` and React Router
- * run (see the ordering comment in `server/index.ts`). No `ShelfError` is ever
- * constructed, so `error()` / `logException()` — the only callers of
- * `Logger.handledClientError` — never fire. That left 429s invisible in EVERY
- * Sentry dataset: the client error-boundary deliberately skips them
- * (`EXPECTED_ERROR_BOUNDARY_STATUSES`), and the handled-4xx log trail is only
- * reachable from a caught `ShelfError`. The sole record was Fly's request log,
- * which is live-tail only and carries no user id — so a customer report ("too
- * many requests when adding a kit to my booking") could not be confirmed after
- * the fact.
+ * This is the ONLY telemetry a 429 produces. Limiters short-circuit inside Hono
+ * middleware, returning `c.json(..., 429)` before `refreshSession()`,
+ * `protect()` and React Router run (see the ordering comment in
+ * `server/index.ts`), so no `ShelfError` is constructed and `error()` /
+ * `logException()` — the only other callers of `Logger.handledClientError` —
+ * never fire. The client error-boundary skips 429 by design
+ * (`EXPECTED_ERROR_BOUNDARY_STATUSES`), and Fly's request log is live-tail only
+ * and carries no user id. Drop this call and rate limiting becomes both
+ * unobservable and unattributable.
  *
  * Routing through `Logger.handledClientError` keeps ONE pipeline for handled
  * 4xx: the entry lands on the Sentry **logs** quota rather than the small

--- a/apps/webapp/server/rate-limit.ts
+++ b/apps/webapp/server/rate-limit.ts
@@ -22,8 +22,53 @@ const TELEMETRY_WINDOW_MS = 60_000;
  */
 const TELEMETRY_MAX_TRACKED_BUCKETS = 5_000;
 
-/** Bucket key → epoch ms of the last telemetry entry emitted for it. */
+/**
+ * Bucket key → epoch ms of the last telemetry entry emitted for it.
+ *
+ * Held in ascending timestamp order: every write goes through a delete-then-set
+ * (see {@link shouldEmitTelemetry}), so the oldest entry is always first. The
+ * expiry sweep relies on that to stop at the first still-live entry instead of
+ * walking all {@link TELEMETRY_MAX_TRACKED_BUCKETS} of them on a path that is
+ * meant to reject cheaply.
+ */
 const lastLoggedAt = new Map<string, number>();
+
+/**
+ * Epoch ms of the last "tracker saturated" notice.
+ *
+ * Deliberately NOT a reserved key inside {@link lastLoggedAt}: that map is full
+ * by definition whenever saturation is being reported, so a reserved key would
+ * be denied by the very code trying to report it.
+ */
+let saturationNoticeAt = 0;
+
+/**
+ * Emit at most one notice per window that telemetry is being dropped because
+ * the tracker is saturated.
+ *
+ * Without this, the fail-closed branch is indistinguishable from "no rate
+ * limiting happened" — a silent empty result that looks perfectly healthy,
+ * which is the failure mode this repo has been bitten by before.
+ *
+ * @param now - Current epoch ms
+ */
+function noticeTelemetrySaturation(now: number) {
+  if (now - saturationNoticeAt < TELEMETRY_WINDOW_MS) {
+    return;
+  }
+  saturationNoticeAt = now;
+
+  Logger.handledClientError(
+    new ShelfError({
+      cause: null,
+      label: "Rate limit",
+      message: `Rate limit telemetry tracker saturated (${TELEMETRY_MAX_TRACKED_BUCKETS} live buckets) — per-bucket entries are being dropped this window`,
+      status: 429,
+      shouldBeCaptured: false,
+      additionalData: {},
+    })
+  );
+}
 
 /**
  * Whether this bucket may emit a telemetry entry now, recording the emission
@@ -40,39 +85,54 @@ const lastLoggedAt = new Map<string, number>();
  * unbounded, a runaway client could bury the very incident trail this telemetry
  * exists to preserve.
  *
+ * When the tracker is saturated this fails CLOSED: new buckets emit nothing
+ * until a slot frees up. Evicting a live entry instead would be a bypass —
+ * an attacker who can mint more than {@link TELEMETRY_MAX_TRACKED_BUCKETS}
+ * buckets could evict a bucket's own suppressor and make it emit again inside
+ * its window, degrading the throttle back to roughly one entry per request.
+ * Minting that many is cheap: `appLoaderRateLimit` keys on
+ * `app:${identity}:${path}` and runs on ANY `.data` path, so one client can
+ * rotate paths. Failing closed is the narrower harm — the silence is scoped to
+ * one window on one machine and self-heals, whereas a flood burns the shared
+ * Sentry logs quota and denies telemetry org-wide for far longer.
+ *
  * @param bucket - The limiter's OWN bucket key. Callers must pass the real key
  *   rather than the log message: `calendarFeedRateLimit`'s message detail is a
  *   redacted placeholder shared by every feed, so throttling on that would
  *   collapse all feeds into one bucket and silence all but the first.
  * @param now - Current epoch ms, injected so tests stay deterministic
  * @returns `true` when the caller should emit
+ * @internal Exported only so the throttle can be unit-tested directly; driving
+ *   these paths over HTTP would take tens of thousands of requests.
  */
-function shouldEmitTelemetry(bucket: string, now: number): boolean {
+export function shouldEmitTelemetry(bucket: string, now: number): boolean {
   const last = lastLoggedAt.get(bucket);
   if (last !== undefined && now - last < TELEMETRY_WINDOW_MS) {
     return false;
   }
 
   if (lastLoggedAt.size >= TELEMETRY_MAX_TRACKED_BUCKETS) {
-    // Drop anything that can no longer suppress an emit (its window has long
-    // passed) before falling back to evicting the least recently emitted.
+    // Sweep entries that can no longer suppress anything — the exact
+    // complement of the liveness test above, so nothing live is dropped.
+    // Ascending order lets the first live entry end the scan.
     for (const [key, at] of lastLoggedAt) {
-      if (now - at >= TELEMETRY_WINDOW_MS * 2) {
-        lastLoggedAt.delete(key);
-      }
-    }
-    while (lastLoggedAt.size >= TELEMETRY_MAX_TRACKED_BUCKETS) {
-      const oldest = lastLoggedAt.keys().next();
-      if (oldest.done) {
+      if (now - at < TELEMETRY_WINDOW_MS) {
         break;
       }
-      lastLoggedAt.delete(oldest.value);
+      lastLoggedAt.delete(key);
+    }
+
+    // Still full: every survivor is a live suppressor, so there is nothing
+    // safe to evict. Drop this emit rather than punch a hole in the throttle.
+    if (lastLoggedAt.size >= TELEMETRY_MAX_TRACKED_BUCKETS) {
+      noticeTelemetrySaturation(now);
+      return false;
     }
   }
 
   // Delete before set so the entry moves to the end of the Map's insertion
   // order — `set` on an existing key keeps its original position, which would
-  // make the eviction above evict by first-seen rather than by least-recent.
+  // break the ascending-timestamp invariant the sweep's early `break` needs.
   lastLoggedAt.delete(bucket);
   lastLoggedAt.set(bucket, now);
   return true;

--- a/apps/webapp/server/rate-limit.ts
+++ b/apps/webapp/server/rate-limit.ts
@@ -8,6 +8,77 @@ import { authSessionKey } from "./session";
 import type { FlashData, SessionData } from "./session";
 
 /**
+ * How long one bucket stays silent after emitting a telemetry entry. Matches
+ * every limiter's `windowMs`, so a bucket contributes at most one log per
+ * limiter window.
+ */
+const TELEMETRY_WINDOW_MS = 60_000;
+
+/**
+ * Hard cap on tracked buckets, so the throttle cannot itself become the leak.
+ * An attacker rotating source IPs mints a fresh bucket per request; without a
+ * ceiling this map would grow without bound and we would have traded a log
+ * flood for a memory exhaustion.
+ */
+const TELEMETRY_MAX_TRACKED_BUCKETS = 5_000;
+
+/** Bucket key → epoch ms of the last telemetry entry emitted for it. */
+const lastLoggedAt = new Map<string, number>();
+
+/**
+ * Whether this bucket may emit a telemetry entry now, recording the emission
+ * when it may.
+ *
+ * `hono-rate-limiter` invokes a limiter's `handler` for EVERY request once the
+ * bucket is over its limit — `MemoryStore.increment` unconditionally bumps
+ * `totalHits`, and the middleware calls `handler` whenever `totalHits > limit`.
+ * So the natural shape of a rate-limit incident (a client that keeps going) is
+ * also the shape that would flood the log trail. `mobileIpRateLimit` runs
+ * before `session()` on a `publicPaths` route, making that flood anonymously
+ * triggerable, and `SENTRY_HANDLED_4XX_SAMPLE_RATE` defaults to 1, so sampling
+ * offers no protection unless someone has explicitly dialled it down. Left
+ * unbounded, a runaway client could bury the very incident trail this telemetry
+ * exists to preserve.
+ *
+ * @param bucket - The limiter's OWN bucket key. Callers must pass the real key
+ *   rather than the log message: `calendarFeedRateLimit`'s message detail is a
+ *   redacted placeholder shared by every feed, so throttling on that would
+ *   collapse all feeds into one bucket and silence all but the first.
+ * @param now - Current epoch ms, injected so tests stay deterministic
+ * @returns `true` when the caller should emit
+ */
+function shouldEmitTelemetry(bucket: string, now: number): boolean {
+  const last = lastLoggedAt.get(bucket);
+  if (last !== undefined && now - last < TELEMETRY_WINDOW_MS) {
+    return false;
+  }
+
+  if (lastLoggedAt.size >= TELEMETRY_MAX_TRACKED_BUCKETS) {
+    // Drop anything that can no longer suppress an emit (its window has long
+    // passed) before falling back to evicting the least recently emitted.
+    for (const [key, at] of lastLoggedAt) {
+      if (now - at >= TELEMETRY_WINDOW_MS * 2) {
+        lastLoggedAt.delete(key);
+      }
+    }
+    while (lastLoggedAt.size >= TELEMETRY_MAX_TRACKED_BUCKETS) {
+      const oldest = lastLoggedAt.keys().next();
+      if (oldest.done) {
+        break;
+      }
+      lastLoggedAt.delete(oldest.value);
+    }
+  }
+
+  // Delete before set so the entry moves to the end of the Map's insertion
+  // order — `set` on an existing key keeps its original position, which would
+  // make the eviction above evict by first-seen rather than by least-recent.
+  lastLoggedAt.delete(bucket);
+  lastLoggedAt.set(bucket, now);
+  return true;
+}
+
+/**
  * Emit a searchable, low-severity trail entry when a rate limiter rejects a
  * request.
  *
@@ -28,8 +99,15 @@ import type { FlashData, SessionData } from "./session";
  * error-event quota, honours `SENTRY_HANDLED_4XX_SAMPLE_RATE`, and is
  * filterable by `label:"Rate limit"`.
  *
+ * Throttled to at most one entry per bucket per window — see
+ * {@link shouldEmitTelemetry} for why an unthrottled emit is self-defeating.
+ *
  * @param scope - Which limiter fired (e.g. `app-loader`), so the three
  *   limiters stay distinguishable in one query
+ * @param bucket - The limiter's own bucket key, used ONLY as the throttle key.
+ *   Never logged: for `calendarFeedRateLimit` it embeds the feed's secret
+ *   token. It stays in process memory, exactly as `hono-rate-limiter`'s own
+ *   MemoryStore already holds it, so this is no new exposure.
  * @param detail - Caller-supplied description of WHAT was limited, appended to
  *   the log message. **Must not contain secrets** — `calendarFeedRateLimit`
  *   keys on a path that embeds the feed's secret token, so it passes a
@@ -41,13 +119,22 @@ import type { FlashData, SessionData } from "./session";
  */
 function logRateLimitHit({
   scope,
+  bucket,
   detail,
   userId,
 }: {
   scope: string;
+  bucket: string;
   detail: string;
   userId?: string;
 }) {
+  // Gate BEFORE constructing the ShelfError: the constructor captures a V8
+  // stack and mints a cuid2 traceId, and this runs on the path whose whole
+  // point is to reject an over-limit request with as little work as possible.
+  if (!shouldEmitTelemetry(`${scope}:${bucket}`, Date.now())) {
+    return;
+  }
+
   Logger.handledClientError(
     new ShelfError({
       cause: null,
@@ -60,6 +147,21 @@ function logRateLimitHit({
     })
   );
 }
+
+/**
+ * Bucket-key builders, shared between each limiter's `keyGenerator` and its
+ * 429 `handler`.
+ *
+ * The handler must throttle on the SAME key the store counted, so these are
+ * defined once rather than duplicated at both call sites — the two drifting
+ * apart would silently mis-scope the throttle.
+ */
+const bucketKeys = {
+  mobileIp: (c: Context) => `mobile:ip:${getClientIp(c)}`,
+  appLoader: (c: Context) =>
+    `app:${resolveAppLoaderIdentity(c).identity}:${c.req.path}`,
+  calendarFeed: (c: Context) => `calendar:${c.req.path}`,
+};
 
 /**
  * Resolve the identity half of {@link appLoaderRateLimit}'s bucket key.
@@ -102,11 +204,15 @@ export const mobileIpRateLimit = () =>
     windowMs: 60_000,
     limit: 30,
     standardHeaders: "draft-7",
-    keyGenerator: (c) => `mobile:ip:${getClientIp(c)}`,
+    keyGenerator: bucketKeys.mobileIp,
     handler: (c) => {
       // Pre-auth surface, so there is no user id to attribute this to; the
       // path is all we can safely record.
-      logRateLimitHit({ scope: "mobile-ip", detail: c.req.path });
+      logRateLimitHit({
+        scope: "mobile-ip",
+        bucket: bucketKeys.mobileIp(c),
+        detail: c.req.path,
+      });
 
       return c.json(
         {
@@ -152,8 +258,7 @@ export const appLoaderRateLimit = (limit = 60) =>
     windowMs: 60_000,
     limit,
     standardHeaders: "draft-7",
-    keyGenerator: (c) =>
-      `app:${resolveAppLoaderIdentity(c as Context).identity}:${c.req.path}`,
+    keyGenerator: (c) => bucketKeys.appLoader(c as Context),
     handler: (c) => {
       const { userId } = resolveAppLoaderIdentity(c as Context);
 
@@ -161,7 +266,12 @@ export const appLoaderRateLimit = (limit = 60) =>
       // report actionable: it names the surface the user was on (e.g.
       // `/bookings/<id>/overview/manage-kits.data`). Loader paths carry no
       // secrets — the query string is excluded from `c.req.path` anyway.
-      logRateLimitHit({ scope: "app-loader", detail: c.req.path, userId });
+      logRateLimitHit({
+        scope: "app-loader",
+        bucket: bucketKeys.appLoader(c as Context),
+        detail: c.req.path,
+        userId,
+      });
 
       return c.json(
         {
@@ -193,7 +303,7 @@ export const calendarFeedRateLimit = () =>
     windowMs: 60_000,
     limit: 60,
     standardHeaders: "draft-7",
-    keyGenerator: (c) => `calendar:${c.req.path}`,
+    keyGenerator: bucketKeys.calendarFeed,
     handler: (c) => {
       // why: this limiter keys on the request PATH, which embeds the feed's
       // SECRET TOKEN (see the doc comment above). Logging the raw path would
@@ -201,6 +311,9 @@ export const calendarFeedRateLimit = () =>
       // was limited — the token is never recoverable from this entry.
       logRateLimitHit({
         scope: "calendar-feed",
+        // The raw key (token included) throttles per-feed; only the redacted
+        // `detail` is ever written to the log.
+        bucket: bucketKeys.calendarFeed(c),
         detail: "/api/calendar/feed/<redacted>",
       });
 

--- a/apps/webapp/server/rate-limit.ts
+++ b/apps/webapp/server/rate-limit.ts
@@ -1,9 +1,88 @@
 import type { Context } from "hono";
 import { rateLimiter } from "hono-rate-limiter";
 import { getSession } from "remix-hono/session";
+import { ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
 import { getClientIp } from "./client-ip";
 import { authSessionKey } from "./session";
 import type { FlashData, SessionData } from "./session";
+
+/**
+ * Emit a searchable, low-severity trail entry when a rate limiter rejects a
+ * request.
+ *
+ * Rate limiters short-circuit inside Hono middleware: they return
+ * `c.json(..., 429)` BEFORE `refreshSession()`, `protect()` and React Router
+ * run (see the ordering comment in `server/index.ts`). No `ShelfError` is ever
+ * constructed, so `error()` / `logException()` — the only callers of
+ * `Logger.handledClientError` — never fire. That left 429s invisible in EVERY
+ * Sentry dataset: the client error-boundary deliberately skips them
+ * (`EXPECTED_ERROR_BOUNDARY_STATUSES`), and the handled-4xx log trail is only
+ * reachable from a caught `ShelfError`. The sole record was Fly's request log,
+ * which is live-tail only and carries no user id — so a customer report ("too
+ * many requests when adding a kit to my booking") could not be confirmed after
+ * the fact.
+ *
+ * Routing through `Logger.handledClientError` keeps ONE pipeline for handled
+ * 4xx: the entry lands on the Sentry **logs** quota rather than the small
+ * error-event quota, honours `SENTRY_HANDLED_4XX_SAMPLE_RATE`, and is
+ * filterable by `label:"Rate limit"`.
+ *
+ * @param scope - Which limiter fired (e.g. `app-loader`), so the three
+ *   limiters stay distinguishable in one query
+ * @param detail - Caller-supplied description of WHAT was limited, appended to
+ *   the log message. **Must not contain secrets** — `calendarFeedRateLimit`
+ *   keys on a path that embeds the feed's secret token, so it passes a
+ *   redacted string rather than the raw path.
+ * @param userId - The authenticated user, when known. `handledClientError`
+ *   promotes this to a log attribute, which is what makes an incident
+ *   attributable to a reporting customer. The client IP is deliberately NOT
+ *   logged: it is PII and useless for attribution.
+ */
+function logRateLimitHit({
+  scope,
+  detail,
+  userId,
+}: {
+  scope: string;
+  detail: string;
+  userId?: string;
+}) {
+  Logger.handledClientError(
+    new ShelfError({
+      cause: null,
+      label: "Rate limit",
+      message: `Rate limit exceeded (${scope}): ${detail}`,
+      status: 429,
+      // Expected, transient, user-facing — never an error event.
+      shouldBeCaptured: false,
+      additionalData: userId ? { userId } : {},
+    })
+  );
+}
+
+/**
+ * Resolve the identity half of {@link appLoaderRateLimit}'s bucket key.
+ *
+ * Shared by the limiter's `keyGenerator` and its 429 `handler` so the value
+ * logged is provably the value that was counted — recomputing the lookup
+ * inline in both places would let them drift.
+ *
+ * @param c - The Hono request context
+ * @returns The signed-session `userId` when authenticated, plus the bucket
+ *   identity actually used (falling back to the client IP for anonymous and
+ *   edge cases).
+ */
+function resolveAppLoaderIdentity(c: Context) {
+  // `hono-rate-limiter` types the handler context with hono's default `Env`,
+  // which is structurally narrower than the `Context<Env>` that remix-hono's
+  // `getSession` expects; cast to bridge the two (the value is a genuine hono
+  // Context, only the generic differs).
+  const auth = getSession<SessionData, FlashData>(c).get(authSessionKey);
+  const userId = auth?.userId;
+
+  return { userId, identity: userId ?? getClientIp(c) };
+}
 
 /**
  * Coarse IP-based rate limit for `/api/mobile/*`.
@@ -24,15 +103,20 @@ export const mobileIpRateLimit = () =>
     limit: 30,
     standardHeaders: "draft-7",
     keyGenerator: (c) => `mobile:ip:${getClientIp(c)}`,
-    handler: (c) =>
-      c.json(
+    handler: (c) => {
+      // Pre-auth surface, so there is no user id to attribute this to; the
+      // path is all we can safely record.
+      logRateLimitHit({ scope: "mobile-ip", detail: c.req.path });
+
+      return c.json(
         {
           error: {
             message: "Too many requests. Please try again later.",
           },
         },
         429
-      ),
+      );
+    },
   });
 
 /**
@@ -68,26 +152,26 @@ export const appLoaderRateLimit = (limit = 60) =>
     windowMs: 60_000,
     limit,
     standardHeaders: "draft-7",
-    keyGenerator: (c) => {
-      // `hono-rate-limiter` types the handler context with hono's default
-      // `Env`, which is structurally narrower than the `Context<Env>` that
-      // remix-hono's `getSession` expects; cast to bridge the two (the value
-      // is a genuine hono Context, only the generic differs).
-      const auth = getSession<SessionData, FlashData>(c as Context).get(
-        authSessionKey
-      );
-      const identity = auth?.userId ?? getClientIp(c);
-      return `app:${identity}:${c.req.path}`;
-    },
-    handler: (c) =>
-      c.json(
+    keyGenerator: (c) =>
+      `app:${resolveAppLoaderIdentity(c as Context).identity}:${c.req.path}`,
+    handler: (c) => {
+      const { userId } = resolveAppLoaderIdentity(c as Context);
+
+      // The path is the other half of the bucket key, and is what makes a
+      // report actionable: it names the surface the user was on (e.g.
+      // `/bookings/<id>/overview/manage-kits.data`). Loader paths carry no
+      // secrets — the query string is excluded from `c.req.path` anyway.
+      logRateLimitHit({ scope: "app-loader", detail: c.req.path, userId });
+
+      return c.json(
         {
           error: {
             message: "Too many requests. Please try again later.",
           },
         },
         429
-      ),
+      );
+    },
   });
 
 /**
@@ -110,5 +194,16 @@ export const calendarFeedRateLimit = () =>
     limit: 60,
     standardHeaders: "draft-7",
     keyGenerator: (c) => `calendar:${c.req.path}`,
-    handler: (c) => c.text("Too many requests. Please try again later.", 429),
+    handler: (c) => {
+      // why: this limiter keys on the request PATH, which embeds the feed's
+      // SECRET TOKEN (see the doc comment above). Logging the raw path would
+      // leak that secret into the Sentry log trail, so record only that a feed
+      // was limited — the token is never recoverable from this entry.
+      logRateLimitHit({
+        scope: "calendar-feed",
+        detail: "/api/calendar/feed/<redacted>",
+      });
+
+      return c.text("Too many requests. Please try again later.", 429);
+    },
   });


### PR DESCRIPTION
## The bug

A customer reported "It keep showing *too man request* when I want to add kit into my booking" on the booking **manage-kits** modal.

Every change to `?s=` is a router navigation, and each navigation issues one single-fetch `*.data` request. The search field had **no debounce** — the handler was still *named* `debouncedHandleChange`, but the 100 ms debounce was removed in `a1f6cd734` (May 2024). So typing produced one server-side loader run **per character**.

`appLoaderRateLimit` caps `.data` at 60 requests per 60 s per `(userId, path)`, and the bucket key deliberately excludes the query string — so `?s=b`, `?s=br`, `?s=bro` all share one budget. Typing ~60 characters into a list search within a minute earns a 429, which the boundary renders as "Too many requests", tearing down the modal mid-task.

Not manage-kits-specific — it's the shared `SearchForm`, so `/assets`, `/kits`, `/bookings` and both `manage-*` modals were all affected. manage-kits just dominates because that's where people search hardest.

## Evidence

Captured from **live production traffic** — a real user typing a 7-character search, one counted request per keystroke:

```
GET /kits/<id>/assets/manage-assets.data?s=0
GET /kits/<id>/assets/manage-assets.data?s=05
GET /kits/<id>/assets/manage-assets.data?s=05-
GET /kits/<id>/assets/manage-assets.data?s=05-0
GET /kits/<id>/assets/manage-assets.data?s=05-01
GET /kits/<id>/assets/manage-assets.data?s=05-017
GET /kits/<id>/assets/manage-assets.data?s=05-017T
```

Measured on the manage-kits modal, typing 64 characters:

| | Before | After |
| --- | --- | --- |
| `.data` requests | 64 | **1** |
| Outcome | 429 → "Too many requests" boundary | **200**, modal intact |

**Why it looked unreproducible:** the limiter's store is in-memory *per Fly machine*, and prod runs 5. Requests scatter, so the effective ceiling is ~60 x N — 125 requests fired at production never tripped it. It bites when a browser's connection concentrates on one machine. Locally (single process) it is deterministic every time.

## Changes

**The fix** — `search-form.tsx`
- 400 ms debounce; a burst of typing is now one navigation.
- `replace: true`, so Back no longer walks backwards through the query one letter at a time.
- Busy state is driven off *pending debounce OR in-flight navigation*, not navigation alone. The original debounce was dropped **because** it left the field looking idle while typing — a test pins the spinner to the first keystroke so that doesn't regress again.
- Clearing cancels a scheduled navigation; the timer is torn down on unmount (these modals close with a debounce in flight).

**Observability** — `rate-limit.ts`

Rate limiting was invisible in production. The limiters short-circuit in Hono middleware, returning `c.json(..., 429)` *before* `refreshSession()`, `protect()` and React Router run — so no `ShelfError` is built and `error()`/`logException()` never fire. Combined with the client boundary deliberately skipping 429 (`EXPECTED_ERROR_BOUNDARY_STATUSES`), **no Sentry dataset — errors, logs, or spans — recorded these**. The only trace was Fly's live-tail request log, which carries no user id, so the customer's report could not be confirmed after the fact.

- All three limiters now emit a `label:"Rate limit"` entry on the handled-4xx log trail via `Logger.handledClientError` — the separate logs quota, not the error quota, and attributable via `userId`.
- The client IP is **never** logged (PII, and useless for attribution).
- `calendarFeedRateLimit` logs a **redacted** path: its bucket key is the request path, which embeds the feed's **secret token**. Logging it verbatim would have leaked that secret into Sentry. Both behaviours are test-pinned.

## Testing

- New `search-form.test.tsx` — 7 tests covering the request-count contract, `replace`, page reset, clear-on-empty, spinner-on-first-keystroke, and no-dispatch-after-unmount.
- Extended `server/rate-limit.test.ts` — the 429 log trail, no-IP-in-logs, and no-secret-in-logs.
- `pnpm --filter @shelf/webapp validate`: 5154 tests pass, 0 lint errors, `tsc -b --force` clean.
- Verified in a browser against a local server (the before/after table above).

## Reviewer notes

Two deliberate scope calls, easy to drop:

1. The log trail is wired into **all three** limiters, not just the app-loader one — all three were equally blind.
2. `replace: true` is a navigation-semantics change beyond the pure debounce.

One caveat: this is the mechanism, proven end-to-end, but the reporting customer's *specific* 429 can't be confirmed — that event was never recorded anywhere. The logging change is what makes the next one attributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Search updates are grouped while typing, reducing unnecessary page refreshes.
  - A loading indicator remains visible throughout search processing.
  - Search results replace the current history entry and reset pagination.
  - Clearing a search immediately removes the filter and returns to the first page.
  - Improved accessibility for the clear-search control.
  - Improved rate-limit monitoring and reporting while protecting sensitive feed information.

- **Bug Fixes**
  - Prevented delayed search updates after the form is closed or cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->