### PR TITLE
feat(audits): assign several people to one audit

### DIFF
--- a/apps/webapp/app/components/assets/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/assets/bulk-start-audit-dialog.tsx
@@ -53,7 +53,7 @@ export default function BulkStartAuditDialog() {
   const nameError = zo.errors.name()?.message;
   const descriptionError = zo.errors.description()?.message;
   const dueDateError = zo.errors.dueDate()?.message;
-  const assigneeError = zo.errors.assignee()?.message;
+  const assigneeError = zo.errors.assignees()?.message;
 
   return (
     <BulkUpdateDialogContent

--- a/apps/webapp/app/components/audit/audit-selector.tsx
+++ b/apps/webapp/app/components/audit/audit-selector.tsx
@@ -192,10 +192,14 @@ const AuditSelector: FunctionComponent<AuditSelectorProps> = ({
                 // "Unassigned" and "Unknown" mean different things: nobody is
                 // assigned, versus someone is but has no name on record — an
                 // SSO account whose IdP sent no name claims resolves to "".
-                const assigneeName =
+                const assigneeNames =
                   audit.assignments.length > 0
-                    ? resolveUserDisplayName(audit.assignments[0].user) ||
-                      "Unknown"
+                    ? audit.assignments
+                        .map(
+                          (assignment) =>
+                            resolveUserDisplayName(assignment.user) || "Unknown"
+                        )
+                        .join(", ")
                     : "Unassigned";
 
                 return (
@@ -219,7 +223,12 @@ const AuditSelector: FunctionComponent<AuditSelectorProps> = ({
                     </div>
                     <div className="mt-1 flex flex-col gap-0.5 text-xs text-gray-600">
                       <span>Created by: {creatorName}</span>
-                      <span>Assignee: {assigneeName}</span>
+                      <span>
+                        {audit.assignments.length > 1
+                          ? "Assignees"
+                          : "Assignee"}
+                        : {assigneeNames}
+                      </span>
                       <span>Expected assets: {audit.expectedAssetCount}</span>
                     </div>
                   </div>

--- a/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
+++ b/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AuditTeamMemberSelector from "./audit-team-member-selector";
+
+/**
+ * The multi-select assignee picker.
+ *
+ * why this test exists: the picker's only output is a set of hidden inputs.
+ * If it emitted repeated same-name fields the server would keep one person;
+ * if a pre-selected member lost their user id before the list loaded, saving
+ * the edit dialog would silently remove the whole team. Both are invisible
+ * in the browser and only show up as missing assignees later.
+ *
+ * @see {@link file://./audit-team-member-selector.tsx}
+ */
+
+const mockUseApiQuery = vi.fn();
+vi.mock("~/hooks/use-api-query", () => ({
+  default: (...args: unknown[]) => mockUseApiQuery(...args),
+}));
+
+vi.mock("~/hooks/use-user-data", () => ({
+  useUserData: () => ({ id: "user-1" }),
+}));
+
+// why: the shared Button pulls in router-aware rendering; a plain button is
+// all the picker needs here.
+vi.mock("~/components/shared/button", () => ({
+  Button: ({ children, ...rest }: any) => <button {...rest}>{children}</button>,
+}));
+
+const members = [
+  {
+    id: "tm-1",
+    name: "Ana Lead",
+    user: {
+      id: "user-1",
+      firstName: "Ana",
+      lastName: "Lead",
+      displayName: null,
+      email: "ana@x.io",
+      profilePicture: null,
+    },
+  },
+  {
+    id: "tm-2",
+    name: "Ben Scan",
+    user: {
+      id: "user-2",
+      firstName: "Ben",
+      lastName: "Scan",
+      displayName: null,
+      email: "ben@x.io",
+      profilePicture: null,
+    },
+  },
+  {
+    id: "tm-3",
+    name: "Cy Count",
+    user: {
+      id: "user-3",
+      firstName: "Cy",
+      lastName: "Count",
+      displayName: null,
+      email: "cy@x.io",
+      profilePicture: null,
+    },
+  },
+];
+
+/** The member's row: a checkbox whose accessible name includes their name. */
+const row = (name: string) =>
+  screen.getByRole("checkbox", { name: new RegExp(name) });
+
+function hiddenInputs(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLInputElement>('input[type="hidden"]')
+  ).map((input) => ({
+    name: input.name,
+    value: JSON.parse(input.value) as {
+      id: string;
+      userId: string;
+      name: string;
+    },
+  }));
+}
+
+describe("AuditTeamMemberSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseApiQuery.mockReturnValue({
+      isLoading: false,
+      data: { teamMembers: members },
+    });
+  });
+
+  it("emits one bracket-indexed hidden input per selected member", () => {
+    const { container } = render(<AuditTeamMemberSelector />);
+
+    fireEvent.click(row("Ben Scan"));
+    fireEvent.click(row("Cy Count"));
+
+    expect(hiddenInputs(container)).toEqual([
+      {
+        name: "assignees[0]",
+        value: { id: "tm-2", userId: "user-2", name: "Ben Scan" },
+      },
+      {
+        name: "assignees[1]",
+        value: { id: "tm-3", userId: "user-3", name: "Cy Count" },
+      },
+    ]);
+    expect(screen.getByText("2 assignees selected")).toBeTruthy();
+  });
+
+  it("clicking a selected member again removes them and re-indexes the rest", () => {
+    const { container } = render(<AuditTeamMemberSelector />);
+
+    fireEvent.click(row("Ben Scan"));
+    fireEvent.click(row("Cy Count"));
+    fireEvent.click(row("Ben Scan"));
+
+    expect(hiddenInputs(container).map((i) => i.name)).toEqual([
+      "assignees[0]",
+    ]);
+    expect(hiddenInputs(container)[0].value.userId).toBe("user-3");
+  });
+
+  it("keeps pre-selected members submittable before the member list has loaded", () => {
+    mockUseApiQuery.mockReturnValue({ isLoading: true, data: undefined });
+
+    const { container } = render(
+      <AuditTeamMemberSelector
+        defaultSelected={[
+          { id: "tm-2", userId: "user-2", name: "Ben Scan" },
+          { id: "tm-3", userId: "user-3", name: "Cy Count" },
+        ]}
+      />
+    );
+
+    expect(hiddenInputs(container).map((i) => i.value.userId)).toEqual([
+      "user-2",
+      "user-3",
+    ]);
+  });
+
+  it("'Assign to self' adds the current user alongside existing selections", () => {
+    const { container } = render(
+      <AuditTeamMemberSelector
+        defaultSelected={[{ id: "tm-2", userId: "user-2", name: "Ben Scan" }]}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Assign to self"));
+
+    expect(hiddenInputs(container).map((i) => i.value.userId)).toEqual([
+      "user-2",
+      "user-1",
+    ]);
+    expect(screen.getByText("You are assigned")).toBeTruthy();
+  });
+
+  it("still submits a selected member when the search filter hides their row", () => {
+    const { container } = render(<AuditTeamMemberSelector />);
+
+    fireEvent.click(row("Ben Scan"));
+    fireEvent.change(screen.getByPlaceholderText("Find team members"), {
+      target: { value: "zzz" },
+    });
+
+    expect(screen.queryByRole("checkbox", { name: /Ben Scan/ })).toBeNull();
+    expect(hiddenInputs(container)[0].value).toEqual({
+      id: "tm-2",
+      userId: "user-2",
+      name: "Ben Scan",
+    });
+  });
+});

--- a/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
+++ b/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
@@ -114,7 +114,9 @@ describe("AuditTeamMemberSelector", () => {
         value: { id: "tm-3", userId: "user-3", name: "Cy Count" },
       },
     ]);
-    expect(screen.getByText("2 assignees selected")).toBeTruthy();
+    expect(screen.getByText("Selected (2):").parentElement?.textContent).toBe(
+      "Selected (2): Ben Scan, Cy Count"
+    );
   });
 
   it("clicking a selected member again removes them and re-indexes the rest", () => {
@@ -161,7 +163,25 @@ describe("AuditTeamMemberSelector", () => {
       "user-2",
       "user-1",
     ]);
-    expect(screen.getByText("You are assigned")).toBeTruthy();
+    expect(screen.getByText("Remove me")).toBeTruthy();
+  });
+
+  it("'Remove me' takes only the current user out of the selection", () => {
+    const { container } = render(
+      <AuditTeamMemberSelector
+        defaultSelected={[
+          { id: "tm-2", userId: "user-2", name: "Ben Scan" },
+          { id: "tm-1", userId: "user-1", name: "Ana Lead" },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Remove me"));
+
+    expect(hiddenInputs(container).map((i) => i.value.userId)).toEqual([
+      "user-2",
+    ]);
+    expect(screen.getByText("Assign to self")).toBeTruthy();
   });
 
   it("still submits a selected member when the search filter hides their row", () => {

--- a/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
+++ b/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentPropsWithoutRef } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -30,7 +31,15 @@ vi.mock("~/hooks/use-user-data", () => ({
 // why: the shared Button pulls in router-aware rendering; a plain button is
 // all the picker needs here.
 vi.mock("~/components/shared/button", () => ({
-  Button: ({ children, ...rest }: any) => <button {...rest}>{children}</button>,
+  Button: ({ children, ...rest }: ComponentPropsWithoutRef<"button">) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+// why: the picker disables its self toggle while the enclosing form submits;
+// no form or navigation exists in this test, so it is never submitting.
+vi.mock("~/hooks/use-disabled", () => ({
+  useDisabled: () => false,
 }));
 
 const members = [

--- a/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
+++ b/apps/webapp/app/components/audit/audit-team-member-selector.test.tsx
@@ -15,11 +15,14 @@ import AuditTeamMemberSelector from "./audit-team-member-selector";
  * @see {@link file://./audit-team-member-selector.tsx}
  */
 
+// why: the picker fetches /api/audits/team-members on mount; the stub feeds a
+// fixed member list and lets one test simulate the still-loading state.
 const mockUseApiQuery = vi.fn();
 vi.mock("~/hooks/use-api-query", () => ({
   default: (...args: unknown[]) => mockUseApiQuery(...args),
 }));
 
+// why: "Assign to self" needs a current user; there is no root loader here.
 vi.mock("~/hooks/use-user-data", () => ({
   useUserData: () => ({ id: "user-1" }),
 }));

--- a/apps/webapp/app/components/audit/audit-team-member-selector.tsx
+++ b/apps/webapp/app/components/audit/audit-team-member-selector.tsx
@@ -105,11 +105,17 @@ export default function AuditTeamMemberSelector({
   const isSelfSelected =
     !!currentUserTeamMember && selectedIds.includes(currentUserTeamMember.id);
 
+  // Toggles only the current user's own row; never touches other picks.
   const handleAssignToSelf = useCallback(() => {
-    if (currentUserTeamMember && !isSelfSelected) {
+    if (currentUserTeamMember) {
       handleTeamMemberSelect(currentUserTeamMember);
     }
-  }, [currentUserTeamMember, isSelfSelected, handleTeamMemberSelect]);
+  }, [currentUserTeamMember, handleTeamMemberSelect]);
+
+  const selectedNames = selectedIds
+    .map((id) => knownMembersRef.current.get(id)?.name)
+    .filter((name): name is string => !!name)
+    .join(", ");
 
   const teamMembers = useMemo(() => {
     if (!data) {
@@ -159,9 +165,8 @@ export default function AuditTeamMemberSelector({
             size="sm"
             className="w-full"
             onClick={handleAssignToSelf}
-            disabled={isSelfSelected}
           >
-            {isSelfSelected ? "You are assigned" : "Assign to self"}
+            {isSelfSelected ? "Remove me" : "Assign to self"}
           </Button>
         </div>
       )}
@@ -172,9 +177,8 @@ export default function AuditTeamMemberSelector({
 
       <When truthy={selectedIds.length > 0}>
         <p className="px-3 pb-2 text-sm text-gray-600">
-          {selectedIds.length === 1
-            ? "1 assignee selected"
-            : `${selectedIds.length} assignees selected`}
+          <span className="font-medium">Selected ({selectedIds.length}):</span>{" "}
+          {selectedNames}
         </p>
       </When>
 

--- a/apps/webapp/app/components/audit/audit-team-member-selector.tsx
+++ b/apps/webapp/app/components/audit/audit-team-member-selector.tsx
@@ -1,40 +1,74 @@
 import type { CSSProperties } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { CheckIcon, UserIcon } from "lucide-react";
 import { Button } from "~/components/shared/button";
 import { Separator } from "~/components/shared/separator";
 import When from "~/components/when/when";
 import useApiQuery from "~/hooks/use-api-query";
 import { useUserData } from "~/hooks/use-user-data";
+import { AUDIT_ASSIGNEES_FIELD } from "~/modules/audit/assignee-form";
 import type { AuditTeamMember } from "~/routes/api+/audits.team-members";
 import { handleActivationKeyPress } from "~/utils/keyboard";
 import { tw } from "~/utils/tw";
 import { resolveTeamMemberName } from "~/utils/user";
 
+/** A team member the dialog wants pre-selected, with the user id it maps to. */
+export type AuditAssigneeDefault = {
+  /** TeamMember id (what the list renders and toggles on). */
+  id: string;
+  /** The member's user id (what the server stores on the assignment). */
+  userId: string;
+  name: string;
+};
+
 type AuditTeamMemberSelectorProps = {
   className?: string;
   style?: CSSProperties;
   error?: string;
-  defaultValue?: string;
+  /**
+   * Members to pre-select (edit dialog). Carries the user id so the hidden
+   * inputs are complete before the member list has loaded — otherwise a save
+   * during that window would submit an empty selection and remove everyone.
+   */
+  defaultSelected?: AuditAssigneeDefault[];
 };
+
+type KnownMember = { userId: string; name: string };
 
 /**
  * Team member selector for audit assignment.
- * Single selection mode - only one assignee can be chosen.
+ *
+ * Multi-select: every selected member becomes an assignee, and any assignee
+ * may scan, annotate and complete the audit. Each selection is submitted as
+ * its own bracket-indexed hidden input (`assignees[0]`, `assignees[1]`, …)
+ * because the server's form parser collapses repeated same-name fields but
+ * turns bracket indices into an array — the convention `assetIds[i]` uses.
+ *
  * Only shows team members with user accounts (excludes NRMs).
  */
 export default function AuditTeamMemberSelector({
   className,
   style,
   error,
-  defaultValue,
+  defaultSelected,
 }: AuditTeamMemberSelectorProps) {
   const [searchQuery, setSearchQuery] = useState("");
   // Lazy initializer avoids a false-positive derived-state lint: after mount this
   // state is user-controlled via the selector, so it must NOT re-sync with the prop.
-  const [selectedTeamMember, setSelectedTeamMember] = useState<
-    string | undefined
-  >(() => defaultValue);
+  const [selectedIds, setSelectedIds] = useState<string[]>(
+    () => defaultSelected?.map((member) => member.id) ?? []
+  );
+  // Everything ever selected, keyed by team member id. Seeded from the
+  // defaults and extended from the loaded list, so a hidden input can always
+  // name the user id even when the search filter hides the row.
+  const knownMembersRef = useRef<Map<string, KnownMember>>(
+    new Map(
+      (defaultSelected ?? []).map((member) => [
+        member.id,
+        { userId: member.userId, name: member.name },
+      ])
+    )
+  );
 
   const user = useUserData();
 
@@ -49,11 +83,33 @@ export default function AuditTeamMemberSelector({
     return data.teamMembers.find((tm) => tm.user?.id === user.id);
   }, [data, user?.id]);
 
+  const remember = useCallback((teamMember: AuditTeamMember) => {
+    knownMembersRef.current.set(teamMember.id, {
+      userId: teamMember.user?.id ?? "",
+      name: teamMember.name,
+    });
+  }, []);
+
+  const handleTeamMemberSelect = useCallback(
+    (teamMember: AuditTeamMember) => {
+      remember(teamMember);
+      setSelectedIds((prev) =>
+        prev.includes(teamMember.id)
+          ? prev.filter((id) => id !== teamMember.id)
+          : [...prev, teamMember.id]
+      );
+    },
+    [remember]
+  );
+
+  const isSelfSelected =
+    !!currentUserTeamMember && selectedIds.includes(currentUserTeamMember.id);
+
   const handleAssignToSelf = useCallback(() => {
-    if (currentUserTeamMember) {
-      setSelectedTeamMember(currentUserTeamMember.id);
+    if (currentUserTeamMember && !isSelfSelected) {
+      handleTeamMemberSelect(currentUserTeamMember);
     }
-  }, [currentUserTeamMember]);
+  }, [currentUserTeamMember, isSelfSelected, handleTeamMemberSelect]);
 
   const teamMembers = useMemo(() => {
     if (!data) {
@@ -76,16 +132,6 @@ export default function AuditTeamMemberSelector({
         tm.user?.email?.includes(normalizedQuery)
     );
   }, [data, searchQuery]);
-
-  const handleTeamMemberSelect = useCallback((teamMember: AuditTeamMember) => {
-    setSelectedTeamMember((prev) => {
-      // Toggle selection: if already selected, deselect
-      if (prev === teamMember.id) {
-        return undefined;
-      }
-      return teamMember.id;
-    });
-  }, []);
 
   return (
     <div
@@ -113,11 +159,9 @@ export default function AuditTeamMemberSelector({
             size="sm"
             className="w-full"
             onClick={handleAssignToSelf}
-            disabled={selectedTeamMember === currentUserTeamMember.id}
+            disabled={isSelfSelected}
           >
-            {selectedTeamMember === currentUserTeamMember.id
-              ? "Assigned to self"
-              : "Assign to self"}
+            {isSelfSelected ? "You are assigned" : "Assign to self"}
           </Button>
         </div>
       )}
@@ -126,24 +170,32 @@ export default function AuditTeamMemberSelector({
         <p className="px-3 pb-2 text-error-500">{error}</p>
       </When>
 
+      <When truthy={selectedIds.length > 0}>
+        <p className="px-3 pb-2 text-sm text-gray-600">
+          {selectedIds.length === 1
+            ? "1 assignee selected"
+            : `${selectedIds.length} assignees selected`}
+        </p>
+      </When>
+
       <Separator />
 
-      {/* Hidden input field for form submission */}
-      {selectedTeamMember && (
-        <input
-          type="hidden"
-          name="assignee"
-          value={JSON.stringify({
-            id: selectedTeamMember,
-            name:
-              teamMembers.find((tm) => tm.id === selectedTeamMember)?.name ??
-              "",
-            userId:
-              teamMembers.find((tm) => tm.id === selectedTeamMember)?.user
-                ?.id ?? "",
-          })}
-        />
-      )}
+      {/* One hidden input per selection, bracket-indexed so the server sees an array */}
+      {selectedIds.map((id, index) => {
+        const known = knownMembersRef.current.get(id);
+        return (
+          <input
+            key={id}
+            type="hidden"
+            name={`${AUDIT_ASSIGNEES_FIELD}[${index}]`}
+            value={JSON.stringify({
+              id,
+              name: known?.name ?? "",
+              userId: known?.userId ?? "",
+            })}
+          />
+        );
+      })}
 
       <When truthy={isLoading}>
         {Array.from({ length: 6 }).map((_, i) => (
@@ -158,7 +210,7 @@ export default function AuditTeamMemberSelector({
           </div>
         ) : (
           teamMembers.map((teamMember) => {
-            const isTeamMemberSelected = selectedTeamMember === teamMember.id;
+            const isTeamMemberSelected = selectedIds.includes(teamMember.id);
 
             return (
               <div
@@ -167,7 +219,8 @@ export default function AuditTeamMemberSelector({
                   "flex cursor-pointer items-center justify-between gap-4 border-b px-6 py-4 hover:bg-gray-100",
                   isTeamMemberSelected && "bg-gray-100"
                 )}
-                role="button"
+                role="checkbox"
+                aria-checked={isTeamMemberSelected}
                 tabIndex={0}
                 onClick={() => handleTeamMemberSelect(teamMember)}
                 onKeyDown={handleActivationKeyPress(() =>

--- a/apps/webapp/app/components/audit/audit-team-member-selector.tsx
+++ b/apps/webapp/app/components/audit/audit-team-member-selector.tsx
@@ -5,6 +5,7 @@ import { Button } from "~/components/shared/button";
 import { Separator } from "~/components/shared/separator";
 import When from "~/components/when/when";
 import useApiQuery from "~/hooks/use-api-query";
+import { useDisabled } from "~/hooks/use-disabled";
 import { useUserData } from "~/hooks/use-user-data";
 import { AUDIT_ASSIGNEES_FIELD } from "~/modules/audit/assignee-form";
 import type { AuditTeamMember } from "~/routes/api+/audits.team-members";
@@ -71,6 +72,9 @@ export default function AuditTeamMemberSelector({
   );
 
   const user = useUserData();
+  // The picker lives inside a form; while that form submits, the self toggle
+  // must not change the selection under the request.
+  const isSubmitting = useDisabled();
 
   const { isLoading, data } = useApiQuery<{
     teamMembers: AuditTeamMember[];
@@ -112,8 +116,15 @@ export default function AuditTeamMemberSelector({
     }
   }, [currentUserTeamMember, handleTeamMemberSelect]);
 
+  // Prefer the loaded row's display name (what the list itself renders); the
+  // remembered name is the fallback until the member list has arrived.
   const selectedNames = selectedIds
-    .map((id) => knownMembersRef.current.get(id)?.name)
+    .map((id) => {
+      const loaded = data?.teamMembers.find((tm) => tm.id === id);
+      return loaded
+        ? resolveTeamMemberName(loaded)
+        : knownMembersRef.current.get(id)?.name;
+    })
     .filter((name): name is string => !!name)
     .join(", ");
 
@@ -165,6 +176,7 @@ export default function AuditTeamMemberSelector({
             size="sm"
             className="w-full"
             onClick={handleAssignToSelf}
+            disabled={isSubmitting}
           >
             {isSelfSelected ? "Remove me" : "Assign to self"}
           </Button>

--- a/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
@@ -38,8 +38,8 @@ export function DuplicateAuditDialog() {
         </p>
         <p>
           A new audit will be created with the same name, description, assets
-          and assignees. Notes, scans, images, and the due date will not be
-          copied.
+          and assignees who are still in this workspace. Notes, scans, images,
+          and the due date will not be copied.
         </p>
       </div>
 

--- a/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/duplicate-audit-dialog.tsx
@@ -37,8 +37,8 @@ export function DuplicateAuditDialog() {
           <strong className="text-gray-900">{audit.name}</strong>.
         </p>
         <p>
-          A new audit will be created with the same name, description, and
-          assets. Assignments, notes, scans, images, and due date will not be
+          A new audit will be created with the same name, description, assets
+          and assignees. Notes, scans, images, and the due date will not be
           copied.
         </p>
       </div>

--- a/apps/webapp/app/components/audit/edit-audit-dialog.tsx
+++ b/apps/webapp/app/components/audit/edit-audit-dialog.tsx
@@ -23,6 +23,9 @@ export const EditAuditSchema = z.object({
     .max(1000, "Description must be 1000 characters or fewer")
     .optional(),
   dueDate: z.string().optional(),
+  /** `assignees[i]` JSON blobs from AuditTeamMemberSelector. */
+  assignees: z.array(z.string()).optional(),
+  /** Pre-multi-assign singular field; still parsed server-side. */
   assignee: z.string().optional(),
 });
 
@@ -33,7 +36,7 @@ type EditAuditDialogProps = {
     description: string | null;
     dueDate: Date | null;
     status: AuditStatus;
-    /** Only `userId` is read — it maps back to the assignee's team member. */
+    /** Only `userId` is read — it maps back to each assignee's team member. */
     assignments: Array<{ userId: string }>;
   };
   teamMembers: Array<{
@@ -62,7 +65,7 @@ export function EditAuditDialog({
   const nameError = zo.errors.name()?.message;
   const descriptionError = zo.errors.description()?.message;
   const dueDateError = zo.errors.dueDate()?.message;
-  const assigneeError = zo.errors.assignee()?.message;
+  const assigneeError = zo.errors.assignees()?.message;
 
   // Resolved timezone preference — the SAME zone date DISPLAY uses. Seed the
   // datetime-local default from the stored UTC instant in this zone (not the
@@ -81,15 +84,27 @@ export function EditAuditDialog({
     );
   }, [audit.dueDate, timeZone]);
 
-  // Get current assignee's team member ID (convert from user ID)
-  const defaultAssigneeTeamMemberId = useMemo(() => {
-    if (audit.assignments.length === 0) {
-      return undefined;
-    }
-    const currentUserId = audit.assignments[0].userId;
-    const teamMember = teamMembers.find((tm) => tm.userId === currentUserId);
-    return teamMember?.id;
-  }, [teamMembers, audit.assignments]);
+  // Pre-select every current assignee (convert user ids to team member ids).
+  // An assignee whose team member row is gone cannot be rendered or re-saved,
+  // so they drop out of the selection; saving then removes that assignment.
+  const defaultAssignees = useMemo(
+    () =>
+      audit.assignments.flatMap((assignment) => {
+        const teamMember = teamMembers.find(
+          (tm) => tm.userId === assignment.userId
+        );
+        return teamMember
+          ? [
+              {
+                id: teamMember.id,
+                userId: assignment.userId,
+                name: teamMember.name,
+              },
+            ]
+          : [];
+      }),
+    [teamMembers, audit.assignments]
+  );
 
   const isActiveAudit = audit.status === "ACTIVE";
 
@@ -109,7 +124,7 @@ export function EditAuditDialog({
           <div className="-mb-3 w-full pb-6">
             <h3>Edit audit details</h3>
             <p className="text-gray-600">
-              Update the name, description, due date, and assignee of this
+              Update the name, description, due date, and assignees of this
               audit.
             </p>
           </div>
@@ -167,8 +182,8 @@ export function EditAuditDialog({
                       Active audit
                     </p>
                     <p className="mt-1 text-sm text-amber-700">
-                      This audit is currently active. Changing the assignee may
-                      affect ongoing scans.
+                      This audit is currently active. Removing an assignee takes
+                      away their access to scan it right away.
                     </p>
                   </div>
                 </div>
@@ -178,14 +193,16 @@ export function EditAuditDialog({
             {/* Right column: Team member selector */}
             <div className="!border-r">
               <Separator className="md:hidden" />
-              <p className="p-3 pb-0 font-medium">Select assignee (optional)</p>
+              <p className="p-3 pb-0 font-medium">
+                Select assignees (optional)
+              </p>
               <p className="border-b p-3">
                 Admins can perform any audit. Choosing assignees also lets those
                 people perform it, including several at different times.
               </p>
               <AuditTeamMemberSelector
                 error={assigneeError}
-                defaultValue={defaultAssigneeTeamMemberId}
+                defaultSelected={defaultAssignees}
               />
             </div>
           </div>

--- a/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
+++ b/apps/webapp/app/components/audit/start-audit-dialog-content.tsx
@@ -169,7 +169,7 @@ export function StartAuditDialogContent({
         {/* Right column: Team member selector */}
         <div className="!border-r">
           <Separator className="md:hidden" />
-          <p className="p-3 pb-0 font-medium">Select assignee (optional).</p>
+          <p className="p-3 pb-0 font-medium">Select assignees (optional).</p>
           <p className="border-b p-3 ">
             Admins can perform any audit. Choosing assignees also lets those
             people perform it, including several at different times.

--- a/apps/webapp/app/components/audit/start-audit-from-context-dialog.tsx
+++ b/apps/webapp/app/components/audit/start-audit-from-context-dialog.tsx
@@ -45,6 +45,9 @@ const StartAuditFromContextFormSchema = z.object({
       },
       { message: "Due date must be in the future" }
     ),
+  /** `assignees[i]` JSON blobs from AuditTeamMemberSelector. */
+  assignees: z.array(z.string()).optional(),
+  /** Pre-multi-assign singular field; still parsed server-side. */
   assignee: z.string().optional(),
 });
 
@@ -269,7 +272,7 @@ export function StartAuditFromContextDialog({
               <div className="!border-r">
                 <Separator className="md:hidden" />
                 <p className="p-3 pb-0 font-medium">
-                  Select assignee (optional).
+                  Select assignees (optional).
                 </p>
                 <p className="border-b p-3 ">
                   Admins can perform any audit. Choosing assignees also lets

--- a/apps/webapp/app/components/kits/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/kits/bulk-start-audit-dialog.tsx
@@ -192,7 +192,7 @@ export default function KitsBulkStartAuditDialog() {
   const nameError = zo.errors.name()?.message;
   const descriptionError = zo.errors.description()?.message;
   const dueDateError = zo.errors.dueDate()?.message;
-  const assigneeError = zo.errors.assignee()?.message;
+  const assigneeError = zo.errors.assignees()?.message;
 
   return (
     <BulkUpdateDialogContent

--- a/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
+++ b/apps/webapp/app/components/location/bulk-start-audit-dialog.tsx
@@ -191,7 +191,7 @@ export default function LocationsBulkStartAuditDialog() {
   const nameError = zo.errors.name()?.message;
   const descriptionError = zo.errors.description()?.message;
   const dueDateError = zo.errors.dueDate()?.message;
-  const assigneeError = zo.errors.assignee()?.message;
+  const assigneeError = zo.errors.assignees()?.message;
 
   return (
     <BulkUpdateDialogContent

--- a/apps/webapp/app/emails/mail.server.ts
+++ b/apps/webapp/app/emails/mail.server.ts
@@ -5,9 +5,14 @@ import { triggerEmail } from "./email.worker.server";
 import type { EmailPayloadType } from "./types";
 
 const label = "Email";
-export const sendEmail = (payload: EmailPayloadType) => {
+/**
+ * Sends an email directly and falls back to the retrying queue when the
+ * direct send fails. Resolves once the send or the enqueue has finished, for
+ * callers that must not move on before delivery is settled.
+ */
+export const sendEmailAndWait = (payload: EmailPayloadType) =>
   // attempt to send email, push to the queue if it fails
-  triggerEmail(payload).catch((cause) => {
+  triggerEmail(payload).catch(async (cause) => {
     Logger.error(
       new ShelfError({
         cause,
@@ -21,8 +26,12 @@ export const sendEmail = (payload: EmailPayloadType) => {
         shouldBeCaptured: false, // Will be captured if all queue retries fail
       })
     );
-    void addToQueue(payload);
+    await addToQueue(payload);
   });
+
+/** Fire-and-forget form of {@link sendEmailAndWait}, for the common case. */
+export const sendEmail = (payload: EmailPayloadType) => {
+  void sendEmailAndWait(payload);
 };
 
 const addToQueue = async (payload: EmailPayloadType) => {

--- a/apps/webapp/app/modules/audit/assignee-form.test.ts
+++ b/apps/webapp/app/modules/audit/assignee-form.test.ts
@@ -1,0 +1,73 @@
+/**
+ * How assignee selections travel from the picker to the server.
+ *
+ * why this test exists: the picker submits JSON blobs, older forms submit a
+ * single bare field, and the server must turn both into one deduplicated list
+ * of user ids without ever letting an empty id through. A regression here
+ * either drops a chosen assignee silently or writes a dangling assignment.
+ *
+ * @see {@link file://./assignee-form.ts}
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseAssigneeUserId, resolveAssigneeUserIds } from "./assignee-form";
+
+const blob = (userId: string, id = `tm-${userId}`) =>
+  JSON.stringify({ id, name: `Member ${userId}`, userId });
+
+describe("parseAssigneeUserId", () => {
+  it("reads the user id out of the picker's JSON blob", () => {
+    expect(parseAssigneeUserId(blob("user-2"))).toBe("user-2");
+  });
+
+  it("accepts a bare user id (pre-multi-assign clients)", () => {
+    expect(parseAssigneeUserId("user-9")).toBe("user-9");
+  });
+
+  it("drops a blob whose user id is empty (member list not loaded yet)", () => {
+    expect(
+      parseAssigneeUserId(JSON.stringify({ id: "tm-1", name: "X", userId: "" }))
+    ).toBeUndefined();
+    expect(
+      parseAssigneeUserId(JSON.stringify({ id: "tm-1", name: "X" }))
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for empty input", () => {
+    expect(parseAssigneeUserId("")).toBeUndefined();
+    expect(parseAssigneeUserId(null)).toBeUndefined();
+    expect(parseAssigneeUserId(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveAssigneeUserIds", () => {
+  it("collects every selected member in submission order", () => {
+    expect(
+      resolveAssigneeUserIds([blob("user-2"), blob("user-3"), blob("user-4")])
+    ).toEqual(["user-2", "user-3", "user-4"]);
+  });
+
+  it("deduplicates a member submitted twice", () => {
+    expect(
+      resolveAssigneeUserIds([blob("user-2"), blob("user-2", "tm-other")])
+    ).toEqual(["user-2"]);
+  });
+
+  it("merges the legacy singular field with the array", () => {
+    expect(resolveAssigneeUserIds([blob("user-2")], blob("user-3"))).toEqual([
+      "user-2",
+      "user-3",
+    ]);
+    expect(resolveAssigneeUserIds(undefined, blob("user-3"))).toEqual([
+      "user-3",
+    ]);
+  });
+
+  it("returns an empty list when nothing usable was submitted", () => {
+    expect(resolveAssigneeUserIds(undefined, undefined)).toEqual([]);
+    expect(resolveAssigneeUserIds([], "")).toEqual([]);
+    expect(
+      resolveAssigneeUserIds([JSON.stringify({ id: "tm-1", userId: "" })])
+    ).toEqual([]);
+  });
+});

--- a/apps/webapp/app/modules/audit/assignee-form.ts
+++ b/apps/webapp/app/modules/audit/assignee-form.ts
@@ -1,0 +1,59 @@
+/**
+ * How audit assignees travel from the picker to the server.
+ *
+ * `AuditTeamMemberSelector` submits one bracket-indexed hidden input per
+ * selected member (`assignees[0]`, `assignees[1]`, …), each a JSON blob
+ * `{ id, name, userId }`; only `userId` matters server-side. The singular
+ * `assignee` field is what forms rendered before multi-assign shipped submit,
+ * and it stays accepted so a page left open across the deploy still saves.
+ *
+ * Client-safe: no server imports, so the zod schemas can use it on both sides.
+ */
+
+/** Form field name the selector emits (bracket-indexed). */
+export const AUDIT_ASSIGNEES_FIELD = "assignees";
+
+/**
+ * Extracts the user id from one submitted assignee value.
+ *
+ * Accepts the picker's JSON blob or a bare user id (the pre-multi-assign
+ * fallback). Returns undefined for anything without a usable user id, so a
+ * hidden input rendered before the member list loaded cannot smuggle an empty
+ * id into the assignment table.
+ */
+export function parseAssigneeUserId(
+  value: string | null | undefined
+): string | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "userId" in parsed &&
+      typeof parsed.userId === "string" &&
+      parsed.userId.length > 0
+    ) {
+      return parsed.userId;
+    }
+    return undefined;
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Resolves the submitted assignee fields to a deduplicated list of user ids.
+ *
+ * @param assignees - The bracket-indexed `assignees[i]` values, if any.
+ * @param assignee - The legacy singular `assignee` value, if any.
+ */
+export function resolveAssigneeUserIds(
+  assignees: string[] | undefined,
+  assignee?: string | null
+): string[] {
+  const ids = [...(assignees ?? []), assignee]
+    .map(parseAssigneeUserId)
+    .filter((id): id is string => !!id);
+  return Array.from(new Set(ids));
+}

--- a/apps/webapp/app/modules/audit/assignment-emails.server.ts
+++ b/apps/webapp/app/modules/audit/assignment-emails.server.ts
@@ -1,0 +1,73 @@
+import { db } from "~/database/db.server";
+import type { ClientHint } from "~/utils/client-hints";
+import { ShelfError } from "~/utils/error";
+import { Logger } from "~/utils/logger";
+import { resolveUserDisplayName } from "~/utils/user";
+import { AUDIT_INCLUDE_FOR_EMAIL } from "./constants";
+import { sendAuditAssignedEmail } from "./email-helpers";
+
+/**
+ * Sends the "You've been assigned to audit" email to each recipient.
+ *
+ * Shared by the create route and the edit action so a person added later gets
+ * the same email as one picked at creation. Loads the audit once and fans out
+ * one send per recipient; callers pass only the users who are NEW to the audit
+ * and never the actor themselves. Fire-and-forget safe: every failure is
+ * logged here, nothing is thrown.
+ */
+export async function sendAuditAssignedEmails({
+  auditId,
+  organizationId,
+  recipientUserIds,
+  hints,
+}: {
+  auditId: string;
+  organizationId: string;
+  recipientUserIds: string[];
+  hints: ClientHint;
+}) {
+  const recipients = Array.from(new Set(recipientUserIds));
+  if (recipients.length === 0) {
+    return;
+  }
+
+  try {
+    // Scoped by organizationId for defense-in-depth even though callers pass
+    // an audit they just created or edited in this org.
+    const audit = await db.auditSession.findFirst({
+      where: { id: auditId, organizationId },
+      include: AUDIT_INCLUDE_FOR_EMAIL,
+    });
+
+    if (!audit) {
+      return;
+    }
+
+    await Promise.all(
+      audit.assignments
+        .filter(
+          (assignment) =>
+            recipients.includes(assignment.userId) && assignment.user.email
+        )
+        .map((assignment) =>
+          sendAuditAssignedEmail({
+            audit,
+            assigneeEmail: assignment.user.email,
+            assigneeName:
+              resolveUserDisplayName(assignment.user) || "Unknown User",
+            assigneeUserId: assignment.userId,
+            hints,
+          })
+        )
+    );
+  } catch (cause) {
+    Logger.error(
+      new ShelfError({
+        cause,
+        message: "Failed to send audit assignment emails",
+        additionalData: { auditId, organizationId, recipients },
+        label: "Audit",
+      })
+    );
+  }
+}

--- a/apps/webapp/app/modules/audit/assignment-emails.server.ts
+++ b/apps/webapp/app/modules/audit/assignment-emails.server.ts
@@ -43,23 +43,21 @@ export async function sendAuditAssignedEmails({
       return;
     }
 
-    await Promise.all(
-      audit.assignments
-        .filter(
-          (assignment) =>
-            recipients.includes(assignment.userId) && assignment.user.email
-        )
-        .map((assignment) =>
-          sendAuditAssignedEmail({
-            audit,
-            assigneeEmail: assignment.user.email,
-            assigneeName:
-              resolveUserDisplayName(assignment.user) || "Unknown User",
-            assigneeUserId: assignment.userId,
-            hints,
-          })
-        )
-    );
+    // Sequential on purpose: each send resolves the recipient's format
+    // preferences and hands the mail to a single unpooled transport, so a
+    // large team must not burst N lookups and N connections at once.
+    for (const assignment of audit.assignments) {
+      if (!recipients.includes(assignment.userId) || !assignment.user.email) {
+        continue;
+      }
+      await sendAuditAssignedEmail({
+        audit,
+        assigneeEmail: assignment.user.email,
+        assigneeName: resolveUserDisplayName(assignment.user) || "Unknown User",
+        assigneeUserId: assignment.userId,
+        hints,
+      });
+    }
   } catch (cause) {
     Logger.error(
       new ShelfError({

--- a/apps/webapp/app/modules/audit/email-helpers.ts
+++ b/apps/webapp/app/modules/audit/email-helpers.ts
@@ -1,6 +1,6 @@
 import type { AuditForEmail } from "~/emails/audit-updates-template";
 import { auditUpdatesTemplateString } from "~/emails/audit-updates-template";
-import { sendEmail } from "~/emails/mail.server";
+import { sendEmail, sendEmailAndWait } from "~/emails/mail.server";
 import type { ClientHint } from "~/utils/client-hints";
 import {
   formatDate,
@@ -192,7 +192,9 @@ export async function sendAuditAssignedEmail({
       assetCount,
     });
 
-    sendEmail({
+    // Awaited so the caller's loop only moves on once this email is sent or
+    // safely queued; a failure lands in the catch below with this recipient.
+    await sendEmailAndWait({
       to: assigneeEmail,
       subject: `🔍 You've been assigned to audit: "${audit.name}" - shelf.nu`,
       text: auditAssignedEmailContent({

--- a/apps/webapp/app/modules/audit/helpers.server.test.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.test.ts
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createAssetScanNote,
+  createAssigneesChangedNote,
   createAuditCreationNote,
   createAuditStartedNote,
   createAuditCompletedNote,
@@ -172,6 +173,95 @@ describe("audit helpers", () => {
       });
 
       expect(mockTx.auditNote.create).toHaveBeenCalled();
+    });
+  });
+
+  describe("createAssigneesChangedNote", () => {
+    let mockTx: any;
+
+    const users = [
+      { id: "user-1", firstName: "Ana", lastName: "Lead" },
+      { id: "user-2", firstName: "Ben", lastName: "Scan" },
+      { id: "user-3", firstName: "Cy", lastName: "Count" },
+      { id: "user-4", firstName: "Di", lastName: "Gone" },
+    ];
+
+    beforeEach(() => {
+      mockTx = {
+        user: {
+          findMany: vi
+            .fn()
+            .mockImplementation(({ where }: any) =>
+              Promise.resolve(users.filter((u) => where.id.in.includes(u.id)))
+            ),
+        },
+        auditNote: {
+          create: vi.fn(),
+        },
+      };
+    });
+
+    it("writes ONE note naming everyone added and everyone removed", async () => {
+      await createAssigneesChangedNote({
+        auditSessionId: "audit-1",
+        userId: "user-1",
+        addedUserIds: ["user-2", "user-3"],
+        removedUserIds: ["user-4"],
+        tx: mockTx,
+      });
+
+      expect(mockTx.auditNote.create).toHaveBeenCalledTimes(1);
+      const { content, userId, type } =
+        mockTx.auditNote.create.mock.calls[0][0].data;
+      expect(userId).toBe("user-1");
+      expect(type).toBe("UPDATE");
+      expect(content).toContain("added assignees:");
+      expect(content).toContain('text="Ben Scan"');
+      expect(content).toContain('text="Cy Count"');
+      expect(content).toContain("removed assignee:");
+      expect(content).toContain('text="Di Gone"');
+      expect(
+        content.startsWith('{% link to="/settings/team/users/user-1"')
+      ).toBe(true);
+    });
+
+    it("uses the singular when one person was added", async () => {
+      await createAssigneesChangedNote({
+        auditSessionId: "audit-1",
+        userId: "user-1",
+        addedUserIds: ["user-2"],
+        removedUserIds: [],
+        tx: mockTx,
+      });
+
+      const { content } = mockTx.auditNote.create.mock.calls[0][0].data;
+      expect(content).toContain("added assignee:");
+      expect(content).not.toContain("removed");
+    });
+
+    it("writes nothing when the change is empty", async () => {
+      await createAssigneesChangedNote({
+        auditSessionId: "audit-1",
+        userId: "user-1",
+        addedUserIds: [],
+        removedUserIds: [],
+        tx: mockTx,
+      });
+
+      expect(mockTx.user.findMany).not.toHaveBeenCalled();
+      expect(mockTx.auditNote.create).not.toHaveBeenCalled();
+    });
+
+    it("skips the note when the updater cannot be found", async () => {
+      await createAssigneesChangedNote({
+        auditSessionId: "audit-1",
+        userId: "user-missing",
+        addedUserIds: ["user-2"],
+        removedUserIds: [],
+        tx: mockTx,
+      });
+
+      expect(mockTx.auditNote.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/app/modules/audit/helpers.server.ts
+++ b/apps/webapp/app/modules/audit/helpers.server.ts
@@ -629,111 +629,82 @@ export async function createDueDateChangedNote({
 }
 
 /**
- * Creates an automatic note when an assignee is added to an audit.
+ * Creates ONE automatic note for an assignee change on an audit, naming every
+ * person added and every person removed in that edit. One note per edit, not
+ * one per person, so assigning a ten-person team does not push ten lines into
+ * the Activity tab.
  */
-export async function createAssigneeAddedNote({
+export async function createAssigneesChangedNote({
   auditSessionId,
   userId,
-  assigneeUserId,
+  addedUserIds,
+  removedUserIds,
   tx,
 }: {
   auditSessionId: string;
+  /** The user making the change. */
   userId: string;
-  assigneeUserId: string;
+  addedUserIds: string[];
+  removedUserIds: string[];
   tx: any; // Prisma transaction client
 }) {
-  const [updater, assignee] = await Promise.all([
-    tx.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        displayName: true,
-      },
-    }),
-    tx.user.findUnique({
-      where: { id: assigneeUserId },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        displayName: true,
-      },
-    }),
-  ]);
-
-  if (!updater || !assignee) {
-    return; // Skip note creation if users not found
+  if (addedUserIds.length === 0 && removedUserIds.length === 0) {
+    return;
   }
 
-  const content = `${wrapUserLinkForNote({
-    ...updater,
-  })} added assignee: ${wrapUserLinkForNote({
-    ...assignee,
-  })}.`;
-
-  await tx.auditNote.create({
-    data: {
-      auditSessionId,
-      userId: updater.id,
-      type: "UPDATE",
-      content,
+  const userIds = Array.from(
+    new Set([userId, ...addedUserIds, ...removedUserIds])
+  );
+  const users: Array<UserNameFields & { id: string }> = await tx.user.findMany({
+    where: { id: { in: userIds } },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      displayName: true,
     },
   });
-}
+  const byId = new Map(users.map((user) => [user.id, user]));
 
-/**
- * Creates an automatic note when an assignee is removed from an audit.
- */
-export async function createAssigneeRemovedNote({
-  auditSessionId,
-  userId,
-  assigneeUserId,
-  tx,
-}: {
-  auditSessionId: string;
-  userId: string;
-  assigneeUserId: string;
-  tx: any; // Prisma transaction client
-}) {
-  const [updater, assignee] = await Promise.all([
-    tx.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        displayName: true,
-      },
-    }),
-    tx.user.findUnique({
-      where: { id: assigneeUserId },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        displayName: true,
-      },
-    }),
-  ]);
-
-  if (!updater || !assignee) {
-    return; // Skip note creation if users not found
+  const updater = byId.get(userId);
+  if (!updater) {
+    return; // Skip note creation if the updater is not found
   }
 
-  const content = `${wrapUserLinkForNote({
-    ...updater,
-  })} removed assignee: ${wrapUserLinkForNote({
-    ...assignee,
-  })}.`;
+  const linkList = (ids: string[]) =>
+    ids
+      .map((id) => byId.get(id))
+      .filter((user): user is UserNameFields & { id: string } => !!user)
+      .map((user) => wrapUserLinkForNote({ ...user }));
+
+  const parts: string[] = [];
+  const added = linkList(addedUserIds);
+  if (added.length > 0) {
+    parts.push(
+      `added ${added.length === 1 ? "assignee" : "assignees"}: ${added.join(
+        ", "
+      )}`
+    );
+  }
+  const removed = linkList(removedUserIds);
+  if (removed.length > 0) {
+    parts.push(
+      `removed ${
+        removed.length === 1 ? "assignee" : "assignees"
+      }: ${removed.join(", ")}`
+    );
+  }
+
+  if (parts.length === 0) {
+    return; // Every referenced user is gone; nothing meaningful to record
+  }
 
   await tx.auditNote.create({
     data: {
       auditSessionId,
       userId: updater.id,
       type: "UPDATE",
-      content,
+      content: `${wrapUserLinkForNote({ ...updater })} ${parts.join(" and ")}.`,
     },
   });
 }

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -7,6 +7,7 @@ import { ShelfError } from "~/utils/error";
 import { ALL_SELECTED_KEY } from "~/utils/list";
 import { sendAuditCancelledEmails } from "./email-helpers";
 import {
+  createAssigneesChangedNote,
   createAuditResumedNote,
   createAuditStartedNote,
 } from "./helpers.server";
@@ -26,6 +27,7 @@ import {
   getAuditScans,
   recordAuditScan,
   requireAuditAssignee,
+  updateAuditSession,
 } from "./service.server";
 
 // why: storage.server calls Supabase over HTTP; mock so delete tests stay offline
@@ -42,6 +44,9 @@ vi.mock("./helpers.server", () => ({
   createAssetsAddedToAuditNote: vi.fn(),
   createAssetRemovedFromAuditNote: vi.fn(),
   createAssetsRemovedFromAuditNote: vi.fn(),
+  createAssigneesChangedNote: vi.fn(),
+  createAuditUpdateNote: vi.fn(),
+  createDueDateChangedNote: vi.fn(),
 }));
 
 // why: deterministic note content for assertions; real impl returns markdoc syntax
@@ -126,6 +131,12 @@ vi.mock("~/database/db.server", () => {
     },
     auditAssignment: {
       createMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    // why: assignees are checked against workspace membership before they
+    // are written; the default below makes every id a member.
+    userOrganization: {
+      findMany: vi.fn(),
     },
     auditImage: {
       findMany: vi.fn(),
@@ -183,6 +194,10 @@ const mockDb = db as unknown as {
   };
   auditAssignment: {
     createMany: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+  userOrganization: {
+    findMany: ReturnType<typeof vi.fn>;
   };
   auditImage: {
     findMany: ReturnType<typeof vi.fn>;
@@ -207,7 +222,7 @@ describe("audit service", () => {
     assetIds: ["asset-1", "asset-2"],
     organizationId: "org-1",
     createdById: "user-1",
-    assignee: "user-2",
+    assigneeIds: ["user-2"],
     scopeMeta: {
       contextType: "SELECTION",
       contextName: "Quarterly warehouse audit",
@@ -216,6 +231,10 @@ describe("audit service", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Every requested assignee is a workspace member unless a test says otherwise.
+    mockDb.userOrganization.findMany.mockImplementation(({ where }: any) =>
+      Promise.resolve(where.userId.in.map((userId: string) => ({ userId })))
+    );
     mockDb.asset.findMany.mockResolvedValue([
       { id: "asset-1", title: "Camera A" },
       { id: "asset-2", title: "Camera B" },
@@ -324,6 +343,7 @@ describe("audit service", () => {
 
     expect(mockDb.auditAssignment.createMany).toHaveBeenCalledWith({
       data: [{ auditSessionId: "audit-1", userId: "user-2", role: undefined }],
+      skipDuplicates: true,
     });
 
     expect(result.expectedAssets).toEqual([
@@ -372,6 +392,191 @@ describe("audit service", () => {
 
     expect(mockDb.auditAssignment.createMany).toHaveBeenCalledWith({
       data: [{ auditSessionId: "audit-1", userId: "user-2", role: undefined }],
+      skipDuplicates: true,
+    });
+  });
+
+  it("assigns every selected member once, in order", async () => {
+    await createAuditSession({
+      ...defaultInput,
+      assigneeIds: ["user-2", "user-3", "user-2", "user-4"],
+    });
+
+    expect(mockDb.userOrganization.findMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org-1",
+        userId: { in: ["user-2", "user-3", "user-4"] },
+      },
+      select: { userId: true },
+    });
+    expect(mockDb.auditAssignment.createMany).toHaveBeenCalledWith({
+      data: [
+        { auditSessionId: "audit-1", userId: "user-2", role: undefined },
+        { auditSessionId: "audit-1", userId: "user-3", role: undefined },
+        { auditSessionId: "audit-1", userId: "user-4", role: undefined },
+      ],
+      skipDuplicates: true,
+    });
+  });
+
+  it("creates no assignments and skips the membership check when nobody is assigned", async () => {
+    await createAuditSession({ ...defaultInput, assigneeIds: [] });
+
+    expect(mockDb.userOrganization.findMany).not.toHaveBeenCalled();
+    expect(mockDb.auditAssignment.createMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects an assignee who is not a member of the workspace with a 400", async () => {
+    mockDb.userOrganization.findMany.mockResolvedValue([{ userId: "user-2" }]);
+
+    await expect(
+      createAuditSession({
+        ...defaultInput,
+        assigneeIds: ["user-2", "user-from-another-org"],
+      })
+    ).rejects.toMatchObject({ status: 400 });
+
+    expect(mockDb.auditSession.create).not.toHaveBeenCalled();
+  });
+
+  describe("updateAuditSession — assignees as a set", () => {
+    const currentAudit = {
+      name: "Q4 audit",
+      description: null,
+      status: AuditStatus.PENDING,
+      dueDate: null,
+      assignments: [{ userId: "user-2" }, { userId: "user-3" }],
+    };
+
+    beforeEach(() => {
+      mockDb.auditSession.findUnique.mockResolvedValue(currentAudit);
+      mockDb.auditSession.update.mockResolvedValue({
+        id: "audit-1",
+        name: "Q4 audit",
+      });
+      mockDb.auditAssignment.deleteMany.mockResolvedValue({ count: 1 });
+      mockDb.auditAssignment.createMany.mockResolvedValue({ count: 1 });
+    });
+
+    it("adds the newcomers, removes the departed, keeps the rest, and reports both", async () => {
+      const result = await updateAuditSession({
+        id: "audit-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        data: {
+          name: "Q4 audit",
+          assigneeUserIds: ["user-3", "user-4", "user-4"],
+        },
+      });
+
+      expect(result.addedAssigneeIds).toEqual(["user-4"]);
+      expect(result.removedAssigneeIds).toEqual(["user-2"]);
+      expect(mockDb.auditAssignment.deleteMany).toHaveBeenCalledWith({
+        where: { auditSessionId: "audit-1", userId: { in: ["user-2"] } },
+      });
+      expect(mockDb.auditAssignment.createMany).toHaveBeenCalledWith({
+        data: [{ auditSessionId: "audit-1", userId: "user-4" }],
+        skipDuplicates: true,
+      });
+      expect(createAssigneesChangedNote).toHaveBeenCalledWith(
+        expect.objectContaining({
+          auditSessionId: "audit-1",
+          userId: "user-1",
+          addedUserIds: ["user-4"],
+          removedUserIds: ["user-2"],
+        })
+      );
+      expect(recordEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "AUDIT_ASSIGNEE_ADDED",
+          targetUserId: "user-4",
+          auditSessionId: "audit-1",
+        }),
+        mockDb
+      );
+      expect(recordEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "AUDIT_ASSIGNEE_REMOVED",
+          targetUserId: "user-2",
+        }),
+        mockDb
+      );
+    });
+
+    it("only checks membership for the people being added", async () => {
+      await updateAuditSession({
+        id: "audit-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        data: { assigneeUserIds: ["user-2", "user-3", "user-5"] },
+      });
+
+      expect(mockDb.userOrganization.findMany).toHaveBeenCalledWith({
+        where: { organizationId: "org-1", userId: { in: ["user-5"] } },
+        select: { userId: true },
+      });
+    });
+
+    it("removes everyone when the set is empty", async () => {
+      const result = await updateAuditSession({
+        id: "audit-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        data: { assigneeUserIds: [] },
+      });
+
+      expect(result.removedAssigneeIds).toEqual(["user-2", "user-3"]);
+      expect(mockDb.auditAssignment.deleteMany).toHaveBeenCalledWith({
+        where: {
+          auditSessionId: "audit-1",
+          userId: { in: ["user-2", "user-3"] },
+        },
+      });
+      expect(mockDb.auditAssignment.createMany).not.toHaveBeenCalled();
+    });
+
+    it("leaves assignments untouched when the field is omitted", async () => {
+      const result = await updateAuditSession({
+        id: "audit-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        data: { name: "Renamed" },
+      });
+
+      expect(result.addedAssigneeIds).toEqual([]);
+      expect(result.removedAssigneeIds).toEqual([]);
+      expect(mockDb.auditAssignment.deleteMany).not.toHaveBeenCalled();
+      expect(mockDb.auditAssignment.createMany).not.toHaveBeenCalled();
+      expect(createAssigneesChangedNote).not.toHaveBeenCalled();
+    });
+
+    it("writes nothing for the assignees when the same set is submitted again", async () => {
+      await updateAuditSession({
+        id: "audit-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        data: { assigneeUserIds: ["user-3", "user-2"] },
+      });
+
+      expect(mockDb.auditAssignment.deleteMany).not.toHaveBeenCalled();
+      expect(mockDb.auditAssignment.createMany).not.toHaveBeenCalled();
+      expect(createAssigneesChangedNote).not.toHaveBeenCalled();
+      expect(recordEvent).not.toHaveBeenCalled();
+    });
+
+    it("refuses a newcomer who is not a workspace member", async () => {
+      mockDb.userOrganization.findMany.mockResolvedValue([]);
+
+      await expect(
+        updateAuditSession({
+          id: "audit-1",
+          organizationId: "org-1",
+          userId: "user-1",
+          data: { assigneeUserIds: ["user-2", "user-3", "outsider"] },
+        })
+      ).rejects.toMatchObject({ status: 400 });
+
+      expect(mockDb.auditAssignment.createMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -236,8 +236,9 @@ describe("audit service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Every requested assignee is a workspace member unless a test says otherwise.
-    mockDb.userOrganization.findMany.mockImplementation(({ where }: any) =>
-      Promise.resolve(where.userId.in.map((userId: string) => ({ userId })))
+    mockDb.userOrganization.findMany.mockImplementation(
+      ({ where }: { where: { userId: { in: string[] } } }) =>
+        Promise.resolve(where.userId.in.map((userId) => ({ userId })))
     );
     mockDb.asset.findMany.mockResolvedValue([
       { id: "asset-1", title: "Camera A" },
@@ -1822,19 +1823,20 @@ describe("audit service", () => {
     });
 
     it("carries the team over, minus anyone who has left the workspace", async () => {
-      mockDb.auditSession.findFirst.mockImplementation(({ where }: any) =>
-        Promise.resolve(
-          where.id === "audit-original"
-            ? {
-                ...originalAudit,
-                assignments: [{ userId: "user-2" }, { userId: "user-gone" }],
-              }
-            : {
-                id: "audit-copy",
-                name: "Hull PC Bank Audit (Copy)",
-                assignments: [],
-              }
-        )
+      mockDb.auditSession.findFirst.mockImplementation(
+        ({ where }: { where: { id: string } }) =>
+          Promise.resolve(
+            where.id === "audit-original"
+              ? {
+                  ...originalAudit,
+                  assignments: [{ userId: "user-2" }, { userId: "user-gone" }],
+                }
+              : {
+                  id: "audit-copy",
+                  name: "Hull PC Bank Audit (Copy)",
+                  assignments: [],
+                }
+          )
       );
       // user-gone is no longer a member of org-1.
       mockDb.userOrganization.findMany.mockResolvedValue([

--- a/apps/webapp/app/modules/audit/service.server.test.ts
+++ b/apps/webapp/app/modules/audit/service.server.test.ts
@@ -152,6 +152,9 @@ vi.mock("~/database/db.server", () => {
       findUnique: vi.fn(),
     },
     $transaction: vi.fn(),
+    // why: updateAuditSession takes a row lock with a raw SELECT ... FOR UPDATE
+    // before reading the assignee list; the mock only needs to resolve.
+    $queryRaw: vi.fn().mockResolvedValue([]),
   };
 
   mockDb.$transaction.mockImplementation((cb: any) => cb(mockDb));
@@ -213,6 +216,7 @@ const mockDb = db as unknown as {
     findUnique: ReturnType<typeof vi.fn>;
   };
   $transaction: ReturnType<typeof vi.fn>;
+  $queryRaw: ReturnType<typeof vi.fn>;
 };
 
 describe("audit service", () => {
@@ -1674,6 +1678,7 @@ describe("audit service", () => {
         { assetId: "asset-2" },
         { assetId: "asset-3" },
       ],
+      assignments: [] as Array<{ userId: string }>,
     };
 
     beforeEach(() => {
@@ -1778,6 +1783,7 @@ describe("audit service", () => {
         where: { id: "audit-original", organizationId: "org-1" },
         include: {
           assets: { where: { expected: true }, select: { assetId: true } },
+          assignments: { select: { userId: true } },
         },
       });
 
@@ -1801,7 +1807,8 @@ describe("audit service", () => {
         }),
       });
 
-      // Due date and assignments must NOT carry over (PRD).
+      // The due date must NOT carry over (PRD); an unassigned source stays
+      // unassigned.
       const createCall = mockDb.auditSession.create.mock.calls[0][0];
       expect(createCall.data.dueDate).toBeUndefined();
       expect(mockDb.auditAssignment.createMany).not.toHaveBeenCalled();
@@ -1810,7 +1817,46 @@ describe("audit service", () => {
         newSession: expect.objectContaining({ id: "audit-copy" }),
         droppedAssetCount: 0,
         originalAssetCount: 3,
+        carriedOverAssigneeIds: [],
       });
+    });
+
+    it("carries the team over, minus anyone who has left the workspace", async () => {
+      mockDb.auditSession.findFirst.mockImplementation(({ where }: any) =>
+        Promise.resolve(
+          where.id === "audit-original"
+            ? {
+                ...originalAudit,
+                assignments: [{ userId: "user-2" }, { userId: "user-gone" }],
+              }
+            : {
+                id: "audit-copy",
+                name: "Hull PC Bank Audit (Copy)",
+                assignments: [],
+              }
+        )
+      );
+      // user-gone is no longer a member of org-1.
+      mockDb.userOrganization.findMany.mockResolvedValue([
+        { userId: "user-2" },
+      ]);
+
+      const result = await duplicateAuditSession(baseInput);
+
+      expect(mockDb.userOrganization.findMany).toHaveBeenCalledWith({
+        where: {
+          organizationId: "org-1",
+          userId: { in: ["user-2", "user-gone"] },
+        },
+        select: { userId: true },
+      });
+      expect(mockDb.auditAssignment.createMany).toHaveBeenCalledWith({
+        data: [
+          { auditSessionId: "audit-copy", userId: "user-2", role: undefined },
+        ],
+        skipDuplicates: true,
+      });
+      expect(result.carriedOverAssigneeIds).toEqual(["user-2"]);
     });
 
     it("succeeds with a non-zero droppedAssetCount when some assets no longer exist", async () => {

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -44,8 +44,7 @@ import {
   createAuditCompletedNote,
   createAuditUpdateNote,
   createDueDateChangedNote,
-  createAssigneeAddedNote,
-  createAssigneeRemovedNote,
+  createAssigneesChangedNote,
   createAssetsAddedToAuditNote,
   createAssetRemovedFromAuditNote,
   createAssetsRemovedFromAuditNote,
@@ -121,7 +120,8 @@ export type CreateAuditSessionInput = {
   assetIds: string[];
   organizationId: string;
   createdById: string;
-  assignee?: string;
+  /** User ids to assign. Every id must belong to a workspace member. */
+  assigneeIds?: string[];
   scopeMeta?: AuditScopeMeta | null;
   dueDate?: Date;
 };
@@ -238,6 +238,49 @@ export type AuditScanData = {
   assetDeleted: boolean;
 };
 
+/**
+ * Every assignee must be a member of the workspace. The picker only offers
+ * members, but the ids arrive from the client, so they are checked here: a
+ * dangling assignment would otherwise grant nobody anything and confuse every
+ * list that renders it.
+ *
+ * @throws {ShelfError} 400 when any id is not a member of the organization
+ */
+async function assertAssigneesAreMembers({
+  userIds,
+  organizationId,
+  tx = db,
+}: {
+  userIds: string[];
+  organizationId: string;
+  tx?: Pick<typeof db, "userOrganization">;
+}) {
+  if (userIds.length === 0) {
+    return;
+  }
+
+  const members = await tx.userOrganization.findMany({
+    where: { organizationId, userId: { in: userIds } },
+    select: { userId: true },
+  });
+
+  if (members.length !== userIds.length) {
+    const memberIds = new Set(members.map((member) => member.userId));
+    throw new ShelfError({
+      cause: null,
+      message:
+        "One or more selected assignees are no longer members of this workspace. Refresh the page and try again.",
+      additionalData: {
+        organizationId,
+        unknownUserIds: userIds.filter((id) => !memberIds.has(id)),
+      },
+      status: 400,
+      shouldBeCaptured: false,
+      label,
+    });
+  }
+}
+
 export async function createAuditSession(
   input: CreateAuditSessionInput
 ): Promise<CreateAuditSessionResult> {
@@ -247,7 +290,7 @@ export async function createAuditSession(
     assetIds,
     organizationId,
     createdById,
-    assignee,
+    assigneeIds,
     scopeMeta,
     dueDate,
   } = input;
@@ -288,7 +331,12 @@ export async function createAuditSession(
 
   // Only add assignees who are explicitly selected
   // Creator is NOT automatically added as an assignee
-  const uniqueAssigneeIds = assignee ? [assignee] : [];
+  const uniqueAssigneeIds = Array.from(new Set(assigneeIds ?? []));
+
+  await assertAssigneesAreMembers({
+    userIds: uniqueAssigneeIds,
+    organizationId,
+  });
 
   const result = await db.$transaction(async (tx) => {
     const session = await tx.auditSession.create({
@@ -319,9 +367,10 @@ export async function createAuditSession(
         data: uniqueAssigneeIds.map((userId) => ({
           auditSessionId: session.id,
           userId,
-          // LEAD role is reserved for future use (e.g., when we support multiple assignees)
+          // LEAD/PARTICIPANT roles are reserved; every assignee is a peer today
           role: undefined,
         })),
+        skipDuplicates: true,
       });
     }
 
@@ -407,9 +456,13 @@ export async function createAuditSession(
 }
 
 /**
- * Updates an audit session's details (name, description, due date, and/or assignee).
+ * Updates an audit session's details (name, description, due date, and/or assignees).
  * Creates automatic notes for tracked changes.
  * Optimized to perform minimal database queries.
+ *
+ * `assigneeUserIds` is the FULL desired set: undefined leaves assignments
+ * untouched, an empty array removes everyone. Returns who was added and
+ * removed so the caller can notify the newcomers.
  */
 export async function updateAuditSession({
   id,
@@ -424,188 +477,231 @@ export async function updateAuditSession({
     name?: string;
     description?: string | null;
     dueDate?: Date | null;
-    assigneeUserId?: string | null;
+    assigneeUserIds?: string[];
   };
 }) {
   // Use transaction to ensure atomicity
-  return db.$transaction(async (tx) => {
-    // Fetch the current audit to track changes
-    const currentAudit = await tx.auditSession.findUnique({
-      where: { id, organizationId },
-      select: {
-        name: true,
-        description: true,
-        status: true,
-        dueDate: true,
-        assignments: {
-          select: {
-            userId: true,
+  return db.$transaction(
+    async (tx) => {
+      // Fetch the current audit to track changes
+      const currentAudit = await tx.auditSession.findUnique({
+        where: { id, organizationId },
+        select: {
+          name: true,
+          description: true,
+          status: true,
+          dueDate: true,
+          assignments: {
+            select: {
+              userId: true,
+            },
           },
         },
-      },
-    });
-
-    if (!currentAudit) {
-      throw new ShelfError({
-        cause: null,
-        message: "Audit not found",
-        additionalData: { id, organizationId },
-        label: "Audit",
-        status: 404,
       });
-    }
 
-    assertAuditNotArchived(currentAudit.status, {
-      auditSessionId: id,
-      organizationId,
-    });
+      if (!currentAudit) {
+        throw new ShelfError({
+          cause: null,
+          message: "Audit not found",
+          additionalData: { id, organizationId },
+          label: "Audit",
+          status: 404,
+        });
+      }
 
-    if (currentAudit.status === AuditStatus.CANCELLED) {
-      throw new ShelfError({
-        cause: null,
-        message: "Cancelled audits cannot be edited.",
-        additionalData: { id, organizationId },
-        label: "Audit",
-        status: 400,
+      assertAuditNotArchived(currentAudit.status, {
+        auditSessionId: id,
+        organizationId,
       });
-    }
 
-    if (currentAudit.status === AuditStatus.COMPLETED) {
-      throw new ShelfError({
-        cause: null,
-        message: "Completed audits cannot be edited.",
-        additionalData: { id, organizationId },
-        label: "Audit",
-        status: 400,
+      if (currentAudit.status === AuditStatus.CANCELLED) {
+        throw new ShelfError({
+          cause: null,
+          message: "Cancelled audits cannot be edited.",
+          additionalData: { id, organizationId },
+          label: "Audit",
+          status: 400,
+        });
+      }
+
+      if (currentAudit.status === AuditStatus.COMPLETED) {
+        throw new ShelfError({
+          cause: null,
+          message: "Completed audits cannot be edited.",
+          additionalData: { id, organizationId },
+          label: "Audit",
+          status: 400,
+        });
+      }
+
+      // Track what changed for activity logging
+      const changes: Array<{ field: string; from: string; to: string }> = [];
+
+      // Assignees are diffed as sets: whoever is in the new list but not the
+      // old is added, whoever is in the old list but not the new is removed.
+      const currentAssigneeIds = currentAudit.assignments.map(
+        (assignment) => assignment.userId
+      );
+      const nextAssigneeIds =
+        data.assigneeUserIds === undefined
+          ? undefined
+          : Array.from(new Set(data.assigneeUserIds));
+      const addedAssigneeIds = nextAssigneeIds
+        ? nextAssigneeIds.filter((id) => !currentAssigneeIds.includes(id))
+        : [];
+      const removedAssigneeIds = nextAssigneeIds
+        ? currentAssigneeIds.filter((id) => !nextAssigneeIds.includes(id))
+        : [];
+
+      await assertAssigneesAreMembers({
+        userIds: addedAssigneeIds,
+        organizationId,
+        tx,
       });
-    }
 
-    // Track what changed for activity logging
-    const changes: Array<{ field: string; from: string; to: string }> = [];
-    const currentAssignee = currentAudit.assignments[0]?.userId || null;
-    const newAssignee =
-      data.assigneeUserId === undefined
-        ? undefined
-        : data.assigneeUserId || null;
+      // Track basic field changes
+      if (data.name !== undefined && data.name !== currentAudit.name) {
+        changes.push({
+          field: "name",
+          from: currentAudit.name,
+          to: data.name,
+        });
+      }
 
-    // Track basic field changes
-    if (data.name !== undefined && data.name !== currentAudit.name) {
-      changes.push({
-        field: "name",
-        from: currentAudit.name,
-        to: data.name,
+      if (
+        data.description !== undefined &&
+        data.description !== currentAudit.description
+      ) {
+        changes.push({
+          field: "description",
+          from: currentAudit.description || "(empty)",
+          to: data.description || "(empty)",
+        });
+      }
+
+      // Check if due date changed
+      const dueDateChanged =
+        data.dueDate !== undefined &&
+        ((currentAudit.dueDate === null && data.dueDate !== null) ||
+          (currentAudit.dueDate !== null && data.dueDate === null) ||
+          (currentAudit.dueDate !== null &&
+            data.dueDate !== null &&
+            currentAudit.dueDate.getTime() !== data.dueDate.getTime()));
+
+      const assigneesChanged =
+        addedAssigneeIds.length > 0 || removedAssigneeIds.length > 0;
+
+      // Single update for all audit session fields
+      const updatedAudit = await tx.auditSession.update({
+        where: { id, organizationId },
+        data: {
+          name: data.name,
+          description: data.description,
+          dueDate: data.dueDate,
+        },
       });
-    }
 
-    if (
-      data.description !== undefined &&
-      data.description !== currentAudit.description
-    ) {
-      changes.push({
-        field: "description",
-        from: currentAudit.description || "(empty)",
-        to: data.description || "(empty)",
-      });
-    }
-
-    // Check if due date changed
-    const dueDateChanged =
-      data.dueDate !== undefined &&
-      ((currentAudit.dueDate === null && data.dueDate !== null) ||
-        (currentAudit.dueDate !== null && data.dueDate === null) ||
-        (currentAudit.dueDate !== null &&
-          data.dueDate !== null &&
-          currentAudit.dueDate.getTime() !== data.dueDate.getTime()));
-
-    // Check if assignee changed
-    const assigneeChanged =
-      newAssignee !== undefined && newAssignee !== currentAssignee;
-
-    // Single update for all audit session fields
-    const updatedAudit = await tx.auditSession.update({
-      where: { id, organizationId },
-      data: {
-        name: data.name,
-        description: data.description,
-        dueDate: data.dueDate,
-      },
-    });
-
-    // Single batch operation for assignee changes
-    if (assigneeChanged) {
-      // Remove old assignee if exists
-      if (currentAssignee) {
+      // Two batch operations cover any size of assignee change
+      if (removedAssigneeIds.length > 0) {
         await tx.auditAssignment.deleteMany({
-          where: { auditSessionId: id, userId: currentAssignee },
+          where: { auditSessionId: id, userId: { in: removedAssigneeIds } },
         });
       }
-      // Add new assignee if provided
-      if (newAssignee) {
-        await tx.auditAssignment.create({
-          data: { auditSessionId: id, userId: newAssignee },
-        });
-      }
-    }
-
-    // Create all activity notes in batch (minimize DB round trips)
-    const notePromises: Promise<any>[] = [];
-
-    // Basic field changes note
-    if (changes.length > 0) {
-      notePromises.push(
-        createAuditUpdateNote({
-          auditSessionId: id,
-          userId,
-          changes,
-          tx,
-        })
-      );
-    }
-
-    // Due date change note
-    if (dueDateChanged) {
-      notePromises.push(
-        createDueDateChangedNote({
-          auditSessionId: id,
-          userId,
-          oldDate: currentAudit.dueDate,
-          newDate: data.dueDate!,
-          tx,
-        })
-      );
-    }
-
-    // Assignee change notes
-    if (assigneeChanged) {
-      if (currentAssignee) {
-        notePromises.push(
-          createAssigneeRemovedNote({
+      if (addedAssigneeIds.length > 0) {
+        await tx.auditAssignment.createMany({
+          data: addedAssigneeIds.map((userId) => ({
             auditSessionId: id,
             userId,
-            assigneeUserId: currentAssignee,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      // Create all activity notes in batch (minimize DB round trips)
+      const notePromises: Promise<any>[] = [];
+
+      // Basic field changes note
+      if (changes.length > 0) {
+        notePromises.push(
+          createAuditUpdateNote({
+            auditSessionId: id,
+            userId,
+            changes,
             tx,
           })
         );
       }
-      if (newAssignee) {
+
+      // Due date change note
+      if (dueDateChanged) {
         notePromises.push(
-          createAssigneeAddedNote({
+          createDueDateChangedNote({
             auditSessionId: id,
             userId,
-            assigneeUserId: newAssignee,
+            oldDate: currentAudit.dueDate,
+            newDate: data.dueDate!,
             tx,
           })
         );
       }
-    }
 
-    // Execute all note creations in parallel
-    if (notePromises.length > 0) {
-      await Promise.all(notePromises);
-    }
+      // One note for the whole assignee change, plus one event per person so
+      // reports can count assignments without parsing note text.
+      if (assigneesChanged) {
+        notePromises.push(
+          createAssigneesChangedNote({
+            auditSessionId: id,
+            userId,
+            addedUserIds: addedAssigneeIds,
+            removedUserIds: removedAssigneeIds,
+            tx,
+          })
+        );
+        for (const targetUserId of addedAssigneeIds) {
+          notePromises.push(
+            recordEvent(
+              {
+                organizationId,
+                actorUserId: userId,
+                action: "AUDIT_ASSIGNEE_ADDED",
+                entityType: "AUDIT",
+                entityId: id,
+                auditSessionId: id,
+                targetUserId,
+              },
+              tx
+            )
+          );
+        }
+        for (const targetUserId of removedAssigneeIds) {
+          notePromises.push(
+            recordEvent(
+              {
+                organizationId,
+                actorUserId: userId,
+                action: "AUDIT_ASSIGNEE_REMOVED",
+                entityType: "AUDIT",
+                entityId: id,
+                auditSessionId: id,
+                targetUserId,
+              },
+              tx
+            )
+          );
+        }
+      }
 
-    return updatedAudit;
-  });
+      // Execute all note creations in parallel
+      if (notePromises.length > 0) {
+        await Promise.all(notePromises);
+      }
+
+      return { audit: updatedAudit, addedAssigneeIds, removedAssigneeIds };
+    },
+    // A ten-person change is two lookups and a few inserts; the Prisma default
+    // 5s is tight when the pool is busy, so match recordAuditScan's budget.
+    { timeout: 15_000 }
+  );
 }
 
 export async function getAuditSessionDetails({

--- a/apps/webapp/app/modules/audit/service.server.ts
+++ b/apps/webapp/app/modules/audit/service.server.ts
@@ -483,6 +483,12 @@ export async function updateAuditSession({
   // Use transaction to ensure atomicity
   return db.$transaction(
     async (tx) => {
+      // Serialise concurrent edits of the same audit: a second editor waits
+      // here and then reads the list the first one committed, so a person
+      // both admins added is inserted, noted and emailed exactly once instead
+      // of the second insert failing on the unique assignment.
+      await tx.$queryRaw`SELECT id FROM "AuditSession" WHERE id = ${id} FOR UPDATE`;
+
       // Fetch the current audit to track changes
       const currentAudit = await tx.auditSession.findUnique({
         where: { id, organizationId },
@@ -4188,6 +4194,8 @@ export type DuplicateAuditResult = {
   droppedAssetCount: number;
   /** Total number of assets in the original audit. */
   originalAssetCount: number;
+  /** Assignees carried over from the original (still workspace members). */
+  carriedOverAssigneeIds: string[];
 };
 
 /**
@@ -4205,7 +4213,8 @@ export type DuplicateAuditResult = {
  * gate is client-side, so the service owns the contract for any caller
  * (route action, background jobs, future internal callers).
  *
- * Assignments, notes, scans, images, and the due date are NOT copied — the
+ * Assignees carry over (those still in the workspace); notes, scans, images,
+ * and the due date are NOT copied — the
  * new audit starts clean. Creator is set to `userId`.
  *
  * @param auditSessionId - ID of the audit to duplicate
@@ -4232,6 +4241,9 @@ export async function duplicateAuditSession({
         // also include unexpected scans (`expected: false`) — those must
         // not be promoted to expected in the duplicate.
         assets: { where: { expected: true }, select: { assetId: true } },
+        // The team carries over: with several assignees, a copy without them
+        // locks every base member out until an admin re-picks each one.
+        assignments: { select: { userId: true } },
       },
     });
 
@@ -4285,12 +4297,28 @@ export async function duplicateAuditSession({
       });
     }
 
+    // Only people who are still workspace members can be assigned; anyone
+    // who left since the original audit ran is dropped here rather than
+    // failing the whole duplicate on the membership guard.
+    const originalAssigneeIds = originalAudit.assignments.map(
+      (assignment) => assignment.userId
+    );
+    const activeMembers =
+      originalAssigneeIds.length > 0
+        ? await db.userOrganization.findMany({
+            where: { organizationId, userId: { in: originalAssigneeIds } },
+            select: { userId: true },
+          })
+        : [];
+    const carriedOverAssigneeIds = activeMembers.map((member) => member.userId);
+
     const { session: newSession } = await createAuditSession({
       name: `${originalAudit.name} (Copy)`,
       description: originalAudit.description,
       assetIds: resolvedAssetIds,
       organizationId,
       createdById: userId,
+      assigneeIds: carriedOverAssigneeIds,
       // PRD: scopeMeta copied as-is. The DB column is Json?, the typed surface
       // is AuditScopeMeta — cast through and let createAuditSession persist it.
       scopeMeta: (originalAudit.scopeMeta ?? null) as AuditScopeMeta | null,
@@ -4300,6 +4328,7 @@ export async function duplicateAuditSession({
       newSession,
       droppedAssetCount,
       originalAssetCount,
+      carriedOverAssigneeIds,
     };
   } catch (cause) {
     if (isLikeShelfError(cause)) throw cause;

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.duplicate.tsx
@@ -17,11 +17,13 @@ import { data, redirect } from "react-router";
 import { z } from "zod";
 import { DuplicateAuditDialog } from "~/components/audit/duplicate-audit-dialog";
 import { db } from "~/database/db.server";
+import { sendAuditAssignedEmails } from "~/modules/audit/assignment-emails.server";
 import {
   DUPLICATE_AUDIT_ALLOWED_STATUSES,
   duplicateAuditSession,
 } from "~/modules/audit/service.server";
 import { appendToMetaTitle } from "~/utils/append-to-meta-title";
+import { getClientHint } from "~/utils/client-hints";
 import { sendNotification } from "~/utils/emitter/send-notification.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import { payload, error, getParams } from "~/utils/http.server";
@@ -157,10 +159,19 @@ export async function action({ request, context, params }: ActionFunctionArgs) {
       action: PermissionAction.create,
     });
 
-    const { newSession } = await duplicateAuditSession({
+    const { newSession, carriedOverAssigneeIds } = await duplicateAuditSession({
       auditSessionId: auditId,
       organizationId,
       userId,
+    });
+
+    // The carried-over team gets the same assignment email as on a fresh
+    // create; the person duplicating is never emailed about their own action.
+    void sendAuditAssignedEmails({
+      auditId: newSession.id,
+      organizationId,
+      recipientUserIds: carriedOverAssigneeIds.filter((id) => id !== userId),
+      hints: getClientHint(request),
     });
 
     sendNotification({

--- a/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
+++ b/apps/webapp/app/routes/_layout+/audits.$auditId.tsx
@@ -23,6 +23,8 @@ import HorizontalTabs from "~/components/layout/horizontal-tabs";
 import { Button } from "~/components/shared/button";
 import { db } from "~/database/db.server";
 import { useUserRoleHelper } from "~/hooks/user-user-role-helper";
+import { resolveAssigneeUserIds } from "~/modules/audit/assignee-form";
+import { sendAuditAssignedEmails } from "~/modules/audit/assignment-emails.server";
 import { completeAuditWithImages } from "~/modules/audit/complete-audit-with-images.server";
 import {
   getAuditSessionDetails,
@@ -81,6 +83,19 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     });
 
     if (intent === "edit-audit") {
+      // Editing details (and the assignee list with them) is an admin/owner
+      // action. The UI hides Edit for other roles; enforce it here too so a
+      // direct POST cannot let a base member assign themselves to an audit.
+      if (isSelfServiceOrBase) {
+        throw new ShelfError({
+          cause: null,
+          message: "You do not have permission to edit audits.",
+          additionalData: { userId, auditId },
+          label,
+          status: 403,
+        });
+      }
+
       const parsedData = parseData(formData, EditAuditSchema);
       const hints = getClientHint(request);
 
@@ -98,18 +113,15 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           }).toJSDate()
         : null;
 
-      // Parse assignee from JSON (same pattern as create audit)
-      let assigneeUserId: string | null = null;
-      if (parsedData.assignee) {
-        try {
-          const parsed = JSON.parse(parsedData.assignee);
-          assigneeUserId = parsed.userId || null;
-        } catch {
-          assigneeUserId = parsedData.assignee || null;
-        }
-      }
+      // The edit form always renders the selector, so an empty list means
+      // "remove everyone". The singular `assignee` is the pre-multi-assign
+      // field, still accepted so a form loaded before the deploy saves cleanly.
+      const assigneeUserIds = resolveAssigneeUserIds(
+        parsedData.assignees,
+        parsedData.assignee
+      );
 
-      await updateAuditSession({
+      const { addedAssigneeIds } = await updateAuditSession({
         id: auditId,
         organizationId,
         userId,
@@ -117,8 +129,17 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           name: parsedData.name,
           description: parsedData.description || null,
           dueDate: dueDateUTC,
-          assigneeUserId,
+          assigneeUserIds,
         },
+      });
+
+      // Newly added people get the same email as on create; the editor is
+      // never emailed about their own change.
+      void sendAuditAssignedEmails({
+        auditId,
+        organizationId,
+        recipientUserIds: addedAssigneeIds.filter((id) => id !== userId),
+        hints,
       });
 
       return payload({ success: true });

--- a/apps/webapp/app/routes/_layout+/audits._index.tsx
+++ b/apps/webapp/app/routes/_layout+/audits._index.tsx
@@ -173,7 +173,7 @@ export default function AuditsIndexPage() {
               <Th>Status</Th>
               <Th>Description</Th>
               <Th>Created by</Th>
-              <Th>Assignee</Th>
+              <Th>Assignees</Th>
               <Th className="whitespace-nowrap">Due date</Th>
               <Th>Created</Th>
               <Th>Started</Th>
@@ -234,6 +234,16 @@ const ListItemContent = ({ item }: { item: AuditListItem }) => {
   const assigneeImg =
     firstAssignment?.user?.profilePicture || "/static/images/default_pfp.jpg";
   const hasMultipleAssignees = item.assignments.length > 1;
+  // The rest of the team, for the "+N" badge's tooltip
+  const otherAssigneeNames = item.assignments
+    .slice(1)
+    .map(
+      (assignment) =>
+        resolveUserDisplayName(assignment.user) ||
+        assignment.user?.email ||
+        "Unknown"
+    )
+    .join(", ");
 
   return (
     <>
@@ -269,7 +279,10 @@ const ListItemContent = ({ item }: { item: AuditListItem }) => {
           <div className="flex items-center gap-1">
             <UserBadge name={assigneeName} img={assigneeImg} />
             {hasMultipleAssignees && (
-              <span className="text-xs text-gray-500">
+              <span
+                className="text-xs text-gray-500"
+                title={otherAssigneeNames}
+              >
                 +{item.assignments.length - 1}
               </span>
             )}

--- a/apps/webapp/app/routes/api+/audits.start.ts
+++ b/apps/webapp/app/routes/api+/audits.start.ts
@@ -3,17 +3,17 @@ import type { ActionFunctionArgs } from "react-router";
 import { data } from "react-router";
 import { z } from "zod";
 
-import { db } from "~/database/db.server";
 import { resolveAssetIdsForBulkOperation } from "~/modules/asset/bulk-operations-helper.server";
 import { CurrentSearchParamsSchema } from "~/modules/asset/utils.server";
 import { getAssetIndexSettings } from "~/modules/asset-index-settings/service.server";
+import { resolveAssigneeUserIds } from "~/modules/audit/assignee-form";
+import { sendAuditAssignedEmails } from "~/modules/audit/assignment-emails.server";
 import { AUDIT_SCHEDULER_EVENTS_ENUM } from "~/modules/audit/constants";
 import {
   resolveAssetIdsForAudit,
   resolveAssetIdsForKitSelection,
   resolveAssetIdsForLocationSelection,
 } from "~/modules/audit/context-helpers.server";
-import { sendAuditAssignedEmail } from "~/modules/audit/email-helpers";
 import {
   createAuditSession,
   scheduleNextAuditJob,
@@ -29,7 +29,6 @@ import {
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
 import { requirePermission } from "~/utils/roles.server";
-import { resolveUserDisplayName } from "~/utils/user";
 
 /**
  * Base schema with common audit fields shared across different entry points.
@@ -42,18 +41,12 @@ export const BaseAuditSchema = z.object({
     .max(1000, "Description must be 1000 characters or fewer")
     .optional(),
   dueDate: z.string().optional(),
-  assignee: z
-    .string()
-    .optional()
-    .transform((val) => {
-      if (!val) return undefined;
-      try {
-        const parsed = JSON.parse(val);
-        return parsed.userId;
-      } catch {
-        return val;
-      }
-    }),
+  // One `assignees[i]` entry per selected member, each a JSON blob from
+  // AuditTeamMemberSelector; resolved to user ids by resolveAssigneeUserIds.
+  assignees: z.array(z.string()).optional(),
+  // Pre-multi-assign singular field, kept so a form loaded before the deploy
+  // still submits cleanly.
+  assignee: z.string().optional(),
 });
 
 /**
@@ -115,6 +108,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
       name,
       description,
       assetIds: directAssetIds,
+      assignees,
       assignee,
       contextType,
       contextId,
@@ -228,77 +222,26 @@ export async function action({ request, context }: ActionFunctionArgs) {
       });
     }
 
+    const assigneeIds = resolveAssigneeUserIds(assignees, assignee);
+
     const { session } = await createAuditSession({
       name,
       description: sanitizedDescription,
       assetIds,
       organizationId,
       createdById: userId,
-      assignee,
+      assigneeIds,
       dueDate: dueDateUTC,
     });
 
-    // Send email notification if audit is assigned to someone other than the creator
-    if (assignee && assignee !== userId) {
-      // Fetch full audit details for email. Scope by organizationId for
-      // defense-in-depth even though session was just created for this org.
-      const auditForEmail = await db.auditSession.findFirst({
-        where: { id: session.id, organizationId },
-        include: {
-          createdBy: {
-            select: {
-              firstName: true,
-              lastName: true,
-              displayName: true,
-            },
-          },
-          organization: {
-            include: {
-              owner: {
-                select: { email: true },
-              },
-            },
-          },
-          _count: {
-            select: { assets: true },
-          },
-          assignments: {
-            include: {
-              user: {
-                select: {
-                  email: true,
-                  firstName: true,
-                  lastName: true,
-                  displayName: true,
-                },
-              },
-            },
-          },
-        },
-      });
-
-      if (auditForEmail) {
-        const assigneeUser = auditForEmail.assignments.find(
-          (a: { userId: string }) => a.userId === assignee
-        );
-
-        if (assigneeUser?.user.email) {
-          const assigneeName =
-            resolveUserDisplayName(assigneeUser.user) || "Unknown User";
-
-          // Send async email (don't await to avoid blocking response).
-          // `assignee` is the recipient user id — plumbed so the email helper
-          // can resolve the assignee's own date/time format preferences.
-          void sendAuditAssignedEmail({
-            audit: auditForEmail,
-            assigneeEmail: assigneeUser.user.email,
-            assigneeName,
-            assigneeUserId: assignee,
-            hints,
-          });
-        }
-      }
-    }
+    // Everyone assigned other than the creator gets the assignment email.
+    // Fire-and-forget: the helper logs its own failures.
+    void sendAuditAssignedEmails({
+      auditId: session.id,
+      organizationId,
+      recipientUserIds: assigneeIds.filter((id) => id !== userId),
+      hints,
+    });
 
     // Schedule reminders if due date is set
     if (session.dueDate && session.dueDate > new Date()) {
@@ -352,9 +295,10 @@ export async function action({ request, context }: ActionFunctionArgs) {
       }
     }
 
-    // If assigned to someone else, redirect to overview page
-    // If assigned to self or no assignee, redirect to scan page
-    const isAssignedToOther = assignee && assignee !== userId;
+    // Creator among the assignees (or nobody assigned): straight to the scanner.
+    // Assigned only to other people: the overview, so the creator can watch.
+    const isAssignedToOther =
+      assigneeIds.length > 0 && !assigneeIds.includes(userId);
     const redirectPath = isAssignedToOther ? "overview" : "scan";
 
     return data(

--- a/apps/webapp/test/routes-tests/_layout+/audits.$auditId.edit-audit.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.$auditId.edit-audit.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Route action tests for `/audits/:auditId` — `edit-audit` intent.
+ *
+ * The service tests cover the assignee set-diff; these cover the wiring the
+ * service cannot see:
+ *   - every `assignees[i]` picker blob is resolved to a user id and forwarded
+ *     as the FULL desired set (an empty selection means "remove everyone");
+ *   - the pre-multi-assign singular `assignee` field is still honoured, so a
+ *     form loaded before the deploy saves without wiping the team;
+ *   - only the people the service reports as ADDED are emailed, never the
+ *     editor themselves.
+ *
+ * Lives under `test/routes-tests/` rather than next to the route itself
+ * because React Router's flat-routes scanner auto-registers any `*.ts` /
+ * `*.tsx` file inside `app/routes/` as a route module.
+ *
+ * @see {@link file://../../../app/routes/_layout+/audits.$auditId.tsx}
+ * @see {@link file://../../../app/modules/audit/assignee-form.ts}
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createActionArgs } from "@mocks/remix";
+
+import { action } from "~/routes/_layout+/audits.$auditId";
+import { sendAuditAssignedEmails } from "~/modules/audit/assignment-emails.server";
+import { updateAuditSession } from "~/modules/audit/service.server";
+import { requirePermission } from "~/utils/roles.server";
+
+// @vitest-environment node
+
+vi.mock("~/modules/audit/service.server", () => ({
+  updateAuditSession: vi.fn(),
+  cancelAuditSession: vi.fn(),
+  archiveAuditSession: vi.fn(),
+  deleteAuditSession: vi.fn(),
+  requireAuditAssignee: vi.fn(),
+  getAuditSessionDetails: vi.fn(),
+}));
+
+vi.mock("~/modules/audit/assignment-emails.server", () => ({
+  sendAuditAssignedEmails: vi.fn(),
+}));
+
+vi.mock("~/modules/audit/complete-audit-with-images.server", () => ({
+  completeAuditWithImages: vi.fn(),
+}));
+
+vi.mock("~/utils/roles.server", () => ({
+  requirePermission: vi.fn(),
+}));
+
+// why: the real db.server calls db.$connect() at module load outside of
+// production. Nothing here touches the DB directly.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    auditScan: { count: vi.fn() },
+    teamMember: { findMany: vi.fn() },
+  },
+}));
+
+const mockContext = {
+  getSession: () => ({ userId: "user-1" }),
+  appVersion: "1.0.0",
+  isAuthenticated: true,
+  setSession: vi.fn(),
+  destroySession: vi.fn(),
+  errorMessage: null,
+} as any;
+
+const blob = (userId: string) =>
+  JSON.stringify({ id: `tm-${userId}`, name: userId, userId });
+
+function makeEditRequest(fields: Record<string, string> = {}): Request {
+  return new Request("http://localhost/audits/audit-1", {
+    method: "POST",
+    body: new URLSearchParams({
+      intent: "edit-audit",
+      name: "Q4 audit",
+      ...fields,
+    }),
+  });
+}
+
+async function runEdit(fields: Record<string, string> = {}) {
+  return action(
+    createActionArgs({
+      request: makeEditRequest(fields),
+      params: { auditId: "audit-1" },
+      context: mockContext,
+    })
+  );
+}
+
+describe("audits.$auditId action — edit-audit intent (assignees)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: false,
+    } as any);
+    vi.mocked(updateAuditSession).mockResolvedValue({
+      audit: { id: "audit-1" },
+      addedAssigneeIds: [],
+      removedAssigneeIds: [],
+    } as any);
+  });
+
+  it("refuses a BASE/SELF_SERVICE caller with 403 before touching the service", async () => {
+    vi.mocked(requirePermission).mockResolvedValue({
+      organizationId: "org-1",
+      isSelfServiceOrBase: true,
+    } as any);
+
+    const response = await runEdit({ "assignees[0]": blob("user-1") });
+
+    expect((response as any).init?.status ?? (response as any).status).toBe(
+      403
+    );
+    expect(updateAuditSession).not.toHaveBeenCalled();
+    expect(sendAuditAssignedEmails).not.toHaveBeenCalled();
+  });
+
+  it("forwards the full selected set of user ids, deduplicated", async () => {
+    await runEdit({
+      "assignees[0]": blob("user-2"),
+      "assignees[1]": blob("user-3"),
+      "assignees[2]": blob("user-2"),
+    });
+
+    expect(updateAuditSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "audit-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        data: expect.objectContaining({
+          name: "Q4 audit",
+          assigneeUserIds: ["user-2", "user-3"],
+        }),
+      })
+    );
+  });
+
+  it("treats an empty selection as 'remove everyone'", async () => {
+    await runEdit();
+
+    expect(updateAuditSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ assigneeUserIds: [] }),
+      })
+    );
+  });
+
+  it("still honours the singular pre-multi-assign field", async () => {
+    await runEdit({ assignee: blob("user-7") });
+
+    expect(updateAuditSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ assigneeUserIds: ["user-7"] }),
+      })
+    );
+  });
+
+  it("emails only the people the service reports as added, never the editor", async () => {
+    vi.mocked(updateAuditSession).mockResolvedValue({
+      audit: { id: "audit-1" },
+      addedAssigneeIds: ["user-3", "user-1"],
+      removedAssigneeIds: ["user-9"],
+    } as any);
+
+    await runEdit({
+      "assignees[0]": blob("user-2"),
+      "assignees[1]": blob("user-3"),
+      "assignees[2]": blob("user-1"),
+    });
+
+    expect(sendAuditAssignedEmails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditId: "audit-1",
+        organizationId: "org-1",
+        recipientUserIds: ["user-3"],
+      })
+    );
+  });
+});

--- a/apps/webapp/test/routes-tests/_layout+/audits.$auditId.edit-audit.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/audits.$auditId.edit-audit.test.ts
@@ -27,6 +27,9 @@ import { requirePermission } from "~/utils/roles.server";
 
 // @vitest-environment node
 
+// why: these tests assert the route's wiring (parsing, guards, who gets
+// emailed), not the set diff itself, which service.server.test.ts covers; the
+// real service would also open a database transaction.
 vi.mock("~/modules/audit/service.server", () => ({
   updateAuditSession: vi.fn(),
   cancelAuditSession: vi.fn(),
@@ -36,14 +39,20 @@ vi.mock("~/modules/audit/service.server", () => ({
   getAuditSessionDetails: vi.fn(),
 }));
 
+// why: the fan-out loads the audit from the DB and sends real mail; a stub
+// lets the tests assert exactly which user ids are handed to it.
 vi.mock("~/modules/audit/assignment-emails.server", () => ({
   sendAuditAssignedEmails: vi.fn(),
 }));
 
+// why: the route imports the completion helper for a different intent; the
+// stub keeps its storage and image imports out of the node test graph.
 vi.mock("~/modules/audit/complete-audit-with-images.server", () => ({
   completeAuditWithImages: vi.fn(),
 }));
 
+// why: permission resolution is driven per test (admin vs BASE) without a
+// session or database.
 vi.mock("~/utils/roles.server", () => ({
   requirePermission: vi.fn(),
 }));

--- a/apps/webapp/test/routes-tests/api+/audits.start.action.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.start.action.test.ts
@@ -29,10 +29,12 @@ const {
   createAuditSession,
   resolveAssetIdsForAudit,
   resolveUserFormatPrefsById,
+  sendAuditAssignedEmails,
 } = vi.hoisted(() => ({
   createAuditSession: vi.fn(),
   resolveAssetIdsForAudit: vi.fn(),
   resolveUserFormatPrefsById: vi.fn(),
+  sendAuditAssignedEmails: vi.fn(),
 }));
 
 // why: the action gates on permission; mock to grant it without hitting auth/DB.
@@ -80,12 +82,14 @@ vi.mock("~/modules/asset-index-settings/service.server", () => ({
   getAssetIndexSettings: vi.fn(),
 }));
 
-// why: no assignee → email branch never runs, but the module is imported at load.
-vi.mock("~/modules/audit/email-helpers", () => ({
-  sendAuditAssignedEmail: vi.fn(),
+// why: the assignment email fan-out loads the audit from the DB; stub it so
+// the tests can assert WHO gets emailed without a database.
+vi.mock("~/modules/audit/assignment-emails.server", () => ({
+  sendAuditAssignedEmails,
 }));
 
-// why: the action imports the global Prisma client at module load.
+// why: modules on the route's import graph touch the global Prisma client at
+// module load; nothing in these tests reaches the DB.
 vi.mock("~/database/db.server", () => ({
   db: { auditSession: { findFirst: vi.fn() } },
 }));
@@ -93,11 +97,14 @@ vi.mock("~/database/db.server", () => ({
 /**
  * Build a POST request + fake context carrying the acting user id.
  */
-function buildArgs(dueDate: string) {
+function buildArgs(dueDate?: string, extra: Record<string, string> = {}) {
   const formData = new FormData();
   formData.set("name", "Quarterly warehouse audit");
   formData.set("assetIds[0]", "asset-1");
-  formData.set("dueDate", dueDate);
+  if (dueDate) formData.set("dueDate", dueDate);
+  for (const [key, value] of Object.entries(extra)) {
+    formData.set(key, value);
+  }
 
   const request = new Request("https://app.shelf.nu/api/audits/start", {
     method: "POST",
@@ -141,5 +148,79 @@ describe("start-audit action — dueDate timezone round-trip", () => {
       "user-1",
       expect.objectContaining({ timeZone: "Europe/Moscow" })
     );
+  });
+});
+
+const blob = (userId: string) =>
+  JSON.stringify({ id: `tm-${userId}`, name: userId, userId });
+
+/**
+ * Who gets assigned and who gets told. The creator is "user-1" (see buildArgs).
+ */
+describe("start-audit action — assignees", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveAssetIdsForAudit.mockResolvedValue(["asset-1"]);
+    createAuditSession.mockResolvedValue({
+      session: { id: "session-1", dueDate: null },
+    });
+    resolveUserFormatPrefsById.mockResolvedValue({ timeZone: "Europe/London" });
+  });
+
+  it("forwards every selected assignee, deduplicated, and emails all but the creator", async () => {
+    const response = await action(
+      buildArgs(undefined, {
+        "assignees[0]": blob("user-2"),
+        "assignees[1]": blob("user-3"),
+        "assignees[2]": blob("user-2"),
+        "assignees[3]": blob("user-1"),
+      })
+    );
+
+    expect(createAuditSession).toHaveBeenCalledWith(
+      expect.objectContaining({ assigneeIds: ["user-2", "user-3", "user-1"] })
+    );
+    expect(sendAuditAssignedEmails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditId: "session-1",
+        organizationId: "org-1",
+        recipientUserIds: ["user-2", "user-3"],
+      })
+    );
+    // The creator is among the assignees, so they land on the scanner.
+    expect((response as any).data.redirectTo).toBe("/audits/session-1/scan");
+  });
+
+  it("sends the creator to the overview when the audit is assigned only to others", async () => {
+    const response = await action(
+      buildArgs(undefined, { "assignees[0]": blob("user-2") })
+    );
+
+    expect((response as any).data.redirectTo).toBe(
+      "/audits/session-1/overview"
+    );
+  });
+
+  it("still accepts the singular pre-multi-assign field", async () => {
+    await action(buildArgs(undefined, { assignee: blob("user-5") }));
+
+    expect(createAuditSession).toHaveBeenCalledWith(
+      expect.objectContaining({ assigneeIds: ["user-5"] })
+    );
+    expect(sendAuditAssignedEmails).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientUserIds: ["user-5"] })
+    );
+  });
+
+  it("emails nobody and opens the scanner when no one is assigned", async () => {
+    const response = await action(buildArgs());
+
+    expect(createAuditSession).toHaveBeenCalledWith(
+      expect.objectContaining({ assigneeIds: [] })
+    );
+    expect(sendAuditAssignedEmails).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientUserIds: [] })
+    );
+    expect((response as any).data.redirectTo).toBe("/audits/session-1/scan");
   });
 });

--- a/apps/webapp/test/routes-tests/api+/audits.start.test.ts
+++ b/apps/webapp/test/routes-tests/api+/audits.start.test.ts
@@ -30,6 +30,30 @@ vitest.mock("~/modules/audit/service.server", () => ({
 const base = { name: "Quarterly audit" };
 
 describe("StartAuditSchema", () => {
+  it("accepts several assignees as an array of picker blobs", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      assetIds: ["a1"],
+      assignees: [
+        JSON.stringify({ id: "tm-1", name: "Ana", userId: "user-1" }),
+        JSON.stringify({ id: "tm-2", name: "Ben", userId: "user-2" }),
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.assignees).toHaveLength(2);
+    }
+  });
+
+  it("still accepts the pre-multi-assign singular assignee field", () => {
+    const result = StartAuditSchema.safeParse({
+      ...base,
+      assetIds: ["a1"],
+      assignee: JSON.stringify({ id: "tm-1", name: "Ana", userId: "user-1" }),
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts a location multi-selection (contextType=location + locationIds)", () => {
     const result = StartAuditSchema.safeParse({
       ...base,


### PR DESCRIPTION
## What

An audit can now be assigned to several people at once, on create and on edit.

The original audits spec (#2036) asked for "assigning multiple auditors". The database already stores one assignment row per person and every page, permission gate and email fan-out already handled a team; only the picker, the create route and the edit path were still single-assignee. This closes that gap so a group can sweep one large audit together.

## Changes

- **Team member picker is multi-select.** Each selected member is submitted as its own bracket-indexed `assignees[i]` field (the same convention `assetIds[i]` uses), because the form parser keeps only the last value for repeated names. Members pre-selected in the edit dialog carry their user id, so saving before the member list has loaded cannot wipe the team. "Assign to self" adds you alongside the others.
- **Create and edit take the full desired set.** Edit diffs it against the current assignments, removes the departed and adds the newcomers, writes **one** Activity note naming everyone added and removed ("added assignees: A, B and removed assignee: C"), and records an activity event per person. Every assignee must be a workspace member.
- **Assignment email on create and on edit.** Each newly added person gets the existing "You've been assigned" email; the person making the change is never emailed about their own edit. Previously only the single assignee chosen at creation was emailed and editing sent nothing.
- **Redirect after create** goes to the scanner whenever the creator is among the assignees, to the overview when the audit is assigned only to other people.
- **Edit is admin/owner only on the server too**, matching what the UI already shows.
- **List polish:** the "+N" badge on the audits index names the rest of the team on hover, the header reads "Assignees", and the pending-audit picker lists every assignee.
- The singular `assignee` form field is still accepted, so a page loaded before this deploys saves cleanly instead of removing everyone.

No schema change and no migration.

## Verification

- `pnpm webapp:validate` green (typecheck, lint, 5,841 tests). New coverage: the picker's hidden-input contract, the form-value parser, the set diff in `updateAuditSession` (add, remove, remove all, untouched, unchanged, non-member), the create and edit route wiring, the batched note.
- Driven live on a local build: edit dialog selects two people with a "2 assignees selected" line; the overview lists both; the Activity tab shows one line per edit; the server log shows exactly one assignment email per newly added person; a second edit that swaps one person produces "added assignee: X and removed assignee: Y"; the index badge reads "+1" with the name on hover; creating through `/api/audits/start` with three entries (one duplicate) yields two assignments and the overview redirect.

## Follow-ups (separate PRs)

1. Show who scanned each asset and when on the scan drawer, overview table, per-asset panel and the PDF assets table. The data is already recorded per scan.
2. Lifecycle guards for team sweeps: reject scans on completed and cancelled audits, and confirm before completing while teammates scanned in the last few minutes.
3. Companion: "scanned by · time" on the scanned list and audit detail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audits can be assigned to multiple team members when created, edited, or duplicated.
  * Assignee pickers support multi-selection, self-assignment, search, and visible selection counts.
  * Audit lists and pending-audit selectors display all assigned team members.
  * Newly added or carried-over assignees receive assignment email notifications.
* **Bug Fixes**
  * Assignment validation errors now display correctly across audit creation dialogs.
  * Audit activity notes summarize multiple assignees added or removed.
  * Removing assignees from active audits clearly warns that scan access is removed immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->