### PR TITLE
fix(workspace): show the current workspace image after it is replaced

### DIFF
--- a/apps/webapp/app/components/settings/invite-user-dialog.tsx
+++ b/apps/webapp/app/components/settings/invite-user-dialog.tsx
@@ -167,6 +167,7 @@ export default function InviteUserDialog({
                             imageId={organization.imageId}
                             alt="img"
                             className="size-6 rounded-[2px] object-cover"
+                            updatedAt={organization.updatedAt}
                           />
 
                           <div className=" ml-px max-w-full truncate text-sm text-gray-900">

--- a/apps/webapp/app/components/shared/image.test.tsx
+++ b/apps/webapp/app/components/shared/image.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * <Image> — unit tests
+ *
+ * Verifies the URL contract of the shared image renderer:
+ *  - `updatedAt` is encoded as a stable `?v=` version so the browser cache is
+ *    busted exactly when the stored blob changes (the serving route uses a
+ *    year-long `Cache-Control` and stored images are replaced in place, so an
+ *    unversioned URL would keep showing the previous image).
+ *  - The version is deterministic — same props, same URL — so server and
+ *    client renders agree and re-renders don't refetch.
+ *  - Missing/invalid `updatedAt` falls back to the bare URL; a missing
+ *    `imageId` renders the placeholder.
+ *
+ * @see {@link file://./image.tsx}
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Image } from "./image";
+
+const UPDATED_AT = new Date("2026-09-01T14:19:22.345Z");
+
+describe("Image", () => {
+  it("versions the URL with the updatedAt timestamp", () => {
+    render(<Image imageId="img_1" alt="logo" updatedAt={UPDATED_AT} />);
+
+    expect(screen.getByRole("img", { name: "logo" })).toHaveAttribute(
+      "src",
+      `/api/image/img_1?v=${UPDATED_AT.getTime()}`
+    );
+  });
+
+  it("accepts a serialized (string) updatedAt, as loader data provides", () => {
+    render(
+      <Image imageId="img_1" alt="logo" updatedAt={UPDATED_AT.toISOString()} />
+    );
+
+    expect(screen.getByRole("img", { name: "logo" })).toHaveAttribute(
+      "src",
+      `/api/image/img_1?v=${UPDATED_AT.getTime()}`
+    );
+  });
+
+  it("renders the same URL on every render for the same props", () => {
+    const { rerender } = render(
+      <Image imageId="img_1" alt="logo" updatedAt={UPDATED_AT} />
+    );
+    const firstSrc = screen
+      .getByRole("img", { name: "logo" })
+      .getAttribute("src");
+
+    rerender(<Image imageId="img_1" alt="logo" updatedAt={UPDATED_AT} />);
+
+    expect(screen.getByRole("img", { name: "logo" }).getAttribute("src")).toBe(
+      firstSrc
+    );
+  });
+
+  it("omits the version when updatedAt is absent or invalid", () => {
+    render(<Image imageId="img_1" alt="logo" />);
+
+    expect(screen.getByRole("img", { name: "logo" })).toHaveAttribute(
+      "src",
+      "/api/image/img_1"
+    );
+  });
+
+  it("renders the placeholder when there is no imageId", () => {
+    render(<Image alt="logo" />);
+
+    expect(screen.getByRole("img", { name: "logo" })).toHaveAttribute(
+      "src",
+      "/static/images/asset-placeholder.jpg"
+    );
+  });
+});

--- a/apps/webapp/app/components/shared/image.tsx
+++ b/apps/webapp/app/components/shared/image.tsx
@@ -1,5 +1,3 @@
-import { tw } from "~/utils/tw";
-
 /**
  * Renders an image stored in the `Image` table, served by `/api/image/:imageId`.
  *
@@ -15,6 +13,18 @@ import { tw } from "~/utils/tw";
  * first-cached copy of the bare URL for up to a year.
  *
  * @see {@link file://../../routes/api+/image.$imageId.ts}
+ */
+import { tw } from "~/utils/tw";
+
+/**
+ * Stored-image renderer. See the file-level doc above for the URL/version
+ * contract.
+ *
+ * @param imageId - `Image` row id; falls back to the placeholder when absent.
+ * @param alt - Image alt text.
+ * @param className - Extra classes for the `img` element.
+ * @param updatedAt - Timestamp of the image (or its owning entity); becomes
+ * the `?v=` cache version.
  */
 export const Image = ({
   imageId,

--- a/apps/webapp/app/components/shared/image.tsx
+++ b/apps/webapp/app/components/shared/image.tsx
@@ -1,7 +1,21 @@
-import { getDifferenceInSeconds } from "~/utils/date-fns";
 import { tw } from "~/utils/tw";
 
-const FORCE_RELOAD_WITHIN_SECONDS = 30;
+/**
+ * Renders an image stored in the `Image` table, served by `/api/image/:imageId`.
+ *
+ * That route serves with a year-long `Cache-Control`, and replacing a stored
+ * image (e.g. the workspace logo) upserts the SAME row — the id, and with it
+ * the bare URL, never changes. The URL therefore carries a stable `?v=`
+ * version derived from `updatedAt`: it changes exactly when the stored blob
+ * changes, which busts the browser cache on update and keeps it effective the
+ * rest of the time.
+ *
+ * Always pass `updatedAt` (the image's own timestamp, or the owning entity's)
+ * for images a user can replace — without it the browser may pin its
+ * first-cached copy of the bare URL for up to a year.
+ *
+ * @see {@link file://../../routes/api+/image.$imageId.ts}
+ */
 export const Image = ({
   imageId,
   alt,
@@ -13,15 +27,14 @@ export const Image = ({
   className?: string;
   updatedAt?: Date | string | number;
 }) => {
-  const imageUpdatedAt = new Date(updatedAt);
-  const imageUpdatedAtDiff = getDifferenceInSeconds(imageUpdatedAt, new Date());
-  // @NOTE: force reload the image, if image is updated with last 30 seconds.
-  const forceReload = imageUpdatedAtDiff < FORCE_RELOAD_WITHIN_SECONDS;
+  const version = new Date(updatedAt).getTime();
   return (
     <img
       src={
         imageId
-          ? `/api/image/${imageId}${forceReload ? `?t=${Date.now()}` : ""}`
+          ? `/api/image/${imageId}${
+              Number.isNaN(version) ? "" : `?v=${version}`
+            }`
           : `/static/images/asset-placeholder.jpg`
       }
       alt={alt}

--- a/apps/webapp/app/routes/api+/image.$imageId.ts
+++ b/apps/webapp/app/routes/api+/image.$imageId.ts
@@ -63,7 +63,11 @@ export async function loader({ context, params }: LoaderFunctionArgs) {
     return new Response(new Uint8Array(image.blob), {
       headers: {
         "Content-Type": image.contentType,
-        "Cache-Control": "max-age=31536000",
+        // Stored images are replaced in place (same id, same URL), so renderers
+        // version the URL with `?v=<updatedAt>` (see ~/components/shared/image.tsx)
+        // — that is what makes a long lifetime safe here. `private` because the
+        // response is authorization-gated, so shared caches must not store it.
+        "Cache-Control": "private, max-age=31536000",
       },
     });
   } catch (cause) {


### PR DESCRIPTION
## Problem

Replacing a workspace's main image appears to work, then visibly "reverts" to the previous image about a minute later. The new image IS saved — what comes back is the browser's cached copy of the old one.

## Root cause (three parts)

1. `updateOrganization` replaces the image via `upsert` on the org's `image` relation — the `Image` row id, and therefore the URL, never changes ([service.server.ts](../blob/main/apps/webapp/app/modules/organization/service.server.ts)).
2. `/api/image/:imageId` serves with `Cache-Control: max-age=31536000`, so browsers cache the old bytes for a year under that never-changing URL.
3. The shared `<Image>` component papered over this by appending `?t=Date.now()` for **30 seconds** after `updatedAt`. Inside that window the new image shows; when it lapses, the `src` flips back to the bare URL and the browser re-serves the year-cached previous image. That flip is the "revert".

The `Date.now()` in render was also producing a React hydration mismatch on the sidebar logo (server and client render different `?t=` values).

## Fix

`<Image>` now appends a **stable version**: `?v=<updatedAt ms>`. The URL changes exactly when the stored blob can have changed — busting the cache on update — and stays constant otherwise, so long-lived caching keeps working. Applies to every surface that renders stored images (sidebar workspace selector, workspace lists, invite dialog, booking/audit/report PDFs).

- `invite-user-dialog.tsx` now passes `updatedAt` like every other call site.
- `/api/image/:imageId` adds `private` to `Cache-Control` (response is authorization-gated, shared caches must not store it). The year-long lifetime stays — safe now that renderers version the URL.
- No action needed by affected users after deploy: the versioned URL bypasses any already-poisoned cache on their next page load.

## Verification (local, driven in a real browser)

| Step | Code | Observed |
|---|---|---|
| Upload logo A, wait >30s, reload | before fix | bare URL fetched, logo A cached (year TTL) |
| Upload logo B → shows B → wait >30s, reload | before fix | **logo A returns** — served from cache, `transferSize: 0` (bug reproduced) |
| Apply fix only, reload (poisoned cache untouched) | after fix | `src=…?v=<updatedAt>`, **logo B renders** (canvas pixel-verified) |
| Upload logo C | after fix | immediately renders C on a new `?v`; stable across reloads, no revert |
| Response headers | after fix | `Cache-Control: private, max-age=31536000` |
| Hydration | after fix | no mismatch — `src` is deterministic |

Unit tests added for the `<Image>` URL contract (version present/absent/invalid, determinism, placeholder).

## Notes

- No migration, webapp-only; no companion impact (companion does not consume `/api/image`).
- Asset/kit images use Supabase signed URLs, a different path — not affected by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace avatars now refresh reliably when organization details change.
  * Image URLs use stable versioning to prevent stale cached images and ensure updated avatars appear consistently.
  * Authorization-protected images are no longer stored by shared caches.
  * Missing or invalid image metadata now falls back gracefully to the original image URL or a placeholder image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->