### PR TITLE
fix(assets): show custody again on the overview and location pages

### DIFF
--- a/apps/webapp/app/modules/asset/fields.test.ts
+++ b/apps/webapp/app/modules/asset/fields.test.ts
@@ -72,3 +72,34 @@ describe("getAssetOverviewFields", () => {
     ).toBe(assetId);
   });
 });
+
+describe("getAssetOverviewFields — bookingAssets", () => {
+  const testAssetId = "asset-123";
+
+  it("returns only the booking the asset is currently out on", () => {
+    // The overview shows ONE booking, taken as `bookingAssets[0]`, and the
+    // loader derives nothing further from it. That is only correct because
+    // the query has already narrowed the relation to the live booking —
+    // if this filter ever widens, the page starts showing an arbitrary one.
+    const result = getAssetOverviewFields(testAssetId, true) as {
+      bookingAssets: {
+        where: {
+          booking: {
+            status: { in: string[] };
+            NOT: { partialCheckins: { some: { assetIds: { has: string } } } };
+          };
+        };
+      };
+    };
+
+    expect(result.bookingAssets.where.booking.status.in).toEqual([
+      "ONGOING",
+      "OVERDUE",
+    ]);
+    // A booking this asset has already been checked in from is not the
+    // booking it is currently out on.
+    expect(
+      result.bookingAssets.where.booking.NOT.partialCheckins.some.assetIds.has
+    ).toBe(testAssetId);
+  });
+});

--- a/apps/webapp/app/modules/asset/fields.ts
+++ b/apps/webapp/app/modules/asset/fields.ts
@@ -48,6 +48,8 @@ export const ASSET_LOCATIONS_INCLUDE = {
 
 export const KITS_INCLUDE_FIELDS = {
   _count: { select: { assetKits: true } },
+  // `Kit.custody` is a single optional record, not a list — there is nothing
+  // to order, and nothing here reaches `getPrimaryCustody`.
   custody: {
     select: {
       custodian: {
@@ -78,6 +80,10 @@ export const getAssetOverviewFields = (
     tags: true,
     assetLocations: ASSET_LOCATIONS_INCLUDE,
     custody: {
+      // Ordered so `getPrimaryCustody` picks the same row every time;
+      // without it a multi-custodian asset can show a different holder
+      // on each request.
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       select: {
         createdAt: true,
         quantity: true,
@@ -239,6 +245,10 @@ export const assetIndexFields = ({
     ...ASSET_MODEL_IMAGE_SELECT,
     assetLocations: ASSET_LOCATIONS_INCLUDE,
     custody: {
+      // Ordered so `getPrimaryCustody` picks the same row every time;
+      // without it a multi-custodian asset can show a different holder
+      // on each request.
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       select: {
         quantity: true,
         custodian: {
@@ -380,6 +390,10 @@ export const advancedAssetIndexFields = () => {
       },
     },
     custody: {
+      // Ordered so `getPrimaryCustody` picks the same row every time;
+      // without it a multi-custodian asset can show a different holder
+      // on each request.
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       select: {
         custodian: {
           select: {

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -4496,6 +4496,9 @@ export async function fetchAssetsForExport({
         assetModel: { select: { name: true } },
         notes: true,
         custody: {
+          // Ordered so `getPrimaryCustody` picks the same row every time — the
+          // custodian it returns is written into the exported file.
+          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
           include: {
             custodian: true,
           },
@@ -6337,6 +6340,11 @@ export async function bulkCheckInAssets({
           title: true,
           type: true,
           custody: {
+            // Ordered so `getPrimaryCustody` picks the same row every time:
+            // the custodian it returns is written into the release note and
+            // the CUSTODY_RELEASED event, so an arbitrary pick puts the wrong
+            // name in the audit trail.
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
             select: { id: true, custodian: { include: { user: true } } },
           },
         },

--- a/apps/webapp/app/modules/custody/utils.ts
+++ b/apps/webapp/app/modules/custody/utils.ts
@@ -18,6 +18,12 @@
  * @param custody - Array of custody records from the Asset relation
  * @returns The first custody record, or null if none exist
  */
+/**
+ * The caller's query decides which row this returns: it takes the FIRST one.
+ * A relation fetched without an `orderBy` has no guaranteed order, so a query
+ * feeding this helper should order the custody rows — `createdAt` ascending,
+ * with `id` to break ties — or the holder shown can change between requests.
+ */
 export function getPrimaryCustody<T extends Record<string, unknown>>(
   custody: T[] | null | undefined
 ): T | null {

--- a/apps/webapp/app/modules/location/service.server.ts
+++ b/apps/webapp/app/modules/location/service.server.ts
@@ -344,6 +344,12 @@ export async function getLocation(
               qrCodes: { take: 1, select: { id: true } },
               barcodes: { select: { id: true, type: true, value: true } },
               custody: {
+                // The list column shows ONE custodian, chosen as `custody[0]`
+                // by `getPrimaryCustody`. Without an order the database is
+                // free to return the rows differently between requests, so a
+                // multi-custodian asset would show a different holder on
+                // refresh. `id` breaks ties on identical timestamps.
+                orderBy: [{ createdAt: "asc" }, { id: "asc" }],
                 select: {
                   quantity: true,
                   custodian: {

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
@@ -288,13 +288,10 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         })
       : { teamMembers: [], totalTeamMembers: 0 };
 
-    const bookingAsset =
-      asset.bookingAssets.length > 0 ? asset.bookingAssets[0] : undefined;
-    const currentBooking: any = null;
-
-    if (bookingAsset && bookingAsset.booking.from) {
-      asset.bookingAssets = [currentBooking];
-    }
+    // `bookingAssets` is already the asset's current booking: the query
+    // filters to ONGOING/OVERDUE and excludes bookings this asset has been
+    // partially checked in from, so the first row is the one the page shows.
+    // Nothing further is derived from it here.
     /** We only need customField with same category of asset or without any category */
     const customFields = asset.categoryId
       ? asset.customFields.filter(

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
@@ -1,3 +1,19 @@
+/**
+ * Location Assets
+ *
+ * The asset list on a location's detail page: every asset with a placement at
+ * this location, with the per-location quantity, whether that placement came
+ * from a kit, and who holds the asset.
+ *
+ * Rows come from `getLocation`, which has no `Location.assets` relation to
+ * follow and instead runs a pivot-filtered query and returns the assets
+ * alongside the location. The row type here is written by hand and must be
+ * kept in step with that query's projection.
+ *
+ * @see {@link file://./../../modules/location/service.server.ts} getLocation
+ * @see {@link file://./locations.$locationId.overview.tsx}
+ */
+
 import type {
   Asset,
   BarcodeType,
@@ -425,10 +441,15 @@ const ListAssetContent = ({
     qrCodes: { id: string }[];
     barcodes: { id: string; type: BarcodeType; value: string }[];
     /**
-     * `Asset.custody` is a LIST — an asset can be held by several custodians
-     * at once for quantity-tracked stock. Typing it as a single record made
-     * `custody?.custodian` read `undefined` on every row, which the compiler
-     * could not see because this projection is hand-written.
+     * Custody rows for this asset, one per holder — quantity-tracked stock can
+     * be held by several people at once. The list column shows one badge, so
+     * it renders the primary holder via `getPrimaryCustody`.
+     *
+     * Optionality mirrors the schema: a `TeamMember` need not be linked to a
+     * `User` (non-registered members exist), and a linked user's name fields
+     * and avatar are all optional. This projection is written by hand, so the
+     * compiler checks it against nothing — keep it in step with the `custody`
+     * select in `getLocation`.
      */
     custody: Array<{
       quantity: number;
@@ -437,10 +458,10 @@ const ListAssetContent = ({
         name: string;
         user: {
           id: string;
-          firstName: string;
-          lastName: string;
+          firstName: string | null;
+          lastName: string | null;
           displayName: string | null;
-          profilePicture: string;
+          profilePicture: string | null;
           email: string;
         } | null;
       };

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.assets.tsx
@@ -48,6 +48,7 @@ import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { isQuantityTracked } from "~/modules/asset/utils";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { resolveDisplayCode } from "~/modules/barcode/display";
+import { getPrimaryCustody } from "~/modules/custody/utils";
 import { resolveLocationAssetIds } from "~/modules/location/bulk-select.server";
 import {
   getLocation,
@@ -423,7 +424,14 @@ const ListAssetContent = ({
     }>;
     qrCodes: { id: string }[];
     barcodes: { id: string; type: BarcodeType; value: string }[];
-    custody: {
+    /**
+     * `Asset.custody` is a LIST — an asset can be held by several custodians
+     * at once for quantity-tracked stock. Typing it as a single record made
+     * `custody?.custodian` read `undefined` on every row, which the compiler
+     * could not see because this projection is hand-written.
+     */
+    custody: Array<{
+      quantity: number;
       custodian: {
         id: string;
         name: string;
@@ -431,15 +439,20 @@ const ListAssetContent = ({
           id: string;
           firstName: string;
           lastName: string;
+          displayName: string | null;
           profilePicture: string;
           email: string;
-        };
+        } | null;
       };
-    };
+    }>;
   };
   extraProps: { canReadCustody: boolean; userRoleCanManageAssets: boolean };
 }) => {
   const { category, tags, custody } = item;
+  // The list column shows one badge, so it shows the primary holder — the
+  // same choice `getPrimaryCustody` makes everywhere else custody is
+  // summarised in a single slot.
+  const primaryCustody = getPrimaryCustody(custody);
   // The location whose detail page we're on — used to pick this asset's
   // pivot row out of `item.assetLocations`. Mirrors the kit-page
   // `useParams<{ kitId }>` pattern at `kits.$kitId.assets.tsx:179`.
@@ -624,8 +637,8 @@ const ListAssetContent = ({
       {/* Custodian */}
       <When truthy={extraProps.canReadCustody}>
         <Td>
-          {custody?.custodian ? (
-            <TeamMemberBadge teamMember={custody.custodian} />
+          {primaryCustody?.custodian ? (
+            <TeamMemberBadge teamMember={primaryCustody.custodian} />
           ) : (
             <EmptyTableValue />
           )}


### PR DESCRIPTION
Two display regressions from the detail.dev OSS scan: **D033** and **D056**.
Both hid custody information the loaders were already fetching — no data was
missing, only the code reading it.

## D033 — the loader replaced its own booking data with `[null]`

```ts
const bookingAsset = asset.bookingAssets.length > 0 ? asset.bookingAssets[0] : undefined;
const currentBooking: any = null;

if (bookingAsset && bookingAsset.booking.from) {
  asset.bookingAssets = [currentBooking];   // → [null]
}
```

The consumer guards on `bookingAssets?.length`. A one-element list **passes**
that guard, and the read after it — `bookingAssets[0]?.booking` — resolves to
`undefined`. So every checked-out asset showed no booking and no custodian.

`currentBooking` was typed `any` and hardcoded `null`, and nothing else derived
from it — it reads like a refactor casualty.

**Removed rather than reconstructed.** The query already does the work the block
was presumably meant to: `bookingAssets` is filtered to `ONGOING`/`OVERDUE` and
excludes bookings this asset has been partially checked in from, so the first
row *is* the booking the page means to show.

That premise is now pinned by a test on `getAssetOverviewFields` — the fix
depends on the filter, so if it ever widens, the page would start showing an
arbitrary booking and that test fails first.

## D056 — a hand-written type hid an array

`Asset.custody` is `Custody[]` in the schema (an asset can be held by several
custodians at once). The page declared it as a single record, so
`custody?.custodian` read `undefined` on every row and the badge never rendered.

The compiler could not see the mismatch, because the projection is hand-written
— the same failure mode as adding a relation to a `select` when a mapper names
its fields explicitly.

The type now matches what `getLocation` actually selects (it was also missing
`displayName` and had `user` non-nullable), and the row resolves through
`getPrimaryCustody`, the same choice every other single-slot custody summary
makes.

**The corrected type is the guard.** The next mismatch here is a compile error,
which is a stronger guarantee than a test.

## Sweep

Every other `custody?.custodian` read is on `Kit.custody`, which genuinely *is*
a single optional `KitCustody?` — those are correct, not siblings. The one
asset-side list item (`audit-asset-list-item.tsx`) already resolves through
`getPrimaryCustody`.

## Verification

- 11 tests pass across the affected suites; `tsc -b --force` and eslint clean.

⚠️ **This pair is the class the repo's own rules say tests do not catch** — an
empty render looks perfectly healthy. D056 now has real compiler coverage;
D033's guard is indirect (it pins the premise, not the render).

The two things worth clicking:

- a **checked-out asset's overview** — should show its booking and custodian
- a **location page with an asset in custody** — badge should appear

## Not included

`OrganizationRoles` is imported but unused in the overview file. It was already
unused before this change, so it is left alone rather than mixed into a fix PR.

No migration. No schema change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Asset overviews now display booking information consistently without replacing valid booking details.
  - Booking lists correctly include ongoing and overdue bookings while excluding assets already checked in.
  - Asset lists, exports, and custody releases now show primary custodian details accurately and consistently when multiple custody records exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->