### PR TITLE
fix(team): report a bulk NRM custody refusal as a client error, not a 500

### DIFF
--- a/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
+++ b/apps/webapp/app/modules/team-member/bulk-delete-nrms.test.ts
@@ -66,6 +66,8 @@ describe("bulkDeleteNRMs", () => {
   });
 
   it("soft-deletes only the rows the scoped query returned", async () => {
+    // why: two unencumbered members are the fixture that lets the write run,
+    // so the ids it is issued with are observable.
     dbMocks.findMany.mockResolvedValue([
       { id: "a", _count: { custodies: 0, kitCustodies: 0 } },
       { id: "b", _count: { custodies: 0, kitCustodies: 0 } },
@@ -82,6 +84,8 @@ describe("bulkDeleteNRMs", () => {
   });
 
   it("re-asserts the NRM scope and custody guard in the write predicate", async () => {
+    // why: an unencumbered member, so nothing short-circuits before the write
+    // whose predicate this asserts on.
     dbMocks.findMany.mockResolvedValue([
       { id: "a", _count: { custodies: 0, kitCustodies: 0 } },
     ]);
@@ -104,6 +108,8 @@ describe("bulkDeleteNRMs", () => {
     // Assigning a kit always writes `KitCustody`; the inherited per-asset
     // rows only appear when the kit has assets. An empty kit's custodian
     // therefore holds nothing an asset-only count would see.
+    // why: kit custody with no asset custody is exactly the member an
+    // asset-only count reports as free.
     dbMocks.findMany.mockResolvedValue([
       { id: "a", _count: { custodies: 0, kitCustodies: 1 } },
     ]);
@@ -114,7 +120,23 @@ describe("bulkDeleteNRMs", () => {
     expect(dbMocks.updateMany).not.toHaveBeenCalled();
   });
 
+  it("treats a custody refusal as a client error, not a server fault", async () => {
+    // why: one encumbered member is all it takes to refuse the batch, and this
+    // asserts how that refusal is reported rather than that it happens.
+    dbMocks.findMany.mockResolvedValue([
+      { id: "a", _count: { custodies: 1, kitCustodies: 0 } },
+    ]);
+
+    // Without a status the wrapper inherits 500 and Sentry captures it, over a
+    // user being told to check in their assets first.
+    await expect(
+      bulkDeleteNRMs({ nrmIds: ["a"], organizationId: ORG })
+    ).rejects.toMatchObject({ status: 400, shouldBeCaptured: false });
+  });
+
   it("still refuses the batch when a selected member holds custody", async () => {
+    // why: an encumbered member is the whole precondition of the rule under
+    // test; the count is stubbed rather than seeded.
     dbMocks.findMany.mockResolvedValue([
       { id: "a", _count: { custodies: 2, kitCustodies: 0 } },
     ]);

--- a/apps/webapp/app/modules/team-member/delete-nrm.test.ts
+++ b/apps/webapp/app/modules/team-member/delete-nrm.test.ts
@@ -91,9 +91,11 @@ describe("deleteNRM", () => {
   });
 
   it("refuses a member who holds custody, and says so", async () => {
-    // No row matched the guarded write, and the member is still a listed NRM —
-    // so custody is what held it back.
+    // why: zero rows written is how the guarded statement reports that the
+    // custody predicate excluded the member.
     dbMocks.updateMany.mockResolvedValue({ count: 0 });
+    // why: the member is still a listed NRM, which is what narrows the reason
+    // for that miss down to custody.
     dbMocks.findFirst.mockResolvedValue({
       _count: { custodies: 3, kitCustodies: 0 },
     });
@@ -106,6 +108,8 @@ describe("deleteNRM", () => {
   it("treats a refused delete as a client error, not a server fault", async () => {
     // A 5xx here would page someone and burn Sentry's error quota over a user
     // being told to check in their assets first.
+    // why: the smallest state that reaches the refusal — one row excluded by
+    // the guard, holding one custody.
     dbMocks.updateMany.mockResolvedValue({ count: 0 });
     dbMocks.findFirst.mockResolvedValue({
       _count: { custodies: 1, kitCustodies: 0 },
@@ -120,6 +124,8 @@ describe("deleteNRM", () => {
     // Assigning a kit always writes `KitCustody`, and only writes the
     // inherited per-asset rows when the kit has assets — so the custodian of
     // an empty kit is invisible to a guard that counts `custodies` alone.
+    // why: zero asset custody with kit custody present IS that member, and it
+    // is a shape no database is needed to produce.
     dbMocks.updateMany.mockResolvedValue({ count: 0 });
     dbMocks.findFirst.mockResolvedValue({
       _count: { custodies: 0, kitCustodies: 2 },
@@ -142,6 +148,8 @@ describe("deleteNRM", () => {
     // The guarded write passed the row by, but by the time we look it holds
     // nothing: what blocked it was released between the two statements.
     // Reporting "release custody" would name something that is already gone.
+    // why: the two responses disagree on purpose. Only stubbing them can put
+    // the pair in a state a real database holds for microseconds.
     dbMocks.updateMany.mockResolvedValue({ count: 0 });
     dbMocks.findFirst.mockResolvedValue({
       _count: { custodies: 0, kitCustodies: 0 },
@@ -160,6 +168,8 @@ describe("deleteNRM", () => {
     // Nothing matched and nothing is there to match: the id belongs to another
     // organization, to a registered user, to a pending invite, or to a row
     // someone else already deleted.
+    // why: a null diagnostic read stands in for all of those at once — the
+    // scope predicate excludes them identically.
     dbMocks.updateMany.mockResolvedValue({ count: 0 });
     dbMocks.findFirst.mockResolvedValue(null);
 

--- a/apps/webapp/app/modules/team-member/service.server.ts
+++ b/apps/webapp/app/modules/team-member/service.server.ts
@@ -1044,8 +1044,11 @@ export async function bulkDeleteNRMs({
       throw new ShelfError({
         cause: null,
         message:
-          "Some team members has custody over some assets. Please release custody or check-in those assets before deleting the user.",
+          "Some team members have custody over some assets or kits. Please release custody or check-in those items before deleting the user.",
+        additionalData: { organizationId },
         label,
+        status: 400,
+        shouldBeCaptured: false,
       });
     }
 
@@ -1069,14 +1072,14 @@ export async function bulkDeleteNRMs({
       data: { deletedAt: new Date() },
     });
   } catch (cause) {
-    const message =
-      cause instanceof ShelfError
-        ? cause.message
-        : "Something went wrong while bulk deleting non-registered members";
+    // The custody refusal above is a deliberate 4xx answer; re-wrapping it
+    // would turn a rule the user can act on into a server fault.
+    rethrowIfClientError(cause);
 
     throw new ShelfError({
       cause,
-      message,
+      message:
+        "Something went wrong while bulk deleting non-registered members",
       label,
     });
   }


### PR DESCRIPTION
Follow-up to #2936. This commit was written and reviewed during that PR's second
review round but never made it onto the branch before it merged, so the two
findings it answers are still open on `main`.

## Bulk custody refusal returned HTTP 500

`bulkDeleteNRMs` threw its custody refusal without a `status`:

```ts
throw new ShelfError({
  cause: null,
  message: "Some team members has custody over some assets. …",
  label,
});
```

`ShelfError` defaults an absent status to 500 and `shouldBeCaptured` to `true`,
and the wrapping catch inherits both. So a user being told to check in their
assets first raised a **server error** and consumed Sentry's error quota.

#2936 gave the single-delete path a 400 for the same rule, which left the two
paths disagreeing — and made the 500 easier to reach, since kit-only custodians
now land on it too.

Now `status: 400` and `shouldBeCaptured: false`, with the message naming kits
alongside assets.

Two things beyond simply setting the status:

- The catch calls `rethrowIfClientError(cause)` before wrapping. Setting the
  status alone would have produced a correct 400 whose message had been replaced
  by "Something went wrong while bulk deleting non-registered members" — the
  right code attached to text the user cannot act on.
- A test pins `{ status: 400, shouldBeCaptured: false }`. Nothing asserted it
  before, which is how it stayed a 500.

## Mock rationale comments

The repo's testing guidelines require a `// why:` on mock configuration.
Added at all seven sites across the two NRM delete test files. The surrounding
prose already described each scenario; what was missing was why the response is
stubbed rather than seeded, so the new comments say that rather than restating
the assertion.

## Verification

- 110 tests pass across 8 team-member suites
- `tsc -b --force` clean, ESLint clean, Prettier clean

No migration. No schema change. No new dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bulk deletion error handling when items or kits are currently in custody.
  - These conflicts now return a clear client error with a 400 status.
  - Preserved expected client-error details while presenting a consistent generic message for unexpected server failures.

- **Tests**
  - Expanded coverage for custody refusals, kit-only custody, race conditions, and missing-item scenarios.
  - Added clearer explanations of the expected outcomes in deletion-related test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->