### PR TITLE
fix(security): org-scope category ids and audit-scope embedded evidence

### DIFF
--- a/apps/webapp/app/modules/asset-model/service.server.test.ts
+++ b/apps/webapp/app/modules/asset-model/service.server.test.ts
@@ -119,7 +119,8 @@ describe("createAssetModel", () => {
     });
     // @ts-expect-error mock setup
     db.assetModel.create.mockResolvedValue(mockModel);
-    // The category is in this workspace, so the org-scope guard passes.
+    // why: the org-scope guard reads the category through this stub; a hit
+    // means the id belongs to the caller's workspace, so the create proceeds.
     // @ts-expect-error mock setup
     db.category.findFirst.mockResolvedValue({ id: "cat-123" });
 
@@ -139,9 +140,9 @@ describe("createAssetModel", () => {
 
   it("rejects a default category from a different organization", async () => {
     expect.assertions(3);
-    // Foreign-org category → the org-scoped lookup finds nothing. Prisma's
-    // foreign key would happily connect it, so the guard is the only thing
-    // standing between form input and another tenant's category.
+    // why: a miss is how the org-scoped lookup reports a foreign-org
+    // category. Prisma's foreign key would connect it regardless, so this
+    // guard is the only thing between form input and another tenant's data.
     // @ts-expect-error mock setup
     db.category.findFirst.mockResolvedValue(null);
 
@@ -364,7 +365,8 @@ describe("updateAssetModel", () => {
     });
     // @ts-expect-error mock setup
     db.assetModel.update.mockResolvedValue(mockModel);
-    // The category is in this workspace, so the org-scope guard passes.
+    // why: the org-scope guard reads the category through this stub; a hit
+    // means the id belongs to the caller's workspace, so the update proceeds.
     // @ts-expect-error mock setup
     db.category.findFirst.mockResolvedValue({ id: "cat-456" });
 
@@ -384,6 +386,8 @@ describe("updateAssetModel", () => {
 
   it("rejects a default category from a different organization", async () => {
     expect.assertions(3);
+    // why: a miss is how the org-scoped lookup reports a foreign-org category,
+    // which is what the guard has to refuse before the connect.
     // @ts-expect-error mock setup
     db.category.findFirst.mockResolvedValue(null);
 

--- a/apps/webapp/app/modules/asset-model/service.server.test.ts
+++ b/apps/webapp/app/modules/asset-model/service.server.test.ts
@@ -31,6 +31,12 @@ vitest.mock("~/database/db.server", () => ({
       findMany: vitest.fn(),
       updateMany: vitest.fn(),
     },
+    // why: `~/utils/org-validation.server` is NOT mocked here, so
+    // `assertCategoryBelongsToOrg` runs for real against this stub whenever a
+    // `defaultCategoryId` is supplied.
+    category: {
+      findFirst: vitest.fn(),
+    },
   },
 }));
 
@@ -113,6 +119,9 @@ describe("createAssetModel", () => {
     });
     // @ts-expect-error mock setup
     db.assetModel.create.mockResolvedValue(mockModel);
+    // The category is in this workspace, so the org-scope guard passes.
+    // @ts-expect-error mock setup
+    db.category.findFirst.mockResolvedValue({ id: "cat-123" });
 
     await createAssetModel({
       name: "Test Model",
@@ -126,6 +135,30 @@ describe("createAssetModel", () => {
         defaultCategory: { connect: { id: "cat-123" } },
       }),
     });
+  });
+
+  it("rejects a default category from a different organization", async () => {
+    expect.assertions(3);
+    // Foreign-org category → the org-scoped lookup finds nothing. Prisma's
+    // foreign key would happily connect it, so the guard is the only thing
+    // standing between form input and another tenant's category.
+    // @ts-expect-error mock setup
+    db.category.findFirst.mockResolvedValue(null);
+
+    await expect(
+      createAssetModel({
+        name: "Test Model",
+        userId: "user-123",
+        organizationId: "org-A",
+        defaultCategoryId: "cat-from-org-B",
+      })
+    ).rejects.toThrow(ShelfError);
+
+    expect(db.category.findFirst).toHaveBeenCalledWith({
+      where: { id: "cat-from-org-B", organizationId: "org-A" },
+      select: { id: true },
+    });
+    expect(db.assetModel.create).not.toHaveBeenCalled();
   });
 
   it("sets default valuation when provided", async () => {
@@ -331,6 +364,9 @@ describe("updateAssetModel", () => {
     });
     // @ts-expect-error mock setup
     db.assetModel.update.mockResolvedValue(mockModel);
+    // The category is in this workspace, so the org-scope guard passes.
+    // @ts-expect-error mock setup
+    db.category.findFirst.mockResolvedValue({ id: "cat-456" });
 
     await updateAssetModel({
       id: "asset-model-123",
@@ -344,6 +380,26 @@ describe("updateAssetModel", () => {
         defaultCategory: { connect: { id: "cat-456" } },
       }),
     });
+  });
+
+  it("rejects a default category from a different organization", async () => {
+    expect.assertions(3);
+    // @ts-expect-error mock setup
+    db.category.findFirst.mockResolvedValue(null);
+
+    await expect(
+      updateAssetModel({
+        id: "asset-model-123",
+        organizationId: "org-A",
+        defaultCategoryId: "cat-from-org-B",
+      })
+    ).rejects.toThrow(ShelfError);
+
+    expect(db.category.findFirst).toHaveBeenCalledWith({
+      where: { id: "cat-from-org-B", organizationId: "org-A" },
+      select: { id: true },
+    });
+    expect(db.assetModel.update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/webapp/app/modules/asset-model/service.server.ts
+++ b/apps/webapp/app/modules/asset-model/service.server.ts
@@ -9,6 +9,7 @@ import {
   maybeUniqueConstraintViolation,
 } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
+import { assertCategoryBelongsToOrg } from "~/utils/org-validation.server";
 import { getFileUploadPath, parseFileFormData } from "~/utils/storage.server";
 import type { CreateAssetFromContentImportPayload } from "../asset/types";
 
@@ -31,6 +32,18 @@ export async function createAssetModel({
   defaultValuation?: number | null;
   userId: User["id"];
 }) {
+  // why: defaultCategoryId comes from form input and Prisma's foreign key
+  // only proves the row exists, not that it belongs to this workspace —
+  // without this the model would connect another tenant's category. Runs
+  // outside the try so its 400 reaches the form instead of being rewritten
+  // into the generic constraint-violation message.
+  if (defaultCategoryId) {
+    await assertCategoryBelongsToOrg({
+      categoryId: defaultCategoryId,
+      organizationId,
+    });
+  }
+
   try {
     return await db.assetModel.create({
       data: {
@@ -162,6 +175,18 @@ export async function updateAssetModel({
   defaultCategoryId?: string | null;
   defaultValuation?: number | null;
 }) {
+  // why: defaultCategoryId comes from form input and Prisma's foreign key
+  // only proves the row exists, not that it belongs to this workspace —
+  // without this the model would connect another tenant's category. Runs
+  // outside the try so its 400 reaches the form instead of being rewritten
+  // into the generic constraint-violation message.
+  if (defaultCategoryId) {
+    await assertCategoryBelongsToOrg({
+      categoryId: defaultCategoryId,
+      organizationId,
+    });
+  }
+
   try {
     return await db.assetModel.update({
       where: { id, organizationId },

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -1919,6 +1919,42 @@ describe("createAsset cross-org guards", () => {
       select: { id: true },
     });
   });
+
+  it("rejects a categoryId from a different organization", async () => {
+    expect.assertions(2);
+    // Prisma's foreign key only proves the Category row exists — it says
+    // nothing about which workspace owns it, so a foreign-org id would be
+    // connected verbatim without this guard.
+    (db.category.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      null
+    );
+
+    await expect(
+      createAsset({
+        title: "New asset",
+        userId: "user-1",
+        organizationId: "org-A",
+        categoryId: "cat-from-org-B",
+      } as any)
+    ).rejects.toThrow(ShelfError);
+
+    expect(db.category.findFirst).toHaveBeenCalledWith({
+      where: { id: "cat-from-org-B", organizationId: "org-A" },
+      select: { id: true },
+    });
+  });
+
+  it("does not look up a category when the asset is uncategorized", async () => {
+    // "uncategorized" is the form's empty sentinel, not an id.
+    await createAsset({
+      title: "New asset",
+      userId: "user-1",
+      organizationId: "org-A",
+      categoryId: "uncategorized",
+    } as any).catch(() => undefined);
+
+    expect(db.category.findFirst).not.toHaveBeenCalled();
+  });
 });
 
 describe("updateAsset custom-field writes", () => {

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -70,6 +70,10 @@ vitest.mock("~/database/db.server", () => ({
     // shared buildAssetSearchUnion, executed as a raw query.
     $queryRaw: vitest.fn().mockResolvedValue([]),
     asset: {
+      // why: createAsset's transaction writes the row through this stub, so a
+      // test that needs the create to SUCCEED (rather than reject at a guard)
+      // has something to resolve.
+      create: vitest.fn().mockResolvedValue({ id: "asset-new" }),
       findFirst: vitest.fn().mockResolvedValue(null),
       findMany: vitest.fn().mockResolvedValue([]),
       findUnique: vitest.fn().mockResolvedValue(null),
@@ -825,11 +829,9 @@ describe("createAsset quantity validation", () => {
     );
   });
 
-  it("does not throw quantity validation for INDIVIDUAL assets", async () => {
-    // This test verifies that INDIVIDUAL assets skip quantity validation.
-    // The function will proceed past validation but will fail on
-    // other operations (e.g., sequential ID generation) which is expected.
-    // We assert the thrown error is NOT a quantity validation error.
+  it("does not require quantity or consumptionType for INDIVIDUAL assets", async () => {
+    // Quantity validation applies only to QUANTITY_TRACKED. An INDIVIDUAL
+    // asset omitting both fields must create normally.
     await expect(
       createAsset({
         title: "Test Laptop",
@@ -839,13 +841,8 @@ describe("createAsset quantity validation", () => {
         valuation: null,
         organizationId: "org-1",
         type: "INDIVIDUAL",
-        // No quantity or consumptionType — should not throw validation error
       })
-    ).rejects.toThrow(
-      expect.objectContaining({
-        message: expect.not.stringContaining("Quantity is required"),
-      })
-    );
+    ).resolves.toEqual({ id: "asset-new" });
   });
 });
 
@@ -1922,9 +1919,10 @@ describe("createAsset cross-org guards", () => {
 
   it("rejects a categoryId from a different organization", async () => {
     expect.assertions(2);
-    // Prisma's foreign key only proves the Category row exists — it says
-    // nothing about which workspace owns it, so a foreign-org id would be
-    // connected verbatim without this guard.
+    // why: a miss is how the org-scoped lookup reports a foreign-org category.
+    // Prisma's foreign key only proves the row exists — it says nothing about
+    // which workspace owns it, so without the guard the id is connected
+    // verbatim.
     (db.category.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue(
       null
     );
@@ -1945,14 +1943,21 @@ describe("createAsset cross-org guards", () => {
   });
 
   it("does not look up a category when the asset is uncategorized", async () => {
-    // "uncategorized" is the form's empty sentinel, not an id.
-    await createAsset({
+    expect.assertions(2);
+
+    // The create has to run to completion: a rejection swallowed here would
+    // satisfy "findFirst was never called" without the guard ever being
+    // reached, and the test would pass for the wrong reason.
+    const created = await createAsset({
       title: "New asset",
       userId: "user-1",
       organizationId: "org-A",
       categoryId: "uncategorized",
-    } as any).catch(() => undefined);
+    } as any);
 
+    expect(created).toEqual({ id: "asset-new" });
+    // "uncategorized" is the form's empty sentinel, not an id, so it must
+    // never reach the org-scope lookup.
     expect(db.category.findFirst).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -136,6 +136,7 @@ import { threeDaysFromNow } from "~/utils/one-week-from-now";
 import {
   assertAssetModelBelongsToOrg,
   assertAssetsBelongToOrg,
+  assertCategoryBelongsToOrg,
   assertCustomFieldsBelongToOrg,
   assertKitsBelongToOrg,
   assertLocationBelongsToOrg,
@@ -1327,8 +1328,14 @@ export async function createAsset({
         );
       }
 
-      /** If a categoryId is passed, link the category to the asset. */
-      if (categoryId && categoryId !== "uncategorized") {
+      /**
+       * If a categoryId is passed, link the category to the asset. The id is
+       * proven to belong to this org inside the transaction below
+       * (assertCategoryBelongsToOrg), matching the kit / assetModel /
+       * custom-field IDOR guards.
+       */
+      const hasCategory = Boolean(categoryId && categoryId !== "uncategorized");
+      if (hasCategory) {
         Object.assign(data, {
           category: {
             connect: {
@@ -1338,13 +1345,13 @@ export async function createAsset({
         });
       }
 
-      /** If an assetModelId is passed, link the asset model to the asset.
-       * Org-scope-guard before the connect — Prisma's FK only enforces
-       * that the row exists, not that it belongs to the caller's
-       * organization, so without this check a user in Org A could
-       * link their new asset to Org B's model (hex-security r3341845640
-       * / r3350881506). Same pattern as the other org-scope guards
-       * in this file (assertLocationBelongsToOrg, assertTagsBelongToOrg).
+      /**
+       * If an assetModelId is passed, link the asset model to the asset.
+       * Org-scope-guard before the connect — Prisma's FK only enforces that
+       * the row exists, not that it belongs to the caller's organization, so
+       * without this check a user in Org A could link their new asset to
+       * Org B's model. Same pattern as the other org-scope guards in this
+       * file (assertLocationBelongsToOrg, assertTagsBelongToOrg).
        */
       if (assetModelId) {
         await assertAssetModelBelongsToOrg({ assetModelId, organizationId });
@@ -1474,6 +1481,17 @@ export async function createAsset({
         // as the assetModel / custom-field guards).
         if (hasKit) {
           await assertKitsBelongToOrg({ kitIds: [kitId!], organizationId }, tx);
+        }
+
+        // SECURITY (cross-org IDOR): the categoryId comes from form/CSV input
+        // and is connected by the nested create above with no org scoping of
+        // its own. Prisma's foreign key only proves the row exists, not that
+        // it belongs to this workspace, so prove ownership before the write.
+        if (hasCategory) {
+          await assertCategoryBelongsToOrg(
+            { categoryId: categoryId!, organizationId },
+            tx
+          );
         }
 
         const created = await tx.asset.create({
@@ -1807,9 +1825,8 @@ export async function bulkCreateAssetsFromModel({
       organizationId,
     });
   }
-  // kitId + customFieldsValues + categoryId — createAsset's connect will
-  // throw a 400 on cross-org id (Prisma surfaces a foreign-key violation).
-  // Could harden with explicit asserts in a future polish.
+  // kitId, customFieldsValues and categoryId need no assert here: createAsset
+  // proves each of them against this organization inside its own transaction.
 
   // ── Read model + resolve defaults ────────────────────────────────────
 

--- a/apps/webapp/app/modules/audit/helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Audit note builders.
+ *
+ * Every note in this module is assembled server-side from a mix of trusted
+ * text and user-supplied values, then rendered through Markdoc by the audit
+ * feed. These tests pin both halves: the stats and wording each builder
+ * produces, and the sanitisation that keeps a user value from becoming a live
+ * Markdoc tag.
+ *
+ * @see {@link file://./helpers.server.ts}
+ * @see {@link file://./note-content.server.ts}
+ */
 import Markdoc from "@markdoc/markdoc";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/webapp/app/modules/audit/helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.test.ts
@@ -1,3 +1,4 @@
+import Markdoc from "@markdoc/markdoc";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -779,6 +780,101 @@ describe("audit helpers", () => {
       const createCall = mockTx.auditNote.create.mock.calls[0][0];
       expect(createCall.data.content).toContain(
         '{% audit_images count=5 ids="abc-123,def-456,ghi-789,jkl-012,mno-345" /%}'
+      );
+    });
+
+    it("cannot be Markdoc-injected through the completion note", async () => {
+      // why: the completion note is free text with no character restrictions
+      // and the audit feed renders note content as Markdoc, so a raw splice
+      // lets the completer forge an `audit_images` tag naming evidence from
+      // an audit they are not on. Assert on the PARSE, not the string.
+      mockTx.user.findUnique.mockResolvedValue({
+        id: "user-13",
+        firstName: "Mallory",
+        lastName: "Attacker",
+      });
+
+      await createAuditCompletedNote({
+        auditSessionId: "audit-13",
+        userId: "user-13",
+        expectedCount: 10,
+        foundCount: 10,
+        missingCount: 0,
+        unexpectedCount: 0,
+        completionNote:
+          'All good {% audit_images count=1 ids="other-audits-image" /%}',
+        tx: mockTx,
+      });
+
+      const { content } = mockTx.auditNote.create.mock.calls[0][0].data;
+      const tags = [...Markdoc.parse(content).walk()].filter(
+        (node) => node.type === "tag"
+      );
+
+      expect(tags).toHaveLength(0);
+    });
+
+    it("strips nested delimiters that a single pass would re-form", async () => {
+      // why: one `.replace()` splices the remainder into a NEW delimiter, so
+      // `{{% … /%}}` would come back out as a working tag.
+      mockTx.user.findUnique.mockResolvedValue({
+        id: "user-14",
+        firstName: "Mallory",
+        lastName: "Attacker",
+      });
+
+      await createAuditCompletedNote({
+        auditSessionId: "audit-14",
+        userId: "user-14",
+        expectedCount: 1,
+        foundCount: 1,
+        missingCount: 0,
+        unexpectedCount: 0,
+        completionNote: '{{% audit_images count=1 ids="sneaky" /%}}',
+        tx: mockTx,
+      });
+
+      const { content } = mockTx.auditNote.create.mock.calls[0][0].data;
+      const tags = [...Markdoc.parse(content).walk()].filter(
+        (node) => node.type === "tag"
+      );
+
+      expect(tags).toHaveLength(0);
+    });
+
+    it("keeps the trusted image tag when the completion note is injected", async () => {
+      // why: sanitising the user text must not disarm the tag the helper
+      // itself appends — the note still has to render its own evidence.
+      mockTx.user.findUnique.mockResolvedValue({
+        id: "user-15",
+        firstName: "Nina",
+        lastName: "Auditor",
+      });
+      mockTx.auditImage.findMany.mockResolvedValue([{ id: "img-1" }]);
+
+      await createAuditCompletedNote({
+        auditSessionId: "audit-15",
+        userId: "user-15",
+        expectedCount: 1,
+        foundCount: 1,
+        missingCount: 0,
+        unexpectedCount: 0,
+        completionNote: '{% audit_images count=1 ids="other-audits-image" /%}',
+        tx: mockTx,
+      });
+
+      const { content } = mockTx.auditNote.create.mock.calls[0][0].data;
+      const tags = [...Markdoc.parse(content).walk()].filter(
+        (node) => node.type === "tag"
+      );
+
+      expect(tags).toHaveLength(1);
+      expect(
+        (tags[0] as unknown as { attributes: { ids: string } }).attributes.ids
+      ).toBe("img-1");
+      // The injected ids survive as inert text, stripped of their delimiters.
+      expect(content).toContain(
+        'audit_images count=1 ids="other-audits-image"'
       );
     });
   });

--- a/apps/webapp/app/modules/audit/helpers.server.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.ts
@@ -343,11 +343,17 @@ export async function createAuditCompletedNote({
   // Build the note content starting with completion stats
   let content = `Audit completed. Found **${foundCount}/${expectedCount}** expected assets (**${percentage}%**), **${missingCount}** missing, **${unexpectedCount}** unexpected. [View receipt](/audits/${auditSessionId}/overview?receipt=1)`;
 
-  // Append user's completion note if provided
+  // Append user's completion note if provided. The note is untrusted text
+  // spliced into a body the feed renders through Markdoc, so its delimiters
+  // are stripped before it becomes literal blockquote content — otherwise a
+  // completer could forge the `{% audit_images %}` tag appended below and
+  // pull evidence from an audit they are not on.
   if (completionNote && completionNote.trim()) {
-    content += `\n\n**Completion note:**\n\n> ${completionNote
-      .trim()
-      .replace(/\n/g, "\n> ")}`;
+    const safeCompletionNote = stripMarkdocDelimiters(completionNote.trim());
+    content += `\n\n**Completion note:**\n\n> ${safeCompletionNote.replace(
+      /\n/g,
+      "\n> "
+    )}`;
   }
 
   // Fetch and append audit images if any were uploaded during completion

--- a/apps/webapp/app/routes/api+/audit-images.tsx
+++ b/apps/webapp/app/routes/api+/audit-images.tsx
@@ -1,3 +1,13 @@
+/**
+ * Audit Images API
+ *
+ * Resolves `AuditImage` ids to renderable thumbnails for the `{% audit_images %}`
+ * Markdoc tag used inside audit notes.
+ *
+ * @see {@link file://./../../components/markdown/audit-images-component.tsx}
+ * @see {@link file://./../../modules/audit/note-content.server.ts}
+ */
+
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import { makeShelfError } from "~/utils/error";
@@ -9,14 +19,24 @@ import {
 import { requirePermission } from "~/utils/roles.server";
 
 /**
- * API route to fetch audit images by IDs for display in completion notes
- * Used by AuditImagesComponent to show image thumbnails with preview
+ * Returns the images whose ids are listed in the `ids` query parameter.
+ *
+ * The ids arrive from note content, which is user-authored: a caller can ask
+ * for any id at all. Access therefore has to be re-derived here rather than
+ * inherited from whichever note did the asking — the same audit-scoped rule
+ * the audit pages enforce. ADMIN/OWNER see every image in the workspace;
+ * BASE and SELF_SERVICE see only images belonging to audits they are
+ * assigned to.
+ *
+ * Ids the caller may not see are dropped from the result instead of failing
+ * the request, so one unreachable image cannot blank out a note that also
+ * embeds legitimate ones.
  */
 export async function loader({ request, context }: LoaderFunctionArgs) {
   const { userId } = context.getSession();
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, isSelfServiceOrBase } = await requirePermission({
       request,
       userId,
       entity: PermissionEntity.audit,
@@ -39,7 +59,12 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     const images = await db.auditImage.findMany({
       where: {
         id: { in: imageIds },
-        organizationId, // Ensure user can only see images from their organization
+        organizationId,
+        ...(isSelfServiceOrBase
+          ? {
+              auditSession: { assignments: { some: { userId } } },
+            }
+          : {}),
       },
       select: {
         id: true,

--- a/apps/webapp/test/routes-tests/api+/audit-images.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audit-images.test.ts
@@ -40,6 +40,9 @@ vi.mock("~/utils/roles.server", () => ({
 const { mockFindMany } = vi.hoisted(() => ({
   mockFindMany: vi.fn().mockResolvedValue([]),
 }));
+// why: the Prisma read is the sink under test — stubbing it lets each case
+// assert the authorization predicate the route built, which is the whole
+// point of the fix, without standing up a database.
 vi.mock("~/database/db.server", () => ({
   db: { auditImage: { findMany: mockFindMany } },
 }));
@@ -49,6 +52,13 @@ import { loader } from "~/routes/api+/audit-images";
 const ORG_ID = "org-1";
 const USER_ID = "user-1";
 
+/**
+ * Builds the loader arguments for one request.
+ *
+ * @param ids - Value for the `ids` query parameter. Omit it to exercise the
+ *   no-parameter path, where the route must not read at all.
+ * @returns Loader args carrying the request and a session for `USER_ID`
+ */
 function args(ids?: string) {
   const url = new URL("https://app.shelf.nu/api/audit-images");
   if (ids !== undefined) {

--- a/apps/webapp/test/routes-tests/api+/audit-images.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audit-images.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment node
+/**
+ * `/api/audit-images` — audit-scoped resolution of embedded evidence.
+ *
+ * The `ids` this endpoint receives come out of note content, which is
+ * user-authored, so the caller effectively chooses them. Membership in the
+ * organization is therefore not sufficient: audits are assignment-scoped for
+ * BASE and SELF_SERVICE, and the query has to re-derive that here rather than
+ * trust whichever note asked.
+ *
+ * @see {@link file://./../../../app/routes/api+/audit-images.tsx}
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+
+// why: React Router v7 single fetch — `data()` must return a real Response so
+// the response body is assertable.
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    data: vi.fn((body: unknown, init?: ResponseInit) => {
+      return new Response(JSON.stringify(body), {
+        status: init?.status || 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  };
+});
+
+const { mockRequirePermission } = vi.hoisted(() => ({
+  mockRequirePermission: vi.fn(),
+}));
+// why: the RBAC gate is not what's under test — it must PASS, so the assertion
+// proves the AUDIT scoping is what narrows the query, not `audit:read`.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: mockRequirePermission,
+}));
+
+const { mockFindMany } = vi.hoisted(() => ({
+  mockFindMany: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("~/database/db.server", () => ({
+  db: { auditImage: { findMany: mockFindMany } },
+}));
+
+import { loader } from "~/routes/api+/audit-images";
+
+const ORG_ID = "org-1";
+const USER_ID = "user-1";
+
+function args(ids?: string) {
+  const url = new URL("https://app.shelf.nu/api/audit-images");
+  if (ids !== undefined) {
+    url.searchParams.set("ids", ids);
+  }
+
+  return {
+    request: new Request(url, { method: "GET" }),
+    params: {},
+    context: { getSession: () => ({ userId: USER_ID, email: "a@b.c" }) },
+  } as unknown as Parameters<typeof loader>[0];
+}
+
+/** The `where` clause the route handed to Prisma on its single read. */
+function whereClause() {
+  return mockFindMany.mock.calls[0][0].where;
+}
+
+describe("GET /api/audit-images", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindMany.mockResolvedValue([]);
+    mockRequirePermission.mockResolvedValue({
+      organizationId: ORG_ID,
+      isSelfServiceOrBase: true,
+      role: OrganizationRoles.BASE,
+    });
+  });
+
+  it("limits a BASE caller to images from audits they are assigned to", async () => {
+    await loader(args("img-1,img-2"));
+
+    expect(whereClause()).toEqual({
+      id: { in: ["img-1", "img-2"] },
+      organizationId: ORG_ID,
+      auditSession: { assignments: { some: { userId: USER_ID } } },
+    });
+  });
+
+  it("limits a SELF_SERVICE caller the same way", async () => {
+    mockRequirePermission.mockResolvedValue({
+      organizationId: ORG_ID,
+      isSelfServiceOrBase: true,
+      role: OrganizationRoles.SELF_SERVICE,
+    });
+
+    await loader(args("img-1"));
+
+    expect(whereClause().auditSession).toEqual({
+      assignments: { some: { userId: USER_ID } },
+    });
+  });
+
+  it("lets an ADMIN read any image in the workspace", async () => {
+    mockRequirePermission.mockResolvedValue({
+      organizationId: ORG_ID,
+      isSelfServiceOrBase: false,
+      role: OrganizationRoles.ADMIN,
+    });
+
+    await loader(args("img-1"));
+
+    // No assignment narrowing — but still org-scoped, which is the tenant
+    // boundary an ADMIN may not cross.
+    expect(whereClause()).toEqual({
+      id: { in: ["img-1"] },
+      organizationId: ORG_ID,
+    });
+  });
+
+  it("drops unreachable ids rather than failing the whole request", async () => {
+    // A note may embed several images; one the caller can't see must not
+    // blank out the ones they can.
+    mockFindMany.mockResolvedValue([{ id: "img-1" }]);
+
+    // The `data()` mock above returns a real Response; the static signature
+    // still describes the single-fetch wrapper, hence the cast.
+    const response = (await loader(args("img-1,img-2"))) as unknown as Response;
+    const body = (await response.json()) as { images: { id: string }[] };
+
+    expect(response.status).toBe(200);
+    expect(body.images).toEqual([{ id: "img-1" }]);
+  });
+
+  it("reads nothing when no ids are asked for", async () => {
+    await loader(args());
+
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes two cross-tenant defects from the detail.dev OSS scan: **D014** (asset
model default category IDOR) and **D040** (Markdoc tag injection in audit
completion notes).

## D014 — a form-supplied `categoryId` was connected without an org check

Prisma's foreign key proves the `Category` row exists. It says nothing about
which workspace owns it, so a user in Org A could connect Org B's category and
read its name back off the asset.

The scan named only `settings.asset-models.$assetModelId_.edit.tsx`. The same
unguarded connect is in three places:

| Path | Reached by |
| --- | --- |
| `createAsset` | `/assets/new`, `api/mobile/asset.create`, `bulkCreateAssetsFromModel` |
| `createAssetModel` | `settings/asset-models/new` |
| `updateAssetModel` | `settings/asset-models/:id/edit` |

Every sibling id on those paths — `assetModelId`, `kitId`, custom fields,
location, tags — already had a guard. Category was the one that didn't. All
three now go through `assertCategoryBelongsToOrg`
(`.claude/rules/org-scope-user-supplied-ids.md`), inside the write transaction
where there is one.

`bulkCreateAssetsFromModel` carried a comment asserting the assert was
unnecessary because *"createAsset's connect will throw a 400 on cross-org id
(Prisma surfaces a foreign-key violation)"*. That was not true. Guarding
`createAsset` makes it true, so the comment now states it as a fact about where
the check lives.

The asset-model guards run **outside** their `try`, so the 400 reaches the form
instead of being rewritten into `maybeUniqueConstraintViolation`'s generic
message.

## D040 — audit completion notes, and the endpoint behind them

Two layers, both needed.

**Write time.** `completionNote` was spliced raw into a note body that already
ends with a trusted `{% audit_images %}` tag. A completer could forge a second
one naming evidence from an audit they are not assigned to. It now goes through
`stripMarkdocDelimiters`, matching every other audit note builder
(`.claude/rules/sanitize-note-content-markdoc.md`).

**Read time — the actual hole.** `/api/audit-images` resolved *any* id, scoped
by `organizationId` alone, while audits are assignment-scoped for BASE and
SELF_SERVICE. The ids arrive from note content, which is user-authored, so the
caller effectively chooses them; access has to be re-derived at the endpoint
rather than inherited from whichever note asked. ADMIN/OWNER still see every
image in the workspace.

Ids the caller may not see are **dropped from the result** rather than failing
the request — a note can embed several images, and one blocked id must not
blank out the ones that are legitimate.

## Verification

- 240 tests pass across the four touched files.
- Each new regression test was confirmed **red with the fix reverted** — the
  three injection tests and the `createAsset` category guard.
- Injection tests assert on the Markdoc **parse** (zero `type === "tag"` nodes),
  not on substrings, and one covers `{{% … /%}}` — the doubled delimiter a
  single-pass strip would re-form into a working tag.
- One test pins that sanitising the user text does not disarm the trusted tag
  the helper appends itself.
- `tsc -b --force` and eslint clean.

No migration. No schema change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented assets and asset models from referencing categories belonging to another workspace.
  * Improved audit image access controls based on permissions and audit assignments.
  * Omitted unauthorized audit images while allowing authorized results to load.
  * Prevented audit completion notes from injecting unsupported formatting or content.
  * Preserved trusted audit image content while safely displaying user-provided notes.

* **Documentation**
  * Clarified audit image access behavior and authorization requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->