### PR TITLE
feat(assets): add PDF attachment upload, replace and delete

### DIFF
--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -169,7 +169,15 @@ export const NewAssetFormSchema = z.object({
   attachmentSize: z
     .string()
     .optional()
-    .transform((val) => (val ? +val : undefined)),
+    .transform((val) => (val === "" || val === undefined ? undefined : +val))
+    .pipe(
+      z
+        .number({ invalid_type_error: "Attachment size must be a number" })
+        .finite("Attachment size must be finite")
+        .int("Attachment size must be a whole number")
+        .nonnegative("Attachment size must not be negative")
+        .optional()
+    ),
 });
 
 /**

--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -157,6 +157,17 @@ export const NewAssetFormSchema = z.object({
       (v) => !v || !/{%|%}/.test(v),
       "Unit of measure may not contain Markdoc syntax (`{%` / `%}`)"
     ),
+
+  // Populated only when a PDF was staged via the attachment widget before
+  // this (new, not-yet-created) asset was submitted - see AssetForm's
+  // pendingId / onAttachmentUploaded. Absent entirely on the edit form,
+  // where the attachment is written directly by its own dedicated route.
+  attachmentUrl: z.string().optional(),
+  attachmentOriginalName: z.string().optional(),
+  attachmentSize: z
+    .string()
+    .optional()
+    .transform((val) => (val ? +val : undefined)),
 });
 
 /**
@@ -283,6 +294,20 @@ export const AssetForm = ({
   // about silent fallback when this asset can't satisfy the workspace preference).
   const currentOrganization = useCurrentOrganization();
   const barcodesInputRef = useRef<BarcodesInputRef>(null);
+
+  // The attachment widget always needs an id to scope its storage path by.
+  // Editing an existing asset uses its real id; creating a new one has none
+  // yet, so mint a client-side placeholder once per mount.
+  const [pendingAttachmentId] = useState(() => id ?? crypto.randomUUID());
+
+  // Lifted staged-attachment state for the create form only (see
+  // AssetAttachmentUpload's onUploaded/onRemoved doc comment) - null on the
+  // edit form, where `attachmentUrl` etc. come from loader data instead.
+  const [pendingAttachment, setPendingAttachment] = useState<{
+    attachmentUrl: string;
+    attachmentOriginalName: string | null;
+    attachmentSize: number;
+  } | null>(null);
 
   // Live mirror of BarcodesInput state — feeds PreferredBarcodeSelector so
   // removing a barcode in the section above immediately removes the matching
@@ -1098,7 +1123,12 @@ export const AssetForm = ({
           </div>
         </FormRow>
 
-        <When truthy={Boolean(id)}>
+        {/*
+          Bulk-create makes N assets from one submission - a single
+          attachment has no obvious asset to belong to, so the row is
+          hidden there. Editing and single (non-bulk) creation both show it.
+        */}
+        <When truthy={Boolean(id) || !bulkMode}>
           <FormRow
             rowLabel={"Attachment"}
             subHeading={
@@ -1110,11 +1140,43 @@ export const AssetForm = ({
             className="pt-[10px]"
           >
             <AssetAttachmentUpload
-              assetId={id as string}
-              attachmentUrl={attachmentUrl}
-              attachmentOriginalName={attachmentOriginalName}
-              attachmentSize={attachmentSize}
+              assetId={id ?? pendingAttachmentId}
+              attachmentUrl={
+                id ? attachmentUrl : pendingAttachment?.attachmentUrl
+              }
+              attachmentOriginalName={
+                id
+                  ? attachmentOriginalName
+                  : pendingAttachment?.attachmentOriginalName
+              }
+              attachmentSize={
+                id ? attachmentSize : pendingAttachment?.attachmentSize
+              }
+              onUploaded={id ? undefined : setPendingAttachment}
+              onRemoved={id ? undefined : () => setPendingAttachment(null)}
             />
+            {/*
+              Only meaningful while creating - the edit route persists
+              directly via AssetAttachmentUpload's own dedicated endpoint,
+              so there is nothing for these to carry on that form.
+            */}
+            <When truthy={!id && Boolean(pendingAttachment)}>
+              <input
+                type="hidden"
+                name="attachmentUrl"
+                value={pendingAttachment?.attachmentUrl ?? ""}
+              />
+              <input
+                type="hidden"
+                name="attachmentOriginalName"
+                value={pendingAttachment?.attachmentOriginalName ?? ""}
+              />
+              <input
+                type="hidden"
+                name="attachmentSize"
+                value={pendingAttachment?.attachmentSize ?? ""}
+              />
+            </When>
           </FormRow>
         </When>
 

--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -331,6 +331,12 @@ export const AssetForm = ({
     attachmentSize: number;
   } | null>(null);
 
+  // Mirrors AssetAttachmentUpload's own pending state (create mode only) so
+  // Save can stay disabled while a drop is still mid-upload/delete - without
+  // this, submitting before onUploaded fires would post a stale/empty
+  // attachmentPath even though a file is visibly staged in the widget.
+  const [attachmentPending, setAttachmentPending] = useState(false);
+
   // Live mirror of BarcodesInput state — feeds PreferredBarcodeSelector so
   // removing a barcode in the section above immediately removes the matching
   // override option. Initial value seeded from the loader; BarcodesInput
@@ -372,6 +378,9 @@ export const AssetForm = ({
 
   const zo = useZorm("NewAssetFormScreen", FormSchema);
   const disabled = isFormProcessing(navigation.state);
+  // Only the Save action needs to wait on the attachment widget - `disabled`
+  // above stays untouched since ~20 other fields in this form share it.
+  const submitDisabled = disabled || attachmentPending;
 
   // Focus the asset Title field on mount so create/edit pages start
   // ready for typing instead of relying on the removed autoFocus prop.
@@ -743,6 +752,7 @@ export const AssetForm = ({
           <div className="hidden flex-1 justify-end gap-2 md:flex">
             <Actions
               disabled={disabled}
+              submitDisabled={submitDisabled}
               cancelTo={cancelTo}
               showAddAnother={!bulkMode}
             />
@@ -1182,6 +1192,7 @@ export const AssetForm = ({
               }
               onUploaded={id ? undefined : setPendingAttachment}
               onRemoved={id ? undefined : () => setPendingAttachment(null)}
+              onPendingChange={id ? undefined : setAttachmentPending}
             />
             {/*
               Only meaningful while creating - the edit route persists
@@ -1204,6 +1215,15 @@ export const AssetForm = ({
                 name="attachmentSize"
                 value={pendingAttachment?.attachmentSize ?? ""}
               />
+              {/* attachmentPath/attachmentOriginalName are unrefined
+                  z.string().optional() - only attachmentSize carries real
+                  Zod checks (finite/int/nonnegative), so it's the only one
+                  of the three that can fail server-side validation. */}
+              {validationErrors?.attachmentSize?.message ? (
+                <div className="text-sm text-error-500">
+                  {validationErrors.attachmentSize.message}
+                </div>
+              ) : null}
             </When>
           </FormRow>
         </When>
@@ -1505,6 +1525,7 @@ export const AssetForm = ({
           <div className="flex flex-1 justify-end gap-2">
             <Actions
               disabled={disabled}
+              submitDisabled={submitDisabled}
               cancelTo={cancelTo}
               showAddAnother={!bulkMode}
             />
@@ -1517,10 +1538,15 @@ export const AssetForm = ({
 
 const Actions = ({
   disabled,
+  submitDisabled,
   cancelTo,
   showAddAnother = true,
 }: {
   disabled: boolean;
+  /** Adds the attachment widget's own pending upload/delete state on top of
+   * `disabled` - Save alone must wait for it, since submitting while a file
+   * is still mid-upload would post a stale/empty attachmentPath. */
+  submitDisabled: boolean;
   /** Already-resolved Cancel destination. Must never be null/undefined —
    * the caller applies the fallback, because `<Button to>` degrades
    * silently (dead button on `undefined`, links to `/` on `null`). */
@@ -1533,7 +1559,7 @@ const Actions = ({
 }) => (
   <>
     {/* Save button is first in DOM order so Enter key triggers it by default */}
-    <Button type="submit" disabled={disabled} className="order-last">
+    <Button type="submit" disabled={submitDisabled} className="order-last">
       Save
     </Button>
 

--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -160,9 +160,11 @@ export const NewAssetFormSchema = z.object({
 
   // Populated only when a PDF was staged via the attachment widget before
   // this (new, not-yet-created) asset was submitted - see AssetForm's
-  // pendingId / onAttachmentUploaded. Absent entirely on the edit form,
-  // where the attachment is written directly by its own dedicated route.
-  attachmentUrl: z.string().optional(),
+  // pendingAttachmentId / pendingAttachment. Absent entirely on the edit
+  // form, where the attachment is written directly by its own dedicated
+  // route. A bare storage path, not a URL - see Asset.attachmentPath's
+  // schema comment.
+  attachmentPath: z.string().optional(),
   attachmentOriginalName: z.string().optional(),
   attachmentSize: z
     .string()
@@ -217,7 +219,6 @@ type Props = Partial<
     | "thumbnailImage"
     | "mainImage"
     | "mainImageExpiration"
-    | "attachmentUrl"
     | "attachmentOriginalName"
     | "attachmentSize"
     | "categoryId"
@@ -236,6 +237,14 @@ type Props = Partial<
   tags?: Tag[];
   barcodes?: Pick<Barcode, "id" | "value" | "type">[];
   referer?: string | null;
+  /**
+   * NOT `Asset["attachmentPath"]` - the DB column is a bare storage path,
+   * but by the time this reaches the form it has already been resolved to
+   * a short-lived signed URL (edit: by the loader; create: staging
+   * response's `attachmentDisplayUrl`, fed through `pendingAttachment`
+   * below), so it genuinely is a URL here.
+   */
+  attachmentUrl?: string | null;
   /**
    * Location is not a column on `Asset` — it lives on the `AssetLocation`
    * pivot. Callers derive the single primary-location id via
@@ -303,8 +312,13 @@ export const AssetForm = ({
   // Lifted staged-attachment state for the create form only (see
   // AssetAttachmentUpload's onUploaded/onRemoved doc comment) - null on the
   // edit form, where `attachmentUrl` etc. come from loader data instead.
+  // `attachmentPath` here is the raw storage path submitted on final create
+  // (see Asset.attachmentPath's schema comment); `attachmentDisplayUrl` is a
+  // short-lived signed URL used only to render the link while still on
+  // this page - it is never itself submitted or persisted.
   const [pendingAttachment, setPendingAttachment] = useState<{
-    attachmentUrl: string;
+    attachmentPath: string;
+    attachmentDisplayUrl: string;
     attachmentOriginalName: string | null;
     attachmentSize: number;
   } | null>(null);
@@ -1141,8 +1155,14 @@ export const AssetForm = ({
           >
             <AssetAttachmentUpload
               assetId={id ?? pendingAttachmentId}
+              // Edit mode: attachmentUrl is already a loader-resolved signed
+              // URL (see the edit route's loader). Create mode: the widget
+              // needs something clickable NOW, before the raw path in
+              // pendingAttachment.attachmentPath has anywhere to be resolved
+              // from - attachmentDisplayUrl is the signed URL minted for
+              // exactly that, at staging-upload time.
               attachmentUrl={
-                id ? attachmentUrl : pendingAttachment?.attachmentUrl
+                id ? attachmentUrl : pendingAttachment?.attachmentDisplayUrl
               }
               attachmentOriginalName={
                 id
@@ -1163,8 +1183,8 @@ export const AssetForm = ({
             <When truthy={!id && Boolean(pendingAttachment)}>
               <input
                 type="hidden"
-                name="attachmentUrl"
-                value={pendingAttachment?.attachmentUrl ?? ""}
+                name="attachmentPath"
+                value={pendingAttachment?.attachmentPath ?? ""}
               />
               <input
                 type="hidden"

--- a/apps/webapp/app/components/assets/form.tsx
+++ b/apps/webapp/app/components/assets/form.tsx
@@ -57,6 +57,7 @@ import { Button } from "../shared/button";
 import { ButtonGroup } from "../shared/button-group";
 import { Card } from "../shared/card";
 import { DisabledReasonHoverCard } from "../shared/disabled-reason-hover-card";
+import { AssetAttachmentUpload } from "../shared/file-dropzone/asset-attachment-upload";
 import {
   HoverCard,
   HoverCardContent,
@@ -205,6 +206,9 @@ type Props = Partial<
     | "thumbnailImage"
     | "mainImage"
     | "mainImageExpiration"
+    | "attachmentUrl"
+    | "attachmentOriginalName"
+    | "attachmentSize"
     | "categoryId"
     | "assetModelId"
     | "description"
@@ -252,6 +256,9 @@ export const AssetForm = ({
   thumbnailImage,
   mainImage,
   mainImageExpiration,
+  attachmentUrl,
+  attachmentOriginalName,
+  attachmentSize,
   categoryId,
   assetModelId,
   locationId,
@@ -1090,6 +1097,26 @@ export const AssetForm = ({
             </div>
           </div>
         </FormRow>
+
+        <When truthy={Boolean(id)}>
+          <FormRow
+            rowLabel={"Attachment"}
+            subHeading={
+              <p>
+                A single PDF file for this asset - a purchase invoice, manual,
+                or calibration certificate.
+              </p>
+            }
+            className="pt-[10px]"
+          >
+            <AssetAttachmentUpload
+              assetId={id as string}
+              attachmentUrl={attachmentUrl}
+              attachmentOriginalName={attachmentOriginalName}
+              attachmentSize={attachmentSize}
+            />
+          </FormRow>
+        </When>
 
         <div>
           <FormRow

--- a/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
@@ -1,3 +1,24 @@
+/**
+ * Drag-and-drop uploader for an asset's single PDF attachment (purchase
+ * invoice, manual, calibration certificate, etc.).
+ *
+ * Owns two independent `useFetcher()` instances - one for upload, one for
+ * delete - both posting to the dedicated `/api/asset/:assetId/attachment`
+ * route, so a file can be added or removed instantly without touching the
+ * rest of whatever form this is embedded in. That route branches
+ * server-side on whether the asset already exists: for an existing asset it
+ * persists directly to the DB and this component relies on React Router's
+ * automatic loader revalidation to pick up the change; for an
+ * asset that doesn't exist yet (the create-asset flow) the route only
+ * touches storage, and this component surfaces the result via the
+ * `onUploaded` / `onRemoved` callbacks so the caller can lift it into its
+ * own form state and submit it once the rest of the form is ready.
+ *
+ * @see {@link file://../../../routes/api+/asset.$assetId.attachment.ts} for
+ * the route and its existing-vs-staged branching.
+ * @see {@link file://../../assets/form.tsx} (`AssetForm`) for the
+ * create-flow caller that consumes `onUploaded` / `onRemoved`.
+ */
 import { useCallback, useEffect } from "react";
 import { useFetcher } from "react-router";
 import { Button } from "~/components/shared/button";

--- a/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
@@ -18,7 +18,10 @@ import { FileDropzone } from "./file-dropzone";
 import { TrashIcon } from "../../icons/library";
 
 type StagedAttachment = {
-  attachmentUrl: string;
+  /** Raw storage path (see Asset.attachmentPath's schema comment). */
+  attachmentPath: string;
+  /** Short-lived signed URL for showing/linking to the file right now. */
+  attachmentDisplayUrl: string;
   attachmentOriginalName: string | null;
   attachmentSize: number;
 };
@@ -89,7 +92,8 @@ export function AssetAttachmentUpload({
       !uploadFetcher.data.error
     ) {
       onUploaded?.({
-        attachmentUrl: uploadFetcher.data.attachmentUrl,
+        attachmentPath: uploadFetcher.data.attachmentPath,
+        attachmentDisplayUrl: uploadFetcher.data.attachmentDisplayUrl,
         attachmentOriginalName: uploadFetcher.data.attachmentOriginalName,
         attachmentSize: uploadFetcher.data.attachmentSize,
       });

--- a/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
@@ -32,6 +32,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "~/components/shared/modal";
+import { useDisabled } from "~/hooks/use-disabled";
 import { ASSET_ATTACHMENT_MAX_SIZE } from "~/utils/constants";
 import { isFormProcessing } from "~/utils/form";
 import { formatBytes } from "~/utils/format-bytes";
@@ -84,6 +85,10 @@ export function AssetAttachmentUpload({
 
   const isUploading = isFormProcessing(uploadFetcher.state);
   const isDeleting = isFormProcessing(deleteFetcher.state);
+  // Also disabled while the enclosing form (edit-asset save, create-asset
+  // submit) is navigating - it's a separate <Form> from this widget's own
+  // fetchers, so isUploading/isDeleting alone miss that submission.
+  const disabled = useDisabled() || isUploading || isDeleting;
 
   const onDropAccepted = useCallback(
     (acceptedFiles: File[]) => {
@@ -162,7 +167,7 @@ export function AssetAttachmentUpload({
               type="button"
               variant="secondary"
               size="sm"
-              disabled={isUploading || isDeleting}
+              disabled={disabled}
               title="Delete attachment"
             >
               <TrashIcon />
@@ -186,11 +191,7 @@ export function AssetAttachmentUpload({
             <AlertDialogFooter>
               <div className="flex justify-center gap-2">
                 <AlertDialogCancel asChild>
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    disabled={isDeleting}
-                  >
+                  <Button type="button" variant="secondary" disabled={disabled}>
                     Cancel
                   </Button>
                 </AlertDialogCancel>
@@ -200,7 +201,7 @@ export function AssetAttachmentUpload({
                 >
                   <Button
                     type="submit"
-                    disabled={isDeleting}
+                    disabled={disabled}
                     className="border-error-600 bg-error-600 hover:border-error-800 hover:!bg-error-800"
                   >
                     Delete

--- a/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
@@ -1,0 +1,158 @@
+import { useCallback } from "react";
+import { useFetcher } from "react-router";
+import { Button } from "~/components/shared/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/shared/modal";
+import { ASSET_ATTACHMENT_MAX_SIZE } from "~/utils/constants";
+import { isFormProcessing } from "~/utils/form";
+import { formatBytes } from "~/utils/format-bytes";
+import { FileDropzone } from "./file-dropzone";
+import { TrashIcon } from "../../icons/library";
+
+type AssetAttachmentUploadProps = {
+  assetId: string;
+  attachmentUrl?: string | null;
+  attachmentOriginalName?: string | null;
+  attachmentSize?: number | null;
+};
+
+/**
+ * Drag-and-drop upload for an asset's single PDF attachment (purchase
+ * invoice, manual, calibration certificate, etc. - issue #2660). Own
+ * fetchers/route so upload and delete happen instantly, independent of the
+ * rest of the edit-asset form.
+ */
+export function AssetAttachmentUpload({
+  assetId,
+  attachmentUrl,
+  attachmentOriginalName,
+  attachmentSize,
+}: AssetAttachmentUploadProps) {
+  const uploadFetcher = useFetcher();
+  const deleteFetcher = useFetcher();
+
+  const isUploading = isFormProcessing(uploadFetcher.state);
+  const isDeleting = isFormProcessing(deleteFetcher.state);
+
+  const onDropAccepted = useCallback(
+    (acceptedFiles: File[]) => {
+      const file = acceptedFiles[0];
+      if (!file) {
+        return;
+      }
+      // fetcher.submit({ file }, { encType: "multipart/form-data" }) does not
+      // encode a File value nested in a plain object - it gets coerced to the
+      // string "[object File]" before the request body is built. Building the
+      // FormData explicitly sidesteps that.
+      const formData = new FormData();
+      formData.append("file", file);
+      void uploadFetcher.submit(formData, {
+        method: "post",
+        action: `/api/asset/${assetId}/attachment`,
+        encType: "multipart/form-data",
+      });
+    },
+    [assetId, uploadFetcher]
+  );
+
+  // Both fetchers submit to a different route than the current page, but
+  // React Router revalidates the current route's loaders after any action
+  // by default - so `attachmentUrl` (a loader-data prop) refreshes on its
+  // own once upload/delete completes, same as ProfilePictureUpload.
+  if (attachmentUrl && !isDeleting) {
+    return (
+      <div className="flex items-center gap-3">
+        <a
+          href={attachmentUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-text-sm font-semibold text-primary-700 hover:text-primary-800"
+        >
+          {attachmentOriginalName || "Attachment.pdf"}
+        </a>
+        {attachmentSize ? (
+          <span className="text-text-sm text-gray-500">
+            {formatBytes(attachmentSize)}
+          </span>
+        ) : null}
+
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={isUploading || isDeleting}
+              title="Delete attachment"
+            >
+              <TrashIcon />
+            </Button>
+          </AlertDialogTrigger>
+
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <div className="mx-auto md:m-0">
+                <span className="flex size-12 items-center justify-center rounded-full bg-error-50 p-2 text-error-600">
+                  <TrashIcon />
+                </span>
+              </div>
+              <AlertDialogTitle>Delete attachment</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete{" "}
+                {attachmentOriginalName || "this attachment"}? This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <div className="flex justify-center gap-2">
+                <AlertDialogCancel asChild>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={isDeleting}
+                  >
+                    Cancel
+                  </Button>
+                </AlertDialogCancel>
+                <deleteFetcher.Form
+                  method="delete"
+                  action={`/api/asset/${assetId}/attachment`}
+                >
+                  <Button
+                    type="submit"
+                    disabled={isDeleting}
+                    className="border-error-600 bg-error-600 hover:border-error-800 hover:!bg-error-800"
+                  >
+                    Delete
+                  </Button>
+                </deleteFetcher.Form>
+              </div>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    );
+  }
+
+  return (
+    <FileDropzone
+      fetcher={uploadFetcher}
+      onDropAccepted={onDropAccepted}
+      fileInputName="file"
+      acceptLabel="PDF"
+      dropzoneOptions={{
+        maxSize: ASSET_ATTACHMENT_MAX_SIZE,
+        maxFiles: 1,
+        accept: { "application/pdf": [".pdf"] },
+      }}
+    />
+  );
+}

--- a/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
@@ -64,6 +64,13 @@ type AssetAttachmentUploadProps = {
   onUploaded?: (attachment: StagedAttachment) => void;
   /** Same rationale as onUploaded, for the delete path. */
   onRemoved?: () => void;
+  /**
+   * Same create-flow-only rationale as onUploaded/onRemoved: notifies the
+   * parent whenever this widget's own upload/delete fetchers transition
+   * between pending and idle, so the create form can hold its submit
+   * button disabled until an in-flight attachment settles.
+   */
+  onPendingChange?: (pending: boolean) => void;
 };
 
 /**
@@ -79,6 +86,7 @@ export function AssetAttachmentUpload({
   attachmentSize,
   onUploaded,
   onRemoved,
+  onPendingChange,
 }: AssetAttachmentUploadProps) {
   const uploadFetcher = useFetcher();
   const deleteFetcher = useFetcher();
@@ -89,6 +97,10 @@ export function AssetAttachmentUpload({
   // submit) is navigating - it's a separate <Form> from this widget's own
   // fetchers, so isUploading/isDeleting alone miss that submission.
   const disabled = useDisabled() || isUploading || isDeleting;
+
+  useEffect(() => {
+    onPendingChange?.(disabled);
+  }, [disabled, onPendingChange]);
 
   const onDropAccepted = useCallback(
     (acceptedFiles: File[]) => {

--- a/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useFetcher } from "react-router";
 import { Button } from "~/components/shared/button";
 import {
@@ -17,11 +17,28 @@ import { formatBytes } from "~/utils/format-bytes";
 import { FileDropzone } from "./file-dropzone";
 import { TrashIcon } from "../../icons/library";
 
+type StagedAttachment = {
+  attachmentUrl: string;
+  attachmentOriginalName: string | null;
+  attachmentSize: number;
+};
+
 type AssetAttachmentUploadProps = {
   assetId: string;
   attachmentUrl?: string | null;
   attachmentOriginalName?: string | null;
   attachmentSize?: number | null;
+  /**
+   * Fires after a successful upload. The edit page doesn't need this - the
+   * asset already exists, so `attachmentUrl` (a loader-data prop) refreshes
+   * on its own via React Router's automatic revalidation after the fetcher
+   * completes. The create-asset form has no loader-backed asset yet, so it
+   * uses this to lift the staged attachment into its own form state and
+   * carry it through as hidden fields on final submit.
+   */
+  onUploaded?: (attachment: StagedAttachment) => void;
+  /** Same rationale as onUploaded, for the delete path. */
+  onRemoved?: () => void;
 };
 
 /**
@@ -35,6 +52,8 @@ export function AssetAttachmentUpload({
   attachmentUrl,
   attachmentOriginalName,
   attachmentSize,
+  onUploaded,
+  onRemoved,
 }: AssetAttachmentUploadProps) {
   const uploadFetcher = useFetcher();
   const deleteFetcher = useFetcher();
@@ -63,10 +82,38 @@ export function AssetAttachmentUpload({
     [assetId, uploadFetcher]
   );
 
-  // Both fetchers submit to a different route than the current page, but
-  // React Router revalidates the current route's loaders after any action
-  // by default - so `attachmentUrl` (a loader-data prop) refreshes on its
-  // own once upload/delete completes, same as ProfilePictureUpload.
+  useEffect(() => {
+    if (
+      uploadFetcher.state === "idle" &&
+      uploadFetcher.data &&
+      !uploadFetcher.data.error
+    ) {
+      onUploaded?.({
+        attachmentUrl: uploadFetcher.data.attachmentUrl,
+        attachmentOriginalName: uploadFetcher.data.attachmentOriginalName,
+        attachmentSize: uploadFetcher.data.attachmentSize,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uploadFetcher.state, uploadFetcher.data]);
+
+  useEffect(() => {
+    if (
+      deleteFetcher.state === "idle" &&
+      deleteFetcher.data &&
+      !deleteFetcher.data.error
+    ) {
+      onRemoved?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deleteFetcher.state, deleteFetcher.data]);
+
+  // Both fetchers submit to a different route than the current page. For an
+  // already-existing asset, React Router revalidates the current route's
+  // loaders after any action by default, so `attachmentUrl` (a loader-data
+  // prop) refreshes on its own - same as ProfilePictureUpload. A caller with
+  // no loader-backed asset yet (the create-asset form) relies on onUploaded /
+  // onRemoved above instead.
   if (attachmentUrl && !isDeleting) {
     return (
       <div className="flex items-center gap-3">

--- a/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/asset-attachment-upload.tsx
@@ -139,7 +139,7 @@ export function AssetAttachmentUpload({
   // prop) refreshes on its own - same as ProfilePictureUpload. A caller with
   // no loader-backed asset yet (the create-asset form) relies on onUploaded /
   // onRemoved above instead.
-  if (attachmentUrl && !isDeleting) {
+  if (attachmentUrl) {
     return (
       <div className="flex items-center gap-3">
         <a

--- a/apps/webapp/app/components/shared/file-dropzone/file-dropzone.tsx
+++ b/apps/webapp/app/components/shared/file-dropzone/file-dropzone.tsx
@@ -20,12 +20,20 @@ export function FileDropzone({
   dropzoneOptions,
   fileInputName,
   className,
+  acceptLabel = "PNG, JPG, JPEG, or WebP",
 }: {
   fetcher: Fetcher;
   onDropAccepted: DropzoneOptions["onDropAccepted"];
   fileInputName: string;
   dropzoneOptions?: DropzoneOptions;
   className?: string;
+  /**
+   * Human-readable description of `dropzoneOptions.accept`, shown next to
+   * the max-size hint. Defaults to the original image-only copy so existing
+   * callers don't need to change; override when passing a non-image
+   * `accept`.
+   */
+  acceptLabel?: string;
 }) {
   const [fileInfo, updateAllFileInfo] = useAtom(derivedFileInfoAtom);
   const { filename, message, error } = fileInfo;
@@ -117,7 +125,7 @@ export function FileDropzone({
           drop
         </p>
         <p>
-          PNG, JPG, JPEG, or WebP (max.{" "}
+          {acceptLabel} (max.{" "}
           {formatBytes(mergedDropzoneOptions?.maxSize as number)})
         </p>
       </div>

--- a/apps/webapp/app/modules/asset/attachment.server.test.ts
+++ b/apps/webapp/app/modules/asset/attachment.server.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: isolate the attachment service functions from real storage/db calls,
+// mirroring modules/audit/image.service.server.test.ts's local-mock style
+// rather than the shared mock in this module's own service.server.test.ts.
+vi.mock("~/utils/storage.server", () => ({
+  parsePdfFormData: vi.fn(),
+  getPublicFileURL: vi.fn(
+    ({ filename }: { filename: string }) =>
+      `https://example.supabase.co/storage/v1/object/public/files/${filename}`
+  ),
+  removePublicFile: vi.fn(),
+}));
+
+vi.mock("~/database/db.server", () => ({
+  db: {
+    asset: {
+      findFirstOrThrow: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import { db } from "~/database/db.server";
+import {
+  getPublicFileURL,
+  parsePdfFormData,
+  removePublicFile,
+} from "~/utils/storage.server";
+import { removeAssetAttachment, updateAssetAttachment } from "./service.server";
+
+describe("asset attachment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("updateAssetAttachment", () => {
+    it("uploads a new attachment and persists its url/name/size", async () => {
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
+        id: "asset-1",
+        attachmentUrl: null,
+      } as any);
+
+      const returnedFormData = new FormData();
+      returnedFormData.append(
+        "file",
+        JSON.stringify({
+          path: "org-1/asset-1/attachment-123.pdf",
+          originalName: "invoice.pdf",
+          size: 1234,
+        })
+      );
+      vi.mocked(parsePdfFormData).mockResolvedValue(returnedFormData);
+      vi.mocked(db.asset.update).mockResolvedValue({
+        id: "asset-1",
+        attachmentOriginalName: "invoice.pdf",
+      } as any);
+
+      const result = await updateAssetAttachment({
+        request: {} as Request,
+        assetId: "asset-1",
+        organizationId: "org-1",
+      });
+
+      expect(getPublicFileURL).toHaveBeenCalledWith({
+        filename: "org-1/asset-1/attachment-123.pdf",
+        bucketName: "files",
+      });
+      expect(removePublicFile).not.toHaveBeenCalled();
+      expect(db.asset.update).toHaveBeenCalledWith({
+        where: { id: "asset-1", organizationId: "org-1" },
+        data: {
+          attachmentUrl:
+            "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-123.pdf",
+          attachmentOriginalName: "invoice.pdf",
+          attachmentSize: 1234,
+        },
+      });
+      expect(result.attachmentOriginalName).toBe("invoice.pdf");
+    });
+
+    it("deletes the previous attachment when replacing one", async () => {
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
+        id: "asset-1",
+        attachmentUrl:
+          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-old.pdf",
+      } as any);
+
+      const returnedFormData = new FormData();
+      returnedFormData.append(
+        "file",
+        JSON.stringify({
+          path: "org-1/asset-1/attachment-new.pdf",
+          originalName: "invoice-2.pdf",
+          size: 999,
+        })
+      );
+      vi.mocked(parsePdfFormData).mockResolvedValue(returnedFormData);
+      vi.mocked(db.asset.update).mockResolvedValue({} as any);
+
+      await updateAssetAttachment({
+        request: {} as Request,
+        assetId: "asset-1",
+        organizationId: "org-1",
+      });
+
+      expect(removePublicFile).toHaveBeenCalledWith({
+        publicUrl:
+          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-old.pdf",
+      });
+    });
+
+    it("throws and does not touch the db when no file was uploaded", async () => {
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
+        id: "asset-1",
+        attachmentUrl: null,
+      } as any);
+      vi.mocked(parsePdfFormData).mockResolvedValue(new FormData());
+
+      await expect(
+        updateAssetAttachment({
+          request: {} as Request,
+          assetId: "asset-1",
+          organizationId: "org-1",
+        })
+      ).rejects.toThrow();
+
+      expect(db.asset.update).not.toHaveBeenCalled();
+    });
+
+    it("still persists the new attachment when deleting the old file fails", async () => {
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
+        id: "asset-1",
+        attachmentUrl:
+          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-old.pdf",
+      } as any);
+      vi.mocked(removePublicFile).mockRejectedValue(new Error("gone already"));
+
+      const returnedFormData = new FormData();
+      returnedFormData.append(
+        "file",
+        JSON.stringify({
+          path: "org-1/asset-1/attachment-new.pdf",
+          originalName: "invoice-2.pdf",
+          size: 999,
+        })
+      );
+      vi.mocked(parsePdfFormData).mockResolvedValue(returnedFormData);
+      vi.mocked(db.asset.update).mockResolvedValue({} as any);
+
+      await expect(
+        updateAssetAttachment({
+          request: {} as Request,
+          assetId: "asset-1",
+          organizationId: "org-1",
+        })
+      ).resolves.toBeDefined();
+
+      expect(db.asset.update).toHaveBeenCalled();
+    });
+  });
+
+  describe("removeAssetAttachment", () => {
+    it("deletes the file and clears the attachment fields", async () => {
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
+        id: "asset-1",
+        attachmentUrl:
+          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-123.pdf",
+      } as any);
+      // Explicit, since a previous test in this file leaves removePublicFile
+      // rejecting - vi.clearAllMocks() (in beforeEach) resets call history
+      // but not a configured mockRejectedValue/mockResolvedValue.
+      vi.mocked(removePublicFile).mockResolvedValue(undefined as any);
+      vi.mocked(db.asset.update).mockResolvedValue({} as any);
+
+      await removeAssetAttachment({
+        assetId: "asset-1",
+        organizationId: "org-1",
+      });
+
+      expect(removePublicFile).toHaveBeenCalledWith({
+        publicUrl:
+          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-123.pdf",
+      });
+      expect(db.asset.update).toHaveBeenCalledWith({
+        where: { id: "asset-1", organizationId: "org-1" },
+        data: {
+          attachmentUrl: null,
+          attachmentOriginalName: null,
+          attachmentSize: null,
+        },
+      });
+    });
+
+    it("is a no-op deletion when there is no existing attachment", async () => {
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
+        id: "asset-1",
+        attachmentUrl: null,
+      } as any);
+      vi.mocked(db.asset.update).mockResolvedValue({} as any);
+
+      await removeAssetAttachment({
+        assetId: "asset-1",
+        organizationId: "org-1",
+      });
+
+      expect(removePublicFile).not.toHaveBeenCalled();
+      expect(db.asset.update).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/webapp/app/modules/asset/attachment.server.test.ts
+++ b/apps/webapp/app/modules/asset/attachment.server.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Tests for the asset attachment service functions: uploading/replacing an
+ * existing asset's attachment, removing it, staging one for an asset that
+ * doesn't exist yet (the create-asset flow), clearing a staged attachment,
+ * and resolving a stored path into a display URL. Storage and DB calls are
+ * mocked - see the `why:` comments below each `vi.mock` for what's being
+ * isolated and why.
+ */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // why: isolate the attachment service functions from real storage/db calls,

--- a/apps/webapp/app/modules/asset/attachment.server.test.ts
+++ b/apps/webapp/app/modules/asset/attachment.server.test.ts
@@ -6,6 +6,7 @@
  * mocked - see the `why:` comments below each `vi.mock` for what's being
  * isolated and why.
  */
+import type { Asset } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // why: isolate the attachment service functions from real storage/db calls,
@@ -50,6 +51,16 @@ import {
   updateAssetAttachment,
 } from "./service.server";
 
+/**
+ * `db.asset.findFirstOrThrow` is mocked, but its static type is still the
+ * full Prisma `Asset` - these tests only need the two fields the code
+ * actually selects (`id`, `attachmentPath`). One cast here, instead of one
+ * per call site, keeps every other field's name/type still checked.
+ */
+function mockAssetRow(row: Pick<Asset, "id" | "attachmentPath">): Asset {
+  return row as Asset;
+}
+
 describe("asset attachment", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -57,10 +68,9 @@ describe("asset attachment", () => {
 
   describe("updateAssetAttachment", () => {
     it("uploads a new attachment and persists its storage path (not a URL)", async () => {
-      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
-        id: "asset-1",
-        attachmentPath: null,
-      } as any);
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue(
+        mockAssetRow({ id: "asset-1", attachmentPath: null })
+      );
 
       vi.mocked(parsePdfFormData).mockResolvedValue({
         path: "org-1/asset-1/attachment-123.pdf",
@@ -93,10 +103,12 @@ describe("asset attachment", () => {
     });
 
     it("deletes the previous attachment's exact path when replacing one", async () => {
-      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
-        id: "asset-1",
-        attachmentPath: "org-1/asset-1/attachment-old.pdf",
-      } as any);
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue(
+        mockAssetRow({
+          id: "asset-1",
+          attachmentPath: "org-1/asset-1/attachment-old.pdf",
+        })
+      );
 
       vi.mocked(parsePdfFormData).mockResolvedValue({
         path: "org-1/asset-1/attachment-new.pdf",
@@ -122,10 +134,9 @@ describe("asset attachment", () => {
     });
 
     it("throws and does not touch the db when no file was uploaded", async () => {
-      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
-        id: "asset-1",
-        attachmentPath: null,
-      } as any);
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue(
+        mockAssetRow({ id: "asset-1", attachmentPath: null })
+      );
       // parsePdfFormData throws when no upload matched the "file" field -
       // it no longer resolves with an empty/absent result, so simulating
       // that means rejecting here rather than resolving with nothing.
@@ -145,10 +156,12 @@ describe("asset attachment", () => {
     });
 
     it("still persists the new attachment when deleting the old file fails", async () => {
-      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
-        id: "asset-1",
-        attachmentPath: "org-1/asset-1/attachment-old.pdf",
-      } as any);
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue(
+        mockAssetRow({
+          id: "asset-1",
+          attachmentPath: "org-1/asset-1/attachment-old.pdf",
+        })
+      );
       vi.mocked(removeFileAtPath).mockRejectedValue(new Error("gone already"));
 
       vi.mocked(parsePdfFormData).mockResolvedValue({
@@ -172,10 +185,12 @@ describe("asset attachment", () => {
 
   describe("removeAssetAttachment", () => {
     it("deletes the file at its exact path and clears the attachment fields", async () => {
-      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
-        id: "asset-1",
-        attachmentPath: "org-1/asset-1/attachment-123.pdf",
-      } as any);
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue(
+        mockAssetRow({
+          id: "asset-1",
+          attachmentPath: "org-1/asset-1/attachment-123.pdf",
+        })
+      );
       // Explicit, since a previous test in this file leaves removeFileAtPath
       // rejecting - vi.clearAllMocks() (in beforeEach) resets call history
       // but not a configured mockRejectedValue/mockResolvedValue.
@@ -202,10 +217,9 @@ describe("asset attachment", () => {
     });
 
     it("is a no-op deletion when there is no existing attachment", async () => {
-      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
-        id: "asset-1",
-        attachmentPath: null,
-      } as any);
+      vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue(
+        mockAssetRow({ id: "asset-1", attachmentPath: null })
+      );
       vi.mocked(db.asset.update).mockResolvedValue({} as any);
 
       await removeAssetAttachment({

--- a/apps/webapp/app/modules/asset/attachment.server.test.ts
+++ b/apps/webapp/app/modules/asset/attachment.server.test.ts
@@ -41,16 +41,11 @@ describe("asset attachment", () => {
         attachmentUrl: null,
       } as any);
 
-      const returnedFormData = new FormData();
-      returnedFormData.append(
-        "file",
-        JSON.stringify({
-          path: "org-1/asset-1/attachment-123.pdf",
-          originalName: "invoice.pdf",
-          size: 1234,
-        })
-      );
-      vi.mocked(parsePdfFormData).mockResolvedValue(returnedFormData);
+      vi.mocked(parsePdfFormData).mockResolvedValue({
+        path: "org-1/asset-1/attachment-123.pdf",
+        originalName: "invoice.pdf",
+        size: 1234,
+      });
       vi.mocked(db.asset.update).mockResolvedValue({
         id: "asset-1",
         attachmentOriginalName: "invoice.pdf",
@@ -86,16 +81,11 @@ describe("asset attachment", () => {
           "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-old.pdf",
       } as any);
 
-      const returnedFormData = new FormData();
-      returnedFormData.append(
-        "file",
-        JSON.stringify({
-          path: "org-1/asset-1/attachment-new.pdf",
-          originalName: "invoice-2.pdf",
-          size: 999,
-        })
-      );
-      vi.mocked(parsePdfFormData).mockResolvedValue(returnedFormData);
+      vi.mocked(parsePdfFormData).mockResolvedValue({
+        path: "org-1/asset-1/attachment-new.pdf",
+        originalName: "invoice-2.pdf",
+        size: 999,
+      });
       vi.mocked(db.asset.update).mockResolvedValue({} as any);
 
       await updateAssetAttachment({
@@ -115,7 +105,12 @@ describe("asset attachment", () => {
         id: "asset-1",
         attachmentUrl: null,
       } as any);
-      vi.mocked(parsePdfFormData).mockResolvedValue(new FormData());
+      // parsePdfFormData throws when no upload matched the "file" field -
+      // it no longer resolves with an empty/absent result, so simulating
+      // that means rejecting here rather than resolving with nothing.
+      vi.mocked(parsePdfFormData).mockRejectedValue(
+        new Error("No file uploaded")
+      );
 
       await expect(
         updateAssetAttachment({
@@ -136,16 +131,11 @@ describe("asset attachment", () => {
       } as any);
       vi.mocked(removePublicFile).mockRejectedValue(new Error("gone already"));
 
-      const returnedFormData = new FormData();
-      returnedFormData.append(
-        "file",
-        JSON.stringify({
-          path: "org-1/asset-1/attachment-new.pdf",
-          originalName: "invoice-2.pdf",
-          size: 999,
-        })
-      );
-      vi.mocked(parsePdfFormData).mockResolvedValue(returnedFormData);
+      vi.mocked(parsePdfFormData).mockResolvedValue({
+        path: "org-1/asset-1/attachment-new.pdf",
+        originalName: "invoice-2.pdf",
+        size: 999,
+      });
       vi.mocked(db.asset.update).mockResolvedValue({} as any);
 
       await expect(

--- a/apps/webapp/app/modules/asset/attachment.server.test.ts
+++ b/apps/webapp/app/modules/asset/attachment.server.test.ts
@@ -13,6 +13,11 @@ vi.mock("~/utils/storage.server", () => ({
   removeFilesByPrefix: vi.fn(),
 }));
 
+// why: these tests exercise the attachment functions' own branching and
+// error handling (existing vs. missing attachment, upload failure, delete
+// failure) - stubbing findFirstOrThrow/update lets each case set up an exact
+// "before" state and assert the exact write, without a real Postgres
+// connection or seeded rows.
 vi.mock("~/database/db.server", () => ({
   db: {
     asset: {

--- a/apps/webapp/app/modules/asset/attachment.server.test.ts
+++ b/apps/webapp/app/modules/asset/attachment.server.test.ts
@@ -5,11 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // rather than the shared mock in this module's own service.server.test.ts.
 vi.mock("~/utils/storage.server", () => ({
   parsePdfFormData: vi.fn(),
-  getPublicFileURL: vi.fn(
+  createSignedUrl: vi.fn(
     ({ filename }: { filename: string }) =>
-      `https://example.supabase.co/storage/v1/object/public/files/${filename}`
+      `https://example.supabase.co/storage/v1/object/sign/assets/${filename}?token=signed`
   ),
-  removePublicFile: vi.fn(),
+  removeFileAtPath: vi.fn(),
+  removeFilesByPrefix: vi.fn(),
 }));
 
 vi.mock("~/database/db.server", () => ({
@@ -23,11 +24,18 @@ vi.mock("~/database/db.server", () => ({
 
 import { db } from "~/database/db.server";
 import {
-  getPublicFileURL,
+  createSignedUrl,
   parsePdfFormData,
-  removePublicFile,
+  removeFileAtPath,
+  removeFilesByPrefix,
 } from "~/utils/storage.server";
-import { removeAssetAttachment, updateAssetAttachment } from "./service.server";
+import {
+  clearStagedAssetAttachment,
+  removeAssetAttachment,
+  resolveAssetAttachmentDisplayUrl,
+  stageAssetAttachment,
+  updateAssetAttachment,
+} from "./service.server";
 
 describe("asset attachment", () => {
   beforeEach(() => {
@@ -35,10 +43,10 @@ describe("asset attachment", () => {
   });
 
   describe("updateAssetAttachment", () => {
-    it("uploads a new attachment and persists its url/name/size", async () => {
+    it("uploads a new attachment and persists its storage path (not a URL)", async () => {
       vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
         id: "asset-1",
-        attachmentUrl: null,
+        attachmentPath: null,
       } as any);
 
       vi.mocked(parsePdfFormData).mockResolvedValue({
@@ -57,16 +65,13 @@ describe("asset attachment", () => {
         organizationId: "org-1",
       });
 
-      expect(getPublicFileURL).toHaveBeenCalledWith({
-        filename: "org-1/asset-1/attachment-123.pdf",
-        bucketName: "files",
-      });
-      expect(removePublicFile).not.toHaveBeenCalled();
+      // No public URL is ever constructed for the new upload - the raw
+      // path from parsePdfFormData is persisted as-is.
+      expect(removeFileAtPath).not.toHaveBeenCalled();
       expect(db.asset.update).toHaveBeenCalledWith({
         where: { id: "asset-1", organizationId: "org-1" },
         data: {
-          attachmentUrl:
-            "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-123.pdf",
+          attachmentPath: "org-1/asset-1/attachment-123.pdf",
           attachmentOriginalName: "invoice.pdf",
           attachmentSize: 1234,
         },
@@ -74,11 +79,10 @@ describe("asset attachment", () => {
       expect(result.attachmentOriginalName).toBe("invoice.pdf");
     });
 
-    it("deletes the previous attachment when replacing one", async () => {
+    it("deletes the previous attachment's exact path when replacing one", async () => {
       vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
         id: "asset-1",
-        attachmentUrl:
-          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-old.pdf",
+        attachmentPath: "org-1/asset-1/attachment-old.pdf",
       } as any);
 
       vi.mocked(parsePdfFormData).mockResolvedValue({
@@ -94,16 +98,20 @@ describe("asset attachment", () => {
         organizationId: "org-1",
       });
 
-      expect(removePublicFile).toHaveBeenCalledWith({
-        publicUrl:
-          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-old.pdf",
+      // Deletes ONLY the old file's exact path - a folder-wide delete here
+      // would also destroy the new file just uploaded into the same
+      // org/asset folder.
+      expect(removeFileAtPath).toHaveBeenCalledWith({
+        path: "org-1/asset-1/attachment-old.pdf",
+        bucketName: "assets",
       });
+      expect(removeFilesByPrefix).not.toHaveBeenCalled();
     });
 
     it("throws and does not touch the db when no file was uploaded", async () => {
       vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
         id: "asset-1",
-        attachmentUrl: null,
+        attachmentPath: null,
       } as any);
       // parsePdfFormData throws when no upload matched the "file" field -
       // it no longer resolves with an empty/absent result, so simulating
@@ -126,10 +134,9 @@ describe("asset attachment", () => {
     it("still persists the new attachment when deleting the old file fails", async () => {
       vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
         id: "asset-1",
-        attachmentUrl:
-          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-old.pdf",
+        attachmentPath: "org-1/asset-1/attachment-old.pdf",
       } as any);
-      vi.mocked(removePublicFile).mockRejectedValue(new Error("gone already"));
+      vi.mocked(removeFileAtPath).mockRejectedValue(new Error("gone already"));
 
       vi.mocked(parsePdfFormData).mockResolvedValue({
         path: "org-1/asset-1/attachment-new.pdf",
@@ -151,16 +158,15 @@ describe("asset attachment", () => {
   });
 
   describe("removeAssetAttachment", () => {
-    it("deletes the file and clears the attachment fields", async () => {
+    it("deletes the file at its exact path and clears the attachment fields", async () => {
       vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
         id: "asset-1",
-        attachmentUrl:
-          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-123.pdf",
+        attachmentPath: "org-1/asset-1/attachment-123.pdf",
       } as any);
-      // Explicit, since a previous test in this file leaves removePublicFile
+      // Explicit, since a previous test in this file leaves removeFileAtPath
       // rejecting - vi.clearAllMocks() (in beforeEach) resets call history
       // but not a configured mockRejectedValue/mockResolvedValue.
-      vi.mocked(removePublicFile).mockResolvedValue(undefined as any);
+      vi.mocked(removeFileAtPath).mockResolvedValue(undefined as any);
       vi.mocked(db.asset.update).mockResolvedValue({} as any);
 
       await removeAssetAttachment({
@@ -168,14 +174,14 @@ describe("asset attachment", () => {
         organizationId: "org-1",
       });
 
-      expect(removePublicFile).toHaveBeenCalledWith({
-        publicUrl:
-          "https://example.supabase.co/storage/v1/object/public/files/org-1/asset-1/attachment-123.pdf",
+      expect(removeFileAtPath).toHaveBeenCalledWith({
+        path: "org-1/asset-1/attachment-123.pdf",
+        bucketName: "assets",
       });
       expect(db.asset.update).toHaveBeenCalledWith({
         where: { id: "asset-1", organizationId: "org-1" },
         data: {
-          attachmentUrl: null,
+          attachmentPath: null,
           attachmentOriginalName: null,
           attachmentSize: null,
         },
@@ -185,7 +191,7 @@ describe("asset attachment", () => {
     it("is a no-op deletion when there is no existing attachment", async () => {
       vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue({
         id: "asset-1",
-        attachmentUrl: null,
+        attachmentPath: null,
       } as any);
       vi.mocked(db.asset.update).mockResolvedValue({} as any);
 
@@ -194,8 +200,94 @@ describe("asset attachment", () => {
         organizationId: "org-1",
       });
 
-      expect(removePublicFile).not.toHaveBeenCalled();
+      expect(removeFileAtPath).not.toHaveBeenCalled();
       expect(db.asset.update).toHaveBeenCalled();
+    });
+  });
+
+  describe("stageAssetAttachment", () => {
+    it("uploads to the private bucket and returns both the path and a display URL", async () => {
+      vi.mocked(parsePdfFormData).mockResolvedValue({
+        path: "org-1/pending-id/attachment-123.pdf",
+        originalName: "invoice.pdf",
+        size: 1234,
+      });
+
+      const result = await stageAssetAttachment({
+        request: {} as Request,
+        assetId: "pending-id",
+        organizationId: "org-1",
+      });
+
+      expect(parsePdfFormData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          newFileName: expect.stringContaining("org-1/pending-id/attachment-"),
+        })
+      );
+      expect(createSignedUrl).toHaveBeenCalledWith({
+        filename: "org-1/pending-id/attachment-123.pdf",
+        bucketName: "assets",
+      });
+      // The path (not the signed URL) is what the create form will
+      // eventually persist via createAsset(); the signed URL is only for
+      // showing the file right now, on this response.
+      expect(result.attachmentPath).toBe("org-1/pending-id/attachment-123.pdf");
+      expect(result.attachmentDisplayUrl).toContain("token=signed");
+      expect(result.attachmentOriginalName).toBe("invoice.pdf");
+      expect(result.attachmentSize).toBe(1234);
+    });
+  });
+
+  describe("clearStagedAssetAttachment", () => {
+    it("removes everything under the org/placeholder-id folder in the private bucket", async () => {
+      await clearStagedAssetAttachment({
+        assetId: "pending-id",
+        organizationId: "org-1",
+      });
+
+      expect(removeFilesByPrefix).toHaveBeenCalledWith({
+        organizationId: "org-1",
+        entityId: "pending-id",
+        bucketName: "assets",
+      });
+    });
+  });
+
+  describe("resolveAssetAttachmentDisplayUrl", () => {
+    it("returns null without calling Supabase when there is no attachment", async () => {
+      const result = await resolveAssetAttachmentDisplayUrl({
+        attachmentPath: null,
+        assetId: "asset-1",
+      });
+
+      expect(result).toBeNull();
+      expect(createSignedUrl).not.toHaveBeenCalled();
+    });
+
+    it("resolves a stored path into a signed URL", async () => {
+      const result = await resolveAssetAttachmentDisplayUrl({
+        attachmentPath: "org-1/asset-1/attachment-123.pdf",
+        assetId: "asset-1",
+      });
+
+      expect(createSignedUrl).toHaveBeenCalledWith({
+        filename: "org-1/asset-1/attachment-123.pdf",
+        bucketName: "assets",
+      });
+      expect(result).toContain("token=signed");
+    });
+
+    it("returns null instead of throwing when signing fails", async () => {
+      vi.mocked(createSignedUrl).mockRejectedValue(
+        new Error("Supabase is down")
+      );
+
+      const result = await resolveAssetAttachmentDisplayUrl({
+        attachmentPath: "org-1/asset-1/attachment-123.pdf",
+        assetId: "asset-1",
+      });
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/apps/webapp/app/modules/asset/attachment.server.test.ts
+++ b/apps/webapp/app/modules/asset/attachment.server.test.ts
@@ -137,9 +137,7 @@ describe("asset attachment", () => {
       vi.mocked(db.asset.findFirstOrThrow).mockResolvedValue(
         mockAssetRow({ id: "asset-1", attachmentPath: null })
       );
-      // parsePdfFormData throws when no upload matched the "file" field -
-      // it no longer resolves with an empty/absent result, so simulating
-      // that means rejecting here rather than resolving with nothing.
+      // parsePdfFormData rejects when no upload matches the "file" field.
       vi.mocked(parsePdfFormData).mockRejectedValue(
         new Error("No file uploaded")
       );

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -1961,6 +1961,40 @@ describe("createAsset cross-org guards", () => {
     // never reach the org-scope lookup.
     expect(db.category.findFirst).not.toHaveBeenCalled();
   });
+
+  it("rejects an attachmentPath outside the caller's organization folder", async () => {
+    expect.assertions(2);
+
+    await expect(
+      createAsset({
+        title: "New asset",
+        userId: "user-1",
+        organizationId: "org-A",
+        attachmentPath: "org-B/some-asset/attachment-123.pdf",
+      } as any)
+    ).rejects.toThrow(ShelfError);
+
+    // The prefix check rejects before ever looking up who owns the path.
+    expect(db.asset.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects an attachmentPath already claimed by another asset", async () => {
+    expect.assertions(1);
+    // why: a hit means some asset already persisted this exact path - a
+    // forged resubmission of it must not adopt that asset's attachment.
+    (db.asset.findFirst as ReturnType<typeof vitest.fn>).mockResolvedValue({
+      id: "asset-owning-it",
+    });
+
+    await expect(
+      createAsset({
+        title: "New asset",
+        userId: "user-1",
+        organizationId: "org-A",
+        attachmentPath: "org-A/asset-owning-it/attachment-123.pdf",
+      } as any)
+    ).rejects.toThrow(ShelfError);
+  });
 });
 
 describe("updateAsset custom-field writes", () => {

--- a/apps/webapp/app/modules/asset/service.server.test.ts
+++ b/apps/webapp/app/modules/asset/service.server.test.ts
@@ -1895,6 +1895,17 @@ describe("createAsset cross-org guards", () => {
     vitest.clearAllMocks();
   });
 
+  // Valid defaults for createAsset's required fields; each test overrides
+  // only the field its guard actually inspects.
+  const baseCreateAssetPayload: Parameters<typeof createAsset>[0] = {
+    title: "New asset",
+    description: null,
+    categoryId: null,
+    userId: "user-1",
+    valuation: null,
+    organizationId: "org-A",
+  };
+
   it("rejects a customFieldId from a different organization", async () => {
     expect.assertions(2);
     // Foreign-org custom field → org-scoped lookup returns nothing → the guard
@@ -1905,11 +1916,18 @@ describe("createAsset cross-org guards", () => {
 
     await expect(
       createAsset({
-        title: "New asset",
-        userId: "user-1",
-        organizationId: "org-A",
-        customFieldsValues: [{ id: "cf-from-org-B", value: { raw: "x" } }],
-      } as any)
+        ...baseCreateAssetPayload,
+        customFieldsValues: [
+          {
+            id: "cf-from-org-B",
+            value: { raw: "x" },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            assetId: "asset-new",
+            customFieldId: "cf-from-org-B",
+          },
+        ],
+      })
     ).rejects.toThrow(ShelfError);
 
     expect(db.customField.findMany).toHaveBeenCalledWith({
@@ -1930,11 +1948,9 @@ describe("createAsset cross-org guards", () => {
 
     await expect(
       createAsset({
-        title: "New asset",
-        userId: "user-1",
-        organizationId: "org-A",
+        ...baseCreateAssetPayload,
         categoryId: "cat-from-org-B",
-      } as any)
+      })
     ).rejects.toThrow(ShelfError);
 
     expect(db.category.findFirst).toHaveBeenCalledWith({
@@ -1950,11 +1966,9 @@ describe("createAsset cross-org guards", () => {
     // satisfy "findFirst was never called" without the guard ever being
     // reached, and the test would pass for the wrong reason.
     const created = await createAsset({
-      title: "New asset",
-      userId: "user-1",
-      organizationId: "org-A",
+      ...baseCreateAssetPayload,
       categoryId: "uncategorized",
-    } as any);
+    });
 
     expect(created).toEqual({ id: "asset-new" });
     // "uncategorized" is the form's empty sentinel, not an id, so it must
@@ -1967,11 +1981,9 @@ describe("createAsset cross-org guards", () => {
 
     await expect(
       createAsset({
-        title: "New asset",
-        userId: "user-1",
-        organizationId: "org-A",
+        ...baseCreateAssetPayload,
         attachmentPath: "org-B/some-asset/attachment-123.pdf",
-      } as any)
+      })
     ).rejects.toThrow(ShelfError);
 
     // The prefix check rejects before ever looking up who owns the path.
@@ -1988,11 +2000,9 @@ describe("createAsset cross-org guards", () => {
 
     await expect(
       createAsset({
-        title: "New asset",
-        userId: "user-1",
-        organizationId: "org-A",
+        ...baseCreateAssetPayload,
         attachmentPath: "org-A/asset-owning-it/attachment-123.pdf",
-      } as any)
+      })
     ).rejects.toThrow(ShelfError);
   });
 });

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -150,6 +150,7 @@ import {
   getPublicFileURL,
   parseFileFormData,
   parsePdfFormData,
+  removeFilesByPrefix,
   removePublicFile,
   uploadImageFromUrl,
 } from "~/utils/storage.server";
@@ -1180,6 +1181,9 @@ export async function createAsset({
   availableToBook = true,
   mainImage,
   mainImageExpiration,
+  attachmentUrl,
+  attachmentOriginalName,
+  attachmentSize,
   barcodes,
   id: assetId, // Add support for passing an ID
   type,
@@ -1204,6 +1208,15 @@ export async function createAsset({
   id?: Asset["id"]; // Make ID optional
   mainImage?: Asset["mainImage"];
   mainImageExpiration?: Asset["mainImageExpiration"];
+  /**
+   * Set when a PDF was staged (via the attachment API's no-DB-row-yet
+   * branch) while this asset was still being created - see
+   * stageAssetAttachment(). Not exposed on the edit form; an existing
+   * asset's attachment is only ever changed through updateAssetAttachment.
+   */
+  attachmentUrl?: Asset["attachmentUrl"];
+  attachmentOriginalName?: Asset["attachmentOriginalName"];
+  attachmentSize?: Asset["attachmentSize"];
   type?: Asset["type"];
   quantity?: Asset["quantity"];
   minQuantity?: Asset["minQuantity"];
@@ -1309,6 +1322,9 @@ export async function createAsset({
         availableToBook,
         mainImage,
         mainImageExpiration,
+        attachmentUrl,
+        attachmentOriginalName,
+        attachmentSize,
         type,
         quantity,
         minQuantity,
@@ -3972,6 +3988,103 @@ export async function removeAssetAttachment({
       message: isShelfError
         ? cause.message
         : "Something went wrong while removing the asset attachment",
+      additionalData: { assetId },
+      label,
+    });
+  }
+}
+
+/**
+ * Uploads a PDF attachment for an asset that doesn't exist in the DB yet -
+ * the create-asset form uses the same instant-upload widget as the edit
+ * page, but there is no row to read/write until the whole form is
+ * submitted. Storage-only: the resulting metadata is carried through the
+ * create form as hidden fields and persisted by createAsset() in the same
+ * insert as the rest of the asset.
+ *
+ * `assetId` here is a client-generated placeholder (not yet a real Asset
+ * id) used only to scope the storage path - see AssetForm's pendingId.
+ */
+export async function stageAssetAttachment({
+  request,
+  assetId,
+  organizationId,
+}: {
+  request: Request;
+  assetId: string;
+  organizationId: Organization["id"];
+}) {
+  try {
+    const formData = await parsePdfFormData({
+      request,
+      newFileName: `${organizationId}/${assetId}/attachment-${dateTimeInUnix(
+        Date.now()
+      )}`,
+    });
+
+    const raw = formData.get("file") as string | null;
+    if (!raw) {
+      throw new ShelfError({
+        cause: null,
+        title: "No file uploaded",
+        message: "Please choose a PDF file to upload.",
+        label,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const { path, originalName, size } = JSON.parse(raw) as {
+      path: string;
+      originalName?: string;
+      size: number;
+    };
+
+    const attachmentUrl = getPublicFileURL({
+      filename: path,
+      bucketName: PUBLIC_BUCKET,
+    });
+
+    return {
+      attachmentUrl,
+      attachmentOriginalName: originalName ?? null,
+      attachmentSize: size,
+    };
+  } catch (cause) {
+    const isShelfError = isLikeShelfError(cause);
+    throw new ShelfError({
+      cause,
+      message: isShelfError
+        ? cause.message
+        : "Something went wrong while uploading the asset attachment",
+      additionalData: { assetId },
+      label,
+    });
+  }
+}
+
+/**
+ * Removes a PDF attachment staged for an asset that doesn't exist in the DB
+ * yet. There is no `attachmentUrl` column to read the exact object key
+ * from, so this clears the whole org+placeholder-id storage folder instead
+ * of a single known path - see removeFilesByPrefix.
+ */
+export async function clearStagedAssetAttachment({
+  assetId,
+  organizationId,
+}: {
+  assetId: string;
+  organizationId: Organization["id"];
+}) {
+  try {
+    await removeFilesByPrefix({
+      organizationId,
+      entityId: assetId,
+      bucketName: PUBLIC_BUCKET,
+    });
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Something went wrong while removing the asset attachment",
       additionalData: { assetId },
       label,
     });

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -1257,6 +1257,28 @@ export async function createAsset({
       });
     }
   }
+  if (attachmentPath) {
+    if (!attachmentPath.startsWith(`${organizationId}/`)) {
+      throw new ShelfError({
+        cause: null,
+        message: "Invalid attachment",
+        label,
+        status: 400,
+      });
+    }
+    const claimedBy = await db.asset.findFirst({
+      where: { attachmentPath },
+      select: { id: true },
+    });
+    if (claimedBy) {
+      throw new ShelfError({
+        cause: null,
+        message: "Invalid attachment",
+        label,
+        status: 400,
+      });
+    }
+  }
 
   let attempts = 0;
   const maxAttempts = 3;

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3888,29 +3888,12 @@ export async function updateAssetAttachment({
       select: { id: true, attachmentUrl: true },
     });
 
-    const formData = await parsePdfFormData({
+    const { path, originalName, size } = await parsePdfFormData({
       request,
       newFileName: `${organizationId}/${assetId}/attachment-${dateTimeInUnix(
         Date.now()
       )}`,
     });
-
-    const raw = formData.get("file") as string | null;
-    if (!raw) {
-      throw new ShelfError({
-        cause: null,
-        title: "No file uploaded",
-        message: "Please choose a PDF file to upload.",
-        label,
-        shouldBeCaptured: false,
-      });
-    }
-
-    const { path, originalName, size } = JSON.parse(raw) as {
-      path: string;
-      originalName?: string;
-      size: number;
-    };
 
     const attachmentUrl = getPublicFileURL({
       filename: path,
@@ -4015,29 +3998,12 @@ export async function stageAssetAttachment({
   organizationId: Organization["id"];
 }) {
   try {
-    const formData = await parsePdfFormData({
+    const { path, originalName, size } = await parsePdfFormData({
       request,
       newFileName: `${organizationId}/${assetId}/attachment-${dateTimeInUnix(
         Date.now()
       )}`,
     });
-
-    const raw = formData.get("file") as string | null;
-    if (!raw) {
-      throw new ShelfError({
-        cause: null,
-        title: "No file uploaded",
-        message: "Please choose a PDF file to upload.",
-        label,
-        shouldBeCaptured: false,
-      });
-    }
-
-    const { path, originalName, size } = JSON.parse(raw) as {
-      path: string;
-      originalName?: string;
-      size: number;
-    };
 
     const attachmentUrl = getPublicFileURL({
       filename: path,

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3893,9 +3893,24 @@ export async function updateAssetAttachment({
       )}-${crypto.randomUUID()}`,
     });
 
+    const updated = await db.asset.update({
+      where: { id: assetId, organizationId },
+      data: {
+        // Not a URL - see the schema comment on Asset.attachmentPath. A
+        // signed URL is minted on demand wherever this is displayed, after
+        // that caller's own permission check.
+        attachmentPath: path,
+        attachmentOriginalName: originalName ?? null,
+        attachmentSize: size,
+      },
+    });
+
     if (asset.attachmentPath) {
-      // Best-effort cleanup of the file being replaced - an orphaned
-      // storage object isn't worth failing the new upload over. Targets the
+      // Best-effort cleanup of the file being replaced, run only after the
+      // new path is persisted above: deleting the old file first and then
+      // failing to persist the new one would leave the asset pointing at a
+      // file that no longer exists. An orphaned storage object is the safer
+      // failure mode, so it isn't worth failing the upload over. Targets the
       // old path specifically (not a folder sweep) - the new upload above
       // already landed in the same org/asset folder under a different,
       // timestamped name.
@@ -3916,17 +3931,7 @@ export async function updateAssetAttachment({
       }
     }
 
-    return await db.asset.update({
-      where: { id: assetId, organizationId },
-      data: {
-        // Not a URL - see the schema comment on Asset.attachmentPath. A
-        // signed URL is minted on demand wherever this is displayed, after
-        // that caller's own permission check.
-        attachmentPath: path,
-        attachmentOriginalName: originalName ?? null,
-        attachmentSize: size,
-      },
-    });
+    return updated;
   } catch (cause) {
     const isShelfError = isLikeShelfError(cause);
     throw new ShelfError({
@@ -3954,14 +3959,7 @@ export async function removeAssetAttachment({
       select: { id: true, attachmentPath: true },
     });
 
-    if (asset.attachmentPath) {
-      await removeFileAtPath({
-        path: asset.attachmentPath,
-        bucketName: "assets",
-      });
-    }
-
-    return await db.asset.update({
+    const updated = await db.asset.update({
       where: { id: assetId, organizationId },
       data: {
         attachmentPath: null,
@@ -3969,6 +3967,29 @@ export async function removeAssetAttachment({
         attachmentSize: null,
       },
     });
+
+    if (asset.attachmentPath) {
+      // Best-effort cleanup, run only after the DB is cleared - see the
+      // matching comment in updateAssetAttachment for why deleting the file
+      // before persisting the metadata change is the wrong order.
+      try {
+        await removeFileAtPath({
+          path: asset.attachmentPath,
+          bucketName: "assets",
+        });
+      } catch (cause) {
+        Logger.error(
+          new ShelfError({
+            cause,
+            message: "Failed to delete the removed asset attachment",
+            additionalData: { assetId },
+            label,
+          })
+        );
+      }
+    }
+
+    return updated;
   } catch (cause) {
     const isShelfError = isLikeShelfError(cause);
     throw new ShelfError({

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -93,6 +93,7 @@ import { getLocale } from "~/utils/client-hints";
 import {
   ASSET_MAX_IMAGE_UPLOAD_SIZE,
   LEGACY_CUID_LENGTH,
+  PUBLIC_BUCKET,
 } from "~/utils/constants";
 import {
   getFiltersFromRequest,
@@ -146,7 +147,10 @@ import {
 } from "~/utils/org-validation.server";
 import {
   createSignedUrl,
+  getPublicFileURL,
   parseFileFormData,
+  parsePdfFormData,
+  removePublicFile,
   uploadImageFromUrl,
 } from "~/utils/storage.server";
 import { resolveTeamMemberName, resolveUserDisplayName } from "~/utils/user";
@@ -3839,6 +3843,136 @@ export async function updateAssetMainImage({
         ? cause.message
         : "Something went wrong while updating asset main image",
       additionalData: { assetId, userId, field: "mainImage" },
+      label,
+    });
+  }
+}
+
+/**
+ * Uploads (or replaces) an asset's single PDF attachment - purchase
+ * invoice, manual, calibration certificate, etc. See issue #2660.
+ *
+ * Deliberately standalone rather than routed through `updateAsset()`: this
+ * is called from its own dedicated API route with an instant drag-and-drop
+ * UI, not as part of the big multi-field edit-asset form submission, so it
+ * only needs to touch the three attachment columns.
+ */
+export async function updateAssetAttachment({
+  request,
+  assetId,
+  organizationId,
+}: {
+  request: Request;
+  assetId: Asset["id"];
+  organizationId: Organization["id"];
+}) {
+  try {
+    const asset = await db.asset.findFirstOrThrow({
+      where: { id: assetId, organizationId },
+      select: { id: true, attachmentUrl: true },
+    });
+
+    const formData = await parsePdfFormData({
+      request,
+      newFileName: `${organizationId}/${assetId}/attachment-${dateTimeInUnix(
+        Date.now()
+      )}`,
+    });
+
+    const raw = formData.get("file") as string | null;
+    if (!raw) {
+      throw new ShelfError({
+        cause: null,
+        title: "No file uploaded",
+        message: "Please choose a PDF file to upload.",
+        label,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const { path, originalName, size } = JSON.parse(raw) as {
+      path: string;
+      originalName?: string;
+      size: number;
+    };
+
+    const attachmentUrl = getPublicFileURL({
+      filename: path,
+      bucketName: PUBLIC_BUCKET,
+    });
+
+    if (asset.attachmentUrl) {
+      // Best-effort cleanup of the file being replaced - an orphaned
+      // storage object isn't worth failing the new upload over.
+      try {
+        await removePublicFile({ publicUrl: asset.attachmentUrl });
+      } catch (cause) {
+        Logger.error(
+          new ShelfError({
+            cause,
+            message: "Failed to delete the previous asset attachment",
+            additionalData: { assetId },
+            label,
+          })
+        );
+      }
+    }
+
+    return await db.asset.update({
+      where: { id: assetId, organizationId },
+      data: {
+        attachmentUrl,
+        attachmentOriginalName: originalName ?? null,
+        attachmentSize: size,
+      },
+    });
+  } catch (cause) {
+    const isShelfError = isLikeShelfError(cause);
+    throw new ShelfError({
+      cause,
+      message: isShelfError
+        ? cause.message
+        : "Something went wrong while uploading the asset attachment",
+      additionalData: { assetId },
+      label,
+    });
+  }
+}
+
+/** Deletes an asset's attachment, both from storage and from the DB. */
+export async function removeAssetAttachment({
+  assetId,
+  organizationId,
+}: {
+  assetId: Asset["id"];
+  organizationId: Organization["id"];
+}) {
+  try {
+    const asset = await db.asset.findFirstOrThrow({
+      where: { id: assetId, organizationId },
+      select: { id: true, attachmentUrl: true },
+    });
+
+    if (asset.attachmentUrl) {
+      await removePublicFile({ publicUrl: asset.attachmentUrl });
+    }
+
+    return await db.asset.update({
+      where: { id: assetId, organizationId },
+      data: {
+        attachmentUrl: null,
+        attachmentOriginalName: null,
+        attachmentSize: null,
+      },
+    });
+  } catch (cause) {
+    const isShelfError = isLikeShelfError(cause);
+    throw new ShelfError({
+      cause,
+      message: isShelfError
+        ? cause.message
+        : "Something went wrong while removing the asset attachment",
+      additionalData: { assetId },
       label,
     });
   }

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -3890,7 +3890,7 @@ export async function updateAssetAttachment({
       request,
       newFileName: `${organizationId}/${assetId}/attachment-${dateTimeInUnix(
         Date.now()
-      )}`,
+      )}-${crypto.randomUUID()}`,
     });
 
     if (asset.attachmentPath) {
@@ -4007,7 +4007,7 @@ export async function stageAssetAttachment({
       request,
       newFileName: `${organizationId}/${assetId}/attachment-${dateTimeInUnix(
         Date.now()
-      )}`,
+      )}-${crypto.randomUUID()}`,
     });
 
     // The asset doesn't exist yet, so `path` (see Asset.attachmentPath's

--- a/apps/webapp/app/modules/asset/service.server.ts
+++ b/apps/webapp/app/modules/asset/service.server.ts
@@ -93,7 +93,6 @@ import { getLocale } from "~/utils/client-hints";
 import {
   ASSET_MAX_IMAGE_UPLOAD_SIZE,
   LEGACY_CUID_LENGTH,
-  PUBLIC_BUCKET,
 } from "~/utils/constants";
 import {
   getFiltersFromRequest,
@@ -147,11 +146,10 @@ import {
 } from "~/utils/org-validation.server";
 import {
   createSignedUrl,
-  getPublicFileURL,
   parseFileFormData,
   parsePdfFormData,
+  removeFileAtPath,
   removeFilesByPrefix,
-  removePublicFile,
   uploadImageFromUrl,
 } from "~/utils/storage.server";
 import { resolveTeamMemberName, resolveUserDisplayName } from "~/utils/user";
@@ -1181,7 +1179,7 @@ export async function createAsset({
   availableToBook = true,
   mainImage,
   mainImageExpiration,
-  attachmentUrl,
+  attachmentPath,
   attachmentOriginalName,
   attachmentSize,
   barcodes,
@@ -1214,7 +1212,7 @@ export async function createAsset({
    * stageAssetAttachment(). Not exposed on the edit form; an existing
    * asset's attachment is only ever changed through updateAssetAttachment.
    */
-  attachmentUrl?: Asset["attachmentUrl"];
+  attachmentPath?: Asset["attachmentPath"];
   attachmentOriginalName?: Asset["attachmentOriginalName"];
   attachmentSize?: Asset["attachmentSize"];
   type?: Asset["type"];
@@ -1322,7 +1320,7 @@ export async function createAsset({
         availableToBook,
         mainImage,
         mainImageExpiration,
-        attachmentUrl,
+        attachmentPath,
         attachmentOriginalName,
         attachmentSize,
         type,
@@ -3885,7 +3883,7 @@ export async function updateAssetAttachment({
   try {
     const asset = await db.asset.findFirstOrThrow({
       where: { id: assetId, organizationId },
-      select: { id: true, attachmentUrl: true },
+      select: { id: true, attachmentPath: true },
     });
 
     const { path, originalName, size } = await parsePdfFormData({
@@ -3895,16 +3893,17 @@ export async function updateAssetAttachment({
       )}`,
     });
 
-    const attachmentUrl = getPublicFileURL({
-      filename: path,
-      bucketName: PUBLIC_BUCKET,
-    });
-
-    if (asset.attachmentUrl) {
+    if (asset.attachmentPath) {
       // Best-effort cleanup of the file being replaced - an orphaned
-      // storage object isn't worth failing the new upload over.
+      // storage object isn't worth failing the new upload over. Targets the
+      // old path specifically (not a folder sweep) - the new upload above
+      // already landed in the same org/asset folder under a different,
+      // timestamped name.
       try {
-        await removePublicFile({ publicUrl: asset.attachmentUrl });
+        await removeFileAtPath({
+          path: asset.attachmentPath,
+          bucketName: "assets",
+        });
       } catch (cause) {
         Logger.error(
           new ShelfError({
@@ -3920,7 +3919,10 @@ export async function updateAssetAttachment({
     return await db.asset.update({
       where: { id: assetId, organizationId },
       data: {
-        attachmentUrl,
+        // Not a URL - see the schema comment on Asset.attachmentPath. A
+        // signed URL is minted on demand wherever this is displayed, after
+        // that caller's own permission check.
+        attachmentPath: path,
         attachmentOriginalName: originalName ?? null,
         attachmentSize: size,
       },
@@ -3949,17 +3951,20 @@ export async function removeAssetAttachment({
   try {
     const asset = await db.asset.findFirstOrThrow({
       where: { id: assetId, organizationId },
-      select: { id: true, attachmentUrl: true },
+      select: { id: true, attachmentPath: true },
     });
 
-    if (asset.attachmentUrl) {
-      await removePublicFile({ publicUrl: asset.attachmentUrl });
+    if (asset.attachmentPath) {
+      await removeFileAtPath({
+        path: asset.attachmentPath,
+        bucketName: "assets",
+      });
     }
 
     return await db.asset.update({
       where: { id: assetId, organizationId },
       data: {
-        attachmentUrl: null,
+        attachmentPath: null,
         attachmentOriginalName: null,
         attachmentSize: null,
       },
@@ -4005,13 +4010,21 @@ export async function stageAssetAttachment({
       )}`,
     });
 
-    const attachmentUrl = getPublicFileURL({
+    // The asset doesn't exist yet, so `path` (see Asset.attachmentPath's
+    // schema comment) is what eventually gets persisted, via a hidden form
+    // field, once the rest of the form is submitted. `attachmentDisplayUrl`
+    // is a short-lived signed URL for ONLY this response - the create form
+    // uses it to let the user click through to the file immediately, the
+    // same as they could on the edit page; it is never itself stored
+    // anywhere.
+    const attachmentDisplayUrl = await createSignedUrl({
       filename: path,
-      bucketName: PUBLIC_BUCKET,
+      bucketName: "assets",
     });
 
     return {
-      attachmentUrl,
+      attachmentPath: path,
+      attachmentDisplayUrl,
       attachmentOriginalName: originalName ?? null,
       attachmentSize: size,
     };
@@ -4029,8 +4042,49 @@ export async function stageAssetAttachment({
 }
 
 /**
+ * Resolves an asset's stored attachment path (see Asset.attachmentPath's
+ * schema comment) into a short-lived signed URL for display. Callers are
+ * expected to already have proven the caller may see this asset (e.g. via
+ * getAsset()/requirePermission) before reaching this - it does not perform
+ * its own permission check.
+ *
+ * Tolerates a signing failure by returning null rather than throwing,
+ * matching how refreshExpiredAssetImages treats a transient storage hiccup
+ * as "no image right now" instead of failing the whole page load.
+ */
+export async function resolveAssetAttachmentDisplayUrl({
+  attachmentPath,
+  assetId,
+}: {
+  attachmentPath: Asset["attachmentPath"];
+  assetId: Asset["id"];
+}): Promise<string | null> {
+  if (!attachmentPath) {
+    return null;
+  }
+
+  try {
+    return await createSignedUrl({
+      filename: attachmentPath,
+      bucketName: "assets",
+    });
+  } catch (cause) {
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: "Failed to create a signed URL for the asset attachment",
+        additionalData: { assetId },
+        label,
+        shouldBeCaptured: true,
+      })
+    );
+    return null;
+  }
+}
+
+/**
  * Removes a PDF attachment staged for an asset that doesn't exist in the DB
- * yet. There is no `attachmentUrl` column to read the exact object key
+ * yet. There is no `attachmentPath` column to read the exact object key
  * from, so this clears the whole org+placeholder-id storage folder instead
  * of a single known path - see removeFilesByPrefix.
  */
@@ -4045,7 +4099,7 @@ export async function clearStagedAssetAttachment({
     await removeFilesByPrefix({
       organizationId,
       entityId: assetId,
-      bucketName: PUBLIC_BUCKET,
+      bucketName: "assets",
     });
   } catch (cause) {
     throw new ShelfError({

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.tsx
@@ -69,6 +69,7 @@ import {
   moveAssetLocationUnits,
   parseAssetValuation,
   placeUnplacedUnits,
+  resolveAssetAttachmentDisplayUrl,
   updateAsset,
   updateAssetBookingAvailability,
 } from "~/modules/asset/service.server";
@@ -100,6 +101,7 @@ import {
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
+import { formatBytes } from "~/utils/format-bytes";
 import { error, getParams, payload, parseData } from "~/utils/http.server";
 import { isLink } from "~/utils/misc";
 import {
@@ -177,6 +179,15 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       userOrganizations,
       request,
       include: getAssetOverviewFields(id, canUseBarcodes),
+    });
+
+    // asset.attachmentPath is a private-bucket storage path (see its schema
+    // comment) - resolve it to a short-lived signed URL now that
+    // requirePermission above gates access to this asset. Unconditional
+    // (not behind canEditAsset below) so view-only roles see it too.
+    const attachmentDisplayUrl = await resolveAssetAttachmentDisplayUrl({
+      attachmentPath: asset.attachmentPath,
+      assetId: asset.id,
     });
 
     /**
@@ -391,10 +402,13 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     return payload({
       // Same reasoning as the parent detail route: this payload carries
       // `custody[].custodian` and is reachable with `asset: read`.
-      asset: redactCustodianForViewer([{ ...asset, customFields }], {
-        canSeeAllCustody,
-        userId,
-      })[0],
+      asset: redactCustodianForViewer(
+        [{ ...asset, customFields, attachmentUrl: attachmentDisplayUrl }],
+        {
+          canSeeAllCustody,
+          userId,
+        }
+      )[0],
       currentOrganization,
       userId,
       lastScan,
@@ -1136,6 +1150,35 @@ export default function AssetOverview() {
                   />
                 )}
               />
+
+              {/* Attachment — read-only display; uploading/replacing/removing
+                  stays exclusive to the Edit page's AssetAttachmentUpload. */}
+              <li className="w-full border-b-[1.1px] border-b-gray-100 p-4 last:border-b-0 md:flex">
+                <span className="w-1/4 text-[14px] font-medium text-gray-900">
+                  Attachment
+                </span>
+                <div className="mt-1 text-gray-600 md:mt-0 md:w-3/5">
+                  {asset.attachmentUrl ? (
+                    <div className="flex items-center gap-2">
+                      <a
+                        href={asset.attachmentUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-semibold text-primary-700 hover:text-primary-800"
+                      >
+                        {asset.attachmentOriginalName || "Attachment.pdf"}
+                      </a>
+                      {asset.attachmentSize ? (
+                        <span className="text-gray-500">
+                          {formatBytes(asset.attachmentSize)}
+                        </span>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <span className="text-gray-600">No attachment</span>
+                  )}
+                </div>
+              </li>
 
               {/* QT-aware: shows total value (per-unit × quantity) below the
                   per-unit Value row. Hidden for INDIVIDUAL assets and QT with

--- a/apps/webapp/app/routes/_layout+/assets.$assetId_.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId_.edit.tsx
@@ -339,6 +339,9 @@ export default function AssetEditPage() {
               ? new Date(asset.mainImageExpiration)
               : null
           }
+          attachmentUrl={asset.attachmentUrl}
+          attachmentOriginalName={asset.attachmentOriginalName}
+          attachmentSize={asset.attachmentSize}
           title={asset.title}
           categoryId={asset.categoryId}
           assetModelId={asset.assetModelId}

--- a/apps/webapp/app/routes/_layout+/assets.$assetId_.edit.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId_.edit.tsx
@@ -17,6 +17,7 @@ import { Button } from "~/components/shared/button";
 import {
   getAllEntriesForCreateAndEdit,
   getAsset,
+  resolveAssetAttachmentDisplayUrl,
   updateAsset,
   updateAssetMainImage,
 } from "~/modules/asset/service.server";
@@ -129,8 +130,16 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
       subHeading: asset.id,
     };
 
+    // asset.attachmentPath is a private-bucket storage path (see its schema
+    // comment) - resolve it to a short-lived signed URL now that
+    // requirePermission above gates access to this asset.
+    const attachmentDisplayUrl = await resolveAssetAttachmentDisplayUrl({
+      attachmentPath: asset.attachmentPath,
+      assetId: asset.id,
+    });
+
     return payload({
-      asset,
+      asset: { ...asset, attachmentUrl: attachmentDisplayUrl },
       header,
       categories,
       totalCategories,

--- a/apps/webapp/app/routes/_layout+/assets.new.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.new.tsx
@@ -202,7 +202,7 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       minQuantity,
       consumptionType,
       unitOfMeasure,
-      attachmentUrl,
+      attachmentPath,
       attachmentOriginalName,
       attachmentSize,
     } = payload;
@@ -300,7 +300,7 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       minQuantity,
       consumptionType,
       unitOfMeasure,
-      attachmentUrl,
+      attachmentPath,
       attachmentOriginalName,
       attachmentSize,
     });

--- a/apps/webapp/app/routes/_layout+/assets.new.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.new.tsx
@@ -202,6 +202,9 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       minQuantity,
       consumptionType,
       unitOfMeasure,
+      attachmentUrl,
+      attachmentOriginalName,
+      attachmentSize,
     } = payload;
 
     /** This checks if tags are passed and build the  */
@@ -297,6 +300,9 @@ export async function action({ context, request }: LoaderFunctionArgs) {
       minQuantity,
       consumptionType,
       unitOfMeasure,
+      attachmentUrl,
+      attachmentOriginalName,
+      attachmentSize,
     });
 
     // `asset.user` is the full User row (createAsset includes `user: true`), so

--- a/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
+++ b/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
@@ -1,0 +1,67 @@
+import { data, type ActionFunctionArgs } from "react-router";
+import { z } from "zod";
+import {
+  removeAssetAttachment,
+  updateAssetAttachment,
+} from "~/modules/asset/service.server";
+import { makeShelfError, notAllowedMethod } from "~/utils/error";
+import {
+  error,
+  payload,
+  getActionMethod,
+  getParams,
+} from "~/utils/http.server";
+import {
+  PermissionAction,
+  PermissionEntity,
+} from "~/utils/permissions/permission.data";
+import { requirePermission } from "~/utils/roles.server";
+
+/**
+ * POST /api/asset/:assetId/attachment - upload (or replace) the asset's
+ * single PDF attachment.
+ * DELETE /api/asset/:assetId/attachment - remove it.
+ *
+ * A dedicated route (rather than folded into the edit-asset form action) so
+ * the drag-and-drop widget can upload/delete instantly, independent of
+ * whatever else is unsaved elsewhere on the edit page. See issue #2660.
+ */
+export async function action({ context, request, params }: ActionFunctionArgs) {
+  const authSession = context.getSession();
+  const { userId } = authSession;
+  const { assetId } = getParams(params, z.object({ assetId: z.string() }), {
+    additionalData: { userId },
+  });
+
+  try {
+    const { organizationId } = await requirePermission({
+      userId,
+      request,
+      entity: PermissionEntity.asset,
+      action: PermissionAction.update,
+    });
+
+    const method = getActionMethod(request);
+
+    switch (method) {
+      case "POST": {
+        const asset = await updateAssetAttachment({
+          request,
+          assetId,
+          organizationId,
+        });
+        return data(payload({ asset }));
+      }
+      case "DELETE": {
+        const asset = await removeAssetAttachment({ assetId, organizationId });
+        return data(payload({ asset }));
+      }
+      default: {
+        throw notAllowedMethod(method);
+      }
+    }
+  } catch (cause) {
+    const reason = makeShelfError(cause, { userId, assetId });
+    return data(error(reason), { status: reason.status });
+  }
+}

--- a/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
+++ b/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
@@ -1,3 +1,13 @@
+/**
+ * Upload / replace / remove endpoint for an asset's single PDF attachment.
+ *
+ * Branches on whether the asset already exists: for an existing asset it
+ * persists directly via `updateAssetAttachment` / `removeAssetAttachment`;
+ * for one that doesn't exist yet (the create-asset form's staging flow) it
+ * only touches storage via `stageAssetAttachment` / `clearStagedAssetAttachment`,
+ * and `createAsset()` persists the staged path once the rest of the form is
+ * submitted. See the `action()` doc comment below for the full behavior.
+ */
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
 import { db } from "~/database/db.server";

--- a/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
+++ b/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
@@ -1,7 +1,10 @@
 import { data, type ActionFunctionArgs } from "react-router";
 import { z } from "zod";
+import { db } from "~/database/db.server";
 import {
+  clearStagedAssetAttachment,
   removeAssetAttachment,
+  stageAssetAttachment,
   updateAssetAttachment,
 } from "~/modules/asset/service.server";
 import { makeShelfError, notAllowedMethod } from "~/utils/error";
@@ -25,6 +28,13 @@ import { requirePermission } from "~/utils/roles.server";
  * A dedicated route (rather than folded into the edit-asset form action) so
  * the drag-and-drop widget can upload/delete instantly, independent of
  * whatever else is unsaved elsewhere on the edit page. See issue #2660.
+ *
+ * The create-asset form reuses this same widget/route before the asset
+ * exists, passing a client-generated placeholder id - see AssetForm's
+ * pendingId. When no asset with `assetId` exists in this org yet, POST/DELETE
+ * fall through to the storage-only staging path (stageAssetAttachment /
+ * clearStagedAssetAttachment) instead of the DB-backed one; createAsset()
+ * persists the staged metadata once the rest of the form is submitted.
  */
 export async function action({ context, request, params }: ActionFunctionArgs) {
   const authSession = context.getSession();
@@ -43,18 +53,41 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 
     const method = getActionMethod(request);
 
+    const existingAsset = await db.asset.findFirst({
+      where: { id: assetId, organizationId },
+      select: { id: true },
+    });
+
     switch (method) {
       case "POST": {
+        if (!existingAsset) {
+          const staged = await stageAssetAttachment({
+            request,
+            assetId,
+            organizationId,
+          });
+          return data(payload(staged));
+        }
         const asset = await updateAssetAttachment({
           request,
           assetId,
           organizationId,
         });
-        return data(payload({ asset }));
+        return data(
+          payload({
+            attachmentUrl: asset.attachmentUrl,
+            attachmentOriginalName: asset.attachmentOriginalName,
+            attachmentSize: asset.attachmentSize,
+          })
+        );
       }
       case "DELETE": {
-        const asset = await removeAssetAttachment({ assetId, organizationId });
-        return data(payload({ asset }));
+        if (!existingAsset) {
+          await clearStagedAssetAttachment({ assetId, organizationId });
+          return data(payload({ success: true }));
+        }
+        await removeAssetAttachment({ assetId, organizationId });
+        return data(payload({ success: true }));
       }
       default: {
         throw notAllowedMethod(method);

--- a/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
+++ b/apps/webapp/app/routes/api+/asset.$assetId.attachment.ts
@@ -68,18 +68,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           });
           return data(payload(staged));
         }
-        const asset = await updateAssetAttachment({
-          request,
-          assetId,
-          organizationId,
-        });
-        return data(
-          payload({
-            attachmentUrl: asset.attachmentUrl,
-            attachmentOriginalName: asset.attachmentOriginalName,
-            attachmentSize: asset.attachmentSize,
-          })
-        );
+        // The response here isn't read client-side: AssetAttachmentUpload
+        // has no onUploaded callback wired for an already-existing asset
+        // (only the create form's not-yet-existing-asset path needs one),
+        // so this relies on React Router's automatic loader revalidation
+        // to pick up the new attachment instead.
+        await updateAssetAttachment({ request, assetId, organizationId });
+        return data(payload({ success: true }));
       }
       case "DELETE": {
         if (!existingAsset) {

--- a/apps/webapp/app/utils/constants.ts
+++ b/apps/webapp/app/utils/constants.ts
@@ -16,6 +16,10 @@ export const ACCEPT_SUPPORTED_IMAGES =
 export const DEFAULT_MAX_IMAGE_UPLOAD_SIZE = 4 * 1024 * 1024; // 4MB in bytes
 export const ASSET_MAX_IMAGE_UPLOAD_SIZE = 8 * 1024 * 1024; // 8MB in bytes
 
+/** For asset attachment uploads (invoices, manuals, certificates - PDF only) */
+export const ASSET_ATTACHMENT_MAX_SIZE = 10 * 1024 * 1024; // 10MB in bytes
+export const ACCEPT_SUPPORTED_ATTACHMENTS = "application/pdf,.pdf";
+
 /** Default date format */
 export const DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm";
 

--- a/apps/webapp/app/utils/constants.ts
+++ b/apps/webapp/app/utils/constants.ts
@@ -18,6 +18,7 @@ export const ASSET_MAX_IMAGE_UPLOAD_SIZE = 8 * 1024 * 1024; // 8MB in bytes
 
 /** For asset attachment uploads (invoices, manuals, certificates - PDF only) */
 export const ASSET_ATTACHMENT_MAX_SIZE = 10 * 1024 * 1024; // 10MB in bytes
+/** HTML `accept` attribute value for PDF-only attachment file inputs. */
 export const ACCEPT_SUPPORTED_ATTACHMENTS = "application/pdf,.pdf";
 
 /** Default date format */

--- a/apps/webapp/app/utils/storage.server.test.ts
+++ b/apps/webapp/app/utils/storage.server.test.ts
@@ -326,10 +326,8 @@ describe("parsePdfFormData", () => {
   });
 
   it("rejects a plain text 'file' field forging an upload result", async () => {
-    // No `filename` attribute - the multipart parser treats this as an
-    // ordinary text field, not a file part, so the upload handler (and
-    // its MIME/magic-byte checks) never runs at all. Before the fix, this
-    // exact payload would have been trusted as if it had been uploaded.
+    // No `filename` attribute - multipart text fields do not invoke the upload
+    // handler and therefore cannot provide stored attachment metadata.
     const forgedPath = "other-org/other-asset/attachment-stolen.pdf";
     const request = multipartRequest([
       {

--- a/apps/webapp/app/utils/storage.server.test.ts
+++ b/apps/webapp/app/utils/storage.server.test.ts
@@ -5,16 +5,26 @@ import {
   isSupabaseRateLimitError,
   isSupabaseServerError,
   parsePdfFormData,
+  removeFilesByPrefix,
 } from "./storage.server";
 
 // why: parsePdfFormData uploads to real Supabase Storage via
 // getSupabaseAdmin() - stub only that network boundary so the multipart
 // parsing this security test exercises runs for real, unmocked.
 const mockUpload = vi.fn();
+// why: removeFilesByPrefix paginates through Supabase Storage's list() and
+// then calls remove() - stub both so the pagination loop can be exercised
+// without a real bucket.
+const mockList = vi.fn();
+const mockRemove = vi.fn();
 vi.mock("~/integrations/supabase/client", () => ({
   getSupabaseAdmin: () => ({
     storage: {
-      from: () => ({ upload: mockUpload }),
+      from: () => ({
+        upload: mockUpload,
+        list: mockList,
+        remove: mockRemove,
+      }),
     },
   }),
 }));
@@ -385,5 +395,73 @@ describe("parsePdfFormData", () => {
     ).rejects.toThrow();
 
     expect(mockUpload).not.toHaveBeenCalled();
+  });
+});
+
+describe("removeFilesByPrefix", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes every entry across multiple list() pages, not just the first", async () => {
+    // Supabase Storage's list() caps a single call at `limit` entries
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({
+      name: `file-${i}.pdf`,
+    }));
+    const secondPage = [{ name: "file-100.pdf" }, { name: "file-101.pdf" }];
+
+    mockList
+      .mockResolvedValueOnce({ data: firstPage, error: null })
+      .mockResolvedValueOnce({ data: secondPage, error: null });
+    mockRemove.mockResolvedValue({ data: [], error: null });
+
+    await removeFilesByPrefix({
+      organizationId: "org-1",
+      entityId: "asset-1",
+      bucketName: "attachments",
+    });
+
+    expect(mockList).toHaveBeenCalledTimes(2);
+    expect(mockList).toHaveBeenNthCalledWith(1, "org-1/asset-1", {
+      limit: 100,
+      offset: 0,
+    });
+    expect(mockList).toHaveBeenNthCalledWith(2, "org-1/asset-1", {
+      limit: 100,
+      offset: 100,
+    });
+
+    const expectedPaths = [...firstPage, ...secondPage].map(
+      (entry) => `org-1/asset-1/${entry.name}`
+    );
+    expect(mockRemove).toHaveBeenCalledOnce();
+    expect(mockRemove).toHaveBeenCalledWith(expectedPaths);
+  });
+
+  it("stops after a single page when it comes back short of the page size", async () => {
+    mockList.mockResolvedValueOnce({
+      data: [{ name: "only-file.pdf" }],
+      error: null,
+    });
+    mockRemove.mockResolvedValue({ data: [], error: null });
+
+    await removeFilesByPrefix({
+      organizationId: "org-1",
+      entityId: "asset-1",
+    });
+
+    expect(mockList).toHaveBeenCalledOnce();
+    expect(mockRemove).toHaveBeenCalledWith(["org-1/asset-1/only-file.pdf"]);
+  });
+
+  it("does nothing when the prefix has no files at all", async () => {
+    mockList.mockResolvedValueOnce({ data: [], error: null });
+
+    await removeFilesByPrefix({
+      organizationId: "org-1",
+      entityId: "asset-1",
+    });
+
+    expect(mockRemove).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/utils/storage.server.test.ts
+++ b/apps/webapp/app/utils/storage.server.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ShelfError } from "./error";
 import {
   findShelfErrorInCause,
   isSupabaseRateLimitError,
   isSupabaseServerError,
+  parsePdfFormData,
 } from "./storage.server";
+
+// why: parsePdfFormData uploads to real Supabase Storage via
+// getSupabaseAdmin() - stub only that network boundary so the multipart
+// parsing this security test exercises runs for real, unmocked.
+const mockUpload = vi.fn();
+vi.mock("~/integrations/supabase/client", () => ({
+  getSupabaseAdmin: () => ({
+    storage: {
+      from: () => ({ upload: mockUpload }),
+    },
+  }),
+}));
 
 describe("isSupabaseRateLimitError", () => {
   it("returns true for StorageApiError with numeric status 429", () => {
@@ -239,5 +252,140 @@ describe("findShelfErrorInCause", () => {
 
   it("returns null for undefined input", () => {
     expect(findShelfErrorInCause(undefined)).toBeNull();
+  });
+});
+
+describe("parsePdfFormData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mirrors Supabase's real upload() response: echoes back the path it
+    // was asked to store at.
+    mockUpload.mockImplementation((path: string) => ({
+      data: { path },
+      error: null,
+    }));
+  });
+
+  /**
+   * Builds a raw multipart/form-data body by hand rather than relying on a
+   * FormData's automatic serialization - the happy-dom test environment
+   * doesn't reliably reproduce a real browser/undici multipart encoding,
+   * and the whole point of these tests is exercising the actual byte-level
+   * parsing this security fix protects.
+   */
+  function multipartRequest(
+    parts: {
+      name: string;
+      filename?: string;
+      contentType?: string;
+      body: string;
+    }[]
+  ) {
+    const boundary = "----vitestboundary123";
+    const segments = parts.map((part) => {
+      const disposition = part.filename
+        ? `Content-Disposition: form-data; name="${part.name}"; filename="${part.filename}"`
+        : `Content-Disposition: form-data; name="${part.name}"`;
+      const contentTypeLine = part.contentType
+        ? `Content-Type: ${part.contentType}\r\n`
+        : "";
+      return `--${boundary}\r\n${disposition}\r\n${contentTypeLine}\r\n${part.body}`;
+    });
+    const body = `${segments.join("\r\n")}\r\n--${boundary}--\r\n`;
+
+    return new Request("http://localhost/test", {
+      method: "POST",
+      headers: {
+        "content-type": `multipart/form-data; boundary=${boundary}`,
+      },
+      body,
+    });
+  }
+
+  const PDF_BODY = "%PDF-1.4\nfake pdf content";
+
+  it("uploads a real PDF and returns its path/name/size directly - not via FormData", async () => {
+    const request = multipartRequest([
+      {
+        name: "file",
+        filename: "invoice.pdf",
+        contentType: "application/pdf",
+        body: PDF_BODY,
+      },
+    ]);
+
+    const result = await parsePdfFormData({
+      request,
+      newFileName: "org-1/asset-1/attachment-123",
+    });
+
+    expect(result.path).toBe("org-1/asset-1/attachment-123.pdf");
+    expect(result.originalName).toBe("invoice.pdf");
+    expect(result.size).toBe(PDF_BODY.length);
+    expect(mockUpload).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a plain text 'file' field forging an upload result", async () => {
+    // No `filename` attribute - the multipart parser treats this as an
+    // ordinary text field, not a file part, so the upload handler (and
+    // its MIME/magic-byte checks) never runs at all. Before the fix, this
+    // exact payload would have been trusted as if it had been uploaded.
+    const forgedPath = "other-org/other-asset/attachment-stolen.pdf";
+    const request = multipartRequest([
+      {
+        name: "file",
+        body: JSON.stringify({
+          path: forgedPath,
+          originalName: "not-really-uploaded.pdf",
+          size: 1,
+        }),
+      },
+    ]);
+
+    await expect(
+      parsePdfFormData({
+        request,
+        newFileName: "org-1/asset-1/attachment-999",
+      })
+    ).rejects.toThrow();
+
+    // Confirms the forged path never reached storage - Supabase's upload()
+    // must never have been called with attacker-supplied data.
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects a file whose declared type is application/pdf but whose bytes are not", async () => {
+    const request = multipartRequest([
+      {
+        name: "file",
+        filename: "fake.pdf",
+        contentType: "application/pdf",
+        body: "<html>not a pdf</html>",
+      },
+    ]);
+
+    await expect(
+      parsePdfFormData({
+        request,
+        newFileName: "org-1/asset-1/attachment-000",
+      })
+    ).rejects.toThrow(/not a valid PDF/);
+
+    expect(mockUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects a file part with no Content-Type header at all", async () => {
+    const request = multipartRequest([
+      { name: "file", filename: "no-type.pdf", body: PDF_BODY },
+    ]);
+
+    await expect(
+      parsePdfFormData({
+        request,
+        newFileName: "org-1/asset-1/attachment-111",
+      })
+    ).rejects.toThrow();
+
+    expect(mockUpload).not.toHaveBeenCalled();
   });
 });

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -362,6 +362,16 @@ export interface UploadOptions {
   contentType: string;
   resizeOptions?: ResizeOptions;
   upsert?: boolean;
+  /**
+   * When set, `uploadRawFile` rejects the upload unless the buffered file's
+   * leading bytes match this signature. The declared `contentType` is
+   * caller-supplied and unverified otherwise - this is the binary-level
+   * check that stands in for `uploadFile`'s Sharp-based image validation on
+   * paths that skip image processing entirely.
+   */
+  expectedMagicBytes?: Uint8Array;
+  /** User-facing message when `expectedMagicBytes` doesn't match. */
+  invalidSignatureMessage?: string;
 }
 
 export async function parseFileFormData({
@@ -502,7 +512,14 @@ export function findShelfErrorInCause(error: unknown): ShelfError | null {
  */
 export async function uploadRawFile(
   fileData: AsyncIterable<Uint8Array>,
-  { filename, contentType, bucketName, upsert = false }: UploadOptions
+  {
+    filename,
+    contentType,
+    bucketName,
+    upsert = false,
+    expectedMagicBytes,
+    invalidSignatureMessage = "Uploaded file does not match its expected format",
+  }: UploadOptions
 ): Promise<{ path: string; size: number }> {
   try {
     const chunks: Uint8Array[] = [];
@@ -510,6 +527,25 @@ export async function uploadRawFile(
       chunks.push(chunk);
     }
     const buffer = Buffer.concat(chunks);
+
+    // The declared contentType comes from the client and is not proof of
+    // the actual bytes - a request can label anything "application/pdf".
+    // Checking the magic bytes here is what actually keeps non-PDF content
+    // out of a bucket that serves files back with that content type.
+    if (
+      expectedMagicBytes &&
+      !buffer
+        .subarray(0, expectedMagicBytes.length)
+        .equals(Buffer.from(expectedMagicBytes))
+    ) {
+      throw new ShelfError({
+        cause: null,
+        title: "Invalid file",
+        message: invalidSignatureMessage,
+        label,
+        shouldBeCaptured: false,
+      });
+    }
 
     const { data, error } = await getSupabaseAdmin()
       .storage.from(bucketName)
@@ -547,6 +583,9 @@ export async function uploadRawFile(
  * `parseFileFormData` stringifies `{ originalPath, thumbnailPath }` when
  * `generateThumbnail` is set).
  */
+/** ASCII "%PDF-" - every valid PDF starts with this, regardless of version. */
+const PDF_MAGIC_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
+
 export async function parsePdfFormData({
   request,
   newFileName,
@@ -568,7 +607,9 @@ export async function parsePdfFormData({
 
       // Only process PDFs - anything else (including a same-form image
       // field, if this is ever reused on a multi-file form) is left alone.
-      if (mimeType && mimeType !== "application/pdf") {
+      // A missing/empty Content-Type is rejected outright rather than
+      // assumed to be a PDF.
+      if (!mimeType || mimeType !== "application/pdf") {
         return undefined;
       }
 
@@ -586,8 +627,10 @@ export async function parsePdfFormData({
 
       const { path, size } = await uploadRawFile(fileStream, {
         filename: targetFilename,
-        contentType: mimeType ?? "application/pdf",
+        contentType: mimeType,
         bucketName,
+        expectedMagicBytes: PDF_MAGIC_BYTES,
+        invalidSignatureMessage: "Uploaded file is not a valid PDF",
       });
 
       return JSON.stringify({ path, originalName, size });

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -9,6 +9,7 @@ import type { ResizeOptions } from "sharp";
 
 import { getSupabaseAdmin } from "~/integrations/supabase/client";
 import {
+  ASSET_ATTACHMENT_MAX_SIZE,
   ASSET_MAX_IMAGE_UPLOAD_SIZE,
   DEFAULT_MAX_IMAGE_UPLOAD_SIZE,
   PUBLIC_BUCKET,
@@ -491,6 +492,136 @@ export function findShelfErrorInCause(error: unknown): ShelfError | null {
   }
 
   return findShelfErrorInCause(cause);
+}
+
+/**
+ * Uploads a file to Supabase Storage as-is, with no image processing.
+ * Companion to `uploadFile()` above for non-image files (e.g. PDF asset
+ * attachments) - `uploadFile()` always runs `cropImage()`, which rejects
+ * anything that isn't a JPEG/PNG/GIF/WebP/BMP.
+ */
+export async function uploadRawFile(
+  fileData: AsyncIterable<Uint8Array>,
+  { filename, contentType, bucketName, upsert = false }: UploadOptions
+): Promise<{ path: string; size: number }> {
+  try {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of fileData) {
+      chunks.push(chunk);
+    }
+    const buffer = Buffer.concat(chunks);
+
+    const { data, error } = await getSupabaseAdmin()
+      .storage.from(bucketName)
+      .upload(filename, buffer, { contentType, upsert });
+
+    if (error) {
+      throw error;
+    }
+
+    return { path: data.path, size: buffer.byteLength };
+  } catch (cause) {
+    const isShelfError = isLikeShelfError(cause);
+
+    throw new ShelfError({
+      cause,
+      message: isShelfError
+        ? cause.message
+        : "Something went wrong while uploading the file. Please try again or contact support.",
+      additionalData: { filename, contentType, bucketName },
+      label,
+      shouldBeCaptured: isShelfError ? cause.shouldBeCaptured : undefined,
+    });
+  }
+}
+
+/**
+ * Parses a single-PDF multipart upload (asset attachments - invoices,
+ * manuals, certificates; see issue #2660). Mirrors `parseFileFormData()`'s
+ * shape, but uploads via `uploadRawFile()` instead of `uploadFile()` since
+ * PDFs must skip the image pipeline entirely.
+ *
+ * The returned FormData's entry for the file field is a JSON string
+ * `{ path, originalName, size }` - callers need `originalName`/`size` for
+ * display, which a bare path string can't carry (mirrors how
+ * `parseFileFormData` stringifies `{ originalPath, thumbnailPath }` when
+ * `generateThumbnail` is set).
+ */
+export async function parsePdfFormData({
+  request,
+  newFileName,
+  bucketName = PUBLIC_BUCKET,
+  maxFileSize = ASSET_ATTACHMENT_MAX_SIZE,
+}: {
+  request: Request;
+  newFileName: string;
+  bucketName?: string;
+  maxFileSize?: number;
+}) {
+  try {
+    const uploadHandler = async (upload: any) => {
+      const file = upload?.file ?? upload;
+      const mimeType =
+        upload?.type ?? upload?.contentType ?? file?.type ?? undefined;
+      const originalName =
+        upload?.name ?? upload?.filename ?? file?.name ?? undefined;
+
+      // Only process PDFs - anything else (including a same-form image
+      // field, if this is ever reused on a multi-file form) is left alone.
+      if (mimeType && mimeType !== "application/pdf") {
+        return undefined;
+      }
+
+      if (!file) {
+        return undefined;
+      }
+
+      const fileStream = await normalizeToAsyncIterable(file);
+
+      if (!fileStream) {
+        return undefined;
+      }
+
+      const targetFilename = `${newFileName}.pdf`;
+
+      const { path, size } = await uploadRawFile(fileStream, {
+        filename: targetFilename,
+        contentType: mimeType ?? "application/pdf",
+        bucketName,
+      });
+
+      return JSON.stringify({ path, originalName, size });
+    };
+
+    return await parseFormData(request, { maxFileSize }, uploadHandler);
+  } catch (cause) {
+    const sizeLimitError = getMaxFileSizeExceededError(cause);
+
+    if (sizeLimitError) {
+      throw new ShelfError({
+        cause,
+        title: "File too large",
+        message: `File size exceeds maximum allowed size of ${
+          maxFileSize / (1024 * 1024)
+        }MB`,
+        additionalData: { maxFileSize },
+        label,
+        shouldBeCaptured: false,
+      });
+    }
+
+    const nestedShelfError = findShelfErrorInCause(cause);
+
+    throw new ShelfError({
+      cause,
+      message: nestedShelfError
+        ? nestedShelfError.message
+        : "Something went wrong while uploading the file. Please try again or contact support.",
+      title: nestedShelfError?.title,
+      label,
+      shouldBeCaptured: nestedShelfError?.shouldBeCaptured,
+    });
+  }
 }
 
 /**

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -1031,6 +1031,53 @@ export async function removePublicFile({ publicUrl }: { publicUrl: string }) {
 }
 
 /**
+ * Deletes every object under an org+entity storage prefix in `bucketName`.
+ * For an entity that doesn't have a DB row yet (e.g. a PDF attachment
+ * staged while a new asset is still being filled out) there is no stored
+ * URL to read the exact path from, so this removes by folder instead of
+ * by a single known key.
+ */
+export async function removeFilesByPrefix({
+  organizationId,
+  entityId,
+  bucketName = PUBLIC_BUCKET,
+}: {
+  organizationId: string;
+  entityId: string;
+  bucketName?: string;
+}) {
+  try {
+    const prefix = `${organizationId}/${entityId}`;
+    const { data: entries, error: listError } = await getSupabaseAdmin()
+      .storage.from(bucketName)
+      .list(prefix);
+
+    if (listError) {
+      throw listError;
+    }
+
+    if (!entries || entries.length === 0) {
+      return;
+    }
+
+    const { error: removeError } = await getSupabaseAdmin()
+      .storage.from(bucketName)
+      .remove(entries.map((entry) => `${prefix}/${entry.name}`));
+
+    if (removeError) {
+      throw removeError;
+    }
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: "Failed to remove staged files",
+      additionalData: { organizationId, entityId, bucketName },
+      label,
+    });
+  }
+}
+
+/**
  * Supabase can sporadically return HTML error pages (e.g., CDN/edge 50x) that the storage
  * client surfaces as StorageUnknownError due to JSON parsing. Detect that shape so callers
  * can retry instead of immediately failing user-visible flows.

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -503,6 +503,26 @@ export function findShelfErrorInCause(error: unknown): ShelfError | null {
  * Companion to `uploadFile()` above for non-image files (e.g. PDF asset
  * attachments) - `uploadFile()` always runs `cropImage()`, which rejects
  * anything that isn't a JPEG/PNG/GIF/WebP/BMP.
+ *
+ * Buffers the entire `fileData` stream into memory before uploading, since
+ * both the magic-byte check and the upload call need the full byte length
+ * up front.
+ *
+ * @param fileData - The file's bytes as an async iterable of chunks.
+ * @param options.filename - Destination path within the bucket.
+ * @param options.contentType - Declared MIME type stored as the object's
+ * Content-Type; not verified against the actual bytes unless
+ * `expectedMagicBytes` is also given.
+ * @param options.bucketName - Target Supabase Storage bucket.
+ * @param options.upsert - Overwrite an existing object at `filename`
+ * instead of failing. Defaults to `false`.
+ * @param options.expectedMagicBytes - When set, the upload is rejected
+ * unless the buffer's leading bytes match this signature exactly.
+ * @param options.invalidSignatureMessage - User-facing message used when
+ * `expectedMagicBytes` doesn't match.
+ * @returns The stored object's path and its size in bytes.
+ * @throws {ShelfError} When the magic-byte check fails, or the underlying
+ * Supabase Storage upload fails for any other reason.
  */
 export async function uploadRawFile(
   fileData: AsyncIterable<Uint8Array>,
@@ -565,28 +585,30 @@ export async function uploadRawFile(
   }
 }
 
-/**
- * Parses a single-PDF multipart upload (asset attachments - invoices,
- * manuals, certificates; see issue #2660). Mirrors `parseFileFormData()`'s
- * shape, but uploads via `uploadRawFile()` instead of `uploadFile()` since
- * PDFs must skip the image pipeline entirely.
- *
- * The returned FormData's entry for the file field is a JSON string
- * `{ path, originalName, size }` - callers need `originalName`/`size` for
- * display, which a bare path string can't carry (mirrors how
- * `parseFileFormData` stringifies `{ originalPath, thumbnailPath }` when
- * `generateThumbnail` is set).
- */
 /** ASCII "%PDF-" - every valid PDF starts with this, regardless of version. */
 const PDF_MAGIC_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
 
 /**
- * Parses a single-PDF upload and returns its storage metadata directly.
-
+ * Parses a single-PDF multipart upload (asset attachments - invoices,
+ * manuals, certificates; see issue #2660) and returns its storage metadata
+ * directly, rather than through the parsed FormData.
+ *
  * We intentionally don't read the result back from FormData, since
  * regular text fields can use the same "file" key and spoof the uploaded
  * file metadata. Keeping the result inside the upload handler ensures the
  * path can only come from a file actually processed by the server.
+ *
+ * @param request - The incoming multipart/form-data request.
+ * @param newFileName - Base filename (without extension) the PDF is
+ * stored under; `.pdf` is appended.
+ * @param bucketName - Target Supabase Storage bucket. Defaults to the
+ * private `"assets"` bucket.
+ * @param maxFileSize - Maximum accepted upload size in bytes.
+ * @returns The stored object's path, the client-supplied original
+ * filename (if any), and its size in bytes.
+ * @throws {ShelfError} When no upload matches the "file" field, the
+ * declared or actual content type isn't `application/pdf`, the upload
+ * exceeds `maxFileSize`, or the file was stored at an unexpected path.
  */
 export async function parsePdfFormData({
   request,

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -1,6 +1,7 @@
 import { Readable } from "node:stream";
 
 import {
+  type FileUpload,
   MaxFileSizeExceededError,
   parseFormData,
 } from "@remix-run/form-data-parser";
@@ -392,23 +393,16 @@ export async function parseFileFormData({
   maxFileSize?: number;
 }) {
   try {
-    const uploadHandler = async (upload: any) => {
-      const file = upload?.file ?? upload;
-      const mimeType =
-        upload?.type ?? upload?.contentType ?? file?.type ?? undefined;
-      const originalName =
-        upload?.name ?? upload?.filename ?? file?.name ?? undefined;
+    const uploadHandler = async (upload: FileUpload) => {
+      const mimeType = upload.type;
+      const originalName = upload.name;
 
       // Only process image files
       if (mimeType && !mimeType.includes("image")) {
         return undefined;
       }
 
-      if (!file) {
-        return undefined;
-      }
-
-      const fileStream = await normalizeToAsyncIterable(file);
+      const fileStream = await normalizeToAsyncIterable(upload);
 
       if (!fileStream) {
         return undefined;
@@ -616,19 +610,16 @@ export async function parsePdfFormData({
       null;
     const targetFilename = `${newFileName}.pdf`;
 
-    const uploadHandler = async (upload: any) => {
+    const uploadHandler = async (upload: FileUpload) => {
       // `upload.fieldName` is set by the multipart parser itself from the
       // part's own Content-Disposition `name`, not from anything this
       // handler trusts
-      if (upload?.fieldName !== "file") {
+      if (upload.fieldName !== "file") {
         return undefined;
       }
 
-      const file = upload?.file ?? upload;
-      const mimeType =
-        upload?.type ?? upload?.contentType ?? file?.type ?? undefined;
-      const originalName =
-        upload?.name ?? upload?.filename ?? file?.name ?? undefined;
+      const mimeType = upload.type;
+      const originalName = upload.name;
 
       // Only process PDFs - anything else is left alone. A missing/empty
       // Content-Type is rejected outright rather than assumed to be a PDF.
@@ -636,11 +627,7 @@ export async function parsePdfFormData({
         return undefined;
       }
 
-      if (!file) {
-        return undefined;
-      }
-
-      const fileStream = await normalizeToAsyncIterable(file);
+      const fileStream = await normalizeToAsyncIterable(upload);
 
       if (!fileStream) {
         return undefined;

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -586,6 +586,14 @@ export async function uploadRawFile(
 /** ASCII "%PDF-" - every valid PDF starts with this, regardless of version. */
 const PDF_MAGIC_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
 
+/**
+ * Parses a single-PDF upload and returns its storage metadata directly.
+
+ * We intentionally don't read the result back from FormData, since
+ * regular text fields can use the same "file" key and spoof the uploaded
+ * file metadata. Keeping the result inside the upload handler ensures the
+ * path can only come from a file actually processed by the server.
+ */
 export async function parsePdfFormData({
   request,
   newFileName,
@@ -596,19 +604,28 @@ export async function parsePdfFormData({
   newFileName: string;
   bucketName?: string;
   maxFileSize?: number;
-}) {
+}): Promise<{ path: string; originalName?: string; size: number }> {
   try {
+    let uploaded: { path: string; originalName?: string; size: number } | null =
+      null;
+    const targetFilename = `${newFileName}.pdf`;
+
     const uploadHandler = async (upload: any) => {
+      // `upload.fieldName` is set by the multipart parser itself from the
+      // part's own Content-Disposition `name`, not from anything this
+      // handler trusts
+      if (upload?.fieldName !== "file") {
+        return undefined;
+      }
+
       const file = upload?.file ?? upload;
       const mimeType =
         upload?.type ?? upload?.contentType ?? file?.type ?? undefined;
       const originalName =
         upload?.name ?? upload?.filename ?? file?.name ?? undefined;
 
-      // Only process PDFs - anything else (including a same-form image
-      // field, if this is ever reused on a multi-file form) is left alone.
-      // A missing/empty Content-Type is rejected outright rather than
-      // assumed to be a PDF.
+      // Only process PDFs - anything else is left alone. A missing/empty
+      // Content-Type is rejected outright rather than assumed to be a PDF.
       if (!mimeType || mimeType !== "application/pdf") {
         return undefined;
       }
@@ -623,8 +640,6 @@ export async function parsePdfFormData({
         return undefined;
       }
 
-      const targetFilename = `${newFileName}.pdf`;
-
       const { path, size } = await uploadRawFile(fileStream, {
         filename: targetFilename,
         contentType: mimeType,
@@ -633,10 +648,32 @@ export async function parsePdfFormData({
         invalidSignatureMessage: "Uploaded file is not a valid PDF",
       });
 
-      return JSON.stringify({ path, originalName, size });
+      if (path !== targetFilename) {
+        throw new ShelfError({
+          cause: null,
+          message: "Uploaded file was stored at an unexpected path",
+          additionalData: { expected: targetFilename, actual: path },
+          label,
+        });
+      }
+
+      uploaded = { path, originalName, size };
+      return undefined;
     };
 
-    return await parseFormData(request, { maxFileSize }, uploadHandler);
+    await parseFormData(request, { maxFileSize }, uploadHandler);
+
+    if (!uploaded) {
+      throw new ShelfError({
+        cause: null,
+        title: "No file uploaded",
+        message: "Please choose a PDF file to upload.",
+        label,
+        shouldBeCaptured: false,
+      });
+    }
+
+    return uploaded;
   } catch (cause) {
     const sizeLimitError = getMaxFileSizeExceededError(cause);
 

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -1178,15 +1178,32 @@ export async function removeFilesByPrefix({
 }) {
   try {
     const prefix = `${organizationId}/${entityId}`;
-    const { data: entries, error: listError } = await getSupabaseAdmin()
-      .storage.from(bucketName)
-      .list(prefix);
 
-    if (listError) {
-      throw listError;
+    // list() caps a single call at PAGE_SIZE entries (Supabase's own default),
+    // paginating via limit/offset.
+    const PAGE_SIZE = 100;
+    const entries: { name: string }[] = [];
+    let offset = 0;
+    let hasMore = true;
+    while (hasMore) {
+      const { data: page, error: listError } = await getSupabaseAdmin()
+        .storage.from(bucketName)
+        .list(prefix, { limit: PAGE_SIZE, offset });
+
+      if (listError) {
+        throw listError;
+      }
+
+      if (!page || page.length === 0) {
+        break;
+      }
+
+      entries.push(...page);
+      offset += page.length;
+      hasMore = page.length === PAGE_SIZE;
     }
 
-    if (!entries || entries.length === 0) {
+    if (entries.length === 0) {
       return;
     }
 

--- a/apps/webapp/app/utils/storage.server.ts
+++ b/apps/webapp/app/utils/storage.server.ts
@@ -597,7 +597,13 @@ const PDF_MAGIC_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
 export async function parsePdfFormData({
   request,
   newFileName,
-  bucketName = PUBLIC_BUCKET,
+  // Private by default - a PDF attachment (invoice, calibration cert,
+  // warranty doc) can carry real business/financial detail, unlike the
+  // photos this bucket's other callers store. Access to it should follow
+  // access to the asset, not be a permanent public link - see
+  // createSignedUrl() for how a caller turns this back into a fetchable
+  // URL only after its own permission check.
+  bucketName = "assets",
   maxFileSize = ASSET_ATTACHMENT_MAX_SIZE,
 }: {
   request: Request;
@@ -1105,6 +1111,41 @@ export async function removePublicFile({ publicUrl }: { publicUrl: string }) {
       message: isLikeShelfError(cause)
         ? cause.message
         : "Failed to remove file. Please try again.",
+      label,
+    });
+  }
+}
+
+/**
+ * Deletes a single, exactly-known object from a private bucket by its raw
+ * storage path. Companion to `removePublicFile()` for buckets that aren't
+ * served through a public URL - there is no URL to parse the path out of,
+ * so the caller passes the path it already has (e.g. a value it previously
+ * stored precisely because it's the private-bucket equivalent of a public
+ * URL for that row).
+ */
+export async function removeFileAtPath({
+  path,
+  bucketName,
+}: {
+  path: string;
+  bucketName: string;
+}) {
+  try {
+    const { error } = await getSupabaseAdmin()
+      .storage.from(bucketName)
+      .remove([path]);
+
+    if (error) {
+      throw error;
+    }
+  } catch (cause) {
+    throw new ShelfError({
+      cause,
+      message: isLikeShelfError(cause)
+        ? cause.message
+        : "Failed to remove file. Please try again.",
+      additionalData: { path, bucketName },
       label,
     });
   }

--- a/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
+++ b/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
@@ -8,3 +8,9 @@
 ALTER TABLE "Asset" ADD COLUMN "attachmentPath" TEXT;
 ALTER TABLE "Asset" ADD COLUMN "attachmentOriginalName" TEXT;
 ALTER TABLE "Asset" ADD COLUMN "attachmentSize" INTEGER;
+
+-- Postgres treats every NULL as distinct under a unique index, so this
+-- does not constrain the (majority of) assets with no attachment - it only
+-- guarantees one asset per storage path, closing the race between
+-- createAsset's own not-already-claimed check and the actual insert.
+CREATE UNIQUE INDEX "Asset_attachmentPath_key" ON "Asset"("attachmentPath");

--- a/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
+++ b/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
@@ -1,8 +1,8 @@
 -- Optional single-file attachment per asset (purchase invoice, manual,
 -- calibration certificate, etc. - see issue #2660).
 --
--- Nullable, additive, no backfill - safe at Shelf's table scale, no lock
--- concern. attachmentUrl is a full public URL (same shape as
+-- Nullable, additive, no backfill.
+-- attachmentUrl is a full public URL (same shape as
 -- Location.imageUrl / AuditImage.imageUrl), not a bare storage path.
 ALTER TABLE "Asset" ADD COLUMN "attachmentUrl" TEXT;
 ALTER TABLE "Asset" ADD COLUMN "attachmentOriginalName" TEXT;

--- a/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
+++ b/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
@@ -1,0 +1,9 @@
+-- Optional single-file attachment per asset (purchase invoice, manual,
+-- calibration certificate, etc. - see issue #2660).
+--
+-- Nullable, additive, no backfill - safe at Shelf's table scale, no lock
+-- concern. attachmentUrl is a full public URL (same shape as
+-- Location.imageUrl / AuditImage.imageUrl), not a bare storage path.
+ALTER TABLE "Asset" ADD COLUMN "attachmentUrl" TEXT;
+ALTER TABLE "Asset" ADD COLUMN "attachmentOriginalName" TEXT;
+ALTER TABLE "Asset" ADD COLUMN "attachmentSize" INTEGER;

--- a/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
+++ b/packages/database/prisma/migrations/20260826120000_add_asset_attachment/migration.sql
@@ -2,8 +2,9 @@
 -- calibration certificate, etc. - see issue #2660).
 --
 -- Nullable, additive, no backfill.
--- attachmentUrl is a full public URL (same shape as
--- Location.imageUrl / AuditImage.imageUrl), not a bare storage path.
-ALTER TABLE "Asset" ADD COLUMN "attachmentUrl" TEXT;
+-- attachmentPath is a bare storage path in the private `assets` bucket, not
+-- a URL - it's resolved to a short-lived signed URL at the point of
+-- display, never persisted as one.
+ALTER TABLE "Asset" ADD COLUMN "attachmentPath" TEXT;
 ALTER TABLE "Asset" ADD COLUMN "attachmentOriginalName" TEXT;
 ALTER TABLE "Asset" ADD COLUMN "attachmentSize" INTEGER;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -221,8 +221,10 @@ model Asset {
   // check rather than being a permanent public link. Resolve it to a
   // short-lived signed URL with createSignedUrl() at the point of display;
   // never persist that signed URL back to this column (it expires; the
-  // path doesn't).
-  attachmentPath         String?
+  // path doesn't). @unique closes the race between createAsset's own
+  // not-already-claimed check and the actual insert - see createAsset's
+  // attachmentPath guard in modules/asset/service.server.ts.
+  attachmentPath         String?     @unique
   attachmentOriginalName String?
   attachmentSize         Int?
   status                 AssetStatus @default(AVAILABLE)
@@ -1007,7 +1009,7 @@ model Organization {
   auditImages        AuditImage[]
 
   usersWithLastSelected User[] @relation("lastSelectedOrg")
-  
+
   scimTokens      ScimToken[]
   scimExternalIds UserScimExternalId[]
   roleChangeLogs  RoleChangeLog[]

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -208,16 +208,23 @@ model UserBusinessIntel {
 }
 
 model Asset {
-  id                  String      @id @default(cuid())
-  title               String
-  description         String?
-  mainImage           String?
-  thumbnailImage      String?
-  mainImageExpiration DateTime?
-  status              AssetStatus @default(AVAILABLE)
-  valuation           Float?      @map("value") // Field to store the monetary value of an asset
-  availableToBook     Boolean     @default(true)
-  sequentialId        String? // Sequential identifier for the asset (e.g., "SAM-0001")
+  id                     String      @id @default(cuid())
+  title                  String
+  description            String?
+  mainImage              String?
+  thumbnailImage         String?
+  mainImageExpiration    DateTime?
+  // Single optional file attachment (purchase invoice, manual,
+  // calibration certificate, etc. - see issue #2660). Stored in the public
+  // `files` bucket alongside location/audit images, so `attachmentUrl` is
+  // a full public URL, not a bare storage path.
+  attachmentUrl          String?
+  attachmentOriginalName String?
+  attachmentSize         Int?
+  status                 AssetStatus @default(AVAILABLE)
+  valuation              Float?      @map("value") // Field to store the monetary value of an asset
+  availableToBook        Boolean     @default(true)
+  sequentialId           String? // Sequential identifier for the asset (e.g., "SAM-0001")
 
   // Tracking method & model
   type            AssetType        @default(INDIVIDUAL)

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -215,10 +215,14 @@ model Asset {
   thumbnailImage         String?
   mainImageExpiration    DateTime?
   // Single optional file attachment (purchase invoice, manual,
-  // calibration certificate, etc. - see issue #2660). Stored in the public
-  // `files` bucket alongside location/audit images, so `attachmentUrl` is
-  // a full public URL, not a bare storage path.
-  attachmentUrl          String?
+  // calibration certificate, etc. - see issue #2660). A bare storage path
+  // in the private `assets` bucket, not a URL - these documents can carry
+  // real business detail, so access must follow the asset's own permission
+  // check rather than being a permanent public link. Resolve it to a
+  // short-lived signed URL with createSignedUrl() at the point of display;
+  // never persist that signed URL back to this column (it expires; the
+  // path doesn't).
+  attachmentPath         String?
   attachmentOriginalName String?
   attachmentSize         Int?
   status                 AssetStatus @default(AVAILABLE)


### PR DESCRIPTION
Closes #2660 

Assets can now have a single optional PDF document attached to it via file upload. 

Upload capability added on the edit-page of each asset.

Adds drag-n-drop uploader, a dedicated API route and some new asset columns.

# Screenshots

<img width="399" height="370" alt="asset_view" src="https://github.com/user-attachments/assets/897ee5db-d973-4958-9b1b-2effd9f468fe" />

<img width="444" height="155" alt="asset_edit" src="https://github.com/user-attachments/assets/27c4936f-9726-446a-bebf-35f22d25e103" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for uploading, viewing, replacing, and deleting one PDF attachment per asset.
- Attachments are supported when creating or editing assets and hidden during bulk creation.
- PDF uploads are limited to 10 MB and validated for file type and content.
- Attachment links display the original filename and file size.
- Downloads use secure, short-lived links.
- Added customizable file-type guidance for upload areas.

## Bug Fixes
- Improved attachment replacement, removal, staging, and cleanup handling.

## Tests
- Added coverage for PDF validation, security checks, and attachment lifecycle actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->