### PR TITLE
feat(companion): open the asset from an audit row

### DIFF
--- a/apps/companion/.maestro/flows/audits/06-row-opens-asset.yaml
+++ b/apps/companion/.maestro/flows/audits/06-row-opens-asset.yaml
@@ -1,0 +1,75 @@
+appId: com.shelf.companion.carlos
+name: "Audits - Row Opens Asset"
+tags:
+  - audits
+
+---
+# Test: an asset row on the audit detail opens the asset detail.
+#
+# The web audit row links its title to the asset page; the phone row does the
+# same so a field worker who finds a missing or unexpected asset can update it
+# on the spot. The row navigates cross-tab through pushIntoTab, which anchors
+# the Assets list beneath the asset detail, so "back" lands on the Assets list
+# (not on the audit) and must never strand the user on a detail with no back
+# target. The audit stays mounted in its own stack: reopening it from Home
+# shows it again.
+#
+# Fixture: SHELF_TEST_AUDIT_NAME is an audit with at least one expected asset.
+# Env: SHELF_TEST_EMAIL / SHELF_TEST_PASSWORD / SHELF_TEST_AUDIT_NAME
+
+- runFlow: ../../shared/login.yaml
+
+- tapOn: "Home"
+- tapOn: "Audits"
+- scrollUntilVisible:
+    element: ".*${SHELF_TEST_AUDIT_NAME}.*"
+    direction: DOWN
+    timeout: 30000
+- tapOn: ".*${SHELF_TEST_AUDIT_NAME}.*"
+
+# Audit detail: the asset section renders once the detail payload lands
+- extendedWaitUntil:
+    visible: "Audit Details"
+    timeout: 15000
+- extendedWaitUntil:
+    visible: "Filter: All.*"
+    timeout: 15000
+
+# ── First asset row opens the asset ──
+# The row's a11y label names the action; a deleted asset's row does not carry
+# it, so this always picks a row that has an asset to open.
+- extendedWaitUntil:
+    visible: ".*, tap to open asset"
+    timeout: 15000
+- tapOn:
+    text: ".*, tap to open asset"
+    index: 0
+
+# Asset detail — "Created" is always rendered there. The header is not a
+# stable anchor: it flips from "Asset Details" to the asset's name on load.
+- extendedWaitUntil:
+    visible: "Created"
+    timeout: 20000
+- takeScreenshot: audit-row-asset-detail
+
+# ── Back has a target: the Assets list, not a dead end ──
+- back
+- extendedWaitUntil:
+    visible: "Search assets"
+    timeout: 15000
+- assertNotVisible: "Created"
+- takeScreenshot: audit-row-back-to-assets
+
+# ── The audit is still reachable and intact ──
+- tapOn: "Home"
+- tapOn: "Audits"
+- scrollUntilVisible:
+    element: ".*${SHELF_TEST_AUDIT_NAME}.*"
+    direction: DOWN
+    timeout: 30000
+- tapOn: ".*${SHELF_TEST_AUDIT_NAME}.*"
+- extendedWaitUntil:
+    visible: "Audit Details"
+    timeout: 15000
+- assertVisible: "Filter: All.*"
+- takeScreenshot: audit-row-back-to-audit

--- a/apps/companion/app/(tabs)/audits/[id].tsx
+++ b/apps/companion/app/(tabs)/audits/[id].tsx
@@ -9,6 +9,7 @@ import {
   RefreshControl,
   Alert,
   Animated,
+  type AccessibilityActionEvent,
 } from "react-native";
 import * as Haptics from "expo-haptics";
 import { Image } from "expo-image";
@@ -26,6 +27,7 @@ import {
   type AuditEvidenceImage,
 } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
+import { pushIntoTab } from "@/lib/navigation";
 import { fontSize, spacing, borderRadius } from "@/lib/constants";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { EvidenceViewer } from "@/components/audit/evidence-viewer";
@@ -106,6 +108,11 @@ function isAssetFilterVisible(
 
 type DisplayAsset = {
   id: string; // assetId or auditAssetId
+  /**
+   * The live asset this row opens. Null for a deleted asset: the scan still
+   * lists it, but there is no asset detail left to navigate to.
+   */
+  assetId: string | null;
   name: string;
   mainImage: string | null;
   status: AuditAssetStatus;
@@ -515,6 +522,7 @@ function AuditDetailContent() {
       const scan = scanMap.get(asset.id);
       items.push({
         id: asset.id,
+        assetId: asset.id,
         name: asset.name,
         mainImage: asset.thumbnailImage || asset.mainImage,
         status: scan ? "FOUND" : notFoundStatus,
@@ -562,6 +570,7 @@ function AuditDetailContent() {
           id: isDeletedAsset
             ? `deleted:${scan.id || scan.code || scan.scannedAt}`
             : scan.assetId,
+          assetId: isDeletedAsset ? null : scan.assetId,
           name: isDeletedAsset
             ? auditDeletedAssetLabel(snapshotTitle)
             : snapshotTitle || "Untitled asset",
@@ -639,9 +648,6 @@ function AuditDetailContent() {
         metaParts.push({ icon: "qr-code-outline", text: item.scannedCode });
       }
 
-      // why: evidence is the ONE thing on this card worth opening. Everything
-      // else (image, name, location, category, custodian, status) is already
-      // shown, which is why the card is otherwise inert — see the note below.
       // why two numbers and not their sum: see scanned-items-list.tsx. The
       // sum changes for identical evidence depending on whether the auditor
       // typed a caption, so it cannot be compared between rows.
@@ -659,18 +665,32 @@ function AuditDetailContent() {
       ]
         .filter(Boolean)
         .join(", ");
-      const Card = hasEvidence ? TouchableOpacity : View;
+      // The card opens the asset, matching the web audit row where the title
+      // links to the asset page: a field worker who finds a missing or
+      // unexpected asset updates it from here. A deleted asset has no detail
+      // left to open, so that row stays an inert summary and only its
+      // evidence chip (below) is tappable.
+      const opensAsset = item.assetId !== null;
+      const Card = opensAsset ? TouchableOpacity : View;
+      const openEvidence = () =>
+        onEvidencePress({
+          auditAssetId: item.auditAssetId as string,
+          name: item.name,
+        });
 
       return (
         <Card
           style={styles.assetCard}
-          {...(hasEvidence
+          {...(opensAsset
             ? {
+                // Cross-tab: pushIntoTab anchors the Assets list beneath the
+                // detail so "back" has a target, and leaves this audit mounted
+                // in its own stack instead of pushing the asset onto it.
                 onPress: () =>
-                  onEvidencePress({
-                    auditAssetId: item.auditAssetId as string,
-                    name: item.name,
-                  }),
+                  pushIntoTab(
+                    "/(tabs)/assets",
+                    `/(tabs)/assets/${item.assetId}`
+                  ),
                 activeOpacity: 0.7,
                 accessibilityRole: "button" as const,
               }
@@ -685,21 +705,27 @@ function AuditDetailContent() {
             item.name,
             statusLabel,
             ...metaParts.map((p) => p.text),
-            hasEvidence ? `${evidenceLabel}, tap to view` : null,
+            hasEvidence ? evidenceLabel : null,
+            opensAsset ? "tap to open asset" : null,
           ]
             .filter(Boolean)
             .join(", ")}
+          // `accessible` folds the chip into the card for a screen reader, so
+          // the evidence viewer is also exposed as a custom action (VoiceOver
+          // rotor / TalkBack actions menu) on every row that has evidence.
+          {...(hasEvidence
+            ? {
+                accessibilityActions: [
+                  { name: "viewEvidence", label: "View evidence" },
+                ],
+                onAccessibilityAction: (event: AccessibilityActionEvent) => {
+                  if (event.nativeEvent.actionName === "viewEvidence") {
+                    openEvidence();
+                  }
+                },
+              }
+            : {})}
         >
-          {/*
-            why: the previous `router.push('/(tabs)/assets/...)' from
-            inside the Audits tab polluted the Assets tab's stack — the
-            Assets tab kept showing the asset detail until the user
-            manually navigated back. Removed the cross-tab navigation
-            entirely; the field worker has everything they need on this
-            card (image, name, location, category, custodian, status).
-            Full asset detail remains reachable from the Assets tab,
-            which is the correct surface for browsing.
-          */}
           {item.mainImage ? (
             <Image
               source={{ uri: item.mainImage }}
@@ -749,7 +775,16 @@ function AuditDetailContent() {
               </Text>
             </View>
             {hasEvidence ? (
-              <View style={styles.evidenceChip}>
+              <TouchableOpacity
+                style={styles.evidenceChip}
+                onPress={openEvidence}
+                activeOpacity={0.7}
+                // The chip is small; slop keeps it easy to hit without
+                // growing it visually or stealing the card's tap.
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel={`${evidenceLabel}, tap to view`}
+              >
                 {noteCount > 0 ? (
                   <>
                     <Ionicons
@@ -770,7 +805,7 @@ function AuditDetailContent() {
                     <Text style={styles.evidenceChipText}>{photoCount}</Text>
                   </>
                 ) : null}
-              </View>
+              </TouchableOpacity>
             ) : null}
           </View>
         </Card>


### PR DESCRIPTION
## Why

A field worker who finds a missing or unexpected asset during an audit needs to open that asset and update it right there. On the web audit detail page the asset row already links its title to the asset page (`audit-asset-list-item.tsx`). On the phone the row was inert unless it had evidence, in which case the whole card opened the evidence viewer.

The row was made inert because an earlier `router.push("/(tabs)/assets/...")` from the Audits stack polluted the Assets tab's stack. `pushIntoTab` (`lib/navigation.ts`) has since solved that for bookings, home and the scanner: it navigates with `withAnchor`, so the Assets list sits beneath the asset detail and "back" has a target. The audit row now uses the same helper.

## Change

- `apps/companion/app/(tabs)/audits/[id].tsx`
  - `DisplayAsset` gains `assetId: string | null`. Expected rows carry the asset id; unexpected scans carry `scan.assetId`, or `null` when the asset was deleted. The existing `id` field (the FlatList key) is unchanged.
  - Card tap: a row with a non-null `assetId` is a `TouchableOpacity` that calls `pushIntoTab("/(tabs)/assets", "/(tabs)/assets/<assetId>")`. A deleted-asset row stays an inert `View` (`accessibilityRole="summary"`).
  - Evidence chip: the note/photo count chip is now its own `TouchableOpacity` (with `hitSlop` 8 on each side) that opens the evidence viewer exactly as the card did before. Evidence stays reachable on every row that has it, including a deleted-asset row, where the chip is the only tappable element.
  - Accessibility: the card keeps `accessible` and a composed label; a card that opens the asset ends with "tap to open asset" and has role `button`. The chip gets its own label (for example `2 notes, 1 photo, tap to view`) and role `button`. Because `accessible` folds the chip into the card for screen readers, rows with evidence also expose a `View evidence` custom accessibility action (VoiceOver rotor / TalkBack actions menu) that opens the viewer.
  - The JSX comment describing the removed cross-tab push is replaced with comments that describe the current behaviour.
  - `useCallback` dependencies are unchanged; `pushIntoTab` is a module import.
- `apps/companion/.maestro/flows/audits/06-row-opens-asset.yaml` (new)
  - Opens `SHELF_TEST_AUDIT_NAME` from the Audits list, taps the first row whose label ends in "tap to open asset", asserts the asset detail ("Created" is always rendered there), presses back and asserts the Assets list is shown (the anchor `pushIntoTab` places beneath the detail), then reopens the audit from Home and asserts the audit detail is intact.

Not changed: `components/audit/scanned-items-list.tsx` (row tap opens the evidence modal on the scan screen) and `components/audit/remaining-assets-list.tsx` (image tap opens an image preview). Neither opens the asset; that is out of scope here.

Note on back navigation: the Audits group is hidden from the tab bar (`href: null`), so after "back" lands on the Assets list the audit is reopened from Home. The audit's own stack stays mounted throughout.

## Testing

Run in `apps/companion`:

- `npx tsc --noEmit`: 0 errors.
- `pnpm lint` (`expo lint` + `scripts/check-version-sync.mjs`): clean; version sync OK.
- `pnpm test` (node test runner, `lib/**/*.test.ts`): 80 passed, 0 failed. The companion has no vitest setup.
- `npx prettier --check` on both changed files: clean.

The Maestro flow `06-row-opens-asset.yaml` has NOT been run on a device or simulator yet. It follows the selectors and fixtures the other audit flows use (`SHELF_TEST_AUDIT_NAME`, "Created" on the asset detail, `Filter: All` on the audit detail, "Search assets" on the Assets list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tapping a live asset row in an audit now opens that asset’s detail page.
  - Evidence can be opened from a dedicated evidence control within the audit row.
  - Back navigation from asset details returns to the audit’s Assets list.

- **Bug Fixes**
  - Deleted assets remain non-interactive summaries instead of attempting to open unavailable details.
  - Audit details remain intact after navigating to an asset and returning.

- **Tests**
  - Added an end-to-end flow covering asset navigation, back navigation, and audit state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->