### PR TITLE
fix(audits): record the scan removal in the activity stream, and cover the mobile endpoint

### DIFF
--- a/apps/webapp/app/modules/audit/remove-scan.server.test.ts
+++ b/apps/webapp/app/modules/audit/remove-scan.server.test.ts
@@ -5,9 +5,11 @@
  *
  * The contract under test: an EXPECTED asset's row survives the removal and
  * returns to MISSING with its scan facts cleared; an UNEXPECTED asset's row is
- * deleted outright (only the scan created it); and the session's aggregate
- * counts are recomputed from the rows, never incremented, so they cannot
- * drift from what the rows say.
+ * deleted outright (only the scan created it); the session's aggregate counts
+ * are recomputed from the rows, never incremented, so they cannot drift from
+ * what the rows say; and an `AUDIT_ASSET_SCAN_REMOVED` activity event is
+ * emitted in the same transaction, so the stream that recorded the scan going
+ * in also records it coming out.
  *
  * @see {@link file://./service.server.ts} — `removeAuditScan`
  */
@@ -15,6 +17,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "~/database/db.server";
+import { recordEvent } from "~/modules/activity-event/service.server";
 import { removeAuditScan } from "~/modules/audit/service.server";
 
 // why: the subject is the branch logic and the recompute; the database is the
@@ -49,6 +52,15 @@ vi.mock("~/modules/audit/helpers.server", () => ({
   createAssetScanRemovedNote: vi.fn(),
 }));
 
+// why: `recordEvent` writes through the transaction client, which is the same
+// mock as `db` here — the real implementation would reach for delegates this
+// suite does not stub. The argument it is called with IS the assertion, so it
+// is captured rather than executed.
+vi.mock("~/modules/activity-event/service.server", () => ({
+  recordEvent: vi.fn(),
+  recordEvents: vi.fn(),
+}));
+
 const session = {
   status: "ACTIVE",
   foundAssetCount: 3,
@@ -65,6 +77,12 @@ const ARGS = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `clearAllMocks` clears call history but does NOT drain a
+  // `mockResolvedValueOnce` queue, so a case that never reaches the recompute
+  // (no scan, dead audit, cross-org) leaves its three queued counts at the
+  // head for the NEXT test to consume. Reset this one mock so each case reads
+  // the values it queued rather than a predecessor's.
+  vi.mocked(db.auditAsset.count).mockReset();
   vi.mocked(db.auditSession.findFirst).mockResolvedValue(session as never);
   // Recomputed counts after the removal: found, missing, unexpected.
   vi.mocked(db.auditAsset.count)
@@ -130,6 +148,69 @@ describe("removeAuditScan", () => {
     });
   });
 
+  it("emits AUDIT_ASSET_SCAN_REMOVED so the scan's removal reaches reports", async () => {
+    // The counterpart to recordAuditScan's AUDIT_ASSET_SCANNED. Without it a
+    // report counting scans on a corrected audit overstates it — the scan goes
+    // into the stream and never comes out.
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue({
+      id: "scan-1",
+      auditAsset: { id: "aa-1", expected: true },
+    } as never);
+
+    await removeAuditScan(ARGS);
+
+    expect(recordEvent).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(recordEvent).mock.calls[0][0]).toEqual({
+      organizationId: "org-1",
+      actorUserId: "user-1",
+      action: "AUDIT_ASSET_SCAN_REMOVED",
+      entityType: "AUDIT",
+      entityId: "audit-1",
+      auditSessionId: "audit-1",
+      auditAssetId: "aa-1",
+      assetId: "asset-1",
+      meta: { isExpected: true },
+    });
+  });
+
+  it("carries the deleted row's id on the unexpected branch, so the pair stays joinable", async () => {
+    // The AuditAsset row is deleted here, but `auditAssetId` on ActivityEvent
+    // is a plain scalar with no FK — keeping it is what lets a reader match
+    // this event to the AUDIT_ASSET_SCANNED that created the row.
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue({
+      id: "scan-2",
+      auditAsset: { id: "aa-2", expected: false },
+    } as never);
+
+    await removeAuditScan(ARGS);
+
+    expect(vi.mocked(recordEvent).mock.calls[0][0]).toMatchObject({
+      auditAssetId: "aa-2",
+      meta: { isExpected: false },
+    });
+  });
+
+  it("writes the event through the same transaction as the mutation", async () => {
+    // An event committed outside the transaction can outlive a rollback and
+    // report a removal that never happened.
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue({
+      id: "scan-1",
+      auditAsset: { id: "aa-1", expected: true },
+    } as never);
+
+    await removeAuditScan(ARGS);
+
+    expect(vi.mocked(recordEvent).mock.calls[0][1]).toBe(db);
+  });
+
+  it("emits no event when there was no scan to remove", async () => {
+    vi.mocked(db.auditScan.findFirst).mockResolvedValue(null as never);
+
+    await removeAuditScan(ARGS);
+
+    expect(recordEvent).not.toHaveBeenCalled();
+  });
+
   it("reports removed: false when no scan exists, touching nothing", async () => {
     vi.mocked(db.auditScan.findFirst).mockResolvedValue(null as never);
 
@@ -147,13 +228,20 @@ describe("removeAuditScan", () => {
     } as never);
 
     await expect(removeAuditScan(ARGS)).rejects.toThrow(/no longer live/i);
-    expect(db.$transaction).not.toHaveBeenCalled();
+    // The status is re-read INSIDE the transaction (an audit can complete
+    // between a check outside it and the write), so the assertion is that
+    // nothing was mutated — a stronger claim than "no transaction opened".
+    expect(db.auditScan.delete).not.toHaveBeenCalled();
+    expect(db.auditAsset.update).not.toHaveBeenCalled();
+    expect(db.auditAsset.delete).not.toHaveBeenCalled();
+    expect(db.auditSession.update).not.toHaveBeenCalled();
   });
 
   it("404s for a session outside the caller's organization", async () => {
     vi.mocked(db.auditSession.findFirst).mockResolvedValue(null as never);
 
     await expect(removeAuditScan(ARGS)).rejects.toThrow(/not found/i);
-    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(db.auditScan.findFirst).not.toHaveBeenCalled();
+    expect(db.auditSession.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1716,39 +1716,43 @@ export async function removeAuditScan(
   const { auditSessionId, assetId, userId, organizationId } = input;
 
   try {
-    const session = await db.auditSession.findFirst({
-      where: { id: auditSessionId, organizationId },
-      select: {
-        status: true,
-        foundAssetCount: true,
-        missingAssetCount: true,
-        unexpectedAssetCount: true,
-      },
-    });
-
-    if (!session) {
-      throw new ShelfError({
-        cause: null,
-        message: "Audit session not found",
-        additionalData: { auditSessionId, organizationId },
-        status: 404,
-        label,
-      });
-    }
-
-    if (session.status !== "PENDING" && session.status !== "ACTIVE") {
-      throw new ShelfError({
-        cause: null,
-        message:
-          "This audit is no longer live, so its scans cannot be changed.",
-        additionalData: { auditSessionId, status: session.status },
-        status: 400,
-        label,
-        shouldBeCaptured: false,
-      });
-    }
-
     return await db.$transaction(async (tx) => {
+      // Read the session INSIDE the transaction. Reading it outside left a
+      // window where an audit completed between the status check and the
+      // write, so a removal could rewrite the numbers of an audit that had
+      // already been reported.
+      const session = await tx.auditSession.findFirst({
+        where: { id: auditSessionId, organizationId },
+        select: {
+          status: true,
+          foundAssetCount: true,
+          missingAssetCount: true,
+          unexpectedAssetCount: true,
+        },
+      });
+
+      if (!session) {
+        throw new ShelfError({
+          cause: null,
+          message: "Audit session not found",
+          additionalData: { auditSessionId, organizationId },
+          status: 404,
+          label,
+        });
+      }
+
+      if (session.status !== "PENDING" && session.status !== "ACTIVE") {
+        throw new ShelfError({
+          cause: null,
+          message:
+            "This audit is no longer live, so its scans cannot be changed.",
+          additionalData: { auditSessionId, status: session.status },
+          status: 400,
+          label,
+          shouldBeCaptured: false,
+        });
+      }
+
       const existingScan = await tx.auditScan.findFirst({
         where: {
           auditSessionId,
@@ -1817,6 +1821,29 @@ export async function removeAuditScan(
           userId,
           tx,
         }),
+        // Activity event — AUDIT_ASSET_SCAN_REMOVED, the counterpart to the
+        // AUDIT_ASSET_SCANNED that `recordAuditScan` emits. Without it the
+        // stream shows scans going in and never coming out, so a report
+        // counting scans on a corrected audit overstates it.
+        //
+        // `auditAssetId` is carried even on the unexpected branch, where the
+        // row has just been deleted: it is a plain scalar with no FK, and
+        // keeping it is what lets a reader pair this event with the
+        // AUDIT_ASSET_SCANNED that created that row.
+        recordEvent(
+          {
+            organizationId,
+            actorUserId: userId,
+            action: "AUDIT_ASSET_SCAN_REMOVED",
+            entityType: "AUDIT",
+            entityId: auditSessionId,
+            auditSessionId,
+            auditAssetId: existingScan.auditAsset?.id,
+            assetId,
+            meta: { isExpected: existingScan.auditAsset?.expected ?? false },
+          },
+          tx
+        ),
       ]);
 
       return {

--- a/apps/webapp/test/routes-tests/api+/mobile.audits.remove-scan.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.audits.remove-scan.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Test suite for POST /api/mobile/audits/remove-scan.
+ *
+ * `removeAuditScan` (the service) has its own behaviour tests, and its JSDoc is
+ * explicit that "callers own authentication and assignee gating" — so the auth
+ * stack is exactly what this endpoint adds and exactly what needs covering
+ * here: the Audits add-on gate, the `audit: update` permission, the assignee
+ * gate, and the role resolution that decides whether the assignee gate binds.
+ *
+ * `parseMobileBody`, `resolveMostPrivilegedRole` and the error helpers are the
+ * REAL implementations. They are the logic under test — mocking them would
+ * leave the route's own wiring unexercised. Only the two boundaries that reach
+ * Supabase and Postgres are stubbed.
+ *
+ * @see {@link file://./../../../app/routes/api+/mobile+/audits.remove-scan.ts}
+ */
+import { action } from "~/routes/api+/mobile+/audits.remove-scan";
+import { createActionArgs } from "@mocks/remix";
+
+// @vitest-environment node
+
+// why: mocking Remix's data() so the handler can be invoked directly and its
+// response read as a plain Response (React Router v7 single fetch).
+const createDataMock = vi.hoisted(
+  () => () =>
+    vi.fn(
+      (body: unknown, init?: ResponseInit) =>
+        new Response(JSON.stringify(body), {
+          status: init?.status || 200,
+          headers: {
+            "Content-Type": "application/json",
+            ...(init?.headers || {}),
+          },
+        })
+    )
+);
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, data: createDataMock() };
+});
+
+// why: external auth — these reach Supabase, which tests must not.
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+  getMobileUserContext: vi.fn(),
+  requireMobilePermission: vi.fn(),
+}));
+
+// why: the service has its own behaviour suite (remove-scan.server.test.ts);
+// here it is a boundary whose ARGUMENTS are the assertion.
+vi.mock("~/modules/audit/service.server", () => ({
+  removeAuditScan: vi.fn(),
+  requireAuditAssignee: vi.fn(),
+}));
+
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+  requireMobilePermission,
+} from "~/modules/api/mobile-auth.server";
+import {
+  removeAuditScan,
+  requireAuditAssignee,
+} from "~/modules/audit/service.server";
+import { ShelfError } from "~/utils/error";
+
+const mockUser = { id: "user-1", email: "test@example.com" };
+
+/** A well-formed remove-scan request; `body` may be a string to send raw. */
+function createRemoveScanRequest(
+  body: Record<string, unknown> | string,
+  orgId = "org-1"
+) {
+  return new Request(
+    `http://localhost/api/mobile/audits/remove-scan?orgId=${orgId}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer token",
+      },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }
+  );
+}
+
+const VALID_BODY = { auditSessionId: "session-1", assetId: "asset-1" };
+
+describe("POST /api/mobile/audits/remove-scan", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(requireMobileAuth).mockResolvedValue({
+      user: mockUser,
+      authUser: { id: "auth-user-1", email: mockUser.email },
+    } as never);
+    vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1" as never);
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      roles: ["ADMIN"],
+      canUseAudits: true,
+    } as never);
+    vi.mocked(requireMobilePermission).mockResolvedValue(undefined as never);
+    vi.mocked(requireAuditAssignee).mockResolvedValue(undefined as never);
+    vi.mocked(removeAuditScan).mockResolvedValue({
+      removed: true,
+      foundAssetCount: 2,
+      missingAssetCount: 2,
+      unexpectedAssetCount: 1,
+    });
+  });
+
+  it("removes the scan and returns the recomputed counts", async () => {
+    const result = (await action(
+      createActionArgs({ request: createRemoveScanRequest(VALID_BODY) })
+    )) as unknown as Response;
+
+    expect(result.status).toBe(200);
+    const body = await result.json();
+    expect(body).toEqual({
+      success: true,
+      removed: true,
+      foundAssetCount: 2,
+      missingAssetCount: 2,
+      unexpectedAssetCount: 1,
+    });
+
+    expect(removeAuditScan).toHaveBeenCalledWith({
+      auditSessionId: "session-1",
+      assetId: "asset-1",
+      userId: "user-1",
+      organizationId: "org-1",
+    });
+  });
+
+  it("passes an ADMIN through the assignee gate unrestricted", async () => {
+    await action(
+      createActionArgs({ request: createRemoveScanRequest(VALID_BODY) })
+    );
+
+    expect(requireAuditAssignee).toHaveBeenCalledWith({
+      auditSessionId: "session-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
+    });
+  });
+
+  it("resolves the most privileged role, not the first one on the membership", async () => {
+    // A membership carries roles as an array in no guaranteed order. Reading
+    // roles[0] would treat this genuine admin as restricted and gate them to
+    // audits they are assigned to. Pinned because the sibling record-scan
+    // endpoint still reads the bare `role`, so this is easy to "simplify" back.
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      roles: ["SELF_SERVICE", "ADMIN"],
+      canUseAudits: true,
+    } as never);
+
+    await action(
+      createActionArgs({ request: createRemoveScanRequest(VALID_BODY) })
+    );
+
+    expect(requireAuditAssignee).toHaveBeenCalledWith(
+      expect.objectContaining({ isSelfServiceOrBase: false })
+    );
+  });
+
+  it("binds the assignee gate for a SELF_SERVICE user", async () => {
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      roles: ["SELF_SERVICE"],
+      canUseAudits: true,
+    } as never);
+
+    await action(
+      createActionArgs({ request: createRemoveScanRequest(VALID_BODY) })
+    );
+
+    expect(requireAuditAssignee).toHaveBeenCalledWith(
+      expect.objectContaining({ isSelfServiceOrBase: true })
+    );
+  });
+
+  it("403s when the workspace has no Audits add-on, without touching the audit", async () => {
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      roles: ["ADMIN"],
+      canUseAudits: false,
+    } as never);
+
+    const result = (await action(
+      createActionArgs({ request: createRemoveScanRequest(VALID_BODY) })
+    )) as unknown as Response;
+
+    expect(result.status).toBe(403);
+    expect(removeAuditScan).not.toHaveBeenCalled();
+    expect(requireAuditAssignee).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the assignee rejection and never reaches the service", async () => {
+    // Removing a scan rewrites audit data, so a non-assignee must not be able
+    // to hollow out an audit they are not part of.
+    vi.mocked(getMobileUserContext).mockResolvedValue({
+      roles: ["BASE"],
+      canUseAudits: true,
+    } as never);
+    // The real guard throws a ShelfError carrying its own status; a bare
+    // Error with a `status` property would be wrapped into a 500 by
+    // makeShelfError, which is not what this path does in production.
+    vi.mocked(requireAuditAssignee).mockRejectedValue(
+      new ShelfError({
+        cause: null,
+        message:
+          "Only users assigned to this audit can perform this action. Please contact the audit creator to be assigned.",
+        label: "Audit",
+        status: 403,
+        shouldBeCaptured: false,
+      })
+    );
+
+    const result = (await action(
+      createActionArgs({ request: createRemoveScanRequest(VALID_BODY) })
+    )) as unknown as Response;
+
+    expect(result.status).toBe(403);
+    expect(removeAuditScan).not.toHaveBeenCalled();
+  });
+
+  it("400s a malformed body instead of 500-ing on it", async () => {
+    // A bare ZodError reaches makeShelfError's generic branch and becomes a
+    // captured 500; parseMobileBody is what keeps client input on the 400 path.
+    const result = (await action(
+      createActionArgs({
+        request: createRemoveScanRequest({ auditSessionId: "session-1" }),
+      })
+    )) as unknown as Response;
+
+    expect(result.status).toBe(400);
+    expect(removeAuditScan).not.toHaveBeenCalled();
+  });
+
+  it("400s a body that is not JSON at all", async () => {
+    const result = (await action(
+      createActionArgs({ request: createRemoveScanRequest("not json{") })
+    )) as unknown as Response;
+
+    expect(result.status).toBe(400);
+    expect(removeAuditScan).not.toHaveBeenCalled();
+  });
+
+  it("reports removed: false when there was no scan to remove", async () => {
+    // Idempotent by design: a double-tap on the phone is not an error.
+    vi.mocked(removeAuditScan).mockResolvedValue({
+      removed: false,
+      foundAssetCount: 3,
+      missingAssetCount: 1,
+      unexpectedAssetCount: 1,
+    });
+
+    const result = (await action(
+      createActionArgs({ request: createRemoveScanRequest(VALID_BODY) })
+    )) as unknown as Response;
+
+    expect(result.status).toBe(200);
+    expect((await result.json()).removed).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to **#2933** (merged as `78cb3e498`), closing two gaps found reviewing
it after the merge.

## 1. The scan removal never reached the activity stream

`ActivityAction` has carried `AUDIT_ASSET_SCAN_REMOVED` since audits shipped,
and **nothing has ever emitted it**. `recordAuditScan` emits
`AUDIT_ASSET_SCANNED`, so the stream showed scans going in and never coming out:
a report counting scans on an audit that had since been corrected overstated it,
and the correction itself was invisible.

`removeAuditScan` now emits it in the same transaction as the note it already
writes, per `.claude/rules/use-record-event.md` — that rule fires on both counts
here, since the function writes a system note *and* changes `AuditAsset.status`.

The event carries `auditAssetId` even on the unexpected-asset branch, where that
row has just been deleted. That is deliberate and was checked against the schema
first: `ActivityEvent.auditAssetId` is a plain nullable scalar with **no foreign
key**, so there is no cascade that would delete the event and no constraint to
violate — and keeping the id is what lets a reader pair the removal with the
`AUDIT_ASSET_SCANNED` that created the row.

This gap predates #2933 (there was no shared removal path to hang the event on
before it). It is fixed here because that PR created the single chokepoint where
it belongs, and took the number of doors onto this operation from one to two.

## 2. The mobile endpoint's auth stack had no route test

Every sibling mobile audit endpoint has one — `record-scan`, `complete`, `note`,
`image`, `evidence`. `remove-scan` shipped without.

The service's five tests cover its branch logic, but its own JSDoc says
*"Callers own authentication and assignee gating"* — so the auth stack is
exactly what the endpoint adds and exactly what was uncovered on a new mobile
**write** endpoint.

Nine cases: the Audits add-on gate, the assignee gate, the role resolution that
decides whether that gate binds, the malformed-body path, and the idempotent
`removed: false` response. `parseMobileBody`, `resolveMostPrivilegedRole` and
the error helpers run for **real** — they are the wiring under test, and mocking
them would have left it unexercised. Only the two boundaries that reach Supabase
and Postgres are stubbed.

## Also in here

**The status check moved inside the transaction.** Read outside it, there was a
window where an audit completed between the check and the write, so a removal
could rewrite the numbers of an audit that had already been reported. The two
guard tests now assert that *nothing was mutated*, which is a stronger claim
than the "no transaction opened" they made before.

**A preventive test-hygiene fix, stated as such:** `vi.clearAllMocks()` does not
drain a `mockResolvedValueOnce` queue, so the three cases that never reach the
recompute were leaving their queued counts at the head for the next test to
consume. I verified the behaviour with a standalone probe rather than assuming
it. No assertion changes as a result — it is invisible today only because every
case queues the same triple — so this is a trap removed, not a bug fixed.

## Testing

- 361 audit tests pass across 19 files; typecheck and lint clean.
- **Mutation-verified**, since a test that cannot fail is not coverage:
  - deleting the `recordEvent` call turns 3 tests red;
  - swapping `resolveMostPrivilegedRole(roles)` for `roles[0]` turns the role
    test red.

## Deliberately NOT in here

**The `role` vs `roles` question**, which I initially flagged as a live
inconsistency and then disproved. 24 mobile routes derive authorization from
`getMobileUserContext().role`, which `mobile-auth.server.ts:299` documents as
`roles[0]` and "wrong for any authorization decision". But **no membership can
currently hold two roles**: every write site sets a single-element array, no
migration creates multi-role rows, and nothing pushes onto the array. The bug is
latent, not reachable, and not worth 24 files of churn.

`remove-scan` already resolves it correctly, and the new route test pins that
behaviour — so if the data model ever does grow multi-role memberships, there is
a worked reference for the sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit scan removal now validates audit status and performs deletion atomically, preventing changes after an audit is completed.
  * Removal activity is recorded with the relevant scan details.
  * Improved handling of missing scans, unauthorized roles, invalid requests, and unavailable audit features.

* **Tests**
  * Added comprehensive coverage for scan removal, permissions, error responses, idempotent behavior, and activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->