### PR TITLE
fix(bookings): scope four surfaces to both custody links, not just the user one

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -240,6 +240,10 @@ vitest.mock("~/database/db.server", () => ({
     },
     teamMember: {
       findUnique: vitest.fn().mockResolvedValue(null),
+      // why: `resolveCustodianScope` reads every team-member row the user holds
+      // in the org, so any query that restricts to "my bookings" reaches this.
+      // Defaults to none; the custodian-scope tests supply their own rows.
+      findMany: vitest.fn().mockResolvedValue([]),
       // why: cross-org IDOR guard (assertTeamMemberBelongsToOrg) and the
       // new-custodian lookup now query teamMember.findFirst scoped by
       // organizationId. Echo a minimal row for the requested id so the
@@ -12176,22 +12180,60 @@ describe("getMinimalBookings", () => {
     expect(arg.where.custodianUserId).toBeUndefined();
   });
 
-  it("scopes to a custodian when custodianUserId is provided (self-service)", async () => {
-    // why: stub the query so we can assert the custodian where-clause
-    // getMinimalBookings adds for self-service callers, not real DB behavior.
+  it("scopes to both custody links when restricted to the custodian", async () => {
+    // Custody sits on the user link OR on a team-member link, and a booking
+    // assigned to a team member before a user was attached to it keeps
+    // `custodianUserId` NULL. Matching the user link alone hides exactly the
+    // bookings those users own.
+    // why: stub the query so the where-clause is observable without a database.
     const findMany = db.booking.findMany as unknown as ReturnType<
       typeof vitest.fn
     >;
     findMany.mockResolvedValueOnce([]);
+    // why: this is the lookup `resolveCustodianScope` performs; the user holds
+    // two team-member rows, which the schema permits (no unique on
+    // `(userId, organizationId)`).
+    (
+      db.teamMember.findMany as unknown as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce([{ id: "tm-1" }, { id: "tm-2" }]);
 
     await getMinimalBookings({
       organizationId: "org-1",
       userId: "user-1",
-      custodianUserId: "user-1",
+      restrictToCustodian: true,
     });
 
     const arg = findMany.mock.calls[0][0];
-    expect(arg.where.custodianUserId).toBe("user-1");
+    // AND-ed, not merged into a top-level OR where another clause could widen
+    // it away.
+    expect(arg.where.custodianUserId).toBeUndefined();
+    expect(arg.where.AND).toContainEqual({
+      OR: [
+        { custodianUserId: "user-1" },
+        { custodianTeamMemberId: { in: ["tm-1", "tm-2"] } },
+      ],
+    });
+  });
+
+  it("falls back to the user link when the user holds no team-member row", async () => {
+    const findMany = db.booking.findMany as unknown as ReturnType<
+      typeof vitest.fn
+    >;
+    findMany.mockResolvedValueOnce([]);
+    // why: a user with no team member in the org — the clause has nothing to
+    // add, and must not degrade into matching everything.
+    (
+      db.teamMember.findMany as unknown as ReturnType<typeof vitest.fn>
+    ).mockResolvedValueOnce([]);
+
+    await getMinimalBookings({
+      organizationId: "org-1",
+      userId: "user-1",
+      restrictToCustodian: true,
+    });
+
+    const arg = findMany.mock.calls[0][0];
+    expect(arg.where.AND).toContainEqual({ custodianUserId: "user-1" });
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -10275,14 +10275,33 @@ export async function getMinimalBookings(params: {
   organizationId: Organization["id"];
   userId: Booking["creatorId"];
   statuses?: Booking["status"][] | null;
-  custodianUserId?: Booking["custodianUserId"] | null;
+  /**
+   * Restrict to bookings that are the acting user's own. Takes a flag rather
+   * than an id so the caller cannot express the restriction narrowly: custody
+   * lives on either the user link OR a team-member link, and this resolves
+   * both through {@link custodianScopeClause}.
+   */
+  restrictToCustodian?: boolean;
 }) {
-  const { organizationId, userId, statuses, custodianUserId } = params;
+  const { organizationId, userId, statuses, restrictToCustodian } = params;
 
   try {
+    const andClauses: Prisma.BookingWhereInput[] = [
+      bookingDraftVisibilityClause(userId),
+    ];
+
+    if (restrictToCustodian && userId) {
+      // AND-ed, never merged into a top-level OR where a filter could widen it.
+      andClauses.push(
+        custodianScopeClause(
+          await resolveCustodianScope({ userId, organizationId })
+        )
+      );
+    }
+
     const where: Prisma.BookingWhereInput = {
       organizationId,
-      AND: [bookingDraftVisibilityClause(userId)],
+      AND: andClauses,
     };
 
     if (statuses?.length) {
@@ -10292,10 +10311,6 @@ export async function getMinimalBookings(params: {
       where.status = {
         notIn: [BookingStatus.ARCHIVED, BookingStatus.CANCELLED],
       };
-    }
-
-    if (custodianUserId) {
-      where.custodianUserId = custodianUserId;
     }
 
     const bookings = await db.booking.findMany({

--- a/apps/webapp/app/routes/api+/bookings.get-all.ts
+++ b/apps/webapp/app/routes/api+/bookings.get-all.ts
@@ -30,7 +30,9 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       // bookings too (added assets stay AVAILABLE — progressive checkout), not
       // just DRAFT/RESERVED ones.
       statuses: ["DRAFT", "RESERVED", "ONGOING", "OVERDUE"],
-      ...(isSelfServiceOrBase && { custodianUserId: userId }),
+      // Custody may sit on the user link or on a team-member link; the
+      // service resolves both.
+      ...(isSelfServiceOrBase && { restrictToCustodian: true }),
     });
 
     return data(payload({ bookings }));

--- a/apps/webapp/app/routes/api+/bookings.get-all.ts
+++ b/apps/webapp/app/routes/api+/bookings.get-all.ts
@@ -8,6 +8,22 @@ import {
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
 
+/**
+ * Bookings the caller may add assets to, for the "add to existing booking"
+ * dialog.
+ *
+ * Returns the slim projection — name and dates only — because the dialog
+ * renders nothing else and filters client-side.
+ *
+ * A restricted caller (SELF_SERVICE / BASE) sees only their own. "Their own"
+ * spans both custody links: a booking may name them through the user link or
+ * through any team-member row they hold, and matching the user link alone hides
+ * the ones assigned before that link existed.
+ *
+ * @param args.context - Carries the auth session
+ * @param args.request - Read for the active organization
+ * @returns `{ bookings }` — DRAFT, RESERVED, ONGOING and OVERDUE only
+ */
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const userId = authSession.userId;

--- a/apps/webapp/app/routes/api+/command-palette.search.ts
+++ b/apps/webapp/app/routes/api+/command-palette.search.ts
@@ -10,6 +10,10 @@ import {
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
 import { getAssets } from "~/modules/asset/service.server";
 import { getPrimaryLocation } from "~/modules/asset/utils";
+import {
+  custodianScopeClause,
+  resolveCustodianScope,
+} from "~/modules/booking/service.server";
 import { getPrimaryCustody } from "~/modules/custody/utils";
 import { makeShelfError } from "~/utils/error";
 import { payload, error } from "~/utils/http.server";
@@ -187,8 +191,19 @@ export async function loader({ context, request }: LoaderFunctionArgs) {
       ...(bookingSearchConditions.length
         ? { OR: bookingSearchConditions }
         : {}),
-      // BASE and SELF_SERVICE users can only see their own bookings unless org settings allow otherwise
-      ...(canSeeAllBookings ? {} : { custodianUserId: userId }),
+      // BASE and SELF_SERVICE users can only see their own bookings unless org
+      // settings allow otherwise. AND-ed rather than merged in beside the
+      // search `OR` above: custody is itself an OR across the user link and any
+      // team-member link, and a search term must not be able to widen it away.
+      ...(canSeeAllBookings
+        ? {}
+        : {
+            AND: [
+              custodianScopeClause(
+                await resolveCustodianScope({ userId, organizationId })
+              ),
+            ],
+          }),
     };
 
     const locationWhere: Prisma.LocationWhereInput = {

--- a/apps/webapp/app/routes/api+/command-palette.search.ts
+++ b/apps/webapp/app/routes/api+/command-palette.search.ts
@@ -30,6 +30,22 @@ const querySchema = z.object({
   q: z.string().trim().max(100).optional(),
 });
 
+/**
+ * Cross-entity search behind the command palette.
+ *
+ * Queries assets, audits, kits, bookings, locations and team members in one
+ * round trip, each scoped to the active organization.
+ *
+ * Bookings carry an extra restriction: unless the role (or the workspace
+ * setting) allows seeing every booking, results are limited to the caller's
+ * own — across both custody links, since a booking may name them through the
+ * user link or through any team-member row they hold. That restriction is
+ * AND-ed, never folded into the search `OR`, so a search term cannot widen it.
+ *
+ * @param args.context - Carries the auth session
+ * @param args.request - Read for the query string and active organization
+ * @returns Matches per entity, each already scoped to what the caller may see
+ */
 export async function loader({ context, request }: LoaderFunctionArgs) {
   const authSession = context.getSession();
   const { userId } = authSession;

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -19,6 +19,8 @@ import { isBookingArchivable } from "~/modules/booking/helpers";
 import {
   bookingDraftVisibilityClause,
   computeBookingAssetRemaining,
+  custodianScopeClause,
+  resolveCustodianScope,
   computeBookingAssetRemainingToCheckOut,
   getBookingFlags,
   getPartiallyCheckedInAssetIds,
@@ -71,7 +73,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       where: {
         id: bookingId,
         organizationId,
-        ...(isSelfServiceOrBase && { custodianUserId: user.id }),
         /**
          * Draft privacy (web parity). A DRAFT booking is private to its
          * creator — web gates the detail route on the same shared clause, so
@@ -79,8 +80,25 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
          * even though the list would (now) hide it. The list fix alone is not
          * enough: booking ids are guessable-adjacent and the detail endpoint
          * is reachable directly.
+         *
+         * The custodian restriction joins the same AND rather than sitting
+         * beside it: custody lives on the user link OR a team-member link, so
+         * the clause is itself an OR and merging it in at this level would
+         * collide with the one above.
          */
-        AND: [bookingDraftVisibilityClause(user.id)],
+        AND: [
+          bookingDraftVisibilityClause(user.id),
+          ...(isSelfServiceOrBase
+            ? [
+                custodianScopeClause(
+                  await resolveCustodianScope({
+                    userId: user.id,
+                    organizationId,
+                  })
+                ),
+              ]
+            : []),
+        ],
       },
       select: {
         id: true,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
@@ -8,6 +8,10 @@ import {
   getMobileUserContext,
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
+import {
+  custodianScopeClause,
+  resolveCustodianScope,
+} from "~/modules/booking/service.server";
 import { getBookingModelTabData } from "~/modules/booking-model-request/service.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
@@ -77,7 +81,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
       where: {
         id: bookingId,
         organizationId,
-        ...(isSelfServiceOrBase && { custodianUserId: user.id }),
+        // Custody sits on the user link OR a team-member link; AND-ed so the
+        // resulting OR cannot be widened by anything beside it.
+        ...(isSelfServiceOrBase
+          ? {
+              AND: [
+                custodianScopeClause(
+                  await resolveCustodianScope({
+                    userId: user.id,
+                    organizationId,
+                  })
+                ),
+              ],
+            }
+          : {}),
       },
       select: {
         id: true,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
@@ -9,6 +9,7 @@ import {
   assertMobileCanUseBookings,
 } from "~/modules/api/mobile-auth.server";
 import {
+  bookingDraftVisibilityClause,
   custodianScopeClause,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
@@ -81,20 +82,31 @@ export async function loader({ request }: LoaderFunctionArgs) {
       where: {
         id: bookingId,
         organizationId,
-        // Custody sits on the user link OR a team-member link; AND-ed so the
-        // resulting OR cannot be widened by anything beside it.
-        ...(isSelfServiceOrBase
-          ? {
-              AND: [
+        AND: [
+          /**
+           * Draft privacy, applied to EVERY role. A DRAFT booking is private
+           * to its creator, which is what the detail route enforces — without
+           * it here, anyone who can name a colleague's draft id reads its model
+           * reservations and availability, and custody scoping does not cover
+           * it because that scoping does not apply to ADMIN/OWNER at all.
+           */
+          bookingDraftVisibilityClause(user.id),
+          /**
+           * Custody sits on the user link OR a team-member link, so the clause
+           * is itself an OR — it joins this AND rather than sitting beside it,
+           * where the two ORs would collide.
+           */
+          ...(isSelfServiceOrBase
+            ? [
                 custodianScopeClause(
                   await resolveCustodianScope({
                     userId: user.id,
                     organizationId,
                   })
                 ),
-              ],
-            }
-          : {}),
+              ]
+            : []),
+        ],
       },
       select: {
         id: true,

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
@@ -31,7 +31,13 @@ import { assertIsDataWithResponseInit } from "@helpers/assertions";
 // why: db is the integration boundary — we assert the `where` the route builds
 // so the custodian scoping is provably applied. Mock booking.findFirst only.
 vi.mock("~/database/db.server", () => ({
-  db: { booking: { findFirst: vi.fn() } },
+  db: {
+    booking: { findFirst: vi.fn() },
+    // why: a custody-restricted read resolves every team-member row the caller
+    // holds in the org, so `resolveCustodianScope` reaches this. Defaults to
+    // none; the scoping test supplies its own.
+    teamMember: { findMany: vi.fn().mockResolvedValue([]) },
+  },
 }));
 
 // why: auth/entitlement helpers are out of scope; stub them but keep
@@ -113,10 +119,34 @@ describe("GET /api/mobile/bookings/available-models", () => {
     await loader(makeArgs());
 
     const where = findFirstMock.mock.calls[0]![0]!.where;
-    expect(where).toMatchObject({
-      id: BOOKING_ID,
-      organizationId: ORG_ID,
-      custodianUserId: CALLER_ID,
+    expect(where).toMatchObject({ id: BOOKING_ID, organizationId: ORG_ID });
+
+    // Custody sits on the caller's user link OR on any team-member row they
+    // hold — a booking assigned to a team member before a user was attached to
+    // it keeps `custodianUserId` NULL, and matching that link alone hides
+    // exactly the bookings those callers own. AND-ed, so nothing beside it can
+    // widen the restriction away.
+    expect(where).not.toHaveProperty("custodianUserId");
+    expect(where!.AND).toContainEqual({ custodianUserId: CALLER_ID });
+  });
+
+  it("includes the caller's team-member links in the custody scope", async () => {
+    withRole(OrganizationRoles.SELF_SERVICE);
+    // why: this is the lookup `resolveCustodianScope` performs; a user may hold
+    // more than one team-member row in an org (no unique on the pair).
+    vi.mocked(db.teamMember.findMany).mockResolvedValueOnce([
+      { id: "tm-1" },
+      { id: "tm-2" },
+    ] as never);
+
+    await loader(makeArgs());
+
+    const where = findFirstMock.mock.calls[0]![0]!.where;
+    expect(where!.AND).toContainEqual({
+      OR: [
+        { custodianUserId: CALLER_ID },
+        { custodianTeamMemberId: { in: ["tm-1", "tm-2"] } },
+      ],
     });
   });
 

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
@@ -150,6 +150,24 @@ describe("GET /api/mobile/bookings/available-models", () => {
     });
   });
 
+  it("hides another member's DRAFT booking, even from an ADMIN", async () => {
+    // A DRAFT booking is private to its creator, which is the rule the detail
+    // route enforces. Custody scoping cannot stand in for it: ADMIN and OWNER
+    // are not custody-scoped at all, so without this clause naming a
+    // colleague's draft id returns its model reservations and availability.
+    withRole(OrganizationRoles.ADMIN);
+
+    await loader(makeArgs());
+
+    const where = findFirstMock.mock.calls[0]![0]!.where;
+    expect(where!.AND).toContainEqual({
+      OR: [
+        { status: { not: "DRAFT" } },
+        { AND: [{ status: "DRAFT" }, { creatorId: CALLER_ID }] },
+      ],
+    });
+  });
+
   it("does NOT custody-scope the booking read for ADMIN", async () => {
     withRole(OrganizationRoles.ADMIN);
 
@@ -157,6 +175,8 @@ describe("GET /api/mobile/bookings/available-models", () => {
 
     const where = findFirstMock.mock.calls[0]![0]!.where;
     expect(where).not.toHaveProperty("custodianUserId");
+    // The AND carries draft privacy for every role, but no custody branch.
+    expect(where!.AND).toHaveLength(1);
   });
 
   it("forwards the `s` query param to getBookingModelTabData as `search` (server-side model search)", async () => {


### PR DESCRIPTION
Three findings from the P2 sweep — **D089**, **D076** and **D018** — that turned
out to be one gap seen from three surfaces.

## The gap

A booking records its custodian on **either of two links**, and may carry only
the team-member one. `createBooking` always connects `custodianTeamMember`, and
connects `custodianUser` only when the caller supplies it — so a booking assigned
to a team member before a user was attached to that team member keeps
`custodianUserId` NULL.

Matching that link alone hides exactly the bookings those users own.

## The codebase already solved this

That is what makes these three findings a sweep rather than a design problem:

- `canSeeBooking` checks **both** links, and its JSDoc explains why
- `resolveCustodianScope` collects **every** team-member row a user holds in an
  org — the schema has no unique on `(userId, organizationId)`, so there can be
  several
- `custodianScopeClause` turns that into the AND-able clause the index and the
  CSV export already use

`custodianScopeClause`'s own docs record this bug happening once before, on
`/api/model-filters`:

> *the endpoint matched the user link alone, so a booking custodied through a
> legacy team-member row showed in the list a picker was seeded with and then
> vanished the moment the user typed.*

Four read surfaces never picked it up and hand-rolled `custodianUserId: me`:

| Surface | Finding |
| --- | --- |
| `api+/command-palette.search.ts` | D089 as filed |
| `api+/bookings.get-all.ts` | the add-to-existing-booking list |
| `api+/mobile+/bookings.available-models.ts` | |
| `api+/mobile+/bookings.$bookingId.ts` | |

## The fix

Each now ANDs in the shared clause.

**AND, not merged in alongside.** The clause is itself an `OR` across the two
links, and the command palette already carries a search `OR` at that level —
merging would let a search term widen the restriction away. That is also what
`custodianScopeClause`'s docs ask for: *"push into `where.AND` — never into a
top-level `OR`"*.

`getMinimalBookings` now takes `restrictToCustodian: boolean` instead of a
`custodianUserId` id. A flag cannot be passed narrowly: the service resolves the
scope itself, so no caller can reintroduce the single-link form.

## What this deliberately does NOT change

**The mutation gates.** `validateBookingOwnership` matches on the user link
alone, and its query-side mirror in `booking-authorization.server.ts` mirrors it
exactly — they agree with each other by design. Seeing a booking and being
allowed to edit it are separate questions, and this PR changes only the first.

`csv.server.ts` was already correct — its clause is a two-link `OR`.

## Tests

Two existing tests asserted the old single-link scoping and are updated; the
mutation (reverting one site) fails both. Three new tests cover a caller holding
**several** team-member rows and the fallback when they hold none.

- Full suite: **434 files, 5722 tests**
- `tsc -b --force` clean, ESLint clean, Prettier clean

The one failure seen in the full run was `audit/asset-details`'s parallel-count
test, which asserts wall-clock elapsed time and passes in isolation — unrelated
module, known timing flake.

No migration. No schema change. No new dependency.

Closes the `detail.dev` D089, D076 and D018 findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved booking access controls for self-service and base-permission users.
  - Bookings now match both direct custodian links and team-member custody links.
  - Applied custody restrictions consistently across booking lists, details, available models, and command-palette search.
  - Ensured draft bookings remain visible only to their creator, regardless of role.
  - Preserved existing organization, draft-visibility, and booking filters alongside custody rules.
- **Tests**
  - Added coverage for multiple team-member links and users without team-member records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->