### PR TITLE
fix(booking): let quantity-tracked assets join an ongoing booking

### DIFF
--- a/apps/webapp/app/components/scanner/drawer/uses/add-assets-to-booking-drawer.tsx
+++ b/apps/webapp/app/components/scanner/drawer/uses/add-assets-to-booking-drawer.tsx
@@ -198,13 +198,36 @@ export default function AddAssetsToBookingDrawer({
     })
     .map(([qrId]) => qrId);
 
-  // Assets already checked out as current booking is checked out
+  // Assets already checked out, blocking only while the booking itself is.
+  //
+  // INDIVIDUAL only: `Asset.status` is one flag for the whole row, so a
+  // QUANTITY_TRACKED pool reads CHECKED_OUT while one unit is out and the rest
+  // is free stock. Qty rows are judged on their own free pool instead
+  // (`noUnitsAvailableIds` below), the same `pickerMeta.maxAllowed` the row's
+  // qty input is capped at.
   const checkedOutAssetsIds = assets
-    .filter((asset) => asset.status === AssetStatus.CHECKED_OUT)
+    .filter(
+      (asset) =>
+        asset.type === AssetType.INDIVIDUAL &&
+        asset.status === AssetStatus.CHECKED_OUT
+    )
     .map((asset) => asset.id);
   const tryingToAddCheckedOutAssets =
     checkedOutAssetsIds.length > 0 &&
     ["ONGOING", "OVERDUE"].includes(booking.status);
+
+  // Qty-tracked rows with nothing left to stage. `pickerMeta.maxAllowed` is the
+  // booking picker's free pool for this asset (total − custody − kits −
+  // windowed reservations); at 0 the row renders no qty input and the server
+  // rejects it, so it belongs in the blocker list where one tap clears it.
+  const noUnitsAvailableIds = assets
+    .filter(
+      (asset) =>
+        isQuantityTracked(asset) &&
+        !booking.bookingAssets.some((ba) => ba.assetId === asset.id) &&
+        (asset.pickerMeta?.maxAllowed ?? asset.quantity ?? 0) <= 0
+    )
+    .map((asset) => asset.id);
 
   // Kits already checked out as current booking is checked out
   const checkedOutKitsIds = kits
@@ -232,6 +255,17 @@ export default function AddAssetsToBookingDrawer({
         </>
       ),
       onResolve: () => removeAssetsFromList(checkedOutAssetsIds),
+    },
+    {
+      condition: noUnitsAvailableIds.length > 0,
+      count: noUnitsAvailableIds.length,
+      message: (count: number) => (
+        <>
+          <strong>{`${count} asset${count > 1 ? "s have" : " has"}`}</strong> no
+          units available.
+        </>
+      ),
+      onResolve: () => removeAssetsFromList(noUnitsAvailableIds),
     },
     {
       condition: tryingToAddCheckedOutKits,
@@ -310,6 +344,7 @@ export default function AddAssetsToBookingDrawer({
         ...assetsPartOfKitIds,
         ...unavailableAssetsIds,
         ...checkedOutAssetsIds,
+        ...noUnitsAvailableIds,
       ]);
       removeItemsFromList([
         ...errors.map(([qrId]) => qrId),
@@ -377,9 +412,24 @@ export default function AddAssetsToBookingDrawer({
 // Implement item renderers if they're not already defined elsewhere
 export function AssetRow({ asset }: { asset: AssetFromQr }) {
   const { booking } = useLoaderData<typeof loader>();
-  // Check if booking is in checked-out state and asset is checked out
+  // Whether the booking is in a checked-out state and the asset is checked out.
+  // INDIVIDUAL only — a QUANTITY_TRACKED row reads CHECKED_OUT while free stock
+  // remains, so it is judged on its own pool (`maxAllowed`) below.
   const bookingIsCheckedOut = ["ONGOING", "OVERDUE"].includes(booking.status);
-  const isCheckedOut = asset.status === AssetStatus.CHECKED_OUT;
+  const isCheckedOut =
+    asset.type === AssetType.INDIVIDUAL &&
+    asset.status === AssetStatus.CHECKED_OUT;
+
+  const qtyTracked = isQuantityTracked(asset) && asset.quantity != null;
+  const alreadyInBooking = booking.bookingAssets.some(
+    (ba) => ba.assetId === asset.id
+  );
+  // `pickerMeta` is the booking picker's available pool — same
+  // formula as `bookings/$bookingId/overview/manage-assets`.
+  const pickerMeta = qtyTracked ? asset.pickerMeta ?? null : null;
+  const totalQty = qtyTracked ? (asset.quantity as number) : 0;
+  const maxAllowed = pickerMeta?.maxAllowed ?? totalQty;
+  const noUnitsAvailable = qtyTracked && !alreadyInBooking && maxAllowed <= 0;
 
   // Use a combination of standard presets and custom configurations
   const availabilityConfigs = [
@@ -406,21 +456,21 @@ export function AssetRow({ asset }: { asset: AssetFromQr }) {
       priority: 80, // High priority - blocking issue
       // Uses default warning colors (red/orange) appropriate for blocking issue
     },
+    // Qty-tracked counterpart of the badge above: the pool itself is out, so
+    // there is nothing to stage even though the row is a single asset.
+    {
+      condition: noUnitsAvailable,
+      badgeText: "No units available",
+      tooltipTitle: "No units available",
+      tooltipContent:
+        "Every unit of this asset is already in custody, in a kit or reserved for the booking window.",
+      priority: 80,
+    },
   ];
 
   // Create the availability labels component
   const [, AssetAvailabilityLabels] =
     createAvailabilityLabels(availabilityConfigs);
-
-  const qtyTracked = isQuantityTracked(asset) && asset.quantity != null;
-  const alreadyInBooking = booking.bookingAssets.some(
-    (ba) => ba.assetId === asset.id
-  );
-  // `pickerMeta` is the booking picker's available pool — same
-  // formula as `bookings/$bookingId/overview/manage-assets`.
-  const pickerMeta = qtyTracked ? asset.pickerMeta ?? null : null;
-  const totalQty = qtyTracked ? (asset.quantity as number) : 0;
-  const maxAllowed = pickerMeta?.maxAllowed ?? totalQty;
 
   return (
     <div className="flex w-full items-start justify-between gap-3">

--- a/apps/webapp/app/components/scanner/drawer/uses/add-assets-to-booking-drawer.tsx
+++ b/apps/webapp/app/components/scanner/drawer/uses/add-assets-to-booking-drawer.tsx
@@ -60,6 +60,25 @@ export const addScannedAssetsToBookingSchema = z
   });
 
 /**
+ * Free units this booking may still draw on for a scanned row, or `null` when
+ * the question doesn't apply because the row is an INDIVIDUAL asset.
+ *
+ * `pickerMeta.maxAllowed` is the booking's pool for this asset, resolved
+ * server-side by the same primitive the write guard enforces with, so a row
+ * judged here agrees with what the submit will do. It is absent only when a
+ * scan carried no picker context; the asset's own stock is the closest stand-in
+ * then, and a quantity-tracked row with no recorded stock has nothing to stage.
+ *
+ * Shared by the blocker list and the row badge so the two can never disagree
+ * about which rows are exhausted — a blocker whose row shows no badge is a
+ * count the user cannot attribute to anything.
+ */
+function resolveScannedUnitsAvailable(asset: AssetFromQr): number | null {
+  if (!isQuantityTracked(asset)) return null;
+  return asset.pickerMeta?.maxAllowed ?? asset.quantity ?? 0;
+}
+
+/**
  * Drawer component for managing scanned assets to be added to bookings
  */
 export default function AddAssetsToBookingDrawer({
@@ -216,17 +235,20 @@ export default function AddAssetsToBookingDrawer({
     checkedOutAssetsIds.length > 0 &&
     ["ONGOING", "OVERDUE"].includes(booking.status);
 
-  // Qty-tracked rows with nothing left to stage. `pickerMeta.maxAllowed` is the
-  // booking picker's free pool for this asset (total − custody − kits −
-  // windowed reservations); at 0 the row renders no qty input and the server
-  // rejects it, so it belongs in the blocker list where one tap clears it.
+  // Qty-tracked rows with nothing left to stage (see
+  // `resolveScannedUnitsAvailable`). At zero the row renders no qty input and
+  // the server would reject it, so it belongs in the blocker list where one
+  // tap clears it. Rows already on the booking are exempt: the scan is a no-op
+  // for them, and "Already added to this booking" is the badge that says so.
   const noUnitsAvailableIds = assets
-    .filter(
-      (asset) =>
-        isQuantityTracked(asset) &&
-        !booking.bookingAssets.some((ba) => ba.assetId === asset.id) &&
-        (asset.pickerMeta?.maxAllowed ?? asset.quantity ?? 0) <= 0
-    )
+    .filter((asset) => {
+      const unitsAvailable = resolveScannedUnitsAvailable(asset);
+      return (
+        unitsAvailable !== null &&
+        unitsAvailable <= 0 &&
+        !booking.bookingAssets.some((ba) => ba.assetId === asset.id)
+      );
+    })
     .map((asset) => asset.id);
 
   // Kits already checked out as current booking is checked out
@@ -420,15 +442,13 @@ export function AssetRow({ asset }: { asset: AssetFromQr }) {
     asset.type === AssetType.INDIVIDUAL &&
     asset.status === AssetStatus.CHECKED_OUT;
 
-  const qtyTracked = isQuantityTracked(asset) && asset.quantity != null;
+  const unitsAvailable = resolveScannedUnitsAvailable(asset);
+  const qtyTracked = unitsAvailable !== null;
   const alreadyInBooking = booking.bookingAssets.some(
     (ba) => ba.assetId === asset.id
   );
-  // `pickerMeta` is the booking picker's available pool — same
-  // formula as `bookings/$bookingId/overview/manage-assets`.
-  const pickerMeta = qtyTracked ? asset.pickerMeta ?? null : null;
-  const totalQty = qtyTracked ? (asset.quantity as number) : 0;
-  const maxAllowed = pickerMeta?.maxAllowed ?? totalQty;
+  const totalQty = asset.quantity ?? 0;
+  const maxAllowed = unitsAvailable ?? 0;
   const noUnitsAvailable = qtyTracked && !alreadyInBooking && maxAllowed <= 0;
 
   // Use a combination of standard presets and custom configurations
@@ -480,9 +500,9 @@ export function AssetRow({ asset }: { asset: AssetFromQr }) {
           {qtyTracked ? (
             <span className="ml-2 text-xs font-normal text-gray-500">
               · {totalQty} {asset.unitOfMeasure || "units"}
-              {pickerMeta && pickerMeta.maxAllowed < totalQty ? (
+              {maxAllowed < totalQty ? (
                 <span className="ml-1 text-warning-700">
-                  · {pickerMeta.maxAllowed} available
+                  · {maxAllowed} available
                 </span>
               ) : null}
             </span>

--- a/apps/webapp/app/modules/booking/helpers.test.ts
+++ b/apps/webapp/app/modules/booking/helpers.test.ts
@@ -1,6 +1,7 @@
-import { AssetStatus, BookingStatus } from "@prisma/client";
+import { AssetStatus, AssetType, BookingStatus } from "@prisma/client";
 import { describe, it, expect } from "vitest";
 import {
+  buildAddToActiveBookingBlockerWhere,
   buildPdfAssetRows,
   buildPdfBookingAssetSlices,
   countRemainingCheckoutAssets,
@@ -1197,5 +1198,33 @@ describe("buildPdfBookingAssetSlices", () => {
 
     const filtered = filterBookingAssets(slices, "Camera");
     expect(filtered.map((s) => s.id).sort()).toEqual(["cam", "tripod"]);
+  });
+});
+
+describe("buildAddToActiveBookingBlockerWhere", () => {
+  it("narrows to CHECKED_OUT INDIVIDUAL assets in the caller's org", () => {
+    expect(
+      buildAddToActiveBookingBlockerWhere({
+        assetIds: ["a1", "a2"],
+        organizationId: "org-1",
+      })
+    ).toEqual({
+      id: { in: ["a1", "a2"] },
+      organizationId: "org-1",
+      status: AssetStatus.CHECKED_OUT,
+      type: AssetType.INDIVIDUAL,
+    });
+  });
+
+  it("excludes QUANTITY_TRACKED assets from the blocker set", () => {
+    // A qty pool reads CHECKED_OUT while free units remain, so matching it
+    // here would refuse an add the picker had already offered. The type
+    // predicate is the whole point of this helper — assert it explicitly.
+    const where = buildAddToActiveBookingBlockerWhere({
+      assetIds: ["a1"],
+      organizationId: "org-1",
+    });
+    expect(where.type).toBe(AssetType.INDIVIDUAL);
+    expect(where.type).not.toBe(AssetType.QUANTITY_TRACKED);
   });
 });

--- a/apps/webapp/app/modules/booking/helpers.ts
+++ b/apps/webapp/app/modules/booking/helpers.ts
@@ -1,4 +1,5 @@
 import { AssetStatus, AssetType, BookingStatus } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
 import { addMinutes, isAfter, isBefore, subMinutes } from "date-fns";
 import { ONE_DAY, ONE_HOUR } from "~/utils/constants";
 import { getPrimaryLocation } from "../asset/utils";
@@ -919,4 +920,39 @@ export function buildPdfBookingAssetSlices<TAsset extends PdfSliceSourceAsset>(
       bookingAssetId: ba.id,
     };
   });
+}
+
+/**
+ * Prisma `where` selecting the assets that physically block an add to an
+ * ONGOING / OVERDUE booking: no free unit exists to stage, so the add cannot
+ * be honoured.
+ *
+ * INDIVIDUAL only. `Asset.status` is a single flag over the whole row, so a
+ * QUANTITY_TRACKED pool reads CHECKED_OUT while one unit is out and the rest of
+ * the pool is free stock: the flag cannot tell "18 of 27 are out" from "nothing
+ * left". The pickers offer a qty asset only while its `bookable` pool is above
+ * zero, so matching one here would refuse an add the UI just offered. Per-unit
+ * capacity for qty assets belongs to `assertAssetQuantitiesAvailable` inside
+ * `updateBookingAssets`, which is windowed and runs under a row lock.
+ *
+ * Both add-to-booking guards — the manage-assets route and `processBooking` —
+ * read through this so the rule stays one rule.
+ *
+ * @param args.assetIds - The NEW asset ids the caller wants to add.
+ * @param args.organizationId - Caller's organization (scopes the query).
+ * @returns A `Prisma.AssetWhereInput` matching only the blocking assets.
+ */
+export function buildAddToActiveBookingBlockerWhere({
+  assetIds,
+  organizationId,
+}: {
+  assetIds: string[];
+  organizationId: string;
+}): Prisma.AssetWhereInput {
+  return {
+    id: { in: assetIds },
+    organizationId,
+    status: AssetStatus.CHECKED_OUT,
+    type: AssetType.INDIVIDUAL,
+  };
 }

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -12444,7 +12444,12 @@ describe("processBooking — checked-out guard for active bookings", () => {
    *  2. the guard — filters `status: CHECKED_OUT`; returns the offending rows.
    */
   function mockAssets(
-    rows: Array<{ id: string; title?: string; status: AssetStatus }>
+    rows: Array<{
+      id: string;
+      title?: string;
+      status: AssetStatus;
+      type?: AssetType;
+    }>
   ) {
     (db.asset.findMany as ReturnType<typeof vitest.fn>).mockImplementation(
       (args?: any) => {
@@ -12455,10 +12460,18 @@ describe("processBooking — checked-out guard for active bookings", () => {
           !requestedIds || requestedIds.includes(id);
 
         if (args?.where?.status === AssetStatus.CHECKED_OUT) {
+          // The guard narrows to INDIVIDUAL rows — honour that here, or a
+          // qty-tracked row would come back and the test would assert the
+          // mock's behaviour rather than the query's.
+          const typeFilter: AssetType | undefined = args?.where?.type;
           return Promise.resolve(
             rows
               .filter(
-                (r) => r.status === AssetStatus.CHECKED_OUT && inScope(r.id)
+                (r) =>
+                  r.status === AssetStatus.CHECKED_OUT &&
+                  inScope(r.id) &&
+                  (typeFilter === undefined ||
+                    (r.type ?? AssetType.INDIVIDUAL) === typeFilter)
               )
               .map((r) => ({ id: r.id, title: r.title ?? r.id }))
           );
@@ -12584,6 +12597,57 @@ describe("processBooking — checked-out guard for active bookings", () => {
       OWNER_AUTH
     );
     expect(finalAssetIds).toEqual(["asset-1"]);
+  });
+
+  it("does NOT block a QUANTITY_TRACKED asset whose pool is partly checked out", async () => {
+    // `Asset.status` is one flag for the whole row: a 27-unit pool with 18
+    // units out on other bookings reads CHECKED_OUT while 9 units are free.
+    // Per-unit capacity is `assertAssetQuantitiesAvailable`'s job inside
+    // `updateBookingAssets`, so the row-level guard must let the pool through.
+    mockBooking(BookingStatus.ONGOING);
+    mockAssets([
+      {
+        id: "asset-1",
+        title: "Compass",
+        status: AssetStatus.CHECKED_OUT,
+        type: AssetType.QUANTITY_TRACKED,
+      },
+    ]);
+
+    const { finalAssetIds } = await processBooking(
+      "booking-1",
+      ["asset-1"],
+      "org-1",
+      OWNER_AUTH
+    );
+    expect(finalAssetIds).toEqual(["asset-1"]);
+  });
+
+  it("still blocks a CHECKED_OUT INDIVIDUAL asset alongside a qty-tracked one", async () => {
+    mockBooking(BookingStatus.ONGOING);
+    mockAssets([
+      {
+        id: "asset-qt",
+        title: "Compass",
+        status: AssetStatus.CHECKED_OUT,
+        type: AssetType.QUANTITY_TRACKED,
+      },
+      {
+        id: "asset-ind",
+        title: "Camera",
+        status: AssetStatus.CHECKED_OUT,
+        type: AssetType.INDIVIDUAL,
+      },
+    ]);
+
+    await expect(
+      processBooking(
+        "booking-1",
+        ["asset-qt", "asset-ind"],
+        "org-1",
+        OWNER_AUTH
+      )
+    ).rejects.toThrow(/Camera/);
   });
 
   it("guards only NEW checked-out assets, ignoring ones already on this booking", async () => {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -12460,9 +12460,9 @@ describe("processBooking — checked-out guard for active bookings", () => {
           !requestedIds || requestedIds.includes(id);
 
         if (args?.where?.status === AssetStatus.CHECKED_OUT) {
-          // The guard narrows to INDIVIDUAL rows — honour that here, or a
-          // qty-tracked row would come back and the test would assert the
-          // mock's behaviour rather than the query's.
+          // why: the guard narrows to INDIVIDUAL rows, so the mock has to
+          // honour `where.type` too — otherwise a qty-tracked row comes back
+          // and the test asserts the mock's behaviour rather than the query's.
           const typeFilter: AssetType | undefined = args?.where?.type;
           return Promise.resolve(
             rows

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -165,6 +165,7 @@ import {
   sendCheckinReminder,
 } from "./email-helpers";
 import {
+  buildAddToActiveBookingBlockerWhere,
   hasAssetBookingConflicts,
   isBookingArchivable,
   isBookingEarlyCheckin,
@@ -14694,6 +14695,11 @@ export async function processBooking(
     // CHECKED_OUT status can be owned by this same booking (progressive
     // checkout), and re-submitting them is handled downstream by the
     // duplicate / "add only the rest" flow — not by this guard.
+    //
+    // Scoped to INDIVIDUAL assets by `buildAddToActiveBookingBlockerWhere`: a
+    // QUANTITY_TRACKED pool reads CHECKED_OUT while one unit is out and the
+    // rest is free to stage, so per-unit capacity is
+    // `assertAssetQuantitiesAvailable`'s job inside `updateBookingAssets`.
     if (
       bookingInfo.status === BookingStatus.ONGOING ||
       bookingInfo.status === BookingStatus.OVERDUE
@@ -14708,11 +14714,10 @@ export async function processBooking(
       const checkedOutAssets =
         newAssetIdsToCheck.length > 0
           ? await db.asset.findMany({
-              where: {
-                id: { in: newAssetIdsToCheck },
+              where: buildAddToActiveBookingBlockerWhere({
+                assetIds: newAssetIdsToCheck,
                 organizationId,
-                status: AssetStatus.CHECKED_OUT,
-              },
+              }),
               select: { id: true, title: true },
             })
           : [];

--- a/apps/webapp/app/modules/scanner/picker-meta.server.test.ts
+++ b/apps/webapp/app/modules/scanner/picker-meta.server.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Scanner Picker Meta — Unit Tests
+ *
+ * `getScannerPickerMeta` answers "how many units may this scan still stage
+ * here" for the three destinations the QR scanner feeds. These tests cover the
+ * BOOKING branch, whose answer has to be the same number the booking write
+ * guard enforces with: the drawer caps its quantity input on it AND refuses a
+ * scan when it reaches zero, so a locally-derived approximation would block an
+ * add the server would have accepted.
+ *
+ * That is why the branch delegates to `getAssetAvailabilityBatch` rather than
+ * summing the pool's parts itself, and why these tests assert the delegation
+ * and its arguments rather than re-deriving an expected figure.
+ *
+ * @see {@link file://./picker-meta.server.ts}
+ */
+import { AssetType } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+import type { AssetAvailability } from "~/modules/asset/availability.server";
+import { getAssetAvailabilityBatch } from "~/modules/asset/availability.server";
+import { getScannerPickerMeta } from "./picker-meta.server";
+
+// why: the booking branch reads the asset row and the target booking from the
+// db singleton; mock it so tests can pin those shapes without Postgres.
+vi.mock("~/database/db.server", () => ({
+  db: {
+    asset: { findFirst: vi.fn() },
+    booking: { findUnique: vi.fn() },
+  },
+}));
+
+// why: this is the collaborator under test — the branch's whole contract is
+// that it asks this primitive instead of computing the pool itself, so the
+// call and its arguments are the assertion.
+vi.mock("~/modules/asset/availability.server", () => ({
+  getAssetAvailabilityBatch: vi.fn(),
+}));
+
+const findAssetMock = vi.mocked(db.asset.findFirst);
+const findBookingMock = vi.mocked(db.booking.findUnique);
+const availabilityMock = vi.mocked(getAssetAvailabilityBatch);
+
+const BOOKING_FROM = new Date("2026-03-02T09:00:00.000Z");
+const BOOKING_TO = new Date("2026-03-06T17:00:00.000Z");
+
+const CONTEXT = { type: "booking", id: "booking-1" } as const;
+
+/** A quantity-tracked asset with 10 units of stock. */
+function qtyAsset(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "asset-1",
+    type: AssetType.QUANTITY_TRACKED,
+    quantity: 10,
+    unitOfMeasure: "pcs",
+    ...overrides,
+  };
+}
+
+/**
+ * Answer the batch read with `bookable` for the asset under test.
+ *
+ * Only `bookable` is filled in: it is the single field this branch reads, and
+ * pinning the rest would assert the primitive's shape rather than this one's
+ * use of it.
+ */
+function mockBookable(bookable: number) {
+  availabilityMock.mockResolvedValue(
+    new Map([["asset-1", { bookable } as AssetAvailability]])
+  );
+}
+
+describe("getScannerPickerMeta — booking context", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    findAssetMock.mockResolvedValue(qtyAsset() as never);
+    findBookingMock.mockResolvedValue({
+      id: "booking-1",
+      from: BOOKING_FROM,
+      to: BOOKING_TO,
+    } as never);
+  });
+
+  it("reports the pool the shared availability primitive resolved", async () => {
+    // A kit slice on an active booking is already inside the primitive's
+    // `inKits` term. Subtracting it a second time — as any local re-derivation
+    // over `BookingAsset` rows does — would report 0 here and disable the
+    // drawer's Confirm while five units were genuinely free.
+    mockBookable(5);
+
+    const meta = await getScannerPickerMeta({
+      assetId: "asset-1",
+      organizationId: "org-1",
+      context: CONTEXT,
+    });
+
+    expect(meta).toEqual({
+      maxAllowed: 5,
+      assetQuantity: 10,
+      unitOfMeasure: "pcs",
+    });
+  });
+
+  it("measures the booking's own window, excluding the booking itself", async () => {
+    // Excluding the target booking is what makes this a top-up figure: its
+    // existing rows are what the scan is adding to, not competition for it.
+    mockBookable(4);
+
+    await getScannerPickerMeta({
+      assetId: "asset-1",
+      organizationId: "org-1",
+      context: CONTEXT,
+    });
+
+    expect(availabilityMock).toHaveBeenCalledWith(["asset-1"], {
+      organizationId: "org-1",
+      window: { from: BOOKING_FROM, to: BOOKING_TO },
+      excludeBookingId: "booking-1",
+    });
+  });
+
+  it("asks for an unwindowed pool when the booking has no dates", async () => {
+    findBookingMock.mockResolvedValue({
+      id: "booking-1",
+      from: null,
+      to: null,
+    } as never);
+    mockBookable(10);
+
+    await getScannerPickerMeta({
+      assetId: "asset-1",
+      organizationId: "org-1",
+      context: CONTEXT,
+    });
+
+    expect(availabilityMock).toHaveBeenCalledWith(
+      ["asset-1"],
+      expect.objectContaining({ window: null })
+    );
+  });
+
+  it("clamps an over-committed pool to zero", async () => {
+    // `bookable` is signed so write guards can tell "already over-committed"
+    // from "exactly full". This number bounds a quantity input, so a negative
+    // one has to surface as nothing left rather than as a negative MAX.
+    mockBookable(-3);
+
+    const meta = await getScannerPickerMeta({
+      assetId: "asset-1",
+      organizationId: "org-1",
+      context: CONTEXT,
+    });
+
+    expect(meta?.maxAllowed).toBe(0);
+  });
+
+  it("treats an asset the batch read did not resolve as exhausted", async () => {
+    availabilityMock.mockResolvedValue(new Map());
+
+    const meta = await getScannerPickerMeta({
+      assetId: "asset-1",
+      organizationId: "org-1",
+      context: CONTEXT,
+    });
+
+    expect(meta?.maxAllowed).toBe(0);
+  });
+
+  it("returns null for an INDIVIDUAL asset without reading availability", async () => {
+    // The drawers render neither a quantity input nor an availability
+    // annotation for these, so the pool is never computed for them.
+    findAssetMock.mockResolvedValue(
+      qtyAsset({ type: AssetType.INDIVIDUAL, quantity: null }) as never
+    );
+
+    const meta = await getScannerPickerMeta({
+      assetId: "asset-1",
+      organizationId: "org-1",
+      context: CONTEXT,
+    });
+
+    expect(meta).toBeNull();
+    expect(availabilityMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the booking is outside the caller's organization", async () => {
+    // The lookup is org-scoped, so a foreign booking id resolves to nothing
+    // and must not fall through to an availability read.
+    findBookingMock.mockResolvedValue(null as never);
+
+    const meta = await getScannerPickerMeta({
+      assetId: "asset-1",
+      organizationId: "org-1",
+      context: CONTEXT,
+    });
+
+    expect(meta).toBeNull();
+    expect(availabilityMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/webapp/app/modules/scanner/picker-meta.server.ts
+++ b/apps/webapp/app/modules/scanner/picker-meta.server.ts
@@ -12,13 +12,14 @@
  *
  * @see {@link file://./../location/picker-meta.server.ts} `getLocationPickerMeta`
  * @see {@link file://./../kit/picker-meta.server.ts} `getKitPickerMeta`
- * @see {@link file://./../../routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx}
- *   booking picker's inline availability formula (Phase 4b)
+ * @see {@link file://./../asset/availability.server.ts} `getAssetAvailabilityBatch`,
+ *   which answers the booking context.
  */
 
-import { AssetType, BookingStatus } from "@prisma/client";
+import { AssetType } from "@prisma/client";
 import { z } from "zod";
 import { db } from "~/database/db.server";
+import { getAssetAvailabilityBatch } from "~/modules/asset/availability.server";
 import { getKitPickerMeta } from "~/modules/kit/picker-meta.server";
 import { getLocationPickerMeta } from "~/modules/location/picker-meta.server";
 
@@ -34,7 +35,7 @@ export type ScannerPickerContext = z.infer<typeof ScannerPickerContextSchema>;
  * Normalised picker-meta shape returned to scanner drawers. Mirrors
  * the fields each manage-assets picker exposes on a per-row basis but
  * collapses the context-specific names (`maxAllowedForThisLocation`,
- * `maxAllowedForThisKit`, ad-hoc booking math) to a uniform `maxAllowed`.
+ * `maxAllowedForThisKit`, a booking's `bookable`) to a uniform `maxAllowed`.
  */
 export type ScannerPickerMeta = {
   /** Strict-available pool the qty input is bounded by. */
@@ -98,71 +99,40 @@ export async function getScannerPickerMeta({
     };
   }
 
-  // Booking: matches the asset overview's "Available" formula so the
-  // scanner MAX agrees with what the user sees on the asset page:
+  // Booking: the pool comes from `getAssetAvailabilityBatch` — the same
+  // primitive the manage-assets picker lists rows by and the write guard
+  // (`assertAssetQuantitiesAvailable`) enforces with. The scanner drawer both
+  // caps its qty input and refuses a scan on this number, so it has to be the
+  // server's number rather than a second derivation of it. Summing the parts
+  // here instead gets two of them wrong: kit-driven `BookingAsset` rows are
+  // already inside `inKits`, so counting them again subtracts a kit slice
+  // twice, and a plain sum stacks bookings that never overlap each other,
+  // where the primitive sweeps for the peak concurrent claim. Both understate
+  // the pool, which refuses an add the server would have accepted.
   //
-  //   maxAllowed = Asset.quantity
-  //              − sum(AssetKit.quantity)                ← kit-committed
-  //              − sum(Custody.quantity)                  ← held by custodians
-  //              − sum(BookingAsset.quantity from overlapping
-  //                    active bookings, excluding this booking)
-  //
-  // The booking picker's inline formula (`bookings.$bookingId.
-  // overview.manage-assets.tsx:264`) drops the kit term because it
-  // pre-filters qty-tracked assets with any kit membership out of the
-  // results entirely — that's a separate bug for the picker, but the
-  // scanner needs the full formula so multi-kit qty-tracked rows can
-  // still be added to a booking from their free pool.
-  //
-  // The "overlapping" filter only fires when the booking has dates.
-  // Bookings without dates compete with every other reservation.
+  // Without dates the primitive falls back to the conservative sum of every
+  // active commitment, so a booking still being planned never over-promises.
   const booking = await db.booking.findUnique({
     where: { id: context.id, organizationId },
     select: { id: true, from: true, to: true },
   });
   if (!booking) return null;
 
-  const [assetKitSum, custodySum, bookingSum] = await Promise.all([
-    db.assetKit.aggregate({
-      where: { assetId, organizationId },
-      _sum: { quantity: true },
-    }),
-    db.custody.aggregate({
-      where: { assetId },
-      _sum: { quantity: true },
-    }),
-    db.bookingAsset.aggregate({
-      where: {
-        assetId,
-        bookingId: { not: booking.id },
-        booking: {
-          status: {
-            in: [
-              BookingStatus.RESERVED,
-              BookingStatus.ONGOING,
-              BookingStatus.OVERDUE,
-            ],
-          },
-          ...(booking.from &&
-            booking.to && {
-              OR: [
-                { from: { lte: booking.to }, to: { gte: booking.from } },
-                { from: { gte: booking.from }, to: { lte: booking.to } },
-              ],
-            }),
-        },
-      },
-      _sum: { quantity: true },
-    }),
-  ]);
-
-  const inKits = assetKitSum._sum.quantity ?? 0;
-  const inCustody = custodySum._sum.quantity ?? 0;
-  const reserved = bookingSum._sum.quantity ?? 0;
-  const maxAllowed = Math.max(0, totalQty - inKits - inCustody - reserved);
+  const availabilityByAsset = await getAssetAvailabilityBatch([assetId], {
+    organizationId,
+    window:
+      booking.from && booking.to
+        ? { from: booking.from, to: booking.to }
+        : null,
+    // This booking's own rows are what the scan is topping up; leaving them in
+    // would measure the request against itself.
+    excludeBookingId: booking.id,
+  });
 
   return {
-    maxAllowed,
+    // `bookable` is signed so write guards can tell "already over-committed"
+    // from "exactly full". This one bounds a qty input, so clamp it.
+    maxAllowed: Math.max(0, availabilityByAsset.get(assetId)?.bookable ?? 0),
     assetQuantity: totalQty,
     unitOfMeasure: asset.unitOfMeasure,
   };

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -18,6 +18,7 @@ import type {
 import {
   data,
   redirect,
+  useActionData,
   useLoaderData,
   useNavigate,
   useNavigation,
@@ -75,6 +76,7 @@ import { isQuantityTracked } from "~/modules/asset/utils";
 import { getAssetsWhereInput } from "~/modules/asset/utils.server";
 import { resolveDisplayCode } from "~/modules/barcode/display";
 import { sendBookingUpdatedEmail } from "~/modules/booking/email-helpers";
+import { buildAddToActiveBookingBlockerWhere } from "~/modules/booking/helpers";
 import {
   getBooking,
   getDetailedPartialCheckinData,
@@ -103,6 +105,7 @@ import {
   parseData,
   safeRedirect,
 } from "~/utils/http.server";
+import type { DataOrErrorResponse } from "~/utils/http.server";
 import { ALL_SELECTED_KEY, isSelectingAllItems } from "~/utils/list";
 import { Logger } from "~/utils/logger";
 import { stripMarkdocDelimiters } from "~/utils/markdoc-sanitize";
@@ -637,13 +640,16 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
     const { partialCheckinDetails } =
       await getDetailedPartialCheckinData(bookingId);
 
-    // Query to get potentially checked out assets
+    /**
+     * Assets that physically block this add. INDIVIDUAL only — see
+     * {@link buildAddToActiveBookingBlockerWhere}; a qty-tracked pool's
+     * per-unit capacity is checked inside `updateBookingAssets`.
+     */
     const potentiallyCheckedOutAssets = await db.asset.findMany({
-      where: {
-        id: { in: newAssetIds },
+      where: buildAddToActiveBookingBlockerWhere({
+        assetIds: newAssetIds,
         organizationId,
-        status: AssetStatus.CHECKED_OUT,
-      },
+      }),
       select: { id: true, title: true, status: true },
     });
 
@@ -670,6 +676,7 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
           bookingId,
           newAssetIds,
         },
+        status: 400,
         shouldBeCaptured: false,
       });
     }
@@ -1049,6 +1056,18 @@ export default function AddAssetsToNewBooking() {
   const [searchParams] = useSearchParams();
   const initialTab = searchParams.get("tab") === "models" ? "models" : "assets";
   const [activeTab, setActiveTab] = useState<"assets" | "models">(initialTab);
+
+  /**
+   * A rejected save returns `data(error(reason))` instead of the redirect.
+   * Render the reason in the footer so a refused add states why in the dialog
+   * itself, rather than only in the SSE toast `error()` emits — that toast
+   * needs a live event stream, and the dialog stays open either way.
+   */
+  const actionData = useActionData<DataOrErrorResponse>();
+  const actionError =
+    actionData && "error" in actionData && actionData.error?.message
+      ? actionData.error.message
+      : null;
 
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
@@ -1448,10 +1467,15 @@ export default function AddAssetsToNewBooking() {
         )}
       >
         {activeTab === "assets" ? (
-          <p>
-            {hasSelectedAllItems ? totalItems : selectedBulkItemsCount} assets
-            selected
-          </p>
+          <div className="min-w-0 pr-3">
+            <p>
+              {hasSelectedAllItems ? totalItems : selectedBulkItemsCount} assets
+              selected
+            </p>
+            {actionError ? (
+              <p className="text-[12px] text-error-500">{actionError}</p>
+            ) : null}
+          </div>
         ) : null}
 
         <div className="flex gap-3">

--- a/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
+++ b/apps/webapp/app/routes/_layout+/bookings.$bookingId.overview.manage-assets.tsx
@@ -1472,8 +1472,13 @@ export default function AddAssetsToNewBooking() {
               {hasSelectedAllItems ? totalItems : selectedBulkItemsCount} assets
               selected
             </p>
+            {/* `role="alert"` is what makes a submit-time rejection audible —
+                the message appears after the user has already pressed Confirm,
+                so nothing else moves focus to it. */}
             {actionError ? (
-              <p className="text-[12px] text-error-500">{actionError}</p>
+              <p role="alert" className="text-[12px] text-error-500">
+                {actionError}
+              </p>
             ) : null}
           </div>
         ) : null}

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-assets.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-assets.test.ts
@@ -1,4 +1,4 @@
-import { AssetStatus, BookingStatus } from "@prisma/client";
+import { AssetStatus, AssetType, BookingStatus } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createActionArgs, createLoaderArgs } from "@mocks/remix";
 
@@ -240,7 +240,8 @@ describe("manage-assets route validation", () => {
 
       // Should return error response for checked out assets
       assertIsDataWithResponseInit(response);
-      expect(response.init?.status).toBe(500);
+      // 400: a refused add is a client error, not a server fault.
+      expect(response.init?.status).toBe(400);
 
       // Should only validate newly added assets (asset3, asset4).
       // Phase 3c added bookingStatus as the 3rd arg so the helper can
@@ -389,7 +390,8 @@ describe("manage-assets route validation", () => {
       );
 
       assertIsDataWithResponseInit(response);
-      expect(response.init?.status).toBe(500);
+      // 400: a refused add is a client error, not a server fault.
+      expect(response.init?.status).toBe(400);
     });
 
     it("should allow available assets regardless of partial check-in status", async () => {
@@ -502,7 +504,8 @@ describe("manage-assets route validation", () => {
       );
 
       assertIsDataWithResponseInit(response);
-      expect(response.init?.status).toBe(500);
+      // 400: a refused add is a client error, not a server fault.
+      expect(response.init?.status).toBe(400);
     });
 
     it("should validate for OVERDUE bookings", async () => {
@@ -544,7 +547,59 @@ describe("manage-assets route validation", () => {
       );
 
       assertIsDataWithResponseInit(response);
-      expect(response.init?.status).toBe(500);
+      // 400: a refused add is a client error, not a server fault.
+      expect(response.init?.status).toBe(400);
+    });
+  });
+
+  describe("quantity-tracked assets are not judged by the row-level flag", () => {
+    /**
+     * `Asset.status` is one flag over the whole row, so a 27-unit pool with 18
+     * units out on other bookings reads CHECKED_OUT while 9 units are free.
+     * The loader lists a qty asset only while its `bookable` pool is above
+     * zero, so the row-level guard must not refuse what the picker offers —
+     * per-unit capacity is `assertAssetQuantitiesAvailable`'s job inside
+     * `updateBookingAssets`.
+     */
+    it("scopes the checked-out query to INDIVIDUAL assets", async () => {
+      const ongoingBooking = { ...mockBooking, status: BookingStatus.ONGOING };
+
+      vi.mocked(httpServer.parseData).mockReturnValue({
+        assetIds: ["asset1", "asset2", "qty-asset"],
+        removedAssetIds: [],
+        redirectTo: null,
+      });
+      vi.mocked(db.booking.findUniqueOrThrow).mockResolvedValue(ongoingBooking);
+      // The guard's query returns nothing because the qty row is filtered out
+      // by `type` in the WHERE clause asserted below.
+      vi.mocked(db.asset.findMany).mockResolvedValue([]);
+      vi.mocked(bookingAssets.isAssetPartiallyCheckedIn).mockReturnValue(false);
+
+      const response = await action(
+        createActionArgs({
+          context: mockContext,
+          request: mockRequest,
+          params: mockParams,
+        })
+      );
+
+      // The add goes through — a redirect, not an error payload.
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status).toBe(302);
+
+      expect(db.asset.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: { in: ["qty-asset"] },
+            organizationId: "org123",
+            status: AssetStatus.CHECKED_OUT,
+            type: AssetType.INDIVIDUAL,
+          }),
+        })
+      );
+      expect(bookingService.updateBookingAssets).toHaveBeenCalledWith(
+        expect.objectContaining({ assetIds: ["qty-asset"] })
+      );
     });
   });
 
@@ -777,7 +832,8 @@ describe("manage-assets route validation", () => {
       );
 
       assertIsDataWithResponseInit(response);
-      expect(response.init?.status).toBe(500);
+      // 400: a refused add is a client error, not a server fault.
+      expect(response.init?.status).toBe(400);
     });
   });
 

--- a/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-assets.test.ts
+++ b/apps/webapp/test/routes-tests/_layout+/bookings.$bookingId.overview.manage-assets.test.ts
@@ -564,15 +564,23 @@ describe("manage-assets route validation", () => {
     it("scopes the checked-out query to INDIVIDUAL assets", async () => {
       const ongoingBooking = { ...mockBooking, status: BookingStatus.ONGOING };
 
+      // why: the action reads its asset list from the parsed form body; this
+      // supplies one NEW qty asset alongside two already on the booking, which
+      // is what narrows the guard's query to `["qty-asset"]`.
       vi.mocked(httpServer.parseData).mockReturnValue({
         assetIds: ["asset1", "asset2", "qty-asset"],
         removedAssetIds: [],
         redirectTo: null,
       });
+      // why: the guard only runs for ONGOING/OVERDUE bookings, so the booking
+      // read has to return an ONGOING one for this case to exercise it at all.
       vi.mocked(db.booking.findUniqueOrThrow).mockResolvedValue(ongoingBooking);
-      // The guard's query returns nothing because the qty row is filtered out
-      // by `type` in the WHERE clause asserted below.
+      // why: stands in for the guard's checked-out query. It returns nothing
+      // because the qty row is filtered out by `type` in the WHERE clause
+      // asserted below — the real query is the assertion, not this value.
       vi.mocked(db.asset.findMany).mockResolvedValue([]);
+      // why: the partial-check-in helper is exercised by its own tests; pinning
+      // it false keeps this case about the `type` predicate alone.
       vi.mocked(bookingAssets.isAssetPartiallyCheckedIn).mockReturnValue(false);
 
       const response = await action(


### PR DESCRIPTION
## Problem

A `QUANTITY_TRACKED` asset cannot be added to an ONGOING/OVERDUE booking whenever **any** unit of it is out anywhere, even when the rest of the pool is free.

`Asset.status` is a single flag over the whole row: a 27-unit pool with 18 units out on other bookings reads `CHECKED_OUT` while 9 units are free. The add-to-booking guards match on that flag, so

- the picker lists the asset — its loader lists a qty asset only while `bookable > 0`, and labels it "9 available",
- the save is refused with *"The following assets are already checked out and cannot be added to the booking"*,
- and the refusal answers **500**, because the `ShelfError` carries no status.

Three surfaces carry the same asset-grain rule:

| Surface | Guard |
| --- | --- |
| Booking → Manage assets | action in `bookings.$bookingId.overview.manage-assets.tsx` |
| Asset → Add to existing booking; assets-index bulk add | `processBooking` |
| Booking → Scan assets drawer | client blocker in `add-assets-to-booking-drawer.tsx` |

The scanner's **server** path was already qty-aware (`hasAssetBookingConflicts` returns `false` for `QUANTITY_TRACKED`), so its drawer was blocking a submit the server would have accepted.

## Change

- One shared `buildAddToActiveBookingBlockerWhere` in `modules/booking/helpers.ts`; both server guards read through it, and it narrows to `type: INDIVIDUAL`.
- Per-unit capacity for qty assets is untouched and still enforced by `assertAssetQuantitiesAvailable` inside `updateBookingAssets` — windowed, under `lockAssetForQuantityUpdate`.
- Scanner drawer: the "Already checked out" badge and blocker are INDIVIDUAL-only. Qty rows get a "No units available" badge/blocker keyed on `pickerMeta.maxAllowed <= 0`, the same pool the row's qty input is capped at, so a fully allocated pool is still stopped before submit.
- The manage-assets refusal answers **400**, and the dialog renders `actionData.error.message` in its footer. `error()`'s toast rides an SSE stream; the dialog stays open either way, so the reason now lives where the action happened.

## Verification

Local dev server against the shared QA database. Fixture: a `QUANTITY_TRACKED` asset, 29 units, 20 in custody, 5 reserved on another (OVERDUE) booking → row status `CHECKED_OUT`, 4 units bookable.

**Booking → Manage assets, ONGOING target**

| | before (`origin/main` files restored) | after |
| --- | --- | --- |
| picker row | `Qty tracked · 4 available` | unchanged |
| `POST …/manage-assets.data` | **500** | **202** (redirect) |
| outcome | "Not allowed. Assets already checked out"; nothing added | `BookingAsset` written, `quantity: 3`, `checkedOutQuantity: 0` |

**Asset → Add to existing booking, OVERDUE target** — `POST` → 202, row written with the submitted quantity; the asset page's Quantity Overview then reads `Available 0 pcs`, `Checked out (bookings) 9 pcs`.

**Booking → Scan assets drawer, OVERDUE target**, same asset scanned by QR

| | before | after |
| --- | --- | --- |
| row | `29 pcs · 9 available` **+ red "Already checked out"** | `29 pcs · 9 available` |
| blockers | `Unresolved blockers (1) — 1 asset is already checked out` | none |
| Confirm | disabled | enabled |

Test rows and notes were removed afterwards; the fixture is back to its original single `BookingAsset` row.

## Tests

- `modules/booking/helpers.test.ts` — the shared `where` narrows to INDIVIDUAL.
- `modules/booking/service.server.test.ts` — `processBooking` lets a partly-dispatched qty pool through, and still blocks a checked-out INDIVIDUAL asset submitted alongside it.
- `test/routes-tests/…/manage-assets.test.ts` — the route's checked-out query is scoped to INDIVIDUAL and the add redirects; the five existing guard cases now assert 400.

Each new test fails against the pre-fix code (verified by removing the type predicate and re-running).

## Follow-ups, deliberately not here

- **Companion.** `apps/companion/lib/batch-blockers.ts` mirrors the same asset-grain rule for `booking_add`. Fixing it needs the scanned asset's `type` plumbed into `BlockableItem`, and #2992 is open on the same companion booking-quantity area — it belongs on top of that, riding the same OTA.
- **Row badge.** A qty asset added to an ONGOING booking shows "Checked out" on the booking row, because the badge reads the asset's global status rather than this booking's slice. Pre-existing and tracked separately; not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Quantity-tracked assets can now be added to active bookings when units remain available, even if some units are checked out.
  - Individual assets that are already checked out remain blocked from being added.
  - Availability indicators now distinguish exhausted quantity pools from checked-out individual assets.
  - Booking asset updates provide clearer rejection feedback, including errors displayed in the assets footer.
  - Availability calculations now more accurately reflect booking windows and remaining capacity.

- **Tests**
  - Added coverage for mixed individual and quantity-tracked asset booking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->