### PR TITLE
fix(exports): serve every CSV download as UTF-8

### DIFF
--- a/apps/webapp/app/components/assets/bulk-update/results-display.tsx
+++ b/apps/webapp/app/components/assets/bulk-update/results-display.tsx
@@ -5,6 +5,7 @@
  *
  * @see {@link file://./form.tsx} Parent orchestration component
  */
+import { CSV_CONTENT_TYPE, withUtf8Bom } from "~/utils/csv-utf8";
 import type { BulkUpdateResult } from "~/utils/import-update.server";
 import { escapeCsvValue } from "./helpers";
 import { SummaryPill } from "./shared";
@@ -62,7 +63,7 @@ export function ResultsDisplay({
     }
 
     const csv = lines.join("\n");
-    const blob = new Blob([csv], { type: "text/csv" });
+    const blob = new Blob([withUtf8Bom(csv)], { type: CSV_CONTENT_TYPE });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.activity[.csv].ts
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.activity[.csv].ts
@@ -1,6 +1,7 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import { csvResponse } from "~/utils/csv-utf8";
 import { exportAssetNotesToCsv } from "~/utils/csv.server";
 import { makeShelfError } from "~/utils/error";
 import { buildContentDisposition, error, getParams } from "~/utils/http.server";
@@ -45,10 +46,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       organizationId,
     });
 
-    return new Response(csv, {
-      status: 200,
+    return csvResponse(csv, {
       headers: {
-        "content-type": "text/csv",
         "content-disposition": buildContentDisposition(asset.title, {
           fallback: "asset",
           suffix: "-activity",

--- a/apps/webapp/app/routes/_layout+/assets.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/assets.export.$fileName[.csv].tsx
@@ -1,6 +1,7 @@
 import { AssetIndexMode } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
+import { csvResponse } from "~/utils/csv-utf8";
 import {
   exportAssetsBackupToCsv,
   exportAssetsForImportToCsv,
@@ -86,12 +87,7 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
       csvString = await exportAssetsBackupToCsv({ organizationId });
     }
 
-    return new Response(csvString, {
-      status: 200,
-      headers: {
-        "content-type": "text/csv",
-      },
-    });
+    return csvResponse(csvString);
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
     return data(error(reason), { status: reason.status });

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.activity[.csv].ts
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.activity[.csv].ts
@@ -2,6 +2,7 @@ import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
 import { requireAuditAssigneeForBaseSelfService } from "~/modules/audit/service.server";
+import { csvResponse } from "~/utils/csv-utf8";
 import { exportAuditNotesToCsv } from "~/utils/csv.server";
 import { makeShelfError } from "~/utils/error";
 import { error, getParams } from "~/utils/http.server";
@@ -72,10 +73,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       organizationId,
     });
 
-    return new Response(csv, {
-      status: 200,
+    return csvResponse(csv, {
       headers: {
-        "content-type": "text/csv",
         "content-disposition": `attachment; filename="${buildFilename(
           audit.name
         )}"`,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.activity[.csv].ts
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.activity[.csv].ts
@@ -2,6 +2,7 @@ import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
 import { canSeeBooking } from "~/utils/booking-authorization.server";
+import { csvResponse } from "~/utils/csv-utf8";
 import { exportBookingNotesToCsv } from "~/utils/csv.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { buildContentDisposition, error, getParams } from "~/utils/http.server";
@@ -68,10 +69,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       organizationId,
     });
 
-    return new Response(csv, {
-      status: 200,
+    return csvResponse(csv, {
       headers: {
-        "content-type": "text/csv",
         "content-disposition": buildContentDisposition(booking.name, {
           fallback: "booking",
           suffix: "-activity",

--- a/apps/webapp/app/routes/_layout+/bookings.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.export.$fileName[.csv].tsx
@@ -1,5 +1,6 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
+import { csvResponse } from "~/utils/csv-utf8";
 import { exportBookingsFromIndexToCsv } from "~/utils/csv.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { error, getCurrentSearchParams } from "~/utils/http.server";
@@ -49,12 +50,7 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
       organizationId,
     });
 
-    return new Response(csvString, {
-      status: 200,
-      headers: {
-        "content-type": "text/csv",
-      },
-    });
+    return csvResponse(csvString);
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
     return data(error(reason), { status: reason.status });

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.activity[.csv].ts
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.activity[.csv].ts
@@ -1,6 +1,7 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import { csvResponse } from "~/utils/csv-utf8";
 import { exportLocationNotesToCsv } from "~/utils/csv.server";
 import { makeShelfError } from "~/utils/error";
 import { buildContentDisposition, error, getParams } from "~/utils/http.server";
@@ -49,10 +50,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       organizationId,
     });
 
-    return new Response(csv, {
-      status: 200,
+    return csvResponse(csv, {
       headers: {
-        "content-type": "text/csv",
         "content-disposition": buildContentDisposition(location.name, {
           fallback: "location",
           suffix: "-activity",

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -419,18 +419,17 @@ function formatReturnStatus(
 /**
  * Assembles a CSV document, escaping EVERY cell.
  *
- * Escaping used to be applied per field, by hand, at each call site — and was
- * missed on `custodianName`, `custodian`, `performedBy`, `category` and
- * `location`, all of which are user-controlled workspace values. A name like
- * `=cmd|'/c calc'!A1` therefore reached the file as a live formula.
+ * Escaping lives here and nowhere else. Headers and body cells alike pass
+ * through {@link escapeCsvField}, so a contributor adding a column gets a safe
+ * cell with no per-field decision to make. Cells carry user-controlled
+ * workspace values — custodian and member names, categories, locations — so
+ * the guarantee has to be unconditional rather than applied where it looks
+ * needed.
  *
- * Escaping here instead means a new column is safe by default: a contributor
- * adding one cannot forget, because there is no per-field decision left to
- * make. That is the property the previous approach lacked, not the escaping
- * itself — `escapeCsvField` was already correct, just unevenly applied.
+ * Callers pass raw values: a cell escaped before it arrives is escaped twice.
  *
  * @param headers - Column headers, escaped like any other cell
- * @param rows - Row cells, already stringified and formatted
+ * @param rows - Row cells, already stringified and formatted, NOT escaped
  * @returns The complete CSV document
  */
 function buildCsv(headers: string[], rows: string[][]): string {

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -40,6 +40,7 @@ import type {
   MonthlyBookingTrendRow,
 } from "~/modules/reports/types";
 import { getClientHint } from "~/utils/client-hints";
+import { csvResponse } from "~/utils/csv-utf8";
 import { type ResolvedFormatPrefs } from "~/utils/date-format";
 import { resolveUserFormatPrefsById } from "~/utils/date-format.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -280,10 +281,8 @@ export const loader = async ({
     // Get filename from URL params (e.g., "booking-compliance-last_30d-2026-04-22")
     const fileName = params.fileName || `${reportId}-export`;
 
-    return new Response(csvString, {
-      status: 200,
+    return csvResponse(csvString, {
       headers: {
-        "content-type": "text/csv",
         "content-disposition": `attachment; filename="${fileName}.csv"`,
         "cache-control": "no-cache",
       },

--- a/apps/webapp/app/routes/api+/admin.export-org-assets.$organizationId.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/api+/admin.export-org-assets.$organizationId.$fileName[.csv].tsx
@@ -1,5 +1,6 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
+import { csvResponse } from "~/utils/csv-utf8";
 import { exportAssetsBackupToCsv } from "~/utils/csv.server";
 import { makeShelfError } from "~/utils/error";
 import { error, getParams } from "~/utils/http.server";
@@ -22,12 +23,7 @@ export async function loader({ context, params }: LoaderFunctionArgs) {
     /** Join the rows with a new line */
     const csvString = await exportAssetsBackupToCsv({ organizationId });
 
-    return new Response(csvString, {
-      status: 200,
-      headers: {
-        "content-type": "text/csv",
-      },
-    });
+    return csvResponse(csvString);
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
     return data(error(reason), { status: reason.status });

--- a/apps/webapp/app/routes/api+/settings.export-nrm.$fileName[.csv].ts
+++ b/apps/webapp/app/routes/api+/settings.export-nrm.$fileName[.csv].ts
@@ -1,5 +1,6 @@
 import { data, type LoaderFunctionArgs } from "react-router";
 import { NRM_ID_PARAM } from "~/components/nrm/export-nrm-button";
+import { csvResponse } from "~/utils/csv-utf8";
 import { exportNRMsToCsv } from "~/utils/csv.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { error, getCurrentSearchParams } from "~/utils/http.server";
@@ -39,10 +40,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       search: searchParams.get("s"),
     });
 
-    return new Response(csvString, {
-      status: 200,
-      headers: { "Content-Type": "text/csv" },
-    });
+    return csvResponse(csvString);
   } catch (cause) {
     const reason = makeShelfError(cause, { userId });
     return data(error(reason), { status: reason.status });

--- a/apps/webapp/app/utils/csv-utf8.test.ts
+++ b/apps/webapp/app/utils/csv-utf8.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the CSV UTF-8 encoding helpers.
+ *
+ * These guard the contract every CSV download depends on: the bytes reach
+ * the user tagged as UTF-8, both by the leading byte order mark that Excel
+ * reads and by the `charset` on the content type. Without the mark, Excel
+ * falls back to the machine's locale codepage and non-Latin content (the
+ * reporting case is Arabic) opens as mojibake.
+ *
+ * @see {@link file://./csv-utf8.ts}
+ */
+import { describe, expect, it } from "vitest";
+
+import { csvResponse, UTF8_BOM, withUtf8Bom } from "./csv-utf8";
+
+/** Arabic sample: the script the reporting export has to survive. */
+const ARABIC_CSV = "Group,Asset Count\nحاسوب محمول,12";
+
+/** Reads the first three body bytes of a response, ahead of any decoding. */
+async function bodyBytesOf(response: Response): Promise<Uint8Array> {
+  return new Uint8Array(await response.arrayBuffer()).slice(0, 3);
+}
+
+describe("withUtf8Bom", () => {
+  it("prefixes the byte order mark", () => {
+    expect(withUtf8Bom(ARABIC_CSV)).toBe(`${UTF8_BOM}${ARABIC_CSV}`);
+  });
+
+  it("leaves a document that already carries the mark unchanged", () => {
+    expect(withUtf8Bom(`${UTF8_BOM}${ARABIC_CSV}`)).toBe(
+      `${UTF8_BOM}${ARABIC_CSV}`
+    );
+  });
+
+  it("encodes the mark as the three UTF-8 bytes Excel looks for", async () => {
+    const bytes = new Uint8Array(
+      await new Blob([withUtf8Bom("Group")]).arrayBuffer()
+    );
+
+    expect(Array.from(bytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+  });
+});
+
+describe("csvResponse", () => {
+  it("declares the UTF-8 charset and emits the marked document", async () => {
+    const response = csvResponse(ARABIC_CSV);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/csv; charset=utf-8"
+    );
+    // The body is read as bytes, not via `text()`: UTF-8 decode drops a
+    // leading mark, so a decoded body cannot show whether the file the
+    // browser writes to disk carries one.
+    await expect(bodyBytesOf(response)).resolves.toEqual(
+      new Uint8Array([0xef, 0xbb, 0xbf])
+    );
+  });
+
+  it("keeps the caller's own headers", () => {
+    const response = csvResponse(ARABIC_CSV, {
+      headers: {
+        "content-disposition": 'attachment; filename="distribution.csv"',
+        "cache-control": "no-cache",
+      },
+    });
+
+    expect(response.headers.get("content-disposition")).toBe(
+      'attachment; filename="distribution.csv"'
+    );
+    expect(response.headers.get("cache-control")).toBe("no-cache");
+  });
+
+  it("overrides a caller-supplied content type", () => {
+    const response = csvResponse(ARABIC_CSV, {
+      headers: { "content-type": "text/csv" },
+    });
+
+    expect(response.headers.get("content-type")).toBe(
+      "text/csv; charset=utf-8"
+    );
+  });
+
+  it("round-trips through a UTF-8 decode without mangling the Arabic", async () => {
+    // `text()` decodes as UTF-8 and drops the mark, leaving the document.
+    await expect(csvResponse(ARABIC_CSV).text()).resolves.toBe(ARABIC_CSV);
+  });
+});

--- a/apps/webapp/app/utils/csv-utf8.ts
+++ b/apps/webapp/app/utils/csv-utf8.ts
@@ -1,0 +1,58 @@
+/**
+ * @file UTF-8 encoding helpers for CSV downloads.
+ *
+ * Spreadsheet applications do not assume UTF-8 when they open a `.csv`
+ * file. Excel in particular decodes a CSV with the machine's legacy
+ * locale codepage unless the file opens with a UTF-8 byte order mark, so
+ * any non-Latin content (Arabic, Cyrillic, Greek, CJK, accented Latin)
+ * renders as mojibake. Every CSV Shelf hands to a user therefore starts
+ * with the BOM and declares `charset=utf-8`.
+ *
+ * Shelf's own CSV parsers strip a leading BOM, so an exported file stays
+ * re-importable.
+ *
+ * @see {@link file://./csv.server.ts} parseCsv — import side, `bom: true`
+ */
+
+/** UTF-8 byte order mark (U+FEFF), encoded as UTF-8 when the string is sent. */
+export const UTF8_BOM = "\uFEFF";
+
+/** The content type every CSV download is served with. */
+export const CSV_CONTENT_TYPE = "text/csv; charset=utf-8";
+
+/**
+ * Prefix a CSV document with the UTF-8 BOM.
+ *
+ * Idempotent: a document that already carries the mark is returned as-is,
+ * so a caller can apply it without knowing what its input did.
+ *
+ * @param csv - the CSV document
+ * @returns the document with exactly one leading BOM
+ */
+export function withUtf8Bom(csv: string): string {
+  return csv.startsWith(UTF8_BOM) ? csv : `${UTF8_BOM}${csv}`;
+}
+
+/**
+ * Build the `Response` for a CSV download.
+ *
+ * Adds the BOM and sets `content-type`, so a route only supplies the
+ * headers that are its own — `content-disposition`, caching, and so on.
+ * Routing every CSV loader through here keeps the encoding a property of
+ * the download itself rather than a per-route decision.
+ *
+ * @param csv - the CSV document, without a BOM
+ * @param init - response init; its headers are merged, and `content-type`
+ *   is always the UTF-8 one
+ * @returns a 200 `Response` carrying the encoded document
+ */
+export function csvResponse(csv: string, init?: ResponseInit): Response {
+  const headers = new Headers(init?.headers);
+  headers.set("content-type", CSV_CONTENT_TYPE);
+
+  return new Response(withUtf8Bom(csv), {
+    status: 200,
+    ...init,
+    headers,
+  });
+}

--- a/apps/webapp/app/utils/csv.server.test.ts
+++ b/apps/webapp/app/utils/csv.server.test.ts
@@ -51,6 +51,31 @@ describe("parseCsv", () => {
       ['MacBook "Pro" 16', "16-inch laptop"],
     ]);
   });
+
+  it("strips the UTF-8 BOM so an exported file re-imports cleanly", async () => {
+    // Every CSV Shelf serves opens with a BOM (see `~/utils/csv-utf8`), and
+    // files coming back from Excel carry one too. The mark has to be consumed
+    // here, or the mark stays glued to the first header and every column
+    // mapped by name silently misses — a round trip the import-ready export
+    // invites users to perform.
+    //
+    // Two layers strip it independently: a UTF-8 decode drops a leading mark
+    // by spec, and `bom: true` catches one that reaches the parser anyway.
+    // `bom: true` therefore looks redundant and is not — this asserts the
+    // outcome rather than either mechanism, so removing one net keeps the
+    // suite green and removing both does not.
+    const withBom = `\uFEFFtitle,category\nحاسوب محمول,أجهزة`;
+    const bytes = new TextEncoder().encode(withBom);
+
+    const result = await parseCsv(
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+    );
+
+    expect(result).toEqual([
+      ["title", "category"],
+      ["حاسوب محمول", "أجهزة"],
+    ]);
+  });
 });
 
 describe("csvDataFromRequest", () => {

--- a/apps/webapp/test/routes-tests/_layout+/assets.$assetId.activity[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/assets.$assetId.activity[.csv].test.ts
@@ -137,11 +137,19 @@ describe("app/routes/_layout+/assets.$assetId.activity[.csv] loader", () => {
     expect(response instanceof Response).toBe(true);
     expect((response as unknown as Response).status).toBe(200);
     expect((response as unknown as Response).headers.get("content-type")).toBe(
-      "text/csv"
+      "text/csv; charset=utf-8"
     );
     expect(
       (response as unknown as Response).headers.get("content-disposition")
     ).toContain("Test Asset-activity");
+
+    // Excel reads the leading byte order mark to pick UTF-8; without it,
+    // non-Latin note content opens in the machine's locale codepage. Read as
+    // bytes, because `text()` decodes as UTF-8 and drops the mark.
+    const bytes = new Uint8Array(
+      await (response as unknown as Response).clone().arrayBuffer()
+    );
+    expect(Array.from(bytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
 
     const csv = await (response as unknown as Response).text();
     const rows = csv.trim().split("\n");

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.activity[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.activity[.csv].test.ts
@@ -142,7 +142,7 @@ describe("app/routes/_layout+/bookings.$bookingId.activity[.csv] loader", () => 
     expect(response instanceof Response).toBe(true);
     expect((response as unknown as Response).status).toBe(200);
     expect((response as unknown as Response).headers.get("content-type")).toBe(
-      "text/csv"
+      "text/csv; charset=utf-8"
     );
     expect(
       (response as unknown as Response).headers.get("content-disposition")

--- a/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
@@ -1,0 +1,158 @@
+/**
+ * Route tests for the report CSV export loader.
+ *
+ * The report exports are the surface users open in Excel, so the assertions
+ * here are about the bytes on the wire: a UTF-8 byte order mark and a
+ * charset on the content type, which together are what make a non-Latin
+ * workspace (Arabic category names, in the reported case) open as text
+ * rather than mojibake.
+ *
+ * @see {@link file://../../../app/routes/_layout+/reports.export.$fileName[.csv].tsx}
+ * @see {@link file://../../../app/utils/csv-utf8.ts}
+ */
+import type { LoaderFunctionArgs } from "react-router";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoaderArgs } from "@mocks/remix";
+import { assetDistributionReport } from "~/modules/reports/helpers.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+
+// why: verifying export encoding without executing real permission checks
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+
+// why: the report builders query Prisma; the loader only needs their shape
+vi.mock("~/modules/reports/helpers.server", () => ({
+  resolveTimeframe: vi.fn(() => ({
+    preset: "last_30d",
+    from: new Date("2026-07-25T00:00:00.000Z"),
+    to: new Date("2026-08-24T00:00:00.000Z"),
+    label: "Last 30 days",
+  })),
+  assetDistributionReport: vi.fn(),
+  bookingComplianceReport: vi.fn(),
+  custodySnapshotReport: vi.fn(),
+  overdueItemsReport: vi.fn(),
+  idleAssetsReport: vi.fn(),
+  topBookedAssetsReport: vi.fn(),
+  topBookedKitsReport: vi.fn(),
+  assetInventoryReport: vi.fn(),
+  assetUtilizationReport: vi.fn(),
+  assetActivityReport: vi.fn(),
+  monthlyBookingTrendsReport: vi.fn(),
+}));
+
+// why: format prefs are resolved from the database for the acting user
+vi.mock("~/utils/date-format.server", () => ({
+  resolveUserFormatPrefsById: vi.fn(() =>
+    Promise.resolve({
+      dateFormat: "MM/DD/YYYY",
+      timeFormat: "12h",
+      timeZone: "UTC",
+      weekStartsOn: 0,
+    })
+  ),
+}));
+
+let loader: (typeof import("~/routes/_layout+/reports.export.$fileName[.csv]"))["loader"];
+
+const requirePermissionMock = vi.mocked(requirePermission);
+const assetDistributionReportMock = vi.mocked(assetDistributionReport);
+
+beforeAll(async () => {
+  ({ loader } = await import(
+    "~/routes/_layout+/reports.export.$fileName[.csv]"
+  ));
+});
+
+describe("app/routes/_layout+/reports.export.$fileName[.csv] loader", () => {
+  const context = {
+    getSession: () => ({ userId: "user-123" }),
+  } as LoaderFunctionArgs["context"];
+
+  /** Arabic group names — the content the encoding has to survive. */
+  const arabicBreakdown = {
+    byCategory: [
+      {
+        id: "cat-1",
+        groupName: "حاسوب محمول",
+        assetCount: 12,
+        percentage: 60,
+        totalValue: 24000,
+      },
+    ],
+    byLocation: [
+      {
+        id: "loc-1",
+        groupName: "مستودع الرياض",
+        assetCount: 8,
+        percentage: 40,
+        totalValue: 16000,
+      },
+    ],
+    byStatus: [
+      {
+        id: "status-1",
+        groupName: "Available",
+        assetCount: 20,
+        percentage: 100,
+        totalValue: 40000,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requirePermissionMock.mockResolvedValue({
+      organizationId: "org-1",
+    } as any);
+    assetDistributionReportMock.mockResolvedValue({
+      distributionBreakdown: arabicBreakdown,
+    } as any);
+  });
+
+  const runLoader = () =>
+    loader(
+      createLoaderArgs({
+        request: new Request(
+          "http://localhost:3000/reports/export/distribution-last_30d-2026-08-24.csv?reportId=distribution"
+        ),
+        params: { fileName: "distribution-last_30d-2026-08-24" },
+        context,
+      })
+    );
+
+  it("serves the distribution CSV as UTF-8", async () => {
+    const response = (await runLoader()) as unknown as Response;
+
+    expect(requirePermissionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: PermissionEntity.asset,
+        action: PermissionAction.export,
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/csv; charset=utf-8"
+    );
+    expect(response.headers.get("content-disposition")).toContain(
+      "distribution-last_30d-2026-08-24.csv"
+    );
+
+    // Read as bytes: `text()` decodes as UTF-8 and drops the mark, so only the
+    // raw body shows what the browser writes to disk.
+    const bytes = new Uint8Array(await response.clone().arrayBuffer());
+    expect(Array.from(bytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+
+    const rows = (await response.text()).trim().split("\n");
+    expect(rows[0]).toBe(
+      "Breakdown Type,Group,Asset Count,Percentage,Total Valuation"
+    );
+    expect(rows[1]).toBe("Category,حاسوب محمول,12,60.0%,24000");
+    expect(rows[2]).toBe("Location,مستودع الرياض,8,40.0%,16000");
+  });
+});

--- a/apps/webapp/test/routes-tests/csv-download-contract.test.ts
+++ b/apps/webapp/test/routes-tests/csv-download-contract.test.ts
@@ -1,0 +1,82 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// @vitest-environment node
+
+/**
+ * Contract test: every route that serves a `.csv` download must build its
+ * response with `csvResponse`.
+ *
+ * Spreadsheet applications pick a CSV's encoding from its first bytes, so a
+ * download without the UTF-8 byte order mark opens as mojibake for any
+ * non-Latin content. `csvResponse` (`~/utils/csv-utf8`) is the one place that
+ * adds the mark and sets `charset=utf-8`; a route that hand-rolls its
+ * `Response` ships the bug again for its own export only, which is invisible
+ * to every other test.
+ *
+ * @see {@link file://../../app/utils/csv-utf8.ts}
+ */
+const ROUTES_DIR = path.resolve(__dirname, "../../app/routes");
+
+/**
+ * Routes that serve a `.csv` path but deliberately do not go through
+ * `csvResponse`. Deliberately empty — an entry here means a download users
+ * open in a spreadsheet is exempt from the encoding guarantee, so it needs a
+ * stated reason and a reviewer, not a quiet addition.
+ */
+const CSV_RESPONSE_EXEMPT = new Set<string>([]);
+
+/**
+ * Every CSV route file, at any depth and either extension.
+ *
+ * Matched on the `[.csv]` filename segment, which is how remix-flat-routes
+ * spells a literal `.csv` in a URL, rather than on a directory: these routes
+ * live under both `_layout+/` and `api+/`, and the next one may live somewhere
+ * else again. Recursive and `.tsx`-inclusive so a route cannot escape the
+ * contract by its location or extension.
+ */
+const CSV_ROUTE_FILES = readdirSync(ROUTES_DIR, { recursive: true })
+  .map((entry) => String(entry))
+  .filter(
+    (f) =>
+      /\[\.csv\]\.(ts|tsx)$/.test(f) &&
+      !f.includes(".test.") &&
+      !f.includes(".spec.")
+  );
+
+const GUARDED_FILES = CSV_ROUTE_FILES.filter(
+  (f) => !CSV_RESPONSE_EXEMPT.has(f)
+);
+
+describe("csv download encoding contract", () => {
+  it("finds the CSV routes (sanity)", () => {
+    // A glob that silently matches nothing would make every assertion below
+    // vacuous, and the suite would stay green with the contract unenforced.
+    expect(CSV_ROUTE_FILES.length).toBeGreaterThan(0);
+  });
+
+  it("exempt routes still exist (catch stale exemptions)", () => {
+    for (const exempt of CSV_RESPONSE_EXEMPT) {
+      expect(
+        CSV_ROUTE_FILES,
+        `${exempt} is exempt but no longer exists`
+      ).toContain(exempt);
+    }
+  });
+
+  it.each(GUARDED_FILES)("%s builds its response with csvResponse", (file) => {
+    const src = readFileSync(path.join(ROUTES_DIR, file), "utf8");
+
+    expect(src, `${file} should import from ~/utils/csv-utf8`).toMatch(
+      /from ["']~\/utils\/csv-utf8["']/
+    );
+    expect(src, `${file} should return csvResponse(...)`).toMatch(
+      /\bcsvResponse\s*\(/
+    );
+    expect(
+      src,
+      `${file} should not hand-roll a text/csv Response — csvResponse sets the content type`
+    ).not.toMatch(/["']text\/csv["']/);
+  });
+});


### PR DESCRIPTION
## Problem

CSV exports were served as `text/csv` with no charset and no UTF-8 byte order mark.

Spreadsheet applications pick a CSV's encoding from its first bytes. With no mark, Excel decodes the file with the machine's locale codepage, so any non-Latin content opens as mojibake: Arabic, Cyrillic, Greek, CJK, and accented Latin. Reported against the Asset Distribution report export, where Arabic category and location names came out unreadable.

The bytes we send were always valid UTF-8. The file just never said so.

## Fix

New `apps/webapp/app/utils/csv-utf8.ts`:

- `withUtf8Bom(csv)` prefixes the mark, idempotently.
- `csvResponse(csv, init)` builds the download response: adds the mark and sets `text/csv; charset=utf-8`, merging whatever headers the route supplies (`content-disposition`, caching).

Every CSV loader now returns through `csvResponse`, so the encoding is a property of the download rather than a per-route decision a new column or a new export can miss:

| Surface | Route |
| --- | --- |
| Report exports (all 11) | `reports.export.$fileName[.csv].tsx` |
| Asset index / backup / import-ready export | `assets.export.$fileName[.csv].tsx` |
| Bookings export | `bookings.export.$fileName[.csv].tsx` |
| Non-registered members export | `settings.export-nrm.$fileName[.csv].ts` |
| Admin org-assets backup | `admin.export-org-assets.$organizationId.$fileName[.csv].tsx` |
| Asset / booking / audit / location activity notes | four `*.activity[.csv].ts` routes |

The bulk-update result report is built client-side, so it gets the same treatment on its `Blob`.

## Re-import safety

An exported file stays re-importable. `parseCsv` runs `csv-parse` with `bom: true` behind `chardet` detection, and the bulk-update client parser strips a leading `﻿` — both already handled the mark, because files coming back from Excel carry one.

## Tests

- `app/utils/csv-utf8.test.ts` — the mark is emitted, applied once, and lands as the three bytes `EF BB BF`; caller headers survive; a caller-supplied content type is overridden.
- `test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts` — new. Drives the real loader for the distribution report with Arabic group names and asserts the response bytes, the charset, and the row content.
- `test/routes-tests/_layout+/assets.$assetId.activity[.csv].test.ts` — asserts the mark on the wire.

Assertions read the body as bytes rather than through `response.text()`: UTF-8 decode drops a leading mark by spec, so a decoded body cannot show whether the file written to disk has one.

Full webapp suite green: 406 files, 5385 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV downloads now use UTF-8 encoding for improved spreadsheet compatibility.
  * Exported CSV files include the correct UTF-8 content type and encoding marker.
  * Multilingual content, including Arabic characters, is preserved in exports.

* **Bug Fixes**
  * Standardized CSV downloads across asset, booking, audit, location, report, and settings exports.
  * Improved CSV re-import compatibility while preserving filenames and download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->