### PR TITLE
docs(companion): record where the 1.5.0 builds are

### DIFF
--- a/COMPANION-RELEASE-STATUS.md
+++ b/COMPANION-RELEASE-STATUS.md
@@ -25,7 +25,20 @@ Fill each one in from the store listing once that build is actually live.
 
 ## In flight
 
-**1.5.0 — cut, not yet submitted.**
+**1.5.0 — built; iOS in TestFlight, Android not submitted.**
+
+|         | Build | State                                                             |
+| ------- | ----- | ----------------------------------------------------------------- |
+| iOS     | 36    | Uploaded to App Store Connect, in TestFlight. Not sent to review. |
+| Android | 16    | Built, not submitted — needs `google-service-account.json`.       |
+
+Both from `27dbeeda7`. Private-server sign-in is verified on a device; the
+camera paths (scan-to-create, and "Create Another" after a scanned QR) are not
+— every other check was a simulator or manual code entry.
+
+Before sending iOS to review, App Review needs the demo domain
+`testapp.shelf.nu` and credentials on that server: see
+[apps/companion/STORE-RELEASE.md](./apps/companion/STORE-RELEASE.md) §5.
 
 Eight companion PRs merged since the 1.4.0 build (`0c85873e4`):
 


### PR DESCRIPTION
Updates the release-status file now the builds exist.

| | Build | State |
| --- | --- | --- |
| iOS | 36 | Uploaded to App Store Connect, in TestFlight. Not sent to review. |
| Android | 16 | Built, not submitted — needs `google-service-account.json`. |

Both from `27dbeeda7`. Also records what has actually been exercised on a device — private-server sign-in has been, by DonKoko; the camera paths have not, since every other check was a simulator or manual code entry — and the App Review prerequisite for sending iOS to review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated companion release status for version 1.5.0.
  * Added iOS and Android build details, including submission status.
  * Documented device and simulator verification coverage.
  * Added App Review requirements for the demo domain and credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->