### PR TITLE
fix(assets): keep filters with colons in their value, and fix the onboarding redirect

### DIFF
--- a/apps/webapp/app/components/assets/assets-index/advanced-filters/helpers.ts
+++ b/apps/webapp/app/components/assets/assets-index/advanced-filters/helpers.ts
@@ -1,5 +1,6 @@
 import type { CustomField } from "@prisma/client";
 import { useSearchParams } from "~/hooks/search-params";
+import { splitFilterParam } from "~/modules/asset/filter-param";
 import type {
   Column,
   ColumnLabelKey,
@@ -131,7 +132,13 @@ export function useInitialFilters(columns: Column[]) {
   searchParams.forEach((value, key) => {
     const column = columns.find((c) => c.name === key);
     if (column) {
-      const [operator, filterValue] = value.split(":");
+      const [operator, filterValue] = splitFilterParam(value);
+
+      // No separator means no value; there is no filter row to rebuild, and
+      // the `between` branch below would read `.split` off `undefined`.
+      if (filterValue === undefined) {
+        return;
+      }
 
       initialFilters.push({
         name: key,

--- a/apps/webapp/app/modules/asset/advanced-filter-colon-values.test.ts
+++ b/apps/webapp/app/modules/asset/advanced-filter-colon-values.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Advanced filters whose VALUE contains a colon.
+ *
+ * The parameter grammar is `operator:value`, and the value is user data. Colons
+ * are legal in Code128, DataMatrix and ExternalQR codes, and a URL custom field
+ * is mostly colon — so a value carrying one is ordinary input, not a malformed
+ * parameter.
+ *
+ * Three layers read that grammar and each one is pinned here, because a colon
+ * fails differently at each: validation removes the parameter outright, the
+ * server parser truncates the value, and the browser rebuilds the filter row
+ * showing the truncation back to the user.
+ *
+ * @see {@link file://./filter-param.ts} the shared split
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseFilters } from "./filter-parsing";
+import type { Column } from "../asset-index-settings/helpers";
+
+// @vitest-environment node
+
+// why: prevent DB connections — `utils.server` transitively reaches the
+// location descendants helper at import time.
+vitest.mock("~/modules/location/descendants.server", () => ({
+  getLocationDescendantIds: vitest.fn().mockResolvedValue([]),
+}));
+
+const { validateAdvancedFilterParams } = await import("./utils.server");
+
+/** A barcode column, the case where colons arrive most often. */
+const COLUMNS: Column[] = [
+  { name: "barcode_Code128" as Column["name"], visible: true, position: 0 },
+  { name: "status" as Column["name"], visible: true, position: 1 },
+];
+
+/** A Code128 payload with an embedded colon — legal, and not unusual. */
+const CODE_WITH_COLON = "ABC:123";
+
+describe("advanced filters with a colon in the value", () => {
+  describe("validateAdvancedFilterParams", () => {
+    it("keeps a filter whose value contains a colon", () => {
+      // Counting colon-separated fields rejects this, and anything rejected is
+      // stripped from the URL — so the filter does not merely mismatch, it
+      // disappears and the user is shown unfiltered results.
+      const params = new URLSearchParams({
+        barcode_Code128: `is:${CODE_WITH_COLON}`,
+      });
+
+      const result = validateAdvancedFilterParams(params, COLUMNS);
+
+      expect(result.get("barcode_Code128")).toBe(`is:${CODE_WITH_COLON}`);
+    });
+
+    it("still keeps an ordinary single-colon filter", () => {
+      const params = new URLSearchParams({ status: "is:AVAILABLE" });
+
+      expect(validateAdvancedFilterParams(params, COLUMNS).get("status")).toBe(
+        "is:AVAILABLE"
+      );
+    });
+
+    it("still drops a parameter with no operator separator at all", () => {
+      // The relaxation is about colons INSIDE the value; a parameter carrying
+      // no separator has no value and is still malformed.
+      const params = new URLSearchParams({ status: "AVAILABLE" });
+
+      expect(validateAdvancedFilterParams(params, COLUMNS).has("status")).toBe(
+        false
+      );
+    });
+
+    it("still drops a parameter whose operator is not a real one", () => {
+      const params = new URLSearchParams({ status: "notAnOperator:AVAILABLE" });
+
+      expect(validateAdvancedFilterParams(params, COLUMNS).has("status")).toBe(
+        false
+      );
+    });
+  });
+
+  describe("parseFilters", () => {
+    it("carries the whole value through, colons included", () => {
+      const [filter] = parseFilters(
+        `barcode_Code128=is:${CODE_WITH_COLON}`,
+        COLUMNS
+      );
+
+      expect(filter.operator).toBe("is");
+      expect(filter.value).toBe(CODE_WITH_COLON);
+    });
+
+    it("keeps a URL value intact", () => {
+      const url = "https://example.com/a:b";
+      const [filter] = parseFilters(`barcode_Code128=is:${url}`, COLUMNS);
+
+      expect(filter.value).toBe(url);
+    });
+
+    it("skips a parameter carrying no value at all", () => {
+      // `splitFilterParam` reports the missing value rather than inventing an
+      // empty one, so this never reaches `parseFilterValue` — which takes a
+      // string and would read straight off `undefined`.
+      expect(parseFilters("status=AVAILABLE", COLUMNS)).toEqual([]);
+    });
+
+    it("keeps a parameter whose value is deliberately empty", () => {
+      // A trailing colon IS a value: the empty string. It is a different thing
+      // from no separator, and only one of the two is malformed.
+      const [filter] = parseFilters("status=is:", COLUMNS);
+
+      expect(filter?.value).toBe("");
+    });
+
+    it("still splits an ordinary value on its single colon", () => {
+      const [filter] = parseFilters("status=is:AVAILABLE", COLUMNS);
+
+      expect(filter.operator).toBe("is");
+      expect(filter.value).toBe("AVAILABLE");
+    });
+  });
+});

--- a/apps/webapp/app/modules/asset/filter-param.test.ts
+++ b/apps/webapp/app/modules/asset/filter-param.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Splitting an advanced-filter URL parameter into its operator and value.
+ *
+ * The grammar is `operator:value`, and the VALUE is user data that may itself
+ * contain colons — Code128, DataMatrix and ExternalQR all permit them, and a
+ * URL custom field is mostly colon. Only the first colon separates; every one
+ * after it belongs to the value.
+ *
+ * @see {@link file://./filter-param.ts}
+ */
+import { describe, expect, it } from "vitest";
+
+import { splitFilterParam } from "./filter-param";
+
+describe("splitFilterParam", () => {
+  it("splits an ordinary operator and value", () => {
+    expect(splitFilterParam("is:AVAILABLE")).toEqual(["is", "AVAILABLE"]);
+  });
+
+  it("keeps colons that belong to the value", () => {
+    // Splitting on every colon and taking the second field silently truncates
+    // to "ABC", which then matches nothing — or, at the validation layer,
+    // rejects the parameter outright and drops the filter from the URL.
+    expect(splitFilterParam("is:ABC:123")).toEqual(["is", "ABC:123"]);
+  });
+
+  it("keeps a URL intact", () => {
+    expect(splitFilterParam("is:https://example.com/a:b")).toEqual([
+      "is",
+      "https://example.com/a:b",
+    ]);
+  });
+
+  it("reports a missing value as undefined rather than empty", () => {
+    // A parameter with no colon has no value at all, which is different from
+    // one whose value is the empty string — the callers gate on it.
+    expect(splitFilterParam("is")).toEqual(["is", undefined]);
+  });
+
+  it("treats a trailing colon as an empty value, not a missing one", () => {
+    expect(splitFilterParam("is:")).toEqual(["is", ""]);
+  });
+
+  it("does not mistake a leading colon for an operator", () => {
+    expect(splitFilterParam(":AVAILABLE")).toEqual(["", "AVAILABLE"]);
+  });
+
+  it("preserves a value that is only colons", () => {
+    expect(splitFilterParam("is:::")).toEqual(["is", "::"]);
+  });
+});

--- a/apps/webapp/app/modules/asset/filter-param.ts
+++ b/apps/webapp/app/modules/asset/filter-param.ts
@@ -1,0 +1,37 @@
+/**
+ * The `operator:value` grammar of an advanced-filter URL parameter.
+ *
+ * Deliberately dependency-free: the same split has to happen in the browser
+ * (rebuilding the filter UI from the URL), on the server (turning the URL into
+ * a query), and in the validation that decides whether a parameter survives at
+ * all. Three readings of one grammar is how they drift.
+ *
+ * @see {@link file://./filter-parsing.ts} the server/shared parser
+ * @see {@link file://./utils.server.ts} `advancedFilterFormatSchema`
+ * @see {@link file://./../../components/assets/assets-index/advanced-filters/helpers.ts}
+ */
+
+/**
+ * Splits a filter parameter on its FIRST colon.
+ *
+ * Only the first colon separates the operator from the value; the rest belong
+ * to the value, which is user data. Code128, DataMatrix and ExternalQR codes
+ * all permit colons and a URL custom field is mostly colon, so splitting on
+ * every colon and keeping the second field silently truncates the value — and
+ * where the count of fields is used to validate the parameter, drops the
+ * filter entirely.
+ *
+ * @param raw - The raw parameter value, e.g. `is:ABC:123`
+ * @returns A `[operator, value]` pair. `value` is `undefined` when the
+ *   parameter carries no colon at all, which is not the same as a colon with
+ *   nothing after it (`""`) — callers gate on the difference.
+ */
+export function splitFilterParam(
+  raw: string
+): [operator: string, value: string | undefined] {
+  const separator = raw.indexOf(":");
+
+  return separator === -1
+    ? [raw, undefined]
+    : [raw.slice(0, separator), raw.slice(separator + 1)];
+}

--- a/apps/webapp/app/modules/asset/filter-parsing.ts
+++ b/apps/webapp/app/modules/asset/filter-parsing.ts
@@ -5,6 +5,7 @@ import type {
 } from "~/components/assets/assets-index/advanced-filters/schema";
 import { isSafeSqlIdentifier } from "~/utils/sql";
 import { getQueryFieldType } from "./field-type-mapping";
+import { splitFilterParam } from "./filter-param";
 import type { Column } from "../asset-index-settings/helpers";
 
 /**
@@ -36,7 +37,15 @@ export function parseFilters(
   searchParams.forEach((value, key) => {
     const column = columns.find((c) => c.name === key);
     if (column) {
-      const [operator, filterValue] = value.split(":");
+      const [operator, filterValue] = splitFilterParam(value);
+
+      // No separator means no value, which is not a filter. `parseFilterValue`
+      // takes a string and would read straight off `undefined`; the server's
+      // own `validateAdvancedFilterParams` drops these for the same reason.
+      if (filterValue === undefined) {
+        return;
+      }
+
       const dbKey = API_TO_DB_FIELD_MAP[key] || key;
 
       // Non-custom-field names are used in Prisma.raw() as SQL identifiers,

--- a/apps/webapp/app/modules/asset/utils.server.ts
+++ b/apps/webapp/app/modules/asset/utils.server.ts
@@ -18,6 +18,7 @@ import { getCustomFieldDisplayValue } from "~/utils/custom-fields";
 import { getParamsValues } from "~/utils/list";
 import { stripMarkdocDelimiters } from "~/utils/markdoc-sanitize";
 import { wrapUserLinkForNote, wrapLinkForNote } from "~/utils/markdoc-wrappers";
+import { splitFilterParam } from "./filter-param";
 import { parseFiltersWithHierarchy } from "./query.server";
 import type { ICustomFieldValueJson } from "./types";
 import type { Column } from "../asset-index-settings/helpers";
@@ -807,10 +808,14 @@ export function getAssetsWhereInput({
  */
 export const advancedFilterFormatSchema = z.string().refine(
   (value) => {
-    const parts = value.split(":");
-    if (parts.length !== 2) return false;
+    // Only the first colon separates; the rest belong to the value. Counting
+    // fields instead would reject any value containing a colon — legal in
+    // Code128, DataMatrix and ExternalQR, and unavoidable in a URL — and
+    // `validateAdvancedFilterParams` drops what fails here, so the filter
+    // would vanish from the URL rather than merely mismatch.
+    const [operator, filterValue] = splitFilterParam(value);
+    if (filterValue === undefined) return false;
 
-    const [operator] = parts;
     return filterOperatorSchema.safeParse(operator).success;
   },
   {

--- a/apps/webapp/app/routes/_layout+/_layout.tsx
+++ b/apps/webapp/app/routes/_layout+/_layout.tsx
@@ -86,6 +86,27 @@ export type LayoutLoaderResponse = typeof loader;
  */
 export const shouldRevalidate = skipRevalidationOnClientViewChange;
 
+/**
+ * Gate for every authenticated route beneath this layout, and the source of the
+ * data its chrome renders.
+ *
+ * The gates run in a fixed order and the order is load-bearing: subscription
+ * validity, then onboarding, then organization resolution. Onboarding has to
+ * clear before org resolution because `getSelectedOrganization` throws for a
+ * user with no membership, which is exactly the state a non-onboarded user is
+ * in — resolving first turns "finish signing up" into an error page.
+ *
+ * Because the gate covers routes at every depth, its redirects are absolute. A
+ * relative target resolves against the URL the user arrived at, so anyone
+ * following a QR or email link into a nested route would be sent somewhere
+ * that does not exist.
+ *
+ * @param args.context - Carries the auth session the gates run against
+ * @param args.request - Read for the per-page cookie and the current URL
+ * @returns The user, their organizations, subscription state and layout prefs
+ * @throws {Response} A redirect to `/onboarding` for a user who has not
+ *   finished signing up, or an error response when a gate refuses
+ */
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;

--- a/apps/webapp/app/routes/_layout+/_layout.tsx
+++ b/apps/webapp/app/routes/_layout+/_layout.tsx
@@ -141,7 +141,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
     }
 
     if (!user.onboarded) {
-      return redirect("onboarding");
+      // Absolute: a relative target resolves against the URL the user arrived
+      // at, so anyone landing deeper than the root — a QR link, a link from an
+      // email — is sent to `<their/path>/onboarding`, which does not exist.
+      return redirect("/onboarding");
     }
 
     // Org resolution runs after the onboarding guard — safe now since


### PR DESCRIPTION
Two unrelated one-line-class bugs, kept as separate commits. Grouped only
because each is small enough that its own review cycle would cost more than the
fix.

---

# 1. Advanced filters whose value contains a colon (D121)

A filter parameter is `operator:value`, and the value is **user data**. Colons
are legal in Code128, DataMatrix and ExternalQR codes, and a URL custom field is
mostly colon — so a value carrying one is ordinary input, not a malformed
parameter.

Three places read that grammar, and all three split on **every** colon and kept
the second field.

## The report named one site. The worst one it didn't.

| Site | What a colon does |
| --- | --- |
| `utils.server.ts` — `advancedFilterFormatSchema` | decides validity with `parts.length !== 2`, so the value is **rejected**. `validateAdvancedFilterParams` strips whatever fails, so the filter **vanishes from the URL** and the user is shown unfiltered results |
| `filter-parsing.ts` *(reported)* | truncates — queries for `ABC` when the user asked for `ABC:123` |
| `advanced-filters/helpers.ts` | client parser; rebuilds the filter row **displaying** the truncation back as though that's what was typed |

The validation one is the user-visible symptom: not "my filter matched the wrong
thing" but "my filter disappeared".

## Fix

One dependency-free `splitFilterParam` that splits on the **first** colon, used
by all three. The grammar is read in the browser, on the server, and in the
validation that decides whether a parameter survives at all — three separate
readings is how they came to disagree.

## A latent bug the types then exposed

`splitFilterParam` reports a missing value as `undefined`. Typecheck immediately
failed at both parsers: `split(":")[1]` had been typing as `string`, hiding that
a parameter with **no** separator reaches `parseFilterValue` — which takes a
`string` — and reads straight off `undefined`.

Both parsers now skip those, which is what the validation layer already did with
them. A trailing colon (`is:`) is still a value, the empty string; only "no
separator at all" is malformed. Both cases are pinned.

---

# 2. Non-onboarded users hit a 404 instead of onboarding (D122)

```ts
return redirect("onboarding");   // relative
```

The target resolved against whatever URL the user arrived at. From the root that
happens to be correct; from anywhere deeper it isn't. Someone following a QR
link or a link from an email lands on `/assets/<id>/overview`, and a relative
`onboarding` sends them to `/assets/<id>/onboarding` — which doesn't exist. The
first thing a brand-new user saw was a 404.

The guard sits in the authenticated layout, so it covers every route beneath it.

**No test.** `_layout.tsx` imports the whole component tree (jotai, sidebar,
command palette), so a loader test would be almost entirely mock scaffolding for
a one-token change. Happy to add one if a reviewer would rather have the guard
than not.

---

## Verification

16 new tests. Mutations confirm each layer's tests catch **its own** bug, not
just the shared helper's:

| Mutation | Result |
| --- | --- |
| restore split-on-every-colon in the helper | 5 failures |
| restore `parts.length !== 2` in the validation | 1 failure — and only that test |

- 732 tests pass across 49 asset/component files
- `tsc -b --force` clean, ESLint clean, Prettier clean

No migration. No schema change. No new dependency.

Closes the `detail.dev` D121 and D122 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Advanced filters now preserve colons within values, including URLs and barcode payloads.
  * Invalid or incomplete filter parameters are handled consistently without creating empty filter rows.
  * Users who need onboarding are now redirected correctly from deep links and nested pages.

* **Tests**
  * Added coverage for colon-containing values, missing separators, empty values, and unsupported operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->