### PR TITLE
feat(companion): close an audit with a note, and set an asset's value on create

### DIFF
--- a/apps/companion/app/(tabs)/assets/new.tsx
+++ b/apps/companion/app/(tabs)/assets/new.tsx
@@ -40,6 +40,7 @@ import {
   type Tag,
   type MobileCustomFieldDefinition,
 } from "@/lib/api";
+import { ValuationField } from "@/components/asset-edit/valuation-field";
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useTheme } from "@/lib/theme-context";
@@ -76,6 +77,9 @@ export default function CreateAssetScreen() {
   // ── Form state ──────────────────────────────────
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  // Held as the raw string the field produces, not a number: an empty box
+  // means "not set", which is different from a deliberate 0.
+  const [valuation, setValuation] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(
     null
   );
@@ -474,6 +478,16 @@ export default function CreateAssetScreen() {
     const customFieldsPayload = buildCustomFieldsPayload();
 
     setIsSubmitting(true);
+    const trimmedValuation = valuation.trim();
+    if (trimmedValuation !== "" && !Number.isFinite(Number(trimmedValuation))) {
+      Alert.alert(
+        "Check the value",
+        "Enter the value as a number, or leave it empty."
+      );
+      setIsSubmitting(false);
+      return;
+    }
+
     const { data, error } = await api.createAsset(currentOrg.id, {
       title: trimmedTitle,
       description: description.trim() || undefined,
@@ -483,6 +497,8 @@ export default function CreateAssetScreen() {
       customFields:
         customFieldsPayload.length > 0 ? customFieldsPayload : undefined,
       qrId: qrId || undefined,
+      // A blank box is omitted; a typed 0 is a real value and is sent.
+      valuation: trimmedValuation === "" ? undefined : Number(trimmedValuation),
     });
 
     setIsSubmitting(false);
@@ -532,6 +548,7 @@ export default function CreateAssetScreen() {
           setImageUri(null);
           setImageMimeType("image/jpeg");
           setCustomFieldValues({});
+          setValuation("");
           setQrId(undefined);
           // The route still carries the old qrId; clear it too, or a screen
           // remount would re-seed the state and resurrect the banner.
@@ -657,6 +674,13 @@ export default function CreateAssetScreen() {
             accessibilityLabel="Description"
           />
         </View>
+
+        {/* ── Value (optional) ─────────────────────── */}
+        <ValuationField
+          value={valuation}
+          onChange={setValuation}
+          currency={currentOrg?.currency ?? "USD"}
+        />
 
         {/* ── Category Picker ──────────────────────── */}
         <View style={styles.field}>

--- a/apps/companion/app/(tabs)/assets/new.tsx
+++ b/apps/companion/app/(tabs)/assets/new.tsx
@@ -281,6 +281,7 @@ export default function CreateAssetScreen() {
   const hasUnsavedChanges =
     title.trim().length > 0 ||
     description.trim().length > 0 ||
+    valuation.trim().length > 0 ||
     !!selectedCategory ||
     !!selectedLocation ||
     selectedTags.length > 0 ||

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -28,6 +28,7 @@ import {
 import { useOrg } from "@/lib/org-context";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useDateFormatter } from "@/lib/use-date-formatter";
+import { CompleteAuditSheet } from "@/components/audit/complete-audit-sheet";
 import { EvidenceViewer } from "@/components/audit/evidence-viewer";
 import {
   AUDIT_ASSET_STATUS_LABELS,
@@ -330,6 +331,7 @@ function AuditDetailContent() {
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isActioning, setIsActioning] = useState(false);
+  const [showCompleteSheet, setShowCompleteSheet] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [assetFilter, setAssetFilter] = useState<AssetFilterValue>("ALL");
 
@@ -433,53 +435,43 @@ function AuditDetailContent() {
   const handleCompleteAudit = () => {
     if (!audit || !currentOrg) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setShowCompleteSheet(true);
+  };
 
-    const pendingCount = audit.expectedAssetCount - audit.foundAssetCount;
+  /**
+   * Finish the audit, carrying the closing note when one was written.
+   *
+   * The sheet's own button is the confirmation and states the consequence for
+   * unscanned assets, so nothing is stacked on top of this.
+   */
+  const performCompleteAudit = async (completionNote?: string) => {
+    if (!audit || !currentOrg) return;
+    setIsActioning(true);
+    const timeZone = (() => {
+      try {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+      } catch {
+        return "UTC";
+      }
+    })();
 
-    Alert.alert(
-      "Complete Audit",
-      pendingCount > 0
-        ? `Complete "${audit.name}"?\n\n${pendingCount} unscanned ${
-            pendingCount === 1 ? "asset" : "assets"
-          } will be marked as missing.`
-        : `Complete "${audit.name}"?\n\nAll expected assets have been found.`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Complete",
-          onPress: async () => {
-            setIsActioning(true);
-            const timeZone = (() => {
-              try {
-                return (
-                  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
-                );
-              } catch {
-                return "UTC";
-              }
-            })();
+    const { error: err } = await api.completeAudit(currentOrg.id, {
+      sessionId: audit.id,
+      timeZone,
+      completionNote,
+    });
+    setIsActioning(false);
 
-            const { error: err } = await api.completeAudit(currentOrg.id, {
-              sessionId: audit.id,
-              timeZone,
-            });
-            setIsActioning(false);
+    if (err) {
+      Alert.alert("Error", err);
+      return;
+    }
 
-            if (err) {
-              Alert.alert("Error", err);
-              return;
-            }
-
-            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-            Alert.alert(
-              "Audit Complete",
-              `"${audit.name}" has been completed.`,
-              [{ text: "OK", onPress: () => fetchAudit() }]
-            );
-          },
-        },
-      ]
-    );
+    setShowCompleteSheet(false);
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    Alert.alert("Audit Complete", `"${audit.name}" has been completed.`, [
+      { text: "OK", onPress: () => fetchAudit() },
+    ]);
   };
 
   // ── Build display assets list ─────────────────────────
@@ -853,6 +845,17 @@ function AuditDetailContent() {
 
   return (
     <View style={styles.container}>
+      {audit ? (
+        <CompleteAuditSheet
+          visible={showCompleteSheet}
+          auditName={audit.name}
+          pendingCount={audit.expectedAssetCount - audit.foundAssetCount}
+          isSubmitting={isActioning}
+          onClose={() => setShowCompleteSheet(false)}
+          onConfirm={(note) => void performCompleteAudit(note)}
+        />
+      ) : null}
+
       {isActioning && (
         <View style={styles.overlay}>
           <ActivityIndicator size="large" color="#fff" />

--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -56,6 +56,7 @@ import {
   SegmentedControl,
   type ListTab,
 } from "@/components/audit/segmented-control";
+import { CompleteAuditSheet } from "@/components/audit/complete-audit-sheet";
 import { EvidenceModal } from "@/components/audit/evidence-modal";
 import { EvidenceCoachmark } from "@/components/audit/evidence-coachmark";
 import type { ScannedItem } from "@/hooks/use-audit-init";
@@ -243,6 +244,8 @@ function AuditScannerContent() {
   // ── Evidence modal (notes + photos per scanned item) ──
 
   const [evidenceModalVisible, setEvidenceModalVisible] = useState(false);
+  const [showCompleteSheet, setShowCompleteSheet] = useState(false);
+  const [isCompleting, setIsCompleting] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ScannedItem | null>(null);
   // Opening the sheet once proves the user found evidence capture, which
   // retires the coachmark for good.
@@ -832,97 +835,108 @@ function AuditScannerContent() {
 
   // Performs the actual completion request + cleanup. Extracted so it can be
   // reached both from the normal confirm and the "complete anyway" path.
-  const runCompletion = useCallback(async () => {
-    if (!auditId || !currentOrg) return;
+  const runCompletion = useCallback(
+    async (completionNote?: string) => {
+      if (!auditId || !currentOrg) return;
 
-    // TOCTOU guard: handleComplete blocked on a non-empty PENDING queue, but the
-    // camera stays live while the confirm dialog is open, so a scan can have
-    // been enqueued since that gate. Completing now would mark its asset MISSING
-    // and the queue-clear below would destroy it. Re-gate on the pending queue
-    // (this is the freshly-scanned path; the failed queue is what "Complete
-    // anyway" intentionally accepts, and is unaffected here).
-    if (scanQueueRef.current.length > 0) {
-      processQueue();
-      reportAuditDurabilityEvent("completion_blocked_unsynced", {
-        auditId,
-        reason: "toctou_pending",
-        pending: scanQueueRef.current.length,
-      });
-      Alert.alert(
-        "Scan still syncing",
-        "A scan just came in and is still saving. Give it a moment, then tap Complete again."
-      );
-      return;
-    }
-
-    const timeZone = (() => {
-      try {
-        return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-      } catch {
-        return "UTC";
+      // TOCTOU guard: handleComplete blocked on a non-empty PENDING queue, but the
+      // camera stays live while the confirm dialog is open, so a scan can have
+      // been enqueued since that gate. Completing now would mark its asset MISSING
+      // and the queue-clear below would destroy it. Re-gate on the pending queue
+      // (this is the freshly-scanned path; the failed queue is what "Complete
+      // anyway" intentionally accepts, and is unaffected here).
+      if (scanQueueRef.current.length > 0) {
+        processQueue();
+        reportAuditDurabilityEvent("completion_blocked_unsynced", {
+          auditId,
+          reason: "toctou_pending",
+          pending: scanQueueRef.current.length,
+        });
+        Alert.alert(
+          "Scan still syncing",
+          "A scan just came in and is still saving. Give it a moment, then tap Complete again."
+        );
+        return;
       }
-    })();
 
-    const { error: err } = await api.completeAudit(currentOrg.id, {
-      sessionId: auditId,
-      timeZone,
-    });
+      const timeZone = (() => {
+        try {
+          return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+        } catch {
+          return "UTC";
+        }
+      })();
 
-    if (err) {
-      // Completion failed — KEEP recovery state so nothing is lost.
-      Alert.alert("Error", err);
-      return;
-    }
+      const { error: err } = await api.completeAudit(currentOrg.id, {
+        sessionId: auditId,
+        timeZone,
+        completionNote,
+      });
 
-    // Server accepted completion — only now is it safe to drop the local
-    // recovery snapshot. Clear the in-memory queues too (in place): otherwise
-    // the unmount cleanup would see a non-empty failedQueue on navigate-back and
-    // re-flush a recovery snapshot for an audit that is already completed.
-    debouncedSaverRef.current?.cancel();
-    scanQueueRef.current.length = 0;
-    failedQueueRef.current.length = 0;
-    await clearAuditScanState(auditId);
+      if (err) {
+        // Completion failed — KEEP recovery state so nothing is lost.
+        Alert.alert("Error", err);
+        return;
+      }
 
-    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-    playScanSound();
-    Alert.alert("Audit Complete", `"${auditName}" has been completed.`, [
-      {
-        text: "OK",
-        onPress: () => {
-          router.back();
-          // Completing an audit is a clear "value delivered" moment — a good
-          // (throttled, OS-gated) time to ask a happy user for a review.
-          void maybeAskForReview();
+      // Server accepted completion — only now is it safe to drop the local
+      // recovery snapshot. Clear the in-memory queues too (in place): otherwise
+      // the unmount cleanup would see a non-empty failedQueue on navigate-back and
+      // re-flush a recovery snapshot for an audit that is already completed.
+      debouncedSaverRef.current?.cancel();
+      scanQueueRef.current.length = 0;
+      failedQueueRef.current.length = 0;
+      await clearAuditScanState(auditId);
+
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      playScanSound();
+      Alert.alert("Audit Complete", `"${auditName}" has been completed.`, [
+        {
+          text: "OK",
+          onPress: () => {
+            router.back();
+            // Completing an audit is a clear "value delivered" moment — a good
+            // (throttled, OS-gated) time to ask a happy user for a review.
+            void maybeAskForReview();
+          },
         },
-      },
-    ]);
-  }, [
-    auditId,
-    currentOrg,
-    auditName,
-    router,
-    debouncedSaverRef,
-    scanQueueRef,
-    failedQueueRef,
-    processQueue,
-  ]);
+      ]);
+    },
+    [
+      auditId,
+      currentOrg,
+      auditName,
+      router,
+      debouncedSaverRef,
+      scanQueueRef,
+      failedQueueRef,
+      processQueue,
+    ]
+  );
 
-  // Standard confirm: warns how many expected assets will be marked missing.
+  // Standard confirm. The sheet names the audit, states how many unscanned
+  // assets become missing, and takes the closing note — the same confirmation
+  // the detail screen shows, so a worker finishing at the scanner gets the note
+  // field too.
   const confirmAndComplete = useCallback(() => {
-    const remaining = expectedTotal - foundCount;
-    Alert.alert(
-      "Complete Audit",
-      remaining > 0
-        ? `Complete "${auditName}"?\n\n${remaining} unscanned ${
-            remaining === 1 ? "asset" : "assets"
-          } will be marked as missing.`
-        : `Complete "${auditName}"?\n\nAll expected assets have been found.`,
-      [
-        { text: "Cancel", style: "cancel" },
-        { text: "Complete", onPress: runCompletion },
-      ]
-    );
-  }, [auditName, expectedTotal, foundCount, runCompletion]);
+    setShowCompleteSheet(true);
+  }, []);
+
+  // Completion driven by the sheet: the note travels with the request, and the
+  // sheet stays up (disabled) until the request settles so a second confirm
+  // cannot fire.
+  const handleSheetConfirm = useCallback(
+    async (completionNote?: string) => {
+      setIsCompleting(true);
+      try {
+        await runCompletion(completionNote);
+      } finally {
+        setIsCompleting(false);
+        setShowCompleteSheet(false);
+      }
+    },
+    [runCompletion]
+  );
 
   const handleComplete = useCallback(() => {
     if (!auditId || !currentOrg) return;
@@ -1463,6 +1477,15 @@ function AuditScannerContent() {
       </View>
 
       {/* Evidence modal for adding notes + photos to scanned items */}
+      <CompleteAuditSheet
+        visible={showCompleteSheet}
+        auditName={auditName}
+        pendingCount={Math.max(0, expectedTotal - foundCount)}
+        isSubmitting={isCompleting}
+        onClose={() => setShowCompleteSheet(false)}
+        onConfirm={(note) => void handleSheetConfirm(note)}
+      />
+
       <EvidenceModal
         visible={evidenceModalVisible}
         onClose={handleCloseEvidenceModal}

--- a/apps/companion/app/(tabs)/audits/scan.tsx
+++ b/apps/companion/app/(tabs)/audits/scan.tsx
@@ -245,6 +245,7 @@ function AuditScannerContent() {
 
   const [evidenceModalVisible, setEvidenceModalVisible] = useState(false);
   const [showCompleteSheet, setShowCompleteSheet] = useState(false);
+  const isCompletingRef = useRef(false);
   const [isCompleting, setIsCompleting] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ScannedItem | null>(null);
   // Opening the sheet once proves the user found evidence capture, which
@@ -890,17 +891,16 @@ function AuditScannerContent() {
 
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       playScanSound();
-      Alert.alert("Audit Complete", `"${auditName}" has been completed.`, [
-        {
-          text: "OK",
-          onPress: () => {
-            router.back();
-            // Completing an audit is a clear "value delivered" moment — a good
-            // (throttled, OS-gated) time to ask a happy user for a review.
-            void maybeAskForReview();
-          },
-        },
-      ]);
+
+      // Leave the scanner before confirming, and never from an alert callback.
+      // The queues and the persisted snapshot are already cleared by this
+      // point, so a confirmation the user never gets to tap would strand them
+      // on a scanner with no recoverable state.
+      router.back();
+      // Completing an audit is a clear "value delivered" moment — a good
+      // (throttled, OS-gated) time to ask a happy user for a review.
+      void maybeAskForReview();
+      Alert.alert("Audit Complete", `"${auditName}" has been completed.`);
     },
     [
       auditId,
@@ -927,12 +927,24 @@ function AuditScannerContent() {
   // cannot fire.
   const handleSheetConfirm = useCallback(
     async (completionNote?: string) => {
+      // Re-entry guard: the sheet is dismissed immediately below, so it cannot
+      // confirm twice, but the ref is set synchronously and covers the gap
+      // before React applies that state.
+      if (isCompletingRef.current) return;
+      isCompletingRef.current = true;
       setIsCompleting(true);
+
+      // Dismissed BEFORE the request. `runCompletion` reports its outcome with
+      // `Alert.alert`, and an alert presented from a modal that is then torn
+      // down can be dismissed along with it — taking the message, and any
+      // action attached to it, with it.
+      setShowCompleteSheet(false);
+
       try {
         await runCompletion(completionNote);
       } finally {
+        isCompletingRef.current = false;
         setIsCompleting(false);
-        setShowCompleteSheet(false);
       }
     },
     [runCompletion]

--- a/apps/companion/components/audit/complete-audit-sheet.tsx
+++ b/apps/companion/components/audit/complete-audit-sheet.tsx
@@ -56,6 +56,16 @@ type Props = {
   onConfirm: (completionNote?: string) => void;
 };
 
+/**
+ * Confirmation sheet for completing an audit, with an optional closing note.
+ *
+ * Completion is irreversible and turns every unscanned expected asset into a
+ * missing one, so the sheet names the audit and that count before it will
+ * confirm.
+ *
+ * @param props - See {@link Props}.
+ * @returns The modal sheet element.
+ */
 export function CompleteAuditSheet({
   visible,
   auditName,

--- a/apps/companion/components/audit/complete-audit-sheet.tsx
+++ b/apps/companion/components/audit/complete-audit-sheet.tsx
@@ -1,0 +1,217 @@
+/**
+ * CompleteAuditSheet — the confirmation for finishing an audit, and the one
+ * place its closing note can be written.
+ *
+ * Completing is the irreversible step: every expected asset nobody scanned is
+ * marked missing, and the counts are finalised into the record the report is
+ * built from. So the sheet states that consequence in numbers before the
+ * button, and offers a note for the thing numbers cannot carry — why the
+ * missing ones are missing.
+ *
+ * The note is optional and free text, capped to match the server's own limit.
+ * Follows the house selection-flow contract (QuantityInputSheet,
+ * TeamMemberPicker): page-sheet modal, header with close, explicit confirm.
+ * React Native has no usable text prompt — `Alert.prompt` is iOS-only — which
+ * is why an Alert cannot do this job.
+ *
+ * The confirm button IS the confirmation: callers must not stack an Alert on
+ * top of `onConfirm`.
+ *
+ * @see {@link file://../../app/(tabs)/audits/[id].tsx} the detail-screen consumer
+ * @see {@link file://../../app/(tabs)/audits/scan.tsx} the scanner consumer
+ * @see {@link file://../quantity-input-sheet.tsx} the modal contract this mirrors
+ */
+import { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  Modal,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+
+/** Matches the server's `completionNote` bound in api+/mobile+/audits.complete.ts. */
+const MAX_NOTE_LENGTH = 5000;
+
+type Props = {
+  /** Whether the sheet is shown. */
+  visible: boolean;
+  /** The audit being completed — named in the body so the act is unambiguous. */
+  auditName: string;
+  /** Expected assets nobody scanned. These become missing on completion. */
+  pendingCount: number;
+  /** True while the completion request is in flight. */
+  isSubmitting: boolean;
+  /** Dismiss without completing. */
+  onClose: () => void;
+  /** Complete the audit, with the note when one was written. */
+  onConfirm: (completionNote?: string) => void;
+};
+
+export function CompleteAuditSheet({
+  visible,
+  auditName,
+  pendingCount,
+  isSubmitting,
+  onClose,
+  onConfirm,
+}: Props) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+  const [note, setNote] = useState("");
+
+  // A note belongs to the audit it was written for, so each opening starts
+  // empty rather than carrying the previous one forward.
+  useEffect(() => {
+    if (visible) setNote("");
+  }, [visible]);
+
+  const trimmedNote = note.trim();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
+          <View style={styles.header}>
+            <Text style={styles.headerTitle} numberOfLines={1}>
+              Complete audit
+            </Text>
+            <TouchableOpacity
+              onPress={onClose}
+              accessibilityLabel="Close"
+              accessibilityRole="button"
+              disabled={isSubmitting}
+            >
+              <Ionicons name="close" size={24} color={colors.foreground} />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.body}>
+            <Text style={styles.lead}>Finish “{auditName}”?</Text>
+            <Text
+              style={[styles.consequence, pendingCount > 0 && styles.warning]}
+            >
+              {pendingCount > 0
+                ? `${pendingCount} unscanned ${
+                    pendingCount === 1 ? "asset" : "assets"
+                  } will be marked as missing.`
+                : "All expected assets have been found."}
+            </Text>
+
+            <Text style={styles.label}>Closing note (optional)</Text>
+            <TextInput
+              style={styles.input}
+              value={note}
+              onChangeText={setNote}
+              placeholder="Anything worth recording — why an asset is missing, who was asked, what happens next."
+              placeholderTextColor={colors.placeholderText}
+              multiline
+              numberOfLines={4}
+              textAlignVertical="top"
+              maxLength={MAX_NOTE_LENGTH}
+              editable={!isSubmitting}
+              accessibilityLabel="Closing note for this audit"
+            />
+            <Text style={styles.hint}>
+              Saved with the audit and shown in its report.
+            </Text>
+          </View>
+
+          <View style={styles.footer}>
+            <TouchableOpacity
+              style={styles.confirm}
+              onPress={() => onConfirm(trimmedNote || undefined)}
+              disabled={isSubmitting}
+              accessibilityRole="button"
+              accessibilityLabel={`Complete the audit ${auditName}`}
+              accessibilityState={{ disabled: isSubmitting }}
+            >
+              {isSubmitting ? (
+                <ActivityIndicator
+                  size="small"
+                  color={colors.primaryForeground}
+                />
+              ) : (
+                <Text style={styles.confirmText}>Complete audit</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const useStyles = createStyles((colors) => ({
+  container: { flex: 1, backgroundColor: colors.background },
+  flex: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: fontSize.lg,
+    fontWeight: "700",
+    color: colors.foreground,
+  },
+  body: { flex: 1, padding: spacing.lg, gap: spacing.sm },
+  lead: { fontSize: fontSize.md, fontWeight: "600", color: colors.foreground },
+  consequence: { fontSize: fontSize.sm, color: colors.muted },
+  warning: { color: colors.error },
+  label: {
+    fontSize: fontSize.sm,
+    fontWeight: "600",
+    color: colors.foreground,
+    marginTop: spacing.md,
+  },
+  input: {
+    minHeight: 108,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.backgroundSecondary,
+    padding: spacing.md,
+    fontSize: fontSize.md,
+    color: colors.foreground,
+  },
+  hint: { fontSize: fontSize.xs, color: colors.mutedLight },
+  footer: {
+    padding: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  confirm: {
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing.md,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  confirmText: {
+    color: colors.primaryForeground,
+    fontSize: fontSize.md,
+    fontWeight: "700",
+  },
+}));

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -20,6 +20,11 @@ export type Organization = {
    * every mobile audit endpoint returns 403.
    */
   auditsEnabled: boolean;
+  /**
+   * ISO currency code for the workspace. Absent on servers older than the
+   * field, so callers fall back rather than rendering an empty prefix.
+   */
+  currency?: string;
 };
 
 export type MeResponse = {

--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -166,6 +166,10 @@ export async function getUserOrganizations(userId: string) {
           imageId: true,
           barcodesEnabled: true,
           auditsEnabled: true,
+          // The workspace currency. Any screen that shows or collects money
+          // needs it before an asset exists to read it from — asset create,
+          // for one, which has no asset yet.
+          currency: true,
         },
       },
     },


### PR DESCRIPTION
## What

Two journey-audit quick wins that were the last unbuilt items on the phone.

**Close an audit with a note.** Completing is the irreversible step — every expected asset nobody scanned becomes *missing*, and the counts are finalised into the record the report is built from. The phone could confirm that, but never record *why*: the endpoint has accepted `completionNote` since it shipped, and nothing ever sent one. A sheet now carries both halves — the consequence stated in numbers, and an optional closing note ("why an asset is missing, who was asked, what happens next"). It replaces the `Alert` because `Alert.prompt` is iOS-only, so an Alert cannot collect text on Android. Follows the house sheet contract (`QuantityInputSheet`, `TeamMemberPicker`): page-sheet modal, header with close, explicit confirm — and the confirm button IS the confirmation, so nothing is stacked on top of it.

**Set an asset's value when creating it on the phone.** The create endpoint already accepts `valuation`, and `ValuationField` already existed on the edit screen — the create screen simply never offered it, so a value could only be added in a second pass from the web or by editing. An empty box stays unset; a typed `0` is a real value and is sent.

To render the currency prefix before an asset exists to read it from, the workspace `currency` now rides on the organizations payload from `/api/mobile/me`. It is optional on the client type, so an older server falls back rather than rendering an empty prefix.

## Why these two

Both were quick wins from the admin journey audit, and both were mislabelled as blocked. The completion note was listed as waiting on nothing in particular; the valuation field was recorded as gated on #2870, which turns out not to touch the create screen at all.

## Verification

Typecheck and lint clean for both apps. Not yet exercised on a device — the audit sheet needs a live audit with unscanned assets, and the valuation field needs a create round trip; both are simulator-reachable and worth a pass before merge.

## Scope

Companion screens plus one additive field on the mobile `/me` payload. No web behaviour changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional asset valuation when creating assets, with numeric validation and support for zero values.
  - Added a guided audit completion sheet with optional completion notes.
  - Added workspace currency support for monetary values.

- **Bug Fixes**
  - Improved audit completion feedback with clearer confirmation, success haptics, and reliable navigation.
  - Prevented duplicate audit completion submissions.
  - Ensured valuation fields reset when creating another asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->