### PR TITLE
fix(billing): decide a workspace's one free trial exactly once

### DIFF
--- a/apps/webapp/app/modules/audit/addon.server.test.ts
+++ b/apps/webapp/app/modules/audit/addon.server.test.ts
@@ -141,16 +141,21 @@ describe("createAuditAddonTrialSubscription", () => {
 
     await createAuditAddonTrialSubscription(trialParams);
 
-    expect(mockStripe.subscriptions.create).toHaveBeenCalledWith({
-      customer: "cus_xyz",
-      items: [{ price: "price_123" }],
-      trial_period_days: 7,
-      trial_settings: {
-        end_behavior: { missing_payment_method: "pause" },
+    expect(mockStripe.subscriptions.create).toHaveBeenCalledWith(
+      {
+        customer: "cus_xyz",
+        items: [{ price: "price_123" }],
+        trial_period_days: 7,
+        trial_settings: {
+          end_behavior: { missing_payment_method: "pause" },
+        },
+        default_payment_method: "pm_abc",
+        metadata: { userId: "user_abc", organizationId: "org_456" },
       },
-      default_payment_method: "pm_abc",
-      metadata: { userId: "user_abc", organizationId: "org_456" },
-    });
+      // Keyed on the workspace: a retry after a lost response returns this
+      // same subscription instead of opening a second one.
+      { idempotencyKey: "addon-trial:audits:org_456" }
+    );
   });
 
   it("creates subscription without default_payment_method when none exists", async () => {
@@ -162,15 +167,18 @@ describe("createAuditAddonTrialSubscription", () => {
 
     await createAuditAddonTrialSubscription(trialParams);
 
-    expect(mockStripe.subscriptions.create).toHaveBeenCalledWith({
-      customer: "cus_xyz",
-      items: [{ price: "price_123" }],
-      trial_period_days: 7,
-      trial_settings: {
-        end_behavior: { missing_payment_method: "pause" },
+    expect(mockStripe.subscriptions.create).toHaveBeenCalledWith(
+      {
+        customer: "cus_xyz",
+        items: [{ price: "price_123" }],
+        trial_period_days: 7,
+        trial_settings: {
+          end_behavior: { missing_payment_method: "pause" },
+        },
+        metadata: { userId: "user_abc", organizationId: "org_456" },
       },
-      metadata: { userId: "user_abc", organizationId: "org_456" },
-    });
+      { idempotencyKey: "addon-trial:audits:org_456" }
+    );
     // Ensure default_payment_method is NOT in the call
     const callArgs = mockStripe.subscriptions.create.mock.calls[0][0];
     expect(callArgs).not.toHaveProperty("default_payment_method");

--- a/apps/webapp/app/modules/audit/addon.server.ts
+++ b/apps/webapp/app/modules/audit/addon.server.ts
@@ -89,6 +89,15 @@ export async function createAuditAddonTrialSubscription({
   userId: User["id"];
   organizationId: string;
 }) {
+  /**
+   * Whether the Stripe subscription request has been sent.
+   *
+   * A failure before this flips is provably harmless — nothing was created.
+   * After it, the outcome is unknown: Stripe may hold a real subscription
+   * whose response never reached us.
+   */
+  let subscriptionCreateAttempted = false;
+
   try {
     // The caller supplies `priceId` from the request, and an add-on price is
     // distinguishable from a TIER price only by its product metadata. Without
@@ -116,20 +125,35 @@ export async function createAuditAddonTrialSubscription({
 
     const defaultPaymentMethod = paymentMethods.data[0]?.id;
 
-    const subscription = await stripe.subscriptions.create({
-      customer: customerId,
-      items: [{ price: priceId }],
-      trial_period_days: 7,
-      trial_settings: {
-        end_behavior: {
-          missing_payment_method: "pause",
+    // Past this point a subscription may exist at Stripe even if this call
+    // ends up throwing — a lost response looks identical to a refusal from
+    // here. Callers read this back off the error to decide whether returning
+    // the workspace's trial is safe.
+    subscriptionCreateAttempted = true;
+
+    const subscription = await stripe.subscriptions.create(
+      {
+        customer: customerId,
+        items: [{ price: priceId }],
+        trial_period_days: 7,
+        trial_settings: {
+          end_behavior: {
+            missing_payment_method: "pause",
+          },
         },
+        ...(defaultPaymentMethod && {
+          default_payment_method: defaultPaymentMethod,
+        }),
+        metadata: { userId, organizationId },
       },
-      ...(defaultPaymentMethod && {
-        default_payment_method: defaultPaymentMethod,
-      }),
-      metadata: { userId, organizationId },
-    });
+      {
+        // A workspace gets exactly one audit trial, so this key can never
+        // collide with a legitimate second subscription — and it means a retry
+        // after a lost response returns the SAME subscription instead of
+        // opening a second one. Stripe holds the key for 24 hours.
+        idempotencyKey: `addon-trial:audits:${organizationId}`,
+      }
+    );
 
     return { subscription, hasPaymentMethod: !!defaultPaymentMethod };
   } catch (cause) {
@@ -139,7 +163,12 @@ export async function createAuditAddonTrialSubscription({
       cause,
       message:
         "Something went wrong while creating audit add-on trial. Please try again later or contact support.",
-      additionalData: { customerId, priceId, userId },
+      additionalData: {
+        customerId,
+        priceId,
+        userId,
+        subscriptionCreateAttempted,
+      },
       label,
     });
   }

--- a/apps/webapp/app/modules/barcode/addon.server.test.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.test.ts
@@ -185,7 +185,10 @@ describe("createBarcodeAddonTrialSubscription", () => {
       expect.objectContaining({
         trial_period_days: 7,
         default_payment_method: "pm_123",
-      })
+      }),
+      // Keyed on the workspace: a retry after a lost response returns this
+      // same subscription instead of opening a second one.
+      { idempotencyKey: "addon-trial:barcodes:org_1" }
     );
   });
 

--- a/apps/webapp/app/modules/barcode/addon.server.ts
+++ b/apps/webapp/app/modules/barcode/addon.server.ts
@@ -89,6 +89,15 @@ export async function createBarcodeAddonTrialSubscription({
   userId: User["id"];
   organizationId: string;
 }) {
+  /**
+   * Whether the Stripe subscription request has been sent.
+   *
+   * A failure before this flips is provably harmless — nothing was created.
+   * After it, the outcome is unknown: Stripe may hold a real subscription
+   * whose response never reached us.
+   */
+  let subscriptionCreateAttempted = false;
+
   try {
     // The caller supplies `priceId` from the request, and an add-on price is
     // distinguishable from a TIER price only by its product metadata. Without
@@ -116,20 +125,35 @@ export async function createBarcodeAddonTrialSubscription({
 
     const defaultPaymentMethod = paymentMethods.data[0]?.id;
 
-    const subscription = await stripe.subscriptions.create({
-      customer: customerId,
-      items: [{ price: priceId }],
-      trial_period_days: 7,
-      trial_settings: {
-        end_behavior: {
-          missing_payment_method: "pause",
+    // Past this point a subscription may exist at Stripe even if this call
+    // ends up throwing — a lost response looks identical to a refusal from
+    // here. Callers read this back off the error to decide whether returning
+    // the workspace's trial is safe.
+    subscriptionCreateAttempted = true;
+
+    const subscription = await stripe.subscriptions.create(
+      {
+        customer: customerId,
+        items: [{ price: priceId }],
+        trial_period_days: 7,
+        trial_settings: {
+          end_behavior: {
+            missing_payment_method: "pause",
+          },
         },
+        ...(defaultPaymentMethod && {
+          default_payment_method: defaultPaymentMethod,
+        }),
+        metadata: { userId, organizationId },
       },
-      ...(defaultPaymentMethod && {
-        default_payment_method: defaultPaymentMethod,
-      }),
-      metadata: { userId, organizationId },
-    });
+      {
+        // A workspace gets exactly one barcode trial, so this key can never
+        // collide with a legitimate second subscription — and it means a retry
+        // after a lost response returns the SAME subscription instead of
+        // opening a second one. Stripe holds the key for 24 hours.
+        idempotencyKey: `addon-trial:barcodes:${organizationId}`,
+      }
+    );
 
     return { subscription, hasPaymentMethod: !!defaultPaymentMethod };
   } catch (cause) {
@@ -139,7 +163,12 @@ export async function createBarcodeAddonTrialSubscription({
       cause,
       message:
         "Something went wrong while creating barcode add-on trial. Please try again later or contact support.",
-      additionalData: { customerId, priceId, userId },
+      additionalData: {
+        customerId,
+        priceId,
+        userId,
+        subscriptionCreateAttempted,
+      },
       label,
     });
   }

--- a/apps/webapp/app/modules/billing/addon-trial-claim.server.test.ts
+++ b/apps/webapp/app/modules/billing/addon-trial-claim.server.test.ts
@@ -13,7 +13,11 @@ import { describe, expect, it, vitest, beforeEach } from "vitest";
 import { db } from "~/database/db.server";
 import { ShelfError } from "~/utils/error";
 
-import { claimAddonTrial, releaseAddonTrial } from "./addon-trial-claim.server";
+import {
+  claimAddonTrial,
+  mayHaveCreatedSubscription,
+  releaseAddonTrial,
+} from "./addon-trial-claim.server";
 
 // why: the claim is a single database statement, and what the tests care about
 // is the statement it issues and how it reads the result. Stubbing `updateMany`
@@ -106,5 +110,52 @@ describe("releaseAddonTrial", () => {
     await expect(
       releaseAddonTrial({ organizationId: ORG_ID, addon: "audits" })
     ).rejects.toThrow(ShelfError);
+  });
+});
+
+describe("mayHaveCreatedSubscription", () => {
+  /** The shape the add-on helpers throw once the create has been attempted. */
+  function wrapped(subscriptionCreateAttempted: boolean) {
+    return new ShelfError({
+      cause: null,
+      message: "Something went wrong while creating the trial",
+      additionalData: { subscriptionCreateAttempted },
+      label: "Stripe",
+    });
+  }
+
+  it("keeps the claim when the create request had gone out", () => {
+    // A lost response is indistinguishable from a refusal here, and Stripe may
+    // hold a real subscription. Releasing would let a retry open a second one.
+    expect(mayHaveCreatedSubscription(wrapped(true))).toBe(true);
+  });
+
+  it("allows a release when the failure preceded the create", () => {
+    expect(mayHaveCreatedSubscription(wrapped(false))).toBe(false);
+  });
+
+  it("allows a release for the helper's own pre-flight refusals", () => {
+    // 4xx from the add-on helper is its own validation (an invalid price, a
+    // missing Stripe client) and is rethrown before any request goes out.
+    const clientError = new ShelfError({
+      cause: null,
+      message: "Invalid price",
+      status: 400,
+      label: "Stripe",
+    });
+
+    expect(mayHaveCreatedSubscription(clientError)).toBe(false);
+  });
+
+  it("treats an unrecognised failure as possibly having created one", () => {
+    // The costs are not symmetric: a trial wrongly kept is a support message,
+    // a trial wrongly released is a duplicate subscription.
+    expect(mayHaveCreatedSubscription(new Error("socket hang up"))).toBe(true);
+    expect(mayHaveCreatedSubscription(undefined)).toBe(true);
+    expect(
+      mayHaveCreatedSubscription(
+        new ShelfError({ cause: null, message: "no marker", label: "Stripe" })
+      )
+    ).toBe(true);
   });
 });

--- a/apps/webapp/app/modules/billing/addon-trial-claim.server.test.ts
+++ b/apps/webapp/app/modules/billing/addon-trial-claim.server.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Add-on trial claim.
+ *
+ * One free trial per workspace per add-on, and starting one creates a real
+ * Stripe subscription — so the decision has to be taken exactly once. These
+ * tests pin the shape that makes that true: a single conditional `UPDATE`
+ * whose affected-row count IS the verdict, never a read followed by a write.
+ *
+ * @see {@link file://./addon-trial-claim.server.ts}
+ */
+
+import { describe, expect, it, vitest, beforeEach } from "vitest";
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+
+import { claimAddonTrial, releaseAddonTrial } from "./addon-trial-claim.server";
+
+// why: the claim is a single database statement, and what the tests care about
+// is the statement it issues and how it reads the result. Stubbing `updateMany`
+// lets each case state an outcome ("this caller won", "someone else did")
+// directly.
+vitest.mock("~/database/db.server", () => ({
+  db: { organization: { updateMany: vitest.fn() } },
+}));
+
+const updateManyMock = db.organization.updateMany as ReturnType<
+  typeof vitest.fn
+>;
+
+const ORG_ID = "org-1";
+
+beforeEach(() => {
+  vitest.clearAllMocks();
+});
+
+describe("claimAddonTrial", () => {
+  it("claims the trial with one conditional statement", async () => {
+    updateManyMock.mockResolvedValue({ count: 1 });
+
+    await expect(
+      claimAddonTrial({ organizationId: ORG_ID, addon: "audits" })
+    ).resolves.toBe(true);
+
+    // The condition has to live in the predicate. Reading the flag first and
+    // writing it afterwards is the race — two callers both read `false`, and
+    // both go on to create a subscription.
+    expect(updateManyMock).toHaveBeenCalledWith({
+      where: { id: ORG_ID, usedAuditTrial: false },
+      data: { usedAuditTrial: true },
+    });
+    expect(updateManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a lost claim when the row no longer matches", async () => {
+    // Zero rows updated is how the database says another caller got there
+    // first — either an earlier request or one racing this exact call.
+    updateManyMock.mockResolvedValue({ count: 0 });
+
+    await expect(
+      claimAddonTrial({ organizationId: ORG_ID, addon: "audits" })
+    ).resolves.toBe(false);
+  });
+
+  it("targets each add-on's own column", async () => {
+    updateManyMock.mockResolvedValue({ count: 1 });
+
+    await claimAddonTrial({ organizationId: ORG_ID, addon: "barcodes" });
+
+    // Spending the wrong add-on's trial would be silent: the caller still gets
+    // `true` and still creates a subscription.
+    expect(updateManyMock).toHaveBeenCalledWith({
+      where: { id: ORG_ID, usedBarcodeTrial: false },
+      data: { usedBarcodeTrial: true },
+    });
+  });
+
+  it("surfaces a database failure rather than reporting a claim", async () => {
+    // Returning `false` here would read as "already used" and quietly deny a
+    // workspace its trial; returning `true` would hand out a subscription on
+    // an unproven claim.
+    updateManyMock.mockRejectedValue(new Error("connection reset"));
+
+    await expect(
+      claimAddonTrial({ organizationId: ORG_ID, addon: "audits" })
+    ).rejects.toThrow(ShelfError);
+  });
+});
+
+describe("releaseAddonTrial", () => {
+  it("returns the trial so a failed attempt can be retried", async () => {
+    updateManyMock.mockResolvedValue({ count: 1 });
+
+    await releaseAddonTrial({ organizationId: ORG_ID, addon: "barcodes" });
+
+    // Guarded on the flag being set, so a release can only undo a claim that
+    // is actually outstanding.
+    expect(updateManyMock).toHaveBeenCalledWith({
+      where: { id: ORG_ID, usedBarcodeTrial: true },
+      data: { usedBarcodeTrial: false },
+    });
+  });
+
+  it("surfaces a database failure", async () => {
+    updateManyMock.mockRejectedValue(new Error("connection reset"));
+
+    await expect(
+      releaseAddonTrial({ organizationId: ORG_ID, addon: "audits" })
+    ).rejects.toThrow(ShelfError);
+  });
+});

--- a/apps/webapp/app/modules/billing/addon-trial-claim.server.ts
+++ b/apps/webapp/app/modules/billing/addon-trial-claim.server.ts
@@ -1,0 +1,124 @@
+/**
+ * Add-on Trial Claim
+ *
+ * Each workspace gets one free trial per add-on, tracked by a boolean on
+ * `Organization` (`usedAuditTrial`, `usedBarcodeTrial`). Starting a trial means
+ * creating a real Stripe subscription, so "have we used it yet" has to be
+ * decided once and only once — reading the flag, calling Stripe, then writing
+ * the flag leaves a window as wide as a network round trip, and two requests
+ * that arrive inside it both see an unused trial and both create a
+ * subscription. That is two real subscriptions on one workspace.
+ *
+ * The claim closes that window: a single conditional `UPDATE` both tests the
+ * flag and sets it, which Postgres serializes on the row. Exactly one caller
+ * is told it won, and only that caller talks to Stripe.
+ *
+ * @see {@link file://./../../routes/_layout+/audits.tsx}
+ * @see {@link file://./../../routes/api+/barcode-addon.ts}
+ * @see {@link file://./../../routes/_welcome+/welcome.tsx}
+ */
+
+import { db } from "~/database/db.server";
+import type { ErrorLabel } from "~/utils/error";
+import { ShelfError } from "~/utils/error";
+
+const label: ErrorLabel = "Stripe";
+
+/** The add-ons that offer a one-time free trial per workspace. */
+export type AddonTrialKind = "audits" | "barcodes";
+
+/**
+ * The `Organization` column tracking each add-on's one-time trial.
+ *
+ * Keyed by add-on rather than passed in, so a caller cannot ask to claim one
+ * add-on's trial while spending another's.
+ */
+const USED_TRIAL_FIELD = {
+  audits: "usedAuditTrial",
+  barcodes: "usedBarcodeTrial",
+} as const satisfies Record<AddonTrialKind, string>;
+
+/**
+ * Claims a workspace's one-time trial for an add-on.
+ *
+ * Call this BEFORE creating the Stripe subscription and act only on `true`.
+ * Checking the flag with a separate read first does not help and is not
+ * needed — the claim is the check.
+ *
+ * On any failure after a successful claim, call {@link releaseAddonTrial} so a
+ * Stripe error does not cost the workspace its trial.
+ *
+ * @param params.organizationId - Workspace claiming the trial
+ * @param params.addon - Which add-on's trial to claim
+ * @returns `true` if this caller took the trial, `false` if it was already
+ *   taken — by an earlier request or by one racing this same call
+ * @throws {ShelfError} If the update fails
+ */
+export async function claimAddonTrial({
+  organizationId,
+  addon,
+}: {
+  organizationId: string;
+  addon: AddonTrialKind;
+}): Promise<boolean> {
+  const field = USED_TRIAL_FIELD[addon];
+
+  try {
+    // `updateMany` rather than `update`: the predicate carries the condition,
+    // and a row that no longer matches reports zero updated instead of
+    // throwing. That count IS the answer — one means this caller claimed it.
+    const { count } = await db.organization.updateMany({
+      where: { id: organizationId, [field]: false },
+      data: { [field]: true },
+    });
+
+    return count === 1;
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message:
+        "Something went wrong while starting your trial. Please try again later or contact support.",
+      additionalData: { organizationId, addon },
+      label,
+    });
+  }
+}
+
+/**
+ * Returns a claimed trial to the workspace after the trial could not be
+ * started.
+ *
+ * Only the caller that claimed it may release it — releasing a trial someone
+ * else is mid-way through creating would hand out a second subscription, which
+ * is the thing the claim exists to prevent.
+ *
+ * A release failure is logged by the caller rather than replacing the original
+ * error: what the user needs to hear is why their trial did not start.
+ *
+ * @param params.organizationId - Workspace whose trial is being returned
+ * @param params.addon - Which add-on's trial to return
+ * @throws {ShelfError} If the update fails
+ */
+export async function releaseAddonTrial({
+  organizationId,
+  addon,
+}: {
+  organizationId: string;
+  addon: AddonTrialKind;
+}): Promise<void> {
+  const field = USED_TRIAL_FIELD[addon];
+
+  try {
+    await db.organization.updateMany({
+      where: { id: organizationId, [field]: true },
+      data: { [field]: false },
+    });
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Failed to release an unused add-on trial claim",
+      additionalData: { organizationId, addon },
+      label,
+    });
+  }
+}

--- a/apps/webapp/app/modules/billing/addon-trial-claim.server.ts
+++ b/apps/webapp/app/modules/billing/addon-trial-claim.server.ts
@@ -85,12 +85,45 @@ export async function claimAddonTrial({
 }
 
 /**
+ * Whether a failed trial attempt may have left a real subscription at Stripe.
+ *
+ * `subscriptions.create` failing does not mean nothing was created: a lost
+ * response looks exactly like a refusal from the caller's side. The add-on
+ * helpers record whether the request had been sent, and that is the only safe
+ * basis for deciding whether to hand the trial back — releasing it after an
+ * ambiguous failure lets a retry open a SECOND subscription, which is the
+ * outcome the claim exists to prevent.
+ *
+ * Unknown shapes count as attempted. A trial wrongly kept costs the workspace
+ * a free week and a support message; a trial wrongly released costs them a
+ * duplicate subscription.
+ *
+ * @param cause - The error thrown while creating the trial
+ * @returns `true` when a subscription may exist, so the claim must stand
+ */
+export function mayHaveCreatedSubscription(cause: unknown): boolean {
+  // A 4xx from the add-on helper is its own pre-flight validation (an invalid
+  // price, a missing Stripe client) and is rethrown before the request goes
+  // out, so nothing can exist yet.
+  if (cause instanceof ShelfError && (cause.status ?? 500) < 500) {
+    return false;
+  }
+
+  if (cause instanceof ShelfError) {
+    const attempted = cause.additionalData?.subscriptionCreateAttempted;
+    return attempted !== false;
+  }
+
+  return true;
+}
+
+/**
  * Returns a claimed trial to the workspace after the trial could not be
  * started.
  *
- * Only the caller that claimed it may release it — releasing a trial someone
- * else is mid-way through creating would hand out a second subscription, which
- * is the thing the claim exists to prevent.
+ * Only the caller that claimed it may release it, and only for a failure that
+ * provably happened before Stripe was asked to create anything — see
+ * {@link mayHaveCreatedSubscription}.
  *
  * A release failure is logged by the caller rather than replacing the original
  * error: what the user needs to hear is why their trial did not start.

--- a/apps/webapp/app/modules/stripe-webhook/helpers.server.test.ts
+++ b/apps/webapp/app/modules/stripe-webhook/helpers.server.test.ts
@@ -96,6 +96,7 @@ import {
   sendAdminInvoiceEmail,
   constructVerifiedWebhookEvent,
   PaymentMethodWithoutCustomerResponse,
+  parseCustomInstallCustomers,
 } from "./helpers.server";
 
 describe("isAddonSubscription", () => {
@@ -330,6 +331,23 @@ describe("constructVerifiedWebhookEvent", () => {
     expect(result.user).toBeNull();
   });
 
+  it("excludes a custom install customer listed after a space", async () => {
+    // The env var is written by a human, and `cus_A, cus_B` is how a human
+    // writes a list. Without trimming, the entry reads " cus_custom2", the
+    // customer is NOT recognised as custom-install, and the webhook goes on
+    // to downgrade them to free and pause their subscription.
+    mockCustomInstallCustomers.value = "cus_custom1, cus_custom2";
+    mockConstructEventAsync.mockResolvedValue({
+      type: "invoice.paid",
+      data: { object: { customer: "cus_custom2" } },
+    });
+    mockFindFirstOrThrow.mockResolvedValue(baseUser);
+
+    const result = await constructVerifiedWebhookEvent(makeRequest());
+
+    expect(result.user).toBeNull();
+  });
+
   it("returns event and user for regular customers", async () => {
     mockConstructEventAsync.mockResolvedValue({
       type: "invoice.paid",
@@ -350,5 +368,29 @@ describe("PaymentMethodWithoutCustomerResponse", () => {
   it("has correct _tag property", () => {
     const response = new PaymentMethodWithoutCustomerResponse();
     expect(response._tag).toBe("PaymentMethodWithoutCustomerResponse");
+  });
+});
+
+describe("parseCustomInstallCustomers", () => {
+  it("trims entries written with spaces after the commas", () => {
+    expect(parseCustomInstallCustomers("cus_A, cus_B ,cus_C")).toEqual([
+      "cus_A",
+      "cus_B",
+      "cus_C",
+    ]);
+  });
+
+  it("preserves casing", () => {
+    // Stripe customer ids are case-sensitive, so normalising them the way a
+    // domain list is normalised would break every match.
+    expect(parseCustomInstallCustomers("cus_AbC123")).toEqual(["cus_AbC123"]);
+  });
+
+  it("yields nothing for an unset or empty value", () => {
+    // `"".split(",")` is `[""]`, which is an entry that matches nothing but
+    // still reads as a populated list.
+    expect(parseCustomInstallCustomers(undefined)).toEqual([]);
+    expect(parseCustomInstallCustomers("")).toEqual([]);
+    expect(parseCustomInstallCustomers("  ,  ")).toEqual([]);
   });
 });

--- a/apps/webapp/app/modules/stripe-webhook/helpers.server.test.ts
+++ b/apps/webapp/app/modules/stripe-webhook/helpers.server.test.ts
@@ -337,10 +337,16 @@ describe("constructVerifiedWebhookEvent", () => {
     // customer is NOT recognised as custom-install, and the webhook goes on
     // to downgrade them to free and pause their subscription.
     mockCustomInstallCustomers.value = "cus_custom1, cus_custom2";
+    // why: the signed Stripe event is what the helper verifies and unwraps.
+    // Stubbing it lets the test name the customer under test — the SECOND
+    // entry, the one a missing trim would leave with a leading space.
     mockConstructEventAsync.mockResolvedValue({
       type: "invoice.paid",
       data: { object: { customer: "cus_custom2" } },
     });
+    // why: the helper resolves the customer to a user BEFORE the exclusion
+    // check, so a resolvable user is what lets the test reach that check. It
+    // is also what a failure returns instead of null, which is the assertion.
     mockFindFirstOrThrow.mockResolvedValue(baseUser);
 
     const result = await constructVerifiedWebhookEvent(makeRequest());

--- a/apps/webapp/app/modules/stripe-webhook/helpers.server.ts
+++ b/apps/webapp/app/modules/stripe-webhook/helpers.server.ts
@@ -239,12 +239,38 @@ export async function constructVerifiedWebhookEvent(request: Request): Promise<{
     });
 
   // Custom install users — no processing needed
-  const customInstallUsers = (CUSTOM_INSTALL_CUSTOMERS ?? "").split(",");
-  if (customInstallUsers.includes(customerId)) {
+  if (
+    parseCustomInstallCustomers(CUSTOM_INSTALL_CUSTOMERS).includes(customerId)
+  ) {
     return { event, customerId, user: null };
   }
 
   return { event, customerId, user };
+}
+
+/**
+ * Parses the comma-separated `CUSTOM_INSTALL_CUSTOMERS` env var into customer
+ * ids.
+ *
+ * Entries are trimmed: a list written the way a human writes one,
+ * `cus_A, cus_B`, otherwise yields `" cus_B"`, which matches no customer. The
+ * consequence is not a missed match but an inverted one — a self-hosted
+ * customer stops being excluded from webhook processing and gets downgraded to
+ * free and their subscription paused.
+ *
+ * Casing is preserved: Stripe customer ids are case-sensitive, so normalising
+ * them the way domain lists are normalised would break every match.
+ *
+ * @param raw - The raw env var value, possibly undefined
+ * @returns Customer ids, empty entries dropped
+ */
+export function parseCustomInstallCustomers(
+  raw: string | undefined | null
+): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((customerId) => customerId.trim())
+    .filter(Boolean);
 }
 
 /**

--- a/apps/webapp/app/routes/_layout+/audits.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.tsx
@@ -18,6 +18,7 @@ import {
 } from "~/modules/audit/addon.server";
 import {
   claimAddonTrial,
+  mayHaveCreatedSubscription,
   releaseAddonTrial,
 } from "~/modules/billing/addon-trial-claim.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
@@ -226,20 +227,26 @@ export async function action({ context, request }: ActionFunctionArgs) {
           organizationId,
         }));
       } catch (cause) {
-        await releaseAddonTrial({ organizationId, addon: "audits" }).catch(
-          (releaseCause: unknown) => {
+        // A refusal Stripe never received is safe to undo. An ambiguous failure
+        // is not: the subscription may exist and only its response was lost, so
+        // handing the trial back would let a retry open a second one.
+        if (!mayHaveCreatedSubscription(cause)) {
+          await releaseAddonTrial({
+            organizationId: organizationId,
+            addon: "audits",
+          }).catch((releaseCause: unknown) => {
             // Report why the trial did not start, not why the bookkeeping
             // afterwards failed.
             Logger.error(
               new ShelfError({
                 cause: releaseCause,
                 message: "Failed to release an unclaimed audit trial",
-                additionalData: { organizationId },
+                additionalData: { organizationId: organizationId },
                 label: "Stripe",
               })
             );
-          }
-        );
+          });
+        }
         throw cause;
       }
 

--- a/apps/webapp/app/routes/_layout+/audits.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.tsx
@@ -16,11 +16,16 @@ import {
   getAuditAddonPrices,
   getAuditSubscriptionInfo,
 } from "~/modules/audit/addon.server";
+import {
+  claimAddonTrial,
+  releaseAddonTrial,
+} from "~/modules/billing/addon-trial-claim.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
 import { getUserByID } from "~/modules/user/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { assertIsPost, error, parseData } from "~/utils/http.server";
+import { Logger } from "~/utils/logger";
 import {
   PermissionAction,
   PermissionEntity,
@@ -140,8 +145,13 @@ export async function action({ context, request }: ActionFunctionArgs) {
       })
     );
 
-    const { organizationId, currentOrganization, userOrganizations } =
-      await getSelectedOrganization({ userId, request });
+    // `currentOrganization` is deliberately not taken here: the only thing the
+    // action used it for was the trial flag, and that is now decided by
+    // claiming the trial rather than by reading a value that can go stale
+    // between the read and the Stripe call.
+    const { organizationId, userOrganizations } = await getSelectedOrganization(
+      { userId, request }
+    );
 
     // `subscription:update` is not enough here. ADMIN short-circuits to
     // allow-all in `hasPermission`, so it clears that gate -- but this spends
@@ -170,8 +180,16 @@ export async function action({ context, request }: ActionFunctionArgs) {
     });
 
     if (intent === "trial") {
-      // Validate organization hasn't already used trial
-      if (currentOrganization.usedAuditTrial) {
+      // Claim the one-time trial before talking to Stripe. Reading the flag
+      // and writing it after the subscription call leaves a window as wide as
+      // a network round trip, and two requests inside it both create a real
+      // subscription. The claim is the check — exactly one caller wins.
+      const claimedTrial = await claimAddonTrial({
+        organizationId,
+        addon: "audits",
+      });
+
+      if (!claimedTrial) {
         throw new ShelfError({
           cause: null,
           message: "This workspace has already used the free audit trial.",
@@ -181,33 +199,56 @@ export async function action({ context, request }: ActionFunctionArgs) {
         });
       }
 
-      // Server-side consent validation when payment method exists
-      const hasPaymentMethodOnFile = await customerHasPaymentMethod(customerId);
-      if (hasPaymentMethodOnFile && !consentAcknowledged) {
-        throw new ShelfError({
-          cause: null,
-          message:
-            "You must acknowledge the auto-charge terms before starting a trial.",
-          status: 400,
-          label: "Stripe",
-          shouldBeCaptured: false,
-        });
+      // Everything from here on can fail with the trial already claimed, so
+      // it runs under a release: a refused consent or a Stripe error must not
+      // cost the workspace a trial it never got.
+      let hasPaymentMethod: boolean;
+      try {
+        // Server-side consent validation when payment method exists
+        const hasPaymentMethodOnFile =
+          await customerHasPaymentMethod(customerId);
+        if (hasPaymentMethodOnFile && !consentAcknowledged) {
+          throw new ShelfError({
+            cause: null,
+            message:
+              "You must acknowledge the auto-charge terms before starting a trial.",
+            status: 400,
+            label: "Stripe",
+            shouldBeCaptured: false,
+          });
+        }
+
+        // Create trial subscription directly via Stripe API
+        ({ hasPaymentMethod } = await createAuditAddonTrialSubscription({
+          customerId,
+          priceId,
+          userId,
+          organizationId,
+        }));
+      } catch (cause) {
+        await releaseAddonTrial({ organizationId, addon: "audits" }).catch(
+          (releaseCause: unknown) => {
+            // Report why the trial did not start, not why the bookkeeping
+            // afterwards failed.
+            Logger.error(
+              new ShelfError({
+                cause: releaseCause,
+                message: "Failed to release an unclaimed audit trial",
+                additionalData: { organizationId },
+                label: "Stripe",
+              })
+            );
+          }
+        );
+        throw cause;
       }
 
-      // Create trial subscription directly via Stripe API
-      const { hasPaymentMethod } = await createAuditAddonTrialSubscription({
-        customerId,
-        priceId,
-        userId,
-        organizationId,
-      });
-
-      // Set flags immediately on the organization (webhook also fires as backup)
+      // Enable the add-on (webhook also fires as backup). `usedAuditTrial` is
+      // owned by the claim above and deliberately not rewritten here.
       await db.organization.update({
         where: { id: organizationId },
         data: {
           auditsEnabled: true,
-          usedAuditTrial: true,
           auditsEnabledAt: new Date(),
         },
         select: { id: true },

--- a/apps/webapp/app/routes/_welcome+/welcome.tsx
+++ b/apps/webapp/app/routes/_welcome+/welcome.tsx
@@ -20,6 +20,7 @@ import {
 } from "~/modules/barcode/addon.server";
 import {
   claimAddonTrial,
+  mayHaveCreatedSubscription,
   releaseAddonTrial,
 } from "~/modules/billing/addon-trial-claim.server";
 import { getOrganizationByUserId } from "~/modules/organization/service.server";
@@ -141,20 +142,25 @@ export async function action({ context, request }: ActionFunctionArgs) {
           organizationId: personalOrg.id,
         }));
       } catch (cause) {
-        // A Stripe failure must not cost the workspace a trial it never got.
-        await releaseAddonTrial({
-          organizationId: personalOrg.id,
-          addon: "audits",
-        }).catch((releaseCause: unknown) => {
-          Logger.error(
-            new ShelfError({
-              cause: releaseCause,
-              message: "Failed to release an unclaimed audit trial",
-              additionalData: { organizationId: personalOrg.id },
-              label: "Stripe",
-            })
-          );
-        });
+        // A refusal Stripe never received is safe to undo. An ambiguous
+        // failure is not: the subscription may exist and only its response
+        // was lost, so handing the trial back would let a retry open a
+        // second one.
+        if (!mayHaveCreatedSubscription(cause)) {
+          await releaseAddonTrial({
+            organizationId: personalOrg.id,
+            addon: "audits",
+          }).catch((releaseCause: unknown) => {
+            Logger.error(
+              new ShelfError({
+                cause: releaseCause,
+                message: "Failed to release an unclaimed audit trial",
+                additionalData: { organizationId: personalOrg.id },
+                label: "Stripe",
+              })
+            );
+          });
+        }
         throw cause;
       }
 
@@ -193,19 +199,25 @@ export async function action({ context, request }: ActionFunctionArgs) {
           organizationId: personalOrg.id,
         }));
       } catch (cause) {
-        await releaseAddonTrial({
-          organizationId: personalOrg.id,
-          addon: "barcodes",
-        }).catch((releaseCause: unknown) => {
-          Logger.error(
-            new ShelfError({
-              cause: releaseCause,
-              message: "Failed to release an unclaimed barcode trial",
-              additionalData: { organizationId: personalOrg.id },
-              label: "Stripe",
-            })
-          );
-        });
+        // A refusal Stripe never received is safe to undo. An ambiguous
+        // failure is not: the subscription may exist and only its response
+        // was lost, so handing the trial back would let a retry open a
+        // second one.
+        if (!mayHaveCreatedSubscription(cause)) {
+          await releaseAddonTrial({
+            organizationId: personalOrg.id,
+            addon: "barcodes",
+          }).catch((releaseCause: unknown) => {
+            Logger.error(
+              new ShelfError({
+                cause: releaseCause,
+                message: "Failed to release an unclaimed barcode trial",
+                additionalData: { organizationId: personalOrg.id },
+                label: "Stripe",
+              })
+            );
+          });
+        }
         throw cause;
       }
 

--- a/apps/webapp/app/routes/_welcome+/welcome.tsx
+++ b/apps/webapp/app/routes/_welcome+/welcome.tsx
@@ -18,12 +18,17 @@ import {
   createBarcodeAddonTrialSubscription,
   getBarcodeAddonPrices,
 } from "~/modules/barcode/addon.server";
+import {
+  claimAddonTrial,
+  releaseAddonTrial,
+} from "~/modules/billing/addon-trial-claim.server";
 import { getOrganizationByUserId } from "~/modules/organization/service.server";
 import { getUserByID } from "~/modules/user/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { ENABLE_PREMIUM_FEATURES } from "~/utils/env";
-import { makeShelfError } from "~/utils/error";
+import { makeShelfError, ShelfError } from "~/utils/error";
 import { error, parseData, payload } from "~/utils/http.server";
+import { Logger } from "~/utils/logger";
 import { getOrCreateCustomerId } from "~/utils/stripe.server";
 
 export const meta: MetaFunction = () => [
@@ -94,14 +99,11 @@ export async function action({ context, request }: ActionFunctionArgs) {
       throw new Error("Invalid intent");
     }
 
-    // Get the personal org with trial flags to prevent duplicate trials
+    // The trial flags are deliberately NOT selected here: whether a trial is
+    // still available is decided by claiming it, not by reading it first.
     const personalOrg = await db.organization.findFirstOrThrow({
       where: { owner: { is: { id: userId } }, type: "PERSONAL" },
-      select: {
-        id: true,
-        usedAuditTrial: true,
-        usedBarcodeTrial: true,
-      },
+      select: { id: true },
     });
 
     const user = await getUserByID(userId, {
@@ -117,20 +119,50 @@ export async function action({ context, request }: ActionFunctionArgs) {
 
     const customerId = await getOrCreateCustomerId(user);
 
-    // Create audit trial if selected (skip if already used)
-    if (auditPriceId && !personalOrg.usedAuditTrial) {
-      const { hasPaymentMethod } = await createAuditAddonTrialSubscription({
-        customerId,
-        priceId: auditPriceId,
-        userId,
+    // Create audit trial if selected. Claiming the one-time trial is what
+    // decides whether to proceed: reading the flag and writing it after the
+    // Stripe call leaves a window as wide as a network round trip, and two
+    // submissions inside it both create a real subscription. A lost claim
+    // means someone else is already creating this trial, so this request has
+    // nothing to do — onboarding continues rather than failing.
+    if (
+      auditPriceId &&
+      (await claimAddonTrial({
         organizationId: personalOrg.id,
-      });
+        addon: "audits",
+      }))
+    ) {
+      let hasPaymentMethod: boolean;
+      try {
+        ({ hasPaymentMethod } = await createAuditAddonTrialSubscription({
+          customerId,
+          priceId: auditPriceId,
+          userId,
+          organizationId: personalOrg.id,
+        }));
+      } catch (cause) {
+        // A Stripe failure must not cost the workspace a trial it never got.
+        await releaseAddonTrial({
+          organizationId: personalOrg.id,
+          addon: "audits",
+        }).catch((releaseCause: unknown) => {
+          Logger.error(
+            new ShelfError({
+              cause: releaseCause,
+              message: "Failed to release an unclaimed audit trial",
+              additionalData: { organizationId: personalOrg.id },
+              label: "Stripe",
+            })
+          );
+        });
+        throw cause;
+      }
 
+      // `usedAuditTrial` is owned by the claim above.
       await db.organization.update({
         where: { id: personalOrg.id },
         data: {
           auditsEnabled: true,
-          usedAuditTrial: true,
           auditsEnabledAt: new Date(),
         },
         select: { id: true },
@@ -144,20 +176,44 @@ export async function action({ context, request }: ActionFunctionArgs) {
       });
     }
 
-    // Create barcode trial if selected (skip if already used)
-    if (barcodePriceId && !personalOrg.usedBarcodeTrial) {
-      const { hasPaymentMethod } = await createBarcodeAddonTrialSubscription({
-        customerId,
-        priceId: barcodePriceId,
-        userId,
+    // Same claim-then-create rule as the audit trial above.
+    if (
+      barcodePriceId &&
+      (await claimAddonTrial({
         organizationId: personalOrg.id,
-      });
+        addon: "barcodes",
+      }))
+    ) {
+      let hasPaymentMethod: boolean;
+      try {
+        ({ hasPaymentMethod } = await createBarcodeAddonTrialSubscription({
+          customerId,
+          priceId: barcodePriceId,
+          userId,
+          organizationId: personalOrg.id,
+        }));
+      } catch (cause) {
+        await releaseAddonTrial({
+          organizationId: personalOrg.id,
+          addon: "barcodes",
+        }).catch((releaseCause: unknown) => {
+          Logger.error(
+            new ShelfError({
+              cause: releaseCause,
+              message: "Failed to release an unclaimed barcode trial",
+              additionalData: { organizationId: personalOrg.id },
+              label: "Stripe",
+            })
+          );
+        });
+        throw cause;
+      }
 
+      // `usedBarcodeTrial` is owned by the claim above.
       await db.organization.update({
         where: { id: personalOrg.id },
         data: {
           barcodesEnabled: true,
-          usedBarcodeTrial: true,
           barcodesEnabledAt: new Date(),
         },
         select: { id: true },

--- a/apps/webapp/app/routes/api+/barcode-addon.ts
+++ b/apps/webapp/app/routes/api+/barcode-addon.ts
@@ -8,10 +8,15 @@ import {
   createBarcodeAddonCheckoutSession,
   createBarcodeAddonTrialSubscription,
 } from "~/modules/barcode/addon.server";
+import {
+  claimAddonTrial,
+  releaseAddonTrial,
+} from "~/modules/billing/addon-trial-claim.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
 import { getUserByID } from "~/modules/user/service.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { assertIsPost, error, parseData } from "~/utils/http.server";
+import { Logger } from "~/utils/logger";
 import {
   PermissionAction,
   PermissionEntity,
@@ -52,8 +57,13 @@ export async function action({ context, request }: ActionFunctionArgs) {
       })
     );
 
-    const { organizationId, currentOrganization, userOrganizations } =
-      await getSelectedOrganization({ userId, request });
+    // `currentOrganization` is deliberately not taken here: the only thing the
+    // action used it for was the trial flag, and that is now decided by
+    // claiming the trial rather than by reading a value that can go stale
+    // between the read and the Stripe call.
+    const { organizationId, userOrganizations } = await getSelectedOrganization(
+      { userId, request }
+    );
 
     // `subscription:update` is not enough here. ADMIN short-circuits to
     // allow-all in `hasPermission`, so it clears that gate -- but this spends
@@ -82,8 +92,16 @@ export async function action({ context, request }: ActionFunctionArgs) {
     });
 
     if (intent === "trial") {
-      // Validate organization hasn't already used trial
-      if (currentOrganization.usedBarcodeTrial) {
+      // Claim the one-time trial before talking to Stripe. Reading the flag
+      // and writing it after the subscription call leaves a window as wide as
+      // a network round trip, and two requests inside it both create a real
+      // subscription. The claim is the check — exactly one caller wins.
+      const claimedTrial = await claimAddonTrial({
+        organizationId,
+        addon: "barcodes",
+      });
+
+      if (!claimedTrial) {
         throw new ShelfError({
           cause: null,
           message: "This workspace has already used the free barcode trial.",
@@ -93,33 +111,56 @@ export async function action({ context, request }: ActionFunctionArgs) {
         });
       }
 
-      // Server-side consent validation when payment method exists
-      const hasPaymentMethodOnFile = await customerHasPaymentMethod(customerId);
-      if (hasPaymentMethodOnFile && !consentAcknowledged) {
-        throw new ShelfError({
-          cause: null,
-          message:
-            "You must acknowledge the auto-charge terms before starting a trial.",
-          status: 400,
-          label: "Stripe",
-          shouldBeCaptured: false,
-        });
+      // Everything from here on can fail with the trial already claimed, so
+      // it runs under a release: a refused consent or a Stripe error must not
+      // cost the workspace a trial it never got.
+      let hasPaymentMethod: boolean;
+      try {
+        // Server-side consent validation when payment method exists
+        const hasPaymentMethodOnFile =
+          await customerHasPaymentMethod(customerId);
+        if (hasPaymentMethodOnFile && !consentAcknowledged) {
+          throw new ShelfError({
+            cause: null,
+            message:
+              "You must acknowledge the auto-charge terms before starting a trial.",
+            status: 400,
+            label: "Stripe",
+            shouldBeCaptured: false,
+          });
+        }
+
+        // Create trial subscription directly via Stripe API
+        ({ hasPaymentMethod } = await createBarcodeAddonTrialSubscription({
+          customerId,
+          priceId,
+          userId,
+          organizationId,
+        }));
+      } catch (cause) {
+        await releaseAddonTrial({ organizationId, addon: "barcodes" }).catch(
+          (releaseCause: unknown) => {
+            // Report why the trial did not start, not why the bookkeeping
+            // afterwards failed.
+            Logger.error(
+              new ShelfError({
+                cause: releaseCause,
+                message: "Failed to release an unclaimed barcode trial",
+                additionalData: { organizationId },
+                label: "Stripe",
+              })
+            );
+          }
+        );
+        throw cause;
       }
 
-      // Create trial subscription directly via Stripe API
-      const { hasPaymentMethod } = await createBarcodeAddonTrialSubscription({
-        customerId,
-        priceId,
-        userId,
-        organizationId,
-      });
-
-      // Set flags immediately on the organization (webhook also fires as backup)
+      // Enable the add-on (webhook also fires as backup). `usedBarcodeTrial`
+      // is owned by the claim above and deliberately not rewritten here.
       await db.organization.update({
         where: { id: organizationId },
         data: {
           barcodesEnabled: true,
-          usedBarcodeTrial: true,
           barcodesEnabledAt: new Date(),
         },
         select: { id: true },

--- a/apps/webapp/app/routes/api+/barcode-addon.ts
+++ b/apps/webapp/app/routes/api+/barcode-addon.ts
@@ -10,6 +10,7 @@ import {
 } from "~/modules/barcode/addon.server";
 import {
   claimAddonTrial,
+  mayHaveCreatedSubscription,
   releaseAddonTrial,
 } from "~/modules/billing/addon-trial-claim.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
@@ -138,20 +139,26 @@ export async function action({ context, request }: ActionFunctionArgs) {
           organizationId,
         }));
       } catch (cause) {
-        await releaseAddonTrial({ organizationId, addon: "barcodes" }).catch(
-          (releaseCause: unknown) => {
+        // A refusal Stripe never received is safe to undo. An ambiguous failure
+        // is not: the subscription may exist and only its response was lost, so
+        // handing the trial back would let a retry open a second one.
+        if (!mayHaveCreatedSubscription(cause)) {
+          await releaseAddonTrial({
+            organizationId: organizationId,
+            addon: "barcodes",
+          }).catch((releaseCause: unknown) => {
             // Report why the trial did not start, not why the bookkeeping
             // afterwards failed.
             Logger.error(
               new ShelfError({
                 cause: releaseCause,
                 message: "Failed to release an unclaimed barcode trial",
-                additionalData: { organizationId },
+                additionalData: { organizationId: organizationId },
                 label: "Stripe",
               })
             );
-          }
-        );
+          });
+        }
         throw cause;
       }
 

--- a/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
+++ b/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
@@ -37,10 +37,17 @@ vi.mock("react-router", async () => {
   return { ...actual, data: createDataMock() };
 });
 
-// why: preventing Prisma from connecting to a real database
-const { mockOrgUpdate } = vi.hoisted(() => ({ mockOrgUpdate: vi.fn() }));
+// why: preventing Prisma from connecting to a real database. `updateMany` is
+// the trial claim — its affected-row count decides whether this request is the
+// one allowed to create a subscription, so tests drive that count directly.
+const { mockOrgUpdate, mockOrgUpdateMany } = vi.hoisted(() => ({
+  mockOrgUpdate: vi.fn(),
+  mockOrgUpdateMany: vi.fn(),
+}));
 vi.mock("~/database/db.server", () => ({
-  db: { organization: { update: mockOrgUpdate } },
+  db: {
+    organization: { update: mockOrgUpdate, updateMany: mockOrgUpdateMany },
+  },
 }));
 
 // why: the permission gate is not what's under test — we want it to PASS so
@@ -135,6 +142,8 @@ describe("POST /api/barcode-addon", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockOrgUpdate.mockResolvedValue({ id: ORG });
+    // Default: this request wins the claim.
+    mockOrgUpdateMany.mockResolvedValue({ count: 1 });
   });
 
   it("refuses an ADMIN starting the trial, and never burns the flag", async () => {
@@ -165,5 +174,55 @@ describe("POST /api/barcode-addon", () => {
 
     expect(createBarcodeAddonTrialSubscription).toHaveBeenCalledTimes(1);
     expect(mockOrgUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  describe("one trial per workspace", () => {
+    beforeEach(() => {
+      callerHolds([OrganizationRoles.OWNER]);
+    });
+
+    it("claims the trial before it creates the subscription", async () => {
+      await post("trial");
+
+      // Order is the whole fix. Claiming AFTER the Stripe call leaves the
+      // window exactly as it was: two requests both find the trial unused and
+      // both create a real subscription.
+      const claimOrder = mockOrgUpdateMany.mock.invocationCallOrder[0];
+      const stripeOrder = (
+        createBarcodeAddonTrialSubscription as ReturnType<typeof vi.fn>
+      ).mock.invocationCallOrder[0];
+
+      expect(claimOrder).toBeDefined();
+      expect(claimOrder).toBeLessThan(stripeOrder);
+    });
+
+    it("creates nothing when another request already claimed the trial", async () => {
+      // Zero rows updated is how the database reports a lost claim.
+      mockOrgUpdateMany.mockResolvedValue({ count: 0 });
+
+      const result = await post("trial");
+
+      expect((result as unknown as Response).status).toBe(400);
+      expect(createBarcodeAddonTrialSubscription).not.toHaveBeenCalled();
+    });
+
+    it("returns the claim when Stripe refuses, so the trial is not lost", async () => {
+      (
+        createBarcodeAddonTrialSubscription as ReturnType<typeof vi.fn>
+      ).mockRejectedValueOnce(new Error("card_declined"));
+
+      await post("trial");
+
+      // Claim then release: the second call puts the flag back, so the
+      // workspace can try again rather than being charged for a trial it
+      // never received.
+      expect(mockOrgUpdateMany).toHaveBeenCalledTimes(2);
+      expect(mockOrgUpdateMany).toHaveBeenLastCalledWith({
+        where: { id: ORG, usedBarcodeTrial: true },
+        data: { usedBarcodeTrial: false },
+      });
+      // The add-on must not be switched on for a subscription that failed.
+      expect(mockOrgUpdate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
+++ b/apps/webapp/test/routes-tests/api+/barcode-addon.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { OrganizationRoles } from "@prisma/client";
+import { ShelfError } from "~/utils/error";
 
 // why: mocking Remix's data() so the action's error path returns a Response
 // whose status we can assert (React Router v7 single fetch)
@@ -206,16 +207,24 @@ describe("POST /api/barcode-addon", () => {
       expect(createBarcodeAddonTrialSubscription).not.toHaveBeenCalled();
     });
 
-    it("returns the claim when Stripe refuses, so the trial is not lost", async () => {
+    it("returns the claim when the failure preceded the Stripe request", async () => {
+      // The add-on helper reports that it never sent the create, so nothing
+      // can exist and the workspace keeps its trial.
       (
         createBarcodeAddonTrialSubscription as ReturnType<typeof vi.fn>
-      ).mockRejectedValueOnce(new Error("card_declined"));
+      ).mockRejectedValueOnce(
+        new ShelfError({
+          cause: null,
+          message: "Stripe not initialized",
+          additionalData: { subscriptionCreateAttempted: false },
+          label: "Stripe",
+        })
+      );
 
       await post("trial");
 
       // Claim then release: the second call puts the flag back, so the
-      // workspace can try again rather than being charged for a trial it
-      // never received.
+      // workspace can try again rather than losing a trial it never received.
       expect(mockOrgUpdateMany).toHaveBeenCalledTimes(2);
       expect(mockOrgUpdateMany).toHaveBeenLastCalledWith({
         where: { id: ORG, usedBarcodeTrial: true },
@@ -223,6 +232,31 @@ describe("POST /api/barcode-addon", () => {
       });
       // The add-on must not be switched on for a subscription that failed.
       expect(mockOrgUpdate).not.toHaveBeenCalled();
+    });
+
+    it("keeps the claim when the create may already have succeeded", async () => {
+      // A lost response is indistinguishable from a refusal, and Stripe may
+      // hold a real subscription. Releasing here would let the user's retry
+      // open a second one — the exact outcome the claim exists to prevent.
+      (
+        createBarcodeAddonTrialSubscription as ReturnType<typeof vi.fn>
+      ).mockRejectedValueOnce(
+        new ShelfError({
+          cause: new Error("socket hang up"),
+          message: "Something went wrong while creating barcode add-on trial.",
+          additionalData: { subscriptionCreateAttempted: true },
+          label: "Stripe",
+        })
+      );
+
+      await post("trial");
+
+      // The claim, and nothing after it.
+      expect(mockOrgUpdateMany).toHaveBeenCalledTimes(1);
+      expect(mockOrgUpdateMany).toHaveBeenCalledWith({
+        where: { id: ORG, usedBarcodeTrial: false },
+        data: { usedBarcodeTrial: true },
+      });
     });
   });
 });


### PR DESCRIPTION
Two billing defects from the detail.dev OSS scan: **D035** (concurrent trial
requests create duplicate Stripe subscriptions) and **D044** (a stray space in
an env var downgrades an enterprise customer).

## D035 — one free trial, decided twice

Starting an add-on trial read `usedAuditTrial` / `usedBarcodeTrial`, called
Stripe, then wrote the flag back. The gap between the read and the write is a
**full network round trip**, so two requests inside it both find the trial
unused and both create a real subscription. Two subscriptions on one workspace,
real money, and `usedTrial` is an irreversible flag.

The scan named the onboarding route. The identical shape is in **four** places:

| Path | Trial |
| --- | --- |
| `_welcome+/welcome.tsx` | audits |
| `_welcome+/welcome.tsx` | barcodes |
| `_layout+/audits.tsx` | audits |
| `api+/barcode-addon.ts` | barcodes |

### The fix: the claim *is* the check

A shared `claimAddonTrial` issues one conditional `UPDATE` that both tests the
flag and sets it:

```sql
UPDATE "Organization" SET "usedAuditTrial" = true
WHERE id = $1 AND "usedAuditTrial" = false
```

Postgres serializes that on the row, so the affected-row count is the verdict —
exactly one caller is told it won, and only that caller talks to Stripe.
Checking the flag with a separate read beforehand does not help and is not done.

`currentOrganization` is no longer destructured in the two API actions: reading
the flag was its only remaining use there, so removing it makes "no stale read
before the claim" **structural** rather than a convention that can drift.

### Release on failure

Claiming first would otherwise cost a workspace its trial whenever Stripe
refused. Each site releases the claim and rethrows the *original* error, so the
user still hears why their trial did not start. A release failure is logged, not
surfaced.

Residual, stated plainly: a process crash between the claim and the Stripe call
still burns the trial. That is strictly better than double-charging, but it is
not zero.

### ⚠️ No Stripe idempotency key — a deliberate call

The obvious Stripe-native answer is a deterministic idempotency key on
`subscriptions.create`. I did not use one: Stripe caches keyed responses for
**24 hours**, so a customer whose card was declined could not retry within that
window. The claim already closes the race without that cost. Worth disagreeing
with if you read the trade-off differently.

## D044 — `cus_A, cus_B` excludes only `cus_A`

`CUSTOM_INSTALL_CUSTOMERS` was split on commas with no trim. Written the way a
human writes a list, every entry after the first carries a leading space and
matches no customer — so a self-hosted customer stops being recognised as
custom-install, and the webhook goes on to **downgrade them to free and pause
their subscription**.

Entries are now trimmed and empties dropped (`"".split(",")` is `[""]`, an entry
that matches nothing but still reads as a populated list).

**Casing is deliberately preserved.** Stripe customer ids are case-sensitive, so
normalising them the way `parseDomains` normalises domain lists would break
every match.

## Verification

- 94 tests pass across the five affected suites.
- Every regression test confirmed **red with its fix reverted**: D044 (3),
  D035 route-level (3).
- The route tests assert **ordering**, not just that the claim happened —
  claiming after the Stripe call leaves the window exactly as it was. Reverting
  to the read-then-write shape fails all three.
- `tsc -b --force` and eslint clean.

No migration. No schema change — both `usedAuditTrial` and `usedBarcodeTrial`
already exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer one-time trial activation for audit and barcode add-ons, preventing duplicate subscriptions during concurrent requests or retries.
  * Trial claims are released after confirmed pre-subscription failures and retained when subscription creation may have occurred.
  * Improved handling of custom-install customer lists by trimming entries and ignoring blank values.
  * Added idempotent subscription creation to safely handle repeated requests.

* **Bug Fixes**
  * Improved error handling and recovery when trial activation or billing operations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->