### PR TITLE
fix(companion): apply the booking edit gate to BASE, not just SELF_SERVICE

### DIFF
--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -136,9 +136,19 @@ export default function BookingDetailScreen() {
   // Android overflow-menu visibility (iOS uses the native ActionSheetIOS).
   const [showActionsMenu, setShowActionsMenu] = useState(false);
 
-  // Mirrors the web's canUserManageBookingAssets: closed statuses reject;
-  // self-service users may only build their own DRAFT bookings.
-  const isSelfService = currentOrg?.roles?.includes("SELF_SERVICE") ?? false;
+  /**
+   * Mirrors the web's `canUserManageBookingAssets`: closed statuses reject, and
+   * a RESTRICTED role may only build its own DRAFT booking.
+   *
+   * BASE as well as SELF_SERVICE. The web passes both roles into that helper
+   * (its parameter is named `isSelfService` but every caller hands it
+   * `isBaseOrSelfService`), while this screen tested SELF_SERVICE alone. A BASE
+   * custodian is a custodian at every status, so the add, browse, remove and
+   * fulfil affordances below stayed on past DRAFT for them.
+   */
+  const isRestrictedRole = Boolean(
+    currentOrg?.roles?.some((r) => r === "SELF_SERVICE" || r === "BASE")
+  );
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isActioning, setIsActioning] = useState(false);
@@ -1032,7 +1042,7 @@ export default function BookingDetailScreen() {
   // users only on their own DRAFTs (server re-checks ownership + status).
   const canManageModels =
     !["COMPLETE", "ARCHIVED", "CANCELLED"].includes(booking.status) &&
-    (!isSelfService || booking.status === "DRAFT");
+    (!isRestrictedRole || booking.status === "DRAFT");
 
   /**
    * Open the model-reservation manager (the picker's Models tab) for this
@@ -1369,7 +1379,7 @@ export default function BookingDetailScreen() {
 
             {booking &&
               !["COMPLETE", "ARCHIVED", "CANCELLED"].includes(booking.status) &&
-              (!isSelfService || booking.status === "DRAFT") && (
+              (!isRestrictedRole || booking.status === "DRAFT") && (
                 <TouchableOpacity
                   style={styles.actionButtonOutline}
                   onPress={() =>
@@ -1397,7 +1407,7 @@ export default function BookingDetailScreen() {
 
             {/* Browse available assets/kits to add (date-aware picker) */}
             {!["COMPLETE", "ARCHIVED", "CANCELLED"].includes(booking.status) &&
-              (!isSelfService || booking.status === "DRAFT") && (
+              (!isRestrictedRole || booking.status === "DRAFT") && (
                 <TouchableOpacity
                   style={styles.actionButtonOutline}
                   onPress={() =>
@@ -1427,7 +1437,7 @@ export default function BookingDetailScreen() {
 
             {/* Select assets to remove (editable bookings with assets) */}
             {!["COMPLETE", "ARCHIVED", "CANCELLED"].includes(booking.status) &&
-              (!isSelfService || booking.status === "DRAFT") &&
+              (!isRestrictedRole || booking.status === "DRAFT") &&
               booking.assetCount > 0 && (
                 <TouchableOpacity
                   style={[
@@ -1538,12 +1548,12 @@ export default function BookingDetailScreen() {
                 web `fulfil-and-checkout` scanner. Scan-first IS the point of
                 book-by-model: reserve the count now, scan the items when you
                 grab them, no browse picker. (Browse to Add above stays for
-                hand-picking.) Gated `!isSelfService` to match the add/browse
-                affordances above: a self-service custodian can only edit a
+                hand-picking.) Gated `!isRestrictedRole` to match the add/browse
+                affordances above: a restricted custodian can only edit a
                 DRAFT booking, so on a RESERVED booking the assign+checkout flow
                 can't succeed for them — showing the CTA would just lead to a
                 rejected submit. */}
-            {!isSelfService &&
+            {!isRestrictedRole &&
               booking.status === "RESERVED" &&
               hasOutstandingModelRequests && (
                 <TouchableOpacity


### PR DESCRIPTION
Companion half of the Base-role booking gap. The web half is [#2954](https://github.com/Shelf-nu/shelf.nu/pull/2954); this PR is app-only and the two do not overlap.

## Problem

The booking detail screen asks one question, `roles.includes("SELF_SERVICE")`, and uses the answer for five affordances:

- Manage model reservations
- Scan to Add
- Browse to Add
- **Select to Remove**
- Assign + check out outstanding model requests

A BASE user never matches that check, so all five stayed available to them past DRAFT.

The web helper these mirror, `canUserManageBookingAssets`, takes a parameter named `isSelfService`, but every caller on web passes it `isBaseOrSelfService`. The parameter name is what got copied across, not what it holds.

## Fix

Renames the flag to `isRestrictedRole` and includes BASE, so all five gates move together. One variable, no behaviour change for any other role.

## Severity

Cosmetic. Every one of the five is already refused server-side for BASE:

| Action | Server gate |
|---|---|
| Remove assets | role + status, `canRoleRemoveBookingAssets` (#2954) |
| Add / scan / browse | `booking:manageAssets` plus a DRAFT-only status gate |
| Check in | `requireMobilePermission(booking:checkin)`, which BASE does not hold |
| Fulfil and check out | `requireMobilePermission(booking:checkout)`, same |

So this removes buttons that could only ever produce an error, rather than closing a hole.

## Not included

The mobile detail endpoint's `canCheckin` flag and its role resolution were the other half of this when I first wrote it. Both have since landed on `main` independently, so this PR is companion-only.

## Testing

`tsc --noEmit` and `expo lint` clean. Not yet exercised on a device: there is no OTA channel, so this ships with the next store build either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated booking management permissions for BASE custodians.
  * BASE custodians can now manage bookings, add or remove models, scan items, and fulfil or check out bookings regardless of booking status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->