### PR TITLE
chore(companion): bump version to 1.4.0

### DIFF
--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shelf",
     "slug": "shelf-companion",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "shelf",
@@ -109,7 +109,7 @@
       }
     },
     "owner": "shelfassetmanagement",
-    "runtimeVersion": "1.3.0",
+    "runtimeVersion": "1.4.0",
     "updates": {
       "url": "https://u.expo.dev/b6d6a6cb-c242-4474-815f-b55d5e691c58",
       "enabled": true,

--- a/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
+++ b/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -396,7 +396,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/companion/ios/Shelf/Info.plist
+++ b/apps/companion/ios/Shelf/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apps/companion/ios/Shelf/Supporting/Expo.plist
+++ b/apps/companion/ios/Shelf/Supporting/Expo.plist
@@ -36,7 +36,7 @@ XDtxmW3U7J2q1cGZG63nBVlCpaRu
 	<key>EXUpdatesLaunchWaitMs</key>
 	<integer>0</integer>
 	<key>EXUpdatesRuntimeVersion</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>EXUpdatesURL</key>
 	<string>https://u.expo.dev/b6d6a6cb-c242-4474-815f-b55d5e691c58</string>
 </dict>


### PR DESCRIPTION
## Why

Prepares the next companion build. The last store release is 1.3.0 (build 32). Everything merged since then rides the 1.4.0 build: the multi-server support (#2834), the booking calendar, and the mobile parity and audit colour fixes.

The first 1.4.0 build goes to TestFlight for a device test of the multi-server flows before anything is submitted for store review.

## What

The marketing version and OTA runtime version move from 1.3.0 to 1.4.0 in the six synced places. `check-version-sync.mjs` (wired into companion lint) confirms all six agree. Build numbers are managed by EAS and are not touched.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Shelf companion app to version 1.4.0.
  * Updated the iOS app and runtime version to 1.4.0 for release compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->