### PR TITLE
fix(audits): show evidence on expected assets nobody scanned

### DIFF
--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -185,22 +185,26 @@ function AuditDetailContent() {
   const evidenceContext =
     currentOrg?.id && id ? `${currentOrg.id}:${id}` : null;
 
-  // Guards concurrent opens without freezing the data, which is what the old
-  // `evidence` guard did. Holds the context it is fetching FOR, so a reply
-  // from a previous context can be recognised and dropped. A ref, not state,
-  // so it cannot itself trigger a render or go stale inside the callback.
-  const evidenceInFlight = useRef<string | null>(null);
-
-  // Aborts the requests themselves, not just their results. The discard check
-  // below already stops a superseded reply from being applied, but without this
-  // the socket stays open until the server answers — and this screen survives a
-  // trip to the scanner, so those add up on a stockroom connection. The client
-  // takes a signal for exactly this; the sibling evidence modal already passes
-  // one.
-  //
-  // Keyed by target, because concurrent fetches for DIFFERENT rows are
-  // deliberate here: opening row B must not cancel row A's fetch, or A's
-  // results never arrive to merge.
+  /**
+   * The evidence requests currently in the air, one entry per target.
+   *
+   * Does three jobs, which is why it is a map and not a flag:
+   *
+   * - **Dedupe.** A target already present is not fetched again.
+   * - **Staleness.** A reply is applied only if its own controller is still
+   *   the one registered for its target. Changing audit or workspace clears
+   *   the map, so every reply in the air at that moment is discarded.
+   * - **Cancellation.** Changing context or leaving the screen aborts the
+   *   requests themselves, not merely their results — this screen survives a
+   *   trip to the scanner, so an abandoned socket would otherwise stay open.
+   *
+   * Keyed by TARGET, never a single slot: concurrent fetches for different
+   * rows are deliberate, and a shared key makes the older reply look stale, so
+   * row A's evidence is thrown away whenever someone opens row B first.
+   *
+   * A ref, not state, so it cannot itself trigger a render or read stale
+   * inside the callback.
+   */
   const evidenceAborts = useRef(new Map<string, AbortController>());
 
   // Drop everything the moment the context changes, before any render can
@@ -210,7 +214,6 @@ function AuditDetailContent() {
     setEvidence(null);
     setEvidenceError(null);
     setEvidenceLoading(false);
-    evidenceInFlight.current = null;
     evidenceAborts.current.forEach((controller) => controller.abort());
     evidenceAborts.current.clear();
   }, [evidenceContext]);
@@ -239,11 +242,10 @@ function AuditDetailContent() {
   const loadEvidence = useCallback(
     async (auditAssetId: string | null) => {
       if (!currentOrg?.id || !id || !evidenceContext) return;
-      // One fetch per target at a time. A fetch for a DIFFERENT target, or for
-      // a different context, is never blocked by an older one still in flight.
+      // One fetch per target at a time; a fetch for a DIFFERENT target is
+      // never blocked, nor discarded, by an older one still in flight.
       const requestFor = `${evidenceContext}:${auditAssetId ?? "general"}`;
-      if (evidenceInFlight.current === requestFor) return;
-      evidenceInFlight.current = requestFor;
+      if (evidenceAborts.current.has(requestFor)) return;
       const controller = new AbortController();
       evidenceAborts.current.set(requestFor, controller);
       // Only show the spinner when there is nothing to show yet — on a refetch
@@ -259,19 +261,13 @@ function AuditDetailContent() {
         controller.signal,
         auditAssetId
       );
-      // Drop the controller the moment the request settles, BEFORE anything
-      // can return early. A superseded request still reaches this line, and
-      // cleaning up after the stale check below would retain its controller
-      // for the life of the context — one per row the user opened while an
-      // earlier fetch was still in the air.
-      if (evidenceAborts.current.get(requestFor) === controller) {
-        evidenceAborts.current.delete(requestFor);
-      }
-
-      // The context may have changed while this was in the air. Anything from
-      // a superseded request is discarded, including its in-flight marker, so
-      // it cannot clear a newer fetch's claim.
-      if (evidenceInFlight.current !== requestFor) return;
+      // Still ours? Only a context change clears the map, so this is the
+      // staleness test. Read it BEFORE releasing the entry, and release
+      // unconditionally — a reply that returns early still has to drop its
+      // controller or the map grows by one per superseded request.
+      const isCurrent = evidenceAborts.current.get(requestFor) === controller;
+      if (isCurrent) evidenceAborts.current.delete(requestFor);
+      if (!isCurrent) return;
       if (error) setEvidenceError(error);
       else if (data) {
         setEvidence((current) => ({
@@ -285,8 +281,9 @@ function AuditDetailContent() {
           },
         }));
       }
-      setEvidenceLoading(false);
-      evidenceInFlight.current = null;
+      // Only when nothing else is still loading, or a fast reply for one row
+      // would clear the spinner another row is still waiting behind.
+      if (evidenceAborts.current.size === 0) setEvidenceLoading(false);
     },
     [currentOrg?.id, id, evidenceContext]
   );

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -259,6 +259,15 @@ function AuditDetailContent() {
         controller.signal,
         auditAssetId
       );
+      // Drop the controller the moment the request settles, BEFORE anything
+      // can return early. A superseded request still reaches this line, and
+      // cleaning up after the stale check below would retain its controller
+      // for the life of the context — one per row the user opened while an
+      // earlier fetch was still in the air.
+      if (evidenceAborts.current.get(requestFor) === controller) {
+        evidenceAborts.current.delete(requestFor);
+      }
+
       // The context may have changed while this was in the air. Anything from
       // a superseded request is discarded, including its in-flight marker, so
       // it cannot clear a newer fetch's claim.
@@ -278,9 +287,6 @@ function AuditDetailContent() {
       }
       setEvidenceLoading(false);
       evidenceInFlight.current = null;
-      if (evidenceAborts.current.get(requestFor) === controller) {
-        evidenceAborts.current.delete(requestFor);
-      }
     },
     [currentOrg?.id, id, evidenceContext]
   );

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -119,8 +119,12 @@ type DisplayAsset = {
   categoryName: string | null;
   custodianName: string | null;
   /**
-   * The audit-asset row id, present only once the asset has been scanned.
-   * Keys this asset's evidence in the `byAuditAsset` payload.
+   * The audit-asset row id, which keys this asset's evidence in the
+   * `byAuditAsset` payload.
+   *
+   * Carried for every EXPECTED asset, scanned or not — evidence can be
+   * attached without a scan. Null only for an unexpected asset the payload has
+   * no expected row for.
    */
   auditAssetId: string | null;
   /** Counts from the detail payload — what the row advertises before any fetch. */
@@ -187,6 +191,18 @@ function AuditDetailContent() {
   // so it cannot itself trigger a render or go stale inside the callback.
   const evidenceInFlight = useRef<string | null>(null);
 
+  // Aborts the requests themselves, not just their results. The discard check
+  // below already stops a superseded reply from being applied, but without this
+  // the socket stays open until the server answers — and this screen survives a
+  // trip to the scanner, so those add up on a stockroom connection. The client
+  // takes a signal for exactly this; the sibling evidence modal already passes
+  // one.
+  //
+  // Keyed by target, because concurrent fetches for DIFFERENT rows are
+  // deliberate here: opening row B must not cancel row A's fetch, or A's
+  // results never arrive to merge.
+  const evidenceAborts = useRef(new Map<string, AbortController>());
+
   // Drop everything the moment the context changes, before any render can
   // show it. Clearing on arrival would be too late: the sheet would paint the
   // previous workspace's rows for a frame first.
@@ -195,7 +211,18 @@ function AuditDetailContent() {
     setEvidenceError(null);
     setEvidenceLoading(false);
     evidenceInFlight.current = null;
+    evidenceAborts.current.forEach((controller) => controller.abort());
+    evidenceAborts.current.clear();
   }, [evidenceContext]);
+
+  // Nothing in flight should outlive the screen.
+  useEffect(() => {
+    const inFlight = evidenceAborts.current;
+    return () => {
+      inFlight.forEach((controller) => controller.abort());
+      inFlight.clear();
+    };
+  }, []);
 
   /**
    * Loads the evidence for ONE target: a single audited asset, or the audit
@@ -217,6 +244,8 @@ function AuditDetailContent() {
       const requestFor = `${evidenceContext}:${auditAssetId ?? "general"}`;
       if (evidenceInFlight.current === requestFor) return;
       evidenceInFlight.current = requestFor;
+      const controller = new AbortController();
+      evidenceAborts.current.set(requestFor, controller);
       // Only show the spinner when there is nothing to show yet — on a refetch
       // the previous evidence stays put underneath.
       setEvidence((current) => {
@@ -227,7 +256,7 @@ function AuditDetailContent() {
       const { data, error } = await api.auditEvidence(
         id,
         currentOrg.id,
-        undefined,
+        controller.signal,
         auditAssetId
       );
       // The context may have changed while this was in the air. Anything from
@@ -249,6 +278,9 @@ function AuditDetailContent() {
       }
       setEvidenceLoading(false);
       evidenceInFlight.current = null;
+      if (evidenceAborts.current.get(requestFor) === controller) {
+        evidenceAborts.current.delete(requestFor);
+      }
     },
     [currentOrg?.id, id, evidenceContext]
   );
@@ -479,9 +511,14 @@ function AuditDetailContent() {
         locationName: asset.locationName ?? null,
         categoryName: asset.categoryName ?? null,
         custodianName: asset.custodianName ?? null,
-        auditAssetId: scan?.auditAssetId ?? null,
-        notesCount: scan?.auditNotesCount ?? 0,
-        imagesCount: scan?.auditImagesCount ?? 0,
+        // Read the EXPECTED asset first, the scan only as a fallback. Evidence
+        // does not require a scan — an auditor can photograph an empty shelf
+        // from the web — so sourcing these from the scan alone left a row with
+        // notes or photos looking empty and refusing to open. Both come from
+        // the same `AuditAsset._count`, so a scanned row is unchanged.
+        auditAssetId: asset.auditAssetId ?? scan?.auditAssetId ?? null,
+        notesCount: asset.auditNotesCount ?? scan?.auditNotesCount ?? 0,
+        imagesCount: asset.auditImagesCount ?? scan?.auditImagesCount ?? 0,
       });
     }
 

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -983,6 +983,15 @@ export type AuditExpectedAsset = {
   id: string;
   name: string;
   auditAssetId: string;
+  /**
+   * Evidence recorded against this asset, whether or not anyone scanned it —
+   * a note or photo can be attached to an expected asset directly.
+   *
+   * Optional because a server predating them omits both; absent then means
+   * "unknown", and the caller falls back to the scan's counts.
+   */
+  auditNotesCount?: number;
+  auditImagesCount?: number;
   mainImage: string | null;
   thumbnailImage: string | null;
   /**
@@ -1059,6 +1068,15 @@ export type AuditDetailResponse = {
  * `authorName` is null when the account has been removed — the evidence
  * survives the person, so the UI says "Unknown" rather than hiding the row.
  */
+/**
+ * One note a person wrote during an audit, as the evidence route serves it.
+ *
+ * Only `COMMENT` rows reach here — the system activity trail is `UPDATE` and is
+ * filtered out server-side, so this never carries Markdoc tag source the phone
+ * cannot render.
+ *
+ * @see GET /api/mobile/audits/:auditId/evidence
+ */
 export type AuditEvidenceNote = {
   id: string;
   content: string;
@@ -1067,6 +1085,13 @@ export type AuditEvidenceNote = {
   authorImage: string | null;
 };
 
+/**
+ * One photo taken during an audit, as the evidence route serves it.
+ *
+ * URLs arrive resolved and ready to render — the client never rebuilds them.
+ *
+ * @see GET /api/mobile/audits/:auditId/evidence
+ */
 export type AuditEvidenceImage = {
   id: string;
   imageUrl: string;

--- a/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.$auditId.ts
@@ -115,6 +115,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         id: a.id,
         name: a.name,
         auditAssetId: a.auditAssetId,
+        // Evidence can exist WITHOUT a scan: an auditor photographs an empty
+        // shelf from the web scan screen, which attaches the note or photo to
+        // the expected `AuditAsset` directly. Serving these only on the scan
+        // shape below left those rows looking empty on the phone. The service
+        // already counts them per expected asset, so this costs no query.
+        auditNotesCount: a.auditNotesCount ?? 0,
+        auditImagesCount: a.auditImagesCount ?? 0,
         mainImage: a.mainImage ?? null,
         thumbnailImage: a.thumbnailImage ?? null,
         // why: surface where the asset should be, what category it

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.auditId.evidence.test.ts
@@ -22,7 +22,6 @@ vi.mock("react-router", async () => {
   return { ...actual, data: createDataMock() };
 });
 
-// why: external auth — no Supabase in tests
 // why: the assignee gate is a shared guard with its own suite; here it only
 // needs to be callable so the route's own behaviour is what is under test.
 vi.mock("~/modules/audit/service.server", () => ({
@@ -34,12 +33,17 @@ vi.mock("~/utils/booking-authorization.server", () => ({
   resolveMostPrivilegedRole: (roles: string[]) =>
     roles.includes("ADMIN") || roles.includes("OWNER") ? "ADMIN" : roles[0],
 }));
+// why: external auth — verifying a bearer token needs Supabase, which these
+// tests neither have nor are testing; the route's own gates are what matter.
 vi.mock("~/modules/api/mobile-auth.server", () => ({
   requireMobileAuth: vi.fn(),
   requireOrganizationAccess: vi.fn(),
   getMobileUserContext: vi.fn(),
 }));
 
+// why: the boundary under test. Every case here is about WHICH queries run and
+// with what where-clause, so the queries themselves must be observable and must
+// not need a database.
 vi.mock("~/database/db.server", () => ({
   db: {
     auditSession: { findFirst: vi.fn() },
@@ -48,6 +52,9 @@ vi.mock("~/database/db.server", () => ({
   },
 }));
 
+// why: the real `makeShelfError` reaches for Sentry and the logger. The route
+// only needs it to turn a thrown error into a status, which is what the cases
+// assert on.
 vi.mock("~/utils/error", () => ({
   makeShelfError: vi.fn((cause: any) => ({
     message: cause?.message ?? "error",


### PR DESCRIPTION
Follow-up to #2898. That PR was merged a moment before its last commit was pushed, so `main` carries everything through `f3883db42` but not `0fae8ceb2`. This is that commit, nothing else.

Nothing on `main` is broken by the gap — what is missing closes a **pre-existing** gap in the feature rather than a regression the merge introduced, and three of its four files are companion-only, so they cannot reach users before a native/OTA build. The single webapp change is additive: two extra fields on a response body.

## Evidence recorded against an asset nobody scanned was invisible on the phone

Evidence does not require a scan. `AuditAsset.scannedAt` is nullable, and the web scan screen deliberately renders the note and photo actions on *pending* rows (`audit-item-row.tsx:306`) — the empty-shelf photo case, which is exactly when a field worker most wants to record something.

The companion built every row's evidence fields from the scan map alone:

```ts
auditAssetId: scan?.auditAssetId ?? null,
notesCount:   scan?.auditNotesCount ?? 0,
imagesCount:  scan?.auditImagesCount ?? 0,
```

So an expected asset with a note or photo but no scan arrived as `null` and `0/0`. `hasEvidence` was false, the card rendered as an inert `View`, and the sheet could not be opened — indistinguishable from a row with nothing recorded against it. That is the gap #2898 exists to close, left open on the surface it is about.

**No query change was needed.** `getAuditSessionDetails` already counts notes and images per expected asset (`service.server.ts:805-806`); the mobile detail endpoint simply dropped both while serializing `expectedAssets`, though it carried them on the scan shape twenty lines below. It now sends them, and the companion prefers the expected asset's values with the scan as fallback. Both derive from the same `AuditAsset._count`, so scanned rows are unchanged.

The companion fields are **optional** and every read falls back, so web-before-OTA and OTA-before-web both degrade rather than break.

## Also here

**The abort signal was documented and never passed.** `api.auditEvidence` takes `signal?: AbortSignal` with the JSDoc "so navigating away mid-flight cancels", and `loadEvidence` passed `undefined` — a request outlived the trip to the scanner that started it, while the sibling evidence modal already used one.

Worth noting how, because the obvious fix is wrong here: the controllers are keyed **by target**, not held singly. Concurrent fetches for different rows are deliberate on this screen, so one shared controller would make opening row B cancel row A's fetch and lose its results. Aborts fire on context change and unmount only; the client already reports an abort as a non-error rather than surfacing it to the user.

**Documentation.** `// why:` on the two mocks that lacked it, JSDoc on the exported `AuditEvidenceNote` / `AuditEvidenceImage` types, a `// why: external auth` comment moved to the mock it actually describes, and a `DisplayAsset` docblock claiming `auditAssetId` arrives "only once the asset has been scanned" corrected — that assumption is precisely what caused the bug above.

## Verification

Webapp and companion typechecks clean, 15 route tests and 50 companion tests pass, lint clean on every touched file.

Not unit-testable here: the companion runner only collects `lib/**`, and these changes are in `app/`. Confirm on a device with an audit where a note was added from the web to an asset that was never scanned — the row should show an attachment count and open the sheet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit evidence now appears for expected assets even when they have not been scanned.
  * Expected assets display associated note and photo counts.
  * Evidence identifiers and counts are prioritized for more accurate audit details.

* **Bug Fixes**
  * Cancelled in-progress evidence requests when leaving or switching audit contexts.
  * Prevented stale evidence from appearing after audit changes.
  * Improved loading behavior while multiple evidence requests are still in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->