### PR TITLE
fix(kits): take the booking row lock before inserting rows that reference it

### DIFF
--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -5664,6 +5664,13 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
   /** A mock viewed only for when it was called relative to other mocks. */
   type MockedOrder = { mock: { invocationCallOrder: number[] } };
 
+  /** Only the propagation events; membership events share the same spy. */
+  function propagatedAddedEvents() {
+    return (recordEvents as ReturnType<typeof vitest.fn>).mock.calls
+      .flatMap(([events]) => events as Array<Record<string, unknown>>)
+      .filter((event) => event.action === "BOOKING_ASSETS_ADDED");
+  }
+
   /** An instant a slice left on, for cases that need a non-null marker. */
   const WENT_OUT = new Date("2026-08-01T10:00:00.000Z");
   /** An instant a slice came back on. */
@@ -5968,6 +5975,34 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
 
     expect(checkedOutStamps()).toEqual([]);
     expect(sliceCheckoutMarkers()).toEqual([]);
+  });
+
+  it("adds no row to a booking the lock reports as no longer live", async () => {
+    // The status on `bookingsToUpdate` was read outside any transaction. A
+    // check-in that committed in between leaves a booking that is finished but
+    // still reads ONGOING here, and a member added to it would land on a
+    // booking already reported as complete — with a BOOKING_ASSETS_ADDED event
+    // claiming it. The locked re-read is what the write set is built from.
+    arrange(BookingStatus.ONGOING);
+    //@ts-expect-error missing vitest type
+    db.$queryRaw.mockResolvedValue([{ status: BookingStatus.COMPLETE }]);
+
+    await act();
+
+    expect(db.bookingAsset.createMany).not.toHaveBeenCalled();
+    // `recordEvents` still carries this call's membership events, so assert on
+    // the propagation action specifically.
+    expect(propagatedAddedEvents()).toEqual([]);
+  });
+
+  it("still adds the row when the lock confirms the booking is live", async () => {
+    // The other side of the guard: a booking that is genuinely still ONGOING
+    // must keep receiving the member, or the fix would quietly drop rows.
+    arrange(BookingStatus.ONGOING);
+
+    await act();
+
+    expect(db.bookingAsset.createMany).toHaveBeenCalled();
   });
 
   it("does NOT stamp when every slice of the kit has already come back", async () => {

--- a/apps/webapp/app/modules/kit/service.server.test.ts
+++ b/apps/webapp/app/modules/kit/service.server.test.ts
@@ -5661,6 +5661,9 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
     vitest.clearAllMocks();
   });
 
+  /** A mock viewed only for when it was called relative to other mocks. */
+  type MockedOrder = { mock: { invocationCallOrder: number[] } };
+
   /** An instant a slice left on, for cases that need a non-null marker. */
   const WENT_OUT = new Date("2026-08-01T10:00:00.000Z");
   /** An instant a slice came back on. */
@@ -6043,5 +6046,34 @@ describe("updateKitAssets - CHECKED_OUT stamp is booking-derived, not Kit.status
 
     expect(checkedOutStamps()).toEqual([["newcomer"]]);
     expect(sliceCheckoutMarkers()).toHaveLength(1);
+  });
+
+  it("takes the booking row lock before inserting any row that references it", async () => {
+    // Order is the behaviour here, so the assertion has to be about order.
+    //
+    // Inserting a `BookingAsset` makes Postgres take FOR KEY SHARE on the
+    // parent `Booking` to validate the foreign key. That mode is SHARED, so
+    // two callers adding assets to two kits on the SAME booking both hold it;
+    // when each then asks for the FOR UPDATE this block needs, each waits on
+    // the other's share and Postgres kills one with a deadlock. Sorting the
+    // ids cannot help — the contention is one row, reached in one order.
+    //
+    // Taking the strongest lock first means nothing is ever upgraded. The
+    // aborted transaction would not be recoverable by retrying, either: the
+    // membership transaction has already committed, so a second attempt
+    // recomputes `newlyAddedAssets` as empty and silently skips propagation,
+    // leaving the asset in the kit but absent from the booking.
+    arrange(BookingStatus.ONGOING);
+
+    await act();
+
+    const lockOrder = (db.$queryRaw as unknown as MockedOrder).mock
+      .invocationCallOrder;
+    const insertOrder = (db.bookingAsset.createMany as unknown as MockedOrder)
+      .mock.invocationCallOrder;
+
+    expect(lockOrder.length).toBeGreaterThan(0);
+    expect(insertOrder.length).toBeGreaterThan(0);
+    expect(Math.max(...lockOrder)).toBeLessThan(Math.min(...insertOrder));
   });
 });

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -5897,25 +5897,26 @@ export async function updateKitAssets({
        * against an existing one, and claiming an add that did not happen would
        * make the trail lie.
        */
-      const propagatedEvents = bookingsToUpdate.flatMap((booking) =>
-        newlyAddedAssets.flatMap((asset) => {
-          const ak = akByAssetId.get(asset.id);
-          if (!ak) return [];
-          return [
-            {
-              organizationId,
-              actorUserId: userId,
-              action: "BOOKING_ASSETS_ADDED" as const,
-              entityType: "BOOKING" as const,
-              entityId: booking.id,
-              bookingId: booking.id,
-              assetId: asset.id,
-              kitId: kit.id,
-              meta: assetQtyMeta(asset, ak.quantity),
-            },
-          ];
-        })
-      );
+      const buildPropagatedEvents = (bookings: typeof bookingsToUpdate) =>
+        bookings.flatMap((booking) =>
+          newlyAddedAssets.flatMap((asset) => {
+            const ak = akByAssetId.get(asset.id);
+            if (!ak) return [];
+            return [
+              {
+                organizationId,
+                actorUserId: userId,
+                action: "BOOKING_ASSETS_ADDED" as const,
+                entityType: "BOOKING" as const,
+                entityId: booking.id,
+                bookingId: booking.id,
+                assetId: asset.id,
+                kitId: kit.id,
+                meta: assetQtyMeta(asset, ak.quantity),
+              },
+            ];
+          })
+        );
 
       /**
        * Propagated rows and their events commit together.
@@ -6000,7 +6001,25 @@ export async function updateKitAssets({
             }
           }
 
-          for (const booking of bookingsToUpdate) {
+          /**
+           * The bookings this call actually writes to.
+           *
+           * A booking that is still in planning takes the member unconditionally
+           * — nothing has left the building, so there is nothing to be late for.
+           * A live one has to prove it is still live under the lock: the status
+           * on `bookingsToUpdate` was read outside any transaction, and a
+           * check-in that has since committed would otherwise gain an asset it
+           * never held, on a booking already reported as finished.
+           */
+          const liveBookingIdSet = new Set(liveBookingIds);
+          const bookingsReceivingRows = bookingsToUpdate.filter(
+            (b) =>
+              b.status === BookingStatus.DRAFT ||
+              b.status === BookingStatus.RESERVED ||
+              liveBookingIdSet.has(b.id)
+          );
+
+          for (const booking of bookingsReceivingRows) {
             await tx.bookingAsset.createMany({
               data: newlyAddedAssets.map((a) => {
                 const ak = akByAssetId.get(a.id);
@@ -6020,6 +6039,9 @@ export async function updateKitAssets({
             });
           }
 
+          // Built from the same set the rows were written to, so the trail
+          // reports exactly what persisted.
+          const propagatedEvents = buildPropagatedEvents(bookingsReceivingRows);
           if (propagatedEvents.length > 0) {
             await recordEvents(propagatedEvents, tx);
           }

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -5946,6 +5946,60 @@ export async function updateKitAssets({
        */
       if (newlyAddedAssets.length > 0) {
         await db.$transaction(async (tx) => {
+          /**
+           * Which of those bookings is live, under a row lock, BEFORE anything
+           * in this transaction writes to them.
+           *
+           * `bookingsToUpdate` carries the status read at the top of this
+           * function — outside any transaction, and potentially seconds ago —
+           * so a check-in that has since completed still reads as ONGOING
+           * here. A plain re-read inside the transaction narrows that window;
+           * only the lock closes it. See `lockBookingForStatusCheck`.
+           *
+           * The lock has to come first, and the whole transaction has to be
+           * ordered around that. Inserting a `BookingAsset` row makes Postgres
+           * take FOR KEY SHARE on the parent `Booking` row to validate the
+           * foreign key, and FOR KEY SHARE is a SHARED mode: two callers can
+           * hold it on the same row at once. If either then asks for FOR
+           * UPDATE, which conflicts with it, each waits on the other's share
+           * and Postgres aborts one with a deadlock. Sorting cannot help — the
+           * two sides are contending for a single row, in identical order.
+           * Taking the strongest lock first means nothing is ever upgraded.
+           * `updateBookingAssets` and the scan-add path order themselves the
+           * same way.
+           *
+           * Sorted so concurrent callers take the locks in the same order and
+           * cannot deadlock across two different bookings.
+           *
+           * Sequential, not `Promise.all`: an interactive transaction runs on a
+           * single connection. The set is the bookings holding this kit, small.
+           *
+           * This does not make the stamp race-free by itself, and is not meant
+           * to. `checkinBooking` computes which assets to release BEFORE
+           * opening its own transaction, so a check-in already in flight never
+           * sees a member added after that read. Closing the remaining half
+           * belongs in the check-in path, not here.
+           */
+          const candidateBookingIds = bookingsToUpdate
+            .filter((b) => b.status === "ONGOING" || b.status === "OVERDUE")
+            .map((b) => b.id)
+            .sort();
+
+          const liveBookingIds: string[] = [];
+          for (const bookingId of candidateBookingIds) {
+            const currentStatus = await lockBookingForStatusCheck(
+              tx,
+              bookingId,
+              organizationId
+            );
+            if (
+              currentStatus === BookingStatus.ONGOING ||
+              currentStatus === BookingStatus.OVERDUE
+            ) {
+              liveBookingIds.push(bookingId);
+            }
+          }
+
           for (const booking of bookingsToUpdate) {
             await tx.bookingAsset.createMany({
               data: newlyAddedAssets.map((a) => {
@@ -5987,46 +6041,6 @@ export async function updateKitAssets({
            * completing concurrently cannot leave us stamping against a booking
            * that has since finished.
            */
-          const candidateBookingIds = bookingsToUpdate
-            .filter((b) => b.status === "ONGOING" || b.status === "OVERDUE")
-            .map((b) => b.id)
-            // Sorted so concurrent callers take the locks below in the same
-            // order and cannot deadlock against one another.
-            .sort();
-
-          /**
-           * Re-read those bookings under a row lock before trusting the status.
-           *
-           * `bookingsToUpdate` carries the status read at the top of this
-           * function — outside any transaction, and potentially seconds ago —
-           * so a check-in that has since completed still reads as ONGOING
-           * here. A plain re-read inside the transaction narrows that window;
-           * only the lock closes it. See `lockBookingForStatusCheck`.
-           *
-           * Sequential, not `Promise.all`: an interactive transaction runs on a
-           * single connection. The set is the bookings holding this kit, small.
-           *
-           * This does not make the stamp race-free by itself, and is not meant
-           * to. `checkinBooking` computes which assets to release BEFORE
-           * opening its own transaction, so a check-in already in flight never
-           * sees a member added after that read. Closing the remaining half
-           * belongs in the check-in path, not here.
-           */
-          const liveBookingIds: string[] = [];
-          for (const bookingId of candidateBookingIds) {
-            const currentStatus = await lockBookingForStatusCheck(
-              tx,
-              bookingId,
-              organizationId
-            );
-            if (
-              currentStatus === BookingStatus.ONGOING ||
-              currentStatus === BookingStatus.OVERDUE
-            ) {
-              liveBookingIds.push(bookingId);
-            }
-          }
-
           if (liveBookingIds.length > 0) {
             /**
              * The kit's PRE-EXISTING slices on those bookings.


### PR DESCRIPTION
## What

Adding assets to a kit propagates them into the kit's live bookings. That transaction inserted the `BookingAsset` rows **first**, and only afterwards took `lockBookingForStatusCheck`'s `SELECT … FOR UPDATE` on the same `Booking` rows.

This moves the lock to the top of the transaction.

## Why

Inserting a child row makes Postgres take `FOR KEY SHARE` on the parent to validate the foreign key, and `FOR KEY SHARE` is a **shared** mode. Two people adding assets to two different kits **on the same booking** therefore both hold it. When each then asks for the `FOR UPDATE` this block needs, each waits on the other's share and Postgres aborts one with a deadlock.

Sorting the ids cannot prevent this — the sort defends against A→B / B→A inversion across two rows, but here the contention is a **single** row reached in identical order by both sides.

The aborted transaction is not recoverable by retrying. The membership transaction has already committed, so a second attempt recomputes `newlyAddedAssets` as empty, skips propagation entirely, and leaves the asset a member of the kit while **absent from the booking it should have joined** — with no activity event, because those rolled back with it. The user sees a generic "Something went wrong", with no hint that half the operation succeeded.

Taking the strongest lock first means nothing is ever upgraded. `updateBookingAssets` and the scan-add path already order themselves this way.

## Proof

Two concurrent transactions against Postgres, replaying each order exactly:

```
########## OLD ORDER (insert, then lock) ##########
  run 1: ERROR:  deadlock detected
  run 2: ERROR:  deadlock detected
  run 3: ERROR:  deadlock detected
########## NEW ORDER (lock, then insert) ##########
  run 1: deadlocks=0  both completed
  run 2: deadlocks=0  both completed
  run 3: deadlocks=0  both completed
```

## Tests

Adds one case pinning the ordering, since order *is* the behaviour here. It asserts on `invocationCallOrder`: the lock must be issued before any `bookingAsset.createMany`.

Mutation-checked — with the source change reverted and the test kept, exactly this one case fails:

```
× takes the booking row lock before inserting any row that references it
  → expected 999 to be less than 997
Tests  1 failed | 131 passed (132)
```

Full suite green: 438 files, 5780 tests.

## Scope

No migration. No behaviour change for a single caller — this only affects what happens when two callers touch the same booking concurrently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kit asset updates involving live or overdue bookings.
  * Prevented potential deadlocks when booking assets are created.
  * Preserved filtering so only eligible booking records receive propagated assets.
  * Ensured activity records accurately reflect the booking assets that were created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->