### PR TITLE
fix(assets): render inherited model cover images on every asset surface

### DIFF
--- a/apps/webapp/app/components/assets/asset-image/utils.ts
+++ b/apps/webapp/app/components/assets/asset-image/utils.ts
@@ -1,16 +1,6 @@
 import type { AssetForPreview, AssetForThumbnail } from "./types";
 
 // Type guard functions to help with type checking
-export function hasMainImage(asset: {
-  mainImage?: unknown;
-}): asset is { mainImage: string } {
-  return (
-    typeof "mainImage" in asset &&
-    asset.mainImage === "string" &&
-    asset.mainImage.length > 0
-  );
-}
-
 export function hasPreviewData(asset: unknown): asset is AssetForPreview {
   return (
     typeof asset === "object" &&

--- a/apps/webapp/app/components/booking/booking-assets-column.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-column.tsx
@@ -4,6 +4,7 @@ import { useLoaderData } from "react-router";
 import { useBookingStatusHelpers } from "~/hooks/use-booking-status";
 import { useViewportHeight } from "~/hooks/use-viewport-height";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import type { AssetWithResolvableImage } from "~/modules/asset/image-resolution";
 import type { BookingPageLoaderData } from "~/routes/_layout+/bookings.$bookingId.overview";
 import type { AssetWithBooking } from "~/routes/_layout+/bookings.$bookingId.overview.manage-assets";
 import { canAssignModelUnits } from "~/utils/booking-model-requests";
@@ -28,16 +29,37 @@ import { Table, Th } from "../table";
 import When from "../when/when";
 
 /**
- * Type assertion helper for booking assets.
- * The loader enriches partial booking assets with full asset details via assetDetailsMap,
- * but TypeScript can't infer this enrichment. This helper documents the intentional
- * assertion and provides a single point of type conversion.
+ * Type assertion helpers for booking asset rows.
+ *
+ * The loader enriches the pivot's asset rows with full details from
+ * `assetDetailsMap`, and the client receives that payload serialized (Dates
+ * arrive as strings), so the runtime shape cannot satisfy `AssetWithBooking`
+ * structurally. These helpers are the single documented point where that gap
+ * is asserted away.
+ *
+ * `T extends AssetWithResolvableImage` is the part that must not be relaxed.
+ * Everything downstream renders `<AssetImage>`, which resolves
+ * `own image → model cover → placeholder`, and a loader that ships the image
+ * SCALARS but omits the `assetModel` relation silently drops every inheriting
+ * asset to the placeholder. Nothing about that is observable in types once a
+ * row has been cast, and nothing fails at runtime either — the page just shows
+ * the wrong picture. The constraint is what forces each loader to prove it
+ * carries all three fields before its rows may enter this path.
+ *
+ * A bare `<T>` here is what let the booking overview ship a loader without the
+ * relation. Do not widen it back.
+ *
+ * @see {@link file://./../../modules/asset/image-resolution.ts}
  */
-function asEnrichedAssets<T>(assets: T[]): AssetWithBooking[] {
+function asEnrichedAssets<T extends AssetWithResolvableImage>(
+  assets: T[]
+): AssetWithBooking[] {
   return assets as unknown as AssetWithBooking[];
 }
 
-function asEnrichedAsset<T>(asset: T): AssetWithBooking {
+function asEnrichedAsset<T extends AssetWithResolvableImage>(
+  asset: T
+): AssetWithBooking {
   return asset as unknown as AssetWithBooking;
 }
 

--- a/apps/webapp/app/components/booking/booking-assets-column.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-column.tsx
@@ -46,8 +46,9 @@ import When from "../when/when";
  * the wrong picture. The constraint is what forces each loader to prove it
  * carries all three fields before its rows may enter this path.
  *
- * A bare `<T>` here is what let the booking overview ship a loader without the
- * relation. Do not widen it back.
+ * Do not relax the constraint to a bare `<T>`: that accepts a row of any shape,
+ * so a loader missing the relation reaches the render path with nothing to stop
+ * it.
  *
  * @see {@link file://./../../modules/asset/image-resolution.ts}
  */

--- a/apps/webapp/app/components/booking/list-asset-content.tsx
+++ b/apps/webapp/app/components/booking/list-asset-content.tsx
@@ -301,7 +301,7 @@ export default function ListAssetContent({
                   mainImage: item.mainImage,
                   thumbnailImage: item.thumbnailImage,
                   mainImageExpiration: item.mainImageExpiration,
-                  assetModel: item.assetModel ?? null,
+                  assetModel: item.assetModel,
                 }}
                 alt={`Image of ${item.title}`}
                 className={tw(

--- a/apps/webapp/app/components/dashboard/newest-assets.tsx
+++ b/apps/webapp/app/components/dashboard/newest-assets.tsx
@@ -93,9 +93,18 @@ const Row = ({
 }: {
   item: Asset & {
     category: Pick<Category, "id" | "name" | "color"> | null;
-    /** Cover image of the asset's model, rendered when the asset has no image
-     * of its own. See `~/modules/asset/image-resolution`. */
-    assetModel?: { image: string | null; thumbnailImage: string | null } | null;
+    /**
+     * Cover image of the asset's model, rendered when the asset has no image
+     * of its own. See `~/modules/asset/image-resolution`.
+     *
+     * REQUIRED, not optional: `null` means "this asset has no model", which is
+     * a real answer, while an absent key means the loader forgot to select the
+     * relation — and that renders every inheriting asset as the placeholder
+     * with nothing failing. Optional here is what let this card ship without
+     * the relation, since `?? null` at the call site made the two
+     * indistinguishable.
+     */
+    assetModel: { image: string | null; thumbnailImage: string | null } | null;
   };
 }) => {
   const { category } = item;
@@ -112,7 +121,7 @@ const Row = ({
                   mainImage: item.mainImage,
                   thumbnailImage: item.thumbnailImage,
                   mainImageExpiration: item.mainImageExpiration,
-                  assetModel: item.assetModel ?? null,
+                  assetModel: item.assetModel,
                 }}
                 alt={`Image of ${item.title}`}
                 className="size-full rounded-[4px] border object-cover"

--- a/apps/webapp/app/components/dashboard/newest-assets.tsx
+++ b/apps/webapp/app/components/dashboard/newest-assets.tsx
@@ -97,12 +97,11 @@ const Row = ({
      * Cover image of the asset's model, rendered when the asset has no image
      * of its own. See `~/modules/asset/image-resolution`.
      *
-     * REQUIRED, not optional: `null` means "this asset has no model", which is
-     * a real answer, while an absent key means the loader forgot to select the
-     * relation — and that renders every inheriting asset as the placeholder
-     * with nothing failing. Optional here is what let this card ship without
-     * the relation, since `?? null` at the call site made the two
-     * indistinguishable.
+     * Required and nullable, which is what keeps the two cases apart: `null`
+     * says "this asset has no model" and is a real answer, while an absent key
+     * says the loader did not select the relation. Making it optional collapses
+     * that distinction, and so does `?? null` at the call site — both render
+     * every inheriting asset as the placeholder without anything failing.
      */
     assetModel: { image: string | null; thumbnailImage: string | null } | null;
   };

--- a/apps/webapp/app/modules/asset/image-resolution.ts
+++ b/apps/webapp/app/modules/asset/image-resolution.ts
@@ -144,3 +144,22 @@ export function serializeAssetImage<T extends AssetWithResolvableImage>({
     imageSource: resolved.source,
   };
 }
+
+/**
+ * The `mainImageExpiration` to serialize next to a resolved image.
+ *
+ * Expiration describes the asset's OWN signed URL only — a model cover is a
+ * public URL that never expires, and the asset row's date can be stale
+ * residue from a removed own image. Any source but `"asset"` therefore
+ * yields `null`, so a client-side expiry check never discards a valid image.
+ *
+ * @param source - Which tier won the cascade for the URLs being serialized
+ * @param expiration - The asset row's raw expiration, in the caller's format
+ * @returns The expiration when the asset's own image won, otherwise null
+ */
+export function serializeImageExpiration<T>(
+  source: AssetImageSource,
+  expiration: T
+): T | null {
+  return source === "asset" ? expiration : null;
+}

--- a/apps/webapp/app/modules/asset/image-select.ts
+++ b/apps/webapp/app/modules/asset/image-select.ts
@@ -5,8 +5,26 @@
  * that surface silently drops assets which inherit their image from their model
  * down to the placeholder — the inconsistency this feature exists to remove.
  *
- * `AssetImageProps` requires the `assetModel` field, so a missing spread shows
- * up as a typecheck failure rather than as a wrong-looking page.
+ * `AssetImageProps` requires `assetModel`, so a missing spread normally shows up
+ * as a typecheck failure rather than as a wrong-looking page. That guarantee is
+ * only as strong as the path between the loader and the render, and exactly two
+ * things dissolve it — both have shipped this bug already:
+ *
+ * 1. **A cast on the row.** `as unknown as SomeRowType` asserts a shape rather
+ *    than checking one, so a row missing the relation passes. Where a cast is
+ *    genuinely needed (serialized loader data cannot satisfy a Prisma-derived
+ *    type structurally), constrain its INPUT — see `asEnrichedAssets` in
+ *    `~/components/booking/booking-assets-column`, whose
+ *    `T extends AssetWithResolvableImage` is what makes the loader prove it
+ *    carries the relation before the cast happens.
+ * 2. **An optional `assetModel?:` on a component's own prop type, plus
+ *    `assetModel: item.assetModel ?? null` at the call site.** Together these
+ *    make "no model" and "loader forgot the relation" indistinguishable. Declare
+ *    it required and pass it straight through; `null` is a real answer and
+ *    survives on its own.
+ *
+ * Neither is visible at runtime: nothing throws, the page just shows the
+ * placeholder for every asset that inherits its image.
  *
  * Kept in its own module (not in `image-resolution.ts`) so the pure resolver
  * stays free of anything Prisma-shaped and can be imported by React components.

--- a/apps/webapp/app/modules/asset/image-select.ts
+++ b/apps/webapp/app/modules/asset/image-select.ts
@@ -8,7 +8,7 @@
  * `AssetImageProps` requires `assetModel`, so a missing spread normally shows up
  * as a typecheck failure rather than as a wrong-looking page. That guarantee is
  * only as strong as the path between the loader and the render, and exactly two
- * things dissolve it — both have shipped this bug already:
+ * patterns dissolve it:
  *
  * 1. **A cast on the row.** `as unknown as SomeRowType` asserts a shape rather
  *    than checking one, so a row missing the relation passes. Where a cast is

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkin-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkin-assets.tsx
@@ -19,6 +19,7 @@ import { db } from "~/database/db.server";
 import { useBookingCheckinSessionInitialization } from "~/hooks/use-booking-checkin-session-initialization";
 import { useScannerCameraId } from "~/hooks/use-scanner-camera-id";
 import { useViewportHeight } from "~/hooks/use-viewport-height";
+import { resolveAssetImage } from "~/modules/asset/image-resolution";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import {
   attributeCategorizedDispositionsByBookingAsset,
@@ -300,8 +301,23 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           id: asset.id,
           bookingAssetId: ba.id,
           title: asset.title,
-          mainImage: asset.mainImage ?? null,
-          thumbnailImage: asset.thumbnailImage ?? null,
+          // Collapse the model-image cascade into the flat fields the
+          // scanner drawer reads (`thumbnailImage || mainImage`), so an
+          // asset with no image of its own renders its model's cover.
+          // `null` stays `null` for the true no-image case — the drawer's
+          // own placeholder branch handles it.
+          ...(() => {
+            const image = resolveAssetImage({
+              mainImage: asset.mainImage ?? null,
+              thumbnailImage: asset.thumbnailImage ?? null,
+              assetModel: asset.assetModel ?? null,
+            });
+            const isPlaceholder = image.source === "placeholder";
+            return {
+              mainImage: isPlaceholder ? null : image.fullUrl,
+              thumbnailImage: isPlaceholder ? null : image.thumbnailUrl,
+            };
+          })(),
           kitId: sourceKit?.id ?? null,
           kitName: sourceKit?.name ?? null,
         };

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkout-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.checkout-assets.tsx
@@ -19,6 +19,7 @@ import { db } from "~/database/db.server";
 import { useBookingCheckinSessionInitialization } from "~/hooks/use-booking-checkin-session-initialization";
 import { useScannerCameraId } from "~/hooks/use-scanner-camera-id";
 import { useViewportHeight } from "~/hooks/use-viewport-height";
+import { resolveAssetImage } from "~/modules/asset/image-resolution";
 import {
   checkoutAssets,
   computeBookingAssetRemainingToCheckOut,
@@ -262,8 +263,23 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           id: asset.id,
           bookingAssetId: ba.id,
           title: asset.title,
-          mainImage: asset.mainImage ?? null,
-          thumbnailImage: asset.thumbnailImage ?? null,
+          // Collapse the model-image cascade into the flat fields the
+          // scanner drawer reads (`thumbnailImage || mainImage`), so an
+          // asset with no image of its own renders its model's cover.
+          // `null` stays `null` for the true no-image case — the drawer's
+          // own placeholder branch handles it.
+          ...(() => {
+            const image = resolveAssetImage({
+              mainImage: asset.mainImage ?? null,
+              thumbnailImage: asset.thumbnailImage ?? null,
+              assetModel: asset.assetModel ?? null,
+            });
+            const isPlaceholder = image.source === "placeholder";
+            return {
+              mainImage: isPlaceholder ? null : image.fullUrl,
+              thumbnailImage: isPlaceholder ? null : image.thumbnailUrl,
+            };
+          })(),
           kitId: sourceKit?.id ?? null,
           kitName: sourceKit?.name ?? null,
         };

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -30,6 +30,7 @@ import type { HeaderData } from "~/components/layout/header/types";
 import { db } from "~/database/db.server";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
 import { LOCATION_WITH_HIERARCHY } from "~/modules/asset/fields";
+import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getPrimaryLocation } from "~/modules/asset/utils";
 import { buildAvailableUnitsByAsset } from "~/modules/booking/booking-overview-availability.server";
 import {
@@ -478,6 +479,11 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           // `~/modules/barcode/display.ts`.
           qrCodes: { take: 1, select: { id: true } },
           barcodes: { select: { id: true, type: true, value: true } },
+          // Model cover image. These rows REPLACE the pivot's `ba.asset`
+          // (`detail ?? ba.asset` below), so every relation `<AssetImage>`
+          // needs must be re-included here — image scalars alone are not
+          // enough for assets that inherit their image from their model.
+          ...ASSET_MODEL_IMAGE_SELECT,
           bookingAssets: {
             where: {
               booking: {

--- a/apps/webapp/app/routes/_layout+/home.tsx
+++ b/apps/webapp/app/routes/_layout+/home.tsx
@@ -33,6 +33,7 @@ import UpcomingReminders from "~/components/home/upcoming-reminders";
 import Header from "~/components/layout/header";
 import type { HeaderData } from "~/components/layout/header/types";
 import { db } from "~/database/db.server";
+import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getUpcomingRemindersForHomePage } from "~/modules/asset-reminder/service.server";
 import { getBookings } from "~/modules/booking/service.server";
 
@@ -265,6 +266,9 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
           include: {
             category: true,
             custody: { select: { quantity: true } },
+            // Model cover image — `<AssetImage>` renders it for assets with
+            // no image of their own.
+            ...ASSET_MODEL_IMAGE_SELECT,
           },
         })
         .catch((cause) => {

--- a/apps/webapp/app/routes/api+/command-palette.search.ts
+++ b/apps/webapp/app/routes/api+/command-palette.search.ts
@@ -388,10 +388,17 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
               return {
                 mainImage: isPlaceholder ? null : image.fullUrl,
                 thumbnailImage: isPlaceholder ? null : image.thumbnailUrl,
+                // Expiration describes the asset's OWN signed URL only — a
+                // model cover is a public URL that never expires, and the
+                // row's date can be stale residue from a removed own image.
+                // Send it only for the tier it describes, or the palette's
+                // expiry check discards a valid image.
+                mainImageExpiration:
+                  image.source === "asset"
+                    ? asset.mainImageExpiration?.toISOString() ?? null
+                    : null,
               };
             })(),
-            mainImageExpiration:
-              asset.mainImageExpiration?.toISOString() ?? null,
             // `getAssets` widens its `extraInclude` arg to
             // `Prisma.AssetInclude`, so the return type can't narrow back
             // to the `assetLocations` shape we requested above. Cast at

--- a/apps/webapp/app/routes/api+/command-palette.search.ts
+++ b/apps/webapp/app/routes/api+/command-palette.search.ts
@@ -3,7 +3,10 @@ import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 
 import { db } from "~/database/db.server";
-import { resolveAssetImage } from "~/modules/asset/image-resolution";
+import {
+  resolveAssetImage,
+  serializeImageExpiration,
+} from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getAssets } from "~/modules/asset/service.server";
 import { getPrimaryLocation } from "~/modules/asset/utils";
@@ -388,15 +391,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
               return {
                 mainImage: isPlaceholder ? null : image.fullUrl,
                 thumbnailImage: isPlaceholder ? null : image.thumbnailUrl,
-                // Expiration describes the asset's OWN signed URL only — a
-                // model cover is a public URL that never expires, and the
-                // row's date can be stale residue from a removed own image.
-                // Send it only for the tier it describes, or the palette's
-                // expiry check discards a valid image.
-                mainImageExpiration:
-                  image.source === "asset"
-                    ? asset.mainImageExpiration?.toISOString() ?? null
-                    : null,
+                mainImageExpiration: serializeImageExpiration(
+                  image.source,
+                  asset.mainImageExpiration?.toISOString() ?? null
+                ),
               };
             })(),
             // `getAssets` widens its `extraInclude` arg to

--- a/apps/webapp/app/routes/api+/get-scanned-barcode.$value.ts
+++ b/apps/webapp/app/routes/api+/get-scanned-barcode.$value.ts
@@ -3,6 +3,7 @@ import { data } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import { serializeAssetImage } from "~/modules/asset/image-resolution";
 import { getBarcodeByValue } from "~/modules/barcode/service.server";
 import {
   getScannerPickerMeta,
@@ -233,7 +234,10 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
           type: barcode.asset ? "asset" : barcode.kit ? "kit" : undefined,
           asset: barcode.asset
             ? {
-                ...barcode.asset,
+                // Collapse the model-image cascade into the flat image
+                // fields the scanner drawers read; the nested relation is
+                // dropped so the row carries one source of truth.
+                ...serializeAssetImage(barcode.asset),
                 auditAssetId,
                 auditNotesCount,
                 auditImagesCount,

--- a/apps/webapp/app/routes/api+/get-scanned-item.$qrId.ts
+++ b/apps/webapp/app/routes/api+/get-scanned-item.$qrId.ts
@@ -3,6 +3,7 @@ import { data } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import { serializeAssetImage } from "~/modules/asset/image-resolution";
 import { getQr } from "~/modules/qr/service.server";
 import {
   getScannerPickerMeta,
@@ -210,7 +211,10 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
           qr: {
             type: "asset" as const,
             asset: {
-              ...asset,
+              // Collapse the model-image cascade into the flat image fields
+              // the scanner drawers read; the nested relation is dropped so
+              // the row carries one source of truth for the image.
+              ...serializeAssetImage(asset),
               auditAssetId,
               auditNotesCount,
               auditImagesCount,
@@ -305,7 +309,10 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
           type: qr.asset ? "asset" : qr.kit ? "kit" : undefined,
           asset: qr.asset
             ? {
-                ...qr.asset,
+                // Collapse the model-image cascade into the flat image
+                // fields the scanner drawers read; the nested relation is
+                // dropped so the row carries one source of truth.
+                ...serializeAssetImage(qr.asset),
                 auditAssetId,
                 auditNotesCount,
                 auditImagesCount,

--- a/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
@@ -12,6 +12,7 @@ import {
   filterMobileCustodyListForViewer,
   viewerCanSeeLegacyCustody,
 } from "~/modules/api/mobile-custody-visibility.server";
+import { serializeImageExpiration } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getAssetQuantityRows } from "~/modules/asset/quantity-breakdown.server";
 import { isQuantityTracked } from "~/modules/asset/utils";
@@ -331,15 +332,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         mainImage: flattened.mainImage,
         thumbnailImage: flattened.thumbnailImage,
         imageSource: flattened.imageSource,
-        // Expiration describes the asset's OWN signed URL only — a model
-        // cover is a public URL that never expires, and the row's date can
-        // be stale residue from a removed own image. Send it only for the
-        // tier it describes, or a client-side expiry check discards a
-        // valid image.
-        mainImageExpiration:
-          flattened.imageSource === "asset"
-            ? assetData.mainImageExpiration
-            : null,
+        mainImageExpiration: serializeImageExpiration(
+          flattened.imageSource,
+          assetData.mainImageExpiration
+        ),
         kit: flattened.kit,
         kitId: flattened.kitId,
         location: flattened.location,

--- a/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
@@ -331,6 +331,15 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         mainImage: flattened.mainImage,
         thumbnailImage: flattened.thumbnailImage,
         imageSource: flattened.imageSource,
+        // Expiration describes the asset's OWN signed URL only — a model
+        // cover is a public URL that never expires, and the row's date can
+        // be stale residue from a removed own image. Send it only for the
+        // tier it describes, or a client-side expiry check discards a
+        // valid image.
+        mainImageExpiration:
+          flattened.imageSource === "asset"
+            ? assetData.mainImageExpiration
+            : null,
         kit: flattened.kit,
         kitId: flattened.kitId,
         location: flattened.location,

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -29,10 +29,13 @@ import { makeShelfError, ShelfError } from "~/utils/error";
  * modules/api/mobile-asset-search.server.ts), the same index-driven path the
  * web indexes use, in a single query.
  *
- * Image URLs are returned as-stored along with `mainImageExpiration`. Mobile
- * clients should call `/api/mobile/asset/refresh-image/:assetId` lazily when
- * they detect an expired URL — keeps this loader read-only and avoids fanning
- * out N writes per paginated read.
+ * Image URLs are returned with the model-image cascade already resolved
+ * (`shapeMobileAssetResponse`), not re-signed. `mainImageExpiration` is only
+ * sent when the asset's OWN signed URL won the cascade — model cover images
+ * are public and never expire. Mobile clients should call
+ * `/api/mobile/asset/refresh-image/:assetId` lazily when they detect an
+ * expired URL — keeps this loader read-only and avoids fanning out N writes
+ * per paginated read.
  */
 export async function loader({ request }: LoaderFunctionArgs) {
   try {
@@ -251,7 +254,13 @@ export async function loader({ request }: LoaderFunctionArgs) {
         custody: visibleCustody,
         custodyList,
         custodyListOthersCount,
-        mainImageExpiration,
+        // Expiration describes the asset's OWN signed URL only — a model
+        // cover is a public URL that never expires, and the row's date can
+        // be stale residue from a removed own image. Send it only for the
+        // tier it describes, or the client's lazy refresh check discards a
+        // valid image.
+        mainImageExpiration:
+          shaped.imageSource === "asset" ? mainImageExpiration : null,
       };
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.ts
@@ -12,6 +12,7 @@ import {
   filterMobileCustodyListForViewer,
   viewerCanSeeLegacyCustody,
 } from "~/modules/api/mobile-custody-visibility.server";
+import { serializeImageExpiration } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { buildAssetStatusWhere } from "~/modules/asset/search.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -254,13 +255,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         custody: visibleCustody,
         custodyList,
         custodyListOthersCount,
-        // Expiration describes the asset's OWN signed URL only — a model
-        // cover is a public URL that never expires, and the row's date can
-        // be stale residue from a removed own image. Send it only for the
-        // tier it describes, or the client's lazy refresh check discards a
-        // valid image.
-        mainImageExpiration:
-          shaped.imageSource === "asset" ? mainImageExpiration : null,
+        mainImageExpiration: serializeImageExpiration(
+          shaped.imageSource,
+          mainImageExpiration
+        ),
       };
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
@@ -1,3 +1,20 @@
+/**
+ * Mobile booking asset picker endpoint.
+ *
+ * Serves the companion's "add assets to booking" screen: an availability-aware
+ * asset list for a specific date window, plus the display code and resolved
+ * image each row renders. It owns no query or availability logic of its own —
+ * `getPaginatedAndFilterableAssets` decides what is bookable, and this route
+ * shapes that result for a native client that cannot re-resolve relations.
+ *
+ * Shaping is the part worth knowing: the response carries FLAT, already-resolved
+ * image fields rather than the nested `assetModel` relation, because the
+ * companion ships as a native binary and must inherit a model's cover image
+ * without a client release. See the loader docblock for the request contract.
+ *
+ * @see {@link file://./../../../modules/asset/image-resolution.ts}
+ * @see {@link file://./../../../modules/asset/service.server.ts} getPaginatedAndFilterableAssets
+ */
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import {

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
@@ -143,9 +143,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
               mainImage: isPlaceholder ? null : image.fullUrl,
               thumbnailImage: isPlaceholder ? null : image.thumbnailUrl,
               imageSource: image.source,
+              // Expiration describes the asset's OWN signed URL only — a
+              // model cover is a public URL that never expires, and the
+              // row's date can be stale residue from a removed own image.
+              // Send it only for the tier it describes, or a client-side
+              // expiry check discards a valid image.
+              mainImageExpiration:
+                image.source === "asset" ? asset.mainImageExpiration : null,
             };
           })(),
-          mainImageExpiration: asset.mainImageExpiration,
           // Kit linkage moved to the AssetKit pivot (quantities restructure);
           // the pivot row's `kitId` FK is the legacy single-kit id the companion
           // contract expects.

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-assets.ts
@@ -5,7 +5,10 @@ import {
   requireOrganizationAccess,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
-import { resolveAssetImage } from "~/modules/asset/image-resolution";
+import {
+  resolveAssetImage,
+  serializeImageExpiration,
+} from "~/modules/asset/image-resolution";
 import { getPaginatedAndFilterableAssets } from "~/modules/asset/service.server";
 import {
   resolveDisplayCode,
@@ -143,13 +146,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
               mainImage: isPlaceholder ? null : image.fullUrl,
               thumbnailImage: isPlaceholder ? null : image.thumbnailUrl,
               imageSource: image.source,
-              // Expiration describes the asset's OWN signed URL only — a
-              // model cover is a public URL that never expires, and the
-              // row's date can be stale residue from a removed own image.
-              // Send it only for the tier it describes, or a client-side
-              // expiry check discards a valid image.
-              mainImageExpiration:
-                image.source === "asset" ? asset.mainImageExpiration : null,
+              mainImageExpiration: serializeImageExpiration(
+                image.source,
+                asset.mainImageExpiration
+              ),
             };
           })(),
           // Kit linkage moved to the AssetKit pivot (quantities restructure);

--- a/apps/webapp/app/utils/scanner-includes.server.ts
+++ b/apps/webapp/app/utils/scanner-includes.server.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from "@prisma/client";
 
+import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
+
 export const CUSTODY_INCLUDE = {
   custody: {
     select: {
@@ -32,6 +34,11 @@ export const CUSTODY_INCLUDE = {
  * without re-adding `status` and `type` explicitly.
  */
 export const ASSET_INCLUDE = {
+  // Model cover image — the scanned-item endpoints collapse the cascade
+  // into flat `mainImage`/`thumbnailImage` via `serializeAssetImage`, so
+  // assets with no image of their own render their model's cover in every
+  // scanner drawer.
+  ...ASSET_MODEL_IMAGE_SELECT,
   // Asset placement lives on the `AssetLocation` pivot. Consumers read
   // the primary placement via `getPrimaryLocation`.
   assetLocations: {

--- a/apps/webapp/app/utils/scanner-includes.server.ts
+++ b/apps/webapp/app/utils/scanner-includes.server.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from "@prisma/client";
 
+import type { AssetImageSource } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 
 export const CUSTODY_INCLUDE = {
@@ -126,8 +127,20 @@ export type ScannerAssetPickerMeta = {
   unitOfMeasure: string | null;
 } | null;
 
-export type AssetFromScanner = Prisma.AssetGetPayload<{
-  include: typeof ASSET_INCLUDE;
-}> & {
+/**
+ * An asset as the scanned-item endpoints RESPOND with it — not as Prisma
+ * returns it. The endpoints collapse the model-image cascade via
+ * `serializeAssetImage`, which drops the `assetModel` relation and adds
+ * `imageSource`, so this type mirrors that serialized shape.
+ */
+export type AssetFromScanner = Omit<
+  Prisma.AssetGetPayload<{
+    include: typeof ASSET_INCLUDE;
+  }>,
+  "assetModel"
+> & {
+  mainImage: string | null;
+  thumbnailImage: string | null;
+  imageSource: AssetImageSource;
   pickerMeta?: ScannerAssetPickerMeta;
 };

--- a/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
@@ -207,6 +207,80 @@ describe("GET /api/mobile/assets", () => {
       custody: null,
     });
   });
+
+  it("sends mainImageExpiration only when the asset's own image won the cascade", async () => {
+    // why: expiration describes the asset's OWN signed URL only. A model
+    // cover is a public URL that never expires, and the row's date can be
+    // stale residue from a removed own image — a client-side expiry check
+    // fed that pairing discards a valid image. This pins the source gate.
+    findManyMock.mockResolvedValueOnce([
+      // Own image: the signed URL and its expiration travel together.
+      {
+        id: "asset-own",
+        title: "Own image",
+        status: "AVAILABLE",
+        mainImage: "https://supabase.test/sign/assets/own.png",
+        thumbnailImage: "https://supabase.test/sign/assets/own-thumbnail.png",
+        mainImageExpiration: "2026-08-01T00:00:00.000Z",
+        availableToBook: true,
+        category: null,
+        assetModel: null,
+        assetKits: [],
+        assetLocations: [],
+        custody: [],
+      },
+      // Inherited image: stale per-asset expiration residue must NOT ship
+      // next to the model's never-expiring public URL.
+      {
+        id: "asset-inherited",
+        title: "Inherited image",
+        status: "AVAILABLE",
+        mainImage: null,
+        thumbnailImage: null,
+        mainImageExpiration: "2026-08-01T00:00:00.000Z",
+        availableToBook: true,
+        category: null,
+        assetModel: {
+          image: "https://supabase.test/public/files/model.png",
+          thumbnailImage:
+            "https://supabase.test/public/files/model-thumbnail.png",
+        },
+        assetKits: [],
+        assetLocations: [],
+        custody: [],
+      },
+    ] as never);
+
+    countMock.mockResolvedValueOnce(2);
+
+    const args = createLoaderArgs({
+      request: new Request("http://localhost:3000/api/mobile/assets"),
+    });
+
+    const response = await loader(args);
+    assertIsDataWithResponseInit(response);
+    const body = response.data as {
+      assets: Array<{
+        id: string;
+        mainImage: string | null;
+        imageSource: string;
+        mainImageExpiration: string | null;
+      }>;
+    };
+
+    expect(body.assets[0]).toMatchObject({
+      id: "asset-own",
+      mainImage: "https://supabase.test/sign/assets/own.png",
+      imageSource: "asset",
+      mainImageExpiration: "2026-08-01T00:00:00.000Z",
+    });
+    expect(body.assets[1]).toMatchObject({
+      id: "asset-inherited",
+      mainImage: "https://supabase.test/public/files/model.png",
+      imageSource: "model",
+      mainImageExpiration: null,
+    });
+  });
 });
 
 describe("GET /api/mobile/assets — status filter", () => {

--- a/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/assets.test.ts
@@ -251,6 +251,8 @@ describe("GET /api/mobile/assets", () => {
       },
     ] as never);
 
+    // why: the loader runs findMany + count in parallel for the pagination
+    // envelope; the count must match the two mocked rows above.
     countMock.mockResolvedValueOnce(2);
 
     const args = createLoaderArgs({


### PR DESCRIPTION
## What

A customer reported that assets inheriting their cover image from their asset model render the placeholder on the booking overview and in quick find, while the asset page and assets index show the image correctly. A full sweep of every surface that renders asset images found the same defect family in seven places. This PR fixes all of them. No migration, no schema change, no new dependencies.

The model-image cascade (`resolveAssetImage`: own image → model cover → placeholder) is resolved per surface, so every loader feeding an image renderer must either carry the `assetModel` relation or collapse the cascade server-side. These surfaces did neither:

### Missing `assetModel` relation (rows reached the renderer without the model half of the cascade)

- **Booking overview** (`bookings.$bookingId.overview.tsx`): the loader's enrichment `findMany` replaces the pivot's asset rows (`detail ?? ba.asset`) and did not include the relation, so every row lost the model cover before render. Now spreads `ASSET_MODEL_IMAGE_SELECT`.
- **Home dashboard "Newest assets"** (`home.tsx`): the newest-5 query included only `category` and `custody`. Newly created model-based assets are exactly what lands in this card.

### Raw-URL readers fed unresolved fields (the drawers read `thumbnailImage || mainImage` directly)

- **Both scan pages** (`checkin-assets.tsx`, `checkout-assets.tsx`): the expected-assets projections now collapse the cascade via `resolveAssetImage`. `null` stays `null` for the true no-image case so the drawers' own placeholder branches keep working.
- **Scanned-item endpoints** (`get-scanned-item.$qrId`, `get-scanned-barcode.$value`): `ASSET_INCLUDE` now carries the relation and both endpoints collapse via `serializeAssetImage`, dropping the nested relation so scanned rows carry one source of truth.

### Per-asset expiration paired with a model URL (client expiry checks discarded a valid image)

A model cover is a public URL that never expires, but an asset row can carry a stale `mainImageExpiration` from a removed own image. Serializers that resolve the cascade now send the expiration only when the asset's own signed URL won it:

- **Command palette** (`api+/command-palette.search.ts`) — this is why two assets of the same model could render differently in quick find.
- **Mobile assets list, asset detail, and booking available-assets** (`api+/mobile+/…`) — same shape, dormant today (the companion declares the field but never reads it for rendering); gated for consistency before it becomes a bug. Mirrors the source rule `asset-image/component.tsx` already applies.

Also removes the dead `hasMainImage` type guard (zero callers; its precedence bug made it always return false).

## How this was verified

- **Live before/after on the same data** (local rig against a real database): a model with a distinctive cover, an inheriting asset with a planted stale `mainImageExpiration`, an own-image control asset with a valid signed URL, and a no-image control. With the fixes stashed, booking overview, quick find, home dashboard and the check-in scan page all render `asset-placeholder.jpg`; with the fixes applied, all render the model cover. The controls behave identically before and after (own image renders and keeps its expiration; no-image keeps the placeholder).
- **Responsive**: booking overview, quick find and the assets index verified at 1987px, 768px, and 375px (mobile emulation with touch), including the palette opened through the mobile header entry point. No layout regressions, no horizontal body scroll.
- **Scanned-item endpoint** verified directly: returns resolved URLs, `imageSource: "model"`, no nested relation. The checkout scan page and barcode endpoint share the exact code paths of their verified twins.
- **Gates**: full unit suite 388 files / 5145 tests passing, typecheck, ESLint, Prettier. A new route test pins the mobile list contract (own image → expiration ships; inherited → `null` + model URL).

Surfaces swept and verified clean (no change needed): QR-link page, kit and location pages, bookings index and its assets sidebar, manage-assets dialogs, reports, booking PDF, audit drawers and serializer, availability calendar, emails (render no asset images), and the mobile refresh endpoint. Known pre-existing gap left untouched: note-embedded asset lists (`markdown/assets-list-component`) have no model data in their payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset images now fall back to model cover images when an asset image is unavailable.
  * Booking, dashboard, mobile, scanner, and barcode views display resolved images consistently.
  * Placeholders remain available when no image exists.
  * Image expiration data is shown only for asset-owned images.

* **Bug Fixes**
  * Improved handling of image URLs and expiration values across asset-related views and APIs.

* **Tests**
  * Added coverage verifying expiration behavior for asset-owned and model-derived images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->