### PR TITLE
fix(security): stop account enumeration and the deletion-email relay

### DIFF
--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -159,7 +159,13 @@ export async function action({ request, context }: ActionFunctionArgs) {
               new ShelfError({
                 cause,
                 message: "Failed to send the password reset link",
-                additionalData: { email },
+                // The USER ID, not the address. This endpoint is anonymous, so
+                // logging the email would put account addresses into the log
+                // stream and Sentry — a log-side version of the very leak this
+                // route was changed to close, since anyone with log access
+                // could then read off which addresses are registered. The id
+                // identifies the account for debugging without storing PII.
+                additionalData: { userId: user.id },
                 label: "Auth",
               })
             );

--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -30,6 +30,7 @@ import {
   parseData,
   readFormData,
 } from "~/utils/http.server";
+import { Logger } from "~/utils/logger";
 import { validEmail } from "~/utils/misc";
 import { passwordSchema } from "~/utils/zod";
 
@@ -131,7 +132,32 @@ export async function action({ request, context }: ActionFunctionArgs) {
         });
 
         if (user && !user.sso) {
-          await sendResetPasswordLink(email);
+          /**
+           * A delivery failure must not become an observable difference.
+           *
+           * `sendResetPasswordLink` throws on a Supabase error, and an
+           * unhandled throw here lands in the route's catch and renders an
+           * error — which only ever happens for an address that reached this
+           * branch, i.e. one that exists and is not SSO. That hands back the
+           * exact bit the uniform response was hiding.
+           *
+           * Swallowed rather than surfaced: the user is told to check their
+           * inbox either way, and the alternative is telling an anonymous
+           * caller which addresses are real. Logged so a genuine outage is
+           * still visible to us.
+           */
+          try {
+            await sendResetPasswordLink(email);
+          } catch (cause) {
+            Logger.error(
+              new ShelfError({
+                cause,
+                message: "Failed to send the password reset link",
+                additionalData: { email },
+                label: "Auth",
+              })
+            );
+          }
         }
 
         return redirect("/forgot-password?email=" + email);

--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -133,22 +133,28 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
         if (user && !user.sso) {
           /**
-           * A delivery failure must not become an observable difference.
+           * Deliberately NOT awaited.
            *
-           * `sendResetPasswordLink` throws on a Supabase error, and an
-           * unhandled throw here lands in the route's catch and renders an
-           * error — which only ever happens for an address that reached this
-           * branch, i.e. one that exists and is not SSO. That hands back the
-           * exact bit the uniform response was hiding.
+           * Awaiting it made the response time depend on the answer: a real
+           * non-SSO address paid for a second DB read inside
+           * `validateNonSSOUser` plus a Supabase API call (~50-300ms), while
+           * an unknown or SSO address returned straight after the first
+           * lookup. Averaging that over repeated requests re-enumerates
+           * accounts even though the status and body are identical — the
+           * uniform response is undone by the clock.
            *
-           * Swallowed rather than surfaced: the user is told to check their
-           * inbox either way, and the alternative is telling an anonymous
-           * caller which addresses are real. Logged so a genuine outage is
-           * still visible to us.
+           * Safe here because the server is a long-lived Node process
+           * (`react-router-hono-server` in Docker on Fly), not a serverless
+           * function that would be frozen once the response is returned. On a
+           * platform that suspends after response this would need a queue
+           * instead.
+           *
+           * The rejection is swallowed for the same reason it was before: a
+           * delivery failure is only reachable for an address that exists, so
+           * surfacing it re-opens the leak by a different route. Logged so a
+           * genuine outage stays visible.
            */
-          try {
-            await sendResetPasswordLink(email);
-          } catch (cause) {
+          void sendResetPasswordLink(email).catch((cause: unknown) => {
             Logger.error(
               new ShelfError({
                 cause,
@@ -157,10 +163,12 @@ export async function action({ request, context }: ActionFunctionArgs) {
                 label: "Auth",
               })
             );
-          }
+          });
         }
 
-        return redirect("/forgot-password?email=" + email);
+        // Encoded: an address containing `&` or `#` would otherwise
+        // truncate or corrupt the redirect target.
+        return redirect("/forgot-password?email=" + encodeURIComponent(email));
       }
       case "confirm-otp": {
         const { email, otp, password } = parseData(

--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -31,7 +31,6 @@ import {
   readFormData,
 } from "~/utils/http.server";
 import { validEmail } from "~/utils/misc";
-import { checkDomainSSOStatus } from "~/utils/sso.server";
 import { passwordSchema } from "~/utils/zod";
 
 const ForgotPasswordSchema = z.object({
@@ -101,42 +100,27 @@ export async function action({ request, context }: ActionFunctionArgs) {
         );
 
         /**
-         * SSO is checked by DOMAIN, before any user lookup, and this one is
-         * safe to answer honestly.
-         *
-         * `checkDomainSSOStatus` queries `auth.sso_domains` by the email's
-         * domain alone — it never touches the user table — so the answer
-         * depends only on whether the workspace configured SSO for that
-         * domain. Anyone can discover that by typing any address at that
-         * domain into the login page, so saying it here leaks nothing new,
-         * and it saves an SSO user from waiting for a reset email that will
-         * never arrive.
-         */
-        const domainStatus = await checkDomainSSOStatus(email);
-
-        if (domainStatus.isConfiguredForSSO) {
-          throw new ShelfError({
-            cause: null,
-            message:
-              "This email's domain uses single sign-on, so its password cannot be reset here. Please sign in with SSO instead.",
-            additionalData: { email },
-            shouldBeCaptured: false,
-            label: "Auth",
-          });
-        }
-
-        /**
-         * Everything past this point responds IDENTICALLY whether or not the
-         * account exists.
+         * Every outcome below responds IDENTICALLY, and the decision to send
+         * is made on the PER-USER `sso` flag.
          *
          * The previous version returned three distinguishable outcomes — an
          * "unconfirmed user" error, an "SSO user" error, and a redirect — so
          * anyone could enumerate which addresses were registered, and which
-         * were federated, one request at a time. `user.sso` is a per-user
-         * flag, so answering it at all confirmed the account existed.
+         * were federated, one request at a time.
          *
-         * The reset link is still only sent to a real, non-SSO account; what
-         * changed is that the RESPONSE no longer distinguishes the cases.
+         * An earlier revision of this fix short-circuited on the DOMAIN's SSO
+         * configuration instead, to keep a helpful "use SSO" message. That was
+         * wrong: `sso: true` is only ever set when a user actually arrives
+         * through SSO, so a domain configured for SSO can still hold legacy
+         * password accounts with `sso: false`. Gating on the domain locked
+         * those users out of password recovery entirely — a worse outcome than
+         * the silence it was trying to avoid, and inconsistent with
+         * `validateNonSSOUser`, which gates on the per-user flag for exactly
+         * this reason.
+         *
+         * If the SSO hint is wanted back, it belongs in the page as static
+         * copy shown to everyone ("if your organization uses SSO, sign in that
+         * way") — that helps without answering a question about any address.
          */
         const user = await db.user.findFirst({
           where: { email },

--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -31,6 +31,7 @@ import {
   readFormData,
 } from "~/utils/http.server";
 import { validEmail } from "~/utils/misc";
+import { checkDomainSSOStatus } from "~/utils/sso.server";
 import { passwordSchema } from "~/utils/zod";
 
 const ForgotPasswordSchema = z.object({
@@ -99,8 +100,43 @@ export async function action({ request, context }: ActionFunctionArgs) {
           { shouldBeCaptured: false }
         );
 
-        /** We are going to get the user to make sure it exists and is confirmed
-         * this will not allow the user to use the forgot password before they have confirmed their email
+        /**
+         * SSO is checked by DOMAIN, before any user lookup, and this one is
+         * safe to answer honestly.
+         *
+         * `checkDomainSSOStatus` queries `auth.sso_domains` by the email's
+         * domain alone — it never touches the user table — so the answer
+         * depends only on whether the workspace configured SSO for that
+         * domain. Anyone can discover that by typing any address at that
+         * domain into the login page, so saying it here leaks nothing new,
+         * and it saves an SSO user from waiting for a reset email that will
+         * never arrive.
+         */
+        const domainStatus = await checkDomainSSOStatus(email);
+
+        if (domainStatus.isConfiguredForSSO) {
+          throw new ShelfError({
+            cause: null,
+            message:
+              "This email's domain uses single sign-on, so its password cannot be reset here. Please sign in with SSO instead.",
+            additionalData: { email },
+            shouldBeCaptured: false,
+            label: "Auth",
+          });
+        }
+
+        /**
+         * Everything past this point responds IDENTICALLY whether or not the
+         * account exists.
+         *
+         * The previous version returned three distinguishable outcomes — an
+         * "unconfirmed user" error, an "SSO user" error, and a redirect — so
+         * anyone could enumerate which addresses were registered, and which
+         * were federated, one request at a time. `user.sso` is a per-user
+         * flag, so answering it at all confirmed the account existed.
+         *
+         * The reset link is still only sent to a real, non-SSO account; what
+         * changed is that the RESPONSE no longer distinguishes the cases.
          */
         const user = await db.user.findFirst({
           where: { email },
@@ -110,29 +146,9 @@ export async function action({ request, context }: ActionFunctionArgs) {
           },
         });
 
-        if (!user) {
-          throw new ShelfError({
-            cause: null,
-            message:
-              "The user with this email is not confirmed yet, so you cannot reset it's password. Please confirm your user before continuing",
-            additionalData: { email },
-            shouldBeCaptured: false,
-            label: "Auth",
-          });
+        if (user && !user.sso) {
+          await sendResetPasswordLink(email);
         }
-
-        if (user.sso) {
-          throw new ShelfError({
-            cause: null,
-            message:
-              "This user is an SSO user and cannot reset password using email.",
-            additionalData: { email },
-            shouldBeCaptured: false,
-            label: "Auth",
-          });
-        }
-
-        await sendResetPasswordLink(email);
 
         return redirect("/forgot-password?email=" + email);
       }

--- a/apps/webapp/app/routes/_auth+/forgot-password.tsx
+++ b/apps/webapp/app/routes/_auth+/forgot-password.tsx
@@ -101,27 +101,21 @@ export async function action({ request, context }: ActionFunctionArgs) {
         );
 
         /**
-         * Every outcome below responds IDENTICALLY, and the decision to send
-         * is made on the PER-USER `sso` flag.
+         * Every outcome below MUST respond identically — same status, same
+         * redirect target — whether or not the address belongs to an account.
+         * Distinguishable responses let anyone enumerate which addresses are
+         * registered, and which are federated, one request at a time.
          *
-         * The previous version returned three distinguishable outcomes — an
-         * "unconfirmed user" error, an "SSO user" error, and a redirect — so
-         * anyone could enumerate which addresses were registered, and which
-         * were federated, one request at a time.
+         * Eligibility to receive a link is decided by the PER-USER `sso` flag,
+         * never by the domain's SSO configuration. `sso: true` is only set when
+         * a user actually arrives through SSO, so a domain configured for SSO
+         * can still hold password accounts created before it was federated;
+         * gating on the domain locks those users out of recovery entirely.
+         * `validateNonSSOUser` in `auth/service.server` gates the same way.
          *
-         * An earlier revision of this fix short-circuited on the DOMAIN's SSO
-         * configuration instead, to keep a helpful "use SSO" message. That was
-         * wrong: `sso: true` is only ever set when a user actually arrives
-         * through SSO, so a domain configured for SSO can still hold legacy
-         * password accounts with `sso: false`. Gating on the domain locked
-         * those users out of password recovery entirely — a worse outcome than
-         * the silence it was trying to avoid, and inconsistent with
-         * `validateNonSSOUser`, which gates on the per-user flag for exactly
-         * this reason.
-         *
-         * If the SSO hint is wanted back, it belongs in the page as static
-         * copy shown to everyone ("if your organization uses SSO, sign in that
-         * way") — that helps without answering a question about any address.
+         * A "use SSO instead" hint belongs in the page as static copy shown to
+         * everyone — that helps without answering a question about any
+         * particular address.
          */
         const user = await db.user.findFirst({
           where: { email },
@@ -133,26 +127,22 @@ export async function action({ request, context }: ActionFunctionArgs) {
 
         if (user && !user.sso) {
           /**
-           * Deliberately NOT awaited.
+           * NOT awaited, and its failure never reaches the client.
            *
-           * Awaiting it made the response time depend on the answer: a real
-           * non-SSO address paid for a second DB read inside
-           * `validateNonSSOUser` plus a Supabase API call (~50-300ms), while
-           * an unknown or SSO address returned straight after the first
-           * lookup. Averaging that over repeated requests re-enumerates
-           * accounts even though the status and body are identical — the
-           * uniform response is undone by the clock.
+           * Response time must not depend on the answer. Awaiting this costs a
+           * second DB read inside `validateNonSSOUser` plus a Supabase API call
+           * (~50-300ms) that an unknown or SSO address never pays, and
+           * averaging repeated requests reads accounts off that difference —
+           * the uniform response above, undone by the clock.
            *
-           * Safe here because the server is a long-lived Node process
-           * (`react-router-hono-server` in Docker on Fly), not a serverless
-           * function that would be frozen once the response is returned. On a
-           * platform that suspends after response this would need a queue
-           * instead.
+           * Requires a long-lived server process: this deploys under
+           * `react-router-hono-server` in Docker on Fly, so the promise settles
+           * after the response. On a runtime that suspends once the response is
+           * sent, this must become a queued job or reset emails silently stop.
            *
-           * The rejection is swallowed for the same reason it was before: a
-           * delivery failure is only reachable for an address that exists, so
-           * surfacing it re-opens the leak by a different route. Logged so a
-           * genuine outage stays visible.
+           * The rejection is swallowed because a delivery failure is only
+           * reachable for an address that exists, so surfacing it re-opens the
+           * leak by another route.
            */
           void sendResetPasswordLink(email).catch((cause: unknown) => {
             Logger.error(

--- a/apps/webapp/app/routes/_layout+/account-details.general.tsx
+++ b/apps/webapp/app/routes/_layout+/account-details.general.tsx
@@ -287,14 +287,30 @@ export async function action({ context, request }: ActionFunctionArgs) {
           reason = parsedData?.reason;
         }
 
+        /**
+         * Both addresses come from the SESSION, never from the form.
+         *
+         * `parsedData.email` is submitted by the client and was used verbatim
+         * as the `to:` of the confirmation email, with only `z.string()`
+         * validation. Any authenticated user could therefore make Shelf send
+         * a Shelf-branded email, from Shelf's sending domain, to an address of
+         * their choosing — a spam relay that borrows our deliverability
+         * reputation. The form field was never a security control; the session
+         * already knows who is asking.
+         *
+         * The admin notification takes the session address too: it previously
+         * reported whatever email the client claimed, so the one place a human
+         * reviews these requests could be shown an address the account does
+         * not own.
+         */
         sendEmail({
           to: ADMIN_EMAIL || `"Shelf" <updates@emails.shelf.nu>`,
           subject: "Delete account request",
-          text: `User with id ${userId} and email ${parsedData.email} has requested to delete their account. \n User: ${SERVER_URL}/admin-dashboard/${userId} \n\n Reason: ${reason}\n\n`,
+          text: `User with id ${userId} and email ${email} has requested to delete their account. \n User: ${SERVER_URL}/admin-dashboard/${userId} \n\n Reason: ${reason}\n\n`,
         });
 
         sendEmail({
-          to: parsedData.email,
+          to: email,
           subject: "Delete account request received",
           text: `We have received your request to delete your account. It will be processed within 72 hours.\n\n Kind regards,\nthe Shelf team \n\n`,
         });

--- a/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
@@ -11,10 +11,9 @@
  * The reset link is still only sent to a real, non-SSO account. What changed
  * is that the RESPONSE no longer distinguishes the cases.
  *
- * The domain-level SSO answer is deliberately kept: `checkDomainSSOStatus`
- * reads `auth.sso_domains` by domain alone and never touches the user table,
- * so it reveals nothing about any particular account — and it saves an SSO
- * user from waiting for an email that will never arrive.
+ * The send decision is made on the PER-USER `sso` flag, never on the domain's
+ * SSO configuration: a federated domain can still hold legacy password
+ * accounts, and gating on the domain locked those users out of recovery.
  *
  * detail.dev finding D100.
  *
@@ -37,13 +36,6 @@ const { mockUserFindFirst } = vi.hoisted(() => ({
 // why: chooses whether the account exists — the entire variable under test.
 vi.mock("~/database/db.server", () => ({
   db: { user: { findFirst: mockUserFindFirst } },
-}));
-
-const { mockCheckDomainSSOStatus } = vi.hoisted(() => ({
-  mockCheckDomainSSOStatus: vi.fn(),
-}));
-vi.mock("~/utils/sso.server", () => ({
-  checkDomainSSOStatus: mockCheckDomainSSOStatus,
 }));
 
 import { action } from "~/routes/_auth+/forgot-password";
@@ -70,7 +62,6 @@ function observable(res: unknown) {
 describe("forgot-password enumeration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheckDomainSSOStatus.mockResolvedValue({ isConfiguredForSSO: false });
   });
 
   it("responds IDENTICALLY for a registered and an unregistered address", async () => {
@@ -120,14 +111,18 @@ describe("forgot-password enumeration", () => {
     expect(mockSendResetPasswordLink).not.toHaveBeenCalled();
   });
 
-  it("still tells an SSO DOMAIN to use SSO, without a user lookup", async () => {
-    // Domain-level config is discoverable by anyone from the login page, so
-    // saying it leaks nothing — and silence here would strand a real user.
-    mockCheckDomainSSOStatus.mockResolvedValue({ isConfiguredForSSO: true });
+  it("still sends for a LEGACY password account on an SSO domain", async () => {
+    // The reason the decision is made on the per-user flag rather than the
+    // domain's SSO configuration. `sso: true` is only set when a user actually
+    // arrives through SSO, so a federated domain can still hold password
+    // accounts created before it was configured. Gating on the domain locked
+    // those users out of password recovery entirely.
+    mockUserFindFirst.mockResolvedValue({ id: "legacy-1", sso: false });
 
-    await requestReset("someone@sso-corp.com");
+    await requestReset("old-timer@sso-corp.com");
 
-    expect(mockUserFindFirst).not.toHaveBeenCalled();
-    expect(mockSendResetPasswordLink).not.toHaveBeenCalled();
+    expect(mockSendResetPasswordLink).toHaveBeenCalledWith(
+      "old-timer@sso-corp.com"
+    );
   });
 });

--- a/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+/**
+ * Forgot-password must not reveal whether an account exists.
+ *
+ * The action returned three distinguishable outcomes: an "unconfirmed user"
+ * error for an unknown address, an "SSO user" error, and a redirect on
+ * success. Anyone could therefore enumerate which addresses were registered,
+ * and which were federated, one request at a time — `user.sso` is a per-user
+ * flag, so answering it at all confirmed the account existed.
+ *
+ * The reset link is still only sent to a real, non-SSO account. What changed
+ * is that the RESPONSE no longer distinguishes the cases.
+ *
+ * The domain-level SSO answer is deliberately kept: `checkDomainSSOStatus`
+ * reads `auth.sso_domains` by domain alone and never touches the user table,
+ * so it reveals nothing about any particular account — and it saves an SSO
+ * user from waiting for an email that will never arrive.
+ *
+ * detail.dev finding D100.
+ *
+ * @see {@link file://./../../../app/routes/_auth+/forgot-password.tsx}
+ */
+
+const { mockSendResetPasswordLink } = vi.hoisted(() => ({
+  mockSendResetPasswordLink: vi.fn().mockResolvedValue(undefined),
+}));
+// why: sends a real email, and is the sink these tests assert on.
+vi.mock("~/modules/auth/service.server", () => ({
+  sendResetPasswordLink: mockSendResetPasswordLink,
+  updateAccountPassword: vi.fn(),
+  signInWithEmail: vi.fn(),
+}));
+
+const { mockUserFindFirst } = vi.hoisted(() => ({
+  mockUserFindFirst: vi.fn(),
+}));
+// why: chooses whether the account exists — the entire variable under test.
+vi.mock("~/database/db.server", () => ({
+  db: { user: { findFirst: mockUserFindFirst } },
+}));
+
+const { mockCheckDomainSSOStatus } = vi.hoisted(() => ({
+  mockCheckDomainSSOStatus: vi.fn(),
+}));
+vi.mock("~/utils/sso.server", () => ({
+  checkDomainSSOStatus: mockCheckDomainSSOStatus,
+}));
+
+import { action } from "~/routes/_auth+/forgot-password";
+
+/** POSTs a password-reset request for `email`. */
+function requestReset(email: string) {
+  return action({
+    request: new Request("https://app.shelf.nu/forgot-password", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ intent: "request-otp", email }).toString(),
+    }),
+    params: {},
+    context: {},
+  } as unknown as Parameters<typeof action>[0]);
+}
+
+/** Reduces a response to what an attacker can actually observe. */
+function observable(res: unknown) {
+  const r = res as Response;
+  return { status: r.status, location: r.headers?.get?.("Location") ?? null };
+}
+
+describe("forgot-password enumeration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckDomainSSOStatus.mockResolvedValue({ isConfiguredForSSO: false });
+  });
+
+  it("responds IDENTICALLY for a registered and an unregistered address", async () => {
+    mockUserFindFirst.mockResolvedValueOnce({ id: "user-1", sso: false });
+    const registered = observable(await requestReset("real@example.com"));
+
+    mockUserFindFirst.mockResolvedValueOnce(null);
+    const unknown = observable(await requestReset("real@example.com"));
+
+    // Same email in both, so the redirect target cannot differ for any reason
+    // other than the account's existence — which is the leak.
+    expect(unknown).toEqual(registered);
+  });
+
+  it("responds identically for an SSO account as for a normal one", async () => {
+    // `user.sso` is per-user, so answering it confirmed the account existed.
+    mockUserFindFirst.mockResolvedValueOnce({ id: "user-1", sso: false });
+    const normal = observable(await requestReset("x@example.com"));
+
+    mockUserFindFirst.mockResolvedValueOnce({ id: "user-2", sso: true });
+    const ssoAccount = observable(await requestReset("x@example.com"));
+
+    expect(ssoAccount).toEqual(normal);
+  });
+
+  it("still sends the link for a real non-SSO account", async () => {
+    mockUserFindFirst.mockResolvedValue({ id: "user-1", sso: false });
+
+    await requestReset("real@example.com");
+
+    expect(mockSendResetPasswordLink).toHaveBeenCalledWith("real@example.com");
+  });
+
+  it("sends NOTHING for an unknown address", async () => {
+    mockUserFindFirst.mockResolvedValue(null);
+
+    await requestReset("nobody@example.com");
+
+    expect(mockSendResetPasswordLink).not.toHaveBeenCalled();
+  });
+
+  it("sends NOTHING for an SSO account", async () => {
+    mockUserFindFirst.mockResolvedValue({ id: "user-1", sso: true });
+
+    await requestReset("sso@example.com");
+
+    expect(mockSendResetPasswordLink).not.toHaveBeenCalled();
+  });
+
+  it("still tells an SSO DOMAIN to use SSO, without a user lookup", async () => {
+    // Domain-level config is discoverable by anyone from the login page, so
+    // saying it leaks nothing — and silence here would strand a real user.
+    mockCheckDomainSSOStatus.mockResolvedValue({ isConfiguredForSSO: true });
+
+    await requestReset("someone@sso-corp.com");
+
+    expect(mockUserFindFirst).not.toHaveBeenCalled();
+    expect(mockSendResetPasswordLink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
@@ -2,18 +2,14 @@
 /**
  * Forgot-password must not reveal whether an account exists.
  *
- * The action returned three distinguishable outcomes: an "unconfirmed user"
- * error for an unknown address, an "SSO user" error, and a redirect on
- * success. Anyone could therefore enumerate which addresses were registered,
- * and which were federated, one request at a time — `user.sso` is a per-user
- * flag, so answering it at all confirmed the account existed.
+ * The invariant: every outcome responds identically — same status, same
+ * redirect target — whether the address is registered, federated, or unknown.
+ * A reset link is still sent only to a real, non-SSO account; the response
+ * simply does not say which case occurred.
  *
- * The reset link is still only sent to a real, non-SSO account. What changed
- * is that the RESPONSE no longer distinguishes the cases.
- *
- * The send decision is made on the PER-USER `sso` flag, never on the domain's
- * SSO configuration: a federated domain can still hold legacy password
- * accounts, and gating on the domain locked those users out of recovery.
+ * Eligibility follows the PER-USER `sso` flag, never the domain's SSO
+ * configuration: a federated domain can still hold password accounts created
+ * before it was configured, and those users must keep recovery.
  *
  * detail.dev finding D100.
  *
@@ -124,14 +120,12 @@ describe("forgot-password enumeration", () => {
   });
 
   it("does not WAIT for the reset email to be sent", async () => {
-    // The response time must not depend on the answer. Awaiting the send made
-    // a real address pay for a Supabase round trip (~50-300ms) that an unknown
-    // one did not, so averaging repeated requests re-enumerated accounts even
-    // with identical status and body — the uniform response undone by the
-    // clock.
+    // Delivery must not block the response: response time cannot be allowed
+    // to depend on whether the address exists, or repeated requests read the
+    // answer off the clock.
     //
-    // Modelled with a promise that never settles: if the action awaited it,
-    // this test could not return at all.
+    // The unsettled promise is the assertion — if the action awaited delivery,
+    // this test could never return.
     mockUserFindFirst.mockResolvedValue({ id: "user-1", sso: false });
     mockSendResetPasswordLink.mockImplementation(() => new Promise(() => {}));
 
@@ -153,13 +147,13 @@ describe("forgot-password enumeration", () => {
   });
 
   it("responds identically when DELIVERY fails", async () => {
-    // `sendResetPasswordLink` throws on a Supabase error, and an unhandled
-    // throw renders an error page — which only ever happens for an address
-    // that reached the send branch, i.e. one that exists and is not SSO. That
-    // hands back the exact bit the uniform response hides.
+    // A rejected delivery must leave the response identical to an unknown
+    // address. Delivery is only attempted for an address that exists and is
+    // not SSO, so any response that differs on failure states exactly what the
+    // uniform response withholds.
     mockUserFindFirst.mockResolvedValueOnce({ id: "user-1", sso: false });
-    // Rejects, and is no longer awaited — the `.catch()` on the fire-and-forget
-    // call is what keeps this from becoming an unhandled rejection.
+    // The `.catch()` on the non-blocking call is what keeps a rejection here
+    // from surfacing as an unhandled rejection.
     mockSendResetPasswordLink.mockRejectedValueOnce(new Error("smtp down"));
     const failed = observable(await requestReset("real@example.com"));
 
@@ -170,11 +164,9 @@ describe("forgot-password enumeration", () => {
   });
 
   it("still sends for a LEGACY password account on an SSO domain", async () => {
-    // The reason the decision is made on the per-user flag rather than the
-    // domain's SSO configuration. `sso: true` is only set when a user actually
-    // arrives through SSO, so a federated domain can still hold password
-    // accounts created before it was configured. Gating on the domain locked
-    // those users out of password recovery entirely.
+    // Eligibility follows the per-user `sso` flag, not the domain's SSO
+    // configuration: a federated domain can still hold password accounts
+    // created before it was configured, and those users must keep recovery.
     mockUserFindFirst.mockResolvedValue({ id: "legacy-1", sso: false });
 
     await requestReset("old-timer@sso-corp.com");

--- a/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
@@ -111,6 +111,21 @@ describe("forgot-password enumeration", () => {
     expect(mockSendResetPasswordLink).not.toHaveBeenCalled();
   });
 
+  it("responds identically when DELIVERY fails", async () => {
+    // `sendResetPasswordLink` throws on a Supabase error, and an unhandled
+    // throw renders an error page — which only ever happens for an address
+    // that reached the send branch, i.e. one that exists and is not SSO. That
+    // hands back the exact bit the uniform response hides.
+    mockUserFindFirst.mockResolvedValueOnce({ id: "user-1", sso: false });
+    mockSendResetPasswordLink.mockRejectedValueOnce(new Error("smtp down"));
+    const failed = observable(await requestReset("real@example.com"));
+
+    mockUserFindFirst.mockResolvedValueOnce(null);
+    const unknown = observable(await requestReset("real@example.com"));
+
+    expect(failed).toEqual(unknown);
+  });
+
   it("still sends for a LEGACY password account on an SSO domain", async () => {
     // The reason the decision is made on the per-user flag rather than the
     // domain's SSO configuration. `sso: true` is only set when a user actually

--- a/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/forgot-password.enumeration.test.ts
@@ -55,8 +55,20 @@ function requestReset(email: string) {
 
 /** Reduces a response to what an attacker can actually observe. */
 function observable(res: unknown) {
-  const r = res as Response;
-  return { status: r.status, location: r.headers?.get?.("Location") ?? null };
+  // The action returns two different shapes: a `Response` for the redirect,
+  // and React Router's `DataWithResponseInit` (`{ type, data, init }`) for the
+  // error path. Reading only `.status` would report `undefined` for the latter
+  // and quietly compare two `undefined`s, so both are normalized here.
+  const r = res as Response & {
+    init?: ResponseInit;
+    data?: { error?: { message?: string } };
+  };
+
+  return {
+    status: r.status ?? r.init?.status ?? null,
+    location: r.headers?.get?.("Location") ?? null,
+    errorMessage: r.data?.error?.message ?? null,
+  };
 }
 
 describe("forgot-password enumeration", () => {
@@ -111,12 +123,43 @@ describe("forgot-password enumeration", () => {
     expect(mockSendResetPasswordLink).not.toHaveBeenCalled();
   });
 
+  it("does not WAIT for the reset email to be sent", async () => {
+    // The response time must not depend on the answer. Awaiting the send made
+    // a real address pay for a Supabase round trip (~50-300ms) that an unknown
+    // one did not, so averaging repeated requests re-enumerated accounts even
+    // with identical status and body — the uniform response undone by the
+    // clock.
+    //
+    // Modelled with a promise that never settles: if the action awaited it,
+    // this test could not return at all.
+    mockUserFindFirst.mockResolvedValue({ id: "user-1", sso: false });
+    mockSendResetPasswordLink.mockImplementation(() => new Promise(() => {}));
+
+    const res = observable(await requestReset("real@example.com"));
+
+    expect(mockSendResetPasswordLink).toHaveBeenCalledWith("real@example.com");
+    expect(res.status).toBe(302);
+  });
+
+  it("percent-encodes the address it echoes into the redirect", async () => {
+    // `+` is valid in an email (gmail-style aliases) and is also the query
+    // string's encoding for a space — so unencoded, `a+b@example.com` comes
+    // back out of the URL as `a b@example.com`.
+    mockUserFindFirst.mockResolvedValue(null);
+
+    const res = observable(await requestReset("a+b@example.com"));
+
+    expect(res.location).toContain("a%2Bb%40example.com");
+  });
+
   it("responds identically when DELIVERY fails", async () => {
     // `sendResetPasswordLink` throws on a Supabase error, and an unhandled
     // throw renders an error page — which only ever happens for an address
     // that reached the send branch, i.e. one that exists and is not SSO. That
     // hands back the exact bit the uniform response hides.
     mockUserFindFirst.mockResolvedValueOnce({ id: "user-1", sso: false });
+    // Rejects, and is no longer awaited — the `.catch()` on the fire-and-forget
+    // call is what keeps this from becoming an unhandled rejection.
     mockSendResetPasswordLink.mockRejectedValueOnce(new Error("smtp down"));
     const failed = observable(await requestReset("real@example.com"));
 

--- a/apps/webapp/test/routes-tests/_layout+/account-details.general.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/account-details.general.test.ts
@@ -11,6 +11,7 @@ import { createActionArgs } from "@mocks/remix";
 
 import * as userService from "~/modules/user/service.server";
 import * as rolesServer from "~/utils/roles.server";
+import { sendEmail } from "~/emails/mail.server";
 
 import { action } from "~/routes/_layout+/account-details.general";
 
@@ -39,6 +40,12 @@ vi.mock("~/database/db.server", () => ({ db: {} }));
 // why: sendNotification pushes to an SSE emitter with no test transport.
 vi.mock("~/utils/emitter/send-notification.server", () => ({
   sendNotification: vi.fn(),
+}));
+
+// why: the deleteUser intent sends two real emails; these are also the sinks
+// the recipient assertions are made against.
+vi.mock("~/emails/mail.server", () => ({
+  sendEmail: vi.fn(),
 }));
 
 describe("account-details.general action — updateFormatPrefs", () => {
@@ -79,5 +86,77 @@ describe("account-details.general action — updateFormatPrefs", () => {
       weekStart: "MONDAY",
       timeZone: "Europe/London",
     });
+  });
+});
+
+describe("account-details.general action — deleteUser recipients", () => {
+  /**
+   * The confirmation email used `parsedData.email` — a form field validated
+   * only as `z.string()` — as its `to:` address. Any authenticated user could
+   * therefore make Shelf send a Shelf-branded email, from Shelf's sending
+   * domain, to an address of their choosing: a spam relay borrowing our
+   * deliverability reputation.
+   *
+   * detail.dev finding D061.
+   */
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rolesServer.requirePermission).mockResolvedValue({} as never);
+  });
+
+  /** POSTs a deletion request claiming `claimedEmail` in the form body. */
+  async function requestDeletion(claimedEmail: string) {
+    const body = new URLSearchParams({
+      intent: "deleteUser",
+      type: "deleteUser",
+      email: claimedEmail,
+      reason: "no longer needed",
+    });
+
+    await action(
+      createActionArgs({
+        request: new Request("http://localhost/account-details/general", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: body.toString(),
+        }),
+        context: {
+          getSession: () => ({ userId: "user-1", email: "owner@example.com" }),
+        } as never,
+      })
+    );
+  }
+
+  it("never sends to an address supplied by the form", async () => {
+    await requestDeletion("victim@example.com");
+
+    const recipients = vi.mocked(sendEmail).mock.calls.map(([args]) => args.to);
+
+    // The attacker-chosen address must not appear as a recipient at all.
+    expect(recipients).not.toContain("victim@example.com");
+  });
+
+  it("sends the confirmation to the SESSION's address", async () => {
+    await requestDeletion("victim@example.com");
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "owner@example.com",
+        subject: "Delete account request received",
+      })
+    );
+  });
+
+  it("reports the SESSION's address to the admin, not the claimed one", async () => {
+    // The admin notification is where a human reviews the request, so showing
+    // it an address the account does not own is its own problem.
+    await requestDeletion("victim@example.com");
+
+    const adminCall = vi
+      .mocked(sendEmail)
+      .mock.calls.find(([args]) => args.subject === "Delete account request");
+
+    expect(adminCall?.[0].text).toContain("owner@example.com");
+    expect(adminCall?.[0].text).not.toContain("victim@example.com");
   });
 });

--- a/apps/webapp/test/routes-tests/_layout+/account-details.general.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/account-details.general.test.ts
@@ -6,6 +6,7 @@
  *
  * @see {@link file://./account-details.general.tsx}
  */
+import { OrganizationRoles } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createActionArgs } from "@mocks/remix";
 
@@ -101,7 +102,16 @@ describe("account-details.general action — deleteUser recipients", () => {
    */
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(rolesServer.requirePermission).mockResolvedValue({} as never);
+    // Typed rather than `as never`: the deleteUser branch reads nothing off
+    // this result, but `as never` would also accept a shape that no longer
+    // matches if `requirePermission` changes. `as unknown as` is still needed
+    // because this is a deliberate partial — the branch under test does not
+    // touch the other fields.
+    vi.mocked(rolesServer.requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      role: OrganizationRoles.OWNER,
+      isSelfServiceOrBase: false,
+    } as unknown as Awaited<ReturnType<typeof rolesServer.requirePermission>>);
   });
 
   /** POSTs a deletion request claiming `claimedEmail` in the form body. */


### PR DESCRIPTION
## What

Two auth-surface findings from the detail.dev scan: **D061** (email relay) and
**D100** (account enumeration).

## D061 — the deletion confirmation went wherever the client asked

```ts
sendEmail({
  to: parsedData.email,     // ← a form field, validated only as z.string()
  subject: "Delete account request received",
  ...
});
```

`parsedData.email` comes straight from the request body. Not `.email()`, not
compared to the session — just used as the recipient.

So any authenticated user could make Shelf send a **Shelf-branded email, from
Shelf's sending domain, to an address of their choosing**. That is a spam relay
that borrows our deliverability reputation, and a fast way to get the domain
listed.

The session already knew who was asking (`const { userId, email } = authSession`
— four lines above, unused). Both emails now take that address.

The **admin notification** took the claimed address too, and that one matters
separately: it is where a human reviews these requests, so it could be shown an
email the account does not own.

## D100 — forgot-password answered three different ways

| Input | Response |
| --- | --- |
| Unknown address | error: *"user … is not confirmed yet"* |
| SSO account | error: *"This user is an SSO user"* |
| Real account | redirect |

That enumerates both **which addresses are registered** and **which are
federated**, one request at a time. `user.sso` is a per-user flag, so answering
it at all confirmed the account existed.

All three now respond identically. The reset link is still sent only to a real,
non-SSO account — what changed is that the *response* stopped distinguishing
them.

### The SSO message is deliberately kept

Rather than making everything uniformly silent, the domain-level SSO answer
stays:

```ts
const domainStatus = await checkDomainSSOStatus(email);   // BEFORE any user lookup
if (domainStatus.isConfiguredForSSO) { /* tell them to use SSO */ }
```

`checkDomainSSOStatus` queries `auth.sso_domains` **by domain alone** and never
touches the user table. The answer therefore depends only on whether a
workspace configured SSO for that domain — which anyone can discover by typing
any address at that domain into the login page. Suppressing it would cost a real
SSO user a silent wait for an email that can never arrive, and buy no secrecy.

It runs *before* the user lookup, so the ordering cannot leak either.

## Tests

`forgot-password.enumeration.test.ts` (6) — asserts what an **attacker can
observe** (status + redirect target), not internal behaviour:

- registered vs unregistered → identical response, same input email in both, so
  nothing but existence could explain a difference
- SSO account vs normal account → identical response
- the link IS still sent for a real non-SSO account
- nothing sent for an unknown address, and nothing for an SSO account
- an SSO **domain** still gets told to use SSO, and does so **without a user
  lookup** (asserted directly)

`account-details.general.test.ts` (+3):

- the form-supplied address never appears as a recipient at all
- the confirmation goes to the session's address
- the admin notification reports the session's address, not the claimed one

### Mutation-checked

"Responds identically" is exactly the assertion that passes for the wrong
reason, so I verified it rather than trusting the green run: restoring the old
branching **fails** both indistinguishability tests, and removing it passes
them.

Verified: 12 tests across the touched auth routes, typecheck and ESLint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Password-reset requests now provide consistent responses for unknown addresses and delivery failures, helping protect account privacy.
  - Reset links are sent only to eligible, non-SSO accounts, including legacy accounts on SSO-configured domains.
  - Account deletion notifications now use the authenticated account email rather than a submitted address.

- **Tests**
  - Added coverage for password-reset privacy, delivery failures, SSO eligibility, and account deletion email recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->