### PR TITLE
fix(companion): stop the booking date pickers crashing Android

### DIFF
--- a/apps/companion/app/(tabs)/bookings/edit.tsx
+++ b/apps/companion/app/(tabs)/bookings/edit.tsx
@@ -28,9 +28,6 @@ import { useRouter, useLocalSearchParams } from "expo-router";
 import { useNavigation } from "@react-navigation/native";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
-import DateTimePicker, {
-  type DateTimePickerEvent,
-} from "@react-native-community/datetimepicker";
 import { api, type BookingTag } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { markBookingDirty } from "@/lib/booking-refresh";
@@ -42,8 +39,18 @@ import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { labelForRequired } from "@/lib/a11y";
 import { TeamMemberPicker } from "@/components/team-member-picker";
+import { DateTimeField } from "@/components/date-time-field";
+import { ErrorBoundary } from "@/components/error-boundary";
 
 export default function EditBookingScreen() {
+  return (
+    <ErrorBoundary screenName="Edit booking">
+      <EditBookingContent />
+    </ErrorBoundary>
+  );
+}
+
+function EditBookingContent() {
   const router = useRouter();
   const { id } = useLocalSearchParams<{ id: string }>();
   const { currentOrg } = useOrg();
@@ -167,30 +174,22 @@ export default function EditBookingScreen() {
   }, [navigation, isLoading, hasUnsavedChanges]);
 
   // ── Date pickers ────────────────────────────────
-  const onFromChange = useCallback(
-    (event: DateTimePickerEvent, selected: Date | undefined) => {
-      if (Platform.OS === "android") setShowFromPicker(false);
-      if (event.type === "dismissed") return;
-      if (selected) {
-        setFrom(selected);
-        setTo((prev) => keepEndAfterStart(prev, selected, prefs.timeZone));
-        if (Platform.OS === "ios") setShowFromPicker(false);
-      }
+  const closeFromPicker = useCallback(() => setShowFromPicker(false), []);
+  const closeToPicker = useCallback(() => setShowToPicker(false), []);
+
+  const onFromConfirm = useCallback(
+    (selected: Date) => {
+      setShowFromPicker(false);
+      setFrom(selected);
+      setTo((prev) => keepEndAfterStart(prev, selected, prefs.timeZone));
     },
     [prefs.timeZone]
   );
 
-  const onToChange = useCallback(
-    (event: DateTimePickerEvent, selected: Date | undefined) => {
-      if (Platform.OS === "android") setShowToPicker(false);
-      if (event.type === "dismissed") return;
-      if (selected) {
-        setTo(selected);
-        if (Platform.OS === "ios") setShowToPicker(false);
-      }
-    },
-    []
-  );
+  const onToConfirm = useCallback((selected: Date) => {
+    setShowToPicker(false);
+    setTo(selected);
+  }, []);
 
   const toggleTag = useCallback((tagId: string) => {
     setSelectedTagIds((prev) => {
@@ -403,18 +402,14 @@ export default function EditBookingScreen() {
             )}
           </TouchableOpacity>
           {isDraft && showFromPicker && (
-            <View
-              style={Platform.OS === "ios" ? styles.dateInlineWrap : undefined}
-            >
-              <DateTimePicker
-                value={from ?? new Date()}
-                mode="datetime"
-                display={Platform.OS === "ios" ? "inline" : "default"}
-                timeZoneName={prefs.timeZone}
-                onChange={onFromChange}
-                accentColor={colors.primary}
-              />
-            </View>
+            <DateTimeField
+              value={from ?? new Date()}
+              timeZoneName={prefs.timeZone}
+              onConfirm={onFromConfirm}
+              onCancel={closeFromPicker}
+              inlineStyle={styles.dateInlineWrap}
+              accentColor={colors.primary}
+            />
           )}
         </View>
 
@@ -446,19 +441,15 @@ export default function EditBookingScreen() {
             )}
           </TouchableOpacity>
           {isDraft && showToPicker && (
-            <View
-              style={Platform.OS === "ios" ? styles.dateInlineWrap : undefined}
-            >
-              <DateTimePicker
-                value={to ?? from ?? new Date()}
-                mode="datetime"
-                display={Platform.OS === "ios" ? "inline" : "default"}
-                timeZoneName={prefs.timeZone}
-                minimumDate={from ?? undefined}
-                onChange={onToChange}
-                accentColor={colors.primary}
-              />
-            </View>
+            <DateTimeField
+              value={to ?? from ?? new Date()}
+              timeZoneName={prefs.timeZone}
+              minimumDate={from ?? undefined}
+              onConfirm={onToConfirm}
+              onCancel={closeToPicker}
+              inlineStyle={styles.dateInlineWrap}
+              accentColor={colors.primary}
+            />
           )}
         </View>
 

--- a/apps/companion/app/(tabs)/bookings/new.tsx
+++ b/apps/companion/app/(tabs)/bookings/new.tsx
@@ -32,9 +32,6 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import { useNavigation } from "@react-navigation/native";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
-import DateTimePicker, {
-  type DateTimePickerEvent,
-} from "@react-native-community/datetimepicker";
 import { api, type BookingTag, type TeamMember } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
@@ -49,6 +46,8 @@ import { useTheme } from "@/lib/theme-context";
 import { createStyles } from "@/lib/create-styles";
 import { labelForRequired } from "@/lib/a11y";
 import { TeamMemberPicker } from "@/components/team-member-picker";
+import { DateTimeField } from "@/components/date-time-field";
+import { ErrorBoundary } from "@/components/error-boundary";
 
 /**
  * The default booking window — 09:00-17:00 as `timeZone` reads it, on `day`
@@ -113,6 +112,14 @@ function defaultBookingWindow(
 }
 
 export default function CreateBookingScreen() {
+  return (
+    <ErrorBoundary screenName="Create booking">
+      <CreateBookingContent />
+    </ErrorBoundary>
+  );
+}
+
+function CreateBookingContent() {
   const router = useRouter();
   /**
    * The calendar lens opens this screen from a day panel, so the booking
@@ -199,32 +206,24 @@ export default function CreateBookingScreen() {
   }, [navigation, hasUnsavedChanges]);
 
   // ── Date pickers ────────────────────────────────
-  const onFromChange = useCallback(
-    (event: DateTimePickerEvent, selected: Date | undefined) => {
-      if (Platform.OS === "android") setShowFromPicker(false);
-      if (event.type === "dismissed") return;
-      if (selected) {
-        datesTouchedRef.current = true;
-        setFrom(selected);
-        setTo((prev) => keepEndAfterStart(prev, selected, prefs.timeZone));
-        if (Platform.OS === "ios") setShowFromPicker(false);
-      }
+  const closeFromPicker = useCallback(() => setShowFromPicker(false), []);
+  const closeToPicker = useCallback(() => setShowToPicker(false), []);
+
+  const onFromConfirm = useCallback(
+    (selected: Date) => {
+      setShowFromPicker(false);
+      datesTouchedRef.current = true;
+      setFrom(selected);
+      setTo((prev) => keepEndAfterStart(prev, selected, prefs.timeZone));
     },
     [prefs.timeZone]
   );
 
-  const onToChange = useCallback(
-    (event: DateTimePickerEvent, selected: Date | undefined) => {
-      if (Platform.OS === "android") setShowToPicker(false);
-      if (event.type === "dismissed") return;
-      if (selected) {
-        datesTouchedRef.current = true;
-        setTo(selected);
-        if (Platform.OS === "ios") setShowToPicker(false);
-      }
-    },
-    []
-  );
+  const onToConfirm = useCallback((selected: Date) => {
+    setShowToPicker(false);
+    datesTouchedRef.current = true;
+    setTo(selected);
+  }, []);
 
   // The preference zone arrives with the user profile, so on a cold start this
   // screen can mount while `/me` is still in flight — at which point
@@ -422,18 +421,14 @@ export default function CreateBookingScreen() {
             />
           </TouchableOpacity>
           {showFromPicker && (
-            <View
-              style={Platform.OS === "ios" ? styles.dateInlineWrap : undefined}
-            >
-              <DateTimePicker
-                value={from ?? new Date()}
-                mode="datetime"
-                display={Platform.OS === "ios" ? "inline" : "default"}
-                timeZoneName={prefs.timeZone}
-                onChange={onFromChange}
-                accentColor={colors.primary}
-              />
-            </View>
+            <DateTimeField
+              value={from ?? new Date()}
+              timeZoneName={prefs.timeZone}
+              onConfirm={onFromConfirm}
+              onCancel={closeFromPicker}
+              inlineStyle={styles.dateInlineWrap}
+              accentColor={colors.primary}
+            />
           )}
         </View>
 
@@ -464,19 +459,15 @@ export default function CreateBookingScreen() {
             />
           </TouchableOpacity>
           {showToPicker && (
-            <View
-              style={Platform.OS === "ios" ? styles.dateInlineWrap : undefined}
-            >
-              <DateTimePicker
-                value={to ?? from ?? new Date()}
-                mode="datetime"
-                display={Platform.OS === "ios" ? "inline" : "default"}
-                timeZoneName={prefs.timeZone}
-                minimumDate={from ?? undefined}
-                onChange={onToChange}
-                accentColor={colors.primary}
-              />
-            </View>
+            <DateTimeField
+              value={to ?? from ?? new Date()}
+              timeZoneName={prefs.timeZone}
+              minimumDate={from ?? undefined}
+              onConfirm={onToConfirm}
+              onCancel={closeToPicker}
+              inlineStyle={styles.dateInlineWrap}
+              accentColor={colors.primary}
+            />
           )}
         </View>
 

--- a/apps/companion/components/date-time-field.tsx
+++ b/apps/companion/components/date-time-field.tsx
@@ -6,8 +6,12 @@
  *
  * Android's native pickers only take a `date` or a `time`, so this component
  * runs them back to back: the date dialog first, then the time dialog seeded
- * with the current value's clock, and reports the merged result once. Cancelling
- * either dialog cancels the whole selection and leaves the value untouched.
+ * with what the date dialog reported. Each step hands back a whole instant
+ * rather than its own half, so the second one's result is the answer and the
+ * two are never recombined here — see `handleAndroidChange`, where doing so
+ * would resolve the clock in the device's zone rather than `timeZoneName`.
+ * Cancelling either dialog cancels the whole selection and leaves the value
+ * untouched.
  *
  * Mount it only while the picker should be showing — `onConfirm` and `onCancel`
  * are both terminal, and the parent is expected to unmount on either.
@@ -38,13 +42,6 @@ type DateTimeFieldProps = {
   /** Highlight colour for the native picker. */
   accentColor?: string;
 };
-
-/** Merge the calendar day of `day` with the clock of `clock`. */
-function mergeDayAndClock(day: Date, clock: Date): Date {
-  const merged = new Date(day);
-  merged.setHours(clock.getHours(), clock.getMinutes(), 0, 0);
-  return merged;
-}
 
 export function DateTimeField({
   value,
@@ -88,12 +85,23 @@ export function DateTimeField({
       }
 
       if (pickedDayRef.current === null) {
+        // The date step reports a whole instant, not a bare day: the chosen
+        // calendar day resolved in `timeZoneName`, still carrying the clock it
+        // opened on. So it is already the right seed for the time step.
         pickedDayRef.current = selected;
         setAndroidStep("time");
         return;
       }
 
-      onConfirmRef.current(mergeDayAndClock(pickedDayRef.current, selected));
+      // Confirmed as reported. The time step opened on the day above and
+      // resolves in `timeZoneName`, so `selected` is already that day at the
+      // chosen clock — recombining the two halves here would have to do it in
+      // the zone the picker used, and any merge through the Date object's own
+      // getters does it in the DEVICE's zone instead. Where the two differ that
+      // silently moves the booking a day: on a UTC phone, 20:00 in Los Angeles
+      // reads back as hour 4, and writing hour 4 onto the chosen day lands on
+      // the day before.
+      onConfirmRef.current(selected);
     },
     []
   );
@@ -102,8 +110,8 @@ export function DateTimeField({
     return (
       <DateTimePicker
         value={
-          androidStep === "time" && pickedDayRef.current
-            ? mergeDayAndClock(pickedDayRef.current, valueRef.current)
+          androidStep === "time"
+            ? pickedDayRef.current ?? valueRef.current
             : valueRef.current
         }
         mode={androidStep}

--- a/apps/companion/components/date-time-field.tsx
+++ b/apps/companion/components/date-time-field.tsx
@@ -1,0 +1,132 @@
+/**
+ * Date + time selector for the booking forms.
+ *
+ * iOS renders a single inline picker in `datetime` mode, so one interaction
+ * yields both halves of the value.
+ *
+ * Android's native pickers only take a `date` or a `time`, so this component
+ * runs them back to back: the date dialog first, then the time dialog seeded
+ * with the current value's clock, and reports the merged result once. Cancelling
+ * either dialog cancels the whole selection and leaves the value untouched.
+ *
+ * Mount it only while the picker should be showing — `onConfirm` and `onCancel`
+ * are both terminal, and the parent is expected to unmount on either.
+ *
+ * @see {@link file://../app/(tabs)/bookings/new.tsx} create-booking form.
+ * @see {@link file://../app/(tabs)/bookings/edit.tsx} edit-booking form.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { Platform, View, type StyleProp, type ViewStyle } from "react-native";
+import DateTimePicker, {
+  type DateTimePickerEvent,
+} from "@react-native-community/datetimepicker";
+
+type DateTimeFieldProps = {
+  /** Value the picker opens on. */
+  value: Date;
+  /** Receives the chosen date-time once the user has confirmed every step. */
+  onConfirm: (next: Date) => void;
+  /** Fires when the user dismisses any step without confirming. */
+  onCancel: () => void;
+  /** Earliest selectable day. Applies to the date step only. */
+  minimumDate?: Date;
+  /** IANA zone the picker reads and reports its value in. */
+  timeZoneName?: string;
+  /** Wrapper style for the inline iOS picker. */
+  inlineStyle?: StyleProp<ViewStyle>;
+  /** Highlight colour for the native picker. */
+  accentColor?: string;
+};
+
+/** Merge the calendar day of `day` with the clock of `clock`. */
+function mergeDayAndClock(day: Date, clock: Date): Date {
+  const merged = new Date(day);
+  merged.setHours(clock.getHours(), clock.getMinutes(), 0, 0);
+  return merged;
+}
+
+export function DateTimeField({
+  value,
+  onConfirm,
+  onCancel,
+  minimumDate,
+  timeZoneName,
+  inlineStyle,
+  accentColor,
+}: DateTimeFieldProps) {
+  /**
+   * Callbacks and the opening value live in refs because the Android picker
+   * re-opens its native dialog whenever `onChange` or `value` change identity,
+   * which would stack a second dialog on every parent re-render.
+   */
+  const onConfirmRef = useRef(onConfirm);
+  onConfirmRef.current = onConfirm;
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
+  const valueRef = useRef(value);
+
+  const [androidStep, setAndroidStep] = useState<"date" | "time">("date");
+  const pickedDayRef = useRef<Date | null>(null);
+
+  const handleIosChange = useCallback(
+    (event: DateTimePickerEvent, selected: Date | undefined) => {
+      if (event.type !== "set" || !selected) {
+        onCancelRef.current();
+        return;
+      }
+      onConfirmRef.current(selected);
+    },
+    []
+  );
+
+  const handleAndroidChange = useCallback(
+    (event: DateTimePickerEvent, selected: Date | undefined) => {
+      if (event.type !== "set" || !selected) {
+        onCancelRef.current();
+        return;
+      }
+
+      if (pickedDayRef.current === null) {
+        pickedDayRef.current = selected;
+        setAndroidStep("time");
+        return;
+      }
+
+      onConfirmRef.current(mergeDayAndClock(pickedDayRef.current, selected));
+    },
+    []
+  );
+
+  if (Platform.OS !== "ios") {
+    return (
+      <DateTimePicker
+        value={
+          androidStep === "time" && pickedDayRef.current
+            ? mergeDayAndClock(pickedDayRef.current, valueRef.current)
+            : valueRef.current
+        }
+        mode={androidStep}
+        display="default"
+        minimumDate={androidStep === "date" ? minimumDate : undefined}
+        timeZoneName={timeZoneName}
+        onChange={handleAndroidChange}
+        accentColor={accentColor}
+      />
+    );
+  }
+
+  return (
+    <View style={inlineStyle}>
+      <DateTimePicker
+        value={value}
+        mode="datetime"
+        display="inline"
+        minimumDate={minimumDate}
+        timeZoneName={timeZoneName}
+        onChange={handleIosChange}
+        accentColor={accentColor}
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
## Problem

Changing the start or end date on the companion booking create/edit screens crashes the app on **Android**. The screen goes blank, only a force-quit clears it, and the in-progress booking is lost. iOS is unaffected. Reported from the field against 1.4.0.

## Cause

`mode="datetime"` is iOS-only — the package types it as `IOSMode`, while `AndroidMode` is `'date' | 'time'`. We passed it on both platforms:

```tsx
mode="datetime"                                        // not platform-guarded
display={Platform.OS === "ios" ? "inline" : "default"} // guarded
```

Android tolerates the bad mode when *opening* (`getOpenPicker` falls through its `default` branch and shows a date dialog), which is why this looked fine in review. The failure is on the way out: the picker's unmount cleanup calls `DateTimePickerAndroid.dismiss(mode)`, which does `pickers[mode].dismiss()`. `pickers` only has `date` and `time` keys, so `pickers["datetime"]` is `undefined` and the cleanup throws `TypeError: Cannot read property 'dismiss' of undefined`.

Confirming or cancelling both hide the picker, so every interaction with it threw. With no `ErrorBoundary` on either booking screen — and none in `app/_layout.tsx` — the throw propagated to the root and unmounted the whole tree, which is the blank screen.

## Fix

- New `components/date-time-field.tsx`. On Android it runs the native date dialog then the time dialog and reports the merged value once; on iOS it keeps the single inline `datetime` picker. Every mode it hands the native module is now a real `AndroidMode`.
- `bookings/new.tsx` and `bookings/edit.tsx` both use it, keeping the existing `keepEndAfterStart` clamp, `datesTouchedRef` seeding, and `timeZoneName` plumbing.
- Both screens are wrapped in `ErrorBoundary`, matching `bookings/index.tsx`. A future unguarded throw on these screens now reports to Sentry with a retry affordance instead of silently blanking the app.

## Scope check

`components/asset-edit/custom-field-input.tsx` is the only other `DateTimePicker` call site. It passes `mode="date"` and is unaffected. All six `ActionSheetIOS` call sites are correctly `Platform.OS === "ios"` guarded.

## Testing

- `tsc --noEmit` clean, `expo lint` clean, version-sync OK, 80/80 unit tests pass.
- Not yet exercised on a device — the e2e suite cannot reach this code path today. `.maestro/scripts/run-all.sh` is hard-coded to `xcrun simctl` and an `iPhone 15 Pro Max`, so no flow can run on Android; and no flow among the 66 taps a date field on any platform, so an Android run of today's suite would still have passed. Closing both gaps is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a consistent date-and-time selection experience for creating and editing bookings across iOS and Android.
  - Date and time selection now combines both values into a single confirmed result, with support for cancellation and minimum-date restrictions.
  - Improved time zone handling during date and time selection for more accurate booking times.

- **Bug Fixes**
  - Added improved error handling to booking creation and editing screens to prevent crashes from disrupting the experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->