### PR TITLE
fix: notify custodian when a reserved booking is reverted to draft

### DIFF
--- a/apps/webapp/app/modules/booking/email-helpers.ts
+++ b/apps/webapp/app/modules/booking/email-helpers.ts
@@ -242,6 +242,18 @@ export const cancelledBookingEmailContent = (
   });
 
 /**
+ * This is the content of the email sent to the custodian when a reserved
+ * booking is reverted back to draft (e.g. an admin sends a reservation
+ * request back for changes). The booking still exists — the recipient can
+ * open it, adjust it and reserve it again.
+ */
+export const revertedToDraftEmailContent = (args: BasicEmailContentArgs) =>
+  baseBookingTextEmailContent({
+    ...args,
+    emailContent: `Your booking reservation has been reverted to draft: "${args.bookingName}". You can review the booking, make changes and submit it again.`,
+  });
+
+/**
  * Booking is extended
  *
  * This email is sent when a booking's end date is extended.

--- a/apps/webapp/app/modules/booking/notification-recipients.server.ts
+++ b/apps/webapp/app/modules/booking/notification-recipients.server.ts
@@ -36,6 +36,7 @@ import { Logger } from "~/utils/logger";
  * - `CHECKIN` — booking assets have been checked in (completed)
  * - `OVERDUE` — booking has passed its end date without checkin
  * - `CANCEL` — booking was cancelled by a user
+ * - `REVERT_TO_DRAFT` — a reserved booking was sent back to draft
  * - `EXTEND` — booking end date was extended
  * - `DELETE` — booking was permanently deleted
  * - `UPDATE` — booking fields or assets were modified
@@ -47,6 +48,7 @@ export type BookingEventType =
   | "CHECKIN"
   | "OVERDUE"
   | "CANCEL"
+  | "REVERT_TO_DRAFT"
   | "EXTEND"
   | "DELETE"
   | "UPDATE";

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -24,6 +24,7 @@ import {
 } from "@shelf/labels";
 
 import { db } from "~/database/db.server";
+import { sendEmail } from "~/emails/mail.server";
 import * as activityEventService from "~/modules/activity-event/service.server";
 import { fulfilModelRequestsForAssets } from "~/modules/booking-model-request/service.server";
 import * as bookingNoteService from "~/modules/booking-note/service.server";
@@ -35,6 +36,7 @@ import { ShelfError } from "~/utils/error";
 import { wrapBookingStatusForNote } from "~/utils/markdoc-wrappers";
 import { scheduler } from "~/utils/scheduler.server";
 import { sendBookingUpdatedEmail } from "./email-helpers";
+import { getBookingNotificationRecipients } from "./notification-recipients.server";
 import {
   createBooking,
   partialCheckinBooking,
@@ -443,6 +445,14 @@ vitest.mock("~/modules/organization/service.server", () => ({
       displayName: null,
     },
   ]),
+}));
+
+// why: recipient resolution has its own tests
+// (notification-recipients.server.test.ts). Mocking the resolver lets each
+// test control the resolved list so the email fan-out can be asserted without
+// real org-settings lookups. Default: nobody resolves, so no emails fire.
+vitest.mock("./notification-recipients.server", () => ({
+  getBookingNotificationRecipients: vitest.fn().mockResolvedValue([]),
 }));
 
 // why: preventing actual job scheduling and queue operations during tests
@@ -7249,11 +7259,13 @@ describe("revertBookingToDraft", () => {
     const result = await revertBookingToDraft({
       id: "booking-1",
       organizationId: "org-1",
+      hints: mockClientHints,
     });
 
     expect(db.booking.update).toHaveBeenCalledWith({
       where: { id: "booking-1" },
       data: { status: BookingStatus.DRAFT },
+      include: expect.any(Object),
     });
     expect(result).toEqual(draftBooking);
   });
@@ -7266,8 +7278,86 @@ describe("revertBookingToDraft", () => {
     db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
 
     await expect(
-      revertBookingToDraft({ id: "booking-1", organizationId: "org-1" })
+      revertBookingToDraft({
+        id: "booking-1",
+        organizationId: "org-1",
+        hints: mockClientHints,
+      })
     ).rejects.toThrow(ShelfError);
+  });
+
+  // why: regression — reverting a reservation used to be silent. The custodian
+  // submitted a request, an admin sent it back, and no email went out (every
+  // other lifecycle transition emails). This pins the notification in place.
+  it("emails the resolved recipients when a reservation is reverted", async () => {
+    const custodianUser = {
+      id: "user-2",
+      email: "custodian@example.com",
+      firstName: "Custodian",
+      lastName: "User",
+      displayName: null,
+      dateFormat: null,
+      timeFormat: null,
+      weekStart: null,
+      timeZone: null,
+    };
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.RESERVED,
+      custodianUserId: "user-2",
+    };
+    const draftBooking = {
+      ...mockBooking,
+      status: BookingStatus.DRAFT,
+      custodianUser,
+      custodianTeamMember: null,
+      creator: custodianUser,
+      notificationRecipients: [],
+      organization: {
+        name: "Test Org",
+        customEmailFooter: null,
+        owner: { email: "owner@example.com" },
+      },
+      _count: { bookingAssets: mockBooking.bookingAssets.length },
+    };
+
+    //@ts-expect-error missing vitest type
+    db.booking.findUniqueOrThrow.mockResolvedValue(mockBooking);
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue(draftBooking);
+    vitest.mocked(getBookingNotificationRecipients).mockResolvedValueOnce([
+      {
+        email: custodianUser.email,
+        firstName: custodianUser.firstName,
+        lastName: custodianUser.lastName,
+        userId: custodianUser.id,
+        dateFormat: null,
+        timeFormat: null,
+        weekStart: null,
+        timeZone: null,
+        reason: "custodian",
+      },
+    ]);
+
+    await revertBookingToDraft({
+      id: "booking-1",
+      organizationId: "org-1",
+      userId: "admin-1",
+      hints: mockClientHints,
+    });
+
+    expect(getBookingNotificationRecipients).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "REVERT_TO_DRAFT",
+        editorUserId: "admin-1",
+      })
+    );
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "custodian@example.com",
+        subject: expect.stringContaining("reverted to draft"),
+      })
+    );
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -159,6 +159,7 @@ import {
   completedBookingEmailContent,
   deletedBookingEmailContent,
   extendBookingEmailContent,
+  revertedToDraftEmailContent,
   sendBookingUpdatedEmail,
   sendCheckinReminder,
 } from "./email-helpers";
@@ -9685,8 +9686,11 @@ export async function revertBookingToDraft({
   id,
   organizationId,
   userId,
+  hints,
 }: Pick<Booking, "id" | "organizationId"> & {
   userId?: User["id"];
+  /** Acting user's client hints — fallback prefs for the notification emails. */
+  hints: ClientHint;
 }) {
   try {
     const booking = await db.booking
@@ -9713,37 +9717,78 @@ export async function revertBookingToDraft({
       });
     }
 
-    const cancelledBooking = await db.booking.update({
+    const draftBooking = await db.booking.update({
       // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: booking id already org-checked via findUniqueOrThrow({where:{id,organizationId}}) at L2773; this is the write on that same proven id
       where: { id: booking.id },
       data: { status: BookingStatus.DRAFT },
+      // The custodian (and other notification recipients) are emailed below,
+      // so pull the same payload the other lifecycle emails use.
+      include: BOOKING_INCLUDE_FOR_EMAIL,
     });
 
     // Add activity log for booking revert to draft
     if (userId) {
       await createStatusTransitionNote({
-        bookingId: cancelledBooking.id,
+        bookingId: draftBooking.id,
         organizationId,
         fromStatus: booking.status,
         toStatus: BookingStatus.DRAFT,
         userId,
-        custodianUserId: cancelledBooking.custodianUserId || undefined,
+        custodianUserId: draftBooking.custodianUserId || undefined,
       });
     } else {
       // System-initiated revert (fallback)
       await createStatusTransitionNote({
-        bookingId: cancelledBooking.id,
+        bookingId: draftBooking.id,
         organizationId,
         fromStatus: booking.status,
         toStatus: BookingStatus.DRAFT,
-        custodianUserId: cancelledBooking.custodianUserId || undefined,
+        custodianUserId: draftBooking.custodianUserId || undefined,
       });
     }
 
     /** Cancels all scheduled events */
-    await cancelScheduler(cancelledBooking);
+    await cancelScheduler(draftBooking);
 
-    return cancelledBooking;
+    // Notify the custodian (and other configured recipients) that their
+    // reservation went back to draft — the same fan-out every other booking
+    // lifecycle transition (reserve, cancel, check-in, …) already does. The
+    // admin broadcast doesn't apply to this event type, and the acting user
+    // is excluded by the resolver.
+    const recipients = await getBookingNotificationRecipients({
+      booking: draftBooking,
+      eventType: "REVERT_TO_DRAFT",
+      organizationId,
+      editorUserId: userId,
+    });
+
+    if (recipients.length > 0) {
+      const custodian = draftBooking.custodianUser
+        ? resolveUserDisplayName(draftBooking.custodianUser)
+        : draftBooking.custodianTeamMember?.name ?? "";
+
+      await sendBookingEmailToAllRecipients({
+        recipients,
+        booking: draftBooking,
+        subject: `↩️ Booking reverted to draft (${draftBooking.name}) - shelf.nu`,
+        buildText: (prefs) =>
+          revertedToDraftEmailContent({
+            bookingName: draftBooking.name,
+            assetsCount: draftBooking._count.bookingAssets,
+            custodian,
+            from: draftBooking.from!,
+            to: draftBooking.to!,
+            bookingId: draftBooking.id,
+            prefs,
+            customEmailFooter: draftBooking.organization.customEmailFooter,
+          }),
+        buildHeading: () =>
+          `Your booking has been reverted to draft: "${draftBooking.name}"`,
+        hints,
+      });
+    }
+
+    return draftBooking;
   } catch (cause) {
     throw new ShelfError({
       cause,

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -9755,37 +9755,54 @@ export async function revertBookingToDraft({
     // lifecycle transition (reserve, cancel, check-in, …) already does. The
     // admin broadcast doesn't apply to this event type, and the acting user
     // is excluded by the resolver.
-    const recipients = await getBookingNotificationRecipients({
-      booking: draftBooking,
-      eventType: "REVERT_TO_DRAFT",
-      organizationId,
-      editorUserId: userId,
-    });
-
-    if (recipients.length > 0) {
-      const custodian = draftBooking.custodianUser
-        ? resolveUserDisplayName(draftBooking.custodianUser)
-        : draftBooking.custodianTeamMember?.name ?? "";
-
-      await sendBookingEmailToAllRecipients({
-        recipients,
+    //
+    // The status write above is already committed, so a notification failure
+    // must not fail the revert: it would report an error for a transition
+    // that happened, and a retry would trip the RESERVED-only guard. Log and
+    // return instead.
+    try {
+      const recipients = await getBookingNotificationRecipients({
         booking: draftBooking,
-        subject: `↩️ Booking reverted to draft (${draftBooking.name}) - shelf.nu`,
-        buildText: (prefs) =>
-          revertedToDraftEmailContent({
-            bookingName: draftBooking.name,
-            assetsCount: draftBooking._count.bookingAssets,
-            custodian,
-            from: draftBooking.from!,
-            to: draftBooking.to!,
-            bookingId: draftBooking.id,
-            prefs,
-            customEmailFooter: draftBooking.organization.customEmailFooter,
-          }),
-        buildHeading: () =>
-          `Your booking has been reverted to draft: "${draftBooking.name}"`,
-        hints,
+        eventType: "REVERT_TO_DRAFT",
+        organizationId,
+        editorUserId: userId,
       });
+
+      if (recipients.length > 0) {
+        const custodian = draftBooking.custodianUser
+          ? resolveUserDisplayName(draftBooking.custodianUser)
+          : draftBooking.custodianTeamMember?.name ?? "";
+
+        await sendBookingEmailToAllRecipients({
+          recipients,
+          booking: draftBooking,
+          subject: `↩️ Booking reverted to draft (${draftBooking.name}) - shelf.nu`,
+          buildText: (prefs) =>
+            revertedToDraftEmailContent({
+              bookingName: draftBooking.name,
+              assetsCount: draftBooking._count.bookingAssets,
+              custodian,
+              from: draftBooking.from!,
+              to: draftBooking.to!,
+              bookingId: draftBooking.id,
+              prefs,
+              customEmailFooter: draftBooking.organization.customEmailFooter,
+            }),
+          buildHeading: () =>
+            `Your booking has been reverted to draft: "${draftBooking.name}"`,
+          hints,
+        });
+      }
+    } catch (cause) {
+      Logger.error(
+        new ShelfError({
+          cause,
+          message:
+            "Failed to send the reverted-to-draft notification emails. The booking itself was reverted successfully.",
+          additionalData: { bookingId: draftBooking.id, organizationId },
+          label,
+        })
+      );
     }
 
     return draftBooking;

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -2022,7 +2022,12 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
         });
       }
       case "revert-to-draft": {
-        await revertBookingToDraft({ id, organizationId, userId });
+        await revertBookingToDraft({
+          id,
+          organizationId,
+          userId,
+          hints: getClientHint(request),
+        });
 
         sendNotification({
           title: "Booking reverted",


### PR DESCRIPTION
## Bug

Reverting a RESERVED booking back to DRAFT is the only booking lifecycle transition that sends no email. A Base/Self-service user submits a reservation request, an admin sends it back with **Revert to Draft**, and the custodian is never told — reserve, cancel, check-in, extend and delete all notify.

`revertBookingToDraft` performed the status write, activity note and scheduler cancel, then returned. No recipient resolution, no email (repro'd with a regression test that fails on `main`: resolver called 0 times).

## Fix

`revertBookingToDraft` now follows the exact pattern of the other lifecycle transitions (mirrors `cancelBooking`):

- Loads the booking with `BOOKING_INCLUDE_FOR_EMAIL` on the status write
- Resolves recipients through the shared `getBookingNotificationRecipients` resolver with a new `REVERT_TO_DRAFT` event type (custodian, creator per org setting, always-notify members, per-booking recipients; acting user excluded; the admins-on-new-booking broadcast does not apply)
- Sends the shared fan-out email: subject `↩️ Booking reverted to draft (…)`, body tells the recipient they can adjust the booking and submit it again

The route passes client hints for date formatting, same as cancel/extend.

## Tests

- New regression test: reverting a reservation resolves `REVERT_TO_DRAFT` recipients and emails the custodian (fails on `main` with 0 calls, passes here)
- Existing `revertBookingToDraft` tests updated for the new signature/include
- Full `service.server.test.ts` (286), `notification-recipients.server.test.ts` + `booking-status-guards.test.ts` (31): all green; typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reverting a reserved booking to draft now sends a notification email to the appropriate recipient.
  - The email explains that the booking can be reviewed, adjusted, and resubmitted.
  - Booking status notes and related scheduling updates are preserved when the booking returns to draft.

- **Bug Fixes**
  - Notifications are triggered consistently after a successful revert.
  - Notification or email issues no longer prevent the booking from returning to draft.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->