### PR TITLE
docs(companion): state multi-server constraints instead of narrating fixes

### DIFF
--- a/apps/companion/lib/api/client.ts
+++ b/apps/companion/lib/api/client.ts
@@ -9,12 +9,12 @@ import { reportServerMismatch } from "../sentry";
 /**
  * Base URL of the Shelf server the app is currently connected to.
  *
- * Deliberately a function rather than the exported constant this used to be: a
- * captured `const` would silently keep pointing at whichever server was active
- * at import time, and neither typecheck nor unit tests can see that mistake —
- * only using the app against a second server would.
+ * Must stay a function, never an exported constant: the app switches servers at
+ * runtime, and a captured `const` would keep pointing at whichever server was
+ * active at import time. Neither typecheck nor the unit tests can see that
+ * mistake — only running the app against a second server would.
  *
- * The Shelf Cloud default (including the `__DEV__` fallback split) now lives on
+ * The Shelf Cloud default, including the `__DEV__` fallback split, lives on
  * `CLOUD_SERVER` in `lib/server/active-server.ts`.
  *
  * @returns The active server's origin, without a trailing slash.
@@ -100,11 +100,11 @@ subscribeToServerChange(() => {
  * multi-server support can actually be enforced: the token we are about to send
  * was minted by the server we are about to send it to.
  *
- * It should never fire — `setActiveServer` signs out and rebuilds before
- * notifying anyone, and sessions are namespaced per Supabase project. It exists
- * because "cannot happen by construction" is exactly what was believed about
- * several guards on this feature that turned out to be reachable. Failing
- * closed converts a silent cross-server credential leak into a clean re-auth.
+ * Defence in depth: it should never fire, because `setActiveServer` signs out
+ * and rebuilds before notifying anyone and sessions are namespaced per Supabase
+ * project. Keep it anyway — the invariant is otherwise only believed, not
+ * checked, and failing closed turns a silent cross-server credential leak into
+ * a clean re-auth.
  *
  * @returns An error result when the request must not proceed, otherwise null.
  */

--- a/apps/companion/lib/server/active-server.ts
+++ b/apps/companion/lib/server/active-server.ts
@@ -186,10 +186,10 @@ async function persistActiveServer(config: ServerConfig): Promise<void> {
 /**
  * Applies a server config: a no-op, a credential refresh, or a full switch.
  *
- * The three cases exist because a customer can rotate their Supabase project
- * while keeping the same base URL. Treating that as "already active" — which an
- * earlier `baseUrl`-only guard did — left every enrolled device holding a stale
- * anon key with no in-app way to recover.
+ * A matching `baseUrl` does NOT mean "already active": a customer can rotate
+ * their Supabase project while keeping the same base URL, and an app that
+ * skips such a config keeps using a stale anon key with no in-app way to
+ * recover. Compare the credentials, not just the URL.
  *
  * A credential refresh deliberately does NOT tear down server-scoped state: the
  * selected organisation and audit drafts still belong to this same instance, so

--- a/apps/companion/lib/server/contract.ts
+++ b/apps/companion/lib/server/contract.ts
@@ -176,9 +176,8 @@ function parseVersionSegments(value: string): number[] | null {
  * `MIN_SERVER_MOBILE_API_VERSION`, which guards the other direction — neither
  * side can update the other, so both checks have to exist.
  *
- * Compares segment-by-segment as NUMBERS. A lexical string compare would make
- * "1.10.0" sort below "1.9.0" and lock every user out one release after the
- * tenth — the classic force-update bug.
+ * Compare segment-by-segment as NUMBERS, never as strings: `"1.10.0" < "1.9.0"`
+ * lexically, which would lock every user out one release after the tenth.
  *
  * Fails OPEN on anything unparseable: a typo in the server's env var must never
  * brick a working install.
@@ -331,13 +330,14 @@ export type ServerChange = "none" | "credentials" | "switch";
 /**
  * Classifies what changed between the active server config and a fresh one.
  *
- * why this exists: both the discovery short-circuit and `setActiveServer`
- * originally keyed on `baseUrl` alone, so a customer who rotated their Supabase
- * project while keeping the same base URL left every enrolled device holding a
- * stale anon key, with no in-app way to recover. Distinguishing a credential
- * refresh from a full switch is what lets the app adopt the new values without
- * wiping the selected organisation and audit drafts, which are still valid for
- * that same instance.
+ * A customer can rotate their Supabase project while keeping the same base URL,
+ * so `baseUrl` alone does not tell you whether anything changed — compare the
+ * credentials too, or enrolled devices keep using a stale anon key with no
+ * in-app way to recover.
+ *
+ * The credentials case must stay distinct from a switch: the selected
+ * organisation and audit drafts still belong to that same instance, so adopting
+ * new credentials must not wipe them.
  *
  * @param current - The active server config.
  * @param next - The config just fetched from `/api/mobile/config`.

--- a/apps/companion/lib/server/discovery.ts
+++ b/apps/companion/lib/server/discovery.ts
@@ -229,20 +229,20 @@ export async function resolveServerForEmail(
     return { ok: true };
   }
 
-  // Deliberately NOT short-circuiting when we are already on this server. The
-  // config is re-read on every login so a customer who rotates their Supabase
-  // project — same base URL, new anon key — is picked up. Short-circuiting here
-  // left every enrolled device holding stale credentials with no in-app way to
-  // recover. `setActiveServer` decides whether anything actually changed, so a
-  // no-op login costs one request and touches nothing.
+  // Re-read the config on every login, even when the resolved URL already
+  // matches the active server. A customer can rotate their Supabase project
+  // behind an unchanged base URL, and skipping the fetch leaves enrolled
+  // devices on a stale anon key with no in-app way to recover. `setActiveServer`
+  // decides whether anything actually changed, so a no-op login costs one
+  // request and touches nothing.
   const alreadyConnected =
     normalizeBaseUrl(baseUrl) === getActiveServer().baseUrl;
 
   const fetched = await fetchServerConfig(baseUrl);
 
   // Already working against this server and the refresh failed: keep going with
-  // the config we have. A transient blip must not block a login that would have
-  // succeeded before this refresh existed.
+  // the config we have. The refresh is an optimisation — a transient blip on it
+  // must never block a login that the stored config can still serve.
   if (!fetched.ok && alreadyConnected) {
     return { ok: true };
   }


### PR DESCRIPTION
Follow-up to #2834. **Comments only — no behaviour change.**

The multi-server modules landed alongside the rule they break. Several comments read as an account of the PR that introduced them rather than as documentation: a guard that "originally keyed on `baseUrl` alone", an "earlier short-circuit", a constant "this used to be", other guards "that turned out to be reachable". None of that helps someone opening the file having never seen that discussion, and [the rule](../blob/main/.claude/rules/comments-describe-code-not-history.md) asks for the constraint instead of the story.

## What changed

| Was | Now |
|---|---|
| "the classic force-update bug" | "Compare as NUMBERS, never as strings: `"1.10.0" < "1.9.0"` lexically" |
| "originally keyed on `baseUrl` alone… left every enrolled device…" | "A matching `baseUrl` does not tell you whether anything changed — compare the credentials too" |
| "which an earlier `baseUrl`-only guard did" | "A matching `baseUrl` does NOT mean 'already active'" |
| "Short-circuiting here left every enrolled device…" | "Re-read the config on every login, even when the resolved URL already matches" |
| "the exported constant this used to be" | "Must stay a function, never an exported constant" |
| "…what was believed about several guards that turned out to be reachable" | "Defence in depth… the invariant is otherwise only believed, not checked" |

The reasons all survive — only the archaeology goes. "Compare segment-by-segment as NUMBERS, never as strings" carries the same warning as recounting the bug, and still reads as documentation a year from now.

**Two deliberately keep naming a trap**, which the rule allows where code would otherwise look wrong and be "corrected" back: `getApiBaseUrl` must stay a function rather than a const, and the session/server guard is defence in depth that should never fire. Both are phrased as standing rules now, not stories.

## Verification

The diff is mechanically comment-only: every changed line, stripped of indentation, begins with `//`, `*`, `/**` or `*/`. Independently confirmed by hashing each file with comments and whitespace removed — `main` and this branch are **byte-identical** after stripping, so compiled output is unchanged.

Each rewritten comment was also checked against the code it describes, since a comment-only diff can still do harm by misleading a future editor into weakening a guard. All the security-relevant claims still match the implementation.

44 companion tests, typecheck and lint pass.

## Scope

The sweep also found history-narrating comments in files this PR doesn't touch — `scanner.tsx:2260`, `constants.ts:77`, `audit-format.ts:94`. Left alone: the rule says fix what you edit, and widening this would turn a diff you can check at a glance into one you can't. Worth a separate sweep if we want the codebase uniformly clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified server switching behavior, including credential changes when URLs remain the same.
  * Documented version comparison and server-change classification more clearly.
  * Clarified server refresh behavior during login and how refresh failures are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->