### PR TITLE
fix(booking): stop three paths from handing out the same units twice

### DIFF
--- a/apps/webapp/app/modules/booking-model-request/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.test.ts
@@ -120,10 +120,11 @@ function installClaimSimulator() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (db.$queryRaw as any).mockImplementation(
     async (strings: TemplateStringsArray) => {
-      // Two different raw statements reach this stub. The pool lock announces
-      // itself by naming "AssetModel"; anything else is the unit claim
-      // simulated below. Keying on the SQL keeps one queue from answering the
-      // other's call.
+      // why: two different raw statements reach this one stub — the pool lock
+      // and the unit claim. Answering both from a single queue lets the lock
+      // consume a row meant for the claim, so the stub routes on the statement
+      // it was handed: the lock is the one naming "AssetModel", and it expects
+      // a row back (an empty result means "not in this workspace").
       if (Array.isArray(strings) && strings.join("").includes('"AssetModel"')) {
         return [{ id: MODEL_ID }];
       }

--- a/apps/webapp/app/modules/booking-model-request/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.test.ts
@@ -118,17 +118,26 @@ vitest.mock("~/modules/booking-note/service.server", () => ({
  */
 function installClaimSimulator() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (db.$queryRaw as any).mockImplementation(async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const row = await (db.bookingModelRequest.findUnique as any)();
-    if (!row) return [];
-    if (row.fulfilledQuantity >= row.quantity) return [];
-    row.fulfilledQuantity += 1;
-    if (row.fulfilledQuantity >= row.quantity) row.fulfilledAt = new Date();
-    return [
-      { fulfilledQuantity: row.fulfilledQuantity, quantity: row.quantity },
-    ];
-  });
+  (db.$queryRaw as any).mockImplementation(
+    async (strings: TemplateStringsArray) => {
+      // Two different raw statements reach this stub. The pool lock announces
+      // itself by naming "AssetModel"; anything else is the unit claim
+      // simulated below. Keying on the SQL keeps one queue from answering the
+      // other's call.
+      if (Array.isArray(strings) && strings.join("").includes('"AssetModel"')) {
+        return [{ id: MODEL_ID }];
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const row = await (db.bookingModelRequest.findUnique as any)();
+      if (!row) return [];
+      if (row.fulfilledQuantity >= row.quantity) return [];
+      row.fulfilledQuantity += 1;
+      if (row.fulfilledQuantity >= row.quantity) row.fulfilledAt = new Date();
+      return [
+        { fulfilledQuantity: row.fulfilledQuantity, quantity: row.quantity },
+      ];
+    }
+  );
 }
 
 const BOOKING_ID = "booking-1";
@@ -275,6 +284,49 @@ describe("getAssetModelAvailability", () => {
   });
 });
 
+describe("getAssetModelAvailability — injected client", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("reads through the supplied client instead of the global db", async () => {
+    // A caller deciding whether a reservation fits passes its own `tx`. If
+    // these counts run on the global client they sit outside that
+    // transaction — they miss its uncommitted writes and take part in none
+    // of its locks, which is what let two reservations claim one pool.
+    const client = {
+      asset: { count: vitest.fn().mockResolvedValue(7) },
+      custody: {
+        aggregate: vitest.fn().mockResolvedValue({ _sum: { quantity: 1 } }),
+      },
+      bookingAsset: {
+        aggregate: vitest.fn().mockResolvedValue({ _sum: { quantity: 2 } }),
+      },
+      bookingModelRequest: {
+        aggregate: vitest
+          .fn()
+          .mockResolvedValue({ _sum: { quantity: 0, fulfilledQuantity: 0 } }),
+      },
+    };
+
+    const availability = await getAssetModelAvailability({
+      assetModelId: MODEL_ID,
+      organizationId: ORG_ID,
+      bookingId: BOOKING_ID,
+      from,
+      to,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: client as any,
+    });
+
+    expect(client.asset.count).toHaveBeenCalledTimes(1);
+    expect(availability.total).toBe(7);
+    expect(availability.available).toBe(4);
+    // The global client must not have been consulted at all.
+    expect(db.asset.count).not.toHaveBeenCalled();
+  });
+});
+
 describe("upsertBookingModelRequest", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
@@ -288,6 +340,74 @@ describe("upsertBookingModelRequest", () => {
       from,
       to,
     });
+  });
+
+  it("locks the model pool before it measures availability", async () => {
+    expect.assertions(2);
+    // @ts-expect-error mocked
+    db.asset.count.mockResolvedValue(5);
+
+    await upsertBookingModelRequest({
+      bookingId: BOOKING_ID,
+      assetModelId: MODEL_ID,
+      quantity: 3,
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    });
+
+    // Measuring a pool nobody has claimed is the race: two callers read the
+    // same free count and both commit. Order is the assertion, not merely
+    // that both happened.
+    const lockOrder = (db.$queryRaw as ReturnType<typeof vitest.fn>).mock
+      .invocationCallOrder[0];
+    const readOrder = (db.asset.count as ReturnType<typeof vitest.fn>).mock
+      .invocationCallOrder[0];
+
+    expect(lockOrder).toBeDefined();
+    expect(lockOrder).toBeLessThan(readOrder);
+  });
+
+  it("scopes the lock to the caller's workspace", async () => {
+    expect.assertions(2);
+    // @ts-expect-error mocked
+    db.asset.count.mockResolvedValue(5);
+
+    await upsertBookingModelRequest({
+      bookingId: BOOKING_ID,
+      assetModelId: MODEL_ID,
+      quantity: 1,
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    });
+
+    // A foreign-org model id must match zero rows rather than take a real
+    // lock on another tenant's row — the same rule the asset lock follows.
+    const [strings, ...values] = (db.$queryRaw as ReturnType<typeof vitest.fn>)
+      .mock.calls[0];
+    expect((strings as TemplateStringsArray).join("?")).toContain(
+      '"organizationId"'
+    );
+    expect(values).toEqual([MODEL_ID, ORG_ID]);
+  });
+
+  it("refuses a model that is not in the caller's workspace", async () => {
+    expect.assertions(2);
+    // The org-scoped lock matches nothing for a foreign model id.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.$queryRaw as any).mockResolvedValue([]);
+
+    await expect(
+      upsertBookingModelRequest({
+        bookingId: BOOKING_ID,
+        assetModelId: "model-from-another-org",
+        quantity: 1,
+        organizationId: ORG_ID,
+        userId: USER_ID,
+      })
+    ).rejects.toThrow(ShelfError);
+
+    // Refused before any pool measurement happens.
+    expect(db.asset.count).not.toHaveBeenCalled();
   });
 
   it("creates the row when quantity is within availability", async () => {

--- a/apps/webapp/app/modules/booking-model-request/service.server.test.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.test.ts
@@ -294,6 +294,13 @@ describe("getAssetModelAvailability — injected client", () => {
     // these counts run on the global client they sit outside that
     // transaction — they miss its uncommitted writes and take part in none
     // of its locks, which is what let two reservations claim one pool.
+    //
+    // why: this stub IS the subject of the test, not a dependency stood in
+    // for convenience. It has to be a client distinct from the mocked `db`
+    // so "which client did the reads go to" is observable at all; the four
+    // delegates below are exactly the reads the function issues, and their
+    // values are chosen to make the returned arithmetic checkable
+    // (7 total − 1 in custody − 2 reserved = 4 available).
     const client = {
       asset: { count: vitest.fn().mockResolvedValue(7) },
       custody: {

--- a/apps/webapp/app/modules/booking-model-request/service.server.ts
+++ b/apps/webapp/app/modules/booking-model-request/service.server.ts
@@ -75,6 +75,58 @@ type GetAssetModelAvailabilityArgs = {
    */
   from?: Date | null;
   to?: Date | null;
+  /**
+   * Prisma client or active transaction; defaults to the global `db`.
+   *
+   * A caller deciding whether a reservation fits MUST pass its own `tx`.
+   * Reading through the global client runs the counts outside the caller's
+   * transaction, so they neither see its uncommitted writes nor participate
+   * in the locks it holds, and two concurrent reservations both measure the
+   * same free pool and both commit.
+   */
+  db?: AssetModelAvailabilityClient;
+};
+
+/**
+ * The tagged-template `$queryRaw` an interactive transaction exposes. Declared
+ * structurally so the transaction client satisfies it without a cast.
+ */
+type RawQueryClient = {
+  $queryRaw<T = unknown>(
+    query: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<T>;
+};
+
+/**
+ * The exact reads {@link getAssetModelAvailability} issues. Structural rather
+ * than Prisma's own client type so an interactive transaction client
+ * satisfies it without casting.
+ */
+export type AssetModelAvailabilityClient = {
+  asset: {
+    count: (args: { where: Prisma.AssetWhereInput }) => Promise<number>;
+  };
+  custody: {
+    aggregate: (args: {
+      where: Prisma.CustodyWhereInput;
+      _sum: { quantity: true };
+    }) => Promise<{ _sum: { quantity: number | null } }>;
+  };
+  bookingAsset: {
+    aggregate: (args: {
+      where: Prisma.BookingAssetWhereInput;
+      _sum: { quantity: true };
+    }) => Promise<{ _sum: { quantity: number | null } }>;
+  };
+  bookingModelRequest: {
+    aggregate: (args: {
+      where: Prisma.BookingModelRequestWhereInput;
+      _sum: { quantity: true; fulfilledQuantity: true };
+    }) => Promise<{
+      _sum: { quantity: number | null; fulfilledQuantity: number | null };
+    }>;
+  };
 };
 
 export type AssetModelAvailability = {
@@ -90,6 +142,48 @@ export type AssetModelAvailability = {
 };
 
 /**
+ * Serializes reservations competing for one `AssetModel`'s pool.
+ *
+ * Availability is a read-then-decide: count what is free, then write a row
+ * claiming some of it. Under READ COMMITTED a plain `SELECT` inside a
+ * transaction takes no lock, so two concurrent reservations both read the
+ * same free pool and both commit — the sum then exceeds what exists. Taking
+ * `FOR UPDATE` on the model row first makes the second caller wait for the
+ * first to commit and re-read the pool it actually left behind.
+ *
+ * The model row is the right grain: contention is exactly "requests for this
+ * model", and every writer of a `BookingModelRequest` passes through here.
+ *
+ * Scoped by `organizationId` as well as `id`, so a caller supplying another
+ * workspace's model id takes no lock at all rather than contending on a row
+ * it cannot see — the same rule as `lockAssetForQuantityUpdate`.
+ *
+ * @param tx - Prisma interactive transaction client
+ * @param assetModelId - Model whose pool is being claimed
+ * @param organizationId - The caller's authenticated organization id
+ * @throws {ShelfError} 404 if the model is not in the caller's workspace
+ */
+async function lockAssetModelForReservation(
+  tx: RawQueryClient,
+  assetModelId: string,
+  organizationId: string
+): Promise<void> {
+  const rows = await tx.$queryRaw<{ id: string }[]>`
+    SELECT id FROM "AssetModel" WHERE id = ${assetModelId} AND "organizationId" = ${organizationId} FOR UPDATE
+  `;
+
+  if (!rows || rows.length === 0) {
+    throw new ShelfError({
+      cause: null,
+      label,
+      status: 404,
+      message: "Asset model not found in current workspace.",
+      shouldBeCaptured: false,
+    });
+  }
+}
+
+/**
  * Compute availability for an `AssetModel` over a booking window.
  *
  * Safe to call from any loader/action path. Does not mutate. Excludes
@@ -101,7 +195,10 @@ export async function getAssetModelAvailability({
   bookingId,
   from,
   to,
+  db: dbClient,
 }: GetAssetModelAvailabilityArgs): Promise<AssetModelAvailability> {
+  const client = dbClient ?? db;
+
   try {
     const dateOverlap =
       from && to
@@ -118,7 +215,7 @@ export async function getAssetModelAvailability({
         // Total INDIVIDUAL assets of this model in the org. QUANTITY_TRACKED
         // assets aren't part of the model-request flow (they have their own
         // quantity booking path from Phase 3b).
-        db.asset.count({
+        client.asset.count({
           where: {
             organizationId,
             assetModelId,
@@ -126,7 +223,7 @@ export async function getAssetModelAvailability({
           },
         }),
         // Units currently held by team members / users.
-        db.custody.aggregate({
+        client.custody.aggregate({
           where: {
             asset: {
               organizationId,
@@ -138,7 +235,7 @@ export async function getAssetModelAvailability({
         }),
         // Concrete BookingAsset rows for assets of this model, in OTHER
         // active-status bookings whose window overlaps.
-        db.bookingAsset.aggregate({
+        client.bookingAsset.aggregate({
           where: {
             asset: {
               organizationId,
@@ -160,7 +257,7 @@ export async function getAssetModelAvailability({
         // `reservedConcrete` above. Summing both `quantity` and
         // `fulfilledQuantity` lets us compute outstanding-only as
         // `SUM(quantity) - SUM(fulfilledQuantity)` in a single query.
-        db.bookingModelRequest.aggregate({
+        client.bookingModelRequest.aggregate({
           where: {
             assetModelId,
             bookingId: { not: bookingId },
@@ -566,12 +663,18 @@ export async function upsertBookingModelRequest({
         });
       }
 
+      // Claim the pool before measuring it. Both statements have to be in
+      // this transaction: the lock serializes competing reservations, and
+      // `db: tx` is what makes the counts observe it.
+      await lockAssetModelForReservation(tx, assetModelId, organizationId);
+
       const availability = await getAssetModelAvailability({
         assetModelId,
         organizationId,
         bookingId,
         from: booking.from,
         to: booking.to,
+        db: tx,
       });
 
       // We only need fresh pool availability for the NEW outstanding

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -10034,6 +10034,105 @@ describe("addScannedAssetsToBooking", () => {
     expect(db.booking.update).not.toHaveBeenCalled();
   });
 
+  describe("QUANTITY_TRACKED pool", () => {
+    const QT_ID = "asset-qty-scan";
+    const from = new Date("2026-07-01T09:00:00Z");
+    const to = new Date("2026-07-01T17:00:00Z");
+
+    /**
+     * One quantity-tracked asset with a fixed pool, answering every
+     * `asset.findMany` this path drives (the org-scope check, the conflict
+     * candidates, the scanned-asset metadata and the availability read — one
+     * mock, different `select` shapes, which the stub does not project).
+     */
+    function mockPool(
+      total: number,
+      type: AssetType = AssetType.QUANTITY_TRACKED
+    ) {
+      (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+        (args?: { where?: { id?: { in?: string[] } } }) =>
+          Promise.resolve(
+            (args?.where?.id?.in ?? []).map((id) => ({
+              id,
+              type,
+              title: "Folding Chairs",
+              unitOfMeasure: "chairs",
+              quantity: total,
+              status: AssetStatus.AVAILABLE,
+              bookingAssets: [],
+            }))
+          )
+      );
+    }
+
+    beforeEach(() => {
+      mockPool(2);
+      // No rows anywhere: nothing already on this booking, nothing reserved
+      // elsewhere, nothing checked out.
+      (
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockResolvedValue([]);
+      (db.booking.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
+        from,
+        to,
+      });
+    });
+
+    it("refuses to scan more units than the pool can cover", async () => {
+      // The conflict guard above this one is INDIVIDUAL semantics — one asset,
+      // one booking at a time. A quantity-tracked asset legitimately sits in
+      // many bookings at once, so nothing there measures the pool and the
+      // units could be promised twice.
+      await expect(
+        addScannedAssetsToBooking({
+          assetIds: [QT_ID],
+          kitIds: [],
+          bookingId: "booking-1",
+          organizationId: "org-1",
+          userId: "user-1",
+          quantities: { [QT_ID]: 5 },
+        })
+      ).rejects.toThrow(ShelfError);
+
+      expect(db.booking.update).not.toHaveBeenCalled();
+    });
+
+    it("locks each quantity-tracked asset before measuring the pool", async () => {
+      await addScannedAssetsToBooking({
+        assetIds: [QT_ID],
+        kitIds: [],
+        bookingId: "booking-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        quantities: { [QT_ID]: 1 },
+      }).catch(() => undefined);
+
+      // Measuring an unclaimed pool is the race: a plain SELECT takes no lock
+      // under READ COMMITTED, so two scans read the same free count.
+      expect(quantityLock.lockAssetForQuantityUpdate).toHaveBeenCalledWith(
+        expect.anything(),
+        QT_ID,
+        "org-1"
+      );
+    });
+
+    it("leaves INDIVIDUAL assets to the conflict guard", async () => {
+      mockPool(2, AssetType.INDIVIDUAL);
+
+      await addScannedAssetsToBooking({
+        assetIds: ["asset-individual"],
+        kitIds: [],
+        bookingId: "booking-1",
+        organizationId: "org-1",
+        userId: "user-1",
+      }).catch(() => undefined);
+
+      // An INDIVIDUAL asset has no pool to draw on — locking it here would
+      // serialize scans that never compete.
+      expect(quantityLock.lockAssetForQuantityUpdate).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects when a scanned asset is reserved for an overlapping booking", async () => {
     const from = new Date("2026-07-01T09:00:00Z");
     const to = new Date("2026-07-01T17:00:00Z");

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -10045,13 +10045,32 @@ describe("addScannedAssetsToBooking", () => {
      * candidates, the scanned-asset metadata and the availability read — one
      * mock, different `select` shapes, which the stub does not project).
      */
+    /**
+     * Order of the two steps that matter, appended as they happen.
+     *
+     * No delegate belongs to the pool read alone — `asset.findMany` serves the
+     * org-scope check, the conflict candidates, the scanned metadata and the
+     * note builder as well — so invocation counters cannot separate them.
+     * The pool read is identifiable by its projection instead: `id` and
+     * `quantity` and nothing else.
+     */
+    let sequence: string[] = [];
+
     function mockPool(
       total: number,
       type: AssetType = AssetType.QUANTITY_TRACKED
     ) {
       (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
-        (args?: { where?: { id?: { in?: string[] } } }) =>
-          Promise.resolve(
+        (args?: {
+          where?: { id?: { in?: string[] } };
+          select?: Record<string, boolean>;
+        }) => {
+          const select = args?.select ?? {};
+          const keys = Object.keys(select).sort();
+          if (keys.length === 2 && keys[0] === "id" && keys[1] === "quantity") {
+            sequence.push("measure");
+          }
+          return Promise.resolve(
             (args?.where?.id?.in ?? []).map((id) => ({
               id,
               type,
@@ -10061,11 +10080,25 @@ describe("addScannedAssetsToBooking", () => {
               status: AssetStatus.AVAILABLE,
               bookingAssets: [],
             }))
-          )
+          );
+        }
       );
     }
 
     beforeEach(() => {
+      sequence = [];
+      // why: the lock is a module mock, so it records its own turn in the
+      // sequence and still resolves the minimal asset stub its callers expect.
+      (
+        quantityLock.lockAssetForQuantityUpdate as ReturnType<typeof vitest.fn>
+      ).mockImplementation(() => {
+        sequence.push("lock");
+        return Promise.resolve({
+          id: QT_ID,
+          title: "Folding Chairs",
+          quantity: 2,
+        });
+      });
       mockPool(2);
       // No rows anywhere: nothing already on this booking, nothing reserved
       // elsewhere, nothing checked out.
@@ -10114,6 +10147,10 @@ describe("addScannedAssetsToBooking", () => {
         QT_ID,
         "org-1"
       );
+
+      // Taking the lock is only half of it — taking it AFTER the measurement
+      // leaves the race exactly as it was.
+      expect(sequence).toEqual(["lock", "measure"]);
     });
 
     it("leaves INDIVIDUAL assets to the conflict guard", async () => {

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -12748,20 +12748,89 @@ async function addScannedAssetsToBookingWithinTx(
    * `bookings.add-scanned-assets` endpoint reaches this same code, so it was
    * reachable from the app too.
    */
-  const preExistingStandaloneScannedIds = new Set<string>(
+  const preExistingStandaloneRows: { assetId: string; quantity: number }[] =
     allScannedAssetIds.length > 0
-      ? (
-          await tx.bookingAsset.findMany({
-            where: {
-              bookingId,
-              assetId: { in: allScannedAssetIds },
-              assetKitId: null,
-            },
-            select: { assetId: true },
-          })
-        ).map((row: { assetId: string }) => row.assetId)
-      : []
+      ? await tx.bookingAsset.findMany({
+          where: {
+            bookingId,
+            assetId: { in: allScannedAssetIds },
+            assetKitId: null,
+          },
+          // `quantity` feeds the availability guard below: what this booking
+          // will hold after the scan is what competes for the pool, and its
+          // own existing rows are excluded from `bookable`.
+          select: { assetId: true, quantity: true },
+        })
+      : [];
+
+  const preExistingStandaloneScannedIds = new Set<string>(
+    preExistingStandaloneRows.map((row) => row.assetId)
   );
+
+  /**
+   * Quantity-tracked standalone scans draw on the shared pool, and nothing
+   * above measures it: the conflict guard is INDIVIDUAL semantics — one asset
+   * can be in one booking at a time — whereas a quantity-tracked asset
+   * legitimately sits in many at once, bounded only by the sum of their
+   * quantities. Without this the same units can be promised twice.
+   *
+   * Kit slices are deliberately excluded, matching `updateBookingAssets`: a
+   * kit-driven row is committed to its kit and bounded on the separate kit
+   * axis, not the loose pool.
+   */
+  const qtScannedAssetIds = [
+    ...new Set(
+      assetIds.filter(
+        (assetId) =>
+          scannedAssetsMetaById.get(assetId)?.type ===
+          AssetType.QUANTITY_TRACKED
+      )
+    ),
+  ];
+
+  if (qtScannedAssetIds.length > 0) {
+    const bookingWindow = await tx.booking.findFirst({
+      where: { id: bookingId, organizationId },
+      select: { from: true, to: true },
+    });
+
+    const preExistingQtyByAssetId = new Map<string, number>(
+      preExistingStandaloneRows.map((row) => [row.assetId, row.quantity])
+    );
+
+    // Sorted so two transactions touching the same assets acquire them in
+    // one global order and cannot deadlock by taking them in opposite ones.
+    // Mirrors `updateBookingAssets` and the checkout guard.
+    for (const assetId of [...qtScannedAssetIds].sort()) {
+      await lockAssetForQuantityUpdate(tx, assetId, organizationId);
+    }
+
+    await assertAssetQuantitiesAvailable(
+      qtScannedAssetIds.map((assetId) => {
+        const meta = scannedAssetsMetaById.get(assetId);
+        return {
+          assetId,
+          // `bookable` excludes this booking, so the figure measured against
+          // it is everything this booking will hold once the scan lands —
+          // the units already on it plus the ones being added now.
+          requestedQuantity:
+            (preExistingQtyByAssetId.get(assetId) ?? 0) +
+            (quantities[assetId] ?? 1),
+          assetTitle: meta?.title ?? "",
+          unitOfMeasure: meta?.unitOfMeasure,
+        };
+      }),
+      {
+        organizationId,
+        tx,
+        window:
+          bookingWindow?.from && bookingWindow?.to
+            ? { from: bookingWindow.from, to: bookingWindow.to }
+            : null,
+        excludeBookingId: bookingId,
+      }
+    );
+  }
 
   /**
    * Provenance for the rows created below: which reservation each asset

--- a/apps/webapp/app/modules/consumption-log/low-stock.server.test.ts
+++ b/apps/webapp/app/modules/consumption-log/low-stock.server.test.ts
@@ -489,8 +489,10 @@ describe("checkAndNotifyLowStock — never rejects", () => {
   // retries, and the non-idempotent mutation behind it allocates twice.
 
   it("swallows a failure of its very first read", async () => {
-    // The opening `asset.findFirst` had no guard of its own, so a transient
-    // database error here propagated all the way out to the route.
+    // why: the opening `asset.findFirst` is the first thing the check does and
+    // carries no guard of its own, so a transient database failure there is
+    // the shortest path to an escaping rejection. The contract under test is
+    // that the returned promise resolves anyway.
     findFirstMock.mockRejectedValue(new Error("connection reset"));
 
     await expect(
@@ -503,9 +505,10 @@ describe("checkAndNotifyLowStock — never rejects", () => {
   });
 
   it("swallows a failure of the availability read", async () => {
-    // Not only the first statement: the custody aggregate that computes
-    // available units is unguarded too, so the promise has to be safe end to
-    // end rather than at one chosen point.
+    // why: a healthy asset row gets the check past its first statement, so the
+    // failure lands on the custody aggregate instead — also unguarded, and far
+    // enough in to show the contract covers the whole check rather than one
+    // chosen statement.
     findFirstMock.mockResolvedValue(assetRow({ quantity: 1, minQuantity: 5 }));
     custodyAggregateMock.mockRejectedValue(new Error("aggregate failed"));
 
@@ -519,7 +522,8 @@ describe("checkAndNotifyLowStock — never rejects", () => {
   });
 
   it("still reports low stock when nothing fails", async () => {
-    // The guard must not turn the notifier into a no-op.
+    // why: an asset below its threshold with nothing failing — the case that
+    // proves the guard did not turn the notifier into a no-op.
     findFirstMock.mockResolvedValue(assetRow({ quantity: 1, minQuantity: 5 }));
 
     await checkAndNotifyLowStock({

--- a/apps/webapp/app/modules/consumption-log/low-stock.server.test.ts
+++ b/apps/webapp/app/modules/consumption-log/low-stock.server.test.ts
@@ -482,3 +482,52 @@ describe("checkAndNotifyLowStock — early bail-outs", () => {
     expect(sendEmailMock).not.toHaveBeenCalled();
   });
 });
+
+describe("checkAndNotifyLowStock — never rejects", () => {
+  // Every caller runs this AFTER its mutation has committed. An escaping
+  // rejection answers 500 for a request whose write succeeded, the client
+  // retries, and the non-idempotent mutation behind it allocates twice.
+
+  it("swallows a failure of its very first read", async () => {
+    // The opening `asset.findFirst` had no guard of its own, so a transient
+    // database error here propagated all the way out to the route.
+    findFirstMock.mockRejectedValue(new Error("connection reset"));
+
+    await expect(
+      checkAndNotifyLowStock({
+        assetId: ASSET_ID,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("swallows a failure of the availability read", async () => {
+    // Not only the first statement: the custody aggregate that computes
+    // available units is unguarded too, so the promise has to be safe end to
+    // end rather than at one chosen point.
+    findFirstMock.mockResolvedValue(assetRow({ quantity: 1, minQuantity: 5 }));
+    custodyAggregateMock.mockRejectedValue(new Error("aggregate failed"));
+
+    await expect(
+      checkAndNotifyLowStock({
+        assetId: ASSET_ID,
+        userId: USER_ID,
+        organizationId: ORG_ID,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("still reports low stock when nothing fails", async () => {
+    // The guard must not turn the notifier into a no-op.
+    findFirstMock.mockResolvedValue(assetRow({ quantity: 1, minQuantity: 5 }));
+
+    await checkAndNotifyLowStock({
+      assetId: ASSET_ID,
+      userId: USER_ID,
+      organizationId: ORG_ID,
+    });
+
+    expect(sendEmailMock).toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/consumption-log/low-stock.server.ts
+++ b/apps/webapp/app/modules/consumption-log/low-stock.server.ts
@@ -212,7 +212,7 @@ function notifyInAppBestEffort(
  * @param params.organizationId - The organization owning the asset (org-scopes
  *   the lookup and resolves the email recipients)
  */
-export async function checkAndNotifyLowStock({
+async function runLowStockCheck({
   assetId,
   userId,
   organizationId,
@@ -376,4 +376,41 @@ export async function checkAndNotifyLowStock({
     });
   }
   /* else: no transition — already-notified-and-still-low, or fine-and-was-fine. */
+}
+
+/**
+ * Best-effort entry point: runs the check above and never rejects.
+ *
+ * Every caller invokes this AFTER its mutation has committed, so a failure
+ * here cannot roll anything back — but an escaping rejection still reaches
+ * the route's error handler and answers 500 for a request whose write
+ * succeeded. Clients retry a 500, and the mutations behind these calls
+ * (quantity check-out, adjustment, release) are not idempotent, so the retry
+ * allocates a second time. A missed stock notification is recoverable; a
+ * double allocation is not.
+ *
+ * This is the single place that guarantee lives, so call sites need no
+ * try/catch of their own — and adding one back per site is how a site gets
+ * missed.
+ *
+ * @param params - See {@link runLowStockCheck}
+ */
+export async function checkAndNotifyLowStock(
+  params: Parameters<typeof runLowStockCheck>[0]
+): Promise<void> {
+  try {
+    await runLowStockCheck(params);
+  } catch (cause) {
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: "Failed to run the low-stock check",
+        label: "Assets",
+        additionalData: {
+          assetId: params.assetId,
+          organizationId: params.organizationId,
+        },
+      })
+    );
+  }
 }


### PR DESCRIPTION
Three ways the same units could be handed out twice, from the detail.dev OSS
scan: **D106**, **D133**, **D126**. Different mechanisms, one invariant — *a
decision about a shared pool has to be atomic with the write that claims it.*

## D106 — a 500 after a successful commit

`checkAndNotifyLowStock` runs **after** its caller's mutation has committed, so
an escaping rejection cannot roll anything back. What it does instead is answer
500 for a request whose write succeeded. Clients retry a 500, and the mutations
behind these calls (`checkOutQuantity`, adjustment, release) are not idempotent
— so the retry allocates a second time.

The scan flagged one call site. There are **eight**, all awaited post-commit:
five already wrapped it in `try/catch`, three did not. The intent was always
best-effort; it was just enforced per-site, so sites got missed. The guarantee
now lives in the function.

Its opening `db.asset.findFirst` was unguarded, and so is the custody aggregate
that computes available units — both now covered.

## D133 — availability measured outside the transaction

`getAssetModelAvailability` read through the global client while sitting inside
a `tx`, so its counts neither saw that transaction's writes nor took part in its
locks.

**Threading `tx` is necessary but not sufficient.** Under READ COMMITTED a plain
`SELECT` takes no lock, so two reservations still measure the same free pool and
both commit — the same lesson as the booking-status work earlier in this series.
The model row is now locked `FOR UPDATE` before the counts run.

Grain: the `AssetModel` row. Contention is exactly "requests for this model",
and every writer of a `BookingModelRequest` passes through here. Org-scoped like
`lockAssetForQuantityUpdate`, so a foreign-org model id takes no lock at all
rather than contending on a row it cannot see.

⚠️ **Worth review:** two people reserving different quantities of the *same*
model now queue behind each other. That is the point of the lock, but it is a
real serialization change.

## D126 — scan-add never measured the pool

The scan-add transaction already has a booking lock, a status guard and an
overlap-conflict guard. But overlap is **INDIVIDUAL** semantics — one asset, one
booking at a time. A `QUANTITY_TRACKED` asset legitimately sits in many bookings
at once, bounded only by the sum of their quantities, and nothing measured that.

Standalone quantity-tracked scans now take sorted-order row locks (one global
order, so concurrent scans cannot deadlock) and go through
`assertAssetQuantitiesAvailable` — the same guard `updateBookingAssets` uses.
Kit slices stay excluded, matching that precedent: a kit-driven row is bounded
on the kit axis, not the loose pool.

⚠️ **Worth review — the easiest thing to get backwards:** `requestedQuantity` is
*existing + added*, not just the units being added. That is correct only because
`excludeBookingId` removes this booking's own rows from `bookable`, so the
figure measured against the pool must be everything the booking will hold once
the scan lands.

## Verification

- 539 tests pass across the six affected suites; 221 more in adjacent asset /
  consumption-log suites to catch collateral damage.
- Every regression test confirmed **red with its own fix reverted** — D106 (2),
  D133 (3), D126 (2).
- One test is deliberately **not** load-bearing and is labelled as such:
  "leaves INDIVIDUAL assets to the conflict guard" asserts a lock is *not*
  taken, so it cannot fail by construction. It is a guard-rail against
  over-eager locking, not a regression test.
- `tsc -b --force` and eslint clean.

### A test-infrastructure note

The new model lock uses `$queryRaw`, which the model-request suite already stubs
with a simulator for the unit-claim SQL. Rather than let one queue answer the
other's call — the `mockResolvedValueOnce` hazard — that stub now keys on the
statement it is answering (the lock names `"AssetModel"`).

### Caught while writing these tests

My first D106 test passed **without** the fix, because `sendLowStockEmails`
already guards itself internally. Replaced with a failure at the genuinely
unguarded custody aggregate.

No migration. No schema change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking reliability by preventing over-allocation of quantity-tracked assets during concurrent reservations.
  * Enforced organization-specific model access and safer availability checks.
  * Low-stock notification failures are now handled without interrupting booking or other completed actions.
* **Tests**
  * Added coverage for concurrent reservations, availability validation, organization boundaries, and notification failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->