### PR TITLE
fix(kits): derive the CHECKED_OUT stamp from bookings, not Kit.status

### DIFF
--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -43,6 +43,12 @@ import { getQr } from "../qr/service.server";
 vitest.mock("~/database/db.server", () => ({
   db: {
     $transaction: vitest.fn().mockImplementation((callback) => callback(db)),
+    // why: `updateKitAssets` locks each live booking row via
+    // `lockBookingForStatusCheck` before trusting the status it read outside
+    // the transaction. Answers "still ONGOING" by default so the existing
+    // cases keep their arranged booking state; a test overrides it to model a
+    // check-in that committed first.
+    $queryRaw: vitest.fn().mockResolvedValue([{ status: "ONGOING" }]),
     kit: {
       create: vitest.fn().mockResolvedValue({}),
       update: vitest.fn().mockResolvedValue({}),
@@ -5680,6 +5686,13 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
     //@ts-expect-error missing vitest type
     db.bookingAsset.count.mockResolvedValue(kitSlicesWereCheckedOut ? 1 : 0);
 
+    // why: the service locks each live booking row and re-reads its status
+    // before trusting it. Set here rather than left to the module-level
+    // default because `clearAllMocks` does not restore implementations, so an
+    // override in one case would otherwise leak into the next.
+    //@ts-expect-error missing vitest type
+    db.$queryRaw.mockResolvedValue([{ status: existingBookingStatus }]);
+
     // why: `updateKitAssets` reads the kit with its members and their booking
     // rows in one go; this is the persisted state each case is arranged around
     // (the kit's own flag, and the booking its sitting member sits on).
@@ -5831,5 +5844,101 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
       where: { id: { in: ["newcomer"] }, organizationId: "org-1" },
       data: { status: AssetStatus.CHECKED_OUT },
     });
+  });
+
+  /**
+   * Slice checkout markers written by this call. Filtered on
+   * `data.checkedOutAt` because `updateKitAssets` also runs
+   * `bookingAsset.updateMany` to sync kit slice quantity edits.
+   */
+  function sliceCheckoutMarkers() {
+    return (
+      db.bookingAsset.updateMany as unknown as {
+        mock: {
+          calls: Array<
+            [
+              {
+                where?: {
+                  bookingId?: { in?: string[] };
+                  assetKitId?: { in?: string[] };
+                };
+                data?: { checkedOutAt?: Date; checkedOutById?: string };
+              },
+            ]
+          >;
+        };
+      }
+    ).mock.calls.filter((c) => c[0]?.data?.checkedOutAt !== undefined);
+  }
+
+  it("marks the newcomer's kit slice checked out alongside the status stamp", async () => {
+    // The two travel together. `Asset.status` says the member is out;
+    // `BookingAsset.checkedOutAt` says which booking it went out ON, and that
+    // is what the check-in guard reads. A status without a marker is refused
+    // at the scanner with "Cannot check in assets that were never checked out".
+    arrange(BookingStatus.ONGOING);
+
+    await act();
+
+    const markers = sliceCheckoutMarkers();
+    expect(markers).toHaveLength(1);
+    // Keyed on the brand-new AssetKit id, never on assetId: a member can hold
+    // a standalone slice on the same booking that did not go out with the kit.
+    expect(markers[0][0].where).toEqual({
+      bookingId: { in: ["booking-1"] },
+      assetKitId: { in: ["ak-newcomer"] },
+    });
+    expect(markers[0][0].data?.checkedOutById).toBe("user-1");
+    expect(markers[0][0].data?.checkedOutAt).toBeInstanceOf(Date);
+  });
+
+  it("writes no slice marker when the kit's flag is stale and nothing is out", async () => {
+    arrange(BookingStatus.COMPLETE);
+
+    await act();
+
+    expect(sliceCheckoutMarkers()).toEqual([]);
+  });
+
+  it("writes no slice marker for a booking that has not started", async () => {
+    // A DRAFT booking still gains the row, but nothing has physically left, so
+    // the slice must stay unmarked.
+    arrange(BookingStatus.DRAFT);
+
+    await act();
+
+    expect(sliceCheckoutMarkers()).toEqual([]);
+  });
+
+  it("does NOT stamp when the booking completed between the status read and the write", async () => {
+    // `bookingsToUpdate` carries a status read at the top of the function,
+    // outside any transaction. The locked re-read is what catches a check-in
+    // that committed in between.
+    arrange(BookingStatus.ONGOING);
+    //@ts-expect-error missing vitest type
+    db.$queryRaw.mockResolvedValue([{ status: BookingStatus.COMPLETE }]);
+
+    await act();
+
+    expect(checkedOutStamps()).toEqual([]);
+    expect(sliceCheckoutMarkers()).toEqual([]);
+  });
+
+  it("counts only slices that are still out when deciding whether the kit vouches", async () => {
+    // A booking stays ONGOING while a different kit is out, so a kit whose
+    // every slice has already come back must not vouch for a new member.
+    arrange(BookingStatus.ONGOING);
+
+    await act();
+
+    expect(db.bookingAsset.count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          sourceKitId: "kit-1",
+          checkedOutAt: { not: null },
+          checkedInAt: null,
+        }),
+      })
+    );
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -142,6 +142,10 @@ vitest.mock("~/database/db.server", () => ({
       // bookings that already hold this kit, one `createMany` per booking.
       createMany: vitest.fn().mockResolvedValue({ count: 0 }),
       deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
+      // why: `updateKitAssets` asks whether this kit's existing slices carry
+      // `checkedOutAt` before inheriting CHECKED_OUT onto a new member. Zero
+      // by default so a test must opt in to "the kit really did go out".
+      count: vitest.fn().mockResolvedValue(0),
     },
     // why: the same helper re-opens any `BookingModelRequest` the deleted
     // slice was fulfilling, mirroring `removeAssets`.
@@ -5662,8 +5666,23 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
    */
   function arrange(
     existingBookingStatus: BookingStatus,
-    kitStatus: KitStatus = KitStatus.CHECKED_OUT
+    kitStatus: KitStatus = KitStatus.CHECKED_OUT,
+    /**
+     * Whether this kit's existing slices carry `checkedOutAt` — i.e. whether
+     * the kit physically went out. A booking can be ONGOING because a
+     * different kit was scanned, so the two are independent.
+     */
+    kitSlicesWereCheckedOut = true
   ) {
+    // why: the service counts this kit's checked-out slices to decide whether
+    // a new member inherits CHECKED_OUT. This is the switch between "the kit
+    // really is out" and "the booking is live but this kit never left".
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.count.mockResolvedValue(kitSlicesWereCheckedOut ? 1 : 0);
+
+    // why: `updateKitAssets` reads the kit with its members and their booking
+    // rows in one go; this is the persisted state each case is arranged around
+    // (the kit's own flag, and the booking its sitting member sits on).
     //@ts-expect-error missing vitest type
     db.kit.findUniqueOrThrow.mockResolvedValue({
       id: "kit-1",
@@ -5698,7 +5717,9 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
       ],
     });
 
-    // Submitted membership: the sitting member plus the newcomer.
+    // why: the service re-reads the submitted asset ids to diff them against
+    // current membership. Returning both the sitting member and the newcomer
+    // is what makes `newlyAddedAssets` exactly `["newcomer"]`.
     //@ts-expect-error missing vitest type
     db.asset.findMany.mockResolvedValue([
       {
@@ -5725,8 +5746,9 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
       },
     ]);
 
-    // The AssetKit row the picker just created for the newcomer, read back by
-    // the propagation block to populate `assetKitId` / `sourceKitId`.
+    // why: the propagation block reads back the AssetKit row the membership
+    // write just created, to populate `assetKitId` / `sourceKitId` on the new
+    // BookingAsset row. Without it the newcomer never reaches the booking.
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([
       { id: "ak-newcomer", assetId: "newcomer", quantity: 1 },
@@ -5787,6 +5809,17 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
     await act();
 
     expect(checkedOutStamps()).toEqual([["newcomer"]]);
+  });
+
+  it("does NOT stamp when the booking is live but this kit was never scanned out", async () => {
+    // Progressive checkout flips a booking to ONGOING on the first scan, and
+    // only stamps kits whose every slice went. So a live booking is not proof
+    // that THIS kit left: its slices carry no `checkedOutAt`.
+    arrange(BookingStatus.ONGOING, KitStatus.CHECKED_OUT, false);
+
+    await act();
+
+    expect(checkedOutStamps()).toEqual([]);
   });
 
   it("scopes the stamp to the caller's organization", async () => {

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -148,10 +148,6 @@ vitest.mock("~/database/db.server", () => ({
       // bookings that already hold this kit, one `createMany` per booking.
       createMany: vitest.fn().mockResolvedValue({ count: 0 }),
       deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
-      // why: `updateKitAssets` asks whether this kit's existing slices carry
-      // `checkedOutAt` before inheriting CHECKED_OUT onto a new member. Zero
-      // by default so a test must opt in to "the kit really did go out".
-      count: vitest.fn().mockResolvedValue(0),
     },
     // why: the same helper re-opens any `BookingModelRequest` the deleted
     // slice was fulfilling, mirroring `removeAssets`.
@@ -5665,6 +5661,18 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
     vitest.clearAllMocks();
   });
 
+  /** An instant a slice left on, for cases that need a non-null marker. */
+  const WENT_OUT = new Date("2026-08-01T10:00:00.000Z");
+  /** An instant a slice came back on. */
+  const CAME_BACK = new Date("2026-08-02T10:00:00.000Z");
+
+  /** One pre-existing kit slice as the eligibility read sees it. */
+  type PriorSlice = {
+    bookingId: string;
+    checkedOutAt: Date | null;
+    checkedInAt: Date | null;
+  };
+
   /**
    * @param existingBookingStatus status of the booking the kit's sitting
    *        member is on, which is what `bookingsToUpdate` is derived from.
@@ -5678,13 +5686,39 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
      * the kit physically went out. A booking can be ONGOING because a
      * different kit was scanned, so the two are independent.
      */
-    kitSlicesWereCheckedOut = true
+    kitSlicesWereCheckedOut = true,
+    options: {
+      /**
+       * Further bookings the sitting member also holds a slice on, so a case
+       * can put this kit on two live bookings at once.
+       */
+      extraBookings?: Array<{ id: string; status: BookingStatus }>;
+      /**
+       * The kit's pre-existing slices, overriding the single slice implied by
+       * `kitSlicesWereCheckedOut`. Lets a case model a kit that only half
+       * left, or one whose members have since come back.
+       */
+      priorSlices?: PriorSlice[];
+    } = {}
   ) {
-    // why: the service counts this kit's checked-out slices to decide whether
-    // a new member inherits CHECKED_OUT. This is the switch between "the kit
-    // really is out" and "the booking is live but this kit never left".
+    const { extraBookings = [], priorSlices } = options;
+
+    // why: the service reads this kit's pre-existing slices to decide, per
+    // booking, whether the whole kit left it. Discriminated on the `select`
+    // because `updateKitAssets` also calls `bookingAsset.findMany` for
+    // detachment impact and planning-booking removal, and those must keep
+    // seeing the empty default — no other call site selects `checkedOutAt`.
+    const slices: PriorSlice[] = priorSlices ?? [
+      {
+        bookingId: "booking-1",
+        checkedOutAt: kitSlicesWereCheckedOut ? WENT_OUT : null,
+        checkedInAt: null,
+      },
+    ];
     //@ts-expect-error missing vitest type
-    db.bookingAsset.count.mockResolvedValue(kitSlicesWereCheckedOut ? 1 : 0);
+    db.bookingAsset.findMany.mockImplementation((args) =>
+      Promise.resolve(args?.select?.checkedOutAt ? slices : [])
+    );
 
     // why: the service locks each live booking row and re-reads its status
     // before trusting it. Set here rather than left to the module-level
@@ -5724,6 +5758,15 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
                 quantity: 1,
                 booking: { id: "booking-1", status: existingBookingStatus },
               },
+              ...extraBookings.map((b) => ({
+                id: `ba-sitting-${b.id}`,
+                bookingId: b.id,
+                assetId: "sitting-member",
+                assetKitId: "ak-sitting",
+                sourceKitId: "kit-1",
+                quantity: 1,
+                booking: { id: b.id, status: b.status },
+              })),
             ],
           },
         },
@@ -5924,21 +5967,81 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
     expect(sliceCheckoutMarkers()).toEqual([]);
   });
 
-  it("counts only slices that are still out when deciding whether the kit vouches", async () => {
-    // A booking stays ONGOING while a different kit is out, so a kit whose
-    // every slice has already come back must not vouch for a new member.
-    arrange(BookingStatus.ONGOING);
+  it("does NOT stamp when every slice of the kit has already come back", async () => {
+    // A booking stays ONGOING while a different kit is still out, so a kit
+    // whose every slice has been returned must not vouch for a new member.
+    arrange(BookingStatus.ONGOING, KitStatus.CHECKED_OUT, true, {
+      priorSlices: [
+        {
+          bookingId: "booking-1",
+          checkedOutAt: WENT_OUT,
+          checkedInAt: CAME_BACK,
+        },
+      ],
+    });
 
     await act();
 
-    expect(db.bookingAsset.count).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          sourceKitId: "kit-1",
-          checkedOutAt: { not: null },
-          checkedInAt: null,
-        }),
-      })
-    );
+    expect(checkedOutStamps()).toEqual([]);
+    expect(sliceCheckoutMarkers()).toEqual([]);
+  });
+
+  it("marks only the booking this kit actually left, not every live booking", async () => {
+    // Progressive checkout flips a booking to ONGOING on the first scan of
+    // ANYTHING, so a second live booking can hold this kit without it having
+    // left there. Evidence from booking-1 must not vouch for booking-2.
+    arrange(BookingStatus.ONGOING, KitStatus.CHECKED_OUT, true, {
+      extraBookings: [{ id: "booking-2", status: BookingStatus.ONGOING }],
+      priorSlices: [
+        { bookingId: "booking-1", checkedOutAt: WENT_OUT, checkedInAt: null },
+        { bookingId: "booking-2", checkedOutAt: null, checkedInAt: null },
+      ],
+    });
+
+    await act();
+
+    const markers = sliceCheckoutMarkers();
+    expect(markers).toHaveLength(1);
+    expect(markers[0][0].where?.bookingId).toEqual({ in: ["booking-1"] });
+  });
+
+  it("does NOT stamp when the kit only half left the booking", async () => {
+    // Progressive checkout stamps only the slices actually scanned, so a kit
+    // can sit half out on one booking. A member that stayed behind is not
+    // evidence that a newcomer went anywhere.
+    arrange(BookingStatus.ONGOING, KitStatus.CHECKED_OUT, true, {
+      priorSlices: [
+        { bookingId: "booking-1", checkedOutAt: WENT_OUT, checkedInAt: null },
+        { bookingId: "booking-1", checkedOutAt: null, checkedInAt: null },
+      ],
+    });
+
+    await act();
+
+    expect(checkedOutStamps()).toEqual([]);
+    expect(sliceCheckoutMarkers()).toEqual([]);
+  });
+
+  it("DOES stamp when the whole kit left and some members have since returned", async () => {
+    // The disqualifier is "never left", not "not out right now". Check-in
+    // clears `Kit.status` only for a complete kit, so a kit returned member by
+    // member still reads CHECKED_OUT and the picker still promises additions
+    // inherit it. Refusing here would be stricter than the behaviour this
+    // replaces.
+    arrange(BookingStatus.ONGOING, KitStatus.CHECKED_OUT, true, {
+      priorSlices: [
+        {
+          bookingId: "booking-1",
+          checkedOutAt: WENT_OUT,
+          checkedInAt: CAME_BACK,
+        },
+        { bookingId: "booking-1", checkedOutAt: WENT_OUT, checkedInAt: null },
+      ],
+    });
+
+    await act();
+
+    expect(checkedOutStamps()).toEqual([["newcomer"]]);
+    expect(sliceCheckoutMarkers()).toHaveLength(1);
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -5637,3 +5637,166 @@ describe("kit custody release must not overwrite CHECKED_OUT", () => {
     expect(currentStatus).toBe(AssetStatus.AVAILABLE);
   });
 });
+
+/**
+ * Regression cover for the stale-`Kit.status` stamp.
+ *
+ * `updateKitAssets` used to stamp every newly added asset CHECKED_OUT whenever
+ * the kit's own status column read CHECKED_OUT, without checking that a live
+ * booking existed. `Kit.status` goes stale on its own (check-in resolves kits
+ * from the assets' CURRENT membership, so detaching a kit's assets mid-booking
+ * leaves the flag set forever), so the stamp landed on assets with no booking
+ * behind it, and no release path clears CHECKED_OUT.
+ *
+ * The stamp now keys on the booking rows this call actually wrote.
+ */
+describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  /**
+   * @param existingBookingStatus status of the booking the kit's sitting
+   *        member is on, which is what `bookingsToUpdate` is derived from.
+   * @param kitStatus the kit's own (possibly stale) status column.
+   */
+  function arrange(
+    existingBookingStatus: BookingStatus,
+    kitStatus: KitStatus = KitStatus.CHECKED_OUT
+  ) {
+    //@ts-expect-error missing vitest type
+    db.kit.findUniqueOrThrow.mockResolvedValue({
+      id: "kit-1",
+      name: "Kit 1",
+      status: kitStatus,
+      location: null,
+      custody: null,
+      assetKits: [
+        {
+          id: "ak-sitting",
+          kitId: "kit-1",
+          quantity: 1,
+          asset: {
+            id: "sitting-member",
+            title: "Sitting member",
+            type: AssetType.INDIVIDUAL,
+            unitOfMeasure: null,
+            assetKits: [{ kitId: "kit-1" }],
+            bookingAssets: [
+              {
+                id: "ba-sitting",
+                bookingId: "booking-1",
+                assetId: "sitting-member",
+                assetKitId: "ak-sitting",
+                sourceKitId: "kit-1",
+                quantity: 1,
+                booking: { id: "booking-1", status: existingBookingStatus },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    // Submitted membership: the sitting member plus the newcomer.
+    //@ts-expect-error missing vitest type
+    db.asset.findMany.mockResolvedValue([
+      {
+        id: "sitting-member",
+        title: "Sitting member",
+        type: AssetType.INDIVIDUAL,
+        quantity: null,
+        unitOfMeasure: null,
+        assetKits: [{ kitId: "kit-1" }],
+        custody: [],
+        bookingAssets: [],
+        assetLocations: [],
+      },
+      {
+        id: "newcomer",
+        title: "Newcomer",
+        type: AssetType.INDIVIDUAL,
+        quantity: null,
+        unitOfMeasure: null,
+        assetKits: [],
+        custody: [],
+        bookingAssets: [],
+        assetLocations: [],
+      },
+    ]);
+
+    // The AssetKit row the picker just created for the newcomer, read back by
+    // the propagation block to populate `assetKitId` / `sourceKitId`.
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([
+      { id: "ak-newcomer", assetId: "newcomer", quantity: 1 },
+    ]);
+  }
+
+  async function act() {
+    const { updateKitAssets } = await import("./service.server");
+    await updateKitAssets({
+      kitId: "kit-1",
+      assetIds: ["sitting-member", "newcomer"],
+      userId: "user-1",
+      organizationId: "org-1",
+      request: new Request("http://test.com"),
+    });
+  }
+
+  /** Every CHECKED_OUT write this call made, as `where.id.in` id lists. */
+  function checkedOutStamps() {
+    return (
+      db.asset.updateMany as unknown as {
+        mock: {
+          calls: Array<
+            [{ where?: { id?: { in?: string[] } }; data?: { status?: string } }]
+          >;
+        };
+      }
+    ).mock.calls
+      .filter((c) => c[0]?.data?.status === AssetStatus.CHECKED_OUT)
+      .map((c) => c[0].where?.id?.in ?? []);
+  }
+
+  it("does NOT stamp CHECKED_OUT when the kit's flag is stale and the booking is over", async () => {
+    // The exact production shape: kit reads CHECKED_OUT, but its only booking
+    // has already been checked in. Nothing is physically out.
+    arrange(BookingStatus.COMPLETE);
+
+    await act();
+
+    expect(checkedOutStamps()).toEqual([]);
+  });
+
+  it("does NOT stamp CHECKED_OUT when the kit is only on a booking that has not started", async () => {
+    // The newcomer joins the DRAFT booking, but nothing has left the building,
+    // so its status must stay untouched.
+    arrange(BookingStatus.DRAFT);
+
+    await act();
+
+    expect(checkedOutStamps()).toEqual([]);
+  });
+
+  it("DOES stamp CHECKED_OUT for an asset added to a kit that is out on an ONGOING booking", async () => {
+    // The legitimate case this write exists for. Guards against "fixing" the
+    // bug by deleting the stamp outright.
+    arrange(BookingStatus.ONGOING);
+
+    await act();
+
+    expect(checkedOutStamps()).toEqual([["newcomer"]]);
+  });
+
+  it("scopes the stamp to the caller's organization", async () => {
+    arrange(BookingStatus.ONGOING);
+
+    await act();
+
+    expect(db.asset.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["newcomer"] }, organizationId: "org-1" },
+      data: { status: AssetStatus.CHECKED_OUT },
+    });
+  });
+});

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -5838,16 +5838,6 @@ export async function updateKitAssets({
     }
 
     /**
-     * Assets that this call actually placed onto a booking that is physically
-     * out (ONGOING / OVERDUE). Populated inside the propagation block below,
-     * consumed by the CHECKED_OUT stamp after it.
-     *
-     * Declared out here because the stamp sits outside
-     * `if (bookingsToUpdate?.length)` and cannot see that block's scope.
-     */
-    let assetIdsOnLiveBooking: string[] = [];
-
-    /**
      * If user is adding/removing an asset to a kit which is a part of DRAFT, RESERVED, ONGOING or OVERDUE booking,
      * then we have to add or remove these assets to booking also
      */
@@ -5978,22 +5968,57 @@ export async function updateKitAssets({
           if (propagatedEvents.length > 0) {
             await recordEvents(propagatedEvents, tx);
           }
-        });
 
-        /**
-         * Record which assets landed on a booking that is physically out, so
-         * the stamp below can key on that fact instead of on `Kit.status`.
-         *
-         * DRAFT and RESERVED are deliberately excluded: `bookingsToUpdate`
-         * includes them so the asset joins the booking, but nothing has left
-         * the building yet, so nothing should read CHECKED_OUT.
-         */
-        const liveBookings = bookingsToUpdate.filter(
-          (b) => b.status === "ONGOING" || b.status === "OVERDUE"
-        );
-        if (liveBookings.length > 0) {
-          assetIdsOnLiveBooking = newlyAddedAssets.map((a) => a.id);
-        }
+          /**
+           * Did THIS kit physically leave on one of those bookings?
+           *
+           * A booking's own status cannot answer that. Progressive checkout
+           * flips a booking to ONGOING on the first scan, so a booking can be
+           * live while this kit was never scanned out — partial checkout only
+           * stamps kits whose every slice went (`completeKitIds`).
+           * `BookingAsset.checkedOutAt` is the authoritative per-slice fact,
+           * so ask the slices instead.
+           *
+           * The rows created above carry a NULL `checkedOutAt`, so they are
+           * excluded by this predicate and cannot vouch for themselves.
+           *
+           * Read inside the same transaction as the writes, so a check-in
+           * completing concurrently cannot leave us stamping against a booking
+           * that has since finished.
+           */
+          const liveBookingIds = bookingsToUpdate
+            .filter((b) => b.status === "ONGOING" || b.status === "OVERDUE")
+            .map((b) => b.id);
+
+          if (liveBookingIds.length > 0) {
+            const checkedOutSlices = await tx.bookingAsset.count({
+              where: {
+                bookingId: { in: liveBookingIds },
+                sourceKitId: kit.id,
+                checkedOutAt: { not: null },
+                booking: {
+                  status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+                },
+              },
+            });
+
+            if (checkedOutSlices > 0) {
+              const assetIdsToStamp = newlyAddedAssets.map((a) => a.id);
+
+              /**
+               * Written in the SAME transaction as the count above and the
+               * rows below it, so the evidence the stamp rests on and the
+               * stamp itself commit together. Outside the tx they could
+               * disagree: a check-in committing in between would release the
+               * kit's other slices and leave this one stamped against nothing.
+               */
+              await tx.asset.updateMany({
+                where: { id: { in: assetIdsToStamp }, organizationId },
+                data: { status: AssetStatus.CHECKED_OUT },
+              });
+            }
+          }
+        });
       }
 
       // why: there is deliberately no delete counterpart here. Removing an
@@ -6010,30 +6035,6 @@ export async function updateKitAssets({
       //
       // Asset-bulk-remove (asset-side flow) is unaffected; it still goes
       // through `removeAssets`, which deletes the rows explicitly.
-    }
-
-    /**
-     * An asset joining a kit that is physically out inherits CHECKED_OUT.
-     *
-     * Keyed on the booking rows this call just wrote, never on `Kit.status`.
-     * That column is a denormalised flag and it can be stale: check-in
-     * resolves which kits to release from the assets' CURRENT membership
-     * (`getKitIdsByAssets`), so a kit whose assets were detached while a
-     * booking was live keeps reading CHECKED_OUT after that booking ends,
-     * with nothing out. Trusting the flag stamps CHECKED_OUT onto assets that
-     * hold no reservation, and nothing clears it again — every release path
-     * runs through `releaseAssetsToAvailableUnlessCheckedOut`, which skips
-     * CHECKED_OUT rows by design.
-     *
-     * DRAFT and RESERVED bookings are excluded on purpose: the asset joins
-     * them (see the propagation block above), but nothing has physically left,
-     * so its status must not move.
-     */
-    if (assetIdsOnLiveBooking.length > 0) {
-      await db.asset.updateMany({
-        where: { id: { in: assetIdsOnLiveBooking }, organizationId },
-        data: { status: AssetStatus.CHECKED_OUT },
-      });
     }
 
     return kit;

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -97,6 +97,7 @@ import {
 } from "../asset/utils.server";
 import type { AllowedCustodianFilterIds } from "../asset/utils.server";
 import { PLANNING_BOOKING_STATUSES } from "../booking/constants";
+import { lockBookingForStatusCheck } from "../booking/utils.server";
 import {
   createSystemBookingNote,
   createSystemBookingNotes,
@@ -5970,7 +5971,7 @@ export async function updateKitAssets({
           }
 
           /**
-           * Did THIS kit physically leave on one of those bookings?
+           * Is THIS kit out right now on one of those bookings?
            *
            * A booking's own status cannot answer that. Progressive checkout
            * flips a booking to ONGOING on the first scan, so a booking can be
@@ -5986,36 +5987,132 @@ export async function updateKitAssets({
            * completing concurrently cannot leave us stamping against a booking
            * that has since finished.
            */
-          const liveBookingIds = bookingsToUpdate
+          const candidateBookingIds = bookingsToUpdate
             .filter((b) => b.status === "ONGOING" || b.status === "OVERDUE")
-            .map((b) => b.id);
+            .map((b) => b.id)
+            // Sorted so concurrent callers take the locks below in the same
+            // order and cannot deadlock against one another.
+            .sort();
+
+          /**
+           * Re-read those bookings under a row lock before trusting the status.
+           *
+           * `bookingsToUpdate` carries the status read at the top of this
+           * function — outside any transaction, and potentially seconds ago —
+           * so a check-in that has since completed still reads as ONGOING
+           * here. A plain re-read inside the transaction narrows that window;
+           * only the lock closes it. See `lockBookingForStatusCheck`.
+           *
+           * Sequential, not `Promise.all`: an interactive transaction runs on a
+           * single connection. The set is the bookings holding this kit, small.
+           *
+           * This does not make the stamp race-free by itself, and is not meant
+           * to. `checkinBooking` computes which assets to release BEFORE
+           * opening its own transaction, so a check-in already in flight never
+           * sees a member added after that read. Closing the remaining half
+           * belongs in the check-in path, not here.
+           */
+          const liveBookingIds: string[] = [];
+          for (const bookingId of candidateBookingIds) {
+            const currentStatus = await lockBookingForStatusCheck(
+              tx,
+              bookingId,
+              organizationId
+            );
+            if (
+              currentStatus === BookingStatus.ONGOING ||
+              currentStatus === BookingStatus.OVERDUE
+            ) {
+              liveBookingIds.push(bookingId);
+            }
+          }
 
           if (liveBookingIds.length > 0) {
             const checkedOutSlices = await tx.bookingAsset.count({
               where: {
                 bookingId: { in: liveBookingIds },
                 sourceKitId: kit.id,
+                // Out RIGHT NOW, not "went out at some point": a booking stays
+                // ONGOING while other kits are still out, so a kit whose every
+                // slice has already been returned must not vouch for a new
+                // member. Same pair the check-in guard and the
+                // `BookingAsset_bookingId_checkedOutAt_idx` partial index use.
                 checkedOutAt: { not: null },
+                checkedInAt: null,
                 booking: {
-                  status: { in: [BookingStatus.ONGOING, BookingStatus.OVERDUE] },
+                  status: {
+                    in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
+                  },
                 },
               },
             });
 
             if (checkedOutSlices > 0) {
-              const assetIdsToStamp = newlyAddedAssets.map((a) => a.id);
-
               /**
-               * Written in the SAME transaction as the count above and the
-               * rows below it, so the evidence the stamp rests on and the
-               * stamp itself commit together. Outside the tx they could
-               * disagree: a check-in committing in between would release the
-               * kit's other slices and leave this one stamped against nothing.
+               * The members whose kit-driven slice this call actually wrote.
+               *
+               * An asset with no resolved `AssetKit` fell back to a standalone
+               * row above, which `skipDuplicates` may have dropped against one
+               * that already existed — so there is no slice this call can
+               * prove it created. Stamping its status anyway would mint the
+               * status-without-a-marker state the pair below exists to avoid.
+               * Same scoping as `propagatedEvents`, for the same reason.
                */
-              await tx.asset.updateMany({
-                where: { id: { in: assetIdsToStamp }, organizationId },
-                data: { status: AssetStatus.CHECKED_OUT },
+              const stampable = newlyAddedAssets.flatMap((a) => {
+                const ak = akByAssetId.get(a.id);
+                return ak ? [{ assetId: a.id, assetKitId: ak.id }] : [];
               });
+
+              if (stampable.length > 0) {
+                /**
+                 * Status and slice marker are written together, in the SAME
+                 * transaction as the count they rest on.
+                 *
+                 * `Asset.status` alone says the member is out; only
+                 * `BookingAsset.checkedOutAt` says which booking it went out
+                 * ON, and that is what the check-in guard reads to decide
+                 * eligibility. A member handed the status without the marker
+                 * is refused at the scanner with "Cannot check in assets that
+                 * were never checked out" — every path that sends an asset out
+                 * maintains both, per
+                 * `.claude/rules/booking-checkout-is-recorded-per-slice.md`.
+                 *
+                 * Outside the tx the two could disagree with the evidence they
+                 * rest on: a check-in committing in between would release the
+                 * kit's other slices and leave these stamped against nothing.
+                 */
+                await tx.asset.updateMany({
+                  where: {
+                    id: { in: stampable.map((s) => s.assetId) },
+                    organizationId,
+                  },
+                  data: { status: AssetStatus.CHECKED_OUT },
+                });
+
+                /**
+                 * Keyed on the `AssetKit` ids the membership write just
+                 * created, never on `assetId`: a member can hold a standalone
+                 * slice on the same booking alongside its kit-driven one (the
+                 * two partial uniques allow exactly that), and the standalone
+                 * one did not go out with this kit. Those ids are new, so the
+                 * only rows they reach are the ones `createMany` wrote above.
+                 *
+                 * Scoped to `liveBookingIds` so a DRAFT or RESERVED booking
+                 * holding the same kit keeps an unmarked slice — nothing has
+                 * physically left for those.
+                 */
+                await tx.bookingAsset.updateMany({
+                  // `BookingAsset` carries no organization column; tenancy here
+                  // comes from both keys — the booking ids from this kit's own
+                  // org-scoped slices, the assetKit ids from the org-scoped
+                  // membership write above.
+                  where: {
+                    bookingId: { in: liveBookingIds },
+                    assetKitId: { in: stampable.map((s) => s.assetKitId) },
+                  },
+                  data: { checkedOutAt: new Date(), checkedOutById: userId },
+                });
+              }
             }
           }
         });

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -6028,26 +6028,67 @@ export async function updateKitAssets({
           }
 
           if (liveBookingIds.length > 0) {
-            const checkedOutSlices = await tx.bookingAsset.count({
-              where: {
-                bookingId: { in: liveBookingIds },
-                sourceKitId: kit.id,
-                // Out RIGHT NOW, not "went out at some point": a booking stays
-                // ONGOING while other kits are still out, so a kit whose every
-                // slice has already been returned must not vouch for a new
-                // member. Same pair the check-in guard and the
-                // `BookingAsset_bookingId_checkedOutAt_idx` partial index use.
-                checkedOutAt: { not: null },
-                checkedInAt: null,
-                booking: {
-                  status: {
-                    in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
-                  },
-                },
-              },
+            /**
+             * The kit's PRE-EXISTING slices on those bookings.
+             *
+             * `thisKitAssetKitIds` is read before the membership transaction,
+             * so it names only memberships that predate this call — and it has
+             * to. The `BookingAsset` rows written above carry this kit's
+             * `sourceKitId` with a NULL `checkedOutAt`, so letting them into
+             * this set would make the "did all of it leave" test below
+             * permanently unsatisfiable.
+             */
+            const preExistingAssetKitIds = [...thisKitAssetKitIds];
+
+            const priorSlices =
+              preExistingAssetKitIds.length > 0
+                ? await tx.bookingAsset.findMany({
+                    where: {
+                      bookingId: { in: liveBookingIds },
+                      // Names this kit's own membership rows, so no separate
+                      // `sourceKitId` filter is needed.
+                      assetKitId: { in: preExistingAssetKitIds },
+                    },
+                    select: {
+                      bookingId: true,
+                      checkedOutAt: true,
+                      checkedInAt: true,
+                    },
+                  })
+                : [];
+
+            /**
+             * A booking earns the stamp on its OWN evidence, and only when the
+             * whole kit left it.
+             *
+             * Per booking, because two live bookings can hold this kit and
+             * disagree: progressive checkout flips a booking to ONGOING on the
+             * first scan of anything, so the second can be live with none of
+             * this kit's slices out. One count across both would let the first
+             * vouch for the second.
+             *
+             * "Every prior slice left" is the other half. Progressive checkout
+             * stamps only the slices actually scanned, so a kit can sit half
+             * out on one booking, and a member that stayed behind is not
+             * evidence that a newcomer went anywhere.
+             *
+             * The disqualifier is `checkedOutAt` NULL — never left — not "not
+             * out right now". Check-in clears `Kit.status` only for a kit whose
+             * every member came back, so a kit returned one member at a time
+             * still reads CHECKED_OUT and the kit picker still promises that
+             * additions inherit that status. Refusing there would be stricter
+             * than the behaviour this replaces.
+             */
+            const eligibleBookingIds = liveBookingIds.filter((bookingId) => {
+              const slices = priorSlices.filter(
+                (s) => s.bookingId === bookingId
+              );
+              if (slices.length === 0) return false;
+              if (slices.some((s) => !s.checkedOutAt)) return false;
+              return slices.some((s) => !s.checkedInAt);
             });
 
-            if (checkedOutSlices > 0) {
+            if (eligibleBookingIds.length > 0) {
               /**
                * The members whose kit-driven slice this call actually wrote.
                *
@@ -6097,9 +6138,9 @@ export async function updateKitAssets({
                  * one did not go out with this kit. Those ids are new, so the
                  * only rows they reach are the ones `createMany` wrote above.
                  *
-                 * Scoped to `liveBookingIds` so a DRAFT or RESERVED booking
-                 * holding the same kit keeps an unmarked slice — nothing has
-                 * physically left for those.
+                 * Scoped to `eligibleBookingIds`, so a booking this kit never
+                 * left — one still in planning, or one that is live for a
+                 * different kit's sake — keeps an unmarked slice.
                  */
                 await tx.bookingAsset.updateMany({
                   // `BookingAsset` carries no organization column; tenancy here
@@ -6107,7 +6148,7 @@ export async function updateKitAssets({
                   // org-scoped slices, the assetKit ids from the org-scoped
                   // membership write above.
                   where: {
-                    bookingId: { in: liveBookingIds },
+                    bookingId: { in: eligibleBookingIds },
                     assetKitId: { in: stampable.map((s) => s.assetKitId) },
                   },
                   data: { checkedOutAt: new Date(), checkedOutById: userId },

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -5838,6 +5838,16 @@ export async function updateKitAssets({
     }
 
     /**
+     * Assets that this call actually placed onto a booking that is physically
+     * out (ONGOING / OVERDUE). Populated inside the propagation block below,
+     * consumed by the CHECKED_OUT stamp after it.
+     *
+     * Declared out here because the stamp sits outside
+     * `if (bookingsToUpdate?.length)` and cannot see that block's scope.
+     */
+    let assetIdsOnLiveBooking: string[] = [];
+
+    /**
      * If user is adding/removing an asset to a kit which is a part of DRAFT, RESERVED, ONGOING or OVERDUE booking,
      * then we have to add or remove these assets to booking also
      */
@@ -5969,6 +5979,21 @@ export async function updateKitAssets({
             await recordEvents(propagatedEvents, tx);
           }
         });
+
+        /**
+         * Record which assets landed on a booking that is physically out, so
+         * the stamp below can key on that fact instead of on `Kit.status`.
+         *
+         * DRAFT and RESERVED are deliberately excluded: `bookingsToUpdate`
+         * includes them so the asset joins the booking, but nothing has left
+         * the building yet, so nothing should read CHECKED_OUT.
+         */
+        const liveBookings = bookingsToUpdate.filter(
+          (b) => b.status === "ONGOING" || b.status === "OVERDUE"
+        );
+        if (liveBookings.length > 0) {
+          assetIdsOnLiveBooking = newlyAddedAssets.map((a) => a.id);
+        }
       }
 
       // why: there is deliberately no delete counterpart here. Removing an
@@ -5988,13 +6013,25 @@ export async function updateKitAssets({
     }
 
     /**
-     * If the kit is part of an ONGOING booking, then we have to make all
-     * the assets CHECKED_OUT
+     * An asset joining a kit that is physically out inherits CHECKED_OUT.
+     *
+     * Keyed on the booking rows this call just wrote, never on `Kit.status`.
+     * That column is a denormalised flag and it can be stale: check-in
+     * resolves which kits to release from the assets' CURRENT membership
+     * (`getKitIdsByAssets`), so a kit whose assets were detached while a
+     * booking was live keeps reading CHECKED_OUT after that booking ends,
+     * with nothing out. Trusting the flag stamps CHECKED_OUT onto assets that
+     * hold no reservation, and nothing clears it again — every release path
+     * runs through `releaseAssetsToAvailableUnlessCheckedOut`, which skips
+     * CHECKED_OUT rows by design.
+     *
+     * DRAFT and RESERVED bookings are excluded on purpose: the asset joins
+     * them (see the propagation block above), but nothing has physically left,
+     * so its status must not move.
      */
-    if (kit.status === KitStatus.CHECKED_OUT) {
+    if (assetIdsOnLiveBooking.length > 0) {
       await db.asset.updateMany({
-        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: newlyAddedAssets derived from `allAssetsForKit` loaded org-scoped at the `where: { id: { in: assetIds }, organizationId }` query (line ~2442); not raw request input
-        where: { id: { in: newlyAddedAssets.map((a) => a.id) } },
+        where: { id: { in: assetIdsOnLiveBooking }, organizationId },
         data: { status: AssetStatus.CHECKED_OUT },
       });
     }


### PR DESCRIPTION
## What

Adding an asset to a kit stamped it `CHECKED_OUT` whenever the kit's own `status`
column read `CHECKED_OUT`, with no check that a live booking existed.

The stamp now keys on the booking rows the same call just wrote, and only for
`ONGOING` / `OVERDUE` bookings.

## Why it matters

`Kit.status` goes stale on its own. `checkinBooking` resolves which kits to release
from the assets' **current** membership (`getKitIdsByAssets`), so detaching a kit's
assets while a booking is live makes the kit invisible at check-in and it keeps
reading `CHECKED_OUT` after the booking completes.

Every asset added to such a kit was then stamped against nothing, and nothing clears
it again — the release paths all route through `releaseAssetsToAvailableUnlessCheckedOut`,
which skips `CHECKED_OUT` rows by design. The result is an asset that reads checked out
with no booking behind it, which also blocks check-out of any booking it is added to.

`DRAFT` and `RESERVED` bookings still receive the asset but leave its status alone,
since nothing has physically left.

## Verification

Four unit tests. Reverting the source turns three of them red; the fourth stays green
in both columns because it guards the legitimate case, so the fix tightens the
condition rather than deleting the behaviour.

Then the full sequence was driven from a clean local Postgres with all migrations
applied, through the real services, no mocks:

| Step | Asset | Kit |
| --- | --- | --- |
| 0. start | AVAILABLE | AVAILABLE |
| 1. asset added to kit | AVAILABLE | AVAILABLE |
| 2. kit on a RESERVED booking | AVAILABLE | AVAILABLE |
| 3. checked out | CHECKED_OUT | CHECKED_OUT |
| 4. asset detached from the kit | CHECKED_OUT | CHECKED_OUT |
| 5. booking checked in | AVAILABLE | **CHECKED_OUT** |
| 6. asset re-added to the stale kit | **AVAILABLE** | CHECKED_OUT |

The identical run against unfixed `main` matches line for line through step 5 and
diverges only at step 6, where the asset ends `CHECKED_OUT` with zero live booking
rows.

Also reproduced through the UI on production before the fix, which is how it was found.

## Open question for review

An asset added to a kit that is *genuinely* out now gets `Asset.status = CHECKED_OUT`
but no `BookingAsset.checkedOutAt` marker, which is the behaviour on `main` too. Per
`.claude/rules/booking-checkout-is-recorded-per-slice.md`, `checkedOutAt` is the
authority on whether a slice physically went out, and the check-in scanner refuses a
slice that has none.

Two defensible answers, and it is a product call rather than mine:

1. **It was handed over** — write the slice marker in the same transaction, mirroring
   the all-at-once checkout writer.
2. **It was not** — drop the stamp entirely and let it stay `AVAILABLE` until someone
   scans it out.

This PR deliberately changes neither. Happy to follow up with whichever you prefer.

## Not in scope

The reason `Kit.status` goes stale (step 5 above) is untouched. That fix spans ten
places that resolve a kit from live membership, three of which inline the lookup and
are therefore invisible to the type checker, so it wants its own PR and its own review.
This one is the circuit breaker: a stale kit that cannot stamp is harmless.

## Checks

`pnpm webapp:test` on the kit suite (122/122), `turbo typecheck`, and eslint on both
changed files — all clean locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Newly added kit assets are marked as checked out only when an active or overdue booking has confirmed checkout activity.
  * Improved checkout status accuracy for kits with fully returned, partially returned, or mixed booking items.
  * Prevented incorrect statuses from stale kit data, completed or not-yet-started bookings, and unrelated returned items.
  * Ensured checkout details are applied only to eligible newly added kit assets and the correct booking items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->