### PR TITLE
fix(reports): exports carry the page's filters and the org's currency

### DIFF
--- a/apps/webapp/app/components/reports/report-pdf.tsx
+++ b/apps/webapp/app/components/reports/report-pdf.tsx
@@ -16,6 +16,7 @@ import { Dialog, DialogPortal } from "~/components/layout/dialog";
 import { Button } from "~/components/shared/button";
 import { Image } from "~/components/shared/image";
 import { Spinner } from "~/components/shared/spinner";
+import { useSearchParams } from "~/hooks/search-params";
 import useApiQuery from "~/hooks/use-api-query";
 import type {
   ReportPdfMeta,
@@ -53,15 +54,22 @@ export function ReportPdf({
   const componentRef = useRef<HTMLDivElement>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [pdfMeta, setPdfMeta] = useState<ReportPdfMeta | null>(null);
+  const [currentSearchParams] = useSearchParams();
 
   // Memoize so a new URLSearchParams reference doesn't refetch every render.
   const searchParams = useMemo(() => {
-    const params = new URLSearchParams();
+    // Seed from the page's current query string so the report's filters
+    // (team member, categories, sort, …) reach the PDF route — the server
+    // mirrors the page loader's params per report, and a PDF must contain
+    // the rows the filtered page shows. The timeframe props then take
+    // precedence: they carry the resolved custom-range dates in exactly the
+    // shape the route parses.
+    const params = new URLSearchParams(currentSearchParams);
     if (timeframe) params.set("timeframe", timeframe);
     if (customFrom) params.set("from", customFrom);
     if (customTo) params.set("to", customTo);
     return params;
-  }, [timeframe, customFrom, customTo]);
+  }, [currentSearchParams, timeframe, customFrom, customTo]);
 
   // Fetch via the shared hook so the underlying useEffect+fetch lives in one
   // dedicated place — mirrors the pattern in `audit-receipt-pdf.tsx`.

--- a/apps/webapp/app/modules/reports/helpers.server.test.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.test.ts
@@ -446,11 +446,47 @@ describe("overdueItemsReport — booked-unit value math", () => {
     };
     vi.mocked(db.booking.findMany).mockResolvedValue([overdueBooking] as any);
 
-    const result = await overdueItemsReport({ organizationId: "org-1" });
+    const result = await overdueItemsReport({
+      organizationId: "org-1",
+      currency: "USD",
+    });
 
     expect(result.rows[0].valueAtRisk).toBe(500);
     const vaRKpi = result.kpis.find((k) => k.id === "total_value_at_risk");
     expect(vaRKpi?.rawValue).toBe(500);
+  });
+
+  it("formats the Value at Risk KPI in the workspace currency", async () => {
+    // The KPI value string is assembled server-side, so the workspace
+    // currency must be threaded in — a EUR workspace must never see "$".
+    const overdueBooking = {
+      id: "booking-eur",
+      name: "EUR Overdue",
+      to: new Date("2026-04-10T12:00:00Z"),
+      custodianUserId: null,
+      custodianUser: null,
+      custodianTeamMember: null,
+      bookingAssets: [
+        {
+          quantity: 5,
+          asset: { id: "asset-1", valuation: 100 },
+        },
+      ],
+      partialCheckins: [],
+      _count: { bookingAssets: 1 },
+    };
+    vi.mocked(db.booking.findMany).mockResolvedValue([overdueBooking] as any);
+
+    const result = await overdueItemsReport({
+      organizationId: "org-1",
+      currency: "EUR",
+    });
+
+    const vaRKpi = result.kpis.find((k) => k.id === "total_value_at_risk");
+    // Server-built KPI strings use the fixed en-US locale (the CSV export
+    // convention); the workspace currency drives the symbol and decimals.
+    expect(vaRKpi?.value).toBe("€500.00");
+    expect(vaRKpi?.value).not.toContain("$");
   });
 });
 
@@ -491,7 +527,10 @@ describe("assetDistributionReport — quantity-aware bucket values", () => {
       },
     ] as any);
 
-    const result = await assetDistributionReport({ organizationId: "org-1" });
+    const result = await assetDistributionReport({
+      organizationId: "org-1",
+      currency: "USD",
+    });
 
     const catBucket = result.distributionBreakdown!.byCategory.find(
       (b) => b.id === "cat-1"
@@ -535,7 +574,10 @@ describe("assetDistributionReport — quantity-aware bucket values", () => {
       },
     ] as any);
 
-    const result = await assetDistributionReport({ organizationId: "org-1" });
+    const result = await assetDistributionReport({
+      organizationId: "org-1",
+      currency: "USD",
+    });
 
     const byLocation = result.distributionBreakdown!.byLocation;
     expect(byLocation.find((b) => b.id === "loc-1")?.totalValue).toBe(30);
@@ -547,7 +589,10 @@ describe("assetDistributionReport — quantity-aware bucket values", () => {
   it("reads the asset table once for all three breakdowns", async () => {
     vi.mocked(db.asset.findMany).mockResolvedValue([] as any);
 
-    await assetDistributionReport({ organizationId: "org-1" });
+    await assetDistributionReport({
+      organizationId: "org-1",
+      currency: "USD",
+    });
 
     expect(vi.mocked(db.asset.findMany)).toHaveBeenCalledTimes(1);
   });

--- a/apps/webapp/app/modules/reports/helpers.server.ts
+++ b/apps/webapp/app/modules/reports/helpers.server.ts
@@ -16,6 +16,7 @@ import type {
   ActivityAction,
   AssetStatus,
   BookingStatus,
+  Currency,
 } from "@prisma/client";
 import { Prisma } from "@prisma/client";
 import { DateTime } from "luxon";
@@ -30,6 +31,7 @@ import {
   resolvePlannedStart,
 } from "~/modules/booking/lateness";
 import { getAssetTotalValue } from "~/utils/asset-value";
+import { formatCurrency } from "~/utils/currency";
 import { ShelfError } from "~/utils/error";
 import type { UserNameFields } from "~/utils/user";
 import { resolveUserDisplayName } from "~/utils/user";
@@ -81,6 +83,24 @@ export { resolveTimeframe } from "./timeframe";
 function stripNameSuffix(name: string | null | undefined): string {
   if (!name) return "Unknown";
   return name.replace(/\s*\(Owner\)$/i, "").trim() || "Unknown";
+}
+
+// -----------------------------------------------------------------------------
+// Money KPI Formatting
+// -----------------------------------------------------------------------------
+
+/**
+ * Format a money KPI value string in the workspace's currency.
+ *
+ * KPI value strings are assembled server-side, where no viewer locale is
+ * available, so they use the same fixed en-US locale as the CSV export
+ * builders (see `~/utils/csv.server.ts`). The workspace currency drives the
+ * symbol and decimal digits — on-screen table cells and the PDF renderer
+ * format from the same organization setting, so the currency always agrees
+ * even though those surfaces apply the viewer's locale.
+ */
+function formatKpiCurrency(value: number, currency: Currency): string {
+  return formatCurrency({ value, currency, locale: "en-US" });
 }
 
 // -----------------------------------------------------------------------------
@@ -1067,6 +1087,8 @@ async function computeCustodianPerformance(
 
 interface OverdueItemsArgs {
   organizationId: string;
+  /** Workspace currency the money KPI value strings are formatted in. */
+  currency: Currency;
   custodianId?: string;
   page?: number;
   pageSize?: number;
@@ -1084,7 +1106,13 @@ interface OverdueItemsArgs {
 export async function overdueItemsReport(
   args: OverdueItemsArgs
 ): Promise<ReportPayload<OverdueItemRow>> {
-  const { organizationId, custodianId, page = 1, pageSize = 50 } = args;
+  const {
+    organizationId,
+    currency,
+    custodianId,
+    page = 1,
+    pageSize = 50,
+  } = args;
 
   const startTime = performance.now();
 
@@ -1103,7 +1131,7 @@ export async function overdueItemsReport(
     const [rows, totalCount, kpis] = await Promise.all([
       fetchOverdueRows(where, page, pageSize),
       db.booking.count({ where }),
-      computeOverdueKpis(organizationId, where),
+      computeOverdueKpis(organizationId, where, currency),
     ]);
 
     const computedMs = Math.round(performance.now() - startTime);
@@ -1258,7 +1286,8 @@ async function fetchOverdueRows(
 
 async function computeOverdueKpis(
   organizationId: string,
-  baseWhere: Prisma.BookingWhereInput
+  baseWhere: Prisma.BookingWhereInput,
+  currency: Currency
 ): Promise<ReportKpi[]> {
   const now = new Date();
 
@@ -1375,7 +1404,9 @@ async function computeOverdueKpis(
       id: "total_value_at_risk",
       label: "Value at Risk",
       value:
-        totalValueAtRisk > 0 ? `$${totalValueAtRisk.toLocaleString()}` : "—",
+        totalValueAtRisk > 0
+          ? formatKpiCurrency(totalValueAtRisk, currency)
+          : "—",
       rawValue: totalValueAtRisk,
       format: "currency",
       delta: null,
@@ -1418,6 +1449,8 @@ async function computeOverdueKpis(
 
 interface IdleAssetsArgs {
   organizationId: string;
+  /** Workspace currency the money KPI value strings are formatted in. */
+  currency: Currency;
   /** Number of days without activity to consider "idle" (default: 30) */
   idleThresholdDays?: number;
   categoryId?: string;
@@ -1440,6 +1473,7 @@ export async function idleAssetsReport(
 ): Promise<ReportPayload<IdleAssetRow>> {
   const {
     organizationId,
+    currency,
     idleThresholdDays = 30,
     categoryId,
     locationId,
@@ -1478,7 +1512,7 @@ export async function idleAssetsReport(
         pageSize
       ),
       countIdleAssets(organizationId, assetWhere, cutoffDate),
-      computeIdleAssetsKpis(organizationId, assetWhere, cutoffDate),
+      computeIdleAssetsKpis(organizationId, assetWhere, cutoffDate, currency),
     ]);
 
     const computedMs = Math.round(performance.now() - startTime);
@@ -1699,7 +1733,8 @@ async function countIdleAssets(
 async function computeIdleAssetsKpis(
   organizationId: string,
   assetWhere: Prisma.AssetWhereInput,
-  cutoffDate: Date
+  cutoffDate: Date,
+  currency: Currency
 ): Promise<ReportKpi[]> {
   const now = new Date();
 
@@ -1813,7 +1848,8 @@ async function computeIdleAssetsKpis(
     {
       id: "total_idle_value",
       label: "Idle Value",
-      value: totalIdleValue > 0 ? `$${totalIdleValue.toLocaleString()}` : "—",
+      value:
+        totalIdleValue > 0 ? formatKpiCurrency(totalIdleValue, currency) : "—",
       rawValue: totalIdleValue,
       format: "currency",
       delta: null,
@@ -1847,6 +1883,8 @@ async function computeIdleAssetsKpis(
 
 interface CustodySnapshotArgs {
   organizationId: string;
+  /** Workspace currency the money KPI value strings are formatted in. */
+  currency: Currency;
   teamMemberId?: string;
   locationId?: string;
   page?: number;
@@ -1867,6 +1905,7 @@ export async function custodySnapshotReport(
 ): Promise<ReportPayload<CustodySnapshotRow>> {
   const {
     organizationId,
+    currency,
     teamMemberId,
     locationId,
     page = 1,
@@ -1902,7 +1941,7 @@ export async function custodySnapshotReport(
     const [rows, totalCount, kpis] = await Promise.all([
       fetchCustodyRows(where, page, pageSize),
       db.custody.count({ where }),
-      computeCustodyKpis(organizationId, where),
+      computeCustodyKpis(organizationId, where, currency),
     ]);
 
     const computedMs = Math.round(performance.now() - startTime);
@@ -2053,7 +2092,8 @@ async function fetchCustodyRows(
 
 async function computeCustodyKpis(
   organizationId: string,
-  baseWhere: Prisma.CustodyWhereInput
+  baseWhere: Prisma.CustodyWhereInput,
+  currency: Currency
 ): Promise<ReportKpi[]> {
   const now = new Date();
 
@@ -2123,7 +2163,7 @@ async function computeCustodyKpis(
     {
       id: "total_custody_value",
       label: "Total Value",
-      value: totalValue > 0 ? `$${totalValue.toLocaleString()}` : "—",
+      value: totalValue > 0 ? formatKpiCurrency(totalValue, currency) : "—",
       rawValue: totalValue,
       format: "currency",
       delta: null,
@@ -2833,6 +2873,8 @@ function buildTopBookedKitsKpis({
 
 interface AssetDistributionArgs {
   organizationId: string;
+  /** Workspace currency the money KPI value strings are formatted in. */
+  currency: Currency;
   page?: number;
   pageSize?: number;
 }
@@ -2853,7 +2895,7 @@ export async function assetDistributionReport(
     distributionBreakdown: DistributionBreakdown;
   }
 > {
-  const { organizationId, page = 1, pageSize = 50 } = args;
+  const { organizationId, currency, page = 1, pageSize = 50 } = args;
 
   const startTime = performance.now();
 
@@ -2863,7 +2905,7 @@ export async function assetDistributionReport(
     // once instead of three times.
     const [assets, kpis] = await Promise.all([
       fetchDistributionAssets(organizationId),
-      computeDistributionKpis(organizationId),
+      computeDistributionKpis(organizationId, currency),
     ]);
     const [byCategory, byLocation, byStatus] = await Promise.all([
       computeDistributionByCategory(assets, organizationId),
@@ -3116,7 +3158,8 @@ function computeDistributionByStatus(
 }
 
 async function computeDistributionKpis(
-  organizationId: string
+  organizationId: string,
+  currency: Currency
 ): Promise<ReportKpi[]> {
   const [totalAssets, totalValueRows, categoryCount, locationCount] =
     await Promise.all([
@@ -3152,7 +3195,10 @@ async function computeDistributionKpis(
     {
       id: "total_value",
       label: "Total Value",
-      value: totalAssetValue > 0 ? `$${totalAssetValue.toLocaleString()}` : "—",
+      value:
+        totalAssetValue > 0
+          ? formatKpiCurrency(totalAssetValue, currency)
+          : "—",
       rawValue: totalAssetValue,
       format: "currency",
       delta: null,
@@ -3185,6 +3231,8 @@ async function computeDistributionKpis(
 
 interface AssetInventoryArgs {
   organizationId: string;
+  /** Workspace currency the money KPI value strings are formatted in. */
+  currency: Currency;
   categoryIds?: string[];
   locationIds?: string[];
   statuses?: string[];
@@ -3205,6 +3253,7 @@ export async function assetInventoryReport(
 ): Promise<ReportPayload<AssetInventoryRow>> {
   const {
     organizationId,
+    currency,
     categoryIds,
     locationIds,
     statuses,
@@ -3235,11 +3284,16 @@ export async function assetInventoryReport(
       db.asset.count({ where }),
       // Filters are passed through so the KPI helper can mirror them in its
       // `$queryRaw` valuation sum (Prisma doesn't expose where → SQL).
-      computeInventoryKpis(organizationId, where, {
-        categoryIds,
-        locationIds,
-        statuses: statuses as AssetStatus[] | undefined,
-      }),
+      computeInventoryKpis(
+        organizationId,
+        where,
+        {
+          categoryIds,
+          locationIds,
+          statuses: statuses as AssetStatus[] | undefined,
+        },
+        currency
+      ),
     ]);
 
     const computedMs = Math.round(performance.now() - startTime);
@@ -3363,7 +3417,8 @@ async function computeInventoryKpis(
     categoryIds?: string[];
     locationIds?: string[];
     statuses?: AssetStatus[];
-  }
+  },
+  currency: Currency
 ): Promise<ReportKpi[]> {
   // Defense-in-depth: enforce organizationId on every query even though
   // callers' `where` already includes it. Cheap to add, prevents an
@@ -3433,7 +3488,10 @@ async function computeInventoryKpis(
     {
       id: "total_value",
       label: "Total Value",
-      value: totalAssetValue > 0 ? `$${totalAssetValue.toLocaleString()}` : "—",
+      value:
+        totalAssetValue > 0
+          ? formatKpiCurrency(totalAssetValue, currency)
+          : "—",
       rawValue: totalAssetValue,
       format: "currency",
       delta: null,

--- a/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
+++ b/apps/webapp/app/routes/_layout+/reports.$reportId.tsx
@@ -113,8 +113,9 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     });
   }
 
-  // Check permissions
-  const { organizationId } = await requirePermission({
+  // Check permissions. `currentOrganization` supplies the workspace currency
+  // for the reports whose KPI strings carry money values.
+  const { organizationId, currentOrganization } = await requirePermission({
     userId,
     request,
     entity: PermissionEntity.reports,
@@ -170,6 +171,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     case "overdue-items":
       reportData = await overdueItemsReport({
         organizationId,
+        currency: currentOrganization.currency,
         custodianId: url.searchParams.get("custodian") || undefined,
         page: parseInt(url.searchParams.get("page") || "1", 10),
         pageSize: parseInt(url.searchParams.get("pageSize") || "50", 10),
@@ -179,6 +181,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     case "idle-assets":
       reportData = await idleAssetsReport({
         organizationId,
+        currency: currentOrganization.currency,
         idleThresholdDays: parseInt(url.searchParams.get("days") || "30", 10),
         categoryId: url.searchParams.get("category") || undefined,
         locationId: url.searchParams.get("location") || undefined,
@@ -190,6 +193,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     case "custody-snapshot":
       reportData = await custodySnapshotReport({
         organizationId,
+        currency: currentOrganization.currency,
         teamMemberId: url.searchParams.get("teamMember") || undefined,
         locationId: url.searchParams.get("location") || undefined,
         page: parseInt(url.searchParams.get("page") || "1", 10),
@@ -220,6 +224,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     case "distribution":
       reportData = await assetDistributionReport({
         organizationId,
+        currency: currentOrganization.currency,
         page: parseInt(url.searchParams.get("page") || "1", 10),
         pageSize: parseInt(url.searchParams.get("pageSize") || "50", 10),
       });
@@ -228,6 +233,7 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     case "asset-inventory":
       reportData = await assetInventoryReport({
         organizationId,
+        currency: currentOrganization.currency,
         categoryIds:
           url.searchParams.get("categories")?.split(",").filter(Boolean) ||
           undefined,

--- a/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
+++ b/apps/webapp/app/routes/_layout+/reports.export.$fileName[.csv].tsx
@@ -23,6 +23,7 @@ import {
   assetActivityReport,
   assetDistributionReport,
   monthlyBookingTrendsReport,
+  type BookingComplianceSortColumn,
 } from "~/modules/reports/helpers.server";
 import { getReportById } from "~/modules/reports/registry";
 import type {
@@ -60,12 +61,15 @@ export const loader = async ({
   const { userId } = authSession;
 
   try {
-    const { organizationId } = await requirePermission({
+    // `currentOrganization` supplies the workspace currency for the reports
+    // whose KPI strings carry money values.
+    const { organizationId, currentOrganization } = await requirePermission({
       userId,
       request,
       entity: PermissionEntity.reports,
       action: PermissionAction.export,
     });
+    const currency = currentOrganization.currency;
 
     const searchParams = getCurrentSearchParams(request);
     const reportId = searchParams.get("reportId");
@@ -119,11 +123,22 @@ export const loader = async ({
       formatPrefs
     );
 
-    // Generate CSV based on report type
+    // Generate CSV based on report type. Each case parses the same filter
+    // params its page-loader counterpart honors (see reports.$reportId.tsx)
+    // and hands them to the same query function — the client forwards the
+    // page's full query string, so the CSV contains exactly the rows the
+    // filtered page shows. Paging is the one deliberate difference: exports
+    // always read page 1 with a 10k page size.
     let csvString: string;
 
     switch (reportId) {
       case "booking-compliance": {
+        // Sort params mirror the page so the CSV row order matches the table.
+        const sortBy = (searchParams.get("sortBy") ||
+          "scheduledEnd") as BookingComplianceSortColumn;
+        const sortOrder = (searchParams.get("sortOrder") || "desc") as
+          | "asc"
+          | "desc";
         const reportData = await bookingComplianceReport({
           organizationId,
           timeframe,
@@ -131,6 +146,8 @@ export const loader = async ({
           timeZone: formatPrefs.timeZone,
           page: 1,
           pageSize: 10000, // Export up to 10k rows
+          sortBy,
+          sortOrder,
         });
         csvString = generateBookingComplianceCsv(
           reportData.rows as BookingComplianceRow[],
@@ -142,6 +159,9 @@ export const loader = async ({
       case "custody-snapshot": {
         const reportData = await custodySnapshotReport({
           organizationId,
+          currency,
+          teamMemberId: searchParams.get("teamMember") || undefined,
+          locationId: searchParams.get("location") || undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -155,6 +175,8 @@ export const loader = async ({
       case "overdue-items": {
         const reportData = await overdueItemsReport({
           organizationId,
+          currency,
+          custodianId: searchParams.get("custodian") || undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -169,7 +191,10 @@ export const loader = async ({
         const idleThreshold = parseInt(searchParams.get("days") || "30", 10);
         const reportData = await idleAssetsReport({
           organizationId,
+          currency,
           idleThresholdDays: idleThreshold,
+          categoryId: searchParams.get("category") || undefined,
+          locationId: searchParams.get("location") || undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -184,6 +209,8 @@ export const loader = async ({
         const reportData = await topBookedAssetsReport({
           organizationId,
           timeframe,
+          categoryId: searchParams.get("category") || undefined,
+          locationId: searchParams.get("location") || undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -209,6 +236,16 @@ export const loader = async ({
       case "asset-inventory": {
         const reportData = await assetInventoryReport({
           organizationId,
+          currency,
+          categoryIds:
+            searchParams.get("categories")?.split(",").filter(Boolean) ||
+            undefined,
+          locationIds:
+            searchParams.get("locations")?.split(",").filter(Boolean) ||
+            undefined,
+          statuses:
+            searchParams.get("statuses")?.split(",").filter(Boolean) ||
+            undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -223,6 +260,8 @@ export const loader = async ({
         const reportData = await assetUtilizationReport({
           organizationId,
           timeframe,
+          categoryId: searchParams.get("category") || undefined,
+          locationId: searchParams.get("location") || undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -236,6 +275,8 @@ export const loader = async ({
         const reportData = await assetActivityReport({
           organizationId,
           timeframe,
+          assetId: searchParams.get("asset") || undefined,
+          categoryId: searchParams.get("category") || undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -249,6 +290,7 @@ export const loader = async ({
       case "distribution": {
         const reportData = await assetDistributionReport({
           organizationId,
+          currency,
           page: 1,
           pageSize: 10000,
         });
@@ -257,6 +299,10 @@ export const loader = async ({
       }
 
       case "monthly-booking-trends": {
+        // why: the page's category/location params are deliberately NOT
+        // forwarded — `monthlyBookingTrendsReport` accepts but ignores them,
+        // and forwarding dead filters would claim a filtering this export
+        // does not perform.
         const reportData = await monthlyBookingTrendsReport({
           organizationId,
           timeframe,

--- a/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
+++ b/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
@@ -18,6 +18,7 @@ import {
   bookingComplianceReport,
   assetInventoryReport,
   custodySnapshotReport,
+  type BookingComplianceSortColumn,
 } from "~/modules/reports/helpers.server";
 import { sumQuantityAwareValue } from "~/modules/reports/pdf-totals";
 import { getReportById } from "~/modules/reports/registry";
@@ -180,11 +181,21 @@ export const loader = async ({
         }),
     };
 
-    // Generate report data based on type
+    // Generate report data based on type. Each case parses the same filter
+    // params its page-loader counterpart honors (see reports.$reportId.tsx)
+    // and hands them to the same query function — the client forwards the
+    // page's full query string, so the PDF contains exactly the rows the
+    // filtered page shows.
     let pdfMeta: ReportPdfMeta;
 
     switch (reportId) {
       case "booking-compliance": {
+        // Sort params mirror the page so the PDF row order matches the table.
+        const sortBy = (searchParams.get("sortBy") ||
+          "scheduledEnd") as BookingComplianceSortColumn;
+        const sortOrder = (searchParams.get("sortOrder") || "desc") as
+          | "asc"
+          | "desc";
         const reportData = await bookingComplianceReport({
           organizationId,
           timeframe,
@@ -192,6 +203,8 @@ export const loader = async ({
           timeZone: prefs.timeZone,
           page: 1,
           pageSize: 10000, // PDF can handle large tables
+          sortBy,
+          sortOrder,
         });
 
         const overdueKpi = reportData.kpis.find(
@@ -246,6 +259,16 @@ export const loader = async ({
       case "asset-inventory": {
         const reportData = await assetInventoryReport({
           organizationId,
+          currency: organization.currency,
+          categoryIds:
+            searchParams.get("categories")?.split(",").filter(Boolean) ||
+            undefined,
+          locationIds:
+            searchParams.get("locations")?.split(",").filter(Boolean) ||
+            undefined,
+          statuses:
+            searchParams.get("statuses")?.split(",").filter(Boolean) ||
+            undefined,
           page: 1,
           pageSize: 10000,
         });
@@ -294,6 +317,9 @@ export const loader = async ({
       case "custody-snapshot": {
         const reportData = await custodySnapshotReport({
           organizationId,
+          currency: organization.currency,
+          teamMemberId: searchParams.get("teamMember") || undefined,
+          locationId: searchParams.get("location") || undefined,
           page: 1,
           pageSize: 10000,
         });

--- a/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
+++ b/apps/webapp/app/routes/api+/reports.$reportId.generate-pdf.tsx
@@ -5,7 +5,13 @@
  * Returns JSON that the client renders as a styled HTML preview,
  * then converts to PDF via react-to-print.
  *
- * @see {@link file://../../components/reports/compliance-report-pdf.tsx}
+ * Serves the three reports that ship a PDF — booking compliance, asset
+ * inventory and custody snapshot. `REPORTS_WITH_PDF` in
+ * `report-export-actions.tsx` gates which pages offer the button, and the
+ * switch below must cover exactly that list.
+ *
+ * @see {@link file://../../components/reports/report-pdf.tsx} the renderer this feeds
+ * @see {@link file://../../components/reports/report-export-actions.tsx} `REPORTS_WITH_PDF`
  */
 
 import { data } from "react-router";

--- a/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
@@ -13,7 +13,12 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLoaderArgs } from "@mocks/remix";
-import { assetDistributionReport } from "~/modules/reports/helpers.server";
+import {
+  assetDistributionReport,
+  assetInventoryReport,
+  bookingComplianceReport,
+  custodySnapshotReport,
+} from "~/modules/reports/helpers.server";
 import {
   PermissionAction,
   PermissionEntity,
@@ -62,6 +67,9 @@ let loader: (typeof import("~/routes/_layout+/reports.export.$fileName[.csv]"))[
 
 const requirePermissionMock = vi.mocked(requirePermission);
 const assetDistributionReportMock = vi.mocked(assetDistributionReport);
+const custodySnapshotReportMock = vi.mocked(custodySnapshotReport);
+const assetInventoryReportMock = vi.mocked(assetInventoryReport);
+const bookingComplianceReportMock = vi.mocked(bookingComplianceReport);
 
 beforeAll(async () => {
   ({ loader } = await import(
@@ -109,6 +117,9 @@ describe("app/routes/_layout+/reports.export.$fileName[.csv] loader", () => {
     vi.clearAllMocks();
     requirePermissionMock.mockResolvedValue({
       organizationId: "org-1",
+      // The loader threads the workspace currency into the money-KPI-bearing
+      // report functions, so the permission result must carry it.
+      currentOrganization: { currency: "USD" },
     } as any);
     assetDistributionReportMock.mockResolvedValue({
       distributionBreakdown: arabicBreakdown,
@@ -154,5 +165,79 @@ describe("app/routes/_layout+/reports.export.$fileName[.csv] loader", () => {
     );
     expect(rows[1]).toBe("Category,حاسوب محمول,12,60.0%,24000");
     expect(rows[2]).toBe("Location,مستودع الرياض,8,40.0%,16000");
+  });
+
+  /**
+   * The export endpoint receives the page's full query string (the client
+   * forwards every current search param), and each report case must hand the
+   * params its page-loader counterpart honors to the same query function —
+   * otherwise a filtered page silently exports the unfiltered workspace.
+   */
+  describe("filter passthrough", () => {
+    const exportUrl = (query: string) =>
+      `http://localhost:3000/reports/export/report-2026-08-28.csv?${query}`;
+
+    const runLoaderWith = (query: string) =>
+      loader(
+        createLoaderArgs({
+          request: new Request(exportUrl(query)),
+          params: { fileName: "report-2026-08-28" },
+          context,
+        })
+      );
+
+    it("forwards the custody-snapshot page filters and workspace currency", async () => {
+      requirePermissionMock.mockResolvedValue({
+        organizationId: "org-1",
+        currentOrganization: { currency: "EUR" },
+      } as any);
+      custodySnapshotReportMock.mockResolvedValue({ rows: [] } as any);
+
+      await runLoaderWith(
+        "reportId=custody-snapshot&teamMember=tm-1&location=loc-1"
+      );
+
+      expect(custodySnapshotReportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          teamMemberId: "tm-1",
+          locationId: "loc-1",
+          currency: "EUR",
+        })
+      );
+    });
+
+    it("forwards the asset-inventory page filters", async () => {
+      assetInventoryReportMock.mockResolvedValue({ rows: [] } as any);
+
+      await runLoaderWith(
+        "reportId=asset-inventory&categories=cat-1,cat-2&locations=loc-1&statuses=AVAILABLE,IN_CUSTODY"
+      );
+
+      expect(assetInventoryReportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          categoryIds: ["cat-1", "cat-2"],
+          locationIds: ["loc-1"],
+          statuses: ["AVAILABLE", "IN_CUSTODY"],
+          currency: "USD",
+        })
+      );
+    });
+
+    it("forwards the booking-compliance sort so CSV row order matches the page", async () => {
+      bookingComplianceReportMock.mockResolvedValue({ rows: [] } as any);
+
+      await runLoaderWith(
+        "reportId=booking-compliance&sortBy=custodian&sortOrder=asc"
+      );
+
+      expect(bookingComplianceReportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sortBy: "custodian",
+          sortOrder: "asc",
+        })
+      );
+    });
   });
 });

--- a/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
@@ -11,14 +11,28 @@
  * @see {@link file://../../../app/utils/csv-utf8.ts}
  */
 import type { LoaderFunctionArgs } from "react-router";
+import type { Mock } from "vitest";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLoaderArgs } from "@mocks/remix";
 import {
+  assetActivityReport,
   assetDistributionReport,
   assetInventoryReport,
+  assetUtilizationReport,
   bookingComplianceReport,
   custodySnapshotReport,
+  idleAssetsReport,
+  monthlyBookingTrendsReport,
+  overdueItemsReport,
+  topBookedAssetsReport,
+  topBookedKitsReport,
 } from "~/modules/reports/helpers.server";
+import type {
+  AssetDistributionRow,
+  MonthlyBookingTrendRow,
+  ReportPayload,
+  ResolvedTimeframe,
+} from "~/modules/reports/types";
 import {
   PermissionAction,
   PermissionEntity,
@@ -168,10 +182,17 @@ describe("app/routes/_layout+/reports.export.$fileName[.csv] loader", () => {
   });
 
   /**
-   * The export endpoint receives the page's full query string (the client
-   * forwards every current search param), and each report case must hand the
-   * params its page-loader counterpart honors to the same query function —
-   * otherwise a filtered page silently exports the unfiltered workspace.
+   * Every report case must hand the params its page-loader counterpart honors
+   * to the same query function, or a filtered page silently exports the whole
+   * workspace — the bug this table exists to keep fixed.
+   *
+   * The table is exhaustive over the loader's `switch`, and deliberately so:
+   * the params are string literals matched by convention against
+   * `reports.$reportId.tsx`, so a typo in one case is invisible to the
+   * compiler and produces no error at runtime. Only an assertion per case can
+   * catch it. Add a report to the switch, add a row here.
+   *
+   * @see {@link file://../../../app/routes/_layout+/reports.$reportId.tsx} the page loader whose params these mirror
    */
   describe("filter passthrough", () => {
     const exportUrl = (query: string) =>
@@ -186,58 +207,173 @@ describe("app/routes/_layout+/reports.export.$fileName[.csv] loader", () => {
         })
       );
 
-    it("forwards the custody-snapshot page filters and workspace currency", async () => {
-      requirePermissionMock.mockResolvedValue({
-        organizationId: "org-1",
-        currentOrganization: { currency: "EUR" },
-      } as any);
-      custodySnapshotReportMock.mockResolvedValue({ rows: [] } as any);
+    const timeframe: ResolvedTimeframe = {
+      preset: "last_30d",
+      from: new Date("2026-07-25T00:00:00.000Z"),
+      to: new Date("2026-08-24T00:00:00.000Z"),
+      label: "Last 30 days",
+    };
 
-      await runLoaderWith(
-        "reportId=custody-snapshot&teamMember=tm-1&location=loc-1"
-      );
-
-      expect(custodySnapshotReportMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          organizationId: "org-1",
-          teamMemberId: "tm-1",
-          locationId: "loc-1",
-          currency: "EUR",
-        })
-      );
+    /**
+     * A payload thin enough for the loader to reach its CSV generator. The
+     * assertions here are about the ARGUMENTS a report function receives, so
+     * the rows it returns never matter.
+     */
+    const emptyPayload = <TRow>(): ReportPayload<TRow> => ({
+      report: { id: "r", title: "R", description: "" },
+      filters: { timeframe, filters: [] },
+      kpis: [],
+      rows: [],
+      computedMs: 0,
+      totalRows: 0,
+      page: 1,
+      pageSize: 10000,
     });
 
-    it("forwards the asset-inventory page filters", async () => {
-      assetInventoryReportMock.mockResolvedValue({ rows: [] } as any);
+    type PassthroughCase = {
+      /** `reportId` param, matching a case in the loader's switch. */
+      reportId: string;
+      /** Filter params as they would appear on the page's URL. */
+      query: string;
+      /** The query function those params must reach. */
+      mock: Mock;
+      /** The argument shape the loader must build from `query`. */
+      expected: Record<string, unknown>;
+    };
 
-      await runLoaderWith(
-        "reportId=asset-inventory&categories=cat-1,cat-2&locations=loc-1&statuses=AVAILABLE,IN_CUSTODY"
-      );
-
-      expect(assetInventoryReportMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          organizationId: "org-1",
+    const cases = (): PassthroughCase[] => [
+      {
+        reportId: "booking-compliance",
+        query: "sortBy=custodian&sortOrder=asc",
+        mock: vi.mocked(bookingComplianceReport),
+        // Sort, not a filter: the CSV's row order has to match the table's.
+        expected: { sortBy: "custodian", sortOrder: "asc" },
+      },
+      {
+        reportId: "custody-snapshot",
+        query: "teamMember=tm-1&location=loc-1",
+        mock: vi.mocked(custodySnapshotReport),
+        expected: {
+          teamMemberId: "tm-1",
+          locationId: "loc-1",
+          currency: "USD",
+        },
+      },
+      {
+        reportId: "overdue-items",
+        query: "custodian=cust-1",
+        mock: vi.mocked(overdueItemsReport),
+        expected: { custodianId: "cust-1", currency: "USD" },
+      },
+      {
+        reportId: "idle-assets",
+        query: "days=60&category=cat-1&location=loc-1",
+        mock: vi.mocked(idleAssetsReport),
+        expected: {
+          idleThresholdDays: 60,
+          categoryId: "cat-1",
+          locationId: "loc-1",
+          currency: "USD",
+        },
+      },
+      {
+        reportId: "top-booked-assets",
+        query: "category=cat-1&location=loc-1",
+        mock: vi.mocked(topBookedAssetsReport),
+        expected: { categoryId: "cat-1", locationId: "loc-1" },
+      },
+      {
+        reportId: "top-booked-kits",
+        // No filter controls on this page, so the only contract is that the
+        // export stays org-scoped. Listed rather than omitted: a row here is
+        // how the next person knows the case was considered.
+        query: "",
+        mock: vi.mocked(topBookedKitsReport),
+        expected: { organizationId: "org-1" },
+      },
+      {
+        reportId: "asset-inventory",
+        query:
+          "categories=cat-1,cat-2&locations=loc-1&statuses=AVAILABLE,IN_CUSTODY",
+        mock: vi.mocked(assetInventoryReport),
+        expected: {
           categoryIds: ["cat-1", "cat-2"],
           locationIds: ["loc-1"],
           statuses: ["AVAILABLE", "IN_CUSTODY"],
           currency: "USD",
-        })
+        },
+      },
+      {
+        reportId: "asset-utilization",
+        query: "category=cat-1&location=loc-1",
+        mock: vi.mocked(assetUtilizationReport),
+        expected: { categoryId: "cat-1", locationId: "loc-1" },
+      },
+      {
+        reportId: "asset-activity",
+        query: "asset=asset-1&category=cat-1",
+        mock: vi.mocked(assetActivityReport),
+        expected: { assetId: "asset-1", categoryId: "cat-1" },
+      },
+      {
+        reportId: "distribution",
+        query: "",
+        mock: vi.mocked(assetDistributionReport),
+        expected: { organizationId: "org-1", currency: "USD" },
+      },
+    ];
+
+    beforeEach(() => {
+      for (const { mock } of cases()) {
+        mock.mockResolvedValue(emptyPayload());
+      }
+      // Distribution builds its CSV from a breakdown rather than from rows.
+      vi.mocked(assetDistributionReport).mockResolvedValue({
+        ...emptyPayload<AssetDistributionRow>(),
+        distributionBreakdown: arabicBreakdown,
+      });
+    });
+
+    it.each(cases())(
+      "$reportId forwards the page's params to its query function",
+      async ({ reportId, query, mock, expected }) => {
+        await runLoaderWith(
+          query ? `reportId=${reportId}&${query}` : `reportId=${reportId}`
+        );
+
+        expect(mock).toHaveBeenCalledWith(expect.objectContaining(expected));
+      }
+    );
+
+    it("reads the workspace currency rather than assuming the default", async () => {
+      requirePermissionMock.mockResolvedValue({
+        organizationId: "org-1",
+        currentOrganization: { currency: "EUR" },
+      } as Awaited<ReturnType<typeof requirePermission>>);
+
+      await runLoaderWith("reportId=custody-snapshot&teamMember=tm-1");
+
+      expect(custodySnapshotReportMock).toHaveBeenCalledWith(
+        expect.objectContaining({ currency: "EUR" })
       );
     });
 
-    it("forwards the booking-compliance sort so CSV row order matches the page", async () => {
-      bookingComplianceReportMock.mockResolvedValue({ rows: [] } as any);
+    it("drops monthly-trends' category and location rather than claiming to filter on them", async () => {
+      // `monthlyBookingTrendsReport` accepts both and uses neither. Forwarding
+      // them would advertise a filtering this export does not perform, so the
+      // loader deliberately omits them — pinned here so a later "consistency"
+      // edit has to confront the dead argument first.
+      vi.mocked(monthlyBookingTrendsReport).mockResolvedValue(
+        emptyPayload<MonthlyBookingTrendRow>()
+      );
 
       await runLoaderWith(
-        "reportId=booking-compliance&sortBy=custodian&sortOrder=asc"
+        "reportId=monthly-booking-trends&category=cat-1&location=loc-1"
       );
 
-      expect(bookingComplianceReportMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          sortBy: "custodian",
-          sortOrder: "asc",
-        })
-      );
+      const args = vi.mocked(monthlyBookingTrendsReport).mock.calls[0][0];
+      expect(args).not.toHaveProperty("categoryId");
+      expect(args).not.toHaveProperty("locationId");
     });
   });
 });

--- a/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/reports.export.$fileName[.csv].test.ts
@@ -371,6 +371,12 @@ describe("app/routes/_layout+/reports.export.$fileName[.csv] loader", () => {
         "reportId=monthly-booking-trends&category=cat-1&location=loc-1"
       );
 
+      // Establish the call before reading it. The assertions below are
+      // NEGATIVE, so a report function that was never reached has to fail as
+      // "expected 1 call, got 0" rather than as a TypeError on `calls[0]` —
+      // and must never be mistaken for the absence it is checking for.
+      expect(monthlyBookingTrendsReport).toHaveBeenCalledTimes(1);
+
       const args = vi.mocked(monthlyBookingTrendsReport).mock.calls[0][0];
       expect(args).not.toHaveProperty("categoryId");
       expect(args).not.toHaveProperty("locationId");


### PR DESCRIPTION
## What

Two export gaps from the reports audit, closing batch 4 of the remediation.

1. **Exports now respect the page's filters.** The CSV and PDF routes call the same query functions as the pages but dropped the filter arguments, so a filtered custody view exported the entire organization. Each export case now parses and forwards exactly what its page loader honors, and the compliance CSV keeps the page's sort order. The PDF button itself only ever sent timeframe params, so it now seeds from the page's current query string; without that, the server change would be unreachable.

2. **Money KPIs use the organization's currency.** Five KPI strings hardcoded "$". The KPI builders now take the org's currency as a required argument (the compiler swept every call site: page loader, CSV route, PDF route) and format through the canonical currency helper, with the same fixed en-US locale convention the CSV export already uses.

Deliberately untouched: Monthly Trends' category and location filters, which its query function ignores; wiring them is a separate question, and a comment says so at the case.

## Testing

Red-first: route tests pin that custody and inventory exports forward their filters and that a EUR org's value KPI renders without "$"; a module test pins the exact formatted string. Full `pnpm webapp:validate` exits 0: 5,770 tests, zero failures, zero unhandled errors. `pnpm turbo typecheck` green across all packages.

## Noted in passing

`compliance-report-pdf.tsx` appears to be dead code (exported but never rendered; `report-pdf.tsx` handles all three PDFs) — left for a cleanup PR rather than mixing it in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Report PDFs and CSV exports now preserve selected filters and sorting.
  * Exports support filters such as team member, category, location, asset, and status.
  * Report KPI values now use the workspace’s configured currency.

* **Bug Fixes**
  * Corrected currency formatting for non-USD report KPIs.
  * Improved consistency between on-screen reports and exported results.
  * Improved report accuracy for archived bookings, overlapping booking periods, kit attribution, and asset utilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->