### PR TITLE
fix(bookings): release kits from booking slices, not just live membership

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -12900,4 +12900,53 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
 
     expect(db.kit.updateMany).not.toHaveBeenCalled();
   });
+
+  /**
+   * The mobile check-in sends no slice id, so its units are spread across the
+   * asset's slices in `compareSlicesForGreedyFill` order — standalone first.
+   * A standalone slice that never left must not absorb that return: it owes
+   * nothing, and every unit it swallows is one the kit-driven slice needs to
+   * settle. Capacity has to be what a slice SENT, the same measure the
+   * threshold uses.
+   */
+  it("does not let a slice that never left absorb an untagged return owed to a kit", async () => {
+    expect.assertions(1);
+
+    const looseSlice = {
+      id: "ba-loose",
+      assetId: "asset-x",
+      quantity: 5,
+      assetKitId: null,
+      sourceKitId: null,
+      // Never went out on this booking.
+      checkedOutAt: null,
+      checkedInAt: null,
+      asset: {
+        id: "asset-x",
+        type: AssetType.QUANTITY_TRACKED,
+        assetKits: [{ kitId: "kit-a" }, { kitId: "kit-b" }],
+      },
+    };
+    const slices = [looseSlice, tapeSlice("ba-kit-a", "kit-a", 5), fillerSlice];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+    // All 5 units that left did so on the kit's slice.
+    (
+      db.partialBookingCheckout.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetIds: ["asset-x"], quantities: [5], bookingAssetIds: ["ba-kit-a"] },
+    ]);
+    // The mobile payload names no slice.
+    (
+      db.consumptionLog.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetId: "asset-x", bookingAssetId: null, quantity: 5 },
+    ]);
+
+    await partialCheckinBooking(
+      params({ checkins: [{ assetId: "asset-x", returned: 5 }] })
+    );
+
+    expect(releasedKitIds()).toEqual(["kit-a"]);
+  });
 });

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -12348,7 +12348,9 @@ describe("getKitIdsByBookingSlices", () => {
     db.assetKit.findMany.mockResolvedValue([]);
 
     const result = await getKitIdsByBookingSlices({
-      slices: [{ assetId: "asset-1", assetKitId: "ak-gone", sourceKitId: null }],
+      slices: [
+        { assetId: "asset-1", assetKitId: "ak-gone", sourceKitId: null },
+      ],
       organizationId: "org-1",
     });
 
@@ -12510,6 +12512,37 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
     (db.bookingAsset.findMany as ReturnType<typeof vitest.fn>)
       .mockReset()
       .mockImplementation((q?: any) => {
+        // `computeBookingAssetsSliceRemainingToCheckOut`, read (1): the slices
+        // it was asked about. Keyed on `where.id.in`, which no other read here
+        // uses.
+        if (q?.where?.id?.in) {
+          return Promise.resolve(
+            args.slices
+              .filter((s) => q.where.id.in.includes(s.id))
+              .map((s) => ({
+                id: s.id,
+                assetId: s.assetId,
+                quantity: s.quantity,
+                assetKitId: s.assetKitId,
+                asset: { status: AssetStatus.CHECKED_OUT },
+              }))
+          );
+        }
+        // Same helper, read (2): every sibling slice of the involved assets, so
+        // its greedy fill sees the full set. `where.assetId` is an `in` filter
+        // here and a scalar in the asset-level read below.
+        if (q?.where?.assetId?.in) {
+          return Promise.resolve(
+            args.slices
+              .filter((s) => q.where.assetId.in.includes(s.assetId))
+              .map((s) => ({
+                id: s.id,
+                assetId: s.assetId,
+                quantity: s.quantity,
+                assetKitId: s.assetKitId,
+              }))
+          );
+        }
         if (q?.where?.assetId) {
           return Promise.resolve(
             args.slices
@@ -12618,10 +12651,11 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
     ];
     arrangeBooking(slices);
     mockSliceReads({ slices, stillOutNow: [] });
-    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
-      .mockResolvedValue([
-        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
-      ]);
+    (
+      db.consumptionLog.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
+    ]);
 
     await partialCheckinBooking(
       params({
@@ -12644,10 +12678,11 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
     ];
     arrangeBooking(slices);
     mockSliceReads({ slices, stillOutNow: [] });
-    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
-      .mockResolvedValue([
-        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
-      ]);
+    (
+      db.consumptionLog.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
+    ]);
 
     await partialCheckinBooking(
       params({
@@ -12713,10 +12748,11 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
     ];
     arrangeBooking(slices);
     mockSliceReads({ slices, stillOutNow: [] });
-    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
-      .mockResolvedValue([
-        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 2 },
-      ]);
+    (
+      db.consumptionLog.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 2 },
+    ]);
 
     await partialCheckinBooking(
       params({
@@ -12751,10 +12787,11 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
         },
       ],
     });
-    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
-      .mockResolvedValue([
-        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
-      ]);
+    (
+      db.consumptionLog.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
+    ]);
 
     await partialCheckinBooking(
       params({
@@ -12797,5 +12834,70 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
     await partialCheckinBooking(params({ assetIds: ["asset-d"] }));
 
     expect(releasedKitIds()).toEqual(["kit-z"]);
+  });
+
+  /**
+   * Progressive checkout stamps `checkedOutAt` as soon as ANY unit leaves, so a
+   * slice booked at 10 with 3 in the field is an ordinary state, not a broken
+   * one. What settles it is those 3 coming back. Measuring against the booked
+   * 10 leaves the kit checked out with nothing of it anywhere, and once the
+   * booking completes no later check-in can release it.
+   */
+  it("releases a kit once every unit its slice actually sent out is back", async () => {
+    expect.assertions(1);
+
+    const slices = [tapeSlice("ba-kit-a", "kit-a", 10), fillerSlice];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+    // Only 3 of the booked 10 ever left.
+    (
+      db.partialBookingCheckout.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetIds: ["asset-x"], quantities: [3], bookingAssetIds: ["ba-kit-a"] },
+    ]);
+    (
+      db.consumptionLog.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 3 },
+    ]);
+
+    await partialCheckinBooking(
+      params({
+        checkins: [
+          { assetId: "asset-x", bookingAssetId: "ba-kit-a", returned: 3 },
+        ],
+      })
+    );
+
+    expect(releasedKitIds()).toEqual(["kit-a"]);
+  });
+
+  it("holds the kit while a unit its slice sent out is still in the field", async () => {
+    expect.assertions(1);
+
+    const slices = [tapeSlice("ba-kit-a", "kit-a", 10), fillerSlice];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+    (
+      db.partialBookingCheckout.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetIds: ["asset-x"], quantities: [3], bookingAssetIds: ["ba-kit-a"] },
+    ]);
+    // 3 went out, 2 came back.
+    (
+      db.consumptionLog.findMany as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue([
+      { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 2 },
+    ]);
+
+    await partialCheckinBooking(
+      params({
+        checkins: [
+          { assetId: "asset-x", bookingAssetId: "ba-kit-a", returned: 2 },
+        ],
+      })
+    );
+
+    expect(db.kit.updateMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -43,6 +43,7 @@ import {
   getTotalPartialCheckinCount,
   getPartiallyCheckedInAssetIds,
   getKitIdsByAssets,
+  getKitIdsByBookingSlices,
   updateBasicBooking,
   updateBookingAssets,
   buildKitSlicesForBooking,
@@ -12272,6 +12273,162 @@ describe("cancelBooking — handled validation (SHELF-WEBAPP-222)", () => {
     expect(err.additionalData).toMatchObject({
       bookingId: "booking-1",
       status: BookingStatus.COMPLETE,
+    });
+  });
+});
+
+/**
+ * Kit release resolves from the booking's own slices as well as from live
+ * membership.
+ *
+ * Membership alone cannot see a kit whose member was detached while the
+ * booking ran, so nothing releases it and `Kit.status` stays CHECKED_OUT with
+ * nothing out. The booking's rows still remember the kit, so they answer where
+ * membership cannot — and the two are UNIONED, never substituted: a standalone
+ * slice carries no provenance even when its asset is a live kit member.
+ */
+describe("getKitIdsByBookingSlices", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("resolves a kit from sourceKitId with no membership left", async () => {
+    const result = await getKitIdsByBookingSlices({
+      slices: [
+        { assetId: "asset-1", assetKitId: null, sourceKitId: "kit-1" },
+        { assetId: "asset-2", assetKitId: null, sourceKitId: "kit-1" },
+        { assetId: "asset-3", assetKitId: null, sourceKitId: "kit-2" },
+      ],
+      organizationId: "org-1",
+    });
+
+    expect([...result.keys()].sort()).toEqual(["kit-1", "kit-2"]);
+    expect([...(result.get("kit-1") ?? [])].sort()).toEqual([
+      "asset-1",
+      "asset-2",
+    ]);
+    // No legacy rows, so the AssetKit hop is skipped entirely.
+    expect(db.assetKit.findMany).not.toHaveBeenCalled();
+  });
+
+  it("falls back to assetKitId for rows written before sourceKitId existed", async () => {
+    // why: the mocked delegate echoes ids back as `kit-of-<id>`, mirroring the
+    // real `assetKitId -> kitId` lookup this leg performs.
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([{ id: "ak-1", kitId: "kit-9" }]);
+
+    const result = await getKitIdsByBookingSlices({
+      slices: [{ assetId: "asset-1", assetKitId: "ak-1", sourceKitId: null }],
+      organizationId: "org-1",
+    });
+
+    expect([...result.keys()]).toEqual(["kit-9"]);
+    // Org-scoped, so the lookup cannot reach another workspace's memberships.
+    expect(db.assetKit.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["ak-1"] }, organizationId: "org-1" },
+      select: { id: true, kitId: true },
+    });
+  });
+
+  it("ignores a standalone slice, which carries no kit provenance", async () => {
+    const result = await getKitIdsByBookingSlices({
+      slices: [{ assetId: "asset-1", assetKitId: null, sourceKitId: null }],
+      organizationId: "org-1",
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it("resolves nothing rather than throwing when a membership has vanished", async () => {
+    // A concurrent detach legitimately removes the row between the two reads.
+    // That means "no kit to release", never "reject the check-in".
+    //@ts-expect-error missing vitest type
+    db.assetKit.findMany.mockResolvedValue([]);
+
+    const result = await getKitIdsByBookingSlices({
+      slices: [{ assetId: "asset-1", assetKitId: "ak-gone", sourceKitId: null }],
+      organizationId: "org-1",
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it("prefers sourceKitId and skips the lookup when every row carries it", async () => {
+    const result = await getKitIdsByBookingSlices({
+      slices: [
+        { assetId: "asset-1", assetKitId: "ak-stale", sourceKitId: "kit-1" },
+      ],
+      organizationId: "org-1",
+    });
+
+    expect([...result.keys()]).toEqual(["kit-1"]);
+    expect(db.assetKit.findMany).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * A kit whose members were detached while the booking ran is still released.
+ *
+ * The detach leaves the slices on the booking with their kit provenance
+ * intact, but the assets themselves no longer name the kit — so membership
+ * alone resolves nothing and the kit keeps reading CHECKED_OUT after the
+ * booking ends. A kit in that state cannot be added to a live booking and has
+ * no way out of the UI.
+ */
+describe("checkinBooking - releases a kit detached mid-booking", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  it("releases the kit from slice provenance when membership is gone", async () => {
+    expect.assertions(1);
+
+    // why: the slices still carry `sourceKitId`, but `assetKits` is empty —
+    // exactly what a mid-booking detach leaves behind. Membership-based
+    // resolution finds no kit here, so nothing would release it.
+    const detachedKitBooking = {
+      ...mockBookingData,
+      status: BookingStatus.ONGOING,
+      bookingAssets: [
+        {
+          asset: {
+            id: "asset-1",
+            type: AssetType.INDIVIDUAL,
+            assetKits: [],
+            status: AssetStatus.CHECKED_OUT,
+            bookingAssets: [
+              { booking: { id: "booking-1", status: BookingStatus.ONGOING } },
+            ],
+          },
+          assetId: "asset-1",
+          quantity: 1,
+          id: "ba-detached",
+          assetKitId: null,
+          sourceKitId: "kit-1",
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: null,
+        },
+      ],
+      partialCheckins: [],
+    };
+
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(detachedKitBooking);
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue({
+      ...detachedKitBooking,
+      status: BookingStatus.COMPLETE,
+    });
+
+    await checkinBooking({
+      id: "booking-1",
+      organizationId: "org-1",
+      hints: mockClientHints,
+    });
+
+    expect(db.kit.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["kit-1"] }, organizationId: "org-1" },
+      data: { status: KitStatus.AVAILABLE },
     });
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -1209,20 +1209,22 @@ describe("partialCheckinBooking", () => {
       assetIds: ["asset-1"],
     });
 
-    // The progressive write is the one scoped by `assetId`; the full check-in
+    // The progressive write is the one scoped by slice id; the full check-in
     // delegate writes booking-wide, and matching that instead would test a
     // guard this code path does not own.
     const markerCall = vitest
       .mocked(db.bookingAsset.updateMany)
       .mock.calls.find(
         ([args]) =>
-          "checkedInAt" in (args?.data ?? {}) &&
-          "assetId" in (args?.where ?? {})
+          "checkedInAt" in (args?.data ?? {}) && "id" in (args?.where ?? {})
       )?.[0];
 
     expect(markerCall).toBeDefined();
     expect(markerCall?.where).toEqual(
-      expect.objectContaining({ checkedOutAt: { not: null } })
+      expect.objectContaining({
+        id: { in: ["ba-went-out"] },
+        checkedOutAt: { not: null },
+      })
     );
   });
 
@@ -12430,5 +12432,370 @@ describe("checkinBooking - releases a kit detached mid-booking", () => {
       where: { id: { in: ["kit-1"] }, organizationId: "org-1" },
       data: { status: KitStatus.AVAILABLE },
     });
+  });
+});
+
+/**
+ * Kit release on partial check-in is decided per `BookingAsset` SLICE.
+ *
+ * A QUANTITY_TRACKED asset holds a standalone slice plus one slice per kit it
+ * belongs to on the same booking, so an asset-keyed answer lets one kit's slice
+ * speak for its siblings: it released a kit whose units were still in the field,
+ * and stranded a kit whose units had all come back.
+ */
+describe("partialCheckinBooking — slice-grained kit release", () => {
+  const ORG = "org-1";
+  /** An instant a slice left on. */
+  const OUT = new Date("2026-01-01T10:00:00.000Z");
+  /** An instant an earlier session reconciled a slice on. */
+  const BACK = new Date("2026-01-02T10:00:00.000Z");
+
+  beforeEach(() => {
+    vitest.clearAllMocks();
+    (db.partialBookingCheckout.findMany as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue([]);
+    (db.partialBookingCheckin.findMany as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue([]);
+    (db.partialBookingCheckin.count as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue(1);
+    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue([]);
+    (db.consumptionLog.aggregate as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue({ _sum: { quantity: 0 } });
+    (db.custody.aggregate as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue({ _sum: { quantity: 0 } });
+    (db.booking.update as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue({ ...mockBookingData, bookingAssets: [] });
+    // The check-in guard's title lookup. Echo the requested ids so it always
+    // describes the batch under test.
+    (db.asset.findMany as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockImplementation((args?: any) =>
+        Promise.resolve(
+          (args?.where?.id?.in ?? []).map((assetId: string) => ({
+            id: assetId,
+            title: assetId,
+            status: AssetStatus.CHECKED_OUT,
+            assetKits: [],
+          }))
+        )
+      );
+    (
+      quantityLock.lockAssetForQuantityUpdate as ReturnType<typeof vitest.fn>
+    ).mockResolvedValue({
+      id: "asset-x",
+      title: "Gaffer tape",
+      quantity: 100,
+      type: AssetType.QUANTITY_TRACKED,
+      unitOfMeasure: null,
+      consumptionType: ConsumptionType.TWO_WAY,
+    });
+  });
+
+  /**
+   * Routes the three `bookingAsset.findMany` shapes this path issues, which one
+   * model-shaped mock cannot tell apart:
+   *   - `where.assetId`   -> `computeBookingAssetRemaining` (asset-level booked)
+   *   - `where.checkedOutAt` -> the kit gate's still-out veto read
+   *   - otherwise         -> `isBookingFullyCheckedIn`
+   */
+  function mockSliceReads(args: { slices: any[]; stillOutNow?: any[] }) {
+    (db.bookingAsset.findMany as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockImplementation((q?: any) => {
+        if (q?.where?.assetId) {
+          return Promise.resolve(
+            args.slices
+              .filter((s) => s.assetId === q.where.assetId)
+              .map((s) => ({ quantity: s.quantity }))
+          );
+        }
+        if (q?.where?.checkedOutAt) {
+          return Promise.resolve(args.stillOutNow ?? []);
+        }
+        // `isBookingFullyCheckedIn`: keep the booking incomplete so the test
+        // exercises the progressive path rather than the COMPLETE branch.
+        return Promise.resolve(
+          args.slices.map((s) => ({
+            assetId: s.assetId,
+            quantity: s.quantity,
+            asset: {
+              id: s.assetId,
+              type: s.asset.type,
+              status: AssetStatus.CHECKED_OUT,
+            },
+          }))
+        );
+      });
+    (db.bookingAsset.findUnique as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockImplementation((q?: any) =>
+        Promise.resolve(args.slices.find((s) => s.id === q?.where?.id) ?? null)
+      );
+  }
+
+  /** Kit ids the transaction released, flattened across calls. */
+  const releasedKitIds = () =>
+    (db.kit.updateMany as ReturnType<typeof vitest.fn>).mock.calls.flatMap(
+      (call: any[]) => call[0]?.where?.id?.in ?? []
+    );
+
+  const params = (overrides: Record<string, unknown>) => ({
+    id: "booking-1",
+    organizationId: ORG,
+    userId: "user-1",
+    hints: mockClientHints,
+    ...overrides,
+  });
+
+  function arrangeBooking(bookingAssets: unknown[]) {
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue({
+      ...mockBookingData,
+      status: BookingStatus.ONGOING,
+      bookingAssets,
+    });
+  }
+
+  /** One kit-driven slice of the shared qty-tracked asset. */
+  const tapeSlice = (
+    id: string,
+    kitId: string,
+    quantity: number,
+    checkedInAt: Date | null = null
+  ) => ({
+    id,
+    assetId: "asset-x",
+    quantity,
+    assetKitId: `ak-${kitId}`,
+    sourceKitId: kitId,
+    checkedOutAt: OUT,
+    checkedInAt,
+    asset: {
+      id: "asset-x",
+      type: AssetType.QUANTITY_TRACKED,
+      assetKits: [{ kitId: "kit-a" }, { kitId: "kit-b" }],
+    },
+  });
+
+  /**
+   * A loose INDIVIDUAL slice on no kit, left outstanding and out of every batch
+   * below. Without it a batch covering everything still out takes the "all
+   * remaining scanned" early exit into `checkinBooking` and never reaches the
+   * progressive gate under test.
+   */
+  const fillerSlice = {
+    id: "ba-filler",
+    assetId: "asset-filler",
+    quantity: 1,
+    assetKitId: null,
+    sourceKitId: null,
+    checkedOutAt: OUT,
+    checkedInAt: null,
+    asset: {
+      id: "asset-filler",
+      type: AssetType.INDIVIDUAL,
+      assetKits: [],
+    },
+  };
+
+  it("releases only the kit whose slice came back", async () => {
+    expect.assertions(1);
+
+    // 6 units booked through kit A, 4 through kit B. The claim names kit A's
+    // slice and returns its six; kit B's four are still in the field.
+    const slices = [
+      tapeSlice("ba-kit-a", "kit-a", 6),
+      tapeSlice("ba-kit-b", "kit-b", 4),
+      fillerSlice,
+    ];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValue([
+        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
+      ]);
+
+    await partialCheckinBooking(
+      params({
+        checkins: [
+          { assetId: "asset-x", bookingAssetId: "ba-kit-a", returned: 6 },
+        ],
+      })
+    );
+
+    expect(releasedKitIds()).toEqual(["kit-a"]);
+  });
+
+  it("stamps the returned slice and leaves its sibling out", async () => {
+    expect.assertions(1);
+
+    const slices = [
+      tapeSlice("ba-kit-a", "kit-a", 6),
+      tapeSlice("ba-kit-b", "kit-b", 4),
+      fillerSlice,
+    ];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValue([
+        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
+      ]);
+
+    await partialCheckinBooking(
+      params({
+        checkins: [
+          { assetId: "asset-x", bookingAssetId: "ba-kit-a", returned: 6 },
+        ],
+      })
+    );
+
+    const markerCall = vitest
+      .mocked(db.bookingAsset.updateMany)
+      .mock.calls.find(([q]) => "checkedInAt" in (q?.data ?? {}))?.[0];
+
+    expect(markerCall?.where).toEqual(
+      expect.objectContaining({
+        id: { in: ["ba-kit-a"] },
+        checkedOutAt: { not: null },
+        checkedInAt: null,
+      })
+    );
+  });
+
+  it("releases a kit whose last slice comes back, whatever a shared asset's other kit still owes", async () => {
+    expect.assertions(1);
+
+    // Kit A holds the tape's six units (reconciled by an earlier session) and
+    // an INDIVIDUAL stand. Kit B holds the tape's other four, still out.
+    const slices = [
+      tapeSlice("ba-kit-a", "kit-a", 6, BACK),
+      tapeSlice("ba-kit-b", "kit-b", 4),
+      {
+        id: "ba-stand",
+        assetId: "asset-stand",
+        quantity: 1,
+        assetKitId: "ak-kit-a",
+        sourceKitId: "kit-a",
+        checkedOutAt: OUT,
+        checkedInAt: null,
+        asset: {
+          id: "asset-stand",
+          type: AssetType.INDIVIDUAL,
+          assetKits: [{ kitId: "kit-a" }],
+        },
+      },
+      fillerSlice,
+    ];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+
+    await partialCheckinBooking(params({ assetIds: ["asset-stand"] }));
+
+    expect(releasedKitIds()).toEqual(["kit-a"]);
+  });
+
+  it("keeps a kit CHECKED_OUT while its slice still owes units", async () => {
+    expect.assertions(1);
+
+    // Two of kit A's six units are back; four are still out.
+    const slices = [
+      tapeSlice("ba-kit-a", "kit-a", 6),
+      tapeSlice("ba-kit-b", "kit-b", 4),
+      fillerSlice,
+    ];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValue([
+        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 2 },
+      ]);
+
+    await partialCheckinBooking(
+      params({
+        checkins: [
+          { assetId: "asset-x", bookingAssetId: "ba-kit-a", returned: 2 },
+        ],
+      })
+    );
+
+    expect(db.kit.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("holds a kit back for a slice checked out after this request loaded the booking", async () => {
+    expect.assertions(1);
+
+    const slices = [
+      tapeSlice("ba-kit-a", "kit-a", 6),
+      tapeSlice("ba-kit-b", "kit-b", 4),
+      fillerSlice,
+    ];
+    arrangeBooking(slices);
+    // `ba-added-late` is kit A's, checked out by another session while this
+    // request ran, so the pre-transaction snapshot cannot see it.
+    mockSliceReads({
+      slices,
+      stillOutNow: [
+        {
+          id: "ba-added-late",
+          assetKitId: "ak-kit-a",
+          sourceKitId: "kit-a",
+          asset: { assetKits: [{ kitId: "kit-a" }] },
+        },
+      ],
+    });
+    (db.consumptionLog.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValue([
+        { assetId: "asset-x", bookingAssetId: "ba-kit-a", quantity: 6 },
+      ]);
+
+    await partialCheckinBooking(
+      params({
+        checkins: [
+          { assetId: "asset-x", bookingAssetId: "ba-kit-a", returned: 6 },
+        ],
+      })
+    );
+
+    expect(db.kit.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("still releases a kit whose member was detached mid-booking", async () => {
+    expect.assertions(1);
+
+    // Membership is gone, so only the slice's own `sourceKitId` names the kit.
+    // Green before this change and after it — the behaviour PR #2973 added,
+    // pinned inside `partialCheckinBooking` so the per-slice gate cannot
+    // quietly take it away.
+    const slices = [
+      {
+        id: "ba-detached",
+        assetId: "asset-d",
+        quantity: 1,
+        assetKitId: null,
+        sourceKitId: "kit-z",
+        checkedOutAt: OUT,
+        checkedInAt: null,
+        asset: {
+          id: "asset-d",
+          type: AssetType.INDIVIDUAL,
+          assetKits: [],
+        },
+      },
+      fillerSlice,
+    ];
+    arrangeBooking(slices);
+    mockSliceReads({ slices, stillOutNow: [] });
+
+    await partialCheckinBooking(params({ assetIds: ["asset-d"] }));
+
+    expect(releasedKitIds()).toEqual(["kit-z"]);
   });
 });

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -6115,64 +6115,28 @@ export async function partialCheckinBooking({
       }
     }
 
-    // For kits: only flip kit status if ALL of its assets are being checked
-    // in this session. Qty-tracked assets aren't kitted, so this logic only
-    // applies to individuals.
-    const assetsBeingCheckedIn = bookingFoundAssets.filter((a) =>
-      effectiveAssetIds.includes(a.id)
-    );
     /**
-     * Kits touched by this session, from live membership AND from the
-     * booking's own slices. See `getKitIdsByBookingSlices` for why both.
+     * The kits each of this booking's slices belongs to.
+     *
+     * Slice-grained because that is the grain the release gate has to answer
+     * at. A QUANTITY_TRACKED asset holds a standalone slice plus one per kit it
+     * belongs to on the same booking — the two partial uniques on
+     * `BookingAsset` allow exactly that — so an asset id names several kits at
+     * once and cannot say which of them a given return came back to.
+     *
+     * Which kits this session actually releases is decided inside the
+     * transaction, once the slices it settled are known: see `completeKitIds`
+     * there.
      */
-    const sliceKitAssetIds = await getKitIdsByBookingSlices({
-      slices: bookingFound.bookingAssets,
+    const kitIdsBySliceId = await getKitIdsBySlice({
+      slices: bookingFound.bookingAssets.map((ba) => ({
+        id: ba.id,
+        assetKitId: ba.assetKitId ?? null,
+        sourceKitId: ba.sourceKitId ?? null,
+        assetKits: ba.asset?.assetKits ?? [],
+      })),
       organizationId,
     });
-    const beingCheckedInIds = new Set(assetsBeingCheckedIn.map((a) => a.id));
-    const kitIdsBeingCheckedIn = [
-      ...new Set([
-        ...getKitIdsByAssets(assetsBeingCheckedIn),
-        ...[...sliceKitAssetIds.entries()]
-          .filter(([, assetIds]) =>
-            [...assetIds].some((assetId) => beingCheckedInIds.has(assetId))
-          )
-          .map(([kitId]) => kitId),
-      ]),
-    ];
-
-    /**
-     * Slices still owed back on this booking. A kit is complete when this
-     * session accounts for every one of them, so slices reconciled by an
-     * earlier session must not keep the kit permanently short.
-     */
-    const outstandingAssetIds = new Set(
-      bookingFound.bookingAssets
-        .filter((ba) => ba.checkedInAt === null)
-        .map((ba) => ba.assetId)
-    );
-
-    const belongsToKit = (assetId: string, kitId: string, kitOfAsset?: string) =>
-      sliceKitAssetIds.get(kitId)?.has(assetId) || kitOfAsset === kitId;
-
-    const completeKitIds: string[] = [];
-    for (const kitId of kitIdsBeingCheckedIn) {
-      const kitAssetsInBooking = bookingFoundAssets.filter(
-        (a) =>
-          belongsToKit(a.id, kitId, a.assetKits?.[0]?.kitId) &&
-          outstandingAssetIds.has(a.id)
-      );
-      const kitAssetsBeingCheckedIn = assetsBeingCheckedIn.filter((a) =>
-        belongsToKit(a.id, kitId, a.assetKits?.[0]?.kitId)
-      );
-
-      if (
-        kitAssetsInBooking.length > 0 &&
-        kitAssetsInBooking.length === kitAssetsBeingCheckedIn.length
-      ) {
-        completeKitIds.push(kitId);
-      }
-    }
 
     /**
      * Per-asset disposition summary — populated inside the transaction as
@@ -6487,13 +6451,6 @@ export async function partialCheckinBooking({
         }
       }
 
-      if (completeKitIds.length > 0) {
-        await tx.kit.updateMany({
-          where: { id: { in: completeKitIds }, organizationId },
-          data: { status: KitStatus.AVAILABLE },
-        });
-      }
-
       /**
        * PartialBookingCheckin session row. `assetIds` intentionally only
        * lists assets FULLY reconciled in this session:
@@ -6520,31 +6477,234 @@ export async function partialCheckinBooking({
       });
 
       /**
-       * Mark the slices this session fully reconciled. Same ids as the session
-       * row above, so a partially-returned qty-tracked slice stays unmarked and
-       * remains checkinable — `checkedInAt` means FULLY reconciled.
+       * The slices this session finished, at slice grain.
        *
-       * Scoped to slices that actually went out, because these ids are
-       * asset-level while the marker is not: an asset's remaining is summed
-       * across ALL its slices, so a slice added after checkout — still
-       * AVAILABLE, never out — sits inside an asset the session can drive to
-       * zero. Stamping it would leave `checkedOutAt` NULL beside a
-       * `checkedInAt`, claiming a return for units that never left.
+       * `checkedInAt` means FULLY reconciled, and "fully" is a property of the
+       * SLICE. `sessionReconciledAssetIds` above is asset-level on purpose —
+       * the session row and `isBookingFullyCheckedIn` read it as an asset-level
+       * obligation — and an asset's `remaining` sums across every slice it has
+       * on the booking. Returning one kit's slice in full finishes that slice
+       * whatever its siblings still owe, and finishes nothing else, so the
+       * marker and the kit gate need their own set.
+       */
+      const settledSliceIds = new Set<string>();
+
+      /** Went out on this booking and has not been reconciled yet. */
+      const isOutstandingSlice = (slice: {
+        checkedOutAt: Date | null;
+        checkedInAt: Date | null;
+      }) => Boolean(slice.checkedOutAt) && !slice.checkedInAt;
+
+      const bookingSlicesByAssetId = new Map<
+        string,
+        (typeof bookingFound.bookingAssets)[number][]
+      >();
+      for (const slice of bookingFound.bookingAssets) {
+        const bucket = bookingSlicesByAssetId.get(slice.assetId);
+        if (bucket) {
+          bucket.push(slice);
+        } else {
+          bookingSlicesByAssetId.set(slice.assetId, [slice]);
+        }
+      }
+
+      /**
+       * INDIVIDUAL assets reconcile by presence: scanning one returns every
+       * slice of it that went out. Unchanged from what the marker has always
+       * done for them.
+       */
+      for (const assetId of individualAssetIds) {
+        for (const slice of bookingSlicesByAssetId.get(assetId) ?? []) {
+          if (isOutstandingSlice(slice)) {
+            settledSliceIds.add(slice.id);
+          }
+        }
+      }
+
+      /**
+       * A QUANTITY_TRACKED slice is finished only when its OWN booked quantity
+       * is accounted for. Read this booking's dispositions back — including the
+       * rows written above — and spread them with
+       * {@link attributeDispositionsByBookingAsset}, the same function every
+       * read site uses: a log tagged with a slice lands on it, an untagged one
+       * greedy-fills in `compareSlicesForGreedyFill` order.
+       *
+       * Resolving an untagged claim any other way would settle a slice the
+       * booking's own screens still report as out — the agreement
+       * `.claude/rules/booking-checkout-is-recorded-per-slice` requires between
+       * the marker writer and the quantity attribution.
+       *
+       * One query for every touched asset rather than one per slice: this loop
+       * runs over a whole batch inside an interactive transaction that already
+       * spends several round-trips per disposition (SHELF-WEBAPP-217).
+       */
+      const qtyAssetIdsTouched = [
+        ...new Set(qtySummaries.map((s) => s.assetId)),
+      ];
+      if (qtyAssetIdsTouched.length > 0) {
+        const dispositionLogs = await tx.consumptionLog.findMany({
+          where: {
+            bookingId: id,
+            assetId: { in: qtyAssetIdsTouched },
+            category: { in: [...CHECKIN_DISPOSITION_CATEGORIES] },
+          },
+          select: { assetId: true, bookingAssetId: true, quantity: true },
+        });
+
+        const logsByAssetId = new Map<
+          string,
+          Array<{ bookingAssetId: string | null; quantity: number }>
+        >();
+        for (const log of dispositionLogs) {
+          const entry = {
+            bookingAssetId: log.bookingAssetId,
+            quantity: log.quantity,
+          };
+          const bucket = logsByAssetId.get(log.assetId);
+          if (bucket) {
+            bucket.push(entry);
+          } else {
+            logsByAssetId.set(log.assetId, [entry]);
+          }
+        }
+
+        for (const assetId of qtyAssetIdsTouched) {
+          const slices = bookingSlicesByAssetId.get(assetId) ?? [];
+          if (slices.length === 0) continue;
+          // The asset's FULL slice set, so a claim tagged to one slice never
+          // leaks into a sibling and the untagged pool is capped per slice.
+          const attributed = attributeDispositionsByBookingAsset({
+            bookingAssetRows: slices.map((slice) => ({
+              id: slice.id,
+              quantity: slice.quantity,
+              assetKitId: slice.assetKitId,
+            })),
+            consumptionLogs: logsByAssetId.get(assetId) ?? [],
+          });
+          for (const slice of slices) {
+            if (
+              isOutstandingSlice(slice) &&
+              (attributed.get(slice.id) ?? 0) >= slice.quantity
+            ) {
+              settledSliceIds.add(slice.id);
+            }
+          }
+        }
+      }
+
+      /**
+       * Mark the slices this session fully reconciled.
+       *
+       * Keyed by `BookingAsset.id`. Keyed by `assetId` it stamped a return on
+       * every sibling slice at once — kit B reading as returned because kit A's
+       * units came back — and, in the other direction, refused to stamp kit A's
+       * slice until kit B's units were accounted for too, because an asset's
+       * remaining sums across all of them.
+       *
+       * `checkedOutAt: { not: null }` still guards the write: a slice added
+       * after checkout never left, and stamping `checkedInAt` beside a NULL
+       * `checkedOutAt` claims a return for units that never went anywhere.
        *
        * `checkedInAt: null` keeps the first reconciliation: where one slice was
        * settled in an earlier session and a sibling in this one, each keeps the
        * moment it was actually reconciled.
        */
-      if (sessionReconciledAssetIds.length > 0) {
+      if (settledSliceIds.size > 0) {
         await tx.bookingAsset.updateMany({
-          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: `id` was org-checked by this action's booking lookup
+          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: these slice ids come from this booking's own rows, which the action's `findUniqueOrThrow({ id, organizationId })` already org-checked
           where: {
             bookingId: id,
-            assetId: { in: sessionReconciledAssetIds },
+            id: { in: [...settledSliceIds] },
             checkedOutAt: { not: null },
             checkedInAt: null,
           },
           data: { checkedInAt: new Date(), checkedInById: userId },
+        });
+      }
+
+      /**
+       * Kits released by this session: one whose slices this session finished,
+       * and which has nothing left out on this booking.
+       *
+       * Both halves are per slice. Counted by asset, a kit's own returned slice
+       * read as outstanding because a SIBLING kit's slice of the same asset had
+       * not come back — the kit stayed CHECKED_OUT with nothing of its own out
+       * — and a kit was released because a sibling kit's slice had come back,
+       * sending it AVAILABLE with its units in the field. Over-release is the
+       * failure that loses equipment, so a kit needs BOTH: something of its own
+       * settled here, and nothing of its own still owed.
+       *
+       * A partially returned QUANTITY_TRACKED slice is outstanding by exactly
+       * this test — `checkedInAt` stays NULL while it still owes units — so its
+       * kit keeps reading CHECKED_OUT until the last unit is logged.
+       */
+      const kitIdsSettledHere = new Set<string>();
+      const kitIdsStillOut = new Set<string>();
+      for (const slice of bookingFound.bookingAssets) {
+        const kitIds = kitIdsBySliceId.get(slice.id);
+        if (!kitIds) continue;
+        if (settledSliceIds.has(slice.id)) {
+          for (const kitId of kitIds) kitIdsSettledHere.add(kitId);
+        } else if (isOutstandingSlice(slice)) {
+          for (const kitId of kitIds) kitIdsStillOut.add(kitId);
+        }
+      }
+
+      /**
+       * Slices this request never saw.
+       *
+       * The booking was loaded before the transaction opened — several
+       * round-trips earlier — so a progressive checkout that committed in
+       * between is invisible to it, and releasing a kit whose gear left in that
+       * window is the failure this gate exists to prevent.
+       *
+       * Read as a VETO only: it runs when a kit is already a candidate, and
+       * only slices absent from the snapshot contribute. It can hold a kit
+       * back; it can never release one. So a read that comes back short leaves
+       * the decision exactly where the snapshot put it.
+       */
+      if (kitIdsSettledHere.size > 0) {
+        const stillOutNow = await tx.bookingAsset.findMany({
+          where: {
+            bookingId: id,
+            checkedOutAt: { not: null },
+            checkedInAt: null,
+          },
+          select: {
+            id: true,
+            assetKitId: true,
+            sourceKitId: true,
+            asset: { select: { assetKits: { select: { kitId: true } } } },
+          },
+        });
+        const unseenSlices = stillOutNow.filter(
+          (slice) => !sliceById.has(slice.id)
+        );
+        if (unseenSlices.length > 0) {
+          const unseenKitIds = await getKitIdsBySlice({
+            slices: unseenSlices.map((slice) => ({
+              id: slice.id,
+              assetKitId: slice.assetKitId,
+              sourceKitId: slice.sourceKitId,
+              assetKits: slice.asset?.assetKits ?? [],
+            })),
+            organizationId,
+            client: tx,
+          });
+          for (const kitIds of unseenKitIds.values()) {
+            for (const kitId of kitIds) kitIdsStillOut.add(kitId);
+          }
+        }
+      }
+
+      const completeKitIds = [...kitIdsSettledHere].filter(
+        (kitId) => !kitIdsStillOut.has(kitId)
+      );
+
+      if (completeKitIds.length > 0) {
+        await tx.kit.updateMany({
+          where: { id: { in: completeKitIds }, organizationId },
+          data: { status: KitStatus.AVAILABLE },
         });
       }
 
@@ -12145,6 +12305,42 @@ type BookingSliceKitProvenance = {
 };
 
 /**
+ * The `AssetKit -> Kit` hop for rows written before `sourceKitId` existed.
+ *
+ * Shared by the two slice resolvers below so the org-scoped lookup and its
+ * deliberate tolerance of a missing row live in one place. Rows carrying
+ * `sourceKitId` need no lookup at all, which is why the query is skipped when
+ * there are no legacy rows.
+ */
+async function resolveKitIdByAssetKitId({
+  slices,
+  organizationId,
+  client,
+}: {
+  slices: Array<{ assetKitId: string | null; sourceKitId: string | null }>;
+  organizationId: Organization["id"];
+  client: Pick<ExtendedPrismaClient, "assetKit">;
+}): Promise<Map<string, string>> {
+  // Truthiness rather than `!== null`: test fixtures hand us rows whose
+  // provenance columns are absent entirely, and `undefined !== null` is true.
+  const legacyAssetKitIds = slices
+    .filter((s) => !s.sourceKitId && Boolean(s.assetKitId))
+    .map((s) => s.assetKitId as string);
+
+  if (legacyAssetKitIds.length === 0) return new Map();
+
+  // Deliberately not `assertAssetKitsBelongToOrg`: that throws a 400 when a
+  // row is missing, and a concurrent detach makes a row legitimately vanish
+  // between these two reads — the very operation these resolvers exist for.
+  // A missing row means "no kit to release", not "reject the check-in".
+  const rows = await client.assetKit.findMany({
+    where: { id: { in: legacyAssetKitIds }, organizationId },
+    select: { id: true, kitId: true },
+  });
+  return new Map(rows.map((r) => [r.id, r.kitId]));
+}
+
+/**
  * Release-path sibling of {@link getKitIdsByAssets}: resolves kits from the
  * BOOKING's own rows rather than from the assets' current membership.
  *
@@ -12161,11 +12357,13 @@ type BookingSliceKitProvenance = {
  * so a rolling deploy can still write a kit-driven row with a NULL
  * `sourceKitId`.
  *
- * Returns kit id to the asset ids this booking took from that kit, because the
- * completeness gates that consume it filter at that grain.
+ * Returns kit id to the asset ids this booking took from that kit. That grain
+ * answers "which kits did this booking touch", not "which kit does THIS row
+ * belong to" — a QUANTITY_TRACKED asset's several rows all collapse to one
+ * asset id here. A gate that must keep them apart wants
+ * {@link getKitIdsBySlice}.
  *
- * @param client Pass the active `tx` if ever called inside a transaction. Every
- *               caller today resolves before opening one.
+ * @param client Pass the active `tx` when called inside a transaction.
  *
  * ALWAYS UNION the result with {@link getKitIdsByAssets}, never substitute it.
  * A standalone slice carries no provenance by design even when its asset is a
@@ -12182,24 +12380,11 @@ export async function getKitIdsByBookingSlices({
   organizationId: Organization["id"];
   client?: Pick<typeof db, "assetKit">;
 }): Promise<Map<string, Set<string>>> {
-  // Truthiness rather than `!== null`: test fixtures hand us rows whose
-  // provenance columns are absent entirely, and `undefined !== null` is true.
-  const legacyAssetKitIds = slices
-    .filter((s) => !s.sourceKitId && Boolean(s.assetKitId))
-    .map((s) => s.assetKitId as string);
-
-  let kitIdByAssetKitId = new Map<string, string>();
-  if (legacyAssetKitIds.length > 0) {
-    // Deliberately not `assertAssetKitsBelongToOrg`: that throws a 400 when a
-    // row is missing, and a concurrent detach makes a row legitimately vanish
-    // between these two reads — the very operation this resolver exists for.
-    // A missing row means "no kit to release", not "reject the check-in".
-    const rows = await client.assetKit.findMany({
-      where: { id: { in: legacyAssetKitIds }, organizationId },
-      select: { id: true, kitId: true },
-    });
-    kitIdByAssetKitId = new Map(rows.map((r) => [r.id, r.kitId]));
-  }
+  const kitIdByAssetKitId = await resolveKitIdByAssetKitId({
+    slices,
+    organizationId,
+    client,
+  });
 
   const assetIdsByKitId = new Map<string, Set<string>>();
   for (const slice of slices) {
@@ -12213,6 +12398,103 @@ export async function getKitIdsByBookingSlices({
   }
 
   return assetIdsByKitId;
+}
+
+/**
+ * One `BookingAsset` row, with everything needed to name the kits it is part
+ * of.
+ *
+ * Every field is REQUIRED for the reason spelled out on
+ * {@link BookingSliceKitProvenance}: a caller that forgets to project one is a
+ * type error rather than a silent resolution to zero kits. `assetKits` earns
+ * that treatment too — dropping it makes every standalone slice look like it
+ * belongs to no kit, and the release gate stops seeing it as something a kit
+ * still owes.
+ */
+type BookingSliceKitAttribution = {
+  /** `BookingAsset.id` — the grain this resolver answers at. */
+  id: string;
+  assetKitId: string | null;
+  sourceKitId: string | null;
+  /** LIVE kit membership of this slice's asset (`Asset.assetKits`). */
+  assetKits: { kitId: string }[];
+};
+
+/**
+ * Slice-grained sibling of {@link getKitIdsByBookingSlices}: the kits a SINGLE
+ * `BookingAsset` row is part of.
+ *
+ * `getKitIdsByBookingSlices` collapses to `kitId -> assetIds`, which answers
+ * which kits a booking touches. The release gate asks the other question — does
+ * kit K still have something out — and at asset grain that cannot be answered:
+ * a QUANTITY_TRACKED asset holds a standalone slice plus one slice per kit it
+ * belongs to on the same booking (the two partial uniques on `BookingAsset`),
+ * and collapsed to one asset id, returning kit A's slice reads as returning kit
+ * B's.
+ *
+ * A kit-driven slice belongs to exactly the kit it was booked under:
+ * `sourceKitId`, the durable pointer that survives a detach, or the
+ * `assetKitId -> AssetKit.kitId` hop for rows written before that column. It
+ * does NOT belong to its asset's other kits — the slice names its own.
+ *
+ * A standalone slice carries no provenance by design, so it belongs to its
+ * asset's LIVE kits: the acquire paths stamp those CHECKED_OUT from membership
+ * ({@link getKitIdsByAssets}), and a release gate that ignored them would let a
+ * kit go AVAILABLE with a member's free-pool units still out. This is where the
+ * union {@link getKitIdsByBookingSlices}'s callers perform by hand lives
+ * instead — per slice, inside the resolver.
+ *
+ * EVERY live membership counts here, not just the first. `getKitIdsByAssets`
+ * reads `assetKits[0]` alone, so the acquire side stamps one kit where an asset
+ * sits in several. Taking all of them on the release side can only add
+ * obligations, never drop one, and over-release is the worse failure.
+ *
+ * A sibling rather than a new shape for {@link getKitIdsByBookingSlices}: five
+ * of its six callers read `.keys()` only, and both shapes are `Map<string,
+ * Set<string>>`, so repointing the value from asset ids to slice ids would
+ * compile everywhere and silently redefine what the remaining caller reads.
+ *
+ * @param client Pass the active `tx` when called inside a transaction.
+ *   `Pick<ExtendedPrismaClient, …>` rather than `Pick<typeof db, …>` for the
+ *   reason given on `CheckoutRemainingTxClient`: the interactive-tx client does
+ *   not reduce to `Prisma.TransactionClient`, but satisfies this structurally.
+ * @returns `BookingAsset.id` to the kit ids that slice is part of. A slice
+ *   belonging to no kit is absent from the map.
+ */
+export async function getKitIdsBySlice({
+  slices,
+  organizationId,
+  client = db,
+}: {
+  slices: BookingSliceKitAttribution[];
+  organizationId: Organization["id"];
+  client?: Pick<ExtendedPrismaClient, "assetKit">;
+}): Promise<Map<string, Set<string>>> {
+  const kitIdByAssetKitId = await resolveKitIdByAssetKitId({
+    slices,
+    organizationId,
+    client,
+  });
+
+  const kitIdsBySliceId = new Map<string, Set<string>>();
+  for (const slice of slices) {
+    const kitIds = new Set<string>();
+    if (slice.sourceKitId || slice.assetKitId) {
+      const kitId =
+        slice.sourceKitId ??
+        (slice.assetKitId
+          ? kitIdByAssetKitId.get(slice.assetKitId)
+          : undefined);
+      if (kitId) kitIds.add(kitId);
+    } else {
+      for (const membership of slice.assetKits ?? []) {
+        if (membership?.kitId) kitIds.add(membership.kitId);
+      }
+    }
+    if (kitIds.size > 0) kitIdsBySliceId.set(slice.id, kitIds);
+  }
+
+  return kitIdsBySliceId;
 }
 
 export async function getBookingFlags(

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -4394,6 +4394,11 @@ export async function checkinBooking({
               id: true,
               assetId: true,
               quantity: true,
+              // Kit provenance: which kit this slice came from, which survives
+              // the member being detached from the kit mid-booking. Required by
+              // `getKitIdsByBookingSlices`, so dropping either is a type error.
+              assetKitId: true,
+              sourceKitId: true,
               asset: {
                 select: {
                   id: true,
@@ -4452,7 +4457,24 @@ export async function checkinBooking({
     /** Map bookingAssets to flat asset array for downstream logic */
     const bookingFoundAssets = bookingFound.bookingAssets.map((ba) => ba.asset);
 
-    const kitIds = getKitIdsByAssets(bookingFoundAssets);
+    /**
+     * Kits to release, from BOTH directions.
+     *
+     * Live membership alone misses a kit whose member was detached while the
+     * booking ran; the booking's own slices alone miss a kit reached through a
+     * standalone row, which carries no provenance. A kit released redundantly
+     * is a no-op write; a kit missed stays stuck with no way out of the UI.
+     */
+    const sliceKitAssetIds = await getKitIdsByBookingSlices({
+      slices: bookingFound.bookingAssets,
+      organizationId,
+    });
+    const kitIds = [
+      ...new Set([
+        ...getKitIdsByAssets(bookingFoundAssets),
+        ...sliceKitAssetIds.keys(),
+      ]),
+    ];
     const hasKits = kitIds.length > 0;
 
     const isEarlyCheckin = isBookingEarlyCheckin(bookingFound.to!);
@@ -4573,8 +4595,13 @@ export async function checkinBooking({
     const assetsToCheckinSet = new Set(assetsToCheckin);
     const kitsToCheckin = hasKits
       ? kitIds.filter((kitId) => {
+          // Same union as the resolution above. Filtering on membership alone
+          // yields [] for a kit reached only through provenance, and `.every()`
+          // on [] is vacuously true — which would release it unconditionally.
           const kitAssetsInBooking = bookingFoundAssets.filter(
-            (asset) => asset.assetKits?.[0]?.kitId === kitId
+            (asset) =>
+              sliceKitAssetIds.get(kitId)?.has(asset.id) ||
+              asset.assetKits?.[0]?.kitId === kitId
           );
           return kitAssetsInBooking.every(
             (asset) =>
@@ -6094,18 +6121,55 @@ export async function partialCheckinBooking({
     const assetsBeingCheckedIn = bookingFoundAssets.filter((a) =>
       effectiveAssetIds.includes(a.id)
     );
-    const kitIdsBeingCheckedIn = getKitIdsByAssets(assetsBeingCheckedIn);
+    /**
+     * Kits touched by this session, from live membership AND from the
+     * booking's own slices. See `getKitIdsByBookingSlices` for why both.
+     */
+    const sliceKitAssetIds = await getKitIdsByBookingSlices({
+      slices: bookingFound.bookingAssets,
+      organizationId,
+    });
+    const beingCheckedInIds = new Set(assetsBeingCheckedIn.map((a) => a.id));
+    const kitIdsBeingCheckedIn = [
+      ...new Set([
+        ...getKitIdsByAssets(assetsBeingCheckedIn),
+        ...[...sliceKitAssetIds.entries()]
+          .filter(([, assetIds]) =>
+            [...assetIds].some((assetId) => beingCheckedInIds.has(assetId))
+          )
+          .map(([kitId]) => kitId),
+      ]),
+    ];
+
+    /**
+     * Slices still owed back on this booking. A kit is complete when this
+     * session accounts for every one of them, so slices reconciled by an
+     * earlier session must not keep the kit permanently short.
+     */
+    const outstandingAssetIds = new Set(
+      bookingFound.bookingAssets
+        .filter((ba) => ba.checkedInAt === null)
+        .map((ba) => ba.assetId)
+    );
+
+    const belongsToKit = (assetId: string, kitId: string, kitOfAsset?: string) =>
+      sliceKitAssetIds.get(kitId)?.has(assetId) || kitOfAsset === kitId;
 
     const completeKitIds: string[] = [];
     for (const kitId of kitIdsBeingCheckedIn) {
       const kitAssetsInBooking = bookingFoundAssets.filter(
-        (a) => a.assetKits?.[0]?.kitId === kitId
+        (a) =>
+          belongsToKit(a.id, kitId, a.assetKits?.[0]?.kitId) &&
+          outstandingAssetIds.has(a.id)
       );
-      const kitAssetsBeingCheckedIn = assetsBeingCheckedIn.filter(
-        (a) => a.assetKits?.[0]?.kitId === kitId
+      const kitAssetsBeingCheckedIn = assetsBeingCheckedIn.filter((a) =>
+        belongsToKit(a.id, kitId, a.assetKits?.[0]?.kitId)
       );
 
-      if (kitAssetsInBooking.length === kitAssetsBeingCheckedIn.length) {
+      if (
+        kitAssetsInBooking.length > 0 &&
+        kitAssetsInBooking.length === kitAssetsBeingCheckedIn.length
+      ) {
         completeKitIds.push(kitId);
       }
     }
@@ -9549,7 +9613,20 @@ export async function cancelBooking({
       });
     }
 
-    const kitIds = getKitIdsByAssets(cancelAssets);
+    /**
+     * Kits to release, from live membership AND the booking's own slices.
+     * A kit released redundantly is a no-op write; a kit missed stays stuck.
+     */
+    const cancelSliceKitIds = await getKitIdsByBookingSlices({
+      slices: bookingFound.bookingAssets,
+      organizationId,
+    });
+    const kitIds = [
+      ...new Set([
+        ...getKitIdsByAssets(cancelAssets),
+        ...cancelSliceKitIds.keys(),
+      ]),
+    ];
     const hasKits = kitIds.length > 0;
 
     const booking = await db.$transaction(async (tx) => {
@@ -11399,10 +11476,20 @@ export async function deleteBooking(
 
     const activeBookingAssets =
       activeBooking?.bookingAssets.map((ba) => ba.asset) ?? [];
-    const assetKitIds = activeBookingAssets
-      .map((a) => a.assetKits?.[0]?.kitId)
-      .filter((id): id is string => Boolean(id));
-    const uniqueKitIds = new Set(assetKitIds);
+    /**
+     * Kits to release, from live membership AND the booking's own slices.
+     * A kit released redundantly is a no-op write; a kit missed stays stuck.
+     */
+    const deleteSliceKitIds = activeBooking
+      ? await getKitIdsByBookingSlices({
+          slices: activeBooking.bookingAssets,
+          organizationId,
+        })
+      : new Map<string, Set<string>>();
+    const uniqueKitIds = new Set([
+      ...getKitIdsByAssets(activeBookingAssets),
+      ...deleteSliceKitIds.keys(),
+    ]);
     const hasKits = uniqueKitIds.size > 0;
 
     // Capture the active asset IDs BEFORE entering the tx: `Booking.delete`
@@ -12042,6 +12129,92 @@ export function getKitIdsByAssets(assets: AssetWithKitId[]) {
   return [...uniqueKitIds];
 }
 
+/**
+ * One `BookingAsset` row's kit provenance.
+ *
+ * Both provenance fields are REQUIRED, deliberately. `getKitIdsByAssets` above
+ * tolerates an unprojected relation with a defensive `?.`, which lets a narrow
+ * `select` resolve silently to zero kits. Here that silence is the failure mode
+ * being designed out: with required props, a caller that forgets to project
+ * them is a type error rather than a no-op that leaves a kit stuck.
+ */
+type BookingSliceKitProvenance = {
+  assetId: string;
+  assetKitId: string | null;
+  sourceKitId: string | null;
+};
+
+/**
+ * Release-path sibling of {@link getKitIdsByAssets}: resolves kits from the
+ * BOOKING's own rows rather than from the assets' current membership.
+ *
+ * A kit whose member was detached while the booking was live is invisible to
+ * membership-based resolution, so nothing releases it and `Kit.status` stays
+ * CHECKED_OUT with nothing out. The booking's rows still remember which kit the
+ * slice came from, so they can answer where membership cannot.
+ *
+ * Two legs, mirroring {@link computeBookingKitDrift}: `sourceKitId` is the
+ * durable pointer that survives the detach, and `assetKitId` resolved through
+ * `AssetKit` is the legacy fallback. Keep both. The
+ * "assetKitId non-null implies sourceKitId non-null" invariant is enforced by
+ * code alone with no CHECK constraint, and the migration lands before the code,
+ * so a rolling deploy can still write a kit-driven row with a NULL
+ * `sourceKitId`.
+ *
+ * Returns kit id to the asset ids this booking took from that kit, because the
+ * completeness gates that consume it filter at that grain.
+ *
+ * @param client Pass the active `tx` if ever called inside a transaction. Every
+ *               caller today resolves before opening one.
+ *
+ * ALWAYS UNION the result with {@link getKitIdsByAssets}, never substitute it.
+ * A standalone slice carries no provenance by design even when its asset is a
+ * live kit member, and the acquire paths stamp that kit CHECKED_OUT from
+ * membership — so provenance alone would leave exactly those kits stuck.
+ * Never use on an acquire path: it names kits the asset has already left.
+ */
+export async function getKitIdsByBookingSlices({
+  slices,
+  organizationId,
+  client = db,
+}: {
+  slices: BookingSliceKitProvenance[];
+  organizationId: Organization["id"];
+  client?: Pick<typeof db, "assetKit">;
+}): Promise<Map<string, Set<string>>> {
+  // Truthiness rather than `!== null`: test fixtures hand us rows whose
+  // provenance columns are absent entirely, and `undefined !== null` is true.
+  const legacyAssetKitIds = slices
+    .filter((s) => !s.sourceKitId && Boolean(s.assetKitId))
+    .map((s) => s.assetKitId as string);
+
+  let kitIdByAssetKitId = new Map<string, string>();
+  if (legacyAssetKitIds.length > 0) {
+    // Deliberately not `assertAssetKitsBelongToOrg`: that throws a 400 when a
+    // row is missing, and a concurrent detach makes a row legitimately vanish
+    // between these two reads — the very operation this resolver exists for.
+    // A missing row means "no kit to release", not "reject the check-in".
+    const rows = await client.assetKit.findMany({
+      where: { id: { in: legacyAssetKitIds }, organizationId },
+      select: { id: true, kitId: true },
+    });
+    kitIdByAssetKitId = new Map(rows.map((r) => [r.id, r.kitId]));
+  }
+
+  const assetIdsByKitId = new Map<string, Set<string>>();
+  for (const slice of slices) {
+    const kitId =
+      slice.sourceKitId ??
+      (slice.assetKitId ? kitIdByAssetKitId.get(slice.assetKitId) : undefined);
+    if (!kitId) continue;
+    const bucket = assetIdsByKitId.get(kitId) ?? new Set<string>();
+    bucket.add(slice.assetId);
+    assetIdsByKitId.set(kitId, bucket);
+  }
+
+  return assetIdsByKitId;
+}
+
 export async function getBookingFlags(
   booking: Pick<Booking, "id" | "from" | "to"> & {
     assetIds: Asset["id"][];
@@ -12250,6 +12423,15 @@ export async function bulkDeleteBookings({
       (booking) => booking.status === "OVERDUE" || booking.status === "ONGOING"
     );
 
+    /**
+     * Resolved before the transaction opens: the legacy provenance hop is a
+     * read, and holding a transaction open across it buys nothing.
+     */
+    const bulkDeleteSliceKitIds = await getKitIdsByBookingSlices({
+      slices: overdueOrOngoingBookings.flatMap((b) => b.bookingAssets),
+      organizationId,
+    });
+
     /** We have to cancel scheduler for the bookings */
     const bookingsWithSchedulerReference = bookings.filter(
       (booking) => !!booking.activeSchedulerReference
@@ -12270,11 +12452,12 @@ export async function bulkDeleteBookings({
           booking.bookingAssets.map((ba) => ba.asset)
         );
 
-        const allKitIds = allAssets
-          .map((asset) => asset.assetKits?.[0]?.kitId)
-          .filter((id): id is string => Boolean(id));
-
-        const uniqueKitIds = new Set(allKitIds);
+        // Union of live membership and booking-slice provenance — a kit whose
+        // member was detached mid-booking is invisible to membership alone.
+        const uniqueKitIds = new Set([
+          ...getKitIdsByAssets(allAssets),
+          ...bulkDeleteSliceKitIds.keys(),
+        ]);
 
         await tx.asset.updateMany({
           where: {
@@ -12657,6 +12840,15 @@ export async function bulkCancelBookings({
       (b) => b.status === "ONGOING" || b.status === "OVERDUE"
     );
 
+    /**
+     * Resolved before the transaction opens: the legacy provenance hop is a
+     * read, and holding a transaction open across it buys nothing.
+     */
+    const bulkCancelSliceKitIds = await getKitIdsByBookingSlices({
+      slices: ongoingOrOverdueBookings.flatMap((b) => b.bookingAssets),
+      organizationId,
+    });
+
     /** We have to cancel scheduler for the bookings */
     const bookingsWithSchedulerReference = bookings.filter(
       (booking) => !!booking.activeSchedulerReference
@@ -12674,11 +12866,12 @@ export async function bulkCancelBookings({
         const allAssets = ongoingOrOverdueBookings.flatMap((b) =>
           b.bookingAssets.map((ba) => ba.asset)
         );
-        const allKitIds = allAssets
-          .map((a) => a.assetKits?.[0]?.kitId)
-          .filter((id): id is string => Boolean(id));
-
-        const uniqueKitIds = new Set(allKitIds);
+        // Union of live membership and booking-slice provenance — a kit whose
+        // member was detached mid-booking is invisible to membership alone.
+        const uniqueKitIds = new Set([
+          ...getKitIdsByAssets(allAssets),
+          ...bulkCancelSliceKitIds.keys(),
+        ]);
 
         /** Making assets available */
         await tx.asset.updateMany({

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -6593,26 +6593,59 @@ export async function partialCheckinBooking({
         for (const assetId of qtyAssetIdsTouched) {
           const slices = bookingSlicesByAssetId.get(assetId) ?? [];
           if (slices.length === 0) continue;
+
+          /**
+           * What each slice owes: the units it actually sent out.
+           *
+           * Both halves of the decision below measure against this one number.
+           * As the CAPACITY it stops a slice that never left from absorbing an
+           * untagged return — the mobile payload names no slice, so its units
+           * are spread standalone-first, and every unit swallowed by a slice
+           * that owes nothing is one the kit-driven slice needs to settle. As
+           * the THRESHOLD it settles a slice on what it owes rather than what
+           * it booked. Sizing the two differently strands a kit either way.
+           *
+           * A slice marked out that the sessions cannot size falls back to its
+           * booked quantity, which holds its kit — the safe direction while the
+           * two disagree. One that never left owes nothing at all.
+           */
+          const owedBySlice = new Map<string, number>();
+          for (const slice of slices) {
+            // Whether a slice left is answered by its OWN marker and nothing
+            // else. `computeBookingAssetsSliceRemainingToCheckOut` reports a
+            // slice with no session claims as fully dispatched whenever the
+            // booking is live and the ASSET reads CHECKED_OUT — and that status
+            // is global, so a sibling slice being out is enough to trigger it.
+            // Sizing from that alone hands a slice that never moved the whole
+            // obligation of one that did.
+            if (!slice.checkedOutAt) {
+              owedBySlice.set(slice.id, 0);
+              continue;
+            }
+            const dispatched =
+              slice.quantity - (remainingToCheckOutBySlice.get(slice.id) ?? 0);
+            owedBySlice.set(
+              slice.id,
+              dispatched > 0 ? dispatched : slice.quantity
+            );
+          }
+
           // The asset's FULL slice set, so a claim tagged to one slice never
           // leaks into a sibling and the untagged pool is capped per slice.
           const attributed = attributeDispositionsByBookingAsset({
             bookingAssetRows: slices.map((slice) => ({
               id: slice.id,
-              quantity: slice.quantity,
+              quantity: owedBySlice.get(slice.id) ?? 0,
               assetKitId: slice.assetKitId,
             })),
             consumptionLogs: logsByAssetId.get(assetId) ?? [],
           });
           for (const slice of slices) {
-            const dispatched =
-              slice.quantity - (remainingToCheckOutBySlice.get(slice.id) ?? 0);
-            // A marked slice that reports nothing dispatched cannot be sized
-            // from the sessions, so it falls back to its booked quantity and
-            // holds the kit — the safe direction while the two disagree.
-            const obligation = dispatched > 0 ? dispatched : slice.quantity;
+            const owed = owedBySlice.get(slice.id) ?? 0;
             if (
               isOutstandingSlice(slice) &&
-              (attributed.get(slice.id) ?? 0) >= obligation
+              owed > 0 &&
+              (attributed.get(slice.id) ?? 0) >= owed
             ) {
               settledSliceIds.add(slice.id);
             }

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -6522,9 +6522,15 @@ export async function partialCheckinBooking({
       }
 
       /**
-       * A QUANTITY_TRACKED slice is finished only when its OWN booked quantity
-       * is accounted for. Read this booking's dispositions back — including the
-       * rows written above — and spread them with
+       * A QUANTITY_TRACKED slice is finished when everything that actually LEFT
+       * on it is accounted for — not when its booked quantity is. Progressive
+       * checkout stamps `checkedOutAt` as soon as any unit goes, so a slice
+       * booked at 10 with 3 in the field is ordinary; measuring against 10 would
+       * leave it outstanding after all 3 came back, and its kit checked out with
+       * nothing of it anywhere.
+       *
+       * Read this booking's dispositions back — including the rows written above
+       * — and spread them with
        * {@link attributeDispositionsByBookingAsset}, the same function every
        * read site uses: a log tagged with a slice lands on it, an untagged one
        * greedy-fills in `compareSlicesForGreedyFill` order.
@@ -6542,6 +6548,22 @@ export async function partialCheckinBooking({
         ...new Set(qtySummaries.map((s) => s.assetId)),
       ];
       if (qtyAssetIdsTouched.length > 0) {
+        /**
+         * Units dispatched per slice = booked minus what is still checkoutable.
+         * {@link computeBookingAssetsSliceRemainingToCheckOut} is the reader
+         * every checkout surface already uses, including its all-at-once
+         * fallback, so a slice sent out by the button reports its whole
+         * quantity dispatched and settles exactly as it always has.
+         */
+        const remainingToCheckOutBySlice =
+          await computeBookingAssetsSliceRemainingToCheckOut(
+            tx,
+            id,
+            qtyAssetIdsTouched.flatMap((assetId) =>
+              (bookingSlicesByAssetId.get(assetId) ?? []).map((s) => s.id)
+            )
+          );
+
         const dispositionLogs = await tx.consumptionLog.findMany({
           where: {
             bookingId: id,
@@ -6582,9 +6604,15 @@ export async function partialCheckinBooking({
             consumptionLogs: logsByAssetId.get(assetId) ?? [],
           });
           for (const slice of slices) {
+            const dispatched =
+              slice.quantity - (remainingToCheckOutBySlice.get(slice.id) ?? 0);
+            // A marked slice that reports nothing dispatched cannot be sized
+            // from the sessions, so it falls back to its booked quantity and
+            // holds the kit — the safe direction while the two disagree.
+            const obligation = dispatched > 0 ? dispatched : slice.quantity;
             if (
               isOutstandingSlice(slice) &&
-              (attributed.get(slice.id) ?? 0) >= slice.quantity
+              (attributed.get(slice.id) ?? 0) >= obligation
             ) {
               settledSliceIds.add(slice.id);
             }


### PR DESCRIPTION
Closes #2971.

## What

A kit could be left reading `CHECKED_OUT` after its booking completed, with nothing
out. That is not a cosmetic badge: such a kit **cannot be added to a live booking**,
is **filtered out of the add-to-kit picker**, shows as unavailable in the booking kit
picker, and has **no way to be cleared from the UI**.

Kit release resolved from the assets' **current** membership (`getKitIdsByAssets`),
so detaching a kit's members while the booking ran made the kit invisible when the
booking ended.

Release paths now **union** membership with the booking's own slice provenance —
`BookingAsset.sourceKitId`, falling back to `assetKitId → AssetKit.kitId`.

## The design decision worth reviewing: union, not substitution

My first plan was to *replace* membership resolution with provenance. That is wrong,
and it would have created this same bug on a commoner path.

A **standalone** slice carries `assetKitId NULL` + `sourceKitId NULL` by design, even
when its asset **is** a live kit member — the scanner drawer skips the kit slice for a
directly-scanned asset. The acquire paths stamp that kit `CHECKED_OUT` from live
membership. So provenance-only release would leave exactly those kits stuck.

The asymmetry that settles it: every release write is `KitStatus.AVAILABLE` through an
org-scoped `updateMany`, so a superfluous kit id is a redundant no-op write, while a
missing one is a permanently stuck kit. Union is the safe direction.

## Changed vs unchanged

**Changed (release):** `checkinBooking`, `partialCheckinBooking`, `cancelBooking`,
`deleteBooking`, `bulkDeleteBookings`, `bulkCancelBookings`.

The last three **inlined** the lookup instead of calling the helper. A signature change
would have left them silently on the old behaviour **with a fully green build** — the
type checker cannot see them. `grep -n 'assetKits?.\[0\]?.kitId'` is the only reliable
way to enumerate coverage here.

**Unchanged (acquire):** `checkoutBooking`, `fulfilModelRequestsAndCheckout`,
`partialCheckoutBooking`. Broadening the kit set there stamps `CHECKED_OUT` on a kit
the asset has already left — minting the very state this PR fixes. Their completeness
loop bodies stay on membership too, so the gate counts the same population it stamps.

`getKitIdsByAssets` is untouched: it still correctly serves all three acquire paths and
two route loaders.

## Behaviour changes to be aware of

1. **A new false-release class.** On main a detached kit is structurally unreachable
   from any release path. Now: detach A from kit K, refill K, K goes out legitimately on
   booking C — cancelling the **old** booking B flips K available via B's residue
   provenance. Narrower than the bug being fixed, but real.
2. **Partial check-in now filters to outstanding slices.** Without it, residue inflates
   the "assets in this kit" side forever and the kit never reads complete. This also
   affects the membership leg, so split-session partial check-ins now clear kits in
   general. That is a fix, and it is broader than #2971.
3. **Multi-kit.** `getKitIdsByAssets` reads only `assetKits[0]`, so an asset in two kits
   silently released one. The provenance leg returns every `sourceKitId`, so release now
   issues writes main never issued.

## Not covered

`mergeStandaloneCollisionsForKitDetachment` **deletes** the kit-driven row and folds its
quantity into a pre-existing standalone row. After that, no row on the booking carries
`sourceKitId`, so this fix cannot reach it. Worth a follow-up; not a regression.

## Verification

**Real Postgres, all migrations, real services, no mocks.** Same script, both versions:

| Step | `origin/main` | this branch |
| --- | --- | --- |
| 3. checked out | kit CHECKED_OUT | kit CHECKED_OUT |
| 4. asset detached from kit while live | kit CHECKED_OUT | kit CHECKED_OUT |
| 5. **booking checked in** | kit **CHECKED_OUT** (stuck) | kit **AVAILABLE** |

**Tests.** Nothing covered this in either direction before. Added 5 unit tests for the
resolver (sourceKitId, legacy `assetKitId` hop with its org scope asserted, standalone
slice ignored, vanished membership tolerated rather than throwing) and 1 behavioural
test on `checkinBooking`. The behavioural one goes **red** against main's logic.

Full webapp suite **5,772 pass**, typecheck clean, eslint clean.

## Relationship to #2969

#2969 was the circuit breaker: a stale kit can no longer stamp assets. This removes the
cause. Independent, no conflict.

## Deliberately separate

#2970 — neither bulk path calls `reconcileAssetStatusForBookingExit`, so both blanket-
flip assets to available while the singular paths reconcile. Asset-status defect, its own
PR. Untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kits are now correctly returned to **Available** when assets are detached during an active booking.
  * Partial check-ins release kits only after all associated booking slices are settled.
  * Kits remain **Checked Out** when slices have outstanding quantities or were checked out after loading.
  * Releases now reflect quantities actually dispatched, including untagged mobile returns.
  * Check-in, cancellation, and deletion flows more reliably release associated kits.
  * Improved handling of legacy booking records and missing membership data without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->