### PR TITLE
fix(bulk-update): count assets, not lines, in the upload check

### DIFF
--- a/apps/webapp/app/components/assets/bulk-update/form.tsx
+++ b/apps/webapp/app/components/assets/bulk-update/form.tsx
@@ -116,7 +116,7 @@ export function UpdateImportForm({
       previewFetcher.reset();
       applyFetcher.reset();
 
-      // Client-side validation: read first few KB to check headers
+      // Client-side validation: read the file to check headers and count rows
       // Use a nonce to ignore stale FileReader results from a previous file
       const nonce = ++activeFileNonce.current;
       const reader = new FileReader();
@@ -126,8 +126,10 @@ export function UpdateImportForm({
         const validation = validateCsvClientSide(text);
         dispatch({ type: "client_validation", validation });
       };
-      // Read enough to get headers + a few rows
-      reader.readAsText(file.slice(0, 50_000));
+      // The whole file, not a prefix: the row count has to see every record,
+      // and a slice can cut a quoted field mid-value. The server reads the
+      // upload into memory in one piece too.
+      reader.readAsText(file);
     },
     [previewFetcher, applyFetcher]
   );

--- a/apps/webapp/app/components/assets/bulk-update/helpers.test.ts
+++ b/apps/webapp/app/components/assets/bulk-update/helpers.test.ts
@@ -80,26 +80,63 @@ describe("splitCsvRecords — quoted fields carrying line breaks", () => {
     '"a2","Mazos","MAZO DE IMPACTO\r\n2 UNDS"\r\n';
 
   it("counts a field's line breaks as part of its record", () => {
-    expect(splitCsvRecords(MULTILINE_CSV)).toHaveLength(3);
+    expect(splitCsvRecords(MULTILINE_CSV).records).toHaveLength(3);
   });
 
   it("keeps the quotes so the record still splits on its delimiters", () => {
-    const [, first] = splitCsvRecords(MULTILINE_CSV);
+    const [, first] = splitCsvRecords(MULTILINE_CSV).records;
     expect(first.startsWith('"a1"')).toBe(true);
   });
 
   it("treats a doubled quote as an escaped quote, not a boundary", () => {
     const csv = '"id","note"\n"a1","he said ""hi""\nthen left"\n';
-    expect(splitCsvRecords(csv)).toHaveLength(2);
+    expect(splitCsvRecords(csv).records).toHaveLength(2);
   });
 
   it("handles LF-only and CRLF line endings alike", () => {
-    expect(splitCsvRecords("a,b\nc,d\n")).toHaveLength(2);
-    expect(splitCsvRecords("a,b\r\nc,d\r\n")).toHaveLength(2);
+    expect(splitCsvRecords("a,b\nc,d\n").records).toHaveLength(2);
+    expect(splitCsvRecords("a,b\r\nc,d\r\n").records).toHaveLength(2);
   });
 
   it("drops blank records", () => {
-    expect(splitCsvRecords("a,b\n\n\nc,d\n")).toHaveLength(2);
+    expect(splitCsvRecords("a,b\n\n\nc,d\n").records).toHaveLength(2);
+  });
+
+  it("reports a well-formed document as balanced", () => {
+    expect(splitCsvRecords(MULTILINE_CSV).unterminatedQuote).toBe(false);
+  });
+
+  it("reports a stray quote that is never closed", () => {
+    // An inches mark typed straight into a cell is the everyday source: the
+    // quote opens a field that never ends, so every later row is absorbed.
+    const csv = 'id,title\n1,24" Monitor\n2,Laptop\n';
+    const { records, unterminatedQuote } = splitCsvRecords(csv);
+
+    expect(unterminatedQuote).toBe(true);
+    expect(records).toHaveLength(2);
+  });
+});
+
+describe("validateCsvClientSide — unbalanced quotes", () => {
+  it("names the stray quote instead of reporting the symptom", () => {
+    // The server rejects this file too ("Invalid Opening Quote"), so blocking
+    // here is not a false stop — it just has to say what is actually wrong,
+    // rather than "no data rows" about a file full of visible rows.
+    const result = validateCsvClientSide('id,tit"le\n1,Laptop\n2,Monitor\n');
+
+    expect(result.valid).toBe(false);
+    expect(result.warnings).toContain(
+      'Unbalanced quote: a " is opened and never closed, so the rows after it run together. Write a literal quote as two ("").'
+    );
+    expect(result.warnings).not.toContain(
+      "No data rows found — only a header row."
+    );
+  });
+
+  it("blocks a stray quote in a data row as well", () => {
+    const result = validateCsvClientSide('id,title\n1,24" Monitor\n2,Laptop\n');
+
+    expect(result.valid).toBe(false);
   });
 });
 

--- a/apps/webapp/app/components/assets/bulk-update/helpers.test.ts
+++ b/apps/webapp/app/components/assets/bulk-update/helpers.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatUnrecognizedColumnLabel,
+  splitCsvRecords,
   validateCsvClientSide,
 } from "./helpers";
 
@@ -65,5 +66,56 @@ describe("formatUnrecognizedColumnLabel (final review fix)", () => {
 
   it("leaves a malformed short 'cf:' header unchanged (guards the non-null assertion)", () => {
     expect(formatUnrecognizedColumnLabel("cf:")).toBe("cf:");
+  });
+});
+
+describe("splitCsvRecords — quoted fields carrying line breaks", () => {
+  /**
+   * A description typed with paragraph breaks, as the Import-ready export
+   * writes it: quoted, CRLF inside the field, CRLF between records.
+   */
+  const MULTILINE_CSV =
+    '"id","title","description"\r\n' +
+    '"a1","Tecles de cadena","Tecles de cadena\r\nMarca EMTOP\r\nSon 2 iguales"\r\n' +
+    '"a2","Mazos","MAZO DE IMPACTO\r\n2 UNDS"\r\n';
+
+  it("counts a field's line breaks as part of its record", () => {
+    expect(splitCsvRecords(MULTILINE_CSV)).toHaveLength(3);
+  });
+
+  it("keeps the quotes so the record still splits on its delimiters", () => {
+    const [, first] = splitCsvRecords(MULTILINE_CSV);
+    expect(first.startsWith('"a1"')).toBe(true);
+  });
+
+  it("treats a doubled quote as an escaped quote, not a boundary", () => {
+    const csv = '"id","note"\n"a1","he said ""hi""\nthen left"\n';
+    expect(splitCsvRecords(csv)).toHaveLength(2);
+  });
+
+  it("handles LF-only and CRLF line endings alike", () => {
+    expect(splitCsvRecords("a,b\nc,d\n")).toHaveLength(2);
+    expect(splitCsvRecords("a,b\r\nc,d\r\n")).toHaveLength(2);
+  });
+
+  it("drops blank records", () => {
+    expect(splitCsvRecords("a,b\n\n\nc,d\n")).toHaveLength(2);
+  });
+});
+
+describe("validateCsvClientSide — row count with multi-line descriptions", () => {
+  it("reports assets, not lines", () => {
+    // Two assets whose descriptions span three and two lines respectively.
+    const csv =
+      '"id","title","description"\r\n' +
+      '"a1","Tecles","Tecles de cadena\r\nMarca EMTOP\r\nSon 2 iguales"\r\n' +
+      '"a2","Mazos","MAZO DE IMPACTO\r\n2 UNDS"\r\n';
+
+    const result = validateCsvClientSide(csv);
+
+    expect(result.rowCount).toBe(2);
+    expect(result.headerCount).toBe(3);
+    expect(result.idColumnFound).toBe("ID");
+    expect(result.valid).toBe(true);
   });
 });

--- a/apps/webapp/app/components/assets/bulk-update/helpers.ts
+++ b/apps/webapp/app/components/assets/bulk-update/helpers.ts
@@ -21,6 +21,17 @@ export const ACCEPTED_ID_COLUMNS = ["Asset ID", "ID"] as const;
 /** Maximum number of asset change rows to display in the preview */
 export const PREVIEW_DISPLAY_LIMIT = 50;
 
+/** What {@link splitCsvRecords} found in a CSV document. */
+export interface CsvRecordSplit {
+  /** One string per record, header first. Blank records are dropped. */
+  records: string[];
+  /**
+   * The text ended inside a quoted field, so a `"` is unbalanced. Records
+   * after the stray quote were absorbed into one, making the row count wrong.
+   */
+  unterminatedQuote: boolean;
+}
+
 export interface ClientValidation {
   valid: boolean;
   /** Which identifier column was found (null if none) */
@@ -37,7 +48,7 @@ export interface ClientValidation {
 export function validateCsvClientSide(text: string): ClientValidation {
   // Strip BOM that Excel adds to UTF-8 CSVs
   const cleanText = text.replace(/^\uFEFF/, "");
-  const records = splitCsvRecords(cleanText);
+  const { records, unterminatedQuote } = splitCsvRecords(cleanText);
   if (records.length === 0) {
     return {
       valid: false,
@@ -69,12 +80,19 @@ export function validateCsvClientSide(text: string): ClientValidation {
     );
   }
 
-  if (rowCount === 0) {
+  if (unterminatedQuote) {
+    // Say what is wrong rather than reporting the symptom. A stray quote
+    // absorbs every following row into one record, so without this the file
+    // looks empty or short — and the real cause is nowhere on screen.
+    warnings.push(
+      'Unbalanced quote: a " is opened and never closed, so the rows after it run together. Write a literal quote as two ("").'
+    );
+  } else if (rowCount === 0) {
     warnings.push("No data rows found — only a header row.");
   }
 
   return {
-    valid: !!idColumnFound && rowCount > 0,
+    valid: !!idColumnFound && rowCount > 0 && !unterminatedQuote,
     idColumnFound,
     headerCount: headerTrimmed.filter(Boolean).length,
     rowCount,
@@ -95,9 +113,9 @@ export function validateCsvClientSide(text: string): ClientValidation {
  * dropped.
  *
  * @param text - Full CSV text, BOM already stripped
- * @returns One string per record, header first
+ * @returns The records (header first) and whether the text ended mid-quote
  */
-export function splitCsvRecords(text: string): string[] {
+export function splitCsvRecords(text: string): CsvRecordSplit {
   const records: string[] = [];
   let current = "";
   let inQuotes = false;
@@ -106,7 +124,13 @@ export function splitCsvRecords(text: string): string[] {
     const char = text[i];
 
     if (char === '"') {
-      // A doubled quote is an escaped quote, not a boundary
+      // A doubled quote is an escaped quote, not a boundary.
+      //
+      // Redundant by construction: two adjacent quotes toggle `inQuotes` twice,
+      // which lands on the state this branch keeps, and no line break can sit
+      // between them — so removing it changes no output. It is kept because it
+      // states the intent, and because a future splitter that reads `inQuotes`
+      // mid-field would need it. Do not read it as load-bearing today.
       if (inQuotes && text[i + 1] === '"') {
         current += '""';
         i++;
@@ -118,7 +142,9 @@ export function splitCsvRecords(text: string): string[] {
     }
 
     if (!inQuotes && (char === "\n" || char === "\r")) {
-      // Consume CRLF as a single break
+      // Consume CRLF as a single break. Also redundant on its own — the blank
+      // check below already drops the empty record a lone `\n` would push —
+      // but it keeps the boundary explicit rather than incidental.
       if (char === "\r" && text[i + 1] === "\n") i++;
       if (current.trim()) records.push(current);
       current = "";
@@ -129,7 +155,11 @@ export function splitCsvRecords(text: string): string[] {
   }
 
   if (current.trim()) records.push(current);
-  return records;
+
+  // Ending inside a quoted field means a `"` was opened and never closed.
+  // Everything after it was absorbed into one record, so the count is wrong and
+  // the file will not parse server-side either.
+  return { records, unterminatedQuote: inQuotes };
 }
 
 /**

--- a/apps/webapp/app/components/assets/bulk-update/helpers.ts
+++ b/apps/webapp/app/components/assets/bulk-update/helpers.ts
@@ -37,8 +37,8 @@ export interface ClientValidation {
 export function validateCsvClientSide(text: string): ClientValidation {
   // Strip BOM that Excel adds to UTF-8 CSVs
   const cleanText = text.replace(/^\uFEFF/, "");
-  const lines = cleanText.split(/\r?\n/).filter((l) => l.trim());
-  if (lines.length === 0) {
+  const records = splitCsvRecords(cleanText);
+  if (records.length === 0) {
     return {
       valid: false,
       idColumnFound: null,
@@ -48,8 +48,8 @@ export function validateCsvClientSide(text: string): ClientValidation {
     };
   }
 
-  // Parse first line as headers (simple CSV split — handles most cases)
-  const headers = parseSimpleCsvLine(lines[0]);
+  // Parse the header record (simple CSV split — handles most cases)
+  const headers = parseSimpleCsvLine(records[0]);
   const headerTrimmed = headers.map((h) => h.trim());
 
   // Find best available identifier column (priority order). Case-insensitive
@@ -60,7 +60,7 @@ export function validateCsvClientSide(text: string): ClientValidation {
       headerTrimmed.some((h) => h.toLowerCase() === col.toLowerCase())
     ) ?? null;
 
-  const rowCount = Math.max(0, lines.length - 1);
+  const rowCount = Math.max(0, records.length - 1);
   const warnings: string[] = [];
 
   if (!idColumnFound) {
@@ -83,13 +83,66 @@ export function validateCsvClientSide(text: string): ClientValidation {
 }
 
 /**
- * Simple CSV line parser for client-side validation.
+ * Splits CSV text into records, honouring quoted fields.
+ *
+ * A quoted field may contain line breaks — a description typed with paragraph
+ * breaks is the common case — and such a field spans several lines of the file
+ * while still being ONE record. Splitting on newlines alone counts each of
+ * those lines as a row, so a file of 174 assets reports hundreds.
+ *
+ * Quotes are preserved in the returned records, because {@link
+ * parseSimpleCsvLine} splits on the delimiters they protect. Blank records are
+ * dropped.
+ *
+ * @param text - Full CSV text, BOM already stripped
+ * @returns One string per record, header first
+ */
+export function splitCsvRecords(text: string): string[] {
+  const records: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (char === '"') {
+      // A doubled quote is an escaped quote, not a boundary
+      if (inQuotes && text[i + 1] === '"') {
+        current += '""';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+        current += char;
+      }
+      continue;
+    }
+
+    if (!inQuotes && (char === "\n" || char === "\r")) {
+      // Consume CRLF as a single break
+      if (char === "\r" && text[i + 1] === "\n") i++;
+      if (current.trim()) records.push(current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.trim()) records.push(current);
+  return records;
+}
+
+/**
+ * Simple CSV parser for one record, for client-side validation.
  * Handles quoted values (via {@link stripQuotes}) and both `,` and `;` delimiters.
  *
+ * Takes a single record, not a slice of the file: record boundaries are
+ * {@link splitCsvRecords}'s job, because a quoted field can carry line breaks.
+ *
  * Note: This is intentionally simplified for quick client-side checks.
- * It does not handle multi-line quoted values, encoding/BOM detection,
- * or leading whitespace trimming. The server uses `csv-parse` with full
- * encoding detection and edge-case handling as the source of truth.
+ * It does not handle encoding/BOM detection or leading whitespace trimming.
+ * The server uses `csv-parse` with full encoding detection and edge-case
+ * handling as the source of truth.
  */
 export function parseSimpleCsvLine(line: string): string[] {
   const result: string[] = [];


### PR DESCRIPTION
## Problem

A quoted CSV field may carry line breaks. That is exactly what an asset description typed with paragraph breaks produces, and the Import-ready export writes it correctly: the field is quoted, so its line breaks are part of the value, not row boundaries.

The mass-update upload screen split the file on newlines with no quote awareness, so every paragraph break counted as another row.

On a real customer export of **174 assets**, the screen reported **562 data rows**.

It also read only the first 50 KB of the file, so on anything larger the count was a prefix count, and the cut could land inside a quoted field.

The server side was never affected. `parseCsv` uses `csv-parse` and reads the same file as 175 records with every column aligned, so the update itself was correct. Only the number in front of the user was wrong.

## Fix

`splitCsvRecords(text)` walks the text tracking quote state, treating a doubled `""` as an escaped quote rather than a boundary, and consuming `CRLF` as one break. A field's own line breaks stay inside its record. Quotes are preserved because `parseSimpleCsvLine` splits on the delimiters they protect.

`validateCsvClientSide` counts records instead of lines, and `form.tsx` reads the whole file rather than a 50 KB prefix — the server already loads the upload into memory in one piece.

## Verification

Against the customer's actual export:

| | before | after |
| --- | --- | --- |
| data rows reported | 562 | **174** |
| columns reported | 23 | 23 |
| actual assets in file | 174 | 174 |

## Tests

Six new cases in `helpers.test.ts`: a field's line breaks counted inside its record, quotes preserved for the delimiter split, a doubled quote not treated as a boundary, LF and CRLF handled alike, blank records dropped, and `validateCsvClientSide` reporting assets rather than lines.

Full webapp suite green: 405 files, 5392 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk CSV validation for quoted fields, escaped quotes, and multiline descriptions.
  * CSV uploads are now read in full, ensuring accurate row counts for large files.
  * LF and CRLF line endings are counted correctly, and blank records are excluded.
  * Files with unbalanced or unterminated quotes are now rejected with a validation warning.

* **Tests**
  * Expanded coverage for multiline fields, escaped quotes, line endings, blank records, and quote validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->