### PR TITLE
fix(bookings): reconcile asset status on bulk cancel and delete

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -69,6 +69,7 @@ import {
   bookingDraftVisibilityClause,
   bulkArchiveBookings,
   bulkCancelBookings,
+  bulkDeleteBookings,
   // Phase 3c helpers
   computeBookingAssetRemaining,
   computeBookingAssetSliceRemaining,
@@ -131,6 +132,7 @@ vitest.mock("~/database/db.server", () => ({
       findFirst: vitest.fn().mockResolvedValue(null),
       findMany: vitest.fn().mockResolvedValue([]),
       delete: vitest.fn().mockResolvedValue({}),
+      deleteMany: vitest.fn().mockResolvedValue({ count: 0 }),
       count: vitest.fn().mockResolvedValue(0),
     },
     asset: {
@@ -11177,6 +11179,124 @@ describe("bulkCancelBookings", () => {
       ]),
       expect.anything()
     );
+  });
+
+  /**
+   * An asset can sit on two live bookings at once. Cancelling one of them says
+   * nothing about the other, so the exit has to ask what commitment is left
+   * rather than blanket-writing AVAILABLE. Marking it available while a
+   * borrower still holds it for the other booking puts it back in the pool for
+   * someone else to book.
+   */
+  it("leaves an asset CHECKED_OUT when another live booking still holds it", async () => {
+    expect.assertions(2);
+
+    //@ts-expect-error missing vitest type
+    db.booking.findMany.mockResolvedValue([
+      {
+        id: "bk-ongoing",
+        name: "Ongoing booking",
+        status: BookingStatus.ONGOING,
+        custodianUserId: null,
+        activeSchedulerReference: null,
+        bookingAssets: [{ asset: { id: "asset-shared", assetKits: [] } }],
+        from: new Date("2025-01-01T09:00:00Z"),
+        to: new Date("2025-01-02T17:00:00Z"),
+        organization: { customEmailFooter: null },
+        custodianUser: null,
+        custodianTeamMember: null,
+        _count: { bookingAssets: 1 },
+      },
+    ]);
+    // The asset is still on one OTHER ONGOING booking, outside this selection.
+    (db.bookingAsset.count as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      1
+    );
+    (db.custody.count as ReturnType<typeof vitest.fn>).mockResolvedValue(0);
+
+    await bulkCancelBookings({
+      bookingIds: ["bk-ongoing"],
+      organizationId: "org-1",
+      userId: "user-1",
+      role: OrganizationRoles.OWNER,
+      hints: mockClientHints,
+    });
+
+    const assetWrites = (
+      db.asset.updateMany as ReturnType<typeof vitest.fn>
+    ).mock.calls.filter((c: any) => c[0]?.data?.status !== undefined);
+
+    expect(
+      assetWrites.some((c: any) => c[0].data.status === AssetStatus.AVAILABLE),
+      "no write may free an asset another live booking still holds"
+    ).toBe(false);
+    expect(
+      assetWrites.some(
+        (c: any) => c[0].data.status === AssetStatus.CHECKED_OUT
+      ),
+      "the remaining commitment should keep it checked out"
+    ).toBe(true);
+  });
+});
+
+describe("bulkDeleteBookings", () => {
+  beforeEach(() => {
+    vitest.clearAllMocks();
+  });
+
+  /**
+   * Same rule as the bulk cancel: deleting a booking says nothing about the
+   * other commitments on its assets. This path deletes the bookings first, so
+   * their own rows are already gone by the time the reconciliation reads.
+   */
+  it("leaves an asset CHECKED_OUT when another live booking still holds it", async () => {
+    expect.assertions(2);
+
+    //@ts-expect-error missing vitest type
+    db.booking.findMany.mockResolvedValue([
+      {
+        id: "bk-del-ongoing",
+        name: "Ongoing booking",
+        status: BookingStatus.ONGOING,
+        custodianUserId: null,
+        activeSchedulerReference: null,
+        bookingAssets: [{ asset: { id: "asset-shared", assetKits: [] } }],
+        from: new Date("2025-01-01T09:00:00Z"),
+        to: new Date("2025-01-02T17:00:00Z"),
+        organization: { customEmailFooter: null },
+        custodianUser: null,
+        custodianTeamMember: null,
+        _count: { bookingAssets: 1 },
+      },
+    ]);
+    // Still on one OTHER ONGOING booking, outside this selection.
+    (db.bookingAsset.count as ReturnType<typeof vitest.fn>).mockResolvedValue(
+      1
+    );
+    (db.custody.count as ReturnType<typeof vitest.fn>).mockResolvedValue(0);
+
+    await bulkDeleteBookings({
+      bookingIds: ["bk-del-ongoing"],
+      organizationId: "org-1",
+      userId: "user-1",
+      role: OrganizationRoles.OWNER,
+      hints: mockClientHints,
+    });
+
+    const assetWrites = (
+      db.asset.updateMany as ReturnType<typeof vitest.fn>
+    ).mock.calls.filter((c: any) => c[0]?.data?.status !== undefined);
+
+    expect(
+      assetWrites.some((c: any) => c[0].data.status === AssetStatus.AVAILABLE),
+      "no write may free an asset another live booking still holds"
+    ).toBe(false);
+    expect(
+      assetWrites.some(
+        (c: any) => c[0].data.status === AssetStatus.CHECKED_OUT
+      ),
+      "the remaining commitment should keep it checked out"
+    ).toBe(true);
   });
 });
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -305,6 +305,9 @@ vitest.mock("~/database/db.server", () => ({
     custody: {
       aggregate: vitest.fn().mockResolvedValue({ _sum: { quantity: 0 } }),
       count: vitest.fn().mockResolvedValue(0),
+      // why: the booking-exit reconciler reads custody holders for a whole
+      // batch in one query rather than counting per asset.
+      findMany: vitest.fn().mockResolvedValue([]),
       // why: `getAssetAvailabilityBatch` sums in-custody units via
       // `custody.groupBy` instead of the singular primitive's `aggregate`.
       // Default to no rows — per-test overrides aren't needed unless a test
@@ -5644,16 +5647,30 @@ describe("cancelBooking", () => {
       otherActiveBookingsByAssetId: Record<string, number>,
       custodyByAssetId: Record<string, number>
     ) {
+      // The reconciler reads the whole batch in two set-based queries and keys
+      // on the slice markers, so these model row PRESENCE per asset rather
+      // than a count per asset.
       (
-        db.bookingAsset.count as ReturnType<typeof vitest.fn>
-      ).mockImplementation((args?: { where?: { assetId?: string } }) => {
-        const assetId = args?.where?.assetId ?? "";
-        return Promise.resolve(otherActiveBookingsByAssetId[assetId] ?? 0);
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockImplementation((args?: any) => {
+        // Only the reconciler's read carries a `checkedOutAt` filter; every
+        // other `bookingAsset.findMany` on these paths keeps the default [].
+        if (args?.where?.checkedOutAt === undefined) return Promise.resolve([]);
+        const ids: string[] = args?.where?.assetId?.in ?? [];
+        return Promise.resolve(
+          ids
+            .filter((id) => (otherActiveBookingsByAssetId[id] ?? 0) > 0)
+            .map((assetId) => ({ assetId }))
+        );
       });
-      (db.custody.count as ReturnType<typeof vitest.fn>).mockImplementation(
-        (args?: { where?: { assetId?: string } }) => {
-          const assetId = args?.where?.assetId ?? "";
-          return Promise.resolve(custodyByAssetId[assetId] ?? 0);
+      (db.custody.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+        (args?: any) => {
+          const ids: string[] = args?.where?.assetId?.in ?? [];
+          return Promise.resolve(
+            ids
+              .filter((id) => (custodyByAssetId[id] ?? 0) > 0)
+              .map((assetId) => ({ assetId }))
+          );
         }
       );
     }
@@ -5701,7 +5718,7 @@ describe("cancelBooking", () => {
       // Per-asset terminal write keeps CHECKED_OUT. NOT the blanket
       // `updateMany({status: AVAILABLE})` of the old code path.
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.CHECKED_OUT },
       });
       // Defence: no blanket flip to AVAILABLE on the asset list.
@@ -5752,11 +5769,11 @@ describe("cancelBooking", () => {
       });
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.IN_CUSTODY },
       });
       expect(db.asset.updateMany).not.toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.AVAILABLE },
       });
     });
@@ -5804,7 +5821,7 @@ describe("cancelBooking", () => {
       });
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.AVAILABLE },
       });
     });
@@ -5844,16 +5861,30 @@ describe("deleteBooking", () => {
       otherActiveBookingsByAssetId: Record<string, number>,
       custodyByAssetId: Record<string, number>
     ) {
+      // The reconciler reads the whole batch in two set-based queries and keys
+      // on the slice markers, so these model row PRESENCE per asset rather
+      // than a count per asset.
       (
-        db.bookingAsset.count as ReturnType<typeof vitest.fn>
-      ).mockImplementation((args?: { where?: { assetId?: string } }) => {
-        const assetId = args?.where?.assetId ?? "";
-        return Promise.resolve(otherActiveBookingsByAssetId[assetId] ?? 0);
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockImplementation((args?: any) => {
+        // Only the reconciler's read carries a `checkedOutAt` filter; every
+        // other `bookingAsset.findMany` on these paths keeps the default [].
+        if (args?.where?.checkedOutAt === undefined) return Promise.resolve([]);
+        const ids: string[] = args?.where?.assetId?.in ?? [];
+        return Promise.resolve(
+          ids
+            .filter((id) => (otherActiveBookingsByAssetId[id] ?? 0) > 0)
+            .map((assetId) => ({ assetId }))
+        );
       });
-      (db.custody.count as ReturnType<typeof vitest.fn>).mockImplementation(
-        (args?: { where?: { assetId?: string } }) => {
-          const assetId = args?.where?.assetId ?? "";
-          return Promise.resolve(custodyByAssetId[assetId] ?? 0);
+      (db.custody.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+        (args?: any) => {
+          const ids: string[] = args?.where?.assetId?.in ?? [];
+          return Promise.resolve(
+            ids
+              .filter((id) => (custodyByAssetId[id] ?? 0) > 0)
+              .map((assetId) => ({ assetId }))
+          );
         }
       );
     }
@@ -5900,7 +5931,7 @@ describe("deleteBooking", () => {
       );
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.CHECKED_OUT },
       });
       // Defence: NOT the old blanket flip-to-AVAILABLE on the asset list.
@@ -5952,7 +5983,7 @@ describe("deleteBooking", () => {
       );
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.IN_CUSTODY },
       });
     });
@@ -5999,7 +6030,7 @@ describe("deleteBooking", () => {
       );
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.AVAILABLE },
       });
     });
@@ -8640,16 +8671,30 @@ describe("removeAssets", () => {
       otherActiveBookingsByAssetId: Record<string, number>,
       custodyByAssetId: Record<string, number>
     ) {
+      // The reconciler reads the whole batch in two set-based queries and keys
+      // on the slice markers, so these model row PRESENCE per asset rather
+      // than a count per asset.
       (
-        db.bookingAsset.count as ReturnType<typeof vitest.fn>
-      ).mockImplementation((args?: { where?: { assetId?: string } }) => {
-        const assetId = args?.where?.assetId ?? "";
-        return Promise.resolve(otherActiveBookingsByAssetId[assetId] ?? 0);
+        db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+      ).mockImplementation((args?: any) => {
+        // Only the reconciler's read carries a `checkedOutAt` filter; every
+        // other `bookingAsset.findMany` on these paths keeps the default [].
+        if (args?.where?.checkedOutAt === undefined) return Promise.resolve([]);
+        const ids: string[] = args?.where?.assetId?.in ?? [];
+        return Promise.resolve(
+          ids
+            .filter((id) => (otherActiveBookingsByAssetId[id] ?? 0) > 0)
+            .map((assetId) => ({ assetId }))
+        );
       });
-      (db.custody.count as ReturnType<typeof vitest.fn>).mockImplementation(
-        (args?: { where?: { assetId?: string } }) => {
-          const assetId = args?.where?.assetId ?? "";
-          return Promise.resolve(custodyByAssetId[assetId] ?? 0);
+      (db.custody.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
+        (args?: any) => {
+          const ids: string[] = args?.where?.assetId?.in ?? [];
+          return Promise.resolve(
+            ids
+              .filter((id) => (custodyByAssetId[id] ?? 0) > 0)
+              .map((assetId) => ({ assetId }))
+          );
         }
       );
     }
@@ -8684,7 +8729,7 @@ describe("removeAssets", () => {
       });
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.CHECKED_OUT },
       });
       // Defence: NOT the old blanket flip-to-AVAILABLE.
@@ -8724,7 +8769,7 @@ describe("removeAssets", () => {
       });
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.IN_CUSTODY },
       });
     });
@@ -8759,7 +8804,7 @@ describe("removeAssets", () => {
       });
 
       expect(db.asset.updateMany).toHaveBeenCalledWith({
-        where: { id: "asset-1", organizationId: "org-1" },
+        where: { id: { in: ["asset-1"] }, organizationId: "org-1" },
         data: { status: AssetStatus.AVAILABLE },
       });
     });
@@ -11209,10 +11254,16 @@ describe("bulkCancelBookings", () => {
       },
     ]);
     // The asset is still on one OTHER ONGOING booking, outside this selection.
-    (db.bookingAsset.count as ReturnType<typeof vitest.fn>).mockResolvedValue(
-      1
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockImplementation((args?: any) =>
+      Promise.resolve(
+        args?.where?.checkedOutAt === undefined
+          ? []
+          : [{ assetId: "asset-shared" }]
+      )
     );
-    (db.custody.count as ReturnType<typeof vitest.fn>).mockResolvedValue(0);
+    (db.custody.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([]);
 
     await bulkCancelBookings({
       bookingIds: ["bk-ongoing"],
@@ -11236,6 +11287,107 @@ describe("bulkCancelBookings", () => {
       ),
       "the remaining commitment should keep it checked out"
     ).toBe(true);
+  });
+
+  /**
+   * A live booking is not by itself evidence that it holds the asset. A slice
+   * added after that booking checked out has never left, and one already
+   * reconciled has come back. Counting either pins the asset to CHECKED_OUT
+   * with nothing in the field, and no later exit can clear it.
+   *
+   * Asserted on the query rather than the outcome: the filter is what the
+   * database applies, so a mocked result cannot demonstrate it.
+   */
+  it("counts only slices that are genuinely still out", async () => {
+    expect.assertions(2);
+
+    //@ts-expect-error missing vitest type
+    db.booking.findMany.mockResolvedValue([
+      {
+        id: "bk-marker",
+        name: "Ongoing booking",
+        status: BookingStatus.ONGOING,
+        custodianUserId: null,
+        activeSchedulerReference: null,
+        bookingAssets: [{ asset: { id: "asset-shared", assetKits: [] } }],
+        from: new Date("2025-01-01T09:00:00Z"),
+        to: new Date("2025-01-02T17:00:00Z"),
+        organization: { customEmailFooter: null },
+        custodianUser: null,
+        custodianTeamMember: null,
+        _count: { bookingAssets: 1 },
+      },
+    ]);
+    (db.custody.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([]);
+
+    await bulkCancelBookings({
+      bookingIds: ["bk-marker"],
+      organizationId: "org-1",
+      userId: "user-1",
+      role: OrganizationRoles.OWNER,
+      hints: mockClientHints,
+    });
+
+    const reconcileRead = (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mock.calls
+      .map((call: any) => call[0])
+      .find((args: any) => args?.where?.assetId?.in && args?.select?.assetId);
+
+    expect(
+      reconcileRead?.where?.checkedOutAt,
+      "a slice that never left must not count as holding the asset"
+    ).toEqual({ not: null });
+    expect(
+      reconcileRead?.where?.checkedInAt,
+      "a slice already reconciled must not count as holding the asset"
+    ).toBeNull();
+  });
+
+  /**
+   * Every booking in the selection must be invisible to the reconciliation,
+   * not just one. Two bookings on their way out that share an asset would
+   * otherwise vouch for each other and pin it to CHECKED_OUT against nothing.
+   */
+  it("excludes every booking in the selection, not just one", async () => {
+    expect.assertions(1);
+
+    const twoBookings = ["bk-a", "bk-b"].map((id) => ({
+      id,
+      name: id,
+      status: BookingStatus.ONGOING,
+      custodianUserId: null,
+      activeSchedulerReference: null,
+      bookingAssets: [{ asset: { id: "asset-shared", assetKits: [] } }],
+      from: new Date("2025-01-01T09:00:00Z"),
+      to: new Date("2025-01-02T17:00:00Z"),
+      organization: { customEmailFooter: null },
+      custodianUser: null,
+      custodianTeamMember: null,
+      _count: { bookingAssets: 1 },
+    }));
+    //@ts-expect-error missing vitest type
+    db.booking.findMany.mockResolvedValue(twoBookings);
+    (db.custody.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([]);
+
+    await bulkCancelBookings({
+      bookingIds: ["bk-a", "bk-b"],
+      organizationId: "org-1",
+      userId: "user-1",
+      role: OrganizationRoles.OWNER,
+      hints: mockClientHints,
+    });
+
+    const reconcileRead = (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mock.calls
+      .map((call: any) => call[0])
+      .find((args: any) => args?.where?.assetId?.in && args?.select?.assetId);
+
+    expect(
+      [...(reconcileRead?.where?.bookingId?.notIn ?? [])].sort(),
+      "both exiting bookings must be excluded from the held-elsewhere read"
+    ).toEqual(["bk-a", "bk-b"]);
   });
 });
 
@@ -11270,10 +11422,16 @@ describe("bulkDeleteBookings", () => {
       },
     ]);
     // Still on one OTHER ONGOING booking, outside this selection.
-    (db.bookingAsset.count as ReturnType<typeof vitest.fn>).mockResolvedValue(
-      1
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockImplementation((args?: any) =>
+      Promise.resolve(
+        args?.where?.checkedOutAt === undefined
+          ? []
+          : [{ assetId: "asset-shared" }]
+      )
     );
-    (db.custody.count as ReturnType<typeof vitest.fn>).mockResolvedValue(0);
+    (db.custody.findMany as ReturnType<typeof vitest.fn>).mockResolvedValue([]);
 
     await bulkDeleteBookings({
       bookingIds: ["bk-del-ongoing"],

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -730,51 +730,86 @@ async function reconcileAssetStatusForBookingExit({
   if (uniqueAssetIds.length === 0) return resolvedStatuses;
 
   try {
-    for (const assetId of uniqueAssetIds) {
-      // Run both queries in parallel — each is a single indexed count, and
-      // they are independent. Scoped to the active tx snapshot so a
-      // concurrent booking write cannot race the decision.
-      const [otherActiveBookings, custodyCount] = await Promise.all([
-        tx.bookingAsset.count({
-          where: {
-            assetId,
-            // Exclude the exiting bookings' own rows so they cannot pin the
-            // asset, or each other.
-            bookingId: { notIn: excludeBookingIds },
-            booking: {
-              status: {
-                in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
-              },
+    /**
+     * Two set-based reads for the whole batch, not two per asset. A bulk exit
+     * runs inside an interactive transaction and its selection is uncapped —
+     * select-all spans every page — so per-asset round trips would hold locks
+     * long enough to hit the transaction timeout and roll the booking mutation
+     * back with it.
+     *
+     * Scoped to the active tx snapshot so a concurrent booking write cannot
+     * race the decision.
+     */
+    const [slicesStillOut, custodies] = await Promise.all([
+      tx.bookingAsset.findMany({
+        where: {
+          assetId: { in: uniqueAssetIds },
+          // Exclude the exiting bookings' own rows so they cannot pin the
+          // asset, or each other.
+          bookingId: { notIn: excludeBookingIds },
+          booking: {
+            status: {
+              in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
             },
           },
-        }),
-        tx.custody.count({ where: { assetId } }),
-      ]);
+          // A live booking is not by itself evidence that it holds this asset.
+          // Only the slice's own markers say that: one added after checkout has
+          // never left, and one already reconciled has come back. Counting
+          // either would pin the asset to CHECKED_OUT with nothing in the
+          // field, and no later exit could clear it. Partially returned
+          // QUANTITY_TRACKED slices keep a null `checkedInAt` and so still
+          // count, which is correct — some of their units are still out.
+          checkedOutAt: { not: null },
+          checkedInAt: null,
+        },
+        select: { assetId: true },
+        distinct: ["assetId"],
+      }),
+      tx.custody.findMany({
+        where: { assetId: { in: uniqueAssetIds } },
+        select: { assetId: true },
+        distinct: ["assetId"],
+      }),
+    ]);
 
-      // Pick the strongest commitment first: CHECKED_OUT beats IN_CUSTODY
-      // beats AVAILABLE. See JSDoc above for the rationale on not
-      // downgrading to IN_CUSTODY when both a booking and a custody coexist.
-      let nextStatus: AssetStatus;
-      if (otherActiveBookings > 0) {
-        nextStatus = AssetStatus.CHECKED_OUT;
-      } else if (custodyCount > 0) {
-        nextStatus = AssetStatus.IN_CUSTODY;
+    const heldByAnotherBooking = new Set(
+      (slicesStillOut as Array<{ assetId: string }>).map((row) => row.assetId)
+    );
+    const heldInCustody = new Set(
+      (custodies as Array<{ assetId: string }>).map((row) => row.assetId)
+    );
+
+    // Pick the strongest commitment first: CHECKED_OUT beats IN_CUSTODY beats
+    // AVAILABLE. See JSDoc above for the rationale on not downgrading to
+    // IN_CUSTODY when both a booking and a custody coexist.
+    const assetIdsByStatus = new Map<AssetStatus, Asset["id"][]>();
+    for (const assetId of uniqueAssetIds) {
+      const nextStatus = heldByAnotherBooking.has(assetId)
+        ? AssetStatus.CHECKED_OUT
+        : heldInCustody.has(assetId)
+        ? AssetStatus.IN_CUSTODY
+        : AssetStatus.AVAILABLE;
+      const bucket = assetIdsByStatus.get(nextStatus);
+      if (bucket) {
+        bucket.push(assetId);
       } else {
-        nextStatus = AssetStatus.AVAILABLE;
+        assetIdsByStatus.set(nextStatus, [assetId]);
       }
+      resolvedStatuses.set(assetId, nextStatus);
+    }
 
-      // Use `updateMany` so we can compound `id` + `organizationId` in the
-      // where clause without depending on a `@@unique` constraint. Org-scope
-      // is defence-in-depth: even though `assetId` originated from a booking
-      // already loaded org-scoped by every caller, this filter makes the
-      // IDOR impossible to (re)introduce by a future refactor. The lint rule
-      // for `require-org-scope-on-id-queries` is exactly what this satisfies.
+    // One write per distinct status, so the whole batch costs at most three.
+    // `updateMany` compounds `id` + `organizationId` without depending on a
+    // `@@unique` constraint. Org-scope is defence-in-depth: even though the
+    // asset ids originated from a booking already loaded org-scoped by every
+    // caller, this filter makes the IDOR impossible to (re)introduce by a
+    // future refactor. The `require-org-scope-on-id-queries` lint rule is
+    // exactly what this satisfies.
+    for (const [nextStatus, idsForStatus] of assetIdsByStatus) {
       await tx.asset.updateMany({
-        where: { id: assetId, organizationId },
+        where: { id: { in: idsForStatus }, organizationId },
         data: { status: nextStatus },
       });
-
-      resolvedStatuses.set(assetId, nextStatus);
     }
 
     return resolvedStatuses;

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -663,15 +663,20 @@ export async function scheduleExpiryArchiveForExistingReservations({
  *   - **`AVAILABLE`** — no other active booking, no custody. Safe to release
  *     back onto the shelf.
  *
- * `excludeBookingId` is REQUIRED so the source booking's own
+ * `excludeBookingIds` is REQUIRED so the exiting bookings' own
  * about-to-be-removed `BookingAsset` rows (cancel / remove / delete) do not
  * count themselves as "another active booking" and pin the asset to
- * `CHECKED_OUT` forever. Callers should invoke this BEFORE deleting the source
- * booking's pivot rows so the `bookingId: { not: excludeBookingId }` filter
- * does the work — OR (equivalently) call it AFTER the deletes, in which case
- * the filter is redundant but harmless.
+ * `CHECKED_OUT` forever. Pass EVERY booking leaving in this operation: a bulk
+ * exit can drop several bookings that share an asset, and if they are not all
+ * excluded, two bookings on their way out vouch for each other. Callers should
+ * invoke this BEFORE deleting the exiting bookings' pivot rows so the
+ * `bookingId: { notIn: excludeBookingIds }` filter does the work — OR
+ * (equivalently) call it AFTER the deletes, in which case the filter is
+ * redundant but harmless.
  *
- * Use this helper on every IN-flow exit path (cancel / remove / delete). The
+ * Use this helper on every IN-flow exit path, single or bulk (cancel / remove /
+ * delete). Blanket-writing `AVAILABLE` across a selection is never correct: it
+ * frees assets that another live booking or a custody row still holds. The
  * RESERVED → ONGOING OUT-flow uses its own targeted `tx.asset.updateMany`
  * inline because every asset is unambiguously transitioning to `CHECKED_OUT`
  * there and no per-asset reconciliation is needed.
@@ -681,9 +686,9 @@ export async function scheduleExpiryArchiveForExistingReservations({
  *             and the status flip commit atomically.
  * @param args.assetIds - Assets exiting the booking. Each is reconciled
  *             independently; ordering does not matter.
- * @param args.excludeBookingId - The source booking's id. Excluded from the
- *             "other active bookings" count so the source booking's own
- *             rows do not block release.
+ * @param args.excludeBookingIds - Every exiting booking's id. Excluded from
+ *             the "other active bookings" count so those bookings' own rows
+ *             neither block release nor vouch for one another.
  * @param args.organizationId - Active org. Used to org-scope the asset write
  *             (defence-in-depth against cross-org IDOR — see
  *             `~/utils/org-validation.server`).
@@ -701,13 +706,20 @@ export async function scheduleExpiryArchiveForExistingReservations({
 async function reconcileAssetStatusForBookingExit({
   tx,
   assetIds,
-  excludeBookingId,
+  excludeBookingIds,
   organizationId,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tx: any;
   assetIds: Asset["id"][];
-  excludeBookingId: Booking["id"];
+  /**
+   * Every booking leaving in this operation, not just one. A bulk exit can
+   * cancel or delete several bookings that share an asset, and each of them
+   * must be invisible to the others' reconciliation — otherwise two bookings
+   * on their way out vouch for each other and the asset stays checked out
+   * against nothing.
+   */
+  excludeBookingIds: Booking["id"][];
   organizationId: Organization["id"];
 }): Promise<Map<Asset["id"], AssetStatus>> {
   // De-dupe up front: an asset can appear on the booking through both a kit
@@ -726,8 +738,9 @@ async function reconcileAssetStatusForBookingExit({
         tx.bookingAsset.count({
           where: {
             assetId,
-            // Exclude the source booking's own rows so we don't self-pin.
-            bookingId: { not: excludeBookingId },
+            // Exclude the exiting bookings' own rows so they cannot pin the
+            // asset, or each other.
+            bookingId: { notIn: excludeBookingIds },
             booking: {
               status: {
                 in: [BookingStatus.ONGOING, BookingStatus.OVERDUE],
@@ -772,7 +785,7 @@ async function reconcileAssetStatusForBookingExit({
         "Something went wrong while reconciling asset statuses after a booking exit.",
       additionalData: {
         assetIds: uniqueAssetIds,
-        excludeBookingId,
+        excludeBookingIds,
         organizationId,
       },
       label,
@@ -4979,7 +4992,7 @@ export async function checkinBooking({
             await reconcileAssetStatusForBookingExit({
               tx,
               assetIds: qtyAssetIds,
-              excludeBookingId: id,
+              excludeBookingIds: [id],
               organizationId,
             });
           }
@@ -9577,7 +9590,7 @@ export async function cancelBooking({
         await reconcileAssetStatusForBookingExit({
           tx,
           assetIds: cancelAssets.map((a) => a.id),
-          excludeBookingId: bookingFound.id,
+          excludeBookingIds: [bookingFound.id],
           organizationId,
         });
 
@@ -11107,7 +11120,7 @@ export async function removeAssets({
         await reconcileAssetStatusForBookingExit({
           tx,
           assetIds,
-          excludeBookingId: id,
+          excludeBookingIds: [id],
           organizationId,
         });
       }
@@ -11443,7 +11456,7 @@ export async function deleteBooking(
         await reconcileAssetStatusForBookingExit({
           tx,
           assetIds: activeAssetIds,
-          excludeBookingId: activeBooking.id,
+          excludeBookingIds: [activeBooking.id],
           organizationId,
         });
       }
@@ -12276,12 +12289,22 @@ export async function bulkDeleteBookings({
 
         const uniqueKitIds = new Set(allKitIds);
 
-        await tx.asset.updateMany({
-          where: {
-            id: { in: allAssets.map((asset) => asset.id) },
-            organizationId,
-          },
-          data: { status: AssetStatus.AVAILABLE },
+        /**
+         * Per asset, never a blanket flip. An asset on one of these bookings
+         * can also sit on a live booking outside the selection, or be held by
+         * a Custody row, and writing AVAILABLE across the set strips those
+         * signals — putting an asset someone is still holding back into the
+         * pool for anyone to book.
+         *
+         * Runs after the `deleteMany` above, so the selection's own pivot rows
+         * are already gone; passing their ids keeps the exclusion explicit
+         * rather than resting on that ordering.
+         */
+        await reconcileAssetStatusForBookingExit({
+          tx,
+          assetIds: allAssets.map((asset) => asset.id),
+          excludeBookingIds: bookings.map((booking) => booking.id),
+          organizationId,
         });
 
         await tx.kit.updateMany({
@@ -12680,10 +12703,22 @@ export async function bulkCancelBookings({
 
         const uniqueKitIds = new Set(allKitIds);
 
-        /** Making assets available */
-        await tx.asset.updateMany({
-          where: { id: { in: allAssets.map((a) => a.id) }, organizationId },
-          data: { status: AssetStatus.AVAILABLE },
+        /**
+         * Per asset, never a blanket flip. An asset on one of these bookings
+         * can also sit on a live booking outside the selection, or be held by
+         * a Custody row, and writing AVAILABLE across the set strips those
+         * signals — putting an asset someone is still holding back into the
+         * pool for anyone to book.
+         *
+         * Runs after the status write above, so the selection is already
+         * CANCELLED and out of the ONGOING/OVERDUE count; passing the ids keeps
+         * the exclusion explicit rather than resting on that ordering.
+         */
+        await reconcileAssetStatusForBookingExit({
+          tx,
+          assetIds: allAssets.map((a) => a.id),
+          excludeBookingIds: bookings.map((b) => b.id),
+          organizationId,
         });
 
         /** Making kits available */


### PR DESCRIPTION
Closes #2970.

## The bug

`bulkCancelBookings` and `bulkDeleteBookings` blanket-write every asset on every ONGOING or OVERDUE booking in the selection to `AVAILABLE`. The four single-booking exit paths all reconcile per asset. These two never did.

This is the dangerous direction. An asset can sit on another live booking, or be held by a `Custody` row, so freeing it across a selection puts something a borrower still has back into the pool for anyone else to book.

> Asset X is out on booking A and also on booking B. Bulk-cancel B, and X reads available while someone still has it for A.

## The fix

Both paths now go through `reconcileAssetStatusForBookingExit`, which picks the strongest remaining commitment per asset: `CHECKED_OUT` > `IN_CUSTODY` > `AVAILABLE`. That is the helper the single paths have used since bug #99 — the bulk paths look like they were missed rather than deliberately excluded.

**The helper now takes `excludeBookingIds` instead of one id.** A bulk exit can drop several bookings that share an asset, and unless all of them are excluded, two bookings on their way out vouch for each other and pin the asset to `CHECKED_OUT` against nothing.

Both call sites already run after their status write or delete, so the selection is out of the `ONGOING`/`OVERDUE` count either way. Passing the ids keeps the exclusion explicit rather than resting on that ordering, which a later refactor could quietly change.

**Kit status is unchanged** — still a blanket flip, still out of scope, same as the single-booking cancel path says.

## Verification

One test per path, each checked against its own mutation:

| mutation | reddens |
|---|---|
| bulk **cancel** back to the blanket flip | only the cancel test |
| bulk **delete** back to the blanket flip | only the delete test |

So neither test is riding on the other's coverage.

`validate` green: 438 files, 5784 tests.

The shared db mock gained `booking.deleteMany` — it did not carry one because no test had reached that path before.

## Note on scope

The regex rename of `excludeBookingId` initially caught four call sites belonging to `availability.server.ts`, which has an unrelated parameter of the same name. Typecheck caught it and those are reverted; only the four reconciler call sites take the new array form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bulk booking cancellations and deletions so assets associated with another active booking remain checked out.
  * Prevented assets with ongoing custody records from being incorrectly marked as available.
  * Improved asset status handling when multiple bookings are processed together.
  * Corrected kit release tracking when assets are detached, returned in stages, or linked to multiple booking records.
  * Ensured partial check-ins release only kits whose associated items have fully returned.
  * Improved handling of legacy kit associations and bookings with missing historical membership data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->