### PR TITLE
feat(team): confirm before revoking a team member's access

### DIFF
--- a/apps/webapp/app/components/workspace/revoke-access-dialog.test.tsx
+++ b/apps/webapp/app/components/workspace/revoke-access-dialog.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Smoke tests for {@link RevokeAccessDialog}.
+ *
+ * Cover the dialog-side contract only: the confirmation renders the affected
+ * user's identity, confirming submits `intent=revokeAccess` for that user,
+ * Cancel closes without submitting, server errors render inside the dialog,
+ * and the SSO group-mapping note appears only for SSO users. Server-side
+ * behaviour (owner guard, membership deletion, email) is covered by the
+ * `resolveUserAction` / `revokeAccessToOrganization` tests.
+ *
+ * @see {@link file://./revoke-access-dialog.tsx}
+ */
+
+import type React from "react";
+import type { ReactNode } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RevokeAccessDialog } from "./revoke-access-dialog";
+
+/**
+ * Mutable per-test fetcher state. Tests reassign before render to control the
+ * fetcher's lifecycle (e.g. set `data.error` to assert in-dialog errors).
+ */
+type FetcherState = {
+  state: "idle" | "submitting" | "loading";
+  data: { error?: { message: string } } | undefined;
+};
+
+let mockFetcherState: FetcherState = { state: "idle", data: undefined };
+let mockSubmit = vi.fn();
+
+// why: useFetcher returns a Form component + state we need to control per
+// test. Wrap the form so submissions surface as native `submit` events that
+// our `mockSubmit` spy captures with the form's field values.
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("react-router");
+  return {
+    ...actual,
+    useFetcher: () => ({
+      ...mockFetcherState,
+      Form: ({
+        children,
+        onSubmit,
+        ...rest
+      }: {
+        children: ReactNode;
+        onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
+        [key: string]: unknown;
+      }) => (
+        <form
+          {...rest}
+          onSubmit={(e) => {
+            e.preventDefault();
+            const formData = new FormData(e.currentTarget);
+            mockSubmit({
+              intent: formData.get("intent"),
+              userId: formData.get("userId"),
+            });
+            onSubmit?.(e);
+          }}
+        >
+          {children}
+        </form>
+      ),
+      submit: mockSubmit,
+      load: vi.fn(),
+    }),
+    useActionData: () => undefined,
+    useNavigation: () => ({ state: "idle" }),
+  };
+});
+
+// why: useDisabled depends on useNavigation plumbing; stabilise to `false`
+// so button availability is deterministic in tests.
+vi.mock("~/hooks/use-disabled", () => ({
+  useDisabled: () => false,
+}));
+
+// why: AlertDialog from `~/components/shared/modal` uses Radix's AlertDialog
+// primitive, which portals content out of the test root. Swap it for a simple
+// `open ? children : null` shell so the controlled `open` prop drives
+// visibility and querying works through the regular RTL roots.
+vi.mock("~/components/shared/modal", () => {
+  const AlertDialog = ({
+    open,
+    children,
+  }: {
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    children: ReactNode;
+  }) => <>{open ? children : null}</>;
+  const AlertDialogContent = ({ children }: { children: ReactNode }) => (
+    <div role="alertdialog">{children}</div>
+  );
+  const AlertDialogHeader = ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  );
+  const AlertDialogTitle = ({ children }: { children: ReactNode }) => (
+    <h2>{children}</h2>
+  );
+  const AlertDialogDescription = ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  );
+  const AlertDialogFooter = ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  );
+  return {
+    AlertDialog,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogFooter,
+  };
+});
+
+function renderDialog(
+  props: Partial<React.ComponentProps<typeof RevokeAccessDialog>> = {}
+) {
+  return render(
+    <RevokeAccessDialog
+      userId="user-1"
+      name="Luke Safranek"
+      email="luke@example.edu"
+      isSSO={false}
+      open
+      onOpenChange={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe("RevokeAccessDialog", () => {
+  beforeEach(() => {
+    mockFetcherState = { state: "idle", data: undefined };
+    mockSubmit = vi.fn();
+  });
+
+  it("renders nothing while closed", () => {
+    renderDialog({ open: false });
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("names the affected user in the confirmation copy", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: "Revoke access" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Luke Safranek (luke@example.edu)")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the email when no name is available", () => {
+    renderDialog({ name: undefined });
+
+    expect(screen.getByText("luke@example.edu")).toBeInTheDocument();
+  });
+
+  it("submits intent=revokeAccess for the target user on confirm", () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "Revoke access" }));
+
+    expect(mockSubmit).toHaveBeenCalledWith({
+      intent: "revokeAccess",
+      userId: "user-1",
+    });
+  });
+
+  it("closes without submitting on Cancel", () => {
+    const onOpenChange = vi.fn();
+    renderDialog({ onOpenChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+
+  it("renders the server error inside the dialog", () => {
+    mockFetcherState = {
+      state: "idle",
+      data: {
+        error: {
+          message:
+            "Only the workspace owner can revoke an Administrator's access.",
+        },
+      },
+    };
+    renderDialog();
+
+    expect(
+      screen.getByText(
+        "Only the workspace owner can revoke an Administrator's access."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("shows the SSO group-mapping note only for SSO users", () => {
+    const { unmount } = renderDialog({ isSSO: true });
+
+    expect(screen.getByText(/signs in via SSO/)).toBeInTheDocument();
+
+    unmount();
+    renderDialog({ isSSO: false });
+
+    expect(screen.queryByText(/signs in via SSO/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/webapp/app/components/workspace/revoke-access-dialog.tsx
+++ b/apps/webapp/app/components/workspace/revoke-access-dialog.tsx
@@ -1,0 +1,109 @@
+import type { User } from "@prisma/client";
+import { useFetcher } from "react-router";
+import { useDisabled } from "~/hooks/use-disabled";
+import { Button } from "../shared/button";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../shared/modal";
+
+/**
+ * Confirmation dialog for revoking a registered team member's access to the
+ * current workspace.
+ *
+ * Opened by the "Revoke access" item in {@link TeamUsersActionsDropdown},
+ * which renders it next to {@link ChangeRoleDialog}. Confirming posts
+ * `intent=revokeAccess` to the current route's action (`resolveUserAction`),
+ * which removes the membership, keeps the team-member record and its history,
+ * and emails the affected user. On success the action redirects to the team
+ * users list, so the dialog unmounts with the page; on failure the error
+ * message renders inside the dialog.
+ *
+ * @param userId - The user whose workspace access is revoked on confirm
+ * @param name - The user's display name; the email identifies them when absent
+ * @param email - The user's email, always shown so the admin can double-check
+ * @param isSSO - Shows a note that SSO group mappings can re-grant access
+ * @param open - Controlled open state
+ * @param onOpenChange - Controlled open state setter
+ */
+export function RevokeAccessDialog({
+  userId,
+  name,
+  email,
+  isSSO,
+  open,
+  onOpenChange,
+}: {
+  userId: User["id"];
+  name?: string;
+  email: string;
+  isSSO: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const fetcher = useFetcher<{ error?: { message: string } }>();
+  const disabled = useDisabled(fetcher);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent aria-describedby="revoke-access-description">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Revoke access</AlertDialogTitle>
+          <AlertDialogDescription id="revoke-access-description">
+            You are about to revoke{" "}
+            <strong>{name ? `${name} (${email})` : email}</strong>&apos;s access
+            to this workspace. They can no longer open it and are notified by
+            email. Their team member record and history are kept, and you can
+            invite them again later.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <fetcher.Form method="post">
+          <input type="hidden" name="intent" value="revokeAccess" />
+          <input type="hidden" name="userId" value={userId} />
+
+          {isSSO ? (
+            <div className="mt-3 rounded-md border border-warning-200 bg-warning-25 p-3">
+              <p className="text-sm text-warning-700">
+                This user signs in via SSO. If workspace membership is assigned
+                from SSO groups, they regain access on their next sign-in unless
+                they are also removed from the mapped group in your identity
+                provider.
+              </p>
+            </div>
+          ) : null}
+
+          {fetcher.data?.error ? (
+            <p className="mt-3 text-sm text-error-500">
+              {fetcher.data.error.message}
+            </p>
+          ) : null}
+
+          <AlertDialogFooter className="mt-4 flex items-center gap-2">
+            <Button
+              variant="secondary"
+              className="flex-1"
+              type="button"
+              disabled={disabled}
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="danger"
+              className="flex-1"
+              disabled={disabled}
+            >
+              {disabled ? "Revoking..." : "Revoke access"}
+            </Button>
+          </AlertDialogFooter>
+        </fetcher.Form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/webapp/app/components/workspace/users-actions-dropdown.tsx
+++ b/apps/webapp/app/components/workspace/users-actions-dropdown.tsx
@@ -21,6 +21,7 @@ import { useUserData } from "~/hooks/use-user-data";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
 import type { UserFriendlyRoles } from "~/routes/_layout+/settings.team";
 import { ChangeRoleDialog } from "./change-role-dialog";
+import { RevokeAccessDialog } from "./revoke-access-dialog";
 import { Button } from "../shared/button";
 import { Spinner } from "../shared/spinner";
 
@@ -53,6 +54,7 @@ export function TeamUsersActionsDropdown({
   const { isAdministrator } = useUserRoleHelper();
 
   const [changeRoleOpen, setChangeRoleOpen] = useState(false);
+  const [revokeAccessOpen, setRevokeAccessOpen] = useState(false);
 
   /** Most users will have an invite, however we have to handle SSO case:
    *
@@ -135,9 +137,6 @@ export function TeamUsersActionsDropdown({
             ) : null}
             {isAcceptedUser ? (
               <>
-                {userId ? (
-                  <input type="hidden" name="userId" value={userId} />
-                ) : null}
                 <Button
                   type="button"
                   variant="link"
@@ -168,12 +167,10 @@ export function TeamUsersActionsDropdown({
                   </span>
                 </Button>
                 <Button
-                  type="submit"
+                  type="button"
                   variant="link"
                   className="justify-start px-4 py-3  text-gray-700 hover:bg-slate-100 hover:text-gray-700 focus:bg-slate-100"
                   width="full"
-                  name="intent"
-                  value="revokeAccess"
                   disabled={
                     isCurrentUser
                       ? {
@@ -189,6 +186,10 @@ export function TeamUsersActionsDropdown({
                         }
                       : disabled
                   }
+                  onClick={() => {
+                    setOpen(false);
+                    setRevokeAccessOpen(true);
+                  }}
                 >
                   <span className="flex items-center gap-2">
                     <RemoveUserIcon /> Revoke access
@@ -201,12 +202,22 @@ export function TeamUsersActionsDropdown({
       </DropdownMenu>
 
       {userId ? (
-        <ChangeRoleDialog
-          userId={userId}
-          currentRoleEnum={roleEnum}
-          open={changeRoleOpen}
-          onOpenChange={setChangeRoleOpen}
-        />
+        <>
+          <ChangeRoleDialog
+            userId={userId}
+            currentRoleEnum={roleEnum}
+            open={changeRoleOpen}
+            onOpenChange={setChangeRoleOpen}
+          />
+          <RevokeAccessDialog
+            userId={userId}
+            name={name}
+            email={email}
+            isSSO={isSSO}
+            open={revokeAccessOpen}
+            onOpenChange={setRevokeAccessOpen}
+          />
+        </>
       ) : null}
     </>
   ) : null;

--- a/apps/webapp/app/routes/_layout+/settings.team.users.$userId.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.team.users.$userId.tsx
@@ -181,6 +181,7 @@ export default function UserPage() {
         <AbsolutePositionedHeaderActions className="hidden w-full md:flex">
           <TeamUsersActionsDropdown
             userId={user.id}
+            name={resolveUserDisplayName(user)}
             email={user.email}
             teamMemberId={user.teamMembers?.[0]?.id}
             inviteStatus={user?.teamMembers?.[0]?.receivedInvites?.[0]?.status}


### PR DESCRIPTION
## What

Clicking **Revoke access** in the team member actions dropdown fired the revocation immediately, with no confirmation step. Destructive actions of this weight elsewhere in the app ask first. This puts a confirmation dialog in front of the existing action, on both surfaces that render the dropdown (team users index and the user detail page).

## Behavior

- The dialog names the affected user (display name + email) and states exactly what happens: they lose access immediately, they are notified by email, their team member record and history are kept, and they can be re-invited later.
- Confirming posts the same `intent=revokeAccess` to the same route action as before. No server-side changes.
- Server errors (e.g. "Only the workspace owner can revoke an Administrator's access") render inside the dialog instead of failing silently behind a closed dropdown.
- For SSO users, the dialog notes that workspaces with SSO group mappings re-grant access on the next sign-in unless the mapped IdP group is also updated.
- The user detail page now passes the resolved display name into the dropdown so the dialog is not email-only there.

Follows the `ChangeRoleDialog` pattern (controlled `AlertDialog` next to the dropdown, `fetcher.Form`, `useDisabled`). "Cancel invite" for pending invites is deliberately unchanged: it is low-stakes and reversible by re-inviting.

## Testing

- 7 unit tests for the dialog contract: identity copy, email fallback, submit payload, cancel does not submit, in-dialog error rendering, SSO note gating.
- Verified in the browser on local dev, both surfaces:
  - Cancel closes the dialog and the member is untouched.
  - Confirm shows the "Access revoked" toast, removes the user from Users, and their team-member record appears under Non-registered members.
  - Mobile width: dialog lays out correctly with stacked buttons.
- `lint` 0 errors, `typecheck` clean, unit suite 5787 passed. One pre-existing DB-dependent test file (`kit/picker-meta.server.test.ts`) fails in my vitest env with P1001 (no reachable test DB); unrelated to this UI-only diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when revoking a team member’s workspace access.
  * Displays the affected member’s name or email before confirmation.
  * Includes SSO-specific guidance and clear error messages when revocation fails.
  * Prevents duplicate actions while the request is processing and supports cancellation without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->