### PR TITLE
fix(auth): stop SSO and email changes leaving an account half-written

### DIFF
--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -178,6 +178,50 @@ export async function findUserByEmail(email: User["email"]) {
   }
 }
 
+/**
+ * Makes sure an SSO user has a `TeamMember` in an organization they can access.
+ *
+ * Org access and the team-member record are two writes, and only the second one
+ * makes custody possible — a user holding the first without the second can sign
+ * in, see the workspace, and never be assignable as a custodian. Returning
+ * early on existing access alone would leave such a user stuck for good, so
+ * every SSO login re-checks rather than assuming the pair is intact.
+ *
+ * Soft-deleted records do not count: a member removed from the workspace and
+ * then re-granted access needs a live record again.
+ *
+ * @param tx - Prisma client or active transaction
+ * @param params.userId - The signing-in user
+ * @param params.organizationId - Organization they hold access to
+ * @param params.name - Display name for a record that has to be created
+ */
+async function ensureUserTeamMember(
+  tx: Omit<ExtendedPrismaClient, ITXClientDenyList>,
+  {
+    userId,
+    organizationId,
+    name,
+  }: {
+    userId: User["id"];
+    organizationId: Organization["id"];
+    name: string;
+  }
+) {
+  const existing = await tx.teamMember.findFirst({
+    where: { userId, organizationId, deletedAt: null },
+    select: { id: true },
+  });
+
+  if (existing) {
+    return existing;
+  }
+
+  return tx.teamMember.create({
+    data: { name, organizationId, userId },
+    select: { id: true },
+  });
+}
+
 async function createUserOrgAssociation(
   tx: Omit<ExtendedPrismaClient, ITXClientDenyList>,
   payload: {
@@ -660,6 +704,17 @@ export async function updateUserFromSSO(
           );
           transitions.push(transition);
 
+          // Repair an account whose team-member record never got written —
+          // only while a role still maps, since a revoked transition is
+          // removing this user's access rather than restoring it.
+          if (desiredRole) {
+            await ensureUserTeamMember(db, {
+              userId,
+              organizationId: org.id,
+              name: `${firstName} ${lastName}`,
+            });
+          }
+
           // The user keeps access only when a role still maps; a null
           // desiredRole makes handleSCIMTransition revoke it, so that org must
           // not become the post-login landing org.
@@ -667,16 +722,21 @@ export async function updateUserFromSSO(
             firstMatchedOrg ??= org;
           }
         } else if (desiredRole && !(await isScimDeactivated(user.id, org.id))) {
-          await createUserOrgAssociation(db, {
-            userId: user.id,
-            organizationIds: [org.id],
-            roles: [desiredRole],
-          });
+          // Both writes or neither: access without a team member is a state
+          // this flow cannot reach again, because the next login would find
+          // the access and take the branch above.
+          await db.$transaction(async (tx) => {
+            await createUserOrgAssociation(tx, {
+              userId: user.id,
+              organizationIds: [org.id],
+              roles: [desiredRole],
+            });
 
-          await createTeamMember({
-            name: `${firstName} ${lastName}`,
-            organizationId: org.id,
-            userId,
+            await ensureUserTeamMember(tx, {
+              userId,
+              organizationId: org.id,
+              name: `${firstName} ${lastName}`,
+            });
           });
 
           transitions.push({
@@ -1062,11 +1122,38 @@ export async function updateUserEmail({
         where: { id: userId },
         data: { email: newEmail },
       })
-      .catch((cause) => {
-        // On failure, revert the change of the user update in auth
-        void getSupabaseAdmin().auth.admin.updateUserById(userId, {
-          email: currentEmail,
-        });
+      .catch(async (cause) => {
+        // Auth already holds the new address, so the revert is what keeps the
+        // two systems agreeing. It has to be awaited: sign-in resolves the
+        // account by its AUTH email and then looks the user up by that address
+        // in the database, so a divergence locks the account out of both apps
+        // with no way back in. A dropped promise would also reject unhandled.
+        const { error: revertError } = await getSupabaseAdmin()
+          .auth.admin.updateUserById(userId, { email: currentEmail })
+          .catch((revertCause: unknown) => ({ error: revertCause }));
+
+        if (revertError) {
+          // Nothing further can be done from here, so say plainly which
+          // address each system holds — repairing it means setting one of
+          // them by hand.
+          Logger.error(
+            new ShelfError({
+              cause: revertError,
+              message:
+                "Email change failed and could not be rolled back in auth. The auth account and the database now hold different addresses, which blocks sign-in until one is corrected.",
+              additionalData: { userId, newEmail, currentEmail },
+              label,
+            })
+          );
+
+          throw new ShelfError({
+            cause,
+            message:
+              "Failed to update your email, and we could not restore the previous one. Please contact support before signing out.",
+            additionalData: { userId, newEmail, currentEmail },
+            label,
+          });
+        }
 
         // Unique email constraint is being handled automatically by `getSupabaseAdmin().auth.admin.generateLink`
         throw new ShelfError({
@@ -1081,7 +1168,12 @@ export async function updateUserEmail({
   } catch (cause) {
     throw new ShelfError({
       cause,
-      message: "Failed to update email",
+      // The steps above already say which of the two systems refused, and
+      // whether the previous address was restored. Replacing that with one
+      // generic line would drop the only guidance the user gets.
+      message: isLikeShelfError(cause)
+        ? cause.message
+        : "Failed to update email",
       additionalData: { userId, currentEmail, newEmail },
       label,
     });

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -183,9 +183,11 @@ export async function findUserByEmail(email: User["email"]) {
  *
  * Org access and the team-member record are two writes, and only the second one
  * makes custody possible — a user holding the first without the second can sign
- * in, see the workspace, and never be assignable as a custodian. Returning
- * early on existing access alone would leave such a user stuck for good, so
- * every SSO login re-checks rather than assuming the pair is intact.
+ * in, see the workspace, and never be assignable as a custodian. Existing
+ * access alone is therefore not taken as proof the pair is intact: a login that
+ * still maps to a role re-checks, so an account left half-written can recover.
+ * A login that maps to no role does not, because that transition is removing
+ * the user's access rather than restoring it.
  *
  * Soft-deleted records do not count: a member removed from the workspace and
  * then re-granted access needs a live record again.
@@ -440,16 +442,21 @@ export async function createUserFromSSO(
 
         if (role) {
           firstMatchedOrg ??= org;
-          await createUserOrgAssociation(db, {
-            userId: user.id,
-            organizationIds: [org.id],
-            roles: [role],
-          });
+          // Both writes or neither, for the same reason as the returning-user
+          // path: access without a team member is an account that can open the
+          // workspace but can never be assigned custody.
+          await db.$transaction(async (tx) => {
+            await createUserOrgAssociation(tx, {
+              userId: user.id,
+              organizationIds: [org.id],
+              roles: [role],
+            });
 
-          await createTeamMember({
-            name: `${firstName} ${lastName}`,
-            organizationId: org.id,
-            userId,
+            await ensureUserTeamMember(tx, {
+              userId,
+              organizationId: org.id,
+              name: `${firstName} ${lastName}`,
+            });
           });
         }
       }

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -55,7 +55,6 @@ import { defaultFields } from "../asset-index-settings/helpers";
 import { ensureAssetIndexModeForRole } from "../asset-index-settings/service.server";
 import { defaultUserCategories } from "../category/default-categories";
 import { getOrganizationsBySsoDomain } from "../organization/service.server";
-import { createTeamMember } from "../team-member/service.server";
 import { USER_CONTACT_SELECT } from "../user-contact/constants";
 import {
   getUserContactById,

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -720,11 +720,20 @@ export async function updateUserFromSSO(
               // insert, leaving one user with two live custodian records. The
               // membership row does have that uniqueness and always exists on
               // this branch, so locking it serialises the pair of repairs.
-              await tx.$queryRaw`
+              const membership = await tx.$queryRaw<{ id: string }[]>`
                 SELECT id FROM "UserOrganization"
                 WHERE "userId" = ${userId} AND "organizationId" = ${org.id}
                 FOR UPDATE
               `;
+
+              // The membership was read before the transition ran and can be
+              // gone by the time the lock resolves — a concurrent callback
+              // whose group claims revoke access deletes the row. Creating the
+              // record anyway would leave a custodian attached to a workspace
+              // its user is no longer in.
+              if (!membership || membership.length === 0) {
+                return;
+              }
 
               await ensureUserTeamMember(tx, {
                 userId,

--- a/apps/webapp/app/modules/user/service.server.ts
+++ b/apps/webapp/app/modules/user/service.server.ts
@@ -708,10 +708,23 @@ export async function updateUserFromSSO(
           // only while a role still maps, since a revoked transition is
           // removing this user's access rather than restoring it.
           if (desiredRole) {
-            await ensureUserTeamMember(db, {
-              userId,
-              organizationId: org.id,
-              name: `${firstName} ${lastName}`,
+            await db.$transaction(async (tx) => {
+              // `TeamMember` has no uniqueness on (userId, organizationId), so
+              // two logins arriving together would both find nothing and both
+              // insert, leaving one user with two live custodian records. The
+              // membership row does have that uniqueness and always exists on
+              // this branch, so locking it serialises the pair of repairs.
+              await tx.$queryRaw`
+                SELECT id FROM "UserOrganization"
+                WHERE "userId" = ${userId} AND "organizationId" = ${org.id}
+                FOR UPDATE
+              `;
+
+              await ensureUserTeamMember(tx, {
+                userId,
+                organizationId: org.id,
+                name: `${firstName} ${lastName}`,
+              });
             });
           }
 

--- a/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
+++ b/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
@@ -267,10 +267,17 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
     // callback whose claims revoke access can delete the row in between. The
     // lock then finds nothing, and creating the record anyway would attach a
     // custodian to a workspace its user is no longer in.
+
+    // why: no SCIM mapping, so the deactivation guard lets the login through
+    // and it reaches the repair branch this test is about.
     // @ts-expect-error - vitest mock type
     mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+    // why: no existing record, so the repair would go on to create one — the
+    // lock is the only thing that can stop it.
     // @ts-expect-error - vitest mock type
     mockDb.db.teamMember.findFirst.mockResolvedValue(null);
+    // why: this IS the condition under test. An empty result is how the lock
+    // reports that the membership row is gone.
     // @ts-expect-error - vitest mock type
     mockDb.db.$queryRaw.mockResolvedValue([]);
 
@@ -285,8 +292,11 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
   });
 
   it("does not duplicate a team member that already exists", async () => {
+    // why: no SCIM mapping, so the login reaches the repair branch.
     // @ts-expect-error - vitest mock type
     mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+    // why: a record already present is the condition under test — the repair
+    // has to leave it alone rather than add a second one.
     // @ts-expect-error - vitest mock type
     mockDb.db.teamMember.findFirst.mockResolvedValue({ id: "tm-1" });
 

--- a/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
+++ b/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
@@ -17,22 +17,73 @@
 import { OrganizationRoles } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// why: exercise the guard's real DB reads/writes without a database
+/**
+ * Writes recorded by the stubbed delegates.
+ *
+ * `staged` holds what the current transaction callback has written; `committed`
+ * holds what a callback that RESOLVED promoted. Asserting that a transaction
+ * was merely opened proves nothing about atomicity — the property under test is
+ * that a body which throws leaves nothing behind, so the tests read `committed`.
+ */
+const { staged, committed, txDepth } = vi.hoisted(() => ({
+  staged: [] as string[],
+  committed: [] as string[],
+  txDepth: { value: 0 },
+}));
+
+// why: exercise the guard's real DB reads/writes without a database. The
+// delegates record what they wrote so the transaction stub below can model
+// commit-versus-rollback rather than just counting calls.
 vi.mock("~/database/db.server", () => {
   const db = {
     user: { update: vi.fn() },
     // Drives isScimDeactivated: a row here (with no membership) = deactivated.
     userScimExternalId: { findUnique: vi.fn() },
     // createUserOrgAssociation upserts here when a grant proceeds.
-    userOrganization: { upsert: vi.fn(), delete: vi.fn(), update: vi.fn() },
+    userOrganization: {
+      upsert: vi.fn(() => {
+        record("userOrganization");
+        return Promise.resolve({});
+      }),
+      delete: vi.fn(),
+      update: vi.fn(),
+    },
     // A grant writes the org association and the team member together, so the
     // team-member record is reachable only through this delegate now.
-    teamMember: { findFirst: vi.fn(), create: vi.fn() },
-    // why: the grant runs both writes in one interactive transaction. Routing
-    // the callback to the same mocked client is what lets the assertions see
-    // the writes it makes.
-    $transaction: vi.fn((cb: (tx: unknown) => unknown) => cb(db)),
+    teamMember: {
+      findFirst: vi.fn(),
+      create: vi.fn(() => {
+        record("teamMember");
+        return Promise.resolve({ id: "tm-1" });
+      }),
+    },
+    // The repair path locks the membership row before its check-and-create.
+    $queryRaw: vi.fn().mockResolvedValue([{ id: "uo-1" }]),
+    $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => {
+      txDepth.value += 1;
+      staged.length = 0;
+      try {
+        const result = await cb(db);
+        committed.push(...staged);
+        return result;
+      } finally {
+        staged.length = 0;
+        txDepth.value -= 1;
+      }
+    }),
   };
+
+  /**
+   * Records a write where it would actually land.
+   *
+   * Inside a transaction it is staged, and only a callback that resolves
+   * promotes it. Outside one it is durable the moment it happens — which is
+   * what makes a sequential pair of writes distinguishable from an atomic one.
+   */
+  function record(table: string) {
+    (txDepth.value > 0 ? staged : committed).push(table);
+  }
+
   return { db };
 });
 
@@ -109,14 +160,13 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
     // @ts-expect-error - vitest mock type
     mockOrg.getOrganizationsBySsoDomain.mockResolvedValue([domainOrg()]);
     // @ts-expect-error - vitest mock type
-    mockDb.db.userOrganization.upsert.mockResolvedValue({});
-    // @ts-expect-error - vitest mock type
     mockTeam.createTeamMember.mockResolvedValue({});
     // Default: no team-member record yet, so a grant writes one.
     // @ts-expect-error - vitest mock type
     mockDb.db.teamMember.findFirst.mockResolvedValue(null);
-    // @ts-expect-error - vitest mock type
-    mockDb.db.teamMember.create.mockResolvedValue({ id: "tm-1" });
+    staged.length = 0;
+    committed.length = 0;
+    txDepth.value = 0;
   });
 
   it("blocks the group-driven grant for a SCIM-deactivated user", async () => {
@@ -146,16 +196,30 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
     expect(result.org?.id).toBe(ORG_ID);
   });
 
-  it("writes the access and the team member in one transaction", async () => {
-    // Separately, a failure between them leaves a user who can sign in and see
-    // the workspace but can never be assigned custody — and the next login
-    // finds the access and takes the branch that does not create the record.
+  it("keeps both writes of a successful grant", async () => {
     // @ts-expect-error - vitest mock type
     mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
 
     await login();
 
-    expect(mockDb.db.$transaction).toHaveBeenCalledTimes(1);
+    expect(committed).toEqual(["userOrganization", "teamMember"]);
+  });
+
+  it("keeps neither write when the team member cannot be created", async () => {
+    // The state this change exists to prevent: access granted with no
+    // team-member record. The next login would find that access and take the
+    // branch that assumes the pair is intact, so it must never be reachable.
+    // @ts-expect-error - vitest mock type
+    mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+    // @ts-expect-error - vitest mock type
+    mockDb.db.teamMember.create.mockRejectedValueOnce(
+      new Error("constraint violation")
+    );
+
+    await expect(login()).rejects.toThrow();
+
+    // Not "the transaction was opened" — nothing survived it.
+    expect(committed).toEqual([]);
   });
 
   it("creates a missing team member for a user who already has access", async () => {
@@ -174,6 +238,28 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
     });
 
     expect(mockDb.db.teamMember.create).toHaveBeenCalled();
+  });
+
+  it("locks the membership row before repairing", async () => {
+    // `TeamMember` has no uniqueness on (userId, organizationId), so two
+    // logins arriving together would both find nothing and both insert. The
+    // membership row does have it, so the lock is what serialises them.
+    // @ts-expect-error - vitest mock type
+    mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+    // @ts-expect-error - vitest mock type
+    mockDb.db.teamMember.findFirst.mockResolvedValue(null);
+
+    await login({
+      userOrganizations: [
+        { organization: { id: ORG_ID }, roles: [OrganizationRoles.ADMIN] },
+      ],
+    });
+
+    const sql = (mockDb.db.$queryRaw as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as TemplateStringsArray;
+
+    expect(sql.join("?")).toContain("FOR UPDATE");
+    expect(sql.join("?")).toContain('"UserOrganization"');
   });
 
   it("does not duplicate a team member that already exists", async () => {

--- a/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
+++ b/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
@@ -223,9 +223,9 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
   });
 
   it("creates a missing team member for a user who already has access", async () => {
-    // The repair path: an account left half-provisioned by an earlier failure
-    // reaches the existing-access branch on every later login, so that branch
-    // is the only place it can be fixed.
+    // The repair path: an account left half-provisioned reaches the
+    // existing-access branch on every later login, so that branch is the only
+    // place it can be fixed.
     // @ts-expect-error - vitest mock type
     mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
     // @ts-expect-error - vitest mock type

--- a/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
+++ b/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
@@ -14,18 +14,27 @@
  *
  * @see {@link file://./service.server.ts}
  */
+import { OrganizationRoles } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // why: exercise the guard's real DB reads/writes without a database
-vi.mock("~/database/db.server", () => ({
-  db: {
+vi.mock("~/database/db.server", () => {
+  const db = {
     user: { update: vi.fn() },
     // Drives isScimDeactivated: a row here (with no membership) = deactivated.
     userScimExternalId: { findUnique: vi.fn() },
     // createUserOrgAssociation upserts here when a grant proceeds.
     userOrganization: { upsert: vi.fn(), delete: vi.fn(), update: vi.fn() },
-  },
-}));
+    // A grant writes the org association and the team member together, so the
+    // team-member record is reachable only through this delegate now.
+    teamMember: { findFirst: vi.fn(), create: vi.fn() },
+    // why: the grant runs both writes in one interactive transaction. Routing
+    // the callback to the same mocked client is what lets the assertions see
+    // the writes it makes.
+    $transaction: vi.fn((cb: (tx: unknown) => unknown) => cb(db)),
+  };
+  return { db };
+});
 
 // why: the SSO org set is fetched from the organization module; stub it so the
 // test controls which orgs (and group mappings) the login reconciles against
@@ -33,7 +42,9 @@ vi.mock("../organization/service.server", () => ({
   getOrganizationsBySsoDomain: vi.fn(),
 }));
 
-// why: a granted membership also creates a team member; isolate that side effect
+// why: other paths in the module under test reach the team-member service;
+// stubbing it keeps them off a database. The SSO grant no longer goes through
+// it — it writes the record inside its own transaction.
 vi.mock("../team-member/service.server", () => ({
   createTeamMember: vi.fn(),
 }));
@@ -68,7 +79,14 @@ function domainOrg() {
  * matched org, so the login takes the "grant new access" branch — the one the
  * guard protects. firstName/lastName match to skip the profile-update path.
  */
-function login() {
+/**
+ * Runs an SSO login.
+ *
+ * @param overrides.userOrganizations - Memberships the user already holds.
+ *   Empty (the default) exercises the grant path; a membership for the domain
+ *   org exercises the existing-access path instead.
+ */
+function login(overrides: { userOrganizations?: unknown[] } = {}) {
   // Only the fields the function reads are supplied; cast to satisfy the
   // Prisma-derived parameter types without building a full user payload.
   return updateUserFromSSO(
@@ -79,7 +97,7 @@ function login() {
       id: USER_ID,
       firstName: "Jane",
       lastName: "Doe",
-      userOrganizations: [],
+      userOrganizations: overrides.userOrganizations ?? [],
     } as unknown as Parameters<typeof updateUserFromSSO>[1],
     { firstName: "Jane", lastName: "Doe", groups: ["g-admin"] }
   );
@@ -94,6 +112,11 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
     mockDb.db.userOrganization.upsert.mockResolvedValue({});
     // @ts-expect-error - vitest mock type
     mockTeam.createTeamMember.mockResolvedValue({});
+    // Default: no team-member record yet, so a grant writes one.
+    // @ts-expect-error - vitest mock type
+    mockDb.db.teamMember.findFirst.mockResolvedValue(null);
+    // @ts-expect-error - vitest mock type
+    mockDb.db.teamMember.create.mockResolvedValue({ id: "tm-1" });
   });
 
   it("blocks the group-driven grant for a SCIM-deactivated user", async () => {
@@ -119,8 +142,53 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
     const result = await login();
 
     expect(mockDb.db.userOrganization.upsert).toHaveBeenCalled();
-    expect(mockTeam.createTeamMember).toHaveBeenCalled();
+    expect(mockDb.db.teamMember.create).toHaveBeenCalled();
     expect(result.org?.id).toBe(ORG_ID);
+  });
+
+  it("writes the access and the team member in one transaction", async () => {
+    // Separately, a failure between them leaves a user who can sign in and see
+    // the workspace but can never be assigned custody — and the next login
+    // finds the access and takes the branch that does not create the record.
+    // @ts-expect-error - vitest mock type
+    mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+
+    await login();
+
+    expect(mockDb.db.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates a missing team member for a user who already has access", async () => {
+    // The repair path: an account left half-provisioned by an earlier failure
+    // reaches the existing-access branch on every later login, so that branch
+    // is the only place it can be fixed.
+    // @ts-expect-error - vitest mock type
+    mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+    // @ts-expect-error - vitest mock type
+    mockDb.db.teamMember.findFirst.mockResolvedValue(null);
+
+    await login({
+      userOrganizations: [
+        { organization: { id: ORG_ID }, roles: [OrganizationRoles.ADMIN] },
+      ],
+    });
+
+    expect(mockDb.db.teamMember.create).toHaveBeenCalled();
+  });
+
+  it("does not duplicate a team member that already exists", async () => {
+    // @ts-expect-error - vitest mock type
+    mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+    // @ts-expect-error - vitest mock type
+    mockDb.db.teamMember.findFirst.mockResolvedValue({ id: "tm-1" });
+
+    await login({
+      userOrganizations: [
+        { organization: { id: ORG_ID }, roles: [OrganizationRoles.ADMIN] },
+      ],
+    });
+
+    expect(mockDb.db.teamMember.create).not.toHaveBeenCalled();
   });
 
   // The guard recognises only SOFT deactivation (active:false), where the

--- a/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
+++ b/apps/webapp/app/modules/user/sso-scim-deactivation-guard.test.ts
@@ -262,6 +262,28 @@ describe("updateUserFromSSO — SCIM deactivation guard", () => {
     expect(sql.join("?")).toContain('"UserOrganization"');
   });
 
+  it("creates nothing when the membership disappeared under the lock", async () => {
+    // The membership is read before the transition runs, so a concurrent
+    // callback whose claims revoke access can delete the row in between. The
+    // lock then finds nothing, and creating the record anyway would attach a
+    // custodian to a workspace its user is no longer in.
+    // @ts-expect-error - vitest mock type
+    mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);
+    // @ts-expect-error - vitest mock type
+    mockDb.db.teamMember.findFirst.mockResolvedValue(null);
+    // @ts-expect-error - vitest mock type
+    mockDb.db.$queryRaw.mockResolvedValue([]);
+
+    await login({
+      userOrganizations: [
+        { organization: { id: ORG_ID }, roles: [OrganizationRoles.ADMIN] },
+      ],
+    });
+
+    expect(mockDb.db.teamMember.create).not.toHaveBeenCalled();
+    expect(committed).toEqual([]);
+  });
+
   it("does not duplicate a team member that already exists", async () => {
     // @ts-expect-error - vitest mock type
     mockDb.db.userScimExternalId.findUnique.mockResolvedValue(null);

--- a/apps/webapp/app/modules/user/update-email-rollback.test.ts
+++ b/apps/webapp/app/modules/user/update-email-rollback.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Email changes across the auth account and the database.
+ *
+ * The address lives in two systems and sign-in needs them to agree: the auth
+ * account resolves the session, and the user is then looked up in the database
+ * by that same address. An account whose two records disagree cannot sign in to
+ * either app, and no self-service path fixes it.
+ *
+ * Auth is written first, so the rollback after a failed database write is what
+ * keeps the two in step. These tests pin that it is awaited and that a rollback
+ * which itself fails is reported rather than dropped.
+ *
+ * @see {@link file://./service.server.ts} updateUserEmail
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ShelfError } from "~/utils/error";
+
+const { mockUpdateUserById } = vi.hoisted(() => ({
+  mockUpdateUserById: vi.fn(),
+}));
+// why: the auth account is a remote service. Stubbing it lets each case choose
+// which of the two auth writes fails — the change or the rollback after it,
+// which is the distinction under test.
+vi.mock("~/integrations/supabase/client", () => ({
+  getSupabaseAdmin: () => ({
+    auth: { admin: { updateUserById: mockUpdateUserById } },
+  }),
+}));
+
+const { mockUserUpdate } = vi.hoisted(() => ({ mockUserUpdate: vi.fn() }));
+// why: the database write is the one that fails in every rollback case, so the
+// test drives it directly rather than through a database.
+vi.mock("~/database/db.server", () => ({
+  db: { user: { update: mockUserUpdate } },
+}));
+
+const { mockLoggerError } = vi.hoisted(() => ({ mockLoggerError: vi.fn() }));
+// why: an unrepairable divergence can only be reported, so the report is the
+// observable behaviour worth asserting.
+vi.mock("~/utils/logger", () => ({
+  Logger: { error: mockLoggerError, warn: vi.fn(), info: vi.fn() },
+}));
+
+import { updateUserEmail } from "./service.server";
+
+const USER_ID = "user-1";
+const CURRENT = "old@example.com";
+const NEW = "new@example.com";
+
+function changeEmail() {
+  return updateUserEmail({
+    userId: USER_ID,
+    currentEmail: CURRENT,
+    newEmail: NEW,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdateUserById.mockResolvedValue({ error: null });
+  mockUserUpdate.mockResolvedValue({ id: USER_ID, email: NEW });
+});
+
+describe("updateUserEmail", () => {
+  it("writes both systems on the happy path", async () => {
+    await expect(changeEmail()).resolves.toEqual({
+      id: USER_ID,
+      email: NEW,
+    });
+
+    expect(mockUpdateUserById).toHaveBeenCalledTimes(1);
+    expect(mockUpdateUserById).toHaveBeenCalledWith(USER_ID, { email: NEW });
+  });
+
+  it("restores the previous address when the database write fails", async () => {
+    mockUserUpdate.mockRejectedValue(new Error("unique constraint"));
+
+    await expect(changeEmail()).rejects.toThrow(ShelfError);
+
+    // Auth was already carrying the new address; the second call puts it back.
+    expect(mockUpdateUserById).toHaveBeenCalledTimes(2);
+    expect(mockUpdateUserById).toHaveBeenLastCalledWith(USER_ID, {
+      email: CURRENT,
+    });
+  });
+
+  it("reports a rollback that fails instead of dropping it", async () => {
+    mockUserUpdate.mockRejectedValue(new Error("unique constraint"));
+    mockUpdateUserById
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({ error: new Error("auth unavailable") });
+
+    await expect(changeEmail()).rejects.toThrow(ShelfError);
+
+    // The two systems now hold different addresses and nothing here can fix
+    // it, so the report is what makes it repairable at all. Both addresses
+    // have to be in it.
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const reported = mockLoggerError.mock.calls[0][0] as ShelfError;
+    expect(reported.additionalData).toMatchObject({
+      userId: USER_ID,
+      currentEmail: CURRENT,
+      newEmail: NEW,
+    });
+  });
+
+  it("tells the user their address may be inconsistent", async () => {
+    mockUserUpdate.mockRejectedValue(new Error("unique constraint"));
+    mockUpdateUserById
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({ error: new Error("auth unavailable") });
+
+    // "Failed to update email in shelf" would read as "nothing happened",
+    // which is the opposite of the truth.
+    await expect(changeEmail()).rejects.toThrow(/contact support/i);
+  });
+
+  it("surfaces a rejected rollback rather than letting it go unhandled", async () => {
+    // The rollback used to be fired without being awaited or caught, so a
+    // rejection escaped the call entirely.
+    mockUserUpdate.mockRejectedValue(new Error("unique constraint"));
+    mockUpdateUserById
+      .mockResolvedValueOnce({ error: null })
+      .mockRejectedValueOnce(new Error("network down"));
+
+    await expect(changeEmail()).rejects.toThrow(ShelfError);
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch the database when the auth write is refused", async () => {
+    mockUpdateUserById.mockResolvedValue({
+      error: new Error("email already registered"),
+    });
+
+    await expect(changeEmail()).rejects.toThrow(ShelfError);
+
+    expect(mockUserUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two accounts-level defects from the detail.dev OSS scan: **D067** and **D029**.
Both leave a user in a state they cannot get themselves out of.

> Note: the scan named routes for both. Both actually live in
> `app/modules/user/service.server.ts` — the same file, which makes them a
> tighter pair than the report suggests.

## D067 — SSO grant writes org access and the team member separately

```ts
await createUserOrgAssociation(db, { ... });   // org access
await createTeamMember({ ... });               // the record custody needs
```

No transaction. If the second write fails, the user can sign in and see the
workspace but can never be assigned custody.

**And the next login cannot repair it.** `existingUserOrganizations.find(...)`
now *succeeds*, so the code takes the existing-access branch — which assumes the
pair is intact and never writes the missing record. The account is stuck for
good.

Two halves, because either alone is insufficient:

| | |
| --- | --- |
| **Atomic grant** | both writes share a transaction, so the state cannot be created |
| **Self-heal** | the existing-access branch ensures the record exists, so accounts already in that state recover on their next login |

The repair is gated on a role still mapping — a revoked transition is *removing*
this user's access, not restoring it.

⚠️ **The self-heal only reaches users who log in again.** If you want to know
whether any affected accounts exist today, that is a read-only query
(`UserOrganization` rows with no live matching `TeamMember`) — happy to run it.

## D029 — the auth rollback was fired and forgotten

```ts
void getSupabaseAdmin().auth.admin.updateUserById(userId, { email: currentEmail });
```

Auth is written first, so this rollback is what keeps the two systems agreeing
after a failed database write. It was not awaited and not caught.

If it failed, **auth held the new address and the database the old one,
silently**. Sign-in resolves the account by its *auth* email and then looks the
user up by that address — so the account is locked out of both web and mobile,
with no self-service way back. A dropped rejection is a process-level hazard on
top of that.

Now awaited, and a rollback that itself fails is reported with **both**
addresses, because repairing it means setting one of them by hand.

### One change beyond the report

The outer handler replaced every message beneath it with a flat
`"Failed to update email"` — which reads as *"nothing happened"*, the opposite
of the truth once the two systems disagree. It now preserves the specific
message, following the `createInvite` precedent already in the codebase.

## Verification

- 132 tests pass across the nine suites touching these surfaces.
- Every regression test confirmed **red with its fix reverted**: the SSO repair
  path (1) and the rollback handling (3).
- `tsc -b --force` and eslint clean.

### A note on the SSO test mock

The existing SSO suite mocked `createTeamMember` and asserted on it. The grant
now writes the record inside its own transaction, so that assertion would have
passed while testing nothing. It asserts on the `teamMember` delegate instead,
and the mocked client routes `$transaction` back to itself so the writes stay
observable.

No migration. No schema change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO and SCIM membership handling by restoring missing team-member access without creating duplicates.
  * Prevented access records from being created when membership is removed during repair.
  * Kept organization access and team-member updates consistent when account changes fail.
  * Improved email update recovery after database errors, with clearer messaging when account information cannot be synchronized.

* **Tests**
  * Added coverage for membership repair, duplicate prevention, transactional updates, rollback behavior, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->