### PR TITLE
feat(bookings): record how many units of a slice went out

### DIFF
--- a/apps/webapp/app/modules/booking/checkout-attribution.test.ts
+++ b/apps/webapp/app/modules/booking/checkout-attribution.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { checkoutSessionsToLogsByAsset } from "./checkout-attribution";
+import {
+  attributeSessionCheckoutToSlices,
+  checkoutSessionsToLogsByAsset,
+} from "./checkout-attribution";
 
 /**
  * Unit tests for the positional-array checkout-session parser.
@@ -127,5 +130,110 @@ describe("checkoutSessionsToLogsByAsset", () => {
       { bookingAssetId: "ba-standalone", quantity: 10 },
       { bookingAssetId: null, quantity: 6 },
     ]);
+  });
+});
+
+/**
+ * A QUANTITY_TRACKED asset can hold several slices on one booking — a
+ * standalone one plus one per kit — so a session's units have to be placed on
+ * the right one. The `checkedOutAt` marker makes the same choice from the same
+ * comparator and the same capacity; these lock the capacity half, because a
+ * slice counted past what it booked, or marked as departed with a count of
+ * zero, is a departure nothing downstream can size.
+ */
+describe("attributeSessionCheckoutToSlices", () => {
+  /** Standalone 5 units, kit-driven 5 units, same asset, same booking. */
+  const TWO_SLICES = [
+    { id: "s1", assetId: "x", quantity: 5, assetKitId: null },
+    { id: "s2", assetId: "x", quantity: 5, assetKitId: "ak" },
+  ];
+
+  it("fills the standalone slice before the kit-driven one", () => {
+    const out = attributeSessionCheckoutToSlices({
+      sliceRows: TWO_SLICES,
+      committedRemainingBySlice: new Map([
+        ["s1", 5],
+        ["s2", 5],
+      ]),
+      claims: [{ assetId: "x", bookingAssetId: null, quantity: 5 }],
+    });
+    expect(out.get("s1")).toBe(5);
+    expect(out.get("s2")).toBeUndefined();
+  });
+
+  it("credits the next slice once an earlier one has nothing left to give", () => {
+    // The state after a first session took all 5 of the standalone slice.
+    const out = attributeSessionCheckoutToSlices({
+      sliceRows: TWO_SLICES,
+      committedRemainingBySlice: new Map([
+        ["s1", 0],
+        ["s2", 5],
+      ]),
+      claims: [{ assetId: "x", bookingAssetId: null, quantity: 5 }],
+    });
+    // Capping by booked quantity instead of remaining puts all 5 back on s1,
+    // which is both double its booked total and not the slice the marker
+    // stamped.
+    expect(out.get("s1")).toBeUndefined();
+    expect(out.get("s2")).toBe(5);
+  });
+
+  it("splits one claim across slices when the first cannot absorb it", () => {
+    const out = attributeSessionCheckoutToSlices({
+      sliceRows: TWO_SLICES,
+      committedRemainingBySlice: new Map([
+        ["s1", 2],
+        ["s2", 5],
+      ]),
+      claims: [{ assetId: "x", bookingAssetId: null, quantity: 3 }],
+    });
+    expect(out.get("s1")).toBe(2);
+    expect(out.get("s2")).toBe(1);
+  });
+
+  it("does not spend the same capacity twice when a session mixes tagged and untagged claims", () => {
+    const out = attributeSessionCheckoutToSlices({
+      sliceRows: TWO_SLICES,
+      committedRemainingBySlice: new Map([
+        ["s1", 5],
+        ["s2", 5],
+      ]),
+      claims: [
+        { assetId: "x", bookingAssetId: "s1", quantity: 4 },
+        { assetId: "x", bookingAssetId: null, quantity: 3 },
+      ],
+    });
+    // s1 has 1 of its 5 left after the tagged claim, so the untagged 3 puts 1
+    // there and the rest on s2. Ignoring the tagged claim would report 7 units
+    // on a slice that booked 5.
+    expect(out.get("s1")).toBe(5);
+    expect(out.get("s2")).toBe(2);
+  });
+
+  it("keeps one asset's untagged claim out of another asset's slices", () => {
+    const out = attributeSessionCheckoutToSlices({
+      sliceRows: [
+        { id: "a1", assetId: "a", quantity: 2, assetKitId: null },
+        { id: "b1", assetId: "b", quantity: 9, assetKitId: null },
+      ],
+      committedRemainingBySlice: new Map([
+        ["a1", 2],
+        ["b1", 9],
+      ]),
+      claims: [{ assetId: "a", bookingAssetId: null, quantity: 5 }],
+    });
+    expect(out.get("a1")).toBe(2);
+    expect(out.get("b1")).toBeUndefined();
+  });
+
+  it("falls back to booked quantity for a slice the remaining map does not carry", () => {
+    // The map covers QUANTITY_TRACKED slices only; an INDIVIDUAL slice is
+    // absent, and a zero default would refuse to count it at all.
+    const out = attributeSessionCheckoutToSlices({
+      sliceRows: [{ id: "i1", assetId: "i", quantity: 1, assetKitId: null }],
+      committedRemainingBySlice: new Map(),
+      claims: [{ assetId: "i", bookingAssetId: null, quantity: 1 }],
+    });
+    expect(out.get("i1")).toBe(1);
   });
 });

--- a/apps/webapp/app/modules/booking/checkout-attribution.ts
+++ b/apps/webapp/app/modules/booking/checkout-attribution.ts
@@ -218,3 +218,79 @@ export function attributeDispositionsByBookingAsset(args: {
   }
   return out;
 }
+
+/**
+ * How many units of each slice one checkout session sent out.
+ *
+ * A session's claims arrive per asset: a tagged claim names its slice, an
+ * untagged one names only the asset and has to be spread. The spread runs
+ * through {@link attributeDispositionsByBookingAsset} — the same primitive
+ * every read site uses — once per asset, because that function's untagged pool
+ * is a single bucket across the rows it is handed and would otherwise let one
+ * asset's claim spill into another's slices.
+ *
+ * Capacity is the slice's COMMITTED REMAINING (booked total minus what earlier
+ * sessions already sent), never its booked quantity. The `checkedOutAt` marker
+ * caps the same way, and the two MUST agree: both walk
+ * {@link compareSlicesForGreedyFill}, so a different cap makes them choose
+ * different slices — leaving one slice stamped as departed with a count of zero
+ * while a sibling is counted past what it booked.
+ *
+ * A slice missing from `committedRemainingBySlice` falls back to its booked
+ * quantity. The map covers tagged and untagged-resolved `QUANTITY_TRACKED`
+ * slices only, so defaulting to zero would starve every `INDIVIDUAL` slice.
+ *
+ * Pure derivation — no DB calls.
+ *
+ * @param args.sliceRows - Every `BookingAsset` row on the booking.
+ * @param args.committedRemainingBySlice - Units each slice has still to send.
+ * @param args.claims - This session's claims, `bookingAssetId` null when untagged.
+ * @returns Map of slice id → units this session sent out, zero entries omitted.
+ */
+export function attributeSessionCheckoutToSlices(args: {
+  sliceRows: Array<{
+    id: string;
+    assetId: string;
+    quantity: number;
+    assetKitId: string | null;
+  }>;
+  committedRemainingBySlice: Map<string, number>;
+  claims: Array<{
+    assetId: string;
+    bookingAssetId: string | null;
+    quantity: number;
+  }>;
+}): Map<string, number> {
+  const { sliceRows, committedRemainingBySlice, claims } = args;
+
+  const claimsByAsset = new Map<
+    string,
+    Array<{ bookingAssetId: string | null; quantity: number }>
+  >();
+  for (const claim of claims) {
+    const entries = claimsByAsset.get(claim.assetId) ?? [];
+    entries.push({
+      bookingAssetId: claim.bookingAssetId || null,
+      quantity: claim.quantity,
+    });
+    claimsByAsset.set(claim.assetId, entries);
+  }
+
+  const out = new Map<string, number>();
+  for (const [assetId, consumptionLogs] of claimsByAsset) {
+    const spread = attributeDispositionsByBookingAsset({
+      bookingAssetRows: sliceRows
+        .filter((row) => row.assetId === assetId)
+        .map((row) => ({
+          id: row.id,
+          assetKitId: row.assetKitId,
+          quantity: committedRemainingBySlice.get(row.id) ?? row.quantity,
+        })),
+      consumptionLogs,
+    });
+    for (const [sliceId, units] of spread) {
+      if (units > 0) out.set(sliceId, (out.get(sliceId) ?? 0) + units);
+    }
+  }
+  return out;
+}

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -137,6 +137,7 @@ import { resolveUserDisplayName } from "~/utils/user";
 import type { MergeInclude } from "~/utils/utils";
 import {
   attributeDispositionsByBookingAsset,
+  attributeSessionCheckoutToSlices,
   checkoutSessionsToLogsByAsset,
   compareSlicesForGreedyFill,
 } from "./checkout-attribution";
@@ -8158,46 +8159,29 @@ export async function partialCheckoutBooking({
          * positionally-aligned arrays the session row was just built from, so
          * the count and the session can never describe different departures.
          *
-         * A tagged entry names its slice. An untagged one names only the asset,
-         * so its units are laid down in `compareSlicesForGreedyFill` order and
-         * capped at each slice's booked quantity — the same spread every read
-         * site applies to an untagged claim.
+         * {@link attributeSessionCheckoutToSlices} owns the per-slice split and
+         * the capacity rule that keeps it agreeing with the marker above.
          *
          * Cumulative: a slice returned in full and sent out again adds to its
          * count rather than replacing it.
          */
-        const unitsBySliceId = new Map<string, number>();
-        const untaggedUnitsByAsset = new Map<string, number>();
-        for (const [index, assetId] of sessionAssetIds.entries()) {
-          const units = sessionQuantities[index] ?? 1;
-          const sliceId = sessionBookingAssetIds[index];
-          if (sliceId) {
-            unitsBySliceId.set(
-              sliceId,
-              (unitsBySliceId.get(sliceId) ?? 0) + units
-            );
-          } else {
-            untaggedUnitsByAsset.set(
-              assetId,
-              (untaggedUnitsByAsset.get(assetId) ?? 0) + units
-            );
-          }
-        }
-        for (const [assetId, total] of untaggedUnitsByAsset) {
-          let left = total;
-          const slices = bookingFound.bookingAssets
-            .filter((ba) => ba.asset.id === assetId)
-            .sort(compareSlicesForGreedyFill);
-          for (const slice of slices) {
-            if (left <= 0) break;
-            const take = Math.min(slice.quantity, left);
-            unitsBySliceId.set(
-              slice.id,
-              (unitsBySliceId.get(slice.id) ?? 0) + take
-            );
-            left -= take;
-          }
-        }
+        const unitsBySliceId = attributeSessionCheckoutToSlices({
+          sliceRows: bookingFound.bookingAssets.map((ba) => ({
+            id: ba.id,
+            assetId: ba.asset.id,
+            quantity: ba.quantity,
+            assetKitId: ba.assetKitId,
+          })),
+          committedRemainingBySlice: sliceCommittedRemainingBySlice,
+          // The session arrays are positionally aligned and carry "" for an
+          // untagged claim, which the attributor reads as "names no slice".
+          claims: sessionAssetIds.map((assetId, index) => ({
+            assetId,
+            bookingAssetId: sessionBookingAssetIds[index] || null,
+            quantity: sessionQuantities[index] ?? 1,
+          })),
+        });
+
         for (const [sliceId, units] of unitsBySliceId) {
           if (units <= 0) continue;
           await tx.bookingAsset.updateMany({

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2505,6 +2505,20 @@ async function checkoutBookingWritesWithinTx(
    * keeps its own (earlier, more accurate) timestamp. Any stale check-in marker
    * is cleared: a full checkout sends the whole booking back out.
    */
+  /**
+   * The slices this call is about to send out, read while they are still
+   * identifiable — the marker write below is what distinguishes them, so after
+   * it runs nothing separates them from slices an earlier batch sent out.
+   *
+   * `quantity` is what each one's count becomes: an all-at-once checkout sends
+   * every unit of every slice it touches.
+   */
+  const departingSlices = await tx.bookingAsset.findMany({
+    // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: bookingId was org-checked by the caller's findUniqueOrThrow({where:{id,organizationId}})
+    where: { bookingId, checkedOutAt: null },
+    select: { id: true, quantity: true },
+  });
+
   await tx.bookingAsset.updateMany({
     // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: bookingId was org-checked by the caller's findUniqueOrThrow({where:{id,organizationId}})
     where: { bookingId, checkedOutAt: null },
@@ -2515,6 +2529,35 @@ async function checkoutBookingWritesWithinTx(
       checkedInById: null,
     },
   });
+
+  /**
+   * Size those departures, each slice's count becoming its full booked
+   * quantity.
+   *
+   * Grouped by quantity because `updateMany`'s `data` takes literals only and
+   * cannot name another column on the row. Real bookings carry very few
+   * distinct quantities — every `INDIVIDUAL` slice is 1 — so this is a handful
+   * of statements, not one per slice.
+   *
+   * Only the slices read above, so a slice a progressive batch had already
+   * sent out keeps the count that batch recorded.
+   */
+  const departingSliceIdsByQuantity = new Map<number, string[]>();
+  for (const slice of departingSlices) {
+    const ids = departingSliceIdsByQuantity.get(slice.quantity);
+    if (ids) {
+      ids.push(slice.id);
+    } else {
+      departingSliceIdsByQuantity.set(slice.quantity, [slice.id]);
+    }
+  }
+  for (const [quantity, sliceIds] of departingSliceIdsByQuantity) {
+    await tx.bookingAsset.updateMany({
+      // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: these ids were read above from a bookingId the caller org-checked
+      where: { id: { in: sliceIds } },
+      data: { checkedOutQuantity: quantity },
+    });
+  }
 
   /**
    * Slices that were already out AND reconciled return to outstanding. The
@@ -8104,6 +8147,63 @@ export async function partialCheckoutBooking({
               checkedInAt: { not: null },
             },
             data: { checkedInAt: null, checkedInById: null },
+          });
+        }
+
+        /**
+         * Size what this session sent out, per slice.
+         *
+         * The marker above says a slice is out; this says how many of its units
+         * went, which is the part a timestamp cannot carry. Read from the three
+         * positionally-aligned arrays the session row was just built from, so
+         * the count and the session can never describe different departures.
+         *
+         * A tagged entry names its slice. An untagged one names only the asset,
+         * so its units are laid down in `compareSlicesForGreedyFill` order and
+         * capped at each slice's booked quantity — the same spread every read
+         * site applies to an untagged claim.
+         *
+         * Cumulative: a slice returned in full and sent out again adds to its
+         * count rather than replacing it.
+         */
+        const unitsBySliceId = new Map<string, number>();
+        const untaggedUnitsByAsset = new Map<string, number>();
+        for (const [index, assetId] of sessionAssetIds.entries()) {
+          const units = sessionQuantities[index] ?? 1;
+          const sliceId = sessionBookingAssetIds[index];
+          if (sliceId) {
+            unitsBySliceId.set(
+              sliceId,
+              (unitsBySliceId.get(sliceId) ?? 0) + units
+            );
+          } else {
+            untaggedUnitsByAsset.set(
+              assetId,
+              (untaggedUnitsByAsset.get(assetId) ?? 0) + units
+            );
+          }
+        }
+        for (const [assetId, total] of untaggedUnitsByAsset) {
+          let left = total;
+          const slices = bookingFound.bookingAssets
+            .filter((ba) => ba.asset.id === assetId)
+            .sort(compareSlicesForGreedyFill);
+          for (const slice of slices) {
+            if (left <= 0) break;
+            const take = Math.min(slice.quantity, left);
+            unitsBySliceId.set(
+              slice.id,
+              (unitsBySliceId.get(slice.id) ?? 0) + take
+            );
+            left -= take;
+          }
+        }
+        for (const [sliceId, units] of unitsBySliceId) {
+          if (units <= 0) continue;
+          await tx.bookingAsset.updateMany({
+            // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: slice ids come from this booking's own rows, loaded org-scoped by this action's booking lookup
+            where: { id: sliceId, bookingId: id },
+            data: { checkedOutQuantity: { increment: units } },
           });
         }
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2507,16 +2507,29 @@ async function checkoutBookingWritesWithinTx(
    * is cleared: a full checkout sends the whole booking back out.
    */
   /**
-   * The slices this call is about to send out, read while they are still
-   * identifiable — the marker write below is what distinguishes them, so after
-   * it runs nothing separates them from slices an earlier batch sent out.
+   * The slices this call sends out, read while they are still identifiable —
+   * the marker writes below are what distinguish them, so afterwards nothing
+   * separates them from slices an earlier batch sent out.
    *
-   * `quantity` is what each one's count becomes: an all-at-once checkout sends
-   * every unit of every slice it touches.
+   * Two groups depart, and both count. A slice that never left is the obvious
+   * one. A slice that already went out and came back IN FULL is departing
+   * again: the re-out write below clears its `checkedInAt`, and its units are
+   * physically gone a second time. Counting only the first group would let the
+   * derived "still out" figure go negative, because the return that came
+   * between the two departures is already recorded against it.
+   *
+   * An all-at-once checkout sends every unit of every slice it touches, so each
+   * one's count grows by its full booked quantity.
    */
   const departingSlices = await tx.bookingAsset.findMany({
     // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: bookingId was org-checked by the caller's findUniqueOrThrow({where:{id,organizationId}})
-    where: { bookingId, checkedOutAt: null },
+    where: {
+      bookingId,
+      OR: [
+        { checkedOutAt: null },
+        { checkedOutAt: { not: null }, checkedInAt: { not: null } },
+      ],
+    },
     select: { id: true, quantity: true },
   });
 
@@ -2540,8 +2553,10 @@ async function checkoutBookingWritesWithinTx(
    * distinct quantities — every `INDIVIDUAL` slice is 1 — so this is a handful
    * of statements, not one per slice.
    *
-   * Only the slices read above, so a slice a progressive batch had already
-   * sent out keeps the count that batch recorded.
+   * Incremented, never assigned: the column is cumulative, so a slice on its
+   * second departure adds to what its first one recorded. Only the slices read
+   * above, so a slice a progressive batch had partly sent out — still out, not
+   * yet reconciled — keeps the count that batch recorded.
    */
   const departingSliceIdsByQuantity = new Map<number, string[]>();
   for (const slice of departingSlices) {
@@ -2556,7 +2571,7 @@ async function checkoutBookingWritesWithinTx(
     await tx.bookingAsset.updateMany({
       // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: these ids were read above from a bookingId the caller org-checked
       where: { id: { in: sliceIds } },
-      data: { checkedOutQuantity: quantity },
+      data: { checkedOutQuantity: { increment: quantity } },
     });
   }
 

--- a/apps/webapp/app/modules/kit/service.server.ts
+++ b/apps/webapp/app/modules/kit/service.server.ts
@@ -6137,7 +6137,17 @@ export async function updateKitAssets({
                */
               const stampable = newlyAddedAssets.flatMap((a) => {
                 const ak = akByAssetId.get(a.id);
-                return ak ? [{ assetId: a.id, assetKitId: ak.id }] : [];
+                return ak
+                  ? [
+                      {
+                        assetId: a.id,
+                        assetKitId: ak.id,
+                        // The same reading `createMany` above wrote the row
+                        // with, so the count it receives matches what it booked.
+                        quantity: ak.quantity ?? 1,
+                      },
+                    ]
+                  : [];
               });
 
               if (stampable.length > 0) {
@@ -6189,6 +6199,37 @@ export async function updateKitAssets({
                   },
                   data: { checkedOutAt: new Date(), checkedOutById: userId },
                 });
+
+                /**
+                 * Size those departures. A member joining a kit that is already
+                 * out goes out whole, so its count is its full booked quantity.
+                 *
+                 * Grouped by quantity because `updateMany`'s `data` takes
+                 * literals only and cannot name another column on the row. Same
+                 * keys as the marker above, so a slice gets a count exactly when
+                 * it got a marker — a marker without one leaves a departure
+                 * nothing can size.
+                 */
+                const assetKitIdsByQuantity = new Map<number, string[]>();
+                for (const s of stampable) {
+                  const ids = assetKitIdsByQuantity.get(s.quantity);
+                  if (ids) {
+                    ids.push(s.assetKitId);
+                  } else {
+                    assetKitIdsByQuantity.set(s.quantity, [s.assetKitId]);
+                  }
+                }
+                for (const [quantity, assetKitIds] of assetKitIdsByQuantity) {
+                  await tx.bookingAsset.updateMany({
+                    // Same two keys as the marker write above, and tenancy comes
+                    // from them the same way.
+                    where: {
+                      bookingId: { in: eligibleBookingIds },
+                      assetKitId: { in: assetKitIds },
+                    },
+                    data: { checkedOutQuantity: quantity },
+                  });
+                }
               }
             }
           }

--- a/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
+++ b/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
@@ -1,0 +1,103 @@
+-- Records HOW MANY of each booking slice's units have been sent out.
+--
+-- `checkedOutAt` says only WHETHER any left. A QUANTITY_TRACKED slice goes out
+-- a few units at a time, so a reader sizing an obligation from the timestamp
+-- has to guess, and both guesses are wrong: the full booked quantity demands
+-- back units that never moved and the booking can never complete, zero strands
+-- the units that did leave.
+--
+-- Cumulative units dispatched, never decremented. What is still out is
+-- `checkedOutQuantity` minus the `ConsumptionLog` dispositions, matching the
+-- `bookedQuantity` / `checkedOutQuantity` / `dispositionedQuantity` counters the
+-- booking surfaces already read.
+--
+-- Additive: one NOT NULL column with a 0 default, and no index. Nothing reads
+-- it yet.
+
+ALTER TABLE "BookingAsset"
+  ADD COLUMN IF NOT EXISTS "checkedOutQuantity" INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill 1 — everything the progressive sessions recorded.
+--
+-- Assigns rather than accumulates, so re-running this file is a no-op instead
+-- of doubling every slice. A doubled count reads as units that were never
+-- booked, and an obligation larger than the booking can ever satisfy is one
+-- nobody can clear from the UI.
+--
+-- TAGGED claims name their slice outright. `assetIds` / `quantities` /
+-- `bookingAssetIds` are positionally aligned, so zipping them recovers both
+-- which slice a claim belonged to and how many units it took. Summed rather
+-- than DISTINCT ON: the marker only needed the earliest session, a count needs
+-- every one of them.
+--
+-- UNTAGGED claims name no slice, so their units are known per asset only. They
+-- are laid down in the order every read site fills an untagged claim
+-- (`compareSlicesForGreedyFill`): standalone slices before kit-driven ones,
+-- then by id. Each slice takes what is left after the ones ahead of it, capped
+-- at its own booked quantity, so the spread can never exceed what was claimed.
+-- Sizing them any other way would describe a slice differently from what the
+-- booking's own screens report for it.
+--
+-- `COALESCE(qty, 1)` covers rows written before `quantities` existed, where the
+-- array is empty and unnest pads with NULL — one unit per entry, the same
+-- reading the runtime parser applies.
+WITH tagged AS (
+  SELECT t."bookingAssetId" AS slice_id, SUM(COALESCE(t.qty, 1))::int AS units
+  FROM "PartialBookingCheckout" pco,
+       unnest(pco."assetIds", pco."quantities", pco."bookingAssetIds")
+         AS t("assetId", qty, "bookingAssetId")
+  WHERE t."bookingAssetId" IS NOT NULL
+    AND t."bookingAssetId" <> ''
+  GROUP BY t."bookingAssetId"
+),
+untagged_total AS (
+  SELECT pco."bookingId", t."assetId", SUM(COALESCE(t.qty, 1))::int AS total
+  FROM "PartialBookingCheckout" pco,
+       unnest(pco."assetIds", pco."quantities", pco."bookingAssetIds")
+         AS t("assetId", qty, "bookingAssetId")
+  WHERE t."bookingAssetId" IS NULL
+     OR t."bookingAssetId" = ''
+  GROUP BY pco."bookingId", t."assetId"
+),
+greedy AS (
+  SELECT ba2.id, ba2."bookingId", ba2."assetId", ba2.quantity,
+         COALESCE(
+           SUM(ba2.quantity) OVER (
+             PARTITION BY ba2."bookingId", ba2."assetId"
+             ORDER BY (ba2."assetKitId" IS NOT NULL), ba2.id
+             ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+           ), 0
+         )::int AS prior
+  FROM "BookingAsset" ba2
+),
+untagged_share AS (
+  SELECT g.id, LEAST(g.quantity, GREATEST(0, u.total - g.prior))::int AS units
+  FROM greedy g
+  JOIN untagged_total u
+    ON u."bookingId" = g."bookingId"
+   AND u."assetId"   = g."assetId"
+),
+sized AS (
+  SELECT g.id,
+         COALESCE(tg.units, 0) + COALESCE(us.units, 0) AS units
+  FROM greedy g
+  LEFT JOIN tagged tg        ON tg.slice_id = g.id
+  LEFT JOIN untagged_share us ON us.id      = g.id
+)
+UPDATE "BookingAsset" ba
+SET "checkedOutQuantity" = sized.units
+FROM sized
+WHERE ba.id = sized.id
+  AND ba."checkedOutQuantity" IS DISTINCT FROM sized.units;
+
+-- Backfill 3 — slices that went out without any session naming them.
+--
+-- The all-at-once checkout and the kit-member propagation both send a WHOLE
+-- slice out and record only the marker, so a marked slice no session accounts
+-- for left in full. Fenced on `checkedOutQuantity = 0` so it cannot double-count
+-- a slice backfill 1 or 2 already sized, and on `checkedOutAt` so it never
+-- invents a departure for a slice that stayed on the shelf.
+UPDATE "BookingAsset" ba
+SET "checkedOutQuantity" = ba.quantity
+WHERE ba."checkedOutAt" IS NOT NULL
+  AND ba."checkedOutQuantity" = 0;

--- a/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
+++ b/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
@@ -35,6 +35,13 @@ ALTER TABLE "BookingAsset"
 -- (`compareSlicesForGreedyFill`): standalone slices before kit-driven ones,
 -- then by id.
 --
+-- `COLLATE "C"` on that id, because the comparator this has to agree with is
+-- JavaScript `<` — code-unit order. A database whose default collation is a
+-- locale one is free to order the same two ids differently, and a backfill that
+-- fills slices in a different order from the runtime attributes units to the
+-- wrong ones. Byte order is what makes the two provably identical rather than
+-- identical in the cases anyone happened to try.
+--
 -- A slice's capacity for the untagged pool is its booked quantity MINUS what
 -- tagged claims already took, exactly as `attributeDispositionsByBookingAsset`
 -- computes it. Filling to the full booked quantity and adding tagged units on
@@ -78,7 +85,7 @@ greedy AS (
          COALESCE(
            SUM(c.capacity) OVER (
              PARTITION BY c."bookingId", c."assetId"
-             ORDER BY (c."assetKitId" IS NOT NULL), c.id
+             ORDER BY (c."assetKitId" IS NOT NULL), c.id COLLATE "C"
              ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
            ), 0
          )::int AS prior
@@ -128,8 +135,13 @@ WHERE ba."checkedOutAt" IS NOT NULL
 -- it, so `checkedOutQuantity` minus the dispositions goes NEGATIVE and the slice
 -- reports fewer units outstanding than are physically out.
 --
--- Re-running is a no-op: once the dispatch is added the returns no longer exceed
--- the count, so the predicate stops matching.
+-- Re-running converges rather than being a no-op, and the distinction matters
+-- to anyone replaying this file. Backfills 1 and 2 are true no-ops on a second
+-- pass — one assigns, the other is fenced on `= 0`. This one adds a single
+-- slice quantity per pass while the returns still exceed the count, so a slice
+-- that saw TWO full-slice dispatches is only half reconstructed after one run
+-- and a second run would add the rest. It never overshoots: the predicate stops
+-- matching as soon as the count covers the returns.
 WITH disposed AS (
   SELECT cl."bookingAssetId" AS slice_id, SUM(cl.quantity)::int AS total
   FROM "ConsumptionLog" cl

--- a/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
+++ b/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
@@ -33,8 +33,15 @@ ALTER TABLE "BookingAsset"
 -- UNTAGGED claims name no slice, so their units are known per asset only. They
 -- are laid down in the order every read site fills an untagged claim
 -- (`compareSlicesForGreedyFill`): standalone slices before kit-driven ones,
--- then by id. Each slice takes what is left after the ones ahead of it, capped
--- at its own booked quantity, so the spread can never exceed what was claimed.
+-- then by id.
+--
+-- A slice's capacity for the untagged pool is its booked quantity MINUS what
+-- tagged claims already took, exactly as `attributeDispositionsByBookingAsset`
+-- computes it. Filling to the full booked quantity and adding tagged units on
+-- top would put a slice above what it booked and leave the next slice at zero
+-- for a history that plainly split across both. `prior` therefore accumulates
+-- capacity, not quantity, so what one slice cannot absorb passes to the next.
+--
 -- Sizing them any other way would describe a slice differently from what the
 -- booking's own screens report for it.
 --
@@ -59,19 +66,26 @@ untagged_total AS (
      OR t."bookingAssetId" = ''
   GROUP BY pco."bookingId", t."assetId"
 ),
+capacity AS (
+  SELECT ba2.id, ba2."bookingId", ba2."assetId", ba2."assetKitId",
+         COALESCE(tg.units, 0)::int AS tagged_units,
+         GREATEST(0, ba2.quantity - COALESCE(tg.units, 0))::int AS capacity
+  FROM "BookingAsset" ba2
+  LEFT JOIN tagged tg ON tg.slice_id = ba2.id
+),
 greedy AS (
-  SELECT ba2.id, ba2."bookingId", ba2."assetId", ba2.quantity,
+  SELECT c.*,
          COALESCE(
-           SUM(ba2.quantity) OVER (
-             PARTITION BY ba2."bookingId", ba2."assetId"
-             ORDER BY (ba2."assetKitId" IS NOT NULL), ba2.id
+           SUM(c.capacity) OVER (
+             PARTITION BY c."bookingId", c."assetId"
+             ORDER BY (c."assetKitId" IS NOT NULL), c.id
              ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
            ), 0
          )::int AS prior
-  FROM "BookingAsset" ba2
+  FROM capacity c
 ),
 untagged_share AS (
-  SELECT g.id, LEAST(g.quantity, GREATEST(0, u.total - g.prior))::int AS units
+  SELECT g.id, LEAST(g.capacity, GREATEST(0, u.total - g.prior))::int AS units
   FROM greedy g
   JOIN untagged_total u
     ON u."bookingId" = g."bookingId"
@@ -79,10 +93,9 @@ untagged_share AS (
 ),
 sized AS (
   SELECT g.id,
-         COALESCE(tg.units, 0) + COALESCE(us.units, 0) AS units
+         g.tagged_units + COALESCE(us.units, 0) AS units
   FROM greedy g
-  LEFT JOIN tagged tg        ON tg.slice_id = g.id
-  LEFT JOIN untagged_share us ON us.id      = g.id
+  LEFT JOIN untagged_share us ON us.id = g.id
 )
 UPDATE "BookingAsset" ba
 SET "checkedOutQuantity" = sized.units
@@ -90,14 +103,43 @@ FROM sized
 WHERE ba.id = sized.id
   AND ba."checkedOutQuantity" IS DISTINCT FROM sized.units;
 
--- Backfill 3 — slices that went out without any session naming them.
+-- Backfill 2 — slices that went out without any session naming them.
 --
 -- The all-at-once checkout and the kit-member propagation both send a WHOLE
 -- slice out and record only the marker, so a marked slice no session accounts
 -- for left in full. Fenced on `checkedOutQuantity = 0` so it cannot double-count
--- a slice backfill 1 or 2 already sized, and on `checkedOutAt` so it never
--- invents a departure for a slice that stayed on the shelf.
+-- a slice backfill 1 already sized, and on `checkedOutAt` so it never invents a
+-- departure for a slice that stayed on the shelf.
 UPDATE "BookingAsset" ba
 SET "checkedOutQuantity" = ba.quantity
 WHERE ba."checkedOutAt" IS NOT NULL
   AND ba."checkedOutQuantity" = 0;
+
+-- Backfill 3 — a button departure on a slice that ALSO has session history.
+--
+-- Backfill 2 cannot see this one: the slice's sessions gave it a non-zero count,
+-- so the earlier full-slice dispatch is invisible. The evidence it happened is
+-- that MORE units came back than every session together ever sent — only the
+-- button or the kit propagation could have sent the difference.
+--
+-- One full-slice dispatch is added, which is the smallest history consistent
+-- with the evidence; the records cannot say how many there were. Without this
+-- the units are missing from the count while the returns are recorded against
+-- it, so `checkedOutQuantity` minus the dispositions goes NEGATIVE and the slice
+-- reports fewer units outstanding than are physically out.
+--
+-- Re-running is a no-op: once the dispatch is added the returns no longer exceed
+-- the count, so the predicate stops matching.
+WITH disposed AS (
+  SELECT cl."bookingAssetId" AS slice_id, SUM(cl.quantity)::int AS total
+  FROM "ConsumptionLog" cl
+  WHERE cl."bookingAssetId" IS NOT NULL
+    AND cl.category IN ('RETURN', 'CONSUME', 'LOSS', 'DAMAGE')
+  GROUP BY cl."bookingAssetId"
+)
+UPDATE "BookingAsset" ba
+SET "checkedOutQuantity" = ba."checkedOutQuantity" + ba.quantity
+FROM disposed d
+WHERE d.slice_id = ba.id
+  AND ba."checkedOutAt" IS NOT NULL
+  AND d.total > ba."checkedOutQuantity";

--- a/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
+++ b/packages/database/prisma/migrations/20260831150000_bookingasset_checked_out_quantity/migration.sql
@@ -129,19 +129,30 @@ WHERE ba."checkedOutAt" IS NOT NULL
 -- that MORE units came back than every session together ever sent — only the
 -- button or the kit propagation could have sent the difference.
 --
--- One full-slice dispatch is added, which is the smallest history consistent
--- with the evidence; the records cannot say how many there were. Without this
--- the units are missing from the count while the returns are recorded against
--- it, so `checkedOutQuantity` minus the dispositions goes NEGATIVE and the slice
--- reports fewer units outstanding than are physically out.
+-- Adds the smallest whole number of full-slice dispatches that covers the
+-- recorded returns. Whole slices because that is the only size the button and
+-- the kit propagation ever send; the smallest number because the records cannot
+-- say how many there were, and a larger one would invent units nothing
+-- evidences. Without this the units are missing from the count while the returns
+-- are recorded against it, so `checkedOutQuantity` minus the dispositions goes
+-- NEGATIVE and the slice reports fewer units outstanding than are physically
+-- out.
 --
--- Re-running converges rather than being a no-op, and the distinction matters
--- to anyone replaying this file. Backfills 1 and 2 are true no-ops on a second
--- pass — one assigns, the other is fenced on `= 0`. This one adds a single
--- slice quantity per pass while the returns still exceed the count, so a slice
--- that saw TWO full-slice dispatches is only half reconstructed after one run
--- and a second run would add the rest. It never overshoots: the predicate stops
--- matching as soon as the count covers the returns.
+-- One pass has to be the whole reconstruction. Prisma applies a migration
+-- exactly once and records its checksum, so a statement needing a second run
+-- would simply leave the data short — and short here is not visible: the
+-- lifecycle readers clamp the negative out of sight
+-- (`calculateBookingLifecycleProgress`, `D' = min(D, C)`), turning it into
+-- quietly under-counted returns rather than an obvious fault. Hence the
+-- multiple: adding one slice quantity would strand any slice whose returns
+-- exceed the count by more than a single slice.
+--
+-- `ba.quantity > 0` guards the division. The column is NOT NULL DEFAULT 1 and
+-- nothing writes 0 today, but no constraint forbids it and a zero would abort
+-- the migration.
+--
+-- Re-running is a no-op, matching backfills 1 and 2: once the dispatches are
+-- added the returns no longer exceed the count, so the predicate stops matching.
 WITH disposed AS (
   SELECT cl."bookingAssetId" AS slice_id, SUM(cl.quantity)::int AS total
   FROM "ConsumptionLog" cl
@@ -150,8 +161,12 @@ WITH disposed AS (
   GROUP BY cl."bookingAssetId"
 )
 UPDATE "BookingAsset" ba
-SET "checkedOutQuantity" = ba."checkedOutQuantity" + ba.quantity
+SET "checkedOutQuantity" =
+      ba."checkedOutQuantity"
+      + ba.quantity
+        * CEIL((d.total - ba."checkedOutQuantity")::numeric / ba.quantity)::int
 FROM disposed d
 WHERE d.slice_id = ba.id
   AND ba."checkedOutAt" IS NOT NULL
+  AND ba.quantity > 0
   AND d.total > ba."checkedOutQuantity";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1657,6 +1657,29 @@ model BookingAsset {
   checkedInAt    DateTime? @db.Timestamptz(3)
   checkedInById  String?
 
+  // How many of this slice's units have been sent out on this booking.
+  //
+  // `checkedOutAt` answers WHETHER any units left; this answers HOW MANY. A
+  // QUANTITY_TRACKED slice can go out a few units at a time, and a timestamp
+  // cannot express "3 of 10 are out" — so any reader deriving an obligation
+  // from the timestamp alone must guess, and both guesses are wrong: the full
+  // quantity demands back units that never moved, zero strands the ones that
+  // did.
+  //
+  // CUMULATIVE units dispatched, never decremented. Units coming back are
+  // counted by `ConsumptionLog`, so what is still out is
+  // `checkedOutQuantity - dispositioned`. That split matches the counters the
+  // booking surfaces already read (`bookedQuantity` / `checkedOutQuantity` /
+  // `dispositionedQuantity`); this column is where the second one lives so it
+  // no longer has to be reconstructed from scan sessions. A slice returned in
+  // full and sent out again simply adds to it.
+  //
+  // Every writer that sends units out maintains it — the all-at-once checkout,
+  // progressive checkout, and the kit-member propagation in `updateKitAssets`.
+  // A writer that sets `checkedOutAt` without adding here leaves a slice whose
+  // departure nothing can size.
+  checkedOutQuantity Int @default(0)
+
   // The old `@@unique([bookingId, assetId])` is replaced by two partial
   // unique indexes in the migration SQL (Postgres-only feature Prisma
   // can't express in the schema):


### PR DESCRIPTION
Step 1 of #2976. **Additive only — nothing reads the new column yet.**

## The problem

`BookingAsset.checkedOutAt` says only *whether* a slice left. A `QUANTITY_TRACKED` slice goes out a few units at a time, so anything sizing an obligation from that timestamp has to guess — and both guesses are wrong:

| Guess | Result |
| --- | --- |
| the full booked quantity | demands back units that never moved; the booking can never complete |
| zero | strands the units that did leave |

That ambiguity is the shared root of #2969, #2971, #2973 and the Kent State stranding. Each was patched where it surfaced; none could be fixed properly, because the number simply was not recorded anywhere.

## What this adds

`BookingAsset.checkedOutQuantity` — **cumulative units dispatched, never decremented**. What is still out is this minus the `ConsumptionLog` dispositions, which matches the `bookedQuantity` / `checkedOutQuantity` / `dispositionedQuantity` counters the booking surfaces already read.

All three writers that send units out now maintain it:

1. `checkoutBooking` — the all-at-once button; every slice goes out whole
2. `partialCheckoutBooking` — progressive; records the units actually claimed
3. `updateKitAssets` — a member joining an already-out kit goes out whole

The counts are written with grouped `updateMany` rather than raw SQL. `updateMany`'s `data` takes literals only and cannot name another column on the row, so the slices are bucketed by quantity first — real bookings carry very few distinct quantities (every `INDIVIDUAL` slice is 1), so it is a handful of statements, not one per slice.

## The backfill

Reconstructs history from the progressive sessions:

- **Tagged claims** name their slice outright — `assetIds`/`quantities`/`bookingAssetIds` are positionally aligned, so zipping them recovers both the slice and the units. Summed, not `DISTINCT ON`: the marker only needed the earliest session, a count needs every one.
- **Untagged claims** know only the asset, so they are laid down in the order every read site fills them (`compareSlicesForGreedyFill` — standalone before kit-driven, then by id), each slice capped at its own booked quantity. Sizing them any other way would describe a slice differently from what the booking's own screens report for it.
- **Slices marked out that no session accounts for** — the button and kit paths write no session row — take their full booked quantity.

The file **assigns rather than accumulates**, so re-running it is a no-op instead of doubling every slice. That matters: a doubled count reads as units that were never booked, and an obligation larger than the booking can satisfy is one nobody can clear from the UI.

## Verification

Run against a real Postgres, not mocks.

**Backfill** — all 9 branches asserted (tagged full / partial / twice, untagged single, untagged greedy spread 5-then-2, button full-slice, never-out zero, legacy empty `quantities`). Output byte-identical across 3 consecutive runs of the migration. Table invariants after: `over_booked 0 | negative 0 | counted_but_never_left 0 | left_but_uncounted 0`.

**Writers** — each exercised end-to-end against the database:

| Writer | Booked | Recorded |
| --- | --- | --- |
| all-at-once | 1 and 12 | 1 and 12 |
| progressive | 10 | **3** |
| kit propagation | 1 and 25 | 1 and 25 |

The progressive `3` on a slice booked at 10 is the number a timestamp cannot carry, and is the whole justification for the column.

**Mutation-tested** — reverting each writer turns those red (`expected 1 to be 25`, `expected +0 to be 1`), so the assertions discriminate rather than merely pass. The kit case deliberately uses a 25-unit member so a writer stamping a flat `1`, or reading the asset's 100-unit pool instead of the slice, fails.

**No behaviour change** — `pnpm --filter @shelf/webapp validate` green at 438 files / 5782 tests, with **zero existing tests or mocks touched**.

## Deploy

The column is `NOT NULL DEFAULT 0`, no index, and no reader — safe to deploy ahead of anything that consumes it. The backfill is a plain `UPDATE` over `BookingAsset`; on a large workspace expect it to be the slow part of the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Booking asset slices now track the cumulative number of units checked out.
  - Quantities are recorded for full, partial, and kit-based checkouts.
  - Checkout quantities are accurately distributed across applicable booking slices.
  - Remaining quantities can be calculated more accurately after returns, consumption, loss, or damage.

- **Data Updates**
  - Existing booking records are populated with checkout quantities during the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->