### PR TITLE
fix(webapp): keep the mouse wheel from stepping focused number inputs

### DIFF
--- a/apps/webapp/app/components/assets/manage-placements-form.tsx
+++ b/apps/webapp/app/components/assets/manage-placements-form.tsx
@@ -28,6 +28,7 @@ import { useMemo, useState } from "react";
 import { Form } from "~/components/custom-form";
 import { Button } from "~/components/shared/button";
 import { useDisabled } from "~/hooks/use-disabled";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 
 type LocationOption = {
   id: string;
@@ -317,6 +318,7 @@ export function ManagePlacementsForm({
               <div className="flex shrink-0 items-center gap-1">
                 <input
                   type="number"
+                  {...numberInputWheelGuard}
                   min={1}
                   max={totalPool}
                   value={row.quantity}

--- a/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.tsx
+++ b/apps/webapp/app/components/booking/bulk-partial-checkout-dialog.tsx
@@ -42,6 +42,7 @@ import {
   flattenSelectedBookingItems,
   isAssetCheckableOut,
 } from "~/utils/booking-assets";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import { tw } from "~/utils/tw";
 import CheckoutDialog from "./checkout-dialog";
 import { AssetImage } from "../assets/asset-image/component";
@@ -132,6 +133,7 @@ function CheckoutQtyInput({
       <span className="text-xs font-medium text-gray-700">Checked out</span>
       <input
         type="number"
+        {...numberInputWheelGuard}
         min={1}
         max={max}
         step={1}

--- a/apps/webapp/app/components/booking/manage-model-requests.tsx
+++ b/apps/webapp/app/components/booking/manage-model-requests.tsx
@@ -35,6 +35,7 @@ import { useDisabled } from "~/hooks/use-disabled";
 import { UpsertModelRequestSchema } from "~/routes/api+/bookings.$bookingId.model-requests";
 import { BADGE_COLORS } from "~/utils/badge-colors";
 import { getValidationErrors } from "~/utils/http";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import { tw } from "~/utils/tw";
 import { AvailabilityBadge } from "./availability-label";
 
@@ -409,6 +410,7 @@ function ExistingRequestRow({
             <input
               id={`model-request-quantity-${request.assetModelId}`}
               type="number"
+              {...numberInputWheelGuard}
               name={zo.fields.quantity()}
               min={1}
               step={1}
@@ -672,6 +674,7 @@ function AddRequestRow({
           <input
             id="model-request-quantity"
             type="number"
+            {...numberInputWheelGuard}
             name={zo.fields.quantity()}
             min={1}
             step={1}

--- a/apps/webapp/app/components/forms/input.test.tsx
+++ b/apps/webapp/app/components/forms/input.test.tsx
@@ -49,6 +49,7 @@ describe("Input wheel guard", () => {
   });
 
   it("keeps caller focus handlers on number inputs", () => {
+    // why: spies prove the caller's own focus handlers still run after Input wires the guard in
     const onFocus = vi.fn();
     const onBlur = vi.fn();
     const { getByLabelText } = render(

--- a/apps/webapp/app/components/forms/input.test.tsx
+++ b/apps/webapp/app/components/forms/input.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * Input — unit tests
+ *
+ * Verifies the wheel guard wiring of the shared form input:
+ *  - `type="number"` inputs ignore the wheel while focused and pass it through
+ *    once focus leaves.
+ *  - Other input types are untouched.
+ *  - Caller-supplied focus handlers keep running on number inputs.
+ *
+ * @see {@link file://./input.tsx}
+ */
+
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Input from "./input";
+
+function dispatchWheel(target: Element) {
+  const event = new WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    deltaY: 100,
+  });
+  target.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+describe("Input wheel guard", () => {
+  it("cancels the wheel on a focused number input", () => {
+    const { getByLabelText } = render(
+      <Input label="Quantity" name="quantity" type="number" />
+    );
+    const input = getByLabelText("Quantity");
+
+    expect(dispatchWheel(input)).toBe(false);
+    fireEvent.focus(input);
+    expect(dispatchWheel(input)).toBe(true);
+    fireEvent.blur(input);
+    expect(dispatchWheel(input)).toBe(false);
+  });
+
+  it("leaves text inputs alone", () => {
+    const { getByLabelText } = render(
+      <Input label="Name" name="name" type="text" />
+    );
+    const input = getByLabelText("Name");
+
+    fireEvent.focus(input);
+    expect(dispatchWheel(input)).toBe(false);
+  });
+
+  it("keeps caller focus handlers on number inputs", () => {
+    const onFocus = vi.fn();
+    const onBlur = vi.fn();
+    const { getByLabelText } = render(
+      <Input
+        label="Quantity"
+        name="quantity"
+        type="number"
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+    );
+    const input = getByLabelText("Quantity");
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/webapp/app/components/forms/input.tsx
+++ b/apps/webapp/app/components/forms/input.tsx
@@ -1,6 +1,7 @@
 import type { RefObject, InputHTMLAttributes } from "react";
 import { forwardRef } from "react";
 
+import { withNumberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import { tw } from "~/utils/tw";
 import { InnerLabel } from "./inner-label";
 import type { IconType } from "../shared/icons-map";
@@ -19,10 +20,10 @@ export interface InputProps
    */
   inputType?: "input" | "textarea";
 
-  /** Weather the label is hidden */
+  /** Whether the label is hidden */
   hideLabel?: boolean;
 
-  /** Weather the label is hidden on md */
+  /** Whether the label is hidden on md */
   hideMd?: boolean;
 
   /** name of any icon available in icons map */
@@ -62,6 +63,12 @@ export interface InputProps
   autoComplete?: string;
 }
 
+/**
+ * Shared form field: label, optional icon or add-on, error text and the app's
+ * input styling. Renders a `<textarea>` when `inputType` is "textarea". Number
+ * inputs ignore the mouse wheel while focused, so scrolling a form cannot
+ * change their value.
+ */
 const Input = forwardRef(function Input(
   {
     className,
@@ -120,9 +127,15 @@ const Input = forwardRef(function Input(
     ...rest,
   };
 
+  // why: a React onWheel cannot cancel the browser's wheel step (React attaches
+  // wheel passively); the guard adds a native listener while the input is focused.
+  const wheelGuard =
+    rest.type === "number" ? withNumberInputWheelGuard(rest) : {};
+
   let input = (
     <input
       {...inputProps}
+      {...wheelGuard}
       aria-label={label}
       ref={ref as RefObject<HTMLInputElement> | undefined}
     />

--- a/apps/webapp/app/components/scanner/drawer/uses/partial-checkin-drawer.tsx
+++ b/apps/webapp/app/components/scanner/drawer/uses/partial-checkin-drawer.tsx
@@ -77,6 +77,7 @@ import type {
   KitFromQr,
 } from "~/routes/api+/get-scanned-item.$qrId";
 import { isAssetPartiallyCheckedIn } from "~/utils/booking-assets";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import { tw } from "~/utils/tw";
 import {
   createAvailabilityLabels,
@@ -2167,6 +2168,7 @@ function QuantityDispositionBlock({
           <input
             ref={primaryInputRef}
             type="number"
+            {...numberInputWheelGuard}
             min={0}
             max={info.remaining}
             step={1}
@@ -2201,6 +2203,7 @@ function QuantityDispositionBlock({
               <span className="text-gray-600">Returned</span>
               <input
                 type="number"
+                {...numberInputWheelGuard}
                 min={0}
                 max={info.remaining}
                 step={1}
@@ -2218,6 +2221,7 @@ function QuantityDispositionBlock({
             <span className="text-gray-600">Lost</span>
             <input
               type="number"
+              {...numberInputWheelGuard}
               min={0}
               max={info.remaining}
               step={1}
@@ -2234,6 +2238,7 @@ function QuantityDispositionBlock({
             <span className="text-gray-600">Damaged</span>
             <input
               type="number"
+              {...numberInputWheelGuard}
               min={0}
               max={info.remaining}
               step={1}

--- a/apps/webapp/app/components/scanner/drawer/uses/partial-checkout-drawer.tsx
+++ b/apps/webapp/app/components/scanner/drawer/uses/partial-checkout-drawer.tsx
@@ -40,6 +40,7 @@ import type {
   AssetFromQr,
   KitFromQr,
 } from "~/routes/api+/get-scanned-item.$qrId";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import { tw } from "~/utils/tw";
 import {
   createAvailabilityLabels,
@@ -1416,6 +1417,7 @@ function QuantityCheckoutBlock({
           <input
             ref={inputRef}
             type="number"
+            {...numberInputWheelGuard}
             min={1}
             max={info.remaining}
             step={1}

--- a/apps/webapp/app/routes/_layout+/admin-dashboard+/org.$organizationId.qr-codes.tsx
+++ b/apps/webapp/app/routes/_layout+/admin-dashboard+/org.$organizationId.qr-codes.tsx
@@ -10,6 +10,7 @@ import { generateOrphanedCodes } from "~/modules/qr/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { payload, error, getParams, parseData } from "~/utils/http.server";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import { requireAdmin } from "~/utils/roles.server";
 
 export const meta = () => [
@@ -159,6 +160,7 @@ export default function AdminOrgQrCodes() {
           <Form method="post">
             <input
               type="number"
+              {...numberInputWheelGuard}
               max={1000}
               min={1}
               name="amount"

--- a/apps/webapp/app/routes/_layout+/assets.$assetId.overview.update-location.tsx
+++ b/apps/webapp/app/routes/_layout+/assets.$assetId.overview.update-location.tsx
@@ -25,6 +25,7 @@ import {
   payload,
 } from "~/utils/http.server";
 import type { DataOrErrorResponse } from "~/utils/http.server";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import {
   PermissionAction,
   PermissionEntity,
@@ -229,6 +230,7 @@ export default function Custody() {
                   id="newLocationQuantity"
                   name="newLocationQuantity"
                   type="number"
+                  {...numberInputWheelGuard}
                   min={1}
                   max={max}
                   value={quantity}

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -112,6 +112,7 @@ import {
   wrapLinkForNote,
   wrapUserLinkForNote,
 } from "~/utils/markdoc-wrappers";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import {
   PermissionAction,
   PermissionEntity,
@@ -1636,6 +1637,7 @@ const RowComponent = ({
               <input
                 id={`qty-${item.id}`}
                 type="number"
+                {...numberInputWheelGuard}
                 min={1}
                 max={item.availableQuantity ?? item.quantity ?? undefined}
                 value={extraProps?.quantities?.[item.id] ?? 1}

--- a/apps/webapp/app/routes/_layout+/kits.$kitId.assets.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/kits.$kitId.assets.manage-assets.tsx
@@ -69,6 +69,7 @@ import { makeShelfError, ShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
 import { payload, error, getParams, parseData } from "~/utils/http.server";
 import { isSelectingAllItems } from "~/utils/list";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import {
   PermissionAction,
   PermissionEntity,
@@ -999,6 +1000,7 @@ const RowComponent = ({
                 <input
                   id={`kit-qty-${item.id}`}
                   type="number"
+                  {...numberInputWheelGuard}
                   min={1}
                   max={Number.isFinite(max) ? max : undefined}
                   value={currentValue}

--- a/apps/webapp/app/routes/_layout+/locations.$locationId.assets.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/locations.$locationId.assets.manage-assets.tsx
@@ -58,6 +58,7 @@ import { ShelfError, makeShelfError } from "~/utils/error";
 import { isFormProcessing } from "~/utils/form";
 import { payload, error, getParams, parseData } from "~/utils/http.server";
 import { isSelectingAllItems } from "~/utils/list";
+import { numberInputWheelGuard } from "~/utils/number-input-wheel-guard";
 import {
   PermissionAction,
   PermissionEntity,
@@ -710,6 +711,7 @@ const RowComponent = ({
                 <input
                   id={`location-qty-${item.id}`}
                   type="number"
+                  {...numberInputWheelGuard}
                   min={1}
                   max={Number.isFinite(max) ? max : undefined}
                   value={currentValue}

--- a/apps/webapp/app/utils/number-input-wheel-guard.test.tsx
+++ b/apps/webapp/app/utils/number-input-wheel-guard.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * numberInputWheelGuard — unit tests
+ *
+ * Verifies the contract of the wheel guard for `<input type="number">`:
+ *  - A wheel event on a focused input is cancelled (the browser's step
+ *    behaviour is suppressed).
+ *  - A wheel event on an unfocused input is left alone so the page scrolls.
+ *  - Read-only inputs never step, so their wheel events are left alone.
+ *  - Focus handlers supplied by the caller keep running.
+ *
+ * @see {@link file://./number-input-wheel-guard.ts}
+ */
+
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  numberInputWheelGuard,
+  withNumberInputWheelGuard,
+} from "./number-input-wheel-guard";
+
+function dispatchWheel(target: Element) {
+  const event = new WheelEvent("wheel", {
+    bubbles: true,
+    cancelable: true,
+    deltaY: 100,
+  });
+  target.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+describe("numberInputWheelGuard", () => {
+  it("cancels wheel events only while the input is focused", () => {
+    const { getByLabelText } = render(
+      <input type="number" aria-label="Quantity" {...numberInputWheelGuard} />
+    );
+    const input = getByLabelText("Quantity");
+
+    expect(dispatchWheel(input)).toBe(false);
+
+    fireEvent.focus(input);
+    expect(dispatchWheel(input)).toBe(true);
+
+    fireEvent.blur(input);
+    expect(dispatchWheel(input)).toBe(false);
+  });
+
+  it("leaves read-only inputs alone", () => {
+    const { getByLabelText } = render(
+      <input
+        type="number"
+        aria-label="Quantity"
+        readOnly
+        {...numberInputWheelGuard}
+      />
+    );
+    const input = getByLabelText("Quantity");
+
+    fireEvent.focus(input);
+    expect(dispatchWheel(input)).toBe(false);
+  });
+
+  it("survives repeated focus without stacking listeners", () => {
+    const { getByLabelText } = render(
+      <input type="number" aria-label="Quantity" {...numberInputWheelGuard} />
+    );
+    const input = getByLabelText("Quantity");
+
+    fireEvent.focus(input);
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+
+    expect(dispatchWheel(input)).toBe(false);
+  });
+});
+
+describe("withNumberInputWheelGuard", () => {
+  it("keeps the caller's focus handlers and still guards the wheel", () => {
+    const onFocus = vi.fn();
+    const onBlur = vi.fn();
+    const { getByLabelText } = render(
+      <input
+        type="number"
+        aria-label="Quantity"
+        {...withNumberInputWheelGuard<HTMLInputElement>({ onFocus, onBlur })}
+      />
+    );
+    const input = getByLabelText("Quantity");
+
+    fireEvent.focus(input);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(dispatchWheel(input)).toBe(true);
+
+    fireEvent.blur(input);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(dispatchWheel(input)).toBe(false);
+  });
+});

--- a/apps/webapp/app/utils/number-input-wheel-guard.test.tsx
+++ b/apps/webapp/app/utils/number-input-wheel-guard.test.tsx
@@ -75,6 +75,7 @@ describe("numberInputWheelGuard", () => {
 
 describe("withNumberInputWheelGuard", () => {
   it("keeps the caller's focus handlers and still guards the wheel", () => {
+    // why: spies prove the caller's own focus handlers still run after the guard wraps them
     const onFocus = vi.fn();
     const onBlur = vi.fn();
     const { getByLabelText } = render(

--- a/apps/webapp/app/utils/number-input-wheel-guard.ts
+++ b/apps/webapp/app/utils/number-input-wheel-guard.ts
@@ -1,0 +1,57 @@
+/**
+ * Keeps the mouse wheel from stepping a focused `<input type="number">`.
+ *
+ * Chromium-based browsers change the value of a focused number input on every
+ * wheel tick while the pointer rests on it, so scrolling past a field rewrites
+ * it. Cancelling the wheel event stops that. React registers `wheel` as a
+ * passive listener, which turns `preventDefault` inside `onWheel` into a no-op,
+ * so the guard attaches its own non-passive listener while the input has focus
+ * and removes it on blur. Typing, paste, arrow keys and the spin buttons keep
+ * working, the wheel scrolls the page again as soon as focus leaves, and
+ * read-only inputs (which never step) are left alone.
+ *
+ * @see {@link file://../components/forms/input.tsx} applies the guard to every
+ * shared input with `type="number"`; plain inputs spread `numberInputWheelGuard`.
+ */
+import type { FocusEvent, FocusEventHandler } from "react";
+
+type FocusHandlers<T extends HTMLElement> = {
+  onFocus?: FocusEventHandler<T>;
+  onBlur?: FocusEventHandler<T>;
+};
+
+function cancelWheelStep(event: WheelEvent) {
+  const input = event.currentTarget;
+  if (input instanceof HTMLInputElement && input.readOnly) return;
+  event.preventDefault();
+}
+
+/**
+ * Wraps a component's focus handlers so the wheel guard runs alongside them.
+ * Use it when the input already receives `onFocus` / `onBlur` props.
+ *
+ * @param handlers - The caller's own `onFocus` / `onBlur`, if any; each runs
+ * after the guard's listener is attached or removed
+ * @returns Both focus handlers, ready to spread onto the element
+ */
+export function withNumberInputWheelGuard<T extends HTMLElement>({
+  onFocus,
+  onBlur,
+}: FocusHandlers<T>): Required<FocusHandlers<T>> {
+  return {
+    onFocus(event: FocusEvent<T>) {
+      event.currentTarget.addEventListener("wheel", cancelWheelStep, {
+        passive: false,
+      });
+      onFocus?.(event);
+    },
+    onBlur(event: FocusEvent<T>) {
+      event.currentTarget.removeEventListener("wheel", cancelWheelStep);
+      onBlur?.(event);
+    },
+  };
+}
+
+/** Focus handlers to spread onto a plain `<input type="number">`. */
+export const numberInputWheelGuard =
+  withNumberInputWheelGuard<HTMLInputElement>({});


### PR DESCRIPTION
## What

Chromium-based browsers step the value of a focused `<input type="number">` on every mouse-wheel tick while the pointer rests on it. In practice: click into Value, type `1250`, scroll down to reach Save, and the field now reads `1247`. This PR cancels the wheel while a number input is focused, and nothing else.

## How

- New `~/utils/number-input-wheel-guard.ts`: `onFocus` attaches a non-passive `wheel` listener that calls `preventDefault()`; `onBlur` removes it. React registers `wheel` as a passive root listener, so `preventDefault` inside a React `onWheel` handler is a no-op; a native listener is required.
- The shared `Input` component applies the guard whenever `type="number"`, composing with any caller-supplied `onFocus` / `onBlur`.
- Plain `<input type="number">` elements spread `{...numberInputWheelGuard}`.

Deliberately **not** `blur()`-on-wheel: focus stays where the user put it, no `onBlur` side effects fire on scroll, and the page scrolls again as soon as focus leaves the field. Typing, paste, arrow keys and the spin buttons are untouched. Read-only number inputs never step, so the guard leaves their wheel alone. Text, date and other input types are not affected.

## Coverage

45 number inputs in `apps/webapp/app`:

| Path | Count |
|---|---|
| via shared `Input` (automatic) | 31 |
| plain `<input>` with the spread | 14 |

Plain-input files: `manage-placements-form`, `bulk-partial-checkout-dialog`, `manage-model-requests` (2), `partial-checkin-drawer` (4), `partial-checkout-drawer`, admin `org.$organizationId.qr-codes`, `assets.$assetId.overview.update-location`, `bookings.$bookingId.overview.manage-assets`, `kits.$kitId.assets.manage-assets`, `locations.$locationId.assets.manage-assets`.

## Proof

Real mouse-wheel events sent through Chrome DevTools Protocol (Google Chrome 152, headless) against the local dev server, field focused, pointer over the field, 3 ticks down then 3 up, then one arrow key:

| Surface | Before (main) | After (this PR) |
|---|---|---|
| `/assets/new` → Value (shared `Input`) | 1250 → **1247** → 1250, ArrowUp → 1251 | 1250 → 1250 → 1250, ArrowUp → 1251 |
| `/assets/:id/overview/update-location` → Quantity (plain input) | 10 → **7** → 10, ArrowDown → 9 | 10 → 10 → 10, ArrowDown → 9 |

Unit tests (Vitest + happy-dom, 7 cases) cover: wheel cancelled only while focused, read-only inputs left alone, no listener stacking on repeated focus, caller focus handlers still run, text inputs untouched.

Locally: full webapp Vitest suite 440 files / 5813 tests pass, `eslint` 0 errors, `tsc -b` 0 errors; pre-commit hooks (eslint, prettier, typecheck, security review, commitlint) passed on the commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented mouse-wheel scrolling from unintentionally changing focused numeric quantities across asset, booking, checkout, scanner, placement, QR-code, and location workflows.
  * Preserved expected behavior for text and read-only fields, including existing focus and blur interactions.

* **Tests**
  * Added coverage confirming wheel protection activates only while numeric fields are focused, does not duplicate event handling, and preserves caller-provided focus and blur behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->