### PR TITLE
fix(companion): coherent bookings journey in personal workspaces, past days, and archive verdict

### DIFF
--- a/apps/companion/app/(tabs)/bookings/index.tsx
+++ b/apps/companion/app/(tabs)/bookings/index.tsx
@@ -152,6 +152,8 @@ function BookingsListContent() {
   const router = useRouter();
   const {
     currentOrg,
+    organizations,
+    setCurrentOrg,
     isLoading: orgLoading,
     error: orgError,
     refresh: refreshOrg,
@@ -239,7 +241,9 @@ function BookingsListContent() {
 
   const fetchBookings = useCallback(
     async (pageNum: number, reset: boolean): Promise<boolean> => {
-      if (!currentOrg) return false;
+      // Personal workspaces have no bookings surface; the screen shows the
+      // switch-workspace state instead of firing a request that cannot succeed.
+      if (!currentOrg || currentOrg.type === "PERSONAL") return false;
       const { data, error: fetchErr } = await api.bookings(currentOrg.id, {
         status: STATUS_FILTERS[activeFilter].value,
         search: debouncedSearch || undefined,
@@ -577,6 +581,52 @@ function BookingsListContent() {
           <Ionicons name="refresh" size={16} color={colors.primaryForeground} />
           <Text style={styles.retryText}>Retry</Text>
         </TouchableOpacity>
+      </View>
+    );
+  }
+
+  // Bookings belong to team workspaces. In a personal workspace, explain that
+  // and hand the user the shortest path to one instead of an empty list.
+  if (currentOrg?.type === "PERSONAL") {
+    const teamOrgs = organizations.filter((org) => org.type === "TEAM");
+    const onlyTeam = teamOrgs.length === 1 ? teamOrgs[0] : null;
+    return (
+      <View style={styles.centered}>
+        <Ionicons name="calendar-outline" size={48} color={colors.border} />
+        <Text style={styles.emptyTitle}>Bookings live in team workspaces</Text>
+        <Text style={styles.emptyText}>
+          {teamOrgs.length > 0
+            ? "Your personal workspace tracks your own gear. Switch to a team workspace to plan and reserve equipment."
+            : "Your personal workspace tracks your own gear. Create a team workspace on the web to plan and reserve equipment."}
+        </Text>
+        {teamOrgs.length > 0 ? (
+          <TouchableOpacity
+            style={styles.retryButton}
+            onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              if (onlyTeam) {
+                setCurrentOrg(onlyTeam);
+              } else {
+                // Several teams: the workspace picker lives in Settings.
+                router.push("/(tabs)/settings");
+              }
+            }}
+            activeOpacity={0.7}
+            accessibilityLabel={
+              onlyTeam ? `Switch to ${onlyTeam.name}` : "Switch workspace"
+            }
+            accessibilityRole="button"
+          >
+            <Ionicons
+              name="swap-horizontal"
+              size={16}
+              color={colors.primaryForeground}
+            />
+            <Text style={styles.retryText}>
+              {onlyTeam ? `Switch to ${onlyTeam.name}` : "Switch workspace"}
+            </Text>
+          </TouchableOpacity>
+        ) : null}
       </View>
     );
   }

--- a/apps/companion/app/(tabs)/bookings/new.tsx
+++ b/apps/companion/app/(tabs)/bookings/new.tsx
@@ -55,7 +55,9 @@ import { TeamMemberPicker } from "@/components/team-member-picker";
  * when one is given and on tomorrow otherwise.
  *
  * Both are real instants. The day and the hours are resolved in `timeZone`, so
- * the window means the same wall clock regardless of where the device is.
+ * the window means the same wall clock regardless of where the device is. The
+ * start never seeds in the past: it is clamped to ten minutes from now, the
+ * earliest start the server accepts.
  *
  * @param timeZone - the acting user's preference zone
  * @param day - a `YYYY-MM-DD` calendar date, as the calendar lens keys its days
@@ -86,7 +88,19 @@ function defaultBookingWindow(
         { year: onDay[0], month: onDay[1], day: onDay[2], hour, minute: 0 },
         timeZone
       );
-    return { from: at(9), to: at(17) };
+    // A booking can only start in the future, so the seed is clamped to ten
+    // minutes from now — the same earliest-start the server holds submissions
+    // to. Without the clamp, opening the form from today's panel after 09:00
+    // (or from a past day left on the back stack) seeds a start the server
+    // rejects on an untouched form.
+    const earliest = new Date(Date.now() + 10 * 60 * 1000);
+    earliest.setSeconds(0, 0);
+    const from = at(9) < earliest ? earliest : at(9);
+    // Keep the day's 17:00 end when it still leaves a window; once the clamp
+    // passes it, fall back to the same eight-hour span 09:00–17:00 describes.
+    const to =
+      at(17) > from ? at(17) : new Date(from.getTime() + 8 * 60 * 60 * 1000);
+    return { from, to };
   }
   const now = new Date();
   return {

--- a/apps/companion/app/(tabs)/bookings/new.tsx
+++ b/apps/companion/app/(tabs)/bookings/new.tsx
@@ -93,8 +93,11 @@ function defaultBookingWindow(
     // to. Without the clamp, opening the form from today's panel after 09:00
     // (or from a past day left on the back stack) seeds a start the server
     // rejects on an untouched form.
-    const earliest = new Date(Date.now() + 10 * 60 * 1000);
-    earliest.setSeconds(0, 0);
+    // Ceil to the next whole minute: flooring the seconds could land up to
+    // 59s inside the ten-minute minimum and fail an untouched form.
+    const earliest = new Date(
+      Math.ceil((Date.now() + 10 * 60 * 1000) / 60_000) * 60_000
+    );
     const from = at(9) < earliest ? earliest : at(9);
     // Keep the day's 17:00 end when it still leaves a window; once the clamp
     // passes it, fall back to the same eight-hour span 09:00–17:00 describes.

--- a/apps/companion/components/bookings/booking-calendar.tsx
+++ b/apps/companion/components/bookings/booking-calendar.tsx
@@ -757,7 +757,9 @@ export function BookingCalendar({
             rather than floating free. */}
         <View style={styles.dayHeader}>
           <Text style={styles.dayTitle}>{formatDate(selectedDay)}</Text>
-          {canCreate ? (
+          {/* Day keys are YYYY-MM-DD, so string order is date order. A day
+              already over cannot take a new booking; today still can. */}
+          {canCreate && selectedDay >= toKey(new Date(), prefs.timeZone) ? (
             <TouchableOpacity
               style={styles.newBooking}
               onPress={() =>

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -15,6 +15,7 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { serializeAssetImage } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
+import { isBookingArchivable } from "~/modules/booking/helpers";
 import {
   bookingDraftVisibilityClause,
   computeBookingAssetRemaining,
@@ -403,8 +404,11 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           booking.status === "ONGOING" ||
           booking.status === "OVERDUE") &&
         canCancelPerm,
-      // Archive: COMPLETE only + archive permission.
-      canArchive: booking.status === "COMPLETE" && canArchivePerm,
+      // Archive: shared web-parity rule (COMPLETE, or RESERVED already past
+      // its end date) + archive permission.
+      canArchive:
+        isBookingArchivable({ status: booking.status, to: booking.to }) &&
+        canArchivePerm,
       // Duplicate: any status; gated by create permission (web's duplicate
       // route enforces create — we hide it for those who lack it rather than
       // 403 on tap).

--- a/apps/webapp/app/routes/api+/mobile+/bookings.archive.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.archive.ts
@@ -21,9 +21,10 @@ import { enforceUserRateLimit } from "~/utils/rate-limit.server";
 /**
  * POST /api/mobile/bookings/archive
  *
- * Archives a COMPLETE booking (→ ARCHIVED) from the Companion app — the mobile
- * twin of the web "archive" intent. Wraps the shared `archiveBooking` service,
- * which enforces the COMPLETE-only status guard and cancels any scheduler.
+ * Archives a booking (→ ARCHIVED) from the Companion app — the mobile twin of
+ * the web "archive" intent. Wraps the shared `archiveBooking` service, which
+ * enforces the archivable-status rule (COMPLETE, or RESERVED already past its
+ * end date — see `isBookingArchivable`) and cancels any scheduler.
  *
  * PARITY: gate on `PermissionAction.archive` (the web ActionsDropdown shows the
  * archive action via `userHasPermission(archive)`). BASE has `booking:update`
@@ -83,7 +84,7 @@ export async function action({ request }: ActionFunctionArgs) {
       action: "archive",
     });
 
-    // archiveBooking enforces the COMPLETE-only status guard itself.
+    // archiveBooking enforces the archivable-status rule itself.
     const archived = await archiveBooking({
       id: bookingId,
       organizationId,


### PR DESCRIPTION
## What

Three edges of the companion bookings journey, found in the admin journey audit, now behave coherently:

**1. Personal workspace: purposeful state instead of a failing list.**
The Bookings tab in a personal workspace no longer fires a request that can only fail. It explains that bookings live in team workspaces and offers the shortest path there: a one-tap **Switch to {team}** when the user has exactly one team workspace, or a jump to the Settings workspace picker when they have several. Users with no team workspace get an explanation instead of a dead button. The fetch itself is gated, so no failed request is made under the state.

**2. Calendar: past days cannot start a booking, and today seeds a valid start.**
The day panel hides **New booking** on days already over (day keys are date-ordered strings, compared in the user's preference zone). Opening the form from today's panel after 09:00 no longer seeds a start the server rejects: the seeded start is clamped to ten minutes from now (the server's earliest accepted start), keeping the day's 17:00 end while it still leaves a window and falling back to the same eight-hour span otherwise.

**3. Mobile archive verdict matches the action it fronts.**
The mobile booking detail's `canArchive` verdict used a COMPLETE-only check while the shared `archiveBooking` service accepts COMPLETE **or** RESERVED past its end date (`isBookingArchivable`). The verdict now calls the same shared rule, so the app shows Archive exactly where the server allows it. Stale comments in the mobile archive route that described the old COMPLETE-only rule are corrected.

## Verification (on-device, iPhone 17 simulator, local API)

- Personal workspace → Bookings: renders the explanation + **Switch to GRANULAR WORKSPACE**; one tap lands back in the team workspace with the live list.
- Calendar: the 18th (past) shows its day panel with no New-booking button; the 26th (today) keeps it.
- New booking from today's panel at 14:35 seeded **Starts 14:45 / Ends 17:00** on an untouched form (previously 09:00, which the server rejects).
- Typecheck and lint green for both apps; webapp `isBookingArchivable` already carries the rule's unit tests.

## Scope

Companion screens plus the mobile API verdict/comments only — no web behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Personal workspaces now explain when bookings are unavailable, with options to switch workspaces or open Settings.
  - Eligible completed and past reserved bookings can now be archived when permitted.

- **Bug Fixes**
  - New bookings now use valid future start times.
  - The create-booking action is hidden for past dates.

- **Documentation**
  - Archive behavior documentation now reflects the available booking types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->