### PR TITLE
fix(bookings): edit companion booking dates in the preference zone

### DIFF
--- a/.claude/rules/working-hours-are-location-local.md
+++ b/.claude/rules/working-hours-are-location-local.md
@@ -46,7 +46,29 @@ is a stored location zone, not a different user-side zone. The UI states the
 semantics at the two places users meet them — the Weekly Schedule settings form
 and the booking form's working-hours info box.
 
+**The accepted proxy is the acting user's resolved preference zone, and it is
+mandatory — not merely tolerated.** Every working-hours TIME evaluation reads
+that one zone, so a single submission is judged the same way at every step. The
+alternative is not "no zone": a bare `getDay()` / `setHours()` / `format()` runs
+against the **ambient clock**, which is the device in the browser and UTC on the
+server. That is strictly worse than the proxy — the same booking can be measured
+in two different zones on either side of one validation.
+
+So the two directions are not symmetrical, and only one of them is a violation:
+
+| Change                                        | Verdict                                           |
+| --------------------------------------------- | ------------------------------------------------- |
+| ambient device/server clock → preference zone | **bug fix** — makes the accepted proxy consistent |
+| preference zone → some other user-side zone   | violation — a second proxy is drift, not a fix    |
+| preference zone → stored location zone        | the real fix, if we ever build the column         |
+
+Switching a calculation off the ambient clock and onto `prefs.timeZone` is
+therefore expected when you touch this code, and reviewing it as "keying working
+hours to the viewer's timezone" is a false positive.
+
 When you touch working-hours code, ask which half you are in: a **date** must
-stay absolute (use the helper), a **time** is on-site wall clock and needs no
-conversion at all. See [[quantity-semantics-per-surface]] for the same
-"name what this value means before reaching for a helper" discipline.
+stay absolute (use `getOverrideDateKey()`); a **time** means on-site wall clock
+and is evaluated in the accepted proxy above — never in whatever zone the
+machine running the code happens to be in. See [[quantity-semantics-per-surface]]
+for the same "name what this value means before reaching for a helper"
+discipline.

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -219,6 +219,19 @@ export default function BookingDetailScreen() {
     announce("Content refreshed");
   };
 
+  /**
+   * The DEVICE zone, deliberately — not the user's preference zone.
+   *
+   * The booking action endpoints take this as a client HINT, standing in for
+   * the `CH-time-zone` cookie a native client cannot set. Web fills the same
+   * field from `getClientHint(request)`, which is also the device. Sending the
+   * preference zone here would make the two platforms disagree on one request
+   * field for no gain.
+   *
+   * The booking FORM screens are the opposite case and use `prefs.timeZone`:
+   * there the zone is not a hint, it is the encoding of a wall-clock string
+   * the user typed. Don't unify the two.
+   */
   const getTimeZone = () => {
     try {
       return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";

--- a/apps/companion/app/(tabs)/bookings/edit.tsx
+++ b/apps/companion/app/(tabs)/bookings/edit.tsx
@@ -35,7 +35,7 @@ import { api, type BookingTag } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { markBookingDirty } from "@/lib/booking-refresh";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
-import { wallClockDateInZone, wallClockWireString } from "@shelf/datetime";
+import { addDaysInZone, wallClockWireInZone } from "@shelf/datetime";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -48,11 +48,9 @@ export default function EditBookingScreen() {
   const { currentOrg } = useOrg();
   const { colors } = useTheme();
   const styles = useStyles();
-  // `from`/`to` below are wall-clock CARRIERS in the user's preference zone, not
-  // instants — their local fields are what the picker edits and what gets
-  // submitted. So the labels must read those local fields verbatim
-  // (`localeOnly`) and apply the user's FORMAT only: converting a carrier
-  // through a zone would shift it away from the value being edited.
+  // `from`/`to` are the booking's real instants throughout. Both pickers are
+  // driven in the preference zone via `timeZoneName`, so the times shown here
+  // match the detail screen the user just came from.
   const { formatDateTime, prefs } = useDateFormatter();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -113,13 +111,8 @@ export default function EditBookingScreen() {
           ? { id: b.custodianTeamMember.id, name: b.custodianTeamMember.name }
           : null
       );
-      // The booking's stored instants become carriers of their wall clock in the
-      // preference zone, so the picker shows the same time the booking detail
-      // screen does — and re-submitting an untouched form is a no-op.
-      const fromCarrier = wallClockDateInZone(b.from, prefs.timeZone);
-      const toCarrier = wallClockDateInZone(b.to, prefs.timeZone);
-      setFrom(fromCarrier);
-      setTo(toCarrier);
+      setFrom(new Date(b.from));
+      setTo(new Date(b.to));
       setSelectedTagIds(new Set(b.tags.map((t) => t.id)));
       setIsDraft(b.status === "DRAFT");
       // Snapshot the loaded values so the discard guard only fires on a REAL
@@ -128,11 +121,8 @@ export default function EditBookingScreen() {
         name: b.name,
         description: b.description ?? "",
         custodianId: b.custodianTeamMember?.id ?? null,
-        // Snapshot the CARRIERS, not the instants: the guard below compares
-        // these against the picker state, which is carriers. Mixing the two
-        // makes an untouched form look edited by the zone's offset.
-        from: fromCarrier.getTime(),
-        to: toCarrier.getTime(),
+        from: new Date(b.from).getTime(),
+        to: new Date(b.to).getTime(),
         tagIds: [...b.tags.map((t) => t.id)].sort().join(","),
       };
       if (tagsRes.data?.tags) setTags(tagsRes.data.tags);
@@ -141,11 +131,7 @@ export default function EditBookingScreen() {
     return () => {
       active = false;
     };
-    // `prefs.timeZone` is inert here in practice: this effect returns early
-    // until `currentOrg` exists, and the org and the user profile are set from
-    // the same `/me` response — so the zone is already resolved by the time a
-    // load runs. Listed because the seeding above genuinely depends on it.
-  }, [id, currentOrg, prefs.timeZone]);
+  }, [id, currentOrg]);
 
   // ── Unsaved-changes guard (only after a REAL edit) ─────
   const navigation = useNavigation();
@@ -186,19 +172,18 @@ export default function EditBookingScreen() {
       if (event.type === "dismissed") return;
       if (selected) {
         setFrom(selected);
-        // Keep `to` after `from`: if it's now invalid, push it to +1 day. Step
-        // the calendar field rather than adding 24h — these are wall-clock
-        // carriers, and a fixed 24h shifts the clock across a device DST edge.
-        setTo((prev) => {
-          if (!prev || prev > selected) return prev;
-          const next = new Date(selected);
-          next.setDate(next.getDate() + 1);
-          return next;
-        });
+        // Keep `to` after `from`: if it's now invalid, push it to +1 day. A
+        // calendar day in the preference zone, not a fixed 24h — across a DST
+        // boundary the day is 23 or 25 hours and the clock would shift.
+        setTo((prev) =>
+          !prev || prev > selected
+            ? prev
+            : addDaysInZone(selected, 1, prefs.timeZone)
+        );
         if (Platform.OS === "ios") setShowFromPicker(false);
       }
     },
-    []
+    [prefs.timeZone]
   );
 
   const onToChange = useCallback(
@@ -248,8 +233,8 @@ export default function EditBookingScreen() {
       name: name.trim(),
       description: description.trim() || undefined,
       custodianTeamMemberId: custodian.id,
-      startDate: wallClockWireString(from),
-      endDate: wallClockWireString(to),
+      startDate: wallClockWireInZone(from, prefs.timeZone),
+      endDate: wallClockWireInZone(to, prefs.timeZone),
       // The wire strings carry no offset, so the zone they were written in has
       // to travel with them — that is the preference zone the pickers edit in.
       timeZone: prefs.timeZone,
@@ -405,9 +390,7 @@ export default function EditBookingScreen() {
             }}
             accessibilityRole="button"
             accessibilityLabel={
-              from
-                ? `Starts ${formatDateTime(from, { localeOnly: true })}`
-                : "Start"
+              from ? `Starts ${formatDateTime(from)}` : "Start"
             }
           >
             <Text
@@ -415,9 +398,7 @@ export default function EditBookingScreen() {
                 from ? styles.pickerSelectedText : styles.pickerPlaceholder
               }
             >
-              {from
-                ? formatDateTime(from, { localeOnly: true })
-                : "Choose start..."}
+              {from ? formatDateTime(from) : "Choose start..."}
             </Text>
             {isDraft && (
               <Ionicons
@@ -435,6 +416,7 @@ export default function EditBookingScreen() {
                 value={from ?? new Date()}
                 mode="datetime"
                 display={Platform.OS === "ios" ? "inline" : "default"}
+                timeZoneName={prefs.timeZone}
                 onChange={onFromChange}
                 accentColor={colors.primary}
               />
@@ -454,14 +436,12 @@ export default function EditBookingScreen() {
               setShowFromPicker(false);
             }}
             accessibilityRole="button"
-            accessibilityLabel={
-              to ? `Ends ${formatDateTime(to, { localeOnly: true })}` : "End"
-            }
+            accessibilityLabel={to ? `Ends ${formatDateTime(to)}` : "End"}
           >
             <Text
               style={to ? styles.pickerSelectedText : styles.pickerPlaceholder}
             >
-              {to ? formatDateTime(to, { localeOnly: true }) : "Choose end..."}
+              {to ? formatDateTime(to) : "Choose end..."}
             </Text>
             {isDraft && (
               <Ionicons
@@ -479,6 +459,7 @@ export default function EditBookingScreen() {
                 value={to ?? from ?? new Date()}
                 mode="datetime"
                 display={Platform.OS === "ios" ? "inline" : "default"}
+                timeZoneName={prefs.timeZone}
                 minimumDate={from ?? undefined}
                 onChange={onToChange}
                 accentColor={colors.primary}

--- a/apps/companion/app/(tabs)/bookings/edit.tsx
+++ b/apps/companion/app/(tabs)/bookings/edit.tsx
@@ -186,11 +186,15 @@ export default function EditBookingScreen() {
       if (event.type === "dismissed") return;
       if (selected) {
         setFrom(selected);
-        setTo((prev) =>
-          prev && prev <= selected
-            ? new Date(selected.getTime() + 24 * 60 * 60 * 1000)
-            : prev
-        );
+        // Keep `to` after `from`: if it's now invalid, push it to +1 day. Step
+        // the calendar field rather than adding 24h — these are wall-clock
+        // carriers, and a fixed 24h shifts the clock across a device DST edge.
+        setTo((prev) => {
+          if (!prev || prev > selected) return prev;
+          const next = new Date(selected);
+          next.setDate(next.getDate() + 1);
+          return next;
+        });
         if (Platform.OS === "ios") setShowFromPicker(false);
       }
     },

--- a/apps/companion/app/(tabs)/bookings/edit.tsx
+++ b/apps/companion/app/(tabs)/bookings/edit.tsx
@@ -35,26 +35,12 @@ import { api, type BookingTag } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { markBookingDirty } from "@/lib/booking-refresh";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { wallClockDateInZone, wallClockWireString } from "@shelf/datetime";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { labelForRequired } from "@/lib/a11y";
 import { TeamMemberPicker } from "@/components/team-member-picker";
-
-function getTimeZone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-  } catch {
-    return "UTC";
-  }
-}
-
-function toLocalWire(d: Date): string {
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(
-    d.getHours()
-  )}:${p(d.getMinutes())}`;
-}
 
 export default function EditBookingScreen() {
   const router = useRouter();
@@ -62,11 +48,12 @@ export default function EditBookingScreen() {
   const { currentOrg } = useOrg();
   const { colors } = useTheme();
   const styles = useStyles();
-  // Picker button labels use the user's date/time FORMAT (order, 12/24h) but stay
-  // DEVICE-local (`localeOnly`) — the native picker and `toLocalWire` submission
-  // are device-local, so formatting them in the preferred timezone would show a
-  // different time than the one being edited and submitted (CodeRabbit, #2798).
-  const { formatDateTime } = useDateFormatter();
+  // `from`/`to` below are wall-clock CARRIERS in the user's preference zone, not
+  // instants — their local fields are what the picker edits and what gets
+  // submitted. So the labels must read those local fields verbatim
+  // (`localeOnly`) and apply the user's FORMAT only: converting a carrier
+  // through a zone would shift it away from the value being edited.
+  const { formatDateTime, prefs } = useDateFormatter();
 
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -126,8 +113,13 @@ export default function EditBookingScreen() {
           ? { id: b.custodianTeamMember.id, name: b.custodianTeamMember.name }
           : null
       );
-      setFrom(new Date(b.from));
-      setTo(new Date(b.to));
+      // The booking's stored instants become carriers of their wall clock in the
+      // preference zone, so the picker shows the same time the booking detail
+      // screen does — and re-submitting an untouched form is a no-op.
+      const fromCarrier = wallClockDateInZone(b.from, prefs.timeZone);
+      const toCarrier = wallClockDateInZone(b.to, prefs.timeZone);
+      setFrom(fromCarrier);
+      setTo(toCarrier);
       setSelectedTagIds(new Set(b.tags.map((t) => t.id)));
       setIsDraft(b.status === "DRAFT");
       // Snapshot the loaded values so the discard guard only fires on a REAL
@@ -136,8 +128,11 @@ export default function EditBookingScreen() {
         name: b.name,
         description: b.description ?? "",
         custodianId: b.custodianTeamMember?.id ?? null,
-        from: new Date(b.from).getTime(),
-        to: new Date(b.to).getTime(),
+        // Snapshot the CARRIERS, not the instants: the guard below compares
+        // these against the picker state, which is carriers. Mixing the two
+        // makes an untouched form look edited by the zone's offset.
+        from: fromCarrier.getTime(),
+        to: toCarrier.getTime(),
         tagIds: [...b.tags.map((t) => t.id)].sort().join(","),
       };
       if (tagsRes.data?.tags) setTags(tagsRes.data.tags);
@@ -146,7 +141,11 @@ export default function EditBookingScreen() {
     return () => {
       active = false;
     };
-  }, [id, currentOrg]);
+    // `prefs.timeZone` is inert here in practice: this effect returns early
+    // until `currentOrg` exists, and the org and the user profile are set from
+    // the same `/me` response — so the zone is already resolved by the time a
+    // load runs. Listed because the seeding above genuinely depends on it.
+  }, [id, currentOrg, prefs.timeZone]);
 
   // ── Unsaved-changes guard (only after a REAL edit) ─────
   const navigation = useNavigation();
@@ -245,9 +244,11 @@ export default function EditBookingScreen() {
       name: name.trim(),
       description: description.trim() || undefined,
       custodianTeamMemberId: custodian.id,
-      startDate: toLocalWire(from),
-      endDate: toLocalWire(to),
-      timeZone: getTimeZone(),
+      startDate: wallClockWireString(from),
+      endDate: wallClockWireString(to),
+      // The wire strings carry no offset, so the zone they were written in has
+      // to travel with them — that is the preference zone the pickers edit in.
+      timeZone: prefs.timeZone,
       tags: Array.from(selectedTagIds),
     });
     setIsSubmitting(false);

--- a/apps/companion/app/(tabs)/bookings/edit.tsx
+++ b/apps/companion/app/(tabs)/bookings/edit.tsx
@@ -35,7 +35,8 @@ import { api, type BookingTag } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { markBookingDirty } from "@/lib/booking-refresh";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
-import { addDaysInZone, wallClockWireInZone } from "@shelf/datetime";
+import { wallClockWireInZone } from "@shelf/datetime";
+import { keepEndAfterStart } from "@/lib/booking-dates";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -172,14 +173,7 @@ export default function EditBookingScreen() {
       if (event.type === "dismissed") return;
       if (selected) {
         setFrom(selected);
-        // Keep `to` after `from`: if it's now invalid, push it to +1 day. A
-        // calendar day in the preference zone, not a fixed 24h — across a DST
-        // boundary the day is 23 or 25 hours and the clock would shift.
-        setTo((prev) =>
-          !prev || prev > selected
-            ? prev
-            : addDaysInZone(selected, 1, prefs.timeZone)
-        );
+        setTo((prev) => keepEndAfterStart(prev, selected, prefs.timeZone));
         if (Platform.OS === "ios") setShowFromPicker(false);
       }
     },

--- a/apps/companion/app/(tabs)/bookings/new.tsx
+++ b/apps/companion/app/(tabs)/bookings/new.tsx
@@ -38,7 +38,11 @@ import DateTimePicker, {
 import { api, type BookingTag, type TeamMember } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
-import { wallClockDateInZone, wallClockWireString } from "@shelf/datetime";
+import {
+  addDaysInZone,
+  wallClockOnDayInZone,
+  wallClockWireInZone,
+} from "@shelf/datetime";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -48,22 +52,18 @@ import { TeamMemberPicker } from "@/components/team-member-picker";
 /**
  * The default booking window — tomorrow 09:00-17:00 as `timeZone` reads it.
  *
- * Returns wall-clock carriers, not instants: their LOCAL fields spell the
- * preference-zone wall clock, which is what the native picker edits and what
- * `wallClockWireString` submits. See {@link wallClockDateInZone}.
+ * Both are real instants. "Tomorrow" and the hours are resolved in `timeZone`,
+ * so the window means the same wall clock regardless of where the device is.
  *
  * @param timeZone - the acting user's preference zone
- * @returns carriers for the start and end of the default window
+ * @returns the start and end instants of the default window
  */
 function defaultBookingWindow(timeZone: string): { from: Date; to: Date } {
-  const tomorrow = wallClockDateInZone(new Date(), timeZone);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-
-  const from = new Date(tomorrow);
-  from.setHours(9, 0, 0, 0);
-  const to = new Date(tomorrow);
-  to.setHours(17, 0, 0, 0);
-  return { from, to };
+  const now = new Date();
+  return {
+    from: wallClockOnDayInZone(now, 1, 9, 0, timeZone),
+    to: wallClockOnDayInZone(now, 1, 17, 0, timeZone),
+  };
 }
 
 export default function CreateBookingScreen() {
@@ -71,11 +71,9 @@ export default function CreateBookingScreen() {
   const { currentOrg } = useOrg();
   const { colors } = useTheme();
   const styles = useStyles();
-  // `from`/`to` below are wall-clock CARRIERS in the user's preference zone, not
-  // instants — their local fields are what the picker edits and what gets
-  // submitted. So the labels must read those local fields verbatim
-  // (`localeOnly`) and apply the user's FORMAT only: converting a carrier
-  // through a zone would shift it away from the value being edited.
+  // `from`/`to` are real instants throughout. Both pickers are driven in the
+  // preference zone via `timeZoneName`, so what the user picks, what the labels
+  // render, and what the detail screen shows after saving are one wall clock.
   const { formatDateTime, prefs } = useDateFormatter();
 
   // ── Form state ──────────────────────────────────
@@ -155,19 +153,18 @@ export default function CreateBookingScreen() {
       if (selected) {
         datesTouchedRef.current = true;
         setFrom(selected);
-        // Keep `to` after `from`: if it's now invalid, push it to +1 day. Step
-        // the calendar field rather than adding 24h — these are wall-clock
-        // carriers, and a fixed 24h shifts the clock across a device DST edge.
-        setTo((prev) => {
-          if (!prev || prev > selected) return prev;
-          const next = new Date(selected);
-          next.setDate(next.getDate() + 1);
-          return next;
-        });
+        // Keep `to` after `from`: if it's now invalid, push it to +1 day. A
+        // calendar day in the preference zone, not a fixed 24h — across a DST
+        // boundary the day is 23 or 25 hours and the clock would shift.
+        setTo((prev) =>
+          !prev || prev > selected
+            ? prev
+            : addDaysInZone(selected, 1, prefs.timeZone)
+        );
         if (Platform.OS === "ios") setShowFromPicker(false);
       }
     },
-    []
+    [prefs.timeZone]
   );
 
   const onToChange = useCallback(
@@ -231,8 +228,8 @@ export default function CreateBookingScreen() {
       name: name.trim(),
       description: description.trim() || undefined,
       custodianTeamMemberId: custodian.id,
-      startDate: wallClockWireString(from),
-      endDate: wallClockWireString(to),
+      startDate: wallClockWireInZone(from, prefs.timeZone),
+      endDate: wallClockWireInZone(to, prefs.timeZone),
       // The wire strings carry no offset, so the zone they were written in has
       // to travel with them — that is the preference zone the pickers edit in.
       timeZone: prefs.timeZone,
@@ -361,9 +358,7 @@ export default function CreateBookingScreen() {
             accessibilityRole="button"
             accessibilityLabel={
               from
-                ? `Starts ${formatDateTime(from, {
-                    localeOnly: true,
-                  })}, tap to change`
+                ? `Starts ${formatDateTime(from)}, tap to change`
                 : "Choose start"
             }
           >
@@ -372,9 +367,7 @@ export default function CreateBookingScreen() {
                 from ? styles.pickerSelectedText : styles.pickerPlaceholder
               }
             >
-              {from
-                ? formatDateTime(from, { localeOnly: true })
-                : "Choose start date & time..."}
+              {from ? formatDateTime(from) : "Choose start date & time..."}
             </Text>
             <Ionicons
               name="calendar-outline"
@@ -390,6 +383,7 @@ export default function CreateBookingScreen() {
                 value={from ?? new Date()}
                 mode="datetime"
                 display={Platform.OS === "ios" ? "inline" : "default"}
+                timeZoneName={prefs.timeZone}
                 onChange={onFromChange}
                 accentColor={colors.primary}
               />
@@ -409,19 +403,13 @@ export default function CreateBookingScreen() {
             }}
             accessibilityRole="button"
             accessibilityLabel={
-              to
-                ? `Ends ${formatDateTime(to, {
-                    localeOnly: true,
-                  })}, tap to change`
-                : "Choose end"
+              to ? `Ends ${formatDateTime(to)}, tap to change` : "Choose end"
             }
           >
             <Text
               style={to ? styles.pickerSelectedText : styles.pickerPlaceholder}
             >
-              {to
-                ? formatDateTime(to, { localeOnly: true })
-                : "Choose end date & time..."}
+              {to ? formatDateTime(to) : "Choose end date & time..."}
             </Text>
             <Ionicons
               name="calendar-outline"
@@ -437,6 +425,7 @@ export default function CreateBookingScreen() {
                 value={to ?? from ?? new Date()}
                 mode="datetime"
                 display={Platform.OS === "ios" ? "inline" : "default"}
+                timeZoneName={prefs.timeZone}
                 minimumDate={from ?? undefined}
                 onChange={onToChange}
                 accentColor={colors.primary}

--- a/apps/companion/app/(tabs)/bookings/new.tsx
+++ b/apps/companion/app/(tabs)/bookings/new.tsx
@@ -38,28 +38,32 @@ import DateTimePicker, {
 import { api, type BookingTag, type TeamMember } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { wallClockDateInZone, wallClockWireString } from "@shelf/datetime";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { labelForRequired } from "@/lib/a11y";
 import { TeamMemberPicker } from "@/components/team-member-picker";
 
-/** Device IANA time zone (falls back to UTC) — sent so the server resolves the
- * local wire dates correctly without a client-hint cookie. */
-function getTimeZone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-  } catch {
-    return "UTC";
-  }
-}
+/**
+ * The default booking window — tomorrow 09:00-17:00 as `timeZone` reads it.
+ *
+ * Returns wall-clock carriers, not instants: their LOCAL fields spell the
+ * preference-zone wall clock, which is what the native picker edits and what
+ * `wallClockWireString` submits. See {@link wallClockDateInZone}.
+ *
+ * @param timeZone - the acting user's preference zone
+ * @returns carriers for the start and end of the default window
+ */
+function defaultBookingWindow(timeZone: string): { from: Date; to: Date } {
+  const tomorrow = wallClockDateInZone(new Date(), timeZone);
+  tomorrow.setDate(tomorrow.getDate() + 1);
 
-/** Format a Date as the server's local wire string: `yyyy-MM-dd'T'HH:mm`. */
-function toLocalWire(d: Date): string {
-  const p = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(
-    d.getHours()
-  )}:${p(d.getMinutes())}`;
+  const from = new Date(tomorrow);
+  from.setHours(9, 0, 0, 0);
+  const to = new Date(tomorrow);
+  to.setHours(17, 0, 0, 0);
+  return { from, to };
 }
 
 export default function CreateBookingScreen() {
@@ -67,11 +71,12 @@ export default function CreateBookingScreen() {
   const { currentOrg } = useOrg();
   const { colors } = useTheme();
   const styles = useStyles();
-  // Picker button labels use the user's date/time FORMAT (order, 12/24h) but stay
-  // DEVICE-local (`localeOnly`) — the native picker and `toLocalWire` submission
-  // are device-local, so formatting them in the preferred timezone would show a
-  // different time than the one being edited and submitted (CodeRabbit, #2798).
-  const { formatDateTime } = useDateFormatter();
+  // `from`/`to` below are wall-clock CARRIERS in the user's preference zone, not
+  // instants — their local fields are what the picker edits and what gets
+  // submitted. So the labels must read those local fields verbatim
+  // (`localeOnly`) and apply the user's FORMAT only: converting a carrier
+  // through a zone would shift it away from the value being edited.
+  const { formatDateTime, prefs } = useDateFormatter();
 
   // ── Form state ──────────────────────────────────
   const [name, setName] = useState("");
@@ -79,22 +84,15 @@ export default function CreateBookingScreen() {
   const [custodian, setCustodian] = useState<TeamMember | null>(null);
   // Default to a sensible near-future window (tomorrow 9:00–17:00) so the form
   // is one-tap usable; the user can still adjust either picker.
-  const [from, setFrom] = useState<Date | null>(() => {
-    const d = new Date();
-    d.setDate(d.getDate() + 1);
-    d.setHours(9, 0, 0, 0);
-    return d;
-  });
-  const [to, setTo] = useState<Date | null>(() => {
-    const d = new Date();
-    d.setDate(d.getDate() + 1);
-    d.setHours(17, 0, 0, 0);
-    return d;
-  });
-  // Capture the initial default window (refs init once) so a date-only change
-  // still counts as an unsaved edit in the discard guard below.
+  const [initialWindow] = useState(() => defaultBookingWindow(prefs.timeZone));
+  const [from, setFrom] = useState<Date | null>(initialWindow.from);
+  const [to, setTo] = useState<Date | null>(initialWindow.to);
+  // Capture the default window so a date-only change still counts as an unsaved
+  // edit in the discard guard below. Re-seeding keeps these in step.
   const initialFromRef = useRef(from?.getTime() ?? null);
   const initialToRef = useRef(to?.getTime() ?? null);
+  // Whether the user has picked a date themselves; gates the re-seed below.
+  const datesTouchedRef = useRef(false);
   const [selectedTagIds, setSelectedTagIds] = useState<Set<string>>(new Set());
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -155,13 +153,17 @@ export default function CreateBookingScreen() {
       if (Platform.OS === "android") setShowFromPicker(false);
       if (event.type === "dismissed") return;
       if (selected) {
+        datesTouchedRef.current = true;
         setFrom(selected);
-        // Keep `to` after `from`: if it's now invalid, push it to +1 day.
-        setTo((prev) =>
-          prev && prev <= selected
-            ? new Date(selected.getTime() + 24 * 60 * 60 * 1000)
-            : prev
-        );
+        // Keep `to` after `from`: if it's now invalid, push it to +1 day. Step
+        // the calendar field rather than adding 24h — these are wall-clock
+        // carriers, and a fixed 24h shifts the clock across a device DST edge.
+        setTo((prev) => {
+          if (!prev || prev > selected) return prev;
+          const next = new Date(selected);
+          next.setDate(next.getDate() + 1);
+          return next;
+        });
         if (Platform.OS === "ios") setShowFromPicker(false);
       }
     },
@@ -173,12 +175,27 @@ export default function CreateBookingScreen() {
       if (Platform.OS === "android") setShowToPicker(false);
       if (event.type === "dismissed") return;
       if (selected) {
+        datesTouchedRef.current = true;
         setTo(selected);
         if (Platform.OS === "ios") setShowToPicker(false);
       }
     },
     []
   );
+
+  // The preference zone arrives with the user profile, so on a cold start this
+  // screen can mount while `/me` is still in flight — at which point
+  // `formatPrefs` still holds the device-zone fallback and the seeded window
+  // means the wrong wall clock. Re-seed once the real zone lands, but never over
+  // a date the user has already picked.
+  useEffect(() => {
+    if (datesTouchedRef.current) return;
+    const seeded = defaultBookingWindow(prefs.timeZone);
+    setFrom(seeded.from);
+    setTo(seeded.to);
+    initialFromRef.current = seeded.from.getTime();
+    initialToRef.current = seeded.to.getTime();
+  }, [prefs.timeZone]);
 
   const toggleTag = useCallback((id: string) => {
     setSelectedTagIds((prev) => {
@@ -214,9 +231,11 @@ export default function CreateBookingScreen() {
       name: name.trim(),
       description: description.trim() || undefined,
       custodianTeamMemberId: custodian.id,
-      startDate: toLocalWire(from),
-      endDate: toLocalWire(to),
-      timeZone: getTimeZone(),
+      startDate: wallClockWireString(from),
+      endDate: wallClockWireString(to),
+      // The wire strings carry no offset, so the zone they were written in has
+      // to travel with them — that is the preference zone the pickers edit in.
+      timeZone: prefs.timeZone,
       tags: selectedTagIds.size > 0 ? Array.from(selectedTagIds) : undefined,
     });
     setIsSubmitting(false);

--- a/apps/companion/app/(tabs)/bookings/new.tsx
+++ b/apps/companion/app/(tabs)/bookings/new.tsx
@@ -38,11 +38,8 @@ import DateTimePicker, {
 import { api, type BookingTag, type TeamMember } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
-import {
-  addDaysInZone,
-  wallClockOnDayInZone,
-  wallClockWireInZone,
-} from "@shelf/datetime";
+import { wallClockOnDayInZone, wallClockWireInZone } from "@shelf/datetime";
+import { keepEndAfterStart } from "@/lib/booking-dates";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
@@ -153,14 +150,7 @@ export default function CreateBookingScreen() {
       if (selected) {
         datesTouchedRef.current = true;
         setFrom(selected);
-        // Keep `to` after `from`: if it's now invalid, push it to +1 day. A
-        // calendar day in the preference zone, not a fixed 24h — across a DST
-        // boundary the day is 23 or 25 hours and the clock would shift.
-        setTo((prev) =>
-          !prev || prev > selected
-            ? prev
-            : addDaysInZone(selected, 1, prefs.timeZone)
-        );
+        setTo((prev) => keepEndAfterStart(prev, selected, prefs.timeZone));
         if (Platform.OS === "ios") setShowFromPicker(false);
       }
     },

--- a/apps/companion/lib/booking-dates.test.ts
+++ b/apps/companion/lib/booking-dates.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the shared booking date rules.
+ *
+ * These run under Node's test runner via tsx, so this file and the module it
+ * tests must not import React Native, Expo, or `@/`-aliased paths.
+ *
+ * The zone cases pass ONE pair of instants through SEVERAL zones and expect
+ * DIFFERENT results, so an implementation that ignores `timeZone` cannot pass.
+ *
+ * @see ./booking-dates.ts
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { keepEndAfterStart } from "./booking-dates";
+
+// ── keepEndAfterStart ────────────────────────────────────
+
+test("keepEndAfterStart leaves an end that is already later alone", () => {
+  const start = new Date("2026-08-20T09:00:00Z");
+  const end = new Date("2026-08-20T17:00:00Z");
+
+  assert.equal(keepEndAfterStart(end, start, "UTC"), end);
+});
+
+test("keepEndAfterStart leaves a null end null rather than inventing one", () => {
+  assert.equal(
+    keepEndAfterStart(null, new Date("2026-08-20T09:00:00Z"), "UTC"),
+    null
+  );
+});
+
+test("keepEndAfterStart moves an end that equals the start", () => {
+  const start = new Date("2026-08-20T09:00:00Z");
+
+  const corrected = keepEndAfterStart(new Date(start), start, "UTC");
+
+  assert.ok(corrected);
+  assert.equal(corrected.toISOString(), "2026-08-21T09:00:00.000Z");
+});
+
+test("keepEndAfterStart moves an end that is before the start", () => {
+  const start = new Date("2026-08-20T09:00:00Z");
+  const end = new Date("2026-08-19T17:00:00Z");
+
+  const corrected = keepEndAfterStart(end, start, "UTC");
+
+  assert.ok(corrected);
+  assert.equal(corrected.toISOString(), "2026-08-21T09:00:00.000Z");
+});
+
+test("keepEndAfterStart holds the wall clock across a DST boundary", () => {
+  // 2026-03-08 is the spring forward in Los Angeles, so that calendar day is 23
+  // hours. Adding a fixed 24h would land at 11:00 local instead of 10:00.
+  const start = new Date("2026-03-07T18:00:00Z"); // 10:00 in Los Angeles
+  const end = new Date("2026-03-07T17:00:00Z"); // 09:00, before the start
+
+  const corrected = keepEndAfterStart(end, start, "America/Los_Angeles");
+
+  assert.ok(corrected);
+  assert.equal(corrected.toISOString(), "2026-03-08T17:00:00.000Z");
+  assert.equal(
+    new Intl.DateTimeFormat("en-GB", {
+      timeZone: "America/Los_Angeles",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).format(corrected),
+    "10:00"
+  );
+});
+
+test("keepEndAfterStart resolves the day in the given zone, not a fixed 24h", () => {
+  // The SAME instants through two zones must give DIFFERENT answers, or the
+  // zone is not doing any work. These straddle the Los Angeles spring forward,
+  // where the calendar day is 23 hours; UTC has no transition, so its day is a
+  // flat 24 and the two land an hour apart.
+  const start = new Date("2026-03-07T18:00:00Z");
+  const end = new Date("2026-03-07T17:00:00Z");
+
+  const inLosAngeles = keepEndAfterStart(end, start, "America/Los_Angeles");
+  const inUtc = keepEndAfterStart(end, start, "UTC");
+
+  assert.ok(inLosAngeles);
+  assert.ok(inUtc);
+  assert.equal(inLosAngeles.toISOString(), "2026-03-08T17:00:00.000Z");
+  assert.equal(inUtc.toISOString(), "2026-03-08T18:00:00.000Z");
+});

--- a/apps/companion/lib/booking-dates.ts
+++ b/apps/companion/lib/booking-dates.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure date rules shared by the booking create and edit forms.
+ *
+ * Both screens drive their pickers in the acting user's preference zone and
+ * hold real instants, so any rule about how one picked date constrains another
+ * belongs here rather than in either screen — a rule that lives in two places
+ * gets fixed in one.
+ *
+ * Runs under Node's test runner via tsx, so this module must not import React
+ * Native, Expo, or `@/`-aliased paths.
+ *
+ * @see {@link file://./booking-dates.test.ts}
+ * @see {@link file://../app/(tabs)/bookings/new.tsx}
+ * @see {@link file://../app/(tabs)/bookings/edit.tsx}
+ */
+import { addDaysInZone } from "@shelf/datetime";
+
+/**
+ * Keep a booking's end after its start, moving it out a day when it is not.
+ *
+ * Called when the user picks a new start: an end at or before it is no longer a
+ * valid window, so it moves to the same clock on the next calendar day. That is
+ * a CALENDAR day in `timeZone`, not a fixed 24 hours — across a DST boundary the
+ * day is 23 or 25 hours long, and adding elapsed time there moves the clock the
+ * user chose.
+ *
+ * A `null` end is left alone: the form has its own "required" handling, and
+ * inventing a value here would mask an empty field as a filled one.
+ *
+ * @param end - the current end instant, or null when unset
+ * @param start - the newly picked start instant
+ * @param timeZone - the acting user's preference zone, whose calendar days count
+ * @returns the unchanged end when it is already after `start`, else the
+ *   next-day instant; `null` stays `null`
+ */
+export function keepEndAfterStart(
+  end: Date | null,
+  start: Date,
+  timeZone: string
+): Date | null {
+  if (!end || end > start) return end;
+  return addDaysInZone(start, 1, timeZone);
+}

--- a/apps/webapp/app/modules/working-hours/utils.test.ts
+++ b/apps/webapp/app/modules/working-hours/utils.test.ts
@@ -3,7 +3,6 @@ import { HARDCODED_DEFAULT_PREFS } from "~/utils/date-format";
 import type { WorkingHoursData, WeeklyScheduleJson } from "./types";
 import {
   calculateBusinessHoursDuration,
-  calculateEffectiveEndDate,
   getBookingDefaultStartEndTimes,
   getOverrideDateKey,
   normalizeWorkingHoursForValidation,
@@ -15,12 +14,12 @@ import {
 /**
  * Resolved prefs carrying a specific zone.
  *
- * `~/utils/date-fns` is deliberately NOT mocked here. It used to be, with a
- * `toISOString().slice(0,16)` stand-in that formatted in UTC while production
- * formatted in the device zone — so these cases agreed with production only
- * because the suite also forced `process.env.TZ = "UTC"` (which V8 does not
- * reliably honour after start). Both crutches are gone: every case now states
- * the zone it means, and the assertions exercise the real conversion.
+ * Every case states the zone it means, and `~/utils/date-fns` is deliberately
+ * NOT mocked — the assertions exercise the real conversion. Keep both
+ * properties. A stand-in formatter agrees with production only by coincidence,
+ * and `process.env.TZ` set in a hook is not a substitute for an explicit zone
+ * (V8 does not reliably honour it after process start), so a suite leaning on
+ * either passes for reasons unrelated to the code under test.
  */
 function prefsFor(timeZone: string): ResolvedFormatPrefs {
   return { ...HARDCODED_DEFAULT_PREFS, timeZone };
@@ -114,183 +113,6 @@ describe("normalizeWorkingHoursForValidation", () => {
     const result = normalizeWorkingHoursForValidation(invalidData);
 
     expect(result).toBeUndefined();
-  });
-});
-
-describe("calculateEffectiveEndDate", () => {
-  const mockWorkingHours: WorkingHoursData = {
-    enabled: true,
-    weeklySchedule: {
-      "0": { isOpen: false }, // Sunday
-      "1": { isOpen: true, openTime: "09:00", closeTime: "17:00" }, // Monday
-      "2": { isOpen: true, openTime: "09:00", closeTime: "17:00" }, // Tuesday
-      "3": { isOpen: true, openTime: "09:00", closeTime: "17:00" }, // Wednesday
-      "4": { isOpen: true, openTime: "09:00", closeTime: "17:00" }, // Thursday
-      "5": { isOpen: true, openTime: "09:00", closeTime: "17:00" }, // Friday
-      "6": { isOpen: false }, // Saturday
-    } as WeeklyScheduleJson,
-    overrides: [],
-  };
-
-  it("should return original end date when not skipping closed days", () => {
-    expect.assertions(1);
-
-    const startDate = new Date("2025-07-25T15:00:00Z"); // Friday
-    const endDate = new Date("2025-07-28T17:00:00Z"); // Monday
-
-    const result = calculateEffectiveEndDate(
-      startDate,
-      endDate,
-      mockWorkingHours,
-      false, // skipClosedDays = false
-      "UTC"
-    );
-
-    expect(result).toBe(endDate);
-  });
-
-  it("should return original end date when working hours disabled", () => {
-    expect.assertions(1);
-
-    const startDate = new Date("2025-07-25T15:00:00Z");
-    const endDate = new Date("2025-07-28T17:00:00Z");
-    const disabledWorkingHours = { ...mockWorkingHours, enabled: false };
-
-    const result = calculateEffectiveEndDate(
-      startDate,
-      endDate,
-      disabledWorkingHours,
-      true, // skipClosedDays = true, but working hours disabled
-      "UTC"
-    );
-
-    expect(result).toBe(endDate);
-  });
-
-  it("should return original end date when no working hours data", () => {
-    expect.assertions(1);
-
-    const startDate = new Date("2025-07-25T15:00:00Z");
-    const endDate = new Date("2025-07-28T17:00:00Z");
-
-    const result = calculateEffectiveEndDate(
-      startDate,
-      endDate,
-      null, // no working hours
-      true,
-      "UTC"
-    );
-
-    expect(result).toBe(endDate);
-  });
-
-  it("should extend end date by 2 days when skipping weekend", () => {
-    expect.assertions(1);
-
-    const startDate = new Date("2025-07-25T15:00:00Z"); // Friday 3 PM
-    const endDate = new Date("2025-07-28T17:00:00Z"); // Monday 5 PM
-
-    const result = calculateEffectiveEndDate(
-      startDate,
-      endDate,
-      mockWorkingHours,
-      true,
-      "UTC"
-    );
-
-    // Should extend by 2 days (Saturday + Sunday)
-    const expected = new Date("2025-07-30T17:00:00Z"); // Wednesday 5 PM
-    expect(result).toEqual(expected);
-  });
-
-  it("should handle date-specific overrides", () => {
-    expect.assertions(1);
-
-    const workingHoursWithOverride: WorkingHoursData = {
-      ...mockWorkingHours,
-      overrides: [
-        {
-          id: "holiday",
-          date: new Date("2025-07-28"), // Monday is now closed (holiday) - absolute date
-          isOpen: false,
-          openTime: null,
-          closeTime: null,
-          reason: "Holiday",
-          createdAt: new Date("2025-01-01T00:00:00.000Z"),
-          updatedAt: new Date("2025-01-01T00:00:00.000Z"),
-          workingHoursId: "working-hours-1",
-        },
-      ],
-    };
-
-    const startDate = new Date("2025-07-25T15:00:00Z"); // Friday
-    const endDate = new Date("2025-07-29T17:00:00Z"); // Tuesday
-
-    const result = calculateEffectiveEndDate(
-      startDate,
-      endDate,
-      workingHoursWithOverride,
-      true,
-      "UTC"
-    );
-
-    // Should extend by 3 days (Saturday + Sunday + Monday holiday)
-    const expected = new Date("2025-08-01T17:00:00Z"); // Friday
-    expect(result).toEqual(expected);
-  });
-
-  it("should handle overrides that open normally closed days", () => {
-    expect.assertions(1);
-
-    const workingHoursWithOverride: WorkingHoursData = {
-      ...mockWorkingHours,
-      overrides: [
-        {
-          id: "special",
-          date: new Date("2025-07-26"), // Saturday is now open (special day) - absolute date
-          isOpen: true,
-          openTime: "10:00",
-          closeTime: "16:00",
-          reason: "Special event",
-          createdAt: new Date("2025-01-01T00:00:00.000Z"),
-          updatedAt: new Date("2025-01-01T00:00:00.000Z"),
-          workingHoursId: "working-hours-1",
-        },
-      ],
-    };
-
-    const startDate = new Date("2025-07-25T15:00:00Z"); // Friday
-    const endDate = new Date("2025-07-28T17:00:00Z"); // Monday
-
-    const result = calculateEffectiveEndDate(
-      startDate,
-      endDate,
-      workingHoursWithOverride,
-      true,
-      "UTC"
-    );
-
-    // Should extend by 1 day (only Sunday, Saturday is now open)
-    const expected = new Date("2025-07-29T17:00:00Z"); // Tuesday
-    expect(result).toEqual(expected);
-  });
-
-  it("should handle booking within same day", () => {
-    expect.assertions(1);
-
-    const startDate = new Date("2025-07-28T10:00:00Z"); // Monday 10 AM
-    const endDate = new Date("2025-07-28T15:00:00Z"); // Monday 3 PM
-
-    const result = calculateEffectiveEndDate(
-      startDate,
-      endDate,
-      mockWorkingHours,
-      true,
-      "UTC"
-    );
-
-    // No closed days in between, should return original
-    expect(result).toEqual(endDate);
   });
 });
 
@@ -632,13 +454,13 @@ describe("getBookingDefaultStartEndTimes", () => {
   });
 
   /**
-   * The bug this parameter exists for: defaults used to be computed on the
-   * DEVICE clock while the form field displays and submits in the user's
-   * PREFERENCE zone. Reported from the field as a "Create booking" dialog
-   * prefilling ~10 hours late.
+   * What `prefs` is for: the form field displays and submits in the user's
+   * PREFERENCE zone, so the defaults it is seeded with must be computed there
+   * too. Computed on the ambient clock instead, they land hours off for anyone
+   * whose device zone differs.
    *
-   * These cases pin the zone-correct behaviour. They pass the same instant with
-   * different prefs, so they assert the zone actually drives the result rather
+   * These cases pass the same instant with different prefs and assert different
+   * wall-clocks, so they pin the zone as the thing driving the result rather
    * than the machine the suite happens to run on.
    */
   describe("preference zone drives the result", () => {
@@ -792,14 +614,15 @@ describe("getOverrideDateKey", () => {
 /**
  * Closed-day math must be done in the zone the caller supplies.
  *
- * Both of these walk day-by-day and ask "is this day open?", so the answer turns
- * entirely on which calendar day an instant falls in. They previously read that
- * off the DEVICE clock, which is what made two cases in this file fail under
- * `TZ=Asia/Tokyo` while passing on UTC CI — green in CI, wrong in production for
- * anyone whose device differed from their preference zone.
+ * The walk asks "is this day open?" day by day, so the answer turns entirely on
+ * which calendar day an instant falls in — and that is a property of the zone,
+ * not of the machine. An implementation that reads the day off the ambient clock
+ * gives one answer in the browser and another on the server for the same
+ * booking, and CI (which runs UTC) would not notice.
  *
- * Each case passes the SAME instants through two zones and asserts different
- * results, so a build that ignores the zone cannot pass.
+ * The case below passes the SAME instants through two zones and asserts
+ * DIFFERENT results, so an implementation that ignores the zone cannot pass.
+ * Keep that shape when adding cases here: two zones agreeing proves nothing.
  */
 describe("closed-day math is zone-driven", () => {
   const weekdaysOpen: WorkingHoursData = {
@@ -825,33 +648,14 @@ describe("closed-day math is zone-driven", () => {
 
     // UTC: 20:00-24:00 is Friday (open), 00:00-04:00 is Saturday (closed).
     // 8 total - 4 closed = 4.
-    expect(calculateBusinessHoursDuration(start, end, weekdaysOpen, "UTC")).toBe(
-      4
-    );
+    expect(
+      calculateBusinessHoursDuration(start, end, weekdaysOpen, "UTC")
+    ).toBe(4);
 
     // Asia/Tokyo (+9): the window is Sat 05:00 → Sat 13:00 local, entirely
     // inside a closed Saturday. 8 total - 8 closed = 0.
     expect(
       calculateBusinessHoursDuration(start, end, weekdaysOpen, "Asia/Tokyo")
     ).toBe(0);
-  });
-
-  it("calculateEffectiveEndDate counts closed days per zone", () => {
-    expect.assertions(2);
-
-    const start = new Date("2025-07-25T20:00:00Z");
-    const end = new Date("2025-07-27T20:00:00Z");
-
-    // UTC: the walk sees Friday (open) then Saturday (closed) → 1 closed day,
-    // so the end shifts out by one.
-    expect(
-      calculateEffectiveEndDate(start, end, weekdaysOpen, true, "UTC")
-    ).toEqual(new Date("2025-07-28T20:00:00Z"));
-
-    // Asia/Tokyo: the same instants are Sat 05:00 → Mon 05:00 local, so the
-    // walk sees Saturday AND Sunday closed → 2 closed days.
-    expect(
-      calculateEffectiveEndDate(start, end, weekdaysOpen, true, "Asia/Tokyo")
-    ).toEqual(new Date("2025-07-29T20:00:00Z"));
   });
 });

--- a/apps/webapp/app/modules/working-hours/utils.ts
+++ b/apps/webapp/app/modules/working-hours/utils.ts
@@ -66,10 +66,10 @@ function atWallClock(zoned: DateTime, time: string): DateTime {
  * Working hours overrides represent an absolute calendar date with no time
  * component — the DB column is `@db.Date`, which Prisma hydrates as a Date at
  * UTC midnight. That Date is only a transport artifact: formatting it in the
- * runtime's local timezone shifts it one day back for users west of UTC, which
- * used to make an override for day D match bookings on day D-1. Reading the
- * date from UTC (or treating an already-YYYY-MM-DD string as-is) preserves the
- * absolute-date meaning.
+ * runtime's local timezone shifts it one day back for users west of UTC, making
+ * an override for day D match bookings on day D-1. Reading the date from UTC
+ * (or treating an already-YYYY-MM-DD string as-is) preserves the absolute-date
+ * meaning.
  *
  * Contract: string inputs must be either date-only ("YYYY-MM-DD") or a UTC ISO
  * timestamp ("YYYY-MM-DD…Z"). Offset-style strings like
@@ -180,8 +180,8 @@ interface NextWorkingDayResult {
  * If no working day is found within 14 days, it defaults to tomorrow's 9 AM - 6 PM.
  * All calendar-day and wall-clock reasoning happens in `timeZone`, so "tomorrow"
  * and "9 AM" mean what the user means. Reading them off a device-local `Date`
- * put the search on the wrong day whenever the device and preference zones
- * straddled midnight.
+ * instead puts the search on the wrong day whenever the device and preference
+ * zones straddle midnight.
  *
  * @param currentDate - The date from which to start searching for the next working day.
  * @param workingHours - The working hours data containing weekly schedules and overrides.
@@ -420,56 +420,6 @@ function getOriginalDefaultTimes(
     startDate,
     endDate: dateForDateTimeInputValue(endDateTime.toJSDate(), timeZone),
   };
-}
-
-/**
- * Calculates the effective end date for a booking by extending the duration
- * to skip closed days when maxBookingLengthSkipClosedDays is enabled.
- *
- * @param startDate - The start date of the booking
- * @param endDate - The end date of the booking
- * @param workingHoursData - Working hours configuration with schedules and overrides
- * @param skipClosedDays - Whether to skip closed days in the calculation
- * @param timeZone - IANA zone that decides which calendar day the walk is on.
- *   Same contract as {@link calculateBusinessHoursDuration}.
- * @returns Effective end date for validation (or original endDate if not skipping)
- */
-export function calculateEffectiveEndDate(
-  startDate: Date,
-  endDate: Date,
-  workingHoursData: WorkingHoursData | null | undefined,
-  skipClosedDays: boolean,
-  timeZone: string
-): Date {
-  // If not skipping closed days or no working hours data, use original endDate
-  if (!skipClosedDays || !workingHoursData?.enabled) {
-    return endDate;
-  }
-
-  let closedDaysCount = 0;
-  let cursor = DateTime.fromJSDate(startDate).setZone(timeZone);
-  const end = DateTime.fromJSDate(endDate).setZone(timeZone);
-
-  // Count closed days between start and original end date
-  while (cursor < end) {
-    // Which day this is, and whether it is open, are decided in `timeZone` —
-    // see the shared resolver. Reading them off a device-local Date put the
-    // count on the wrong days whenever the device and preference zones
-    // straddled midnight.
-    const isOpen =
-      resolveDaySchedule(cursor, workingHoursData)?.isOpen ?? false;
-
-    if (!isOpen) {
-      closedDaysCount++;
-    }
-
-    // Move to next day. `plus({ days })` steps by calendar day in `timeZone`,
-    // so the walk stays correct across a DST boundary.
-    cursor = cursor.plus({ days: 1 });
-  }
-
-  // Extend the end date by the number of closed days
-  return end.plus({ days: closedDaysCount }).toJSDate();
 }
 
 /**

--- a/apps/webapp/test/shared/wall-clock.runtime-zone.test.ts
+++ b/apps/webapp/test/shared/wall-clock.runtime-zone.test.ts
@@ -1,84 +1,128 @@
-import { wallClockDateInZone, wallClockWireString } from "@shelf/datetime";
+import {
+  addDaysInZone,
+  instantFromWallClockInZone,
+  wallClockOnDayInZone,
+  wallClockPartsInZone,
+  wallClockWireInZone,
+} from "@shelf/datetime";
 
 // @vitest-environment node
 
 /**
- * How a wall-clock carrier behaves against the RUNTIME zone's own DST.
+ * The wall-clock primitives must not depend on the zone the code runs in.
  *
- * why a separate file that moves the clock: a carrier holds its wall clock in a
- * `Date`'s local fields, so the runtime zone decides which clocks are
- * representable at all. That is invisible to the main suite, which is
- * deliberately runtime-zone-independent and would agree with a broken
- * implementation under CI's UTC.
+ * This is the property the booking pickers need and the one that is easiest to
+ * lose: any `new Date(y, m, d, h)` or `getHours()` reaches for the runtime zone,
+ * which is the device in the companion and UTC on the server. A helper that does
+ * so answers differently on a Los Angeles phone than on CI for the same booking,
+ * and the main suite cannot see it — that suite runs in one zone, where a
+ * runtime-dependent implementation and a correct one agree exactly.
  *
- * `process.env.TZ` is re-read per `Date` operation, so setting it immediately
- * around a construction works. Setting it once in a hook and expecting later
- * operations to follow does not — pin the zone at the point of use, as
- * `inRuntimeZone` does.
+ * So every case here runs the SAME call under three runtime zones and asserts
+ * ONE answer. Add cases in that shape; a single-zone assertion belongs in
+ * wall-clock.test.ts instead.
  *
- * @see {@link file://./wall-clock.test.ts} the zone-independent contract
+ * `process.env.TZ` is re-read per `Date` operation, so setting it around a call
+ * works. Setting it once in a hook and expecting later operations to follow does
+ * not — pin it at the point of use, as `inEachRuntimeZone` does.
+ *
+ * @see {@link file://./wall-clock.test.ts} the per-zone contract
  */
 
-/** Runs `assert` with the process clock moved to `timeZone`, then restores it. */
-function inRuntimeZone(timeZone: string, assert: () => void) {
+const RUNTIME_ZONES = ["UTC", "America/Los_Angeles", "Asia/Tokyo"];
+
+/** Runs `compute` once per runtime zone and returns the distinct results. */
+function inEachRuntimeZone(compute: () => string): string[] {
   const previous = process.env.TZ;
-  process.env.TZ = timeZone;
   try {
-    assert();
+    return [
+      ...new Set(
+        RUNTIME_ZONES.map((zone) => {
+          process.env.TZ = zone;
+          return compute();
+        })
+      ),
+    ];
   } finally {
     if (previous === undefined) delete process.env.TZ;
     else process.env.TZ = previous;
   }
 }
 
-describe("carrier day arithmetic across a runtime DST edge", () => {
-  it("preserves the wall clock when the calendar field is stepped", () => {
+describe("runtime-zone independence", () => {
+  it("reads an instant's wall clock identically wherever it runs", () => {
     expect.assertions(1);
 
-    // 2026-03-08 is the PST→PDT spring forward, so that calendar day is 23h.
-    inRuntimeZone("America/Los_Angeles", () => {
-      const carrier = wallClockDateInZone("2026-03-07T18:00:00Z", "UTC");
-      carrier.setDate(carrier.getDate() + 1);
-
-      expect(wallClockWireString(carrier)).toBe("2026-03-08T18:00");
-    });
+    expect(
+      inEachRuntimeZone(() =>
+        JSON.stringify(wallClockPartsInZone("2026-08-20T23:30:00Z", "UTC"))
+      )
+    ).toHaveLength(1);
   });
 
-  it("does NOT preserve it when a fixed 24h is added instead", () => {
+  it("writes the wire string identically wherever it runs", () => {
     expect.assertions(1);
 
-    // The reason both booking screens step the calendar field. Pinned so the
-    // shorter-looking `+ 24h` cannot come back unnoticed.
-    inRuntimeZone("America/Los_Angeles", () => {
-      const carrier = wallClockDateInZone("2026-03-07T18:00:00Z", "UTC");
-      const shifted = new Date(carrier.getTime() + 24 * 60 * 60 * 1000);
-
-      expect(wallClockWireString(shifted)).toBe("2026-03-08T19:00");
-    });
+    expect(
+      inEachRuntimeZone(() =>
+        wallClockWireInZone("2026-08-20T23:30:00Z", "Europe/Amsterdam")
+      )
+    ).toEqual(["2026-08-21T01:30"]);
   });
-});
 
-describe("wall clocks the runtime zone skips", () => {
-  it("normalises forward by an hour — a known limitation", () => {
-    expect.assertions(2);
+  it("locates a wall clock at one instant wherever it runs", () => {
+    expect.assertions(1);
 
-    // 02:30 does not exist on 2026-03-08 in Los Angeles, so a `Date` cannot
-    // carry it and resolves forward. A booking stored as 02:30 UTC therefore
-    // re-submits as 03:30 from an LA device even if untouched.
-    //
-    // Driving the picker with its `timeZoneName` prop instead would remove the
-    // device-local hop entirely; that is a different contract, not a patch.
-    inRuntimeZone("America/Los_Angeles", () => {
-      expect(
-        wallClockWireString(wallClockDateInZone("2026-03-08T02:30:00Z", "UTC"))
-      ).toBe("2026-03-08T03:30");
-    });
+    // A clock in the RUNTIME zone's spring-forward gap. Assembling it from a
+    // runtime-local `Date` normalises it an hour, so this is the case that
+    // separates a zone-solved implementation from a device-local one: under
+    // `America/Los_Angeles` a local-fields build answers 03:30 here.
+    expect(
+      inEachRuntimeZone(() =>
+        wallClockWireInZone(
+          instantFromWallClockInZone(
+            { year: 2026, month: 3, day: 8, hour: 2, minute: 30 },
+            "UTC"
+          ),
+          "UTC"
+        )
+      )
+    ).toEqual(["2026-03-08T02:30"]);
+  });
 
-    // Same instant, same carried zone, a runtime zone with no gap there: exact.
-    inRuntimeZone("UTC", () => {
-      expect(
-        wallClockWireString(wallClockDateInZone("2026-03-08T02:30:00Z", "UTC"))
-      ).toBe("2026-03-08T02:30");
-    });
+  it("steps a calendar day identically wherever it runs", () => {
+    expect.assertions(1);
+
+    // The step crosses the RUNTIME zone's DST boundary as well as the carried
+    // zone's, so a runtime-local implementation drifts under Los Angeles only.
+    expect(
+      inEachRuntimeZone(() =>
+        wallClockWireInZone(
+          addDaysInZone("2026-03-07T18:00:00Z", 1, "America/Los_Angeles"),
+          "America/Los_Angeles"
+        )
+      )
+    ).toEqual(["2026-03-08T10:00"]);
+  });
+
+  it("resolves a form default identically wherever it runs", () => {
+    expect.assertions(1);
+
+    // 23:00Z is already tomorrow in Tokyo and still today in Los Angeles, so a
+    // default anchored to the runtime's calendar day lands on the wrong date.
+    expect(
+      inEachRuntimeZone(() =>
+        wallClockWireInZone(
+          wallClockOnDayInZone(
+            "2026-08-20T23:00:00Z",
+            1,
+            9,
+            0,
+            "Europe/Amsterdam"
+          ),
+          "Europe/Amsterdam"
+        )
+      )
+    ).toEqual(["2026-08-22T09:00"]);
   });
 });

--- a/apps/webapp/test/shared/wall-clock.runtime-zone.test.ts
+++ b/apps/webapp/test/shared/wall-clock.runtime-zone.test.ts
@@ -1,0 +1,84 @@
+import { wallClockDateInZone, wallClockWireString } from "@shelf/datetime";
+
+// @vitest-environment node
+
+/**
+ * How a wall-clock carrier behaves against the RUNTIME zone's own DST.
+ *
+ * why a separate file that moves the clock: a carrier holds its wall clock in a
+ * `Date`'s local fields, so the runtime zone decides which clocks are
+ * representable at all. That is invisible to the main suite, which is
+ * deliberately runtime-zone-independent and would agree with a broken
+ * implementation under CI's UTC.
+ *
+ * `process.env.TZ` is re-read per `Date` operation, so setting it immediately
+ * around a construction works. Setting it once in a hook and expecting later
+ * operations to follow does not — pin the zone at the point of use, as
+ * `inRuntimeZone` does.
+ *
+ * @see {@link file://./wall-clock.test.ts} the zone-independent contract
+ */
+
+/** Runs `assert` with the process clock moved to `timeZone`, then restores it. */
+function inRuntimeZone(timeZone: string, assert: () => void) {
+  const previous = process.env.TZ;
+  process.env.TZ = timeZone;
+  try {
+    assert();
+  } finally {
+    if (previous === undefined) delete process.env.TZ;
+    else process.env.TZ = previous;
+  }
+}
+
+describe("carrier day arithmetic across a runtime DST edge", () => {
+  it("preserves the wall clock when the calendar field is stepped", () => {
+    expect.assertions(1);
+
+    // 2026-03-08 is the PST→PDT spring forward, so that calendar day is 23h.
+    inRuntimeZone("America/Los_Angeles", () => {
+      const carrier = wallClockDateInZone("2026-03-07T18:00:00Z", "UTC");
+      carrier.setDate(carrier.getDate() + 1);
+
+      expect(wallClockWireString(carrier)).toBe("2026-03-08T18:00");
+    });
+  });
+
+  it("does NOT preserve it when a fixed 24h is added instead", () => {
+    expect.assertions(1);
+
+    // The reason both booking screens step the calendar field. Pinned so the
+    // shorter-looking `+ 24h` cannot come back unnoticed.
+    inRuntimeZone("America/Los_Angeles", () => {
+      const carrier = wallClockDateInZone("2026-03-07T18:00:00Z", "UTC");
+      const shifted = new Date(carrier.getTime() + 24 * 60 * 60 * 1000);
+
+      expect(wallClockWireString(shifted)).toBe("2026-03-08T19:00");
+    });
+  });
+});
+
+describe("wall clocks the runtime zone skips", () => {
+  it("normalises forward by an hour — a known limitation", () => {
+    expect.assertions(2);
+
+    // 02:30 does not exist on 2026-03-08 in Los Angeles, so a `Date` cannot
+    // carry it and resolves forward. A booking stored as 02:30 UTC therefore
+    // re-submits as 03:30 from an LA device even if untouched.
+    //
+    // Driving the picker with its `timeZoneName` prop instead would remove the
+    // device-local hop entirely; that is a different contract, not a patch.
+    inRuntimeZone("America/Los_Angeles", () => {
+      expect(
+        wallClockWireString(wallClockDateInZone("2026-03-08T02:30:00Z", "UTC"))
+      ).toBe("2026-03-08T03:30");
+    });
+
+    // Same instant, same carried zone, a runtime zone with no gap there: exact.
+    inRuntimeZone("UTC", () => {
+      expect(
+        wallClockWireString(wallClockDateInZone("2026-03-08T02:30:00Z", "UTC"))
+      ).toBe("2026-03-08T02:30");
+    });
+  });
+});

--- a/apps/webapp/test/shared/wall-clock.test.ts
+++ b/apps/webapp/test/shared/wall-clock.test.ts
@@ -1,0 +1,157 @@
+import {
+  wallClockDateInZone,
+  wallClockPartsInZone,
+  wallClockWireString,
+} from "@shelf/datetime";
+
+// @vitest-environment node
+
+/**
+ * The wall-clock carrier contract that the companion's booking pickers rest on.
+ *
+ * A native date picker can only speak `Date`, and a `Date`'s field accessors
+ * answer in the runtime's own zone. To let the picker edit ANOTHER zone's wall
+ * clock, `wallClockDateInZone` returns a Date whose local fields spell that
+ * zone's clock, and `wallClockWireString` reads them back out.
+ *
+ * why no `process.env.TZ` juggling: the round trip is deliberately independent
+ * of the runtime zone — carrier in, same wall clock out — so the assertions
+ * hold identically on a UTC CI box and a JST laptop. A test that needed the
+ * clock moved would be asserting something weaker.
+ *
+ * Every zone-sensitive case passes ONE instant through SEVERAL zones and
+ * expects DIFFERENT output. An implementation that ignores `timeZone` cannot
+ * satisfy both halves.
+ */
+
+describe("wallClockPartsInZone", () => {
+  it("reads one instant differently in each zone", () => {
+    expect.assertions(3);
+
+    // 2026-08-20T23:30Z — already the 21st in Tokyo, still the 20th in LA.
+    const instant = new Date("2026-08-20T23:30:00Z");
+
+    expect(wallClockPartsInZone(instant, "UTC")).toEqual({
+      year: 2026,
+      month: 8,
+      day: 20,
+      hour: 23,
+      minute: 30,
+    });
+    expect(wallClockPartsInZone(instant, "Asia/Tokyo")).toEqual({
+      year: 2026,
+      month: 8,
+      day: 21,
+      hour: 8,
+      minute: 30,
+    });
+    expect(wallClockPartsInZone(instant, "America/Los_Angeles")).toEqual({
+      year: 2026,
+      month: 8,
+      day: 20,
+      hour: 16,
+      minute: 30,
+    });
+  });
+
+  it("reports month as 1-12, not a Date's 0-11", () => {
+    expect.assertions(1);
+
+    expect(
+      wallClockPartsInZone(new Date("2026-01-15T12:00:00Z"), "UTC").month
+    ).toBe(1);
+  });
+
+  it("tracks the zone's DST offset rather than a fixed one", () => {
+    expect.assertions(2);
+
+    // Los Angeles is UTC-7 in July and UTC-8 in January.
+    expect(
+      wallClockPartsInZone(
+        new Date("2026-07-01T18:00:00Z"),
+        "America/Los_Angeles"
+      ).hour
+    ).toBe(11);
+    expect(
+      wallClockPartsInZone(
+        new Date("2026-01-01T18:00:00Z"),
+        "America/Los_Angeles"
+      ).hour
+    ).toBe(10);
+  });
+
+  it("reports midnight as hour 0, never 24", () => {
+    expect.assertions(2);
+
+    // `Intl` can answer "24" for midnight under an h24 hour cycle, which would
+    // make the wire string unparseable. Pinned for both zone directions.
+    expect(wallClockPartsInZone("2026-08-20T00:00:00Z", "UTC").hour).toBe(0);
+    expect(
+      wallClockPartsInZone("2026-08-20T15:00:00Z", "Asia/Tokyo").hour
+    ).toBe(0);
+  });
+
+  it("accepts an ISO string as well as a Date", () => {
+    expect.assertions(1);
+
+    expect(wallClockPartsInZone("2026-08-20T23:30:00Z", "Asia/Tokyo")).toEqual(
+      wallClockPartsInZone(new Date("2026-08-20T23:30:00Z"), "Asia/Tokyo")
+    );
+  });
+});
+
+describe("wallClockDateInZone → wallClockWireString round trip", () => {
+  it("returns the wall clock of the requested zone, not of the runtime", () => {
+    expect.assertions(3);
+
+    const instant = new Date("2026-08-20T23:30:00Z");
+
+    expect(wallClockWireString(wallClockDateInZone(instant, "UTC"))).toBe(
+      "2026-08-20T23:30"
+    );
+    expect(
+      wallClockWireString(wallClockDateInZone(instant, "Asia/Tokyo"))
+    ).toBe("2026-08-21T08:30");
+    expect(
+      wallClockWireString(wallClockDateInZone(instant, "America/Los_Angeles"))
+    ).toBe("2026-08-20T16:30");
+  });
+
+  it("pads every field to two digits and emits no seconds", () => {
+    expect.assertions(1);
+
+    expect(
+      wallClockWireString(wallClockDateInZone("2026-01-02T03:04:05Z", "UTC"))
+    ).toBe("2026-01-02T03:04");
+  });
+
+  it("steps whole calendar days of the carried zone, not of the runtime", () => {
+    expect.assertions(2);
+
+    // 23:30Z is 08:30 the NEXT day in Tokyo, so +1 day lands on the 22nd there
+    // while the same step from the UTC reading lands on the 21st.
+    const tokyo = wallClockDateInZone("2026-08-20T23:30:00Z", "Asia/Tokyo");
+    tokyo.setDate(tokyo.getDate() + 1);
+    expect(wallClockWireString(tokyo)).toBe("2026-08-22T08:30");
+
+    const utc = wallClockDateInZone("2026-08-20T23:30:00Z", "UTC");
+    utc.setDate(utc.getDate() + 1);
+    expect(wallClockWireString(utc)).toBe("2026-08-21T23:30");
+  });
+
+  it("keeps the wall clock fixed across the carried zone's DST change", () => {
+    expect.assertions(2);
+
+    // Both instants are 18:00Z; LA reads 11:00 in July and 10:00 in January.
+    expect(
+      wallClockWireString(
+        wallClockDateInZone("2026-07-01T18:00:00Z", "America/Los_Angeles")
+      )
+    ).toBe("2026-07-01T11:00");
+    expect(
+      wallClockWireString(
+        wallClockDateInZone("2026-01-01T18:00:00Z", "America/Los_Angeles")
+      )
+    ).toBe("2026-01-01T10:00");
+  });
+});

--- a/apps/webapp/test/shared/wall-clock.test.ts
+++ b/apps/webapp/test/shared/wall-clock.test.ts
@@ -1,27 +1,25 @@
 import {
-  wallClockDateInZone,
+  addDaysInZone,
+  instantFromWallClockInZone,
+  wallClockOnDayInZone,
   wallClockPartsInZone,
-  wallClockWireString,
+  wallClockWireInZone,
 } from "@shelf/datetime";
 
 // @vitest-environment node
 
 /**
- * The wall-clock carrier contract that the companion's booking pickers rest on.
+ * The zone-aware wall-clock primitives the booking pickers rest on.
  *
- * A native date picker can only speak `Date`, and a `Date`'s field accessors
- * answer in the runtime's own zone. To let the picker edit ANOTHER zone's wall
- * clock, `wallClockDateInZone` returns a Date whose local fields spell that
- * zone's clock, and `wallClockWireString` reads them back out.
- *
- * why no `process.env.TZ` juggling: the round trip is deliberately independent
- * of the runtime zone — carrier in, same wall clock out — so the assertions
- * hold identically on a UTC CI box and a JST laptop. A test that needed the
- * clock moved would be asserting something weaker.
+ * A booking is stored as an instant but chosen, shown and submitted as a wall
+ * clock in the acting user's preference zone. These helpers are the only places
+ * that cross between the two, so every rule about which zone decides a calendar
+ * day, an hour, or a day-step lives here.
  *
  * Every zone-sensitive case passes ONE instant through SEVERAL zones and
- * expects DIFFERENT output. An implementation that ignores `timeZone` cannot
- * satisfy both halves.
+ * expects DIFFERENT output, so an implementation that ignores `timeZone` cannot
+ * satisfy both halves. Keep that shape when adding cases: two zones agreeing
+ * proves nothing.
  */
 
 describe("wallClockPartsInZone", () => {
@@ -62,6 +60,17 @@ describe("wallClockPartsInZone", () => {
     ).toBe(1);
   });
 
+  it("reports midnight as hour 0, never 24", () => {
+    expect.assertions(2);
+
+    // `Intl` can answer "24" for midnight under an h24 hour cycle, which would
+    // make the wire string unparseable. Pinned for both zone directions.
+    expect(wallClockPartsInZone("2026-08-20T00:00:00Z", "UTC").hour).toBe(0);
+    expect(
+      wallClockPartsInZone("2026-08-20T15:00:00Z", "Asia/Tokyo").hour
+    ).toBe(0);
+  });
+
   it("tracks the zone's DST offset rather than a fixed one", () => {
     expect.assertions(2);
 
@@ -80,17 +89,6 @@ describe("wallClockPartsInZone", () => {
     ).toBe(10);
   });
 
-  it("reports midnight as hour 0, never 24", () => {
-    expect.assertions(2);
-
-    // `Intl` can answer "24" for midnight under an h24 hour cycle, which would
-    // make the wire string unparseable. Pinned for both zone directions.
-    expect(wallClockPartsInZone("2026-08-20T00:00:00Z", "UTC").hour).toBe(0);
-    expect(
-      wallClockPartsInZone("2026-08-20T15:00:00Z", "Asia/Tokyo").hour
-    ).toBe(0);
-  });
-
   it("accepts an ISO string as well as a Date", () => {
     expect.assertions(1);
 
@@ -100,58 +98,167 @@ describe("wallClockPartsInZone", () => {
   });
 });
 
-describe("wallClockDateInZone → wallClockWireString round trip", () => {
-  it("returns the wall clock of the requested zone, not of the runtime", () => {
+describe("wallClockWireInZone", () => {
+  it("writes the wall clock of the requested zone", () => {
     expect.assertions(3);
 
     const instant = new Date("2026-08-20T23:30:00Z");
 
-    expect(wallClockWireString(wallClockDateInZone(instant, "UTC"))).toBe(
-      "2026-08-20T23:30"
+    expect(wallClockWireInZone(instant, "UTC")).toBe("2026-08-20T23:30");
+    expect(wallClockWireInZone(instant, "Asia/Tokyo")).toBe("2026-08-21T08:30");
+    expect(wallClockWireInZone(instant, "America/Los_Angeles")).toBe(
+      "2026-08-20T16:30"
     );
-    expect(
-      wallClockWireString(wallClockDateInZone(instant, "Asia/Tokyo"))
-    ).toBe("2026-08-21T08:30");
-    expect(
-      wallClockWireString(wallClockDateInZone(instant, "America/Los_Angeles"))
-    ).toBe("2026-08-20T16:30");
   });
 
   it("pads every field to two digits and emits no seconds", () => {
     expect.assertions(1);
 
-    expect(
-      wallClockWireString(wallClockDateInZone("2026-01-02T03:04:05Z", "UTC"))
-    ).toBe("2026-01-02T03:04");
+    expect(wallClockWireInZone("2026-01-02T03:04:05Z", "UTC")).toBe(
+      "2026-01-02T03:04"
+    );
+  });
+});
+
+describe("instantFromWallClockInZone", () => {
+  it("round-trips against wallClockPartsInZone in every zone", () => {
+    expect.assertions(4);
+
+    // Includes a whole-hour, a half-hour (+05:45) and a DST-observing zone, so
+    // a solver that assumes whole-hour offsets cannot pass.
+    for (const zone of [
+      "UTC",
+      "Asia/Tokyo",
+      "Asia/Kathmandu",
+      "America/Los_Angeles",
+    ]) {
+      const instant = "2026-07-04T23:30:00Z";
+      const parts = wallClockPartsInZone(instant, zone);
+
+      expect(
+        wallClockWireInZone(instantFromWallClockInZone(parts, zone), zone)
+      ).toBe(wallClockWireInZone(instant, zone));
+    }
   });
 
-  it("steps whole calendar days of the carried zone, not of the runtime", () => {
-    expect.assertions(2);
+  it("locates the same wall clock at a different instant per zone", () => {
+    expect.assertions(1);
 
-    // 23:30Z is 08:30 the NEXT day in Tokyo, so +1 day lands on the 22nd there
-    // while the same step from the UTC reading lands on the 21st.
-    const tokyo = wallClockDateInZone("2026-08-20T23:30:00Z", "Asia/Tokyo");
-    tokyo.setDate(tokyo.getDate() + 1);
-    expect(wallClockWireString(tokyo)).toBe("2026-08-22T08:30");
+    const nineAm = { year: 2026, month: 8, day: 20, hour: 9, minute: 0 };
 
-    const utc = wallClockDateInZone("2026-08-20T23:30:00Z", "UTC");
-    utc.setDate(utc.getDate() + 1);
-    expect(wallClockWireString(utc)).toBe("2026-08-21T23:30");
+    expect(
+      instantFromWallClockInZone(nineAm, "Asia/Tokyo").getTime()
+    ).toBeLessThan(
+      instantFromWallClockInZone(nineAm, "America/Los_Angeles").getTime()
+    );
   });
 
-  it("keeps the wall clock fixed across the carried zone's DST change", () => {
+  it("resolves a clock the zone repeats to the first of its two instants", () => {
     expect.assertions(2);
 
-    // Both instants are 18:00Z; LA reads 11:00 in July and 10:00 in January.
+    // 2026-11-01 in Los Angeles runs 01:00-02:00 twice (PDT then PST). Picking
+    // the first keeps the mapping total and monotonic, so a booking made during
+    // the repeat does not jump an hour later on the next save.
+    const repeated = { year: 2026, month: 11, day: 1, hour: 1, minute: 30 };
+    const resolved = instantFromWallClockInZone(
+      repeated,
+      "America/Los_Angeles"
+    );
+
+    expect(resolved.toISOString()).toBe("2026-11-01T08:30:00.000Z");
+    expect(wallClockWireInZone(resolved, "America/Los_Angeles")).toBe(
+      "2026-11-01T01:30"
+    );
+  });
+
+  it("resolves a clock the zone skips to just after the transition", () => {
+    expect.assertions(1);
+
+    // 02:30 does not exist in Los Angeles on 2026-03-08 (02:00 → 03:00). It has
+    // no instant, so it cannot round-trip; resolving forward is the defined
+    // answer rather than a throw.
+    const skipped = { year: 2026, month: 3, day: 8, hour: 2, minute: 30 };
+
     expect(
-      wallClockWireString(
-        wallClockDateInZone("2026-07-01T18:00:00Z", "America/Los_Angeles")
+      wallClockWireInZone(
+        instantFromWallClockInZone(skipped, "America/Los_Angeles"),
+        "America/Los_Angeles"
       )
-    ).toBe("2026-07-01T11:00");
+    ).toBe("2026-03-08T03:30");
+  });
+});
+
+describe("addDaysInZone", () => {
+  it("keeps the wall clock across the zone's DST boundary", () => {
+    expect.assertions(2);
+
+    // 2026-03-08 is the spring forward in Los Angeles, so that calendar day is
+    // 23 hours long. The clock must not move with it.
+    const dayBefore = "2026-03-07T18:00:00Z"; // 10:00 in Los Angeles
+    const stepped = addDaysInZone(dayBefore, 1, "America/Los_Angeles");
+
+    expect(wallClockWireInZone(stepped, "America/Los_Angeles")).toBe(
+      "2026-03-08T10:00"
+    );
+
+    // The elapsed-time alternative this exists to prevent.
+    const naive = new Date(new Date(dayBefore).getTime() + 24 * 60 * 60 * 1000);
+    expect(wallClockWireInZone(naive, "America/Los_Angeles")).toBe(
+      "2026-03-08T11:00"
+    );
+  });
+
+  it("rolls the month and the year", () => {
+    expect.assertions(2);
+
     expect(
-      wallClockWireString(
-        wallClockDateInZone("2026-01-01T18:00:00Z", "America/Los_Angeles")
+      wallClockWireInZone(
+        addDaysInZone("2026-01-31T12:00:00Z", 1, "UTC"),
+        "UTC"
       )
-    ).toBe("2026-01-01T10:00");
+    ).toBe("2026-02-01T12:00");
+    expect(
+      wallClockWireInZone(
+        addDaysInZone("2026-12-31T12:00:00Z", 1, "UTC"),
+        "UTC"
+      )
+    ).toBe("2027-01-01T12:00");
+  });
+
+  it("counts the day in the given zone, not in UTC", () => {
+    expect.assertions(2);
+
+    // 23:00Z is already tomorrow in Tokyo, so +1 lands two UTC days out.
+    const instant = "2026-08-20T23:00:00Z";
+
+    expect(wallClockWireInZone(addDaysInZone(instant, 1, "UTC"), "UTC")).toBe(
+      "2026-08-21T23:00"
+    );
+    expect(
+      wallClockWireInZone(addDaysInZone(instant, 1, "Asia/Tokyo"), "Asia/Tokyo")
+    ).toBe("2026-08-22T08:00");
+  });
+});
+
+describe("wallClockOnDayInZone", () => {
+  it("resolves tomorrow's opening hour in the given zone", () => {
+    expect.assertions(2);
+
+    // The same instant is a different calendar day in the two zones, so
+    // "tomorrow at 09:00" is a different day in each.
+    const now = "2026-08-20T23:00:00Z";
+
+    expect(
+      wallClockWireInZone(
+        wallClockOnDayInZone(now, 1, 9, 0, "America/Los_Angeles"),
+        "America/Los_Angeles"
+      )
+    ).toBe("2026-08-21T09:00");
+    expect(
+      wallClockWireInZone(
+        wallClockOnDayInZone(now, 1, 9, 0, "Asia/Tokyo"),
+        "Asia/Tokyo"
+      )
+    ).toBe("2026-08-22T09:00");
   });
 });

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -249,10 +249,20 @@ export function wallClockPartsInZone(
  *
  * Day arithmetic on the result works in wall-clock terms, which is usually what
  * a form default wants: `d.setDate(d.getDate() + 1)` moves to the next calendar
- * day IN `timeZone`. The one caveat is the runtime's own DST — a wall clock the
- * runtime zone skips cannot be represented by a `Date`, so it lands an hour
- * off. That is inherent to picking dates through `Date` and affects the native
- * picker identically.
+ * day IN `timeZone`. Step the calendar field to do it — adding a fixed 24h is
+ * absolute-timeline arithmetic and lands on a different clock across a runtime
+ * DST edge.
+ *
+ * KNOWN LIMITATION — a wall clock that the RUNTIME zone skips has no `Date` to
+ * carry it, so it normalises forward an hour: `2026-03-08T02:30` carried on a
+ * device in America/Los_Angeles round-trips as `03:30`. It bites only when the
+ * runtime zone differs from `timeZone` (when they match, the clock does not
+ * exist in `timeZone` either and moving forward is the defensible answer), and
+ * costs one hour of clocks per zone per year. The escape hatch is to stop
+ * routing through device-local fields at all: React Native's date picker takes
+ * a `timeZoneName` prop on iOS and Android, so it can be driven in `timeZone`
+ * directly and hand back a real instant — a different contract from this one,
+ * not a patch to it.
  *
  * @param value - a Date or parseable date string (a UTC instant)
  * @param timeZone - the IANA zone whose wall clock should be carried

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -180,6 +180,116 @@ export function calendarDayIndex(
   );
 }
 
+/** An instant's wall-clock reading in some zone, as plain calendar numbers. */
+export type WallClockParts = {
+  /** Full year, e.g. 2026. */
+  year: number;
+  /** 1-12, NOT the 0-11 a `Date` constructor wants. */
+  month: number;
+  /** 1-31. */
+  day: number;
+  /** 0-23. */
+  hour: number;
+  /** 0-59. */
+  minute: number;
+};
+
+/**
+ * What a clock on the wall in `timeZone` reads at the given instant.
+ *
+ * The returned numbers carry no zone of their own — they are what a person
+ * standing in `timeZone` would see, which is exactly what a naive wall-clock
+ * wire string (`"2026-08-20T09:00"`) and a native date picker both deal in.
+ * Pair them with the zone they were read in, or they mean nothing.
+ *
+ * `month` is 1-12 so the parts read like the wire format. Remember to subtract
+ * one when feeding a `Date` constructor.
+ *
+ * @param value - a Date or parseable date string (a UTC instant)
+ * @param timeZone - the IANA zone to read the clock in
+ * @returns the calendar/clock fields as seen in that zone
+ */
+export function wallClockPartsInZone(
+  value: string | Date,
+  timeZone: string
+): WallClockParts {
+  const date = value instanceof Date ? value : new Date(value);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const get = (t: string) => Number(parts.find((p) => p.type === t)?.value);
+  return {
+    year: get("year"),
+    month: get("month"),
+    day: get("day"),
+    hour: get("hour"),
+    minute: get("minute"),
+  };
+}
+
+/**
+ * A `Date` whose LOCAL fields carry an instant's wall clock in `timeZone`.
+ *
+ * The result is deliberately NOT the instant you passed in, and comparing it to
+ * one is meaningless. It is a carrier: `getFullYear()` … `getMinutes()` on it
+ * return what a clock in `timeZone` reads, which is what a UI that can only
+ * speak `Date` in the runtime's own zone needs in order to display and edit
+ * another zone's wall clock. React Native's date picker is exactly that UI.
+ *
+ * Round-trip it with {@link wallClockWireString} to get the naive wire string,
+ * and send the zone alongside — the pair is what carries the meaning. Never
+ * hand one of these to anything expecting a real instant (an API that wants an
+ * ISO timestamp, a duration subtraction, a sort against real instants).
+ *
+ * Day arithmetic on the result works in wall-clock terms, which is usually what
+ * a form default wants: `d.setDate(d.getDate() + 1)` moves to the next calendar
+ * day IN `timeZone`. The one caveat is the runtime's own DST — a wall clock the
+ * runtime zone skips cannot be represented by a `Date`, so it lands an hour
+ * off. That is inherent to picking dates through `Date` and affects the native
+ * picker identically.
+ *
+ * @param value - a Date or parseable date string (a UTC instant)
+ * @param timeZone - the IANA zone whose wall clock should be carried
+ * @returns a `Date` whose local fields spell that wall clock
+ */
+export function wallClockDateInZone(
+  value: string | Date,
+  timeZone: string
+): Date {
+  const { year, month, day, hour, minute } = wallClockPartsInZone(
+    value,
+    timeZone
+  );
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
+/**
+ * Serialise a wall-clock carrier to the naive wire format, `yyyy-MM-ddTHH:mm`.
+ *
+ * Reads the LOCAL fields, so it is the inverse of {@link wallClockDateInZone}
+ * and inherits the same contract: the string alone is ambiguous, and the
+ * receiver must be told which zone it was written in. Shelf's booking APIs take
+ * that as a sibling `timeZone` field.
+ *
+ * @param wallClock - a carrier from {@link wallClockDateInZone}, or a `Date`
+ *   whose local fields are already the wall clock you mean
+ * @returns the naive `yyyy-MM-ddTHH:mm` string, no offset, no seconds
+ */
+export function wallClockWireString(wallClock: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${wallClock.getFullYear()}-${pad(wallClock.getMonth() + 1)}-` +
+    `${pad(wallClock.getDate())}T${pad(wallClock.getHours())}:` +
+    `${pad(wallClock.getMinutes())}`
+  );
+}
+
 /** Superset of the option shapes DateS callers pass today (facts-02 §C). */
 export type DateFormatOptions = {
   weekday?: "long" | "short" | "narrow";

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -234,69 +234,149 @@ export function wallClockPartsInZone(
 }
 
 /**
- * A `Date` whose LOCAL fields carry an instant's wall clock in `timeZone`.
+ * `timeZone`'s offset from UTC at `date`, in milliseconds.
  *
- * The result is deliberately NOT the instant you passed in, and comparing it to
- * one is meaningless. It is a carrier: `getFullYear()` … `getMinutes()` on it
- * return what a clock in `timeZone` reads, which is what a UI that can only
- * speak `Date` in the runtime's own zone needs in order to display and edit
- * another zone's wall clock. React Native's date picker is exactly that UI.
+ * Derived by reading the zone's own clock rather than from a table, so it is
+ * correct across DST and historical offset changes without any zone data of its
+ * own. Minute resolution — every IANA offset is a whole number of minutes.
  *
- * Round-trip it with {@link wallClockWireString} to get the naive wire string,
- * and send the zone alongside — the pair is what carries the meaning. Never
- * hand one of these to anything expecting a real instant (an API that wants an
- * ISO timestamp, a duration subtraction, a sort against real instants).
- *
- * Day arithmetic on the result works in wall-clock terms, which is usually what
- * a form default wants: `d.setDate(d.getDate() + 1)` moves to the next calendar
- * day IN `timeZone`. Step the calendar field to do it — adding a fixed 24h is
- * absolute-timeline arithmetic and lands on a different clock across a runtime
- * DST edge.
- *
- * KNOWN LIMITATION — a wall clock that the RUNTIME zone skips has no `Date` to
- * carry it, so it normalises forward an hour: `2026-03-08T02:30` carried on a
- * device in America/Los_Angeles round-trips as `03:30`. It bites only when the
- * runtime zone differs from `timeZone` (when they match, the clock does not
- * exist in `timeZone` either and moving forward is the defensible answer), and
- * costs one hour of clocks per zone per year. The escape hatch is to stop
- * routing through device-local fields at all: React Native's date picker takes
- * a `timeZoneName` prop on iOS and Android, so it can be driven in `timeZone`
- * directly and hand back a real instant — a different contract from this one,
- * not a patch to it.
- *
- * @param value - a Date or parseable date string (a UTC instant)
- * @param timeZone - the IANA zone whose wall clock should be carried
- * @returns a `Date` whose local fields spell that wall clock
+ * @param date - the instant to measure the offset at
+ * @param timeZone - the IANA zone
+ * @returns offset in ms, positive east of UTC
  */
-export function wallClockDateInZone(
-  value: string | Date,
+function zoneOffsetMs(date: Date, timeZone: string): number {
+  const p = wallClockPartsInZone(date, timeZone);
+  const asIfUtc = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute);
+  const truncatedToMinute = Math.floor(date.getTime() / 60_000) * 60_000;
+  return asIfUtc - truncatedToMinute;
+}
+
+/**
+ * The instant at which `timeZone`'s clock reads the given wall-clock fields.
+ *
+ * The inverse of {@link wallClockPartsInZone}. Solves for the offset by reading
+ * the zone at a guess and correcting, which converges for every real zone
+ * because offsets change by far less than a day. Day/month/hour values outside
+ * their normal range roll over, so `{ day: 32 }` is the 1st of the next month —
+ * which is what makes calendar arithmetic on the parts safe.
+ *
+ * DST leaves two wall clocks that are not a simple 1:1 with an instant, and
+ * this resolves both the way a calendar app should:
+ *
+ * - A clock the zone SKIPS (the spring-forward hour) exists nowhere on the
+ *   timeline. It resolves FORWARD, to the instant the clock jumps to — so
+ *   02:30 on a 02:00→03:00 morning is 03:30, never 01:30.
+ * - A clock the zone REPEATS (the autumn hour) has two instants. It resolves to
+ *   the FIRST, i.e. before the clocks go back.
+ *
+ * @param parts - the wall clock to locate, `month` 1-12
+ * @param timeZone - the IANA zone whose clock reads it
+ * @returns the instant, with zero seconds and milliseconds
+ */
+export function instantFromWallClockInZone(
+  parts: WallClockParts,
   timeZone: string
 ): Date {
+  const asIfUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute
+  );
+
+  // Guess with the offset in force AT the target clock read as UTC, then again
+  // with the offset in force at that guess. Either candidate is right when the
+  // offset it was built from still holds there.
+  const offsetAtGuess = zoneOffsetMs(new Date(asIfUtc), timeZone);
+  const candidate = asIfUtc - offsetAtGuess;
+  const offsetAtCandidate = zoneOffsetMs(new Date(candidate), timeZone);
+  if (offsetAtCandidate === offsetAtGuess) return new Date(candidate);
+
+  const corrected = asIfUtc - offsetAtCandidate;
+  if (zoneOffsetMs(new Date(corrected), timeZone) === offsetAtCandidate) {
+    return new Date(corrected);
+  }
+
+  // Neither holds: the clock falls in a gap, so it has no instant of its own.
+  // The later candidate is the far side of the transition — resolve forward.
+  return new Date(Math.max(candidate, corrected));
+}
+
+/**
+ * Format an instant as the naive wire string `yyyy-MM-ddTHH:mm` in `timeZone`.
+ *
+ * The string carries no offset, so it means nothing on its own — send the zone
+ * it was written in alongside it. Shelf's booking APIs take that as a sibling
+ * `timeZone` field, and the server decodes in the zone the client declares.
+ *
+ * @param value - a Date or parseable date string (a UTC instant)
+ * @param timeZone - the IANA zone to write the wall clock in
+ * @returns the naive `yyyy-MM-ddTHH:mm` string, no offset, no seconds
+ */
+export function wallClockWireInZone(
+  value: string | Date,
+  timeZone: string
+): string {
   const { year, month, day, hour, minute } = wallClockPartsInZone(
     value,
     timeZone
   );
-  return new Date(year, month - 1, day, hour, minute, 0, 0);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${year}-${pad(month)}-${pad(day)}T${pad(hour)}:${pad(minute)}`;
 }
 
 /**
- * Serialise a wall-clock carrier to the naive wire format, `yyyy-MM-ddTHH:mm`.
+ * Move an instant by whole CALENDAR days as `timeZone` counts them.
  *
- * Reads the LOCAL fields, so it is the inverse of {@link wallClockDateInZone}
- * and inherits the same contract: the string alone is ambiguous, and the
- * receiver must be told which zone it was written in. Shelf's booking APIs take
- * that as a sibling `timeZone` field.
+ * Keeps the wall clock fixed across a DST boundary, where the day is 23 or 25
+ * hours — which is what a booking form means by "the next day at the same
+ * time". Adding `days * 86_400_000` instead keeps the elapsed time fixed and
+ * moves the clock, which is almost never what a date field wants.
  *
- * @param wallClock - a carrier from {@link wallClockDateInZone}, or a `Date`
- *   whose local fields are already the wall clock you mean
- * @returns the naive `yyyy-MM-ddTHH:mm` string, no offset, no seconds
+ * @param value - a Date or parseable date string (a UTC instant)
+ * @param days - calendar days to add; may be negative
+ * @param timeZone - the IANA zone whose calendar and clock are used
+ * @returns the instant one wall-clock-identical calendar day away
  */
-export function wallClockWireString(wallClock: Date): string {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return (
-    `${wallClock.getFullYear()}-${pad(wallClock.getMonth() + 1)}-` +
-    `${pad(wallClock.getDate())}T${pad(wallClock.getHours())}:` +
-    `${pad(wallClock.getMinutes())}`
+export function addDaysInZone(
+  value: string | Date,
+  days: number,
+  timeZone: string
+): Date {
+  const parts = wallClockPartsInZone(value, timeZone);
+  return instantFromWallClockInZone(
+    { ...parts, day: parts.day + days },
+    timeZone
+  );
+}
+
+/**
+ * The instant at which `timeZone`'s clock next reads `hour:minute` on the
+ * calendar day `dayOffset` days from `from`.
+ *
+ * Form defaults are written in wall-clock terms ("tomorrow at 9"), but the
+ * value a picker and an API want is an instant. This does both steps in one
+ * place so callers never assemble a `Date` from another zone's fields.
+ *
+ * @param from - the instant the offset counts from (usually now)
+ * @param dayOffset - calendar days ahead, in `timeZone`
+ * @param hour - target hour, 0-23 on that day's clock
+ * @param minute - target minute, 0-59
+ * @param timeZone - the IANA zone the wall clock belongs to
+ * @returns the instant of that wall clock
+ */
+export function wallClockOnDayInZone(
+  from: string | Date,
+  dayOffset: number,
+  hour: number,
+  minute: number,
+  timeZone: string
+): Date {
+  const parts = wallClockPartsInZone(from, timeZone);
+  return instantFromWallClockInZone(
+    { ...parts, day: parts.day + dayOffset, hour, minute },
+    timeZone
   );
 }
 


### PR DESCRIPTION
Closes out the booking timezone series (#2896 decode → #2905 produce → #2907 rule → #2908 closed-day math) by fixing the last surface and clearing the two loose ends those PRs deferred.

## 1. Companion booking pickers edited the wrong zone

The companion's create/edit booking screens drove their `DateTimePicker` with device-local `Date`s and submitted device-local wall clocks, while booking **detail and list** render in the user's preference zone. Anyone whose device zone differs from their Shelf preference picked one time and saw a different one the moment they saved.

The fix reframes `from`/`to` as **wall-clock carriers**: a `Date` whose *local* fields spell the **preference-zone** clock. A native picker can only speak `Date` in the runtime's zone, so the carrier is what lets it edit another zone's clock at all.

That framing collapses most of the change:

| Piece | Before | After |
|---|---|---|
| Picker state | device-local instant | preference-zone carrier |
| Button labels | `localeOnly` (workaround) | `localeOnly` (now the correct read) |
| Wire string | `toLocalWire`, hand-rolled ×2 | `wallClockWireString`, unchanged behaviour |
| Declared `timeZone` | device zone | `prefs.timeZone` |

The server already decodes in the zone the client declares (`prefsForDeclaredZone`, shipped in #2896, and true on `main` before that too), so there is **no rollout ordering requirement** — old and new servers both honour the declared zone.

### Deliberately unchanged: the detail screen

`bookings/[id].tsx` still sends the **device** zone. There the field is a client *hint* standing in for the `CH-time-zone` cookie a native client cannot set, and web fills the same field from `getClientHint(request)` — also the device. Sending the preference zone would make the two platforms disagree on one request field for no gain. Documented at the call site so it doesn't get "unified" later.

### Two defects found while converting

- **The edit screen's unsaved-changes guard would have broken.** It snapshotted the booking's *instant* but compares against picker state — now carriers. The two differ by the zone offset, so backing out of an untouched form would have prompted "discard changes?" for every affected user.
- **The create screen can mount before the preference zone exists.** `formatPrefs` falls back to the device zone while `/me` is in flight, so on a cold start the seeded window meant the wrong wall clock. It now re-seeds when the real zone lands — never over a date the user has already picked. The edit screen can't hit this: it returns early until `currentOrg`, which is set from the same `/me` response.

## 2. `@shelf/datetime` gains the wall-clock primitives

`wallClockPartsInZone`, `wallClockDateInZone`, `wallClockWireString` — pure, `Intl`-only, no deps. They replace two hand-rolled copies each of `toLocalWire` and `getTimeZone` that had already drifted apart in comments.

## 3. `calculateEffectiveEndDate` deleted

Zero production callers; only its own tests referenced it. 50 lines of implementation plus 194 of tests.

## 4. Working-hours rule wording

The rule's closing line read as a blanket ban on user zones in working-hours code, which produced a **review finding against correct code** on #2908. It now states the asymmetry:

| Change | Verdict |
|---|---|
| ambient device/server clock → preference zone | **bug fix** |
| preference zone → some other user-side zone | violation |
| preference zone → stored location zone | the real fix, if we build the column |

The accepted proxy is *mandatory*, not merely tolerated — the alternative to it isn't "no zone", it's the ambient clock, which is the device in the browser and UTC on the server for the same submission.

## Verification

- **163 tests** pass across the working-hours / booking surface.
- The 9 new package tests were checked by **mutation**: making the implementation ignore `timeZone` turns 5 of them red. They pass identically under `TZ=UTC`, `Asia/Tokyo` and `America/Los_Angeles`, so they need no `process.env.TZ` juggling — the old suite's crutch.
- Webapp `tsc -b --force` clean; eslint and prettier clean on every touched file.

**Not verified on a device.** The picker behaviour is the kind of thing only a real build confirms, and it ships on the native release train regardless. JS-only, so it is OTA-able.

## For reviewers

`pnpm install` if your checkout predates `@shelf/datetime`. This adds no new workspace package, but a stale install shows up as a `Failed to resolve import "@shelf/datetime"` that reads like a Vite bug. My own worktree is missing `react-native-calendars`, which is why `pnpm --filter @shelf/companion typecheck` reports one pre-existing error on `booking-calendar.tsx` — unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Booking creation and editing now consistently use your preferred time zone instead of the device’s time zone.
  * Booking times remain accurate across daylight-saving transitions, calendar-day changes, and different regional offsets.
  * Default booking hours are calculated correctly in your preferred time zone.
  * End times automatically remain valid when booking start dates or times change.
  * Booking actions now provide clearer time-zone context for reliable scheduling.

* **Documentation**
  * Added guidance explaining how time zones apply to booking actions and forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->