### PR TITLE
fix(reports): gate report surfaces on a dedicated reports permission entity

### DIFF
--- a/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
+++ b/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
@@ -117,7 +117,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   const { organizationId } = await requirePermission({
     userId,
     request,
-    entity: PermissionEntity.asset,
+    entity: PermissionEntity.reports,
     action: PermissionAction.read,
   });
 

--- a/apps/webapp/app/routes/_layout+/reports._index.tsx
+++ b/apps/webapp/app/routes/_layout+/reports._index.tsx
@@ -38,12 +38,10 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;
 
-  // For now, require asset read permission as a proxy
-  // TODO: Add PermissionEntity.reports when schema is updated
   await requirePermission({
     userId,
     request,
-    entity: PermissionEntity.asset,
+    entity: PermissionEntity.reports,
     action: PermissionAction.read,
   });
 

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -63,7 +63,7 @@ export const loader = async ({
     const { organizationId } = await requirePermission({
       userId,
       request,
-      entity: PermissionEntity.asset,
+      entity: PermissionEntity.reports,
       action: PermissionAction.export,
     });
 

--- a/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
+++ b/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
@@ -100,7 +100,9 @@ export const loader = async ({
       userId,
       request,
       entity: PermissionEntity.reports,
-      action: PermissionAction.read,
+      // PDF generation hands the data out of the app, like the CSV route:
+      // both are export surfaces and share the export action.
+      action: PermissionAction.export,
     });
 
     // Acting user's resolved prefs drive both the timeframe label ordering and

--- a/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
+++ b/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
@@ -99,7 +99,7 @@ export const loader = async ({
     const { organizationId } = await requirePermission({
       userId,
       request,
-      entity: PermissionEntity.asset,
+      entity: PermissionEntity.reports,
       action: PermissionAction.read,
     });
 

--- a/apps/webapp/app/utils/permissions/permission.validator.client.test.ts
+++ b/apps/webapp/app/utils/permissions/permission.validator.client.test.ts
@@ -51,7 +51,7 @@ describe("userHasPermission (client adapter)", () => {
 
     expect(disagreements).toEqual([]);
     // Guard against the sweep silently covering nothing if an enum is emptied.
-    expect(roles.length * entities.length * actions.length).toBe(1800);
+    expect(roles.length * entities.length * actions.length).toBe(1860);
   });
 
   it("forwards action ARRAYS to the resolver rather than reimplementing them", () => {

--- a/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
@@ -131,7 +131,7 @@ describe("app/routes/_layout+/reports.export.$fileName[.csv] loader", () => {
 
     expect(requirePermissionMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        entity: PermissionEntity.asset,
+        entity: PermissionEntity.reports,
         action: PermissionAction.export,
       })
     );

--- a/packages/permissions/src/matrix.ts
+++ b/packages/permissions/src/matrix.ts
@@ -22,6 +22,10 @@ export const Role2PermissionMap: {
 } = {
   BASE: {
     [PermissionEntity.asset]: [PermissionAction.read],
+    // Reports aggregate org-wide custody, booking and value data; the
+    // sidebar offers them to admins and owners only, and the server gate
+    // matches that. Empty = no access.
+    [PermissionEntity.reports]: [],
     [PermissionEntity.assetIndexSettings]: [PermissionAction.read],
     [PermissionEntity.booking]: [
       PermissionAction.create,
@@ -71,6 +75,7 @@ export const Role2PermissionMap: {
   },
   SELF_SERVICE: {
     [PermissionEntity.asset]: [PermissionAction.read, PermissionAction.custody],
+    [PermissionEntity.reports]: [],
     [PermissionEntity.assetIndexSettings]: [PermissionAction.read],
     [PermissionEntity.booking]: [
       PermissionAction.create,
@@ -124,6 +129,10 @@ export const Role2PermissionMap: {
     [PermissionEntity.commandPaletteSearch]: [PermissionAction.read],
   },
   ADMIN: {
+    [PermissionEntity.reports]: [
+      PermissionAction.read,
+      PermissionAction.export,
+    ],
     [PermissionEntity.asset]: [
       PermissionAction.create,
       PermissionAction.read,
@@ -269,6 +278,10 @@ export const Role2PermissionMap: {
     [PermissionEntity.commandPaletteSearch]: [PermissionAction.read],
   },
   OWNER: {
+    [PermissionEntity.reports]: [
+      PermissionAction.read,
+      PermissionAction.export,
+    ],
     [PermissionEntity.asset]: [
       PermissionAction.create,
       PermissionAction.read,

--- a/packages/permissions/src/resolver.test.ts
+++ b/packages/permissions/src/resolver.test.ts
@@ -225,3 +225,42 @@ describe("roleHasPermission — absent or unknown roles", () => {
     );
   });
 });
+
+describe("roleHasPermission — reports entity", () => {
+  test("denies BASE and SELF_SERVICE both read and export", () => {
+    // Reports aggregate org-wide custody, booking and value data. The
+    // sidebar never offers them below ADMIN, and the server matrix must
+    // agree — an empty action list, not a missing entry.
+    for (const role of ["BASE", "SELF_SERVICE"]) {
+      assert.deepEqual(
+        Role2PermissionMap[role]?.[PermissionEntity.reports],
+        []
+      );
+      for (const action of [PermissionAction.read, PermissionAction.export]) {
+        assert.equal(
+          roleHasPermission({
+            roles: [role],
+            entity: PermissionEntity.reports,
+            action,
+          }),
+          false
+        );
+      }
+    }
+  });
+
+  test("grants ADMIN and OWNER read and export", () => {
+    for (const role of ["ADMIN", "OWNER"]) {
+      for (const action of [PermissionAction.read, PermissionAction.export]) {
+        assert.equal(
+          roleHasPermission({
+            roles: [role],
+            entity: PermissionEntity.reports,
+            action,
+          }),
+          true
+        );
+      }
+    }
+  });
+});

--- a/packages/permissions/src/resolver.test.ts
+++ b/packages/permissions/src/resolver.test.ts
@@ -231,7 +231,7 @@ describe("roleHasPermission — reports entity", () => {
     // Reports aggregate org-wide custody, booking and value data. The
     // sidebar never offers them below ADMIN, and the server matrix must
     // agree — an empty action list, not a missing entry.
-    for (const role of ["BASE", "SELF_SERVICE"]) {
+    for (const role of ["BASE", "SELF_SERVICE"] as const) {
       assert.deepEqual(
         Role2PermissionMap[role]?.[PermissionEntity.reports],
         []
@@ -250,7 +250,7 @@ describe("roleHasPermission — reports entity", () => {
   });
 
   test("grants ADMIN and OWNER read and export", () => {
-    for (const role of ["ADMIN", "OWNER"]) {
+    for (const role of ["ADMIN", "OWNER"] as const) {
       // The resolver grants these roles everything via the short-circuit, so
       // assert the matrix rows directly too — the role-matrix contract must
       // hold even for readers that consult the map without the resolver.

--- a/packages/permissions/src/resolver.test.ts
+++ b/packages/permissions/src/resolver.test.ts
@@ -251,6 +251,12 @@ describe("roleHasPermission — reports entity", () => {
 
   test("grants ADMIN and OWNER read and export", () => {
     for (const role of ["ADMIN", "OWNER"]) {
+      // The resolver grants these roles everything via the short-circuit, so
+      // assert the matrix rows directly too — the role-matrix contract must
+      // hold even for readers that consult the map without the resolver.
+      const entry = Role2PermissionMap[role]?.[PermissionEntity.reports] ?? [];
+      assert.equal(entry.includes(PermissionAction.read), true);
+      assert.equal(entry.includes(PermissionAction.export), true);
       for (const action of [PermissionAction.read, PermissionAction.export]) {
         assert.equal(
           roleHasPermission({

--- a/packages/permissions/src/vocabulary.ts
+++ b/packages/permissions/src/vocabulary.ts
@@ -58,6 +58,8 @@ export enum PermissionEntity {
   assetReminders = "assetReminders",
   audit = "audit",
   auditNote = "auditNote",
+  /** Org-wide analytics under `/reports` — pages, CSV and PDF exports. */
+  reports = "reports",
   teamMemberNote = "teamMemberNote",
   assetModel = "assetModel",
   emailSettings = "emailSettings",


### PR DESCRIPTION
## What

Gives reports their own permission entity, closing the gap between what the sidebar intends and what the server enforces.

The four report surfaces (index, report pages, CSV export, PDF export) were gated on `asset` permissions as a stand-in, with an in-code TODO saying a dedicated `PermissionEntity.reports` was the plan. The sidebar already hides Reports from BASE and SELF_SERVICE, but the loaders did not match it, so the pages were reachable by direct URL for roles the navigation never offers them to. This aligns the server with the sidebar's existing intent; nothing changes for anyone using the app through its own navigation.

## How

- `@shelf/permissions`: new `PermissionEntity.reports`. The `Record<PermissionEntity, ...>` typing forces every role to declare a position: ADMIN and OWNER get `read` and `export`, BASE and SELF_SERVICE get an explicit empty list. Resolver tests pin all four roles for both actions.
- The four report routes now require `reports: read` (pages, PDF) and `reports: export` (CSV) instead of the asset stand-in; the TODO comments are gone.
- Sidebar untouched: it already expressed this policy.

## Defaults taken here, vetoable in this review

- Roles follow the sidebar: admins and owners only. If BASE should see reports later, it is one matrix line plus unhiding the nav item.
- Plan gating is deliberately unchanged: reports remain available on every plan. If they should become a paid feature, that is a separate product decision and PR.

## Testing

New resolver tests cover the matrix rows and both actions for all four roles; the compiler enforces that no role is missing an entry. Webapp typecheck and full validate green. No new workspace package and no migration; existing checkouts need nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated permissions for viewing and exporting reports.
  * Administrators and owners can access report pages and CSV/PDF exports.
  * Base and self-service roles do not receive report access by default.
  * CSV exports now separate units, unit value, and total value.

* **Bug Fixes**
  * Report access and export checks now use report-specific permissions.

* **Tests**
  * Updated coverage for report permissions and export workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->