### PR TITLE
fix(bookings): do not auto-complete a booking while button-checked-out assets are unreturned

### DIFF
--- a/apps/webapp/app/modules/booking/checkout-attribution.ts
+++ b/apps/webapp/app/modules/booking/checkout-attribution.ts
@@ -218,3 +218,82 @@ export function attributeDispositionsByBookingAsset(args: {
   }
   return out;
 }
+
+/**
+ * Units actually dispatched per ASSET on a booking, judged slice by slice.
+ *
+ * Two dispatch writers exist and each leaves a different record: progressive
+ * scans record exact unit counts in `PartialBookingCheckout` sessions, while
+ * the all-at-once checkout stamps `BookingAsset.checkedOutAt` and writes no
+ * session rows. A single asset can mix both across its slices (an 8-unit
+ * slice out via the button plus a later sibling scanned out progressively),
+ * so neither source alone is the answer:
+ * - session units judged asset-level would erase the button slices'
+ *   obligation the moment ANY sibling has a session record;
+ * - stamps alone would inflate a partially-dispatched progressive slice to
+ *   its full booked quantity (the stamp is boolean, per slice).
+ *
+ * So per slice: session units attributed to that slice (tagged + greedy,
+ * via {@link attributeDispositionsByBookingAsset} — the same order the
+ * stamper uses) when any exist, capped by the slice's booked quantity;
+ * otherwise the whole slice when it is stamped; otherwise zero. The
+ * asset's dispatched units are the sum over its slices.
+ *
+ * Pure derivation — no DB calls; caller pre-fetches slices and sessions.
+ * Consumed by completion (`isBookingFullyCheckedIn`) and by the lifecycle
+ * progress loaders so the two can never disagree on what went out.
+ *
+ * @param args.slices - ALL of the booking's slices (`id`, `assetId`, booked
+ *   `quantity`, `assetKitId`, `checkedOutAt`).
+ * @param args.checkoutSessions - The booking's raw checkout sessions.
+ * @returns Map keyed by `assetId` → dispatched units (absent = 0).
+ */
+export function computeDispatchedUnitsByAsset(args: {
+  slices: Array<{
+    id: string;
+    assetId: string;
+    quantity: number;
+    assetKitId: string | null;
+    checkedOutAt: Date | null;
+  }>;
+  checkoutSessions: CheckoutSession[];
+}): Map<string, number> {
+  const { slices, checkoutSessions } = args;
+
+  const logsByAsset = checkoutSessionsToLogsByAsset(
+    checkoutSessions,
+    () => true
+  );
+
+  const slicesByAsset = new Map<string, typeof slices>();
+  for (const s of slices) {
+    const group = slicesByAsset.get(s.assetId);
+    if (group) group.push(s);
+    else slicesByAsset.set(s.assetId, [s]);
+  }
+
+  const dispatchedByAsset = new Map<string, number>();
+  for (const [assetId, assetSlices] of slicesByAsset) {
+    const sessionUnitsBySlice = attributeDispositionsByBookingAsset({
+      bookingAssetRows: assetSlices.map((s) => ({
+        id: s.id,
+        quantity: s.quantity,
+        assetKitId: s.assetKitId,
+      })),
+      consumptionLogs: logsByAsset.get(assetId) ?? [],
+    });
+
+    let dispatched = 0;
+    for (const s of assetSlices) {
+      const sessionUnits = sessionUnitsBySlice.get(s.id) ?? 0;
+      if (sessionUnits > 0) {
+        dispatched += Math.min(sessionUnits, s.quantity);
+      } else if (s.checkedOutAt) {
+        dispatched += s.quantity;
+      }
+    }
+    if (dispatched > 0) dispatchedByAsset.set(assetId, dispatched);
+  }
+
+  return dispatchedByAsset;
+}

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -3825,6 +3825,86 @@ describe("checkoutBooking", () => {
     });
   });
 
+  it("tops up checkedOutQuantity by the same residue it records as a session", async () => {
+    expect.assertions(2);
+
+    // Same shape as above: 3 of 8 units already scanned out, 5 departing now.
+    // The stored counter and the session-derived one must agree — the
+    // departure statement cannot carry this slice, because it adds a whole
+    // booked quantity while only the residue leaves here.
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.RESERVED,
+      bookingAssets: [
+        {
+          asset: {
+            id: "asset-qty",
+            assetKits: [{ kitId: "kit-1" }],
+            title: "Cables",
+            type: AssetType.QUANTITY_TRACKED,
+            status: "AVAILABLE",
+            bookingAssets: [],
+          },
+          assetId: "asset-qty",
+          quantity: 8,
+          id: "ba-qty",
+          assetKitId: "ak-1",
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: null,
+        },
+      ],
+    };
+    (db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce(mockBooking)
+      .mockResolvedValueOnce({ ...mockBooking, status: BookingStatus.ONGOING });
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue({ id: "booking-1" });
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockImplementation((args?: { where?: { checkedOutAt?: unknown } }) =>
+      Promise.resolve(
+        args?.where?.checkedOutAt
+          ? [
+              {
+                id: "ba-qty",
+                assetId: "asset-qty",
+                quantity: 8,
+                assetKitId: "ak-1",
+              },
+            ]
+          : []
+      )
+    );
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      { assetIds: ["asset-qty"], quantities: [3], bookingAssetIds: ["ba-qty"] },
+    ]);
+
+    await checkoutBooking(mockCheckoutParams);
+
+    // Only the counter writes; `updateMany` also stamps the slice markers.
+    const counterWrites = (
+      db.bookingAsset.updateMany as unknown as {
+        mock: {
+          calls: Array<
+            [
+              {
+                where?: { id?: { in?: string[] } };
+                data?: { checkedOutQuantity?: { increment?: number } };
+              },
+            ]
+          >;
+        };
+      }
+    ).mock.calls.filter((c) => c[0]?.data?.checkedOutQuantity !== undefined);
+
+    expect(counterWrites).toHaveLength(1);
+    expect(counterWrites[0][0]).toEqual({
+      where: { id: { in: ["ba-qty"] } },
+      data: { checkedOutQuantity: { increment: 5 } },
+    });
+  });
+
   it("should throw error when assets have booking conflicts", async () => {
     expect.assertions(1);
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -9498,21 +9498,124 @@ describe("isBookingFullyCheckedIn", () => {
         },
       ])
       .mockResolvedValueOnce([{ quantity: 8 }]);
+    // why: both individuals are reconciled via checkin sessions, so only the
+    // qty asset's outstanding units can (and must) block completion.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
       { assetIds: ["asset-ind", "asset-scanned"] },
     ]);
+    // why: the booking's single progressive session — the row that used to
+    // flip completion into session-only accounting for every asset.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckout.findMany.mockResolvedValue([
       { assetIds: ["asset-scanned"], quantities: [1], bookingAssetIds: [""] },
     ]);
-    // No returns logged for the qty asset — its 8 units are still out.
+    // why: no returns logged for the qty asset — its 8 units are still out.
     //@ts-expect-error missing vitest type
     db.consumptionLog.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
 
     const result = await isBookingFullyCheckedIn(db, "booking-1");
 
     expect(result).toBe(false);
+  });
+
+  it("keeps a mixed multi-slice qty asset's button obligation when a sibling slice was scanned progressively", async () => {
+    expect.assertions(1);
+
+    // One QT asset, two slices: 8 units stamped by the button (no session
+    // record) plus a 1-unit sibling scanned progressively (tagged session).
+    // The sibling's session row must not erase the button slice's obligation.
+    // why: first response = the booking's slices; second = the rows
+    // `computeBookingAssetRemaining` aggregates for the same asset.
+    (db.bookingAsset.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce([
+        {
+          id: "slice-button",
+          assetId: "asset-qty",
+          quantity: 8,
+          assetKitId: null,
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: null,
+          asset: { id: "asset-qty", type: AssetType.QUANTITY_TRACKED },
+        },
+        {
+          id: "slice-scanned",
+          assetId: "asset-qty",
+          quantity: 1,
+          assetKitId: null,
+          checkedOutAt: new Date("2026-01-01T12:00:00.000Z"),
+          checkedInAt: null,
+          asset: { id: "asset-qty", type: AssetType.QUANTITY_TRACKED },
+        },
+      ])
+      .mockResolvedValueOnce([{ quantity: 8 }, { quantity: 1 }]);
+    // why: no full-asset reconciliation recorded — only unit returns below.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([]);
+    // why: the progressive session names its exact slice, so attribution must
+    // put its 1 unit on `slice-scanned` and leave the button slice untouched.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-qty"],
+        quantities: [1],
+        bookingAssetIds: ["slice-scanned"],
+      },
+    ]);
+    // why: only the scanned unit came back — booked 9 − logged 1 → 8 of the 9
+    // obligated units are outstanding, so completion must be refused.
+    //@ts-expect-error missing vitest type
+    db.consumptionLog.aggregate.mockResolvedValue({ _sum: { quantity: 1 } });
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(false);
+  });
+
+  it("completes the mixed multi-slice qty asset once all dispatched units are reconciled", async () => {
+    expect.assertions(1);
+
+    // why: same two-slice shape as above; this time every dispatched unit has
+    // a logged return.
+    (db.bookingAsset.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce([
+        {
+          id: "slice-button",
+          assetId: "asset-qty",
+          quantity: 8,
+          assetKitId: null,
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: null,
+          asset: { id: "asset-qty", type: AssetType.QUANTITY_TRACKED },
+        },
+        {
+          id: "slice-scanned",
+          assetId: "asset-qty",
+          quantity: 1,
+          assetKitId: null,
+          checkedOutAt: new Date("2026-01-01T12:00:00.000Z"),
+          checkedInAt: null,
+          asset: { id: "asset-qty", type: AssetType.QUANTITY_TRACKED },
+        },
+      ])
+      .mockResolvedValueOnce([{ quantity: 8 }, { quantity: 1 }]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-qty"],
+        quantities: [1],
+        bookingAssetIds: ["slice-scanned"],
+      },
+    ]);
+    // why: booked 9 − logged 9 → zero remaining, all obligated units back.
+    //@ts-expect-error missing vitest type
+    db.consumptionLog.aggregate.mockResolvedValue({ _sum: { quantity: 9 } });
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(true);
   });
 
   it("completes the mixed-mode booking once the button-checked-out qty units are reconciled", async () => {
@@ -9536,15 +9639,17 @@ describe("isBookingFullyCheckedIn", () => {
         },
       ])
       .mockResolvedValueOnce([{ quantity: 8 }]);
+    // why: the individual is reconciled via its checkin session.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
       { assetIds: ["asset-scanned"] },
     ]);
+    // why: the same single progressive session as the blocking case above.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckout.findMany.mockResolvedValue([
       { assetIds: ["asset-scanned"], quantities: [1], bookingAssetIds: [""] },
     ]);
-    // Booked 8 − logged 8 → remaining 0.
+    // why: booked 8 − logged 8 → remaining 0, the qty obligation is settled.
     //@ts-expect-error missing vitest type
     db.consumptionLog.aggregate.mockResolvedValue({ _sum: { quantity: 8 } });
 
@@ -9575,6 +9680,8 @@ describe("isBookingFullyCheckedIn", () => {
         asset: { id: "asset-late", type: AssetType.INDIVIDUAL },
       },
     ]);
+    // why: only the dispatched asset has a checkin session — the undispatched
+    // one has nothing to reconcile and must not be waited for.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
       { assetIds: ["asset-1"] },

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -3854,11 +3854,19 @@ describe("checkoutBooking", () => {
         },
       ],
     };
+    // why: the flow reads the booking twice — once to validate, once after the
+    // status write — and the second read must come back ONGOING or the
+    // post-checkout branch takes the not-yet-started path.
     (db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>)
       .mockResolvedValueOnce(mockBooking)
       .mockResolvedValueOnce({ ...mockBooking, status: BookingStatus.ONGOING });
+    // why: the status write itself is not under test here; it only has to
+    // resolve so the transaction reaches the counter writes below.
     //@ts-expect-error missing vitest type
     db.booking.update.mockResolvedValue({ id: "booking-1" });
+    // why: the residue derivation reads pre-stamped slices via the
+    // `checkedOutAt` filter. Every other slice read in this flow gets an empty
+    // list, so only that one shapes the result.
     (
       db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
     ).mockImplementation((args?: { where?: { checkedOutAt?: unknown } }) =>
@@ -3875,6 +3883,8 @@ describe("checkoutBooking", () => {
           : []
       )
     );
+    // why: the earlier progressive scan recorded 3 of this slice's 8 units,
+    // which is what leaves a 5-unit residue for this checkout to record.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckout.findMany.mockResolvedValue([
       { assetIds: ["asset-qty"], quantities: [3], bookingAssetIds: ["ba-qty"] },
@@ -3902,6 +3912,100 @@ describe("checkoutBooking", () => {
     expect(counterWrites[0][0]).toEqual({
       where: { id: { in: ["ba-qty"] } },
       data: { checkedOutQuantity: { increment: 5 } },
+    });
+  });
+
+  it("counts a re-dispatched slice once, not its quantity plus a residue", async () => {
+    expect.assertions(2);
+
+    // 3 of 8 units scanned out earlier, then the slice came back IN FULL, and
+    // now departs again whole. The departure statement adds its 8; the residue
+    // top-up must not also add 5, or the counter claims 13 units left when 8
+    // did. The residue session row is still written — that records the
+    // dispatch, the counter records the units.
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.RESERVED,
+      bookingAssets: [
+        {
+          asset: {
+            id: "asset-qty",
+            assetKits: [{ kitId: "kit-1" }],
+            title: "Cables",
+            type: AssetType.QUANTITY_TRACKED,
+            status: "AVAILABLE",
+            bookingAssets: [],
+          },
+          assetId: "asset-qty",
+          quantity: 8,
+          id: "ba-qty",
+          assetKitId: "ak-1",
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: new Date("2026-01-02T10:00:00.000Z"),
+        },
+      ],
+    };
+    // why: as above — two booking reads, the second of which must report
+    // ONGOING for the flow to continue past the status write.
+    (db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce(mockBooking)
+      .mockResolvedValueOnce({ ...mockBooking, status: BookingStatus.ONGOING });
+    // why: the status write only has to resolve; it is not what this asserts.
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue({ id: "booking-1" });
+    // why: this flow issues two slice reads with different shapes — the
+    // pre-stamp scan keys on `checkedOutAt`, the departure scan on `OR`. A
+    // fully-returned slice answers BOTH, which is what creates the overlap
+    // this test pins.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockImplementation(
+      (args?: { where?: { checkedOutAt?: unknown; OR?: unknown } }) => {
+        if (args?.where?.checkedOutAt) {
+          return Promise.resolve([
+            {
+              id: "ba-qty",
+              assetId: "asset-qty",
+              quantity: 8,
+              assetKitId: "ak-1",
+            },
+          ]);
+        }
+        if (args?.where?.OR) {
+          return Promise.resolve([{ id: "ba-qty", quantity: 8 }]);
+        }
+        return Promise.resolve([]);
+      }
+    );
+    // why: the earlier progressive scan recorded 3 of this slice's 8 units, so
+    // the residue derivation sees 5 outstanding and would otherwise top up.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      { assetIds: ["asset-qty"], quantities: [3], bookingAssetIds: ["ba-qty"] },
+    ]);
+
+    await checkoutBooking(mockCheckoutParams);
+
+    const counterWrites = (
+      db.bookingAsset.updateMany as unknown as {
+        mock: {
+          calls: Array<
+            [
+              {
+                where?: { id?: { in?: string[] } };
+                data?: { checkedOutQuantity?: { increment?: number } };
+              },
+            ]
+          >;
+        };
+      }
+    ).mock.calls.filter((c) => c[0]?.data?.checkedOutQuantity !== undefined);
+
+    // Exactly one counter write, and it is the whole-slice departure.
+    expect(counterWrites).toHaveLength(1);
+    expect(counterWrites[0][0]).toEqual({
+      where: { id: { in: ["ba-qty"] } },
+      data: { checkedOutQuantity: { increment: 8 } },
     });
   });
 
@@ -12995,8 +13099,9 @@ describe("getKitIdsByBookingSlices", () => {
   });
 
   it("falls back to assetKitId for rows written before sourceKitId existed", async () => {
-    // why: the mocked delegate echoes ids back as `kit-of-<id>`, mirroring the
-    // real `assetKitId -> kitId` lookup this leg performs.
+    // why: overrides the module default, which derives a kitId from the input
+    // (`kit-of-<id>`). A fixed row instead, so the assertion names the kit this
+    // leg must resolve `ak-1` to rather than a value echoed back from the id.
     //@ts-expect-error missing vitest type
     db.assetKit.findMany.mockResolvedValue([{ id: "ak-1", kitId: "kit-9" }]);
 
@@ -13187,7 +13292,9 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
    * model-shaped mock cannot tell apart:
    *   - `where.assetId`   -> `computeBookingAssetRemaining` (asset-level booked)
    *   - `where.checkedOutAt` -> the kit gate's still-out veto read
-   *   - otherwise         -> `isBookingFullyCheckedIn`
+   *   - otherwise         -> `isBookingFullyCheckedIn`, and the post-transaction
+   *     toast read, which shares the bookingId-only shape but reads just
+   *     `assetId` and `asset.type` — the slice markers below are inert for it.
    */
   function mockSliceReads(args: { slices: any[]; stillOutNow?: any[] }) {
     (db.bookingAsset.findMany as ReturnType<typeof vitest.fn>)
@@ -13236,10 +13343,21 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
         }
         // `isBookingFullyCheckedIn`: keep the booking incomplete so the test
         // exercises the progressive path rather than the COMPLETE branch.
+        //
+        // The slice markers are what make that true, so they have to be here.
+        // The helper judges dispatch per slice, and a row without
+        // `checkedOutAt` reads as never dispatched — every slice skipped, no
+        // obligation left, and the booking completes. `id` matters for the
+        // same reason: session units are attributed by slice id, so a row
+        // without one cannot be matched by a tagged checkout session either.
         return Promise.resolve(
           args.slices.map((s) => ({
+            id: s.id,
             assetId: s.assetId,
             quantity: s.quantity,
+            assetKitId: s.assetKitId,
+            checkedOutAt: s.checkedOutAt,
+            checkedInAt: s.checkedInAt,
             asset: {
               id: s.assetId,
               type: s.asset.type,
@@ -13489,9 +13607,8 @@ describe("partialCheckinBooking — slice-grained kit release", () => {
     expect.assertions(1);
 
     // Membership is gone, so only the slice's own `sourceKitId` names the kit.
-    // Green before this change and after it — the behaviour PR #2973 added,
-    // pinned inside `partialCheckinBooking` so the per-slice gate cannot
-    // quietly take it away.
+    // The per-slice release gate must still resolve it from that provenance
+    // alone: detaching a member mid-booking cannot cost the kit its release.
     const slices = [
       {
         id: "ba-detached",

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -3742,6 +3742,81 @@ describe("checkoutBooking", () => {
     expect(result).toEqual(hydratedBooking);
   });
 
+  it("records the residue of a partially-scanned qty slice as a tagged session row", async () => {
+    expect.assertions(1);
+
+    // A QT slice with 3 of 8 units already dispatched by a progressive scan
+    // (slice stamped + a 3-unit tagged session). The full checkout sends the
+    // remaining 5 out and must record them — session attribution otherwise
+    // reads the asset as 3 dispatched and completion could settle the booking
+    // with 5 units still out.
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.RESERVED,
+      bookingAssets: [
+        {
+          asset: {
+            id: "asset-qty",
+            assetKits: [{ kitId: "kit-1" }],
+            title: "Cables",
+            type: AssetType.QUANTITY_TRACKED,
+            status: "AVAILABLE",
+            bookingAssets: [],
+          },
+          assetId: "asset-qty",
+          quantity: 8,
+          id: "ba-qty",
+          // why: kit-driven slice — keeps the free-pool availability sweep
+          // (which needs the full availability query chain) out of this test;
+          // the residue derivation itself is kit/standalone-agnostic.
+          assetKitId: "ak-1",
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: null,
+        },
+      ],
+    };
+    (db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce(mockBooking)
+      .mockResolvedValueOnce({ ...mockBooking, status: BookingStatus.ONGOING });
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue({ id: "booking-1" });
+    // why: the residue derivation reads pre-stamped slices (checkedOutAt
+    // filter); any other bookingAsset read in the flow gets an empty list.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockImplementation((args?: { where?: { checkedOutAt?: unknown } }) =>
+      Promise.resolve(
+        args?.where?.checkedOutAt
+          ? [
+              {
+                id: "ba-qty",
+                assetId: "asset-qty",
+                quantity: 8,
+                assetKitId: "ak-1",
+              },
+            ]
+          : []
+      )
+    );
+    // why: the prior progressive scan recorded 3 units against this slice.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      { assetIds: ["asset-qty"], quantities: [3], bookingAssetIds: ["ba-qty"] },
+    ]);
+
+    await checkoutBooking(mockCheckoutParams);
+
+    expect(db.partialBookingCheckout.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        bookingId: "booking-1",
+        assetIds: ["asset-qty"],
+        quantities: [5],
+        bookingAssetIds: ["ba-qty"],
+        checkoutCount: 1,
+      }),
+    });
+  });
+
   it("should throw error when assets have booking conflicts", async () => {
     expect.assertions(1);
 

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -837,15 +837,35 @@ describe("partialCheckinBooking", () => {
     db.booking.findUniqueOrThrow.mockResolvedValue(bookingWithAssets);
 
     // why: isBookingFullyCheckedIn reads tx.bookingAsset.findMany to decide
-    // the ONGOING→COMPLETE transition. Returning the 3 booking assets keeps
-    // the booking in the partial (non-complete) branch so txResult.booking
-    // resolves to bookingWithAssets (with name set) and the note block
-    // succeeds. Also feeds the post-tx "outstanding" count.
+    // the ONGOING→COMPLETE transition. All three slices carry `checkedOutAt`
+    // (as every dispatched slice does in production) and asset-3 has no
+    // recorded return, which keeps the booking in the partial (non-complete)
+    // branch so txResult.booking resolves to bookingWithAssets (with name
+    // set) and the note block succeeds. Also feeds the post-tx "outstanding"
+    // count.
     //@ts-expect-error missing vitest type
     db.bookingAsset.findMany.mockResolvedValue([
-      { assetId: "asset-1", asset: { type: AssetType.INDIVIDUAL } },
-      { assetId: "asset-2", asset: { type: AssetType.INDIVIDUAL } },
-      { assetId: "asset-3", asset: { type: AssetType.INDIVIDUAL } },
+      {
+        assetId: "asset-1",
+        quantity: 1,
+        checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+        checkedInAt: null,
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+      {
+        assetId: "asset-2",
+        quantity: 1,
+        checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+        checkedInAt: null,
+        asset: { id: "asset-2", type: AssetType.INDIVIDUAL },
+      },
+      {
+        assetId: "asset-3",
+        quantity: 1,
+        checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+        checkedInAt: null,
+        asset: { id: "asset-3", type: AssetType.INDIVIDUAL },
+      },
     ]);
 
     // why: so isBookingFullyCheckedIn sees asset-1 and asset-2 as reconciled
@@ -9438,6 +9458,127 @@ describe("isBookingFullyCheckedIn", () => {
     db.bookingAsset.findMany.mockResolvedValue([]);
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([]);
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(true);
+  });
+
+  it("keeps the booking open while button-checked-out qty units are unreturned, even with a progressive checkout row present", async () => {
+    expect.assertions(1);
+
+    // The mixed-mode shape: a button checkout stamped every slice (writing
+    // no PartialBookingCheckout rows), one late-added individual was scanned
+    // out progressively (the booking's single session row), and every
+    // individual was scanned back in — but a button-checked-out QT asset
+    // never was. One session row must not strip the return obligation off
+    // the other assets.
+    (db.bookingAsset.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce([
+        {
+          assetId: "asset-ind",
+          quantity: 1,
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: new Date("2026-01-04T10:00:00.000Z"),
+          asset: { id: "asset-ind", type: AssetType.INDIVIDUAL },
+        },
+        {
+          assetId: "asset-scanned",
+          quantity: 1,
+          checkedOutAt: new Date("2026-01-01T12:00:00.000Z"),
+          checkedInAt: new Date("2026-01-04T10:05:00.000Z"),
+          asset: { id: "asset-scanned", type: AssetType.INDIVIDUAL },
+        },
+        {
+          assetId: "asset-qty",
+          quantity: 8,
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: null,
+          asset: { id: "asset-qty", type: AssetType.QUANTITY_TRACKED },
+        },
+      ])
+      .mockResolvedValueOnce([{ quantity: 8 }]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      { assetIds: ["asset-ind", "asset-scanned"] },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      { assetIds: ["asset-scanned"], quantities: [1], bookingAssetIds: [""] },
+    ]);
+    // No returns logged for the qty asset — its 8 units are still out.
+    //@ts-expect-error missing vitest type
+    db.consumptionLog.aggregate.mockResolvedValue({ _sum: { quantity: 0 } });
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(false);
+  });
+
+  it("completes the mixed-mode booking once the button-checked-out qty units are reconciled", async () => {
+    expect.assertions(1);
+
+    (db.bookingAsset.findMany as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce([
+        {
+          assetId: "asset-scanned",
+          quantity: 1,
+          checkedOutAt: new Date("2026-01-01T12:00:00.000Z"),
+          checkedInAt: new Date("2026-01-04T10:05:00.000Z"),
+          asset: { id: "asset-scanned", type: AssetType.INDIVIDUAL },
+        },
+        {
+          assetId: "asset-qty",
+          quantity: 8,
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: null,
+          asset: { id: "asset-qty", type: AssetType.QUANTITY_TRACKED },
+        },
+      ])
+      .mockResolvedValueOnce([{ quantity: 8 }]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      { assetIds: ["asset-scanned"] },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([
+      { assetIds: ["asset-scanned"], quantities: [1], bookingAssetIds: [""] },
+    ]);
+    // Booked 8 − logged 8 → remaining 0.
+    //@ts-expect-error missing vitest type
+    db.consumptionLog.aggregate.mockResolvedValue({ _sum: { quantity: 8 } });
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(true);
+  });
+
+  it("ignores never-dispatched slices (added onto an ONGOING booking)", async () => {
+    expect.assertions(1);
+
+    // A slice with no `checkedOutAt` cannot be checked in (the eligibility
+    // guard reads the same marker), so it must not gate completion either.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        assetId: "asset-1",
+        quantity: 1,
+        checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+        checkedInAt: new Date("2026-01-04T10:00:00.000Z"),
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+      {
+        assetId: "asset-late",
+        quantity: 1,
+        checkedOutAt: null,
+        checkedInAt: null,
+        asset: { id: "asset-late", type: AssetType.INDIVIDUAL },
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      { assetIds: ["asset-1"] },
+    ]);
 
     const result = await isBookingFullyCheckedIn(db, "booking-1");
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -4127,24 +4127,26 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
  * Determines whether a booking has been fully checked in across all of
  * its assets.
  *
- * Progressive semantics (Wave B): when a booking has been through at
- * least one progressive `PartialBookingCheckout`, assets/units that were
- * NEVER checked out do not need to be reconciled. They were "left at the
- * warehouse" and there is nothing to check in. Only the slices/units that
- * actually went out the door gate the COMPLETE transition.
+ * Dispatch is judged per asset from that asset's OWN records — the slice
+ * markers (`BookingAsset.checkedOutAt`, stamped by both the all-at-once
+ * checkout and progressive scans) plus its progressive session units. There
+ * is deliberately no booking-level "has any progressive checkout" mode
+ * switch: `PartialBookingCheckout` rows record scan SESSIONS, absence proves
+ * nothing (the Check-out button writes none — see the model's doc comment),
+ * and a booking-level test would let one scanned asset strip the return
+ * obligation off every button-checked-out asset on the booking.
  *
- * Legacy (non-progressive) semantics: when there are NO PartialBookingCheckout
- * rows for this booking (e.g. all-at-once flow), the function preserves the
- * original behaviour byte-for-byte — every BookingAsset must be reconciled.
+ * For `INDIVIDUAL` assets: a slice with `checkedOutAt` must be reconciled —
+ * `checkedInAt` set, or present in a `PartialBookingCheckin.assetIds` row
+ * (rows reconciled before the marker existed carry only the session record).
+ * Slices never dispatched (added onto an ONGOING booking, or left behind by
+ * a progressive checkout) have nothing to check in and never block.
  *
- * For `INDIVIDUAL` assets: must appear in at least one
- * `PartialBookingCheckin.assetIds` row — but only if it was ever checked out
- * (recorded in a `PartialBookingCheckout` OR live `CHECKED_OUT`). Assets never
- * checked out are skipped.
- *
- * For `QUANTITY_TRACKED` assets: `min(checkedOutUnits, slice.quantity) -
- * checkedInUnits === 0` per slice. Uncheck-outed units cannot block COMPLETE
- * because there is nothing to check in.
+ * For `QUANTITY_TRACKED` assets: obligated units are the progressive session
+ * units when any were recorded (capped by booked), otherwise the booked
+ * units of stamped slices (an all-at-once stamp dispatches the whole slice).
+ * Complete when every obligated unit is reconciled; units that never left
+ * the warehouse carry no obligation.
  *
  * Called by both `partialCheckinBooking` and `checkinBooking` to decide
  * the ONGOING/OVERDUE → COMPLETE transition. Keeping this in one place
@@ -4164,12 +4166,14 @@ export async function isBookingFullyCheckedIn(
       select: {
         assetId: true,
         quantity: true,
-        // `status` is needed to detect assets checked out via the all-at-once
-        // flow (which writes no PartialBookingCheckout records but flips the
-        // asset to CHECKED_OUT). This mirrors the union-with-live-status
-        // fallback in `partialCheckoutBooking` so completion stays consistent
-        // whether checkout happened progressively or all-at-once.
-        asset: { select: { id: true, type: true, status: true } },
+        // The slice markers are the per-booking dispatch record — stamped by
+        // the all-at-once checkout (which writes no PartialBookingCheckout
+        // rows) and by progressive scans alike. They are the same source the
+        // check-in eligibility guard reads, so an item gates completion
+        // exactly when it is checkinable.
+        checkedOutAt: true,
+        checkedInAt: true,
+        asset: { select: { id: true, type: true } },
       },
     }),
     tx.partialBookingCheckin.findMany({
@@ -4200,9 +4204,10 @@ export async function isBookingFullyCheckedIn(
   // rows record the unit count; legacy rows (pre-Wave-B) with an empty
   // `quantities[]` fall back to 1 per entry — all handled inside the parser.
   // Completion is an ASSET-level obligation, so the per-slice `bookingAssetId`
-  // tags are irrelevant here; we only need the per-asset unit totals. The
-  // `() => true` predicate keeps BOTH INDIVIDUAL and QT assets (the parser's
-  // non-QT skip must not drop INDIVIDUAL ids, which gate the check-in below).
+  // tags are irrelevant here; we only need the per-asset unit totals, which
+  // set the QT obligation below (INDIVIDUAL reconciliation reads the slice
+  // markers and checkin sessions instead). The `() => true` predicate keeps
+  // both asset types in the parse.
   const logsByAsset = checkoutSessionsToLogsByAsset(
     partialCheckouts as Array<{
       assetIds: string[];
@@ -4211,7 +4216,6 @@ export async function isBookingFullyCheckedIn(
     }>,
     () => true
   );
-  const checkedOutAssetIds = new Set<string>(logsByAsset.keys());
   const checkedOutUnitsByAsset = new Map<string, number>();
   for (const [assetId, logs] of logsByAsset) {
     checkedOutUnitsByAsset.set(
@@ -4220,74 +4224,84 @@ export async function isBookingFullyCheckedIn(
     );
   }
 
-  // Detect whether ANY progressive checkout has occurred. If not, preserve the
-  // legacy "every BookingAsset must reconcile" semantics so all-at-once flows
-  // and pre-Wave-B bookings behave exactly as before.
-  const hasProgressiveCheckout = partialCheckouts.length > 0;
-
-  for (const ba of bookingAssets as Array<{
+  type SliceRow = {
     assetId: string;
     quantity: number;
-    asset: { id: string; type: AssetType; status: AssetStatus } | null;
-  }>) {
+    checkedOutAt: Date | null;
+    checkedInAt: Date | null;
+    asset: { id: string; type: AssetType } | null;
+  };
+  const slices = bookingAssets as SliceRow[];
+
+  // Booked and dispatched-by-stamp units summed per ASSET across all of its
+  // slices (standalone + kit-driven) — reconciliation below is asset-level.
+  const bookedUnitsByAsset = new Map<string, number>();
+  const stampedUnitsByAsset = new Map<string, number>();
+  for (const s of slices) {
+    bookedUnitsByAsset.set(
+      s.assetId,
+      (bookedUnitsByAsset.get(s.assetId) ?? 0) + s.quantity
+    );
+    if (s.checkedOutAt) {
+      stampedUnitsByAsset.set(
+        s.assetId,
+        (stampedUnitsByAsset.get(s.assetId) ?? 0) + s.quantity
+      );
+    }
+  }
+
+  /** QT assets already judged — an asset's slices are evaluated as one. */
+  const qtyAssetIdsEvaluated = new Set<string>();
+
+  for (const ba of slices) {
     const isQtyTrackedAsset = ba.asset?.type === AssetType.QUANTITY_TRACKED;
 
     if (!isQtyTrackedAsset) {
-      // INDIVIDUAL. Under progressive semantics: an asset that was NEVER
-      // checked out (not in any PartialBookingCheckout AND not currently
-      // CHECKED_OUT) cannot — and need not — be checked in. Under legacy
-      // semantics (no PartialBookingCheckout rows at all), the asset must
-      // appear in a partial-checkin session, preserving previous behaviour.
-      const wasCheckedOut =
-        checkedOutAssetIds.has(ba.assetId) ||
-        ba.asset?.status === AssetStatus.CHECKED_OUT;
-
-      if (hasProgressiveCheckout && !wasCheckedOut) {
-        // Never went out → nothing to reconcile.
-        continue;
-      }
-
-      if (!individuallyCheckedInIds.has(ba.assetId)) return false;
-      continue;
+      // INDIVIDUAL. The slice marker is the same source the check-in
+      // eligibility guard reads, so an asset gates completion exactly when
+      // it is checkinable. A slice never dispatched on THIS booking (added
+      // onto an ONGOING booking, or left behind by a progressive checkout)
+      // has nothing to reconcile and never blocks.
+      if (!ba.checkedOutAt) continue;
+      // Reconciled — by the slice marker, or by a partial-checkin session
+      // for rows reconciled before the marker existed.
+      if (ba.checkedInAt) continue;
+      if (individuallyCheckedInIds.has(ba.assetId)) continue;
+      return false;
     }
 
-    // QUANTITY_TRACKED. Under legacy semantics, require zero remaining
-    // (booked − logged === 0). Under progressive semantics, the cap is
-    // `min(checkedOutUnits, slice.quantity)` — uncheck-outed units have no
-    // reconciliation obligation.
-    if (!hasProgressiveCheckout) {
-      const remaining = await computeBookingAssetRemaining(
-        tx,
-        bookingId,
-        ba.assetId
-      );
-      if (remaining > 0) return false;
-      continue;
-    }
+    // QUANTITY_TRACKED — judged once per ASSET, because `remaining` and the
+    // unit sums span all of the asset's slices.
+    if (qtyAssetIdsEvaluated.has(ba.assetId)) continue;
+    qtyAssetIdsEvaluated.add(ba.assetId);
 
-    const checkedOutUnits = checkedOutUnitsByAsset.get(ba.assetId) ?? 0;
-    if (checkedOutUnits === 0) {
-      // This asset was never checked out under the progressive flow — nothing
-      // to reconcile for this slice (or any other slice of the same asset).
+    // Obligated units, from this asset's OWN records: progressive sessions
+    // recorded exact unit counts → those units (capped by booked); no
+    // session units but stamped slices → the stamp came from the
+    // all-at-once checkout, which dispatches every unit of the slices it
+    // stamps. Judging this per asset keeps one scanned-out asset from
+    // stripping the return obligation off every button-checked-out asset
+    // on the booking.
+    const sessionUnits = checkedOutUnitsByAsset.get(ba.assetId) ?? 0;
+    const booked = bookedUnitsByAsset.get(ba.assetId) ?? 0;
+    const stampedUnits = stampedUnitsByAsset.get(ba.assetId) ?? 0;
+    const obligatedUnits =
+      sessionUnits > 0 ? Math.min(sessionUnits, booked) : stampedUnits;
+    if (obligatedUnits === 0) {
+      // Never dispatched in any form — nothing to reconcile.
       continue;
     }
 
     // `computeBookingAssetRemaining` returns `booked − logged` clamped at 0.
     // The "logged" half is what we actually care about (units already checked
-    // in); recover it via `booked - remaining` where `booked` sums every slice
-    // of the same asset. Cap by `checkedOutUnits` so units that never left the
-    // warehouse don't block COMPLETE.
-    const [bookedSum, remaining] = await Promise.all([
-      tx.bookingAsset.aggregate({
-        where: { bookingId, assetId: ba.assetId },
-        _sum: { quantity: true },
-      }),
-      computeBookingAssetRemaining(tx, bookingId, ba.assetId),
-    ]);
-    const booked =
-      (bookedSum as { _sum: { quantity: number | null } })._sum.quantity ?? 0;
+    // in); recover it via `booked - remaining`. Units that never left the
+    // warehouse don't block COMPLETE because `obligatedUnits` excludes them.
+    const remaining = await computeBookingAssetRemaining(
+      tx,
+      bookingId,
+      ba.assetId
+    );
     const checkedInUnits = Math.max(0, booked - remaining);
-    const obligatedUnits = Math.min(checkedOutUnits, booked);
     if (obligatedUnits - checkedInUnits > 0) return false;
   }
 

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2677,8 +2677,9 @@ async function checkoutBookingWritesWithinTx(
    *
    * Incremented, never assigned: the column is cumulative, so a slice on its
    * second departure adds to what its first one recorded. Only the slices read
-   * above, so a slice a progressive batch had partly sent out — still out, not
-   * yet reconciled — keeps the count that batch recorded.
+   * above — a slice a progressive batch had partly sent out is not among them,
+   * because its residue rather than its whole quantity departs now; it is
+   * topped up alongside the residue session row below.
    */
   const departingSliceIdsByQuantity = new Map<number, string[]>();
   for (const slice of departingSlices) {
@@ -2698,9 +2699,18 @@ async function checkoutBookingWritesWithinTx(
   }
 
   /**
-   * The residue of partially-scanned slices, recorded as one session row so
-   * their full obligation reads back out of session attribution (tagged per
-   * slice — no greedy ambiguity).
+   * The residue of partially-scanned slices, recorded in BOTH places that
+   * answer "how many units left", because two readers ask it differently and
+   * a residue in only one of them is a disagreement rather than a record.
+   *
+   * The session row makes the slice's full obligation read back out of session
+   * attribution (tagged per slice — no greedy ambiguity), which is what
+   * completion and the lifecycle progress derive from.
+   * `BookingAsset.checkedOutQuantity` is the stored counter every quantity
+   * surface reads, and the departure statement above cannot carry these
+   * slices: it adds a whole booked quantity, while only the residue departs
+   * here. Topping it up by the same figure keeps the stored count and the
+   * derived one equal.
    */
   if (checkoutTopUps.length > 0) {
     await tx.partialBookingCheckout.create({
@@ -2713,6 +2723,25 @@ async function checkoutBookingWritesWithinTx(
         checkoutCount: checkoutTopUps.length,
       },
     });
+
+    // Grouped by residue for the same reason the departure statement groups by
+    // quantity: `updateMany`'s `data` takes literals and cannot name a column.
+    const topUpSliceIdsByResidue = new Map<number, string[]>();
+    for (const topUp of checkoutTopUps) {
+      const ids = topUpSliceIdsByResidue.get(topUp.residue);
+      if (ids) {
+        ids.push(topUp.id);
+      } else {
+        topUpSliceIdsByResidue.set(topUp.residue, [topUp.id]);
+      }
+    }
+    for (const [residue, sliceIds] of topUpSliceIdsByResidue) {
+      await tx.bookingAsset.updateMany({
+        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: these ids were read above from a bookingId the caller org-checked
+        where: { id: { in: sliceIds } },
+        data: { checkedOutQuantity: { increment: residue } },
+      });
+    }
   }
 
   /**

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2498,9 +2498,82 @@ async function checkoutBookingWritesWithinTx(
   });
 
   /**
-   * Record the checkout on each slice. This is the ONLY thing that marks an
-   * all-at-once checkout — this path writes no `PartialBookingCheckout` row —
-   * and it is what the check-in guard reads to decide eligibility.
+   * A quantity-tracked slice partially dispatched by progressive scans before
+   * this full checkout keeps its earlier stamp, but its residual units go out
+   * NOW and would otherwise leave no record of their own: dispatched units
+   * are judged from session attribution wherever a slice has session units
+   * (see `computeDispatchedUnitsByAsset`), so an unrecorded residue would let
+   * the booking complete once just the scanned units return. Read the
+   * pre-stamp state here; the matching session row is written below, after
+   * the stamps.
+   */
+  const preStampedQtySlices = (await tx.bookingAsset.findMany({
+    // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: bookingId was org-checked by the caller's findUniqueOrThrow({where:{id,organizationId}})
+    where: {
+      bookingId,
+      checkedOutAt: { not: null },
+      asset: { type: AssetType.QUANTITY_TRACKED },
+    },
+    select: { id: true, assetId: true, quantity: true, assetKitId: true },
+  })) as Array<{
+    id: string;
+    assetId: string;
+    quantity: number;
+    assetKitId: string | null;
+  }>;
+  const checkoutTopUps: Array<{
+    id: string;
+    assetId: string;
+    residue: number;
+  }> = [];
+  if (preStampedQtySlices.length > 0) {
+    const priorSessions = (await tx.partialBookingCheckout.findMany({
+      where: { bookingId },
+      select: { assetIds: true, quantities: true, bookingAssetIds: true },
+    })) as Array<{
+      assetIds: string[];
+      quantities: number[];
+      bookingAssetIds: string[];
+    }>;
+    const logsByAsset = checkoutSessionsToLogsByAsset(
+      priorSessions,
+      () => true
+    );
+    const slicesByAsset = new Map<string, typeof preStampedQtySlices>();
+    for (const s of preStampedQtySlices) {
+      const group = slicesByAsset.get(s.assetId);
+      if (group) group.push(s);
+      else slicesByAsset.set(s.assetId, [s]);
+    }
+    for (const [assetId, group] of slicesByAsset) {
+      const attributed = attributeDispositionsByBookingAsset({
+        bookingAssetRows: group.map((s) => ({
+          id: s.id,
+          quantity: s.quantity,
+          assetKitId: s.assetKitId,
+        })),
+        consumptionLogs: logsByAsset.get(assetId) ?? [],
+      });
+      for (const s of group) {
+        const units = attributed.get(s.id) ?? 0;
+        // Only a slice with SOME session units under-reads — a stamped slice
+        // with none reads back as fully dispatched from its stamp alone.
+        if (units > 0 && units < s.quantity) {
+          checkoutTopUps.push({
+            id: s.id,
+            assetId: s.assetId,
+            residue: s.quantity - units,
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Record the checkout on each slice. Together with the residue session row
+   * below, this is what marks an all-at-once checkout — the path writes no
+   * `PartialBookingCheckout` row for slices without prior session units — and
+   * it is what the check-in guard reads to decide eligibility.
    *
    * Scoped to slices not already out so a progressive batch that ran earlier
    * keeps its own (earlier, more accurate) timestamp. Any stale check-in marker
@@ -2516,6 +2589,24 @@ async function checkoutBookingWritesWithinTx(
       checkedInById: null,
     },
   });
+
+  /**
+   * The residue of partially-scanned slices, recorded as one session row so
+   * their full obligation reads back out of session attribution (tagged per
+   * slice — no greedy ambiguity).
+   */
+  if (checkoutTopUps.length > 0) {
+    await tx.partialBookingCheckout.create({
+      data: {
+        bookingId,
+        checkedOutById,
+        assetIds: checkoutTopUps.map((t) => t.assetId),
+        quantities: checkoutTopUps.map((t) => t.residue),
+        bookingAssetIds: checkoutTopUps.map((t) => t.id),
+        checkoutCount: checkoutTopUps.length,
+      },
+    });
+  }
 
   /**
    * Slices that were already out AND reconciled return to outstanding. The

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -139,6 +139,7 @@ import {
   attributeDispositionsByBookingAsset,
   checkoutSessionsToLogsByAsset,
   compareSlicesForGreedyFill,
+  computeDispatchedUnitsByAsset,
 } from "./checkout-attribution";
 import {
   ADDABLE_BOOKING_STATUSES,
@@ -4142,11 +4143,14 @@ export async function computeBookingAssetsSliceRemainingToCheckOut(
  * Slices never dispatched (added onto an ONGOING booking, or left behind by
  * a progressive checkout) have nothing to check in and never block.
  *
- * For `QUANTITY_TRACKED` assets: obligated units are the progressive session
- * units when any were recorded (capped by booked), otherwise the booked
- * units of stamped slices (an all-at-once stamp dispatches the whole slice).
- * Complete when every obligated unit is reconciled; units that never left
- * the warehouse carry no obligation.
+ * For `QUANTITY_TRACKED` assets: obligated units are judged PER SLICE and
+ * summed — a slice's session-attributed units when any exist (capped by its
+ * booked quantity), otherwise its whole booked quantity when its marker is
+ * stamped (an all-at-once stamp dispatches the full slice). One asset can
+ * mix both across its slices, so neither source alone may answer for the
+ * asset (see `computeDispatchedUnitsByAsset`). Complete when every obligated
+ * unit is reconciled; units that never left the warehouse carry no
+ * obligation.
  *
  * Called by both `partialCheckinBooking` and `checkinBooking` to decide
  * the ONGOING/OVERDUE → COMPLETE transition. Keeping this in one place
@@ -4164,8 +4168,13 @@ export async function isBookingFullyCheckedIn(
     tx.bookingAsset.findMany({
       where: { bookingId },
       select: {
+        // `id` + `assetKitId` feed the per-slice session attribution in
+        // `computeDispatchedUnitsByAsset` (tagged claims name a slice; greedy
+        // fill orders by the discriminator).
+        id: true,
         assetId: true,
         quantity: true,
+        assetKitId: true,
         // The slice markers are the per-booking dispatch record — stamped by
         // the all-at-once checkout (which writes no PartialBookingCheckout
         // rows) and by progressive scans alike. They are the same source the
@@ -4198,56 +4207,40 @@ export async function isBookingFullyCheckedIn(
     }
   }
 
-  // Aggregate per-asset checked-out units across every PartialBookingCheckout
-  // session for this booking through the shared positional parser. `quantities`
-  // is positional with `assetIds`: INDIVIDUAL rows record `1`, QUANTITY_TRACKED
-  // rows record the unit count; legacy rows (pre-Wave-B) with an empty
-  // `quantities[]` fall back to 1 per entry — all handled inside the parser.
-  // Completion is an ASSET-level obligation, so the per-slice `bookingAssetId`
-  // tags are irrelevant here; we only need the per-asset unit totals, which
-  // set the QT obligation below (INDIVIDUAL reconciliation reads the slice
-  // markers and checkin sessions instead). The `() => true` predicate keeps
-  // both asset types in the parse.
-  const logsByAsset = checkoutSessionsToLogsByAsset(
-    partialCheckouts as Array<{
-      assetIds: string[];
-      quantities: number[];
-      bookingAssetIds: string[];
-    }>,
-    () => true
-  );
-  const checkedOutUnitsByAsset = new Map<string, number>();
-  for (const [assetId, logs] of logsByAsset) {
-    checkedOutUnitsByAsset.set(
-      assetId,
-      logs.reduce((sum, log) => sum + log.quantity, 0)
-    );
-  }
-
   type SliceRow = {
+    id: string;
     assetId: string;
     quantity: number;
+    assetKitId: string | null;
     checkedOutAt: Date | null;
     checkedInAt: Date | null;
     asset: { id: string; type: AssetType } | null;
   };
   const slices = bookingAssets as SliceRow[];
 
-  // Booked and dispatched-by-stamp units summed per ASSET across all of its
-  // slices (standalone + kit-driven) — reconciliation below is asset-level.
+  // Dispatched units per ASSET, judged slice by slice: a slice's progressive
+  // session units when any were attributed to it, otherwise its whole booked
+  // quantity when its marker is stamped. One asset can mix both across its
+  // slices (a button-checked-out slice plus a progressively-scanned sibling),
+  // so neither sessions nor stamps alone may answer for the asset — see
+  // `computeDispatchedUnitsByAsset`.
+  const dispatchedUnitsByAsset = computeDispatchedUnitsByAsset({
+    slices,
+    checkoutSessions: partialCheckouts as Array<{
+      assetIds: string[];
+      quantities: number[];
+      bookingAssetIds: string[];
+    }>,
+  });
+
+  // Booked units summed per ASSET across all of its slices (standalone +
+  // kit-driven) — reconciliation below is asset-level.
   const bookedUnitsByAsset = new Map<string, number>();
-  const stampedUnitsByAsset = new Map<string, number>();
   for (const s of slices) {
     bookedUnitsByAsset.set(
       s.assetId,
       (bookedUnitsByAsset.get(s.assetId) ?? 0) + s.quantity
     );
-    if (s.checkedOutAt) {
-      stampedUnitsByAsset.set(
-        s.assetId,
-        (stampedUnitsByAsset.get(s.assetId) ?? 0) + s.quantity
-      );
-    }
   }
 
   /** QT assets already judged — an asset's slices are evaluated as one. */
@@ -4275,18 +4268,17 @@ export async function isBookingFullyCheckedIn(
     if (qtyAssetIdsEvaluated.has(ba.assetId)) continue;
     qtyAssetIdsEvaluated.add(ba.assetId);
 
-    // Obligated units, from this asset's OWN records: progressive sessions
-    // recorded exact unit counts → those units (capped by booked); no
-    // session units but stamped slices → the stamp came from the
-    // all-at-once checkout, which dispatches every unit of the slices it
-    // stamps. Judging this per asset keeps one scanned-out asset from
-    // stripping the return obligation off every button-checked-out asset
+    // Obligated units = what actually went out for this asset, judged slice
+    // by slice (session-attributed units per slice, else the stamped slice's
+    // booked quantity). Judging per slice keeps one progressively-scanned
+    // sibling from erasing a button-checked-out slice's obligation, and one
+    // scanned-out asset from stripping the obligation off every other asset
     // on the booking.
-    const sessionUnits = checkedOutUnitsByAsset.get(ba.assetId) ?? 0;
     const booked = bookedUnitsByAsset.get(ba.assetId) ?? 0;
-    const stampedUnits = stampedUnitsByAsset.get(ba.assetId) ?? 0;
-    const obligatedUnits =
-      sessionUnits > 0 ? Math.min(sessionUnits, booked) : stampedUnits;
+    const obligatedUnits = Math.min(
+      dispatchedUnitsByAsset.get(ba.assetId) ?? 0,
+      booked
+    );
     if (obligatedUnits === 0) {
       // Never dispatched in any form — nothing to reconcile.
       continue;

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2724,10 +2724,23 @@ async function checkoutBookingWritesWithinTx(
       },
     });
 
+    // A slice already counted by the departure statement is skipped here.
+    // `checkoutTopUps` is derived from every stamped slice, including one that
+    // went out earlier and came back IN FULL — that slice departs again whole,
+    // so the statement above already added its entire booked quantity, and
+    // adding a residue on top would count units that never left. Only a slice
+    // still partly out reaches this loop, which is the case the residue
+    // describes. Its session row is written regardless: that row records the
+    // dispatch, while this counter records the units.
+    const departingSliceIds = new Set(
+      departingSlices.map((s: { id: string }) => s.id)
+    );
+
     // Grouped by residue for the same reason the departure statement groups by
     // quantity: `updateMany`'s `data` takes literals and cannot name a column.
     const topUpSliceIdsByResidue = new Map<number, string[]>();
     for (const topUp of checkoutTopUps) {
+      if (departingSliceIds.has(topUp.id)) continue;
       const ids = topUpSliceIdsByResidue.get(topUp.residue);
       if (ids) {
         ids.push(topUp.id);

--- a/apps/webapp/app/modules/booking/utils.server.test.ts
+++ b/apps/webapp/app/modules/booking/utils.server.test.ts
@@ -573,8 +573,10 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     expect(p.hasPartialCheckins).toBe(true);
   });
 
-  it("COMPLETE booking with qty residual checkout (C>D) — collapses to Returned", () => {
-    // C=10 > 0 at COMPLETE → asset collapses to Returned; never per-unit math.
+  it("COMPLETE booking with qty residual checkout (C>D) — stays visibly Partial", () => {
+    // 10 units went out on record and only 7 came back. A closed booking
+    // holding unreturned units must show it — collapsing to Returned is what
+    // hid the early-complete data loss from users.
     const p = calculateBookingLifecycleProgress({
       bookingAssets: [QT("pencils", 50, 10, 7)],
       checkedInAssetIds: ["pencils"],
@@ -583,11 +585,9 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     });
     expect(p.totalUnits).toBe(1);
     expect(p.bookedCount).toBe(0);
-    expect(p.partialCount).toBe(0);
+    expect(p.partialCount).toBe(1);
     expect(p.checkedOutCount).toBe(0);
-    expect(p.returnedCount).toBe(1);
-    expect(p.checkoutProgressPercentage).toBe(100);
-    expect(p.checkinProgressPercentage).toBe(100);
+    expect(p.returnedCount).toBe(0);
   });
 
   it("COMPLETE booking with a quick-checked-out QT row (no records) → Returned", () => {
@@ -608,11 +608,12 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
 
   it("COMPLETE multi-slice QT — never-checked-out slice stays Booked when records exist", () => {
     // checkedOutAssetIds is asset-level; with progressive records present a
-    // checked-out slice must NOT drag a sibling never-checked-out slice into
-    // Returned. Each slice uses its own C.
+    // checked-out slice must NOT drag a sibling never-checked-out slice out
+    // of Booked. Each slice uses its own C — and the checked-out slice has
+    // no recorded return (D=0), so it reads Checked out, not Returned.
     const p = calculateBookingLifecycleProgress({
       bookingAssets: [
-        QT("gloves", 50, 50, 0, "K1"), // slice checked out
+        QT("gloves", 50, 50, 0, "K1"), // slice checked out, never returned
         QT("gloves", 30, 0, 0, null), // sibling slice never checked out
       ],
       checkedInAssetIds: [],
@@ -620,8 +621,68 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
       bookingStatus: BookingStatus.COMPLETE,
     });
     expect(p.totalUnits).toBe(2);
-    expect(p.returnedCount).toBe(1); // the checked-out slice
+    expect(p.checkedOutCount).toBe(1); // out with no recorded return
+    expect(p.returnedCount).toBe(0);
     expect(p.bookedCount).toBe(1); // the never-checked-out slice
+  });
+
+  it("COMPLETE mixed-mode booking — slice markers keep button-checked-out rows truthful", () => {
+    // The shape behind the early-complete incident: a button checkout stamps
+    // slices but writes no session rows, one asset was scanned out
+    // progressively, and a button-checked-out QT row never got its return
+    // recorded. With slice markers supplied, returned rows read Returned and
+    // the stranded row stays visibly Checked out — one scanned asset must
+    // not flip every other row to Booked at COMPLETE.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        {
+          id: "scanned",
+          kitId: null,
+          status: AssetStatus.AVAILABLE,
+          assetType: AssetType.INDIVIDUAL,
+          sliceCheckedOut: true,
+          sliceCheckedIn: true,
+        },
+        {
+          ...QT("cables", 25, 0, 25),
+          sliceCheckedOut: true,
+          sliceCheckedIn: true,
+        },
+        {
+          ...QT("keyboards", 8, 0, 0),
+          sliceCheckedOut: true,
+          sliceCheckedIn: false,
+        },
+      ],
+      checkedInAssetIds: ["scanned"],
+      checkedOutAssetIds: ["scanned", "cables", "keyboards"],
+      bookingStatus: BookingStatus.COMPLETE,
+    });
+    expect(p.totalUnits).toBe(3);
+    expect(p.returnedCount).toBe(2);
+    expect(p.checkedOutCount).toBe(1); // the stranded qty row
+    expect(p.bookedCount).toBe(0);
+    expect(p.checkinProgressCount).toBe(2);
+  });
+
+  it("ONGOING button-checked-out QT row reads Checked out via its slice marker", () => {
+    // Button checkout writes no session rows (C=0) — the slice marker is
+    // what says this row's booked units are out. Without it the row would
+    // wrongly read Booked whenever the booking also has scan records.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        {
+          ...QT("keyboards", 8, 0, 0),
+          sliceCheckedOut: true,
+          sliceCheckedIn: false,
+        },
+      ],
+      checkedInAssetIds: [],
+      checkedOutAssetIds: ["some-other-asset"],
+      bookingStatus: BookingStatus.ONGOING,
+    });
+    expect(p.checkedOutCount).toBe(1);
+    expect(p.bookedCount).toBe(0);
   });
 
   it("qty asset with two slices (kit-driven + standalone) — each slice is its own asset count", () => {

--- a/apps/webapp/app/modules/booking/utils.server.test.ts
+++ b/apps/webapp/app/modules/booking/utils.server.test.ts
@@ -685,6 +685,30 @@ describe("calculateBookingLifecycleProgress (quantity-tracked)", () => {
     expect(p.bookedCount).toBe(0);
   });
 
+  it("COMPLETE collapsed QT row honors dispatchedQuantity over its session counter", () => {
+    // Asset-collapsed rows (the mobile shape) can mix a button-checked-out
+    // slice with a progressively-scanned sibling: 9 units dispatched (8
+    // stamped + 1 session-recorded) but C only carries the session unit.
+    // The caller-computed dispatchedQuantity must outrank C — judged by C
+    // alone (1 out, 1 back) the row would wrongly read Returned.
+    const p = calculateBookingLifecycleProgress({
+      bookingAssets: [
+        {
+          ...QT("mixed", 9, 1, 1),
+          sliceCheckedOut: true,
+          sliceCheckedIn: false,
+          dispatchedQuantity: 9,
+        },
+      ],
+      checkedInAssetIds: [],
+      checkedOutAssetIds: ["mixed"],
+      bookingStatus: BookingStatus.COMPLETE,
+    });
+    expect(p.partialCount).toBe(1); // 1 of 9 dispatched units back on record
+    expect(p.returnedCount).toBe(0);
+    expect(p.bookedCount).toBe(0);
+  });
+
   it("qty asset with two slices (kit-driven + standalone) — each slice is its own asset count", () => {
     // Slice 1: QT in K1, 0 < C(2) < B(5) → Partial.
     // Slice 2: QT standalone, C=0, D=0 → Booked.

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -354,9 +354,12 @@ export function calculateUnitCheckinProgress(
  *   checkedOut = max(0, C - D')
  *   booked     = max(0, B - C)
  *
- * For COMPLETE/ARCHIVED bookings, the `checkedOut` slice collapses into
- * `returned` (a residual C>D at COMPLETE is treated as having come back),
- * mirroring the INDIVIDUAL-side `finalBucketOf` behavior.
+ * For COMPLETE/ARCHIVED bookings, buckets follow the recorded dispatch and
+ * return evidence: rows whose dispatched units are covered by dispositions
+ * read Returned, rows dispatched with no recorded return stay visibly
+ * Checked out (or Partial when only some units came back) — a closed booking
+ * holding unreturned items says so. Only pure legacy data with no records of
+ * any kind keeps the historical collapse-to-Returned.
  */
 type LifecycleAsset = {
   id: string;
@@ -370,6 +373,17 @@ type LifecycleAsset = {
   checkedOutQuantity?: number;
   /** Units dispositioned (returned + consumed + lost + damaged); QT rows only. */
   dispositionedQuantity?: number;
+  /**
+   * Slice dispatch markers (`BookingAsset.checkedOutAt` / `checkedInAt`),
+   * when the caller has the slice rows. These are the per-booking dispatch
+   * truth: the all-at-once checkout stamps them but writes NO
+   * `PartialBookingCheckout` rows, so session-derived inputs alone cannot
+   * tell a button-checked-out row from a never-checked-out one on a booking
+   * that also has scan records. Callers without slice rows omit them and the
+   * session-based fallbacks apply.
+   */
+  sliceCheckedOut?: boolean;
+  sliceCheckedIn?: boolean;
 };
 
 /**
@@ -389,7 +403,8 @@ export type BookingLifecycleProgress = {
   bookedCount: number;
   /**
    * Items mid-flight — only QUANTITY_TRACKED rows can land here (some units
-   * out or some units returned, but not all). Always 0 at COMPLETE/ARCHIVED.
+   * out or some units returned, but not all). At COMPLETE/ARCHIVED this is
+   * non-zero only for bookings closed while holding partially-returned rows.
    */
   partialCount: number;
   checkedOutCount: number;
@@ -431,10 +446,13 @@ export type BookingLifecycleProgress = {
  * - Else if all members share a single label → that label.
  * - Else (members disagree across Booked/CheckedOut/Returned) → Booked.
  *
- * For COMPLETE/ARCHIVED bookings, every asset that was ever checked out
- * (`wasCheckedOut` for INDIVIDUAL, `checkedOutQuantity > 0` for QT) collapses
- * to Returned; QT rows that were never out stay Booked. By construction the
- * Partial and Checked-out buckets are 0 at COMPLETE/ARCHIVED.
+ * For COMPLETE/ARCHIVED bookings, an asset is Returned only when a return is
+ * recorded for it (slice `checkedInAt` / checkin session for INDIVIDUAL,
+ * dispositions covering the dispatched units for QT). Dispatched assets with
+ * no recorded return stay Checked out (or Partial for a QT row with some
+ * units back); never-dispatched rows stay Booked. Pure legacy data — no
+ * slice markers and no session records at all — collapses to Returned as it
+ * historically did.
  *
  * For pre-checkout bookings (DRAFT/RESERVED/CANCELLED) no checkout has happened
  * in THIS booking — only ONGOING/OVERDUE own a live checkout — so every unit is
@@ -505,12 +523,28 @@ export function calculateBookingLifecycleProgress({
     a: LifecycleAsset
   ): Exclude<Bucket, "partial"> => {
     if (isFinal) {
-      // Final bookings: live status is AVAILABLE for every asset at this point,
-      // so an asset is "Returned" only if it was ever checked out. CHECKED_OUT
-      // live status, if somehow present, is treated as returned defensively.
-      return a.status === AssetStatus.CHECKED_OUT || wasCheckedOut(a.id)
-        ? "returned"
-        : "booked";
+      // Final bookings: a recorded return (slice `checkedInAt`, or a
+      // partial-checkin session) is what makes an asset "Returned". An asset
+      // that went out but has no recorded return stays "Checked out" — a
+      // closed booking holding unreturned items must say so rather than
+      // report them Returned (or, worse, Booked). Never-dispatched assets
+      // stay Booked. With no per-asset records at all (pure all-at-once
+      // legacy data: empty `checkedOutAssetIds`, no sessions, no slice
+      // markers), everything collapses to Returned as before.
+      const reconciled = (a.sliceCheckedIn ?? false) || checkedInSet.has(a.id);
+      if (reconciled) return "returned";
+      // Dispatch truth: the slice marker when the caller supplied it,
+      // otherwise session records with the empty-set-means-all-at-once
+      // convention.
+      const dispatched = a.sliceCheckedOut ?? wasCheckedOut(a.id);
+      if (!dispatched) return "booked";
+      // Dispatched with no recorded return. When per-asset records exist
+      // (slice markers supplied, or session rows present) this is a real
+      // unreturned item and must show as still out. Pure legacy data — no
+      // records of any kind — keeps the old collapse to Returned.
+      const hasPerAssetRecords =
+        a.sliceCheckedOut !== undefined || !wasAllAtOnceCheckout;
+      return hasPerAssetRecords ? "checkedOut" : "returned";
     }
     if (a.status === AssetStatus.CHECKED_OUT) return "checkedOut";
     if (checkedInSet.has(a.id)) return "returned";
@@ -549,19 +583,40 @@ export function calculateBookingLifecycleProgress({
     const B = Math.max(0, a.bookedQuantity ?? 0);
     let C = Math.max(0, a.checkedOutQuantity ?? 0);
     const D = Math.max(0, a.dispositionedQuantity ?? 0);
-    // Quick checkout: an all-at-once checkout of THIS booking (no progressive
-    // records ⇒ empty checkedOutAssetIds) put every booked unit out. Only ever
-    // raises C toward B, so progressive partial counts are untouched. When
-    // records DO exist we trust the per-row counter.
-    if (!isFinal && wasAllAtOnceCheckout && D === 0 && C < B) {
+    // Quick checkout: a checkout that recorded no per-unit sessions still put
+    // this row's booked units out — signalled per row by its slice marker
+    // (the button checkout stamps `checkedOutAt` but writes no session rows),
+    // or booking-wide by the empty-records convention when no slice info was
+    // supplied. Only ever raises C toward B, so progressive partial counts
+    // are untouched.
+    if (
+      !isFinal &&
+      D === 0 &&
+      C < B &&
+      (a.sliceCheckedOut === true || wasAllAtOnceCheckout)
+    ) {
       C = B;
     }
     if (isFinal) {
-      // Any units ever checked out → Returned; otherwise still Booked. A pure
-      // all-at-once checkout leaves no records (C=0), so treat every row as
-      // Returned. When records exist, use the per-row C so a never-checked-out
-      // slice of a multi-slice QT asset correctly stays Booked.
-      return C > 0 || wasAllAtOnceCheckout ? "returned" : "booked";
+      // Dispatched units for this row: the session counter when units were
+      // recorded, otherwise the whole row if its slice was stamped (an
+      // all-at-once stamp dispatches the full slice). Never-dispatched rows
+      // stay Booked.
+      const dispatchedUnits =
+        C > 0 ? Math.min(C, B) : a.sliceCheckedOut === true ? B : 0;
+      if (dispatchedUnits === 0) {
+        // No per-row dispatch evidence. Pure legacy data (no records
+        // anywhere) keeps the old collapse to Returned.
+        return wasAllAtOnceCheckout && a.sliceCheckedOut === undefined
+          ? "returned"
+          : "booked";
+      }
+      // Recorded dispositions covering the dispatch → Returned. Otherwise
+      // the row still holds unreturned dispatched units, and a closed
+      // booking must show them: Partial when some units came back on
+      // record, Checked out when none did.
+      if (D >= dispatchedUnits) return "returned";
+      return D > 0 ? "partial" : "checkedOut";
     }
     if (B > 0 && D >= B) return "returned";
     if (B > 0 && C >= B && D < B) return "checkedOut";
@@ -634,9 +689,10 @@ export function calculateBookingLifecycleProgress({
   const totalUnits = booked + partial + checkedOut + returned;
 
   if (isFinal) {
-    // At COMPLETE/ARCHIVED the priority chain only emits Booked or Returned,
-    // so `partial` and `checkedOut` are 0 here. Progress is derived from the
-    // returned/booked split — never hard-coded to 100%.
+    // At COMPLETE/ARCHIVED most bookings emit only Booked/Returned, but a
+    // booking closed while holding unreturned items keeps those in the
+    // Checked-out/Partial buckets deliberately. Progress is derived from the
+    // actual split — never hard-coded to 100%.
     const checkoutProgressCount = partial + checkedOut + returned;
     const pctFinal = (n: number) =>
       totalUnits > 0 ? Math.round((n / totalUnits) * 100) : 0;

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -369,7 +369,16 @@ type LifecycleAsset = {
   assetType?: AssetType;
   /** Units booked on this row (BookingAsset.quantity); QT rows only. */
   bookedQuantity?: number;
-  /** Units already checked out via PartialBookingCheckout; QT rows only. */
+  /**
+   * Units already checked out via PartialBookingCheckout; QT rows only.
+   *
+   * NOT `BookingAsset.checkedOutQuantity`, despite the matching name. This one
+   * is session-derived and counts only what scans recorded, so it reads 0 for a
+   * button checkout; the column is the stored cumulative counter every
+   * dispatch writer maintains. Passing the column here would silently change
+   * what the buckets below mean — feed `dispatchedQuantity` instead, which is
+   * the field that answers "how many units left" without qualification.
+   */
   checkedOutQuantity?: number;
   /** Units dispositioned (returned + consumed + lost + damaged); QT rows only. */
   dispositionedQuantity?: number;
@@ -393,6 +402,11 @@ type LifecycleAsset = {
    * it outranks the `checkedOutQuantity`/`sliceCheckedOut` approximations,
    * which cannot express an asset mixing button-checked-out and
    * progressively-scanned slices.
+   *
+   * Those two exist only for callers that cannot supply this one. Once every
+   * caller does, they are redundant and this becomes the single dispatch input
+   * — keep that collapse in mind rather than adding a fourth signal beside
+   * them.
    */
   dispatchedQuantity?: number;
 };

--- a/apps/webapp/app/modules/booking/utils.server.ts
+++ b/apps/webapp/app/modules/booking/utils.server.ts
@@ -379,11 +379,22 @@ type LifecycleAsset = {
    * truth: the all-at-once checkout stamps them but writes NO
    * `PartialBookingCheckout` rows, so session-derived inputs alone cannot
    * tell a button-checked-out row from a never-checked-out one on a booking
-   * that also has scan records. Callers without slice rows omit them and the
-   * session-based fallbacks apply.
+   * that also has scan records. Callers without slice rows omit them
+   * (`undefined`) and the session-based fallbacks apply — pass `undefined`,
+   * not `false`, when marker data is absent, or the legacy collapse for
+   * record-less bookings is disabled.
    */
   sliceCheckedOut?: boolean;
   sliceCheckedIn?: boolean;
+  /**
+   * Units actually dispatched for this row/asset, judged slice by slice
+   * (session-attributed units per slice, else the stamped slice's booked
+   * quantity — `computeDispatchedUnitsByAsset`). QT rows only. When provided
+   * it outranks the `checkedOutQuantity`/`sliceCheckedOut` approximations,
+   * which cannot express an asset mixing button-checked-out and
+   * progressively-scanned slices.
+   */
+  dispatchedQuantity?: number;
 };
 
 /**
@@ -584,26 +595,35 @@ export function calculateBookingLifecycleProgress({
     let C = Math.max(0, a.checkedOutQuantity ?? 0);
     const D = Math.max(0, a.dispositionedQuantity ?? 0);
     // Quick checkout: a checkout that recorded no per-unit sessions still put
-    // this row's booked units out — signalled per row by its slice marker
-    // (the button checkout stamps `checkedOutAt` but writes no session rows),
-    // or booking-wide by the empty-records convention when no slice info was
-    // supplied. Only ever raises C toward B, so progressive partial counts
-    // are untouched.
-    if (
-      !isFinal &&
-      D === 0 &&
-      C < B &&
-      (a.sliceCheckedOut === true || wasAllAtOnceCheckout)
-    ) {
-      C = B;
+    // this row's booked units out — signalled by the caller-computed
+    // `dispatchedQuantity` when provided, per row by the slice marker (the
+    // button checkout stamps `checkedOutAt` but writes no session rows), or
+    // booking-wide by the empty-records convention when no slice info was
+    // supplied. Only ever raises C toward the dispatched count, so
+    // progressive partial counts are untouched.
+    if (!isFinal && D === 0 && C < B) {
+      const dispatchedNow =
+        a.dispatchedQuantity !== undefined
+          ? Math.min(a.dispatchedQuantity, B)
+          : a.sliceCheckedOut === true || wasAllAtOnceCheckout
+          ? B
+          : C;
+      if (dispatchedNow > C) C = dispatchedNow;
     }
     if (isFinal) {
-      // Dispatched units for this row: the session counter when units were
+      // Dispatched units for this row: the caller-computed per-slice count
+      // when provided; otherwise the session counter when units were
       // recorded, otherwise the whole row if its slice was stamped (an
       // all-at-once stamp dispatches the full slice). Never-dispatched rows
       // stay Booked.
       const dispatchedUnits =
-        C > 0 ? Math.min(C, B) : a.sliceCheckedOut === true ? B : 0;
+        a.dispatchedQuantity !== undefined
+          ? Math.min(a.dispatchedQuantity, B)
+          : C > 0
+          ? Math.min(C, B)
+          : a.sliceCheckedOut === true
+          ? B
+          : 0;
       if (dispatchedUnits === 0) {
         // No per-row dispatch evidence. Pure legacy data (no records
         // anywhere) keeps the old collapse to Returned.

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -1126,24 +1126,44 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           .map((ba) => ba.assetId)
       ),
     ];
+    // With no stamped slice anywhere, pass `undefined` markers (not `false`)
+    // so the calculation's legacy collapse for record-less bookings stays
+    // reachable — `false` means "this row was verifiably never dispatched".
+    const bookingHasSliceMarkers = sliceCheckedOutAssetIds.length > 0;
     const lifecycleProgress = calculateBookingLifecycleProgress({
       bookingAssets: enrichedAssetsForView.map((a) => {
         const isQty = a.type === "QUANTITY_TRACKED";
         const marker = sliceMarkersByBookingAssetId.get(a.bookingAssetId);
+        const rowCheckedOutUnits = isQty
+          ? checkedOutByBookingAsset.get(a.bookingAssetId) ?? 0
+          : 0;
         return {
           id: a.id,
           kitId: a.kitId,
           status: a.status,
           assetType: a.type,
           bookedQuantity: a.bookedQuantity,
-          checkedOutQuantity: isQty
-            ? checkedOutByBookingAsset.get(a.bookingAssetId) ?? 0
-            : 0,
+          checkedOutQuantity: rowCheckedOutUnits,
           dispositionedQuantity: isQty
             ? dispositionedByBookingAsset.get(a.bookingAssetId) ?? 0
             : 0,
-          sliceCheckedOut: marker?.out ?? false,
-          sliceCheckedIn: marker?.in ?? false,
+          sliceCheckedOut: bookingHasSliceMarkers
+            ? marker?.out ?? false
+            : undefined,
+          sliceCheckedIn: bookingHasSliceMarkers
+            ? marker?.in ?? false
+            : undefined,
+          // Rows here are per slice, so the row's dispatched units are exact:
+          // its session-attributed units when any exist, else the whole row
+          // when its slice is stamped.
+          dispatchedQuantity:
+            isQty && bookingHasSliceMarkers
+              ? rowCheckedOutUnits > 0
+                ? Math.min(rowCheckedOutUnits, a.bookedQuantity ?? 0)
+                : marker?.out
+                ? a.bookedQuantity ?? 0
+                : 0
+              : undefined,
         };
       }),
       checkedInAssetIds,

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.tsx
@@ -1105,9 +1105,31 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
     // is physically out. The qty maps populated above
     // (`checkedOutByBookingAsset`, `dispositionedByBookingAsset`) supply
     // those per-row counters via the slice's `bookingAssetId`.
+    //
+    // Dispatch truth for the bar comes from the slice markers
+    // (`BookingAsset.checkedOutAt`/`checkedInAt`): the Check out button
+    // stamps them but writes NO PartialBookingCheckout rows, so the
+    // session-derived `checkedOutAssetIds` (kept for the "Checked out
+    // on/by" columns) cannot tell a button-checked-out row from a
+    // never-checked-out one on a booking that also has scan records — one
+    // scanned asset would flip every other asset's bucket at COMPLETE.
+    const sliceMarkersByBookingAssetId = new Map(
+      booking.bookingAssets.map((ba) => [
+        ba.id,
+        { out: Boolean(ba.checkedOutAt), in: Boolean(ba.checkedInAt) },
+      ])
+    );
+    const sliceCheckedOutAssetIds = [
+      ...new Set(
+        booking.bookingAssets
+          .filter((ba) => ba.checkedOutAt)
+          .map((ba) => ba.assetId)
+      ),
+    ];
     const lifecycleProgress = calculateBookingLifecycleProgress({
       bookingAssets: enrichedAssetsForView.map((a) => {
         const isQty = a.type === "QUANTITY_TRACKED";
+        const marker = sliceMarkersByBookingAssetId.get(a.bookingAssetId);
         return {
           id: a.id,
           kitId: a.kitId,
@@ -1120,10 +1142,12 @@ export async function loader({ context, request, params }: LoaderFunctionArgs) {
           dispositionedQuantity: isQty
             ? dispositionedByBookingAsset.get(a.bookingAssetId) ?? 0
             : 0,
+          sliceCheckedOut: marker?.out ?? false,
+          sliceCheckedIn: marker?.in ?? false,
         };
       }),
       checkedInAssetIds,
-      checkedOutAssetIds,
+      checkedOutAssetIds: sliceCheckedOutAssetIds,
       bookingStatus: booking.status,
       countKitsAsSingleUnit,
     });

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -15,6 +15,7 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { serializeAssetImage } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
+import { computeDispatchedUnitsByAsset } from "~/modules/booking/checkout-attribution";
 import { isBookingArchivable } from "~/modules/booking/helpers";
 import {
   bookingDraftVisibilityClause,
@@ -517,10 +518,31 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // (`BookingAsset.checkedOutAt`/`checkedInAt`): the Check out button
     // stamps them but writes NO PartialBookingCheckout rows, so session
     // records cannot tell a button-checked-out asset from a
-    // never-checked-out one on a booking that also has scan records.
-    const sliceRows = await db.bookingAsset.findMany({
-      where: { bookingId: booking.id },
-      select: { assetId: true, checkedOutAt: true, checkedInAt: true },
+    // never-checked-out one on a booking that also has scan records. The
+    // sessions are still fetched: per-asset dispatched units are judged
+    // slice by slice from stamps + session attribution (an asset can mix a
+    // button-checked-out slice with a progressively-scanned sibling — see
+    // `computeDispatchedUnitsByAsset`).
+    const [sliceRows, checkoutSessionRows] = await Promise.all([
+      db.bookingAsset.findMany({
+        where: { bookingId: booking.id },
+        select: {
+          id: true,
+          assetId: true,
+          quantity: true,
+          assetKitId: true,
+          checkedOutAt: true,
+          checkedInAt: true,
+        },
+      }),
+      db.partialBookingCheckout.findMany({
+        where: { bookingId: booking.id },
+        select: { assetIds: true, quantities: true, bookingAssetIds: true },
+      }),
+    ]);
+    const dispatchedUnitsByAsset = computeDispatchedUnitsByAsset({
+      slices: sliceRows,
+      checkoutSessions: checkoutSessionRows,
     });
     const sliceMarkersByAssetId = new Map<
       string,
@@ -540,6 +562,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const checkedOutAssetIds = [
       ...new Set(sliceRows.filter((s) => s.checkedOutAt).map((s) => s.assetId)),
     ];
+    // With no stamped slice anywhere, pass `undefined` markers (not `false`)
+    // so the calculation's legacy collapse for record-less bookings stays
+    // reachable — `false` means "this row was verifiably never dispatched".
+    const bookingHasSliceMarkers = checkedOutAssetIds.length > 0;
     const lifecycleProgress = calculateBookingLifecycleProgress({
       bookingAssets: assets.map((a) => {
         const isQty = a.type === AssetType.QUANTITY_TRACKED;
@@ -551,9 +577,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           kitId: a.kitId,
           status: a.status,
           assetType: a.type,
-          sliceCheckedOut: marker?.out ?? false,
-          sliceCheckedIn:
-            (marker?.out ?? false) && (marker?.allStampedIn ?? false),
+          sliceCheckedOut: bookingHasSliceMarkers
+            ? marker?.out ?? false
+            : undefined,
+          sliceCheckedIn: bookingHasSliceMarkers
+            ? (marker?.out ?? false) && (marker?.allStampedIn ?? false)
+            : undefined,
+          dispatchedQuantity:
+            isQty && bookingHasSliceMarkers
+              ? Math.min(dispatchedUnitsByAsset.get(a.id) ?? 0, booked)
+              : undefined,
           bookedQuantity: isQty ? booked : undefined,
           // checked-out = booked − still-to-check-out; dispositioned =
           // booked − still-to-check-in. Both from the per-asset remaining

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -513,26 +513,47 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // web booking overview uses (`calculateBookingLifecycleProgress`), so the
     // mobile bar and the web bar can never disagree. QT rows bucket by their
     // per-asset unit counters; INDIVIDUAL rows by status + `checkedInAssetIds`.
-    // `checkedOutAssetIds` (assets with a PartialBookingCheckout record) drives
-    // the COMPLETE-branch "was it ever out?" test; an empty list means an
-    // all-at-once checkout.
-    const partialCheckoutRows = await db.partialBookingCheckout.findMany({
+    // Dispatch truth comes from the slice markers
+    // (`BookingAsset.checkedOutAt`/`checkedInAt`): the Check out button
+    // stamps them but writes NO PartialBookingCheckout rows, so session
+    // records cannot tell a button-checked-out asset from a
+    // never-checked-out one on a booking that also has scan records.
+    const sliceRows = await db.bookingAsset.findMany({
       where: { bookingId: booking.id },
-      select: { assetIds: true },
+      select: { assetId: true, checkedOutAt: true, checkedInAt: true },
     });
+    const sliceMarkersByAssetId = new Map<
+      string,
+      { out: boolean; allStampedIn: boolean }
+    >();
+    for (const s of sliceRows) {
+      const m = sliceMarkersByAssetId.get(s.assetId) ?? {
+        out: false,
+        allStampedIn: true,
+      };
+      if (s.checkedOutAt) {
+        m.out = true;
+        if (!s.checkedInAt) m.allStampedIn = false;
+      }
+      sliceMarkersByAssetId.set(s.assetId, m);
+    }
     const checkedOutAssetIds = [
-      ...new Set(partialCheckoutRows.flatMap((r) => r.assetIds)),
+      ...new Set(sliceRows.filter((s) => s.checkedOutAt).map((s) => s.assetId)),
     ];
     const lifecycleProgress = calculateBookingLifecycleProgress({
       bookingAssets: assets.map((a) => {
         const isQty = a.type === AssetType.QUANTITY_TRACKED;
         const rem = remainingByAsset.get(a.id);
         const booked = a.quantity ?? 0;
+        const marker = sliceMarkersByAssetId.get(a.id);
         return {
           id: a.id,
           kitId: a.kitId,
           status: a.status,
           assetType: a.type,
+          sliceCheckedOut: marker?.out ?? false,
+          sliceCheckedIn:
+            (marker?.out ?? false) && (marker?.allStampedIn ?? false),
           bookedQuantity: isQty ? booked : undefined,
           // checked-out = booked − still-to-check-out; dispositioned =
           // booked − still-to-check-in. Both from the per-asset remaining

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.serialization.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.serialization.test.ts
@@ -29,10 +29,12 @@ import { assertIsDataWithResponseInit } from "@helpers/assertions";
 vi.mock("~/database/db.server", () => ({
   db: {
     booking: { findFirst: vi.fn() },
-    // why: lifecycle-progress roll-up queries the partial-checkout log to
-    // decide whether an asset was ever checked out. Not relevant to the
-    // model-request serialization under test — stub to an empty log. (Survives
+    // why: the lifecycle-progress roll-up reads the slice markers
+    // (BookingAsset.checkedOutAt/checkedInAt) plus the checkout sessions to
+    // judge dispatched units per asset. Not relevant to the model-request
+    // serialization under test — stub both to empty. (Survives
     // `clearAllMocks`, which clears call history but keeps implementations.)
+    bookingAsset: { findMany: vi.fn().mockResolvedValue([]) },
     partialBookingCheckout: { findMany: vi.fn().mockResolvedValue([]) },
   },
 }));

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.slices.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.slices.test.ts
@@ -43,6 +43,11 @@ import { assertIsDataWithResponseInit } from "@helpers/assertions";
 vi.mock("~/database/db.server", () => ({
   db: {
     booking: { findFirst: vi.fn() },
+    // why: the lifecycle-progress roll-up reads the slice markers
+    // (BookingAsset.checkedOutAt/checkedInAt) plus the checkout sessions to
+    // judge dispatched units per asset; stub both to empty — orthogonal to
+    // the slices/merged-kit serialization contract under test.
+    bookingAsset: { findMany: vi.fn().mockResolvedValue([]) },
     partialBookingCheckout: { findMany: vi.fn().mockResolvedValue([]) },
   },
 }));


### PR DESCRIPTION
## Problem

A booking checked out with the **Check out button** that also has at least one **progressive (scanner) checkout** record completes too early: partial check-in decides completion from `PartialBookingCheckout` session rows, and one such row switched the whole booking into "only session-recorded units matter" mode. Button-checked-out QUANTITY_TRACKED assets have zero session units, so they stopped gating completion entirely — the booking auto-completed at the last INDIVIDUAL check-in while quantity items were still out. Their returns can then never be recorded (a COMPLETE booking refuses check-ins) and the assets stay `CHECKED_OUT` with no active booking.

A second symptom on the completed page: the lifecycle stats decided "was this asset ever checked out" from the same session rows, so a single scanner row made the other N-1 returned assets render as never-checked-out "Booked" (progress 1/N).

The `PartialBookingCheckout` model's own doc comment already warns about exactly this: sessions record scans; **absence proves nothing** — the button checkout writes no rows. `BookingAsset.checkedOutAt` (introduced with the per-slice markers, #2951) is the dispatch truth.

## Fix

- `isBookingFullyCheckedIn` now judges each asset from its **own** records, with no booking-level mode switch:
  - INDIVIDUAL: a slice with `checkedOutAt` must be reconciled (`checkedInAt`, or a check-in session for pre-marker rows). Never-dispatched slices never block.
  - QUANTITY_TRACKED: obligated units = progressive session units when any were recorded (capped by booked), otherwise the booked units of stamped slices. Complete when every obligated unit is reconciled.
  - This matches the check-in eligibility guard, which already reads the slice markers: an item gates completion exactly when it is checkinable.
- `calculateBookingLifecycleProgress` accepts per-row slice markers (`sliceCheckedOut` / `sliceCheckedIn`); the web overview loader and the mobile bookings API now pass them (web reuses the already-loaded rows; mobile adds one narrow `bookingAsset` select).
- Truthful final-state buckets: a COMPLETE/ARCHIVED booking that holds dispatched-but-unreturned items now shows them as **Checked out** (or **Partial** for partly-returned quantity rows) instead of collapsing everything to Returned. Pure legacy data with no records of any kind keeps the historical collapse.

## Tests

- 5 new regression tests, including the exact mixed-mode shape (button checkout + one scanner row + unreturned quantity asset): completion is blocked, then allowed once the units are reconciled; the stats keep the stranded row visible at COMPLETE.
- 2 existing fixtures updated where they encoded the old collapse-to-Returned behavior; 1 thin mock gained the `checkedOutAt` stamps every dispatched slice has in production.
- Measured locally: `vitest run` on the two booking suites (325/325 passing) and `tsc -b` clean. CI runs without a database; no e2e was run for this change.


## Manually verified (this branch + real database, full browser flow)

Reproduced the incident shape end to end on a local server running this branch against the staging database: an INDIVIDUAL and a QUANTITY_TRACKED asset checked out with the button, a second INDIVIDUAL added onto the ONGOING booking and scanned out progressively (creating the booking's single `PartialBookingCheckout` row), then both individuals scanned back in.

- Before this fix, that last scan auto-completed the booking. On this branch the booking stays ONGOING at 2/3 with the quantity asset shown Fully out.
- Scanning the quantity asset back in then completes the booking (with the early-check-in confirmation), and the completed page reads 3/3 Returned with per-row check-in stamps — previously the button-checked-out rows rendered as never-checked-out "Booked".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved booking progress accuracy for quantity-tracked assets across web and mobile views.
  * Correctly distinguishes dispatched, returned, partially returned, and never-dispatched units.
  * Fixed mixed checkout scenarios so one scanned item no longer changes other booking items’ statuses.
  * Recorded remaining units when completing checkout after a partial progressive checkout.
  * Improved kit availability updates when booking slices are checked in, cancelled, or deleted.

* **Tests**
  * Added coverage for multi-slice bookings, progressive checkouts, partial returns, and completion states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->