### PR TITLE
feat(webapp): print the preferred asset code on the booking and audit PDFs, and make the QR optional

### DIFF
--- a/apps/webapp/app/components/assets/asset-code-print-text.tsx
+++ b/apps/webapp/app/components/assets/asset-code-print-text.tsx
@@ -1,0 +1,44 @@
+/**
+ * AssetCodePrintText
+ *
+ * The asset's resolved display code (QR id, SAM id, or barcode value) rendered
+ * as plain text for the printed PDFs — the booking checklist and the audit
+ * receipt. Pairs with `resolveDisplayCode` from `~/modules/barcode/display`,
+ * which the PDF data helpers call server-side.
+ *
+ * Deliberately NOT `<AssetCodeBadge>`: that chip is built around a tooltip, and
+ * paper has no hover. What the badge explains on hover — "the type your
+ * workspace asked for wasn't available on this asset, so this is the QR id" —
+ * is printed here as a caption under the value instead, because a picker
+ * holding the sheet has no other way to learn it.
+ *
+ * Renders nothing when there is no resolved code. Defensive: every asset has a
+ * QR fallback, so this only happens if a caller omits the map entry.
+ */
+
+import type { ResolvedDisplayCode } from "~/modules/barcode/display";
+import { labelForPreference } from "~/modules/barcode/display";
+
+export function AssetCodePrintText({
+  displayCode,
+}: {
+  /** The entry this asset's row read out of the PDF's display-code map. */
+  displayCode: ResolvedDisplayCode | undefined;
+}) {
+  if (!displayCode?.value) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span className="break-all font-mono text-sm font-medium text-gray-900">
+        {displayCode.value}
+      </span>
+      {displayCode.isFallback ? (
+        <span className="text-[10px] text-gray-500">
+          {labelForPreference(displayCode.type)}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/webapp/app/components/assets/asset-code-print-text.tsx
+++ b/apps/webapp/app/components/assets/asset-code-print-text.tsx
@@ -19,6 +19,14 @@
 import type { ResolvedDisplayCode } from "~/modules/barcode/display";
 import { labelForPreference } from "~/modules/barcode/display";
 
+/**
+ * Renders one asset's display code as a printable line, with a caption naming
+ * the code's type when it is not the type the workspace asked for.
+ *
+ * @param props.displayCode - The `ResolvedDisplayCode` this row read out of the
+ *   PDF's display-code map, or `undefined` when the map has no entry for it.
+ * @returns The code line, or `null` when there is no code to print.
+ */
 export function AssetCodePrintText({
   displayCode,
 }: {

--- a/apps/webapp/app/components/assets/asset-code-print-text.tsx
+++ b/apps/webapp/app/components/assets/asset-code-print-text.tsx
@@ -38,7 +38,7 @@ export function AssetCodePrintText({
   }
 
   return (
-    <div className="flex flex-col items-center gap-0.5">
+    <div className="flex flex-col items-start gap-0.5">
       <span className="break-all font-mono text-sm font-medium text-gray-900">
         {displayCode.value}
       </span>

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * The Code column of the audit receipt PDF.
+ *
+ * The receipt is the audit's output — the sheet somebody keeps, attaches to a
+ * claim, or walks the shelves with. Its asset table used to print a QR image
+ * and no readable identifier, so a workspace that labels its equipment with
+ * SAM IDs could not match a printed row to a physical label without a scanner.
+ *
+ * @see {@link file://./audit-receipt-pdf.tsx}
+ * @see {@link file://../assets/asset-code-print-text.tsx}
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AuditPdfDbResult } from "~/modules/audit/pdf-helpers";
+import type {
+  DateFormatOptions,
+  ResolvedFormatPrefs,
+} from "~/utils/date-format";
+
+import { AuditPDFContent } from "./audit-receipt-pdf";
+
+// why: the receipt renders `DateS`, which reads the acting user's format prefs
+// through this hook — it reaches the root route loader, and there is no router
+// in a unit test. Same stub shape as `reports/report-table.test.tsx`.
+vi.mock("~/hooks/use-date-formatter", async () => {
+  const actual = (await vi.importActual("~/utils/date-format")) as {
+    formatDate: (
+      value: string | Date,
+      prefs: ResolvedFormatPrefs,
+      opts?: DateFormatOptions
+    ) => string;
+  };
+  const prefs: ResolvedFormatPrefs = {
+    dateFormat: "DD_MM_YYYY",
+    timeFormat: "H12",
+    weekStartsOn: 1,
+    timeZone: "UTC",
+  };
+  return {
+    useDateFormatter: () => ({
+      prefs,
+      formatDate: (value: string | Date, opts?: DateFormatOptions) =>
+        actual.formatDate(value, prefs, opts),
+      formatTime: (value: string | Date, opts?: DateFormatOptions) =>
+        actual.formatDate(value, prefs, { ...opts, onlyTime: true }),
+      formatDateTime: (value: string | Date, opts?: DateFormatOptions) =>
+        actual.formatDate(value, prefs, { ...opts, includeTime: true }),
+    }),
+  };
+});
+
+const QR_IMAGE = "data:image/png;base64,iVBORw0KGgo=";
+
+/**
+ * A one-asset receipt. Cast rather than spelled out: the real shape is a full
+ * Prisma `Asset` plus audit status, and none of the columns this component
+ * never reads would make the test say more.
+ */
+function pdfMetaWith({
+  displayCode,
+  qrImage = QR_IMAGE,
+}: {
+  displayCode: AuditPdfDbResult["assetIdToDisplayCodeMap"][string] | undefined;
+  qrImage?: string | null;
+}): AuditPdfDbResult {
+  return {
+    session: {
+      id: "audit-1",
+      name: "Quarterly check",
+      status: "COMPLETED",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      completedAt: new Date("2026-01-02T00:00:00.000Z"),
+      dueDate: null,
+      expectedAssetCount: 1,
+      scannedAssetCount: 1,
+      missingAssetCount: 0,
+      unexpectedAssetCount: 0,
+      createdBy: {
+        firstName: "Ada",
+        lastName: "L",
+        displayName: null,
+        email: "ada@example.com",
+        profilePicture: null,
+      },
+      assignments: [],
+    },
+    organization: {
+      id: "org-1",
+      name: "Org",
+      imageId: null,
+      currency: "USD",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    },
+    assets: [
+      {
+        id: "asset-1",
+        title: "Camera",
+        thumbnailImage: null,
+        category: null,
+        location: null,
+        auditData: { expected: true, auditStatus: "SCANNED" },
+      },
+    ],
+    assetIdToQrCodeMap: qrImage ? { "asset-1": qrImage } : {},
+    assetIdToDisplayCodeMap: displayCode ? { "asset-1": displayCode } : {},
+    generalImages: [],
+    assetImages: [],
+    conditionNotes: [],
+    activityNotes: [],
+  } as unknown as AuditPdfDbResult;
+}
+
+const SAM_CODE = {
+  value: "SAM-0001",
+  type: "SAM_ID",
+  isFallback: false,
+  entityKind: "asset",
+  workspacePreference: "SAM_ID",
+} as AuditPdfDbResult["assetIdToDisplayCodeMap"][string];
+
+function renderReceipt(
+  args: Parameters<typeof pdfMetaWith>[0]
+): ReturnType<typeof render> {
+  return render(
+    <AuditPDFContent
+      componentRef={{ current: null }}
+      pdfMeta={pdfMetaWith(args)}
+    />
+  );
+}
+
+/** The table cell holding the row's code — found by the row, not by the image,
+ * so the no-image case can use the same helper. */
+function codeCell() {
+  const cells = screen
+    .getByText("Camera")
+    .closest("tr")
+    ?.querySelectorAll("td");
+  expect(cells).toBeTruthy();
+  return cells![cells!.length - 1];
+}
+
+describe("audit receipt PDF — Code column", () => {
+  it("names the column for what it now holds", () => {
+    // why: it read "QR Code" while holding only an image. It now holds the
+    // identifier a reader matches against the shelf, and the QR is one
+    // rendering of it.
+    renderReceipt({ displayCode: SAM_CODE });
+
+    expect(
+      screen.getByRole("columnheader", { name: "Code" })
+    ).toBeInTheDocument();
+  });
+
+  it("prints the workspace's preferred code beside the QR image", () => {
+    renderReceipt({ displayCode: SAM_CODE });
+
+    const cell = codeCell();
+    expect(cell).toHaveTextContent("SAM-0001");
+    expect(cell.querySelector("img")).not.toBeNull();
+  });
+
+  it("prints the code even when no QR image was generated", () => {
+    // why: the image is signed at request time and can come back empty. The
+    // code is the part the receipt exists to record, so it must not be
+    // conditional on the image the way the image itself is.
+    renderReceipt({ displayCode: SAM_CODE, qrImage: null });
+
+    const cell = codeCell();
+    expect(cell).toHaveTextContent("SAM-0001");
+    expect(cell.querySelector("img")).toBeNull();
+  });
+
+  it("says which code it fell back to when the preferred one is missing", () => {
+    // why: on screen the outlined badge + tooltip carry this. Paper has no
+    // hover, so an unexplained QR id where the workspace expects a SAM ID
+    // reads as the feature being broken.
+    renderReceipt({
+      displayCode: {
+        value: "qr-visible-id",
+        type: "QR_ID",
+        isFallback: true,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      } as AuditPdfDbResult["assetIdToDisplayCodeMap"][string],
+    });
+
+    const cell = codeCell();
+    expect(cell).toHaveTextContent("qr-visible-id");
+    expect(cell).toHaveTextContent("QR Code ID");
+  });
+
+  it("still renders the row when no code resolved", () => {
+    // why: defensive. Every asset has a QR fallback, so an empty map means a
+    // caller bug — which must not take the whole receipt down.
+    renderReceipt({ displayCode: undefined });
+
+    expect(screen.getByText("Camera")).toBeInTheDocument();
+  });
+});

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
@@ -60,9 +60,11 @@ const QR_IMAGE = "data:image/png;base64,iVBORw0KGgo=";
 function pdfMetaWith({
   displayCode,
   qrImage = QR_IMAGE,
+  showQrCodesOnPdfs = true,
 }: {
   displayCode: AuditPdfDbResult["assetIdToDisplayCodeMap"][string] | undefined;
   qrImage?: string | null;
+  showQrCodesOnPdfs?: boolean;
 }): AuditPdfDbResult {
   return {
     session: {
@@ -93,6 +95,7 @@ function pdfMetaWith({
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       qrIdDisplayPreference: "SAM_ID",
       barcodesEnabled: false,
+      showQrCodesOnPdfs,
     },
     assets: [
       {
@@ -192,6 +195,16 @@ describe("audit receipt PDF — Code column", () => {
     const cell = codeCell();
     expect(cell).toHaveTextContent("qr-visible-id");
     expect(cell).toHaveTextContent("QR Code ID");
+  });
+
+  it("prints no QR image when the workspace turned them off", () => {
+    // why: an audit records what was physically present, so a receipt whose QR
+    // can be scanned from a desk undermines the record it is. The code stays,
+    // so the row is still matchable by eye.
+    renderReceipt({ displayCode: SAM_CODE, showQrCodesOnPdfs: false });
+
+    expect(codeCell().querySelector("img")).toBeNull();
+    expect(codeCell()).toHaveTextContent("SAM-0001");
   });
 
   it("still renders the row when no code resolved", () => {

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
@@ -164,7 +164,8 @@ describe("audit receipt PDF — Code column", () => {
   });
 
   it("prints the code even when no QR image was generated", () => {
-    // why: the image is signed at request time and can come back empty. The
+    // why: the image is generated per request, and `getQrCodeMaps` leaves out
+    // any asset whose generation threw, so a row can arrive with no image. The
     // code is the part the receipt exists to record, so it must not be
     // conditional on the image the way the image itself is.
     renderReceipt({ displayCode: SAM_CODE, qrImage: null });

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.test.tsx
@@ -2,9 +2,9 @@
  * The Code column of the audit receipt PDF.
  *
  * The receipt is the audit's output — the sheet somebody keeps, attaches to a
- * claim, or walks the shelves with. Its asset table used to print a QR image
- * and no readable identifier, so a workspace that labels its equipment with
- * SAM IDs could not match a printed row to a physical label without a scanner.
+ * claim, or walks the shelves with. Its asset table prints the code a reader
+ * matches against a physical label, so a workspace that labels its equipment
+ * with SAM IDs can work the sheet without a scanner.
  *
  * @see {@link file://./audit-receipt-pdf.tsx}
  * @see {@link file://../assets/asset-code-print-text.tsx}
@@ -144,10 +144,10 @@ function codeCell() {
 }
 
 describe("audit receipt PDF — Code column", () => {
-  it("names the column for what it now holds", () => {
-    // why: it read "QR Code" while holding only an image. It now holds the
-    // identifier a reader matches against the shelf, and the QR is one
-    // rendering of it.
+  it('heads the column "Code"', () => {
+    // why: the column holds the identifier a reader matches against the
+    // shelf. The QR image is one rendering of that identifier, not a second
+    // thing, so the header names the code rather than the image.
     renderReceipt({ displayCode: SAM_CODE });
 
     expect(

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -15,6 +15,7 @@ import { tw } from "~/utils/tw";
 import { resolveUserDisplayName } from "~/utils/user";
 import { AuditAssetStatusBadge } from "./audit-asset-status-badge";
 import { AuditStatusBadgeWithOverdue } from "./audit-status-badge-with-overdue";
+import { AssetCodePrintText } from "../assets/asset-code-print-text";
 import { CategoryBadge } from "../assets/category-badge";
 import { Dialog, DialogPortal } from "../layout/dialog";
 import { Button } from "../shared/button";
@@ -152,7 +153,7 @@ export const AuditReceiptPDF = ({
  * @param pdfMeta - All audit data needed for the PDF (note content is already sanitized server-side)
  */
 // react-doctor:no-giant-component — deferred for follow-up refactor
-const AuditPDFContent = ({
+export const AuditPDFContent = ({
   componentRef,
   pdfMeta,
 }: {
@@ -166,6 +167,7 @@ const AuditPDFContent = ({
     organization,
     assets,
     assetIdToQrCodeMap,
+    assetIdToDisplayCodeMap,
     generalImages,
     assetImages,
     conditionNotes,
@@ -542,8 +544,12 @@ const AuditPDFContent = ({
                 <th className="w-20 border border-gray-300 p-2.5 text-left text-xs font-medium">
                   Status
                 </th>
-                <th className="min-w-[80px] border border-gray-300 p-2.5 text-left text-xs font-medium">
-                  QR Code
+                {/* 120px, not the 80px that held only an image. This cell has
+                    no tick box, so 120px leaves the code ~100px — the same
+                    room the booking checklist gives it at 150px. Wider would
+                    only squeeze the Name column. */}
+                <th className="min-w-[120px] border border-gray-300 p-2.5 text-left text-xs font-medium">
+                  Code
                 </th>
               </tr>
             </thead>
@@ -600,13 +606,21 @@ const AuditPDFContent = ({
                       />
                     </td>
                     <td className="border border-gray-300 p-2.5 align-top">
-                      {assetIdToQrCodeMap[asset.id] && (
-                        <img
-                          src={assetIdToQrCodeMap[asset.id]}
-                          alt={`QR code for ${asset.title}`}
-                          className="size-16"
+                      <div className="flex flex-col items-center gap-1">
+                        {assetIdToQrCodeMap[asset.id] && (
+                          <img
+                            src={assetIdToQrCodeMap[asset.id]}
+                            alt={`QR code for ${asset.title}`}
+                            className="size-16"
+                          />
+                        )}
+                        {/* Printed even when the QR image is missing: the code
+                            is the part a reader matches against the physical
+                            label. */}
+                        <AssetCodePrintText
+                          displayCode={assetIdToDisplayCodeMap[asset.id]}
                         />
-                      )}
+                      </div>
                     </td>
                   </tr>
                 </Fragment>

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -177,8 +177,8 @@ export const AuditPDFContent = ({
   // why: the receipt can be downloaded at ANY point in an audit's life — the
   // Actions dropdown offers it with no status gate — so it must apply the same
   // completion rule as the screen it was printed from. `missingAssetCount` is
-  // seeded with the full expected count at creation, so a receipt for a
-  // never-started audit used to assert that every one of its assets was lost.
+  // seeded with the full expected count at creation, so it only means "lost"
+  // once the audit is complete.
   const auditIsCompleted = isAuditCompleted(session);
   const unscannedLabel = auditAssetStatusLabel("PENDING", auditIsCompleted);
 
@@ -544,11 +544,11 @@ export const AuditPDFContent = ({
                 <th className="w-20 border border-gray-300 p-2.5 text-left text-xs font-medium">
                   Status
                 </th>
-                {/* 120px, not the 80px that held only an image. This cell has
-                    no tick box, so 120px leaves the code ~100px — the same
-                    room the booking checklist gives it at 150px. Wider would
-                    only squeeze the Name column. */}
-                <th className="min-w-[120px] border border-gray-300 p-2.5 text-left text-xs font-medium">
+                {/* Sized for the code, which sits under the image: 140px gives
+                    it ~120px, enough for a 25-character legacy QR id on two
+                    lines. Below 140px those take three, and the extra line
+                    costs more table height than the Name column loses. */}
+                <th className="min-w-[140px] border border-gray-300 p-2.5 text-left text-xs font-medium">
                   Code
                 </th>
               </tr>

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -174,6 +174,11 @@ export const AuditPDFContent = ({
     activityNotes,
   } = pdfMeta;
 
+  // An audit is a claim about what was physically present, so a receipt whose
+  // QR can be scanned from the desk undermines the thing it records. Workspaces
+  // that care turn the image off; the text code still prints.
+  const showQrCodesOnPdfs = organization.showQrCodesOnPdfs ?? true;
+
   // why: the receipt can be downloaded at ANY point in an audit's life — the
   // Actions dropdown offers it with no status gate — so it must apply the same
   // completion rule as the screen it was printed from. `missingAssetCount` is
@@ -607,13 +612,17 @@ export const AuditPDFContent = ({
                     </td>
                     <td className="border border-gray-300 p-2.5 align-top">
                       <div className="flex flex-col items-start gap-1">
-                        {assetIdToQrCodeMap[asset.id] && (
+                        <When
+                          truthy={
+                            showQrCodesOnPdfs && !!assetIdToQrCodeMap[asset.id]
+                          }
+                        >
                           <img
                             src={assetIdToQrCodeMap[asset.id]}
                             alt={`QR code for ${asset.title}`}
                             className="size-16"
                           />
-                        )}
+                        </When>
                         {/* Printed even when the QR image is missing: the code
                             is the part a reader matches against the physical
                             label. */}

--- a/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
+++ b/apps/webapp/app/components/audit/audit-receipt-pdf.tsx
@@ -606,7 +606,7 @@ export const AuditPDFContent = ({
                       />
                     </td>
                     <td className="border border-gray-300 p-2.5 align-top">
-                      <div className="flex flex-col items-center gap-1">
+                      <div className="flex flex-col items-start gap-1">
                         {assetIdToQrCodeMap[asset.id] && (
                           <img
                             src={assetIdToQrCodeMap[asset.id]}

--- a/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
@@ -124,14 +124,19 @@ function renderPreview(args: Parameters<typeof pdfMetaWith>[0]) {
 }
 
 /**
- * The table cell holding the row's code — located by the QR `<img>`, which the
- * checklist renders unconditionally (with an empty `src` when no image was
- * generated), so the no-image case finds the same cell.
+ * The table cell holding the row's code — the last cell of the asset's row.
+ *
+ * Located by the row rather than by the QR image, because the image is absent
+ * whenever there is nothing to show: no code generated, or the workspace turned
+ * QR images off.
  */
 function codeCell() {
-  const cell = screen.getByAltText("QR Code").closest("td");
-  expect(cell).not.toBeNull();
-  return cell as HTMLTableCellElement;
+  const cells = screen
+    .getByText("Tripod")
+    .closest("tr")
+    ?.querySelectorAll("td");
+  expect(cells).toBeTruthy();
+  return cells![cells!.length - 1];
 }
 
 describe("booking checklist PDF — Code column", () => {
@@ -210,8 +215,9 @@ describe("booking checklist PDF — Code column", () => {
     });
 
     expect(codeCell()).toHaveTextContent("SAM-0001");
-    // The `<img>` still renders, sourceless — the code is what carries the row.
-    expect(codeCell().querySelector("img")?.getAttribute("src")).toBeFalsy();
+    // why: no entry means no image to show, so the element is omitted rather
+    // than rendered with an empty `src`. Same as the audit receipt.
+    expect(codeCell().querySelector("img")).toBeNull();
   });
 
   it("prints no QR image when the workspace turned them off", () => {
@@ -231,7 +237,7 @@ describe("booking checklist PDF — Code column", () => {
     });
 
     expect(screen.queryByAltText("QR Code")).not.toBeInTheDocument();
-    expect(screen.getByText("SAM-0001")).toBeInTheDocument();
+    expect(codeCell()).toHaveTextContent("SAM-0001");
   });
 
   it("keeps the pick-off checkbox when the QR image is off", () => {

--- a/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
@@ -210,7 +210,9 @@ describe("booking checklist PDF — Code column", () => {
     expect(codeCell().querySelector("img")?.getAttribute("src")).toBeFalsy();
   });
 
-  it("keeps the pick-off checkbox in the code cell", () => {
+  it("keeps a named pick-off checkbox in the code cell", () => {
+    // why: one sheet carries a checkbox per row, so the name has to say WHICH
+    // asset is being ticked or a screen reader reads a column of bare boxes.
     renderPreview({
       displayCode: {
         value: "SAM-0001",
@@ -221,6 +223,10 @@ describe("booking checklist PDF — Code column", () => {
       },
     });
 
-    expect(codeCell().querySelector('input[type="checkbox"]')).not.toBeNull();
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Mark Tripod as picked",
+    });
+
+    expect(codeCell()).toContainElement(checkbox);
   });
 });

--- a/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
@@ -191,7 +191,8 @@ describe("booking checklist PDF — Code column", () => {
   });
 
   it("prints the code even when no QR image was generated", () => {
-    // why: the image is signed at request time and can come back empty. The
+    // why: the image is generated per request, and `getQrCodeMaps` leaves out
+    // any asset whose generation threw, so a row can arrive with no image. The
     // code is what a picker matches against the shelf, so it must not be
     // rendered behind the image's presence the way the image itself is.
     renderPreview({

--- a/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * The Code column of the booking checklist PDF.
+ *
+ * The checklist is printed and carried around a warehouse. A workspace that
+ * labels its shelves with SAM IDs used to get a sheet of QR images and nothing
+ * else, so every row had to be translated by hand during picking.
+ *
+ * These tests are about what ends up ON PAPER: that the code is printed, that
+ * it sits with the QR image rather than in some other column, and that a row
+ * whose preferred code was unavailable says so — the badge's tooltip, which is
+ * how the app explains that on screen, does not survive printing.
+ *
+ * @see {@link file://./booking-overview-pdf.tsx}
+ * @see {@link file://../assets/asset-code-print-text.tsx}
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { PdfDbResult } from "~/modules/booking/pdf-helpers";
+import type {
+  DateFormatOptions,
+  ResolvedFormatPrefs,
+} from "~/utils/date-format";
+
+import { BookingPDFPreview } from "./booking-overview-pdf";
+
+// why: the header renders `DateS`, which reads the acting user's format prefs
+// through this hook — it reaches the root route loader, and there is no router
+// in a unit test. Same stub shape as `reports/report-table.test.tsx`.
+vi.mock("~/hooks/use-date-formatter", async () => {
+  const actual = (await vi.importActual("~/utils/date-format")) as {
+    formatDate: (
+      value: string | Date,
+      prefs: ResolvedFormatPrefs,
+      opts?: DateFormatOptions
+    ) => string;
+  };
+  const prefs: ResolvedFormatPrefs = {
+    dateFormat: "DD_MM_YYYY",
+    timeFormat: "H12",
+    weekStartsOn: 1,
+    timeZone: "UTC",
+  };
+  return {
+    useDateFormatter: () => ({
+      prefs,
+      formatDate: (value: string | Date, opts?: DateFormatOptions) =>
+        actual.formatDate(value, prefs, opts),
+      formatTime: (value: string | Date, opts?: DateFormatOptions) =>
+        actual.formatDate(value, prefs, { ...opts, onlyTime: true }),
+      formatDateTime: (value: string | Date, opts?: DateFormatOptions) =>
+        actual.formatDate(value, prefs, { ...opts, includeTime: true }),
+    }),
+  };
+});
+
+const QR_IMAGE = "data:image/png;base64,iVBORw0KGgo=";
+
+/**
+ * A one-row `PdfDbResult`. Cast rather than spelled out: the real shape is a
+ * full Prisma `Asset` plus the per-slice fields, and none of the ~40 columns
+ * this component never reads would make the test say more.
+ */
+function pdfMetaWith(
+  displayCode: PdfDbResult["assetIdToDisplayCodeMap"][string] | undefined
+): PdfDbResult {
+  return {
+    booking: {
+      id: "booking-1",
+      name: "Shoot",
+      description: null,
+      custodianUser: null,
+      custodianTeamMember: { name: "Ada" },
+      tags: [],
+    },
+    organization: {
+      id: "org-1",
+      name: "Org",
+      imageId: null,
+      currency: "USD",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    },
+    assets: [
+      {
+        id: "asset-1",
+        bookingAssetId: "ba-1",
+        title: "Tripod",
+        description: null,
+        quantity: 2,
+        mainImage: null,
+        thumbnailImage: null,
+        mainImageExpiration: null,
+        assetModel: null,
+        category: { name: "Support" },
+        location: { name: "Studio" },
+        kit: null,
+        isRemovedFromKit: false,
+      },
+    ],
+    totalValue: "$100",
+    assetIdToQrCodeMap: { "asset-1": QR_IMAGE },
+    assetIdToDisplayCodeMap: displayCode ? { "asset-1": displayCode } : {},
+    modelRequests: [],
+  } as unknown as PdfDbResult;
+}
+
+function renderPreview(
+  displayCode: PdfDbResult["assetIdToDisplayCodeMap"][string] | undefined
+) {
+  return render(
+    <BookingPDFPreview
+      componentRef={{ current: null }}
+      pdfMeta={pdfMetaWith(displayCode)}
+    />
+  );
+}
+
+/** The table cell holding the row's QR image — i.e. the Code column. */
+function codeCell() {
+  const cell = screen.getByAltText("QR Code").closest("td");
+  expect(cell).not.toBeNull();
+  return cell as HTMLTableCellElement;
+}
+
+describe("booking checklist PDF — Code column", () => {
+  it("prints the workspace's preferred code beside the QR image", () => {
+    renderPreview({
+      value: "SAM-0001",
+      type: "SAM_ID",
+      isFallback: false,
+      entityKind: "asset",
+      workspacePreference: "SAM_ID",
+    });
+
+    // why: `getByText` alone would pass if the code were printed in the Name
+    // column, or anywhere else on the sheet. The column is the claim.
+    expect(codeCell()).toHaveTextContent("SAM-0001");
+  });
+
+  it("says which code it fell back to when the preferred one is missing", () => {
+    // why: on screen the outlined badge + tooltip carry this. Paper has no
+    // hover, so an unexplained QR id where the workspace expects a SAM ID
+    // reads as the feature being broken.
+    renderPreview({
+      value: "qr-visible-id",
+      type: "QR_ID",
+      isFallback: true,
+      entityKind: "asset",
+      workspacePreference: "SAM_ID",
+    });
+
+    const cell = codeCell();
+    expect(cell).toHaveTextContent("qr-visible-id");
+    expect(cell).toHaveTextContent("QR Code ID");
+  });
+
+  it("prints no caption when the code is the one the workspace asked for", () => {
+    renderPreview({
+      value: "SAM-0001",
+      type: "SAM_ID",
+      isFallback: false,
+      entityKind: "asset",
+      workspacePreference: "SAM_ID",
+    });
+
+    expect(codeCell()).not.toHaveTextContent("SAM ID");
+  });
+
+  it("still renders the row when no code resolved", () => {
+    // why: defensive. Every asset has a QR fallback, so an empty map means a
+    // caller bug — which must not take the whole checklist down.
+    renderPreview(undefined);
+
+    expect(screen.getByText("Tripod")).toBeInTheDocument();
+    expect(codeCell()).toBeInTheDocument();
+  });
+
+  it("keeps the pick-off checkbox next to the code", () => {
+    renderPreview({
+      value: "SAM-0001",
+      type: "SAM_ID",
+      isFallback: false,
+      entityKind: "asset",
+      workspacePreference: "SAM_ID",
+    });
+
+    expect(codeCell().querySelector('input[type="checkbox"]')).not.toBeNull();
+  });
+});

--- a/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
@@ -1,9 +1,9 @@
 /**
  * The Code column of the booking checklist PDF.
  *
- * The checklist is printed and carried around a warehouse. A workspace that
- * labels its shelves with SAM IDs used to get a sheet of QR images and nothing
- * else, so every row had to be translated by hand during picking.
+ * The checklist is printed and carried around a warehouse, so each row has to
+ * carry the identifier the picker reads off the shelf. A sheet of QR images
+ * alone leaves a SAM ID workspace translating every row by hand.
  *
  * These tests are about what ends up ON PAPER: that the code is printed, that
  * it sits with the QR image rather than in some other column, and that a row
@@ -61,9 +61,13 @@ const QR_IMAGE = "data:image/png;base64,iVBORw0KGgo=";
  * full Prisma `Asset` plus the per-slice fields, and none of the ~40 columns
  * this component never reads would make the test say more.
  */
-function pdfMetaWith(
-  displayCode: PdfDbResult["assetIdToDisplayCodeMap"][string] | undefined
-): PdfDbResult {
+function pdfMetaWith({
+  displayCode,
+  qrImage = QR_IMAGE,
+}: {
+  displayCode: PdfDbResult["assetIdToDisplayCodeMap"][string] | undefined;
+  qrImage?: string | null;
+}): PdfDbResult {
   return {
     booking: {
       id: "booking-1",
@@ -100,24 +104,27 @@ function pdfMetaWith(
       },
     ],
     totalValue: "$100",
-    assetIdToQrCodeMap: { "asset-1": QR_IMAGE },
+    assetIdToQrCodeMap: qrImage ? { "asset-1": qrImage } : {},
     assetIdToDisplayCodeMap: displayCode ? { "asset-1": displayCode } : {},
     modelRequests: [],
   } as unknown as PdfDbResult;
 }
 
-function renderPreview(
-  displayCode: PdfDbResult["assetIdToDisplayCodeMap"][string] | undefined
-) {
+/** Renders the printable checklist body around a single asset row. */
+function renderPreview(args: Parameters<typeof pdfMetaWith>[0]) {
   return render(
     <BookingPDFPreview
       componentRef={{ current: null }}
-      pdfMeta={pdfMetaWith(displayCode)}
+      pdfMeta={pdfMetaWith(args)}
     />
   );
 }
 
-/** The table cell holding the row's QR image — i.e. the Code column. */
+/**
+ * The table cell holding the row's code — located by the QR `<img>`, which the
+ * checklist renders unconditionally (with an empty `src` when no image was
+ * generated), so the no-image case finds the same cell.
+ */
 function codeCell() {
   const cell = screen.getByAltText("QR Code").closest("td");
   expect(cell).not.toBeNull();
@@ -127,11 +134,13 @@ function codeCell() {
 describe("booking checklist PDF — Code column", () => {
   it("prints the workspace's preferred code beside the QR image", () => {
     renderPreview({
-      value: "SAM-0001",
-      type: "SAM_ID",
-      isFallback: false,
-      entityKind: "asset",
-      workspacePreference: "SAM_ID",
+      displayCode: {
+        value: "SAM-0001",
+        type: "SAM_ID",
+        isFallback: false,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      },
     });
 
     // why: `getByText` alone would pass if the code were printed in the Name
@@ -144,11 +153,13 @@ describe("booking checklist PDF — Code column", () => {
     // hover, so an unexplained QR id where the workspace expects a SAM ID
     // reads as the feature being broken.
     renderPreview({
-      value: "qr-visible-id",
-      type: "QR_ID",
-      isFallback: true,
-      entityKind: "asset",
-      workspacePreference: "SAM_ID",
+      displayCode: {
+        value: "qr-visible-id",
+        type: "QR_ID",
+        isFallback: true,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      },
     });
 
     const cell = codeCell();
@@ -158,11 +169,13 @@ describe("booking checklist PDF — Code column", () => {
 
   it("prints no caption when the code is the one the workspace asked for", () => {
     renderPreview({
-      value: "SAM-0001",
-      type: "SAM_ID",
-      isFallback: false,
-      entityKind: "asset",
-      workspacePreference: "SAM_ID",
+      displayCode: {
+        value: "SAM-0001",
+        type: "SAM_ID",
+        isFallback: false,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      },
     });
 
     expect(codeCell()).not.toHaveTextContent("SAM ID");
@@ -171,19 +184,41 @@ describe("booking checklist PDF — Code column", () => {
   it("still renders the row when no code resolved", () => {
     // why: defensive. Every asset has a QR fallback, so an empty map means a
     // caller bug — which must not take the whole checklist down.
-    renderPreview(undefined);
+    renderPreview({ displayCode: undefined });
 
     expect(screen.getByText("Tripod")).toBeInTheDocument();
     expect(codeCell()).toBeInTheDocument();
   });
 
-  it("keeps the pick-off checkbox next to the code", () => {
+  it("prints the code even when no QR image was generated", () => {
+    // why: the image is signed at request time and can come back empty. The
+    // code is what a picker matches against the shelf, so it must not be
+    // rendered behind the image's presence the way the image itself is.
     renderPreview({
-      value: "SAM-0001",
-      type: "SAM_ID",
-      isFallback: false,
-      entityKind: "asset",
-      workspacePreference: "SAM_ID",
+      displayCode: {
+        value: "SAM-0001",
+        type: "SAM_ID",
+        isFallback: false,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      },
+      qrImage: null,
+    });
+
+    expect(codeCell()).toHaveTextContent("SAM-0001");
+    // The `<img>` still renders, sourceless — the code is what carries the row.
+    expect(codeCell().querySelector("img")?.getAttribute("src")).toBeFalsy();
+  });
+
+  it("keeps the pick-off checkbox in the code cell", () => {
+    renderPreview({
+      displayCode: {
+        value: "SAM-0001",
+        type: "SAM_ID",
+        isFallback: false,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      },
     });
 
     expect(codeCell().querySelector('input[type="checkbox"]')).not.toBeNull();

--- a/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.test.tsx
@@ -64,9 +64,11 @@ const QR_IMAGE = "data:image/png;base64,iVBORw0KGgo=";
 function pdfMetaWith({
   displayCode,
   qrImage = QR_IMAGE,
+  showQrCodesOnPdfs = true,
 }: {
   displayCode: PdfDbResult["assetIdToDisplayCodeMap"][string] | undefined;
   qrImage?: string | null;
+  showQrCodesOnPdfs?: boolean;
 }): PdfDbResult {
   return {
     booking: {
@@ -85,6 +87,7 @@ function pdfMetaWith({
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       qrIdDisplayPreference: "SAM_ID",
       barcodesEnabled: false,
+      showQrCodesOnPdfs,
     },
     assets: [
       {
@@ -209,6 +212,45 @@ describe("booking checklist PDF — Code column", () => {
     expect(codeCell()).toHaveTextContent("SAM-0001");
     // The `<img>` still renders, sourceless — the code is what carries the row.
     expect(codeCell().querySelector("img")?.getAttribute("src")).toBeFalsy();
+  });
+
+  it("prints no QR image when the workspace turned them off", () => {
+    // why: the sheet carries the same codes as the labels on the equipment, so
+    // a workspace that wants people scanning the item itself has to be able to
+    // stop the sheet being scannable. The code stays: the row still has to be
+    // matchable by eye, which is the whole point of turning the image off.
+    renderPreview({
+      displayCode: {
+        value: "SAM-0001",
+        type: "SAM_ID",
+        isFallback: false,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      },
+      showQrCodesOnPdfs: false,
+    });
+
+    expect(screen.queryByAltText("QR Code")).not.toBeInTheDocument();
+    expect(screen.getByText("SAM-0001")).toBeInTheDocument();
+  });
+
+  it("keeps the pick-off checkbox when the QR image is off", () => {
+    // why: the tick box is how a picker works the sheet; hiding the image must
+    // not take it with it.
+    renderPreview({
+      displayCode: {
+        value: "SAM-0001",
+        type: "SAM_ID",
+        isFallback: false,
+        entityKind: "asset",
+        workspacePreference: "SAM_ID",
+      },
+      showQrCodesOnPdfs: false,
+    });
+
+    expect(
+      screen.getByRole("checkbox", { name: "Mark Tripod as picked" })
+    ).toBeInTheDocument();
   });
 
   it("keeps a named pick-off checkbox in the code cell", () => {

--- a/apps/webapp/app/components/booking/booking-overview-pdf.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.tsx
@@ -12,6 +12,7 @@ import type { PdfDbResult } from "~/modules/booking/pdf-helpers";
 import { getOutstandingModelRequests } from "~/utils/booking-model-requests";
 import { tw } from "~/utils/tw";
 import { resolveUserDisplayName } from "~/utils/user";
+import { AssetCodePrintText } from "../assets/asset-code-print-text";
 import { AssetImage } from "../assets/asset-image/component";
 import { Dialog, DialogPortal } from "../layout/dialog";
 import { DateS } from "../shared/date";
@@ -161,7 +162,7 @@ export const BookingOverviewPDF = ({
   );
 };
 
-const BookingPDFPreview = ({
+export const BookingPDFPreview = ({
   componentRef,
   pdfMeta,
 }: {
@@ -175,6 +176,7 @@ const BookingPDFPreview = ({
     organization,
     assets,
     assetIdToQrCodeMap,
+    assetIdToDisplayCodeMap,
     totalValue,
     modelRequests,
   } = pdfMeta;
@@ -347,7 +349,13 @@ const BookingPDFPreview = ({
               <th className="w-24 border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
                 Location
               </th>
-              <th className="min-w-[120px] border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
+              {/* 150px, not the 120px this column used to be. The cell holds
+                  the QR image, the tick box and the code, which left the code
+                  67px — half a pixel short of an eight-character SAM ID, so
+                  every one of them broke across two lines. 150px leaves ~98px,
+                  enough for a SAM ID or a ten-character QR id on one line;
+                  longer barcode values still wrap on `break-all`. */}
+              <th className="min-w-[150px] border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
                 Code
               </th>
             </tr>
@@ -389,6 +397,9 @@ const BookingPDFPreview = ({
                     {asset.quantity ?? 1}
                   </td>
                   <td className="border-r border-gray-300 p-2.5 text-sm text-gray-600">
+                    {/* why: out of this rule — the checklist prints the kit's
+                        name only; a kit code was not asked for, and kits have
+                        no `sequentialId` to print for a SAM_ID workspace. */}
                     {asset?.kit?.name}
                     {/* Print-medium equivalent of the overview's
                         "Removed from kit" badge — a tooltip can't exist on
@@ -412,11 +423,19 @@ const BookingPDFPreview = ({
                   </td>
                   <td className="border-r border-gray-300 p-2.5 text-sm text-gray-600">
                     <div className="flex items-center gap-3">
-                      <img
-                        src={assetIdToQrCodeMap[asset.id] || ""}
-                        alt="QR Code"
-                        className="size-14 object-cover"
-                      />
+                      <div className="flex flex-col items-center gap-1">
+                        <img
+                          src={assetIdToQrCodeMap[asset.id] || ""}
+                          alt="QR Code"
+                          className="size-14 object-cover"
+                        />
+                        {/* Printed even when the QR image failed to generate:
+                            the code is the part a picker matches against the
+                            physical label. */}
+                        <AssetCodePrintText
+                          displayCode={assetIdToDisplayCodeMap[asset.id]}
+                        />
+                      </div>
                       <input type="checkbox" className="block size-5 border" />
                     </div>
                   </td>

--- a/apps/webapp/app/components/booking/booking-overview-pdf.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.tsx
@@ -194,6 +194,11 @@ export const BookingPDFPreview = ({
     modelRequests,
   } = pdfMeta;
 
+  // Workspaces that want people scanning the label on the item, not the sheet,
+  // turn the QR image off. The text code prints either way, so the row is still
+  // matchable by eye.
+  const showQrCodesOnPdfs = organization.showQrCodesOnPdfs ?? true;
+
   // Phase 3d (Book-by-Model): defensively re-filter here so a caller
   // that feeds pre-computed `PdfDbResult` with stale rows (e.g. after a
   // model request was fulfilled concurrently) can't leak a fulfilled
@@ -434,27 +439,31 @@ export const BookingPDFPreview = ({
                   </td>
                   <td className="border-r border-gray-300 p-2.5 text-sm text-gray-600">
                     <div className="flex flex-col items-start gap-1">
-                      <div className="flex items-center gap-3">
+                      {/* The QR is optional; the tick box and the code are not.
+                          Keeping the image on its own line means the cell reads
+                          the same with it and without it, and gives the code the
+                          whole cell to wrap in — a 25-character legacy QR id
+                          needs two lines here. */}
+                      <When truthy={showQrCodesOnPdfs}>
                         <img
                           src={assetIdToQrCodeMap[asset.id] || ""}
                           alt="QR Code"
                           className="size-14 object-cover"
                         />
+                      </When>
+                      <div className="flex items-center gap-3">
                         <input
                           type="checkbox"
                           aria-label={`Mark ${asset.title} as picked`}
                           className="block size-5 border"
                         />
+                        {/* Printed even when the QR image failed to generate:
+                            the code is the part a picker matches against the
+                            physical label. */}
+                        <AssetCodePrintText
+                          displayCode={assetIdToDisplayCodeMap[asset.id]}
+                        />
                       </div>
-                      {/* Printed even when the QR image failed to generate: the
-                          code is the part a picker matches against the physical
-                          label. It sits under the image and the tick box rather
-                          than beside them so it has the whole cell to wrap in —
-                          a 25-character legacy QR id needs two lines here and
-                          would need three squeezed alongside the tick box. */}
-                      <AssetCodePrintText
-                        displayCode={assetIdToDisplayCodeMap[asset.id]}
-                      />
                     </div>
                   </td>
                 </tr>

--- a/apps/webapp/app/components/booking/booking-overview-pdf.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.tsx
@@ -162,6 +162,19 @@ export const BookingOverviewPDF = ({
   );
 };
 
+/**
+ * The printable body of the booking checklist: the sheet `react-to-print`
+ * copies to paper, and what the dialog shows as its preview.
+ *
+ * Exported so it can be rendered on its own. {@link BookingOverviewPDF}, the
+ * dialog around it, needs a router for the fetcher that loads `pdfMeta`.
+ *
+ * @param props.componentRef - Ref `react-to-print` prints from. Pass
+ *   `{ current: null }` to render the sheet without printing it.
+ * @param props.pdfMeta - Everything the sheet renders, as returned by
+ *   `fetchAllPdfRelatedData`. Renders nothing until it arrives.
+ * @returns The checklist, or `null` while `pdfMeta` is still loading.
+ */
 export const BookingPDFPreview = ({
   componentRef,
   pdfMeta,
@@ -429,6 +442,9 @@ export const BookingPDFPreview = ({
                         />
                         <input
                           type="checkbox"
+                          aria-label={`Mark ${
+                            asset.title ?? asset.id
+                          } as picked`}
                           className="block size-5 border"
                         />
                       </div>

--- a/apps/webapp/app/components/booking/booking-overview-pdf.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.tsx
@@ -433,7 +433,7 @@ export const BookingPDFPreview = ({
                     {asset?.location?.name}
                   </td>
                   <td className="border-r border-gray-300 p-2.5 text-sm text-gray-600">
-                    <div className="flex flex-col items-center gap-1">
+                    <div className="flex flex-col items-start gap-1">
                       <div className="flex items-center gap-3">
                         <img
                           src={assetIdToQrCodeMap[asset.id] || ""}
@@ -442,9 +442,7 @@ export const BookingPDFPreview = ({
                         />
                         <input
                           type="checkbox"
-                          aria-label={`Mark ${
-                            asset.title ?? asset.id
-                          } as picked`}
+                          aria-label={`Mark ${asset.title} as picked`}
                           className="block size-5 border"
                         />
                       </div>

--- a/apps/webapp/app/components/booking/booking-overview-pdf.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.tsx
@@ -444,9 +444,13 @@ export const BookingPDFPreview = ({
                           the same with it and without it, and gives the code the
                           whole cell to wrap in — a 25-character legacy QR id
                           needs two lines here. */}
-                      <When truthy={showQrCodesOnPdfs}>
+                      <When
+                        truthy={
+                          showQrCodesOnPdfs && !!assetIdToQrCodeMap[asset.id]
+                        }
+                      >
                         <img
-                          src={assetIdToQrCodeMap[asset.id] || ""}
+                          src={assetIdToQrCodeMap[asset.id]}
                           alt="QR Code"
                           className="size-14 object-cover"
                         />

--- a/apps/webapp/app/components/booking/booking-overview-pdf.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.tsx
@@ -349,12 +349,10 @@ export const BookingPDFPreview = ({
               <th className="w-24 border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
                 Location
               </th>
-              {/* 150px, not the 120px this column used to be. The cell holds
-                  the QR image, the tick box and the code, which left the code
-                  67px — half a pixel short of an eight-character SAM ID, so
-                  every one of them broke across two lines. 150px leaves ~98px,
-                  enough for a SAM ID or a ten-character QR id on one line;
-                  longer barcode values still wrap on `break-all`. */}
+              {/* Sized for the code, which spans the cell under the image: at
+                  150px it gets ~130px, enough for a SAM ID or a ten-character
+                  QR id on one line and a 25-character legacy QR id on two.
+                  Longer barcode values wrap further on `break-all`. */}
               <th className="min-w-[150px] border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
                 Code
               </th>
@@ -398,8 +396,8 @@ export const BookingPDFPreview = ({
                   </td>
                   <td className="border-r border-gray-300 p-2.5 text-sm text-gray-600">
                     {/* why: out of this rule — the checklist prints the kit's
-                        name only; a kit code was not asked for, and kits have
-                        no `sequentialId` to print for a SAM_ID workspace. */}
+                        name only. Kits carry no `sequentialId`, so a SAM_ID
+                        workspace has no kit code to print here. */}
                     {asset?.kit?.name}
                     {/* Print-medium equivalent of the overview's
                         "Removed from kit" badge — a tooltip can't exist on
@@ -422,21 +420,27 @@ export const BookingPDFPreview = ({
                     {asset?.location?.name}
                   </td>
                   <td className="border-r border-gray-300 p-2.5 text-sm text-gray-600">
-                    <div className="flex items-center gap-3">
-                      <div className="flex flex-col items-center gap-1">
+                    <div className="flex flex-col items-center gap-1">
+                      <div className="flex items-center gap-3">
                         <img
                           src={assetIdToQrCodeMap[asset.id] || ""}
                           alt="QR Code"
                           className="size-14 object-cover"
                         />
-                        {/* Printed even when the QR image failed to generate:
-                            the code is the part a picker matches against the
-                            physical label. */}
-                        <AssetCodePrintText
-                          displayCode={assetIdToDisplayCodeMap[asset.id]}
+                        <input
+                          type="checkbox"
+                          className="block size-5 border"
                         />
                       </div>
-                      <input type="checkbox" className="block size-5 border" />
+                      {/* Printed even when the QR image failed to generate: the
+                          code is the part a picker matches against the physical
+                          label. It sits under the image and the tick box rather
+                          than beside them so it has the whole cell to wrap in —
+                          a 25-character legacy QR id needs two lines here and
+                          would need three squeezed alongside the tick box. */}
+                      <AssetCodePrintText
+                        displayCode={assetIdToDisplayCodeMap[asset.id]}
+                      />
                     </div>
                   </td>
                 </tr>

--- a/apps/webapp/app/components/workspace/edit-form.tsx
+++ b/apps/webapp/app/components/workspace/edit-form.tsx
@@ -85,6 +85,13 @@ export const EditGeneralWorkspaceSettingsFormSchema = (
         return value === "on";
       })
       .optional(),
+    showQrCodesOnPdfs: z
+      .union([z.literal("on"), z.literal("off"), z.undefined()])
+      .transform((value) => {
+        if (value === undefined) return undefined;
+        return value === "on";
+      })
+      .optional(),
   });
 
 export const WorkspaceEditForms = ({
@@ -317,6 +324,50 @@ const WorkspaceGeneralEditForms = ({
                 className="text-[14px] text-gray-600"
               >
                 Toggle Shelf branding on downloadable QR and barcode labels.
+              </p>
+            </div>
+          </div>
+        </FormRow>
+
+        <FormRow
+          rowLabel={"QR codes on PDFs"}
+          className={"border-b-0"}
+          subHeading={
+            <p>
+              Control whether the QR image is printed on the booking checklist
+              and the audit receipt.
+            </p>
+          }
+        >
+          <div className="flex items-center gap-3">
+            <input
+              type="hidden"
+              name={zo.fields.showQrCodesOnPdfs()}
+              value="off"
+            />
+            <Switch
+              id="showQrCodesOnPdfs"
+              name={zo.fields.showQrCodesOnPdfs()}
+              defaultChecked={organization.showQrCodesOnPdfs ?? true}
+              aria-labelledby="showQrCodesOnPdfs-label"
+              aria-describedby="showQrCodesOnPdfs-desc"
+            />
+            <div>
+              <label
+                id="showQrCodesOnPdfs-label"
+                htmlFor="showQrCodesOnPdfs"
+                className="cursor-pointer text-[14px] font-medium text-gray-700"
+              >
+                Print QR codes on PDFs
+              </label>
+              <p
+                id="showQrCodesOnPdfs-desc"
+                className="text-[14px] text-gray-600"
+              >
+                Turn this off when people should scan the label on the item
+                itself. A printed sheet carries the same codes, so it can be
+                scanned instead of walking to the equipment. The code still
+                prints as text either way.
               </p>
             </div>
           </div>

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -124,3 +124,154 @@ describe("audit receipt — what it may truncate", () => {
     expect(q?.orderBy).toEqual({ createdAt: "desc" });
   });
 });
+
+/**
+ * The receipt's Code column.
+ *
+ * Same wiring as the booking checklist, same reason: the sheet is read next to
+ * physical labels. The resolution rules are covered by `display.test.ts`; what
+ * is tested here is that the query asks for the columns the resolver reads and
+ * that the org's preference is one of them.
+ *
+ * Each case sets the two preference fields EXPLICITLY. Left off, the resolver's
+ * `undefined` preference falls through its `default` branch to the QR id — so a
+ * QR-id assertion would pass on an org row that never carried a preference at
+ * all, which is the bug this column exists to prevent.
+ */
+describe("audit receipt — the printed asset code", () => {
+  const mockOf = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+  const ASSET = {
+    id: "asset-1",
+    title: "Camera",
+    thumbnailImage: null,
+    // Widened so a case can drop it: the fallback branch is the point.
+    sequentialId: "SAM-0001" as string | null,
+    preferredBarcodeId: null,
+    qrCodes: [{ id: "qr-visible-id", version: 0, errorCorrection: "L" }],
+    barcodes: [{ id: "bc-1", type: "Code128", value: "128-VALUE" }],
+    category: null,
+    assetLocations: [],
+  };
+
+  async function run(
+    prefs: { qrIdDisplayPreference: string; barcodesEnabled: boolean },
+    overrides: Partial<typeof ASSET> = {}
+  ) {
+    vi.clearAllMocks();
+    mockOf(db.auditSession.findUnique).mockResolvedValue(SESSION);
+    mockOf(db.auditAsset.findMany).mockResolvedValue([
+      { assetId: "asset-1", expected: true, status: null },
+    ]);
+    mockOf(db.auditImage.findMany).mockResolvedValue([]);
+    mockOf(db.auditNote.findMany).mockResolvedValue([]);
+    mockOf(db.asset.findMany).mockResolvedValue([{ ...ASSET, ...overrides }]);
+    mockOf(db.organization.findUnique).mockResolvedValue({
+      id: "org-1",
+      name: "Org",
+      imageId: null,
+      currency: "USD",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      ...prefs,
+    });
+
+    return fetchAllAuditPdfRelatedData(
+      "audit-1",
+      "org-1",
+      "user-1",
+      undefined,
+      new Request("http://localhost/x")
+    );
+  }
+
+  it("asks the database for the columns the resolver reads", async () => {
+    await run({ qrIdDisplayPreference: "QR_ID", barcodesEnabled: false });
+
+    const include = mockOf(db.asset.findMany).mock.calls[0][0].include;
+
+    expect(include.barcodes).toEqual({
+      select: { id: true, type: true, value: true },
+    });
+    // why: NOT the tight `{ take: 1, select: { id } }` the code-bearing-entity
+    // rule asks for — `getQrCodeMaps` renders the image from `version` /
+    // `errorCorrection`, so narrowing this breaks the QR images in print only.
+    expect(include.qrCodes).toBe(true);
+  });
+
+  it("asks the database which code the workspace wants printed", async () => {
+    await run({ qrIdDisplayPreference: "QR_ID", barcodesEnabled: false });
+
+    expect(
+      mockOf(db.organization.findUnique).mock.calls[0][0].select
+    ).toMatchObject({
+      qrIdDisplayPreference: true,
+      barcodesEnabled: true,
+    });
+  });
+
+  it("prints the SAM ID for a workspace that asked for SAM IDs", async () => {
+    const result = await run({
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    });
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "SAM-0001",
+      type: "SAM_ID",
+      isFallback: false,
+    });
+  });
+
+  it("prints the QR id for a default workspace", async () => {
+    const result = await run({
+      qrIdDisplayPreference: "QR_ID",
+      barcodesEnabled: false,
+    });
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "qr-visible-id",
+      type: "QR_ID",
+      isFallback: false,
+    });
+  });
+
+  it("prints the barcode value for a barcode-preference workspace", async () => {
+    const result = await run({
+      qrIdDisplayPreference: "Code128",
+      barcodesEnabled: true,
+    });
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "128-VALUE",
+      type: "Code128",
+      isFallback: false,
+    });
+  });
+
+  it("flags the fallback when the preferred code is missing from the asset", async () => {
+    const result = await run(
+      { qrIdDisplayPreference: "SAM_ID", barcodesEnabled: false },
+      { sequentialId: null }
+    );
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "qr-visible-id",
+      type: "QR_ID",
+      isFallback: true,
+      workspacePreference: "SAM_ID",
+    });
+  });
+
+  it("resolves a code even when no QR image could be generated", async () => {
+    // why: `getQrCodeMaps` is stubbed to return {} here, which is also what a
+    // real signing failure produces. The row still has to print something a
+    // reader can match against the shelf.
+    const result = await run({
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    });
+
+    expect(result.assetIdToQrCodeMap["asset-1"]).toBeUndefined();
+    expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
+  });
+});

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -134,9 +134,9 @@ describe("audit receipt — what it may truncate", () => {
  * that the org's preference is one of them.
  *
  * Each case sets the two preference fields EXPLICITLY. Left off, the resolver's
- * `undefined` preference falls through its `default` branch to the QR id — so a
- * QR-id assertion would pass on an org row that never carried a preference at
- * all, which is the bug this column exists to prevent.
+ * `undefined` preference falls through its `default` branch to the QR id, so a
+ * QR-id assertion passes on an org row that never carried a preference at all.
+ * The preference is the thing under test; it has to be set.
  */
 describe("audit receipt — the printed asset code", () => {
   const mockOf = (fn: unknown) => fn as ReturnType<typeof vi.fn>;

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -145,7 +145,7 @@ describe("audit receipt — the printed asset code", () => {
     id: "asset-1",
     title: "Camera",
     thumbnailImage: null,
-    // Widened so a case can drop it: the fallback branch is the point.
+    // Nullable: an asset without one is what sends SAM_ID to its fallback.
     sequentialId: "SAM-0001" as string | null,
     preferredBarcodeId: null,
     qrCodes: [{ id: "qr-visible-id", version: 0, errorCorrection: "L" }],
@@ -159,13 +159,21 @@ describe("audit receipt — the printed asset code", () => {
     overrides: Partial<typeof ASSET> = {}
   ) {
     vi.clearAllMocks();
+    // why: the audit under test. A missing one is a 404 before anything else.
     mockOf(db.auditSession.findUnique).mockResolvedValue(SESSION);
+    // why: names which assets are on the audit; the helper skips the asset
+    // read entirely when this is empty, and there would be no row to check.
     mockOf(db.auditAsset.findMany).mockResolvedValue([
       { assetId: "asset-1", expected: true, status: null },
     ]);
+    // why: the receipt's photo and note sections. Empty keeps these cases
+    // about the Code column.
     mockOf(db.auditImage.findMany).mockResolvedValue([]);
     mockOf(db.auditNote.findMany).mockResolvedValue([]);
+    // why: the row the resolver runs over — its QR, barcodes and SAM id are
+    // what each case varies.
     mockOf(db.asset.findMany).mockResolvedValue([{ ...ASSET, ...overrides }]);
+    // why: carries the preference under test.
     mockOf(db.organization.findUnique).mockResolvedValue({
       id: "org-1",
       name: "Org",

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -274,4 +274,19 @@ describe("audit receipt — the printed asset code", () => {
     expect(result.assetIdToQrCodeMap["asset-1"]).toBeUndefined();
     expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
   });
+  it("keeps the code-resolution relations out of the rows it returns", async () => {
+    // why: the rows are serialised to the browser, and the relations exist only
+    // to build the two maps above them.
+    const result = await run({
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    });
+
+    for (const row of result.assets) {
+      expect(row).not.toHaveProperty("barcodes");
+      expect(row).not.toHaveProperty("qrCodes");
+    }
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
+  });
 });

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -217,6 +217,8 @@ describe("audit receipt — the printed asset code", () => {
     ).toMatchObject({
       qrIdDisplayPreference: true,
       barcodesEnabled: true,
+      // why: the sheet cannot decide whether to print the QR image without it.
+      showQrCodesOnPdfs: true,
     });
   });
 

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -151,7 +151,9 @@ describe("audit receipt — the printed asset code", () => {
     qrCodes: [{ id: "qr-visible-id", version: 0, errorCorrection: "L" }],
     barcodes: [{ id: "bc-1", type: "Code128", value: "128-VALUE" }],
     category: null,
-    assetLocations: [],
+    // A location so the strip can be shown NOT to take the derived
+    // `location` field with it.
+    assetLocations: [{ location: { name: "Store room" } }],
   };
 
   async function run(
@@ -159,7 +161,7 @@ describe("audit receipt — the printed asset code", () => {
     overrides: Partial<typeof ASSET> = {}
   ) {
     vi.clearAllMocks();
-    // why: the audit under test. A missing one is a 404 before anything else.
+    // why: the audit under test. The helper throws immediately without it.
     mockOf(db.auditSession.findUnique).mockResolvedValue(SESSION);
     // why: names which assets are on the audit; the helper skips the asset
     // read entirely when this is empty, and there would be no row to check.
@@ -284,7 +286,7 @@ describe("audit receipt — the printed asset code", () => {
   });
   it("keeps the code-resolution relations out of the rows it returns", async () => {
     // why: the rows are serialised to the browser, and the relations exist only
-    // to build the two maps above them.
+    // to build the two maps the helper returns alongside them.
     const result = await run({
       qrIdDisplayPreference: "SAM_ID",
       barcodesEnabled: false,
@@ -293,7 +295,12 @@ describe("audit receipt — the printed asset code", () => {
     for (const row of result.assets) {
       expect(row).not.toHaveProperty("barcodes");
       expect(row).not.toHaveProperty("qrCodes");
+      expect(row).not.toHaveProperty("assetLocations");
     }
+
+    // why: `location` is derived from `assetLocations`, so dropping the
+    // relation must not take the derived field with it.
+    expect(result.assets[0].location).toEqual({ name: "Store room" });
 
     expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
   });

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -28,7 +28,8 @@ vi.mock("~/database/db.server", () => ({
   },
 }));
 
-// why: signing QR images reaches Supabase storage; irrelevant to note queries
+// why: rendering a QR per asset (qrcode-generator + sharp) is real work and
+// irrelevant to note queries
 vi.mock("~/modules/qr/service.server", () => ({
   getQrCodeMaps: vi.fn().mockResolvedValue({}),
 }));
@@ -273,9 +274,10 @@ describe("audit receipt — the printed asset code", () => {
   });
 
   it("resolves a code even when no QR image could be generated", async () => {
-    // why: `getQrCodeMaps` is stubbed to return {} here, which is also what a
-    // real signing failure produces. The row still has to print something a
-    // reader can match against the shelf.
+    // why: `getQrCodeMaps` is stubbed to return {} here, which is also what
+    // the real thing produces for an asset whose image generation threw — it
+    // logs and moves on, leaving no entry. The row still has to print
+    // something a reader can match against the shelf.
     const result = await run({
       qrIdDisplayPreference: "SAM_ID",
       barcodesEnabled: false,

--- a/apps/webapp/app/modules/audit/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.test.ts
@@ -36,6 +36,7 @@ vi.mock("~/modules/qr/service.server", () => ({
 
 import { db } from "~/database/db.server";
 import { fetchAllAuditPdfRelatedData } from "~/modules/audit/pdf-helpers";
+import { getQrCodeMaps } from "~/modules/qr/service.server";
 
 const SESSION = {
   id: "audit-1",
@@ -158,7 +159,12 @@ describe("audit receipt — the printed asset code", () => {
   };
 
   async function run(
-    prefs: { qrIdDisplayPreference: string; barcodesEnabled: boolean },
+    prefs: {
+      qrIdDisplayPreference: string;
+      barcodesEnabled: boolean;
+      /** Defaults to the column default (`true`) when a case doesn't set it. */
+      showQrCodesOnPdfs?: boolean;
+    },
     overrides: Partial<typeof ASSET> = {}
   ) {
     vi.clearAllMocks();
@@ -183,6 +189,9 @@ describe("audit receipt — the printed asset code", () => {
       imageId: null,
       currency: "USD",
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      // Matches the column default, so a case that says nothing about the
+      // switch exercises the path that prints the image.
+      showQrCodesOnPdfs: true,
       ...prefs,
     });
 
@@ -306,6 +315,27 @@ describe("audit receipt — the printed asset code", () => {
     // relation must not take the derived field with it.
     expect(result.assets[0].location).toEqual({ name: "Store room" });
 
+    expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
+  });
+
+  it("encodes a QR per asset when the workspace prints them", async () => {
+    await run({ qrIdDisplayPreference: "QR_ID", barcodesEnabled: false });
+
+    expect(mockOf(getQrCodeMaps)).toHaveBeenCalledTimes(1);
+  });
+
+  it("encodes nothing when the workspace prints no QR image", async () => {
+    // The receipt renders no image in this case, so encoding one would cost a
+    // QR per asset and carry a data URL per asset to a browser that drops it.
+    // The printed code is resolved independently, so the row stays matchable.
+    const result = await run({
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+      showQrCodesOnPdfs: false,
+    });
+
+    expect(mockOf(getQrCodeMaps)).not.toHaveBeenCalled();
+    expect(result.assetIdToQrCodeMap).toEqual({});
     expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
   });
 });

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -76,6 +76,8 @@ export interface AuditPdfDbResult {
     // Read by `resolveDisplayCode` when building `assetIdToDisplayCodeMap`.
     | "qrIdDisplayPreference"
     | "barcodesEnabled"
+    // Whether the sheet prints the QR image at all.
+    | "showQrCodesOnPdfs"
   >;
   // QR code data URLs mapped by asset ID
   assetIdToQrCodeMap: Record<string, string>;
@@ -332,9 +334,11 @@ export async function fetchAllAuditPdfRelatedData(
           imageId: true,
           currency: true,
           updatedAt: true,
-          // Which code the workspace wants printed under the QR image.
+          // Which code the workspace wants printed under the QR image, and
+          // whether the QR image is printed at all.
           qrIdDisplayPreference: true,
           barcodesEnabled: true,
+          showQrCodesOnPdfs: true,
         },
       }),
     ]);

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -315,10 +315,8 @@ export async function fetchAllAuditPdfRelatedData(
                   },
                 },
               },
-              // why: out of this rule — the code-bearing-entity rule asks for
-              // a tight `qrCodes: { take: 1, select: { id } }`, but this
-              // payload is also handed to `getQrCodeMaps`, which renders the
-              // image from `Qr.version` and `Qr.errorCorrection`.
+              // why: out of this rule — `getQrCodeMaps` renders the image from
+              // `Qr.version`/`errorCorrection`, so the tight select cannot be used.
               qrCodes: true,
               // Feeds `resolveDisplayCode` so a barcode-preference workspace
               // gets its barcode value printed instead of the QR id.
@@ -370,10 +368,11 @@ export async function fetchAllAuditPdfRelatedData(
       size: "small",
     });
 
-    // Resolve the printed code alongside the QR image, off the same raw rows:
-    // `assetsWithAuditStatus` is typed as a plain `Asset`, so resolving from it
-    // would silently hand the resolver undefined `qrCodes`/`barcodes` and print
-    // an empty string.
+    // Resolve off the same raw rows the QR map is built from, so the two maps
+    // have one source. `assetsWithAuditStatus` is typed as a plain `Asset`,
+    // which declares neither `qrCodes` nor `barcodes`, and every field on the
+    // resolver's entity type is optional — so resolving from it would still
+    // compile on the day those relations stop coming through.
     const assetIdToDisplayCodeMap: Record<string, ResolvedDisplayCode> =
       Object.fromEntries(
         assets.map((asset) => [

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -10,6 +10,8 @@ import type {
   AuditAssetStatus,
 } from "@prisma/client";
 import { db } from "~/database/db.server";
+import type { ResolvedDisplayCode } from "~/modules/barcode/display";
+import { resolveDisplayCode } from "~/modules/barcode/display";
 import { ShelfError } from "~/utils/error";
 import type { UserNameFields } from "~/utils/user";
 import { getPrimaryLocation } from "../asset/utils";
@@ -66,10 +68,24 @@ export interface AuditPdfDbResult {
   // Organization details for header
   organization: Pick<
     Organization,
-    "id" | "name" | "imageId" | "currency" | "updatedAt"
+    | "id"
+    | "name"
+    | "imageId"
+    | "currency"
+    | "updatedAt"
+    // Read by `resolveDisplayCode` when building `assetIdToDisplayCodeMap`.
+    | "qrIdDisplayPreference"
+    | "barcodesEnabled"
   >;
   // QR code data URLs mapped by asset ID
   assetIdToQrCodeMap: Record<string, string>;
+  /**
+   * The code to PRINT under each QR image — the same one the workspace's
+   * on-screen asset lists show: the QR id, the SAM id, or a barcode value,
+   * with a per-asset override winning over the workspace preference. Keyed by
+   * `Asset.id`.
+   */
+  assetIdToDisplayCodeMap: Record<string, ResolvedDisplayCode>;
   // Images not linked to specific assets
   generalImages: AuditImage[];
   // Images linked to specific assets (grouped by auditAssetId)
@@ -299,7 +315,14 @@ export async function fetchAllAuditPdfRelatedData(
                   },
                 },
               },
+              // why: out of this rule — the code-bearing-entity rule asks for
+              // a tight `qrCodes: { take: 1, select: { id } }`, but this
+              // payload is also handed to `getQrCodeMaps`, which renders the
+              // image from `Qr.version` and `Qr.errorCorrection`.
               qrCodes: true,
+              // Feeds `resolveDisplayCode` so a barcode-preference workspace
+              // gets its barcode value printed instead of the QR id.
+              barcodes: { select: { id: true, type: true, value: true } },
             },
           })
         : Promise.resolve([]),
@@ -311,6 +334,9 @@ export async function fetchAllAuditPdfRelatedData(
           imageId: true,
           currency: true,
           updatedAt: true,
+          // Which code the workspace wants printed under the QR image.
+          qrIdDisplayPreference: true,
+          barcodesEnabled: true,
         },
       }),
     ]);
@@ -344,11 +370,28 @@ export async function fetchAllAuditPdfRelatedData(
       size: "small",
     });
 
+    // Resolve the printed code alongside the QR image, off the same raw rows:
+    // `assetsWithAuditStatus` is typed as a plain `Asset`, so resolving from it
+    // would silently hand the resolver undefined `qrCodes`/`barcodes` and print
+    // an empty string.
+    const assetIdToDisplayCodeMap: Record<string, ResolvedDisplayCode> =
+      Object.fromEntries(
+        assets.map((asset) => [
+          asset.id,
+          resolveDisplayCode({
+            entity: asset,
+            organization,
+            entityKind: "asset",
+          }),
+        ])
+      );
+
     return {
       session,
       assets: assetsWithAuditStatus,
       organization,
       assetIdToQrCodeMap,
+      assetIdToDisplayCodeMap,
       generalImages,
       assetImages,
       conditionNotes,

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -348,22 +348,29 @@ export async function fetchAllAuditPdfRelatedData(
       });
     }
 
-    // Merge audit status data into each asset.
-    //
-    // The code-resolution relations are dropped here: they feed the QR and
-    // display-code maps below, off the raw rows, and nothing downstream reads
-    // them off a receipt row — so carrying them would only make the JSON the
-    // browser downloads bigger.
-    const assetsWithAuditStatus: AssetWithAuditStatus[] = assets.map(
-      ({ qrCodes: _qrCodes, barcodes: _barcodes, ...asset }) => ({
+    // Merge audit status data into each asset, dropping the fetch-only
+    // relations as we go: the code relations feed the two maps below, off the
+    // raw rows, and `assetLocations` is reduced to `location` here. None of
+    // them is read off a receipt row, so carrying them would only enlarge the
+    // JSON the browser downloads. `getPrimaryLocation` reads the RAW row,
+    // which still has `assetLocations`.
+    const assetsWithAuditStatus: AssetWithAuditStatus[] = assets.map((raw) => {
+      const {
+        qrCodes: _qrCodes,
+        barcodes: _barcodes,
+        assetLocations: _assetLocations,
+        ...asset
+      } = raw;
+
+      return {
         ...asset,
-        location: getPrimaryLocation(asset),
-        auditData: auditStatusMap.get(asset.id) || {
+        location: getPrimaryLocation(raw),
+        auditData: auditStatusMap.get(raw.id) || {
           expected: false,
           auditStatus: null,
         },
-      })
-    );
+      };
+    });
 
     // Generate QR code data URLs for each asset
     const assetIdToQrCodeMap = await getQrCodeMaps({

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -348,9 +348,14 @@ export async function fetchAllAuditPdfRelatedData(
       });
     }
 
-    // Merge audit status data into each asset
+    // Merge audit status data into each asset.
+    //
+    // The code-resolution relations are dropped here: they feed the QR and
+    // display-code maps below, off the raw rows, and nothing downstream reads
+    // them off a receipt row — so carrying them would only make the JSON the
+    // browser downloads bigger.
     const assetsWithAuditStatus: AssetWithAuditStatus[] = assets.map(
-      (asset) => ({
+      ({ qrCodes: _qrCodes, barcodes: _barcodes, ...asset }) => ({
         ...asset,
         location: getPrimaryLocation(asset),
         auditData: auditStatusMap.get(asset.id) || {

--- a/apps/webapp/app/modules/audit/pdf-helpers.ts
+++ b/apps/webapp/app/modules/audit/pdf-helpers.ts
@@ -376,13 +376,19 @@ export async function fetchAllAuditPdfRelatedData(
       };
     });
 
-    // Generate QR code data URLs for each asset
-    const assetIdToQrCodeMap = await getQrCodeMaps({
-      assets,
-      userId,
-      organizationId,
-      size: "small",
-    });
+    // QR data URLs per asset, encoded only when the receipt will print them.
+    // A workspace with the QR image turned off renders nothing from this map,
+    // so generating it would cost a QR encode per asset and put a data URL per
+    // asset in the response that nothing reads. The renderer already treats a
+    // missing entry as "no image", so an empty map needs no handling of its own.
+    const assetIdToQrCodeMap = organization.showQrCodesOnPdfs
+      ? await getQrCodeMaps({
+          assets,
+          userId,
+          organizationId,
+          size: "small",
+        })
+      : {};
 
     // Resolve off the same raw rows the QR map is built from, so the two maps
     // have one source. `assetsWithAuditStatus` is typed as a plain `Asset`,

--- a/apps/webapp/app/modules/booking/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.test.ts
@@ -236,4 +236,20 @@ describe("booking checklist PDF — the printed asset code", () => {
       expect(result.assetIdToDisplayCodeMap[row.id]?.value).toBe("SAM-0001");
     }
   });
+  it("keeps the code-resolution relations out of the rows it returns", async () => {
+    // why: the rows are serialised to the browser, and the render list is one
+    // row per slice — so a relation left on a row ships once per slice, for a
+    // map the client already has. Both maps are built before this point.
+    const result = await run({
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    });
+
+    for (const row of result.assets) {
+      expect(row).not.toHaveProperty("barcodes");
+      expect(row).not.toHaveProperty("qrCodes");
+    }
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
+  });
 });

--- a/apps/webapp/app/modules/booking/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.test.ts
@@ -117,11 +117,14 @@ async function run(prefs: OrgPrefs, overrides: Partial<typeof ASSET> = {}) {
   // why: the deduped asset read the resolver runs over. One row, because the
   // helper fetches each asset once however many slices reference it.
   mockOf(db.asset.findMany).mockResolvedValue([asset]);
-  // why: the kit-driven slice carries a `sourceKitId`, so the helper looks the
-  // kit up; an empty result would drop that slice to a standalone row.
+  // why: the helper looks up the kits named by `sourceKitId` and maps over the
+  // result, which throws on an unstubbed `vi.fn()`. It does NOT decide this
+  // slice's kit — `assetKitId` matches a live membership on the asset, so
+  // `buildPdfAssetRows` resolves the kit from that and never reads the snapshot
+  // map. The snapshot path is the detached-residue case, not covered here.
   mockOf(db.kit.findMany).mockResolvedValue([KIT]);
   // why: carries the preference under test. `currency` is read by the total,
-  // and a missing organization is a 404 before any of this runs.
+  // and the helper throws before building anything if this returns nothing.
   mockOf(db.organization.findUnique).mockResolvedValue({
     id: "org-1",
     name: "Org",
@@ -256,7 +259,15 @@ describe("booking checklist PDF — the printed asset code", () => {
     for (const row of result.assets) {
       expect(row).not.toHaveProperty("barcodes");
       expect(row).not.toHaveProperty("qrCodes");
+      expect(row).not.toHaveProperty("assetKits");
+      expect(row).not.toHaveProperty("assetLocations");
     }
+
+    // why: `getBooking` carries a SECOND copy of every asset — the code
+    // relations among them — on `bookingAssets`, once per slice. Stripping the
+    // render rows alone would leave that copy in the response, which is the
+    // larger of the two.
+    expect(result.booking).not.toHaveProperty("bookingAssets");
 
     expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
   });

--- a/apps/webapp/app/modules/booking/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.test.ts
@@ -25,8 +25,9 @@ vi.mock("~/database/db.server", () => ({
   },
 }));
 
-// why: signing QR images reaches Supabase storage; the printed code is
-// resolved independently of whether an image came back.
+// why: rendering a QR per asset is real work (qrcode-generator + sharp) and
+// irrelevant here — the printed code is resolved independently of whether an
+// image came back.
 vi.mock("~/modules/qr/service.server", () => ({
   getQrCodeMaps: vi.fn().mockResolvedValue({}),
 }));
@@ -263,11 +264,16 @@ describe("booking checklist PDF — the printed asset code", () => {
       expect(row).not.toHaveProperty("assetLocations");
     }
 
-    // why: `getBooking` carries a SECOND copy of every asset — the code
-    // relations among them — on `bookingAssets`, once per slice. Stripping the
-    // render rows alone would leave that copy in the response, which is the
-    // larger of the two.
+    // why: `getBooking` carries a second, select-shaped copy of every asset —
+    // the code relations among them — on `bookingAssets`, once per slice, and
+    // `modelRequests` with full `AssetModel` rows that the sheet reads from
+    // the projected `modelRequests` instead. Stripping the render rows alone
+    // leaves both in the response.
     expect(result.booking).not.toHaveProperty("bookingAssets");
+    expect(result.booking).not.toHaveProperty("modelRequests");
+
+    // The projection the sheet actually reads is untouched.
+    expect(result.modelRequests).toEqual([]);
 
     expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
   });

--- a/apps/webapp/app/modules/booking/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.test.ts
@@ -56,7 +56,7 @@ const ASSET = {
   mainImage: null,
   thumbnailImage: null,
   mainImageExpiration: null,
-  // Widened so a case can drop it: the fallback branch is the point.
+  // Nullable: an asset without one is what sends SAM_ID to its fallback.
   sequentialId: "SAM-0001" as string | null,
   preferredBarcodeId: null,
   qrCodes: [{ id: "qr-visible-id", version: 0, errorCorrection: "L" }],
@@ -102,6 +102,8 @@ async function run(prefs: OrgPrefs, overrides: Partial<typeof ASSET> = {}) {
 
   const asset = { ...ASSET, ...overrides };
 
+  // why: supplies the `BookingAsset` slices, which decide how many rows the
+  // render list has — two here, for one asset booked twice.
   mockOf(getBooking).mockResolvedValue({
     id: "booking-1",
     name: "Shoot",
@@ -112,8 +114,14 @@ async function run(prefs: OrgPrefs, overrides: Partial<typeof ASSET> = {}) {
     modelRequests: [],
     bookingAssets: BOOKING_ASSETS.map((ba) => ({ ...ba, asset })),
   });
+  // why: the deduped asset read the resolver runs over. One row, because the
+  // helper fetches each asset once however many slices reference it.
   mockOf(db.asset.findMany).mockResolvedValue([asset]);
+  // why: the kit-driven slice carries a `sourceKitId`, so the helper looks the
+  // kit up; an empty result would drop that slice to a standalone row.
   mockOf(db.kit.findMany).mockResolvedValue([KIT]);
+  // why: carries the preference under test. `currency` is read by the total,
+  // and a missing organization is a 404 before any of this runs.
   mockOf(db.organization.findUnique).mockResolvedValue({
     id: "org-1",
     name: "Org",

--- a/apps/webapp/app/modules/booking/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.test.ts
@@ -1,0 +1,239 @@
+/**
+ * What the booking checklist PDF prints in its Code column.
+ *
+ * The checklist is carried around a warehouse and matched against physical
+ * labels. A workspace that labels its shelves with SAM IDs and then gets a
+ * sheet of QR ids has to translate every row by hand, which is the whole
+ * reason the code is printed at all.
+ *
+ * The resolution rules themselves live in `~/modules/barcode/display` and are
+ * covered by `display.test.ts`. What is tested here is the wiring: that the
+ * query asks for the columns the resolver reads, and that every rendered row —
+ * including the several a QUANTITY_TRACKED asset produces — can find its code.
+ *
+ * @see {@link file://./pdf-helpers.ts}
+ * @see {@link file://./../../components/booking/booking-overview-pdf.tsx}
+ */
+// @vitest-environment node
+
+// why: external database — don't hit the real DB
+vi.mock("~/database/db.server", () => ({
+  db: {
+    asset: { findMany: vi.fn() },
+    organization: { findUnique: vi.fn() },
+    kit: { findMany: vi.fn() },
+  },
+}));
+
+// why: signing QR images reaches Supabase storage; the printed code is
+// resolved independently of whether an image came back.
+vi.mock("~/modules/qr/service.server", () => ({
+  getQrCodeMaps: vi.fn().mockResolvedValue({}),
+}));
+
+// why: the booking read is a large org-scoped query with its own tests; this
+// suite only cares which slices reach the render list.
+vi.mock("./service.server", () => ({
+  getBooking: vi.fn(),
+}));
+
+import type { QrIdDisplayPreference } from "@prisma/client";
+
+import { db } from "~/database/db.server";
+import { fetchAllPdfRelatedData } from "~/modules/booking/pdf-helpers";
+
+import { getBooking } from "./service.server";
+
+const mockOf = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+/** A QUANTITY_TRACKED asset that is a member of one kit. */
+const ASSET = {
+  id: "asset-1",
+  title: "Tripod",
+  description: null,
+  status: "AVAILABLE",
+  valuation: 100,
+  mainImage: null,
+  thumbnailImage: null,
+  mainImageExpiration: null,
+  // Widened so a case can drop it: the fallback branch is the point.
+  sequentialId: "SAM-0001" as string | null,
+  preferredBarcodeId: null,
+  qrCodes: [{ id: "qr-visible-id", version: 0, errorCorrection: "L" }],
+  barcodes: [{ id: "bc-1", type: "Code128", value: "128-VALUE" }],
+  category: { name: "Support" },
+  assetLocations: [{ location: { name: "Studio" } }],
+  assetKits: [
+    { id: "ak-1", kit: { id: "kit-1", name: "Camera kit", location: null } },
+  ],
+  assetModel: null,
+};
+
+const KIT = { id: "kit-1", name: "Camera kit", location: null };
+
+/**
+ * The same asset booked twice: once standalone, once through its kit. Two
+ * `BookingAsset` rows, so two printed rows, one deduped asset fetch.
+ */
+const BOOKING_ASSETS = [
+  {
+    id: "ba-standalone",
+    quantity: 2,
+    assetKitId: null,
+    sourceKitId: null,
+    asset: ASSET,
+  },
+  {
+    id: "ba-via-kit",
+    quantity: 3,
+    assetKitId: "ak-1",
+    sourceKitId: "kit-1",
+    asset: ASSET,
+  },
+];
+
+type OrgPrefs = {
+  qrIdDisplayPreference: QrIdDisplayPreference;
+  barcodesEnabled: boolean;
+};
+
+async function run(prefs: OrgPrefs, overrides: Partial<typeof ASSET> = {}) {
+  vi.clearAllMocks();
+
+  const asset = { ...ASSET, ...overrides };
+
+  mockOf(getBooking).mockResolvedValue({
+    id: "booking-1",
+    name: "Shoot",
+    description: null,
+    custodianUser: null,
+    custodianTeamMember: { name: "Ada" },
+    tags: [],
+    modelRequests: [],
+    bookingAssets: BOOKING_ASSETS.map((ba) => ({ ...ba, asset })),
+  });
+  mockOf(db.asset.findMany).mockResolvedValue([asset]);
+  mockOf(db.kit.findMany).mockResolvedValue([KIT]);
+  mockOf(db.organization.findUnique).mockResolvedValue({
+    id: "org-1",
+    name: "Org",
+    imageId: null,
+    currency: "USD",
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...prefs,
+  });
+
+  return fetchAllPdfRelatedData(
+    "booking-1",
+    "org-1",
+    "user-1",
+    // No role: the ownership check is exercised by its own tests.
+    undefined,
+    new Request("http://localhost/x")
+  );
+}
+
+const QR_ORG: OrgPrefs = {
+  qrIdDisplayPreference: "QR_ID",
+  barcodesEnabled: false,
+};
+
+describe("booking checklist PDF — the printed asset code", () => {
+  it("asks the database for the columns the resolver reads", async () => {
+    await run(QR_ORG);
+
+    const include = mockOf(db.asset.findMany).mock.calls[0][0].include;
+
+    expect(include.barcodes).toEqual({
+      select: { id: true, type: true, value: true },
+    });
+    // why: NOT the tight `{ take: 1, select: { id } }` the code-bearing-entity
+    // rule asks for. The same payload is handed to `getQrCodeMaps`, which
+    // renders the image from `version` / `errorCorrection`. Narrowing this
+    // select breaks the QR images, silently, in print only.
+    expect(include.qrCodes).toBe(true);
+  });
+
+  it("asks the database which code the workspace wants printed", async () => {
+    await run(QR_ORG);
+
+    expect(
+      mockOf(db.organization.findUnique).mock.calls[0][0].select
+    ).toMatchObject({
+      qrIdDisplayPreference: true,
+      barcodesEnabled: true,
+    });
+  });
+
+  it("prints the SAM ID for a workspace that asked for SAM IDs", async () => {
+    const result = await run({
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    });
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "SAM-0001",
+      type: "SAM_ID",
+      isFallback: false,
+    });
+  });
+
+  it("prints the QR id for a default workspace", async () => {
+    const result = await run(QR_ORG);
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "qr-visible-id",
+      type: "QR_ID",
+      isFallback: false,
+    });
+  });
+
+  it("prints the barcode value for a barcode-preference workspace", async () => {
+    const result = await run({
+      qrIdDisplayPreference: "Code128",
+      barcodesEnabled: true,
+    });
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "128-VALUE",
+      type: "Code128",
+      isFallback: false,
+    });
+  });
+
+  it("flags the fallback when the preferred code is missing from the asset", async () => {
+    // why: on screen the badge explains this in a tooltip. On paper the only
+    // way to say it is the caption the renderer prints under the value, and
+    // that caption is driven by this flag.
+    const result = await run(
+      { qrIdDisplayPreference: "SAM_ID", barcodesEnabled: false },
+      { sequentialId: null }
+    );
+
+    expect(result.assetIdToDisplayCodeMap["asset-1"]).toMatchObject({
+      value: "qr-visible-id",
+      type: "QR_ID",
+      isFallback: true,
+      workspacePreference: "SAM_ID",
+    });
+  });
+
+  it("gives every per-slice row a code, from one entry", async () => {
+    // why: the render list is one row per BookingAsset, so a QT asset booked
+    // standalone AND through a kit prints twice. Keying the map by asset id
+    // is what lets both rows read the same resolved code — a map keyed by
+    // `bookingAssetId` would need the resolver run per row for no gain, and a
+    // map built from the per-slice list would resolve the same asset twice.
+    const result = await run({
+      qrIdDisplayPreference: "SAM_ID",
+      barcodesEnabled: false,
+    });
+
+    expect(result.assets.map((row) => row.bookingAssetId)).toHaveLength(2);
+    expect(Object.keys(result.assetIdToDisplayCodeMap)).toEqual(["asset-1"]);
+
+    for (const row of result.assets) {
+      expect(result.assetIdToDisplayCodeMap[row.id]?.value).toBe("SAM-0001");
+    }
+  });
+});

--- a/apps/webapp/app/modules/booking/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.test.ts
@@ -174,6 +174,8 @@ describe("booking checklist PDF — the printed asset code", () => {
     ).toMatchObject({
       qrIdDisplayPreference: true,
       barcodesEnabled: true,
+      // why: the sheet cannot decide whether to print the QR image without it.
+      showQrCodesOnPdfs: true,
     });
   });
 

--- a/apps/webapp/app/modules/booking/pdf-helpers.test.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.test.ts
@@ -42,6 +42,7 @@ import type { QrIdDisplayPreference } from "@prisma/client";
 
 import { db } from "~/database/db.server";
 import { fetchAllPdfRelatedData } from "~/modules/booking/pdf-helpers";
+import { getQrCodeMaps } from "~/modules/qr/service.server";
 
 import { getBooking } from "./service.server";
 
@@ -96,6 +97,8 @@ const BOOKING_ASSETS = [
 type OrgPrefs = {
   qrIdDisplayPreference: QrIdDisplayPreference;
   barcodesEnabled: boolean;
+  /** Defaults to the column default (`true`) when a case doesn't set it. */
+  showQrCodesOnPdfs?: boolean;
 };
 
 async function run(prefs: OrgPrefs, overrides: Partial<typeof ASSET> = {}) {
@@ -132,6 +135,9 @@ async function run(prefs: OrgPrefs, overrides: Partial<typeof ASSET> = {}) {
     imageId: null,
     currency: "USD",
     updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    // Matches the column default, so a case that says nothing about the switch
+    // exercises the path that prints the image.
+    showQrCodesOnPdfs: true,
     ...prefs,
   });
 
@@ -278,5 +284,24 @@ describe("booking checklist PDF — the printed asset code", () => {
     expect(result.modelRequests).toEqual([]);
 
     expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe("SAM-0001");
+  });
+
+  it("encodes a QR per asset when the workspace prints them", async () => {
+    await run(QR_ORG);
+
+    expect(mockOf(getQrCodeMaps)).toHaveBeenCalledTimes(1);
+  });
+
+  it("encodes nothing when the workspace prints no QR image", async () => {
+    // The sheet renders no image in this case, so encoding one would cost a
+    // QR per asset and carry a data URL per asset to a browser that drops it.
+    // The printed code is resolved independently, so the row stays matchable.
+    const result = await run({ ...QR_ORG, showQrCodesOnPdfs: false });
+
+    expect(mockOf(getQrCodeMaps)).not.toHaveBeenCalled();
+    expect(result.assetIdToQrCodeMap).toEqual({});
+    expect(result.assetIdToDisplayCodeMap["asset-1"].value).toBe(
+      "qr-visible-id"
+    );
   });
 });

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -9,6 +9,8 @@ import type {
 } from "@prisma/client";
 import { db } from "~/database/db.server";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
+import type { ResolvedDisplayCode } from "~/modules/barcode/display";
+import { resolveDisplayCode } from "~/modules/barcode/display";
 import { validateBookingOwnership } from "~/utils/booking-authorization.server";
 import { getOutstandingModelRequests } from "~/utils/booking-model-requests";
 import { calculateTotalValueOfAssets } from "~/utils/bookings";
@@ -87,9 +89,26 @@ export interface PdfDbResult {
   totalValue: string;
   organization: Pick<
     Organization,
-    "id" | "name" | "imageId" | "currency" | "updatedAt"
+    | "id"
+    | "name"
+    | "imageId"
+    | "currency"
+    | "updatedAt"
+    // Read by `resolveDisplayCode` when building `assetIdToDisplayCodeMap`.
+    | "qrIdDisplayPreference"
+    | "barcodesEnabled"
   >;
   assetIdToQrCodeMap: Record<string, string>;
+  /**
+   * The code to PRINT under each QR image — the same one the workspace's
+   * on-screen asset lists show: the QR id, the SAM id, or a barcode value,
+   * with a per-asset override winning over the workspace preference.
+   *
+   * Keyed by `Asset.id`, not by `bookingAssetId`: the render list is
+   * per-slice, so a QUANTITY_TRACKED asset booked standalone + via kits has
+   * several rows that all resolve to this one entry.
+   */
+  assetIdToDisplayCodeMap: Record<string, ResolvedDisplayCode>;
   /**
    * Outstanding model-level reservations on the booking (Phase 3d).
    * Only rows with `quantity > 0` are meaningful for the PDF — the
@@ -179,7 +198,14 @@ export async function fetchAllPdfRelatedData(
               name: true,
             },
           },
+          // why: out of this rule — the code-bearing-entity rule asks for a
+          // tight `qrCodes: { take: 1, select: { id } }`, but this payload is
+          // also handed to `getQrCodeMaps`, which renders the image from
+          // `Qr.version` and `Qr.errorCorrection`.
           qrCodes: true,
+          // Feeds `resolveDisplayCode` so a barcode-preference workspace gets
+          // its barcode value printed instead of the QR id.
+          barcodes: { select: { id: true, type: true, value: true } },
           assetLocations: {
             select: {
               location: {
@@ -219,6 +245,9 @@ export async function fetchAllPdfRelatedData(
           id: true,
           currency: true,
           updatedAt: true,
+          // Which code the workspace wants printed under the QR image.
+          qrIdDisplayPreference: true,
+          barcodesEnabled: true,
         },
       }),
       // SECURITY (cross-org IDOR): `sourceKitId`'s FK accepts a `Kit` in ANY
@@ -282,6 +311,23 @@ export async function fetchAllPdfRelatedData(
       size: "small",
     });
 
+    // Resolve the printed code once per unique asset, over the same deduped
+    // list the QR images are generated from. Resolving per rendered row would
+    // repeat identical work for every slice of a QUANTITY_TRACKED asset and
+    // would have to be threaded through `PdfAssetRow`; a map keyed by asset id
+    // leaves the row types untouched.
+    const assetIdToDisplayCodeMap: Record<string, ResolvedDisplayCode> =
+      Object.fromEntries(
+        uniqueAssetsForQr.map((asset) => [
+          asset.id,
+          resolveDisplayCode({
+            entity: asset,
+            organization,
+            entityKind: "asset",
+          }),
+        ])
+      );
+
     // Phase 3d (Book-by-Model): surface outstanding model-level
     // reservations so the PDF can render a dedicated "Requested models"
     // section. `getBooking` merges with `BOOKING_WITH_ASSETS_INCLUDE`
@@ -325,6 +371,7 @@ export async function fetchAllPdfRelatedData(
       }),
       organization,
       assetIdToQrCodeMap,
+      assetIdToDisplayCodeMap,
       modelRequests,
     };
   } catch (cause) {

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -198,10 +198,8 @@ export async function fetchAllPdfRelatedData(
               name: true,
             },
           },
-          // why: out of this rule — the code-bearing-entity rule asks for a
-          // tight `qrCodes: { take: 1, select: { id } }`, but this payload is
-          // also handed to `getQrCodeMaps`, which renders the image from
-          // `Qr.version` and `Qr.errorCorrection`.
+          // why: out of this rule — `getQrCodeMaps` renders the image from
+          // `Qr.version`/`errorCorrection`, so the tight select cannot be used.
           qrCodes: true,
           // Feeds `resolveDisplayCode` so a barcode-preference workspace gets
           // its barcode value printed instead of the QR id.

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -346,17 +346,30 @@ export async function fetchAllPdfRelatedData(
       },
     }));
 
-    // The code-resolution relations have done their job in the two maps above,
-    // and nothing downstream reads them off a row. Dropping them here keeps
-    // them out of the JSON the browser downloads, where they would otherwise
-    // repeat per SLICE: a QUANTITY_TRACKED asset booked standalone and through
-    // three kits ships four copies of its barcodes and its full Qr row.
+    // Everything dropped here is fetch-only. The code relations have done their
+    // job in the two maps above; `assetKits` and `assetLocations` were reduced
+    // to this row's `kit` and `location` by `buildPdfAssetRows`. Nothing reads
+    // any of them again, here or in the browser, and the render list is one row
+    // per SLICE — so a QUANTITY_TRACKED asset booked standalone and through
+    // three kits would otherwise serialise four copies of each.
     const printableAssets = sortedAssets.map(
-      ({ qrCodes: _qrCodes, barcodes: _barcodes, ...row }) => row
+      ({
+        qrCodes: _qrCodes,
+        barcodes: _barcodes,
+        assetKits: _assetKits,
+        assetLocations: _assetLocations,
+        ...row
+      }) => row
     );
 
+    // `getBooking` returns the whole booking, and its `bookingAssets` carry a
+    // second, full copy of every asset — code relations included — once per
+    // slice. The sheet reads the booking only for its name, description,
+    // custodian and tags; `assets` above is the per-slice view it renders.
+    const { bookingAssets: _bookingAssets, ...printableBooking } = booking;
+
     return {
-      booking,
+      booking: printableBooking,
       assets: printableAssets,
       // Keep the total aligned with the exported (search-filtered) rows so a
       // searched PDF doesn't show a subset of assets with a full-booking total.

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -97,6 +97,8 @@ export interface PdfDbResult {
     // Read by `resolveDisplayCode` when building `assetIdToDisplayCodeMap`.
     | "qrIdDisplayPreference"
     | "barcodesEnabled"
+    // Whether the sheet prints the QR image at all.
+    | "showQrCodesOnPdfs"
   >;
   assetIdToQrCodeMap: Record<string, string>;
   /**
@@ -243,9 +245,11 @@ export async function fetchAllPdfRelatedData(
           id: true,
           currency: true,
           updatedAt: true,
-          // Which code the workspace wants printed under the QR image.
+          // Which code the workspace wants printed under the QR image, and
+          // whether the QR image is printed at all.
           qrIdDisplayPreference: true,
           barcodesEnabled: true,
+          showQrCodesOnPdfs: true,
         },
       }),
       // SECURITY (cross-org IDOR): `sourceKitId`'s FK accepts a `Kit` in ANY

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -362,11 +362,17 @@ export async function fetchAllPdfRelatedData(
       }) => row
     );
 
-    // `getBooking` returns the whole booking, and its `bookingAssets` carry a
-    // second, full copy of every asset — code relations included — once per
-    // slice. The sheet reads the booking only for its name, description,
-    // custodian and tags; `assets` above is the per-slice view it renders.
-    const { bookingAssets: _bookingAssets, ...printableBooking } = booking;
+    // `getBooking` returns the whole booking, and `BOOKING_WITH_ASSETS_INCLUDE`
+    // hangs two things off it that the sheet never reads: `bookingAssets`,
+    // carrying a second, select-shaped copy of every asset — code relations
+    // included — once per slice, and `modelRequests` with full `AssetModel`
+    // rows, which the sheet reads from the projection above instead. The
+    // booking itself is here for its name, description, custodian and tags.
+    const {
+      bookingAssets: _bookingAssets,
+      modelRequests: _bookingModelRequests,
+      ...printableBooking
+    } = booking as typeof booking & { modelRequests?: unknown };
 
     return {
       booking: printableBooking,

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -346,9 +346,18 @@ export async function fetchAllPdfRelatedData(
       },
     }));
 
+    // The code-resolution relations have done their job in the two maps above,
+    // and nothing downstream reads them off a row. Dropping them here keeps
+    // them out of the JSON the browser downloads, where they would otherwise
+    // repeat per SLICE: a QUANTITY_TRACKED asset booked standalone and through
+    // three kits ships four copies of its barcodes and its full Qr row.
+    const printableAssets = sortedAssets.map(
+      ({ qrCodes: _qrCodes, barcodes: _barcodes, ...row }) => row
+    );
+
     return {
       booking,
-      assets: sortedAssets,
+      assets: printableAssets,
       // Keep the total aligned with the exported (search-filtered) rows so a
       // searched PDF doesn't show a subset of assets with a full-booking total.
       totalValue: calculateTotalValueOfAssets({

--- a/apps/webapp/app/modules/booking/pdf-helpers.ts
+++ b/apps/webapp/app/modules/booking/pdf-helpers.ts
@@ -306,12 +306,19 @@ export async function fetchAllPdfRelatedData(
     const uniqueAssetsForQr = Array.from(
       new Map(sortedAssets.map((asset) => [asset.id, asset])).values()
     );
-    const assetIdToQrCodeMap = await getQrCodeMaps({
-      assets: uniqueAssetsForQr,
-      userId,
-      organizationId,
-      size: "small",
-    });
+    // Encoded only when the sheet will print them. A workspace with the QR
+    // image turned off renders nothing from this map, so generating it would
+    // cost a QR encode per asset and put a data URL per asset in the response
+    // that nothing reads. The renderer already treats a missing entry as
+    // "no image", so an empty map needs no handling of its own.
+    const assetIdToQrCodeMap = organization.showQrCodesOnPdfs
+      ? await getQrCodeMaps({
+          assets: uniqueAssetsForQr,
+          userId,
+          organizationId,
+          size: "small",
+        })
+      : {};
 
     // Resolve the printed code once per unique asset, over the same deduped
     // list the QR images are generated from. Resolving per rendered row would

--- a/apps/webapp/app/modules/organization/service.server.ts
+++ b/apps/webapp/app/modules/organization/service.server.ts
@@ -270,6 +270,7 @@ export async function updateOrganization({
   hasSequentialIdsMigrated,
   qrIdDisplayPreference,
   showShelfBranding,
+  showQrCodesOnPdfs,
   customEmailFooter,
 }: Pick<Organization, "id"> & {
   currency?: Organization["currency"];
@@ -284,6 +285,7 @@ export async function updateOrganization({
   hasSequentialIdsMigrated?: Organization["hasSequentialIdsMigrated"];
   qrIdDisplayPreference?: Organization["qrIdDisplayPreference"];
   showShelfBranding?: Organization["showShelfBranding"];
+  showQrCodesOnPdfs?: Organization["showQrCodesOnPdfs"];
   customEmailFooter?: string | null;
 }) {
   try {
@@ -296,6 +298,9 @@ export async function updateOrganization({
       }),
       ...(typeof showShelfBranding === "boolean" && {
         showShelfBranding,
+      }),
+      ...(typeof showQrCodesOnPdfs === "boolean" && {
+        showQrCodesOnPdfs,
       }),
       ...(customEmailFooter !== undefined && { customEmailFooter }),
       ...(ssoDetails && {
@@ -430,6 +435,7 @@ const ORGANIZATION_SELECT_FIELDS = {
   hasSequentialIdsMigrated: true,
   qrIdDisplayPreference: true,
   showShelfBranding: true,
+  showQrCodesOnPdfs: true,
   customEmailFooter: true,
 };
 

--- a/apps/webapp/app/routes/_layout+/settings.general.tsx
+++ b/apps/webapp/app/routes/_layout+/settings.general.tsx
@@ -270,8 +270,14 @@ export async function action({ context, request }: ActionFunctionArgs) {
           additionalData: { userId, organizationId },
         });
 
-        const { name, currency, id, qrIdDisplayPreference, showShelfBranding } =
-          payload;
+        const {
+          name,
+          currency,
+          id,
+          qrIdDisplayPreference,
+          showShelfBranding,
+          showQrCodesOnPdfs,
+        } = payload;
 
         /** User is allowed to edit his/her current organization only not other organizations. */
         if (currentOrganization.id !== id) {
@@ -326,6 +332,10 @@ export async function action({ context, request }: ActionFunctionArgs) {
           currency,
           qrIdDisplayPreference,
           showShelfBranding: nextShowShelfBranding,
+          // No tier gate and no resolver: the zod transform yields `undefined`
+          // when the switch was not part of the submit, and `updateOrganization`
+          // writes the column only for a real boolean.
+          showQrCodesOnPdfs,
         });
 
         sendNotification({

--- a/packages/database/prisma/migrations/20260904080000_organization_show_qr_codes_on_pdfs/migration.sql
+++ b/packages/database/prisma/migrations/20260904080000_organization_show_qr_codes_on_pdfs/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Organization" ADD COLUMN     "showQrCodesOnPdfs" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1013,6 +1013,10 @@ model Organization {
   // Branding preference for downloadable labels
   showShelfBranding Boolean @default(true)
 
+  // Whether the booking checklist and audit receipt PDFs print the QR image.
+  // Off means the sheet cannot be scanned in place of the label on the item.
+  showQrCodesOnPdfs Boolean @default(true)
+
   // Custom footer text appended to workspace emails
   customEmailFooter String? @db.VarChar(500)
 


### PR DESCRIPTION
Printed sheets showed a QR image and no readable identifier. This adds the text code, and lets a workspace turn the QR image off.

## The problem

Both printed sheets — the booking checklist and the audit receipt — rendered a QR square in their code column and nothing else.

**1. The code was unreadable.** Every on-screen asset list honours `Organization.qrIdDisplayPreference` (QR id, SAM ID, or a barcode value). The PDFs did not. A workspace whose physical labels carry SAM IDs got a sheet it could not match to a shelf without a scanner.

**2. The QR made the sheet a substitute for the equipment.** Every asset QR encodes `${baseUrl}/${qr.id}` and is produced by the same `generateCode` (`modules/qr/utils.server.ts:19-44`), so the square on the sheet and the sticker on the item are the same code. A phone cannot tell them apart. Scanning the sheet during a pick or an audit therefore records a scan without anyone going near the equipment — which is the opposite of what the scan is for.

## What changed

### 1. Print the workspace's code as text

`resolveDisplayCode` is called **server-side**, once per unique asset, in both PDF helpers. The result is returned as `assetIdToDisplayCodeMap: Record<string, ResolvedDisplayCode>`, mirroring the existing `assetIdToQrCodeMap`.

Keyed by **asset id, not `bookingAssetId`**: the booking PDF renders one row per `BookingAsset` slice, so a QUANTITY_TRACKED asset booked standalone *and* through kits has several rows. They all read the same entry, and the row types stay untouched.

Rendered as **plain text, not `<AssetCodeBadge>`**. The badge explains a fallback in a tooltip, and paper has no hover, so when the preferred type is unavailable the fallback prints as a small caption under the value. Shared by both sheets as `<AssetCodePrintText>` so they cannot drift.

The audit receipt's column header changes from "QR Code" to "Code".

> **Visible to every workspace, not only SAM ID ones.** A QR_ID workspace — the default — now sees the QR id printed under the image where before there was only the image.

### 2. `Organization.showQrCodesOnPdfs`

A switch on **Settings → General**, under "Label branding". Default `true`, so nothing changes until a workspace turns it off.

It is a workspace setting rather than a per-print checkbox on purpose: a control that the person taking the shortcut can untick before printing is not a control.

Follows `showShelfBranding` verbatim — same tri-state union so a partial submit cannot flip it, same hidden `"off"` input so an unchecked switch posts something, same conditional spread so `undefined` is a no-op. **No tier gate:** branding is a paid feature, but a control that stops a scan being faked should not be sold as an upgrade. Flagging that as a product call, not a technical one.

Off, the image goes and nothing else does:

| | QR on (default) | QR off |
|---|---|---|
| Booking row | QR square, then `☐ SAM-0002` | `☐ SAM-0002` |
| Booking row height | 101px | 77px |
| Audit receipt, 14 rows | 1564px | 1308px |

The code prints either way, so a row stays matchable by eye — which is why the two halves ship together. Without the printed code, hiding the QR would leave a blank column.

The tick box now sits beside the code rather than beside the image, so the cell reads the same with the QR and without it. One structure, not a branching layout.

### 3. Column width

`Qr.id` exists in two lengths: a 10-character form and a 25-character legacy cuid. A meaningful share of workspaces hold **only** the legacy form, so the long case is their every-row case rather than an edge case.

| PDF | before | after | the code gets |
|---|---|---|---|
| Booking checklist | `min-w-[120px]` | `min-w-[150px]` | ~130px |
| Audit receipt | `min-w-[80px]` | `min-w-[140px]` | ~120px |

Measured in the rendered preview, which lays out at the print width: a SAM ID or a 10-character QR id takes one line; a 25-character id takes two. Squeezed beside the tick box it needed three, and on a 14-row receipt that third line cost 280px of table height. The longest barcode value seen in production wraps inside the cell on `break-all` with the table's `scrollWidth` still equal to its `clientWidth`.

### 4. Response size

Both helpers fetch `qrCodes` and `barcodes` only to build the two maps, and the booking helper returned the whole booking — whose `bookingAssets` carry a second, select-shaped copy of every asset, once per slice. Neither sheet reads any of it. All of it is dropped once the maps are built, along with `assetKits`, `assetLocations` and `modelRequests`.

A 25-slice booking's response went from **49,400 to 28,178 bytes**, measured against the running app on the same endpoint. `bookingAssets` was 19,500 of it.

## Deploy

**Carries a migration.** `20260904080000_organization_show_qr_codes_on_pdfs`:

```sql
ALTER TABLE "public"."Organization" ADD COLUMN "showQrCodesOnPdfs" BOOLEAN NOT NULL DEFAULT true;
```

**Migrate first, then deploy.** Backwards compatible in both directions: older code never selects the column, and every existing row defaults to `true`.

## Deliberately not in scope

- **Kit codes.** The checklist prints the kit's name only; kits carry no `sequentialId`. Marked with a `// why: out of this rule` comment at the Kit cell.
- **Barcode graphics.** A barcode-type preference prints the barcode *value* as text, no image.
- **`include: { qrCodes: true }` stays** on both asset queries. The tight `{ take: 1, select: { id } }` that `.claude/rules/code-bearing-entity-list-consistency.md` asks for cannot be used, because the same payload feeds `getQrCodeMaps`, which renders the image from `Qr.version` / `Qr.errorCorrection`. There is a `// why: out of this rule` comment at each include.
- **Companion app.**

### This narrows the sheet-scanning shortcut, it does not close it

Other surfaces still produce scannable codes away from the equipment: the bulk "Download QR Codes" zip, the per-asset label Download/Print, and the per-row QR button on the index. Those exist so people can print labels and stick them on things.

The checklist was different in kind — it put a scannable code in the picker's hand, during the process it undermines, with a tick box printed next to it. Closing the rest is a separate conversation, and `BookingSettings` having `requireExplicitCheckinFor{Admin,SelfService}` with no check-*out* equivalent is probably where it starts.

## Verification

- `pnpm webapp:validate` green: 444 test files, 5860 tests.
- `react-doctor`: no new error-level findings. The two `no-giant-component` warnings on these files pre-date this PR.
- Tests cover the query shape, each preference branch, the fallback caption, the no-code row, the no-QR-image row, that every per-slice row of a QUANTITY_TRACKED asset resolves from one map entry, that no returned row carries a fetch-only relation, and that both sheets print no QR when the workspace turns it off. **Each was mutation-tested** — reverting the behaviour fails the case.
- Rendered in a browser against a real database at each preference and with the switch both ways.
