### PR TITLE
fix(kits): count reservations against the pool a kit may claim

### DIFF
--- a/apps/webapp/app/modules/asset/availability-primitives.server.ts
+++ b/apps/webapp/app/modules/asset/availability-primitives.server.ts
@@ -216,6 +216,53 @@ export type AssertAssetQuantityNotBelowReservationsTxClient = Pick<
  * @throws {ShelfError} 400 (`shouldBeCaptured: false`) when `newTotal` would drop below `committed`.
  */
 /**
+ * The two reads {@link getPeakReservedUnitsByAsset} issues.
+ *
+ * Structural, and declared here rather than widened out of the shared
+ * availability client: the `groupBy` needs `bookingAssetId` in its `by`, which
+ * the shared client does not expose, and broadening that type reaches every
+ * other availability read.
+ */
+export type PeakReservedTxClient = {
+  bookingAsset: {
+    findMany: (args: {
+      where: Prisma.BookingAssetWhereInput;
+      select: {
+        id: true;
+        assetId: true;
+        bookingId: true;
+        quantity: true;
+        assetKitId: true;
+        booking: { select: { from: true; to: true; status: true } };
+      };
+    }) => Promise<
+      Array<{
+        id: string;
+        assetId: string;
+        bookingId: string;
+        quantity: number;
+        assetKitId: string | null;
+        booking: { from: Date; to: Date; status: BookingStatus } | null;
+      }>
+    >;
+  };
+  consumptionLog: {
+    groupBy: (args: {
+      by: ["bookingAssetId", "bookingId", "assetId"];
+      where: Prisma.ConsumptionLogWhereInput;
+      _sum: { quantity: true };
+    }) => Promise<
+      Array<{
+        bookingAssetId: string | null;
+        bookingId: string | null;
+        assetId: string;
+        _sum: { quantity: number | null };
+      }>
+    >;
+  };
+};
+
+/**
  * Peak concurrent standalone reserved units, per asset, across the whole
  * future timeline.
  *
@@ -229,11 +276,17 @@ export type AssertAssetQuantityNotBelowReservationsTxClient = Pick<
  * Batched because the kit picker asks about a page of assets at once; the
  * single-asset guard below asks the same question of one.
  *
- * Reservations are STANDALONE only (`assetKitId: null`) — kit-driven slices
- * are counted through `AssetKit.quantity` by every caller of this, and would
- * otherwise be subtracted twice. Already-logged
- * {@link RESERVATION_REDUCING_CATEGORIES} dispositions reduce a booking's
- * remaining footprint first, exactly as the windowed reads do.
+ * Only STANDALONE reservations enter the peak — kit-driven slices are counted
+ * through `AssetKit.quantity` by every caller of this, and would otherwise be
+ * subtracted twice.
+ *
+ * Already-logged {@link RESERVATION_REDUCING_CATEGORIES} dispositions reduce a
+ * booking's remaining footprint first. They are attributed per
+ * `BookingAsset` ROW: one (booking, asset) pair can hold a standalone slice
+ * and kit-driven ones at once, so a return logged against a kit slice must not
+ * shrink the standalone reservation this guard is protecting. Dispositions
+ * predating per-row attribution carry no row id and fill kit-driven slices
+ * first, per `ConsumptionLog.bookingAssetId`.
  *
  * @param args.assetIds - Assets to compute for. Empty issues no queries.
  * @param args.organizationId - Caller's organization; scopes every read
@@ -247,57 +300,100 @@ export async function getPeakReservedUnitsByAsset({
 }: {
   assetIds: string[];
   organizationId: string;
-  tx: AssertAssetQuantityNotBelowReservationsTxClient;
+  tx: PeakReservedTxClient;
 }): Promise<Map<string, number>> {
   const peaks = new Map<string, number>();
   if (assetIds.length === 0) return peaks;
 
-  const reservedRows = await tx.bookingAsset.findMany({
+  // Both kinds of row are fetched, not just standalone. Kit-driven rows are
+  // never summed into the peak — they are counted through `AssetKit.quantity`
+  // by every caller — but they are needed to place legacy dispositions, which
+  // attribute kit-driven-first (see `ConsumptionLog.bookingAssetId`).
+  const rows = await tx.bookingAsset.findMany({
     where: {
       assetId: { in: assetIds },
-      assetKitId: null,
       // `window: null` — the full active-reservation timeline, because the
       // holder asking has no window of its own.
       booking: buildActiveBookingWhere(organizationId, null),
     },
     select: {
+      id: true,
       assetId: true,
       bookingId: true,
       quantity: true,
+      assetKitId: true,
       booking: { select: { from: true, to: true, status: true } },
     },
   });
 
-  if (reservedRows.length === 0) return peaks;
+  if (rows.length === 0) return peaks;
 
   const loggedGroups = await tx.consumptionLog.groupBy({
-    by: ["bookingId", "assetId"],
+    by: ["bookingAssetId", "bookingId", "assetId"],
     where: {
       assetId: { in: assetIds },
-      bookingId: { in: [...new Set(reservedRows.map((r) => r.bookingId))] },
+      bookingId: { in: [...new Set(rows.map((r) => r.bookingId))] },
       category: { in: [...RESERVATION_REDUCING_CATEGORIES] },
     },
     _sum: { quantity: true },
   });
 
-  // Keyed by booking AND asset: one booking can carry several assets, and a
-  // disposition logged against one of them must not reduce another's.
-  const loggedByBookingAsset = new Map<string, number>();
+  /** Dispositions attributed to one specific `BookingAsset` row. */
+  const loggedByRowId = new Map<string, number>();
+  /**
+   * Dispositions from before per-row attribution existed, keyed by the
+   * (booking, asset) pair they belong to. These have to be placed by hand.
+   */
+  const legacyLoggedByPair = new Map<string, number>();
+
   for (const group of loggedGroups) {
-    if (group.bookingId) {
-      loggedByBookingAsset.set(
-        `${group.bookingId}:${group.assetId}`,
-        group._sum.quantity ?? 0
+    const quantity = group._sum.quantity ?? 0;
+    if (quantity === 0) continue;
+
+    if (group.bookingAssetId) {
+      loggedByRowId.set(
+        group.bookingAssetId,
+        (loggedByRowId.get(group.bookingAssetId) ?? 0) + quantity
       );
+      continue;
     }
+
+    if (!group.bookingId) continue;
+    const pair = `${group.bookingId}:${group.assetId}`;
+    legacyLoggedByPair.set(
+      pair,
+      (legacyLoggedByPair.get(pair) ?? 0) + quantity
+    );
+  }
+
+  // Legacy dispositions fill kit-driven slices before standalone ones, so a
+  // pair's kit-driven capacity absorbs them first and only the remainder
+  // reaches the standalone row. Attributing the whole legacy total to the
+  // standalone row would shrink the reservation this guard is protecting.
+  const legacyForStandalone = new Map<string, number>();
+  for (const [pair, legacyQuantity] of legacyLoggedByPair) {
+    const kitDrivenCapacity = rows
+      .filter(
+        (r) => r.assetKitId !== null && `${r.bookingId}:${r.assetId}` === pair
+      )
+      .reduce((sum, r) => sum + r.quantity, 0);
+
+    legacyForStandalone.set(
+      pair,
+      Math.max(0, legacyQuantity - kitDrivenCapacity)
+    );
   }
 
   const intervalsByAsset = new Map<string, AvailabilityInterval[]>();
-  for (const row of reservedRows) {
+  for (const row of rows) {
+    // Kit-driven slices are counted through `AssetKit.quantity`; summing them
+    // here too would subtract the same units twice.
+    if (row.assetKitId !== null) continue;
     if (!row.booking) continue;
 
+    const pair = `${row.bookingId}:${row.assetId}`;
     const logged =
-      loggedByBookingAsset.get(`${row.bookingId}:${row.assetId}`) ?? 0;
+      (loggedByRowId.get(row.id) ?? 0) + (legacyForStandalone.get(pair) ?? 0);
     const remaining = Math.max(0, row.quantity - logged);
     if (remaining === 0) continue;
 

--- a/apps/webapp/app/modules/asset/availability-primitives.server.ts
+++ b/apps/webapp/app/modules/asset/availability-primitives.server.ts
@@ -215,6 +215,110 @@ export type AssertAssetQuantityNotBelowReservationsTxClient = Pick<
  * @param args - See {@link AssertAssetQuantityNotBelowReservationsArgs}.
  * @throws {ShelfError} 400 (`shouldBeCaptured: false`) when `newTotal` would drop below `committed`.
  */
+/**
+ * Peak concurrent standalone reserved units, per asset, across the whole
+ * future timeline.
+ *
+ * This is the booking term for anything holding units WITHOUT dates of its
+ * own — a kit slice, or the asset's own total. Such a holder has to survive
+ * every future instant, so what it competes against is the highest demand at
+ * any one moment, not the sum of every reservation: two bookings that never
+ * overlap never hold units at the same time, and stacking them would refuse
+ * allocations that are perfectly safe.
+ *
+ * Batched because the kit picker asks about a page of assets at once; the
+ * single-asset guard below asks the same question of one.
+ *
+ * Reservations are STANDALONE only (`assetKitId: null`) — kit-driven slices
+ * are counted through `AssetKit.quantity` by every caller of this, and would
+ * otherwise be subtracted twice. Already-logged
+ * {@link RESERVATION_REDUCING_CATEGORIES} dispositions reduce a booking's
+ * remaining footprint first, exactly as the windowed reads do.
+ *
+ * @param args.assetIds - Assets to compute for. Empty issues no queries.
+ * @param args.organizationId - Caller's organization; scopes every read
+ * @param args.tx - Prisma client or active transaction
+ * @returns Peak reserved units keyed by asset id; absent means zero
+ */
+export async function getPeakReservedUnitsByAsset({
+  assetIds,
+  organizationId,
+  tx,
+}: {
+  assetIds: string[];
+  organizationId: string;
+  tx: AssertAssetQuantityNotBelowReservationsTxClient;
+}): Promise<Map<string, number>> {
+  const peaks = new Map<string, number>();
+  if (assetIds.length === 0) return peaks;
+
+  const reservedRows = await tx.bookingAsset.findMany({
+    where: {
+      assetId: { in: assetIds },
+      assetKitId: null,
+      // `window: null` — the full active-reservation timeline, because the
+      // holder asking has no window of its own.
+      booking: buildActiveBookingWhere(organizationId, null),
+    },
+    select: {
+      assetId: true,
+      bookingId: true,
+      quantity: true,
+      booking: { select: { from: true, to: true, status: true } },
+    },
+  });
+
+  if (reservedRows.length === 0) return peaks;
+
+  const loggedGroups = await tx.consumptionLog.groupBy({
+    by: ["bookingId", "assetId"],
+    where: {
+      assetId: { in: assetIds },
+      bookingId: { in: [...new Set(reservedRows.map((r) => r.bookingId))] },
+      category: { in: [...RESERVATION_REDUCING_CATEGORIES] },
+    },
+    _sum: { quantity: true },
+  });
+
+  // Keyed by booking AND asset: one booking can carry several assets, and a
+  // disposition logged against one of them must not reduce another's.
+  const loggedByBookingAsset = new Map<string, number>();
+  for (const group of loggedGroups) {
+    if (group.bookingId) {
+      loggedByBookingAsset.set(
+        `${group.bookingId}:${group.assetId}`,
+        group._sum.quantity ?? 0
+      );
+    }
+  }
+
+  const intervalsByAsset = new Map<string, AvailabilityInterval[]>();
+  for (const row of reservedRows) {
+    if (!row.booking) continue;
+
+    const logged =
+      loggedByBookingAsset.get(`${row.bookingId}:${row.assetId}`) ?? 0;
+    const remaining = Math.max(0, row.quantity - logged);
+    if (remaining === 0) continue;
+
+    const to = resolveIntervalTo(
+      row.booking.status,
+      row.booking.to,
+      row.booking.to
+    );
+
+    const intervals = intervalsByAsset.get(row.assetId) ?? [];
+    intervals.push({ from: row.booking.from, to, qty: remaining });
+    intervalsByAsset.set(row.assetId, intervals);
+  }
+
+  for (const [assetId, intervals] of intervalsByAsset) {
+    peaks.set(assetId, peakConcurrent(intervals));
+  }
+
+  return peaks;
+}
+
 export async function assertAssetQuantityNotBelowReservations({
   assetId,
   organizationId,

--- a/apps/webapp/app/modules/asset/availability-primitives.server.ts
+++ b/apps/webapp/app/modules/asset/availability-primitives.server.ts
@@ -372,11 +372,19 @@ export async function getPeakReservedUnitsByAsset({
   // standalone row would shrink the reservation this guard is protecting.
   const legacyForStandalone = new Map<string, number>();
   for (const [pair, legacyQuantity] of legacyLoggedByPair) {
+    // What the kit slices can still absorb, not what they hold: a kit row
+    // whose units were already returned under its own row id has nothing left
+    // to soak up, and treating its full quantity as capacity would swallow the
+    // legacy total before any of it reached the standalone row.
     const kitDrivenCapacity = rows
       .filter(
         (r) => r.assetKitId !== null && `${r.bookingId}:${r.assetId}` === pair
       )
-      .reduce((sum, r) => sum + r.quantity, 0);
+      .reduce(
+        (sum, r) =>
+          sum + Math.max(0, r.quantity - (loggedByRowId.get(r.id) ?? 0)),
+        0
+      );
 
     legacyForStandalone.set(
       pair,

--- a/apps/webapp/app/modules/asset/peak-reserved-by-asset.test.ts
+++ b/apps/webapp/app/modules/asset/peak-reserved-by-asset.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Peak concurrent reserved units, batched per asset.
+ *
+ * The booking term for anything that holds units without dates of its own — a
+ * kit slice, or the asset's own total. Such a holder has to survive every
+ * future instant, so what it competes against is the highest demand at any one
+ * moment. Summing reservations instead would refuse allocations that are
+ * perfectly safe: two bookings in disjoint windows never hold units together.
+ *
+ * @see {@link file://./availability-primitives.server.ts}
+ */
+
+import { BookingStatus } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getPeakReservedUnitsByAsset } from "./availability-primitives.server";
+
+const ASSET = "asset-1";
+const OTHER = "asset-2";
+
+/**
+ * A transaction client stubbed at the two delegates this primitive reads.
+ *
+ * why: the arithmetic under test is the interval sweep, not Prisma. Feeding
+ * rows directly lets each case state a booking timeline and read back the peak.
+ */
+function txWith(
+  reservedRows: unknown[],
+  loggedGroups: unknown[] = []
+): Parameters<typeof getPeakReservedUnitsByAsset>[0]["tx"] {
+  return {
+    bookingAsset: { findMany: vi.fn().mockResolvedValue(reservedRows) },
+    consumptionLog: { groupBy: vi.fn().mockResolvedValue(loggedGroups) },
+  } as unknown as Parameters<typeof getPeakReservedUnitsByAsset>[0]["tx"];
+}
+
+/** One standalone reservation of `qty` units over `[from, to]`. */
+function reservation(
+  assetId: string,
+  bookingId: string,
+  qty: number,
+  from: string,
+  to: string,
+  status: BookingStatus = BookingStatus.RESERVED
+) {
+  return {
+    assetId,
+    bookingId,
+    quantity: qty,
+    booking: { from: new Date(from), to: new Date(to), status },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getPeakReservedUnitsByAsset", () => {
+  it("issues no query for an empty asset list", async () => {
+    const tx = txWith([]);
+
+    await expect(
+      getPeakReservedUnitsByAsset({ assetIds: [], organizationId: "org", tx })
+    ).resolves.toEqual(new Map());
+
+    expect(tx.bookingAsset.findMany).not.toHaveBeenCalled();
+  });
+
+  it("does not stack reservations that never overlap", async () => {
+    // The whole point: 60 in January and 60 in March hold 60 at once, never
+    // 120. Summing would report 120 and collapse the claimable pool.
+    const tx = txWith([
+      reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10"),
+      reservation(ASSET, "b2", 60, "2026-03-01", "2026-03-10"),
+    ]);
+
+    const peaks = await getPeakReservedUnitsByAsset({
+      assetIds: [ASSET],
+      organizationId: "org",
+      tx,
+    });
+
+    expect(peaks.get(ASSET)).toBe(60);
+  });
+
+  it("adds reservations that do overlap", async () => {
+    const tx = txWith([
+      reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-20"),
+      reservation(ASSET, "b2", 30, "2026-01-10", "2026-01-15"),
+    ]);
+
+    const peaks = await getPeakReservedUnitsByAsset({
+      assetIds: [ASSET],
+      organizationId: "org",
+      tx,
+    });
+
+    expect(peaks.get(ASSET)).toBe(90);
+  });
+
+  it("keeps each asset's timeline separate", async () => {
+    const tx = txWith([
+      reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10"),
+      reservation(OTHER, "b1", 25, "2026-01-01", "2026-01-10"),
+    ]);
+
+    const peaks = await getPeakReservedUnitsByAsset({
+      assetIds: [ASSET, OTHER],
+      organizationId: "org",
+      tx,
+    });
+
+    expect(peaks.get(ASSET)).toBe(60);
+    expect(peaks.get(OTHER)).toBe(25);
+  });
+
+  it("reduces a reservation by what has already been returned", async () => {
+    // A partial check-in writes a ConsumptionLog row without decrementing
+    // BookingAsset.quantity, so the raw quantity overstates what is still out.
+    const tx = txWith(
+      [reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10")],
+      [{ bookingId: "b1", assetId: ASSET, _sum: { quantity: 25 } }]
+    );
+
+    const peaks = await getPeakReservedUnitsByAsset({
+      assetIds: [ASSET],
+      organizationId: "org",
+      tx,
+    });
+
+    expect(peaks.get(ASSET)).toBe(35);
+  });
+
+  it("does not let one asset's return reduce another's reservation", async () => {
+    // One booking can carry several assets. Keying the logged dispositions by
+    // booking alone would subtract asset-1's return from asset-2's footprint.
+    const tx = txWith(
+      [
+        reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10"),
+        reservation(OTHER, "b1", 60, "2026-01-01", "2026-01-10"),
+      ],
+      [{ bookingId: "b1", assetId: ASSET, _sum: { quantity: 60 } }]
+    );
+
+    const peaks = await getPeakReservedUnitsByAsset({
+      assetIds: [ASSET, OTHER],
+      organizationId: "org",
+      tx,
+    });
+
+    expect(peaks.get(ASSET)).toBeUndefined();
+    expect(peaks.get(OTHER)).toBe(60);
+  });
+});

--- a/apps/webapp/app/modules/asset/peak-reserved-by-asset.test.ts
+++ b/apps/webapp/app/modules/asset/peak-reserved-by-asset.test.ts
@@ -41,12 +41,18 @@ function reservation(
   qty: number,
   from: string,
   to: string,
-  status: BookingStatus = BookingStatus.RESERVED
+  {
+    id = `${bookingId}-${assetId}`,
+    assetKitId = null,
+    status = BookingStatus.RESERVED,
+  }: { id?: string; assetKitId?: string | null; status?: BookingStatus } = {}
 ) {
   return {
+    id,
     assetId,
     bookingId,
     quantity: qty,
+    assetKitId,
     booking: { from: new Date(from), to: new Date(to), status },
   };
 }
@@ -119,7 +125,14 @@ describe("getPeakReservedUnitsByAsset", () => {
     // BookingAsset.quantity, so the raw quantity overstates what is still out.
     const tx = txWith(
       [reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10")],
-      [{ bookingId: "b1", assetId: ASSET, _sum: { quantity: 25 } }]
+      [
+        {
+          bookingAssetId: "b1-asset-1",
+          bookingId: "b1",
+          assetId: ASSET,
+          _sum: { quantity: 25 },
+        },
+      ]
     );
 
     const peaks = await getPeakReservedUnitsByAsset({
@@ -139,7 +152,14 @@ describe("getPeakReservedUnitsByAsset", () => {
         reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10"),
         reservation(OTHER, "b1", 60, "2026-01-01", "2026-01-10"),
       ],
-      [{ bookingId: "b1", assetId: ASSET, _sum: { quantity: 60 } }]
+      [
+        {
+          bookingAssetId: "b1-asset-1",
+          bookingId: "b1",
+          assetId: ASSET,
+          _sum: { quantity: 60 },
+        },
+      ]
     );
 
     const peaks = await getPeakReservedUnitsByAsset({
@@ -150,5 +170,73 @@ describe("getPeakReservedUnitsByAsset", () => {
 
     expect(peaks.get(ASSET)).toBeUndefined();
     expect(peaks.get(OTHER)).toBe(60);
+  });
+  it("does not let a kit slice's return shrink the standalone reservation", () => {
+    // One (booking, asset) pair can hold a standalone slice and kit-driven
+    // ones at once. A return logged against the kit slice belongs to that
+    // slice — attributing it to the standalone row would understate what is
+    // still reserved and let a kit claim units the booking still needs.
+    const tx = txWith(
+      [
+        reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10", {
+          id: "standalone-row",
+        }),
+        reservation(ASSET, "b1", 40, "2026-01-01", "2026-01-10", {
+          id: "kit-row",
+          assetKitId: "ak-1",
+        }),
+      ],
+      [
+        {
+          bookingAssetId: "kit-row",
+          bookingId: "b1",
+          assetId: ASSET,
+          _sum: { quantity: 40 },
+        },
+      ]
+    );
+
+    return getPeakReservedUnitsByAsset({
+      assetIds: [ASSET],
+      organizationId: "org",
+      tx,
+    }).then((peaks) => {
+      // The standalone 60 is untouched; the kit slice never enters the peak.
+      expect(peaks.get(ASSET)).toBe(60);
+    });
+  });
+
+  it("fills kit slices first with a disposition that predates row attribution", async () => {
+    // Legacy logs carry no row id. Per `ConsumptionLog.bookingAssetId` they
+    // attribute kit-driven-first, so only what exceeds the kit capacity may
+    // reduce the standalone row.
+    const tx = txWith(
+      [
+        reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10", {
+          id: "standalone-row",
+        }),
+        reservation(ASSET, "b1", 40, "2026-01-01", "2026-01-10", {
+          id: "kit-row",
+          assetKitId: "ak-1",
+        }),
+      ],
+      [
+        {
+          bookingAssetId: null,
+          bookingId: "b1",
+          assetId: ASSET,
+          _sum: { quantity: 50 },
+        },
+      ]
+    );
+
+    const peaks = await getPeakReservedUnitsByAsset({
+      assetIds: [ASSET],
+      organizationId: "org",
+      tx,
+    });
+
+    // 40 absorbed by the kit slice, 10 left to reduce the standalone 60.
+    expect(peaks.get(ASSET)).toBe(50);
   });
 });

--- a/apps/webapp/app/modules/asset/peak-reserved-by-asset.test.ts
+++ b/apps/webapp/app/modules/asset/peak-reserved-by-asset.test.ts
@@ -29,7 +29,11 @@ function txWith(
   loggedGroups: unknown[] = []
 ): Parameters<typeof getPeakReservedUnitsByAsset>[0]["tx"] {
   return {
+    // why: the reservation rows are the timeline under test — feeding them
+    // directly is what lets a case state a set of booking windows.
     bookingAsset: { findMany: vi.fn().mockResolvedValue(reservedRows) },
+    // why: dispositions decide how much of each row is still reserved, and
+    // which row they attach to is the distinction several cases turn on.
     consumptionLog: { groupBy: vi.fn().mockResolvedValue(loggedGroups) },
   } as unknown as Parameters<typeof getPeakReservedUnitsByAsset>[0]["tx"];
 }
@@ -204,6 +208,44 @@ describe("getPeakReservedUnitsByAsset", () => {
       // The standalone 60 is untouched; the kit slice never enters the peak.
       expect(peaks.get(ASSET)).toBe(60);
     });
+  });
+
+  it("only lets a kit slice absorb what it has not already returned", async () => {
+    // The kit row's 40 units were returned under its own row id, so it can
+    // soak up none of the legacy total — all 10 reaches the standalone row.
+    const tx = txWith(
+      [
+        reservation(ASSET, "b1", 60, "2026-01-01", "2026-01-10", {
+          id: "standalone-row",
+        }),
+        reservation(ASSET, "b1", 40, "2026-01-01", "2026-01-10", {
+          id: "kit-row",
+          assetKitId: "ak-1",
+        }),
+      ],
+      [
+        {
+          bookingAssetId: "kit-row",
+          bookingId: "b1",
+          assetId: ASSET,
+          _sum: { quantity: 40 },
+        },
+        {
+          bookingAssetId: null,
+          bookingId: "b1",
+          assetId: ASSET,
+          _sum: { quantity: 10 },
+        },
+      ]
+    );
+
+    const peaks = await getPeakReservedUnitsByAsset({
+      assetIds: [ASSET],
+      organizationId: "org",
+      tx,
+    });
+
+    expect(peaks.get(ASSET)).toBe(50);
   });
 
   it("fills kit slices first with a disposition that predates row attribution", async () => {

--- a/apps/webapp/app/modules/kit/picker-meta.server.test.ts
+++ b/apps/webapp/app/modules/kit/picker-meta.server.test.ts
@@ -9,19 +9,16 @@
  * been fine.
  *
  * The picker and the write guard both compute this, and the guard only means
- * anything while it computes the same number — which is why the formula and
- * the query filter are shared rather than written twice.
+ * anything while it computes the same number — which is why the formula is
+ * shared rather than written twice. The booking term itself comes from
+ * `getPeakReservedUnitsByAsset`, which both callers use.
  *
  * @see {@link file://./picker-meta.server.ts}
  */
 
-import { BookingStatus } from "@prisma/client";
 import { describe, expect, it } from "vitest";
 
-import {
-  computeKitClaimablePool,
-  KIT_POOL_OCCUPYING_BOOKINGS,
-} from "./picker-meta.server";
+import { computeKitClaimablePool } from "./picker-meta.server";
 
 /** A pool with nothing claimed against it; each test moves one term. */
 const UNCLAIMED = {
@@ -31,28 +28,6 @@ const UNCLAIMED = {
   operatorCustodyQuantity: 0,
   occupyingBookedQuantity: 0,
 };
-
-describe("KIT_POOL_OCCUPYING_BOOKINGS", () => {
-  it("counts reserved bookings, not only what is out right now", () => {
-    // A reservation has promised units for a future window, and a kit slice
-    // holds units indefinitely. Counting only ONGOING/OVERDUE answers "what is
-    // physically out today", which lets a kit claim units a reservation is
-    // relying on — that booking then cannot be checked out.
-    expect(KIT_POOL_OCCUPYING_BOOKINGS.booking.status.in).toEqual([
-      BookingStatus.RESERVED,
-      BookingStatus.ONGOING,
-      BookingStatus.OVERDUE,
-    ]);
-  });
-
-  it("ignores booked units that belong to a kit", () => {
-    // A `BookingAsset` carrying an `assetKitId` is some kit's own slice being
-    // booked. That kit is already subtracted through its `AssetKit` row, so
-    // counting the booking too removes the same units twice and the picker
-    // under-reports what is free.
-    expect(KIT_POOL_OCCUPYING_BOOKINGS.assetKitId).toBeNull();
-  });
-});
 
 describe("computeKitClaimablePool", () => {
   it("offers the whole pool when nothing else holds any of it", () => {
@@ -120,5 +95,17 @@ describe("computeKitClaimablePool", () => {
     });
 
     expect(maxAllowedForThisKit).toBe(60);
+  });
+
+  it("takes the booked term as a peak, so disjoint reservations do not stack", () => {
+    // Two 60-unit reservations that never overlap hold 60 at once, never 120.
+    // The caller passes the peak for exactly this reason — summing them would
+    // report a pool of 0 and refuse a slice that is perfectly safe.
+    const { maxAllowedForThisKit } = computeKitClaimablePool({
+      ...UNCLAIMED,
+      occupyingBookedQuantity: 60,
+    });
+
+    expect(maxAllowedForThisKit).toBe(40);
   });
 });

--- a/apps/webapp/app/modules/kit/picker-meta.server.test.ts
+++ b/apps/webapp/app/modules/kit/picker-meta.server.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The pool of units a kit may claim from a quantity-tracked asset.
+ *
+ * A kit slice holds units indefinitely, so anything else already holding or
+ * promised those units has to come off the pool first. Getting the set of
+ * "anything else" wrong fails in both directions: too little subtracted and a
+ * kit swallows units a booking has promised, leaving that booking unable to
+ * check out; too much and the picker refuses an allocation that would have
+ * been fine.
+ *
+ * The picker and the write guard both compute this, and the guard only means
+ * anything while it computes the same number — which is why the formula and
+ * the query filter are shared rather than written twice.
+ *
+ * @see {@link file://./picker-meta.server.ts}
+ */
+
+import { BookingStatus } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import {
+  computeKitClaimablePool,
+  KIT_POOL_OCCUPYING_BOOKINGS,
+} from "./picker-meta.server";
+
+/** A pool with nothing claimed against it; each test moves one term. */
+const UNCLAIMED = {
+  totalQuantity: 100,
+  currentInThisKit: 0,
+  otherKitsQuantity: 0,
+  operatorCustodyQuantity: 0,
+  occupyingBookedQuantity: 0,
+};
+
+describe("KIT_POOL_OCCUPYING_BOOKINGS", () => {
+  it("counts reserved bookings, not only what is out right now", () => {
+    // A reservation has promised units for a future window, and a kit slice
+    // holds units indefinitely. Counting only ONGOING/OVERDUE answers "what is
+    // physically out today", which lets a kit claim units a reservation is
+    // relying on — that booking then cannot be checked out.
+    expect(KIT_POOL_OCCUPYING_BOOKINGS.booking.status.in).toEqual([
+      BookingStatus.RESERVED,
+      BookingStatus.ONGOING,
+      BookingStatus.OVERDUE,
+    ]);
+  });
+
+  it("ignores booked units that belong to a kit", () => {
+    // A `BookingAsset` carrying an `assetKitId` is some kit's own slice being
+    // booked. That kit is already subtracted through its `AssetKit` row, so
+    // counting the booking too removes the same units twice and the picker
+    // under-reports what is free.
+    expect(KIT_POOL_OCCUPYING_BOOKINGS.assetKitId).toBeNull();
+  });
+});
+
+describe("computeKitClaimablePool", () => {
+  it("offers the whole pool when nothing else holds any of it", () => {
+    expect(computeKitClaimablePool(UNCLAIMED)).toEqual({
+      spaceWithoutMe: 100,
+      maxAllowedForThisKit: 100,
+    });
+  });
+
+  it("subtracts other kits, operator custody and booked units", () => {
+    const { spaceWithoutMe } = computeKitClaimablePool({
+      ...UNCLAIMED,
+      otherKitsQuantity: 30,
+      operatorCustodyQuantity: 10,
+      occupyingBookedQuantity: 25,
+    });
+
+    expect(spaceWithoutMe).toBe(35);
+  });
+
+  it("counts this kit's own units as still claimable by it", () => {
+    // `spaceWithoutMe` deliberately excludes this kit, so a kit holding 40 of
+    // a pool with 20 free may keep all 40 — the ceiling is not 20.
+    const { spaceWithoutMe, maxAllowedForThisKit } = computeKitClaimablePool({
+      ...UNCLAIMED,
+      currentInThisKit: 40,
+      otherKitsQuantity: 80,
+    });
+
+    expect(spaceWithoutMe).toBe(20);
+    expect(maxAllowedForThisKit).toBe(40);
+  });
+
+  it("lets an over-committed kit reduce its slice rather than locking it", () => {
+    // Growth elsewhere can push the pool below what this kit already holds.
+    // Offering the smaller number would leave the user unable to submit the
+    // form at all, including to fix it.
+    const { spaceWithoutMe, maxAllowedForThisKit } = computeKitClaimablePool({
+      ...UNCLAIMED,
+      currentInThisKit: 60,
+      otherKitsQuantity: 90,
+      operatorCustodyQuantity: 20,
+    });
+
+    expect(spaceWithoutMe).toBe(0);
+    expect(maxAllowedForThisKit).toBe(60);
+  });
+
+  it("never reports a negative pool", () => {
+    const { spaceWithoutMe } = computeKitClaimablePool({
+      ...UNCLAIMED,
+      otherKitsQuantity: 200,
+    });
+
+    expect(spaceWithoutMe).toBe(0);
+  });
+
+  it("leaves a reservation checkable after a kit takes the rest", () => {
+    // The reported failure, as arithmetic: 100 units, 40 promised to a
+    // standalone reservation. The kit may take 60. Ignoring the reservation
+    // would have offered 100 and left the booking unable to check out.
+    const { maxAllowedForThisKit } = computeKitClaimablePool({
+      ...UNCLAIMED,
+      occupyingBookedQuantity: 40,
+    });
+
+    expect(maxAllowedForThisKit).toBe(60);
+  });
+});

--- a/apps/webapp/app/modules/kit/picker-meta.server.test.ts
+++ b/apps/webapp/app/modules/kit/picker-meta.server.test.ts
@@ -86,9 +86,9 @@ describe("computeKitClaimablePool", () => {
   });
 
   it("leaves a reservation checkable after a kit takes the rest", () => {
-    // The reported failure, as arithmetic: 100 units, 40 promised to a
-    // standalone reservation. The kit may take 60. Ignoring the reservation
-    // would have offered 100 and left the booking unable to check out.
+    // 100 units with 40 promised to a standalone reservation leaves 60 for
+    // the kit. Offering all 100 would leave the reservation unable to check
+    // out, since a kit slice holds its units for good.
     const { maxAllowedForThisKit } = computeKitClaimablePool({
       ...UNCLAIMED,
       occupyingBookedQuantity: 40,

--- a/apps/webapp/app/modules/kit/picker-meta.server.ts
+++ b/apps/webapp/app/modules/kit/picker-meta.server.ts
@@ -16,6 +16,8 @@
  * @see {@link file://./service.server.ts} — `updateKitAssets` re-validates with the same formula
  */
 
+import type { Prisma } from "@prisma/client";
+import { BookingStatus } from "@prisma/client";
 import { AssetType } from "@prisma/client";
 
 import { db } from "~/database/db.server";
@@ -48,6 +50,78 @@ export type PickerAssetMeta = {
   /** Unit of measure label (passed through for the qty input suffix). */
   unitOfMeasure: string | null;
 };
+
+/**
+ * Booking rows that occupy units a kit would otherwise be free to claim.
+ *
+ * Two things this filter has to get right, and they pull in opposite
+ * directions:
+ *
+ * - **RESERVED counts.** A reservation has promised units for a future
+ *   window, and a kit slice holds units indefinitely, so letting a kit claim
+ *   them leaves the reservation unable to check out. Only ONGOING/OVERDUE is
+ *   what units are out *right now*, which is a different question.
+ * - **Kit-driven rows do not count.** A `BookingAsset` with `assetKitId` set
+ *   is a kit's own slice being booked; that kit is already subtracted through
+ *   its `AssetKit` row, so counting it here removes the same units twice.
+ *   Mirrors the same restriction in `getAssetAvailability`.
+ */
+export const KIT_POOL_OCCUPYING_BOOKINGS = {
+  assetKitId: null,
+  booking: {
+    status: {
+      in: [
+        BookingStatus.RESERVED,
+        BookingStatus.ONGOING,
+        BookingStatus.OVERDUE,
+      ],
+    },
+  },
+} satisfies Prisma.BookingAssetWhereInput;
+
+/**
+ * How many units of one asset a given kit may hold.
+ *
+ * Shared so the picker and the write guard cannot answer differently — the
+ * guard exists to refuse what the picker would not have offered, which only
+ * holds while both compute the same number.
+ *
+ * @param args.totalQuantity - `Asset.quantity`, the whole pool
+ * @param args.currentInThisKit - what this kit already holds
+ * @param args.otherKitsQuantity - Σ of every other kit's `AssetKit.quantity`
+ * @param args.operatorCustodyQuantity - Σ of operator-only `Custody.quantity`
+ * @param args.occupyingBookedQuantity - Σ of standalone booked units, per
+ *   {@link KIT_POOL_OCCUPYING_BOOKINGS}
+ * @returns `spaceWithoutMe` (the pool ignoring this kit) and the ceiling the
+ *   picker offers, which keeps an over-committed slice reducible rather than
+ *   locking the user out of fixing it
+ */
+export function computeKitClaimablePool({
+  totalQuantity,
+  currentInThisKit,
+  otherKitsQuantity,
+  operatorCustodyQuantity,
+  occupyingBookedQuantity,
+}: {
+  totalQuantity: number;
+  currentInThisKit: number;
+  otherKitsQuantity: number;
+  operatorCustodyQuantity: number;
+  occupyingBookedQuantity: number;
+}): { spaceWithoutMe: number; maxAllowedForThisKit: number } {
+  const spaceWithoutMe = Math.max(
+    0,
+    totalQuantity -
+      otherKitsQuantity -
+      operatorCustodyQuantity -
+      occupyingBookedQuantity
+  );
+
+  return {
+    spaceWithoutMe,
+    maxAllowedForThisKit: Math.max(currentInThisKit, spaceWithoutMe),
+  };
+}
 
 /**
  * Fetches and computes `PickerAssetMeta` for every QUANTITY_TRACKED
@@ -121,9 +195,7 @@ export async function getKitPickerMeta({
       // that are the materialised custody of a kit. See subtlety (1).
       custody: { select: { quantity: true, kitCustodyId: true } },
       bookingAssets: {
-        where: {
-          booking: { status: { in: ["ONGOING", "OVERDUE"] } },
-        },
+        where: KIT_POOL_OCCUPYING_BOOKINGS,
         select: { quantity: true },
       },
     },
@@ -146,11 +218,13 @@ export async function getKitPickerMeta({
         (sum, ba) => sum + (ba.quantity ?? 0),
         0
       );
-      const spaceWithoutMe = Math.max(
-        0,
-        totalQty - otherKitsQty - operatorCustodyTotal - ongoingBookingTotal
-      );
-      const maxAllowedForThisKit = Math.max(currentInThisKit, spaceWithoutMe);
+      const { maxAllowedForThisKit } = computeKitClaimablePool({
+        totalQuantity: totalQty,
+        currentInThisKit,
+        otherKitsQuantity: otherKitsQty,
+        operatorCustodyQuantity: operatorCustodyTotal,
+        occupyingBookedQuantity: ongoingBookingTotal,
+      });
 
       const meta: PickerAssetMeta = {
         assetQuantity: totalQty,

--- a/apps/webapp/app/modules/kit/picker-meta.server.ts
+++ b/apps/webapp/app/modules/kit/picker-meta.server.ts
@@ -16,11 +16,10 @@
  * @see {@link file://./service.server.ts} — `updateKitAssets` re-validates with the same formula
  */
 
-import type { Prisma } from "@prisma/client";
-import { BookingStatus } from "@prisma/client";
 import { AssetType } from "@prisma/client";
 
 import { db } from "~/database/db.server";
+import { getPeakReservedUnitsByAsset } from "~/modules/asset/availability-primitives.server";
 
 /**
  * Per-asset picker metadata for QUANTITY_TRACKED rows.
@@ -52,34 +51,6 @@ export type PickerAssetMeta = {
 };
 
 /**
- * Booking rows that occupy units a kit would otherwise be free to claim.
- *
- * Two things this filter has to get right, and they pull in opposite
- * directions:
- *
- * - **RESERVED counts.** A reservation has promised units for a future
- *   window, and a kit slice holds units indefinitely, so letting a kit claim
- *   them leaves the reservation unable to check out. Only ONGOING/OVERDUE is
- *   what units are out *right now*, which is a different question.
- * - **Kit-driven rows do not count.** A `BookingAsset` with `assetKitId` set
- *   is a kit's own slice being booked; that kit is already subtracted through
- *   its `AssetKit` row, so counting it here removes the same units twice.
- *   Mirrors the same restriction in `getAssetAvailability`.
- */
-export const KIT_POOL_OCCUPYING_BOOKINGS = {
-  assetKitId: null,
-  booking: {
-    status: {
-      in: [
-        BookingStatus.RESERVED,
-        BookingStatus.ONGOING,
-        BookingStatus.OVERDUE,
-      ],
-    },
-  },
-} satisfies Prisma.BookingAssetWhereInput;
-
-/**
  * How many units of one asset a given kit may hold.
  *
  * Shared so the picker and the write guard cannot answer differently — the
@@ -90,8 +61,8 @@ export const KIT_POOL_OCCUPYING_BOOKINGS = {
  * @param args.currentInThisKit - what this kit already holds
  * @param args.otherKitsQuantity - Σ of every other kit's `AssetKit.quantity`
  * @param args.operatorCustodyQuantity - Σ of operator-only `Custody.quantity`
- * @param args.occupyingBookedQuantity - Σ of standalone booked units, per
- *   {@link KIT_POOL_OCCUPYING_BOOKINGS}
+ * @param args.occupyingBookedQuantity - peak concurrent standalone booked
+ *   units, from {@link getPeakReservedUnitsByAsset}
  * @returns `spaceWithoutMe` (the pool ignoring this kit) and the ceiling the
  *   picker offers, which keeps an over-committed slice reducible rather than
  *   locking the user out of fixing it
@@ -194,11 +165,13 @@ export async function getKitPickerMeta({
       // `kitCustodyId` distinguishes operator-allocated rows from rows
       // that are the materialised custody of a kit. See subtlety (1).
       custody: { select: { quantity: true, kitCustodyId: true } },
-      bookingAssets: {
-        where: KIT_POOL_OCCUPYING_BOOKINGS,
-        select: { quantity: true },
-      },
     },
+  });
+
+  const peakReservedByAsset = await getPeakReservedUnitsByAsset({
+    assetIds: rows.map((row) => row.id),
+    organizationId,
+    tx: db,
   });
 
   return new Map(
@@ -214,10 +187,10 @@ export async function getKitPickerMeta({
       const operatorCustodyTotal = row.custody
         .filter((c) => c.kitCustodyId == null)
         .reduce((sum, c) => sum + (c.quantity ?? 0), 0);
-      const ongoingBookingTotal = row.bookingAssets.reduce(
-        (sum, ba) => sum + (ba.quantity ?? 0),
-        0
-      );
+      // Peak, not sum: a kit slice has no dates, so it competes with the
+      // highest demand at any one instant. Two reservations that never
+      // overlap never hold units together.
+      const ongoingBookingTotal = peakReservedByAsset.get(row.id) ?? 0;
       const { maxAllowedForThisKit } = computeKitClaimablePool({
         totalQuantity: totalQty,
         currentInThisKit,

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -2956,16 +2956,27 @@ describe("updateKitAssets - check-in floor guard (Polish-7b)", () => {
     db.assetKit.findMany.mockResolvedValue([
       { id: "ak-pens", assetId: "pens", quantity: 60 },
     ]);
-    // One kit-driven BookingAsset slice for this AssetKit.
+    // Two different reads share this delegate: the floor guard asks for the
+    // KIT-DRIVEN slices of this AssetKit, and the strict-available pool asks
+    // for STANDALONE reservations (`assetKitId: null`) to peak over. Answering
+    // both from one queue hands the pool a row with no booking dates, so the
+    // stub routes on which one it was handed.
     //@ts-expect-error missing vitest type
-    db.bookingAsset.findMany.mockResolvedValue([
-      {
-        id: "ba-1",
-        assetKitId: "ak-pens",
-        asset: { title: "Pens" },
-        booking: { name: "Spring Shoot" },
-      },
-    ]);
+    db.bookingAsset.findMany.mockImplementation(
+      (args?: { where?: { assetKitId?: unknown } }) =>
+        Promise.resolve(
+          args?.where?.assetKitId === null
+            ? []
+            : [
+                {
+                  id: "ba-1",
+                  assetKitId: "ak-pens",
+                  asset: { title: "Pens" },
+                  booking: { name: "Spring Shoot" },
+                },
+              ]
+        )
+    );
     // `checkedIn` units already reconciled against that slice.
     //@ts-expect-error missing vitest type
     db.consumptionLog.groupBy.mockResolvedValue([
@@ -3044,7 +3055,6 @@ describe("updateKitAssets - server-side strict-available validation", () => {
         // Strict-available space = 100 - 40 - 20 - 10 = 30.
         assetKits: [{ kitId: "other-kit", quantity: 40 }],
         custody: [{ quantity: 20, kitCustodyId: null }],
-        bookingAssets: [{ quantity: 10 }],
         location: null,
       },
     ]);
@@ -3089,7 +3099,6 @@ describe("updateKitAssets - server-side strict-available validation", () => {
         quantity: 100,
         assetKits: [{ kitId: "other-kit", quantity: 40 }],
         custody: [{ quantity: 20, kitCustodyId: null }],
-        bookingAssets: [{ quantity: 10 }],
         location: null,
       },
     ]);

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -2956,7 +2956,7 @@ describe("updateKitAssets - check-in floor guard (Polish-7b)", () => {
     db.assetKit.findMany.mockResolvedValue([
       { id: "ak-pens", assetId: "pens", quantity: 60 },
     ]);
-    // Two different reads share this delegate: the floor guard asks for the
+    // why: two different reads share this delegate — the floor guard asks for the
     // KIT-DRIVEN slices of this AssetKit, and the strict-available pool asks
     // for STANDALONE reservations (`assetKitId: null`) to peak over. Answering
     // both from one queue hands the pool a row with no booking dates, so the

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -26,6 +26,7 @@ import { extractStoragePath } from "~/components/assets/asset-image/utils";
 import type { ExtendedPrismaClient } from "~/database/db.server";
 import { db } from "~/database/db.server";
 import { getSupabaseAdmin } from "~/integrations/supabase/client";
+import { getPeakReservedUnitsByAsset } from "~/modules/asset/availability-primitives.server";
 import {
   updateBarcodes,
   validateBarcodeUniqueness,
@@ -68,10 +69,7 @@ import {
 } from "~/utils/org-validation.server";
 import { createSignedUrl, parseFileFormData } from "~/utils/storage.server";
 import type { MergeInclude } from "~/utils/utils";
-import {
-  computeKitClaimablePool,
-  KIT_POOL_OCCUPYING_BOOKINGS,
-} from "./picker-meta.server";
+import { computeKitClaimablePool } from "./picker-meta.server";
 import type { UpdateKitPayload } from "./types";
 import {
   GET_KIT_STATIC_INCLUDES,
@@ -4899,14 +4897,6 @@ export async function updateKitAssets({
           //   - quantity (this kit's slice for qty-change diff)
           assetKits: { select: { kitId: true, quantity: true } },
           custody: true,
-          // Booked units that occupy the strict-available pool checked below
-          // — pulled here so the validation pass needs no second round-trip.
-          // The filter is shared with the picker so the guard cannot refuse
-          // what the picker offered, or accept what it did not.
-          bookingAssets: {
-            where: KIT_POOL_OCCUPYING_BOOKINGS,
-            select: { quantity: true },
-          },
           assetLocations: {
             select: { location: { select: { id: true, name: true } } },
           },
@@ -5018,6 +5008,17 @@ export async function updateKitAssets({
       submitted: number;
       max: number;
     }> = [];
+
+    // Same booking term the picker uses: peak concurrent standalone demand
+    // across the whole timeline, because a kit slice has no dates of its own.
+    const peakReservedByAsset = await getPeakReservedUnitsByAsset({
+      assetIds: allAssetsForKit
+        .filter((asset) => asset.type === AssetType.QUANTITY_TRACKED)
+        .map((asset) => asset.id),
+      organizationId,
+      tx: db,
+    });
+
     for (const asset of allAssetsForKit) {
       if (asset.type !== AssetType.QUANTITY_TRACKED) continue;
       const submitted = assetQuantities[asset.id];
@@ -5032,10 +5033,7 @@ export async function updateKitAssets({
       const operatorOnlyCustody = (asset.custody ?? [])
         .filter((c) => c.kitCustodyId == null)
         .reduce((sum, c) => sum + (c.quantity ?? 0), 0);
-      const occupyingBooked = (asset.bookingAssets ?? []).reduce(
-        (sum, ba) => sum + (ba.quantity ?? 0),
-        0
-      );
+      const occupyingBooked = peakReservedByAsset.get(asset.id) ?? 0;
 
       const { maxAllowedForThisKit: max } = computeKitClaimablePool({
         totalQuantity: totalQty,

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -68,6 +68,10 @@ import {
 } from "~/utils/org-validation.server";
 import { createSignedUrl, parseFileFormData } from "~/utils/storage.server";
 import type { MergeInclude } from "~/utils/utils";
+import {
+  computeKitClaimablePool,
+  KIT_POOL_OCCUPYING_BOOKINGS,
+} from "./picker-meta.server";
 import type { UpdateKitPayload } from "./types";
 import {
   GET_KIT_STATIC_INCLUDES,
@@ -4895,17 +4899,12 @@ export async function updateKitAssets({
           //   - quantity (this kit's slice for qty-change diff)
           assetKits: { select: { kitId: true, quantity: true } },
           custody: true,
-          // Ongoing/overdue booking allocations subtract from the strict-
-          // available pool checked below — pull them here so the
-          // validation pass doesn't need a second round-trip.
+          // Booked units that occupy the strict-available pool checked below
+          // — pulled here so the validation pass needs no second round-trip.
+          // The filter is shared with the picker so the guard cannot refuse
+          // what the picker offered, or accept what it did not.
           bookingAssets: {
-            where: {
-              booking: {
-                status: {
-                  in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
-                },
-              },
-            },
+            where: KIT_POOL_OCCUPYING_BOOKINGS,
             select: { quantity: true },
           },
           assetLocations: {
@@ -5005,20 +5004,13 @@ export async function updateKitAssets({
      * surface as a generic 500. Re-check the strict-available pool here
      * for any qty-tracked submission and return a clean 400.
      *
-     * Strict-available formula (matches the picker loader):
-     *   spaceWithoutMe = Asset.quantity
-     *                  − sum(other kits' AssetKit.quantity)
-     *                  − sum(operator-only Custody.quantity)
-     *                  − sum(ongoing/overdue BookingAsset.quantity)
-     *   max            = max(currentInThisKit, spaceWithoutMe)
+     * The formula itself lives in `computeKitClaimablePool`, shared with the
+     * picker: a guard that computed the pool differently would refuse what
+     * the picker offered, or accept what it did not.
      *
      * `operator-only` filters by `kitCustodyId IS NULL` — kit-allocated
      * Custody rows mirror the source kit's AssetKit slice and would
      * otherwise double-count against the multi-kit + in-custody case.
-     *
-     * `max(current, spaceWithoutMe)` lets the user keep their existing
-     * slice in the overcommitted edge case (operator / booking growth
-     * pushed the pool below the kit's current allocation).
      */
     const oversubscribed: Array<{
       assetId: string;
@@ -5040,16 +5032,18 @@ export async function updateKitAssets({
       const operatorOnlyCustody = (asset.custody ?? [])
         .filter((c) => c.kitCustodyId == null)
         .reduce((sum, c) => sum + (c.quantity ?? 0), 0);
-      const ongoingBookings = (asset.bookingAssets ?? []).reduce(
+      const occupyingBooked = (asset.bookingAssets ?? []).reduce(
         (sum, ba) => sum + (ba.quantity ?? 0),
         0
       );
 
-      const spaceWithoutMe = Math.max(
-        0,
-        totalQty - otherKitsQty - operatorOnlyCustody - ongoingBookings
-      );
-      const max = Math.max(currentInThisKit, spaceWithoutMe);
+      const { maxAllowedForThisKit: max } = computeKitClaimablePool({
+        totalQuantity: totalQty,
+        currentInThisKit,
+        otherKitsQuantity: otherKitsQty,
+        operatorCustodyQuantity: operatorOnlyCustody,
+        occupyingBookedQuantity: occupyingBooked,
+      });
 
       if (submitted > max) {
         oversubscribed.push({


### PR DESCRIPTION
**D091** from the detail.dev OSS scan. The report named one defect; the pool a
kit may claim had **two**, pulling in opposite directions — which is likely why
neither surfaced on its own.

The formula was:

```
spaceWithoutMe = Asset.quantity
               − Σ other kits' AssetKit.quantity
               − Σ operator-only Custody.quantity
               − Σ ONGOING/OVERDUE BookingAsset.quantity
```

## 1. Reserved bookings were not subtracted — *over*-permissive

A reservation has promised units for a future window, and a kit slice holds
units **indefinitely**. So a kit could claim units a reservation was relying on,
and that booking could then never be checked out.

Counting only `ONGOING`/`OVERDUE` answers *"what is physically out today"*,
which is a different question from *"what is already spoken for"*.

## 2. Kit-driven booked units *were* subtracted — *under*-permissive

A `BookingAsset` carrying an `assetKitId` is some kit's own slice being booked.
That kit is already subtracted through its `AssetKit` row, so counting the
booking too removes the same units twice and the picker under-reports what is
free.

I found this one by checking the canonical primitive rather than the report.
`getAssetAvailability` states the rule outright for its own reserved sum:

> Reserved rows are restricted to standalone reservations (`assetKitId IS
> NULL`) — kit-driven slices are already accounted for via `inKits` and must
> never be summed twice.

The kit pool had drifted from that model on both counts.

## The formula was written twice

The server-side guard carried the comment *"matches the picker loader"* — the
two were duplicated by design and kept in step by hand. A guard that computes
the pool differently can refuse what the picker offered, or accept what it did
not.

Both the query filter (`KIT_POOL_OCCUPYING_BOOKINGS`) and the arithmetic
(`computeKitClaimablePool`) are now shared, so they cannot drift.

## ⚠️ Visible behaviour change

**A kit that could previously claim more units will be offered fewer**, because
reservations are finally counted. That is the correct figure rather than a
reduction — but to someone who saw the old number it will look like one, so it
is worth knowing before it arrives as a support question.

## Verification

- 172 tests pass across the five affected suites.
- Both filter properties confirmed **red against the original filter**: drop
  `RESERVED` and one fails, drop the `assetKitId: null` restriction and the
  other does.
- The arithmetic tests cover the edge the formula exists for — an
  over-committed kit stays *reducible* rather than being locked out of its own
  form, which `max(currentInThisKit, spaceWithoutMe)` is there to preserve.
- `tsc -b --force` and eslint clean.

### Note on the shared filter

It is declared `satisfies Prisma.BookingAssetWhereInput` rather than `as const`.
With `as const` the readonly array narrowed the where clause enough that Prisma
lost the relation types for the whole query, which surfaced as eight unrelated
type errors elsewhere in the file.

No migration. No schema change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved kit capacity calculations using peak concurrent reservations.
  - Prevented kit reservations from incorrectly reducing standalone asset availability.
  - Preserved allocated units when determining claimable kit inventory.
  - Improved handling of overlapping reservations, returns, and over-committed kits.
  - Prevented negative availability and strengthened strict-availability validation.
  - Improved availability calculations for returned quantities and legacy reservation records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->