### PR TITLE
feat(reports): add the Audit Completion report

### DIFF
--- a/apps/webapp/app/components/reports/audit-completion-content.tsx
+++ b/apps/webapp/app/components/reports/audit-completion-content.tsx
@@ -58,7 +58,7 @@ const AUDIT_COMPLETION_COLUMNS: ColumnDef<AuditCompletionRow>[] = [
   {
     accessorKey: "missingAssetCount",
     header: "Missing",
-    cell: ({ row }) => <NumberCell value={row.original.missingAssetCount} />,
+    cell: ({ row }) => <MissingCell value={row.original.missingAssetCount} />,
   },
   {
     accessorKey: "unexpectedAssetCount",
@@ -100,9 +100,21 @@ const AUDIT_COMPLETION_COLUMNS: ColumnDef<AuditCompletionRow>[] = [
  *
  * @param accuracy - found/expected as a whole percentage, or null
  */
+/**
+ * Missing-asset count for a session. Null means the session has not
+ * completed yet — the counter still measures "not scanned", so the cell
+ * says that instead of branding in-progress audits as having lost assets.
+ */
+function MissingCell({ value }: { value: number | null }) {
+  if (value === null) {
+    return <span className="text-xs text-gray-600">Not scanned</span>;
+  }
+  return <NumberCell value={value} />;
+}
+
 function AccuracyCell({ accuracy }: { accuracy: number | null }) {
   if (accuracy === null) {
-    return <span className="text-gray-400">—</span>;
+    return <span className="text-gray-600">—</span>;
   }
   return (
     <div className="flex items-center gap-3">

--- a/apps/webapp/app/components/reports/audit-completion-content.tsx
+++ b/apps/webapp/app/components/reports/audit-completion-content.tsx
@@ -1,0 +1,247 @@
+/**
+ * @file Audit Completion report content.
+ *
+ * Renders the Audit Completion report body: a hero with the completion rate
+ * and its supporting counts, followed by a table of every audit session in
+ * the timeframe. Column definitions live at module scope so cell function
+ * identities stay stable across renders (see
+ * `.claude/rules/react-render-stability.md`).
+ *
+ * Status renders through the shared `AuditStatusBadgeWithOverdue`, which
+ * derives overdue-ness (due date past, session still open) as a separate red
+ * chip beside the status badge — overdue is a schedule fact, not a status.
+ *
+ * @see {@link file://../../routes/_layout+/reports.$reportId.tsx}
+ * @see {@link file://../../modules/reports/audit-completion.server.ts}
+ */
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { AuditStatusBadgeWithOverdue } from "~/components/audit/audit-status-badge-with-overdue";
+import type { AuditCompletionRow, ReportKpi } from "~/modules/reports/types";
+import { tw } from "~/utils/tw";
+
+import { ReportEmptyState } from "./report-empty-state";
+import { DateCell, NumberCell, ReportTable } from "./report-table";
+
+/**
+ * Column definitions for the Audit Completion table, declared at module
+ * scope so cell function identities stay stable across renders. See
+ * `.claude/rules/react-render-stability.md` for the underlying rule.
+ */
+const AUDIT_COMPLETION_COLUMNS: ColumnDef<AuditCompletionRow>[] = [
+  {
+    accessorKey: "name",
+    header: "Audit",
+    cell: ({ row }) => <span className="font-medium">{row.original.name}</span>,
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <AuditStatusBadgeWithOverdue
+        status={row.original.status}
+        dueDate={row.original.dueDate}
+      />
+    ),
+  },
+  {
+    accessorKey: "expectedAssetCount",
+    header: "Expected",
+    cell: ({ row }) => <NumberCell value={row.original.expectedAssetCount} />,
+  },
+  {
+    accessorKey: "foundAssetCount",
+    header: "Found",
+    cell: ({ row }) => <NumberCell value={row.original.foundAssetCount} />,
+  },
+  {
+    accessorKey: "missingAssetCount",
+    header: "Missing",
+    cell: ({ row }) => <NumberCell value={row.original.missingAssetCount} />,
+  },
+  {
+    accessorKey: "unexpectedAssetCount",
+    header: "Unexpected",
+    cell: ({ row }) => <NumberCell value={row.original.unexpectedAssetCount} />,
+  },
+  {
+    accessorKey: "accuracy",
+    header: "Accuracy",
+    cell: ({ row }) => <AccuracyCell accuracy={row.original.accuracy} />,
+  },
+  {
+    accessorKey: "createdByName",
+    header: "Created by",
+    cell: ({ row }) => row.original.createdByName,
+  },
+  {
+    accessorKey: "startedAt",
+    header: "Started",
+    cell: ({ row }) => <DateCell date={row.original.startedAt} />,
+  },
+  {
+    accessorKey: "dueDate",
+    header: "Due Date",
+    cell: ({ row }) => <DateCell date={row.original.dueDate} />,
+  },
+  {
+    accessorKey: "completedAt",
+    header: "Completed",
+    cell: ({ row }) => <DateCell date={row.original.completedAt} />,
+  },
+];
+
+/**
+ * Accuracy cell: a brand-color bar whose width is the found/expected rate,
+ * next to the percentage. Brand color, no judgment — the width shows the
+ * magnitude (see the progress-bar rule in `.claude/rules/reports-styling.md`).
+ * Null accuracy (session expected 0 assets) renders as "—".
+ *
+ * @param accuracy - found/expected as a whole percentage, or null
+ */
+function AccuracyCell({ accuracy }: { accuracy: number | null }) {
+  if (accuracy === null) {
+    return <span className="text-gray-400">—</span>;
+  }
+  return (
+    <div className="flex items-center gap-3">
+      <div className="h-2 w-16 overflow-hidden rounded-full bg-gray-100">
+        <div
+          className="h-full rounded-full bg-primary-500"
+          style={{ width: `${Math.min(accuracy, 100)}%` }}
+        />
+      </div>
+      <span className="text-sm font-semibold tabular-nums text-gray-900">
+        {accuracy}%
+      </span>
+    </div>
+  );
+}
+
+/** Props for {@link AuditCompletionContent}. */
+type Props = {
+  /** Audit sessions for the current page (already paginated by the server). */
+  rows: AuditCompletionRow[];
+  /** KPI values driving the hero (total, completed, rate, overdue, missing). */
+  kpis: ReportKpi[];
+  /** Total row count, shown as a pill next to the table heading. */
+  totalRows: number;
+  /** Human-readable label for the selected timeframe (e.g. "Last 30 days"). */
+  timeframeLabel?: string;
+  /** Called when a row is clicked — navigates to the audit detail page. */
+  onRowClick?: (row: AuditCompletionRow) => void;
+};
+
+/**
+ * Reads a KPI's numeric value by id, defaulting to 0 when the KPI is absent
+ * or carries no raw value.
+ */
+function kpiNumber(kpis: ReportKpi[], id: string): number {
+  const raw = kpis.find((k) => k.id === id)?.rawValue;
+  return typeof raw === "number" ? raw : 0;
+}
+
+/**
+ * Audit Completion report body.
+ *
+ * Renders the completion-rate hero with its supporting counts, then the
+ * session table.
+ *
+ * @param props - See {@link Props}.
+ * @returns The rendered report content.
+ */
+export function AuditCompletionContent({
+  rows,
+  kpis,
+  totalRows,
+  timeframeLabel,
+  onRowClick,
+}: Props) {
+  // The rate KPI carries no rawValue when there are no measurable sessions —
+  // null here renders "—", never 0% (the null-not-zero convention).
+  const rateRaw = kpis.find((k) => k.id === "completion_rate")?.rawValue;
+  const completionRate = typeof rateRaw === "number" ? rateRaw : null;
+
+  const totalAudits = kpiNumber(kpis, "total_audits");
+  const completedAudits = kpiNumber(kpis, "completed_audits");
+  const overdueAudits = kpiNumber(kpis, "overdue_audits");
+  const assetsMissing = kpiNumber(kpis, "assets_missing");
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Hero section */}
+      <div className="rounded border border-gray-200 bg-white">
+        <div className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between md:p-6">
+          {/* Main metric: completion rate with threshold colors */}
+          <div className="flex items-center gap-4">
+            <span
+              className={tw(
+                "text-3xl font-semibold",
+                completionRate === null
+                  ? "text-gray-900"
+                  : completionRate >= 70
+                  ? "text-green-600"
+                  : completionRate >= 30
+                  ? "text-blue-600"
+                  : "text-yellow-600"
+              )}
+            >
+              {completionRate !== null ? `${completionRate}%` : "—"}
+            </span>
+            <div className="flex flex-col">
+              <span className="text-sm font-medium text-gray-700">
+                Completion Rate
+              </span>
+              <span className="text-xs text-gray-500">
+                {completedAudits} of {totalAudits} audit
+                {totalAudits !== 1 ? "s" : ""} completed
+                {timeframeLabel ? ` · ${timeframeLabel}` : ""}
+              </span>
+            </div>
+          </div>
+
+          {/* Supporting stats */}
+          <div className="flex gap-6 border-t border-gray-100 pt-3 md:border-l md:border-t-0 md:pl-6 md:pt-0">
+            <div className="flex flex-col">
+              <span className="text-xs text-gray-500">Overdue</span>
+              <span className="text-lg font-medium text-gray-900">
+                {overdueAudits}
+              </span>
+            </div>
+            <div className="flex flex-col">
+              <span className="text-xs text-gray-500">Assets Missing</span>
+              <span className="text-lg font-medium text-gray-900">
+                {assetsMissing}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Session table */}
+      <div className="overflow-hidden rounded border border-gray-200 bg-white">
+        <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-3 md:px-6">
+          <h3 className="text-sm font-semibold text-gray-900">
+            Audit Sessions
+          </h3>
+          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+            {totalRows}
+          </span>
+        </div>
+        <ReportTable
+          data={rows}
+          columns={AUDIT_COMPLETION_COLUMNS}
+          onRowClick={onRowClick}
+          emptyContent={
+            <ReportEmptyState
+              reason="no_data"
+              title="No audits found"
+              description="No audit sessions were created in the selected timeframe."
+            />
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/app/components/reports/index.ts
+++ b/apps/webapp/app/components/reports/index.ts
@@ -119,6 +119,7 @@ export { AssetInventoryContent } from "./asset-inventory-content";
 export { MonthlyBookingTrendsContent } from "./monthly-booking-trends-content";
 export { AssetUtilizationContent } from "./asset-utilization-content";
 export { AssetActivityContent } from "./asset-activity-content";
+export { AuditCompletionContent } from "./audit-completion-content";
 
 // Route-level page composition pieces — these are the chunks the
 // reports.$reportId route stitches together.

--- a/apps/webapp/app/components/reports/report-content-switch.tsx
+++ b/apps/webapp/app/components/reports/report-content-switch.tsx
@@ -17,6 +17,7 @@ import type {
   AssetActivityRow,
   AssetInventoryRow,
   AssetUtilizationRow,
+  AuditCompletionRow,
   BookingComplianceRow,
   ChartSeries,
   ComplianceData,
@@ -35,6 +36,7 @@ import { AssetActivityContent } from "./asset-activity-content";
 import { AssetDistributionContent } from "./asset-distribution-content";
 import { AssetInventoryContent } from "./asset-inventory-content";
 import { AssetUtilizationContent } from "./asset-utilization-content";
+import { AuditCompletionContent } from "./audit-completion-content";
 import { BookingComplianceContent } from "./booking-compliance-content";
 import { CustodySnapshotContent } from "./custody-snapshot-content";
 import { IdleAssetsContent } from "./idle-assets-content";
@@ -225,6 +227,17 @@ export function ReportContentSwitch({
         />
       );
 
+    case "audit-completion":
+      return (
+        <AuditCompletionContent
+          rows={rows as AuditCompletionRow[]}
+          kpis={kpis}
+          totalRows={totalRows}
+          timeframeLabel={timeframe.label}
+          onRowClick={handlers.onAuditRowClick}
+        />
+      );
+
     default:
       return (
         <ReportEmptyState
@@ -268,6 +281,8 @@ function getEmptyStateTitle(reportId: string): string {
       return "No utilization data";
     case "asset-activity":
       return "No activity recorded";
+    case "audit-completion":
+      return "No audits to analyze";
     default:
       return "No data in this timeframe";
   }
@@ -300,6 +315,10 @@ function getEmptyStateDescription(reportId: string): string {
       return "No booking activity within the selected timeframe. Assets need bookings to calculate utilization rates.";
     case "asset-activity":
       return "No activity has been recorded for your assets in this timeframe. Activity appears when assets are updated, booked, or custody changes.";
+    case "audit-completion":
+      // Orgs without the audits add-on simply have no sessions, so this
+      // doubles as their empty state — keep it about finding data.
+      return "No audit sessions were created within the selected timeframe. Try selecting a longer period to see completed audits and their findings.";
     default:
       return "Try selecting a different timeframe to find data for this report.";
   }

--- a/apps/webapp/app/components/reports/use-report-row-handlers.ts
+++ b/apps/webapp/app/components/reports/use-report-row-handlers.ts
@@ -31,6 +31,11 @@ export type ReportRowHandlers = {
   /** Navigate to a kit detail page. Accepts any row that exposes
    *  a `kitId`. */
   onKitRowClick: (row: { kitId: string }) => void;
+  /** Navigate to an audit session detail page. Audit rows carry the
+   *  session id as their row `id`, so any row shape qualifies
+   *  structurally — only wire this to rows whose `id` IS an audit
+   *  session id. */
+  onAuditRowClick: (row: { id: string }) => void;
 };
 
 /**
@@ -61,5 +66,12 @@ export function useReportRowHandlers(): ReportRowHandlers {
     [navigate]
   );
 
-  return { onBookingRowClick, onAssetRowClick, onKitRowClick };
+  const onAuditRowClick = useCallback(
+    (row: { id: string }) => {
+      void navigate(`/audits/${row.id}`);
+    },
+    [navigate]
+  );
+
+  return { onBookingRowClick, onAssetRowClick, onKitRowClick, onAuditRowClick };
 }

--- a/apps/webapp/app/modules/activity-event/reports.server.test.ts
+++ b/apps/webapp/app/modules/activity-event/reports.server.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   assetChangeHistory,
-  auditCompletionStats,
   bookingStatusTransitionCounts,
   custodyDurationsByAsset,
 } from "./reports.server";
@@ -99,37 +98,6 @@ describe("activity event reports", () => {
         { toStatus: "ONGOING", count: 4 },
         { toStatus: "COMPLETE", count: 2 },
       ]);
-    });
-  });
-
-  describe("auditCompletionStats", () => {
-    it("returns rows with meta payload and filters out any with missing auditSessionId", async () => {
-      findManyMock.mockResolvedValueOnce([
-        {
-          auditSessionId: "audit-1",
-          actorUserId: "user-1",
-          occurredAt: new Date("2026-01-15"),
-          meta: { expectedCount: 10, foundCount: 8 },
-        },
-        {
-          auditSessionId: null, // should be filtered
-          actorUserId: "user-2",
-          occurredAt: new Date("2026-01-16"),
-          meta: {},
-        },
-      ] as any);
-
-      const result = await auditCompletionStats({
-        organizationId: org,
-        from,
-        to,
-      });
-
-      expect(result).toHaveLength(1);
-      expect(result[0]).toMatchObject({
-        auditSessionId: "audit-1",
-        meta: { expectedCount: 10, foundCount: 8 },
-      });
     });
   });
 

--- a/apps/webapp/app/modules/activity-event/reports.server.ts
+++ b/apps/webapp/app/modules/activity-event/reports.server.ts
@@ -118,53 +118,6 @@ export async function bookingStatusTransitionCounts({
   }
 }
 
-/** Audit completion event with its counters (expected/found/missing/unexpected) in `meta`. */
-export type AuditCompletionRow = {
-  auditSessionId: string;
-  actorUserId: string | null;
-  occurredAt: Date;
-  meta: Prisma.JsonValue;
-};
-
-/**
- * All `AUDIT_COMPLETED` events within a timeframe. `meta` holds the counters
- * written by the audit service — consumer formats them for display.
- */
-export async function auditCompletionStats({
-  organizationId,
-  from,
-  to,
-}: ReportScope): Promise<AuditCompletionRow[]> {
-  try {
-    const rows = await db.activityEvent.findMany({
-      where: {
-        organizationId,
-        action: "AUDIT_COMPLETED",
-        occurredAt: { gte: from, lte: to },
-      },
-      select: {
-        auditSessionId: true,
-        actorUserId: true,
-        occurredAt: true,
-        meta: true,
-      },
-      orderBy: { occurredAt: "desc" },
-    });
-    return rows
-      .filter((r): r is typeof r & { auditSessionId: string } =>
-        Boolean(r.auditSessionId)
-      )
-      .map((r) => ({
-        auditSessionId: r.auditSessionId,
-        actorUserId: r.actorUserId,
-        occurredAt: r.occurredAt,
-        meta: r.meta as Prisma.JsonValue,
-      }));
-  } catch (cause) {
-    throw wrap(cause, "auditCompletionStats", { organizationId });
-  }
-}
-
 /** One custody window — assigned at `heldFrom`, released at `heldTo` (null if still held). */
 export type CustodyWindow = {
   assetId: string;

--- a/apps/webapp/app/modules/reports/audit-completion.server.test.ts
+++ b/apps/webapp/app/modules/reports/audit-completion.server.test.ts
@@ -108,6 +108,8 @@ describe("auditCompletionReport", () => {
   it("counts completion by completedAt, never by status", async () => {
     await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -127,6 +129,8 @@ describe("auditCompletionReport", () => {
 
     const result = await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -141,6 +145,8 @@ describe("auditCompletionReport", () => {
   it("excludes cancelled sessions from the total via cancelledAt, not status", async () => {
     await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -158,6 +164,8 @@ describe("auditCompletionReport", () => {
     const before = new Date();
     await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
     const after = new Date();
@@ -179,6 +187,8 @@ describe("auditCompletionReport", () => {
 
     const result = await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -212,6 +222,8 @@ describe("auditCompletionReport", () => {
 
     const result = await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -231,6 +243,8 @@ describe("auditCompletionReport", () => {
 
     const result = await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -242,6 +256,8 @@ describe("auditCompletionReport", () => {
 
     const result = await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -257,6 +273,8 @@ describe("auditCompletionReport", () => {
 
     const result = await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -273,6 +291,8 @@ describe("auditCompletionReport", () => {
 
     const result = await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
       page: 3,
       pageSize: 20,
@@ -298,6 +318,8 @@ describe("auditCompletionReport", () => {
   it("scopes every query to the organization and the createdAt window", async () => {
     await auditCompletionReport({
       organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
       timeframe: TIMEFRAME,
     });
 
@@ -324,5 +346,106 @@ describe("auditCompletionReport", () => {
     ).where;
     expect(aggregateWhere.organizationId).toBe("org-1");
     expect(aggregateWhere.createdAt).toEqual(window);
+  });
+});
+
+describe("auditCompletionReport — assignment scoping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // why: every query resolves empty — these tests assert only the WHERE
+    // shapes the report sends, not result math.
+    vi.mocked(db.auditSession.findMany).mockResolvedValue([] as any);
+    vi.mocked(db.auditSession.count).mockResolvedValue(0 as any);
+    vi.mocked(db.auditSession.aggregate).mockResolvedValue({
+      _sum: { missingAssetCount: null },
+    } as any);
+  });
+
+  it("counts a session with both timestamps as cancelled, not completed", async () => {
+    // A cancellation that races the completion write can leave both
+    // `completedAt` and `cancelledAt` set; the cancellation wins so the
+    // completed count can never exceed the never-cancelled total.
+    vi.mocked(db.auditSession.findMany).mockResolvedValue([] as any);
+
+    await auditCompletionReport({
+      organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
+      timeframe: TIMEFRAME,
+    });
+
+    const countWheres = vi
+      .mocked(db.auditSession.count)
+      .mock.calls.map((c) => (c[0] as any).where);
+    const completedWhere = countWheres.find(
+      (w) => w.completedAt && w.completedAt.not === null
+    );
+    expect(completedWhere.cancelledAt).toBeNull();
+    const aggWhere = (
+      vi.mocked(db.auditSession.aggregate).mock.calls[0][0] as any
+    ).where;
+    expect(aggWhere.completedAt).toEqual({ not: null });
+    expect(aggWhere.cancelledAt).toBeNull();
+  });
+
+  it("reports missing and accuracy as null until a session completes", async () => {
+    // The missing counter starts at the expected count and counts DOWN while
+    // scanning, so an in-progress session must read "not scanned", never
+    // "lost every asset" — and a 0/19 accuracy score before completion would
+    // brand an audit nobody finished as a failure.
+    vi.mocked(db.auditSession.findMany).mockResolvedValue([
+      makeSession({
+        id: "in-progress",
+        status: "ACTIVE",
+        expectedAssetCount: 19,
+        foundAssetCount: 0,
+        missingAssetCount: 19,
+        completedAt: null,
+      }),
+    ] as any);
+
+    const payload = await auditCompletionReport({
+      organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
+      timeframe: TIMEFRAME,
+    });
+
+    expect(payload.rows[0].missingAssetCount).toBeNull();
+    expect(payload.rows[0].accuracy).toBeNull();
+  });
+
+  it("scopes every query to assigned audits for BASE and SELF_SERVICE viewers", async () => {
+    await auditCompletionReport({
+      organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: true,
+      timeframe: TIMEFRAME,
+    });
+
+    // The audits index applies assignments.some.userId for these roles; the
+    // report must never list a session its viewer cannot open.
+    for (const call of [
+      ...vi.mocked(db.auditSession.findMany).mock.calls,
+      ...vi.mocked(db.auditSession.count).mock.calls,
+      ...vi.mocked(db.auditSession.aggregate).mock.calls,
+    ]) {
+      expect((call[0] as any).where.assignments).toEqual({
+        some: { userId: "user-1" },
+      });
+    }
+  });
+
+  it("applies no assignment filter for admins and owners", async () => {
+    await auditCompletionReport({
+      organizationId: "org-1",
+      userId: "user-1",
+      isSelfServiceOrBase: false,
+      timeframe: TIMEFRAME,
+    });
+
+    for (const call of vi.mocked(db.auditSession.findMany).mock.calls) {
+      expect((call[0] as any).where.assignments).toBeUndefined();
+    }
   });
 });

--- a/apps/webapp/app/modules/reports/audit-completion.server.test.ts
+++ b/apps/webapp/app/modules/reports/audit-completion.server.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Audit Completion Report — Query & KPI Tests
+ *
+ * Covers the public `auditCompletionReport` function: that completion and
+ * cancellation are read from their timestamp columns (never `status`, which
+ * archiving rewrites), that the overdue KPI targets past-due unfinished
+ * sessions, that per-row accuracy is null-safe, that the completion rate
+ * follows the null-not-zero convention, and that pagination happens at the
+ * database with a deterministic sort.
+ *
+ * @see {@link file://./audit-completion.server.ts}
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: Mock the Prisma client so the unit tests never touch a real database.
+// Matches the pattern in `helpers.server.test.ts`. The report issues four
+// `count`s (window total for pagination + three KPI counts) distinguished by
+// their where shapes, one `findMany` for the page of rows, and one
+// `aggregate` for the missing-assets sum.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    auditSession: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+      aggregate: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "~/database/db.server";
+
+import { auditCompletionReport } from "./audit-completion.server";
+import type { ResolvedTimeframe } from "./types";
+
+const TIMEFRAME: ResolvedTimeframe = {
+  preset: "last_30d",
+  label: "Last 30 days",
+  from: new Date("2026-04-01T00:00:00Z"),
+  to: new Date("2026-04-30T23:59:59Z"),
+};
+
+/** A session row shaped like the report's `findMany` select. */
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "audit-1",
+    name: "Q1 Warehouse Audit",
+    status: "COMPLETED",
+    expectedAssetCount: 10,
+    foundAssetCount: 8,
+    missingAssetCount: 2,
+    unexpectedAssetCount: 1,
+    startedAt: new Date("2026-04-02T09:00:00Z"),
+    dueDate: new Date("2026-04-20T00:00:00Z"),
+    completedAt: new Date("2026-04-10T12:00:00Z"),
+    createdBy: { firstName: "Jane", lastName: "Doe", displayName: "JD" },
+    ...overrides,
+  };
+}
+
+/**
+ * Stubs the four `auditSession.count` calls by the distinguishing key of
+ * each where shape. The shapes themselves are pinned by the where-clause
+ * tests below — this helper only routes values to them.
+ */
+function stubCounts({
+  windowTotal = 0,
+  total = 0,
+  completed = 0,
+  overdue = 0,
+}: {
+  windowTotal?: number;
+  total?: number;
+  completed?: number;
+  overdue?: number;
+}) {
+  vi.mocked(db.auditSession.count).mockImplementation(((args: {
+    where?: Record<string, unknown>;
+  }) => {
+    const where = args?.where ?? {};
+    if ("dueDate" in where) return Promise.resolve(overdue);
+    if ("completedAt" in where) return Promise.resolve(completed);
+    if ("cancelledAt" in where) return Promise.resolve(total);
+    return Promise.resolve(windowTotal);
+  }) as never);
+}
+
+/** Returns the where clause of the count call matched by `pick`. */
+function findCountWhere(
+  pick: (where: Record<string, unknown>) => boolean
+): Record<string, unknown> | undefined {
+  return vi
+    .mocked(db.auditSession.count)
+    .mock.calls.map(([args]) => (args as { where?: never })?.where ?? {})
+    .find(pick);
+}
+
+describe("auditCompletionReport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.auditSession.findMany).mockResolvedValue([] as never);
+    stubCounts({});
+    vi.mocked(db.auditSession.aggregate).mockResolvedValue({
+      _sum: { missingAssetCount: null },
+    } as never);
+  });
+
+  it("counts completion by completedAt, never by status", async () => {
+    await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    const completedWhere = findCountWhere((w) => "completedAt" in w);
+    expect(completedWhere).toBeDefined();
+    expect(completedWhere!.completedAt).toEqual({ not: null });
+    // Archiving rewrites `status`, so the predicate must not reference it —
+    // an ARCHIVED session that finished still counts as completed.
+    expect(completedWhere).not.toHaveProperty("status");
+  });
+
+  it("keeps the raw status on rows, so an ARCHIVED-but-completed session renders as archived AND is counted completed", async () => {
+    vi.mocked(db.auditSession.findMany).mockResolvedValue([
+      makeSession({ id: "audit-archived", status: "ARCHIVED" }),
+    ] as never);
+    stubCounts({ windowTotal: 1, total: 1, completed: 1 });
+
+    const result = await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.rows[0].status).toBe("ARCHIVED");
+    expect(result.rows[0].completedAt).toEqual(
+      new Date("2026-04-10T12:00:00Z")
+    );
+    const completedKpi = result.kpis.find((k) => k.id === "completed_audits");
+    expect(completedKpi?.rawValue).toBe(1);
+  });
+
+  it("excludes cancelled sessions from the total via cancelledAt, not status", async () => {
+    await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    const totalWhere = findCountWhere(
+      (w) => "cancelledAt" in w && !("completedAt" in w) && !("dueDate" in w)
+    );
+    expect(totalWhere).toBeDefined();
+    expect(totalWhere!.cancelledAt).toBeNull();
+    // A cancelled audit that is later archived keeps `cancelledAt` while its
+    // status becomes ARCHIVED — a status-based exclusion would re-admit it.
+    expect(totalWhere).not.toHaveProperty("status");
+  });
+
+  it("counts overdue as past-due sessions that are neither completed nor cancelled", async () => {
+    const before = new Date();
+    await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+    const after = new Date();
+
+    const overdueWhere = findCountWhere((w) => "dueDate" in w);
+    expect(overdueWhere).toBeDefined();
+    expect(overdueWhere!.completedAt).toBeNull();
+    expect(overdueWhere!.cancelledAt).toBeNull();
+    const dueDate = overdueWhere!.dueDate as { lt: Date };
+    expect(dueDate.lt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(dueDate.lt.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it("sums missing assets over completed sessions only", async () => {
+    vi.mocked(db.auditSession.aggregate).mockResolvedValue({
+      _sum: { missingAssetCount: 7 },
+    } as never);
+    stubCounts({ windowTotal: 2, total: 2, completed: 2 });
+
+    const result = await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    const aggregateArgs = vi.mocked(db.auditSession.aggregate).mock
+      .calls[0][0] as {
+      where: Record<string, unknown>;
+      _sum: Record<string, unknown>;
+    };
+    expect(aggregateArgs._sum).toEqual({ missingAssetCount: true });
+    expect(aggregateArgs.where.completedAt).toEqual({ not: null });
+
+    const missingKpi = result.kpis.find((k) => k.id === "assets_missing");
+    expect(missingKpi?.rawValue).toBe(7);
+    expect(missingKpi?.value).toBe("7");
+  });
+
+  it("computes per-row accuracy as found/expected and leaves it null when expected is 0", async () => {
+    vi.mocked(db.auditSession.findMany).mockResolvedValue([
+      makeSession({
+        id: "audit-1",
+        expectedAssetCount: 10,
+        foundAssetCount: 8,
+      }),
+      makeSession({
+        id: "audit-empty-scope",
+        expectedAssetCount: 0,
+        foundAssetCount: 0,
+      }),
+    ] as never);
+    stubCounts({ windowTotal: 2, total: 2, completed: 2 });
+
+    const result = await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.rows[0].accuracy).toBe(80);
+    // 0 expected assets means there is nothing to be accurate against —
+    // null, not 0%, so the UI renders "—" instead of a failing score.
+    expect(result.rows[1].accuracy).toBeNull();
+  });
+
+  it("resolves createdByName through displayName", async () => {
+    vi.mocked(db.auditSession.findMany).mockResolvedValue([
+      makeSession({
+        createdBy: { firstName: "Jane", lastName: "Doe", displayName: "JD" },
+      }),
+    ] as never);
+    stubCounts({ windowTotal: 1, total: 1, completed: 1 });
+
+    const result = await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    expect(result.rows[0].createdByName).toBe("JD");
+  });
+
+  it("returns a null completion rate rendered as an em dash when there are no sessions", async () => {
+    stubCounts({ windowTotal: 0, total: 0, completed: 0, overdue: 0 });
+
+    const result = await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    const rateKpi = result.kpis.find((k) => k.id === "completion_rate");
+    expect(rateKpi?.value).toBe("—");
+    expect(rateKpi?.rawValue).toBeUndefined();
+    expect(result.rows).toHaveLength(0);
+    expect(result.totalRows).toBe(0);
+  });
+
+  it("computes the completion rate from completed/total when sessions exist", async () => {
+    stubCounts({ windowTotal: 5, total: 4, completed: 3, overdue: 1 });
+
+    const result = await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    const byId = (id: string) => result.kpis.find((k) => k.id === id);
+    expect(byId("total_audits")?.rawValue).toBe(4);
+    expect(byId("completed_audits")?.rawValue).toBe(3);
+    expect(byId("completion_rate")?.value).toBe("75%");
+    expect(byId("completion_rate")?.rawValue).toBe(75);
+    expect(byId("overdue_audits")?.rawValue).toBe(1);
+  });
+
+  it("paginates at the database and orders by createdAt desc with an id tiebreaker", async () => {
+    stubCounts({ windowTotal: 120 });
+
+    const result = await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+      page: 3,
+      pageSize: 20,
+    });
+
+    const findManyArgs = vi.mocked(db.auditSession.findMany).mock
+      .calls[0][0] as {
+      skip: number;
+      take: number;
+      orderBy: unknown;
+    };
+    expect(findManyArgs.skip).toBe(40);
+    expect(findManyArgs.take).toBe(20);
+    expect(findManyArgs.orderBy).toEqual([
+      { createdAt: "desc" },
+      { id: "asc" },
+    ]);
+    expect(result.totalRows).toBe(120);
+    expect(result.page).toBe(3);
+    expect(result.pageSize).toBe(20);
+  });
+
+  it("scopes every query to the organization and the createdAt window", async () => {
+    await auditCompletionReport({
+      organizationId: "org-1",
+      timeframe: TIMEFRAME,
+    });
+
+    const window = { gte: TIMEFRAME.from, lte: TIMEFRAME.to };
+
+    const findManyWhere = (
+      vi.mocked(db.auditSession.findMany).mock.calls[0][0] as {
+        where: Record<string, unknown>;
+      }
+    ).where;
+    expect(findManyWhere.organizationId).toBe("org-1");
+    expect(findManyWhere.createdAt).toEqual(window);
+
+    for (const [args] of vi.mocked(db.auditSession.count).mock.calls) {
+      const where = (args as { where: Record<string, unknown> }).where;
+      expect(where.organizationId).toBe("org-1");
+      expect(where.createdAt).toEqual(window);
+    }
+
+    const aggregateWhere = (
+      vi.mocked(db.auditSession.aggregate).mock.calls[0][0] as {
+        where: Record<string, unknown>;
+      }
+    ).where;
+    expect(aggregateWhere.organizationId).toBe("org-1");
+    expect(aggregateWhere.createdAt).toEqual(window);
+  });
+});

--- a/apps/webapp/app/modules/reports/audit-completion.server.ts
+++ b/apps/webapp/app/modules/reports/audit-completion.server.ts
@@ -1,0 +1,280 @@
+/**
+ * Audit Completion Report — Server-Side Data Fetching
+ *
+ * Builds the Audit Completion report from `AuditSession` directly — the
+ * authoritative base table whose counters
+ * (`expectedAssetCount`/`foundAssetCount`/`missingAssetCount`/
+ * `unexpectedAssetCount`) and lifecycle timestamps the audit service
+ * maintains.
+ *
+ * Lifecycle facts are read from timestamps, never from `status`:
+ * - **Completed** means `completedAt IS NOT NULL`. Archiving rewrites
+ *   `status` to ARCHIVED (from COMPLETED or CANCELLED) while leaving the
+ *   timestamps intact, so a status-based predicate silently drops every
+ *   archived session from the metric it belongs to.
+ * - **Cancelled** likewise means `cancelledAt IS NOT NULL` — a cancelled
+ *   session that is later archived must stay excluded from the totals.
+ *
+ * Lives in its own module (not `helpers.server.ts`) so the audits category
+ * has a seam of its own; the payload shape and query discipline mirror the
+ * sibling report helpers.
+ *
+ * @see {@link file://./types.ts}
+ * @see {@link file://./registry.ts}
+ * @see {@link file://./helpers.server.ts}
+ */
+
+import { db } from "~/database/db.server";
+import { ShelfError } from "~/utils/error";
+import { resolveUserDisplayName } from "~/utils/user";
+
+import type {
+  AuditCompletionKpiId,
+  AuditCompletionRow,
+  ReportKpi,
+  ReportPayload,
+  ResolvedTimeframe,
+} from "./types";
+import { USER_NAME_SELECT } from "../user/fields";
+
+/** Arguments for {@link auditCompletionReport}. */
+interface AuditCompletionArgs {
+  organizationId: string;
+  /** Window applied to `AuditSession.createdAt` — a session belongs to the
+   * period it was created in, regardless of when it finished. */
+  timeframe: ResolvedTimeframe;
+  page?: number;
+  pageSize?: number;
+}
+
+/**
+ * Generate the Audit Completion report.
+ *
+ * Answers: "Are audits getting done, and what are they finding?" KPIs cover
+ * volume (total non-cancelled sessions), throughput (completed sessions and
+ * the completion rate), follow-up pressure (overdue sessions), and the
+ * headline finding (assets missing across completed sessions). Rows list
+ * every session created in the window — cancelled and archived included, so
+ * the table reconciles with the audits index — newest first.
+ *
+ * Orgs without the audits add-on simply have no sessions; the report renders
+ * its standard empty state with zero KPIs and a "—" rate.
+ *
+ * @param args - Report parameters
+ * @returns Complete report payload
+ * @throws {ShelfError} If any of the underlying queries fail
+ */
+export async function auditCompletionReport(
+  args: AuditCompletionArgs
+): Promise<ReportPayload<AuditCompletionRow>> {
+  const { organizationId, timeframe, page = 1, pageSize = 50 } = args;
+
+  const startTime = performance.now();
+
+  try {
+    const now = new Date();
+
+    // Session-belongs-to-period predicate shared by every query below, so
+    // the rows, the pagination total, and each KPI all measure one window.
+    const windowWhere = {
+      organizationId,
+      createdAt: { gte: timeframe.from, lte: timeframe.to },
+    };
+
+    const [
+      sessions,
+      totalRows,
+      totalAudits,
+      completedAudits,
+      overdueAudits,
+      missingAggregate,
+    ] = await Promise.all([
+      db.auditSession.findMany({
+        where: windowWhere,
+        // `id` tiebreaker keeps skip/take paging deterministic for rows
+        // sharing a `createdAt` (bulk creation lands in the same
+        // millisecond).
+        orderBy: [{ createdAt: "desc" }, { id: "asc" }],
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        select: {
+          id: true,
+          name: true,
+          status: true,
+          expectedAssetCount: true,
+          foundAssetCount: true,
+          missingAssetCount: true,
+          unexpectedAssetCount: true,
+          startedAt: true,
+          dueDate: true,
+          completedAt: true,
+          createdBy: { select: USER_NAME_SELECT },
+        },
+      }),
+      // Pagination total: every session in the window, cancelled included,
+      // matching what the table lists.
+      db.auditSession.count({ where: windowWhere }),
+      // Total for the KPI/rate: sessions that were never cancelled.
+      // `cancelledAt`, not `status` — archiving a cancelled session
+      // rewrites its status to ARCHIVED but keeps the timestamp.
+      db.auditSession.count({
+        where: { ...windowWhere, cancelledAt: null },
+      }),
+      // Completed: `completedAt`, not `status` — archiving a completed
+      // session rewrites its status to ARCHIVED but keeps the timestamp.
+      db.auditSession.count({
+        where: { ...windowWhere, completedAt: { not: null } },
+      }),
+      // Overdue: past due and still open — neither finished nor cancelled.
+      db.auditSession.count({
+        where: {
+          ...windowWhere,
+          dueDate: { lt: now },
+          completedAt: null,
+          cancelledAt: null,
+        },
+      }),
+      // The headline finding: assets missing across completed sessions.
+      // Scoped to completed sessions because an in-flight session's
+      // missing counter still shrinks as scanning proceeds.
+      db.auditSession.aggregate({
+        _sum: { missingAssetCount: true },
+        where: { ...windowWhere, completedAt: { not: null } },
+      }),
+    ]);
+
+    const rows: AuditCompletionRow[] = sessions.map((session) => ({
+      id: session.id,
+      name: session.name,
+      status: session.status,
+      expectedAssetCount: session.expectedAssetCount,
+      foundAssetCount: session.foundAssetCount,
+      missingAssetCount: session.missingAssetCount,
+      unexpectedAssetCount: session.unexpectedAssetCount,
+      // Null when the session expected 0 assets — nothing to be accurate
+      // against, and null (not 0%) renders as "—" instead of a failing score.
+      accuracy:
+        session.expectedAssetCount > 0
+          ? Math.round(
+              (session.foundAssetCount / session.expectedAssetCount) * 100
+            )
+          : null,
+      createdByName: resolveUserDisplayName(session.createdBy),
+      startedAt: session.startedAt,
+      dueDate: session.dueDate,
+      completedAt: session.completedAt,
+    }));
+
+    const kpis = buildAuditCompletionKpis({
+      totalAudits,
+      completedAudits,
+      overdueAudits,
+      assetsMissing: missingAggregate._sum.missingAssetCount ?? 0,
+    });
+
+    const computedMs = Math.round(performance.now() - startTime);
+
+    return {
+      report: {
+        id: "audit-completion",
+        title: "Audit Completion",
+        description:
+          "Track audit sessions: completion rate, overdue audits, and assets found missing.",
+      },
+      filters: {
+        timeframe,
+        filters: [],
+      },
+      kpis,
+      rows,
+      computedMs,
+      totalRows,
+      page,
+      pageSize,
+    };
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      label: "Report",
+      message: "Failed to generate Audit Completion report",
+      additionalData: { organizationId },
+    });
+  }
+}
+
+/**
+ * Assemble the KPI cards from the pre-computed counts.
+ *
+ * The completion rate follows the null-not-zero convention: with no
+ * measurable sessions there is no rate, so the card shows "—" and carries no
+ * `rawValue` — 0% would misread as "every audit failed to finish".
+ *
+ * @param counts - Window-scoped counts computed by the report queries
+ * @returns KPI cards in display order
+ */
+function buildAuditCompletionKpis(counts: {
+  totalAudits: number;
+  completedAudits: number;
+  overdueAudits: number;
+  assetsMissing: number;
+}): ReportKpi[] {
+  const { totalAudits, completedAudits, overdueAudits, assetsMissing } = counts;
+
+  const completionRate =
+    totalAudits > 0 ? Math.round((completedAudits / totalAudits) * 100) : null;
+
+  // Explicitly typed so each entry's `id` stays inside the report's KPI union.
+  const kpis: Array<ReportKpi & { id: AuditCompletionKpiId }> = [
+    {
+      id: "total_audits",
+      label: "Total Audits",
+      value: totalAudits.toLocaleString(),
+      rawValue: totalAudits,
+      format: "number",
+      delta: null,
+      deltaType: "neutral",
+      description:
+        "Audit sessions created in the timeframe, excluding cancelled ones.",
+    },
+    {
+      id: "completed_audits",
+      label: "Completed",
+      value: completedAudits.toLocaleString(),
+      rawValue: completedAudits,
+      format: "number",
+      delta: null,
+      deltaType: "neutral",
+    },
+    {
+      id: "completion_rate",
+      label: "Completion Rate",
+      value: completionRate !== null ? `${completionRate}%` : "—",
+      ...(completionRate !== null ? { rawValue: completionRate } : {}),
+      format: "percent",
+      delta: null,
+      deltaType: "neutral",
+    },
+    {
+      id: "overdue_audits",
+      label: "Overdue",
+      value: overdueAudits.toLocaleString(),
+      rawValue: overdueAudits,
+      format: "number",
+      delta: null,
+      deltaType: "neutral",
+      description: "Past their due date and neither completed nor cancelled.",
+    },
+    {
+      id: "assets_missing",
+      label: "Assets Missing",
+      value: assetsMissing.toLocaleString(),
+      rawValue: assetsMissing,
+      format: "number",
+      delta: null,
+      deltaType: "neutral",
+      description: "Sum of missing assets across completed audits.",
+    },
+  ];
+
+  return kpis;
+}

--- a/apps/webapp/app/modules/reports/audit-completion.server.ts
+++ b/apps/webapp/app/modules/reports/audit-completion.server.ts
@@ -40,6 +40,11 @@ import { USER_NAME_SELECT } from "../user/fields";
 /** Arguments for {@link auditCompletionReport}. */
 interface AuditCompletionArgs {
   organizationId: string;
+  /** Acting user — the subject of assignment scoping below. */
+  userId: string;
+  /** BASE and SELF_SERVICE see only audits assigned to them, mirroring the
+   * audits index (`getAuditsForOrganization`); admins and owners see all. */
+  isSelfServiceOrBase: boolean;
   /** Window applied to `AuditSession.createdAt` — a session belongs to the
    * period it was created in, regardless of when it finished. */
   timeframe: ResolvedTimeframe;
@@ -67,7 +72,14 @@ interface AuditCompletionArgs {
 export async function auditCompletionReport(
   args: AuditCompletionArgs
 ): Promise<ReportPayload<AuditCompletionRow>> {
-  const { organizationId, timeframe, page = 1, pageSize = 50 } = args;
+  const {
+    organizationId,
+    userId,
+    isSelfServiceOrBase,
+    timeframe,
+    page = 1,
+    pageSize = 50,
+  } = args;
 
   const startTime = performance.now();
 
@@ -79,6 +91,10 @@ export async function auditCompletionReport(
     const windowWhere = {
       organizationId,
       createdAt: { gte: timeframe.from, lte: timeframe.to },
+      // Assignment scoping for low-permission roles, the same
+      // `assignments.some.userId` predicate the audits index applies — the
+      // report must never show a session its viewer cannot open.
+      ...(isSelfServiceOrBase ? { assignments: { some: { userId } } } : {}),
     };
 
     const [
@@ -122,8 +138,15 @@ export async function auditCompletionReport(
       }),
       // Completed: `completedAt`, not `status` — archiving a completed
       // session rewrites its status to ARCHIVED but keeps the timestamp.
+      // `cancelledAt: null` besides: a cancellation that raced the
+      // completion write leaves both timestamps set, and the cancellation
+      // wins here so completed can never exceed the never-cancelled total.
       db.auditSession.count({
-        where: { ...windowWhere, completedAt: { not: null } },
+        where: {
+          ...windowWhere,
+          completedAt: { not: null },
+          cancelledAt: null,
+        },
       }),
       // Overdue: past due and still open — neither finished nor cancelled.
       db.auditSession.count({
@@ -139,7 +162,13 @@ export async function auditCompletionReport(
       // missing counter still shrinks as scanning proceeds.
       db.auditSession.aggregate({
         _sum: { missingAssetCount: true },
-        where: { ...windowWhere, completedAt: { not: null } },
+        // Same completed-family guard as the count above: a cancellation
+        // that raced the completion write wins.
+        where: {
+          ...windowWhere,
+          completedAt: { not: null },
+          cancelledAt: null,
+        },
       }),
     ]);
 
@@ -149,12 +178,20 @@ export async function auditCompletionReport(
       status: session.status,
       expectedAssetCount: session.expectedAssetCount,
       foundAssetCount: session.foundAssetCount,
-      missingAssetCount: session.missingAssetCount,
+      // The counter starts at the expected count and counts DOWN as assets
+      // are scanned, so until the session completes it measures "not yet
+      // scanned", not "lost". Null until `completedAt`, matching the audits
+      // index's "Not scanned" wording.
+      missingAssetCount:
+        session.completedAt !== null ? session.missingAssetCount : null,
       unexpectedAssetCount: session.unexpectedAssetCount,
       // Null when the session expected 0 assets — nothing to be accurate
       // against, and null (not 0%) renders as "—" instead of a failing score.
+      // Accuracy is only meaningful once the session finished; an unfinished
+      // session would read as a failing score while people are still
+      // scanning. Also null when the session expected 0 assets.
       accuracy:
-        session.expectedAssetCount > 0
+        session.completedAt !== null && session.expectedAssetCount > 0
           ? Math.round(
               (session.foundAssetCount / session.expectedAssetCount) * 100
             )

--- a/apps/webapp/app/modules/reports/registry.ts
+++ b/apps/webapp/app/modules/reports/registry.ts
@@ -200,6 +200,22 @@ export const REPORTS: ReportDefinition[] = [
     hasChart: false,
     exportable: true,
   },
+
+  // -------------------------------------------------------------------------
+  // Audit Reports
+  // -------------------------------------------------------------------------
+  {
+    id: "audit-completion",
+    title: "Audit Completion",
+    description:
+      "Track audit sessions: completion rate, overdue audits, and assets found missing.",
+    category: "audits",
+    icon: "ClipboardCheck",
+    enabled: true,
+    filters: [],
+    hasChart: false,
+    exportable: true,
+  },
 ];
 
 /**

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -10,7 +10,12 @@
  * @see {@link file://./helpers.server.ts}
  */
 
-import type { AssetType, BookingStatus, Currency } from "@prisma/client";
+import type {
+  AssetType,
+  AuditStatus,
+  BookingStatus,
+  Currency,
+} from "@prisma/client";
 import type { ResolvableAssetModelImage } from "../asset/image-resolution";
 
 // -----------------------------------------------------------------------------
@@ -667,6 +672,56 @@ export type AssetActivityKpiId =
   | "custody_changes"
   | "booking_activities"
   | "most_active_asset";
+
+// -----------------------------------------------------------------------------
+// Audit Completion Report Types
+// -----------------------------------------------------------------------------
+
+/**
+ * Row type for the Audit Completion report — one audit session.
+ *
+ * `status` is the raw enum for badge rendering; whether the session is
+ * *finished* is answered by `completedAt`, never by the status column,
+ * because archiving rewrites `status` while leaving the timestamps intact.
+ */
+export interface AuditCompletionRow {
+  /** The audit session id — row clicks navigate to `/audits/{id}`. */
+  id: string;
+  /** Session name as entered by the creator. */
+  name: string;
+  /** Raw status enum, rendered as a badge. Not a completion signal — see
+   * the interface doc: archiving rewrites this column. */
+  status: AuditStatus;
+  /** Assets the session expected to find. */
+  expectedAssetCount: number;
+  /** Expected assets actually scanned. */
+  foundAssetCount: number;
+  /** Expected assets never scanned. */
+  missingAssetCount: number;
+  /** Scanned assets that were not expected. */
+  unexpectedAssetCount: number;
+  /** found/expected as a whole percentage (0-100). Null when the session
+   * expected 0 assets — there is nothing to be accurate against, and null
+   * (not 0%) is what renders as "—". */
+  accuracy: number | null;
+  /** Display name of the user who created the session. */
+  createdByName: string;
+  /** When scanning began; null while the session is still pending. */
+  startedAt: Date | null;
+  /** Deadline for the session; null when none was set. */
+  dueDate: Date | null;
+  /** When the session finished; null while unfinished. The authoritative
+   * completion signal for this report. */
+  completedAt: Date | null;
+}
+
+/** KPI IDs for the Audit Completion report */
+export type AuditCompletionKpiId =
+  | "total_audits"
+  | "completed_audits"
+  | "completion_rate"
+  | "overdue_audits"
+  | "assets_missing";
 
 // -----------------------------------------------------------------------------
 // PDF Export Types

--- a/apps/webapp/app/modules/reports/types.ts
+++ b/apps/webapp/app/modules/reports/types.ts
@@ -697,7 +697,9 @@ export interface AuditCompletionRow {
   /** Expected assets actually scanned. */
   foundAssetCount: number;
   /** Expected assets never scanned. */
-  missingAssetCount: number;
+  /** Null until the session completes — the counter counts down while
+   * scanning, so pre-completion it means "not yet scanned", not "lost". */
+  missingAssetCount: number | null;
   /** Scanned assets that were not expected. */
   unexpectedAssetCount: number;
   /** found/expected as a whole percentage (0-100). Null when the session

--- a/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
+++ b/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
@@ -30,6 +30,7 @@ import {
   useCsvExport,
   useReportRowHandlers,
 } from "~/components/reports";
+import { auditCompletionReport } from "~/modules/reports/audit-completion.server";
 import {
   resolveTimeframe,
   bookingComplianceReport,
@@ -270,6 +271,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
         timeframe,
         assetId: url.searchParams.get("asset") || undefined,
         categoryId: url.searchParams.get("category") || undefined,
+        page: parseInt(url.searchParams.get("page") || "1", 10),
+        pageSize: parseInt(url.searchParams.get("pageSize") || "50", 10),
+      });
+      break;
+
+    case "audit-completion":
+      reportData = await auditCompletionReport({
+        organizationId,
+        timeframe,
         page: parseInt(url.searchParams.get("page") || "1", 10),
         pageSize: parseInt(url.searchParams.get("pageSize") || "50", 10),
       });

--- a/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
+++ b/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
@@ -115,7 +115,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
   }
 
   // Check permissions
-  const { organizationId } = await requirePermission({
+  const { organizationId, isSelfServiceOrBase } = await requirePermission({
     userId,
     request,
     entity: PermissionEntity.asset,
@@ -279,6 +279,8 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     case "audit-completion":
       reportData = await auditCompletionReport({
         organizationId,
+        userId,
+        isSelfServiceOrBase,
         timeframe,
         page: parseInt(url.searchParams.get("page") || "1", 10),
         pageSize: parseInt(url.searchParams.get("pageSize") || "50", 10),

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -7,8 +7,10 @@
  * @see {@link file://../../modules/reports/helpers.server.ts}
  */
 
+import { AUDIT_STATUS_LABELS } from "@shelf/labels";
 import { data, type LoaderFunctionArgs } from "react-router";
 
+import { auditCompletionReport } from "~/modules/reports/audit-completion.server";
 import { formatDateForCsv } from "~/modules/reports/csv-format";
 import {
   resolveTimeframe,
@@ -25,6 +27,7 @@ import {
   monthlyBookingTrendsReport,
 } from "~/modules/reports/helpers.server";
 import { getReportById } from "~/modules/reports/registry";
+import type { AuditCompletionRow } from "~/modules/reports/types";
 import type {
   TimeframePreset,
   BookingComplianceRow,
@@ -265,6 +268,20 @@ export const loader = async ({
         });
         csvString = generateMonthlyBookingTrendsCsv(
           reportData.rows as MonthlyBookingTrendRow[]
+        );
+        break;
+      }
+
+      case "audit-completion": {
+        const reportData = await auditCompletionReport({
+          organizationId,
+          timeframe,
+          page: 1,
+          pageSize: 10000,
+        });
+        csvString = generateAuditCompletionCsv(
+          reportData.rows as AuditCompletionRow[],
+          formatPrefs
         );
         break;
       }
@@ -744,6 +761,58 @@ function generateDistributionCsv(breakdown: DistributionBreakdown): string {
   ];
 
   return buildCsv(headers, allRows);
+}
+
+/**
+ * Generate CSV for the Audit Completion report.
+ *
+ * Columns match the UI table: raw counters, accuracy, and the lifecycle
+ * dates. Status uses the shared `AUDIT_STATUS_LABELS` words so the export
+ * reads the same as every badge in the app.
+ */
+function generateAuditCompletionCsv(
+  rows: AuditCompletionRow[],
+  prefs: ResolvedFormatPrefs
+): string {
+  const headers = [
+    "Audit ID",
+    "Name",
+    "Status",
+    "Expected",
+    "Found",
+    "Missing",
+    "Unexpected",
+    "Accuracy",
+    "Created By",
+    "Started",
+    "Due Date",
+    "Completed",
+  ];
+
+  const csvRows = rows.map((row) => [
+    row.id,
+    row.name,
+    AUDIT_STATUS_LABELS[row.status] || row.status,
+    row.expectedAssetCount.toString(),
+    row.foundAssetCount.toString(),
+    row.missingAssetCount.toString(),
+    row.unexpectedAssetCount.toString(),
+    // Null accuracy (0 expected assets) exports as an empty cell, not "0%".
+    row.accuracy !== null ? `${row.accuracy}%` : "",
+    row.createdByName,
+    // Datetime columns: include the time part; empty when unset.
+    row.startedAt
+      ? formatDateForCsv(row.startedAt, prefs, { includeTime: true })
+      : "",
+    row.dueDate
+      ? formatDateForCsv(row.dueDate, prefs, { includeTime: true })
+      : "",
+    row.completedAt
+      ? formatDateForCsv(row.completedAt, prefs, { includeTime: true })
+      : "",
+  ]);
+
+  return buildCsv(headers, csvRows);
 }
 
 /**

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -63,7 +63,7 @@ export const loader = async ({
   const { userId } = authSession;
 
   try {
-    const { organizationId } = await requirePermission({
+    const { organizationId, isSelfServiceOrBase } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.asset,
@@ -275,6 +275,10 @@ export const loader = async ({
       case "audit-completion": {
         const reportData = await auditCompletionReport({
           organizationId,
+          // The CSV must carry the same assignment scoping as the page —
+          // an export is just the page's data in a file.
+          userId,
+          isSelfServiceOrBase,
           timeframe,
           page: 1,
           pageSize: 10000,
@@ -795,7 +799,8 @@ function generateAuditCompletionCsv(
     AUDIT_STATUS_LABELS[row.status] || row.status,
     row.expectedAssetCount.toString(),
     row.foundAssetCount.toString(),
-    row.missingAssetCount.toString(),
+    // Null until completion (counter still counts "not scanned"): empty cell.
+    row.missingAssetCount !== null ? row.missingAssetCount.toString() : "",
     row.unexpectedAssetCount.toString(),
     // Null accuracy (0 expected assets) exports as an empty cell, not "0%".
     row.accuracy !== null ? `${row.accuracy}%` : "",

--- a/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
@@ -25,6 +25,13 @@ vi.mock("~/utils/roles.server", () => ({
   requirePermission: vi.fn(),
 }));
 
+// why: same as the helpers mock below — the audit report builder queries
+// Prisma, and importing it for real loads `~/database/db.server`, whose
+// module-level `$connect()` rejects (unhandled) with no database around.
+vi.mock("~/modules/reports/audit-completion.server", () => ({
+  auditCompletionReport: vi.fn(),
+}));
+
 // why: the report builders query Prisma; the loader only needs their shape
 vi.mock("~/modules/reports/helpers.server", () => ({
   resolveTimeframe: vi.fn(() => ({


### PR DESCRIPTION
## What

Fills the reports page's empty "Audits" category with its first report: Audit Completion. Are audits getting done, how accurate are they, and what did they find?

Hero is the completion rate; supporting KPIs are total audits, completed, overdue, and total assets found missing by completed audits. Rows list each session with its expected, found, missing and unexpected counts, an accuracy bar, who created it, and its lifecycle dates; clicking a row opens the audit. CSV export included; timeframe picker applies (window on session creation).

## How

- The query reads `AuditSession` directly, in its own module (`modules/reports/audit-completion.server.ts`). Lifecycle facts come from timestamps, never from `status`: completed means `completedAt` is set and cancelled means `cancelledAt` is set, because archiving rewrites `status` and would silently drop archived sessions from their metrics. The comments state this as a standing constraint.
- Status badges reuse the shared audit status badge with its overdue chip, so the report can never disagree with the audit pages about what a session's state looks like.
- The dead `auditCompletionStats` helper (event-based, never consumed by anything) is deleted: this report supersedes it by reading the authoritative table.
- Orgs without the audits add-on simply have no sessions and get the standard empty state.

## Testing

Red-first: 11 new tests pin the timestamp-not-status predicates (an archived-after-completion session still counts completed; a cancelled-then-archived session stays excluded), the overdue definition, missing-asset sums scoped to completed sessions, accuracy math including the divide-by-zero case, pagination shape, and org plus window scoping on every query. Full `pnpm webapp:validate`: 5,731 tests pass; the only error is the known picker-meta unhandled rejection fixed in PR 2941.

Live check against the QA database: an org with 83 real sessions reports 69 completed, an 85 percent rate over the 81 never-cancelled sessions, 9 overdue and 284 assets missing, matching independently computed SQL exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Audit Completion report under the Audits category.
  * Displays completion rate, overdue audits, missing assets, accuracy, status, counts, dates, and creators.
  * Supports pagination, empty states, audit-detail navigation, and CSV export.
  * Report results respect assignment-based access for applicable roles.

* **Bug Fixes**
  * Metrics now correctly account for completed and cancelled audits, including archived records.
  * Incomplete audits clearly show unavailable missing-asset and accuracy values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->