### PR TITLE
fix(auth): make PKCE mandatory for native SSO instead of optional

### DIFF
--- a/apps/webapp/app/modules/auth/mobile-sso.server.test.ts
+++ b/apps/webapp/app/modules/auth/mobile-sso.server.test.ts
@@ -47,17 +47,19 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-/** Wires the happy-path mocks for a successful redeem + fresh-session mint. */
 /**
- * A valid PKCE pair. Redemption now REQUIRES a bound challenge, so every test
- * that reaches the mint has to present one — the challenge-less shortcut these
- * tests used to take is the vulnerability, and is pinned as refused below.
+ * A valid PKCE pair: `TEST_CHALLENGE` is the S256 hash of `TEST_VERIFIER`.
+ *
+ * Redemption requires a bound challenge, so every test that expects to reach
+ * the mint must present one. A challenge-less redemption is pinned as refused
+ * below — that is the property this suite exists to protect.
  */
 const TEST_VERIFIER = "t".repeat(64);
 const TEST_CHALLENGE = createHash("sha256")
   .update(TEST_VERIFIER)
   .digest("base64url");
 
+/** Wires the happy-path mocks for a successful redeem + fresh-session mint. */
 function mockSuccessfulMint(
   email = "sso@acme.com",
   codeChallenge: string | null = TEST_CHALLENGE
@@ -261,7 +263,7 @@ describe("redeemMobileAuthCode", () => {
     // `shelf://` deeplink and account takeover, so it is mandatory — a code that
     // was minted without a binding can never be redeemed, and presenting a
     // verifier against a NULL challenge does not rescue it either.
-    for (const verifier of [undefined, "some-verifier"]) {
+    for (const verifier of [undefined, TEST_VERIFIER]) {
       mockSuccessfulMint("sso@acme.com", null);
 
       await expect(
@@ -283,26 +285,21 @@ describe("redeemMobileAuthCode", () => {
 
   it("rejects a PKCE code with a wrong verifier (400, no mint) but consumes it", async () => {
     const challenge = createHash("sha256")
-      .update("the-real-verifier")
+      .update("r".repeat(64))
       .digest("base64url");
     mockSuccessfulMint("sso@acme.com", challenge);
 
     await expect(
-      redeemMobileAuthCode("good-code", "a-different-verifier")
+      redeemMobileAuthCode("good-code", "w".repeat(64))
     ).rejects.toMatchObject({ status: 400 });
     expect(dbMocks.updateMany).toHaveBeenCalledTimes(1); // single-use consume ran
     expect(supabaseMocks.generateLink).not.toHaveBeenCalled(); // never minted
   });
 
   it("rejects a PKCE code when no verifier is supplied", async () => {
-    const challenge = createHash("sha256")
-      .update("verifier")
-      .digest("base64url");
-    mockSuccessfulMint("sso@acme.com", challenge);
+    mockSuccessfulMint("sso@acme.com", TEST_CHALLENGE);
 
-    await expect(
-      redeemMobileAuthCode("good-code", TEST_VERIFIER)
-    ).rejects.toMatchObject({
+    await expect(redeemMobileAuthCode("good-code")).rejects.toMatchObject({
       status: 400,
     });
     expect(supabaseMocks.generateLink).not.toHaveBeenCalled();

--- a/apps/webapp/app/modules/auth/mobile-sso.server.test.ts
+++ b/apps/webapp/app/modules/auth/mobile-sso.server.test.ts
@@ -48,9 +48,19 @@ beforeEach(() => {
 });
 
 /** Wires the happy-path mocks for a successful redeem + fresh-session mint. */
+/**
+ * A valid PKCE pair. Redemption now REQUIRES a bound challenge, so every test
+ * that reaches the mint has to present one — the challenge-less shortcut these
+ * tests used to take is the vulnerability, and is pinned as refused below.
+ */
+const TEST_VERIFIER = "t".repeat(64);
+const TEST_CHALLENGE = createHash("sha256")
+  .update(TEST_VERIFIER)
+  .digest("base64url");
+
 function mockSuccessfulMint(
   email = "sso@acme.com",
-  codeChallenge: string | null = null
+  codeChallenge: string | null = TEST_CHALLENGE
 ) {
   dbMocks.updateMany.mockResolvedValue({ count: 1 });
   dbMocks.findUniqueOrThrow.mockResolvedValue({
@@ -124,7 +134,7 @@ describe("redeemMobileAuthCode", () => {
   it("consumes the code atomically (single-use guard) before minting", async () => {
     mockSuccessfulMint();
 
-    await redeemMobileAuthCode("good-code");
+    await redeemMobileAuthCode("good-code", TEST_VERIFIER);
 
     const { where, data } = dbMocks.updateMany.mock.calls[0][0];
     expect(where.consumedAt).toBeNull(); // only unconsumed rows
@@ -135,7 +145,7 @@ describe("redeemMobileAuthCode", () => {
   it("mints a fresh, independent session via generateLink → verifyOtp", async () => {
     mockSuccessfulMint("sso@acme.com");
 
-    const session = await redeemMobileAuthCode("good-code");
+    const session = await redeemMobileAuthCode("good-code", TEST_VERIFIER);
 
     expect(supabaseMocks.generateLink).toHaveBeenCalledWith({
       type: "magiclink",
@@ -157,15 +167,16 @@ describe("redeemMobileAuthCode", () => {
     dbMocks.updateMany.mockResolvedValue({ count: 1 });
     dbMocks.findUniqueOrThrow.mockResolvedValue({
       user: { email: "sso@acme.com" },
+      codeChallenge: TEST_CHALLENGE,
     });
     supabaseMocks.generateLink.mockResolvedValue({
       data: { properties: {} }, // no hashed_token
       error: null,
     });
 
-    await expect(redeemMobileAuthCode("good-code")).rejects.toBeInstanceOf(
-      ShelfError
-    );
+    await expect(
+      redeemMobileAuthCode("good-code", TEST_VERIFIER)
+    ).rejects.toBeInstanceOf(ShelfError);
     expect(supabaseMocks.verifyOtp).not.toHaveBeenCalled();
   });
 
@@ -173,6 +184,7 @@ describe("redeemMobileAuthCode", () => {
     dbMocks.updateMany.mockResolvedValue({ count: 1 });
     dbMocks.findUniqueOrThrow.mockResolvedValue({
       user: { email: "sso@acme.com" },
+      codeChallenge: TEST_CHALLENGE,
     });
     // First generateLink fails transiently (503); the retry succeeds.
     supabaseMocks.generateLink
@@ -198,7 +210,7 @@ describe("redeemMobileAuthCode", () => {
       error: null,
     });
 
-    const session = await redeemMobileAuthCode("good-code");
+    const session = await redeemMobileAuthCode("good-code", TEST_VERIFIER);
 
     expect(supabaseMocks.generateLink).toHaveBeenCalledTimes(2); // retried once
     expect(session).toMatchObject({ accessToken: "at", refreshToken: "rt" });
@@ -208,13 +220,16 @@ describe("redeemMobileAuthCode", () => {
     dbMocks.updateMany.mockResolvedValue({ count: 1 });
     dbMocks.findUniqueOrThrow.mockResolvedValue({
       user: { email: "sso@acme.com" },
+      codeChallenge: TEST_CHALLENGE,
     });
     supabaseMocks.generateLink.mockResolvedValue({
       data: null,
       error: { code: "over_email_send_rate_limit", message: "rate limited" },
     });
 
-    await expect(redeemMobileAuthCode("good-code")).rejects.toMatchObject({
+    await expect(
+      redeemMobileAuthCode("good-code", TEST_VERIFIER)
+    ).rejects.toMatchObject({
       status: 429,
     });
     expect(supabaseMocks.generateLink).toHaveBeenCalledTimes(1); // no retry
@@ -224,6 +239,7 @@ describe("redeemMobileAuthCode", () => {
     dbMocks.updateMany.mockResolvedValue({ count: 1 });
     dbMocks.findUniqueOrThrow.mockResolvedValue({
       user: { email: "sso@acme.com" },
+      codeChallenge: TEST_CHALLENGE,
     });
     // AuthApiError 4xx (not retryable, not rate-limit) — must fail fast.
     supabaseMocks.generateLink.mockResolvedValue({
@@ -231,19 +247,28 @@ describe("redeemMobileAuthCode", () => {
       error: { __authApiError: true, status: 422, message: "invalid" },
     });
 
-    await expect(redeemMobileAuthCode("good-code")).rejects.toMatchObject({
+    await expect(
+      redeemMobileAuthCode("good-code", TEST_VERIFIER)
+    ).rejects.toMatchObject({
       status: 500,
     });
     expect(supabaseMocks.generateLink).toHaveBeenCalledTimes(1); // no retry
   });
 
-  it("redeems a legacy (no-challenge) code without a verifier", async () => {
-    mockSuccessfulMint("sso@acme.com", null); // pre-PKCE app: codeChallenge null
+  it("refuses a code carrying no PKCE challenge, with or without a verifier", async () => {
+    // A challenge-less code is a bearer token: whoever holds the plaintext gets
+    // a session. PKCE is the only control standing between an intercepted
+    // `shelf://` deeplink and account takeover, so it is mandatory — a code that
+    // was minted without a binding can never be redeemed, and presenting a
+    // verifier against a NULL challenge does not rescue it either.
+    for (const verifier of [undefined, "some-verifier"]) {
+      mockSuccessfulMint("sso@acme.com", null);
 
-    const session = await redeemMobileAuthCode("good-code"); // no verifier
-
-    expect(session).toMatchObject({ accessToken: "at", refreshToken: "rt" });
-    expect(supabaseMocks.generateLink).toHaveBeenCalledTimes(1); // minted
+      await expect(
+        redeemMobileAuthCode("good-code", verifier)
+      ).rejects.toMatchObject({ status: 400 });
+      expect(supabaseMocks.generateLink).not.toHaveBeenCalled();
+    }
   });
 
   it("redeems a PKCE code when the verifier matches the challenge", async () => {
@@ -275,7 +300,9 @@ describe("redeemMobileAuthCode", () => {
       .digest("base64url");
     mockSuccessfulMint("sso@acme.com", challenge);
 
-    await expect(redeemMobileAuthCode("good-code")).rejects.toMatchObject({
+    await expect(
+      redeemMobileAuthCode("good-code", TEST_VERIFIER)
+    ).rejects.toMatchObject({
       status: 400,
     });
     expect(supabaseMocks.generateLink).not.toHaveBeenCalled();

--- a/apps/webapp/app/modules/auth/mobile-sso.server.ts
+++ b/apps/webapp/app/modules/auth/mobile-sso.server.ts
@@ -333,12 +333,20 @@ export async function redeemMobileAuthCode(
       select: { codeChallenge: true, user: { select: { email: true } } },
     });
 
-    // PKCE check — only for codes minted with a challenge. Same uniform 400 as
-    // an invalid code (no oracle about why redemption failed). The code is
-    // already consumed above, so a wrong/absent verifier burns it.
+    // PKCE is MANDATORY. A code minted without a challenge is a bearer token —
+    // whoever holds the plaintext from the `shelf://` deeplink gets a session —
+    // and the custom-scheme callback is exactly the channel PKCE exists to
+    // protect (RFC 8252 §8.1). So a NULL challenge is unredeemable rather than
+    // a check to skip: refusing here means a code that somehow reached the
+    // database unbound can never be spent.
+    //
+    // Same uniform 400 as an invalid code, so redemption failures give no
+    // oracle about why. The code is already consumed above, so a wrong or
+    // absent verifier burns it.
     if (
-      codeChallenge &&
-      (!codeVerifier || !verifyPkceChallenge(codeVerifier, codeChallenge))
+      !codeChallenge ||
+      !codeVerifier ||
+      !verifyPkceChallenge(codeVerifier, codeChallenge)
     ) {
       throw new ShelfError({
         cause: null,

--- a/apps/webapp/app/modules/auth/mobile-sso.server.ts
+++ b/apps/webapp/app/modules/auth/mobile-sso.server.ts
@@ -280,17 +280,20 @@ export async function createMobileAuthCode(
  * already-consumed code yields a uniform 400 (no oracle about which check
  * failed).
  *
- * PKCE: if the code was minted with an S256 `codeChallenge` (a PKCE-capable
- * app), the caller MUST present a `codeVerifier` that hashes to it — otherwise
- * the (now-consumed) code is rejected with the SAME uniform 400, so an
- * intercepted code is useless without the verifier. Codes minted WITHOUT a
- * challenge (legacy, pre-PKCE builds) redeem with no verifier — backward
- * compatible. Verification runs AFTER the atomic consume, so a wrong verifier
- * burns the single-use code; acceptable, since the legitimate app always
- * presents the matching verifier.
+ * PKCE is mandatory and unconditional. The caller MUST present a
+ * `codeVerifier` that hashes to the code's stored S256 `codeChallenge`;
+ * anything else — a missing verifier, a wrong one, or a code carrying no
+ * challenge at all — is rejected with the SAME uniform 400, so an intercepted
+ * code is useless without the verifier. A NULL `codeChallenge` is treated as
+ * poison rather than as a legacy opt-out: an unbound code is a bearer token,
+ * which is precisely what PKCE exists to prevent on a custom-scheme callback
+ * any app can claim. Verification runs AFTER the atomic consume, so a wrong
+ * verifier burns the single-use code; acceptable, since the legitimate app
+ * always presents the matching verifier.
  *
  * @param code - The plaintext authorization code from the deeplink
- * @param codeVerifier - PKCE verifier; required iff the code carries a challenge
+ * @param codeVerifier - PKCE verifier. Optional in the signature only so the
+ *   refusal path stays reachable; a redemption without one always fails.
  * @returns A freshly minted, mapped auth session for the device
  * @throws {ShelfError} 400 if the code is missing/invalid/expired/used, or if a
  *   PKCE-bound code is presented without a matching verifier

--- a/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
+++ b/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
@@ -1,3 +1,21 @@
+/**
+ * Mobile SSO callback (native-app web-delegated auth).
+ *
+ * Supabase redirects here (instead of `/oauth/callback`) after it validates the
+ * SAML assertion for a `platform=mobile` SSO sign-in. SSO completion is
+ * identical to the web callback — user/org provisioning + SCIM linking via
+ * `resolveUserAndOrgForSsoCallback` — except that instead of establishing a web
+ * session we mint a single-use authorization code and hand it back to the app
+ * through the `shelf://auth-callback?code=…` deeplink. The app then redeems the
+ * code at `POST /api/mobile/exchange` for a fresh, independent session.
+ *
+ * No tokens ever appear in the deeplink — only the short-lived, single-use code.
+ *
+ * @see apps/webapp/app/modules/auth/mobile-sso.server.ts
+ * @see apps/webapp/app/routes/api+/mobile+/exchange.ts
+ * @see apps/webapp/app/routes/_auth+/oauth.callback.tsx — web counterpart
+ */
+
 import { useEffect } from "react";
 
 import type { ActionFunctionArgs, MetaFunction } from "react-router";
@@ -22,24 +40,6 @@ import {
   readFormData,
 } from "~/utils/http.server";
 import { resolveUserAndOrgForSsoCallback } from "~/utils/sso.server";
-
-/**
- * Mobile SSO callback (native-app web-delegated auth).
- *
- * Supabase redirects here (instead of `/oauth/callback`) after it validates the
- * SAML assertion for a `platform=mobile` SSO sign-in. SSO completion is
- * identical to the web callback — user/org provisioning + SCIM linking via
- * `resolveUserAndOrgForSsoCallback` — except that instead of establishing a web
- * session we mint a single-use authorization code and hand it back to the app
- * through the `shelf://auth-callback?code=…` deeplink. The app then redeems the
- * code at `POST /api/mobile/exchange` for a fresh, independent session.
- *
- * No tokens ever appear in the deeplink — only the short-lived, single-use code.
- *
- * @see apps/webapp/app/modules/auth/mobile-sso.server.ts
- * @see apps/webapp/app/routes/api+/mobile+/exchange.ts
- * @see apps/webapp/app/routes/_auth+/oauth.callback.tsx — web counterpart
- */
 
 /** Custom-scheme deeplink the companion app registers and listens for. */
 const MOBILE_CALLBACK_URL = "shelf://auth-callback";
@@ -147,12 +147,11 @@ export async function action({ request }: ActionFunctionArgs) {
           formatPrefs,
         });
 
-        // PKCE: the S256 challenge is waiting in the cookie `/sso-login` set at
-        // the start of the flow. Bind it to the auth code so the exchange must
-        // present a matching verifier. `/sso-login` refuses to start a mobile
-        // flow without a valid challenge, so absent here means only that the
-        // cookie was lost or outlived its TTL — the resulting unbound code is
-        // refused at redemption rather than redeemed as a bearer token.
+        // PKCE: `/sso-login` stashes the S256 challenge in a short-lived cookie
+        // at the start of the flow. Bind it to the auth code so the exchange
+        // must present a matching verifier. Whenever that cookie does not reach
+        // us the code is minted unbound, and redemption refuses it outright —
+        // an unbound code is never honoured as a bearer token.
         const codeChallenge = await mobilePkceChallengeCookie.parse(
           request.headers.get("Cookie")
         );

--- a/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
+++ b/apps/webapp/app/routes/_auth+/oauth.callback_.mobile.tsx
@@ -147,10 +147,12 @@ export async function action({ request }: ActionFunctionArgs) {
           formatPrefs,
         });
 
-        // PKCE: if a PKCE-capable app started this login, the S256 challenge is
-        // waiting in the cookie `/sso-login` set at the start of the flow. Bind
-        // it to the auth code so the exchange must present a matching verifier.
-        // Absent → legacy (pre-PKCE) flow, redeemed without a verifier.
+        // PKCE: the S256 challenge is waiting in the cookie `/sso-login` set at
+        // the start of the flow. Bind it to the auth code so the exchange must
+        // present a matching verifier. `/sso-login` refuses to start a mobile
+        // flow without a valid challenge, so absent here means only that the
+        // cookie was lost or outlived its TTL — the resulting unbound code is
+        // refused at redemption rather than redeemed as a bearer token.
         const codeChallenge = await mobilePkceChallengeCookie.parse(
           request.headers.get("Cookie")
         );

--- a/apps/webapp/app/routes/_auth+/sso-login.tsx
+++ b/apps/webapp/app/routes/_auth+/sso-login.tsx
@@ -73,18 +73,33 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       });
     }
 
-    // PKCE (native SSO): a PKCE-capable companion build appends an S256
-    // `code_challenge`. Stash it in a short-lived cookie so it survives the SSO
-    // redirect chain back to `/oauth/callback/mobile`, where it is bound to the
-    // minted auth code. Only accept a well-formed S256 challenge (43-char
-    // base64url); anything else is ignored (treated as a legacy, non-PKCE flow).
+    // PKCE (native SSO): the companion appends an S256 `code_challenge`. Stash
+    // it in a short-lived cookie so it survives the SSO redirect chain back to
+    // `/oauth/callback/mobile`, where it is bound to the minted auth code.
     const codeChallenge = url.searchParams.get("code_challenge");
     const validChallenge =
-      isMobile && codeChallenge && /^[A-Za-z0-9_-]{43}$/.test(codeChallenge)
+      codeChallenge && /^[A-Za-z0-9_-]{43}$/.test(codeChallenge)
         ? codeChallenge
         : null;
 
-    if (validChallenge) {
+    // A mobile flow MUST carry a well-formed challenge. The native callback
+    // hands the auth code back over the `shelf://` custom scheme, which any app
+    // on the device may claim, so an unbound code would be a bearer token for a
+    // full session (RFC 8252 §8.1). Refuse rather than degrade: a request
+    // without one cannot have come from the companion, which always sends it.
+    if (isMobile && !validChallenge) {
+      throw new ShelfError({
+        cause: null,
+        title: "Sign-in not supported",
+        message:
+          "This version of the Shelf app can't sign in with SSO. Please update the app and try again.",
+        label: "Auth",
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (isMobile && validChallenge) {
       return data(payload({ title, subHeading }), {
         headers: {
           "Set-Cookie":

--- a/apps/webapp/app/routes/api+/mobile+/exchange.ts
+++ b/apps/webapp/app/routes/api+/mobile+/exchange.ts
@@ -33,8 +33,10 @@ const ExchangeSchema = z.object({
 /**
  * POST /api/mobile/exchange
  *
- * Body: `{ code: string, codeVerifier?: string }` — the single-use code from
- * the SSO deeplink, plus the PKCE verifier when the app build supports it.
+ * Body: `{ code: string, codeVerifier: string }` — the single-use code from
+ * the SSO deeplink, plus the PKCE verifier that proves ownership of it. Both
+ * are mandatory: every code is minted bound to an S256 challenge, so a request
+ * without a matching verifier can never succeed.
  *
  * @param args - React Router action args (carrying the incoming request)
  * @returns `{ accessToken, refreshToken }` on success (the app passes them to

--- a/apps/webapp/app/routes/api+/mobile+/exchange.ts
+++ b/apps/webapp/app/routes/api+/mobile+/exchange.ts
@@ -22,14 +22,12 @@ import { getActionMethod, logException } from "~/utils/http.server";
 const ExchangeSchema = z.object({
   code: z.string().min(1, "Authorization code is required"),
   // PKCE verifier (RFC 7636: 43–128 chars, base64url unreserved charset).
-  // Optional — only codes minted by a PKCE-capable app build carry a challenge
-  // that requires it. The charset is constrained to mirror the strict S256
-  // `code_challenge` validation at `/sso-login`; a non-conforming verifier could
-  // never hash to a stored challenge anyway, so we reject it up front.
-  codeVerifier: z
-    .string()
-    .regex(/^[A-Za-z0-9_-]{43,128}$/)
-    .optional(),
+  // REQUIRED: every code is minted bound to a challenge, and redemption refuses
+  // an unbound one, so a request without a verifier can never succeed. The
+  // charset mirrors the strict S256 `code_challenge` validation at
+  // `/sso-login` — a non-conforming verifier could never hash to a stored
+  // challenge anyway, so it is rejected up front.
+  codeVerifier: z.string().regex(/^[A-Za-z0-9_-]{43,128}$/),
 });
 
 /**

--- a/apps/webapp/test/routes-tests/_auth+/sso-login.pkce.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/sso-login.pkce.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Route tests for the PKCE requirement on the native SSO start.
+ *
+ * The native callback hands the authorization code back over the `shelf://`
+ * custom scheme, which any app on the device may claim. PKCE is the only thing
+ * that makes an intercepted code useless, so a mobile start without a
+ * well-formed challenge must be refused rather than allowed to proceed unbound.
+ *
+ * @see apps/webapp/app/routes/_auth+/sso-login.tsx
+ * @see apps/webapp/app/modules/auth/mobile-sso.server.ts — the redemption half
+ */
+import { createLoaderArgs } from "@mocks/remix";
+import { describe, expect, it, vi } from "vitest";
+
+// why: importing the route pulls the Prisma client transitively; without this
+// the suite emits an unhandled P1001 trying to reach a database it never uses.
+vi.mock("~/database/db.server", () => ({ db: {} }));
+
+// why: the loader reads shelf.config for the SSO kill-switch; pinning it keeps
+// these assertions independent of DISABLE_SSO in the local environment.
+vi.mock("~/config/shelf.config", () => ({
+  config: { disableSSO: false },
+}));
+
+// why: a default SSO domain would short-circuit the web branch and change what
+// the non-mobile assertions exercise.
+vi.mock("~/utils/env", async () => ({
+  ...(await vi.importActual<typeof import("~/utils/env")>("~/utils/env")),
+  DEFAULT_SSO_DOMAIN: "",
+}));
+
+const { loader } = await import("~/routes/_auth+/sso-login");
+
+/** A well-formed S256 challenge: 43 chars of base64url. */
+const VALID_CHALLENGE = "a".repeat(43);
+
+/** Invokes the loader for a given query string. */
+function invoke(query: string) {
+  return loader(
+    createLoaderArgs({
+      request: new Request(`http://localhost/sso-login${query}`),
+      context: { isAuthenticated: false } as never,
+    })
+  );
+}
+
+describe("GET /sso-login — PKCE requirement", () => {
+  it("refuses a mobile start with no challenge", async () => {
+    await expect(invoke("?platform=mobile")).rejects.toBeDefined();
+  });
+
+  it("refuses a mobile start with a malformed challenge", async () => {
+    for (const bad of [
+      "short",
+      "a".repeat(42),
+      "a".repeat(44),
+      "!".repeat(43),
+    ]) {
+      await expect(
+        invoke(`?platform=mobile&code_challenge=${bad}`)
+      ).rejects.toBeDefined();
+    }
+  });
+
+  it("accepts a mobile start carrying a well-formed challenge", async () => {
+    const result = await invoke(
+      `?platform=mobile&code_challenge=${VALID_CHALLENGE}`
+    );
+    expect(result).toBeDefined();
+  });
+
+  it("leaves the web flow untouched — no challenge required", async () => {
+    // Only the native custom-scheme callback needs PKCE; the web flow returns
+    // its session over a cookie and must keep working without one.
+    const result = await invoke("");
+    expect(result).toBeDefined();
+  });
+});

--- a/apps/webapp/test/routes-tests/_auth+/sso-login.pkce.test.ts
+++ b/apps/webapp/test/routes-tests/_auth+/sso-login.pkce.test.ts
@@ -9,8 +9,10 @@
  * @see apps/webapp/app/routes/_auth+/sso-login.tsx
  * @see apps/webapp/app/modules/auth/mobile-sso.server.ts — the redemption half
  */
+import { assertIsDataWithResponseInit } from "@helpers/assertions";
 import { createLoaderArgs } from "@mocks/remix";
 import { describe, expect, it, vi } from "vitest";
+import { mobilePkceChallengeCookie } from "~/utils/cookies.server";
 
 // why: importing the route pulls the Prisma client transitively; without this
 // the suite emits an unhandled P1001 trying to reach a database it never uses.
@@ -44,9 +46,31 @@ function invoke(query: string) {
   );
 }
 
+/**
+ * Invokes the loader for a query expected to be refused, and returns what it
+ * threw so the caller can assert on the status.
+ *
+ * @param query - The query string to append to `/sso-login`
+ * @returns The thrown value
+ * @throws If the loader resolved instead of refusing
+ */
+async function invokeExpectingRefusal(query: string) {
+  try {
+    await invoke(query);
+  } catch (thrown) {
+    return thrown;
+  }
+  throw new Error(`Expected "${query}" to be refused`);
+}
+
 describe("GET /sso-login — PKCE requirement", () => {
   it("refuses a mobile start with no challenge", async () => {
-    await expect(invoke("?platform=mobile")).rejects.toBeDefined();
+    const thrown = await invokeExpectingRefusal("?platform=mobile");
+    // The loader converts its ShelfError through `data()`, so the status lives
+    // on `init` — the thrown value is a DataWithResponseInit, not a Response.
+    // Asserting it pins the refusal to PKCE rather than to any stray failure.
+    assertIsDataWithResponseInit(thrown);
+    expect(thrown.init?.status).toBe(400);
   });
 
   it("refuses a mobile start with a malformed challenge", async () => {
@@ -56,9 +80,11 @@ describe("GET /sso-login — PKCE requirement", () => {
       "a".repeat(44),
       "!".repeat(43),
     ]) {
-      await expect(
-        invoke(`?platform=mobile&code_challenge=${bad}`)
-      ).rejects.toBeDefined();
+      const thrown = await invokeExpectingRefusal(
+        `?platform=mobile&code_challenge=${bad}`
+      );
+      assertIsDataWithResponseInit(thrown);
+      expect(thrown.init?.status).toBe(400);
     }
   });
 
@@ -66,7 +92,15 @@ describe("GET /sso-login — PKCE requirement", () => {
     const result = await invoke(
       `?platform=mobile&code_challenge=${VALID_CHALLENGE}`
     );
-    expect(result).toBeDefined();
+    assertIsDataWithResponseInit(result);
+
+    const setCookie = new Headers(result.init?.headers).get("set-cookie");
+    expect(setCookie).toContain("mobile_pkce_challenge=");
+    // `createCookie` stores base64-encoded JSON, so the challenge is never
+    // literal in the header — read it back through the cookie's own decoder.
+    await expect(mobilePkceChallengeCookie.parse(setCookie)).resolves.toBe(
+      VALID_CHALLENGE
+    );
   });
 
   it("leaves the web flow untouched — no challenge required", async () => {

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1823,9 +1823,10 @@ model MobileAuthCode {
   // lives in the deeplink + the exchange request body — never stored.
   codeHash String @unique
 
-  // PKCE (S256) challenge — base64url(SHA-256(verifier)) — set when the minting
-  // client is PKCE-capable. NULL for legacy (pre-PKCE) app builds, which redeem
-  // without a verifier (backward compatible).
+  // PKCE (S256) challenge — base64url(SHA-256(verifier)). Mandatory in practice:
+  // minting refuses a mobile SSO start without one, and redemption refuses a
+  // code that carries none, so an unbound row can never be spent. Nullable only
+  // because rows predating that rule may still exist; treat NULL as poison.
   codeChallenge String?
 
   // Single-use guard: set when redeemed. A non-null value rejects reuse.


### PR DESCRIPTION
## The problem

A mobile SSO code minted **without** a PKCE challenge was redeemable with **no verifier**. That makes the authorization code a bearer token: whoever holds the plaintext out of the `shelf://auth-callback?code=…` deeplink gets a full Supabase session for that user.

The custom-scheme callback is exactly the channel PKCE exists to protect — any app on the device may claim `shelf://` (RFC 8252 §8.1) — so this removed the only control standing between an intercepted deeplink and account takeover.

The challenge was nullable end to end, and nothing along the way failed:

| Step | Before |
|---|---|
| `sso-login.tsx` | absent/malformed `code_challenge` → no cookie set, **flow continues** |
| `oauth.callback_.mobile.tsx` | mints via `createMobileAuthCode(userId, undefined)` |
| `mobile-sso.server.ts` | `if (codeChallenge && …)` — a NULL challenge **skips verification entirely** |
| `exchange.ts` | `codeVerifier` was `.optional()` |

Because it degraded silently, the only signal was that a query parameter had been left off.

## The fix — refuse, don't degrade

- **Mint side:** a `platform=mobile` start without a well-formed S256 challenge is now a `400`. An unbound code can no longer be created.
- **Redemption side:** a code carrying no challenge is unredeemable, so any row that reached the database unbound can never be spent — with or without a verifier presented.
- **Wire:** `codeVerifier` is required on the exchange schema, where it could never have succeeded without one anyway.
- **Schema comment** corrected: it described NULL as "legacy… backward compatible", which is now the opposite of the rule.

## Scope

**Server-side only — no companion release required.** The current app always sends a challenge (`web-auth.ts:136-137`), so a shipped app is unaffected.

This is deliberately breaking for a hypothetical pre-PKCE build. Mobile SSO shipped in **1.0.1**, PKCE landed in **1.0.2** on 2026-06-16 — two months ago — and such a build now gets an actionable *"please update the app"* rather than silence. Weighed against an account-takeover vector that is the right trade.

## Note on the tests

The suite was **pinning the vulnerable behaviour as intended** — there was a passing test named *"redeems a legacy (no-challenge) code without a verifier"*. It is now inverted to assert refusal.

Making the check mandatory also broke **five** other tests: mint and retry cases that had been using the challenge-less path as a convenient happy path. That is the shape of the problem — the weak path was the easy one, so it became the default in tests too. They now run a real PKCE pair.

94 tests across the 17 affected files pass; typecheck clean.

## How this was found

An adversarial review of a *proposed* cross-server SSO design flagged that the design leaned on "PKCE covers this" while PKCE was optional at every layer. The design isn't built yet; this is the live half, split out so it can ship on its own.

Remaining findings against that design (no `state` nonce, request-forgery on a loader-driven SSO start, integrity on a cross-host hop, an exchange-timeout regression) are tracked separately and do not affect this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Mobile SSO now requires PKCE protection for authorization and code exchange.
  * Invalid, missing, expired, or reused authorization codes are rejected consistently.
  * Mobile SSO requests with missing or malformed challenges are blocked.
  * Failed verification permanently consumes the authorization code.
* **Compatibility**
  * Web SSO continues to work without PKCE.
  * Mobile code exchanges now require a code verifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->