### PR TITLE
perf(bookings): slim the booking loader payloads and load the assets drawer on open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Always run `pnpm webapp:validate` before committing - this runs:
 #### Organizing Mocks and Factories
 
 - **Test files**: Co-located with source files (e.g., `apps/webapp/app/modules/user/service.server.test.ts`)
+- **Route tests**: `apps/webapp/test/routes-tests/`, mirroring the route path — **never** inside `app/routes/`. Vite's dev-server warmup treats every file under `app/routes/` as a client module, so a co-located route test importing a `*.server` module breaks `pnpm webapp:dev` while `validate` and CI stay green. Import the route via `~/routes/...`, not a relative path. Enforced by the `local-rules/no-test-files-in-routes` ESLint rule (blocks the pre-commit hook).
 - **Shared mocks**: Place in `apps/webapp/test/mocks/` directory, organized by domain (remix.tsx, database.ts)
 - **Factories**: Place in `apps/webapp/test/factories/` directory for generating test data
 - **MSW handlers**: Keep in `apps/webapp/mocks/` directory for API mocking

--- a/apps/webapp/app/components/booking/booking-assets-sidebar.test.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-sidebar.test.tsx
@@ -153,7 +153,15 @@ function makeBooking({
   } as unknown as Parameters<typeof BookingAssetsSidebar>[0]["booking"];
 }
 
-/** The settled resource-route payload for a single standalone QT row. */
+/**
+ * The settled resource-route payload for a single standalone QT row.
+ *
+ * `error: null` is NOT decoration — the route wraps its response in `payload()`
+ * (`~/utils/http.server`), which returns `{ error: null, ...data }`. A fixture
+ * without that key does not describe any response this route can produce, and a
+ * success/failure guard written against it can be wrong in production while
+ * every test here passes.
+ */
 function makePayload({
   asset,
   bookedQuantity,
@@ -162,6 +170,7 @@ function makePayload({
   bookedQuantity: number;
 }) {
   return {
+    error: null,
     bookingAssets: [
       { id: "ba-1", quantity: bookedQuantity, assetKitId: null, asset },
     ],
@@ -317,6 +326,28 @@ describe("BookingAssetsSidebar lazy loading", () => {
 
     expect(await screen.findByRole("status")).toBeInTheDocument();
     expect(screen.queryByTestId("asset-status-badge")).not.toBeInTheDocument();
+  });
+
+  it("treats a success envelope carrying `error: null` as success, not failure", async () => {
+    // Regression: the guard used to ask `!("error" in fetcher.data)`. Every
+    // successful response goes through `payload()`, which returns
+    // `{ error: null, ...data }`, so that test was false for good payloads and
+    // the drawer showed its retry state 100% of the time. The discriminant is
+    // the presence of `bookingAssets`.
+    const asset = makeQtAsset();
+    fetcher.data = makePayload({ asset, bookedQuantity: 3 });
+    expect(fetcher.data).toHaveProperty("error", null);
+
+    render(
+      <BookingAssetsSidebar booking={makeBooking({ status: "RESERVED" })} />
+    );
+    await openSidebar();
+
+    expect(await screen.findByTestId("asset-status-badge")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /try again/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
   it("offers a retry instead of spinning forever when the fetch fails", async () => {

--- a/apps/webapp/app/components/booking/booking-assets-sidebar.test.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-sidebar.test.tsx
@@ -8,12 +8,15 @@
  * caught by the other's tests.
  *
  * The sidebar renders inside a Radix `Sheet` (closed by default), so tests
- * open it first via the default trigger button.
+ * open it first via the default trigger button. Its rows arrive from
+ * `/api/bookings/:bookingId/assets-sidebar` rather than from props, so the
+ * `useFetcher` mock below is how each case supplies them — and the second
+ * suite covers that loading contract itself.
  */
 import type { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BookingAssetsSidebar } from "./booking-assets-sidebar";
 
@@ -84,6 +87,30 @@ vi.mock("../kits/kit-image", () => ({
   default: () => <div data-testid="kit-image" />,
 }));
 
+/**
+ * The fetcher the component sees. Reassigned per test so each case can pick a
+ * state (in-flight / settled payload / settled error) without a router.
+ */
+let fetcher: {
+  load: ReturnType<typeof vi.fn>;
+  state: "idle" | "loading" | "submitting";
+  data: unknown;
+};
+
+// why: the drawer no longer receives its rows as props — it loads them from
+// `/api/bookings/:bookingId/assets-sidebar` when the sheet opens. Mocking
+// `useFetcher` is what lets these tests supply that payload. Spread the real
+// module so `Link` and friends keep working.
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-router");
+  return {
+    ...actual,
+    // Read lazily: `fetcher` is assigned in `beforeEach`, long after this
+    // factory is hoisted and run.
+    useFetcher: () => fetcher,
+  };
+});
+
 /** Minimal QT asset row satisfying `SidebarAssetBase` for these tests. */
 function makeQtAsset(overrides: Record<string, unknown> = {}) {
   return {
@@ -107,24 +134,41 @@ function makeQtAsset(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/** Minimal booking with a single standalone QT booking-asset row. */
+/**
+ * Minimal list row: a count and a status, which is all the drawer trigger
+ * needs. The asset rows themselves arrive from the fetcher.
+ */
 function makeBooking({
   status,
-  asset,
-  bookedQuantity,
+  assetCount = 1,
 }: {
   status: string;
-  asset: ReturnType<typeof makeQtAsset>;
-  bookedQuantity: number;
+  assetCount?: number;
 }) {
   return {
     id: "booking-1",
     name: "Test booking",
     status,
+    _count: { bookingAssets: assetCount },
+  } as unknown as Parameters<typeof BookingAssetsSidebar>[0]["booking"];
+}
+
+/** The settled resource-route payload for a single standalone QT row. */
+function makePayload({
+  asset,
+  bookedQuantity,
+}: {
+  asset: ReturnType<typeof makeQtAsset>;
+  bookedQuantity: number;
+}) {
+  return {
     bookingAssets: [
       { id: "ba-1", quantity: bookedQuantity, assetKitId: null, asset },
     ],
-  } as unknown as Parameters<typeof BookingAssetsSidebar>[0]["booking"];
+    dispositionedByAsset: {},
+    dispositionBreakdownByAsset: {},
+    checkedOutByAsset: {},
+  };
 }
 
 /** Opens the sidebar sheet via its default trigger and returns once settled. */
@@ -133,14 +177,15 @@ async function openSidebar() {
   await user.click(screen.getByText(/assets?$/i));
 }
 
+beforeEach(() => {
+  fetcher = { load: vi.fn(), state: "idle", data: undefined };
+});
+
 describe("BookingAssetsSidebar QT stock badges", () => {
   it("renders the red InsufficientStockBadge when bookedQuantity exceeds bookable", async () => {
     const asset = makeQtAsset();
-    const booking = makeBooking({
-      status: "ONGOING",
-      asset,
-      bookedQuantity: 10,
-    });
+    const booking = makeBooking({ status: "ONGOING" });
+    fetcher.data = makePayload({ asset, bookedQuantity: 10 });
 
     render(
       <BookingAssetsSidebar
@@ -163,11 +208,8 @@ describe("BookingAssetsSidebar QT stock badges", () => {
     // booking's window opens (bookable=10) but only 3 are on the shelf
     // right now (physicalNow=3).
     const asset = makeQtAsset();
-    const booking = makeBooking({
-      status: "RESERVED",
-      asset,
-      bookedQuantity: 7,
-    });
+    const booking = makeBooking({ status: "RESERVED" });
+    fetcher.data = makePayload({ asset, bookedQuantity: 7 });
 
     render(
       <BookingAssetsSidebar
@@ -194,11 +236,8 @@ describe("BookingAssetsSidebar QT stock badges", () => {
 
   it("does NOT render any stock badge when bookedQuantity fits within physicalNow", async () => {
     const asset = makeQtAsset();
-    const booking = makeBooking({
-      status: "RESERVED",
-      asset,
-      bookedQuantity: 2,
-    });
+    const booking = makeBooking({ status: "RESERVED" });
+    fetcher.data = makePayload({ asset, bookedQuantity: 2 });
 
     render(
       <BookingAssetsSidebar
@@ -223,11 +262,8 @@ describe("BookingAssetsSidebar QT stock badges", () => {
     // sidebar's own qty-progress branches apply (no checkedOutByAsset /
     // dispositionedByAsset entries supplied).
     const asset = makeQtAsset({ status: "CHECKED_OUT" });
-    const booking = makeBooking({
-      status: "ONGOING",
-      asset,
-      bookedQuantity: 22,
-    });
+    const booking = makeBooking({ status: "ONGOING" });
+    fetcher.data = makePayload({ asset, bookedQuantity: 22 });
 
     render(
       <BookingAssetsSidebar
@@ -243,5 +279,85 @@ describe("BookingAssetsSidebar QT stock badges", () => {
 
     expect(screen.queryByText("Insufficient stock")).not.toBeInTheDocument();
     expect(screen.queryByText("Checked out elsewhere")).not.toBeInTheDocument();
+  });
+});
+
+describe("BookingAssetsSidebar lazy loading", () => {
+  it("fetches this booking's payload when the sheet opens", async () => {
+    render(
+      <BookingAssetsSidebar booking={makeBooking({ status: "RESERVED" })} />
+    );
+
+    expect(fetcher.load).not.toHaveBeenCalled();
+
+    await openSidebar();
+
+    expect(fetcher.load).toHaveBeenCalledTimes(1);
+    expect(fetcher.load).toHaveBeenCalledWith(
+      "/api/bookings/booking-1/assets-sidebar"
+    );
+  });
+
+  it("does not stack a second request while one is in flight", async () => {
+    fetcher.state = "loading";
+
+    render(
+      <BookingAssetsSidebar booking={makeBooking({ status: "RESERVED" })} />
+    );
+    await openSidebar();
+
+    expect(fetcher.load).not.toHaveBeenCalled();
+  });
+
+  it("shows a spinner until the payload lands", async () => {
+    render(
+      <BookingAssetsSidebar booking={makeBooking({ status: "RESERVED" })} />
+    );
+    await openSidebar();
+
+    expect(await screen.findByRole("status")).toBeInTheDocument();
+    expect(screen.queryByTestId("asset-status-badge")).not.toBeInTheDocument();
+  });
+
+  it("offers a retry instead of spinning forever when the fetch fails", async () => {
+    // The fetch is only retried on a user action, so a settled error has to
+    // replace the spinner or the drawer spins until the page is reloaded.
+    fetcher.data = { error: { message: "Booking not found." } };
+
+    render(
+      <BookingAssetsSidebar booking={makeBooking({ status: "RESERVED" })} />
+    );
+    await openSidebar();
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    const retry = await screen.findByRole("button", { name: /try again/i });
+
+    fetcher.load.mockClear();
+    await userEvent.click(retry);
+
+    expect(fetcher.load).toHaveBeenCalledTimes(1);
+    expect(fetcher.load).toHaveBeenCalledWith(
+      "/api/bookings/booking-1/assets-sidebar"
+    );
+  });
+
+  it("counts assets from the list row, not from the fetched payload", () => {
+    // The count revalidates with every navigation; a payload fetched on an
+    // earlier open can be stale, and before the first open there is none.
+    const booking = makeBooking({ status: "RESERVED", assetCount: 12 });
+
+    render(<BookingAssetsSidebar booking={booking} />);
+
+    expect(screen.getByText("12 assets")).toBeInTheDocument();
+  });
+
+  it("does not open, or fetch, for a booking with nothing in it", async () => {
+    const booking = makeBooking({ status: "RESERVED", assetCount: 0 });
+
+    render(<BookingAssetsSidebar booking={booking} />);
+    await openSidebar();
+
+    expect(fetcher.load).not.toHaveBeenCalled();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 });

--- a/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
@@ -5,21 +5,29 @@
  * booking (kits + individual assets) along with qty-progress indicators
  * for partial check-ins.
  *
+ * The rows are fetched from `/api/bookings/:bookingId/assets-sidebar` when the
+ * sheet OPENS, not shipped with the bookings list. That payload is the
+ * heaviest thing on the five bookings-list routes and most users never expand
+ * a row, so the list ships a count (`booking._count.bookingAssets`) and this
+ * component asks for the rest on demand. Re-opening refetches, so a drawer
+ * reflects check-in/out activity since the last look; the previous payload
+ * stays rendered meanwhile, so there is no spinner flash on a re-open.
+ *
  * Renders an "Unassigned model reservations" section (Book-by-Model)
  * above the asset list whenever the booking has outstanding
- * `BookingModelRequest` rows (quantity > 0). The `booking.modelRequests`
- * prop is optional so existing callers using the narrower inline
- * Prisma shape (see `_layout+/bookings._index.tsx`) keep working — the
- * section just renders nothing when the field is absent.
+ * `BookingModelRequest` rows (quantity > 0). Those come with the list — they
+ * are small, and the drawer trigger needs them to know whether a pure
+ * book-by-model booking has anything worth opening.
  *
- * @see {@link file://./../../modules/booking/constants.ts} BOOKING_WITH_ASSETS_INCLUDE
+ * @see {@link file://./../../routes/api+/bookings.$bookingId.assets-sidebar.ts}
+ * @see {@link file://./../../modules/booking/constants.ts} BOOKINGS_LIST_ASSETS_INCLUDE
  * @see {@link file://./../../modules/booking-model-request/service.server.ts}
  */
 import React, { useState } from "react";
 import type { ReactNode } from "react";
 import type { BookingStatus, Prisma } from "@prisma/client";
 import { ChevronDownIcon } from "lucide-react";
-import { Link } from "react-router";
+import { Link, useFetcher } from "react-router";
 import { Button } from "~/components/shared/button";
 import {
   Sheet,
@@ -28,6 +36,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "~/components/shared/sheet";
+import { Spinner } from "~/components/shared/spinner";
 import {
   Tooltip,
   TooltipContent,
@@ -56,6 +65,12 @@ import { CategoryBadge } from "../assets/category-badge";
 import { ConsumptionTypeBadge } from "../assets/consumption-type-badge";
 import KitImage from "../kits/kit-image";
 
+/**
+ * Mirror of `BOOKINGS_LIST_ASSETS_INCLUDE` — the shape
+ * `/api/bookings/:bookingId/assets-sidebar` returns. Declared as a
+ * `BookingGetPayload` rather than imported from the server module so this
+ * component stays free of server-only imports.
+ */
 type BookingWithAssets = Prisma.BookingGetPayload<{
   include: {
     bookingAssets: {
@@ -127,6 +142,9 @@ type BookingWithAssets = Prisma.BookingGetPayload<{
   };
 }>;
 
+/** The `bookingAssets` rows the resource route returns. */
+export type SidebarBookingAssets = BookingWithAssets["bookingAssets"];
+
 /**
  * Shape of a single `BookingModelRequest` row as consumed by this
  * sidebar. Matches the `BOOKING_WITH_ASSETS_INCLUDE` model-requests
@@ -158,54 +176,64 @@ export type DispositionBreakdown = {
   damaged: number;
 };
 
+/**
+ * The payload `/api/bookings/:bookingId/assets-sidebar` returns.
+ *
+ * Declared here rather than inferred from the route module: importing the
+ * route's `typeof loader` would pull a server module into this component's
+ * import graph.
+ */
+type SidebarPayload = {
+  bookingAssets: SidebarBookingAssets;
+  /**
+   * `assetId → dispositionedQuantity` (sum of RETURN + CONSUME + LOSS +
+   * DAMAGE ConsumptionLog rows). Drives the `N / M` qty progress column and
+   * the "Partially checked in" badge for qty-tracked assets with some units
+   * dispositioned but a non-zero remaining.
+   */
+  dispositionedByAsset: Record<string, number>;
+  /**
+   * `assetId → per-category split`, so the tooltip can show Returned /
+   * Consumed / Lost / Damaged separately — lost and damaged units shouldn't
+   * read the same as units back in the pool.
+   */
+  dispositionBreakdownByAsset: Record<string, DispositionBreakdown>;
+  /**
+   * `assetId → checkedOutQuantity` (sum of progressive
+   * PartialBookingCheckout slices across every row of that asset). Drives the
+   * `PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN` (amber, "partially checked
+   * out, no returns yet") badge, mirroring the per-row treatment on the
+   * booking overview. Aggregated at the asset level because the sidebar
+   * renders one row per asset.
+   *
+   * Multi-slice tie-break: if a multi-slice asset has one slice partly IN
+   * (any disposition) and another still fully OUT, the check-IN signal wins
+   * at this aggregate level — consistent with the existing
+   * `PARTIALLY_CHECKED_OUT_QTY` precedence in this component.
+   */
+  checkedOutByAsset: Record<string, number>;
+};
+
 interface BookingAssetsSidebarProps {
   /**
-   * Booking object to render. Typed as `BookingWithAssets` plus an
-   * optional `modelRequests` array so callers using the narrower inline
-   * include (`bookings._index.tsx`) can pass their object without a
-   * widening cast. When `modelRequests` is missing or empty, the
-   * "Unassigned model reservations" section is not rendered.
+   * The list row this drawer hangs off. Carries no asset rows — only the
+   * count the trigger shows and the model reservations the trigger gates on.
+   * Everything else arrives from the resource route when the sheet opens.
    */
-  booking: BookingWithAssets & {
+  booking: {
+    id: string;
+    name: string;
+    status: BookingStatus;
+    /** Concrete `BookingAsset` rows, from the list loader's `_count`. */
+    _count: { bookingAssets: number };
+    /**
+     * Outstanding model-level reservations. Optional so a caller that does
+     * not select them can still render the drawer — the "Unassigned model
+     * reservations" section simply doesn't appear.
+     */
     modelRequests?: SidebarModelRequest[] | null;
   };
   trigger?: ReactNode;
-  /**
-   * Optional map of `assetId → dispositionedQuantity` for this booking,
-   * i.e. sum of RETURN + CONSUME + LOSS + DAMAGE ConsumptionLog rows.
-   * When provided, the sidebar renders the qty column as `N / M`
-   * progress with an explanatory tooltip and swaps the status badge
-   * to "Partially checked in" for qty-tracked assets that have some
-   * units dispositioned but a non-zero remaining. When undefined, the
-   * sidebar falls back to the plain `× N` booked-quantity display —
-   * which keeps older call sites working without changes.
-   */
-  dispositionedByAsset?: Record<string, number>;
-  /**
-   * Optional map of `assetId → per-category split`. Lets the tooltip
-   * show Returned / Consumed / Lost / Damaged separately instead of
-   * conflating them into a single "Checked in" total — lost and
-   * damaged units shouldn't read the same as units back in the pool.
-   * When undefined, the tooltip falls back to the single-total layout.
-   */
-  dispositionBreakdownByAsset?: Record<string, DispositionBreakdown>;
-  /**
-   * Optional map of `assetId → checkedOutQuantity` for this booking
-   * (sum of progressive PartialBookingCheckout slices across every row
-   * of that asset). Drives the new
-   * `PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN` (amber, "partially
-   * checked out, no returns yet") badge: an asset with
-   * `checkedOutQuantity > 0 && dispositionedQuantity === 0` on an active
-   * booking gets the amber badge, mirroring the per-row treatment on
-   * the booking overview. Aggregated at the asset level (not per-row)
-   * because the sidebar renders one row per asset.
-   *
-   * Multi-slice tie-break: if a multi-slice asset has one slice partly
-   * IN (any disposition) and another slice still fully OUT, the
-   * check-IN signal wins at this aggregate level — consistent with the
-   * existing `PARTIALLY_CHECKED_OUT_QTY` precedence in this component.
-   */
-  checkedOutByAsset?: Record<string, number>;
   /**
    * Optional map of `assetId → { bookable, physicalNow, reserved }` units
    * available across the workspace pool (after subtracting operator
@@ -596,15 +624,48 @@ function AssetTitleAndStatus({
 export function BookingAssetsSidebar({
   booking,
   trigger,
-  dispositionedByAsset,
-  dispositionBreakdownByAsset,
-  checkedOutByAsset,
   availableUnitsByAsset,
 }: BookingAssetsSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [expandedKits, setExpandedKits] = useState<Record<string, boolean>>({});
 
-  const paginatedItems = groupAssets(booking.bookingAssets);
+  /**
+   * The drawer's payload, fetched on open. `fetcher.data` survives the sheet
+   * closing, so a re-open renders the previous rows immediately while the
+   * refetch is in flight rather than flashing a spinner.
+   */
+  const fetcher = useFetcher<SidebarPayload | { error: unknown }>();
+  const settled =
+    fetcher.data && !("error" in fetcher.data) ? fetcher.data : undefined;
+  const bookingAssets = settled?.bookingAssets;
+  const dispositionedByAsset = settled?.dispositionedByAsset;
+  const dispositionBreakdownByAsset = settled?.dispositionBreakdownByAsset;
+  const checkedOutByAsset = settled?.checkedOutByAsset;
+
+  /**
+   * A settled error has to surface instead of the spinner. The fetch is only
+   * retried on a user action, so without this a failed load (booking deleted
+   * or permission lost since the page rendered) would spin forever.
+   */
+  const hasFetchError =
+    fetcher.state === "idle" &&
+    !!fetcher.data &&
+    "error" in fetcher.data &&
+    !bookingAssets;
+  const isLoadingAssets = !bookingAssets && !hasFetchError;
+
+  const loadSidebarAssets = () => {
+    // Don't stack a second request while one is in flight.
+    if (fetcher.state !== "idle") return;
+    void fetcher.load(`/api/bookings/${booking.id}/assets-sidebar`);
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (open) loadSidebarAssets();
+  };
+
+  const paginatedItems = groupAssets(bookingAssets ?? []);
 
   const toggleKitExpansion = (kitId: string) => {
     setExpandedKits((prev) => ({
@@ -616,12 +677,17 @@ export function BookingAssetsSidebar({
   // The drawer is worth opening whenever the booking contains anything
   // worth showing — concrete assets OR outstanding model-level
   // reservations. Pure book-by-model bookings legitimately have
-  // `bookingAssets.length === 0` but still carry content.
+  // zero concrete assets but still carry content.
   const outstandingModelRequestCount = getOutstandingModelRequests(
     booking.modelRequests
   ).length;
-  const hasItems =
-    booking.bookingAssets.length > 0 || outstandingModelRequestCount > 0;
+  /**
+   * The list loader's count, not `bookingAssets.length`: it revalidates with
+   * every navigation, while a previously fetched payload can be stale from an
+   * earlier open, and before the first open there is no payload at all.
+   */
+  const assetCount = booking._count.bookingAssets;
+  const hasItems = assetCount > 0 || outstandingModelRequestCount > 0;
 
   /**
    * Scan-to-assign is offered whenever the booking is in a manage-eligible
@@ -639,15 +705,15 @@ export function BookingAssetsSidebar({
     <Button
       type="button"
       variant="link-gray"
-      onClick={hasItems ? () => setIsOpen(true) : undefined}
+      onClick={hasItems ? () => handleOpenChange(true) : undefined}
       className={!hasItems ? "hover:text-gray cursor-default no-underline" : ""}
     >
-      {booking.bookingAssets.length} assets
+      {assetCount} assets
     </Button>
   );
 
   return (
-    <Sheet open={isOpen} onOpenChange={setIsOpen}>
+    <Sheet open={isOpen} onOpenChange={handleOpenChange}>
       {trigger || defaultTrigger}
 
       <SheetContent className="w-full border-l-0 bg-white p-0 md:w-[85vw] md:max-w-[85vw]">
@@ -657,8 +723,7 @@ export function BookingAssetsSidebar({
               Assets in "{booking.name}"
             </SheetTitle>
             <SheetDescription className="text-left">
-              {booking.bookingAssets.length}{" "}
-              {booking.bookingAssets.length === 1 ? "asset" : "assets"} in this
+              {assetCount} {assetCount === 1 ? "asset" : "assets"} in this
               booking
             </SheetDescription>
           </SheetHeader>
@@ -687,220 +752,253 @@ export function BookingAssetsSidebar({
                   : undefined
               }
             />
-            <div className="border border-b-0 bg-white px-4 pb-3 pt-4 text-left font-normal text-gray-600 md:mx-0 md:px-6">
-              <h5 className="text-left capitalize">Assets & kits</h5>
-              <p>
-                {/* Same helper the booking overview uses. This drawer groups
+            {isLoadingAssets ? (
+              <div
+                className="flex flex-1 items-center justify-center"
+                role="status"
+                aria-live="polite"
+              >
+                <Spinner />
+                <span className="sr-only">Loading assets</span>
+              </div>
+            ) : hasFetchError ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center">
+                <p className="text-gray-600">
+                  We couldn&apos;t load the assets for this booking.
+                </p>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={loadSidebarAssets}
+                >
+                  Try again
+                </Button>
+              </div>
+            ) : (
+              <>
+                <div className="border border-b-0 bg-white px-4 pb-3 pt-4 text-left font-normal text-gray-600 md:mx-0 md:px-6">
+                  <h5 className="text-left capitalize">Assets & kits</h5>
+                  <p>
+                    {/* Same helper the booking overview uses. This drawer groups
                     kits into one row exactly as the overview does, so a bare
                     "N items" here disagreed with the "N assets" in this very
                     drawer's own header one line above. */}
-                <span>{describeBookingRows(paginatedItems)}</span>
-              </p>
-            </div>
+                    <span>{describeBookingRows(paginatedItems)}</span>
+                  </p>
+                </div>
 
-            <div className="flex-1 overflow-auto border border-b-0 border-gray-200 bg-white md:mx-0">
-              <table className="w-full border-collapse">
-                <thead>
-                  <tr className="border-b border-gray-200 text-left ">
-                    <th className="px-6 py-3 font-normal text-gray-600">
-                      Name
-                    </th>
-                    <th className="px-6 py-3"> </th>
-                    <th className="px-6 py-3 font-normal text-gray-600">
-                      Category
-                    </th>
-                    <th className="px-6 py-3"> </th>
-                  </tr>
-                </thead>
-                <tbody className="">
-                  {paginatedItems.map((item) => {
-                    if (item.type === "kit") {
-                      const kit = item.kit;
-                      const isExpanded = expandedKits[item.id] ?? false;
+                <div className="flex-1 overflow-auto border border-b-0 border-gray-200 bg-white md:mx-0">
+                  <table className="w-full border-collapse">
+                    <thead>
+                      <tr className="border-b border-gray-200 text-left ">
+                        <th className="px-6 py-3 font-normal text-gray-600">
+                          Name
+                        </th>
+                        <th className="px-6 py-3"> </th>
+                        <th className="px-6 py-3 font-normal text-gray-600">
+                          Category
+                        </th>
+                        <th className="px-6 py-3"> </th>
+                      </tr>
+                    </thead>
+                    <tbody className="">
+                      {paginatedItems.map((item) => {
+                        if (item.type === "kit") {
+                          const kit = item.kit;
+                          const isExpanded = expandedKits[item.id] ?? false;
 
-                      if (!kit) {
-                        return null;
-                      }
+                          if (!kit) {
+                            return null;
+                          }
 
-                      return (
-                        <React.Fragment key={`kit-${item.id}`}>
-                          {/* Kit Row */}
-                          <tr className="relative border-b border-gray-200 bg-gray-50">
-                            <td className="w-full whitespace-normal p-0 md:p-0">
-                              <div className="flex items-center gap-3 px-6 py-4 md:justify-normal md:pr-6">
-                                <KitImage
-                                  kit={{
-                                    image: kit.image,
-                                    imageExpiration: kit.imageExpiration,
-                                    alt: kit.name,
-                                    kitId: kit.id,
-                                  }}
-                                  className="size-12 rounded-[4px] border object-cover"
-                                />
-                                <div>
-                                  <Button
-                                    to={`/kits/${kit.id}`}
-                                    variant="link"
-                                    className="text-gray-900 hover:text-gray-700"
-                                    target="_blank"
-                                    onlyNewTabIconOnHover={true}
-                                    aria-label="Go to kit"
-                                  >
-                                    <div className="max-w-[200px] truncate sm:max-w-[250px] md:max-w-[350px] lg:max-w-[450px]">
-                                      {kit.name}
+                          return (
+                            <React.Fragment key={`kit-${item.id}`}>
+                              {/* Kit Row */}
+                              <tr className="relative border-b border-gray-200 bg-gray-50">
+                                <td className="w-full whitespace-normal p-0 md:p-0">
+                                  <div className="flex items-center gap-3 px-6 py-4 md:justify-normal md:pr-6">
+                                    <KitImage
+                                      kit={{
+                                        image: kit.image,
+                                        imageExpiration: kit.imageExpiration,
+                                        alt: kit.name,
+                                        kitId: kit.id,
+                                      }}
+                                      className="size-12 rounded-[4px] border object-cover"
+                                    />
+                                    <div>
+                                      <Button
+                                        to={`/kits/${kit.id}`}
+                                        variant="link"
+                                        className="text-gray-900 hover:text-gray-700"
+                                        target="_blank"
+                                        onlyNewTabIconOnHover={true}
+                                        aria-label="Go to kit"
+                                      >
+                                        <div className="max-w-[200px] truncate sm:max-w-[250px] md:max-w-[350px] lg:max-w-[450px]">
+                                          {kit.name}
+                                        </div>
+                                      </Button>
+                                      <p className="text-sm text-gray-600">
+                                        {item.assets.length} assets
+                                      </p>
                                     </div>
-                                  </Button>
-                                  <p className="text-sm text-gray-600">
-                                    {item.assets.length} assets
-                                  </p>
+                                  </div>
+                                </td>
+                                <td className="px-6 py-4"> </td>
+                                <td className="px-6 py-4">
+                                  <CategoryBadge
+                                    category={kit.category}
+                                    className="whitespace-nowrap"
+                                  />
+                                </td>
+                                <td className="px-6 py-4 pr-4 text-right align-middle">
+                                  <div className="flex items-center justify-end gap-5">
+                                    <Button
+                                      type="button"
+                                      onClick={() => toggleKitExpansion(kit.id)}
+                                      variant="link"
+                                      className="text-center font-bold text-gray-600 hover:text-gray-900"
+                                      aria-label="Toggle kit expand"
+                                    >
+                                      <ChevronDownIcon
+                                        className={tw(
+                                          `size-6 ${
+                                            !isExpanded ? "rotate-180" : ""
+                                          }`
+                                        )}
+                                      />
+                                    </Button>
+                                  </div>
+                                </td>
+                              </tr>
+
+                              {/* Kit Assets (when expanded) */}
+                              {isExpanded &&
+                                item.assets.map((asset) => (
+                                  <tr
+                                    key={`kit-asset-${asset.id}`}
+                                    className="relative border-b border-gray-200"
+                                  >
+                                    <td className="w-full whitespace-normal p-0 md:p-0">
+                                      <div className="absolute inset-y-0 left-0 h-full w-2 bg-gray-100" />
+                                      <div className="flex justify-between gap-3 bg-gray-50/50 px-6 py-4 md:justify-normal md:pr-6">
+                                        <div className="flex items-center gap-3">
+                                          <div className="relative flex size-12 shrink-0 items-center justify-center">
+                                            <AssetImage
+                                              asset={{
+                                                id: asset.id,
+                                                mainImage: asset.mainImage,
+                                                thumbnailImage:
+                                                  asset.thumbnailImage,
+                                                mainImageExpiration:
+                                                  asset.mainImageExpiration,
+                                                assetModel:
+                                                  asset.assetModel ?? null,
+                                              }}
+                                              alt={`Image of ${asset.title}`}
+                                              className="size-full rounded-[4px] border border-gray-300 object-cover"
+                                              withPreview
+                                            />
+                                          </div>
+                                          <AssetTitleAndStatus
+                                            asset={asset}
+                                            bookingStatus={booking.status}
+                                            dispositionedByAsset={
+                                              dispositionedByAsset
+                                            }
+                                            dispositionBreakdownByAsset={
+                                              dispositionBreakdownByAsset
+                                            }
+                                            checkedOutByAsset={
+                                              checkedOutByAsset
+                                            }
+                                            availableUnitsByAsset={
+                                              availableUnitsByAsset
+                                            }
+                                          />
+                                        </div>
+                                      </div>
+                                    </td>
+                                    <td className="bg-gray-50/50 px-6 py-4">
+                                      {" "}
+                                    </td>
+                                    <td className="bg-gray-50/50 px-6 py-4">
+                                      <CategoryBadge
+                                        category={asset.category}
+                                        className="whitespace-nowrap"
+                                      />
+                                    </td>
+                                    <td className="bg-gray-50/50 px-6 py-4 pr-4 text-right">
+                                      {" "}
+                                    </td>
+                                  </tr>
+                                ))}
+
+                              <tr className="kit-separator h-1 bg-gray-100">
+                                <td colSpan={4} className="h-1 p-0"></td>
+                              </tr>
+                            </React.Fragment>
+                          );
+                        }
+
+                        // Individual asset
+                        const asset = item.assets[0];
+                        return (
+                          <tr
+                            key={`asset-${asset.id}`}
+                            className="border-b border-gray-200"
+                          >
+                            <td className="w-full whitespace-normal p-0 md:p-0">
+                              <div className="flex justify-between gap-3 px-6 py-4 md:justify-normal md:pr-6">
+                                <div className="flex items-center gap-3">
+                                  <div className="relative flex size-12 shrink-0 items-center justify-center">
+                                    <AssetImage
+                                      asset={{
+                                        id: asset.id,
+                                        mainImage: asset.mainImage,
+                                        thumbnailImage: asset.thumbnailImage,
+                                        mainImageExpiration:
+                                          asset.mainImageExpiration,
+                                        assetModel: asset.assetModel ?? null,
+                                      }}
+                                      alt={`Image of ${asset.title}`}
+                                      className="size-full rounded-[4px] border object-cover"
+                                      withPreview
+                                    />
+                                  </div>
+                                  <AssetTitleAndStatus
+                                    asset={asset}
+                                    bookingStatus={booking.status}
+                                    dispositionedByAsset={dispositionedByAsset}
+                                    dispositionBreakdownByAsset={
+                                      dispositionBreakdownByAsset
+                                    }
+                                    checkedOutByAsset={checkedOutByAsset}
+                                    availableUnitsByAsset={
+                                      availableUnitsByAsset
+                                    }
+                                  />
                                 </div>
                               </div>
                             </td>
                             <td className="px-6 py-4"> </td>
                             <td className="px-6 py-4">
                               <CategoryBadge
-                                category={kit.category}
+                                category={asset.category}
                                 className="whitespace-nowrap"
                               />
                             </td>
-                            <td className="px-6 py-4 pr-4 text-right align-middle">
-                              <div className="flex items-center justify-end gap-5">
-                                <Button
-                                  type="button"
-                                  onClick={() => toggleKitExpansion(kit.id)}
-                                  variant="link"
-                                  className="text-center font-bold text-gray-600 hover:text-gray-900"
-                                  aria-label="Toggle kit expand"
-                                >
-                                  <ChevronDownIcon
-                                    className={tw(
-                                      `size-6 ${
-                                        !isExpanded ? "rotate-180" : ""
-                                      }`
-                                    )}
-                                  />
-                                </Button>
-                              </div>
-                            </td>
+                            <td className="px-6 py-4 pr-4 text-right"> </td>
                           </tr>
-
-                          {/* Kit Assets (when expanded) */}
-                          {isExpanded &&
-                            item.assets.map((asset) => (
-                              <tr
-                                key={`kit-asset-${asset.id}`}
-                                className="relative border-b border-gray-200"
-                              >
-                                <td className="w-full whitespace-normal p-0 md:p-0">
-                                  <div className="absolute inset-y-0 left-0 h-full w-2 bg-gray-100" />
-                                  <div className="flex justify-between gap-3 bg-gray-50/50 px-6 py-4 md:justify-normal md:pr-6">
-                                    <div className="flex items-center gap-3">
-                                      <div className="relative flex size-12 shrink-0 items-center justify-center">
-                                        <AssetImage
-                                          asset={{
-                                            id: asset.id,
-                                            mainImage: asset.mainImage,
-                                            thumbnailImage:
-                                              asset.thumbnailImage,
-                                            mainImageExpiration:
-                                              asset.mainImageExpiration,
-                                            assetModel:
-                                              asset.assetModel ?? null,
-                                          }}
-                                          alt={`Image of ${asset.title}`}
-                                          className="size-full rounded-[4px] border border-gray-300 object-cover"
-                                          withPreview
-                                        />
-                                      </div>
-                                      <AssetTitleAndStatus
-                                        asset={asset}
-                                        bookingStatus={booking.status}
-                                        dispositionedByAsset={
-                                          dispositionedByAsset
-                                        }
-                                        dispositionBreakdownByAsset={
-                                          dispositionBreakdownByAsset
-                                        }
-                                        checkedOutByAsset={checkedOutByAsset}
-                                        availableUnitsByAsset={
-                                          availableUnitsByAsset
-                                        }
-                                      />
-                                    </div>
-                                  </div>
-                                </td>
-                                <td className="bg-gray-50/50 px-6 py-4"> </td>
-                                <td className="bg-gray-50/50 px-6 py-4">
-                                  <CategoryBadge
-                                    category={asset.category}
-                                    className="whitespace-nowrap"
-                                  />
-                                </td>
-                                <td className="bg-gray-50/50 px-6 py-4 pr-4 text-right">
-                                  {" "}
-                                </td>
-                              </tr>
-                            ))}
-
-                          <tr className="kit-separator h-1 bg-gray-100">
-                            <td colSpan={4} className="h-1 p-0"></td>
-                          </tr>
-                        </React.Fragment>
-                      );
-                    }
-
-                    // Individual asset
-                    const asset = item.assets[0];
-                    return (
-                      <tr
-                        key={`asset-${asset.id}`}
-                        className="border-b border-gray-200"
-                      >
-                        <td className="w-full whitespace-normal p-0 md:p-0">
-                          <div className="flex justify-between gap-3 px-6 py-4 md:justify-normal md:pr-6">
-                            <div className="flex items-center gap-3">
-                              <div className="relative flex size-12 shrink-0 items-center justify-center">
-                                <AssetImage
-                                  asset={{
-                                    id: asset.id,
-                                    mainImage: asset.mainImage,
-                                    thumbnailImage: asset.thumbnailImage,
-                                    mainImageExpiration:
-                                      asset.mainImageExpiration,
-                                    assetModel: asset.assetModel ?? null,
-                                  }}
-                                  alt={`Image of ${asset.title}`}
-                                  className="size-full rounded-[4px] border object-cover"
-                                  withPreview
-                                />
-                              </div>
-                              <AssetTitleAndStatus
-                                asset={asset}
-                                bookingStatus={booking.status}
-                                dispositionedByAsset={dispositionedByAsset}
-                                dispositionBreakdownByAsset={
-                                  dispositionBreakdownByAsset
-                                }
-                                checkedOutByAsset={checkedOutByAsset}
-                                availableUnitsByAsset={availableUnitsByAsset}
-                              />
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4"> </td>
-                        <td className="px-6 py-4">
-                          <CategoryBadge
-                            category={asset.category}
-                            className="whitespace-nowrap"
-                          />
-                        </td>
-                        <td className="px-6 py-4 pr-4 text-right"> </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </SheetContent>

--- a/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
+++ b/apps/webapp/app/components/booking/booking-assets-sidebar.tsx
@@ -212,7 +212,21 @@ type SidebarPayload = {
    * `PARTIALLY_CHECKED_OUT_QTY` precedence in this component.
    */
   checkedOutByAsset: Record<string, number>;
+  /**
+   * Always `null` on the success path — `payload()` stamps it onto every
+   * response it builds. Modelled explicitly so the discriminant below reads as
+   * the deliberate choice it is: this key is present either way, so it cannot
+   * tell success from failure.
+   */
+  error: null;
 };
+
+/**
+ * Either half of what the resource route can return: `payload()` on success,
+ * `error()` on a 404 / 403 / 500. Only the success half carries
+ * `bookingAssets`, which is what makes it a usable discriminant.
+ */
+type SidebarResponse = SidebarPayload | { error: { message: string } };
 
 interface BookingAssetsSidebarProps {
   /**
@@ -634,9 +648,16 @@ export function BookingAssetsSidebar({
    * closing, so a re-open renders the previous rows immediately while the
    * refetch is in flight rather than flashing a spinner.
    */
-  const fetcher = useFetcher<SidebarPayload | { error: unknown }>();
+  const fetcher = useFetcher<SidebarResponse>();
+  /**
+   * Discriminate on the presence of `bookingAssets`, NOT on the absence of an
+   * `error` key. The route's success path goes through `payload()`
+   * (`~/utils/http.server`), which returns `{ error: null, ...data }` — so
+   * `"error" in data` is true for a perfectly good response, and keying off it
+   * puts the drawer in its error state every single time.
+   */
   const settled =
-    fetcher.data && !("error" in fetcher.data) ? fetcher.data : undefined;
+    fetcher.data && "bookingAssets" in fetcher.data ? fetcher.data : undefined;
   const bookingAssets = settled?.bookingAssets;
   const dispositionedByAsset = settled?.dispositionedByAsset;
   const dispositionBreakdownByAsset = settled?.dispositionBreakdownByAsset;
@@ -647,11 +668,7 @@ export function BookingAssetsSidebar({
    * retried on a user action, so without this a failed load (booking deleted
    * or permission lost since the page rendered) would spin forever.
    */
-  const hasFetchError =
-    fetcher.state === "idle" &&
-    !!fetcher.data &&
-    "error" in fetcher.data &&
-    !bookingAssets;
+  const hasFetchError = fetcher.state === "idle" && !!fetcher.data && !settled;
   const isLoadingAssets = !bookingAssets && !hasFetchError;
 
   const loadSidebarAssets = () => {

--- a/apps/webapp/app/components/booking/list-bookings-content.test.tsx
+++ b/apps/webapp/app/components/booking/list-bookings-content.test.tsx
@@ -1,14 +1,16 @@
 /**
  * Render tests for `ListBookingsContent` (the bookings-list row component),
- * focused on the amber "Stock conflict" pill in the Assets column.
+ * focused on the two pills in the Assets column: amber "Stock conflict" and
+ * "Includes unavailable assets".
  *
- * `ListBookingsContent` is shared by both the main bookings index
- * (`bookings._index.tsx`) and the asset's Bookings tab
- * (`assets.$assetId.bookings.tsx`, which renders `<BookingsIndexPage />`) —
- * both loaders attach `hasStockConflict` to each row via
- * `getStockConflictedBookingIds` (`~/modules/booking/stock-conflicts.server`).
- * This test exercises the render logic directly, so it covers both surfaces
- * at once.
+ * `ListBookingsContent` is shared by all five bookings-list surfaces, each of
+ * which renders `<BookingsIndexPage />` and attaches both flags to every row
+ * via `decorateBookingsForList` (`~/modules/booking/list-flags.server`). This
+ * test exercises the render logic directly, so it covers all of them at once.
+ *
+ * The RULE behind `hasUnavailableAssets` — which assets count as unavailable,
+ * and the quantity-tracked custody exemption — is a Prisma `where` now, and is
+ * covered in `list-flags.server.test.ts`. What is left here is the wiring.
  *
  * Heavy/unrelated children (`BookingAssetsSidebar`, `TeamMemberBadge`,
  * `Button`, `DateS`) are mocked out — mirrors the isolation pattern in
@@ -18,21 +20,7 @@
  */
 import type { ComponentProps, ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const mockUseLoaderData = vi.fn();
-
-// why: `ListBookingsContent` reads `dispositionedByBooking` /
-// `dispositionBreakdownByBooking` / `checkedOutByBooking` off
-// `useLoaderData()` for the sidebar's qty-progress display — irrelevant to
-// the stock-conflict pill under test, so an empty object is sufficient.
-vi.mock("react-router", async () => {
-  const actual = await vi.importActual<Record<string, unknown>>("react-router");
-  return {
-    ...actual,
-    useLoaderData: () => mockUseLoaderData(),
-  };
-});
+import { describe, expect, it, vi } from "vitest";
 
 // why: `to`-style Button renders react-router's `Link`, which needs a
 // router context this render test doesn't set up. A plain anchor is enough
@@ -102,42 +90,14 @@ function buildItem(overrides: Partial<BookingItem> = {}): BookingItem {
     },
     tags: [],
     modelRequests: [],
-    bookingAssets: [
-      {
-        id: "ba-1",
-        quantity: 5,
-        assetKitId: null,
-        asset: {
-          id: "asset-1",
-          title: "Widget",
-          type: "QUANTITY_TRACKED",
-          consumptionType: "STANDARD",
-          availableToBook: true,
-          custody: [],
-          status: "AVAILABLE",
-          mainImage: null,
-          thumbnailImage: null,
-          mainImageExpiration: null,
-          sequentialId: null,
-          preferredBarcodeId: null,
-          qrCodes: [],
-          barcodes: [],
-          category: null,
-          assetKits: [],
-        },
-      },
-    ],
+    _count: { bookingAssets: 5 },
     hasStockConflict: false,
+    hasUnavailableAssets: false,
     ...overrides,
   } as unknown as BookingItem;
 }
 
 describe("ListBookingsContent — Stock conflict pill", () => {
-  beforeEach(() => {
-    // Reset the loader-data mock's return value for each test in this file.
-    mockUseLoaderData.mockReturnValue({});
-  });
-
   it('renders the amber "Stock conflict" pill when item.hasStockConflict is true', () => {
     render(
       <table>
@@ -202,88 +162,48 @@ describe("ListBookingsContent — Stock conflict pill", () => {
 });
 
 /**
- * The "Includes unavailable assets" badge has TWO triggers and they are not
- * equivalent:
+ * The row used to decide this badge itself, by walking `item.bookingAssets`.
+ * That array is no longer shipped with the list, so the decision moved to
+ * `getBookingIdsWithUnavailableAssets` and the row just renders the flag.
  *
- * - `availableToBook === false` means "this asset may never be booked",
- *   which is true regardless of how the asset counts its units.
- * - custody presence means "someone is holding it", which only makes the
- *   booking unavailable for an INDIVIDUAL asset. A quantity-tracked asset is
- *   a pool: 20 of 29 units on loan still leaves 9 bookable.
- *
- * Keying the badge off raw custody presence flagged perfectly valid
- * quantity-tracked bookings — including one that had already checked out
- * successfully. The QT stock signal is `hasStockConflict` → the separate
- * "Stock conflict" pill covered by the suite above.
+ * The rule it encodes — `availableToBook === false` counts for any asset,
+ * while custody counts only for INDIVIDUAL assets, because a quantity-tracked
+ * asset is a pool and 20 of 29 units on loan still leaves 9 bookable — is
+ * covered in `list-flags.server.test.ts`. Getting that wrong flagged perfectly
+ * valid quantity-tracked bookings, including one that had already checked out
+ * successfully, which is why it has its own tests wherever it lives.
  */
 describe("ListBookingsContent — 'Includes unavailable assets' badge", () => {
   const BADGE_TEXT = "Includes unavailable assets";
 
-  beforeEach(() => {
-    mockUseLoaderData.mockReturnValue({});
-  });
-
-  /** Renders one row whose single booked asset carries the given overrides. */
-  function renderRowWithAsset(assetOverrides: Record<string, unknown>) {
-    const base = buildItem({});
-    const [firstSlice] = (
-      base as unknown as {
-        bookingAssets: Array<{ asset: Record<string, unknown> }>;
-      }
-    ).bookingAssets;
-
-    const item = buildItem({
-      bookingAssets: [
-        {
-          ...firstSlice,
-          asset: { ...firstSlice.asset, ...assetOverrides },
-        },
-      ],
-    } as never);
-
+  /** Renders one row with the given flag value. */
+  function renderRow(overrides: Partial<BookingItem> = {}) {
     render(
       <table>
         <tbody>
           <tr>
-            <ListBookingsContent item={item} />
+            <ListBookingsContent item={buildItem(overrides)} />
           </tr>
         </tbody>
       </table>
     );
   }
 
-  it("does NOT flag a quantity-tracked asset that merely has units on custody", () => {
-    renderRowWithAsset({
-      type: "QUANTITY_TRACKED",
-      availableToBook: true,
-      // 20 of 29 units are with a custodian; the booking drew on the free 9.
-      custody: [{ id: "custody-1", quantity: 20 }],
-      status: "IN_CUSTODY",
-    });
+  it("renders the badge when the loader flagged the row", () => {
+    renderRow({ hasUnavailableAssets: true } as Partial<BookingItem>);
+
+    expect(screen.getByText(BADGE_TEXT)).toBeInTheDocument();
+  });
+
+  it("does NOT render the badge when the row is not flagged", () => {
+    renderRow({ hasUnavailableAssets: false } as Partial<BookingItem>);
 
     expect(screen.queryByText(BADGE_TEXT)).not.toBeInTheDocument();
   });
 
-  it("DOES flag an individual asset in custody — one custodian holds the one thing", () => {
-    renderRowWithAsset({
-      type: "INDIVIDUAL",
-      availableToBook: true,
-      custody: [{ id: "custody-1" }],
-      status: "IN_CUSTODY",
-    });
+  it("does NOT render the badge for a loader that hasn't wired the flag", () => {
+    renderRow({ hasUnavailableAssets: undefined } as Partial<BookingItem>);
 
-    expect(screen.getByText(BADGE_TEXT)).toBeInTheDocument();
-  });
-
-  it("DOES flag a quantity-tracked asset marked as not available to book", () => {
-    // `availableToBook` is type-agnostic: the flag means "never bookable".
-    renderRowWithAsset({
-      type: "QUANTITY_TRACKED",
-      availableToBook: false,
-      custody: [],
-      status: "AVAILABLE",
-    });
-
-    expect(screen.getByText(BADGE_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(BADGE_TEXT)).not.toBeInTheDocument();
   });
 });

--- a/apps/webapp/app/components/booking/list-bookings-content.tsx
+++ b/apps/webapp/app/components/booking/list-bookings-content.tsx
@@ -1,10 +1,11 @@
 /**
  * Row renderer for the shared bookings list (`<List ItemComponent={...}>`).
  *
- * Used by BOTH the main bookings index (`bookings._index.tsx`) and the
- * asset's Bookings tab (`assets.$assetId.bookings.tsx`, which renders
- * `<BookingsIndexPage />` and therefore reuses this same row component) —
- * one render change here covers both surfaces.
+ * Used by all FIVE bookings-list surfaces — the main index
+ * (`bookings._index.tsx`) plus `me.bookings`, `assets.$assetId.bookings`,
+ * `kits.$kitId.bookings` and `settings.team.users.$userId.bookings`, each of
+ * which renders `<BookingsIndexPage />` and so reuses this same row. One
+ * render change here covers all of them.
  *
  * Kept in its own file (rather than inline in the route module) so it can be
  * unit-tested without pulling in the route's `loader` (real `db`) and its
@@ -14,10 +15,6 @@
  * @see {@link file://../../routes/_layout+/bookings._index.tsx}
  */
 import type { Prisma } from "@prisma/client";
-import { useLoaderData } from "react-router";
-import { isQuantityTracked } from "~/modules/asset/utils";
-import { hasCustody } from "~/modules/custody/utils";
-import type { BookingsIndexLoaderData } from "~/routes/_layout+/bookings._index";
 import { BADGE_COLORS } from "~/utils/badge-colors";
 import {
   canAssignModelUnits,
@@ -96,66 +93,6 @@ function StockConflictPill() {
 type ListBookingsContentProps = {
   item: Prisma.BookingGetPayload<{
     include: {
-      bookingAssets: {
-        select: {
-          id: true;
-          quantity: true;
-          // Surfaces the kit-source discriminator the sidebar groups
-          // by. Without this field on the index loader's type, the
-          // sidebar's `BookingWithAssets` type check rejects the data.
-          assetKitId: true;
-          asset: {
-            select: {
-              id: true;
-              title: true;
-              type: true;
-              consumptionType: true;
-              availableToBook: true;
-              custody: true;
-              status: true;
-              mainImage: true;
-              thumbnailImage: true;
-              mainImageExpiration: true;
-              // Model cover image for assets with no image of their own. Type
-              // literal, so it mirrors ASSET_MODEL_IMAGE_SELECT by hand.
-              assetModel: { select: { image: true; thumbnailImage: true } };
-              // Code-resolution fields - mirror of getBookings' assets select
-              sequentialId: true;
-              preferredBarcodeId: true;
-              qrCodes: { take: 1; select: { id: true } };
-              barcodes: { select: { id: true; type: true; value: true } };
-              category: {
-                select: {
-                  id: true;
-                  name: true;
-                  color: true;
-                };
-              };
-              assetKits: {
-                select: {
-                  id: true;
-                  kitId: true;
-                  kit: {
-                    select: {
-                      id: true;
-                      name: true;
-                      image: true;
-                      imageExpiration: true;
-                      category: {
-                        select: {
-                          id: true;
-                          name: true;
-                          color: true;
-                        };
-                      };
-                    };
-                  };
-                };
-              };
-            };
-          };
-        };
-      };
       creator: {
         select: {
           id: true;
@@ -168,8 +105,9 @@ type ListBookingsContentProps = {
       custodianUser: true;
       custodianTeamMember: true;
       tags: { select: { id: true; name: true; color: true } };
-      // Included via `extraInclude` in the bookings-index loader so the
-      // assets-sidebar drawer can show outstanding model reservations.
+      // Included via `extraInclude` in every bookings-list loader so the
+      // assets-sidebar drawer can show outstanding model reservations, and so
+      // the drawer trigger opens for a pure book-by-model booking.
       modelRequests: {
         include: {
           assetModel: {
@@ -180,89 +118,43 @@ type ListBookingsContentProps = {
     };
   }> & {
     /**
-     * Set by both bookings-list loaders (`bookings._index.tsx` and
-     * `assets.$assetId.bookings.tsx`, which share this component) via
-     * `getStockConflictedBookingIds` — true when ≥1 of this booking's
-     * QUANTITY_TRACKED assets is over-committed in its window. Optional
-     * because it's computed, not a real Prisma column.
+     * Concrete `BookingAsset` rows on this booking. The rows themselves are
+     * NOT shipped with the list — the drawer fetches them on open — so the
+     * count is what the trigger renders.
+     */
+    _count: { bookingAssets: number };
+    /**
+     * Set by every bookings-list loader via `decorateBookingsForList` — true
+     * when ≥1 of this booking's QUANTITY_TRACKED assets is over-committed in
+     * its window. Optional because it is computed, not a real Prisma column.
      */
     hasStockConflict?: boolean;
+    /**
+     * Set by the same decorator — true when this booking holds an asset that
+     * is not bookable, or an INDIVIDUAL asset someone has custody of. This
+     * used to be derived in the browser from `bookingAssets`, which the list
+     * no longer ships; the type-aware rule now lives in
+     * `~/modules/booking/list-flags.server`.
+     */
+    hasUnavailableAssets?: boolean;
   };
 };
 
 /**
  * Renders one row of the shared bookings list.
  *
- * @param props.item - The booking row, plus the computed `hasStockConflict`
- *   flag. See {@link ListBookingsContentProps}.
+ * Every signal this row shows comes from the row itself. The two pills are
+ * resolved server-side by `decorateBookingsForList` and the drawer fetches its
+ * own payload, so there is nothing here to derive from an asset array — which
+ * is also why the SHELF-WEBAPP-1NW normalisation this function used to open
+ * with is gone: there is no `bookingAssets` left to be undefined.
+ *
+ * @param props.item - The booking row plus the two computed pill flags. See
+ *   {@link ListBookingsContentProps}.
  */
 export default function ListBookingsContent({
-  item: rawItem,
+  item,
 }: ListBookingsContentProps) {
-  // Defensive normalisation against a Sentry-observed crash
-  // (SHELF-WEBAPP-1NW): a single client-side render hit
-  // `item.bookingAssets` as undefined and tripped `.some(...)`, breaking
-  // the row through the error boundary. The component's prop type
-  // declares `bookingAssets` as required and the loader always selects
-  // it, so the undefined was either a stale-bundle / hydration mismatch
-  // in the deploy window or an as-yet unidentified loader edge case.
-  //
-  // Normalise once at the top so EVERY downstream reader gets a safe
-  // array — the badge calc below, `<BookingAssetsSidebar />` (which
-  // calls `groupAssets(booking.bookingAssets)` + reads
-  // `booking.bookingAssets.length` in multiple places), and any future
-  // additions. A scoped `?? []` on each reader would be brittle.
-  const item = {
-    ...rawItem,
-    bookingAssets: rawItem.bookingAssets ?? [],
-  };
-
-  /**
-   * `hasCustody` is a bare "does this asset have ANY custody row" test, which
-   * is the right question for an INDIVIDUAL asset (one custodian holds the
-   * one physical thing, so the booking really is compromised) and the WRONG
-   * one for `QUANTITY_TRACKED`. A QT asset is a pool: handing 20 of 29 units
-   * to a custodian leaves 9 bookable, and a booking drawing on those free
-   * units is perfectly valid. Flagging it "Includes unavailable assets"
-   * scared a customer off a booking that had already checked out cleanly.
-   *
-   * Every other surface already makes this distinction — `getBookingFlags`
-   * (`hasAssetsInCustody`), the per-asset booking row, and the three
-   * server-side checkout guards all exempt QT from custody blocking. This
-   * row was the last one keying off raw custody presence.
-   *
-   * The genuine QT signal is stock, not custody, and it has its own pill:
-   * `item.hasStockConflict` → `<StockConflictPill />` further down this row
-   * fires when booked quantity exceeds available quantity. `availableToBook`
-   * still applies to both types — that flag means "never bookable", which is
-   * true regardless of how the asset counts its units.
-   */
-  const hasUnavaiableAssets =
-    item.bookingAssets.some(
-      (ba) =>
-        !ba.asset.availableToBook ||
-        (!isQuantityTracked(ba.asset) && hasCustody(ba.asset.custody))
-    ) && !["COMPLETE", "CANCELLED", "ARCHIVED"].includes(item.status);
-
-  /**
-   * Pull this booking's slice of the page-wide dispositioned-quantity
-   * map so the sidebar can render qty progress + partial-checkin badge.
-   * Reading from loader data here (instead of threading a prop through
-   * `<List ItemComponent=…>`) keeps the list plumbing unchanged.
-   */
-  const loaderData = useLoaderData<BookingsIndexLoaderData>();
-  const dispositionedByAsset =
-    loaderData?.dispositionedByBooking?.[item.id] ?? undefined;
-  const dispositionBreakdownByAsset =
-    loaderData?.dispositionBreakdownByBooking?.[item.id] ?? undefined;
-  /**
-   * Per-asset progressive-checkout totals for this booking. Drives the
-   * sidebar's new amber "partially checked out, no returns yet" badge
-   * + the `{checkedOut}/{booked}` qty display.
-   */
-  const checkedOutByAsset =
-    loaderData?.checkedOutByBooking?.[item.id] ?? undefined;
-
   return (
     <>
       {/* Item */}
@@ -297,7 +189,7 @@ export default function ListBookingsContent({
        * 3. Have other bookings with the same period - this I am not sure how to handle yet
        * */}
       <Td>
-        {hasUnavaiableAssets ? (
+        {item.hasUnavailableAssets ? (
           <AvailabilityBadge
             badgeText={"Includes unavailable assets"}
             tooltipTitle={"Booking includes unavailable assets"}
@@ -311,12 +203,7 @@ export default function ListBookingsContent({
       {/* Assets count */}
       <Td>
         <div className="flex items-center gap-2">
-          <BookingAssetsSidebar
-            booking={item}
-            dispositionedByAsset={dispositionedByAsset}
-            dispositionBreakdownByAsset={dispositionBreakdownByAsset}
-            checkedOutByAsset={checkedOutByAsset}
-          />
+          <BookingAssetsSidebar booking={item} />
           {/* The asset count above is concrete assets only. A booking can also
               hold model-level reservations with no physical asset behind them
               yet, which the count cannot express — so they get their own

--- a/apps/webapp/app/modules/booking/constants.ts
+++ b/apps/webapp/app/modules/booking/constants.ts
@@ -187,6 +187,100 @@ export const BOOKING_COMMON_INCLUDE = {
   tags: TAG_WITH_COLOR_SELECT,
 } as Prisma.BookingInclude;
 
+/**
+ * Per-booking `bookingAssets` payload for the bookings LIST surfaces.
+ *
+ * Single source of truth for the row shape the bookings-list assets drawer
+ * (`BookingAssetsSidebar`) renders, shared by:
+ * - `getBookings` (service.server.ts) — attached when `includeAssets` is true,
+ *   which today means the bookings CSV select-all export;
+ * - the `/api/bookings/:bookingId/assets-sidebar` resource route — the five
+ *   bookings-list loaders no longer ship assets (the drawer fetches this exact
+ *   shape when a row is expanded).
+ *
+ * Keeping both callers on one constant is what guarantees the drawer renders
+ * identically no matter which path supplied the data.
+ */
+export const BOOKINGS_LIST_ASSETS_INCLUDE = {
+  bookingAssets: {
+    // Explicit `select` (instead of `include`) so the inferred
+    // type surfaces `assetKitId` on each row — the bookings list
+    // sidebar (`BookingAssetsSidebar`) groups by it. Without an
+    // explicit select, Prisma's type inference for
+    // `include + nested include` doesn't expose the parent
+    // scalars in a form the local component types accept.
+    select: {
+      id: true,
+      quantity: true,
+      assetKitId: true,
+      asset: {
+        select: {
+          title: true,
+          id: true,
+          type: true,
+          quantity: true,
+          custody: true,
+          availableToBook: true,
+          status: true,
+          mainImage: true,
+          thumbnailImage: true,
+          // Model cover image for assets with no image of their own
+          ...ASSET_MODEL_IMAGE_SELECT,
+          mainImageExpiration: true,
+          // Asset-code resolution fields — see `app/modules/barcode/display.ts`.
+          // Surfaced by the BookingAssetsSidebar so the chip matches the
+          // simple-mode booking overview list and every other code-bearing
+          // surface (see .claude/rules/code-bearing-entity-list-consistency.md).
+          sequentialId: true,
+          preferredBarcodeId: true,
+          qrCodes: { take: 1, select: { id: true } },
+          barcodes: { select: { id: true, type: true, value: true } },
+          category: {
+            select: {
+              id: true,
+              name: true,
+              color: true,
+            },
+          },
+          // NOTE: deliberately NO `bookingAssets` here. A previous
+          // version selected each asset's entire lifetime
+          // `bookingAssets: { bookingId }` pivot history, which grows
+          // without bound and had zero consumers (every reader of
+          // `asset.bookingAssets` needs `ba.booking.{id,status}` from
+          // asset-centric queries, which this shape cannot provide).
+          // If a surface ever needs conflict info here, scope it with
+          // a `where` on active statuses + date overlap like
+          // getBookingFlags does.
+          assetKits: {
+            select: {
+              // See the comment in `bookings.$bookingId.overview.tsx`
+              // for why both `id` (the AssetKit row id) and `kitId`
+              // are needed for kit-source grouping.
+              id: true,
+              kitId: true,
+              kit: {
+                select: {
+                  id: true,
+                  name: true,
+                  image: true,
+                  imageExpiration: true,
+                  category: {
+                    select: {
+                      id: true,
+                      name: true,
+                      color: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} satisfies Prisma.BookingInclude;
+
 export const BOOKING_WITH_ASSETS_INCLUDE = {
   ...BOOKING_COMMON_INCLUDE,
   bookingAssets: {

--- a/apps/webapp/app/modules/booking/list-flags.server.test.ts
+++ b/apps/webapp/app/modules/booking/list-flags.server.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for the bookings-list row flags.
+ *
+ * The "Includes unavailable assets" badge used to be computed in the browser
+ * by walking each row's `bookingAssets`; it now lives in a Prisma `where`.
+ * That move is exactly why these tests assert on MEANING and not only on
+ * shape: a clause can be present and still be composed so that something else
+ * widens it away, and a badge that silently starts flagging every
+ * quantity-tracked booking is the regression this file exists to prevent — it
+ * scared a customer off a booking that had already checked out cleanly.
+ *
+ * The three asset cases below are ported from
+ * `list-bookings-content.test.tsx`, which owned them while the check was
+ * client-side.
+ *
+ * @see {@link file://./list-flags.server.ts}
+ */
+import type { Prisma } from "@prisma/client";
+
+import { db } from "~/database/db.server";
+import {
+  decorateBookingsForList,
+  getBookingIdsWithUnavailableAssets,
+} from "./list-flags.server";
+import { decorateBookingsWithStockConflicts } from "./stock-conflicts.server";
+
+// @vitest-environment node
+// 👋 see https://vitest.dev/guide/environment.html#environments-for-specific-files
+
+// why: the subject is the `where` this module builds, not what a database
+// returns, so the client is mocked to capture the argument.
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    booking: {
+      findMany: vitest.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
+// why: `decorateBookingsForList` composes the stock-conflict decorator, which
+// has its own 1000-line suite. Mocking it keeps these tests about the second
+// flag and the composition, not about stock maths.
+vitest.mock("./stock-conflicts.server", () => ({
+  decorateBookingsWithStockConflicts: vitest.fn(),
+}));
+
+const findManyMock = db.booking.findMany as unknown as ReturnType<
+  typeof vitest.fn
+>;
+const stockDecoratorMock =
+  decorateBookingsWithStockConflicts as unknown as ReturnType<typeof vitest.fn>;
+
+const ORG_ID = "org-1";
+
+/** The subset of asset columns the unavailability predicate reads. */
+type CandidateAsset = {
+  type: "INDIVIDUAL" | "QUANTITY_TRACKED";
+  availableToBook: boolean;
+  custody: unknown[];
+};
+
+/**
+ * Evaluates the captured asset predicate against a candidate asset.
+ *
+ * Models only the operator subset {@link getBookingIdsWithUnavailableAssets}
+ * emits and **throws on anything else**, so an unmodelled operator fails
+ * loudly instead of quietly reporting a match.
+ *
+ * @param clause - A node of the captured `asset` where-input
+ * @param asset - The candidate asset
+ * @returns Whether the clause matches
+ */
+function assetMatches(
+  clause: Prisma.AssetWhereInput,
+  asset: CandidateAsset
+): boolean {
+  const entries = Object.entries(clause);
+  if (entries.length === 0) {
+    return true;
+  }
+
+  return entries.every(([key, value]) => {
+    switch (key) {
+      case "OR":
+        return (value as Prisma.AssetWhereInput[]).some((sub) =>
+          assetMatches(sub, asset)
+        );
+      case "AND":
+        return (value as Prisma.AssetWhereInput[]).every((sub) =>
+          assetMatches(sub, asset)
+        );
+      case "availableToBook":
+        return asset.availableToBook === value;
+      case "type": {
+        const operator = value as { not?: string };
+        if (typeof operator?.not !== "string") {
+          throw new Error(`Unmodelled type operator: ${JSON.stringify(value)}`);
+        }
+        return asset.type !== operator.not;
+      }
+      case "custody": {
+        const operator = value as { some?: Record<string, unknown> };
+        if (!operator?.some || Object.keys(operator.some).length > 0) {
+          throw new Error(
+            `Unmodelled custody operator: ${JSON.stringify(value)}`
+          );
+        }
+        return asset.custody.length > 0;
+      }
+      default:
+        throw new Error(`Unmodelled asset clause: ${key}`);
+    }
+  });
+}
+
+/**
+ * Runs the lookup and returns the `asset` predicate it handed to Prisma.
+ *
+ * @returns The captured asset where-input
+ */
+async function captureAssetPredicate(): Promise<Prisma.AssetWhereInput> {
+  await getBookingIdsWithUnavailableAssets({
+    bookingIds: ["booking-1"],
+    organizationId: ORG_ID,
+  });
+
+  const where = findManyMock.mock.calls[0][0].where as Prisma.BookingWhereInput;
+
+  return (
+    where.bookingAssets as {
+      some: { asset: Prisma.AssetWhereInput };
+    }
+  ).some.asset;
+}
+
+beforeEach(() => {
+  vitest.clearAllMocks();
+  findManyMock.mockResolvedValue([]);
+  stockDecoratorMock.mockImplementation(
+    ({ bookings }: { bookings: Array<{ id: string }> }) =>
+      Promise.resolve(
+        bookings.map((booking) => ({ ...booking, hasStockConflict: false }))
+      )
+  );
+});
+
+describe("getBookingIdsWithUnavailableAssets — which assets count", () => {
+  it("does NOT flag a quantity-tracked asset that merely has units on custody", async () => {
+    const predicate = await captureAssetPredicate();
+
+    // 20 of 29 units are with a custodian; the booking drew on the free 9.
+    expect(
+      assetMatches(predicate, {
+        type: "QUANTITY_TRACKED",
+        availableToBook: true,
+        custody: [{ id: "custody-1", quantity: 20 }],
+      })
+    ).toBe(false);
+  });
+
+  it("DOES flag an individual asset in custody — one custodian holds the one thing", async () => {
+    const predicate = await captureAssetPredicate();
+
+    expect(
+      assetMatches(predicate, {
+        type: "INDIVIDUAL",
+        availableToBook: true,
+        custody: [{ id: "custody-1" }],
+      })
+    ).toBe(true);
+  });
+
+  it("DOES flag a quantity-tracked asset marked as not available to book", async () => {
+    const predicate = await captureAssetPredicate();
+
+    // `availableToBook` is type-agnostic: the flag means "never bookable".
+    expect(
+      assetMatches(predicate, {
+        type: "QUANTITY_TRACKED",
+        availableToBook: false,
+        custody: [],
+      })
+    ).toBe(true);
+  });
+
+  it("does NOT flag a bookable asset nobody holds", async () => {
+    const predicate = await captureAssetPredicate();
+
+    expect(
+      assetMatches(predicate, {
+        type: "INDIVIDUAL",
+        availableToBook: true,
+        custody: [],
+      })
+    ).toBe(false);
+  });
+});
+
+describe("getBookingIdsWithUnavailableAssets — scoping", () => {
+  it("scopes to the caller's organization", async () => {
+    await getBookingIdsWithUnavailableAssets({
+      bookingIds: ["booking-1"],
+      organizationId: ORG_ID,
+    });
+
+    const where = findManyMock.mock.calls[0][0]
+      .where as Prisma.BookingWhereInput;
+
+    expect(where.organizationId).toBe(ORG_ID);
+    expect(where.id).toEqual({ in: ["booking-1"] });
+  });
+
+  it("leaves settled bookings unflagged — a finished booking has no problem to report", async () => {
+    await getBookingIdsWithUnavailableAssets({
+      bookingIds: ["booking-1"],
+      organizationId: ORG_ID,
+    });
+
+    const where = findManyMock.mock.calls[0][0]
+      .where as Prisma.BookingWhereInput;
+
+    expect(where.status).toEqual({
+      notIn: ["COMPLETE", "CANCELLED", "ARCHIVED"],
+    });
+  });
+
+  it("issues no query at all for an empty page", async () => {
+    const flagged = await getBookingIdsWithUnavailableAssets({
+      bookingIds: [],
+      organizationId: ORG_ID,
+    });
+
+    expect(findManyMock).not.toHaveBeenCalled();
+    expect(flagged.size).toBe(0);
+  });
+
+  it("returns the ids the query matched", async () => {
+    findManyMock.mockResolvedValue([{ id: "booking-2" }]);
+
+    const flagged = await getBookingIdsWithUnavailableAssets({
+      bookingIds: ["booking-1", "booking-2"],
+      organizationId: ORG_ID,
+    });
+
+    expect([...flagged]).toEqual(["booking-2"]);
+  });
+});
+
+describe("decorateBookingsForList", () => {
+  const BOOKINGS = [
+    { id: "booking-1", status: "RESERVED", from: null, to: null },
+    { id: "booking-2", status: "RESERVED", from: null, to: null },
+  ] as unknown as Parameters<typeof decorateBookingsForList>[0]["bookings"];
+
+  it("attaches both flags, preserving the row's own fields", async () => {
+    findManyMock.mockResolvedValue([{ id: "booking-2" }]);
+
+    const rows = await decorateBookingsForList({
+      bookings: BOOKINGS,
+      organizationId: ORG_ID,
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        id: "booking-1",
+        status: "RESERVED",
+        hasStockConflict: false,
+        hasUnavailableAssets: false,
+      }),
+      expect.objectContaining({
+        id: "booking-2",
+        hasStockConflict: false,
+        hasUnavailableAssets: true,
+      }),
+    ]);
+  });
+
+  it("renders the list unflagged rather than throwing when the lookup fails", async () => {
+    // A decorative badge must never 500 a bookings list.
+    findManyMock.mockRejectedValue(new Error("connection lost"));
+
+    const rows = await decorateBookingsForList({
+      bookings: BOOKINGS,
+      organizationId: ORG_ID,
+    });
+
+    expect(rows.map((row) => row.hasUnavailableAssets)).toEqual([false, false]);
+  });
+});

--- a/apps/webapp/app/modules/booking/list-flags.server.ts
+++ b/apps/webapp/app/modules/booking/list-flags.server.ts
@@ -1,0 +1,175 @@
+/**
+ * Bookings-list row flags.
+ *
+ * The five bookings-list loaders (`bookings._index`, `me.bookings`,
+ * `kits.$kitId.bookings`, `assets.$assetId.bookings`,
+ * `settings.team.users.$userId.bookings`) all render the same row component,
+ * and that row shows two decorative pills that are not answerable from the
+ * booking record alone:
+ *
+ * - **"Stock conflict"** — owned by {@link decorateBookingsWithStockConflicts}
+ *   in `./stock-conflicts.server`, reused here unchanged.
+ * - **"Includes unavailable assets"** — computed here.
+ *
+ * The second one used to be derived in the browser by walking each row's
+ * `bookingAssets` array. That array is no longer shipped with the list (the
+ * assets drawer fetches it from `/api/bookings/:bookingId/assets-sidebar` when
+ * a row is expanded), so the signal is resolved server-side instead: one
+ * bounded query per page, alongside the one the stock pill already runs.
+ *
+ * Both pills are DECORATIVE. Neither may take a bookings list down, so a
+ * failing lookup logs and degrades to "not flagged" rather than throwing.
+ *
+ * @see {@link file://./stock-conflicts.server.ts}
+ * @see {@link file://./../../components/booking/list-bookings-content.tsx}
+ */
+import { AssetType, BookingStatus } from "@prisma/client";
+
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
+import {
+  decorateBookingsWithStockConflicts,
+  type BookingForStockConflictLookup,
+} from "./stock-conflicts.server";
+
+const label = "Booking" as const;
+
+/**
+ * Statuses where an unavailable asset no longer says anything useful.
+ *
+ * The booking is finished, cancelled or archived — whatever custody or
+ * bookability an asset picked up since then is not this booking's problem, and
+ * flagging it would put a permanent warning on historical rows.
+ */
+const SETTLED_BOOKING_STATUSES: BookingStatus[] = [
+  BookingStatus.COMPLETE,
+  BookingStatus.CANCELLED,
+  BookingStatus.ARCHIVED,
+];
+
+/**
+ * Returns the subset of `bookingIds` that hold at least one unavailable asset.
+ *
+ * "Unavailable" is deliberately type-aware, mirroring what every other surface
+ * already does:
+ *
+ * - `availableToBook: false` counts for both asset types — the flag means
+ *   "never bookable", which is true however the asset counts its units.
+ * - Custody counts only for `INDIVIDUAL` assets. One custodian holding the one
+ *   physical thing really does compromise the booking. A `QUANTITY_TRACKED`
+ *   asset is a pool: handing 20 of 29 units to a custodian leaves 9 bookable,
+ *   and a booking drawing on those free units is perfectly valid. The genuine
+ *   QT signal is stock, and it has its own pill.
+ *
+ * @param args.bookingIds - Booking ids on the current page
+ * @param args.organizationId - Caller's organization — scopes the query
+ * @param args.db - Prisma client or active transaction; defaults to `db`
+ * @returns The ids that should show the "Includes unavailable assets" badge
+ * @throws {ShelfError} If the query fails
+ */
+export async function getBookingIdsWithUnavailableAssets({
+  bookingIds,
+  organizationId,
+  db: dbOrTx = db,
+}: {
+  bookingIds: string[];
+  organizationId: string;
+  db?: Pick<typeof db, "booking">;
+}): Promise<Set<string>> {
+  if (bookingIds.length === 0) {
+    return new Set();
+  }
+
+  try {
+    const rows = await dbOrTx.booking.findMany({
+      where: {
+        id: { in: bookingIds },
+        // The ids come from an already org-scoped list query, but this helper
+        // is exported and must be safe on its own terms.
+        organizationId,
+        status: { notIn: SETTLED_BOOKING_STATUSES },
+        bookingAssets: {
+          some: {
+            asset: {
+              OR: [
+                { availableToBook: false },
+                {
+                  AND: [
+                    { type: { not: AssetType.QUANTITY_TRACKED } },
+                    // Any custody row at all — the same bare presence test
+                    // `hasCustody` makes in the browser.
+                    { custody: { some: {} } },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+      select: { id: true },
+    });
+
+    return new Set(rows.map((row) => row.id));
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message:
+        "Something went wrong while checking the bookings for unavailable assets.",
+      additionalData: { organizationId, bookingCount: bookingIds.length },
+      label,
+    });
+  }
+}
+
+/**
+ * Loader helper: decorates a bookings-list page's rows with both pill flags.
+ *
+ * Runs the two lookups concurrently — they are independent, and serialising
+ * them would put a second round trip on the critical path of every bookings
+ * list. Replaces the direct {@link decorateBookingsWithStockConflicts} call
+ * the five loaders used to make.
+ *
+ * @param args.bookings - The loader's booking rows (each needs at least
+ *   `{ id, status, from, to }`; extra fields are preserved)
+ * @param args.organizationId - Caller's organization — scopes every query
+ * @returns The same rows, each extended with `hasStockConflict` and
+ *   `hasUnavailableAssets`
+ */
+export async function decorateBookingsForList<
+  B extends BookingForStockConflictLookup,
+>({
+  bookings,
+  organizationId,
+}: {
+  bookings: B[];
+  organizationId: string;
+}): Promise<
+  Array<B & { hasStockConflict: boolean; hasUnavailableAssets: boolean }>
+> {
+  const [withStockConflicts, unavailableIds] = await Promise.all([
+    decorateBookingsWithStockConflicts({ bookings, organizationId }),
+    // The stock decorator swallows its own failures; this one has to swallow
+    // its own too, or a decorative badge takes the whole list down with a 500.
+    getBookingIdsWithUnavailableAssets({
+      bookingIds: bookings.map((booking) => booking.id),
+      organizationId,
+    }).catch((cause) => {
+      Logger.error(
+        new ShelfError({
+          cause,
+          message:
+            "Failed to check the bookings for unavailable assets; rendering the bookings list without that badge.",
+          additionalData: { organizationId, bookingCount: bookings.length },
+          label,
+        })
+      );
+      return new Set<string>();
+    }),
+  ]);
+
+  return withStockConflicts.map((booking) => ({
+    ...booking,
+    hasUnavailableAssets: unavailableIds.has(booking.id),
+  }));
+}

--- a/apps/webapp/app/modules/booking/service.server.get-bookings-payload.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.get-bookings-payload.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Payload-shape tests for `getBookings`.
+ *
+ * `getBookings` feeds surfaces with wildly different appetites: the CSV export
+ * reads every booked asset, while the calendar, the dashboard widgets and the
+ * five bookings-list loaders render nothing but booking scalars and a count.
+ * Two knobs express that difference — `includeAssets` (attach the
+ * `bookingAssets` subtree at all) and `takeCap` (fetch one bounded set instead
+ * of a page of it).
+ *
+ * Both are invisible in the returned rows when they work and expensive when
+ * they silently stop working: a regression that re-attaches `bookingAssets`
+ * costs payload on six loaders without changing a single pixel, and a
+ * regression that drops `takeCap` re-introduces the `perPage` clamp bug that
+ * had the dashboard computing "top custodians" from 20 bookings. So these
+ * tests assert on the arguments handed to Prisma, the same way
+ * `service.server.get-bookings-permissions.test.ts` asserts on the `where`.
+ *
+ * @see {@link file://./service.server.ts} — `getBookings`
+ * @see {@link file://./constants.ts} — `BOOKINGS_LIST_ASSETS_INCLUDE`
+ */
+import type { Prisma } from "@prisma/client";
+
+import { db } from "~/database/db.server";
+import { getBookings } from "./service.server";
+
+// @vitest-environment node
+// 👋 see https://vitest.dev/guide/environment.html#environments-for-specific-files
+
+// why: `getBookings` executes real Prisma queries, but the subject under test
+// is the include/take it builds, not what a database returns. Mocking the
+// client lets us capture those arguments; `count` is mocked because
+// `getBookings` issues it alongside `findMany` in a `Promise.all`.
+vitest.mock("~/database/db.server", () => ({
+  db: {
+    booking: {
+      findMany: vitest.fn().mockResolvedValue([]),
+      count: vitest.fn().mockResolvedValue(0),
+    },
+  },
+}));
+
+const findManyMock = db.booking.findMany as unknown as ReturnType<
+  typeof vitest.fn
+>;
+const countMock = db.booking.count as unknown as ReturnType<typeof vitest.fn>;
+
+/** The arguments `getBookings` handed to `db.booking.findMany`. */
+type CapturedFindManyArgs = {
+  include: Prisma.BookingInclude;
+  take?: number;
+  skip?: number;
+};
+
+/**
+ * Runs `getBookings` and returns the arguments it handed to `findMany`.
+ *
+ * @param params - Overrides merged over the minimal required arguments
+ * @returns The captured `findMany` arguments
+ */
+async function captureFindManyArgs(
+  params: Partial<Parameters<typeof getBookings>[0]> = {}
+): Promise<CapturedFindManyArgs> {
+  await getBookings({
+    organizationId: "org-1",
+    page: 1,
+    userId: "user-1",
+    canSeeAllBookings: true,
+    ...params,
+  } as Parameters<typeof getBookings>[0]);
+
+  return findManyMock.mock.calls[0][0] as CapturedFindManyArgs;
+}
+
+beforeEach(() => {
+  // why: `clearAllMocks` resets call history but NOT queued `*Once` values;
+  // these mocks use plain resolved values, so history is all that needs
+  // clearing between cases.
+  vitest.clearAllMocks();
+});
+
+describe("getBookings — asset payload", () => {
+  it("attaches the bookingAssets subtree by default", async () => {
+    const { include } = await captureFindManyArgs();
+
+    expect(include).toHaveProperty("bookingAssets");
+  });
+
+  it("omits the bookingAssets key entirely when includeAssets is false", async () => {
+    const { include } = await captureFindManyArgs({ includeAssets: false });
+
+    // `toHaveProperty` would pass for an explicit `bookingAssets: undefined`,
+    // which Prisma treats differently from an absent key in some positions.
+    // Assert on the key set so the include is genuinely narrower.
+    expect(Object.keys(include)).not.toContain("bookingAssets");
+  });
+
+  it("still attaches whatever the caller asked for via extraInclude when assets are skipped", async () => {
+    const { include } = await captureFindManyArgs({
+      includeAssets: false,
+      extraInclude: { _count: { select: { bookingAssets: true } } },
+    });
+
+    expect(Object.keys(include)).not.toContain("bookingAssets");
+    expect(include._count).toEqual({ select: { bookingAssets: true } });
+  });
+
+  it("selects the asset-code fields the drawer's chip needs on the eager path", async () => {
+    const { include } = await captureFindManyArgs();
+
+    // The drawer resolves its code chip from these four fields
+    // (`~/modules/barcode/display`). Losing one degrades the chip silently on
+    // every list surface, so pin them rather than only the top-level key.
+    const assetSelect = (
+      include.bookingAssets as {
+        select: { asset: { select: Record<string, unknown> } };
+      }
+    ).select.asset.select;
+
+    expect(assetSelect).toMatchObject({
+      sequentialId: true,
+      preferredBarcodeId: true,
+      qrCodes: { take: 1, select: { id: true } },
+      barcodes: { select: { id: true, type: true, value: true } },
+    });
+  });
+});
+
+describe("getBookings — row cap", () => {
+  it("clamps an out-of-range perPage to 20, which is why takeCap exists", async () => {
+    const { take } = await captureFindManyArgs({ perPage: 1000 });
+
+    expect(take).toBe(20);
+  });
+
+  it("uses takeCap instead of the clamped perPage", async () => {
+    const { take } = await captureFindManyArgs({
+      perPage: 1000,
+      takeCap: 1000,
+    });
+
+    expect(take).toBe(1000);
+  });
+
+  it("leaves an in-range perPage alone when no takeCap is given", async () => {
+    const { take } = await captureFindManyArgs({ perPage: 50 });
+
+    expect(take).toBe(50);
+  });
+
+  it("ignores takeCap under takeAll, which fetches unbounded", async () => {
+    const args = await captureFindManyArgs({ takeAll: true, takeCap: 10 });
+
+    expect(args.take).toBeUndefined();
+    expect(args.skip).toBeUndefined();
+  });
+});
+
+describe("getBookings — count companion query", () => {
+  it("issues the count query by default", async () => {
+    await captureFindManyArgs();
+
+    expect(countMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the count query when the caller never reads the total", async () => {
+    await captureFindManyArgs({ skipCount: true });
+
+    expect(countMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -119,6 +119,7 @@ import {
   BOOKING_INCLUDE_FOR_RESERVATION_EMAIL,
   BOOKING_SCHEDULER_EVENTS_ENUM,
   BOOKING_WITH_ASSETS_INCLUDE,
+  BOOKINGS_LIST_ASSETS_INCLUDE,
 } from "./constants";
 import type {
   ReservationEmailAsset,
@@ -9920,6 +9921,20 @@ export async function getBookings(params: {
    * `false`, so paginated callers are unaffected.
    */
   skipCount?: boolean;
+  /**
+   * Attach the `bookingAssets` payload — by far the heaviest part of this
+   * query. Callers that render no asset data (the calendar, the dashboard
+   * widgets, the bookings-list surfaces whose drawer fetches on open) pass
+   * `false`, which omits the key from the Prisma include entirely. Defaults
+   * to `true`, so existing callers are unaffected.
+   */
+  includeAssets?: boolean;
+  /**
+   * Hard row cap, bypassing the `perPage` ≤ 100 clamp below. For callers that
+   * fetch one bounded set in a single query rather than a page of it. Unlike
+   * `takeAll` the query stays bounded; ignored when `takeAll` is set.
+   */
+  takeCap?: number;
 }) {
   const {
     organizationId,
@@ -9942,6 +9957,8 @@ export async function getBookings(params: {
     kitId,
     tags,
     skipCount = false,
+    includeAssets = true,
+    takeCap,
   } = params;
 
   try {
@@ -10120,88 +10137,26 @@ export async function getBookings(params: {
       db.booking.findMany({
         ...(!takeAll && {
           skip,
-          take,
+          take: takeCap ?? take,
         }),
         where,
         include: {
           ...BOOKING_COMMON_INCLUDE,
-          bookingAssets: {
-            // Explicit `select` (instead of `include`) so the inferred
-            // type surfaces `assetKitId` on each row — the bookings list
-            // sidebar (`BookingAssetsSidebar`) groups by it. Without an
-            // explicit select, Prisma's type inference for
-            // `include + nested include` doesn't expose the parent
-            // scalars in a form the local component types accept.
-            select: {
-              id: true,
-              quantity: true,
-              assetKitId: true,
-              asset: {
-                select: {
-                  title: true,
-                  id: true,
-                  type: true,
-                  quantity: true,
-                  custody: true,
-                  availableToBook: true,
-                  status: true,
-                  mainImage: true,
-                  thumbnailImage: true,
-                  // Model cover image for assets with no image of their own
-                  ...ASSET_MODEL_IMAGE_SELECT,
-                  mainImageExpiration: true,
-                  // Asset-code resolution fields — see `app/modules/barcode/display.ts`.
-                  // Surfaced by the BookingAssetsSidebar so the chip matches the
-                  // simple-mode booking overview list and every other code-bearing
-                  // surface (see .claude/rules/code-bearing-entity-list-consistency.md).
-                  sequentialId: true,
-                  preferredBarcodeId: true,
-                  qrCodes: { take: 1, select: { id: true } },
-                  barcodes: { select: { id: true, type: true, value: true } },
-                  category: {
-                    select: {
-                      id: true,
-                      name: true,
-                      color: true,
-                    },
-                  },
-                  // NOTE: deliberately NO `bookingAssets` here. A previous
-                  // version selected each asset's entire lifetime
-                  // `bookingAssets: { bookingId }` pivot history, which grows
-                  // without bound and had zero consumers (every reader of
-                  // `asset.bookingAssets` needs `ba.booking.{id,status}` from
-                  // asset-centric queries, which this shape cannot provide).
-                  // If a surface ever needs conflict info here, scope it with
-                  // a `where` on active statuses + date overlap like
-                  // getBookingFlags does.
-                  assetKits: {
-                    select: {
-                      // See the comment in `bookings.$bookingId.overview.tsx`
-                      // for why both `id` (the AssetKit row id) and `kitId`
-                      // are needed for kit-source grouping.
-                      id: true,
-                      kitId: true,
-                      kit: {
-                        select: {
-                          id: true,
-                          name: true,
-                          image: true,
-                          imageExpiration: true,
-                          category: {
-                            select: {
-                              id: true,
-                              name: true,
-                              color: true,
-                            },
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
+          // NOTE: deliberately NO `bookingAssets` when `includeAssets` is
+          // false — the calendar, the dashboard widgets and the five
+          // bookings-list surfaces render no asset data. The cast keeps the
+          // inferred row type stable for default-true callers; opt-out
+          // callers must not read `bookingAssets` (the same runtime/static
+          // divergence `extraInclude` already has). A conditional generic
+          // would type this honestly, but this webapp sits at TypeScript's
+          // instantiation ceiling over the extended Prisma client, where a
+          // generic here surfaces as TS2321 somewhere unrelated.
+          //
+          // The include itself lives in `./constants` so the assets-sidebar
+          // resource route serves the byte-identical shape.
+          ...((includeAssets
+            ? BOOKINGS_LIST_ASSETS_INCLUDE
+            : {}) as typeof BOOKINGS_LIST_ASSETS_INCLUDE),
           creator: {
             select: {
               id: true,
@@ -11327,7 +11282,6 @@ export async function getBookingsForCalendar(params: {
     const { bookings } = await getBookings({
       organizationId,
       page: 1,
-      perPage: 1000,
       search,
       userId,
       ...(status && {
@@ -11339,9 +11293,26 @@ export async function getBookingsForCalendar(params: {
       custodianTeamMemberIds: teamMemberIds,
       ...selfServiceData,
       tags,
+      // Calendar events carry no asset data — the mapping below projects
+      // booking scalars, two names and the tags — so the per-booking asset
+      // subtree is pure transfer cost here.
+      includeAssets: false,
+      // Only `bookings` is read below; skip the COUNT companion query.
+      skipCount: true,
       extraInclude: {
-        custodianTeamMember: true,
-        custodianUser: true,
+        // Narrow selects: the mapping reads `name` off the team member and
+        // the display-name fields + picture off the two users. `true` pulled
+        // whole `User` rows (every column, per booking, per request).
+        custodianTeamMember: { select: { id: true, name: true } },
+        custodianUser: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            displayName: true,
+            profilePicture: true,
+          },
+        },
         creator: {
           select: {
             id: true,
@@ -11353,6 +11324,8 @@ export async function getBookingsForCalendar(params: {
         },
         tags: TAG_WITH_COLOR_SELECT,
       },
+      // Every booking in the window, not a page of them. `takeAll` ignores
+      // `perPage`, which is why the old `perPage: 1000` was already dead.
       takeAll: true,
     });
 

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.bookings.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.bookings.tsx
@@ -3,11 +3,11 @@ import { data, type LoaderFunctionArgs, type MetaFunction } from "react-router";
 import { z } from "zod";
 import type { HeaderData } from "~/components/layout/header/types";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
+import { decorateBookingsForList } from "~/modules/booking/list-flags.server";
 import {
   getBookings,
   getBookingsFilterData,
 } from "~/modules/booking/service.server";
-import { decorateBookingsWithStockConflicts } from "~/modules/booking/stock-conflicts.server";
 import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
 import { TAG_WITH_COLOR_SELECT } from "~/modules/tag/constants";
 import { getTagsForBookingTagsFilter } from "~/modules/tag/service.server";
@@ -102,7 +102,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           orderDirection,
           custodianTeamMemberIds: teamMemberIds,
           tags: filterTags,
+          // PERF: the list renders booking-level fields plus an asset COUNT. The
+          // per-booking `bookingAssets` payload existed only for the assets
+          // drawer, which now fetches it from
+          // `/api/bookings/:bookingId/assets-sidebar` when a row is expanded.
+          includeAssets: false,
           extraInclude: {
+            // Asset count for the row's drawer trigger, now that the pivot rows
+            // themselves are no longer loaded.
+            _count: { select: { bookingAssets: true } },
             tags: TAG_WITH_COLOR_SELECT,
             /**
              * Needed for the amber "N units unassigned" pill.
@@ -147,7 +155,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
      * `.claude/rules/quantity-semantics-per-surface.md` / the module doc in
      * `~/modules/booking/stock-conflicts.server`).
      */
-    const decoratedBookings = await decorateBookingsWithStockConflicts({
+    const decoratedBookings = await decorateBookingsForList({
       bookings,
       organizationId,
     });

--- a/apps/webapp/app/routes/_layout+/bookings._index.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings._index.tsx
@@ -22,11 +22,11 @@ import { Th } from "~/components/table";
 import { db } from "~/database/db.server";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import { decorateBookingsForList } from "~/modules/booking/list-flags.server";
 import {
   getBookings,
   getBookingsFilterData,
 } from "~/modules/booking/service.server";
-import { decorateBookingsWithStockConflicts } from "~/modules/booking/stock-conflicts.server";
 import { setSelectedOrganizationIdCookie } from "~/modules/organization/context.server";
 import { TAG_WITH_COLOR_SELECT } from "~/modules/tag/constants";
 import {
@@ -140,7 +140,15 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         orderBy,
         orderDirection,
         tags: filterTags,
+        // PERF: the list renders booking-level fields plus an asset COUNT. The
+        // per-booking `bookingAssets` payload existed only for the assets
+        // drawer, which now fetches it from
+        // `/api/bookings/:bookingId/assets-sidebar` when a row is expanded.
+        includeAssets: false,
         extraInclude: {
+          // Asset count for the row's drawer trigger, now that the pivot rows
+          // themselves are no longer loaded.
+          _count: { select: { bookingAssets: true } },
           tags: TAG_WITH_COLOR_SELECT,
           // Include outstanding model-level reservations so the
           // assets-sidebar drawer can render the "Unassigned model
@@ -196,123 +204,16 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     const totalPages = Math.ceil(bookingCount / perPage);
 
     /**
-     * One amber "Stock conflict" pill per booking that has ≥1 over-committed
-     * QUANTITY_TRACKED asset in its window (see
-     * `~/modules/booking/stock-conflicts.server`). Bounded to the current
-     * page's bookings — same batching contract as the disposition/checkout
-     * maps below, just one more fixed-cost query group.
+     * The two row pills — amber "Stock conflict" (≥1 over-committed
+     * QUANTITY_TRACKED asset in this booking's window) and "Includes
+     * unavailable assets" — both need a query the booking row cannot answer.
+     * `decorateBookingsForList` runs them concurrently, bounded to the current
+     * page's bookings. See `~/modules/booking/list-flags.server`.
      */
-    const decoratedBookings = await decorateBookingsWithStockConflicts({
+    const decoratedBookings = await decorateBookingsForList({
       bookings,
       organizationId,
     });
-
-    /**
-     * Compute a per-booking map of `assetId → dispositionedQty` (sum
-     * of RETURN + CONSUME + LOSS + DAMAGE ConsumptionLog rows) for
-     * every qty-tracked asset currently visible on this page. Feeds
-     * the `BookingAssetsSidebar` so it can render the same qty
-     * progress indicator and "Partially checked in" badge the
-     * overview page uses.
-     *
-     * Strategy: one aggregate query scoped to the bookingIds on this
-     * page (at most `perPage` bookings, so bounded). Then we bucket the
-     * rows by bookingId and store a Map<string, Record<string, number>>
-     * keyed by bookingId. Empty record for bookings with no activity.
-     */
-    const bookingIdsOnPage = bookings.map((b) => b.id);
-    const dispositionRows =
-      bookingIdsOnPage.length > 0
-        ? await db.consumptionLog.groupBy({
-            by: ["bookingId", "assetId", "category"],
-            where: {
-              bookingId: { in: bookingIdsOnPage },
-              category: { in: ["RETURN", "CONSUME", "LOSS", "DAMAGE"] },
-            },
-            _sum: { quantity: true },
-          })
-        : [];
-    /**
-     * Per-booking → per-asset disposition totals AND a per-category
-     * breakdown. The sidebar tooltip uses the breakdown to show
-     * Returned / Consumed / Lost / Damaged separately (lost and
-     * damaged units are conceptually different from returned ones).
-     * Both derivations come from the same single groupBy — no extra
-     * DB round-trip.
-     */
-    const dispositionedByBooking: Record<string, Record<string, number>> = {};
-    const dispositionBreakdownByBooking: Record<
-      string,
-      Record<
-        string,
-        { returned: number; consumed: number; lost: number; damaged: number }
-      >
-    > = {};
-    for (const row of dispositionRows) {
-      if (!row.bookingId) continue;
-      const qty = row._sum.quantity ?? 0;
-
-      if (!dispositionedByBooking[row.bookingId]) {
-        dispositionedByBooking[row.bookingId] = {};
-      }
-      dispositionedByBooking[row.bookingId][row.assetId] =
-        (dispositionedByBooking[row.bookingId][row.assetId] ?? 0) + qty;
-
-      if (!dispositionBreakdownByBooking[row.bookingId]) {
-        dispositionBreakdownByBooking[row.bookingId] = {};
-      }
-      const bucket =
-        dispositionBreakdownByBooking[row.bookingId][row.assetId] ??
-        ({
-          returned: 0,
-          consumed: 0,
-          lost: 0,
-          damaged: 0,
-        } as const);
-      const next = { ...bucket };
-      if (row.category === "RETURN") next.returned += qty;
-      else if (row.category === "CONSUME") next.consumed += qty;
-      else if (row.category === "LOSS") next.lost += qty;
-      else if (row.category === "DAMAGE") next.damaged += qty;
-      dispositionBreakdownByBooking[row.bookingId][row.assetId] = next;
-    }
-
-    /**
-     * Per-booking → per-asset progressively-checked-out total. Sums
-     * `PartialBookingCheckout.quantities[i]` across every checkout
-     * session for the bookings on this page, bucketed by
-     * `(bookingId, assetIds[i])`. Feeds the sidebar's new amber
-     * `PARTIALLY_CHECKED_OUT_QTY_PENDING_RETURN` badge: an asset with
-     * `checkedOutQuantity > 0 && dispositionedQuantity === 0` on an
-     * active booking is "partly out, no returns yet".
-     *
-     * Legacy fallback: pre-progressive-checkout rows have
-     * `quantities[].length !== assetIds[].length` (often empty). We
-     * count one unit per occurrence in that case, matching the
-     * service-layer read convention (`countCheckedOutUnitsForAsset` in
-     * `apps/webapp/app/modules/booking/service.server.ts`).
-     */
-    const checkoutSessionRows =
-      bookingIdsOnPage.length > 0
-        ? await db.partialBookingCheckout.findMany({
-            where: { bookingId: { in: bookingIdsOnPage } },
-            select: { bookingId: true, assetIds: true, quantities: true },
-          })
-        : [];
-    const checkedOutByBooking: Record<string, Record<string, number>> = {};
-    for (const session of checkoutSessionRows) {
-      const ids = session.assetIds ?? [];
-      const qtys = session.quantities ?? [];
-      const aligned = qtys.length === ids.length;
-      const bucket =
-        checkedOutByBooking[session.bookingId] ??
-        (checkedOutByBooking[session.bookingId] = {});
-      for (let i = 0; i < ids.length; i += 1) {
-        const assetId = ids[i];
-        const quantity = aligned ? qtys[i] ?? 1 : 1;
-        bucket[assetId] = (bucket[assetId] ?? 0) + quantity;
-      }
-    }
 
     const header: HeaderData = {
       title: "Bookings",
@@ -334,9 +235,6 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         perPage,
         modelName,
         hasActiveFilters,
-        dispositionedByBooking,
-        dispositionBreakdownByBooking,
-        checkedOutByBooking,
         ...teamMembersData,
         // For BASE/SELF_SERVICE users, provide dedicated form team members
         // For ADMIN users, reuse the filter team members

--- a/apps/webapp/app/routes/_layout+/home.tsx
+++ b/apps/webapp/app/routes/_layout+/home.tsx
@@ -104,6 +104,8 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       locationDistribution,
       locationsCount,
       categoriesCount,
+      // Onboarding checklist booleans
+      checklistData,
       // Cookie
       cookieResult,
     ] = await Promise.all([
@@ -199,12 +201,19 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       }),
 
       // 1d. Ongoing + overdue bookings for custodian merge
+      // The four booking calls below render booking scalars, the custodian and
+      // `_count.bookingAssets` — never an asset row — so they all skip the
+      // per-booking asset payload.
       getBookings({
         organizationId,
         userId,
         page: 1,
-        perPage: 1000,
+        // `perPage` is clamped to 20 for anything over 100, so the previous
+        // `perPage: 1000` merged custodians from the first 20 active bookings
+        // only. `takeCap` is the bounded escape hatch that sees them all.
+        takeCap: 1000,
         statuses: ["ONGOING", "OVERDUE"],
+        includeAssets: false,
         extraInclude: {
           custodianTeamMember: true,
           custodianUser: true,
@@ -222,6 +231,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         statuses: ["RESERVED"],
         bookingFrom: new Date(),
         bookingTo: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+        includeAssets: false,
         extraInclude: {
           custodianTeamMember: true,
           custodianUser: true,
@@ -236,6 +246,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         page: 1,
         perPage: 5,
         statuses: ["OVERDUE"],
+        includeAssets: false,
         extraInclude: {
           custodianTeamMember: true,
           custodianUser: true,
@@ -250,6 +261,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
         page: 1,
         perPage: 5,
         statuses: ["ONGOING"],
+        includeAssets: false,
         extraInclude: {
           custodianTeamMember: true,
           custodianUser: true,
@@ -304,27 +316,46 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       }),
 
       // Location distribution (top 5)
-      db.location
-        .findMany({
+      // Counts pivot rows (one per asset placed at this location). Aggregating
+      // the pivot once and then resolving five names beats a correlated count
+      // per location, and `groupBy` only returns locations that have rows — the
+      // `> 0` filter the previous shape needed is implicit.
+      db.assetLocation
+        .groupBy({
+          by: ["locationId"],
           where: { organizationId },
-          select: {
-            id: true,
-            name: true,
-            // Count pivot rows (one per asset placed at this location).
-            _count: { select: { assetLocations: true } },
-          },
-          orderBy: { assetLocations: { _count: "desc" } },
+          _count: { locationId: true },
+          orderBy: { _count: { locationId: "desc" } },
           take: 5,
         })
-        .then((locs) =>
-          locs
-            .filter((l) => l._count.assetLocations > 0)
-            .map((l) => ({
-              locationId: l.id,
-              locationName: l.name,
-              assetCount: l._count.assetLocations,
-            }))
-        ),
+        .then(async (groups) => {
+          if (groups.length === 0) return [];
+
+          const locations = await db.location.findMany({
+            where: {
+              id: { in: groups.map((g) => g.locationId) },
+              organizationId,
+            },
+            select: { id: true, name: true },
+          });
+          const nameById = new Map(locations.map((l) => [l.id, l.name]));
+
+          return groups.flatMap((g) => {
+            const locationName = nameById.get(g.locationId);
+            // Location deleted between the two queries — drop the row rather
+            // than render a nameless bar. The single-query shape could not
+            // produce this case, so it has no prior behaviour to preserve.
+            if (!locationName) return [];
+
+            return [
+              {
+                locationId: g.locationId,
+                locationName,
+                assetCount: g._count.locationId,
+              },
+            ];
+          });
+        }),
 
       // KPI: total locations
       db.location.count({
@@ -335,6 +366,12 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       db.category.count({
         where: { organizationId },
       }),
+
+      // Onboarding checklist counts
+      // Joins this `Promise.all` rather than being awaited after it: nothing
+      // above feeds it, so serialising it just added a round trip to the
+      // loader's critical path.
+      checklistOptions({ organizationId }),
 
       // Cookie
       userPrefs.parse(request.headers.get("Cookie")).then((c: any) => c || {}),
@@ -379,10 +416,15 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
             content: parseMarkdownToReact(announcement.content),
           }
         : null,
-      checklistOptions: await checklistOptions({
+      checklistOptions: {
         hasAssets: totalAssets > 0,
-        organizationId,
-      }),
+        // `directCustodians` is already the "team members holding custody"
+        // query, with the same where clause the dropped `custodiesCount`
+        // used — `take: 20` cannot change a `> 0` test — so counting them
+        // again server-side was a redundant round trip.
+        hasCustodies: directCustodians.length > 0,
+        ...checklistData,
+      },
     });
   } catch (cause) {
     const reason = makeShelfError(cause);

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.bookings.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.bookings.tsx
@@ -4,11 +4,11 @@ import { z } from "zod";
 import type { HeaderData } from "~/components/layout/header/types";
 import { db } from "~/database/db.server";
 import { hasGetAllValue } from "~/hooks/use-model-filters";
+import { decorateBookingsForList } from "~/modules/booking/list-flags.server";
 import {
   getBookings,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
-import { decorateBookingsWithStockConflicts } from "~/modules/booking/stock-conflicts.server";
 import { TAG_WITH_COLOR_SELECT } from "~/modules/tag/constants";
 import { getTagsForBookingTagsFilter } from "~/modules/tag/service.server";
 import { getTeamMemberForCustodianFilter } from "~/modules/team-member/service.server";
@@ -89,7 +89,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           custodianTeamMemberIds: teamMemberIds,
           kitId,
           tags: filterTags,
+          // PERF: the list renders booking-level fields plus an asset COUNT. The
+          // per-booking `bookingAssets` payload existed only for the assets
+          // drawer, which now fetches it from
+          // `/api/bookings/:bookingId/assets-sidebar` when a row is expanded.
+          includeAssets: false,
           extraInclude: {
+            // Asset count for the row's drawer trigger, now that the pivot rows
+            // themselves are no longer loaded.
+            _count: { select: { bookingAssets: true } },
             tags: TAG_WITH_COLOR_SELECT,
             // Same reason as the asset Bookings tab: this route renders the
             // shared bookings row via `BookingsIndexPage`, and the
@@ -131,7 +139,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     // Flag bookings whose QUANTITY_TRACKED assets are over-committed in their
     // window, so the shared list renders the amber "Stock conflict" pill here
     // too (see `~/modules/booking/stock-conflicts.server`).
-    const decoratedBookings = await decorateBookingsWithStockConflicts({
+    const decoratedBookings = await decorateBookingsForList({
       bookings,
       organizationId,
     });

--- a/apps/webapp/app/routes/_layout+/me.bookings.tsx
+++ b/apps/webapp/app/routes/_layout+/me.bookings.tsx
@@ -1,11 +1,11 @@
 import type { MetaFunction } from "react-router";
 import { data, type LoaderFunctionArgs } from "react-router";
 import type { HeaderData } from "~/components/layout/header/types";
+import { decorateBookingsForList } from "~/modules/booking/list-flags.server";
 import {
   getBookings,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
-import { decorateBookingsWithStockConflicts } from "~/modules/booking/stock-conflicts.server";
 import { TAG_WITH_COLOR_SELECT } from "~/modules/tag/constants";
 import { getTagsForBookingTagsFilter } from "~/modules/tag/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
@@ -69,7 +69,15 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
           statuses: [status],
         }),
         tags: filterTags,
+        // PERF: the list renders booking-level fields plus an asset COUNT. The
+        // per-booking `bookingAssets` payload existed only for the assets
+        // drawer, which now fetches it from
+        // `/api/bookings/:bookingId/assets-sidebar` when a row is expanded.
+        includeAssets: false,
         extraInclude: {
+          // Asset count for the row's drawer trigger, now that the pivot rows
+          // themselves are no longer loaded.
+          _count: { select: { bookingAssets: true } },
           tags: TAG_WITH_COLOR_SELECT,
           // The unassigned-units pill reads `item.modelRequests`, and this
           // route renders the shared bookings row via `BookingsIndexPage`.
@@ -90,7 +98,7 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     // Flag bookings whose QUANTITY_TRACKED assets are over-committed in their
     // window, so the shared list renders the amber "Stock conflict" pill here
     // too (see `~/modules/booking/stock-conflicts.server`).
-    const decoratedBookings = await decorateBookingsWithStockConflicts({
+    const decoratedBookings = await decorateBookingsForList({
       bookings,
       organizationId,
     });

--- a/apps/webapp/app/routes/_layout+/settings.team.users.$userId.bookings.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.$userId.bookings.tsx
@@ -2,11 +2,11 @@ import type { MetaFunction } from "react-router";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { z } from "zod";
 import type { HeaderData } from "~/components/layout/header/types";
+import { decorateBookingsForList } from "~/modules/booking/list-flags.server";
 import {
   getBookings,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
-import { decorateBookingsWithStockConflicts } from "~/modules/booking/stock-conflicts.server";
 import { TAG_WITH_COLOR_SELECT } from "~/modules/tag/constants";
 import { getTagsForBookingTagsFilter } from "~/modules/tag/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
@@ -92,7 +92,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           statuses: [status],
         }),
         tags: filterTags,
+        // PERF: the list renders booking-level fields plus an asset COUNT. The
+        // per-booking `bookingAssets` payload existed only for the assets
+        // drawer, which now fetches it from
+        // `/api/bookings/:bookingId/assets-sidebar` when a row is expanded.
+        includeAssets: false,
         extraInclude: {
+          // Asset count for the row's drawer trigger, now that the pivot rows
+          // themselves are no longer loaded.
+          _count: { select: { bookingAssets: true } },
           tags: TAG_WITH_COLOR_SELECT,
           // The unassigned-units pill reads `item.modelRequests`, and this
           // route renders the shared bookings row via `BookingsIndexPage`.
@@ -112,7 +120,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     // Flag bookings whose QUANTITY_TRACKED assets are over-committed in their
     // window, so the shared list renders the amber "Stock conflict" pill here
     // too (see `~/modules/booking/stock-conflicts.server`).
-    const decoratedBookings = await decorateBookingsWithStockConflicts({
+    const decoratedBookings = await decorateBookingsForList({
       bookings,
       organizationId,
     });

--- a/apps/webapp/app/routes/api+/bookings.$bookingId.assets-sidebar.ts
+++ b/apps/webapp/app/routes/api+/bookings.$bookingId.assets-sidebar.ts
@@ -1,0 +1,201 @@
+/**
+ * API Route: Booking Assets Sidebar (the drawer's payload)
+ *
+ * Returns the per-booking `bookingAssets` rows plus the qty-progress maps the
+ * bookings-list assets drawer (`BookingAssetsSidebar`) renders when a user
+ * expands a row.
+ *
+ * The five bookings-list loaders deliberately no longer ship this data
+ * (`includeAssets: false`): it is the heaviest thing on those routes and dead
+ * weight for everyone who never opens a drawer. The `bookingAssets` shape here
+ * is `BOOKINGS_LIST_ASSETS_INCLUDE` — the same constant `getBookings` attaches
+ * on its eager path — which is what guarantees the drawer renders identically
+ * whichever query supplied the rows.
+ *
+ * The read gate mirrors the bookings index exactly: `requirePermission`
+ * (booking/read) for the org scope, `bookingDraftVisibilityClause` so drafts
+ * stay creator-only, and `canSeeBooking` for the restricted-role custody
+ * scope. `booking.read` passes for BASE and SELF_SERVICE too, so the org scope
+ * alone would let either role fetch any booking's asset list by id.
+ *
+ * @see {@link file://./../../components/booking/booking-assets-sidebar.tsx}
+ * @see {@link file://./../_layout+/bookings._index.tsx}
+ */
+import { data, type LoaderFunctionArgs } from "react-router";
+import { z } from "zod";
+import type { DispositionBreakdown } from "~/components/booking/booking-assets-sidebar";
+import { db } from "~/database/db.server";
+import { BOOKINGS_LIST_ASSETS_INCLUDE } from "~/modules/booking/constants";
+import { bookingDraftVisibilityClause } from "~/modules/booking/service.server";
+import { canSeeBooking } from "~/utils/booking-authorization.server";
+import { makeShelfError, ShelfError } from "~/utils/error";
+import { error, getParams, payload } from "~/utils/http.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+
+/**
+ * A closed drawer keeps its fetcher mounted for as long as its row is on the
+ * page, so without this every action on the bookings list would revalidate the
+ * payload of every drawer anybody had opened. Reopening a drawer always
+ * refetches (see `loadSidebarAssets`), so nothing goes stale by skipping this.
+ *
+ * This is a CLIENT export, unlike `loader` — every `*.server` import above is
+ * referenced only inside the loader so none of them reaches the browser
+ * bundle. See `.claude/rules/no-server-module-in-route-client-exports.md`.
+ */
+export function shouldRevalidate() {
+  return false;
+}
+
+/** ConsumptionLog categories that count as units having left the booking. */
+const DISPOSITION_CATEGORIES = ["RETURN", "CONSUME", "LOSS", "DAMAGE"] as const;
+
+export async function loader({ context, request, params }: LoaderFunctionArgs) {
+  const authSession = context.getSession();
+  const { userId } = authSession;
+
+  const { bookingId } = getParams(params, z.object({ bookingId: z.string() }), {
+    additionalData: { userId },
+  });
+
+  try {
+    const { organizationId, canSeeAllBookings } = await requirePermission({
+      userId,
+      request,
+      entity: PermissionEntity.booking,
+      action: PermissionAction.read,
+    });
+
+    const booking = await db.booking.findFirst({
+      where: {
+        id: bookingId,
+        organizationId,
+        // Drafts are visible to their creator only — the same clause the index
+        // applies, so this route cannot serve a row the list would hide.
+        AND: [bookingDraftVisibilityClause(userId)],
+      },
+      select: {
+        id: true,
+        custodianUserId: true,
+        // Custody can be recorded on the team-member link alone; `canSeeBooking`
+        // matches on either link, so select both.
+        custodianTeamMember: { select: { userId: true } },
+        ...BOOKINGS_LIST_ASSETS_INCLUDE,
+      },
+    });
+
+    if (!booking) {
+      throw new ShelfError({
+        cause: null,
+        title: "Not found",
+        message: "Booking not found.",
+        additionalData: { userId, bookingId, organizationId },
+        label: "Booking",
+        status: 404,
+        shouldBeCaptured: false,
+      });
+    }
+
+    if (!canSeeBooking({ canSeeAllBookings, booking, userId })) {
+      throw new ShelfError({
+        cause: null,
+        message: "You are not authorized to view this booking",
+        additionalData: { userId, bookingId, organizationId },
+        label: "Booking",
+        status: 403,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const [dispositionRows, checkoutSessionRows] = await Promise.all([
+      /**
+       * `assetId → dispositionedQty` for this booking. Feeds the drawer's qty
+       * progress indicator and "Partially checked in" badge — the same
+       * aggregate the bookings index used to compute page-wide for every row,
+       * now scoped to the one booking actually being expanded.
+       */
+      db.consumptionLog.groupBy({
+        by: ["assetId", "category"],
+        where: {
+          bookingId,
+          category: { in: [...DISPOSITION_CATEGORIES] },
+        },
+        _sum: { quantity: true },
+      }),
+      /**
+       * Progressive-checkout sessions for this booking, summed per asset to
+       * drive the amber "partially checked out, no returns yet" badge.
+       */
+      db.partialBookingCheckout.findMany({
+        where: { bookingId },
+        select: { assetIds: true, quantities: true },
+      }),
+    ]);
+
+    /**
+     * Per-asset disposition totals AND a per-category breakdown, both derived
+     * from the one groupBy above. The tooltip shows Returned / Consumed / Lost
+     * / Damaged separately — lost and damaged units should not read the same
+     * as units back in the pool.
+     */
+    const dispositionedByAsset: Record<string, number> = {};
+    const dispositionBreakdownByAsset: Record<string, DispositionBreakdown> =
+      {};
+    for (const row of dispositionRows) {
+      const qty = row._sum.quantity ?? 0;
+
+      dispositionedByAsset[row.assetId] =
+        (dispositionedByAsset[row.assetId] ?? 0) + qty;
+
+      const bucket = dispositionBreakdownByAsset[row.assetId] ?? {
+        returned: 0,
+        consumed: 0,
+        lost: 0,
+        damaged: 0,
+      };
+      const next = { ...bucket };
+      if (row.category === "RETURN") next.returned += qty;
+      else if (row.category === "CONSUME") next.consumed += qty;
+      else if (row.category === "LOSS") next.lost += qty;
+      else if (row.category === "DAMAGE") next.damaged += qty;
+      dispositionBreakdownByAsset[row.assetId] = next;
+    }
+
+    /**
+     * Per-asset progressively-checked-out total.
+     *
+     * Legacy fallback: pre-progressive-checkout rows have
+     * `quantities[].length !== assetIds[].length` (often empty). Count one
+     * unit per occurrence in that case, matching the service-layer read
+     * convention (`countCheckedOutUnitsForAsset` in
+     * `~/modules/booking/service.server`).
+     */
+    const checkedOutByAsset: Record<string, number> = {};
+    for (const session of checkoutSessionRows) {
+      const ids = session.assetIds ?? [];
+      const qtys = session.quantities ?? [];
+      const aligned = qtys.length === ids.length;
+      for (let i = 0; i < ids.length; i += 1) {
+        const assetId = ids[i];
+        const quantity = aligned ? qtys[i] ?? 1 : 1;
+        checkedOutByAsset[assetId] =
+          (checkedOutByAsset[assetId] ?? 0) + quantity;
+      }
+    }
+
+    return data(
+      payload({
+        bookingAssets: booking.bookingAssets,
+        dispositionedByAsset,
+        dispositionBreakdownByAsset,
+        checkedOutByAsset,
+      })
+    );
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId, bookingId });
+    return data(error(reason), { status: reason.status });
+  }
+}

--- a/apps/webapp/app/routes/api+/mobile+/dashboard.ts
+++ b/apps/webapp/app/routes/api+/mobile+/dashboard.ts
@@ -140,6 +140,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         userId: user.id,
         custodianScope,
         bookingFrom: new Date(),
+        // The companion renders booking scalars, a custodian name and a count
+        // — never an asset row — so the per-booking asset payload is skipped
+        // and the count comes from the aggregate instead.
+        includeAssets: false,
         extraInclude: {
           custodianUser: {
             select: {
@@ -149,6 +153,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             },
           },
           custodianTeamMember: { select: { name: true } },
+          _count: { select: { bookingAssets: true } },
         },
       }),
 
@@ -160,6 +165,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         statuses: ["ONGOING"],
         userId: user.id,
         custodianScope,
+        // The companion renders booking scalars, a custodian name and a count
+        // — never an asset row — so the per-booking asset payload is skipped
+        // and the count comes from the aggregate instead.
+        includeAssets: false,
         extraInclude: {
           custodianUser: {
             select: {
@@ -169,6 +178,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             },
           },
           custodianTeamMember: { select: { name: true } },
+          _count: { select: { bookingAssets: true } },
         },
       }),
 
@@ -180,6 +190,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
         statuses: ["OVERDUE"],
         userId: user.id,
         custodianScope,
+        // The companion renders booking scalars, a custodian name and a count
+        // — never an asset row — so the per-booking asset payload is skipped
+        // and the count comes from the aggregate instead.
+        includeAssets: false,
         extraInclude: {
           custodianUser: {
             select: {
@@ -189,6 +203,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             },
           },
           custodianTeamMember: { select: { name: true } },
+          _count: { select: { bookingAssets: true } },
         },
       }),
 
@@ -227,19 +242,43 @@ export async function loader({ request }: LoaderFunctionArgs) {
       statusCounts[group.status] = group._count.id;
     }
 
+    /**
+     * The booking row shape the three `getBookings` calls above produce, as
+     * far as this projection reads it.
+     *
+     * Spelled out instead of `any` because the field it gets wrong is
+     * invisible at runtime: the previous `b._count?.assets` named a relation
+     * that does not exist on `Booking` (it is `bookingAssets`) and no `_count`
+     * was selected at all, so every booking reported `assetCount: 0` and the
+     * `any` kept the compiler quiet about it.
+     */
+    type MobileDashboardBooking = {
+      id: string;
+      name: string;
+      status: string;
+      from: Date | string | null;
+      to: Date | string | null;
+      custodianUser?: {
+        firstName: string | null;
+        lastName: string | null;
+      } | null;
+      custodianTeamMember?: { name: string } | null;
+      _count?: { bookingAssets: number };
+    };
+
     // Format booking results
-    const formatBooking = (b: any) => ({
+    const formatBooking = (b: MobileDashboardBooking) => ({
       id: b.id,
       name: b.name,
       status: b.status,
-      from: b.from?.toISOString?.() ?? b.from,
-      to: b.to?.toISOString?.() ?? b.to,
+      from: b.from instanceof Date ? b.from.toISOString() : b.from,
+      to: b.to instanceof Date ? b.to.toISOString() : b.to,
       custodianName: b.custodianUser
         ? [b.custodianUser.firstName, b.custodianUser.lastName]
             .filter(Boolean)
             .join(" ") || null
         : b.custodianTeamMember?.name || null,
-      assetCount: b._count?.assets ?? 0,
+      assetCount: b._count?.bookingAssets ?? 0,
     });
 
     return data({

--- a/apps/webapp/app/utils/dashboard.server.ts
+++ b/apps/webapp/app/utils/dashboard.server.ts
@@ -236,59 +236,54 @@ export function getCustodiansOrderedByTotalCustodies({
 // checklistOptions
 // ---------------------------------------------------------------------------
 
+/**
+ * Computes the count-backed onboarding checklist booleans.
+ *
+ * `hasAssets` and `hasCustodies` are composed at the call site (the home
+ * loader) from queries it already runs, so they are deliberately not
+ * re-counted here — see the `checklistOptions` object it builds.
+ *
+ * @param args.organizationId - The workspace to compute the checklist for
+ * @returns Checklist booleans keyed by onboarding step
+ * @throws {ShelfError} If any count query fails
+ */
 export async function checklistOptions({
-  hasAssets,
   organizationId,
 }: {
-  hasAssets: boolean;
   organizationId: string;
 }) {
   try {
-    const [
-      categoriesCount,
-      tagsCount,
-      teamMembersCount,
-      custodiesCount,
-      customFieldsCount,
-    ] = await Promise.all([
-      db.category.count({
-        where: {
-          organizationId,
-          name: {
-            notIn: defaultUserCategories.map((uc) => uc.name),
+    const [categoriesCount, tagsCount, teamMembersCount, customFieldsCount] =
+      await Promise.all([
+        db.category.count({
+          where: {
+            organizationId,
+            name: {
+              notIn: defaultUserCategories.map((uc) => uc.name),
+            },
           },
-        },
-      }),
+        }),
 
-      db.tag.count({
-        where: { organizationId },
-      }),
+        db.tag.count({
+          where: { organizationId },
+        }),
 
-      db.teamMember.count({
-        where: { organizationId },
-      }),
+        db.teamMember.count({
+          where: { organizationId },
+        }),
 
-      db.teamMember.count({
-        where: {
-          organizationId,
-          custodies: { some: {} },
-        },
-      }),
-
-      db.customField.count({
-        where: {
-          organizationId,
-          deletedAt: null,
-        },
-      }),
-    ]);
+        db.customField.count({
+          where: {
+            organizationId,
+            deletedAt: null,
+          },
+        }),
+      ]);
 
     return {
-      hasAssets,
       hasCategories: categoriesCount > 0,
       hasTags: tagsCount > 0,
       hasTeamMembers: teamMembersCount > 0,
-      hasCustodies: custodiesCount > 0,
       hasCustomFields: customFieldsCount > 0,
     };
   } catch (cause) {

--- a/apps/webapp/test/routes-tests/api+/bookings.$bookingId.assets-sidebar.test.ts
+++ b/apps/webapp/test/routes-tests/api+/bookings.$bookingId.assets-sidebar.test.ts
@@ -1,0 +1,230 @@
+// @vitest-environment node
+// why: the route imports `bookingDraftVisibilityClause` from
+// `booking/service.server`, whose import graph transitively reaches
+// canvas-dependent UI deps (lottie) that crash happy-dom at import time. A
+// route-handler test needs no DOM — the repo's established fix for this.
+/**
+ * Guard tests for `api+/bookings.$bookingId.assets-sidebar.ts`.
+ *
+ * This route exists because the bookings-list loaders stopped shipping asset
+ * payloads — which means a read that used to be gated by the list query is now
+ * addressable by booking id. `booking:read` passes for SELF_SERVICE and BASE
+ * too, so the org scope alone would let either role pull any booking's asset
+ * list. These tests pin the three things that keep the route as narrow as the
+ * list it replaced: the org scope, the draft-visibility clause, and the
+ * restricted-role custody check.
+ *
+ * @see {@link file://./../../../app/routes/api+/bookings.$bookingId.assets-sidebar.ts}
+ */
+import type { LoaderFunctionArgs } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loader } from "~/routes/api+/bookings.$bookingId.assets-sidebar";
+import { requirePermission } from "~/utils/roles.server";
+
+// why: data() returns a fetch Response so the route handler can be invoked
+// directly inside vitest without a Remix runtime.
+const createDataMock = vi.hoisted(
+  () => () =>
+    vi.fn(
+      (payload: unknown, init?: ResponseInit) =>
+        new Response(JSON.stringify(payload), {
+          status: init?.status || 200,
+          headers: {
+            "Content-Type": "application/json",
+            ...(init?.headers || {}),
+          },
+        })
+    )
+);
+
+const dbMocks = vi.hoisted(() => ({
+  bookingFindFirst: vi.fn(),
+  consumptionLogGroupBy: vi.fn(),
+  partialCheckoutFindMany: vi.fn(),
+}));
+
+// why: the route reads the booking and two aggregates directly via Prisma;
+// injecting the responses drives the guard branches without a database.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    booking: { findFirst: dbMocks.bookingFindFirst },
+    consumptionLog: { groupBy: dbMocks.consumptionLogGroupBy },
+    partialBookingCheckout: { findMany: dbMocks.partialCheckoutFindMany },
+  },
+}));
+
+// why: each test supplies the (organizationId, canSeeAllBookings) it needs
+// rather than running the real permission machinery.
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+const requirePermissionMock = vi.mocked(requirePermission);
+
+const CURRENT_USER = "user-current";
+
+/**
+ * Builds the loader arguments for a request against `booking-1`.
+ *
+ * @returns Loader args with a session for {@link CURRENT_USER}
+ */
+function buildArgs(): LoaderFunctionArgs {
+  return {
+    context: { getSession: () => ({ userId: CURRENT_USER }) },
+    request: new Request(
+      "https://example.com/api/bookings/booking-1/assets-sidebar"
+    ),
+    params: { bookingId: "booking-1" },
+  } as unknown as LoaderFunctionArgs;
+}
+
+/** A booking row as the route selects it, with no custody links by default. */
+function bookingRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "booking-1",
+    custodianUserId: null,
+    custodianTeamMember: null,
+    bookingAssets: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.consumptionLogGroupBy.mockResolvedValue([]);
+  dbMocks.partialCheckoutFindMany.mockResolvedValue([]);
+  requirePermissionMock.mockResolvedValue({
+    organizationId: "org-1",
+    canSeeAllBookings: true,
+  } as never);
+});
+
+describe("api/bookings/:bookingId/assets-sidebar — read gate", () => {
+  it("scopes the lookup to the caller's organization and hides other people's drafts", async () => {
+    dbMocks.bookingFindFirst.mockResolvedValue(bookingRow());
+
+    await loader(buildArgs());
+
+    const where = dbMocks.bookingFindFirst.mock.calls[0][0].where;
+    expect(where.id).toBe("booking-1");
+    expect(where.organizationId).toBe("org-1");
+    // `bookingDraftVisibilityClause` — a DRAFT is visible to its creator only.
+    expect(where.AND).toEqual([
+      {
+        OR: [
+          { status: { not: "DRAFT" } },
+          { AND: [{ status: "DRAFT" }, { creatorId: CURRENT_USER }] },
+        ],
+      },
+    ]);
+  });
+
+  it("404s when the booking is outside the caller's organization", async () => {
+    // The org scope is in the `where`, so a cross-org id simply matches nothing.
+    dbMocks.bookingFindFirst.mockResolvedValue(null);
+
+    const response = (await loader(buildArgs())) as unknown as Response;
+
+    expect(response.status).toBe(404);
+  });
+
+  it("403s a restricted user asking for a booking they do not hold", async () => {
+    requirePermissionMock.mockResolvedValue({
+      organizationId: "org-1",
+      canSeeAllBookings: false,
+    } as never);
+    dbMocks.bookingFindFirst.mockResolvedValue(
+      bookingRow({
+        custodianUserId: "someone-else",
+        custodianTeamMember: { userId: "someone-else" },
+      })
+    );
+
+    const response = (await loader(buildArgs())) as unknown as Response;
+
+    expect(response.status).toBe(403);
+  });
+
+  it("serves a restricted user their own booking, matched on the team-member link", async () => {
+    // Legacy rows record custody on the team member alone, with
+    // `custodianUserId` never backfilled — `canSeeBooking` matches either link.
+    requirePermissionMock.mockResolvedValue({
+      organizationId: "org-1",
+      canSeeAllBookings: false,
+    } as never);
+    dbMocks.bookingFindFirst.mockResolvedValue(
+      bookingRow({
+        custodianUserId: null,
+        custodianTeamMember: { userId: CURRENT_USER },
+      })
+    );
+
+    const response = (await loader(buildArgs())) as unknown as Response;
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("api/bookings/:bookingId/assets-sidebar — payload", () => {
+  it("returns the asset rows with the qty-progress maps the drawer renders", async () => {
+    dbMocks.bookingFindFirst.mockResolvedValue(
+      bookingRow({
+        bookingAssets: [{ id: "ba-1", quantity: 5, assetKitId: null }],
+      })
+    );
+    dbMocks.consumptionLogGroupBy.mockResolvedValue([
+      { assetId: "asset-1", category: "RETURN", _sum: { quantity: 2 } },
+      { assetId: "asset-1", category: "DAMAGE", _sum: { quantity: 1 } },
+    ]);
+    dbMocks.partialCheckoutFindMany.mockResolvedValue([
+      { assetIds: ["asset-1"], quantities: [4] },
+    ]);
+
+    const response = (await loader(buildArgs())) as unknown as Response;
+    const body = await response.json();
+
+    expect(body.bookingAssets).toEqual([
+      { id: "ba-1", quantity: 5, assetKitId: null },
+    ]);
+    // Returned and damaged both leave the booking, so they sum into the total…
+    expect(body.dispositionedByAsset).toEqual({ "asset-1": 3 });
+    // …but the tooltip has to tell them apart.
+    expect(body.dispositionBreakdownByAsset).toEqual({
+      "asset-1": { returned: 2, consumed: 0, lost: 0, damaged: 1 },
+    });
+    expect(body.checkedOutByAsset).toEqual({ "asset-1": 4 });
+  });
+
+  it("counts one unit per entry for legacy checkout rows with no quantities", async () => {
+    // Pre-progressive-checkout rows have `quantities` shorter than `assetIds`
+    // (often empty). Matches `countCheckedOutUnitsForAsset`.
+    dbMocks.bookingFindFirst.mockResolvedValue(bookingRow());
+    dbMocks.partialCheckoutFindMany.mockResolvedValue([
+      { assetIds: ["asset-1", "asset-2", "asset-1"], quantities: [] },
+    ]);
+
+    const response = (await loader(buildArgs())) as unknown as Response;
+    const body = await response.json();
+
+    expect(body.checkedOutByAsset).toEqual({ "asset-1": 2, "asset-2": 1 });
+  });
+
+  it("scopes both aggregates to this booking", async () => {
+    dbMocks.bookingFindFirst.mockResolvedValue(bookingRow());
+
+    await loader(buildArgs());
+
+    expect(dbMocks.consumptionLogGroupBy.mock.calls[0][0].where).toMatchObject({
+      bookingId: "booking-1",
+    });
+    expect(dbMocks.partialCheckoutFindMany.mock.calls[0][0].where).toEqual({
+      bookingId: "booking-1",
+    });
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/bookings.$bookingId.assets-sidebar.test.ts
+++ b/apps/webapp/test/routes-tests/api+/bookings.$bookingId.assets-sidebar.test.ts
@@ -60,6 +60,8 @@ vi.mock("~/utils/roles.server", () => ({
   requirePermission: vi.fn(),
 }));
 
+// why: the loader returns `data(...)`; swapping it for a plain Response factory
+// lets the handler be invoked directly, with no router runtime to stand up.
 vi.mock("react-router", async () => {
   const actual = await vi.importActual("react-router");
   return { ...actual, data: createDataMock() };
@@ -189,6 +191,11 @@ describe("api/bookings/:bookingId/assets-sidebar — payload", () => {
     const response = (await loader(buildArgs())) as unknown as Response;
     const body = await response.json();
 
+    // The whole envelope, not just the rows: the success path runs through
+    // `payload()`, which stamps `error: null` onto every response. The drawer
+    // has to discriminate on `bookingAssets` because of it, so the shape is
+    // part of this route's contract rather than an implementation detail.
+    expect(body.error).toBeNull();
     expect(body.bookingAssets).toEqual([
       { id: "ba-1", quantity: 5, assetKitId: null },
     ]);


### PR DESCRIPTION
Re-applies the good parts of **#2738** (`perf/p95-under-300ms`, closed) against
current `main`, and re-implements its bookings-drawer change rather than merging
it.

That branch was 933 `main` commits behind with four conflicting files, so this
is a fresh application, not a merge. Everything below was verified against
`main` at `870a12cd4`. What #2738 measured is still measurable: `/calendar` p95
136ms → 28ms and `/home` 60ms → 33ms on its rig, and `/bookings` shipped a
343KB document.

## Why not just merge #2738

Three of its five pieces port cleanly. The other two do not:

- **Its assets-index CTE rewrite is dropped.** It targets
  `buildAdvancedAssetsQuery`, which has been reworked since by #2849 / #2897 /
  #2911 and has its own streaming redesign pending. It was also the smallest
  measured win there (~12%) and never touches the `COUNT` query that dominates
  that route.
- **Its bookings-drawer change is re-implemented, not merged.** `main` rebuilt
  that sidebar in the model-reservations wave (`0cefc0ca5`, `93421187c`,
  `77806f84d`), so merging would mean resolving a rewrite against a rewrite —
  and its badge query predates the quantity-tracked custody exemption `main`
  added since, so it would have flagged every QT booking (see below).

## What this changes

### `getBookings` learns to skip assets

Two options, both defaulting to today's behaviour:

- `includeAssets` (default `true`) omits the `bookingAssets` key from the Prisma
  include entirely when `false`. The include moves verbatim to
  `BOOKINGS_LIST_ASSETS_INCLUDE` in `modules/booking/constants.ts`, so the eager
  path (the bookings CSV select-all export) and the new resource route cannot
  drift apart.
- `takeCap` sets a hard row cap that bypasses the `perPage ≤ 100` clamp, for
  callers fetching one bounded set rather than a page of it. Ignored under
  `takeAll`.

The `as typeof BOOKINGS_LIST_ASSETS_INCLUDE` cast is kept on purpose and
commented: opt-out callers still see `bookingAssets` in the inferred type, the
same runtime/static divergence `extraInclude` already has. A conditional generic
would type it honestly, but this webapp sits at TypeScript's instantiation
ceiling over the extended Prisma client, where that surfaces as TS2321 somewhere
unrelated.

### `/calendar`

Skips the asset subtree and the `COUNT` companion query, and narrows the
custodian/creator selects — `custodianTeamMember: true` / `custodianUser: true`
pulled whole `User` rows, per booking, per request, for a mapping that reads
three name fields. The dead `perPage: 1000` is dropped (`takeAll` ignores it).

**One deliberate difference from #2738:** it swapped `takeAll` for
`takeCap: 1000`. That silently drops the latest-starting bookings in a busy
month. `takeAll` is kept here — the win is the payload, and an unbounded-query
ceiling is a separate decision.

### `/home` — plus a live bug

All four `getBookings` calls skip the asset subtree; the widgets read booking
scalars, the custodian and `_count.bookingAssets`.

> **Bug fix:** the custodian-merge call passed `perPage: 1000` into
> `const take = perPage >= 1 && perPage <= 100 ? perPage : 20`. "Top custodians"
> on the dashboard has been computed from the **first 20** ONGOING/OVERDUE
> bookings, not all of them. `takeCap` fixes it.

Also: location distribution goes `groupBy`-first instead of a correlated count
per location, and `checklistOptions` joins the loader's existing `Promise.all`
instead of being awaited after it, losing a duplicate custody count on the way
(`directCustodians` already runs that exact query, and `take: 20` cannot change
a `> 0` test).

### Mobile dashboard — another live bug

> **Bug fix:** `api+/mobile+/dashboard.ts` projected
> `assetCount: b._count?.assets` off a `(b: any)`. `_count.assets` is not a
> relation on `Booking` (it's `bookingAssets`) and no `_count` was selected at
> all, so **every booking on the companion dashboard has reported 0 assets**.
> The `any` is what kept the compiler quiet.

Fixed, with a real parameter type so the next wrong field name fails the build
instead of the screen. The three calls also stop fetching assets they never read.

### The assets drawer loads on open

Five surfaces render the bookings list — the index plus `me.bookings`,
`assets/$id/bookings`, `kits/$id/bookings`,
`settings/team/users/$id/bookings` — all reusing `BookingsIndexPage`. All five
shipped the full per-booking asset payload for a drawer most users never expand;
the index shipped two page-wide ConsumptionLog/checkout aggregates on top.

The drawer now fetches from `GET /api/bookings/:bookingId/assets-sidebar` on
open, and the lists ship `_count.bookingAssets`. Re-opening refetches so the
drawer reflects check-in/out activity since the last look; the previous payload
stays rendered meanwhile, so there's no spinner flash.

**Going lazy on all five instead of just the index made this smaller, not
bigger.** #2738 converted only `/bookings`, which forced the component into a
dual eager/lazy mode with `bookingAssets` optional and the badge computed two
different ways — including the `rawItem.bookingAssets ?? []` normalisation that
reads as "eager with zero assets" and silently suppresses the fetch, a trap that
bit that branch during its own merge. One path has none of that.

**Auth.** The read gate mirrors the index exactly: `requirePermission`
(`booking/read`) for the org scope, `bookingDraftVisibilityClause` so drafts stay
creator-only, and `canSeeBooking` for the restricted-role custody scope.
`booking:read` passes for SELF_SERVICE and BASE, so the org scope alone would let
either role pull any booking's asset list by id. New route tests pin the 404, the
cross-org case, the restricted-role 403 and the legacy team-member-link match.

**The "Includes unavailable assets" badge** could no longer be computed in the
browser, so it moved into `decorateBookingsForList`
(`modules/booking/list-flags.server.ts`), which runs it concurrently with the
existing stock-conflict lookup and attaches both flags per row. The rule is
type-aware: `availableToBook: false` counts for any asset, custody counts only
for INDIVIDUAL ones, because a quantity-tracked asset is a pool and units on loan
still leave units bookable. **#2738's query lacked that exemption** — it predates
it — and would have flagged every QT booking, the exact false positive that
scared a customer off a booking that had already checked out cleanly. Its three
cases moved from the row component's tests to the new module's, where the `where`
clause now lives.

`decorateBookingsWithStockConflicts` and its 1018-line suite are untouched; the
new decorator composes it. Both lookups keep the decorative-never-500 contract: a
failing query logs and degrades to an unflagged row.

Dropping the array also retires the SHELF-WEBAPP-1NW defensive normalisation in
the row component — there is no `bookingAssets` left to arrive `undefined`.

## Testing

- **704 tests across 30 booking files**, plus the new suites: `getBookings`
  payload/cap contract, `list-flags.server`, and the resource route's guards.
- **Mutation-tested** the three new guards — dropping `includeAssets` from the
  conditional spread, dropping `takeCap`, and flipping the QT exemption each turn
  a test red, so none of them are decorative.
- Typecheck and lint clean.
- **Production build clean**, which was the specific risk worth checking: this is
  the only `api+` route in the repo exporting `shouldRevalidate` (a client
  export), and every `*.server` import in it is referenced only inside `loader`
  per `.claude/rules/no-server-module-in-route-client-exports.md`. Its client
  chunk builds to **0.05 kB** — just that function.

**Not yet done:** the browser pass. Port 3000 was serving a different worktree,
so the drawer's one-request-per-open, kit grouping, spinner/retry states and the
two pills have not been exercised against a real database. Worth doing before
merge.

## Deliberately out of scope

- The assets-index CTE rewrite from #2738 (above).
- `consumptionType` is declared by both the sidebar's type and the row prop type
  but has never been selected by `getBookings`, so `<ConsumptionTypeBadge>` is
  dead on all five surfaces today. The include stays faithful to `main` — lighting
  it up is a UI change, not a perf one.
- `availableUnitsByAsset` on the drawer (the `InsufficientStockBadge` /
  `PendingReturnBadge` gap #2738 also documented) — a new feature on these
  surfaces.
- The add-to-existing-booking picker (`service.server.ts`, `loadBookingsData`)
  over-fetches the same way, but its `bookings` array is handed wholesale to a
  modal whose readers weren't traced. Follow-up candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking asset details now load on demand when opening the assets sidebar.
  * Added loading, error, and retry states, with asset counts shown in booking lists.
  * Booking lists now display unavailable-asset and stock-conflict indicators.
  * Added permission-aware asset details, availability summaries, checkout quantities, and category breakdowns.
* **Performance**
  * Reduced initial booking-list and dashboard loading by fetching asset details only when needed.
  * Improved dashboard and calendar data loading efficiency.
* **Bug Fixes**
  * Improved handling of unavailable assets, authorization, missing bookings, and failed asset requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->