### PR TITLE
fix(assets): stop deactivating a custom field from deleting an unrelated column

### DIFF
--- a/apps/webapp/app/modules/asset-index-settings/helpers.ts
+++ b/apps/webapp/app/modules/asset-index-settings/helpers.ts
@@ -7,6 +7,78 @@ export type Column = {
   position: number;
   cfType?: CustomFieldType;
 };
+/**
+ * Brings one custom field's column in a single settings row into step with the
+ * field, returning the updated column list.
+ *
+ * Every settings row in the organization is reconciled separately — there is
+ * one per user — and a row is not obliged to have a column for the field.
+ * A row written before the field existed does not, and `validateColumns` only
+ * re-adds the FIXED columns on read, never custom-field ones. So "there is no
+ * column here" is an ordinary state, and on deactivation it means there is
+ * nothing to do.
+ *
+ * That case is the trap this function exists to contain. `findIndex` reports a
+ * miss as `-1`, and `-1` is a perfectly valid `splice` start index — it counts
+ * from the end — so a removal aimed at an absent column silently takes the LAST
+ * column instead. The row then loses a column that has nothing to do with the
+ * field: a fixed one returns on the next read but reset to the static default,
+ * losing whatever the user had chosen for it, and a custom-field one does not
+ * return at all.
+ *
+ * @param columns - The row's current columns; not modified
+ * @param field.oldName - The field's name BEFORE this change, which is what the
+ *   existing column is keyed on
+ * @param field.newName - The field's name after it, used for the column it
+ *   keeps or gains
+ * @param field.active - Whether the field is active after this change
+ * @param field.cfType - The field's type, recorded on the column
+ * @returns A new column list reflecting the change
+ */
+export function syncCustomFieldColumn(
+  columns: Column[],
+  {
+    oldName,
+    newName,
+    active,
+    cfType,
+  }: {
+    oldName: string;
+    newName: string;
+    active: boolean;
+    cfType?: CustomFieldType;
+  }
+): Column[] {
+  const next = [...columns];
+  const index = next.findIndex((col) => col?.name === `cf_${oldName}`);
+
+  if (!active) {
+    // Absent is not an error, and it is emphatically not "remove the last one".
+    return index === -1 ? next : next.filter((_, i) => i !== index);
+  }
+
+  const name = `cf_${newName}` as Column["name"];
+
+  if (index === -1) {
+    const highestPosition = next.reduce(
+      (acc, col) => (col.position > acc ? col.position : acc),
+      0
+    );
+    next.push({ name, visible: true, position: highestPosition + 1, cfType });
+    return next;
+  }
+
+  // The column is the user's: they chose whether to show it and where to put
+  // it, and reactivating or renaming the field is not a reason to override that.
+  next[index] = {
+    name,
+    visible: next[index].visible,
+    position: next[index].position,
+    cfType,
+  };
+  return next;
+}
+
 // Define the fixed fields
 export const fixedFields = [
   "id",

--- a/apps/webapp/app/modules/asset-index-settings/service.server.ts
+++ b/apps/webapp/app/modules/asset-index-settings/service.server.ts
@@ -9,6 +9,7 @@ import type { ExtendedPrismaClient } from "~/database/db.server";
 import { db } from "~/database/db.server";
 import { ShelfError, type ErrorLabel } from "~/utils/error";
 import type { Column, ColumnLabelKey } from "./helpers";
+import { syncCustomFieldColumn } from "./helpers";
 import {
   barcodeFields,
   defaultFields,
@@ -274,35 +275,15 @@ export async function updateAssetIndexSettingsAfterCfUpdate({
     });
 
     const updates = settings.map((entry) => {
-      const columns = Array.from(entry.columns as Prisma.JsonArray) as Column[];
-      const cfIndex = columns.findIndex(
-        (col) => col?.name === `cf_${oldField.name}`
-      );
-
-      if (newField.active) {
-        /** Field is missing so we add it */
-        if (cfIndex === -1) {
-          const prevHighestPosition = columns.reduce(
-            (acc, col) => (col.position > acc ? col.position : acc),
-            0
-          );
-          columns.push({
-            name: `cf_${newField.name}`,
-            visible: true,
-            position: prevHighestPosition + 1,
-            cfType: newField.type,
-          });
-        } else {
-          columns[cfIndex] = {
-            name: `cf_${newField.name}`,
-            visible: columns[cfIndex].visible,
-            position: columns[cfIndex].position,
-            cfType: newField.type,
-          };
+      const columns = syncCustomFieldColumn(
+        Array.from(entry.columns as Prisma.JsonArray) as Column[],
+        {
+          oldName: oldField.name,
+          newName: newField.name,
+          active: newField.active,
+          cfType: newField.type,
         }
-      } else {
-        columns.splice(cfIndex, 1);
-      }
+      );
 
       return db.assetIndexSettings.update({
         // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: entry.id comes from the org-scoped findMany on lines 272-274 (where organizationId)

--- a/apps/webapp/app/modules/asset-index-settings/sync-custom-field-column.test.ts
+++ b/apps/webapp/app/modules/asset-index-settings/sync-custom-field-column.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Keeping one custom field's asset-index column in step with the field.
+ *
+ * Activating a field must give it a column, renaming it must carry the column
+ * across, and deactivating it must take the column away — in every settings row
+ * in the organization, one row per user.
+ *
+ * The case that matters most is the one where there is nothing to do. A
+ * settings row need not have a column for the field at all: a row written
+ * before the field existed does not, and `validateColumns` only re-adds the
+ * fixed columns, never custom-field ones. Deactivating then has to leave that
+ * row alone, because the alternative is destroying a column that has nothing
+ * to do with the field being deactivated.
+ *
+ * @see {@link file://./helpers.ts} syncCustomFieldColumn
+ */
+import { CustomFieldType } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { syncCustomFieldColumn, type Column } from "./helpers";
+
+/** A settings row with three columns; `category` is last, so it is what a
+ * mis-aimed removal would take. */
+function columns(): Column[] {
+  return [
+    { name: "id", visible: true, position: 0 },
+    { name: "status", visible: false, position: 1 },
+    { name: "category", visible: true, position: 2 },
+  ];
+}
+
+/** Adds a column for a custom field named `name`. */
+function withCustomField(name: string, position = 3): Column[] {
+  return [
+    ...columns(),
+    {
+      name: `cf_${name}` as Column["name"],
+      visible: false,
+      position,
+      cfType: CustomFieldType.TEXT,
+    },
+  ];
+}
+
+describe("syncCustomFieldColumn", () => {
+  describe("deactivating", () => {
+    it("removes the field's own column", () => {
+      const result = syncCustomFieldColumn(withCustomField("warranty"), {
+        oldName: "warranty",
+        newName: "warranty",
+        active: false,
+      });
+
+      expect(result.map((col) => col.name)).toEqual([
+        "id",
+        "status",
+        "category",
+      ]);
+    });
+
+    it("leaves every column alone when the field has none here", () => {
+      // `findIndex` reports a miss as -1, and -1 is a valid `splice` start:
+      // it counts from the end, so a removal aimed at a column that is not
+      // there takes the last one instead.
+      const result = syncCustomFieldColumn(columns(), {
+        oldName: "warranty",
+        newName: "warranty",
+        active: false,
+      });
+
+      expect(result).toEqual(columns());
+    });
+
+    it("does not touch the other settings values it leaves behind", () => {
+      const result = syncCustomFieldColumn(withCustomField("warranty"), {
+        oldName: "warranty",
+        newName: "warranty",
+        active: false,
+      });
+
+      // A restored fixed column comes back from the static defaults, so a
+      // wrongly-removed one loses whatever the user had chosen for it.
+      expect(result).toContainEqual({
+        name: "status",
+        visible: false,
+        position: 1,
+      });
+    });
+  });
+
+  describe("activating", () => {
+    it("adds a column after the highest position when the field has none", () => {
+      const result = syncCustomFieldColumn(columns(), {
+        oldName: "warranty",
+        newName: "warranty",
+        active: true,
+        cfType: CustomFieldType.TEXT,
+      });
+
+      expect(result).toContainEqual({
+        name: "cf_warranty",
+        visible: true,
+        position: 3,
+        cfType: CustomFieldType.TEXT,
+      });
+    });
+
+    it("keeps the user's visibility and position when the column exists", () => {
+      // The column is theirs — they hid it and placed it. Re-activating the
+      // field is not a reason to move it or show it again.
+      const result = syncCustomFieldColumn(withCustomField("warranty", 7), {
+        oldName: "warranty",
+        newName: "warranty",
+        active: true,
+        cfType: CustomFieldType.TEXT,
+      });
+
+      expect(result).toContainEqual({
+        name: "cf_warranty",
+        visible: false,
+        position: 7,
+        cfType: CustomFieldType.TEXT,
+      });
+    });
+
+    it("carries the column across a rename", () => {
+      const result = syncCustomFieldColumn(withCustomField("warranty", 7), {
+        oldName: "warranty",
+        newName: "guarantee",
+        active: true,
+        cfType: CustomFieldType.TEXT,
+      });
+
+      const names = result.map((col) => col.name);
+      expect(names).toContain("cf_guarantee");
+      expect(names).not.toContain("cf_warranty");
+    });
+
+    it("records the field's type on the column", () => {
+      // `validateColumns` repairs a missing `cfType` on the next read, so an
+      // omission here is invisible rather than harmful — which is exactly why
+      // one of the two call sites could drop it unnoticed.
+      const result = syncCustomFieldColumn(columns(), {
+        oldName: "notes",
+        newName: "notes",
+        active: true,
+        cfType: CustomFieldType.MULTILINE_TEXT,
+      });
+
+      expect(result.find((col) => col.name === "cf_notes")?.cfType).toBe(
+        CustomFieldType.MULTILINE_TEXT
+      );
+    });
+  });
+
+  it("returns a new array rather than editing the caller's", () => {
+    const original = withCustomField("warranty");
+    const snapshot = JSON.parse(JSON.stringify(original)) as Column[];
+
+    syncCustomFieldColumn(original, {
+      oldName: "warranty",
+      newName: "warranty",
+      active: false,
+    });
+
+    expect(original).toEqual(snapshot);
+  });
+});

--- a/apps/webapp/app/modules/custom-field/service.server.ts
+++ b/apps/webapp/app/modules/custom-field/service.server.ts
@@ -18,6 +18,7 @@ import { getRedirectUrlFromRequest } from "~/utils/http";
 import type { CustomFieldDraftPayload } from "./types";
 import type { CreateAssetFromContentImportPayload } from "../asset/types";
 import type { Column } from "../asset-index-settings/helpers";
+import { syncCustomFieldColumn } from "../asset-index-settings/helpers";
 import {
   removeCustomFieldFromAssetIndexSettings,
   updateAssetIndexSettingsAfterCfUpdate,
@@ -71,17 +72,16 @@ export async function createCustomField({
     if (customField.active) {
       await Promise.all(
         assetIndexSettingsEntries.map(async (entry) => {
-          const columns = Array.from(entry.columns as Prisma.JsonArray);
-          const prevHighestPosition = (columns as Column[]).reduce(
-            (acc, col) => (col.position > acc ? col.position : acc),
-            0
+          const columns = syncCustomFieldColumn(
+            Array.from(entry.columns as Prisma.JsonArray) as Column[],
+            {
+              // A field being created has no former name and no column yet.
+              oldName: customField.name,
+              newName: customField.name,
+              active: true,
+              cfType: customField.type,
+            }
           );
-
-          columns.push({
-            name: `cf_${customField.name}`,
-            visible: true,
-            position: prevHighestPosition + 1,
-          });
 
           await db.assetIndexSettings.update({
             where: { id: entry.id, organizationId },
@@ -676,37 +676,19 @@ export async function bulkActivateOrDeactivateCustomFields({
 
     /** Update the asset index settings for each entry */
     const updates = settings.map((entry) => {
-      const columns = Array.from(entry.columns as Prisma.JsonArray) as Column[];
-
-      customFields.forEach((field) => {
-        const oldField = field;
-        const newField = { ...field, active };
-        const cfIndex = columns.findIndex(
-          (col) => col?.name === `cf_${oldField.name}`
-        );
-        if (newField.active) {
-          /** Field is missing so we add it */
-          if (cfIndex === -1) {
-            const prevHighestPosition = columns.reduce(
-              (acc, col) => (col.position > acc ? col.position : acc),
-              0
-            );
-            columns.push({
-              name: `cf_${newField.name}`,
-              visible: true,
-              position: prevHighestPosition + 1,
-            });
-          } else {
-            columns[cfIndex] = {
-              name: `cf_${newField.name}`,
-              visible: columns[cfIndex].visible,
-              position: columns[cfIndex].position,
-            };
-          }
-        } else {
-          columns.splice(cfIndex, 1);
-        }
-      });
+      // Each field folds into the running column list, so a batch touching
+      // several fields on one row lands as one write.
+      const columns = customFields.reduce(
+        (acc, field) =>
+          syncCustomFieldColumn(acc, {
+            // The batch only flips `active`; names are unchanged by it.
+            oldName: field.name,
+            newName: field.name,
+            active,
+            cfType: field.type,
+          }),
+        Array.from(entry.columns as Prisma.JsonArray) as Column[]
+      );
 
       return db.assetIndexSettings.update({
         where: { id: entry.id, organizationId },

--- a/apps/webapp/app/modules/custom-field/service.server.ts
+++ b/apps/webapp/app/modules/custom-field/service.server.ts
@@ -27,6 +27,18 @@ import {
 
 const label: ErrorLabel = "Custom fields";
 
+/**
+ * Creates a custom field and gives it a column on the asset index.
+ *
+ * An active field gets a column in every settings row in the organization —
+ * one per user — so it is visible to everyone from the moment it exists. An
+ * inactive one gets none; activating it later adds the columns.
+ *
+ * @param args - The field's definition, its organization, and its author
+ * @returns The created CustomField
+ * @throws {ShelfError} 409 if the organization already has a field with this
+ *   name, or on any other write failure
+ */
 export async function createCustomField({
   name,
   helpText,
@@ -650,6 +662,23 @@ export async function countActiveCustomFields({
   }
 }
 
+/**
+ * Activates or deactivates several custom fields at once, keeping the asset
+ * index in step.
+ *
+ * Every settings row in the organization is reconciled for every field in the
+ * batch, so the columns follow whichever way the fields move: activating adds
+ * the ones a row is missing and leaves the rest as the user arranged them,
+ * deactivating takes them away.
+ *
+ * @param args.customFields - The fields to move; their `name` and `type` are
+ *   read for the columns
+ * @param args.organizationId - The active organization
+ * @param args.userId - The acting user, recorded on failure
+ * @param args.active - The state to move every field in the batch to
+ * @returns The Prisma batch payload for the field update
+ * @throws {ShelfError} If the field update or any settings write fails
+ */
 export async function bulkActivateOrDeactivateCustomFields({
   customFields,
   organizationId,


### PR DESCRIPTION
## The bug

Deactivating a custom field removed its asset-index column like this:

```ts
const cfIndex = columns.findIndex((col) => col?.name === `cf_${oldField.name}`);
…
} else {
  columns.splice(cfIndex, 1);   // cfIndex may be -1
}
```

`findIndex` reports a miss as `-1`, and `-1` is a perfectly valid `splice` start
index — it counts from the end. So a removal aimed at a column that isn't there
**takes the last column instead**.

The miss is an ordinary state, not an exotic one: a settings row need not carry
a column for every field. A row written before the field existed doesn't, and
the *activate* branch immediately above each of these removals already handles
`-1` explicitly by pushing a new column.

Both functions reconcile **every settings row in the organization** — one per
user — so a single deactivation could strip a column from everyone at once.

### What the user actually loses

| Column that happened to be last | Result |
| --- | --- |
| a fixed column (`category`, `status`, …) | `validateColumns` re-adds it on the next read, but **from the static defaults** — the user's visibility and position choices are silently reset |
| a custom-field column (`cf_*`) | not re-added at all; it stays gone |

Silent loss of user configuration either way, though narrower than "column gone
forever" — worth stating plainly, since the self-healing read path is easy to
miss when reading this code.

## Two sites, not one

The scan reported `custom-field/service.server.ts`. The identical bug also sat in
`updateAssetIndexSettingsAfterCfUpdate`
(`asset-index-settings/service.server.ts`), which the scan never mentioned.

The two were near-verbatim copies — and had already **drifted**: one recorded
`cfType` on the column, the other didn't. That particular omission turns out to
be invisible in practice, because `validateColumns` backfills a missing `cfType`
from the `CustomField` records on every read (the CSV export goes through that
same path). But it is precisely the divergence duplicated logic produces, and it
made the case for deleting the duplication rather than patching each copy.

## The fix

One `syncCustomFieldColumn` helper in `asset-index-settings/helpers.ts`, where
the absent-column case returns the list unchanged instead of removing anything.

**Three** call sites now route through it:

- `updateAssetIndexSettingsAfterCfUpdate` — single-field update
- `bulkActivateOrDeactivateCustomFields` — bulk activate/deactivate
- `createCustomField` — was hand-rolling the same push, without `cfType`

The two services come out **69 lines shorter**, and the `cfType` divergence is
now impossible by construction rather than fixed in three places.

## Tests

8 new tests. Two mutations confirm they bite:

| Mutation | Result |
| --- | --- |
| restore the unguarded `splice(index, 1)` | 1 failure |
| drop `cfType` on the add path | 2 failures |

The load-bearing case is `leaves every column alone when the field has none
here` — the one the original code got wrong.

## Verification

- 20 tests pass across the 4 affected suites
- `tsc -b --force` clean, ESLint clean, Prettier clean

No migration. No schema change. Existing rows already damaged by this are not
retroactively repairable from here — the original column settings weren't
recorded anywhere — but fixed columns self-heal to defaults on the next load.

Closes the `detail.dev` D016 finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization of custom fields in asset indexes when fields are activated, deactivated, created, renamed, or have their type changed.
  - Preserved users’ column visibility and ordering during custom-field updates.
  - Safely handled missing columns and retained fixed asset-index columns.

- **Documentation**
  - Added documentation for custom-field creation and bulk activation or deactivation.

- **Tests**
  - Added comprehensive coverage for custom-field column synchronization and non-mutating updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->