### PR TITLE
fix(assets): resume the asset sequence above the highest id, not the count

### DIFF
--- a/apps/webapp/app/modules/asset/sequential-id-bulk-sequence.test.ts
+++ b/apps/webapp/app/modules/asset/sequential-id-bulk-sequence.test.ts
@@ -26,7 +26,6 @@ vi.mock("~/database/db.server", () => ({
   db: {
     $executeRaw: vi.fn(),
     $queryRaw: vi.fn(),
-    asset: { count: vi.fn(), findFirst: vi.fn() },
   },
 }));
 
@@ -46,30 +45,23 @@ function sqlOf(strings: unknown): string {
 /**
  * Stands the service up against an in-memory model of one organization.
  *
- * @param options.highestExisting - The highest number already assigned, which
- *   is what the sequence has to clear
- * @param options.numberedAssets - How many assets already carry an id. Lower
- *   than `highestExisting` is the ordinary state of any org that has ever
- *   deleted a numbered asset.
+ * @param options.highestExisting - The highest number already issued, which is
+ *   what the sequence has to clear. How many assets still CARRY one is not a
+ *   parameter, because it is not something the service reads — which is the
+ *   whole point: only the maximum bounds what is safe to issue next.
  * @param options.unnumbered - How many assets the backfill has to number
  * @returns The value handed to `setval`, and the `is_called` flag beside it
  */
 function runBackfill({
   highestExisting,
-  numberedAssets,
   unnumbered,
 }: {
   highestExisting: number;
-  numberedAssets: number;
   unnumbered: number;
 }) {
   const state = { max: highestExisting };
   let setvalArgs: unknown[] = [];
   let setvalSql = "";
-
-  vi.mocked(db.asset.count).mockResolvedValue(
-    (numberedAssets + unnumbered) as never
-  );
 
   vi.mocked(db.$queryRaw).mockImplementation(((strings: unknown) => {
     const sql = sqlOf(strings);
@@ -123,7 +115,6 @@ describe("generateBulkSequentialIdsEfficient — where the sequence resumes", ()
   it("resumes above the highest id when numbering has no gaps", async () => {
     const { value, finalMax } = await runBackfill({
       highestExisting: 10,
-      numberedAssets: 10,
       unnumbered: 5,
     });
 
@@ -132,13 +123,12 @@ describe("generateBulkSequentialIdsEfficient — where the sequence resumes", ()
   });
 
   it("resumes above the highest id even when assets have been deleted", async () => {
-    // 20 numbers issued, 12 assets still carrying one: eight were deleted. The
-    // count is 12 and the maximum is 20, and only one of those is safe to
-    // resume from. Resuming at the count would re-issue ids 13 through 20,
-    // every one of which is still taken.
+    // 20 numbers have been issued, and some of those assets have since been
+    // deleted — so fewer than 20 assets carry an id, while ids up to 20 are
+    // still spoken for. Anything derived from how many assets remain lands
+    // below 20 and re-issues ids that exist; only the maximum bounds it.
     const { value, finalMax } = await runBackfill({
       highestExisting: 20,
-      numberedAssets: 12,
       unnumbered: 3,
     });
 
@@ -150,7 +140,6 @@ describe("generateBulkSequentialIdsEfficient — where the sequence resumes", ()
     // The property the unique index cares about, stated directly.
     const { value, finalMax } = await runBackfill({
       highestExisting: 500,
-      numberedAssets: 4,
       unnumbered: 0,
     });
 
@@ -163,7 +152,6 @@ describe("generateBulkSequentialIdsEfficient — where the sequence resumes", ()
     // silently burns the first id — the third argument is what avoids it.
     const { value, isCalled } = await runBackfill({
       highestExisting: 0,
-      numberedAssets: 0,
       unnumbered: 0,
     });
 

--- a/apps/webapp/app/modules/asset/sequential-id-bulk-sequence.test.ts
+++ b/apps/webapp/app/modules/asset/sequential-id-bulk-sequence.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Where the org's asset sequence resumes after a bulk backfill.
+ *
+ * `generateBulkSequentialIdsEfficient` numbers every asset that has no
+ * sequential id yet, then points the Postgres sequence at where new assets
+ * should carry on from. Getting that landing point wrong is not cosmetic:
+ * `Asset` is unique on `(organizationId, sequentialId)`, so a sequence sitting
+ * below an id that already exists hands out a duplicate, `createAsset` takes a
+ * P2002, and with only three attempts a wide enough gap fails the creation
+ * outright in front of the user.
+ *
+ * The count of numbered assets and the highest number among them are the same
+ * figure only while numbering is unbroken. Deleting a numbered asset drops the
+ * count and leaves the maximum alone, and from then on they disagree by one
+ * more for every deletion.
+ *
+ * @see {@link file://./sequential-id.server.ts}
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { db } from "~/database/db.server";
+
+// why: the whole behaviour under test is which value reaches `setval`, so the
+// raw calls are stubbed and asserted on rather than run against a database.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    $executeRaw: vi.fn(),
+    $queryRaw: vi.fn(),
+    asset: { count: vi.fn(), findFirst: vi.fn() },
+  },
+}));
+
+// @vitest-environment node
+
+const { generateBulkSequentialIdsEfficient } = await import(
+  "./sequential-id.server"
+);
+
+const ORG = "org-1";
+
+/** Flattens a tagged-template call into something matchable. */
+function sqlOf(strings: unknown): string {
+  return Array.isArray(strings) ? strings.join("?") : String(strings);
+}
+
+/**
+ * Stands the service up against an in-memory model of one organization.
+ *
+ * @param options.highestExisting - The highest number already assigned, which
+ *   is what the sequence has to clear
+ * @param options.numberedAssets - How many assets already carry an id. Lower
+ *   than `highestExisting` is the ordinary state of any org that has ever
+ *   deleted a numbered asset.
+ * @param options.unnumbered - How many assets the backfill has to number
+ * @returns The value handed to `setval`, and the `is_called` flag beside it
+ */
+function runBackfill({
+  highestExisting,
+  numberedAssets,
+  unnumbered,
+}: {
+  highestExisting: number;
+  numberedAssets: number;
+  unnumbered: number;
+}) {
+  const state = { max: highestExisting };
+  let setvalArgs: unknown[] = [];
+  let setvalSql = "";
+
+  vi.mocked(db.asset.count).mockResolvedValue(
+    (numberedAssets + unnumbered) as never
+  );
+
+  vi.mocked(db.$queryRaw).mockImplementation(((strings: unknown) => {
+    const sql = sqlOf(strings);
+    if (sql.includes("max_num")) {
+      return Promise.resolve([{ max_num: state.max }]);
+    }
+    if (sql.includes("IS NULL")) {
+      return Promise.resolve(
+        Array.from({ length: unnumbered }, (_, i) => ({ id: `asset-${i}` }))
+      );
+    }
+    return Promise.resolve([]);
+  }) as never);
+
+  vi.mocked(db.$executeRaw).mockImplementation(((
+    strings: unknown,
+    ...values: unknown[]
+  ) => {
+    const sql = sqlOf(strings);
+    if (sql.includes("setval")) {
+      setvalArgs = values;
+      setvalSql = sql;
+      return Promise.resolve(1);
+    }
+    if (sql.includes("UPDATE")) {
+      // The backfill numbers from `max + 1` upward, so the highest id in the
+      // organization climbs by however many rows it just wrote.
+      state.max += unnumbered;
+      return Promise.resolve(unnumbered);
+    }
+    return Promise.resolve(0);
+  }) as never);
+
+  return generateBulkSequentialIdsEfficient(ORG).then(() => ({
+    /** The number `setval` was given. */
+    value: setvalArgs[1] as number,
+    /**
+     * The literal `is_called` argument. It is written into the statement
+     * rather than bound, so it is read back off the SQL, not the values.
+     */
+    isCalled: /,\s*false\s*\)/.test(setvalSql),
+    finalMax: state.max,
+  }));
+}
+
+describe("generateBulkSequentialIdsEfficient — where the sequence resumes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resumes above the highest id when numbering has no gaps", async () => {
+    const { value, finalMax } = await runBackfill({
+      highestExisting: 10,
+      numberedAssets: 10,
+      unnumbered: 5,
+    });
+
+    expect(finalMax).toBe(15);
+    expect(value).toBeGreaterThan(15);
+  });
+
+  it("resumes above the highest id even when assets have been deleted", async () => {
+    // 20 numbers issued, 12 assets still carrying one: eight were deleted. The
+    // count is 12 and the maximum is 20, and only one of those is safe to
+    // resume from. Resuming at the count would re-issue ids 13 through 20,
+    // every one of which is still taken.
+    const { value, finalMax } = await runBackfill({
+      highestExisting: 20,
+      numberedAssets: 12,
+      unnumbered: 3,
+    });
+
+    expect(finalMax).toBe(23);
+    expect(value).toBeGreaterThan(23);
+  });
+
+  it("never resumes at or below an id that already exists", async () => {
+    // The property the unique index cares about, stated directly.
+    const { value, finalMax } = await runBackfill({
+      highestExisting: 500,
+      numberedAssets: 4,
+      unnumbered: 0,
+    });
+
+    expect(value).toBeGreaterThan(finalMax);
+  });
+
+  it("still issues the first id to an organization with no assets", async () => {
+    // An empty organization must start at 1. The two-argument `setval` makes
+    // the next value one HIGHER than what it is given, so clamping to 1 there
+    // silently burns the first id — the third argument is what avoids it.
+    const { value, isCalled } = await runBackfill({
+      highestExisting: 0,
+      numberedAssets: 0,
+      unnumbered: 0,
+    });
+
+    // `setval(seq, 1)` would leave the next value at 2; `setval(seq, 1, false)`
+    // hands out 1 itself.
+    expect(isCalled).toBe(true);
+    expect(value).toBe(1);
+  });
+});

--- a/apps/webapp/app/modules/asset/sequential-id.server.ts
+++ b/apps/webapp/app/modules/asset/sequential-id.server.ts
@@ -71,7 +71,7 @@ export async function getNextSequentialId(
  *
  * @param organizationId - The organization to look within
  * @param prefix - The id prefix to measure, e.g. `SAM`
- * @returns The highest number issued, or `0` when none has been
+ * @returns The highest number issued, or `0` when none has been issued
  */
 async function getHighestIssuedNumber(
   organizationId: string,

--- a/apps/webapp/app/modules/asset/sequential-id.server.ts
+++ b/apps/webapp/app/modules/asset/sequential-id.server.ts
@@ -58,6 +58,42 @@ export async function getNextSequentialId(
 }
 
 /**
+ * The highest number currently issued under `prefix` in this organization.
+ *
+ * Read from the assets themselves rather than from the sequence, because the
+ * two can disagree — the sequence is a counter that anything may have moved,
+ * while the assets are the ids that actually exist and that
+ * `(organizationId, sequentialId)` is unique on.
+ *
+ * Numeric extraction, not string ordering: `SAM-9` sorts after `SAM-10` as
+ * text. Ids under a different prefix count as 0, since they cannot collide
+ * with one issued under this one.
+ *
+ * @param organizationId - The organization to look within
+ * @param prefix - The id prefix to measure, e.g. `SAM`
+ * @returns The highest number issued, or `0` when none has been
+ */
+async function getHighestIssuedNumber(
+  organizationId: string,
+  prefix: string
+): Promise<number> {
+  const rows = await db.$queryRaw<[{ max_num: number | null }]>`
+    SELECT COALESCE(MAX(
+      CASE
+        WHEN "sequentialId" ~ ('^' || ${prefix} || '-[0-9]+$')
+        THEN CAST(SUBSTRING("sequentialId" FROM (${prefix} || '-([0-9]+)')) AS INTEGER)
+        ELSE 0
+      END
+    ), 0) as max_num
+    FROM "Asset"
+    WHERE "organizationId" = ${organizationId}
+    AND "sequentialId" IS NOT NULL
+  `;
+
+  return rows[0]?.max_num || 0;
+}
+
+/**
  * Estimates what the next sequential ID would be without consuming the sequence
  * Safe to use for previews and UI display purposes
  *
@@ -112,20 +148,7 @@ export async function estimateNextSequentialId(
 
   // Fallback: derive the estimate from the highest existing sequential ID using proper
   // numeric extraction. This avoids string-sorting issues once IDs grow beyond 9999.
-  const maxExisting = await db.$queryRaw<[{ max_num: number | null }]>`
-    SELECT COALESCE(MAX(
-      CASE
-        WHEN "sequentialId" ~ ('^' || ${prefix} || '-[0-9]+$')
-        THEN CAST(SUBSTRING("sequentialId" FROM (${prefix} || '-([0-9]+)')) AS INTEGER)
-        ELSE 0
-      END
-    ), 0) as max_num
-    FROM "Asset"
-    WHERE "organizationId" = ${organizationId}
-    AND "sequentialId" IS NOT NULL
-  `;
-
-  const highestNumber = maxExisting[0]?.max_num || 0;
+  const highestNumber = await getHighestIssuedNumber(organizationId, prefix);
   return formatSequentialId(highestNumber + 1, prefix);
 }
 
@@ -267,22 +290,10 @@ export async function generateBulkSequentialIdsEfficient(
     // Ensure sequence exists
     await createOrganizationSequence(organizationId);
 
-    // First, find the highest existing sequential ID to avoid conflicts
-    // Using proper regex pattern [0-9]+ instead of \d to handle 1000+ assets
-    const maxExisting = await db.$queryRaw<[{ max_num: number | null }]>`
-      SELECT COALESCE(MAX(
-        CASE 
-          WHEN "sequentialId" ~ ('^' || ${prefix} || '-[0-9]+$')
-          THEN CAST(SUBSTRING("sequentialId" FROM (${prefix} || '-([0-9]+)')) AS INTEGER)
-          ELSE 0 
-        END
-      ), 0) as max_num
-      FROM "Asset"
-      WHERE "organizationId" = ${organizationId} 
-      AND "sequentialId" IS NOT NULL
-    `;
-
-    const startingNumber = (maxExisting[0]?.max_num || 0) + 1;
+    // Number from above the highest id already issued, so nothing written here
+    // can collide with one that exists.
+    const startingNumber =
+      (await getHighestIssuedNumber(organizationId, prefix)) + 1;
 
     // The CTE approach is creating duplicates - let's use batch processing instead
     // First, get all asset IDs that need sequential IDs, ordered consistently
@@ -334,18 +345,28 @@ export async function generateBulkSequentialIdsEfficient(
     }
 
     const result = totalUpdated;
-    // Update the sequence to continue from the right place for new assets
-    const totalAssetsWithIds = await db.asset.count({
-      where: {
-        organizationId,
-        sequentialId: { not: null },
-      },
-    });
 
+    // Resume the sequence above the HIGHEST id now issued, never the count of
+    // them. The two agree only while numbering is unbroken: deleting a numbered
+    // asset drops the count and leaves the maximum where it was, so an
+    // organization that has ever deleted one would resume at a number it has
+    // already used. `(organizationId, sequentialId)` is unique, so the next
+    // asset creation collides — and `createAsset` gives up after three
+    // attempts, which a gap of three or more exhausts in front of the user.
+    //
+    // Re-read rather than deriving from `startingNumber + totalUpdated`: the
+    // batch writes are guarded on `sequentialId IS NULL`, so a row filled
+    // concurrently is skipped and the arithmetic would drift below the truth.
+    const highestIssued = await getHighestIssuedNumber(organizationId, prefix);
+
+    // Three-argument form: `is_called = false` makes the next `nextval` return
+    // exactly this value instead of one past it. That is what lets an
+    // organization with no assets still be handed id 1.
     await db.$executeRaw`
       SELECT setval(
-        'org_' || ${organizationId} || '_asset_sequence', 
-        GREATEST(${totalAssetsWithIds}, 1)
+        'org_' || ${organizationId} || '_asset_sequence',
+        ${highestIssued + 1},
+        false
       )
     `;
 


### PR DESCRIPTION
## The bug

`generateBulkSequentialIdsEfficient` numbers every asset that has no sequential
id, then points the organization's Postgres sequence at where new assets should
carry on from. It chose the **count** of numbered assets:

```ts
const startingNumber = (maxExisting[0]?.max_num || 0) + 1;   // MAX — "to avoid conflicts"
…
setval('org_…_asset_sequence', GREATEST(totalAssetsWithIds, 1))   // COUNT
```

The same function reads **MAX** to decide where to start and writes **COUNT** as
where to resume. That self-contradiction is the clearest evidence this was a
slip rather than deliberate gap-filling — nothing anywhere reassigns existing
ids, and the backfill only ever touches rows where `sequentialId IS NULL`.

## Why it bites

The two figures agree only while numbering is unbroken. Delete a numbered asset
and the count drops while the maximum stays put; they diverge by one more for
every deletion after that.

`Asset` is unique on `(organizationId, sequentialId)`, so resuming at the count
re-issues ids that still exist. `createAsset` catches the P2002 and retries —
but `maxAttempts = 3`, so a gap of three or more exhausts the retries and the
creation fails in front of the user.

It does escape eventually, because every attempt advances the sequence. The
price is roughly a third of the gap in user-visible failures first.

The failing tests said it plainly before the fix:

```
✕ resumes above the highest id even when assets have been deleted
  → expected 15 to be greater than 23
✕ never resumes at or below an id that already exists
  → expected 4 to be greater than 500
```

## The fix

**1. Resume from the highest issued id.** Re-read from the assets rather than
computing `startingNumber + totalUpdated` — the batch writes are guarded on
`sequentialId IS NULL`, so a row filled concurrently is skipped and the
arithmetic would drift below the truth.

**2. Use the three-argument `setval`.** Not in the report, and a real
off-by-one: `setval(seq, 1)` leaves the *next* value at **2**, so running the
backfill over an organization with no assets set the sequence to 1 and handed
the first asset `SAM-0002`. With `is_called = false` the next value is the
number given, so an empty organization starts at 1.

**3. One MAX read instead of three.** The query already existed twice, byte for
byte, and this change needed a third. Extracted to a shared helper rather than
adding another copy.

## Existing organizations

Sequences already sitting at the count are **left to heal themselves**, and this
is a deliberate call rather than an oversight. Repairing them means walking every
organization's sequence in a `DO` block that runs on deploy — a heavier and
riskier change than the fault it would pre-empt, given that the fault resolves on
its own after a handful of retries. Happy to do it as a separate PR if that
trade looks wrong.

## Verification

4 new tests. Two mutations confirm they bite:

| Mutation | Result |
| --- | --- |
| resume from the COUNT again | 4 failures |
| back to the two-argument `setval` | 4 failures |

- 605 tests pass across 30 asset-module files
- `tsc -b --force` clean, ESLint clean, Prettier clean

No migration. No schema change. No new dependency.

Closes the `detail.dev` D034 finding — the last of the P1 set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk sequential ID generation to resume after the highest previously issued ID.
  * Prevented newly generated IDs from duplicating IDs that already exist, including after assets are deleted.
  * Ensured the first generated ID for an empty organization starts correctly at 1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->