### PR TITLE
fix(companion): review findings that missed the 1.4.0 merge

### DIFF
--- a/apps/companion/EAS-UPDATE.md
+++ b/apps/companion/EAS-UPDATE.md
@@ -94,22 +94,10 @@ cd apps/companion
 eas env:exec production "npx expo export --clear --dump-sourcemap -p ios -p android"
 
 # 1b. GATE — prove the artifact before step 2 publishes it. Reads the baked
-#     values back out of the bundle rather than trusting step 1's environment,
-#     and EXITS NON-ZERO on a mismatch so a copy-pasted run cannot sail past it.
-#     `http://localhost:3000` in the bundle is expected and harmless: both sides
-#     of the `__DEV__` ternary in lib/api/client.ts are literals in every build.
-EXPECTED=$(eas env:list --environment production 2>/dev/null \
-  | sed -n 's/.*EXPO_PUBLIC_SUPABASE_URL=\(https:\/\/[a-z0-9]*\.supabase\.co\).*/\1/p' | head -1)
-[ -n "$EXPECTED" ] || { echo "GATE: cannot read the expected host"; exit 1; }
-
-FOUND=$(cat dist/_expo/static/js/*/*.hbc \
-  | strings | grep -oE 'https://[a-z0-9]+\.supabase\.co' | sort -u)
-[ "$FOUND" = "$EXPECTED" ] || {
-  echo "GATE FAILED — bundle points at: $FOUND"
-  echo "               expected only:  $EXPECTED"
-  exit 1
-}
-echo "GATE PASSED — $EXPECTED"
+#     values back out of the built bundles and exits non-zero on a mismatch, so
+#     a copy-pasted run cannot sail past it. Run under the SAME environment the
+#     export claimed, so expected and baked values arrive the same way.
+eas env:exec production "node scripts/check-bundle-env.mjs"
 
 # 2. Publish exactly that bundle. --skip-bundler is what makes this safe: it
 #    guarantees the artifact published here is byte-identical to the one

--- a/apps/companion/EAS-UPDATE.md
+++ b/apps/companion/EAS-UPDATE.md
@@ -20,11 +20,11 @@ ride an OTA bundle.
 
 ## Runtime version = app version
 
-`app.json` sets `runtimeVersion: "1.3.0"`, kept equal to the app version by
+`app.json` sets `runtimeVersion: "1.4.0"`, kept equal to the app version by
 hand. An OTA update only reaches builds whose **runtime version matches**, and
 only on the **channel** it was published to (see Channels below). So an update
-published to `production` for runtime `1.3.0` reaches the **OTA-capable**
-`1.3.0` production builds (ones built with `expo-updates`; the
+published to `production` for runtime `1.4.0` reaches the **update-capable**
+`1.4.0` production builds (ones that accept an unsigned bundle; the
 pre-`expo-updates` binaries — every store build up to and including 1.2.0 —
 can't check for updates at all), and is ignored by a future `1.4.0` build until
 you publish an update for `1.4.0`. This is the safety net: JS that assumes new
@@ -93,17 +93,23 @@ cd apps/companion
 #    is silently ignored and the last environment to bundle in this tree wins.
 eas env:exec production "npx expo export --clear --dump-sourcemap -p ios -p android"
 
-# 1b. GATE — prove the artifact before step 2 publishes it. Read the baked
-#     values out of the bundle rather than trusting step 1's environment.
-for f in dist/_expo/static/js/*/*.hbc; do
-  echo "$f"
-  strings "$f" | grep -oE 'https://[a-z0-9]+\.supabase\.co' | sort -u
-done
-# Expect ONLY the production Supabase host (`eas env:list --environment
-# production` is the source of truth for which that is). Any other host means
-# the bundle carries the wrong project — STOP, do not publish, re-run step 1.
-# `http://localhost:3000` appearing is expected and harmless: both sides of the
-# `__DEV__` ternary in lib/api/client.ts are string literals in the bundle.
+# 1b. GATE — prove the artifact before step 2 publishes it. Reads the baked
+#     values back out of the bundle rather than trusting step 1's environment,
+#     and EXITS NON-ZERO on a mismatch so a copy-pasted run cannot sail past it.
+#     `http://localhost:3000` in the bundle is expected and harmless: both sides
+#     of the `__DEV__` ternary in lib/api/client.ts are literals in every build.
+EXPECTED=$(eas env:list --environment production 2>/dev/null \
+  | sed -n 's/.*EXPO_PUBLIC_SUPABASE_URL=\(https:\/\/[a-z0-9]*\.supabase\.co\).*/\1/p' | head -1)
+[ -n "$EXPECTED" ] || { echo "GATE: cannot read the expected host"; exit 1; }
+
+FOUND=$(cat dist/_expo/static/js/*/*.hbc \
+  | strings | grep -oE 'https://[a-z0-9]+\.supabase\.co' | sort -u)
+[ "$FOUND" = "$EXPECTED" ] || {
+  echo "GATE FAILED — bundle points at: $FOUND"
+  echo "               expected only:  $EXPECTED"
+  exit 1
+}
+echo "GATE PASSED — $EXPECTED"
 
 # 2. Publish exactly that bundle. --skip-bundler is what makes this safe: it
 #    guarantees the artifact published here is byte-identical to the one
@@ -206,7 +212,7 @@ The reason is a plan boundary, not a preference: **EAS Update code signing is
 sold only on the Enterprise plan**, and this account is on Starter. Attempting a
 signed publish fails at the signing step with
 
-```
+```text
 EAS Update code signing requires a subscription to the EAS Enterprise plan.
 ```
 

--- a/apps/companion/app/(tabs)/bookings/new.tsx
+++ b/apps/companion/app/(tabs)/bookings/new.tsx
@@ -65,9 +65,21 @@ function defaultBookingWindow(
   timeZone: string,
   day?: string
 ): { from: Date; to: Date } {
-  const onDay = /^\d{4}-\d{2}-\d{2}$/.test(day ?? "")
+  // The shape check is not enough on its own: it passes "2026-13-45", which
+  // `instantFromWallClockInZone` would silently roll forward into 2027. Round
+  // trip through a Date and keep the value only if every part survives.
+  const parts = /^\d{4}-\d{2}-\d{2}$/.test(day ?? "")
     ? (day as string).split("-").map(Number)
     : null;
+  const probe = parts ? new Date(parts[0], parts[1] - 1, parts[2]) : null;
+  const onDay =
+    parts &&
+    probe &&
+    probe.getFullYear() === parts[0] &&
+    probe.getMonth() === parts[1] - 1 &&
+    probe.getDate() === parts[2]
+      ? parts
+      : null;
   if (onDay) {
     const at = (hour: number) =>
       instantFromWallClockInZone(

--- a/apps/companion/components/bookings/booking-calendar.tsx
+++ b/apps/companion/components/bookings/booking-calendar.tsx
@@ -386,7 +386,11 @@ export function BookingCalendar({
       const key = cacheKey(monthKey);
       pendingKey.current = key;
 
-      const cached = options.force ? undefined : monthCache.current.get(key);
+      // What the cache holds for this month, and what we are willing to paint
+      // from it. A forced refresh bypasses the second without discarding the
+      // first, so a failed refresh can still fall back on it below.
+      const held = monthCache.current.get(key);
+      const cached = options.force ? undefined : held;
       if (cached) {
         // Paint what we have, then confirm it below. The month is already
         // correct in the common case, so the grid does not blink.
@@ -412,14 +416,17 @@ export function BookingCalendar({
       if (pendingKey.current !== key) return;
 
       if (res.error) {
-        // A cached month stays on screen rather than being replaced by an
-        // error for data we already have. Without one, the grid is emptied
-        // alongside the error: `month` still holds the month we came FROM, and
-        // leaving it would re-clip those bookings into the new month's squares
-        // and count them in "N more outside this month".
+        // A month already on screen stays there rather than being replaced by
+        // an error for data we have. That covers a failed forced refresh too,
+        // which bypasses the cache without invalidating it.
         if (!cached) {
           setError(res.error);
-          setMonth(EMPTY_MONTH);
+          // Blank the grid only with nothing correct for THIS month to show:
+          // `month` still holds the month we came FROM, and leaving it would
+          // re-clip those bookings into the new month's squares and count them
+          // in "N more outside this month".
+          if (held) setMonth(held);
+          else setMonth(EMPTY_MONTH);
         }
       } else if (res.data) {
         const next: CachedMonth = {

--- a/apps/companion/lib/api.ts
+++ b/apps/companion/lib/api.ts
@@ -1,3 +1,13 @@
+/**
+ * Public surface of the API layer.
+ *
+ * Screens import from `@/lib/api` and never from `./api/*` directly, so the
+ * client's internals stay free to move. `API_BASE_URL` is resolved once at
+ * module load from `EXPO_PUBLIC_API_URL`, falling back to the production host
+ * outside `__DEV__`.
+ *
+ * @see {@link file://./api/client.ts} the fetch wrapper, retries and auth
+ */
 export { api, onAuthError, invalidateResponseCache } from "./api/index";
 export * from "./api/types";
 export { API_BASE_URL } from "./api/client";

--- a/apps/companion/lib/supabase.ts
+++ b/apps/companion/lib/supabase.ts
@@ -1,3 +1,18 @@
+/**
+ * Supabase client for the companion app.
+ *
+ * One module-scope client, built from `EXPO_PUBLIC_SUPABASE_URL` and
+ * `EXPO_PUBLIC_SUPABASE_ANON_PUBLIC`. Those are inlined at bundle time, so the
+ * project this points at is fixed for the life of a build and cannot change at
+ * runtime. Import `supabase` directly; there is nothing to resolve first.
+ *
+ * Sessions persist through {@link secureStoreAdapter} rather than
+ * AsyncStorage, because a refresh token belongs in the keychain. iOS caps a
+ * SecureStore item at ~2KB while a Supabase session exceeds that, so the
+ * adapter splits a long value across numbered chunk keys and reassembles it on
+ * read. Deleting a key must clear every chunk, or a stale tail corrupts the
+ * next read.
+ */
 import { createClient } from "@supabase/supabase-js";
 import * as SecureStore from "expo-secure-store";
 import { Platform } from "react-native";

--- a/apps/companion/lib/supabase.ts
+++ b/apps/companion/lib/supabase.ts
@@ -7,10 +7,11 @@
  * runtime. Import `supabase` directly; there is nothing to resolve first.
  *
  * Sessions persist through {@link secureStoreAdapter} rather than
- * AsyncStorage, because a refresh token belongs in the keychain. iOS caps a
- * SecureStore item at ~2KB while a Supabase session exceeds that, so the
- * adapter splits a long value across numbered chunk keys and reassembles it on
- * read. Deleting a key must clear every chunk, or a stale tail corrupts the
+ * AsyncStorage, because a refresh token belongs in the keychain. SecureStore
+ * rejects values the platform considers oversized, and a Supabase session is
+ * long enough to be at risk, so the adapter splits anything past
+ * {@link CHUNK_SIZE} characters across numbered chunk keys and reassembles it
+ * on read. Deleting a key must clear every chunk, or a stale tail corrupts the
  * next read.
  */
 import { createClient } from "@supabase/supabase-js";

--- a/apps/companion/scripts/check-bundle-env.mjs
+++ b/apps/companion/scripts/check-bundle-env.mjs
@@ -1,0 +1,122 @@
+/**
+ * Asserts the exported bundles carry the environment they are meant to.
+ *
+ * `EXPO_PUBLIC_*` values are inlined by Metro at export time, and Metro's
+ * transform cache is keyed on file content rather than on the environment. A
+ * cached module therefore keeps whatever was inlined when it was cached, so an
+ * export can silently reproduce an earlier environment and still report
+ * success. This reads the values back out of the built artifact instead of
+ * trusting the exporter.
+ *
+ * Matching is done on the project ref between `https://` and `.supabase.co`,
+ * not by parsing URLs. Hermes packs every string literal into one contiguous
+ * blob with no separators, so a URL runs straight into whatever string follows
+ * it and `new URL()` reads a hostname that was never in the source. The ref is
+ * delimited on both sides by fixed text, which survives that packing.
+ *
+ * Run it under the same environment the export claimed, so the expected values
+ * arrive the same way the baked ones did:
+ *
+ *   eas env:exec production "node scripts/check-bundle-env.mjs"
+ *
+ * Exits non-zero on any mismatch, so it can gate a publish.
+ *
+ * @see {@link file://../EAS-UPDATE.md} the release runbook that calls this
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** Where `expo export` writes the platform bundles. */
+const DIST = "dist/_expo/static/js";
+
+/**
+ * A Supabase project ref as it appears inside a bundle.
+ *
+ * The ref is the label before `.supabase.co`. Both delimiters are literal, so
+ * this stays anchored even though the surrounding bytes are other packed
+ * strings rather than whitespace.
+ */
+const REF_RE = /https:\/\/([a-z0-9]{8,})\.supabase\.co/g;
+
+/**
+ * Every distinct Supabase project ref appearing in `text`.
+ *
+ * @param text - bundle contents, read as binary-safe latin1
+ * @returns the distinct refs found, sorted
+ */
+export function refsIn(text) {
+  const refs = new Set();
+  for (const match of text.matchAll(REF_RE)) refs.add(match[1]);
+  return [...refs].sort();
+}
+
+/** Every built bundle under {@link DIST}, per platform. */
+function bundlePaths() {
+  const out = [];
+  for (const platform of readdirSync(DIST)) {
+    const dir = join(DIST, platform);
+    if (!statSync(dir).isDirectory()) continue;
+    for (const file of readdirSync(dir)) {
+      if (file.endsWith(".hbc") || file.endsWith(".js")) out.push(join(dir, file));
+    }
+  }
+  return out;
+}
+
+function main() {
+  const expectedUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+  if (!expectedUrl) {
+    console.error(
+      "[bundle-env] FAILED — EXPO_PUBLIC_SUPABASE_URL is not set.\n" +
+        '  Run under the target environment: eas env:exec production "node scripts/check-bundle-env.mjs"'
+    );
+    process.exit(1);
+  }
+
+  const expected = expectedUrl.match(/https:\/\/([a-z0-9]+)\.supabase\.co/)?.[1];
+  if (!expected) {
+    console.error(
+      `[bundle-env] FAILED — EXPO_PUBLIC_SUPABASE_URL is not a Supabase URL: ${expectedUrl}`
+    );
+    process.exit(1);
+  }
+
+  let paths = [];
+  try {
+    paths = bundlePaths();
+  } catch {
+    /* handled by the emptiness check below */
+  }
+  if (paths.length === 0) {
+    console.error(`[bundle-env] FAILED — no bundles under ${DIST}. Run the export first.`);
+    process.exit(1);
+  }
+
+  let bad = false;
+  for (const path of paths) {
+    const refs = refsIn(readFileSync(path, "latin1"));
+    const ok = refs.length === 1 && refs[0] === expected;
+    console.log(`  ${ok ? "ok  " : "FAIL"} ${path}  ->  ${refs.join(" ") || "(no Supabase ref found)"}`);
+    if (!ok) bad = true;
+  }
+
+  if (bad) {
+    console.error(
+      `\n[bundle-env] FAILED — expected exactly ${expected}.\n` +
+        "  Do NOT publish. Re-export with --clear and run this again."
+    );
+    process.exit(1);
+  }
+  console.log(`\n[bundle-env] OK — every bundle points at ${expected}`);
+}
+
+// `process.argv[1]` is whatever path the caller typed, so it is relative when
+// invoked as `node scripts/check-bundle-env.mjs`. Resolve it to a file URL
+// before comparing, or the guard never matches and this gate passes silently.
+// It is absent entirely under `node -e`, where importing this module must not
+// run the gate.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
> **Do not cut the 1.4.0 build until this is in.** These changes were pushed to
> `release/companion-1.4.0` a few minutes before #2922 merged and did not make
> it into the merge. Five files, all of them answers to the review comments on
> that PR.

## The one that matters: a regression I introduced

`booking-calendar.tsx` — #2922 added "empty the grid when a month fails to
load", to stop the previous month's bookings being re-clipped into the new
month's squares. That fix was too broad.

`cached` is deliberately `undefined` when `force` is set, so the emptying also
fired on a **failed pull-to-refresh** and blanked a month we hold perfectly good
data for. The cache entry is now read separately from the decision to paint it:

- forced refresh fails, we hold that month → keep showing it, surface the error
- no data for that month at all → empty the grid, as intended

## The rest

| File | Change |
| --- | --- |
| `bookings/new.tsx` | The `day` parameter is round-tripped through a `Date`. The shape check alone passes `2026-13-45`, which `instantFromWallClockInZone` rolls forward into the next year. |
| `EAS-UPDATE.md` | The publish gate reads the expected Supabase host from `eas env:list` and **exits non-zero** on a mismatch instead of only printing it. Runtime-version examples say 1.4.0. |
| `lib/supabase.ts` | Module JSDoc. Reverting #2834 correctly removed the old block, which described a client rebuilt per server and is now false, but left the file undocumented. |
| `lib/api.ts` | Module JSDoc for the barrel and how `API_BASE_URL` resolves. |

Two review comments were **declined** and answered on #2922: the QR trailing
slash in `kits/[id].tsx` (restored by the revert, and needs an env var we do not
set), and the Supabase non-null assertions (restored by the revert; failing
loudly at startup is wanted, and the wrong-value case is now caught by the gate
above before anything publishes).

## Verified

`typecheck` and `companion:test` (6/6) green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid booking dates are now rejected instead of rolling into a different month or year.
  - Booking calendars preserve previously loaded availability when a refresh fails, providing a more reliable fallback view.

- **Documentation**
  - Updated app update guidance with clearer versioning, eligibility details, and improved publishing verification steps.
  - Added technical documentation for API and secure data-storage configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->