### PR TITLE
test(kits): stop the picker-meta test from opening a real database connection

### DIFF
--- a/apps/webapp/app/modules/kit/picker-meta.server.test.ts
+++ b/apps/webapp/app/modules/kit/picker-meta.server.test.ts
@@ -16,7 +16,15 @@
  * @see {@link file://./picker-meta.server.ts}
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// why: `picker-meta.server.ts` imports the real db client at module level,
+// but this file tests only the pure `computeKitClaimablePool`. Without the
+// mock, the imported Prisma client attempts a connection against the
+// placeholder DATABASE_URL from `test/setup-test-env.ts` and its async
+// rejection lands after the tests finish — vitest counts it as a run-level
+// error and the whole suite exits red on a clean checkout.
+vi.mock("~/database/db.server", () => ({ db: {} }));
 
 import { computeKitClaimablePool } from "./picker-meta.server";
 


### PR DESCRIPTION
## What

`pnpm webapp:validate` exits red on a clean checkout of main, even though every test passes. The kit picker-meta test file tests only the pure `computeKitClaimablePool`, but the module under test imports the real database client at module level. Under vitest, `test/setup-test-env.ts` sets `DATABASE_URL` to a literal placeholder, and the imported Prisma client's connection attempt rejects asynchronously after the tests finish. Vitest counts that as a run-level error ("Errors 1") and exits 1.

CI is unaffected, which is why this survived: it only bites local `webapp:validate` runs, and a validate gate that is red on clean main trains everyone to ignore red validates.

## How

One `vi.mock("~/database/db.server", () => ({ db: {} }))` in the test file, with a `// why:` comment. The function under test is pure, so an empty db object is sufficient.

Verified: on clean main the file reports 7 passed plus 1 unhandled error; with the mock it reports 7 passed and no errors, and the full `pnpm webapp:validate` exits 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by preventing database connection attempts during pool-calculation tests.
  * Added database mocking to ensure tests run against predictable, controlled conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->