### PR TITLE
feat(audits): mobile scan undo endpoint, and honest zero-scan completion

### DIFF
--- a/apps/webapp/app/components/audit/audit-drawer.tsx
+++ b/apps/webapp/app/components/audit/audit-drawer.tsx
@@ -495,10 +495,10 @@ export default function AuditDrawer({
       showLocation,
     });
 
-  const shouldDisableSubmit =
-    hasBlockers ||
-    !auditSession ||
-    stats.foundCount + stats.unexpectedCount === 0;
+  // Completing with nothing scanned is legal — it marks every expected asset
+  // missing. The CompleteAuditDialog this drawer submits through states that
+  // outcome before anything is committed, so the button itself stays enabled.
+  const shouldDisableSubmit = hasBlockers || !auditSession;
 
   return (
     <ConfigurableDrawer

--- a/apps/webapp/app/components/audit/complete-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/complete-audit-dialog.tsx
@@ -95,6 +95,14 @@ export default function CompleteAuditDialog({
                 . This action cannot be undone.
               </p>
 
+              {stats.foundCount + stats.unexpectedCount === 0 ? (
+                <div className="rounded-lg border border-warning-300 bg-warning-25 p-3 text-sm text-warning-700">
+                  No assets were scanned. Completing now marks all{" "}
+                  <span className="font-semibold">{stats.expectedCount}</span>{" "}
+                  expected assets as missing.
+                </div>
+              ) : null}
+
               <div className="rounded-lg bg-gray-50 p-4">
                 <h4 className="mb-2 text-sm font-semibold text-gray-700">
                   Audit Summary

--- a/apps/webapp/app/modules/audit/remove-scan.server.test.ts
+++ b/apps/webapp/app/modules/audit/remove-scan.server.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment node
+/**
+ * Behaviour tests for {@link removeAuditScan} — the shared undo both the web
+ * scan page and the mobile remove-scan endpoint delegate to.
+ *
+ * The contract under test: an EXPECTED asset's row survives the removal and
+ * returns to MISSING with its scan facts cleared; an UNEXPECTED asset's row is
+ * deleted outright (only the scan created it); and the session's aggregate
+ * counts are recomputed from the rows, never incremented, so they cannot
+ * drift from what the rows say.
+ *
+ * @see {@link file://./service.server.ts} — `removeAuditScan`
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+import { removeAuditScan } from "~/modules/audit/service.server";
+
+// why: the subject is the branch logic and the recompute; the database is the
+// boundary being asserted against, so it is the one thing mocked. $transaction
+// hands back the same mock so `tx.*` assertions read naturally.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    $transaction: vi
+      .fn()
+      .mockImplementation((cb: (tx: unknown) => unknown) => cb(db)),
+    auditSession: {
+      findFirst: vi.fn(),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    auditScan: {
+      findFirst: vi.fn(),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    auditAsset: {
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+      count: vi.fn(),
+    },
+  },
+}));
+
+// why: the note builder reaches into user/asset tables that are not part of
+// this contract; the assertion is only that a removal note is written inside
+// the same transaction.
+vi.mock("~/modules/audit/helpers.server", async () => {
+  const actual = await vi.importActual<object>(
+    "~/modules/audit/helpers.server"
+  );
+  return { ...actual, createAssetScanRemovedNote: vi.fn() };
+});
+
+const session = {
+  status: "ACTIVE",
+  foundAssetCount: 3,
+  missingAssetCount: 1,
+  unexpectedAssetCount: 1,
+};
+
+const ARGS = {
+  auditSessionId: "audit-1",
+  assetId: "asset-1",
+  userId: "user-1",
+  organizationId: "org-1",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(db.auditSession.findFirst).mockResolvedValue(session as never);
+  // Recomputed counts after the removal: found, missing, unexpected.
+  vi.mocked(db.auditAsset.count)
+    .mockResolvedValueOnce(2 as never)
+    .mockResolvedValueOnce(2 as never)
+    .mockResolvedValueOnce(1 as never);
+});
+
+describe("removeAuditScan", () => {
+  it("returns an expected asset to MISSING and keeps its row", async () => {
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue({
+      id: "scan-1",
+      auditAsset: { id: "aa-1", expected: true },
+    } as never);
+
+    const result = await removeAuditScan(ARGS);
+
+    expect(db.auditAsset.update).toHaveBeenCalledWith({
+      where: { id: "aa-1" },
+      data: { status: "MISSING", scannedAt: null, scannedById: null },
+    });
+    expect(db.auditAsset.delete).not.toHaveBeenCalled();
+    expect(db.auditScan.delete).toHaveBeenCalledWith({
+      where: { id: "scan-1" },
+    });
+    expect(result).toEqual({
+      removed: true,
+      foundAssetCount: 2,
+      missingAssetCount: 2,
+      unexpectedAssetCount: 1,
+    });
+  });
+
+  it("deletes an unexpected asset's row along with the scan", async () => {
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue({
+      id: "scan-2",
+      auditAsset: { id: "aa-2", expected: false },
+    } as never);
+
+    await removeAuditScan(ARGS);
+
+    expect(db.auditAsset.delete).toHaveBeenCalledWith({
+      where: { id: "aa-2" },
+    });
+    expect(db.auditAsset.update).not.toHaveBeenCalled();
+  });
+
+  it("writes the recomputed counts to the session, never increments", async () => {
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue({
+      id: "scan-1",
+      auditAsset: { id: "aa-1", expected: true },
+    } as never);
+
+    await removeAuditScan(ARGS);
+
+    expect(db.auditSession.update).toHaveBeenCalledWith({
+      where: { id: "audit-1" },
+      data: {
+        foundAssetCount: 2,
+        missingAssetCount: 2,
+        unexpectedAssetCount: 1,
+      },
+    });
+  });
+
+  it("reports removed: false when no scan exists, touching nothing", async () => {
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue(null as never);
+
+    const result = await removeAuditScan(ARGS);
+
+    expect(result.removed).toBe(false);
+    expect(db.auditScan.delete).not.toHaveBeenCalled();
+    expect(db.auditSession.update).not.toHaveBeenCalled();
+  });
+
+  it("404s for a session outside the caller's organization", async () => {
+    vi.mocked(db.auditSession.findFirst).mockResolvedValue(null as never);
+
+    await expect(removeAuditScan(ARGS)).rejects.toThrow(/not found/i);
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/audit/remove-scan.server.test.ts
+++ b/apps/webapp/app/modules/audit/remove-scan.server.test.ts
@@ -42,14 +42,12 @@ vi.mock("~/database/db.server", () => ({
 }));
 
 // why: the note builder reaches into user/asset tables that are not part of
-// this contract; the assertion is only that a removal note is written inside
-// the same transaction.
-vi.mock("~/modules/audit/helpers.server", async () => {
-  const actual = await vi.importActual<object>(
-    "~/modules/audit/helpers.server"
-  );
-  return { ...actual, createAssetScanRemovedNote: vi.fn() };
-});
+// this contract, and loading the real helpers module pulls a dependency graph
+// this suite does not need. Only the export removeAuditScan touches is stubbed;
+// nothing else from the module runs here.
+vi.mock("~/modules/audit/helpers.server", () => ({
+  createAssetScanRemovedNote: vi.fn(),
+}));
 
 const session = {
   status: "ACTIVE",
@@ -140,6 +138,16 @@ describe("removeAuditScan", () => {
     expect(result.removed).toBe(false);
     expect(db.auditScan.delete).not.toHaveBeenCalled();
     expect(db.auditSession.update).not.toHaveBeenCalled();
+  });
+
+  it("refuses removal from an audit that is no longer live", async () => {
+    vi.mocked(db.auditSession.findFirst).mockResolvedValue({
+      ...session,
+      status: "COMPLETED",
+    } as never);
+
+    await expect(removeAuditScan(ARGS)).rejects.toThrow(/no longer live/i);
+    expect(db.$transaction).not.toHaveBeenCalled();
   });
 
   it("404s for a session outside the caller's organization", async () => {

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1704,8 +1704,10 @@ export interface RemoveAuditScanResult {
  * so the session's numbers can never drift from its rows, and a system note
  * records the removal.
  *
- * Status gating matches {@link recordAuditScan}: archived audits refuse all
- * mutation. Callers own authentication and assignee gating.
+ * Only a live audit (PENDING or ACTIVE) accepts removal: a COMPLETED or
+ * CANCELLED audit is a finished record whose numbers have been reported, and a
+ * removal would rewrite them after the fact. Callers own authentication and
+ * assignee gating.
  *
  * @param input - the scan to remove, org-proven by the session fetch
  * @returns whether a scan was removed, plus the recalculated counts
@@ -1737,7 +1739,17 @@ export async function removeAuditScan(
       });
     }
 
-    assertAuditNotArchived(session.status, { auditSessionId, organizationId });
+    if (session.status !== "PENDING" && session.status !== "ACTIVE") {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "This audit is no longer live, so its scans cannot be changed.",
+        additionalData: { auditSessionId, status: session.status },
+        status: 400,
+        label,
+        shouldBeCaptured: false,
+      });
+    }
 
     return await db.$transaction(async (tx) => {
       const existingScan = await tx.auditScan.findFirst({
@@ -1818,12 +1830,12 @@ export async function removeAuditScan(
       };
     });
   } catch (cause) {
+    // ShelfErrors carry their own status and message; rethrow untouched so a
+    // 400/404 reaches the caller as itself rather than as a generic 500.
+    if (cause instanceof ShelfError) throw cause;
     throw new ShelfError({
       cause,
-      message:
-        cause instanceof ShelfError
-          ? cause.message
-          : "Failed to remove the scan",
+      message: "Failed to remove the scan",
       additionalData: { auditSessionId, assetId, organizationId },
       label,
     });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -47,6 +47,7 @@ import {
   createAssetsAddedToAuditNote,
   createAssetRemovedFromAuditNote,
   createAssetsRemovedFromAuditNote,
+  createAssetScanRemovedNote,
 } from "./helpers.server";
 import type { AuditSchedulerData } from "./types";
 import { recordEvent, recordEvents } from "../activity-event/service.server";
@@ -1672,6 +1673,158 @@ export async function recordAuditScan(
       cause,
       message: "Failed to record audit scan",
       additionalData: { auditSessionId, assetId, userId },
+      label,
+    });
+  }
+}
+
+/** Arguments for {@link removeAuditScan}. */
+export interface RemoveAuditScanInput {
+  auditSessionId: string;
+  assetId: string;
+  userId: string;
+  organizationId: string;
+}
+
+/** Result of {@link removeAuditScan}, with the recalculated aggregate counts. */
+export interface RemoveAuditScanResult {
+  /** False when no scan for this asset existed — nothing changed. */
+  removed: boolean;
+  foundAssetCount: number;
+  missingAssetCount: number;
+  unexpectedAssetCount: number;
+}
+
+/**
+ * Removes a recorded scan from a live audit — the undo for a mis-scan.
+ *
+ * An expected asset's row returns to MISSING with its scan fields cleared; an
+ * unexpected asset's row is deleted outright, since only the scan created it.
+ * Aggregate counts are recomputed from the rows inside the same transaction,
+ * so the session's numbers can never drift from its rows, and a system note
+ * records the removal.
+ *
+ * Status gating matches {@link recordAuditScan}: archived audits refuse all
+ * mutation. Callers own authentication and assignee gating.
+ *
+ * @param input - the scan to remove, org-proven by the session fetch
+ * @returns whether a scan was removed, plus the recalculated counts
+ * @throws {ShelfError} 404 when the session is not in this organization
+ */
+export async function removeAuditScan(
+  input: RemoveAuditScanInput
+): Promise<RemoveAuditScanResult> {
+  const { auditSessionId, assetId, userId, organizationId } = input;
+
+  try {
+    const session = await db.auditSession.findFirst({
+      where: { id: auditSessionId, organizationId },
+      select: {
+        status: true,
+        foundAssetCount: true,
+        missingAssetCount: true,
+        unexpectedAssetCount: true,
+      },
+    });
+
+    if (!session) {
+      throw new ShelfError({
+        cause: null,
+        message: "Audit session not found",
+        additionalData: { auditSessionId, organizationId },
+        status: 404,
+        label,
+      });
+    }
+
+    assertAuditNotArchived(session.status, { auditSessionId, organizationId });
+
+    return await db.$transaction(async (tx) => {
+      const existingScan = await tx.auditScan.findFirst({
+        where: {
+          auditSessionId,
+          assetId,
+          auditSession: { organizationId },
+        },
+        include: {
+          auditAsset: { select: { id: true, expected: true } },
+        },
+      });
+
+      if (!existingScan) {
+        return {
+          removed: false,
+          foundAssetCount: session.foundAssetCount,
+          missingAssetCount: session.missingAssetCount,
+          unexpectedAssetCount: session.unexpectedAssetCount,
+        };
+      }
+
+      if (existingScan.auditAsset?.expected) {
+        // Expected asset: the row predates the scan, so it stays and returns
+        // to MISSING with its scan facts cleared.
+        await Promise.all([
+          tx.auditAsset.update({
+            where: { id: existingScan.auditAsset.id },
+            data: { status: "MISSING", scannedAt: null, scannedById: null },
+          }),
+          tx.auditScan.delete({ where: { id: existingScan.id } }),
+        ]);
+      } else if (existingScan.auditAsset?.id) {
+        // Unexpected asset: only the scan created the row, so both go.
+        await Promise.all([
+          tx.auditAsset.delete({ where: { id: existingScan.auditAsset.id } }),
+          tx.auditScan.delete({ where: { id: existingScan.id } }),
+        ]);
+      } else {
+        await tx.auditScan.delete({ where: { id: existingScan.id } });
+      }
+
+      // Recompute aggregates from the rows rather than incrementing, so the
+      // session's numbers cannot drift from what its rows actually say.
+      const [foundAssetCount, missingAssetCount, unexpectedAssetCount] =
+        await Promise.all([
+          tx.auditAsset.count({
+            where: { auditSessionId, expected: true, status: "FOUND" },
+          }),
+          tx.auditAsset.count({
+            where: { auditSessionId, expected: true, status: "MISSING" },
+          }),
+          tx.auditAsset.count({
+            where: { auditSessionId, expected: false, status: "UNEXPECTED" },
+          }),
+        ]);
+
+      await Promise.all([
+        tx.auditSession.update({
+          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: auditSessionId proven to belong to organizationId by the findFirst above (404 otherwise); update() requires a unique where
+          where: { id: auditSessionId },
+          data: { foundAssetCount, missingAssetCount, unexpectedAssetCount },
+        }),
+        createAssetScanRemovedNote({
+          auditSessionId,
+          assetId,
+          organizationId,
+          userId,
+          tx,
+        }),
+      ]);
+
+      return {
+        removed: true,
+        foundAssetCount,
+        missingAssetCount,
+        unexpectedAssetCount,
+      };
+    });
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message:
+        cause instanceof ShelfError
+          ? cause.message
+          : "Failed to remove the scan",
+      additionalData: { auditSessionId, assetId, organizationId },
       label,
     });
   }

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.scan.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.scan.tsx
@@ -30,12 +30,12 @@ import { useAuditScanPersistence } from "~/hooks/use-audit-scan-persistence";
 import { useAuditSessionInitialization } from "~/hooks/use-audit-session-initialization";
 import { useViewportHeight } from "~/hooks/use-viewport-height";
 import { completeAuditWithImages } from "~/modules/audit/complete-audit-with-images.server";
-import { createAssetScanRemovedNote } from "~/modules/audit/helpers.server";
 import {
   getAuditSessionDetails,
   getAuditScans,
   requireAuditAssignee,
   requireAuditAssigneeForBaseSelfService,
+  removeAuditScan,
 } from "~/modules/audit/service.server";
 import scannerCss from "~/styles/scanner.css?url";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
@@ -153,111 +153,11 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
 
-      await db.$transaction(async (tx) => {
-        const existingScan = await tx.auditScan.findFirst({
-          where: { auditSessionId: auditId, assetId },
-          include: {
-            auditAsset: {
-              select: { id: true, expected: true },
-            },
-          },
-        });
-
-        if (!existingScan) {
-          return;
-        }
-
-        // Keep audit asset state aligned with removal before recalculating counts.
-        // These operations target different tables and are independent, so run in parallel.
-        if (existingScan.auditAsset?.expected) {
-          await Promise.all([
-            tx.auditAsset.update({
-              where: { id: existingScan.auditAsset.id },
-              data: {
-                status: "MISSING",
-                scannedAt: null,
-                scannedById: null,
-              },
-            }),
-            tx.auditSession.update({
-              // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: auditId proven to belong to organizationId at the findFirst guard above (lines 95-108, throws 404 otherwise); update() requires a unique where (no compound org filter possible)
-              where: { id: auditId },
-              data: {
-                foundAssetCount: { decrement: 1 },
-                missingAssetCount: { increment: 1 },
-              },
-            }),
-            tx.auditScan.delete({
-              where: { id: existingScan.id },
-            }),
-          ]);
-        } else if (existingScan.auditAsset?.id) {
-          await Promise.all([
-            tx.auditAsset.delete({
-              where: { id: existingScan.auditAsset.id },
-            }),
-            tx.auditSession.update({
-              // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: auditId proven to belong to organizationId at the findFirst guard above (lines 95-108, throws 404 otherwise); update() requires a unique where (no compound org filter possible)
-              where: { id: auditId },
-              data: {
-                unexpectedAssetCount: { decrement: 1 },
-              },
-            }),
-            tx.auditScan.delete({
-              where: { id: existingScan.id },
-            }),
-          ]);
-        } else {
-          await tx.auditScan.delete({
-            where: { id: existingScan.id },
-          });
-        }
-
-        // Recalculate counts to ensure overview stats reflect current state.
-        const [foundCount, missingCount, unexpectedCount] = await Promise.all([
-          tx.auditAsset.count({
-            where: {
-              auditSessionId: auditId,
-              expected: true,
-              status: "FOUND",
-            },
-          }),
-          tx.auditAsset.count({
-            where: {
-              auditSessionId: auditId,
-              expected: true,
-              status: "MISSING",
-            },
-          }),
-          tx.auditAsset.count({
-            where: {
-              auditSessionId: auditId,
-              expected: false,
-              status: "UNEXPECTED",
-            },
-          }),
-        ]);
-
-        // Update aggregate counts and append the note in parallel — these touch
-        // different tables and are independent of each other.
-        await Promise.all([
-          tx.auditSession.update({
-            // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: auditId proven to belong to organizationId at the findFirst guard above (lines 95-108, throws 404 otherwise); update() requires a unique where (no compound org filter possible)
-            where: { id: auditId },
-            data: {
-              foundAssetCount: foundCount,
-              missingAssetCount: missingCount,
-              unexpectedAssetCount: unexpectedCount,
-            },
-          }),
-          createAssetScanRemovedNote({
-            auditSessionId: auditId,
-            assetId,
-            organizationId,
-            userId,
-            tx,
-          }),
-        ]);
+      await removeAuditScan({
+        auditSessionId: auditId,
+        assetId,
+        organizationId,
+        userId,
       });
 
       return payload({ success: true });

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -426,11 +426,7 @@ export default function AuditDetailsPage() {
             !isCancelled &&
             !isArchived &&
             canScanAndComplete && (
-              <CompleteAuditDialog
-                disabled={!hasScans}
-                auditName={session.name}
-                stats={stats}
-              />
+              <CompleteAuditDialog auditName={session.name} stats={stats} />
             )}
         </div>
       </Header>

--- a/apps/webapp/app/routes/api+/mobile+/audits.remove-scan.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.remove-scan.ts
@@ -11,6 +11,7 @@ import {
   removeAuditScan,
   requireAuditAssignee,
 } from "~/modules/audit/service.server";
+import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -41,10 +42,14 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
-    const { canUseAudits, role } = await getMobileUserContext(
+    const { canUseAudits, roles } = await getMobileUserContext(
       user.id,
       organizationId
     );
+    // A membership can carry several roles in any order; gate on the most
+    // privileged one, or an actual admin ordered [SELF_SERVICE, ADMIN] would
+    // be treated as restricted.
+    const role = resolveMostPrivilegedRole(roles);
     if (!canUseAudits) {
       return data(
         {

--- a/apps/webapp/app/routes/api+/mobile+/audits.remove-scan.ts
+++ b/apps/webapp/app/routes/api+/mobile+/audits.remove-scan.ts
@@ -1,0 +1,112 @@
+import { data, type ActionFunctionArgs } from "react-router";
+import { z } from "zod";
+import {
+  requireMobileAuth,
+  requireMobilePermission,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+import { parseMobileBody } from "~/modules/api/mobile-body.server";
+import {
+  removeAuditScan,
+  requireAuditAssignee,
+} from "~/modules/audit/service.server";
+import { makeShelfError } from "~/utils/error";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+
+/**
+ * POST /api/mobile/audits/remove-scan
+ *
+ * Removes a recorded scan from a live audit — the undo for a mis-scan. The
+ * mobile twin of the web scan page's remove action: both delegate to
+ * `removeAuditScan`, so an expected asset returns to "not scanned", an
+ * unexpected one disappears from the audit, and the session's counts are
+ * recomputed in the same transaction.
+ *
+ * Query params:
+ *   - orgId (required): organization ID
+ *
+ * Body:
+ *   - auditSessionId: string — the audit session the scan belongs to
+ *   - assetId: string — the asset whose scan is being removed
+ *
+ * Gated exactly like record-scan: audits enabled for the workspace, `audit:
+ * update` permission, and ADMIN/OWNER act on any audit while BASE/SELF_SERVICE
+ * must be assignees.
+ */
+export async function action({ request }: ActionFunctionArgs) {
+  try {
+    const { user } = await requireMobileAuth(request);
+    const organizationId = await requireOrganizationAccess(request, user.id);
+    const { canUseAudits, role } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
+    if (!canUseAudits) {
+      return data(
+        {
+          error: {
+            message:
+              "Audits are not enabled for this workspace. Contact your admin to enable this feature.",
+          },
+        },
+        { status: 403 }
+      );
+    }
+
+    await requireMobilePermission({
+      userId: user.id,
+      organizationId,
+      entity: PermissionEntity.audit,
+      action: PermissionAction.update,
+    });
+
+    const { auditSessionId, assetId } = await parseMobileBody(
+      z.object({
+        auditSessionId: z.string().min(1),
+        assetId: z.string().min(1),
+      }),
+      request,
+      "Audit"
+    );
+
+    // Removing a scan rewrites audit data, so it carries the same gate as
+    // recording one: without it a non-assignee could hollow out an audit
+    // they are not part of.
+    await requireAuditAssignee({
+      auditSessionId,
+      organizationId,
+      userId: user.id,
+      isSelfServiceOrBase: role === "SELF_SERVICE" || role === "BASE",
+    });
+
+    const {
+      removed,
+      foundAssetCount,
+      missingAssetCount,
+      unexpectedAssetCount,
+    } = await removeAuditScan({
+      auditSessionId,
+      assetId,
+      userId: user.id,
+      organizationId,
+    });
+
+    return data({
+      success: true,
+      removed,
+      foundAssetCount,
+      missingAssetCount,
+      unexpectedAssetCount,
+    });
+  } catch (cause) {
+    const reason = makeShelfError(cause);
+    return data(
+      { error: { message: reason.message } },
+      { status: reason.status }
+    );
+  }
+}


### PR DESCRIPTION
## What

Two halves of the same principle: the audit record should be correctable while
live, and its completion should be explicit rather than silently blocked.

### 1. Scan undo reaches the phone

The web scan page has per-row scan removal; the phone had none — a mis-scan in
the warehouse meant abandoning the audit and finding the row on desktop.

- The web action's remove-scan transaction is extracted into
  `removeAuditScan()` in the audit service (verbatim logic, now unit-tested):
  expected asset → row returns to MISSING with scan facts cleared; unexpected
  asset → row deleted outright; counts recomputed from rows in the same
  transaction, so aggregates cannot drift.
- New `POST /api/mobile/audits/remove-scan` delegates to it, with the exact
  auth stack of record-scan (audits enabled, `audit: update`, assignee gate).
- The web route action now calls the same function — one implementation, two
  doors.

The companion UI for this lands separately as an OTA once #2879's row redesign
merges; the endpoint is deliberately first so the app change is pure UI.

### 2. Zero-scan completion is allowed and honest

`completeAuditSession` accepts an audit with zero scans (the mobile app
completes them today), but the web hid completion behind a disabled button
with no explanation — "the shelf is empty, everything is missing" could not be
recorded from the desktop.

The Complete button now opens on both the detail page and the scan drawer, and
the confirm states the consequence before anything commits:

> No assets were scanned. Completing now marks all N expected assets as
> missing.

## Testing

- New `remove-scan.server.test.ts`: 5 cases — expected-branch, unexpected-
  branch, recompute-not-increment, no-scan no-op, cross-org 404.
- Full audit test suites: 305 passed. Webapp typecheck green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to remove an incorrectly recorded scan during an active audit.
  * Added mobile support for removing scans with appropriate access and permission checks.
  * Audits can now be completed without scanned assets; all expected assets are marked missing.

* **Bug Fixes**
  * Scan removal now correctly restores expected assets, removes unexpected assets, and refreshes audit totals.
  * Added a confirmation warning when completing an audit with no scanned assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->