### PR TITLE
fix(mobile): land mobile sessions in the workspace the user last chose

### DIFF
--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -42,6 +42,13 @@ export type MeResponse = {
     timeZone?: string | null;
   };
   organizations: Organization[];
+  /**
+   * The workspace the user last chose, when they still belong to it — the
+   * server's explicit landing signal. `organizations[0]` already reflects it;
+   * this field lets the app distinguish "the server picked for me" from "I
+   * chose this on this device". Absent on older servers.
+   */
+  lastSelectedOrganizationId?: string | null;
 };
 
 /**

--- a/apps/companion/lib/org-context.tsx
+++ b/apps/companion/lib/org-context.tsx
@@ -4,6 +4,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -75,20 +76,32 @@ export function OrgProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * The live selection, readable from async continuations. `fetchOrgs` is
+   * memoized on `[user]`, so its closure's `currentOrg` can be stale by the
+   * time a fetch resolves; a landing decision taken then must see the
+   * workspace the user has ACTUALLY selected meanwhile, not the one from
+   * when the fetch started.
+   */
+  const currentOrgRef = useRef<Organization | null>(null);
+
   /** The user chose this workspace — apply it and remember the choice. */
   const handleSetCurrentOrg = useCallback((org: Organization) => {
+    currentOrgRef.current = org;
     setCurrentOrg(org);
     AsyncStorage.setItem(SELECTED_ORG_KEY, org.id).catch(() => {});
   }, []);
 
   /** The app landed here on its own — apply it without recording a choice. */
   const applyLandingOrg = useCallback((org: Organization) => {
+    currentOrgRef.current = org;
     setCurrentOrg(org);
   }, []);
 
   const fetchOrgs = useCallback(async () => {
     if (!user) {
       setOrganizations([]);
+      currentOrgRef.current = null;
       setCurrentOrg(null);
       setUserProfile(null);
       setIsLoading(false);
@@ -132,9 +145,12 @@ export function OrgProvider({ children }: { children: ReactNode }) {
       return serverChoice || orgs[0];
     };
 
-    // Preserve current selection if still valid
-    if (currentOrg) {
-      const stillExists = orgs.find((o) => o.id === currentOrg.id);
+    // Preserve the LIVE selection if still valid — read through the ref, so a
+    // workspace picked while this fetch was in flight is never stomped by a
+    // landing decision based on pre-fetch state.
+    const liveOrg = currentOrgRef.current;
+    if (liveOrg) {
+      const stillExists = orgs.find((o) => o.id === liveOrg.id);
       if (!stillExists && orgs.length > 0) {
         applyLandingOrg(resolveLandingOrg());
       }

--- a/apps/companion/lib/org-context.tsx
+++ b/apps/companion/lib/org-context.tsx
@@ -19,7 +19,16 @@ import { useAuth } from "./auth-context";
 import { api, type Organization } from "./api";
 import { setSentryUser } from "./sentry";
 
-const SELECTED_ORG_KEY = "shelf_selected_org_id";
+/**
+ * Where an EXPLICIT workspace choice made on this device is persisted.
+ *
+ * Only the user's own switches are written here — automatic landings never
+ * are, so an empty key means "this device has no opinion" and the server's
+ * landing order decides. (The retired un-suffixed key was written by automatic
+ * landings too, which made it meaningless as a signal of choice; it is left
+ * behind unread.)
+ */
+const SELECTED_ORG_KEY = "shelf_selected_org_id_v2";
 
 /** User profile data returned by the /me endpoint */
 export type UserProfile = {
@@ -66,10 +75,15 @@ export function OrgProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Persist selected org when it changes
+  /** The user chose this workspace — apply it and remember the choice. */
   const handleSetCurrentOrg = useCallback((org: Organization) => {
     setCurrentOrg(org);
     AsyncStorage.setItem(SELECTED_ORG_KEY, org.id).catch(() => {});
+  }, []);
+
+  /** The app landed here on its own — apply it without recording a choice. */
+  const applyLandingOrg = useCallback((org: Organization) => {
+    setCurrentOrg(org);
   }, []);
 
   const fetchOrgs = useCallback(async () => {
@@ -99,27 +113,33 @@ export function OrgProvider({ children }: { children: ReactNode }) {
     const orgs = data.organizations;
     setOrganizations(orgs);
 
-    // Try to restore previously selected org from storage
+    // Landing hierarchy: an explicit choice made on THIS device wins, then the
+    // server's cross-device choice, then the server's landing order (which
+    // already leads with its own best pick).
     let savedOrgId: string | null = null;
     try {
       savedOrgId = await AsyncStorage.getItem(SELECTED_ORG_KEY);
     } catch {}
 
+    const resolveLandingOrg = () => {
+      const deviceChoice = savedOrgId
+        ? orgs.find((o) => o.id === savedOrgId)
+        : null;
+      if (deviceChoice) return deviceChoice;
+      const serverChoice = data.lastSelectedOrganizationId
+        ? orgs.find((o) => o.id === data.lastSelectedOrganizationId)
+        : null;
+      return serverChoice || orgs[0];
+    };
+
     // Preserve current selection if still valid
     if (currentOrg) {
       const stillExists = orgs.find((o) => o.id === currentOrg.id);
       if (!stillExists && orgs.length > 0) {
-        const restoredOrg = savedOrgId
-          ? orgs.find((o) => o.id === savedOrgId)
-          : null;
-        handleSetCurrentOrg(restoredOrg || orgs[0]);
+        applyLandingOrg(resolveLandingOrg());
       }
     } else if (orgs.length > 0) {
-      // First load — try restoring from storage, otherwise pick first
-      const restoredOrg = savedOrgId
-        ? orgs.find((o) => o.id === savedOrgId)
-        : null;
-      handleSetCurrentOrg(restoredOrg || orgs[0]);
+      applyLandingOrg(resolveLandingOrg());
     }
 
     setIsLoading(false);

--- a/apps/webapp/app/modules/api/mobile-auth.server.landing-order.test.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.landing-order.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment node
+/**
+ * Landing-order tests for the mobile `getUserOrganizations`.
+ *
+ * The companion has no workspace cookie: it opens `organizations[0]`, so the
+ * ARRAY ORDER of this function's result is the wire contract for where a
+ * mobile session lands. These tests pin that contract to the web resolver's
+ * hierarchy (last-selected → personal for non-SSO → oldest first) and pin the
+ * SSO rule that a personal workspace is never offered at all, so the two
+ * clients cannot drift on "which workspace am I in?".
+ *
+ * `db.userOrganization.findMany` is mocked because the subject under test is
+ * the ordering/filtering applied ON TOP of the query result; rows are fed in
+ * base (oldest-first) order exactly as the query's `orderBy` yields them.
+ *
+ * @see {@link file://./mobile-auth.server.ts} — `getUserOrganizations`
+ * @see {@link file://./../organization/context.server.ts} — the web hierarchy this mirrors
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+import { getUserOrganizations } from "~/modules/api/mobile-auth.server";
+
+vi.mock("~/database/db.server", () => ({
+  db: {
+    userOrganization: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+/** A findMany row in the shape the function selects. */
+function row(
+  id: string,
+  type: "PERSONAL" | "TEAM",
+  user: { sso: boolean; lastSelectedOrganizationId: string | null }
+) {
+  return {
+    roles: ["ADMIN"],
+    user,
+    organization: {
+      id,
+      name: id,
+      type,
+      imageId: null,
+      barcodesEnabled: false,
+      auditsEnabled: false,
+    },
+  };
+}
+
+const findMany = vi.mocked(db.userOrganization.findMany);
+
+beforeEach(() => {
+  findMany.mockReset();
+});
+
+describe("getUserOrganizations landing order", () => {
+  it("puts the last-selected workspace first", async () => {
+    const user = { sso: false, lastSelectedOrganizationId: "team-b" };
+    findMany.mockResolvedValue([
+      row("personal", "PERSONAL", user),
+      row("team-a", "TEAM", user),
+      row("team-b", "TEAM", user),
+    ] as never);
+
+    const result = await getUserOrganizations("u1");
+
+    expect(result.organizations.map((o) => o.id)).toEqual([
+      "team-b",
+      "personal",
+      "team-a",
+    ]);
+    expect(result.lastSelectedOrganizationId).toBe("team-b");
+  });
+
+  it("falls back to the personal workspace for non-SSO users", async () => {
+    const user = { sso: false, lastSelectedOrganizationId: null };
+    findMany.mockResolvedValue([
+      row("team-a", "TEAM", user),
+      row("personal", "PERSONAL", user),
+    ] as never);
+
+    const result = await getUserOrganizations("u1");
+
+    expect(result.organizations.map((o) => o.id)).toEqual([
+      "personal",
+      "team-a",
+    ]);
+    expect(result.lastSelectedOrganizationId).toBeNull();
+  });
+
+  it("never offers a personal workspace to an SSO user", async () => {
+    const user = { sso: true, lastSelectedOrganizationId: null };
+    findMany.mockResolvedValue([
+      row("personal", "PERSONAL", user),
+      row("team-a", "TEAM", user),
+      row("team-b", "TEAM", user),
+    ] as never);
+
+    const result = await getUserOrganizations("u1");
+
+    expect(result.organizations.map((o) => o.id)).toEqual(["team-a", "team-b"]);
+  });
+
+  it("nulls a last-selected id that points at a workspace the user cannot land in", async () => {
+    // An SSO user whose last selection was their (now hidden) personal
+    // workspace must not have index 0 decided by an unreachable id.
+    const user = { sso: true, lastSelectedOrganizationId: "personal" };
+    findMany.mockResolvedValue([
+      row("personal", "PERSONAL", user),
+      row("team-a", "TEAM", user),
+    ] as never);
+
+    const result = await getUserOrganizations("u1");
+
+    expect(result.organizations.map((o) => o.id)).toEqual(["team-a"]);
+    expect(result.lastSelectedOrganizationId).toBeNull();
+  });
+
+  it("keeps oldest-first order among otherwise equal workspaces", async () => {
+    const user = { sso: false, lastSelectedOrganizationId: null };
+    findMany.mockResolvedValue([
+      row("team-old", "TEAM", user),
+      row("team-new", "TEAM", user),
+    ] as never);
+
+    const result = await getUserOrganizations("u1");
+
+    expect(result.organizations.map((o) => o.id)).toEqual([
+      "team-old",
+      "team-new",
+    ]);
+  });
+
+  it("returns empty organizations for an SSO user with only a personal workspace", async () => {
+    // The caller decides what "no visible workspaces" means for the app; this
+    // function's contract is just an empty, honest list.
+    const user = { sso: true, lastSelectedOrganizationId: null };
+    findMany.mockResolvedValue([row("personal", "PERSONAL", user)] as never);
+
+    const result = await getUserOrganizations("u1");
+
+    expect(result.organizations).toEqual([]);
+    expect(result.lastSelectedOrganizationId).toBeNull();
+  });
+});

--- a/apps/webapp/app/modules/api/mobile-auth.server.landing-order.test.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.landing-order.test.ts
@@ -22,6 +22,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "~/database/db.server";
 import { getUserOrganizations } from "~/modules/api/mobile-auth.server";
 
+// why: the subject under test is the ordering/filtering applied on top of the
+// query result, so the query itself is the one boundary mocked. Rows are fed
+// in the query's own (createdAt, id ascending) order.
 vi.mock("~/database/db.server", () => ({
   db: {
     userOrganization: {

--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -122,13 +122,37 @@ export async function requireMobileAuth(request: Request) {
 }
 
 /**
- * Fetches organizations for a user, with their roles.
+ * Fetches a user's organizations, with their roles, in landing order.
+ *
+ * `organizations[0]` is the workspace the companion should open: the app has
+ * no workspace cookie, so the ARRAY ORDER is the wire contract for where a
+ * session lands. The order mirrors the web resolver in
+ * `~/modules/organization/context.server.ts` so both clients answer "which
+ * workspace am I in?" the same way:
+ *
+ *   1. the user's `lastSelectedOrganizationId`, when they still belong to it
+ *   2. for non-SSO users, their personal workspace
+ *   3. everything else, oldest first (stable across calls)
+ *
+ * SSO users never see their personal workspace — it is filtered out here for
+ * the same reason the web filters it at every touchpoint: their membership is
+ * driven by the IdP, and the personal workspace is not part of that world.
+ *
+ * `lastSelectedOrganizationId` is also returned explicitly (null when unset or
+ * no longer valid) so the app can distinguish "the server picked for me" from
+ * "I chose this workspace" without re-deriving the hierarchy.
+ *
+ * @param userId - the authenticated user
+ * @returns organizations in landing order, plus the explicit last-selected id
  */
 export async function getUserOrganizations(userId: string) {
   const userOrgs = await db.userOrganization.findMany({
     where: { userId },
+    // Oldest-first base order keeps rank ties deterministic across calls.
+    orderBy: { organization: { createdAt: "asc" } },
     select: {
       roles: true,
+      user: { select: { sso: true, lastSelectedOrganizationId: true } },
       organization: {
         select: {
           id: true,
@@ -142,18 +166,43 @@ export async function getUserOrganizations(userId: string) {
     },
   });
 
+  const isSSO = userOrgs[0]?.user?.sso === true;
+  const lastSelectedId = userOrgs[0]?.user?.lastSelectedOrganizationId ?? null;
+
+  const visible = isSSO
+    ? userOrgs.filter((uo) => uo.organization.type !== "PERSONAL")
+    : userOrgs;
+
+  const lastSelectedOrganizationId = visible.some(
+    (uo) => uo.organization.id === lastSelectedId
+  )
+    ? lastSelectedId
+    : null;
+
+  /** Landing rank per the hierarchy above; sort is stable, so ties keep the
+   * oldest-first base order. */
+  const rank = (uo: (typeof visible)[number]) => {
+    if (uo.organization.id === lastSelectedOrganizationId) return 0;
+    if (!isSSO && uo.organization.type === "PERSONAL") return 1;
+    return 2;
+  };
+  const ordered = [...visible].sort((a, b) => rank(a) - rank(b));
+
   // Serialize the *canonical* add-on capability (premium-aware), not the
   // raw DB flags, so the companion's client-side gating
   // (`currentOrg.auditsEnabled` / `.barcodesEnabled`) stays aligned with
   // the server gating, which now uses canUseAudits/canUseBarcodes. Without
   // this, non-premium/self-hosted deployments would allow the feature on
   // the API but hide it in the app.
-  return userOrgs.map((uo) => ({
-    ...uo.organization,
-    barcodesEnabled: canUseBarcodes(uo.organization),
-    auditsEnabled: canUseAudits(uo.organization),
-    roles: uo.roles,
-  }));
+  return {
+    organizations: ordered.map((uo) => ({
+      ...uo.organization,
+      barcodesEnabled: canUseBarcodes(uo.organization),
+      auditsEnabled: canUseAudits(uo.organization),
+      roles: uo.roles,
+    })),
+    lastSelectedOrganizationId,
+  };
 }
 
 /**

--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -148,8 +148,12 @@ export async function requireMobileAuth(request: Request) {
 export async function getUserOrganizations(userId: string) {
   const userOrgs = await db.userOrganization.findMany({
     where: { userId },
-    // Oldest-first base order keeps rank ties deterministic across calls.
-    orderBy: { organization: { createdAt: "asc" } },
+    // Oldest-first base order keeps rank ties deterministic across calls; the
+    // id tie-break pins organizations created in the same instant.
+    orderBy: [
+      { organization: { createdAt: "asc" } },
+      { organization: { id: "asc" } },
+    ],
     select: {
       roles: true,
       user: { select: { sso: true, lastSelectedOrganizationId: true } },

--- a/apps/webapp/app/routes/api+/mobile+/me.ts
+++ b/apps/webapp/app/routes/api+/mobile+/me.ts
@@ -14,11 +14,13 @@ import { makeShelfError } from "~/utils/error";
 export async function loader({ request }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
-    const organizations = await getUserOrganizations(user.id);
+    const { organizations, lastSelectedOrganizationId } =
+      await getUserOrganizations(user.id);
 
     return data({
       user,
       organizations,
+      lastSelectedOrganizationId,
     });
   } catch (cause) {
     const reason = makeShelfError(cause);


### PR DESCRIPTION
## What

`GET /api/mobile/me` now returns organizations in **landing order**, and carries
`lastSelectedOrganizationId` explicitly.

The companion has no workspace cookie — it opens `organizations[0]`, so the
array order of this endpoint is the wire contract for where a mobile session
lands. Until now the query had no `orderBy` at all: the landing workspace was
whatever the database happened to return first, which for invited teammates was
routinely their empty personal workspace rather than the team they were invited
to.

## The order

Mirrors the web resolver (`~/modules/organization/context.server.ts`), so both
clients answer "which workspace am I in?" the same way:

1. the user's `lastSelectedOrganizationId`, when they still belong to it
2. for non-SSO users, their personal workspace
3. everything else, oldest first (deterministic across calls)

SSO users are never offered a personal workspace — same rule the web applies at
every touchpoint (#2282 established the hierarchy, #2432 the SSO filtering).

## Compatibility

Purely additive for the installed fleet: existing app versions keep reading
`organizations[0]` and simply start landing in the right workspace. The new
top-level field is ignored by older clients and lets a future app version
distinguish a server pick from a user choice.

## Testing

- New `mobile-auth.server.landing-order.test.ts` pins the contract: 6 cases
  covering last-selected priority, non-SSO personal fallback, SSO filtering,
  an unreachable last-selected id, stable ordering, and the SSO-with-only-
  personal edge (empty list).
- Existing `mobile-auth.server.test.ts` (13 tests) and webapp typecheck green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile account responses now include the last-selected workspace.
  * Workspaces are presented in a consistent landing order, prioritizing the last-selected workspace and applying personal-workspace rules based on sign-in configuration.
  * Automatic workspace selection now follows device choice, server preference, then the first available workspace.
* **Bug Fixes**
  * Unavailable selections are safely cleared.
  * Automatically selected workspaces no longer overwrite explicit workspace choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->