### PR TITLE
fix(team): refuse to delete a non-registered member who still holds custody

### DIFF
--- a/apps/webapp/app/components/workspace/delete-member.tsx
+++ b/apps/webapp/app/components/workspace/delete-member.tsx
@@ -14,6 +14,7 @@ import {
   AlertDialogTrigger,
 } from "~/components/shared/modal";
 
+import { getHeldCustodyCount } from "~/modules/team-member/custody-count";
 import { isFormProcessing } from "~/utils/form";
 import { tw } from "~/utils/tw";
 import { Form } from "../custom-form";
@@ -27,13 +28,14 @@ export const DeleteMember = ({
       _count: {
         select: {
           custodies: true;
+          kitCustodies: true;
         };
       };
     };
   }>;
 }) => {
-  const hasCustodies = useMemo(
-    () => teamMember?._count.custodies > 0,
+  const custodiesCount = useMemo(
+    () => getHeldCustodyCount(teamMember._count),
     [teamMember]
   );
   return (
@@ -54,10 +56,8 @@ export const DeleteMember = ({
           </Button>
         </AlertDialogTrigger>
 
-        {hasCustodies ? (
-          <UnableToDeleteMemberContent
-            custodiesCount={teamMember?._count.custodies}
-          />
+        {custodiesCount > 0 ? (
+          <UnableToDeleteMemberContent custodiesCount={custodiesCount} />
         ) : (
           <DeleteMemberContent id={teamMember.id} />
         )}
@@ -118,8 +118,8 @@ const UnableToDeleteMemberContent = ({
       <AlertDialogTitle>Unable to delete team member</AlertDialogTitle>
       <AlertDialogDescription>
         The team member you are trying to delete has custody over{" "}
-        {custodiesCount} assets. Please release custody or check-in those assets
-        before deleting the user.
+        {custodiesCount} assets or kits. Please release custody or check-in
+        those items before deleting the user.
       </AlertDialogDescription>
       <AlertDialogCancel
         asChild

--- a/apps/webapp/app/components/workspace/nrm-actions-dropdown.tsx
+++ b/apps/webapp/app/components/workspace/nrm-actions-dropdown.tsx
@@ -23,6 +23,7 @@ export function TeamMembersActionsDropdown({
       _count: {
         select: {
           custodies: true;
+          kitCustodies: true;
         };
       };
     };

--- a/apps/webapp/app/modules/settings/service.server.ts
+++ b/apps/webapp/app/modules/settings/service.server.ts
@@ -171,7 +171,10 @@ export async function getPaginatedAndFilterableSettingTeamMembers({
         take,
         skip,
         include: {
-          _count: { select: { custodies: true } },
+          // Both custody shapes: a kit custodian may hold no per-asset
+          // `Custody` rows at all (an empty kit inherits none), and the row
+          // and its delete dialog must still show them as encumbered.
+          _count: { select: { custodies: true, kitCustodies: true } },
         },
       }),
       db.teamMember.count({ where }),

--- a/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
+++ b/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
@@ -67,8 +67,8 @@ describe("bulkDeleteNRMs", () => {
 
   it("soft-deletes only the rows the scoped query returned", async () => {
     dbMocks.findMany.mockResolvedValue([
-      { id: "a", _count: { custodies: 0 } },
-      { id: "b", _count: { custodies: 0 } },
+      { id: "a", _count: { custodies: 0, kitCustodies: 0 } },
+      { id: "b", _count: { custodies: 0, kitCustodies: 0 } },
     ]);
 
     await bulkDeleteNRMs({ nrmIds: [ALL_SELECTED_KEY], organizationId: ORG });
@@ -82,7 +82,9 @@ describe("bulkDeleteNRMs", () => {
   });
 
   it("re-asserts the NRM scope and custody guard in the write predicate", async () => {
-    dbMocks.findMany.mockResolvedValue([{ id: "a", _count: { custodies: 0 } }]);
+    dbMocks.findMany.mockResolvedValue([
+      { id: "a", _count: { custodies: 0, kitCustodies: 0 } },
+    ]);
 
     await bulkDeleteNRMs({ nrmIds: [ALL_SELECTED_KEY], organizationId: ORG });
 
@@ -94,11 +96,28 @@ describe("bulkDeleteNRMs", () => {
       ...NRM_BASE_SCOPE,
       id: { in: ["a"] },
       custodies: { none: {} },
+      kitCustodies: { none: {} },
     });
   });
 
+  it("refuses the batch for a kit-only custodian", async () => {
+    // Assigning a kit always writes `KitCustody`; the inherited per-asset
+    // rows only appear when the kit has assets. An empty kit's custodian
+    // therefore holds nothing an asset-only count would see.
+    dbMocks.findMany.mockResolvedValue([
+      { id: "a", _count: { custodies: 0, kitCustodies: 1 } },
+    ]);
+
+    await expect(
+      bulkDeleteNRMs({ nrmIds: ["a"], organizationId: ORG })
+    ).rejects.toThrow(/custody/i);
+    expect(dbMocks.updateMany).not.toHaveBeenCalled();
+  });
+
   it("still refuses the batch when a selected member holds custody", async () => {
-    dbMocks.findMany.mockResolvedValue([{ id: "a", _count: { custodies: 2 } }]);
+    dbMocks.findMany.mockResolvedValue([
+      { id: "a", _count: { custodies: 2, kitCustodies: 0 } },
+    ]);
 
     await expect(
       bulkDeleteNRMs({ nrmIds: ["a"], organizationId: ORG })

--- a/apps/webapp/app/modules/team-member/custody-count.ts
+++ b/apps/webapp/app/modules/team-member/custody-count.ts
@@ -1,0 +1,35 @@
+/**
+ * How much custody a team member holds.
+ *
+ * Custody comes in two independent shapes and a member can hold either without
+ * the other, so anything deciding "is this member encumbered" has to count
+ * both. Assigning a kit ALWAYS writes a `KitCustody` row, while the inherited
+ * per-asset `Custody` rows are only written when the kit has assets to inherit
+ * them — so the custodian of an empty kit holds no `custodies` at all and looks
+ * unencumbered to anything counting only those.
+ *
+ * Deliberately dependency-free: this is read on the server when refusing a
+ * delete and in the browser when rendering the row and its confirmation
+ * dialog, and the two must agree.
+ *
+ * @see {@link file://./service.server.ts} deleteNRM, bulkDeleteNRMs
+ * @see {@link file://./../../components/workspace/delete-member.tsx}
+ */
+
+/** The `_count` shape a team member row must select to be judged. */
+export type TeamMemberCustodyCounts = {
+  /** Per-asset custody rows, operator-assigned or inherited from a kit. */
+  custodies: number;
+  /** Kit-level custody rows, one per kit the member holds. */
+  kitCustodies: number;
+};
+
+/**
+ * Total custody a member holds, across both shapes.
+ *
+ * @param counts - The member's `_count` selection
+ * @returns The combined count; `0` means the member can be deleted
+ */
+export function getHeldCustodyCount(counts: TeamMemberCustodyCounts): number {
+  return counts.custodies + counts.kitCustodies;
+}

--- a/apps/webapp/app/modules/team-member/delete-nrm.test.ts
+++ b/apps/webapp/app/modules/team-member/delete-nrm.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Deleting a single non-registered member.
+ *
+ * Deleting an NRM is a SOFT delete, so the row and every `Custody` pointing at
+ * it survive the write. A member who still holds custody must therefore not be
+ * deletable: the assets keep naming them as custodian while the member is gone
+ * from every list and every custodian picker, leaving no way to find what they
+ * hold except asset by asset.
+ *
+ * The rule itself is not new — bulk delete and the confirmation dialog both
+ * enforce it. These tests pin that the single delete enforces it too, in the
+ * write predicate rather than in a preceding read, and that it can only ever
+ * reach a row the NRM index actually lists.
+ *
+ * @see {@link file://./service.server.ts} deleteNRM
+ * @see {@link file://./bulk-delete-nrms.test.ts} the same rule on the bulk path
+ */
+import { InviteStatuses } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  findFirst: vi.fn(),
+  updateMany: vi.fn(),
+}));
+
+// why: the `where` the delete is issued with IS the behaviour under test — it
+// is what makes the custody rule enforceable rather than advisory — so the
+// tests assert on what Prisma receives instead of standing up a database.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    teamMember: {
+      findFirst: dbMocks.findFirst,
+      updateMany: dbMocks.updateMany,
+    },
+  },
+}));
+
+const { deleteNRM } = await import("~/modules/team-member/service.server");
+
+const ORG = "org-1";
+const NRM_ID = "nrm-1";
+
+/** The predicates that make a TeamMember row an NRM the index lists. */
+const NRM_BASE_SCOPE = {
+  deletedAt: null,
+  organizationId: ORG,
+  userId: null,
+  receivedInvites: { none: { status: InviteStatuses.PENDING } },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.updateMany.mockResolvedValue({ count: 1 });
+  dbMocks.findFirst.mockResolvedValue(null);
+});
+
+describe("deleteNRM", () => {
+  it("soft-deletes a member who holds no custody", async () => {
+    await deleteNRM({ nrmId: NRM_ID, organizationId: ORG });
+
+    expect(dbMocks.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { deletedAt: expect.any(Date) } })
+    );
+  });
+
+  it("carries the custody rule in the write predicate", async () => {
+    // The rule has to be part of the statement that writes. Checking custody
+    // in a preceding read leaves a window: the list page is rendered, someone
+    // else assigns custody, and the delete still lands on the stale answer.
+    await deleteNRM({ nrmId: NRM_ID, organizationId: ORG });
+
+    const { where } = dbMocks.updateMany.mock.calls[0][0];
+    expect(where).toEqual({
+      ...NRM_BASE_SCOPE,
+      id: { in: [NRM_ID] },
+      custodies: { none: {} },
+    });
+  });
+
+  it("refuses a member who holds custody, and says so", async () => {
+    // No row matched the guarded write, and the member is still a listed NRM —
+    // so custody is what held it back.
+    dbMocks.updateMany.mockResolvedValue({ count: 0 });
+    dbMocks.findFirst.mockResolvedValue({ _count: { custodies: 3 } });
+
+    await expect(
+      deleteNRM({ nrmId: NRM_ID, organizationId: ORG })
+    ).rejects.toThrow(/custody/i);
+  });
+
+  it("treats a refused delete as a client error, not a server fault", async () => {
+    // A 5xx here would page someone and burn Sentry's error quota over a user
+    // being told to check in their assets first.
+    dbMocks.updateMany.mockResolvedValue({ count: 0 });
+    dbMocks.findFirst.mockResolvedValue({ _count: { custodies: 1 } });
+
+    await expect(
+      deleteNRM({ nrmId: NRM_ID, organizationId: ORG })
+    ).rejects.toMatchObject({ status: 400, shouldBeCaptured: false });
+  });
+
+  it("reports an id that is not a deletable NRM as not found", async () => {
+    // Nothing matched and nothing is there to match: the id belongs to another
+    // organization, to a registered user, to a pending invite, or to a row
+    // someone else already deleted.
+    dbMocks.updateMany.mockResolvedValue({ count: 0 });
+    dbMocks.findFirst.mockResolvedValue(null);
+
+    await expect(
+      deleteNRM({ nrmId: NRM_ID, organizationId: ORG })
+    ).rejects.toMatchObject({ status: 404, shouldBeCaptured: false });
+  });
+
+  it("cannot reach the row backing a registered user", async () => {
+    // Those belong to the Users tab. Soft-deleting one there would strip the
+    // custodian record out from under a member who still belongs to the
+    // workspace, and the NRM index would never show it to put it back.
+    await deleteNRM({ nrmId: NRM_ID, organizationId: ORG });
+
+    const { where } = dbMocks.updateMany.mock.calls[0][0];
+    expect(where.userId).toBeNull();
+  });
+
+  it("cannot reach a member whose invite is still pending", async () => {
+    // Those are listed on the Invites tab, not here.
+    await deleteNRM({ nrmId: NRM_ID, organizationId: ORG });
+
+    const { where } = dbMocks.updateMany.mock.calls[0][0];
+    expect(where.receivedInvites).toEqual({
+      none: { status: InviteStatuses.PENDING },
+    });
+  });
+
+  it("stays inside the caller's organization", async () => {
+    await deleteNRM({ nrmId: NRM_ID, organizationId: ORG });
+
+    const { where } = dbMocks.updateMany.mock.calls[0][0];
+    expect(where.organizationId).toBe(ORG);
+  });
+});

--- a/apps/webapp/app/modules/team-member/delete-nrm.test.ts
+++ b/apps/webapp/app/modules/team-member/delete-nrm.test.ts
@@ -7,16 +7,17 @@
  * from every list and every custodian picker, leaving no way to find what they
  * hold except asset by asset.
  *
- * The rule itself is not new — bulk delete and the confirmation dialog both
- * enforce it. These tests pin that the single delete enforces it too, in the
- * write predicate rather than in a preceding read, and that it can only ever
- * reach a row the NRM index actually lists.
+ * The rule lives in the write predicate rather than in a preceding read, so
+ * that custody assigned between the two cannot slip past it, and the delete can
+ * only ever reach a row the NRM index itself lists. Bulk delete and the
+ * confirmation dialog apply the same rule, and all three must agree.
  *
  * @see {@link file://./service.server.ts} deleteNRM
  * @see {@link file://./bulk-delete-nrms.test.ts} the same rule on the bulk path
  */
 import { InviteStatuses } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ALL_SELECTED_KEY } from "~/utils/list";
 
 const dbMocks = vi.hoisted(() => ({
   findFirst: vi.fn(),
@@ -72,16 +73,30 @@ describe("deleteNRM", () => {
     const { where } = dbMocks.updateMany.mock.calls[0][0];
     expect(where).toEqual({
       ...NRM_BASE_SCOPE,
-      id: { in: [NRM_ID] },
+      id: NRM_ID,
       custodies: { none: {} },
+      kitCustodies: { none: {} },
     });
+  });
+
+  it("treats the select-all sentinel as an ordinary id, not a wildcard", async () => {
+    // `ALL_SELECTED_KEY` is how the bulk endpoints spell "every row matching
+    // the current filters". Routing a single id through a helper that reads
+    // that sentinel would drop the id filter entirely, turning one member's
+    // delete into every custody-free NRM in the organization.
+    await deleteNRM({ nrmId: ALL_SELECTED_KEY, organizationId: ORG });
+
+    const { where } = dbMocks.updateMany.mock.calls[0][0];
+    expect(where.id).toBe(ALL_SELECTED_KEY);
   });
 
   it("refuses a member who holds custody, and says so", async () => {
     // No row matched the guarded write, and the member is still a listed NRM —
     // so custody is what held it back.
     dbMocks.updateMany.mockResolvedValue({ count: 0 });
-    dbMocks.findFirst.mockResolvedValue({ _count: { custodies: 3 } });
+    dbMocks.findFirst.mockResolvedValue({
+      _count: { custodies: 3, kitCustodies: 0 },
+    });
 
     await expect(
       deleteNRM({ nrmId: NRM_ID, organizationId: ORG })
@@ -92,11 +107,53 @@ describe("deleteNRM", () => {
     // A 5xx here would page someone and burn Sentry's error quota over a user
     // being told to check in their assets first.
     dbMocks.updateMany.mockResolvedValue({ count: 0 });
-    dbMocks.findFirst.mockResolvedValue({ _count: { custodies: 1 } });
+    dbMocks.findFirst.mockResolvedValue({
+      _count: { custodies: 1, kitCustodies: 0 },
+    });
 
     await expect(
       deleteNRM({ nrmId: NRM_ID, organizationId: ORG })
     ).rejects.toMatchObject({ status: 400, shouldBeCaptured: false });
+  });
+
+  it("refuses a kit-only custodian, who holds no asset custody at all", async () => {
+    // Assigning a kit always writes `KitCustody`, and only writes the
+    // inherited per-asset rows when the kit has assets — so the custodian of
+    // an empty kit is invisible to a guard that counts `custodies` alone.
+    dbMocks.updateMany.mockResolvedValue({ count: 0 });
+    dbMocks.findFirst.mockResolvedValue({
+      _count: { custodies: 0, kitCustodies: 2 },
+    });
+
+    await expect(
+      deleteNRM({ nrmId: NRM_ID, organizationId: ORG })
+    ).rejects.toThrow(/custody/i);
+  });
+
+  it("guards both custody shapes in the write predicate", async () => {
+    await deleteNRM({ nrmId: NRM_ID, organizationId: ORG });
+
+    const { where } = dbMocks.updateMany.mock.calls[0][0];
+    expect(where.custodies).toEqual({ none: {} });
+    expect(where.kitCustodies).toEqual({ none: {} });
+  });
+
+  it("does not blame custody that was released mid-delete", async () => {
+    // The guarded write passed the row by, but by the time we look it holds
+    // nothing: what blocked it was released between the two statements.
+    // Reporting "release custody" would name something that is already gone.
+    dbMocks.updateMany.mockResolvedValue({ count: 0 });
+    dbMocks.findFirst.mockResolvedValue({
+      _count: { custodies: 0, kitCustodies: 0 },
+    });
+
+    const error = await deleteNRM({
+      nrmId: NRM_ID,
+      organizationId: ORG,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toMatchObject({ status: 409, shouldBeCaptured: false });
+    expect((error as Error).message).not.toMatch(/release custody/i);
   });
 
   it("reports an id that is not a deletable NRM as not found", async () => {

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -6,7 +6,11 @@ import { withBackgroundWriteSlot } from "~/utils/background-write-limiter.server
 import { updateCookieWithPerPage } from "~/utils/cookies.server";
 import { CUSTODY_FILTER_REFUSED } from "~/utils/custody-filter";
 import type { ErrorLabel } from "~/utils/error";
-import { isNotFoundError, ShelfError } from "~/utils/error";
+import {
+  isNotFoundError,
+  rethrowIfClientError,
+  ShelfError,
+} from "~/utils/error";
 import { getCurrentSearchParams } from "~/utils/http.server";
 import { getParamsValues } from "~/utils/list";
 import { Logger } from "~/utils/logger";
@@ -868,6 +872,93 @@ export async function getTeamMember({
       // Suppress only true Prisma not-found (P2025); let DB / connectivity
       // failures bubble up to Sentry.
       shouldBeCaptured: !isNotFoundError(cause),
+    });
+  }
+}
+
+/**
+ * Soft-deletes one non-registered member, refusing while they still hold
+ * custody over any asset.
+ *
+ * The custody rule is not advisory. Deleting an NRM only sets `deletedAt`, so
+ * every `Custody` row keeps pointing at the member: the assets go on naming a
+ * custodian who is gone from the NRM index and from every custodian picker,
+ * and nothing short of opening assets one at a time can find what they hold.
+ *
+ * Both halves of the `where` are load-bearing, and both belong in the write
+ * rather than in a preceding read — the list page the caller is acting from was
+ * rendered earlier, and a member can be given custody in between:
+ *
+ * - `custodies: { none: {} }` enforces the rule at the moment of the write.
+ * - the NRM scope keeps the delete on a row this index actually lists. A bare
+ *   `{ id, organizationId }` also matches the TeamMember backing a registered
+ *   user, or one holding a pending invite, neither of which is deletable here.
+ *
+ * A miss is therefore ordinary, not exceptional: it is reported as a client
+ * error, with a second read only to say which of the two reasons applied.
+ *
+ * @param params.nrmId - The member to delete
+ * @param params.organizationId - The active organization
+ * @throws {ShelfError} 400 if the member still holds custody, 404 if the id is
+ *   not a deletable NRM in this organization, 500 if the write fails
+ */
+export async function deleteNRM({
+  nrmId,
+  organizationId,
+}: {
+  nrmId: TeamMember["id"];
+  organizationId: TeamMember["organizationId"];
+}) {
+  try {
+    const scope = getNrmSelectionWhere({ nrmIds: [nrmId], organizationId });
+
+    const { count } = await db.teamMember.updateMany({
+      where: { ...scope, custodies: { none: {} } },
+      data: { deletedAt: new Date() },
+    });
+
+    if (count > 0) {
+      return;
+    }
+
+    // Nothing matched. Read again purely to tell the two reasons apart so the
+    // caller gets an actionable message; the write above is what enforced.
+    const member = await db.teamMember.findFirst({
+      where: scope,
+      select: { _count: { select: { custodies: true } } },
+    });
+
+    if (member) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "This team member has custody over some assets. Please release custody or check-in those assets before deleting the user.",
+        additionalData: { nrmId, organizationId },
+        label,
+        status: 400,
+        shouldBeCaptured: false,
+      });
+    }
+
+    throw new ShelfError({
+      cause: null,
+      message:
+        "This team member could not be found in your workspace, or is not one that can be deleted here.",
+      additionalData: { nrmId, organizationId },
+      label,
+      status: 404,
+      shouldBeCaptured: false,
+    });
+  } catch (cause) {
+    // The refusals above are deliberate 4xx answers; re-wrapping them would
+    // replace a message written for the user with "try again later".
+    rethrowIfClientError(cause);
+
+    throw new ShelfError({
+      cause,
+      message: "Failed to delete team member",
+      additionalData: { nrmId, organizationId },
+      label,
     });
   }
 }

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -15,7 +15,7 @@ import { getCurrentSearchParams } from "~/utils/http.server";
 import { getParamsValues } from "~/utils/list";
 import { Logger } from "~/utils/logger";
 import { resolveUserDisplayName } from "~/utils/user";
-import { getNrmSelectionWhere } from "./nrm-scope";
+import { getNrmIndexWhere, getNrmSelectionWhere } from "./nrm-scope";
 import type { CreateAssetFromContentImportPayload } from "../asset/types";
 
 const label: ErrorLabel = "Team Member";
@@ -910,10 +910,27 @@ export async function deleteNRM({
   organizationId: TeamMember["organizationId"];
 }) {
   try {
-    const scope = getNrmSelectionWhere({ nrmIds: [nrmId], organizationId });
+    // Built from the index scope plus this one id. NOT `getNrmSelectionWhere`:
+    // that helper reads `ALL_SELECTED_KEY` and drops the id filter entirely for
+    // it, so a request naming that sentinel as its member would match — and
+    // soft-delete — every unencumbered NRM in the organization.
+    const scope: Prisma.TeamMemberWhereInput = {
+      ...getNrmIndexWhere({ organizationId }),
+      id: nrmId,
+    };
+
+    // Custody comes in two independent shapes and either one is enough to make
+    // a member undeletable. Assigning a kit ALWAYS writes `KitCustody`, while
+    // the inherited per-asset `Custody` rows are only written when the kit has
+    // assets to inherit them — so the custodian of an empty kit holds no
+    // `custodies` at all and would pass an asset-only guard.
+    const holdsNothing = {
+      custodies: { none: {} },
+      kitCustodies: { none: {} },
+    };
 
     const { count } = await db.teamMember.updateMany({
-      where: { ...scope, custodies: { none: {} } },
+      where: { ...scope, ...holdsNothing },
       data: { deletedAt: new Date() },
     });
 
@@ -921,18 +938,30 @@ export async function deleteNRM({
       return;
     }
 
-    // Nothing matched. Read again purely to tell the two reasons apart so the
-    // caller gets an actionable message; the write above is what enforced.
+    // Nothing matched. Read again purely to say why, so the caller gets an
+    // actionable message; the write above is what enforced.
     const member = await db.teamMember.findFirst({
       where: scope,
-      select: { _count: { select: { custodies: true } } },
+      select: { _count: { select: { custodies: true, kitCustodies: true } } },
     });
 
-    if (member) {
+    if (!member) {
       throw new ShelfError({
         cause: null,
         message:
-          "This team member has custody over some assets. Please release custody or check-in those assets before deleting the user.",
+          "This team member could not be found in your workspace, or is not one that can be deleted here.",
+        additionalData: { nrmId, organizationId },
+        label,
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (member._count.custodies + member._count.kitCustodies > 0) {
+      throw new ShelfError({
+        cause: null,
+        message:
+          "This team member has custody over some assets or kits. Please release custody or check-in those items before deleting the user.",
         additionalData: { nrmId, organizationId },
         label,
         status: 400,
@@ -940,13 +969,16 @@ export async function deleteNRM({
       });
     }
 
+    // The row is here and holds nothing, yet the guarded write passed it by:
+    // whatever it held was released between the two statements. Telling the
+    // caller to release custody would name something that no longer exists.
     throw new ShelfError({
       cause: null,
       message:
-        "This team member could not be found in your workspace, or is not one that can be deleted here.",
+        "This team member changed while it was being deleted. Please try again.",
       additionalData: { nrmId, organizationId },
       label,
-      status: 404,
+      status: 409,
       shouldBeCaptured: false,
     });
   } catch (cause) {
@@ -992,12 +1024,20 @@ export async function bulkDeleteNRMs({
 
     const teamMembers = await db.teamMember.findMany({
       where,
-      select: { id: true, _count: { select: { custodies: true } } },
+      select: {
+        id: true,
+        _count: { select: { custodies: true, kitCustodies: true } },
+      },
     });
 
-    /** If some team members have custody, then delete is not allowed */
+    /**
+     * If some team members have custody, then delete is not allowed. Kit
+     * custody counts: assigning a kit always writes `KitCustody`, and only
+     * writes the inherited per-asset `Custody` rows when the kit has assets,
+     * so the custodian of an empty kit holds no `custodies` at all.
+     */
     const someTeamMemberHasCustodies = teamMembers.some(
-      (tm) => tm._count.custodies > 0
+      (tm) => tm._count.custodies + tm._count.kitCustodies > 0
     );
 
     if (someTeamMemberHasCustodies) {
@@ -1024,6 +1064,7 @@ export async function bulkDeleteNRMs({
           organizationId,
         }),
         custodies: { none: {} },
+        kitCustodies: { none: {} },
       },
       data: { deletedAt: new Date() },
     });

--- a/apps/webapp/app/routes/_layout+/settings.team.nrm.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.nrm.tsx
@@ -18,9 +18,9 @@ import { Button } from "~/components/shared/button";
 import { Td, Th } from "~/components/table";
 import { ImportNrmButton } from "~/components/workspace/import-nrm-button";
 import { TeamMembersActionsDropdown } from "~/components/workspace/nrm-actions-dropdown";
-import { db } from "~/database/db.server";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { getPaginatedAndFilterableSettingTeamMembers } from "~/modules/settings/service.server";
+import { deleteNRM } from "~/modules/team-member/service.server";
 import { getOrganizationTierLimit } from "~/modules/tier/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError, ShelfError } from "~/utils/error";
@@ -132,24 +132,7 @@ export async function action({ context, request }: ActionFunctionArgs) {
           }
         );
 
-        await db.teamMember
-          .update({
-            where: {
-              id: teamMemberId,
-              organizationId,
-            },
-            data: {
-              deletedAt: new Date(),
-            },
-          })
-          .catch((cause) => {
-            throw new ShelfError({
-              cause,
-              message: "Failed to delete team member",
-              additionalData: { teamMemberId, userId, organizationId },
-              label: "Team",
-            });
-          });
+        await deleteNRM({ nrmId: teamMemberId, organizationId });
 
         return redirect(`/settings/team/nrm`);
       }

--- a/apps/webapp/app/routes/_layout+/settings.team.nrm.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.nrm.tsx
@@ -20,6 +20,7 @@ import { ImportNrmButton } from "~/components/workspace/import-nrm-button";
 import { TeamMembersActionsDropdown } from "~/components/workspace/nrm-actions-dropdown";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import { getPaginatedAndFilterableSettingTeamMembers } from "~/modules/settings/service.server";
+import { getHeldCustodyCount } from "~/modules/team-member/custody-count";
 import { deleteNRM } from "~/modules/team-member/service.server";
 import { getOrganizationTierLimit } from "~/modules/tier/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
@@ -215,6 +216,7 @@ function TeamMemberRow({
       _count: {
         select: {
           custodies: true;
+          kitCustodies: true;
         };
       };
     };
@@ -228,9 +230,7 @@ function TeamMemberRow({
         </div>
       </Td>
       <Td className="w-full whitespace-normal">{item.name}</Td>
-      <Td className="text-right">
-        {item._count.custodies ? item._count.custodies : 0}
-      </Td>
+      <Td className="text-right">{getHeldCustodyCount(item._count)}</Td>
       <Td className="text-right">
         <TeamMembersActionsDropdown teamMember={item} />
       </Td>

--- a/apps/webapp/test/routes-tests/_layout+/settings.team.nrm.delete.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/settings.team.nrm.delete.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Route tests for the NRM delete action.
+ *
+ * The confirmation dialog swaps the submit button for an explanation once a
+ * member holds custody, so the only requests that reach this action are ones
+ * the client believed were allowed. That belief can be wrong — the list page
+ * was rendered before custody was assigned, or the request never came from the
+ * page at all — which is why the refusal has to live on the server.
+ *
+ * These pin the wiring: the action delegates to the service that enforces the
+ * rule, and a refusal reaches the user as the message written for them rather
+ * than as a generic failure.
+ *
+ * @see {@link file://../../../app/routes/_layout+/settings.team.nrm.tsx}
+ * @see {@link file://../../../app/modules/team-member/delete-nrm.test.ts} the rule itself
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { createActionArgs } from "@mocks/remix";
+import { deleteNRM } from "~/modules/team-member/service.server";
+import { ShelfError } from "~/utils/error";
+import { requirePermission } from "~/utils/roles.server";
+
+const ORG = "org-1";
+
+// why: the action's job here is delegation, not authorization — run it without
+// executing a real permission check.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+
+// why: importing the route reaches `db.server`, which constructs the Prisma
+// client and connects at module scope — leaving an unhandled connection error
+// in the run. Nothing under test touches a delegate, so an empty client is
+// enough to keep the import side-effect off a database.
+vi.mock("~/database/db.server", () => ({ db: {} }));
+
+// why: the service owns the custody rule and is tested directly next to it.
+// Stubbing it lets these tests state "the delete was refused" without seeding
+// custody rows, and makes the payload the route forwards observable.
+vi.mock("~/modules/team-member/service.server", () => ({
+  deleteNRM: vi.fn(),
+}));
+
+const { action } = await import("~/routes/_layout+/settings.team.nrm");
+
+const requirePermissionMock = vi.mocked(requirePermission);
+const deleteNRMMock = vi.mocked(deleteNRM);
+
+/**
+ * Posts a delete for `teamMemberId`.
+ *
+ * why: a `URLSearchParams` body rather than `FormData` — happy-dom drops empty
+ * fields when a `FormData` round-trips through `Request`, which silently
+ * changes what the action parses.
+ */
+function submitDelete(teamMemberId: string) {
+  const body = new URLSearchParams({ intent: "delete", teamMemberId });
+
+  return action(
+    createActionArgs({
+      request: new Request("http://localhost:3000/settings/team/nrm", {
+        method: "POST",
+        body,
+      }),
+      context: {
+        getSession: () => ({ userId: "user-1" }),
+      } as never,
+    })
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  requirePermissionMock.mockResolvedValue({ organizationId: ORG } as never);
+  deleteNRMMock.mockResolvedValue(undefined);
+});
+
+describe("settings.team.nrm delete action", () => {
+  it("routes the delete through the service that enforces the custody rule", async () => {
+    await submitDelete("nrm-1");
+
+    // Writing the soft-delete inline here again is the regression: the route
+    // has no way to express the rule atomically, so it would drop it.
+    expect(deleteNRMMock).toHaveBeenCalledWith({
+      nrmId: "nrm-1",
+      organizationId: ORG,
+    });
+  });
+
+  it("scopes the delete to the caller's organization, not the submitted form", async () => {
+    await submitDelete("nrm-1");
+
+    const [{ organizationId }] = deleteNRMMock.mock.calls[0];
+    expect(organizationId).toBe(ORG);
+  });
+
+  it("returns the refusal to the user instead of a generic failure", async () => {
+    deleteNRMMock.mockRejectedValue(
+      new ShelfError({
+        cause: null,
+        message:
+          "This team member has custody over some assets. Please release custody or check-in those assets before deleting the user.",
+        label: "Team Member",
+        status: 400,
+        shouldBeCaptured: false,
+      })
+    );
+
+    const response = await submitDelete("nrm-1");
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(400);
+    expect(JSON.stringify(response.data)).toMatch(/custody/i);
+  });
+
+  it("redirects back to the index when the delete succeeds", async () => {
+    const response = await submitDelete("nrm-1");
+
+    expect(response).toMatchObject({ status: 302 });
+  });
+});

--- a/apps/webapp/test/routes-tests/_layout+/settings.team.nrm.delete.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/settings.team.nrm.delete.test.ts
@@ -80,8 +80,9 @@ describe("settings.team.nrm delete action", () => {
   it("routes the delete through the service that enforces the custody rule", async () => {
     await submitDelete("nrm-1");
 
-    // Writing the soft-delete inline here again is the regression: the route
-    // has no way to express the rule atomically, so it would drop it.
+    // The write has to stay in the service: the rule it carries is a predicate
+    // on the same statement, which a route issuing its own update cannot
+    // express.
     expect(deleteNRMMock).toHaveBeenCalledWith({
       nrmId: "nrm-1",
       organizationId: ORG,


### PR DESCRIPTION
## The bug

Deleting a non-registered member is a **soft** delete — it only sets
`deletedAt`, so the row and every `Custody` pointing at it survive. The single
delete wrote that unconditionally:

```ts
await db.teamMember.update({
  where: { id: teamMemberId, organizationId },
  data: { deletedAt: new Date() },
});
```

The result is an invisible custodian. Assets go on showing "in custody by
[name]", while the member is gone from the NRM index and from every custodian
picker — so there is no way to find what they hold except opening assets one at
a time.

The rule itself already existed. `bulkDeleteNRMs` enforces it, and the
confirmation dialog swaps the submit button for an explanation once
`_count.custodies > 0`. **Enforcement was client-side only.**

## This is a race, not just a bypass

Reaching the unguarded write takes no crafted request. The list page is
rendered, someone else assigns custody, the admin clicks Delete — and the
decision was made against an answer that has since gone stale.

That is why the guard goes **in the write**, not in a check before it. A
read-then-write fix still loses this race.

## A second defect in the same `where`

`{ id, organizationId }` is org-scoped, so this is not an IDOR — but it is
wider than the surface it serves. It also matches:

- the `TeamMember` backing a **registered user** → belongs to the Users tab.
  Soft-deleting it strips the custodian record out from under someone who is
  still a member, and the NRM index would never show it again to put it back.
- a member with a **pending invite** → belongs to the Invites tab.

`nrm-scope.ts` exists precisely to stop this, and its JSDoc says every caller
"MUST derive their Prisma `where` from here rather than hand-rolling one". This
call site hand-rolled one.

## The fix

A `deleteNRM` service function beside `bulkDeleteNRMs`, carrying both
predicates in one guarded statement:

```ts
where: { ...getNrmSelectionWhere({ nrmIds: [nrmId], organizationId }),
         custodies: { none: {} } }
```

A miss is ordinary rather than exceptional, so the second read runs **only on
the failure path**, purely to tell the two reasons apart:

| Outcome | Status | Captured |
| --- | --- | --- |
| still holds custody | 400 | no |
| not a deletable NRM here | 404 | no |

Neither is a server fault — a 5xx would page someone over a user being told to
check in their assets first. `rethrowIfClientError` keeps the message written
for the user from being replaced by "try again later".

This mirrors `revokeAccessToOrganization`, which already uses the same idiom:
read for an actionable message, enforce in a conditional write, re-read on zero
to disambiguate.

## Sweep

Every sibling delete path was checked before writing any code:

| Path | State |
| --- | --- |
| `bulkDeleteNRMs` | already sound — JS guard **and** re-asserted `custodies: { none: {} }` in the write |
| `revokeAccessToOrganization` | different operation; unlinks the User rather than soft-deleting, custodies stay on a row that remains visible |
| API / mobile routes | none delete NRMs |

One defective site — unusually, since the last several findings each had
siblings.

## Tests

12 new tests, following the conventions of the sibling
`bulk-delete-nrms.test.ts`:

- **8 service tests** (`app/modules/team-member/delete-nrm.test.ts`) — the
  custody rule is in the write predicate, the NRM scope holds, refusals carry
  the right status and are not captured.
- **4 route tests** (`test/routes-tests/_layout+/settings.team.nrm.delete.test.ts`)
  — the action delegates rather than writing inline, scopes to the caller's org
  rather than the form, and surfaces a refusal as a 400 with the real message.

Two mutations confirm they bite:

| Mutation | Result |
| --- | --- |
| drop `custodies: { none: {} }` from the write | 1 failure |
| restore the original bare `{ id, organizationId }` scope | 3 failures |

## Verification

- 108 tests pass across all 9 team-member suites
- `tsc -b --force` clean; ESLint and Prettier clean
- Removed the now-unused `db` import from the route, and silenced an unhandled
  Prisma connect the route import was leaving in the test run

No migration. No new workspace dependency. No schema change.

Closes the `detail.dev` D111 finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deletion of non-registered team members with organization scoping and eligibility checks.
  * Prevented deletion when a member holds assets or kits.
  * Added clearer responses for invalid, missing, or custody-linked members.
  * Improved handling of concurrent deletion conflicts.
  * Updated custody counts and warnings to include kits.
  * Successful deletions now redirect back to the team member list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->