### PR TITLE
chore(companion): cut 1.5.0

### DIFF
--- a/COMPANION-RELEASE-STATUS.md
+++ b/COMPANION-RELEASE-STATUS.md
@@ -8,14 +8,20 @@ Cutting a build: [apps/companion/STORE-RELEASE.md](./apps/companion/STORE-RELEAS
 
 ## Live in the stores
 
-|             | Version | Build | Notes                                                      |
-| ----------- | ------- | ----- | ---------------------------------------------------------- |
-| App Store   | 1.4.0   | —     | Confirm with `eas build:list --platform ios --limit 1`     |
-| Google Play | 1.4.0   | —     | Confirm with `eas build:list --platform android --limit 1` |
+|             | Version | Build | Notes                       |
+| ----------- | ------- | ----- | --------------------------- |
+| App Store   | 1.4.0   | —     | Read from App Store Connect |
+| Google Play | 1.4.0   | —     | Read from the Play Console  |
 
-Build numbers are deliberately blank rather than guessed: `eas.json` sets
-`appVersionSource: "remote"`, so EAS holds them and the repo never sees them.
-Fill them in from `eas build:list` when a build ships.
+Take these from the stores themselves, not from EAS. `eas build:list` reports
+the most recent BUILD, which is a different thing from what customers have: a
+build can be waiting in review, rejected, or superseded, and Play can hold a
+release as a draft. App Store Connect and the Play Console are the only places
+that say what is live.
+
+Build numbers are blank rather than guessed because `eas.json` sets
+`appVersionSource: "remote"` — EAS assigns them and the repo never sees them.
+Fill each one in from the store listing once that build is actually live.
 
 ## In flight
 

--- a/COMPANION-RELEASE-STATUS.md
+++ b/COMPANION-RELEASE-STATUS.md
@@ -1,0 +1,48 @@
+# Companion release status
+
+What is live in each store, next to what is merged and waiting. Update it when
+a build reaches a store, so the gap between `main` and customers is written
+down somewhere other than someone's memory.
+
+Cutting a build: [apps/companion/STORE-RELEASE.md](./apps/companion/STORE-RELEASE.md).
+
+## Live in the stores
+
+|             | Version | Build | Notes                                                      |
+| ----------- | ------- | ----- | ---------------------------------------------------------- |
+| App Store   | 1.4.0   | —     | Confirm with `eas build:list --platform ios --limit 1`     |
+| Google Play | 1.4.0   | —     | Confirm with `eas build:list --platform android --limit 1` |
+
+Build numbers are deliberately blank rather than guessed: `eas.json` sets
+`appVersionSource: "remote"`, so EAS holds them and the repo never sees them.
+Fill them in from `eas build:list` when a build ships.
+
+## In flight
+
+**1.5.0 — cut, not yet submitted.**
+
+Eight companion PRs merged since the 1.4.0 build (`0c85873e4`):
+
+| PR    | What a customer gets                                                                       |
+| ----- | ------------------------------------------------------------------------------------------ |
+| #2934 | Connect the app to a private Shelf server, then sign in against it                         |
+| #2944 | Scanner says what happened: cross-workspace jump, repeat scans, kit scans while fulfilling |
+| #2953 | Undo a mis-scan during an audit                                                            |
+| #2899 | Scans keep the asset's title and whether it was expected                                   |
+| #2879 | Audit rows say where the asset is, and surface exceptions                                  |
+| #2931 | Land in the workspace last chosen on that device                                           |
+| #2942 | Bookings: personal workspace, past days, archive parity                                    |
+| #2943 | Account URL, currency on amount fields, QR banner                                          |
+
+Store text: [apps/companion/RELEASE-NOTES-1.5.0.md](./apps/companion/RELEASE-NOTES-1.5.0.md).
+
+## Known gap between a release note and a build
+
+The 1.4.0 notes announced that audit scan rows count notes and photos
+separately. That change (#2879) landed two days before the 1.4.0 build was cut
+but was not an ancestor of it, so it never shipped — customers were told about
+a feature they did not get. It ships for real in 1.5.0, which is why the same
+line appears in both files.
+
+The lesson is cheap to apply: write the release notes from what is an ancestor
+of the build commit, not from what was merged that week.

--- a/apps/companion/EAS-UPDATE.md
+++ b/apps/companion/EAS-UPDATE.md
@@ -20,15 +20,21 @@ ride an OTA bundle.
 
 ## Runtime version = app version
 
-`app.json` sets `runtimeVersion: "1.4.0"`, kept equal to the app version by
-hand. An OTA update only reaches builds whose **runtime version matches**, and
-only on the **channel** it was published to (see Channels below). So an update
-published to `production` for runtime `1.4.0` reaches the **update-capable**
-`1.4.0` production builds (ones that accept an unsigned bundle; the
+`app.json` sets `runtimeVersion` equal to the app version, by hand — it reads
+`1.5.0` today, and every store cut bumps it (see
+[STORE-RELEASE.md](./STORE-RELEASE.md) for the six places that must agree). An
+update only reaches builds whose **runtime version matches**, and only on the
+**channel** it was published to (see Channels below). So an update published to
+`production` for the current runtime reaches the **update-capable** production
+builds on that exact version (ones that accept an unsigned bundle; the
 pre-`expo-updates` binaries — every store build up to and including 1.2.0 —
-can't check for updates at all), and is ignored by a future `1.4.0` build until
-you publish an update for `1.4.0`. This is the safety net: JS that assumes new
+can't check for updates at all), and is ignored by builds on any other runtime
+until you publish for theirs. This is the safety net: JS that assumes new
 native code can never land on a build that lacks it.
+
+**A store cut resets this.** Bumping the runtime to a new version means nothing
+previously published reaches the new builds, so the first update for a release
+has to be published against its own runtime version.
 
 > **Why a hard-coded string and not `{ "policy": "appVersion" }`.** `ios/` is
 > committed, so expo-updates classifies iOS as the **generic (bare)** workflow,

--- a/apps/companion/RELEASE-NOTES-1.5.0.md
+++ b/apps/companion/RELEASE-NOTES-1.5.0.md
@@ -1,6 +1,8 @@
 # Shelf Companion 1.5.0 — store release notes
 
-Paste as-is. App Store Connect allows 4000 characters; Google Play allows 500.
+Paste **one section**: the App Store text into App Store Connect (4000
+characters allowed), the Google Play text into Play (500). The last section is
+internal and must not reach a store listing.
 
 ---
 

--- a/apps/companion/RELEASE-NOTES-1.5.0.md
+++ b/apps/companion/RELEASE-NOTES-1.5.0.md
@@ -1,0 +1,82 @@
+# Shelf Companion 1.5.0 — store release notes
+
+Paste as-is. App Store Connect allows 4000 characters; Google Play allows 500.
+
+---
+
+## App Store — What's New
+
+Connect the app to your own Shelf server.
+
+- Tap "Connect to a private server" on the sign-in screen and enter your
+  organisation's domain
+- Sign in with your password or your company's single sign-on, against your own
+  server
+- Switch back to Shelf Cloud whenever you like, from the sign-in screen or from
+  Settings
+
+The scanner tells you what actually happened.
+
+- Scan a code that belongs to another of your workspaces and the app names that
+  workspace and offers to switch and open it, in one tap
+- Scanning something already in your list is shown as a repeat, not an error
+- Scanning a kit while fulfilling a reservation explains that reservations match
+  individual assets, instead of appearing to succeed
+
+Audits.
+
+- Undo a scan: open a scanned row and remove it, and the asset goes back to
+  where it was so you can scan it again
+- Scanned rows show where the asset lives instead of repeating "Found"
+- A count of assets that should not be there, which you can tap to see just
+  those
+- Notes and photos are counted separately on each row
+- Archived audits are reachable, and "All" now includes them
+
+Bookings.
+
+- In a personal workspace the Bookings tab explains that bookings live in team
+  workspaces, and offers to switch
+- Days that have already passed no longer offer a new booking
+- A new booking opens with a start time you can actually save
+- Archive is available on reserved bookings that are past their end date, the
+  same as on the web
+
+Fixes.
+
+- The app opens in the workspace you last chose on that device
+- Delete Account opens the right page
+- Amount custom fields show their currency
+- Creating another asset no longer claims it will link a QR code it will not
+
+---
+
+## Google Play — What's New (under 500 characters)
+
+Connect the app to your own Shelf server: enter your organisation's domain and
+sign in with a password or single sign-on.
+
+Scanner: a code from another of your workspaces now offers to switch and open
+it. Repeat scans read as repeats, not errors.
+
+Audits: undo a scan, see where each asset lives, and reach archived audits.
+
+Bookings: clearer personal workspace, no bookings on past days, and a start
+time that saves.
+
+---
+
+## Not for the stores — worth knowing internally
+
+**Everyone's remembered workspace resets once.** The app stores that choice
+under a new key, so the first launch of 1.5.0 falls back to the server's answer
+before the device's own preference takes over again. A person with several
+workspaces may open the app somewhere they did not expect, once.
+
+**Private-server access is gated by the registry, not the app.** A domain only
+resolves if Shelf has registered it, and only over HTTPS. Adding a customer is
+a server-side change and needs no new build.
+
+**Two behaviours changed that people were trained on.** "Found" no longer
+appears on scanned audit rows (the location is there instead), and the audits
+"All" filter now returns archived audits, so existing lists get longer.

--- a/apps/companion/RELEASE-NOTES-1.5.0.md
+++ b/apps/companion/RELEASE-NOTES-1.5.0.md
@@ -77,6 +77,12 @@ workspaces may open the app somewhere they did not expect, once.
 resolves if Shelf has registered it, and only over HTTPS. Adding a customer is
 a server-side change and needs no new build.
 
+**One line here was already announced in 1.4.0 and never shipped.** The notes
+and photos count on audit scan rows was in the 1.4.0 store text, but the change
+landed two days before that build was cut and was not an ancestor of it. It
+ships for real now, so it belongs in these notes even though it reads as a
+repeat.
+
 **Two behaviours changed that people were trained on.** "Found" no longer
 appears on scanned audit rows (the location is there instead), and the audits
 "All" filter now returns archived audits, so existing lists get longer.

--- a/apps/companion/STORE-RELEASE.md
+++ b/apps/companion/STORE-RELEASE.md
@@ -1,0 +1,98 @@
+# Cutting a companion store build
+
+How a version of the app reaches the App Store and Google Play. For shipping
+JavaScript to installs that already exist, see [EAS-UPDATE.md](./EAS-UPDATE.md)
+instead — this document is the binary.
+
+## Before you start
+
+- `eas whoami` returns an account with access to the Shelf project.
+- `apps/companion/google-service-account.json` exists. It is git-ignored and
+  holds the Play submission key; without it the Android submit fails.
+- Everything intended for this release is merged to `main`.
+
+## 1. The version bump
+
+The version lives in **six declarations across four files**, and the runtime
+version is a hand-written literal because iOS is the bare workflow — nothing
+derives it. `scripts/check-version-sync.mjs` asserts all six agree and runs as
+part of `pnpm --filter @shelf/companion lint`, so CI fails a PR that misses one.
+
+| File                                  | Declaration                   |
+| ------------------------------------- | ----------------------------- |
+| `app.json`                            | `expo.version`                |
+| `app.json`                            | `expo.runtimeVersion`         |
+| `ios/Shelf/Info.plist`                | `CFBundleShortVersionString`  |
+| `ios/Shelf.xcodeproj/project.pbxproj` | `MARKETING_VERSION` (Debug)   |
+| `ios/Shelf.xcodeproj/project.pbxproj` | `MARKETING_VERSION` (Release) |
+| `ios/Shelf/Supporting/Expo.plist`     | `EXUpdatesRuntimeVersion`     |
+
+Bump them in a release PR rather than on the day, so the change is reviewed and
+CI proves the six agree:
+
+```bash
+node apps/companion/scripts/check-version-sync.mjs
+```
+
+**Build numbers are not in this repo.** `eas.json` sets
+`cli.appVersionSource: "remote"` and `build.production.autoIncrement: true`, so
+EAS holds the iOS build number and the Android version code and increments them
+itself. Do not edit `CFBundleVersion` or add `android.versionCode`.
+
+## 2. Write the release notes
+
+Add `RELEASE-NOTES-<version>.md` beside the previous one. It carries the App
+Store text, a Google Play version under 500 characters, and an internal section
+for behaviour worth knowing that does not belong in a store listing.
+
+## 3. Build
+
+From `apps/companion`, on the merged release commit:
+
+```bash
+eas build --platform all --profile production
+```
+
+The `production` profile builds both platforms against the `production` channel.
+Watch it to completion — a failure here is cheaper to fix than a rejected
+submission.
+
+## 4. Submit
+
+```bash
+eas submit --platform ios --profile production
+```
+
+```bash
+eas submit --platform android --profile production
+```
+
+Credentials come from `eas.json`: App Store app id `6765639874`, Apple team
+`27Q4MHFB8K`; Play uploads to the `production` track with
+`releaseStatus: "draft"`, so Play never publishes on its own — someone releases
+it deliberately.
+
+## 5. App Review notes
+
+Anything a reviewer cannot reach on their own has to be written down, or the
+submission is rejected as incomplete rather than refused on its merits.
+
+Private-server sign-in is the current example. A reviewer cannot exercise it
+without a domain registered in the server registry and an account on that
+server — credentials for Shelf Cloud do not work there, because each server is a
+separate Supabase project. The review notes need:
+
+- What the feature is for, and that Shelf Cloud is the default
+- The exact domain to type
+- Credentials on **that** server
+- The steps: sign-in screen → Connect to a private server → type the domain →
+  sign in → Settings → Server → Disconnect
+
+Check `disablePasswordLogin` is false for whichever domain you give them.
+When it is true the reviewer only sees single sign-on, which hands off to an
+identity provider they cannot pass, and a working feature looks like a dead end.
+
+## After it ships
+
+Update `COMPANION-RELEASE-STATUS.md` at the repo root so what is live per store
+is written down next to what is merged.

--- a/apps/companion/app.json
+++ b/apps/companion/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Shelf",
     "slug": "shelf-companion",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "shelf",
@@ -110,7 +110,7 @@
       }
     },
     "owner": "shelfassetmanagement",
-    "runtimeVersion": "1.4.0",
+    "runtimeVersion": "1.5.0",
     "updates": {
       "url": "https://u.expo.dev/b6d6a6cb-c242-4474-815f-b55d5e691c58",
       "enabled": true,

--- a/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
+++ b/apps/companion/ios/Shelf.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -396,7 +396,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.5.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/companion/ios/Shelf/Info.plist
+++ b/apps/companion/ios/Shelf/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apps/companion/ios/Shelf/Supporting/Expo.plist
+++ b/apps/companion/ios/Shelf/Supporting/Expo.plist
@@ -9,7 +9,7 @@
 	<key>EXUpdatesLaunchWaitMs</key>
 	<integer>0</integer>
 	<key>EXUpdatesRuntimeVersion</key>
-	<string>1.4.0</string>
+	<string>1.5.0</string>
 	<key>EXUpdatesURL</key>
 	<string>https://u.expo.dev/b6d6a6cb-c242-4474-815f-b55d5e691c58</string>
 </dict>


### PR DESCRIPTION
## What

Cuts companion 1.5.0 so the build can go to the stores.

**The version bump.** 1.4.0 → 1.5.0 across the six declarations in four files. `scripts/check-version-sync.mjs` runs in lint, so CI proves they agree rather than someone checking by eye:

```
[version-sync] OK — 6 declarations agree on 1.5.0
```

Build numbers are deliberately untouched: `eas.json` sets `appVersionSource: "remote"` with `autoIncrement` on the production profile, so EAS owns the iOS build number and the Android version code.

**`RELEASE-NOTES-1.5.0.md`** — App Store text, a Google Play version under 500 characters, and an internal section for the two things worth knowing that do not belong in a store listing: everyone's remembered workspace resets once because the storage key changed, and two behaviours people were trained on have moved ("Found" is gone from scanned audit rows in favour of the location, and the audits "All" filter now includes archived).

**`STORE-RELEASE.md`** — the repo documented the update path and nothing about cutting a binary, so that sequence lived in one person's head. This writes down the six version declarations, the build and submit commands with the credentials `eas.json` already carries, and what App Review needs.

## What ships in this build

Eight companion PRs merged since 1.4.0 went live:

| | |
| --- | --- |
| #2934 | Connect to a private Shelf server, then sign in against it |
| #2944 | Scanner tells the truth: cross-workspace jump, repeat scans, kit scans while fulfilling |
| #2953 | Undo a mis-scan during an audit |
| #2899 | Scans keep the asset's title and expectedness |
| #2879 | Audit rows say where the asset is, and surface exceptions |
| #2931 | Land in the workspace you last chose on that device |
| #2942 | Coherent bookings journey: personal workspace, past days, archive |
| #2943 | Account URL, currency on amount fields, QR banner |

## Before submitting

App Review cannot exercise private-server sign-in without a registered domain and an account on that server — Shelf Cloud credentials do not work there, since each server is its own Supabase project. `testapp.shelf.nu` is registered and has password login enabled (verified against production's `resolve-server`), so it works as the demo. The review notes need the domain, credentials for it, and the steps; `STORE-RELEASE.md` says what to write.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added private-server connection with domain entry, password, or single sign-on.
  - Improved scanning across workspaces, repeat scans, and kit or reservation mismatches.
  - Expanded audits with scan undo, location details, misplaced-asset counts, notes, photos, and archived records.
  - Enhanced bookings with clearer workspace guidance, saved start times, restrictions on past-day bookings, and automatic archiving for ended reservations.
- **Bug Fixes**
  - Improved workspace persistence, account deletion access, currency display, and QR-code link messaging.
- **Release**
  - Updated the companion app to version 1.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->