### PR TITLE
fix(companion): point the settings footer at the connected server

### DIFF
--- a/apps/companion/app/(tabs)/settings.tsx
+++ b/apps/companion/app/(tabs)/settings.tsx
@@ -425,6 +425,9 @@ export default function SettingsScreen() {
         <View style={styles.card}>
           <TouchableOpacity
             style={styles.settingRow}
+            // Stays Shelf's own site on every server, unlike the links
+            // around it: this policy covers the APP, which is Shelf's
+            // regardless of who hosts the instance its data lives on.
             onPress={() =>
               WebBrowser.openBrowserAsync("https://www.shelf.nu/privacy")
             }
@@ -484,11 +487,14 @@ export default function SettingsScreen() {
         For advanced features, visit{" "}
         <Text
           style={styles.companionFooterLink}
-          // why: the marketing site, not the user's instance — this one stays
-          // Shelf Cloud even for self-hosted users.
-          onPress={() => WebBrowser.openBrowserAsync("https://app.shelf.nu")}
+          // The web app this companion belongs to, which is the CONNECTED
+          // server — a self-hosted user's advanced features live on their own
+          // instance, and Shelf Cloud has no account of theirs to show them.
+          onPress={() => WebBrowser.openBrowserAsync(getApiBaseUrl())}
+          accessibilityLabel={`Open ${serverLabel} in a browser`}
+          accessibilityRole="link"
         >
-          app.shelf.nu
+          {serverLabel}
         </Text>
       </Text>
 


### PR DESCRIPTION
## What

The Settings footer read "For advanced features, visit **app.shelf.nu**" on
every install, including one connected to a private server. Shelf Cloud holds no
account for a self-hosted user, so the link sent them somewhere they cannot use.

The link and its label now both come from the active server, reusing the same
`serverLabel` the Server row and the Delete Account alert already display.

## Why it missed 1.5.0

Committed on `feat/companion-explicit-server-selection` after #2934 had already
merged, so it never reached the remote. The build in review still has the
hardcoded host.

**This is JS-only** — no native change — so it can ship as an EAS Update to
1.5.0 rather than waiting for the next store build.

## Swept the siblings

Every other web hand-off already resolves through `getApiBaseUrl()`: both QR
bridges in `scanner.tsx`, the QR fallback in `deep-links.ts`, forgot-password on
the login screen, and Delete Account. This was the last hardcoded one.

The Privacy Policy link deliberately stays on `shelf.nu` — that policy covers
the app, which is Shelf's regardless of who hosts the instance — and now says so
in a comment, since every link around it is dynamic and it would otherwise read
as an oversight.

## Testing

Companion typecheck, lint, and 80 unit tests pass. The change is a display
surface no repo test can reach (nothing importing React Native is loadable by
the Node runner), so it wants a glance on the next build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the settings footer link to open the connected server instead of a fixed website.
  * The footer now displays the connected server’s name and includes improved accessibility information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->