### PR TITLE
fix(audits): backfill scan snapshots and correct deleted-asset handling

### DIFF
--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import {
   View,
   Text,
@@ -34,6 +34,7 @@ import {
   AUDIT_STATUS_LABELS,
   AUDIT_UNASSIGNED_LABELS,
   auditAssetStatusLabel,
+  auditDeletedAssetLabel,
   isAuditCompleted,
 } from "@shelf/labels";
 import { useTheme } from "@/lib/theme-context";
@@ -108,7 +109,6 @@ type DisplayAsset = {
   name: string;
   mainImage: string | null;
   status: AuditAssetStatus;
-  isExpected: boolean;
   scannedAt: string | null;
   /**
    * The code that was scanned. Kept for rows whose asset has been deleted:
@@ -484,7 +484,10 @@ function AuditDetailContent() {
 
   // ── Build display assets list ─────────────────────────
 
-  const displayAssets = useCallback((): DisplayAsset[] => {
+  // Memoised rather than a callback: both the list and the header count read
+  // this every render, so a function would rebuild the whole expected+scan
+  // merge twice per keystroke, filter tap and refresh tick.
+  const displayAssets = useMemo((): DisplayAsset[] => {
     if (!audit) return [];
 
     // Build a map of scanned assets by assetId
@@ -515,7 +518,6 @@ function AuditDetailContent() {
         name: asset.name,
         mainImage: asset.thumbnailImage || asset.mainImage,
         status: scan ? "FOUND" : notFoundStatus,
-        isExpected: true,
         scannedAt: scan?.scannedAt || null,
         scannedCode: null,
         locationName: asset.locationName ?? null,
@@ -537,44 +539,39 @@ function AuditDetailContent() {
     for (const scan of existingScans) {
       if (!expectedIds.has(scan.assetId)) {
         /**
-         * A scan whose asset has since been DELETED, not an unexpected one.
+         * A scan with no matching expected row: either an asset that is not
+         * part of the audit, or one that has since been DELETED.
          *
          * Deleting an asset cascades away its AuditAsset row and SetNulls the
-         * scan's asset, so the scan survives pointing at nothing. Read
-         * `assetDeleted` to tell the two apart: a deleted asset can never match
-         * the expected list, so treating an unmatched scan as unexpected would
-         * mislabel it. `assetTitle` is the name captured at scan time and names
-         * the row; the scanned code covers rows written before that column
-         * existed.
+         * scan's asset, so the scan survives pointing at nothing and can never
+         * match the expected list. `assetDeleted` is what tells the two apart —
+         * an empty title cannot, because a scan recorded before the title was
+         * captured by value looks the same. Older servers omit the flag, so an
+         * empty `assetId` stands in for it.
          */
         const isDeletedAsset = scan.assetDeleted || !scan.assetId;
         const snapshotTitle = scan.assetTitle?.trim();
         items.push({
-          // why: every deleted-asset scan would otherwise share the id "",
-          // colliding in the list's keyExtractor. The scan ROW id is the
-          // identity that survives the asset — code is nullable and
-          // non-unique, and scannedAt can collide. Older servers don't send
-          // the id, so those keep the code/scannedAt fallback.
+          // A deleted asset's `assetId` is empty, so every such row would share
+          // one key and collide in the list's keyExtractor. The scan ROW id is
+          // the identity that survives the asset; `code` is nullable and
+          // non-unique and `scannedAt` can collide, so they are a last resort
+          // for servers that do not send the id. `||`, not `??`: the server
+          // flattens a null code to "", which is not nullish and would swallow
+          // the remaining fallback.
           id: isDeletedAsset
-            ? `deleted:${scan.id ?? scan.code ?? scan.scannedAt}`
+            ? `deleted:${scan.id || scan.code || scan.scannedAt}`
             : scan.assetId,
           name: isDeletedAsset
-            ? snapshotTitle
-              ? `${snapshotTitle} (deleted)`
-              : "Deleted asset"
+            ? auditDeletedAssetLabel(snapshotTitle)
             : snapshotTitle || "Untitled asset",
           mainImage: null,
-          // why NOT a hardcoded UNEXPECTED: this branch handles scans with no
-          // matching expected row, and a DELETED asset always lands here — its
-          // assetId is empty, so it can never match expectedIds. Hardcoding
-          // false threw away the very fact this PR added: the server restores
-          // expectedness from the scan's own snapshot
-          // (`auditAsset?.expected ?? scan.wasExpected`) and sends it as
-          // `isExpected`. Without this, a deleted asset that WAS expected still
-          // reads "Unexpected" on the phone — the exact mislabelling the
-          // snapshot exists to prevent, and it contradicts the activity feed.
+          // Expectedness comes from the server, never from membership of the
+          // expected list: a deleted asset always lands in this branch, and the
+          // server restores whether it belonged to the audit from the scan's
+          // own snapshot. Deciding it here would report every deleted asset as
+          // unexpected, contradicting the activity feed.
           status: scan.isExpected ? "FOUND" : "UNEXPECTED",
-          isExpected: scan.isExpected,
           scannedAt: scan.scannedAt,
           scannedCode: isDeletedAsset ? scan.code || null : null,
           // why: the scan payload carries the asset's location
@@ -594,13 +591,11 @@ function AuditDetailContent() {
     return items;
   }, [audit, expectedAssets, existingScans]);
 
-  const filteredAssets = useCallback((): DisplayAsset[] => {
-    const all = displayAssets();
-    if (effectiveFilter === "ALL") return all;
-    // Statuses are now computed correctly per audit state (PENDING while
-    // active, MISSING once completed), so a direct match is unambiguous —
-    // no more Pending/Missing aliasing.
-    return all.filter((a) => a.status === effectiveFilter);
+  const filteredAssets = useMemo((): DisplayAsset[] => {
+    if (effectiveFilter === "ALL") return displayAssets;
+    // Status encodes the audit state (PENDING while active, MISSING once
+    // completed), so a direct match is unambiguous.
+    return displayAssets.filter((a) => a.status === effectiveFilter);
   }, [displayAssets, effectiveFilter]);
 
   // ── Render functions ──────────────────────────────────
@@ -852,7 +847,7 @@ function AuditDetailContent() {
     AUDIT_STATUS_LABELS[audit.status as keyof typeof AUDIT_STATUS_LABELS] ??
     audit.status;
 
-  const assets = filteredAssets();
+  const assets = filteredAssets;
 
   // ── Render ────────────────────────────────────────────
 
@@ -1201,7 +1196,7 @@ function AuditDetailContent() {
             {/* Asset filter pills */}
             <View style={styles.assetFilterSection}>
               <Text style={styles.sectionTitle}>
-                Assets ({displayAssets().length})
+                Assets ({displayAssets.length})
               </Text>
               <View style={styles.filterRow} accessibilityRole="tablist">
                 {visibleFilters.map((f) => (

--- a/apps/companion/components/audit/scanned-items-list.tsx
+++ b/apps/companion/components/audit/scanned-items-list.tsx
@@ -73,11 +73,28 @@ export function ScannedItemsList({
         .join(", ");
       const syncFailed = item.syncFailed === true;
 
+      // A scan whose asset was deleted has nothing left to attach evidence to:
+      // the AuditAsset row went with the asset, so the evidence sheet has no
+      // target and would sit on its pending spinner forever. The row is history
+      // now, so it renders inert rather than offering an action that cannot
+      // complete.
+      //
+      // Gated on `assetDeleted`, NOT on a missing `auditAssetId`: a scan still
+      // in the sync queue is also missing one, and for that row the pending
+      // state is correct and clears itself once the scan lands.
+      const isDeleted = item.assetDeleted === true;
+      const Row = isDeleted ? View : TouchableOpacity;
+
       return (
-        <TouchableOpacity
+        <Row
           style={styles.scannedItem}
-          onPress={() => onItemPress?.(item)}
-          activeOpacity={0.7}
+          {...(isDeleted
+            ? { accessible: true, accessibilityRole: "summary" as const }
+            : {
+                onPress: () => onItemPress?.(item),
+                activeOpacity: 0.7,
+                accessibilityRole: "button" as const,
+              })}
           // why: the visible "Found" label was removed as redundant, but a
           // screen reader has no tab context and no colour, so the state stays
           // in the spoken label along with the location.
@@ -85,8 +102,9 @@ export function ScannedItemsList({
             item.isExpected ? "found" : "unexpected, not on this audit"
           }${item.locationName ? `, at ${item.locationName}` : ""}${
             hasEvidence ? `, ${evidenceLabel}` : ""
-          }${syncFailed ? ", not synced" : ""}. Tap to add notes or photos.`}
-          accessibilityRole="button"
+          }${syncFailed ? ", not synced" : ""}${
+            isDeleted ? "." : ". Tap to add notes or photos."
+          }`}
         >
           <Ionicons
             name={item.isExpected ? "checkmark-circle" : "alert-circle"}
@@ -170,7 +188,7 @@ export function ScannedItemsList({
                 </>
               ) : null}
             </View>
-          ) : (
+          ) : isDeleted ? null : (
             <View style={styles.addEvidenceChip}>
               <Ionicons
                 name="camera-outline"
@@ -182,7 +200,7 @@ export function ScannedItemsList({
               </Text>
             </View>
           )}
-        </TouchableOpacity>
+        </Row>
       );
     },
     [colors, styles, onItemPress]

--- a/apps/companion/components/audit/scanned-items-list.tsx
+++ b/apps/companion/components/audit/scanned-items-list.tsx
@@ -30,7 +30,11 @@ import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import type { ScannedItem } from "@/hooks/use-audit-init";
 
 const SCANNED_ITEM_HEIGHT = 58;
-const keyExtractor = (item: ScannedItem) => item.assetId;
+// A scan whose asset was deleted has an empty `assetId`, so every such row
+// would share one key. The scan row id is the identity that survives the
+// asset; `scannedAt` is a last resort for servers that do not send it.
+const keyExtractor = (item: ScannedItem) =>
+  item.assetId || item.scanId || item.scannedAt;
 
 type ScannedItemsListProps = {
   items: ScannedItem[];

--- a/apps/companion/hooks/use-audit-init.ts
+++ b/apps/companion/hooks/use-audit-init.ts
@@ -6,6 +6,7 @@ import {
   clearAuditScanState,
   createDebouncedSaver,
 } from "@/lib/audit-scan-persistence";
+import { auditDeletedAssetLabel } from "@shelf/labels";
 import { announce } from "@/lib/a11y";
 import { reportAuditDurabilityEvent } from "@/lib/sentry";
 
@@ -16,6 +17,18 @@ export type ScannedItem = {
   name: string;
   isExpected: boolean;
   scannedAt: string;
+  /**
+   * The AuditScan row id. Carried only for restored scans whose asset has been
+   * DELETED: `assetId` is empty for those, so it is the only identity left to
+   * key the row on. Absent for live scans, which have a real `assetId`.
+   */
+  scanId?: string;
+  /**
+   * The scanned asset has since been deleted, so nothing behind this row can
+   * be opened or re-fetched. The name already says so; this is what the list
+   * reads to keep the row from being treated as an ordinary scan.
+   */
+  assetDeleted?: boolean;
   /** The audit-asset record ID, needed for adding notes/photos. Set after server confirms scan. */
   auditAssetId?: string;
   /** Local count of notes added during this session (optimistic). */
@@ -147,9 +160,19 @@ export function useAuditInit({
         // why: an expected asset already has its full record client-side, so
         // prefer it for the image; the scan payload only carries a location.
         const expected = expectedMap.get(scan.assetId);
+        // A scan whose asset was deleted keeps only the title captured at scan
+        // time. Naming it plainly would render it as an ordinary live asset,
+        // which is worse than the blank row it replaced — the auditor would go
+        // looking for something that no longer exists. Older servers omit the
+        // flag, so an empty `assetId` stands in for it.
+        const assetDeleted = scan.assetDeleted || !scan.assetId;
         restoredItems.push({
           assetId: scan.assetId,
-          name: scan.assetTitle,
+          scanId: scan.id,
+          assetDeleted,
+          name: assetDeleted
+            ? auditDeletedAssetLabel(scan.assetTitle)
+            : scan.assetTitle,
           isExpected: scan.isExpected,
           scannedAt: scan.scannedAt,
           auditAssetId: scan.auditAssetId ?? undefined,

--- a/apps/companion/hooks/use-audit-init.ts
+++ b/apps/companion/hooks/use-audit-init.ts
@@ -18,9 +18,12 @@ export type ScannedItem = {
   isExpected: boolean;
   scannedAt: string;
   /**
-   * The AuditScan row id. Carried only for restored scans whose asset has been
-   * DELETED: `assetId` is empty for those, so it is the only identity left to
-   * key the row on. Absent for live scans, which have a real `assetId`.
+   * The AuditScan row id, set on every scan restored from the server.
+   *
+   * A deleted asset's row REQUIRES it as its list key — `assetId` is empty for
+   * those, so nothing else identifies the row. Absent on scans made live in
+   * this session, which have not reached the server yet, and on servers too
+   * old to send it.
    */
   scanId?: string;
   /**

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -1040,8 +1040,11 @@ export type AuditScanData = {
   /**
    * The scanned asset has since been DELETED. Distinct from an empty title,
    * which a scan recorded before the snapshot columns existed also has.
+   *
+   * Absent on older servers, like `id` above — consumers must keep the empty
+   * `assetId` fallback rather than trusting this alone.
    */
-  assetDeleted: boolean;
+  assetDeleted?: boolean;
 };
 
 export type AuditDetailResponse = {

--- a/apps/webapp/app/components/audit/audit-drawer.tsx
+++ b/apps/webapp/app/components/audit/audit-drawer.tsx
@@ -32,7 +32,10 @@ import { Button } from "~/components/shared/button";
 import { Progress } from "~/components/shared/progress";
 import { Spinner } from "~/components/shared/spinner";
 import type { AssetFromQr } from "~/routes/api+/get-scanned-item.$qrId";
-import { resolveScannedExpectedness } from "~/utils/audit-scan-expectedness";
+import {
+  countDeletedExpectedScans,
+  resolveScannedExpectedness,
+} from "~/utils/audit-scan-expectedness";
 import { tw } from "~/utils/tw";
 
 const AuditSchema = z.object({
@@ -366,6 +369,27 @@ export default function AuditDrawer({
     [items]
   );
 
+  // A deleted asset the audit expected is gone from `expectedAssets` — its
+  // AuditAsset row was cascaded away — but it is still counted as found above,
+  // and the session's own expectedAssetCount still counts it. Leaving it out of
+  // the expected total is what makes the drawer read "1 of 0 found".
+  const deletedExpectedCount = useMemo(
+    () =>
+      countDeletedExpectedScans(
+        Object.values(items).map((item) =>
+          item && item.type === "asset"
+            ? (item.data as
+                | (AssetFromQr & {
+                    assetDeleted?: boolean;
+                    isExpected?: boolean;
+                  })
+                | undefined)
+            : undefined
+        )
+      ),
+    [items]
+  );
+
   const foundAssets = scannedAssets.filter(
     (asset) => asset.auditStatus === "found"
   );
@@ -378,13 +402,14 @@ export default function AuditDrawer({
 
   const stats: AuditDrawerStats = useMemo(
     () => ({
-      totalExpected: expectedAssets.length,
+      totalExpected: expectedAssets.length + deletedExpectedCount,
       foundCount: foundAssets.length,
       missingCount: missingAssets.length,
       unexpectedCount: unexpectedAssets.length,
     }),
     [
       expectedAssets.length,
+      deletedExpectedCount,
       foundAssets.length,
       missingAssets.length,
       unexpectedAssets.length,

--- a/apps/webapp/app/components/audit/audit-drawer.tsx
+++ b/apps/webapp/app/components/audit/audit-drawer.tsx
@@ -264,6 +264,20 @@ function AuditDrawerEmptyState({
  * @param props.emptyStateContent - Overrides the default empty-state render.
  * @returns The audit scan drawer.
  */
+/**
+ * A scanned asset as the drawer reads it.
+ *
+ * `AssetFromQr` describes an asset fetched live by the scanner. A row restored
+ * from an audit's saved scans carries two extra facts that no live scan has —
+ * whether the asset has since been deleted, and the expectedness the server
+ * resolved from the scan's own snapshot — and a deleted row is the one case
+ * where the expected list cannot answer for it.
+ */
+type ScannedAssetData = AssetFromQr & {
+  assetDeleted?: boolean;
+  isExpected?: boolean;
+};
+
 export default function AuditDrawer({
   contextLabel,
   contextName,
@@ -336,10 +350,7 @@ export default function AuditDrawer({
       Object.values(items)
         .filter((item) => !!item && item.data && item.type === "asset")
         .map((item) => {
-          const assetData = item!.data as AssetFromQr & {
-            assetDeleted?: boolean;
-            isExpected?: boolean;
-          };
+          const assetData = item!.data as ScannedAssetData;
           const wasExpected = resolveScannedExpectedness({
             assetId: assetData.id,
             assetDeleted: assetData.assetDeleted,
@@ -378,12 +389,7 @@ export default function AuditDrawer({
       countDeletedExpectedScans(
         Object.values(items).map((item) =>
           item && item.type === "asset"
-            ? (item.data as
-                | (AssetFromQr & {
-                    assetDeleted?: boolean;
-                    isExpected?: boolean;
-                  })
-                | undefined)
+            ? (item.data as ScannedAssetData | undefined)
             : undefined
         )
       ),

--- a/apps/webapp/app/components/audit/audit-drawer.tsx
+++ b/apps/webapp/app/components/audit/audit-drawer.tsx
@@ -32,6 +32,7 @@ import { Button } from "~/components/shared/button";
 import { Progress } from "~/components/shared/progress";
 import { Spinner } from "~/components/shared/spinner";
 import type { AssetFromQr } from "~/routes/api+/get-scanned-item.$qrId";
+import { resolveScannedExpectedness } from "~/utils/audit-scan-expectedness";
 import { tw } from "~/utils/tw";
 
 const AuditSchema = z.object({
@@ -332,12 +333,21 @@ export default function AuditDrawer({
       Object.values(items)
         .filter((item) => !!item && item.data && item.type === "asset")
         .map((item) => {
-          const assetData = item!.data as AssetFromQr;
+          const assetData = item!.data as AssetFromQr & {
+            assetDeleted?: boolean;
+            isExpected?: boolean;
+          };
+          const wasExpected = resolveScannedExpectedness({
+            assetId: assetData.id,
+            assetDeleted: assetData.assetDeleted,
+            isExpected: assetData.isExpected,
+            expectedAssetIds,
+          });
           return {
             id: assetData.id,
             name: assetData.title,
             type: "asset" as const,
-            auditStatus: expectedAssetIds.has(assetData.id)
+            auditStatus: wasExpected
               ? ("found" as const)
               : ("unexpected" as const),
           } satisfies AuditScannedItem;

--- a/apps/webapp/app/components/audit/audit-item-row.tsx
+++ b/apps/webapp/app/components/audit/audit-item-row.tsx
@@ -44,6 +44,7 @@ import {
   Tr,
 } from "~/components/scanner/drawer/generic-item-row";
 import { Button } from "~/components/shared/button";
+import { resolveScannedExpectedness } from "~/utils/audit-scan-expectedness";
 import { tw } from "~/utils/tw";
 
 /**
@@ -126,9 +127,17 @@ export function AuditItemRow({
       )}
       renderItem={(data: any) => {
         const isAsset = itemType === "asset";
-        const isExpected = isAsset && data?.id && expectedAssetIds.has(data.id);
-        const isUnexpected =
-          isAsset && data?.id && !expectedAssetIds.has(data.id);
+        // An asset row is one or the other; a non-asset row is neither.
+        const wasExpected =
+          isAsset &&
+          resolveScannedExpectedness({
+            assetId: data?.id,
+            assetDeleted: data?.assetDeleted,
+            isExpected: data?.isExpected,
+            expectedAssetIds,
+          });
+        const isExpected = wasExpected;
+        const isUnexpected = isAsset && !wasExpected;
         const auditAssetId =
           typeof data?.auditAssetId === "string"
             ? data.auditAssetId

--- a/apps/webapp/app/hooks/use-audit-session-initialization.ts
+++ b/apps/webapp/app/hooks/use-audit-session-initialization.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { auditDeletedAssetLabel } from "@shelf/labels";
 import { useSetAtom } from "jotai";
 import {
   startAuditSessionAtom,
@@ -114,13 +115,29 @@ export function useAuditSessionInitialization({
     if (existingScans.length > 0) {
       const restoredItems: any = {};
       existingScans.forEach((scan) => {
+        // A scan whose asset was deleted keeps only the title captured at scan
+        // time, and its `assetId` is empty. Naming it plainly would render it
+        // as an ordinary live asset — worse than the blank row it replaced,
+        // because the auditor would go looking for something that no longer
+        // exists. The scan ROW id is the identity that survives the asset.
+        const assetDeleted = scan.assetDeleted || !scan.assetId;
+
+        // Keyed on the scan row for deleted assets: `code` is nullable and
+        // non-unique, so codeless rows would otherwise overwrite each other.
+        const itemKey = assetDeleted
+          ? `deleted:${scan.id || scan.code || scan.scannedAt}`
+          : scan.code;
+
         // Add QR codes to the atom with full data so GenericItemRow doesn't re-fetch
-        restoredItems[scan.code] = {
+        restoredItems[itemKey] = {
           codeType: "qr",
           type: "asset",
           data: {
             id: scan.assetId,
-            title: scan.assetTitle,
+            title: assetDeleted
+              ? auditDeletedAssetLabel(scan.assetTitle)
+              : scan.assetTitle,
+            assetDeleted,
             auditAssetId: scan.auditAssetId,
             auditNotesCount: scan.auditNotesCount,
             auditImagesCount: scan.auditImagesCount,
@@ -129,8 +146,13 @@ export function useAuditSessionInitialization({
               : null,
           },
         };
-        // Mark them as already persisted so we don't try to persist again
-        persistedItemsRef.current.add(scan.assetId);
+        // Mark them as already persisted so we don't try to persist again.
+        // A deleted asset has no id to dedupe on and can never be re-scanned,
+        // so it contributes nothing here — adding "" would collapse every such
+        // row onto one entry.
+        if (scan.assetId) {
+          persistedItemsRef.current.add(scan.assetId);
+        }
       });
       setScannedItems(restoredItems);
     }

--- a/apps/webapp/app/hooks/use-audit-session-initialization.ts
+++ b/apps/webapp/app/hooks/use-audit-session-initialization.ts
@@ -7,8 +7,40 @@ import {
   endAuditSessionAtom,
   scannedItemsAtom,
   type AuditScannedItem,
+  type ScanListItems,
 } from "~/atoms/qr-scanner";
 import type { AuditScanData } from "~/modules/audit/service.server";
+
+/**
+ * One entry in the restored `scannedItemsAtom` map.
+ *
+ * `data` is deliberately a SUBSET of `AssetFromQr`: the audit-scan payload
+ * carries only what a scanned row renders, and the row is populated from it
+ * precisely so `GenericItemRow` does not have to re-fetch the asset. Anything
+ * added here must come from `AuditScanData` — there is no asset to read.
+ */
+type RestoredScanEntry = {
+  codeType: "qr";
+  type: "asset";
+  data: {
+    id: string;
+    title: string;
+    /** True once the scanned asset has been deleted; the row renders inert. */
+    assetDeleted: boolean;
+    /**
+     * Whether the scan belonged to the audit, as the SERVER resolved it.
+     *
+     * Needed only because a deleted asset cannot be looked up in the expected
+     * list — its AuditAsset row was cascaded away with it, and its `id` here is
+     * empty. For a live asset the list is still the authority.
+     */
+    isExpected: boolean;
+    auditAssetId: string | null;
+    auditNotesCount: number;
+    auditImagesCount: number;
+    location: { name: string } | null;
+  };
+};
 
 /**
  * Audit session data loaded from the database.
@@ -113,7 +145,7 @@ export function useAuditSessionInitialization({
     // Restore existing scans by directly setting scanned items atom
     // We include full asset data to avoid re-fetching via GenericItemRow
     if (existingScans.length > 0) {
-      const restoredItems: any = {};
+      const restoredItems: Record<string, RestoredScanEntry> = {};
       existingScans.forEach((scan) => {
         // A scan whose asset was deleted keeps only the title captured at scan
         // time, and its `assetId` is empty. Naming it plainly would render it
@@ -138,6 +170,7 @@ export function useAuditSessionInitialization({
               ? auditDeletedAssetLabel(scan.assetTitle)
               : scan.assetTitle,
             assetDeleted,
+            isExpected: scan.isExpected,
             auditAssetId: scan.auditAssetId,
             auditNotesCount: scan.auditNotesCount,
             auditImagesCount: scan.auditImagesCount,
@@ -154,7 +187,13 @@ export function useAuditSessionInitialization({
           persistedItemsRef.current.add(scan.assetId);
         }
       });
-      setScannedItems(restoredItems);
+      // why the cast: `ScanListItem.data` is typed as a FULL `AssetFromQr`
+      // (a complete Prisma payload), but a restored row only ever has the
+      // handful of fields the scan payload carries. Reconstructing the rest
+      // would mean re-fetching every asset, which is the cost restoring from
+      // the payload exists to avoid. The narrow type above is what keeps this
+      // honest — it still catches a typo in any field the rows actually use.
+      setScannedItems(restoredItems as unknown as ScanListItems);
     }
   }, [
     expectedItems,

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -2589,6 +2589,57 @@ describe("audit service", () => {
       });
     });
 
+    it("snapshots the asset title onto the scan row at create", async () => {
+      // why this is pinned separately from `wasExpected`: the title is the half
+      // of the snapshot nothing else can reconstruct. Every other assertion in
+      // this file feeds `assetTitle` in as mock INPUT to the read path, so
+      // deleting the write leaves the whole suite green while the column it
+      // fills silently stays null — and the gap only becomes visible once an
+      // asset is deleted, which no test with live data can reach.
+      mockDb.auditAsset.findUnique.mockResolvedValue({
+        id: "audit-asset-1",
+        expected: true,
+        status: "PENDING",
+      });
+      mockDb.auditAsset.updateMany.mockResolvedValue({ count: 1 });
+
+      await recordAuditScan(scanInput);
+
+      expect(mockDb.auditScan.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ assetTitle: "Camera" }),
+        })
+      );
+    });
+
+    it("takes the snapshotted title from the org-verified asset, not the request", async () => {
+      // why: the title is written by value and outlives every check that could
+      // later contradict it, so it has to come from the row this scan already
+      // proved belongs to the caller's organization. `recordAuditScan` takes no
+      // title argument at all — this pins that it stays that way.
+      mockDb.asset.findUnique.mockResolvedValue({
+        id: "asset-1",
+        title: "Arri Fresnel 650 Plus",
+        organizationId: "org-1",
+      });
+      mockDb.auditAsset.findUnique.mockResolvedValue({
+        id: "audit-asset-1",
+        expected: true,
+        status: "PENDING",
+      });
+      mockDb.auditAsset.updateMany.mockResolvedValue({ count: 1 });
+
+      await recordAuditScan(scanInput);
+
+      expect(mockDb.auditScan.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            assetTitle: "Arri Fresnel 650 Plus",
+          }),
+        })
+      );
+    });
+
     it("refreshes a surviving unexpected row and counts it when its status drifted", async () => {
       // why: removing a scan can leave the AuditAsset row behind. Re-scanning
       // must reuse that row (the unique constraint rules out a second one) and
@@ -2803,5 +2854,34 @@ describe("getAuditScans — a scan whose asset was deleted", () => {
     expect(scan.isExpected).toBe(true);
     expect(scan.assetTitle).toBe("Live title");
     expect(scan.assetDeleted).toBe(false);
+  });
+
+  it("does not resurrect an asset REMOVED from the audit as expected", async () => {
+    // why: `AuditScan.auditAsset` is SetNull, not Cascade, so removing an asset
+    // from a pending audit deletes the AuditAsset row and leaves the scan
+    // behind with its asset intact. A missing AuditAsset therefore does not
+    // mean "deleted" — it can equally mean "no longer part of this audit", and
+    // that row must not read as expected off a snapshot taken when it still
+    // was. The fallback keys on the asset being gone, which only deletion
+    // causes.
+    mockDb.auditScan.findMany.mockResolvedValue([
+      {
+        id: "scan-4",
+        code: "abc",
+        assetId: "asset-1",
+        asset: { id: "asset-1", title: "Still here", assetLocations: [] },
+        auditAsset: null,
+        assetTitle: "Still here",
+        wasExpected: true,
+        scannedAt: new Date("2026-08-19T10:00:00Z"),
+      },
+    ]);
+    // The AuditAsset row is gone, so the by-assetId rescue lookup finds nothing.
+    mockDb.auditAsset.findMany.mockResolvedValue([]);
+
+    const [scan] = await getAuditScans(ARGS);
+
+    expect(scan.assetDeleted).toBe(false);
+    expect(scan.isExpected).toBe(false);
   });
 });

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -1598,9 +1598,9 @@ export async function recordAuditScan(
             auditAssetId,
             // why: recorded here rather than at create because expectedness is
             // derived from AuditAsset above, never trusted from the request.
-            // Snapshotting it means a deleted asset's row can still say
-            // whether it belonged to the audit — today that fact dies with
-            // the cascaded AuditAsset row and the scan gets mislabelled.
+            // Snapshotting it is what lets a deleted asset's row still say
+            // whether it belonged to the audit, once the cascade has taken the
+            // AuditAsset row that would otherwise answer that.
             wasExpected: isExpected,
           },
         });
@@ -2008,13 +2008,26 @@ export async function getAuditScans({
         scan.auditAsset ??
         (scan.assetId ? auditAssetsByAssetId.get(scan.assetId) : undefined);
 
-      // why the live row wins over the snapshot: a rename should show the
-      // CURRENT name, not the one from the day of the scan. The snapshot's job
-      // is to survive DELETION, not to freeze naming. Rows written before the
-      // snapshot columns existed have neither, and fall back to "" — the
-      // client then has the `code`, which also outlives the asset.
+      // The asset is gone precisely when `assetId` is null: `AuditScan.asset`
+      // is SetNull, so deletion is the only thing that empties it.
+      const assetDeleted = scan.assetId === null;
+
+      // The live row wins over the snapshot: a rename must show the CURRENT
+      // name. The snapshot's job is to survive deletion, not to freeze naming.
+      // A row written before the snapshot columns existed has neither and
+      // falls back to "", leaving the client the `code`, which also outlives
+      // the asset.
       const assetTitle = scan.asset?.title ?? scan.assetTitle ?? "";
-      const isExpected = auditAsset?.expected ?? scan.wasExpected ?? false;
+
+      // Expectedness falls back to the snapshot ONLY once the asset is gone.
+      // `AuditScan.auditAsset` is SetNull too, so a missing AuditAsset does not
+      // imply deletion — removing an asset from a pending audit leaves the scan
+      // behind with its asset intact, and that row is genuinely no longer part
+      // of the audit. Keying on deletion keeps the snapshot from resurrecting
+      // it as expected.
+      const isExpected = assetDeleted
+        ? scan.wasExpected ?? false
+        : auditAsset?.expected ?? false;
 
       return {
         id: scan.id,
@@ -2027,7 +2040,7 @@ export async function getAuditScans({
         // Distinguishes "the asset is gone" from "this scan predates the
         // snapshot columns", so the client can say which it is instead of
         // guessing from an empty title.
-        assetDeleted: scan.assetId === null,
+        assetDeleted,
         auditAssetId: auditAsset?.id ?? null,
         auditNotesCount: auditAsset?._count?.notes ?? 0,
         auditImagesCount: auditAsset?._count?.images ?? 0,
@@ -3108,7 +3121,10 @@ export async function removeAssetFromAudit({
         });
       }
 
-      // Delete the audit asset (cascade will delete related scans). Scoped
+      // Delete the audit asset. `AuditScan.auditAsset` is SetNull, so any scan
+      // of this asset SURVIVES with its `auditAssetId` emptied — the row stays
+      // in the audit's scan history while ceasing to be part of the audit.
+      // `getAuditScans` relies on that distinction. Scoped
       // again rather than by id alone: defence in depth, so the write cannot
       // outlive a future refactor of the check above.
       const removed = await tx.auditAsset.deleteMany({

--- a/apps/webapp/app/utils/audit-scan-expectedness.test.ts
+++ b/apps/webapp/app/utils/audit-scan-expectedness.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveScannedExpectedness } from "./audit-scan-expectedness";
+import {
+  countDeletedExpectedScans,
+  resolveScannedExpectedness,
+} from "./audit-scan-expectedness";
 
 /**
  * The rule this pins: a deleted asset's expectedness comes from the scan's own
@@ -83,5 +86,42 @@ describe("resolveScannedExpectedness", () => {
         expectedAssetIds: new Set([""]),
       })
     ).toBe(false);
+  });
+});
+
+/**
+ * The rule this pins: a deleted asset the audit expected still counts toward
+ * the expected total. Counting it as found without counting the expectation is
+ * what produces "1 of 0 found".
+ */
+describe("countDeletedExpectedScans", () => {
+  it("counts a deleted asset that was expected", () => {
+    expect(
+      countDeletedExpectedScans([{ assetDeleted: true, isExpected: true }])
+    ).toBe(1);
+  });
+
+  it("ignores a deleted asset that was never expected", () => {
+    // It is already counted as unexpected; adding it to the expected total
+    // would inflate the denominator.
+    expect(
+      countDeletedExpectedScans([{ assetDeleted: true, isExpected: false }])
+    ).toBe(0);
+  });
+
+  it("ignores a live asset, expected or not", () => {
+    // A live expected asset is already in the loader's expected list; counting
+    // it here would double it.
+    expect(
+      countDeletedExpectedScans([
+        { assetDeleted: false, isExpected: true },
+        { assetDeleted: false, isExpected: false },
+        {},
+      ])
+    ).toBe(0);
+  });
+
+  it("survives null and undefined rows", () => {
+    expect(countDeletedExpectedScans([null, undefined])).toBe(0);
   });
 });

--- a/apps/webapp/app/utils/audit-scan-expectedness.test.ts
+++ b/apps/webapp/app/utils/audit-scan-expectedness.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveScannedExpectedness } from "./audit-scan-expectedness";
+
+/**
+ * The rule this pins: a deleted asset's expectedness comes from the scan's own
+ * snapshot, and a live asset's from the audit's expected list. Getting it wrong
+ * is invisible — every row still renders, just under the wrong heading — so the
+ * deleted cases are asserted in BOTH directions.
+ */
+describe("resolveScannedExpectedness", () => {
+  const expectedAssetIds = new Set(["asset-1", "asset-2"]);
+
+  it("reads a live asset from the expected list", () => {
+    expect(
+      resolveScannedExpectedness({
+        assetId: "asset-1",
+        assetDeleted: false,
+        isExpected: false, // stale snapshot must lose to the live list
+        expectedAssetIds,
+      })
+    ).toBe(true);
+  });
+
+  it("calls a live asset that is not on the list unexpected", () => {
+    expect(
+      resolveScannedExpectedness({
+        assetId: "asset-99",
+        assetDeleted: false,
+        isExpected: true, // stale snapshot must lose here too
+        expectedAssetIds,
+      })
+    ).toBe(false);
+  });
+
+  it("reads a DELETED asset from its snapshot, not the list", () => {
+    // The deleted asset's id is empty, so the list can never match it. Without
+    // the snapshot this row reports unexpected — the mislabel the snapshot
+    // exists to prevent.
+    expect(
+      resolveScannedExpectedness({
+        assetId: "",
+        assetDeleted: true,
+        isExpected: true,
+        expectedAssetIds,
+      })
+    ).toBe(true);
+  });
+
+  it("still reports a deleted UNEXPECTED scan as unexpected", () => {
+    // why the pair: without this, "deleted means expected" would pass above.
+    expect(
+      resolveScannedExpectedness({
+        assetId: "",
+        assetDeleted: true,
+        isExpected: false,
+        expectedAssetIds,
+      })
+    ).toBe(false);
+  });
+
+  it("treats a deleted row with no snapshot as unexpected", () => {
+    // A scan recorded before the snapshot columns existed, whose asset is now
+    // gone. Nothing can classify it; unexpected is the honest floor.
+    expect(
+      resolveScannedExpectedness({
+        assetId: "",
+        assetDeleted: true,
+        isExpected: undefined,
+        expectedAssetIds,
+      })
+    ).toBe(false);
+  });
+
+  it("does not let an empty id match an empty entry in the list", () => {
+    // Guards the truthiness check: a stray "" in the expected list must not
+    // make every unclassifiable row read as expected.
+    expect(
+      resolveScannedExpectedness({
+        assetId: "",
+        assetDeleted: false,
+        isExpected: undefined,
+        expectedAssetIds: new Set([""]),
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/webapp/app/utils/audit-scan-expectedness.ts
+++ b/apps/webapp/app/utils/audit-scan-expectedness.ts
@@ -1,0 +1,39 @@
+/**
+ * Whether a scanned row belonged to the audit.
+ *
+ * The audit scan screen normally answers this by looking the asset up in the
+ * expected list. That fails for exactly one row: a scan whose asset has been
+ * DELETED. Deleting an asset cascades away its `AuditAsset` row, so it can
+ * never appear in the expected list, and the restored row's `id` is empty —
+ * which makes a membership test report "unexpected", or, where the id is used
+ * as a truthiness guard, report neither expected nor unexpected.
+ *
+ * Those rows carry the answer with them instead: the server resolves
+ * expectedness from the scan's own `wasExpected` snapshot and sends it as
+ * `isExpected`. This is the one place that decides between the two sources, so
+ * the drawer's counts and the row's badge cannot disagree.
+ *
+ * @see {@link file://./../components/audit/audit-drawer.tsx}
+ * @see {@link file://./../components/audit/audit-item-row.tsx}
+ */
+export function resolveScannedExpectedness({
+  assetId,
+  assetDeleted,
+  isExpected,
+  expectedAssetIds,
+}: {
+  /** The scanned asset's id — empty string once the asset is deleted. */
+  assetId: string | undefined;
+  /** True when the asset behind this scan has been deleted. */
+  assetDeleted: boolean | undefined;
+  /** The server's resolved expectedness, from the scan's snapshot. */
+  isExpected: boolean | undefined;
+  /** Ids of the assets the audit expects. */
+  expectedAssetIds: Set<string>;
+}): boolean {
+  if (assetDeleted) {
+    return isExpected === true;
+  }
+
+  return !!assetId && expectedAssetIds.has(assetId);
+}

--- a/apps/webapp/app/utils/audit-scan-expectedness.ts
+++ b/apps/webapp/app/utils/audit-scan-expectedness.ts
@@ -37,3 +37,26 @@ export function resolveScannedExpectedness({
 
   return !!assetId && expectedAssetIds.has(assetId);
 }
+
+/**
+ * How many scanned rows are assets the audit expected but that have since been
+ * DELETED.
+ *
+ * These rows are missing from the loader's expected list — their `AuditAsset`
+ * row was cascaded away with the asset — while still counting as found, which
+ * would leave the scan drawer reporting more assets found than it ever
+ * expected. The audit still expected them, and the session's own
+ * `expectedAssetCount` still counts them, so the expected total has to as well.
+ *
+ * @param scans - the restored scan rows, in whatever shape the surface holds
+ * @returns the number to ADD to the expected total
+ */
+export function countDeletedExpectedScans(
+  scans: Array<
+    { assetDeleted?: boolean; isExpected?: boolean } | null | undefined
+  >
+): number {
+  return scans.filter(
+    (scan) => scan?.assetDeleted === true && scan?.isExpected === true
+  ).length;
+}

--- a/packages/database/prisma/migrations/20260827120000_auditscan_backfill_asset_facts/migration.sql
+++ b/packages/database/prisma/migrations/20260827120000_auditscan_backfill_asset_facts/migration.sql
@@ -1,0 +1,47 @@
+-- Fills the AuditScan snapshot columns for scans recorded before they existed.
+--
+-- The columns were added nullable and unbackfilled, which leaves every scan
+-- taken before that deploy depending on its Asset and AuditAsset rows to stay
+-- alive — the exact dependency the snapshot exists to remove. Deleting the
+-- asset cascades the AuditAsset away and SetNulls the scan's asset, and a row
+-- with no snapshot has nothing left to name or classify it.
+--
+-- These rows CAN be filled: the ones worth protecting are the ones whose asset
+-- is still present, and they are the overwhelming majority. Only scans already
+-- orphaned are unrecoverable, and the `IS NULL` guards leave them untouched
+-- rather than writing a wrong value over them.
+--
+-- Idempotent by construction: every statement is guarded on the column still
+-- being NULL, so re-running changes nothing, and a scan recorded after the
+-- deploy already carries its own snapshot and is skipped.
+--
+-- Every join is index-backed — AuditScan has indexes on "assetId" and
+-- "auditAssetId", AuditAsset is unique on ("auditSessionId", "assetId").
+
+-- The title as it stands now. A rename between the scan and this backfill is
+-- not a loss: readers prefer the live asset anyway, so the snapshot only ever
+-- has to answer for the row once the asset is gone.
+UPDATE "AuditScan" s
+SET "assetTitle" = a."title"
+FROM "Asset" a
+WHERE s."assetId" = a."id"
+  AND s."assetTitle" IS NULL;
+
+-- Expectedness, taken from the AuditAsset row the scan is linked to.
+UPDATE "AuditScan" s
+SET "wasExpected" = aa."expected"
+FROM "AuditAsset" aa
+WHERE s."auditAssetId" = aa."id"
+  AND s."wasExpected" IS NULL;
+
+-- Scans predating the auditAssetId link carry no relation, so they resolve the
+-- same way the read path does: by (auditSessionId, assetId), which AuditAsset
+-- is unique on and which is therefore the authority on whether the asset
+-- belongs to the audit.
+UPDATE "AuditScan" s
+SET "wasExpected" = aa."expected"
+FROM "AuditAsset" aa
+WHERE s."auditAssetId" IS NULL
+  AND s."auditSessionId" = aa."auditSessionId"
+  AND s."assetId" = aa."assetId"
+  AND s."wasExpected" IS NULL;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -2402,8 +2402,12 @@ model AuditScan {
   /// descriptive facts are snapshotted here rather than only referenced.
   ///
   /// Readers prefer the LIVE asset when it still exists (a rename should show
-  /// the current name) and fall back to these. Null on rows written before
-  /// this existed; those degrade to the scanned `code`, which also survives.
+  /// the current name) and fall back to these.
+  ///
+  /// Null means the snapshot could not be taken: scans whose asset had already
+  /// been deleted before these columns were backfilled. Nothing can recover
+  /// those, and they degrade to the scanned `code`, which also survives. Every
+  /// other row carries a snapshot, so null is never merely "old".
   assetTitle  String?
   wasExpected Boolean?
 

--- a/packages/labels/index.d.ts
+++ b/packages/labels/index.d.ts
@@ -70,6 +70,29 @@ export declare const AUDIT_ASSET_STATUS_LABELS: {
   readonly UNEXPECTED: "Unexpected";
 };
 
+/**
+ * Wording for an audit scan whose asset no longer exists.
+ *
+ * Deleting an asset leaves the scan row behind with nothing to name it but the
+ * title captured at scan time, so both apps must say it the same way. Prefer
+ * {@link auditDeletedAssetLabel} over indexing this map — only that helper
+ * applies the "keep the snapshotted title" rule.
+ */
+export declare const AUDIT_DELETED_ASSET_LABELS: {
+  readonly UNTITLED: "Deleted asset";
+};
+
+/**
+ * Names a scan whose asset has been deleted, keeping the title it had when it
+ * was scanned and marking it as gone.
+ *
+ * @param title - the snapshotted title, if any
+ * @returns the row's display name
+ */
+export declare function auditDeletedAssetLabel(
+  title: string | null | undefined
+): string;
+
 /** Enum keys of {@link AUDIT_ASSET_STATUS_LABELS} — the Prisma status values. */
 export type AuditAssetStatusKey = keyof typeof AUDIT_ASSET_STATUS_LABELS;
 

--- a/packages/labels/index.js
+++ b/packages/labels/index.js
@@ -101,6 +101,34 @@ export const AUDIT_ASSET_STATUS_LABELS = Object.freeze({
 });
 
 /**
+ * Wording for an audit scan whose asset no longer exists.
+ *
+ * Deleting an asset leaves the scan row behind with nothing to name it but the
+ * title captured at scan time, so these two strings are the only thing standing
+ * between an auditor and an anonymous row. Both apps must say it the same way:
+ * an audit is a historical record, and two surfaces describing the same
+ * surviving row differently is exactly the drift this package exists to stop.
+ *
+ * `UNTITLED` covers a row scanned before the title was recorded by value —
+ * there is no name left to qualify, so the row says only what it is.
+ */
+export const AUDIT_DELETED_ASSET_LABELS = Object.freeze({
+  UNTITLED: "Deleted asset",
+});
+
+/**
+ * Names a scan whose asset has been deleted, keeping the title it had when it
+ * was scanned and marking it as gone.
+ *
+ * @param {string | null | undefined} title - the snapshotted title, if any
+ * @returns {string} the row's display name
+ */
+export function auditDeletedAssetLabel(title) {
+  const trimmed = typeof title === "string" ? title.trim() : "";
+  return trimmed ? `${trimmed} (deleted)` : AUDIT_DELETED_ASSET_LABELS.UNTITLED;
+}
+
+/**
  * The ONE derivation of the "is this audit concluded?" flag every audit label
  * depends on. Read `completedAt`, never `status`.
  *

--- a/packages/labels/index.test.js
+++ b/packages/labels/index.test.js
@@ -22,9 +22,11 @@ import { test } from "node:test";
 import {
   AUDIT_ASSET_STATUS_LABELS,
   AUDIT_ASSET_STATUS_TONES,
+  AUDIT_DELETED_ASSET_LABELS,
   AUDIT_STATUS_LABELS,
   AUDIT_STATUS_TONES,
   auditAssetStatusLabel,
+  auditDeletedAssetLabel,
   isAuditCompleted,
 } from "./index.js";
 
@@ -154,9 +156,33 @@ test("the exported maps cannot be mutated by a consumer", () => {
   for (const map of [
     AUDIT_STATUS_LABELS,
     AUDIT_ASSET_STATUS_LABELS,
+    AUDIT_DELETED_ASSET_LABELS,
     AUDIT_STATUS_TONES,
     AUDIT_ASSET_STATUS_TONES,
   ]) {
     assert.ok(Object.isFrozen(map));
   }
+});
+
+// ---------------------------------------------------------------------------
+// Deleted-asset wording
+// ---------------------------------------------------------------------------
+
+test("a deleted asset keeps the title it was scanned under", () => {
+  assert.equal(
+    auditDeletedAssetLabel("Arri Fresnel 650"),
+    "Arri Fresnel 650 (deleted)"
+  );
+});
+
+test("a deleted asset with no snapshotted title says only what it is", () => {
+  // A scan recorded before the title was captured by value has nothing left to
+  // qualify, so the row must not read " (deleted)" with an empty name.
+  for (const empty of [null, undefined, "", "   "]) {
+    assert.equal(auditDeletedAssetLabel(empty), "Deleted asset");
+  }
+});
+
+test("surrounding whitespace never reaches the rendered name", () => {
+  assert.equal(auditDeletedAssetLabel("  Tripod  "), "Tripod (deleted)");
 });


### PR DESCRIPTION
Follow-up to #2899. That PR was merged before this review landed, so these
fixes ship separately — the end state is what #2899 would have merged with the
review applied.

## ⚠️ Contains a migration

One migration, **backfill only** — no DDL. It fills `AuditScan.assetTitle` and
`wasExpected` for scans recorded before #2899 added the columns. Kept separate
from `20260819140000` rather than edited into it: that migration is already
applied, and rewriting an applied migration breaks Prisma's checksum.

Every statement is guarded on the column still being `NULL`, so it is
idempotent, and all three joins are index-backed (`AuditScan` on `assetId` /
`auditAssetId`, `AuditAsset` unique on `auditSessionId, assetId`).

Verified against a local database inside a rolled-back transaction:
**1426 / 1426 scans filled, 0 unrecoverable.**

## Why the backfill exists

#2899 argued no backfill was possible: *"the rows that would benefit are
precisely the ones whose asset is already deleted, where there is nothing left
to backfill FROM."*

That holds only for rows **already** orphaned, which are the minority. Every
pre-#2899 scan whose asset is still alive can be snapshotted right now — and
without it, each one stays permanently exposed to the exact failure the
snapshot exists to prevent, for any deletion happening from here on. Only
scans recorded after #2899 deployed were protected.

## Correctness

**The deleted-row list key could still collide.** The key used `??`, but the
server flattens a null code to `""`, which is not nullish and therefore
swallowed the `scannedAt` fallback. Every codeless deleted scan shared the key
`"deleted:"` — the collision the comment above it said it prevented. The web
and companion scan restores had the same bug from the other direction, keying
deleted rows on an empty `assetId`.

**Expectedness could be restored to a row that no longer belongs to the audit.**
`getAuditScans` fell back to the `wasExpected` snapshot whenever the
`AuditAsset` relation was missing. That relation is `SetNull`, not `Cascade`,
so a missing row also means *"removed from the audit"* — not only *"asset
deleted"*. The fallback now keys on the asset actually being gone, which is
the only thing that empties `assetId`.

Not reachable today (nothing sets a session back to `PENDING`), so this is
hardening rather than a live bug — but the comment claiming
`removeAssetFromAudit` cascades its scans was simply wrong, and is corrected
here. That wrong mental model is what made the fallback look safe.

## Tests

Each of these was confirmed by mutation — breaking the code it pins makes it
fail:

- **`assetTitle` on the create call.** Deleting that write previously left the
  entire suite green at 108/108: every other assertion feeds `assetTitle` in as
  mock *input* to the read path, so nothing watched the side that produces it.
  The gap is invisible to live data — it only surfaces once an asset is deleted.
- **The title comes from the org-verified fetch**, never the request.
- **An asset removed from an audit is not resurrected as expected.**

## Surface parity

`assetDeleted` now reaches both scan-restore paths, so a deleted asset reads as
`<title> (deleted)` instead of rendering as an ordinary live asset. Before
this, #2899's change from `""` to a real title made a deleted asset
indistinguishable from a present one on those screens — worse than the blank
row it replaced, because an auditor would go looking for something that no
longer exists.

Wording moved into `@shelf/labels` so the two apps cannot drift.

**Still open:** the web audit overview builds its table from `AuditAsset`,
which cascades away, so a deleted asset's row is still absent above a counter
that still counts it. Left deliberately — merging orphaned scans into that
table is a feature, not a fix.

## Also

- `assetDeleted` typed optional, matching `id` — both are absent from exactly
  the same older servers, and the consumer already guards for it.
- Dropped the write-only `DisplayAsset.isExpected` field (assigned twice, read
  nowhere).
- `displayAssets` / `filteredAssets` were `useCallback`s invoked during render,
  rebuilding the full expected-plus-scan merge twice per render; both memoised.

## Verification

Both apps typecheck (`tsc -b --force`) and lint clean; react-doctor reports no
errors; 494 audit tests across 36 files and 15 `@shelf/labels` tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Audit history now preserves scans after associated assets are deleted.
  - Deleted assets retain their original names when available and are clearly labeled.
  - Deleted scan entries remain distinct and show accurate expected-status information.
  - Audit totals now include expected assets that were later deleted.

- **Bug Fixes**
  - Prevented deleted scans from merging, disappearing, or appearing as expected incorrectly.
  - Deleted scan entries are no longer interactive.

- **Data Updates**
  - Historical audit records are backfilled with asset names and expected-status details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->