### PR TITLE
feat(companion): partial-quantity location moves for quantity-tracked assets

### DIFF
--- a/apps/companion/.maestro/flows/assets/partial-move-location.yaml
+++ b/apps/companion/.maestro/flows/assets/partial-move-location.yaml
@@ -1,0 +1,67 @@
+# Partial-quantity location move on a QUANTITY_TRACKED asset (MoveQuantitySheet).
+#
+# Precondition: app foregrounded with a signed-in session (qa-admin1 /
+# GRANULAR WORKSPACE) — uses the no-login pattern, so NO launchApp/clearState.
+# Test asset: "QA Qty Test — Tripod (10 pcs)" (cmqzf1xt20001s0iitjd72rkb).
+#
+# Verifies: Location quick action -> picker -> the move sheet (replaces the
+# whole-asset alert for QUANTITY_TRACKED) -> quantity 4 of 10 -> unplaced-pool
+# hint -> Move -> detail shows the new location. DB cross-check (pivot row
+# quantity, ASSET_LOCATION_CHANGED meta, "placed/moved 4 pcs" note) happens
+# outside Maestro.
+#
+# Re-runnable: from the second run the tripod is already at Equipment Storage
+# with 4 placed; the same submission is then a server-side no-op and every
+# assertion still holds. Restoring the unplaced fixture state is a manual
+# AssetLocation delete outside Maestro.
+#
+# Maestro full-matches a11y labels, so text matchers are regex-wrapped with .*
+# per .maestro/LESSONS.md.
+appId: com.shelf.companion.carlos
+---
+# Assets tab -> find the tripod via search
+- tapOn: "Assets"
+- tapOn: ".*Search assets.*"
+- inputText: "QA Qty Test"
+- extendedWaitUntil:
+    visible: ".*QA Qty Test — Tripod.*"
+    timeout: 10000
+# First tap may be consumed dismissing the keyboard — tap twice, second optional.
+- tapOn: ".*QA Qty Test — Tripod.*"
+- tapOn:
+    text: ".*QA Qty Test — Tripod.*"
+    optional: true
+- extendedWaitUntil:
+    visible: ".*10 pcs.*"
+    timeout: 15000
+
+# Location quick action (a11y label; visible text is "Move"/"Location")
+- tapOn: "Update location"
+- extendedWaitUntil:
+    visible: "Select Location"
+    timeout: 10000
+- tapOn: ".*Equipment Storage.*"
+
+# The move sheet replaces the whole-asset alert for QUANTITY_TRACKED
+- extendedWaitUntil:
+    visible: "Quantity to place at this location:"
+    timeout: 10000
+
+# Partial: 4 of 10 -> unplaced-pool hint appears. The input seeds with the
+# current placement (or the full pool) and focuses on open, so erase first.
+- eraseText
+- inputText: "4"
+- extendedWaitUntil:
+    visible: ".*unplaced pool.*"
+    timeout: 5000
+
+# Confirm (a11y label carries qty + destination)
+- tapOn: "Move 4 pcs to Equipment Storage"
+- tapOn:
+    text: "Move 4 pcs to Equipment Storage"
+    optional: true
+
+# Detail refreshes with the new location
+- extendedWaitUntil:
+    visible: ".*Equipment Storage.*"
+    timeout: 20000

--- a/apps/companion/app/(tabs)/assets/[id].tsx
+++ b/apps/companion/app/(tabs)/assets/[id].tsx
@@ -43,6 +43,7 @@ import { TeamMemberPicker } from "@/components/team-member-picker";
 import { LocationPicker } from "@/components/location-picker";
 import { QuantityInputSheet } from "@/components/quantity-input-sheet";
 import { AdjustQuantitySheet } from "@/components/adjust-quantity-sheet";
+import { MoveQuantitySheet } from "@/components/move-quantity-sheet";
 import { AssetDetailSkeleton } from "@/components/skeleton-loader";
 import { AssetHeader } from "@/components/asset-detail/asset-header";
 import { QuickActions } from "@/components/asset-detail/quick-actions";
@@ -178,8 +179,24 @@ export default function AssetDetailScreen() {
 
   // ── Location Action ─────────────────────────────────
 
+  // Pending move target for QUANTITY_TRACKED assets. Non-null doubles as the
+  // "move sheet visible" flag AND carries the picked location, so the sheet
+  // and the confirm handler can never disagree about the destination
+  // (same pattern as `assignQtyMember`).
+  const [moveTarget, setMoveTarget] = useState<LocationType | null>(null);
+
   const handleLocationSelect = (location: LocationType) => {
     setShowLocationPicker(false);
+
+    if (isQtyTracked) {
+      // QUANTITY_TRACKED: the move sheet is the confirm step — it asks how
+      // many units to place. Re-picking the current location is allowed:
+      // placing a different quantity there is a real placement edit (web
+      // dialog parity), and the server short-circuits true no-ops.
+      setMoveTarget(location);
+      return;
+    }
+
     if (location.id === asset?.location?.id) return; // same location
 
     Alert.alert(
@@ -192,13 +209,22 @@ export default function AssetDetailScreen() {
     );
   };
 
-  const performUpdateLocation = async (locationId: string) => {
+  /**
+   * Applies the location update and refreshes the asset. `quantity` is the
+   * per-placement amount for QUANTITY_TRACKED assets (units to place at the
+   * location); INDIVIDUAL moves omit it.
+   */
+  const performUpdateLocation = async (
+    locationId: string,
+    quantity?: number
+  ) => {
     if (!currentOrg || !asset) return;
     setIsActionLoading(true);
     const { error: err } = await api.updateLocation(
       currentOrg.id,
       asset.id,
-      locationId
+      locationId,
+      quantity
     );
     if (err) Alert.alert("Error", err);
     else {
@@ -868,6 +894,28 @@ export default function AssetDetailScreen() {
               INDIVIDUAL rendering stays byte-identical. */}
           {isQtyTracked && (
             <>
+              <MoveQuantitySheet
+                visible={moveTarget != null}
+                locationName={moveTarget?.name ?? ""}
+                totalQuantity={asset.quantity ?? 1}
+                unitOfMeasure={asset.unitOfMeasure}
+                // Pre-fill: units at the current primary placement, else the
+                // full pool (web dialog parity). `locationQuantity` is the
+                // per-row placement quantity, NOT workspace stock.
+                initialQuantity={asset.locationQuantity ?? asset.quantity ?? 1}
+                // Older servers omit placementCount — fall back to what the
+                // flat `location` field implies so the warning never renders
+                // from missing data.
+                placementCount={
+                  asset.placementCount ?? (asset.location ? 1 : 0)
+                }
+                onConfirm={(quantity) => {
+                  const target = moveTarget;
+                  setMoveTarget(null);
+                  if (target) void performUpdateLocation(target.id, quantity);
+                }}
+                onClose={() => setMoveTarget(null)}
+              />
               <AdjustQuantitySheet
                 visible={showAdjustSheet}
                 // Physical removal cap (custodyAvailable chain), NOT

--- a/apps/companion/components/move-quantity-sheet.tsx
+++ b/apps/companion/components/move-quantity-sheet.tsx
@@ -1,0 +1,426 @@
+/**
+ * MoveQuantitySheet — a page-sheet modal that confirms a location move for a
+ * QUANTITY_TRACKED asset with a per-placement quantity. Mobile twin of the
+ * web's asset-overview "Update location" dialog
+ * (apps/webapp/app/routes/_layout+/assets.$assetId.overview.update-location.tsx):
+ * a "quantity to place at this location" input bounded by the asset's total
+ * pool, the unplaced-pool hint, and the multi-placement collapse warning.
+ *
+ * The move itself is a pivot REPLACE on the server: every placement is
+ * cleared and one new row is created at the target location. Units not
+ * placed stay in the unplaced pool. That is why `placementCount > 1` shows
+ * a warning rather than merging placements.
+ *
+ * Follows the house selection-flow contract (AdjustQuantitySheet /
+ * QuantityInputSheet): `<Modal animationType="slide"
+ * presentationStyle="pageSheet">` + SafeAreaView + header-with-close,
+ * digits-only numeric input flanked by -/+ steppers.
+ *
+ * INDIVIDUAL assets never see this sheet — the caller keeps the plain
+ * confirm alert for them.
+ *
+ * @see {@link file://../app/(tabs)/assets/[id].tsx} the consumer
+ * @see {@link file://./adjust-quantity-sheet.tsx} the modal contract this mirrors
+ */
+import { useEffect, useRef, useState } from "react";
+import { View, Text, Modal, TextInput, TouchableOpacity } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import { fontSize, spacing, borderRadius } from "@/lib/constants";
+import { useTheme } from "@/lib/theme-context";
+import { createStyles } from "@/lib/create-styles";
+import { formatQuantity } from "@/lib/quantity-format";
+
+type Props = {
+  /** Whether the sheet is shown. */
+  visible: boolean;
+  /** Name of the target location the user picked. */
+  locationName: string;
+  /** The asset's total pool (`Asset.quantity`) — the input's upper bound. */
+  totalQuantity: number;
+  /** Display unit echoed in copy (e.g. "pcs"); null/undefined falls back to "units". */
+  unitOfMeasure?: string | null;
+  /**
+   * Pre-fill for the input: the units currently placed at the primary
+   * location, or the full pool when the asset is unplaced (web dialog
+   * parity).
+   */
+  initialQuantity: number;
+  /**
+   * Number of placements the asset currently has. > 1 renders the collapse
+   * warning, because confirming replaces every placement with the single
+   * new one.
+   */
+  placementCount: number;
+  /** Called with the confirmed per-placement quantity. */
+  onConfirm: (quantity: number) => void;
+  /** Called when the user dismisses the sheet without confirming. */
+  onClose: () => void;
+};
+
+/**
+ * Location-move prompt sheet for QUANTITY_TRACKED assets.
+ *
+ * Renders the target location, a number-pad TextInput flanked by -/+ stepper
+ * buttons bounded to `1..totalQuantity`, the unplaced-pool hint when moving
+ * fewer units than the pool, the multi-placement collapse warning, and a
+ * Move / Cancel pair.
+ *
+ * @param props - See {@link Props}.
+ * @returns The modal sheet element.
+ */
+export function MoveQuantitySheet({
+  visible,
+  locationName,
+  totalQuantity,
+  unitOfMeasure,
+  initialQuantity,
+  placementCount,
+  onConfirm,
+  onClose,
+}: Props) {
+  const { colors } = useTheme();
+  const styles = useStyles();
+
+  const [value, setValue] = useState(String(initialQuantity));
+  const inputRef = useRef<TextInput>(null);
+
+  // Re-seed the input every time the sheet opens: each open is a fresh move
+  // (possibly of a different asset), so stale values must not leak across.
+  useEffect(() => {
+    if (visible) {
+      setValue(String(initialQuantity));
+    }
+  }, [visible, initialQuantity]);
+
+  const parsed = value ? parseInt(value, 10) : NaN;
+  const hasValue = Number.isFinite(parsed);
+  const isValid = hasValue && parsed >= 1 && parsed <= totalQuantity;
+
+  const unitLabel = unitOfMeasure || "units";
+  const totalLabel =
+    formatQuantity(totalQuantity, unitOfMeasure) ?? String(totalQuantity);
+  const echo = hasValue ? formatQuantity(parsed, unitOfMeasure) : null;
+  const isPartial = hasValue && parsed < totalQuantity;
+
+  /** Step the current value by `delta`, clamped to `1..totalQuantity`. */
+  const step = (delta: number) => {
+    const current = hasValue ? parsed : 0;
+    const next = Math.min(Math.max(current + delta, 1), totalQuantity);
+    setValue(String(next));
+  };
+
+  const submit = () => {
+    if (!isValid) return;
+    onConfirm(parsed);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+      // why: imperative focus once the sheet has actually presented — an
+      // autoFocus prop fires before the modal animation and misses the
+      // keyboard (and jsx-a11y/no-autofocus flags it).
+      onShow={() => inputRef.current?.focus()}
+    >
+      <SafeAreaView style={styles.container} accessibilityViewIsModal={true}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>Update Location</Text>
+          <TouchableOpacity
+            onPress={onClose}
+            style={styles.closeButton}
+            accessibilityLabel="Close update location"
+            accessibilityRole="button"
+          >
+            <Ionicons name="close" size={24} color={colors.foreground} />
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.body}>
+          {/* Target location */}
+          <View style={styles.locationRow}>
+            <Ionicons
+              name="location-outline"
+              size={18}
+              color={colors.foregroundSecondary}
+            />
+            <Text style={styles.locationName} numberOfLines={1}>
+              {locationName}
+            </Text>
+          </View>
+
+          <Text style={styles.subtitle}>
+            Quantity to place at this location:
+          </Text>
+
+          {/* Quantity row: [-] [input] [+] */}
+          <View style={styles.quantityRow}>
+            <TouchableOpacity
+              style={[
+                styles.stepButton,
+                (!hasValue || parsed <= 1) && styles.stepButtonDisabled,
+              ]}
+              onPress={() => step(-1)}
+              disabled={!hasValue || parsed <= 1}
+              activeOpacity={0.7}
+              accessibilityLabel="Decrease quantity"
+              accessibilityRole="button"
+              accessibilityState={{ disabled: !hasValue || parsed <= 1 }}
+            >
+              <Ionicons name="remove" size={22} color={colors.foreground} />
+            </TouchableOpacity>
+            <TextInput
+              ref={inputRef}
+              style={styles.input}
+              value={value}
+              onChangeText={(text) => {
+                // Digits only — placement quantities are positive integers.
+                // The pool bound is enforced live so the input can never
+                // read more than the asset owns (web dialog parity).
+                const digits = text.replace(/[^0-9]/g, "");
+                if (!digits) {
+                  setValue("");
+                  return;
+                }
+                const capped = Math.min(parseInt(digits, 10), totalQuantity);
+                setValue(String(capped));
+              }}
+              placeholder="Enter quantity"
+              placeholderTextColor={colors.placeholderText}
+              keyboardType="number-pad"
+              returnKeyType="done"
+              accessibilityLabel="Quantity to place at this location"
+            />
+            <TouchableOpacity
+              style={[
+                styles.stepButton,
+                hasValue &&
+                  parsed >= totalQuantity &&
+                  styles.stepButtonDisabled,
+              ]}
+              onPress={() => step(1)}
+              disabled={hasValue && parsed >= totalQuantity}
+              activeOpacity={0.7}
+              accessibilityLabel="Increase quantity"
+              accessibilityRole="button"
+              accessibilityState={{
+                disabled: hasValue && parsed >= totalQuantity,
+              }}
+            >
+              <Ionicons name="add" size={22} color={colors.foreground} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Echo under the input */}
+          <Text style={styles.echoHint}>
+            {echo ?? `Enter a quantity`} of {totalLabel}
+          </Text>
+
+          {/* Unplaced-pool hint — only when moving fewer units than the pool */}
+          {isPartial ? (
+            <Text style={styles.poolHint}>
+              The other {totalQuantity - parsed} {unitLabel} stay in the
+              unplaced pool, not at the current location.
+            </Text>
+          ) : null}
+
+          {/* Multi-placement collapse warning */}
+          {placementCount > 1 ? (
+            <View style={styles.warningBox}>
+              <Ionicons
+                name="warning-outline"
+                size={18}
+                color={colors.warningText}
+              />
+              <Text style={styles.warningText}>
+                This asset is placed at {placementCount} locations. Moving will
+                replace all placements with a single placement at {locationName}
+                .
+              </Text>
+            </View>
+          ) : null}
+
+          {/* Confirm */}
+          <TouchableOpacity
+            style={[styles.confirmPrimary, !isValid && styles.confirmDisabled]}
+            onPress={submit}
+            disabled={!isValid}
+            activeOpacity={0.7}
+            accessibilityLabel={`Move ${echo ?? "quantity"} to ${locationName}`}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !isValid }}
+          >
+            <Ionicons
+              name="location"
+              size={20}
+              color={colors.primaryForeground}
+            />
+            <Text style={styles.confirmText}>Move</Text>
+          </TouchableOpacity>
+
+          {/* Cancel */}
+          <TouchableOpacity
+            style={styles.cancelButton}
+            onPress={onClose}
+            activeOpacity={0.7}
+            accessibilityLabel="Cancel move"
+            accessibilityRole="button"
+          >
+            <Text style={styles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const useStyles = createStyles((colors, shadows) => ({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: {
+    fontSize: fontSize.xl,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  closeButton: {
+    padding: spacing.xs,
+  },
+  body: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.lg,
+    gap: spacing.md,
+  },
+  locationRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    ...shadows.sm,
+  },
+  locationName: {
+    flex: 1,
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+    color: colors.foreground,
+  },
+  subtitle: {
+    fontSize: fontSize.lg,
+    color: colors.foregroundSecondary,
+    lineHeight: 22,
+  },
+  quantityRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  stepButton: {
+    width: 44,
+    height: 44,
+    borderRadius: borderRadius.sm,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    justifyContent: "center",
+    alignItems: "center",
+    ...shadows.sm,
+  },
+  stepButtonDisabled: {
+    opacity: 0.4,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: fontSize.lg,
+    color: colors.foreground,
+    textAlign: "center",
+    ...shadows.sm,
+  },
+  echoHint: {
+    fontSize: fontSize.sm,
+    color: colors.muted,
+    textAlign: "center",
+  },
+  poolHint: {
+    fontSize: fontSize.sm,
+    color: colors.foregroundSecondary,
+    textAlign: "center",
+    lineHeight: 18,
+  },
+  warningBox: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.sm,
+    backgroundColor: colors.warningBg,
+    borderWidth: 1,
+    borderColor: colors.warning,
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  warningText: {
+    flex: 1,
+    fontSize: fontSize.sm,
+    color: colors.warningText,
+    lineHeight: 18,
+  },
+  confirmPrimary: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.primary,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    marginTop: spacing.sm,
+    gap: spacing.sm,
+    ...shadows.sm,
+  },
+  confirmDisabled: {
+    opacity: 0.5,
+  },
+  confirmText: {
+    color: colors.primaryForeground,
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+  },
+  cancelButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.white,
+    borderWidth: 1,
+    borderColor: colors.gray300,
+    borderRadius: borderRadius.lg,
+    paddingVertical: 14,
+    ...shadows.sm,
+  },
+  cancelText: {
+    color: colors.foreground,
+    fontSize: fontSize.lg,
+    fontWeight: "600",
+  },
+}));

--- a/apps/companion/lib/api/custody.ts
+++ b/apps/companion/lib/api/custody.ts
@@ -101,17 +101,28 @@ export const custodyApi = {
     return result;
   },
 
-  /** Update asset location */
+  /**
+   * Update asset location. `quantity` is the per-placement amount for a
+   * QUANTITY_TRACKED asset (units to place at the location — the remainder
+   * stays in the unplaced pool); omit it to place the full pool. INDIVIDUAL
+   * assets ignore it. The server treats the write as a pivot replace, so any
+   * multi-placement collapses to the single new row.
+   */
   updateLocation: async (
     orgId: string,
     assetId: string,
-    locationId: string
+    locationId: string,
+    quantity?: number
   ) => {
     const result = await apiFetch<UpdateLocationResponse>(
       `/api/mobile/asset/update-location?orgId=${orgId}`,
       {
         method: "POST",
-        body: JSON.stringify({ assetId, locationId }),
+        body: JSON.stringify({
+          assetId,
+          locationId,
+          ...(quantity != null ? { quantity } : {}),
+        }),
       }
     );
     if (!result.error) invalidateResponseCache("/api/mobile/locations");

--- a/apps/companion/lib/api/types.ts
+++ b/apps/companion/lib/api/types.ts
@@ -255,6 +255,18 @@ export type AssetDetail = {
    * shows a muted "+N other(s) hold this asset" row. Absent on older servers.
    */
   custodyListOthersCount?: number;
+  /**
+   * Number of AssetLocation placements the asset currently has. A location
+   * update is a pivot REPLACE, so > 1 drives the multi-placement collapse
+   * warning in the move sheet. Absent on older servers.
+   */
+  placementCount?: number;
+  /**
+   * Units placed at the primary location (the per-row AssetLocation.quantity,
+   * NOT workspace stock) — the move sheet's pre-fill. `null` when the asset
+   * is unplaced; absent on older servers.
+   */
+  locationQuantity?: number | null;
 } & AssetQuantityFields;
 
 /**
@@ -520,6 +532,12 @@ export type UpdateLocationResponse = {
     title: string;
     location: { id: string; name: string } | null;
   };
+  /**
+   * Units now placed at the location (per-row AssetLocation.quantity; 1 for
+   * INDIVIDUAL assets). Absent on the no-op short-circuit and on older
+   * servers.
+   */
+  placedQuantity?: number;
 };
 
 export type UpdateImageResponse = {

--- a/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
@@ -155,101 +155,106 @@ export async function action({ request }: ActionFunctionArgs) {
     // ASSET_LOCATION_CHANGED activity event is recorded atomically so
     // reports + activity-event aggregations include mobile-initiated
     // location changes.
-    const { refreshedAsset, placedQuantity } = await db.$transaction(
-      async (tx) => {
-        /**
-         * Row-lock the asset before writing the pivot, the same lock every
-         * stock-lowering path takes. This write RAISES the manual
-         * `AssetLocation` sum for a QUANTITY_TRACKED asset, and
-         * `enforce_asset_location_sum_within_total` validating at COMMIT only
-         * covers one interleaving: a concurrent consume can read the
-         * pre-placement rows, conclude they fit under the reduced total, and
-         * commit an `Asset` write that fires no location trigger at all.
-         *
-         * Locking also makes `quantity` trustworthy — the pre-transaction read
-         * above can be stale by the time the row is written, which would place
-         * more units than the asset owns.
-         */
-        const locked = await lockAssetForQuantityUpdate(
-          tx,
-          assetId,
-          organizationId
-        );
+    const {
+      refreshedAsset,
+      placedQuantity,
+      previousLocation,
+      previousQuantity,
+    } = await db.$transaction(async (tx) => {
+      /**
+       * Row-lock the asset before writing the pivot, the same lock every
+       * stock-lowering path takes. This write RAISES the manual
+       * `AssetLocation` sum for a QUANTITY_TRACKED asset, and
+       * `enforce_asset_location_sum_within_total` validating at COMMIT only
+       * covers one interleaving: a concurrent consume can read the
+       * pre-placement rows, conclude they fit under the reduced total, and
+       * commit an `Asset` write that fires no location trigger at all.
+       *
+       * Locking also makes `quantity` trustworthy — the pre-transaction read
+       * above can be stale by the time the row is written, which would place
+       * more units than the asset owns.
+       */
+      const locked = await lockAssetForQuantityUpdate(
+        tx,
+        assetId,
+        organizationId
+      );
 
-        // Per-placement bound: the requested units must fit the asset's
-        // total pool (measured on the locked row, mirroring the web
-        // service's in-transaction check in `updateAsset`).
-        const isQty = isQuantityTracked(locked);
-        if (isQty && quantity != null && quantity > (locked.quantity ?? 0)) {
-          throw new ShelfError({
-            cause: null,
-            title: "Quantity exceeds available pool",
-            message: `Requested ${quantity} but the asset has only ${
-              locked.quantity ?? 0
-            } units total.`,
-            additionalData: {
-              assetId,
-              organizationId,
-              quantity,
-              totalQuantity: locked.quantity,
-            },
-            label: "Assets",
-            status: 400,
-            shouldBeCaptured: false,
-          });
-        }
-
-        const pivotQuantity = isQty ? quantity ?? locked.quantity ?? 1 : 1;
-
-        // Clear MANUAL placements only — kit-driven rows
-        // (`assetKitId IS NOT NULL`) are owned by the kit's flow. The kit
-        // guard above rejects kit members outright, so this filter mirrors
-        // the web service's pivot write rather than changing behavior.
-        await tx.assetLocation.deleteMany({
-          where: { assetId, assetKitId: null },
-        });
-        await tx.assetLocation.create({
-          data: {
+      // Per-placement bound: the requested units must fit the asset's
+      // total pool (measured on the locked row, mirroring the web
+      // service's in-transaction check in `updateAsset`).
+      const isQty = isQuantityTracked(locked);
+      if (isQty && quantity != null && quantity > (locked.quantity ?? 0)) {
+        throw new ShelfError({
+          cause: null,
+          title: "Quantity exceeds available pool",
+          message: `Requested ${quantity} but the asset has only ${
+            locked.quantity ?? 0
+          } units total.`,
+          additionalData: {
             assetId,
-            locationId,
             organizationId,
-            quantity: pivotQuantity,
+            quantity,
+            totalQuantity: locked.quantity,
           },
+          label: "Assets",
+          status: 400,
+          shouldBeCaptured: false,
         });
+      }
 
-        /**
-         * A pivot replace collapses EVERY manual placement, not just the
-         * primary one. Each of the others leaves the location it was at, and
-         * the single change event below only names the primary, so without
-         * these the asset silently stops being at a location that reports and
-         * history still show it at.
-         *
-         * Emitted as removals (`toValue: null`) because that is what happened
-         * to them; the arrival at the requested location is the event below.
-         */
-        const collapsedPlacements = asset.assetLocations.filter(
-          (al) =>
-            al.location?.id && al.location.id !== currentPrimaryLocation?.id
-        );
-        for (const placement of collapsedPlacements) {
-          await recordEvent(
-            {
-              organizationId,
-              actorUserId: user.id,
-              action: "ASSET_LOCATION_CHANGED",
-              entityType: "ASSET",
-              entityId: assetId,
-              assetId,
-              locationId: placement.location!.id,
-              field: "locationId",
-              fromValue: placement.location!.id,
-              toValue: null,
-              meta: assetQtyMeta(locked, placement.quantity ?? 1),
-            },
-            tx
-          );
-        }
+      const pivotQuantity = isQty ? quantity ?? locked.quantity ?? 1 : 1;
 
+      /**
+       * The placements as they stand under the lock, not as they looked when
+       * the request was parsed. Two requests collapsing the same asset would
+       * otherwise both describe the pre-transaction world: the second would
+       * record removals for rows the first already deleted, and name a
+       * primary location that has since changed.
+       */
+      const placementsBefore = await tx.assetLocation.findMany({
+        where: { assetId, assetKitId: null },
+        select: {
+          quantity: true,
+          location: { select: { id: true, name: true } },
+        },
+      });
+      const primaryBefore =
+        placementsBefore.find((al) => al.location)?.location ?? null;
+      const primaryQuantityBefore =
+        placementsBefore.find((al) => al.location?.id === primaryBefore?.id)
+          ?.quantity ?? null;
+
+      // Clear MANUAL placements only — kit-driven rows
+      // (`assetKitId IS NOT NULL`) are owned by the kit's flow. The kit
+      // guard above rejects kit members outright, so this filter mirrors
+      // the web service's pivot write rather than changing behavior.
+      await tx.assetLocation.deleteMany({
+        where: { assetId, assetKitId: null },
+      });
+      await tx.assetLocation.create({
+        data: {
+          assetId,
+          locationId,
+          organizationId,
+          quantity: pivotQuantity,
+        },
+      });
+
+      /**
+       * A pivot replace collapses EVERY manual placement, not just the
+       * primary one. Each of the others leaves the location it was at, and
+       * the single change event below only names the primary, so without
+       * these the asset silently stops being at a location that reports and
+       * history still show it at.
+       *
+       * Emitted as removals (`toValue: null`) because that is what happened
+       * to them; the arrival at the requested location is the event below.
+       */
+      const collapsedPlacements = placementsBefore.filter(
+        (al) => al.location?.id && al.location.id !== primaryBefore?.id
+      );
+      for (const placement of collapsedPlacements) {
         await recordEvent(
           {
             organizationId,
@@ -258,32 +263,54 @@ export async function action({ request }: ActionFunctionArgs) {
             entityType: "ASSET",
             entityId: assetId,
             assetId,
-            locationId: location.id,
+            locationId: placement.location!.id,
             field: "locationId",
-            fromValue: currentPrimaryLocation?.id ?? null,
-            toValue: location.id,
-            // Qty-tracked: the per-row AssetLocation.quantity placed at the
-            // location. No-op for INDIVIDUAL.
-            meta: assetQtyMeta(locked, pivotQuantity),
+            fromValue: placement.location!.id,
+            toValue: null,
+            meta: assetQtyMeta(locked, placement.quantity ?? 1),
           },
           tx
         );
-
-        const refreshed = await tx.asset.findUniqueOrThrow({
-          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: `assetId` already org-verified by the `db.asset.findUnique({ where: { id, organizationId } })` guard at the top of this action; this is the in-tx re-read
-          where: { id: assetId },
-          select: {
-            id: true,
-            title: true,
-            assetLocations: {
-              select: { location: { select: { id: true, name: true } } },
-            },
-          },
-        });
-
-        return { refreshedAsset: refreshed, placedQuantity: pivotQuantity };
       }
-    );
+
+      await recordEvent(
+        {
+          organizationId,
+          actorUserId: user.id,
+          action: "ASSET_LOCATION_CHANGED",
+          entityType: "ASSET",
+          entityId: assetId,
+          assetId,
+          locationId: location.id,
+          field: "locationId",
+          fromValue: primaryBefore?.id ?? null,
+          toValue: location.id,
+          // Qty-tracked: the per-row AssetLocation.quantity placed at the
+          // location. No-op for INDIVIDUAL.
+          meta: assetQtyMeta(locked, pivotQuantity),
+        },
+        tx
+      );
+
+      const refreshed = await tx.asset.findUniqueOrThrow({
+        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: `assetId` already org-verified by the `db.asset.findUnique({ where: { id, organizationId } })` guard at the top of this action; this is the in-tx re-read
+        where: { id: assetId },
+        select: {
+          id: true,
+          title: true,
+          assetLocations: {
+            select: { location: { select: { id: true, name: true } } },
+          },
+        },
+      });
+
+      return {
+        refreshedAsset: refreshed,
+        placedQuantity: pivotQuantity,
+        previousLocation: primaryBefore,
+        previousQuantity: primaryQuantityBefore,
+      };
+    });
 
     const { assetLocations: _, ...updatedAssetRest } = refreshedAsset;
     const updatedAssetWithLocation = {
@@ -304,8 +331,6 @@ export async function action({ request }: ActionFunctionArgs) {
       location.name.trim()
     );
 
-    const previousLocation = getPrimaryLocation(asset);
-
     // Qty-tracked placements name the unit count the way the web note does
     // ("moved 4 pcs from X to Y."); INDIVIDUAL keeps the original phrasing
     // (`formatUnitCount` returns null for it).
@@ -316,7 +341,7 @@ export async function action({ request }: ActionFunctionArgs) {
       // Nothing moved: the asset stays where it is and only the placed amount
       // changed. Phrasing this as a move reads as "moved 6 pcs from Storage to
       // Storage", which describes a journey that did not happen.
-      const previousUnitCount = formatUnitCount(asset, currentPrimaryQuantity);
+      const previousUnitCount = formatUnitCount(asset, previousQuantity);
       noteContent =
         unitCount && previousUnitCount
           ? `${actor} changed the quantity at ${newLocationLink} from ${previousUnitCount} to ${unitCount} via mobile app.`

--- a/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
@@ -124,10 +124,16 @@ export async function action({ request }: ActionFunctionArgs) {
       asset.assetLocations.find(
         (al) => al.location?.id === currentPrimaryLocation?.id
       )?.quantity ?? null;
+    // An omitted `quantity` means the full pool, not "leave it as it is", so it
+    // has to be resolved before the comparison. Treating it as unchanged left a
+    // partially-placed asset at its old amount while the caller had asked for
+    // every unit. `pivotQuantity` inside the transaction resolves it the same
+    // way, against the locked row.
+    const requestedQuantity = isQuantityTracked(asset)
+      ? quantity ?? asset.quantity ?? 1
+      : 1;
     const quantityUnchanged =
-      !isQuantityTracked(asset) ||
-      quantity == null ||
-      quantity === currentPrimaryQuantity;
+      !isQuantityTracked(asset) || requestedQuantity === currentPrimaryQuantity;
     if (
       currentPrimaryLocation?.id === location.id &&
       asset.assetLocations.length === 1 &&
@@ -211,6 +217,39 @@ export async function action({ request }: ActionFunctionArgs) {
           },
         });
 
+        /**
+         * A pivot replace collapses EVERY manual placement, not just the
+         * primary one. Each of the others leaves the location it was at, and
+         * the single change event below only names the primary, so without
+         * these the asset silently stops being at a location that reports and
+         * history still show it at.
+         *
+         * Emitted as removals (`toValue: null`) because that is what happened
+         * to them; the arrival at the requested location is the event below.
+         */
+        const collapsedPlacements = asset.assetLocations.filter(
+          (al) =>
+            al.location?.id && al.location.id !== currentPrimaryLocation?.id
+        );
+        for (const placement of collapsedPlacements) {
+          await recordEvent(
+            {
+              organizationId,
+              actorUserId: user.id,
+              action: "ASSET_LOCATION_CHANGED",
+              entityType: "ASSET",
+              entityId: assetId,
+              assetId,
+              locationId: placement.location!.id,
+              field: "locationId",
+              fromValue: placement.location!.id,
+              toValue: null,
+              meta: assetQtyMeta(locked, placement.quantity ?? 1),
+            },
+            tx
+          );
+        }
+
         await recordEvent(
           {
             organizationId,
@@ -273,7 +312,16 @@ export async function action({ request }: ActionFunctionArgs) {
     const unitCount = formatUnitCount(asset, placedQuantity);
 
     let noteContent: string;
-    if (previousLocation) {
+    if (previousLocation && previousLocation.id === location.id) {
+      // Nothing moved: the asset stays where it is and only the placed amount
+      // changed. Phrasing this as a move reads as "moved 6 pcs from Storage to
+      // Storage", which describes a journey that did not happen.
+      const previousUnitCount = formatUnitCount(asset, currentPrimaryQuantity);
+      noteContent =
+        unitCount && previousUnitCount
+          ? `${actor} changed the quantity at ${newLocationLink} from ${previousUnitCount} to ${unitCount} via mobile app.`
+          : `${actor} updated the placement at ${newLocationLink} via mobile app.`;
+    } else if (previousLocation) {
       const currentLocationLink = wrapLinkForNote(
         `/locations/${previousLocation.id}`,
         previousLocation.name.trim()

--- a/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
+++ b/apps/webapp/app/routes/api+/mobile+/asset.update-location.ts
@@ -11,7 +11,8 @@ import { parseMobileBody } from "~/modules/api/mobile-body.server";
 import { getPrimaryLocation, isQuantityTracked } from "~/modules/asset/utils";
 import { lockAssetForQuantityUpdate } from "~/modules/consumption-log/quantity-lock.server";
 import { createNote } from "~/modules/note/service.server";
-import { makeShelfError } from "~/utils/error";
+import { assetQtyMeta, formatUnitCount } from "~/utils/asset-quantity";
+import { makeShelfError, ShelfError } from "~/utils/error";
 import { wrapUserLinkForNote, wrapLinkForNote } from "~/utils/markdoc-wrappers";
 import {
   PermissionAction,
@@ -21,8 +22,19 @@ import {
 /**
  * POST /api/mobile/asset/update-location
  *
- * Updates the location of a single asset.
- * Body: { assetId: string, locationId: string }
+ * Updates the location of a single asset. Mobile twin of the web's
+ * asset-overview "Update location" dialog
+ * (`_layout+/assets.$assetId.overview.update-location.tsx`): the write is a
+ * pivot replace — every manual `AssetLocation` row is cleared and at most one
+ * new row is created at the requested location.
+ *
+ * Body: { assetId: string, locationId: string, quantity?: number }
+ *
+ * `quantity` is the per-placement `AssetLocation.quantity` for a
+ * QUANTITY_TRACKED asset (units to place at the location — NOT a change to
+ * `Asset.quantity`, the workspace stock). Omitted → the full pool is placed.
+ * Units left over stay in the unplaced pool, exactly like the web dialog.
+ * INDIVIDUAL assets ignore it (their single placement is always quantity 1).
  */
 export async function action({ request }: ActionFunctionArgs) {
   try {
@@ -36,10 +48,11 @@ export async function action({ request }: ActionFunctionArgs) {
       action: PermissionAction.update,
     });
 
-    const { assetId, locationId } = await parseMobileBody(
+    const { assetId, locationId, quantity } = await parseMobileBody(
       z.object({
         assetId: z.string().min(1),
         locationId: z.string().min(1),
+        quantity: z.number().int().positive().optional(),
       }),
       request,
       "Assets"
@@ -53,8 +66,12 @@ export async function action({ request }: ActionFunctionArgs) {
         title: true,
         type: true,
         quantity: true,
+        unitOfMeasure: true,
         assetLocations: {
-          select: { location: { select: { id: true, name: true } } },
+          select: {
+            quantity: true,
+            location: { select: { id: true, name: true } },
+          },
         },
         assetKits: {
           select: { kit: { select: { id: true, name: true } } },
@@ -92,14 +109,30 @@ export async function action({ request }: ActionFunctionArgs) {
       );
     }
 
-    // why: short-circuit when the requested location matches the asset's
-    // current primary placement. Without this guard the route would write a
-    // no-op pivot replace, an `ASSET_LOCATION_CHANGED` event whose
-    // `fromValue === toValue`, and a misleading "updated the location from
-    // X to X" note. Mirrors the singular/bulk parity rule in
-    // `.claude/rules/bulk-event-parity.md`.
+    // why: short-circuit when the write would not change anything — same
+    // primary location, no other placements the replace would collapse, and
+    // (for QUANTITY_TRACKED) the same per-row quantity as already placed
+    // there. Without this guard the route would write a no-op pivot replace,
+    // an `ASSET_LOCATION_CHANGED` event whose `fromValue === toValue`, and a
+    // misleading "updated the location from X to X" note. Mirrors the
+    // singular/bulk parity rule in `.claude/rules/bulk-event-parity.md`.
+    // Same location with a DIFFERENT quantity falls through: re-placing a
+    // different amount at the current location is a real placement edit,
+    // exactly as the web dialog treats it.
     const currentPrimaryLocation = getPrimaryLocation(asset);
-    if (currentPrimaryLocation?.id === location.id) {
+    const currentPrimaryQuantity =
+      asset.assetLocations.find(
+        (al) => al.location?.id === currentPrimaryLocation?.id
+      )?.quantity ?? null;
+    const quantityUnchanged =
+      !isQuantityTracked(asset) ||
+      quantity == null ||
+      quantity === currentPrimaryQuantity;
+    if (
+      currentPrimaryLocation?.id === location.id &&
+      asset.assetLocations.length === 1 &&
+      quantityUnchanged
+    ) {
       return data({
         asset: {
           id: asset.id,
@@ -109,74 +142,114 @@ export async function action({ request }: ActionFunctionArgs) {
       });
     }
 
-    // Setting a single primary location is a pivot replace: wipe any
-    // existing AssetLocation rows then create the new link.
-    // QUANTITY_TRACKED assets place their full quantity at the location;
-    // INDIVIDUAL assets are always quantity 1. The ASSET_LOCATION_CHANGED
-    // activity event is recorded atomically so reports + activity-event
-    // aggregations include mobile-initiated location changes.
-    const updatedAsset = await db.$transaction(async (tx) => {
-      /**
-       * Row-lock the asset before writing the pivot, the same lock every
-       * stock-lowering path takes. This write RAISES the manual
-       * `AssetLocation` sum for a QUANTITY_TRACKED asset, and
-       * `enforce_asset_location_sum_within_total` validating at COMMIT only
-       * covers one interleaving: a concurrent consume can read the
-       * pre-placement rows, conclude they fit under the reduced total, and
-       * commit an `Asset` write that fires no location trigger at all.
-       *
-       * Locking also makes `quantity` trustworthy — the pre-transaction read
-       * above can be stale by the time the row is written, which would place
-       * more units than the asset owns.
-       */
-      const locked = await lockAssetForQuantityUpdate(
-        tx,
-        assetId,
-        organizationId
-      );
-      const pivotQuantity =
-        isQuantityTracked(locked) && locked.quantity != null
-          ? locked.quantity
-          : 1;
-
-      await tx.assetLocation.deleteMany({ where: { assetId } });
-      await tx.assetLocation.create({
-        data: { assetId, locationId, organizationId, quantity: pivotQuantity },
-      });
-
-      await recordEvent(
-        {
-          organizationId,
-          actorUserId: user.id,
-          action: "ASSET_LOCATION_CHANGED",
-          entityType: "ASSET",
-          entityId: assetId,
+    // Setting a single primary location is a pivot replace: wipe the manual
+    // AssetLocation rows then create the new link. QUANTITY_TRACKED assets
+    // place the requested `quantity` (or their full pool when omitted) at
+    // the location; INDIVIDUAL assets are always quantity 1. The
+    // ASSET_LOCATION_CHANGED activity event is recorded atomically so
+    // reports + activity-event aggregations include mobile-initiated
+    // location changes.
+    const { refreshedAsset, placedQuantity } = await db.$transaction(
+      async (tx) => {
+        /**
+         * Row-lock the asset before writing the pivot, the same lock every
+         * stock-lowering path takes. This write RAISES the manual
+         * `AssetLocation` sum for a QUANTITY_TRACKED asset, and
+         * `enforce_asset_location_sum_within_total` validating at COMMIT only
+         * covers one interleaving: a concurrent consume can read the
+         * pre-placement rows, conclude they fit under the reduced total, and
+         * commit an `Asset` write that fires no location trigger at all.
+         *
+         * Locking also makes `quantity` trustworthy — the pre-transaction read
+         * above can be stale by the time the row is written, which would place
+         * more units than the asset owns.
+         */
+        const locked = await lockAssetForQuantityUpdate(
+          tx,
           assetId,
-          locationId: location.id,
-          field: "locationId",
-          fromValue: currentPrimaryLocation?.id ?? null,
-          toValue: location.id,
-        },
-        tx
-      );
+          organizationId
+        );
 
-      return tx.asset.findUniqueOrThrow({
-        // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: `assetId` already org-verified by the `db.asset.findUnique({ where: { id, organizationId } })` guard at the top of this action; this is the in-tx re-read
-        where: { id: assetId },
-        select: {
-          id: true,
-          title: true,
-          assetLocations: {
-            select: { location: { select: { id: true, name: true } } },
+        // Per-placement bound: the requested units must fit the asset's
+        // total pool (measured on the locked row, mirroring the web
+        // service's in-transaction check in `updateAsset`).
+        const isQty = isQuantityTracked(locked);
+        if (isQty && quantity != null && quantity > (locked.quantity ?? 0)) {
+          throw new ShelfError({
+            cause: null,
+            title: "Quantity exceeds available pool",
+            message: `Requested ${quantity} but the asset has only ${
+              locked.quantity ?? 0
+            } units total.`,
+            additionalData: {
+              assetId,
+              organizationId,
+              quantity,
+              totalQuantity: locked.quantity,
+            },
+            label: "Assets",
+            status: 400,
+            shouldBeCaptured: false,
+          });
+        }
+
+        const pivotQuantity = isQty ? quantity ?? locked.quantity ?? 1 : 1;
+
+        // Clear MANUAL placements only — kit-driven rows
+        // (`assetKitId IS NOT NULL`) are owned by the kit's flow. The kit
+        // guard above rejects kit members outright, so this filter mirrors
+        // the web service's pivot write rather than changing behavior.
+        await tx.assetLocation.deleteMany({
+          where: { assetId, assetKitId: null },
+        });
+        await tx.assetLocation.create({
+          data: {
+            assetId,
+            locationId,
+            organizationId,
+            quantity: pivotQuantity,
           },
-        },
-      });
-    });
+        });
 
-    const { assetLocations: _, ...updatedAssetRest } = updatedAsset;
+        await recordEvent(
+          {
+            organizationId,
+            actorUserId: user.id,
+            action: "ASSET_LOCATION_CHANGED",
+            entityType: "ASSET",
+            entityId: assetId,
+            assetId,
+            locationId: location.id,
+            field: "locationId",
+            fromValue: currentPrimaryLocation?.id ?? null,
+            toValue: location.id,
+            // Qty-tracked: the per-row AssetLocation.quantity placed at the
+            // location. No-op for INDIVIDUAL.
+            meta: assetQtyMeta(locked, pivotQuantity),
+          },
+          tx
+        );
+
+        const refreshed = await tx.asset.findUniqueOrThrow({
+          // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: `assetId` already org-verified by the `db.asset.findUnique({ where: { id, organizationId } })` guard at the top of this action; this is the in-tx re-read
+          where: { id: assetId },
+          select: {
+            id: true,
+            title: true,
+            assetLocations: {
+              select: { location: { select: { id: true, name: true } } },
+            },
+          },
+        });
+
+        return { refreshedAsset: refreshed, placedQuantity: pivotQuantity };
+      }
+    );
+
+    const { assetLocations: _, ...updatedAssetRest } = refreshedAsset;
     const updatedAssetWithLocation = {
       ...updatedAssetRest,
-      location: getPrimaryLocation(updatedAsset),
+      location: getPrimaryLocation(refreshedAsset),
     };
 
     // Create activity note (matches webapp format)
@@ -194,15 +267,24 @@ export async function action({ request }: ActionFunctionArgs) {
 
     const previousLocation = getPrimaryLocation(asset);
 
+    // Qty-tracked placements name the unit count the way the web note does
+    // ("moved 4 pcs from X to Y."); INDIVIDUAL keeps the original phrasing
+    // (`formatUnitCount` returns null for it).
+    const unitCount = formatUnitCount(asset, placedQuantity);
+
     let noteContent: string;
     if (previousLocation) {
       const currentLocationLink = wrapLinkForNote(
         `/locations/${previousLocation.id}`,
         previousLocation.name.trim()
       );
-      noteContent = `${actor} updated the location from ${currentLocationLink} to ${newLocationLink} via mobile app.`;
+      noteContent = unitCount
+        ? `${actor} moved ${unitCount} from ${currentLocationLink} to ${newLocationLink} via mobile app.`
+        : `${actor} updated the location from ${currentLocationLink} to ${newLocationLink} via mobile app.`;
     } else {
-      noteContent = `${actor} set the location to ${newLocationLink} via mobile app.`;
+      noteContent = unitCount
+        ? `${actor} placed ${unitCount} at ${newLocationLink} via mobile app.`
+        : `${actor} set the location to ${newLocationLink} via mobile app.`;
     }
 
     await createNote({
@@ -213,7 +295,13 @@ export async function action({ request }: ActionFunctionArgs) {
       organizationId,
     });
 
-    return data({ asset: updatedAssetWithLocation });
+    return data({
+      asset: updatedAssetWithLocation,
+      // Additive: the per-row AssetLocation.quantity now placed at the
+      // location (1 for INDIVIDUAL) so the app can confirm the partial
+      // placement without a second round trip.
+      placedQuantity,
+    });
   } catch (cause) {
     const reason = makeShelfError(cause);
     return data(

--- a/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/assets.$assetId.ts
@@ -94,9 +94,16 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         userId: true,
         category: { select: { id: true, name: true, color: true } },
         // Select location through the pivot and synthesise the singular
-        // `location` below so the mobile JSON contract stays flat.
+        // `location` below so the mobile JSON contract stays flat. The
+        // per-row `quantity` is the units placed at that location
+        // (AssetLocation.quantity — NOT workspace stock); it feeds the
+        // `placementCount` / `locationQuantity` fields the qty-aware
+        // "Update location" sheet reads.
         assetLocations: {
-          select: { location: { select: { id: true, name: true } } },
+          select: {
+            quantity: true,
+            location: { select: { id: true, name: true } },
+          },
         },
         custody: {
           // Oldest-first so the flattened single custody + custodyList are
@@ -340,6 +347,17 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         kit: flattened.kit,
         kitId: flattened.kitId,
         location: flattened.location,
+        // Placement metadata (additive) for the qty-aware "Update location"
+        // sheet: how many AssetLocation rows exist (drives the
+        // multi-placement collapse warning — the update is a pivot replace)
+        // and the units placed at the primary location (the sheet's
+        // pre-fill). `locationQuantity` is the per-row placement quantity,
+        // NOT workspace stock.
+        placementCount: asset.assetLocations.length,
+        locationQuantity:
+          asset.assetLocations.find(
+            (al) => al.location.id === flattened.location?.id
+          )?.quantity ?? null,
         // Name only (no id, no image fields — see the destructure above).
         assetModel,
         // why: re-attach the detail-shape custody (with createdAt +

--- a/apps/webapp/test/routes-tests/api+/mobile+/asset.update-location.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/asset.update-location.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Tests for POST /api/mobile/asset/update-location — the mobile twin of the
+ * web asset-overview "Update location" dialog. Asserts observable behavior:
+ * the per-placement `quantity` handling for QUANTITY_TRACKED assets (partial
+ * placement, pool bound, INDIVIDUAL ignoring it), the no-op short-circuit,
+ * and the quantity-aware event meta + note phrasing.
+ *
+ * @see {@link file://../../../../app/routes/api+/mobile+/asset.update-location.ts}
+ */
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // why: the route pre-reads the asset + location and opens an interactive
@@ -32,6 +42,9 @@ vi.mock("~/modules/consumption-log/quantity-lock.server", () => ({
 vi.mock("~/modules/activity-event/service.server", () => ({
   recordEvent: vi.fn(),
 }));
+// why: `createNote` writes through the real Prisma client. The note's wording
+// is the observable output under test, so the writer is stubbed and the content
+// asserted from the call.
 vi.mock("~/modules/note/service.server", () => ({
   createNote: vi.fn(),
 }));
@@ -46,16 +59,6 @@ import { lockAssetForQuantityUpdate } from "~/modules/consumption-log/quantity-l
 import { recordEvent } from "~/modules/activity-event/service.server";
 import { createNote } from "~/modules/note/service.server";
 import { action } from "~/routes/api+/mobile+/asset.update-location";
-
-/**
- * Tests for POST /api/mobile/asset/update-location — the mobile twin of the
- * web asset-overview "Update location" dialog. Asserts observable behavior:
- * the per-placement `quantity` handling for QUANTITY_TRACKED assets (partial
- * placement, pool bound, INDIVIDUAL ignoring it), the no-op short-circuit,
- * and the quantity-aware event meta + note phrasing.
- *
- * @see {@link file://../../../../app/routes/api+/mobile+/asset.update-location.ts}
- */
 
 /** Shape of the `data()` result the route action returns. */
 type DataResult<T> = { data: T; init: ResponseInit | null };
@@ -319,5 +322,103 @@ describe("POST /api/mobile/asset/update-location", () => {
     // exists — the replace is a real change (it collapses the other row).
     expect(status).toBe(200);
     expect(db.$transaction).toHaveBeenCalled();
+  });
+
+  it("records the placement it collapsed, not just the one it kept", async () => {
+    vi.mocked(db.asset.findUnique).mockResolvedValue(
+      qtyAsset({
+        assetLocations: [
+          { quantity: 6, location: { id: "loc-storage", name: "Storage" } },
+          { quantity: 4, location: { id: "loc-van", name: "Van" } },
+        ],
+      }) as never
+    );
+    vi.mocked(db.location.findFirst).mockResolvedValue({
+      id: "loc-storage",
+      name: "Storage",
+    } as never);
+
+    await callAction({
+      assetId: "asset-1",
+      locationId: "loc-storage",
+      quantity: 6,
+    });
+
+    // The Van row is deleted by the pivot replace. Without its own event the
+    // asset silently stops being at the Van while reports still show it there.
+    expect(recordEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ASSET_LOCATION_CHANGED",
+        assetId: "asset-1",
+        fromValue: "loc-van",
+        toValue: null,
+      }),
+      expect.anything()
+    );
+  });
+
+  it("places the full pool when quantity is omitted at the current location", async () => {
+    // 4 of 10 units are placed at Storage and the caller asks for Storage with
+    // no quantity, which means the whole pool. Reading the omission as
+    // "unchanged" short-circuits and leaves 4 placed.
+    vi.mocked(db.asset.findUnique).mockResolvedValue(
+      qtyAsset({
+        assetLocations: [
+          { quantity: 4, location: { id: "loc-storage", name: "Storage" } },
+        ],
+      }) as never
+    );
+    vi.mocked(db.location.findFirst).mockResolvedValue({
+      id: "loc-storage",
+      name: "Storage",
+    } as never);
+
+    const { status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-storage",
+    });
+
+    expect(status).toBe(200);
+    expect(
+      db.$transaction,
+      "the placement must be rewritten to 10"
+    ).toHaveBeenCalled();
+    expect(tx.assetLocation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ quantity: 10 }),
+      })
+    );
+  });
+
+  it("describes a same-location edit as a quantity change, not a move", async () => {
+    vi.mocked(db.asset.findUnique).mockResolvedValue(
+      qtyAsset({
+        assetLocations: [
+          { quantity: 4, location: { id: "loc-storage", name: "Storage" } },
+        ],
+      }) as never
+    );
+    vi.mocked(db.location.findFirst).mockResolvedValue({
+      id: "loc-storage",
+      name: "Storage",
+    } as never);
+    tx.asset.findUniqueOrThrow.mockResolvedValue({
+      id: "asset-1",
+      title: "Cords",
+      assetLocations: [{ location: { id: "loc-storage", name: "Storage" } }],
+    });
+
+    await callAction({
+      assetId: "asset-1",
+      locationId: "loc-storage",
+      quantity: 6,
+    });
+
+    const note = vi.mocked(createNote).mock.calls[0][0].content as string;
+    expect(
+      note,
+      "nothing moved, so the note must not describe a journey"
+    ).not.toMatch(/moved .* from .* to /);
+    expect(note).toContain("changed the quantity");
   });
 });

--- a/apps/webapp/test/routes-tests/api+/mobile+/asset.update-location.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/asset.update-location.test.ts
@@ -84,7 +84,13 @@ async function callAction(body: unknown) {
 
 /** Tx stub handed to the `$transaction` callback. */
 const tx = {
-  assetLocation: { deleteMany: vi.fn(), create: vi.fn() },
+  assetLocation: {
+    // The route reads the placements under the asset lock, so this read is what
+    // the collapse events, the primary event and the note are all derived from.
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+    create: vi.fn(),
+  },
   asset: { findUniqueOrThrow: vi.fn() },
 };
 
@@ -132,6 +138,11 @@ beforeEach(() => {
   vi.mocked(db.$transaction).mockImplementation((async (cb: never) =>
     (cb as (t: typeof tx) => Promise<unknown>)(tx)) as never);
   vi.mocked(lockAssetForQuantityUpdate).mockResolvedValue(qtyAsset() as never);
+  // Default locked read: the standard fixture's single placement. Tests that
+  // seed a different set of placements override this alongside `db.asset.findUnique`,
+  // because the route derives the collapse events, the primary event and the
+  // note from THIS read rather than from the pre-transaction one.
+  tx.assetLocation.findMany.mockResolvedValue(qtyAsset().assetLocations);
   tx.asset.findUniqueOrThrow.mockResolvedValue({
     id: "asset-1",
     title: "Cords",
@@ -307,6 +318,10 @@ describe("POST /api/mobile/asset/update-location", () => {
         ],
       }) as never
     );
+    tx.assetLocation.findMany.mockResolvedValue([
+      { quantity: 6, location: { id: "loc-storage", name: "Storage" } },
+      { quantity: 4, location: { id: "loc-van", name: "Van" } },
+    ]);
     vi.mocked(db.location.findFirst).mockResolvedValue({
       id: "loc-storage",
       name: "Storage",
@@ -333,6 +348,10 @@ describe("POST /api/mobile/asset/update-location", () => {
         ],
       }) as never
     );
+    tx.assetLocation.findMany.mockResolvedValue([
+      { quantity: 6, location: { id: "loc-storage", name: "Storage" } },
+      { quantity: 4, location: { id: "loc-van", name: "Van" } },
+    ]);
     vi.mocked(db.location.findFirst).mockResolvedValue({
       id: "loc-storage",
       name: "Storage",
@@ -357,6 +376,43 @@ describe("POST /api/mobile/asset/update-location", () => {
     );
   });
 
+  it("describes the placements it found under the lock, not the ones it read first", async () => {
+    // The pre-transaction read is stale by the time the lock is held: a
+    // concurrent request can have collapsed a placement already. Recording
+    // removals from the stale set would invent events for rows that no longer
+    // exist and name a primary that has since changed.
+    vi.mocked(db.asset.findUnique).mockResolvedValue(
+      qtyAsset({
+        assetLocations: [
+          { quantity: 6, location: { id: "loc-storage", name: "Storage" } },
+          { quantity: 4, location: { id: "loc-van", name: "Van" } },
+        ],
+      }) as never
+    );
+    // Under the lock, the Van row is already gone.
+    tx.assetLocation.findMany.mockResolvedValue([
+      { quantity: 6, location: { id: "loc-storage", name: "Storage" } },
+    ]);
+    vi.mocked(db.location.findFirst).mockResolvedValue({
+      id: "loc-van",
+      name: "Van",
+    } as never);
+
+    await callAction({
+      assetId: "asset-1",
+      locationId: "loc-van",
+      quantity: 6,
+    });
+
+    const removals = vi
+      .mocked(recordEvent)
+      .mock.calls.filter((c: any) => c[0]?.toValue === null);
+    expect(
+      removals,
+      "the Van row was already collapsed, so nothing may claim to remove it"
+    ).toHaveLength(0);
+  });
+
   it("places the full pool when quantity is omitted at the current location", async () => {
     // 4 of 10 units are placed at Storage and the caller asks for Storage with
     // no quantity, which means the whole pool. Reading the omission as
@@ -368,6 +424,9 @@ describe("POST /api/mobile/asset/update-location", () => {
         ],
       }) as never
     );
+    tx.assetLocation.findMany.mockResolvedValue([
+      { quantity: 4, location: { id: "loc-storage", name: "Storage" } },
+    ]);
     vi.mocked(db.location.findFirst).mockResolvedValue({
       id: "loc-storage",
       name: "Storage",
@@ -398,6 +457,9 @@ describe("POST /api/mobile/asset/update-location", () => {
         ],
       }) as never
     );
+    tx.assetLocation.findMany.mockResolvedValue([
+      { quantity: 4, location: { id: "loc-storage", name: "Storage" } },
+    ]);
     vi.mocked(db.location.findFirst).mockResolvedValue({
       id: "loc-storage",
       name: "Storage",

--- a/apps/webapp/test/routes-tests/api+/mobile+/asset.update-location.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/asset.update-location.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// why: the route pre-reads the asset + location and opens an interactive
+// transaction; stubbing the client avoids the real Prisma client (no DB in
+// unit tests). `$transaction` runs its callback against a tx stub so the
+// pivot writes and the in-tx re-read stay observable.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    asset: { findUnique: vi.fn() },
+    location: { findFirst: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+// why: `mobile-auth.server` transitively loads the Supabase admin client and
+// the real Prisma client (no DB / env in unit tests). The route only calls
+// these three gate functions.
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+  requireMobilePermission: vi.fn(),
+}));
+
+// why: the lock helper issues a raw `SELECT ... FOR UPDATE`; the test drives
+// the quantity validation through its resolved value instead of a DB.
+vi.mock("~/modules/consumption-log/quantity-lock.server", () => ({
+  lockAssetForQuantityUpdate: vi.fn(),
+}));
+
+// why: side-effect writers with their own suites — the route's observable
+// job here is WHAT it hands them (event meta quantity, note phrasing).
+vi.mock("~/modules/activity-event/service.server", () => ({
+  recordEvent: vi.fn(),
+}));
+vi.mock("~/modules/note/service.server", () => ({
+  createNote: vi.fn(),
+}));
+
+import { db } from "~/database/db.server";
+import {
+  requireMobileAuth,
+  requireMobilePermission,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { lockAssetForQuantityUpdate } from "~/modules/consumption-log/quantity-lock.server";
+import { recordEvent } from "~/modules/activity-event/service.server";
+import { createNote } from "~/modules/note/service.server";
+import { action } from "~/routes/api+/mobile+/asset.update-location";
+
+/**
+ * Tests for POST /api/mobile/asset/update-location — the mobile twin of the
+ * web asset-overview "Update location" dialog. Asserts observable behavior:
+ * the per-placement `quantity` handling for QUANTITY_TRACKED assets (partial
+ * placement, pool bound, INDIVIDUAL ignoring it), the no-op short-circuit,
+ * and the quantity-aware event meta + note phrasing.
+ *
+ * @see {@link file://../../../../app/routes/api+/mobile+/asset.update-location.ts}
+ */
+
+/** Shape of the `data()` result the route action returns. */
+type DataResult<T> = { data: T; init: ResponseInit | null };
+
+/** Runs the action with a JSON body and unwraps the data() envelope. */
+async function callAction(body: unknown) {
+  const request = new Request(
+    "http://localhost/api/mobile/asset/update-location?orgId=org-1",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+  const result = await action({ request, params: {}, context: {} } as never);
+  const { data, init } = result as unknown as DataResult<{
+    asset?: { id: string; location: { id: string; name: string } | null };
+    placedQuantity?: number;
+    error?: { message: string };
+  }>;
+  return { body: data, status: init?.status ?? 200 };
+}
+
+/** Tx stub handed to the `$transaction` callback. */
+const tx = {
+  assetLocation: { deleteMany: vi.fn(), create: vi.fn() },
+  asset: { findUniqueOrThrow: vi.fn() },
+};
+
+/**
+ * A QUANTITY_TRACKED asset with 10 units, all placed at Storage. Individual
+ * tests override the pieces their branch exercises.
+ */
+function qtyAsset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "asset-1",
+    title: "Cords",
+    type: "QUANTITY_TRACKED",
+    quantity: 10,
+    unitOfMeasure: "pcs",
+    assetLocations: [
+      {
+        quantity: 10,
+        location: { id: "loc-storage", name: "Storage" },
+      },
+    ],
+    assetKits: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireMobileAuth).mockResolvedValue({
+    user: {
+      id: "user-1",
+      firstName: "Carla",
+      lastName: "Tester",
+      displayName: null,
+    },
+  } as never);
+  vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1");
+  vi.mocked(requireMobilePermission).mockResolvedValue(undefined as never);
+
+  // why: cast — the route selects narrow shapes, not full rows.
+  vi.mocked(db.asset.findUnique).mockResolvedValue(qtyAsset() as never);
+  vi.mocked(db.location.findFirst).mockResolvedValue({
+    id: "loc-van",
+    name: "Van",
+  } as never);
+  vi.mocked(db.$transaction).mockImplementation((async (cb: never) =>
+    (cb as (t: typeof tx) => Promise<unknown>)(tx)) as never);
+  vi.mocked(lockAssetForQuantityUpdate).mockResolvedValue(qtyAsset() as never);
+  tx.asset.findUniqueOrThrow.mockResolvedValue({
+    id: "asset-1",
+    title: "Cords",
+    assetLocations: [{ location: { id: "loc-van", name: "Van" } }],
+  });
+});
+
+describe("POST /api/mobile/asset/update-location", () => {
+  it("places a partial quantity and reports it back", async () => {
+    const { body, status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-van",
+      quantity: 4,
+    });
+
+    expect(status).toBe(200);
+    expect(body.placedQuantity).toBe(4);
+    expect(body.asset?.location).toEqual({ id: "loc-van", name: "Van" });
+    expect(tx.assetLocation.create).toHaveBeenCalledWith({
+      data: {
+        assetId: "asset-1",
+        locationId: "loc-van",
+        organizationId: "org-1",
+        quantity: 4,
+      },
+    });
+    // The replace clears manual rows only — kit-driven rows are the kit
+    // flow's to manage.
+    expect(tx.assetLocation.deleteMany).toHaveBeenCalledWith({
+      where: { assetId: "asset-1", assetKitId: null },
+    });
+  });
+
+  it("records the placed quantity on the event and in the note", async () => {
+    await callAction({
+      assetId: "asset-1",
+      locationId: "loc-van",
+      quantity: 4,
+    });
+
+    expect(recordEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "ASSET_LOCATION_CHANGED",
+        fromValue: "loc-storage",
+        toValue: "loc-van",
+        meta: { quantity: 4 },
+      }),
+      tx
+    );
+    expect(createNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("moved 4 pcs from"),
+      })
+    );
+  });
+
+  it("places the full pool when quantity is omitted", async () => {
+    const { body, status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-van",
+    });
+
+    expect(status).toBe(200);
+    expect(body.placedQuantity).toBe(10);
+    expect(tx.assetLocation.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ quantity: 10 }),
+    });
+  });
+
+  it("rejects a quantity above the asset's total pool", async () => {
+    const { body, status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-van",
+      quantity: 11,
+    });
+
+    expect(status).toBe(400);
+    expect(body.error?.message).toContain("Requested 11");
+    expect(tx.assetLocation.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive quantity via the body schema", async () => {
+    const { status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-van",
+      quantity: 0,
+    });
+
+    expect(status).toBe(400);
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("ignores quantity for INDIVIDUAL assets (placement is always 1)", async () => {
+    const individual = qtyAsset({
+      type: "INDIVIDUAL",
+      quantity: null,
+      unitOfMeasure: null,
+    });
+    vi.mocked(db.asset.findUnique).mockResolvedValue(individual as never);
+    vi.mocked(lockAssetForQuantityUpdate).mockResolvedValue(
+      individual as never
+    );
+
+    const { body, status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-van",
+      quantity: 4,
+    });
+
+    expect(status).toBe(200);
+    expect(body.placedQuantity).toBe(1);
+    expect(tx.assetLocation.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ quantity: 1 }),
+    });
+    // INDIVIDUAL keeps the original phrasing — no unit count.
+    expect(createNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("updated the location from"),
+      })
+    );
+  });
+
+  it("short-circuits when location and quantity are both unchanged", async () => {
+    vi.mocked(db.location.findFirst).mockResolvedValue({
+      id: "loc-storage",
+      name: "Storage",
+    } as never);
+
+    const { body, status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-storage",
+      quantity: 10,
+    });
+
+    expect(status).toBe(200);
+    expect(body.asset?.location).toEqual({
+      id: "loc-storage",
+      name: "Storage",
+    });
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("re-places at the same location when the quantity differs", async () => {
+    tx.asset.findUniqueOrThrow.mockResolvedValue({
+      id: "asset-1",
+      title: "Cords",
+      assetLocations: [{ location: { id: "loc-storage", name: "Storage" } }],
+    });
+    vi.mocked(db.location.findFirst).mockResolvedValue({
+      id: "loc-storage",
+      name: "Storage",
+    } as never);
+
+    const { body, status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-storage",
+      quantity: 6,
+    });
+
+    expect(status).toBe(200);
+    expect(body.placedQuantity).toBe(6);
+    expect(tx.assetLocation.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ quantity: 6 }),
+    });
+  });
+
+  it("still writes through when a multi-placement collapses (the app warns first)", async () => {
+    vi.mocked(db.asset.findUnique).mockResolvedValue(
+      qtyAsset({
+        assetLocations: [
+          { quantity: 6, location: { id: "loc-storage", name: "Storage" } },
+          { quantity: 4, location: { id: "loc-van", name: "Van" } },
+        ],
+      }) as never
+    );
+    vi.mocked(db.location.findFirst).mockResolvedValue({
+      id: "loc-storage",
+      name: "Storage",
+    } as never);
+
+    const { status } = await callAction({
+      assetId: "asset-1",
+      locationId: "loc-storage",
+      quantity: 6,
+    });
+
+    // Same primary location + same row quantity, but a second placement
+    // exists — the replace is a real change (it collapses the other row).
+    expect(status).toBe(200);
+    expect(db.$transaction).toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.update-location.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.update-location.test.ts
@@ -44,6 +44,7 @@ const dbMocks = vi.hoisted(() => ({
     findUniqueOrThrow: vi.fn(),
   },
   assetLocation: {
+    findMany: vi.fn(),
     create: vi.fn(),
     deleteMany: vi.fn(),
   },
@@ -132,6 +133,14 @@ function createRequest(body: Record<string, unknown>) {
 
 describe("POST /api/mobile/asset/update-location", () => {
   beforeEach(() => {
+    // The route reads the manual placements under the asset lock, and derives
+    // the collapse events, the primary event and the note from THAT read rather
+    // than the pre-transaction one. Default to the single old placement these
+    // tests set up; a test seeding more overrides it.
+    (dbMocks.assetLocation.findMany as any).mockResolvedValue([
+      { quantity: 1, location: { id: "loc-old", name: "Old Office" } },
+    ]);
+
     vi.clearAllMocks();
 
     (requireMobileAuth as any).mockResolvedValue({

--- a/apps/webapp/test/routes-tests/api+/mobile.asset.update-location.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.asset.update-location.test.ts
@@ -197,9 +197,15 @@ describe("POST /api/mobile/asset/update-location", () => {
     // `getPrimaryLocation`, so the API surface stays stable for mobile.
     expect(body.asset.location.name).toBe("New Office");
 
-    // Phase 4b: assert the pivot writes happened inside the tx.
+    // Assert the pivot writes happened inside the tx.
+    //
+    // The clear is scoped to MANUAL placements. A kit owns its members'
+    // kit-driven rows (`assetKitId IS NOT NULL`) and the two axes are bounded
+    // by separate triggers, so clearing both here would delete placement the
+    // kit flow is responsible for. Every web-side `assetLocation.deleteMany`
+    // carries the same filter.
     expect(dbMocks.assetLocation.deleteMany).toHaveBeenCalledWith({
-      where: { assetId: "asset-1" },
+      where: { assetId: "asset-1", assetKitId: null },
     });
     expect(dbMocks.assetLocation.create).toHaveBeenCalledWith({
       data: {


### PR DESCRIPTION
## What

On mobile, updating a QUANTITY_TRACKED asset's location always moved the **full pool** and silently **collapsed any multi-placement** (the route wiped every `AssetLocation` row and re-placed the whole quantity). The web asset-overview dialog already supports placing N of M units. This brings the companion to parity — a customer-requested workflow (moving part of a stock of cables between sites from the phone).

- `POST /api/mobile/asset/update-location` accepts an optional `quantity` (per-placement units). Validated inside the existing `lockAssetForQuantityUpdate` transaction against the locked pool (400 above it). The pivot delete is now scoped to `assetKitId: null`, mirroring the web service's manual-row replace. `ASSET_LOCATION_CHANGED` now carries `meta.quantity` (via `assetQtyMeta`) and notes use the web's qty phrasing ("moved/placed 4 pcs …") with the existing "via mobile app" suffix.
- `GET /api/mobile/assets/:assetId` ships two additive fields: `placementCount` and `locationQuantity` (per-row placement quantity, NOT workspace stock — see `.claude/rules/quantity-semantics-per-surface.md`).
- Companion: new `MoveQuantitySheet` replaces the whole-asset confirm alert for QUANTITY_TRACKED assets — location chip, stepper capped at the pool, "N pcs of M pcs" echo, unplaced-pool hint when partial, and a multi-placement collapse warning (web dialog parity; previously the collapse happened with no warning at all). INDIVIDUAL assets keep the existing alert flow byte-identical.
- Re-picking the current location now opens the sheet for qty-tracked assets (changing the placed amount at the same location is a real placement edit, like on web); the server no-op guard short-circuits true no-ops.

## Verification

- 9 route tests (`test/routes-tests/api+/mobile+/asset.update-location.test.ts`): partial placement, full-pool default, pool-bound 400, schema 400, INDIVIDUAL forcing qty 1, no-op short-circuit, same-location re-place, multi-placement write-through.
- On-simulator e2e (Maestro, QA workspace): sheet default → 4 of 10 → hint → Move → detail refresh. DB cross-check: `AssetLocation` row quantity 4 at the target, event `meta: {"quantity": 4}`, note "placed 4 pcs at … via mobile app." Multi-placement warning state driven and captured. Fixture restored afterwards.
- New committed regression flow: `.maestro/flows/assets/partial-move-location.yaml` (re-runnable; second run is a server-side no-op).
- `tsc` clean on both apps; eslint + prettier clean on touched files.

## Deploy order

No migration. The server half is additive and backward compatible (older apps send no `quantity` → full-pool behavior unchanged). It must be live before the app release that carries the sheet — the normal order, since app releases trail webapp deploys. On an older server the sheet degrades gracefully (absent fields → pre-fill = pool, no warning) but a submitted `quantity` would be ignored, so the app half should not ship ahead.

## Out of scope

The scanner's bulk "update location" mode stays full-quantity (`bulk-update-location` unchanged) — per-item quantities in the batch drawer are a separate UX; candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quantity-tracked assets can be moved partially between locations.
  * A quantity selector provides validation, stepper controls, unit limits, and placement warnings.
  * Asset details show placement counts and quantities at the selected location.
  * Activity records include the number of units moved.
  * Moving quantities displays remaining unplaced units.

* **Bug Fixes**
  * Improved handling of repeated moves, multi-location placements, and unplaced quantities.
  * Individual assets continue to move as a single unit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->