### PR TITLE
chore(companion): run the e2e suite on Android, and cover the date pickers

### DIFF
--- a/apps/companion/.maestro/flows/bookings/15-date-picker-survives.yaml
+++ b/apps/companion/.maestro/flows/bookings/15-date-picker-survives.yaml
@@ -1,0 +1,129 @@
+appId: com.shelf.companion.carlos
+name: "Bookings - Date pickers survive a selection"
+tags:
+  - bookings
+  - create
+  - high-impact
+
+---
+# Test: opening and confirming the start and end date pickers leaves the create
+# form alive.
+#
+# This is a crash regression test, not a date-correctness test. On Android the
+# booking forms once passed `mode="datetime"` — an iOS-only value — to the
+# native picker. Opening it worked, but dismissing it threw
+# `Cannot read property 'dismiss' of undefined` out of the picker's unmount
+# cleanup, which unmounted the whole screen and left the app blank until a
+# force-quit. Shipped in 1.4.0 and reported from the field.
+#
+# The other create-booking flows never touch these fields — they rely on the
+# default tomorrow 09:00-17:00 window — so nothing else covers this path.
+#
+# RUN THIS ON BOTH PLATFORMS. The bug it guards is invisible on iOS.
+#
+# Requires (in the test org): GRANULAR WORKSPACE (TEAM). Creates nothing —
+# the form is abandoned at the end.
+
+- runFlow: ../../shared/login.yaml
+- runFlow: ../../shared/switch-to-team-ws.yaml
+
+- tapOn: "Bookings"
+- extendedWaitUntil:
+    visible: "Create booking"
+    timeout: 15000
+- tapOn: "Create booking"
+
+- extendedWaitUntil:
+    visible: "Booking name, required"
+    timeout: 15000
+
+# ── Start date ───────────────────────────────────────────────
+# Both fields are pre-seeded, so the a11y label is always the "tap to change"
+# variant. Regex full-matches in Maestro, hence the leading/trailing `.*`.
+- tapOn: ".*Starts.*tap to change.*"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      # Android runs two native dialogs back to back: date, then time.
+      - extendedWaitUntil:
+          visible: "OK"
+          timeout: 10000
+      - tapOn: "OK"
+      - extendedWaitUntil:
+          visible: "OK"
+          timeout: 10000
+      - tapOn: "OK"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      # iOS shows one inline picker; confirming closes it.
+      - waitForAnimationToEnd
+      - tapOn:
+          text: "15"
+          optional: true
+
+# The assertion that fails on the crash: the form is still mounted. A blank
+# screen has no "Ends" field, and the ErrorBoundary fallback reads "Error".
+- extendedWaitUntil:
+    visible: ".*Ends.*tap to change.*"
+    timeout: 10000
+- assertNotVisible: ".*Error.*"
+- takeScreenshot: booking-start-picker-survived
+
+# ── End date ─────────────────────────────────────────────────
+- tapOn: ".*Ends.*tap to change.*"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: "OK"
+          timeout: 10000
+      - tapOn: "OK"
+      - extendedWaitUntil:
+          visible: "OK"
+          timeout: 10000
+      - tapOn: "OK"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - waitForAnimationToEnd
+      - tapOn:
+          text: "20"
+          optional: true
+
+- extendedWaitUntil:
+    visible: ".*Starts.*tap to change.*"
+    timeout: 10000
+- assertVisible: ".*Ends.*tap to change.*"
+- assertNotVisible: ".*Error.*"
+- takeScreenshot: booking-end-picker-survived
+
+# ── Cancelling a picker must not crash either ────────────────
+# Dismissing runs the same unmount path as confirming, so it failed the same
+# way. On Android the dialog's own Cancel; on iOS, re-tapping the field closes
+# the inline picker.
+- tapOn: ".*Starts.*tap to change.*"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - extendedWaitUntil:
+          visible: "Cancel"
+          timeout: 10000
+      - tapOn: "Cancel"
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - waitForAnimationToEnd
+      - tapOn: ".*Starts.*tap to change.*"
+
+- extendedWaitUntil:
+    visible: ".*Ends.*tap to change.*"
+    timeout: 10000
+- assertNotVisible: ".*Error.*"
+- takeScreenshot: booking-picker-cancel-survived

--- a/apps/companion/.maestro/scripts/platform.sh
+++ b/apps/companion/.maestro/scripts/platform.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#############################################################################
+# Platform helpers for the Maestro runners.
+#
+# Maestro flows are platform-agnostic, but everything around them — booting a
+# device, clearing the stored session between runs, capturing logs, toggling
+# dark mode — is not. Each of those lives here behind one name so `run-all.sh`
+# and `run-suite.sh` read the same on either platform.
+#
+# Select with PLATFORM=ios (default) or PLATFORM=android. Override the device
+# with IOS_SIMULATOR / ANDROID_AVD.
+#
+# Source this file; it defines functions and sets MAESTRO_DEVICE_FLAGS.
+#############################################################################
+
+PLATFORM="${PLATFORM:-ios}"
+IOS_SIMULATOR="${IOS_SIMULATOR:-iPhone 15 Pro Max}"
+ANDROID_AVD="${ANDROID_AVD:-}"
+
+if [ "$PLATFORM" != "ios" ] && [ "$PLATFORM" != "android" ]; then
+  echo "✗ PLATFORM must be 'ios' or 'android' (got: $PLATFORM)" >&2
+  exit 1
+fi
+
+ANDROID_SDK="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+ADB="$ANDROID_SDK/platform-tools/adb"
+EMULATOR="$ANDROID_SDK/emulator/emulator"
+
+# The app id the flows target, so `pm clear` wipes the right package. Read from
+# config.yaml rather than duplicated here — the dev launcher and the store build
+# use different ids and the flows follow config.yaml.
+maestro_app_id() {
+  local config="$1/config.yaml"
+  [ -f "$config" ] && sed -n 's/^appId:[[:space:]]*//p' "$config" | head -1
+}
+
+# Human-readable device name for the run report.
+platform_label() {
+  if [ "$PLATFORM" = "ios" ]; then
+    echo "iOS Simulator ($IOS_SIMULATOR)"
+  else
+    echo "Android Emulator (${ANDROID_AVD:-$($ADB devices | sed -n '2s/\t.*//p')})"
+  fi
+}
+
+# Boot a device if none is running, then export MAESTRO_DEVICE_FLAGS so every
+# `maestro test` call targets it explicitly. Without this, a Mac with both an
+# iOS simulator and an Android emulator up lets Maestro pick either one.
+platform_ensure_device() {
+  if [ "$PLATFORM" = "ios" ]; then
+    local booted
+    booted=$(xcrun simctl list devices booted 2>/dev/null | grep -c "Booted" || true)
+    if [ "$booted" -eq 0 ]; then
+      echo "  Booting simulator: $IOS_SIMULATOR..."
+      xcrun simctl boot "$IOS_SIMULATOR" 2>/dev/null || true
+      sleep 5
+    fi
+    local udid
+    udid=$(xcrun simctl list devices booted -j 2>/dev/null \
+      | sed -n 's/.*"udid" : "\([^"]*\)".*/\1/p' | head -1)
+    MAESTRO_DEVICE_FLAGS=(--device "$udid")
+    return
+  fi
+
+  if [ ! -x "$ADB" ]; then
+    echo "✗ adb not found at $ADB — set ANDROID_HOME" >&2
+    exit 1
+  fi
+
+  if [ -z "$("$ADB" devices | sed -n '2p')" ]; then
+    if [ -z "$ANDROID_AVD" ]; then
+      ANDROID_AVD=$("$EMULATOR" -list-avds 2>/dev/null | head -1)
+    fi
+    if [ -z "$ANDROID_AVD" ]; then
+      echo "✗ No Android emulator running and no AVD to boot." >&2
+      echo "  Create one in Android Studio, or set ANDROID_AVD." >&2
+      exit 1
+    fi
+    echo "  Booting emulator: $ANDROID_AVD..."
+    nohup "$EMULATOR" -avd "$ANDROID_AVD" >/dev/null 2>&1 &
+  fi
+
+  "$ADB" wait-for-device
+  # `wait-for-device` returns as soon as adb can talk to the device, which is
+  # well before the launcher is up; installing or driving the app before then
+  # fails in ways that look like flow bugs.
+  local waited=0
+  until [ "$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do
+    sleep 3
+    waited=$((waited + 3))
+    if [ "$waited" -ge 180 ]; then
+      echo "✗ Emulator did not finish booting within 180s" >&2
+      exit 1
+    fi
+  done
+
+  MAESTRO_DEVICE_FLAGS=(--device "$("$ADB" devices | sed -n '2s/\t.*//p')")
+}
+
+# Clear the stored auth session so a run always starts logged out.
+# `clearState` in a flow only clears AsyncStorage, not the platform keystore
+# that SecureStore actually writes the tokens to.
+platform_reset_credentials() {
+  local app_id="$1"
+  if [ "$PLATFORM" = "ios" ]; then
+    xcrun simctl keychain booted reset 2>/dev/null || true
+    echo "✓ Keychain reset (SecureStore cleared)"
+  else
+    if [ -n "$app_id" ]; then
+      "$ADB" shell pm clear "$app_id" >/dev/null 2>&1 || true
+      echo "✓ App data cleared for $app_id (SecureStore cleared)"
+    else
+      echo "⚠ No appId in config.yaml — stored session left in place"
+    fi
+  fi
+}
+
+# Stream device logs to $1 in the background; sets PLATFORM_LOG_PID.
+platform_start_log_capture() {
+  local log_file="$1"
+  if [ "$PLATFORM" = "ios" ]; then
+    xcrun simctl spawn booted log stream --level=debug \
+      --predicate 'processImagePath CONTAINS "Shelf"' > "$log_file" 2>&1 &
+  else
+    "$ADB" logcat -c 2>/dev/null || true
+    "$ADB" logcat > "$log_file" 2>&1 &
+  fi
+  PLATFORM_LOG_PID=$!
+}
+
+platform_stop_log_capture() {
+  [ -n "${PLATFORM_LOG_PID:-}" ] && kill "$PLATFORM_LOG_PID" 2>/dev/null || true
+}
+
+# Switch the OS between light and dark for the dark-mode suite.
+platform_set_appearance() {
+  local mode="$1" # dark | light
+  if [ "$PLATFORM" = "ios" ]; then
+    xcrun simctl ui booted appearance "$mode" 2>/dev/null || true
+  else
+    local night="no"
+    [ "$mode" = "dark" ] && night="yes"
+    "$ADB" shell cmd uimode night "$night" >/dev/null 2>&1 || true
+  fi
+}

--- a/apps/companion/.maestro/scripts/run-all.sh
+++ b/apps/companion/.maestro/scripts/run-all.sh
@@ -8,13 +8,20 @@ set -euo pipefail
 # generates a report, and appends to LESSONS.md.
 #
 # Usage:
-#   ./run-all.sh                   # Run all suites
-#   SKIP_DARK=1 ./run-all.sh       # Skip dark mode suite
+#   ./run-all.sh                     # Run all suites on iOS (default)
+#   PLATFORM=android ./run-all.sh    # Run all suites on an Android emulator
+#   SKIP_DARK=1 ./run-all.sh         # Skip dark mode suite
+#
+# Both platforms run the same flows. Run BOTH before cutting a release: the
+# native modules behind date pickers, action sheets, permissions and the camera
+# are where iOS and Android diverge, and a green iOS run says nothing about them.
 #############################################################################
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAESTRO_DIR="$(dirname "$SCRIPT_DIR")"
 MOBILE_DIR="$(dirname "$MAESTRO_DIR")"
+# shellcheck source=./platform.sh
+source "$SCRIPT_DIR/platform.sh"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 RESULTS_DIR="$MAESTRO_DIR/results/$TIMESTAMP"
 
@@ -35,6 +42,7 @@ BOLD='\033[1m'
 
 echo -e "${CYAN}${BOLD}═══════════════════════════════════════════════════${NC}"
 echo -e "${CYAN}${BOLD}  Shelf Mobile — Maestro E2E Test Runner${NC}"
+echo -e "${CYAN}${BOLD}  Platform: $(platform_label)${NC}"
 echo -e "${CYAN}${BOLD}  $(date '+%Y-%m-%d %H:%M:%S')${NC}"
 echo -e "${CYAN}${BOLD}═══════════════════════════════════════════════════${NC}"
 echo ""
@@ -71,30 +79,20 @@ if ! command -v maestro &>/dev/null; then
 fi
 echo -e "${GREEN}✓ Maestro $(maestro --version 2>/dev/null | tail -1)${NC}"
 
-# ─── Boot iOS simulator if needed ───────────────────────────────────
-SIMULATOR_NAME="iPhone 15 Pro Max"
-BOOTED=$(xcrun simctl list devices booted 2>/dev/null | grep -c "Booted" || true)
-if [ "$BOOTED" -eq 0 ]; then
-  echo -e "${YELLOW}  Booting simulator: $SIMULATOR_NAME...${NC}"
-  xcrun simctl boot "$SIMULATOR_NAME" 2>/dev/null || true
-  sleep 5
-fi
-echo -e "${GREEN}✓ iOS Simulator ready${NC}"
+# ─── Boot the device if needed ──────────────────────────────────────
+platform_ensure_device
+echo -e "${GREEN}✓ $(platform_label) ready${NC}"
 
-# Clear iOS Keychain to reset SecureStore auth tokens
-# (clearState only clears AsyncStorage, not Keychain)
-xcrun simctl keychain booted reset 2>/dev/null || true
-echo -e "${GREEN}✓ Keychain reset (SecureStore cleared)${NC}"
+platform_reset_credentials "$(maestro_app_id "$MAESTRO_DIR")"
 
 # ─── Create results directory ───────────────────────────────────────
 mkdir -p "$RESULTS_DIR"
 echo -e "${GREEN}✓ Results dir: $RESULTS_DIR${NC}"
 
 # ─── Start simulator log collection ────────────────────────────────
-LOG_FILE="$RESULTS_DIR/simulator.log"
-xcrun simctl spawn booted log stream --level=debug --predicate 'processImagePath CONTAINS "Shelf"' > "$LOG_FILE" 2>&1 &
-LOG_PID=$!
-echo -e "${GREEN}✓ Simulator log collection started (PID: $LOG_PID)${NC}"
+LOG_FILE="$RESULTS_DIR/device.log"
+platform_start_log_capture "$LOG_FILE"
+echo -e "${GREEN}✓ Device log collection started (PID: $PLATFORM_LOG_PID)${NC}"
 echo ""
 
 # ─── Define test suites ────────────────────────────────────────────
@@ -127,7 +125,7 @@ for suite in "${SUITES[@]}"; do
     echo -n "  ▸ $FLOW_NAME ... "
 
     FLOW_OUTPUT="$RESULTS_DIR/${suite}_${FLOW_NAME}.log"
-    if maestro test "${MAESTRO_ENV_FLAGS[@]}" "$flow" --output "$RESULTS_DIR" > "$FLOW_OUTPUT" 2>&1; then
+    if maestro test "${MAESTRO_DEVICE_FLAGS[@]}" "${MAESTRO_ENV_FLAGS[@]}" "$flow" --output "$RESULTS_DIR" > "$FLOW_OUTPUT" 2>&1; then
       echo -e "${GREEN}PASS${NC}"
       PASS_COUNT=$((PASS_COUNT + 1))
       SUITE_PASS=$((SUITE_PASS + 1))
@@ -150,7 +148,7 @@ if [ "${SKIP_DARK:-}" != "1" ]; then
     echo -e "${CYAN}${BOLD}━━━ Running: dark-mode ━━━${NC}"
 
     # Set simulator to dark mode
-    xcrun simctl ui booted appearance dark 2>/dev/null || true
+    platform_set_appearance dark
     SUITE_PASS=0
     SUITE_FAIL=0
 
@@ -162,7 +160,7 @@ if [ "${SKIP_DARK:-}" != "1" ]; then
       echo -n "  ▸ $FLOW_NAME ... "
 
       FLOW_OUTPUT="$RESULTS_DIR/dark-mode_${FLOW_NAME}.log"
-      if maestro test "${MAESTRO_ENV_FLAGS[@]}" "$flow" --output "$RESULTS_DIR" > "$FLOW_OUTPUT" 2>&1; then
+      if maestro test "${MAESTRO_DEVICE_FLAGS[@]}" "${MAESTRO_ENV_FLAGS[@]}" "$flow" --output "$RESULTS_DIR" > "$FLOW_OUTPUT" 2>&1; then
         echo -e "${GREEN}PASS${NC}"
         PASS_COUNT=$((PASS_COUNT + 1))
         SUITE_PASS=$((SUITE_PASS + 1))
@@ -177,14 +175,14 @@ if [ "${SKIP_DARK:-}" != "1" ]; then
     SUITE_RESULTS+=("dark-mode: $SUITE_PASS passed, $SUITE_FAIL failed")
 
     # Reset simulator back to light mode
-    xcrun simctl ui booted appearance light 2>/dev/null || true
+    platform_set_appearance light
     echo ""
   fi
 fi
 
 # ─── Stop log collection ───────────────────────────────────────────
-kill "$LOG_PID" 2>/dev/null || true
-echo -e "${GREEN}✓ Simulator log collection stopped${NC}"
+platform_stop_log_capture
+echo -e "${GREEN}✓ Device log collection stopped${NC}"
 
 # ─── Generate report ───────────────────────────────────────────────
 REPORT_FILE="$RESULTS_DIR/REPORT.md"
@@ -192,7 +190,7 @@ cat > "$REPORT_FILE" <<EOF
 # Maestro E2E Test Report
 
 **Date:** $(date '+%Y-%m-%d %H:%M:%S')
-**Platform:** iOS Simulator ($SIMULATOR_NAME)
+**Platform:** $(platform_label)
 **Maestro:** $(maestro --version 2>/dev/null | tail -1)
 
 ## Summary
@@ -231,7 +229,7 @@ cat >> "$REPORT_FILE" <<EOF
 ## Files
 
 - Report: \`$REPORT_FILE\`
-- Simulator Log: \`simulator.log\`
+- Device Log: \`device.log\`
 - Screenshots: \`*.png\` files in this directory
 - Flow Logs: \`*_*.log\` files in this directory
 EOF

--- a/apps/companion/.maestro/scripts/run-suite.sh
+++ b/apps/companion/.maestro/scripts/run-suite.sh
@@ -10,10 +10,13 @@ set -euo pipefail
 #   ./run-suite.sh auth           # Run auth suite
 #   ./run-suite.sh dashboard      # Run dashboard suite
 #   ./run-suite.sh dark-mode      # Run dark mode suite
+#   PLATFORM=android ./run-suite.sh bookings
 #############################################################################
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAESTRO_DIR="$(dirname "$SCRIPT_DIR")"
+# shellcheck source=./platform.sh
+source "$SCRIPT_DIR/platform.sh"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 RESULTS_DIR="$MAESTRO_DIR/results/$TIMESTAMP"
 
@@ -75,16 +78,18 @@ while IFS='=' read -r key value; do
   MAESTRO_ENV_FLAGS+=(-e "$key=$value")
 done < "$ENV_FILE"
 
-echo -e "${CYAN}${BOLD}━━━ Running suite: $SUITE_NAME ━━━${NC}"
+echo -e "${CYAN}${BOLD}━━━ Running suite: $SUITE_NAME on $(platform_label) ━━━${NC}"
 echo ""
+
+platform_ensure_device
 
 # Create results dir
 mkdir -p "$RESULTS_DIR"
 
 # Toggle dark mode for dark-mode suite
 if [ "$SUITE_NAME" = "dark-mode" ]; then
-  xcrun simctl ui booted appearance dark 2>/dev/null || true
-  echo -e "${YELLOW}  Set simulator to dark mode${NC}"
+  platform_set_appearance dark
+  echo -e "${YELLOW}  Set device to dark mode${NC}"
 fi
 
 PASS_COUNT=0
@@ -98,7 +103,7 @@ for flow in "$SUITE_DIR"/*.yaml; do
   echo -n "  ▸ $FLOW_NAME ... "
 
   FLOW_OUTPUT="$RESULTS_DIR/${SUITE_NAME}_${FLOW_NAME}.log"
-  if maestro test "${MAESTRO_ENV_FLAGS[@]}" "$flow" --output "$RESULTS_DIR" > "$FLOW_OUTPUT" 2>&1; then
+  if maestro test "${MAESTRO_DEVICE_FLAGS[@]}" "${MAESTRO_ENV_FLAGS[@]}" "$flow" --output "$RESULTS_DIR" > "$FLOW_OUTPUT" 2>&1; then
     echo -e "${GREEN}PASS${NC}"
     PASS_COUNT=$((PASS_COUNT + 1))
   else
@@ -110,7 +115,7 @@ done
 
 # Reset dark mode
 if [ "$SUITE_NAME" = "dark-mode" ]; then
-  xcrun simctl ui booted appearance light 2>/dev/null || true
+  platform_set_appearance light
 fi
 
 TOTAL=$((PASS_COUNT + FAIL_COUNT))

--- a/apps/companion/README.md
+++ b/apps/companion/README.md
@@ -22,7 +22,7 @@ A native iOS/Android companion app for [Shelf.nu](https://shelf.nu) built with *
 | **Dashboard**            | Stats overview, pull-to-refresh, quick actions                                  |
 | **Dark Mode**            | Full theme support with system preference detection                             |
 | **Offline Support**      | Network detection, cached API responses, offline audit persistence              |
-| **E2E Tests**            | 40+ Maestro test flows covering all features                                    |
+| **E2E Tests**            | 65+ Maestro test flows covering all features, runnable on iOS and Android       |
 
 ### How Authentication Works
 
@@ -261,8 +261,23 @@ All scripts can be run from the **monorepo root**:
 | `pnpm companion:build:android`    | Build native Android + run on emulator/device           |
 | `pnpm companion:prebuild`         | Regenerate native projects from Expo config             |
 | `pnpm companion:prebuild:clean`   | Clean regenerate iOS native project (wipes ios/)        |
-| `pnpm companion:test:e2e`         | Run all Maestro E2E flows                               |
+| `pnpm companion:test:e2e`         | Run all Maestro E2E flows (iOS by default)              |
 | `pnpm companion:test:e2e:suite`   | Run a specific E2E test suite                           |
+
+The runners take `PLATFORM=ios` (default) or `PLATFORM=android`, and boot the
+device for you:
+
+```bash
+PLATFORM=android pnpm companion:test:e2e
+PLATFORM=android pnpm companion:test:e2e:suite bookings
+```
+
+**Run both platforms before cutting a release.** The flows are identical, but
+the native modules under them are not: date pickers, action sheets, permission
+dialogs and the camera all take different props and fail differently on Android.
+A green iOS run tells you nothing about any of them — 1.4.0 shipped an
+Android-only crash in the booking date picker for exactly this reason.
+Override the device with `IOS_SIMULATOR` or `ANDROID_AVD`.
 
 **Typical workflow:**
 


### PR DESCRIPTION
## Why

1.4.0 shipped an Android-only crash in the booking date pickers (fixed in #2965). Two things in the test setup let it through, and both are still true on `main`:

**The suite cannot run on Android at all.** `run-all.sh` hard-codes `SIMULATOR_NAME="iPhone 15 Pro Max"` and uses `xcrun simctl` for booting, keychain reset, log capture and dark mode. Every report is stamped `**Platform:** iOS Simulator`. There is no `adb` anywhere in `.maestro/`.

**No flow touches a date field.** Across all 66 flows, nothing opens a picker on either platform — `06-create-booking.yaml` explicitly relies on the default window (*"start/end default to tomorrow 9–17"*). So even after making the suite dual-platform, an Android run would still have passed while shipping that crash. Both gaps had to close for this to be caught.

## Changes

- **`scripts/platform.sh`** (new) — the platform-specific half of the runners behind one name per operation: `platform_ensure_device`, `platform_reset_credentials`, `platform_start_log_capture`, `platform_set_appearance`, `platform_label`. Android gets emulator boot with a real `sys.boot_completed` poll (`adb wait-for-device` returns long before the launcher is up), `pm clear` for the stored session, `adb logcat`, and `cmd uimode night`.
- **`run-all.sh` / `run-suite.sh`** — take `PLATFORM=ios` (default, unchanged behaviour) or `PLATFORM=android`. Both now pass `--device` to every `maestro test` call: with an iOS simulator and an Android emulator both up, Maestro would otherwise pick either one, which is easy to have happen and hard to notice in a report.
- **`flows/bookings/15-date-picker-survives.yaml`** (new) — opens the start and end pickers, confirms each, then cancels one, asserting after each that the form is still mounted. Platform-conditional only where the native dialogs genuinely differ (Android runs date then time; iOS has a single inline picker). A blank screen has no `Ends` field, so the crash fails this flow rather than passing quietly.
- **README** — documents `PLATFORM=android`, `IOS_SIMULATOR` / `ANDROID_AVD`, and why both platforms need running before a release cut.

## Testing

- All three scripts pass `bash -n`.
- Helpers exercised against live devices: Android resolved `--device emulator-5554` and read `appId: com.shelf.companion.carlos` from `config.yaml`; iOS resolved the booted simulator's UDID.
- The new flow has not had a full green run yet — it needs a dev client on the emulator, which is building. I'll post the run output here before asking for a merge.

## Not in scope

CI. Both runners stay local, on free tooling. Wiring this into GitHub Actions means paying for Android emulator minutes, and that is a separate decision from being able to run it at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added cross-platform end-to-end coverage for booking date-picker interactions on iOS and Android.
  * Expanded test execution support with platform-specific device setup, logging, credential resets, and appearance controls.
  * Added regression coverage to verify the booking form remains available after date and time picker interactions.

* **Documentation**
  * Updated testing guidance for Android execution and platform-specific native behavior.
  * Documented the expanded suite of 65+ end-to-end flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->