### PR TITLE
fix(database): retry transient failures on raw SQL, not just model queries

### DIFF
--- a/apps/webapp/app/modules/api/mobile-asset-search.server.ts
+++ b/apps/webapp/app/modules/api/mobile-asset-search.server.ts
@@ -56,8 +56,8 @@ export async function resolveMobileAssetSearchWhere({
   }
 
   // Shared with the web getAssets fetcher: resolveAssetSearchIds runs the
-  // org-scoped UNION (retry-wrapped, since a raw $queryRaw bypasses the
-  // client's auto-retry extension) and guards the id set against Postgres'
+  // org-scoped UNION (retry-wrapped, to claim the read semantics the client
+  // extension cannot infer) and guards the id set against Postgres'
   // ~65k bind-param ceiling, throwing a friendly 400 rather than hard-failing.
   const ids = await resolveAssetSearchIds({
     organizationId,

--- a/apps/webapp/app/modules/asset/search-ids.server.ts
+++ b/apps/webapp/app/modules/asset/search-ids.server.ts
@@ -31,11 +31,14 @@ import { assertAssetSearchIdCeiling } from "./search.server";
  * the shared org-scoped UNION ({@link buildAssetSearchUnion}) — index-driven,
  * org-scoped branches across all 10 search sources.
  *
- * Wrapped in `withPrismaRetry({ operationIsRead: true })` because a raw
- * `$queryRaw` bypasses the client's auto-retry extension, so a transient
- * pool/connection blip on this id-resolution query would otherwise surface as a
- * hard error (the SHELF-WEBAPP-227 class) instead of being retried. Guards the
- * materialized set against the bind-param ceiling before returning.
+ * Wrapped in `withPrismaRetry({ operationIsRead: true })` to declare what the
+ * client extension cannot work out on its own: this raw statement is a pure
+ * read. The extension classifies all raw SQL as a write and so retries it only
+ * when the connection never opened, which would leave a transient pool blip
+ * mid-flight (the SHELF-WEBAPP-227 class) surfacing as a hard error. The
+ * extension steps aside while this wrapper runs, so the attempts are not
+ * doubled. Guards the materialized set against the bind-param ceiling before
+ * returning.
  *
  * @param params.organizationId - Tenant scope (bound as a literal in every branch).
  * @param params.terms - Non-empty list of trimmed, lowercased search terms.

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -655,8 +655,8 @@ export async function getAssets(params: {
         // Resolve the search to a set of matching asset ids via the shared
         // org-scoped UNION (resolveAssetSearchIds → buildAssetSearchUnion) —
         // index-driven, org-scoped branches, ~165ms vs the old multi-table OR's
-        // cross-org seq scans. The helper is retry-wrapped (a raw $queryRaw
-        // bypasses the client's auto-retry extension) and guards the id set
+        // cross-org seq scans. The helper is retry-wrapped (to claim the read
+        // semantics the client extension cannot infer) and guards the id set
         // against Postgres' ~65k bind-param ceiling, throwing a friendly 400
         // rather than letting an extreme org + very broad term hard-fail.
         // Setting where.OR here — BEFORE the category/tag/location/team-member
@@ -1080,14 +1080,17 @@ export async function getAdvancedPaginatedAndFilterableAssets({
       paginationClause,
     });
 
-    // Retry the raw read on transient DB failures. The auto-applied client
-    // retry extension covers model operations but NOT raw escapes like
-    // `$queryRaw`, so wrap it explicitly. This heavy query trips Postgres
-    // shared-lock-table exhaustion (SQLSTATE 53200) under the per-request fan-out
-    // on large workspaces (SHELF-WEBAPP-227); the pressure is momentary, so a
-    // short backed-off retry usually succeeds. `operationIsRead: true` — this is
-    // a pure read, safe to re-run. On exhausted retries it rethrows to the catch
-    // below, which surfaces as the friendly retryable 503 (see makeShelfError).
+    // Retry the raw read on transient DB failures. The client extension retries
+    // raw SQL too, but only where the connection never opened — it cannot read
+    // a raw statement to tell a pure read from one that consumes a sequence or
+    // takes locks, so it assumes the worst. This one IS a pure read, which
+    // `operationIsRead: true` declares: safe to re-run mid-flight. That matters
+    // because this heavy query trips Postgres shared-lock-table exhaustion
+    // (SQLSTATE 53200) under the per-request fan-out on large workspaces
+    // (SHELF-WEBAPP-227), where the pressure is momentary and a short backed-off
+    // retry usually succeeds. The extension steps aside while this runs, so the
+    // attempts below are the only ones. On exhausted retries it rethrows to the
+    // catch below, which surfaces as the friendly retryable 503 (makeShelfError).
     const result = await withPrismaRetry(
       () => db.$queryRaw<AdvancedIndexQueryResult>(query),
       { operationIsRead: true }

--- a/packages/database/src/client.test.ts
+++ b/packages/database/src/client.test.ts
@@ -11,12 +11,14 @@
  * @see ./client.ts
  */
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { test } from "node:test";
-import { fileURLToPath } from "node:url";
+
+import { Prisma } from "@prisma/client";
 
 import {
+  createDatabaseClient,
   getRetryableErrorCode,
+  isReadOperation,
   isLockTableExhaustionError,
   isRetryablePrismaError,
   PRISMA_RETRYABLE_ERROR_CODES,
@@ -548,42 +550,275 @@ test("withPrismaRetry", async (t) => {
   });
 });
 
-test("createDatabaseClient wires the transient-retry extension onto the client", () => {
-  // The retry LOGIC is covered exhaustively above; this guards the WIRING — the
-  // exact regression that already happened once, when the monorepo migration
-  // silently dropped the retry `$extends` from this factory.
-  //
-  // A behavioral guard would have to intercept the applied extension chain, but
-  // Prisma's client is a Proxy (its `$extends` isn't reachable on the prototype)
-  // and injecting a fake base client perturbs Prisma's inferred client type
-  // enough to break downstream typechecks. So this asserts the wiring at the
-  // source level — the same cheap regression guard the repo uses elsewhere for
-  // seams that can't be mocked (see the raw-SQL `@map` column-name rule).
-  const source = readFileSync(
-    fileURLToPath(new URL("./client.ts", import.meta.url)),
-    "utf8"
-  );
+/**
+ * A syntactically valid connection string that is never dialled: every test
+ * below short-circuits the engine (see {@link clientWithProbe}), so no socket
+ * is ever opened. A test that DOES reach the engine fails with a connection
+ * error, which is the loud signal that the short-circuit stopped working.
+ */
+const UNREACHABLE_URL = "postgresql://user:pass@127.0.0.1:1/never-dialled";
 
-  const factoryStart = source.indexOf("export function createDatabaseClient");
-  assert.notEqual(factoryStart, -1, "createDatabaseClient factory not found");
+/**
+ * Builds a real client from {@link createDatabaseClient} with a probe chained
+ * onto it, standing in for the database.
+ *
+ * Query-extension callbacks run in registration order, so the factory's retry
+ * extension runs first and its `query(args)` resolves into the probe rather
+ * than the engine. That makes the factory's own wiring observable — the probe
+ * counts how many times each operation actually reached "the database", which
+ * is exactly what a retry changes.
+ *
+ * @param respond - Called per attempt with the 1-based attempt number for that
+ *   operation. Return a value to resolve the query; throw to fail it.
+ * @returns The client, plus the operations recorded in the order they arrived.
+ */
+function clientWithProbe(respond: (attempt: number) => unknown) {
+  const attempts: string[] = [];
+  const seenArgs: unknown[] = [];
+  const client = createDatabaseClient(UNREACHABLE_URL).$extends({
+    query: {
+      async $allOperations({ operation, args }) {
+        attempts.push(operation);
+        seenArgs.push(args);
+        return respond(attempts.length) as never;
+      },
+    },
+  });
+  return { client, attempts, seenArgs };
+}
 
-  // Bound the slice to the factory body — stop at the next top-level `export`
-  // (or EOF) so a `$extends` / `withPrismaRetry` reference elsewhere in the file
-  // can't satisfy these assertions after the factory wiring is removed. Collapse
-  // whitespace so the assertions survive prettier reformatting.
-  const afterFactory = source.indexOf("\nexport ", factoryStart + 1);
-  const factory = source
-    .slice(factoryStart, afterFactory === -1 ? undefined : afterFactory)
-    .replace(/\s+/g, " ");
+/**
+ * Exercises the client the factory actually builds, rather than asserting on
+ * the shape of its source. Retrying is observable as a repeated attempt, so
+ * the probe's attempt count is a direct read of whether an operation is
+ * covered — which no source-level pattern match can tell you.
+ *
+ * A case that provokes an extension retry sleeps for real, since the backoff
+ * belongs to the extension and no test can reach past it — 500ms before the
+ * first retry. Cases that drive the backoff themselves pass a no-op `delay`.
+ */
+test("createDatabaseClient retries raw SQL, not just model operations", async (t) => {
+  await t.test("retries $queryRaw on a connection-level error", async () => {
+    // Raw SQL carries the SSO user-id migration, sequential-ID generation and
+    // the dashboard aggregates. A connection blip on any of them surfaced to
+    // the user as a 503 while every model query beside it was quietly retried.
+    const { client, attempts } = clientWithProbe((attempt) => {
+      if (attempt === 1) throw prismaError("P1001");
+      return [{ ok: true }];
+    });
 
-  assert.match(
-    factory,
-    /\$extends\(\{ query: \{ \$allModels: \{/,
-    "the retry query `$extends` appears to have been removed from createDatabaseClient"
+    const rows = await client.$queryRaw`SELECT 1`;
+
+    assert.deepEqual(rows, [{ ok: true }]);
+    assert.deepEqual(attempts, ["$queryRaw", "$queryRaw"]);
+  });
+
+  await t.test("retries all four raw entry points", async () => {
+    // `$executeRaw` and the two `Unsafe` variants are separate Prisma
+    // operations with their own dispatch, so covering one proves nothing
+    // about the others.
+    for (const run of [
+      (c: ReturnType<typeof clientWithProbe>["client"]) =>
+        c.$executeRaw`SELECT 1`,
+      (c: ReturnType<typeof clientWithProbe>["client"]) =>
+        c.$queryRawUnsafe("SELECT 1"),
+      (c: ReturnType<typeof clientWithProbe>["client"]) =>
+        c.$executeRawUnsafe("SELECT 1"),
+    ]) {
+      const { client, attempts } = clientWithProbe((attempt) => {
+        if (attempt === 1) throw prismaError("P1002");
+        return 1;
+      });
+
+      await run(client);
+
+      assert.equal(attempts.length, 2, `${attempts[0]} was not retried`);
+    }
+  });
+
+  await t.test("still retries model reads on an in-flight error", async () => {
+    // The switch that brings raw SQL in must not cost model operations their
+    // existing classification.
+    const { client, attempts } = clientWithProbe((attempt) => {
+      if (attempt === 1) throw prismaError("P1017");
+      return [];
+    });
+
+    await client.user.findMany({});
+
+    assert.deepEqual(attempts, ["findMany", "findMany"]);
+  });
+
+  await t.test("does NOT retry raw SQL on an in-flight error", async () => {
+    // `P1017` can surface after the statement reached the server, so the
+    // statement may already have run. Raw SQL is opaque to this layer — a
+    // `$queryRaw` in this repo consumes a Postgres sequence, and several take
+    // `FOR UPDATE` locks — so it is classified as a write and left alone.
+    const { client, attempts } = clientWithProbe(() => {
+      throw prismaError("P1017");
+    });
+
+    await assert.rejects(
+      client.$queryRaw`SELECT get_next_sequential_id('org', 'SAM')`,
+      (error: unknown) => rejectedWithCode(error, "P1017")
+    );
+    assert.deepEqual(attempts, ["$queryRaw"]);
+  });
+
+  await t.test("does not stack its retries on a caller's own", async () => {
+    // Two raw queries in the app wrap themselves in `withPrismaRetry` to claim
+    // read semantics the extension cannot infer. If both layers retried, the
+    // attempts would multiply and a failing request would hold on ~4x longer
+    // during the outage that provoked it.
+    const { client, attempts } = clientWithProbe(() => {
+      throw prismaError("P1001");
+    });
+
+    await assert.rejects(
+      withPrismaRetry(() => client.$queryRaw`SELECT 1`, {
+        operationIsRead: true,
+        // why: the caller's own backoff is not what this asserts, and skipping
+        // it keeps the case instant. An extension retry that wrongly stacked
+        // would still be counted — it just would not be slow about it.
+        delay: async () => {},
+      }),
+      (error: unknown) => rejectedWithCode(error, "P1001")
+    );
+
+    // Three: the caller's own attempt plus its two retries, and no more.
+    assert.equal(attempts.length, 3);
+  });
+
+  await t.test("honours a caller's read claim on a raw query", async () => {
+    // The extension classifies raw SQL as a write, so it would not retry an
+    // in-flight failure. A caller that has read its own statement can, and
+    // that judgement has to survive passing through the extension — it is why
+    // the advanced asset index recovers from lock-table exhaustion.
+    const { client, attempts } = clientWithProbe((attempt) => {
+      if (attempt === 1) throw prismaError("P1017");
+      return [];
+    });
+
+    await withPrismaRetry(() => client.$queryRaw`SELECT 1`, {
+      operationIsRead: true,
+      // why: as above — the backoff itself is covered by the withPrismaRetry
+      // tests, so this case skips it and stays instant.
+      delay: async () => {},
+    });
+
+    assert.deepEqual(attempts, ["$queryRaw", "$queryRaw"]);
+  });
+
+  await t.test("hands raw parameters to the engine unchanged", async () => {
+    // Intercepting an operation makes Prisma clone its arguments before the
+    // callback sees them — a step the raw path skipped entirely while it had
+    // no callback. The cloner reconstructs `Sql` and rebuilds each parameter
+    // by type, so a type it mishandled would corrupt every raw query in the
+    // codebase without raising anything.
+    const { client, seenArgs } = clientWithProbe(() => []);
+
+    const id = "org-1";
+    const when = new Date("2026-08-25T10:00:00.000Z");
+    const bytes = Buffer.from([1, 2, 3]);
+    const amount = new Prisma.Decimal("12.34");
+
+    await client.$queryRaw`SELECT ${id}, ${when}, ${1n}, ${bytes}, ${amount}, ${null}`;
+
+    const tagged = seenArgs[0] as Prisma.Sql;
+    assert.equal(tagged.text, "SELECT $1, $2, $3, $4, $5, $6");
+    const [gotId, gotDate, gotBigInt, gotBytes, gotAmount, gotNull] =
+      tagged.values as unknown[];
+    assert.equal(gotId, id);
+    assert.ok(gotDate instanceof Date, "a Date parameter must stay a Date");
+    assert.equal((gotDate as Date).getTime(), when.getTime());
+    assert.equal(gotBigInt, 1n);
+    assert.ok(ArrayBuffer.isView(gotBytes), "bytes must stay a typed array");
+    assert.deepEqual([...(gotBytes as Uint8Array)], [1, 2, 3]);
+    assert.equal(String(gotAmount), "12.34");
+    assert.equal(gotNull, null);
+
+    // `$queryRawUnsafe`/`$executeRawUnsafe` arrive as `[sql, ...params]`
+    // instead of a `Sql`, and take a different branch of the same cloner.
+    await client.$queryRawUnsafe("SELECT $1::text, $2::int", id, 7);
+    assert.deepEqual(seenArgs[1], ["SELECT $1::text, $2::int", id, 7]);
+  });
+
+  await t.test(
+    "does NOT retry a model write on an in-flight error",
+    async () => {
+      const { client, attempts } = clientWithProbe(() => {
+        throw prismaError("P1017");
+      });
+
+      await assert.rejects(
+        client.user.update({ where: { id: "u1" }, data: {} }),
+        (error: unknown) => rejectedWithCode(error, "P1017")
+      );
+      assert.deepEqual(attempts, ["update"]);
+    }
   );
-  assert.match(
-    factory,
-    /withPrismaRetry\(\(\) => query\(args\)/,
-    "createDatabaseClient no longer routes operations through withPrismaRetry"
-  );
+});
+
+test("isReadOperation", async (t) => {
+  await t.test("classifies the model read operations as reads", () => {
+    for (const operation of [
+      "findUnique",
+      "findUniqueOrThrow",
+      "findFirst",
+      "findFirstOrThrow",
+      "findMany",
+      "count",
+      "aggregate",
+      "groupBy",
+    ]) {
+      assert.equal(
+        isReadOperation({ model: "Asset", operation }),
+        true,
+        `${operation} should classify as a read`
+      );
+    }
+  });
+
+  await t.test("classifies model mutations as writes", () => {
+    for (const operation of [
+      "create",
+      "createMany",
+      "update",
+      "updateMany",
+      "upsert",
+      "delete",
+      "deleteMany",
+    ]) {
+      assert.equal(isReadOperation({ model: "Asset", operation }), false);
+    }
+  });
+
+  await t.test("classifies every raw operation as a write", () => {
+    // A raw `SELECT` is not a promise of purity, and this layer cannot read
+    // the SQL to find out: `SELECT get_next_sequential_id(...)` consumes a
+    // Postgres sequence, and `SELECT ... FOR UPDATE` takes locks. Calling
+    // either one a read would let an in-flight failure re-run it.
+    for (const operation of [
+      "$queryRaw",
+      "$queryRawUnsafe",
+      "$executeRaw",
+      "$executeRawUnsafe",
+    ]) {
+      assert.equal(
+        isReadOperation({ model: undefined, operation }),
+        false,
+        `${operation} must not be treated as a read`
+      );
+    }
+  });
+
+  await t.test("keys off the missing model, not the operation name", () => {
+    // Prisma passes no model for a raw query, which is the only signal that
+    // separates the two. An operation name that happens to look like a read
+    // does not make an unmodelled operation retryable.
+    assert.equal(
+      isReadOperation({ model: undefined, operation: "findMany" }),
+      false
+    );
+  });
 });

--- a/packages/database/src/client.ts
+++ b/packages/database/src/client.ts
@@ -13,6 +13,8 @@
  * @see apps/webapp/app/database/db.server.ts — thin re-export consumed by the webapp.
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { Prisma, PrismaClient } from "@prisma/client";
 
 export type ExtendedPrismaClient = ReturnType<typeof createDatabaseClient>;
@@ -84,6 +86,53 @@ const READ_OPERATIONS = new Set([
   "aggregate",
   "groupBy",
 ]);
+
+/**
+ * Classifies one intercepted Prisma operation, deciding which transient codes
+ * it may be retried on (see {@link withPrismaRetry}).
+ *
+ * Raw SQL — `$queryRaw`, `$executeRaw` and their `Unsafe` variants — carries no
+ * model, and is always classified as a WRITE however harmless the statement
+ * looks. The SQL is opaque at this layer, and a `SELECT` is not a promise of
+ * purity: `SELECT get_next_sequential_id(...)` consumes a Postgres sequence,
+ * and `SELECT ... FOR UPDATE` exists to take locks. Re-running either after an
+ * in-flight failure would spend a second sequence value or re-take a lock the
+ * caller has already lost, so raw SQL retries only on the
+ * {@link CONNECTION_ERROR_CODES}, where the statement provably never ran.
+ *
+ * @param params.model - The model the operation targets, or `undefined` for a
+ *   raw query — the only signal that separates the two.
+ * @param params.operation - The Prisma operation name (`findMany`,
+ *   `$queryRaw`, ...).
+ * @returns `true` only for a model operation in {@link READ_OPERATIONS}.
+ */
+export function isReadOperation({
+  model,
+  operation,
+}: {
+  model?: string;
+  operation: string;
+}): boolean {
+  if (model === undefined) {
+    return false;
+  }
+  return READ_OPERATIONS.has(operation);
+}
+
+/**
+ * Set while a caller-supplied {@link withPrismaRetry} is running, so the client
+ * extension can tell that this operation's retries are already someone else's
+ * job and pass it straight through.
+ *
+ * Without this the two layers compose multiplicatively — three extension
+ * attempts each running three caller attempts — turning a 1.5s failure during
+ * an outage into a ~6s one, on exactly the requests that should be giving up
+ * quickly. It is also the channel that makes a caller's read/write
+ * classification stick: `isReadOperation` cannot see inside a raw statement,
+ * so a caller that knows its SQL is a pure read keeps that judgement only by
+ * owning the retry outright.
+ */
+const CALLER_MANAGED_RETRY = new AsyncLocalStorage<true>();
 
 /** Maximum number of retry attempts for a transient Prisma error. */
 const MAX_RETRIES = 2;
@@ -228,9 +277,11 @@ export function isRetryablePrismaError(
  * codes `P1008`/`P1017` on a WRITE — rethrow immediately on the first failure,
  * exactly like a call with no wrapper.
  *
- * Extracted out of {@link createDatabaseClient}'s `$allOperations` extension
- * so the retry/backoff logic can be unit-tested without a real Prisma client
- * or database connection.
+ * Exported for callers that need a retry the client extension cannot give them
+ * on its own — in practice, a raw statement the caller knows is a pure read
+ * (see {@link isReadOperation}). While this runs, the extension passes its
+ * operations straight through, so the attempts you configure here are the only
+ * ones that happen.
  *
  * @param operation - The Prisma operation to execute (and retry on failure).
  * @param options - Optional overrides.
@@ -246,7 +297,30 @@ export function isRetryablePrismaError(
  * @returns The resolved value of `operation`.
  * @throws The final error, once retries are exhausted or the error isn't retryable.
  */
-export async function withPrismaRetry<T>(
+export function withPrismaRetry<T>(
+  operation: () => Promise<T>,
+  options?: {
+    operationIsRead?: boolean;
+    log?: (message: string) => void;
+    delay?: (ms: number) => Promise<void>;
+  }
+): Promise<T> {
+  return CALLER_MANAGED_RETRY.run(true, () => retryLoop(operation, options));
+}
+
+/**
+ * The retry loop itself, without the caller-managed marker.
+ *
+ * The client extension calls this directly: it IS the outermost retry for the
+ * operation, so marking it would only make every query pay for a marker no
+ * one reads.
+ *
+ * @param operation - The Prisma operation to execute (and retry on failure).
+ * @param options - Same as {@link withPrismaRetry}.
+ * @returns The resolved value of `operation`.
+ * @throws The final error, once retries are exhausted or the error isn't retryable.
+ */
+async function retryLoop<T>(
   operation: () => Promise<T>,
   options?: {
     operationIsRead?: boolean;
@@ -294,9 +368,11 @@ export async function withPrismaRetry<T>(
  * Extensions applied (in order):
  * 1. `dynamicFindMany` — allows calling `findMany` generically across models.
  * 2. Transient-error retry — retries connection-level failures (see
- *    {@link PRISMA_RETRYABLE_ERROR_CODES}) on all models. Reads additionally
- *    retry the ambiguous in-flight codes; writes do not, to avoid re-applying
- *    a mutation that may already have committed (see {@link withPrismaRetry}).
+ *    {@link PRISMA_RETRYABLE_ERROR_CODES}) on every operation the client
+ *    dispatches, model queries and raw SQL alike. Model reads additionally
+ *    retry the ambiguous in-flight codes; writes and all raw SQL do not, to
+ *    avoid re-applying a statement that may already have committed (see
+ *    {@link isReadOperation} and {@link withPrismaRetry}).
  */
 export function createDatabaseClient(url?: string) {
   const client = new PrismaClient(url ? { datasourceUrl: url } : undefined)
@@ -312,12 +388,20 @@ export function createDatabaseClient(url?: string) {
     })
     .$extends({
       query: {
-        $allModels: {
-          async $allOperations({ operation, args, query }) {
-            return withPrismaRetry(() => query(args), {
-              operationIsRead: READ_OPERATIONS.has(operation),
-            });
-          },
+        // Top-level `$allOperations`, NOT `$allModels.$allOperations`: Prisma
+        // dispatches raw queries with no model, and the `$allModels` form is
+        // skipped for exactly those. Nesting this under `$allModels` leaves
+        // every `$queryRaw`/`$executeRaw` in the codebase with no retry at all.
+        async $allOperations({ model, operation, args, query }) {
+          // A caller already retrying this operation owns the decision,
+          // including the read/write call that `isReadOperation` cannot make
+          // for raw SQL. Wrapping it again would just multiply the attempts.
+          if (CALLER_MANAGED_RETRY.getStore()) {
+            return query(args);
+          }
+          return retryLoop(() => query(args), {
+            operationIsRead: isReadOperation({ model, operation }),
+          });
         },
       },
     });

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -2,9 +2,10 @@
 export { createDatabaseClient } from "./client";
 export type { ExtendedPrismaClient } from "./client";
 
-// Re-export the transient-error retry wrapper so consumers can extend retry to
-// the raw escapes (`$queryRaw` / `$executeRaw`) that the auto-applied client
-// extension does not cover. See `withPrismaRetry` in ./client.
+// Re-export the transient-error retry wrapper. The client extension already
+// retries every operation, raw SQL included; this is for the caller that can
+// claim MORE than the extension is able to infer — a raw statement it knows to
+// be a pure read. See `withPrismaRetry` in ./client.
 export { withPrismaRetry } from "./client";
 
 // Re-export all Prisma types and enums so consumers don't need @prisma/client directly


### PR DESCRIPTION
## The bug

The database client's transient-error retry was registered as
`$allModels.$allOperations`. Prisma dispatches that form **only for model
operations** — a raw query carries no model, and the `$allModels` branch is
skipped for exactly those.

So every `$queryRaw` / `$executeRaw` in the codebase had **no retry at all**:

| Surface | Raw query |
| --- | --- |
| SSO login | the SCIM user-id migration (`$executeRawUnsafe`) |
| Asset creation | sequential-ID generation |
| Locations | the recursive descendants CTE |
| Dashboard / reports | the QT-aware valuation aggregates |
| Asset index | the search UNION and the advanced-index query |

A connection blip on any of them failed outright, while every model query
beside it was quietly retried.

Verified against Prisma 6.19.3's own dispatcher rather than assumed — a probe
against a real client shows `$allModels` firing for `findMany` only, and the
top-level form firing for all four raw entry points.

## The fix

Register the callback at the top level, which covers model operations *and*
raw queries.

**Raw SQL is classified as a write**, so it retries only on the
connection-level codes (`P1001`/`P1002`) where the statement provably never
reached the database. It cannot be classified any other way:

- `getNextSequentialId` runs `SELECT get_next_sequential_id(...)`, which
  consumes a Postgres sequence — its own JSDoc warns about this.
- Four further raw reads are `SELECT ... FOR UPDATE`, i.e. lock acquisition.

Retrying either after an *in-flight* failure would spend a second sequential ID
or re-take a lock the caller has already lost. Write classification still fixes
the whole reported impact, since the failures described are connection-level.

## The part that needed care

Two call sites already hand-wrapped their raw queries in `withPrismaRetry` as a
workaround for this gap:

- `modules/asset/service.server.ts` — the advanced asset index
- `modules/asset/search-ids.server.ts` — the search-id resolver

Left alone, they would now **stack** with the extension: up to nine attempts and
~6s of backoff per request during an outage — the same spiral the deliberate
`P2024` exclusion exists to avoid.

They also can't just be deleted. Both declare `operationIsRead: true` on reads
their authors verified by hand, and that claim is what lets the advanced index
recover from Postgres shared-lock-table exhaustion (SHELF-WEBAPP-227).

So the extension now **steps aside while a caller-managed retry is running**
(`AsyncLocalStorage`). The caller's read/write judgement stays authoritative —
it is strictly better informed than anything this layer can infer from an opaque
SQL string — and the attempts are not multiplied.

## Tests

The previous wiring guard asserted on the **source text** of the factory, and
its own comment said a behavioral guard was impossible because Prisma's client
is a Proxy. It also asserted `$allModels`, which pinned this bug in place.

It turns out to be possible: chaining a short-circuit probe *after* the retry
extension makes `query(args)` resolve into the probe instead of the engine, so
retries are observable as repeated attempts **with no database**. The source
regex is replaced by tests against the client the factory actually builds.

46 tests pass (was 39). Three mutations confirm they bite:

| Mutation | Result |
| --- | --- |
| revert to `$allModels.$allOperations` | 3 failures |
| classify `$queryRaw` as a read | 4 failures |
| remove the caller-managed deferral | 2 failures |

Also pinned: raw parameters (`Sql`, `Date`, `BigInt`, `Buffer`, `Decimal`,
`null`) survive Prisma's argument cloner. Intercepting an operation makes Prisma
clone its args — a step the raw path skipped entirely while it had no callback —
so this is the silent-corruption risk the change introduces.

## Verification

- `pnpm -r --filter "./packages/*" run test` — 46 pass
- Webapp asset suites — 182 pass
- `tsc -b --force` across webapp + database — clean
- **Full production build** — green. `node:async_hooks` inside an
  `ssr.noExternal` package is the one risk a typecheck cannot see;
  `app/utils/tab-id.server.ts` already uses it in the same bundle.
- Five comments across four files that asserted the extension doesn't cover raw
  SQL are corrected.

No migration. No new workspace dependency.

## Noted, not fixed here

A `PrismaClientInitializationError` from a refused connection arrived with
`errorCode: undefined`, so `getRetryableErrorCode` would not retry it — despite
the code's comment stating init errors carry `P1001` there. That's a question
about retry *efficacy* rather than raw-SQL *coverage*, so it is out of scope for
this PR and worth its own look.

Closes the `detail.dev` D063 finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic retry handling for database operations, including raw SQL queries.
  - Reduced duplicate retry attempts and improved classification of read and write operations.
  - Preserved parameter types for raw database queries.

- **Tests**
  - Added integration coverage for transient failures, retry behavior, read/write classification, and nested retry scenarios.

- **Documentation**
  - Clarified database retry behavior and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->