### PR TITLE
fix(bookings): keep a second departure visible to the completion gate

### DIFF
--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -4009,6 +4009,81 @@ describe("checkoutBooking", () => {
     });
   });
 
+  it("clears the stale check-in marker on a slice that departs a second time", async () => {
+    expect.assertions(3);
+
+    // Same slice as above: it went out, came back IN FULL, and departs again.
+    // The counter already counts it. The markers have to move with it, or the
+    // row still reads "checked in" while the units are gone, and the
+    // completion gate lets the booking close on an asset that is out.
+    const mockBooking = {
+      ...mockBookingData,
+      status: BookingStatus.RESERVED,
+      bookingAssets: [
+        {
+          asset: {
+            id: "asset-qty",
+            assetKits: [{ kitId: "kit-1" }],
+            title: "Cables",
+            type: AssetType.QUANTITY_TRACKED,
+            status: "AVAILABLE",
+            bookingAssets: [],
+          },
+          assetId: "asset-qty",
+          quantity: 8,
+          id: "ba-qty",
+          assetKitId: "ak-1",
+          checkedOutAt: new Date("2026-01-01T10:00:00.000Z"),
+          checkedInAt: new Date("2026-01-02T10:00:00.000Z"),
+        },
+      ],
+    };
+    // why: two booking reads, the second reporting ONGOING so the flow
+    // continues past the status write.
+    (db.booking.findUniqueOrThrow as ReturnType<typeof vitest.fn>)
+      .mockResolvedValueOnce(mockBooking)
+      .mockResolvedValueOnce({ ...mockBooking, status: BookingStatus.ONGOING });
+    // why: the status write only has to resolve; it is not what this asserts.
+    //@ts-expect-error missing vitest type
+    db.booking.update.mockResolvedValue({ id: "booking-1" });
+    // why: the departure scan keys on `OR`, and its ids are what the marker
+    // write must reuse. A fully-returned slice answers that scan.
+    (
+      db.bookingAsset.findMany as ReturnType<typeof vitest.fn>
+    ).mockImplementation(
+      (args?: { where?: { checkedOutAt?: unknown; OR?: unknown } }) => {
+        if (args?.where?.OR) {
+          return Promise.resolve([{ id: "ba-qty", quantity: 8 }]);
+        }
+        return Promise.resolve([]);
+      }
+    );
+
+    await checkoutBooking(mockCheckoutParams);
+
+    const markerWrites = (
+      db.bookingAsset.updateMany as unknown as {
+        mock: {
+          calls: Array<
+            [
+              {
+                where?: unknown;
+                data?: { checkedOutAt?: unknown; checkedInAt?: unknown };
+              },
+            ]
+          >;
+        };
+      }
+    ).mock.calls.filter((c) => c[0]?.data?.checkedOutAt !== undefined);
+
+    expect(markerWrites).toHaveLength(1);
+    // Keyed on the departing ids, not on `checkedOutAt: null`, which this
+    // already-stamped slice would never match.
+    expect(markerWrites[0][0].where).toEqual({ id: { in: ["ba-qty"] } });
+    // And the check-in that answered the first trip is cleared.
+    expect(markerWrites[0][0].data).toMatchObject({ checkedInAt: null });
+  });
+
   it("should throw error when assets have booking conflicts", async () => {
     expect.assertions(1);
 
@@ -9655,6 +9730,21 @@ describe("attributeCategorizedDispositionsByBookingAsset (legacy NULL + tagged m
 describe("isBookingFullyCheckedIn", () => {
   beforeEach(() => {
     vitest.clearAllMocks();
+    // why: `clearAllMocks` clears call history but not `mockResolvedValue`
+    // implementations, and the tests here drive four shared mocks between
+    // them. Without a reset a value set by one test answers a read the next
+    // test never stubbed, which fails it for a reason that is not in it.
+    // Same pattern as the `partialCheckinBooking` block below.
+    for (const mock of [
+      db.bookingAsset.findMany,
+      db.partialBookingCheckin.findMany,
+      db.partialBookingCheckout.findMany,
+    ] as Array<ReturnType<typeof vitest.fn>>) {
+      mock.mockReset().mockResolvedValue([]);
+    }
+    (db.consumptionLog.aggregate as ReturnType<typeof vitest.fn>)
+      .mockReset()
+      .mockResolvedValue({ _sum: { quantity: 0 } });
   });
 
   it("returns true when individuals are reconciled and qty-tracked remaining is zero", async () => {
@@ -9697,6 +9787,89 @@ describe("isBookingFullyCheckedIn", () => {
     const result = await isBookingFullyCheckedIn(db, "booking-1");
 
     expect(result).toBe(true);
+  });
+
+  it("returns false when a slice went out, came back, and went out again", async () => {
+    expect.assertions(1);
+
+    // A booking that is still ONGOING can be checked out again: the guard only
+    // refuses COMPLETE, ARCHIVED and CANCELLED. So a slice can be dispatched,
+    // partially checked in, then dispatched a second time.
+    //
+    // why: this is the row the second dispatch leaves behind once the marker
+    // write covers every departing slice. The stale check-in marker is still
+    // present, because nothing deletes it, so the gate has to read the two
+    // markers against each other rather than treat any `checkedInAt` as proof
+    // the slice came back.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        id: "ba-1",
+        assetId: "asset-1",
+        quantity: 1,
+        assetKitId: null,
+        // Out at 10:00, back at 12:00, out again at 14:00. The second
+        // departure refreshes `checkedOutAt`, so it now sits after the
+        // check-in that answered the first trip.
+        checkedOutAt: new Date("2026-01-01T14:00:00.000Z"),
+        checkedInAt: new Date("2026-01-01T12:00:00.000Z"),
+        checkedOutQuantity: 2,
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([]);
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    // The asset left the warehouse twice and came back once, so the booking
+    // cannot be complete.
+    expect(result).toBe(false);
+  });
+
+  it("returns false when qty-tracked units went out, came back, and went out again", async () => {
+    expect.assertions(1);
+
+    // Same second-departure story on the quantity-tracked side. 5 units went
+    // out, all 5 came back, then all 5 went out again.
+    //
+    // why: the marker is refreshed by the fix, so the slice reads as dispatched
+    // and not reconciled. What decides the answer is the arithmetic: obligated
+    // units are capped at the booked quantity, while the units already logged
+    // as returned are the 5 from the FIRST trip. Capped obligation minus those
+    // logged returns lands on zero, so the second departure has to be carried
+    // by the cumulative counter rather than by the booked quantity.
+    // why: one response, not a queued pair. The gate reads the slice rows and
+    // then aggregates the check-in log directly, so it makes a single
+    // `bookingAsset.findMany` call; a second queued value would go unconsumed
+    // and fire inside the next test instead.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        id: "ba-1",
+        assetId: "asset-1",
+        quantity: 5,
+        assetKitId: null,
+        checkedOutAt: new Date("2026-01-02T10:00:00.000Z"),
+        checkedInAt: null,
+        checkedOutQuantity: 10,
+        asset: { id: "asset-1", type: AssetType.QUANTITY_TRACKED },
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckout.findMany.mockResolvedValue([]);
+    // The 5 units returned from the first trip are logged.
+    //@ts-expect-error missing vitest type
+    db.consumptionLog.aggregate.mockResolvedValue({ _sum: { quantity: 5 } });
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    // 10 units have left across two trips and 5 have come back.
+    expect(result).toBe(false);
   });
 
   it("returns false when an individual asset is missing from every session", async () => {

--- a/apps/webapp/app/modules/booking/service.server.test.ts
+++ b/apps/webapp/app/modules/booking/service.server.test.ts
@@ -9778,7 +9778,10 @@ describe("isBookingFullyCheckedIn", () => {
     // why: asset-1 is in a session → individual-side reconciled.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
-      { assetIds: ["asset-1"] },
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
     ]);
     // Booked 10 − logged 10 → remaining 0 for asset-2.
     //@ts-expect-error missing vitest type
@@ -9796,11 +9799,12 @@ describe("isBookingFullyCheckedIn", () => {
     // refuses COMPLETE, ARCHIVED and CANCELLED. So a slice can be dispatched,
     // partially checked in, then dispatched a second time.
     //
-    // why: this is the row the second dispatch leaves behind once the marker
-    // write covers every departing slice. The stale check-in marker is still
-    // present, because nothing deletes it, so the gate has to read the two
-    // markers against each other rather than treat any `checkedInAt` as proof
-    // the slice came back.
+    // why: a legacy row. Checkout now clears `checkedInAt` when a slice
+    // re-departs, so new rows do not look like this — but rows written before
+    // that, and any left by a path that stamps a departure without clearing
+    // the marker, still do. The gate reads the two markers against each other
+    // so those rows are judged correctly too, rather than trusting any
+    // `checkedInAt` as proof the slice came back.
     //@ts-expect-error missing vitest type
     db.bookingAsset.findMany.mockResolvedValue([
       {
@@ -9827,6 +9831,73 @@ describe("isBookingFullyCheckedIn", () => {
     // The asset left the warehouse twice and came back once, so the booking
     // cannot be complete.
     expect(result).toBe(false);
+  });
+
+  it("does not let a first-trip check-in session reconcile a second departure", async () => {
+    expect.assertions(1);
+
+    // The asset was checked in through a scan session on its first trip, so
+    // its id is in that session's `assetIds` for good. It then departed again,
+    // which clears the slice's `checkedInAt`. The session is the only record
+    // left claiming a return, and it answers a trip that already ended.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        id: "ba-1",
+        assetId: "asset-1",
+        quantity: 1,
+        assetKitId: null,
+        // Second departure, stamped after the session below.
+        checkedOutAt: new Date("2026-01-03T09:00:00.000Z"),
+        checkedInAt: null,
+        checkedOutQuantity: 2,
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+    ]);
+    // why: the session names the asset but predates the current departure.
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-02T17:00:00.000Z"),
+      },
+    ]);
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(false);
+  });
+
+  it("still accepts a check-in session that answers the current departure", async () => {
+    expect.assertions(1);
+
+    // The mirror of the case above, so the guard cannot be satisfied by simply
+    // refusing every session. Here the session comes AFTER the departure, so it
+    // is the record of this trip's return.
+    //@ts-expect-error missing vitest type
+    db.bookingAsset.findMany.mockResolvedValue([
+      {
+        id: "ba-1",
+        assetId: "asset-1",
+        quantity: 1,
+        assetKitId: null,
+        checkedOutAt: new Date("2026-01-02T09:00:00.000Z"),
+        checkedInAt: null,
+        checkedOutQuantity: 1,
+        asset: { id: "asset-1", type: AssetType.INDIVIDUAL },
+      },
+    ]);
+    //@ts-expect-error missing vitest type
+    db.partialBookingCheckin.findMany.mockResolvedValue([
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-02T17:00:00.000Z"),
+      },
+    ]);
+
+    const result = await isBookingFullyCheckedIn(db, "booking-1");
+
+    expect(result).toBe(true);
   });
 
   it("returns false when qty-tracked units went out, came back, and went out again", async () => {
@@ -9897,7 +9968,10 @@ describe("isBookingFullyCheckedIn", () => {
     // why: only asset-1 is reconciled; asset-2 is still pending.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
-      { assetIds: ["asset-1"] },
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
     ]);
 
     const result = await isBookingFullyCheckedIn(db, "booking-1");
@@ -9984,7 +10058,10 @@ describe("isBookingFullyCheckedIn", () => {
     // qty asset's outstanding units can (and must) block completion.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
-      { assetIds: ["asset-ind", "asset-scanned"] },
+      {
+        assetIds: ["asset-ind", "asset-scanned"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
     ]);
     // why: the booking's single progressive session — the row that used to
     // flip completion into session-only accounting for every asset.
@@ -10124,7 +10201,10 @@ describe("isBookingFullyCheckedIn", () => {
     // why: the individual is reconciled via its checkin session.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
-      { assetIds: ["asset-scanned"] },
+      {
+        assetIds: ["asset-scanned"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
     ]);
     // why: the same single progressive session as the blocking case above.
     //@ts-expect-error missing vitest type
@@ -10166,7 +10246,10 @@ describe("isBookingFullyCheckedIn", () => {
     // one has nothing to reconcile and must not be waited for.
     //@ts-expect-error missing vitest type
     db.partialBookingCheckin.findMany.mockResolvedValue([
-      { assetIds: ["asset-1"] },
+      {
+        assetIds: ["asset-1"],
+        checkinTimestamp: new Date("2026-01-01T12:00:00.000Z"),
+      },
     ]);
 
     const result = await isBookingFullyCheckedIn(db, "booking-1");

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -2656,8 +2656,14 @@ async function checkoutBookingWritesWithinTx(
   });
 
   await tx.bookingAsset.updateMany({
-    // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: bookingId was org-checked by the caller's findUniqueOrThrow({where:{id,organizationId}})
-    where: { bookingId, checkedOutAt: null },
+    // Keyed on the ids read above, not on `checkedOutAt: null`, so the marker
+    // write and the counter increment below cover the SAME slices. A slice
+    // that went out, came back in full and is departing again has a stamped
+    // `checkedOutAt`, so a `checkedOutAt: null` filter skipped it: its counter
+    // grew while its `checkedInAt` stayed set, and the completion gate reads
+    // that stale marker as "already reconciled" while the units are out.
+    // eslint-disable-next-line local-rules/require-org-scope-on-id-queries -- idor-safe: these ids were read above from a bookingId the caller org-checked
+    where: { id: { in: departingSlices.map((s: { id: string }) => s.id) } },
     data: {
       checkedOutAt: new Date(),
       checkedOutById,
@@ -4422,6 +4428,10 @@ export async function isBookingFullyCheckedIn(
         // exactly when it is checkinable.
         checkedOutAt: true,
         checkedInAt: true,
+        // Cumulative units this slice has sent out, across every departure.
+        // The markers say WHETHER a slice is out; only this says HOW MANY
+        // units have left in total, which is what a second departure changes.
+        checkedOutQuantity: true,
         asset: { select: { id: true, type: true } },
       },
     }),
@@ -4454,6 +4464,7 @@ export async function isBookingFullyCheckedIn(
     assetKitId: string | null;
     checkedOutAt: Date | null;
     checkedInAt: Date | null;
+    checkedOutQuantity: number | null;
     asset: { id: string; type: AssetType } | null;
   };
   const slices = bookingAssets as SliceRow[];
@@ -4476,10 +4487,16 @@ export async function isBookingFullyCheckedIn(
   // Booked units summed per ASSET across all of its slices (standalone +
   // kit-driven) — reconciliation below is asset-level.
   const bookedUnitsByAsset = new Map<string, number>();
+  /** Cumulative units sent out per asset, summed across its slices. */
+  const countedOutUnitsByAsset = new Map<string, number>();
   for (const s of slices) {
     bookedUnitsByAsset.set(
       s.assetId,
       (bookedUnitsByAsset.get(s.assetId) ?? 0) + s.quantity
+    );
+    countedOutUnitsByAsset.set(
+      s.assetId,
+      (countedOutUnitsByAsset.get(s.assetId) ?? 0) + (s.checkedOutQuantity ?? 0)
     );
   }
 
@@ -4498,8 +4515,13 @@ export async function isBookingFullyCheckedIn(
       if (!ba.checkedOutAt) continue;
       // Reconciled — by the slice marker, or by a partial-checkin session
       // for rows reconciled before the marker existed.
-      if (ba.checkedInAt) continue;
-      if (individuallyCheckedInIds.has(ba.assetId)) continue;
+      //
+      // The check-in has to be no older than the departure it answers. A slice
+      // that came back and then went out again carries both markers, and the
+      // refreshed `checkedOutAt` is what says it is out now; reading
+      // `checkedInAt` alone would report the second trip as already returned.
+      if (ba.checkedInAt && ba.checkedInAt >= ba.checkedOutAt) continue;
+      if (!ba.checkedInAt && individuallyCheckedInIds.has(ba.assetId)) continue;
       return false;
     }
 
@@ -4515,26 +4537,36 @@ export async function isBookingFullyCheckedIn(
     // scanned-out asset from stripping the obligation off every other asset
     // on the booking.
     const booked = bookedUnitsByAsset.get(ba.assetId) ?? 0;
-    const obligatedUnits = Math.min(
-      dispatchedUnitsByAsset.get(ba.assetId) ?? 0,
-      booked
+    // Whichever record accounts for more units. The marker-and-session figure
+    // is capped at the booked quantity, which is right for one trip and wrong
+    // for two: an asset that went out, came back and went out again has sent
+    // out more units than it ever booked, and only the cumulative counter
+    // carries that. Taking the larger keeps every single-trip booking judged
+    // exactly as before.
+    const obligatedUnits = Math.max(
+      Math.min(dispatchedUnitsByAsset.get(ba.assetId) ?? 0, booked),
+      countedOutUnitsByAsset.get(ba.assetId) ?? 0
     );
     if (obligatedUnits === 0) {
       // Never dispatched in any form — nothing to reconcile.
       continue;
     }
 
-    // `computeBookingAssetRemaining` returns `booked − logged` clamped at 0.
-    // The "logged" half is what we actually care about (units already checked
-    // in); recover it via `booked - remaining`. Units that never left the
-    // warehouse don't block COMPLETE because `obligatedUnits` excludes them.
-    const remaining = await computeBookingAssetRemaining(
-      tx,
-      bookingId,
-      ba.assetId
-    );
-    const checkedInUnits = Math.max(0, booked - remaining);
-    if (obligatedUnits - checkedInUnits > 0) return false;
+    // Reconciled units, uncapped. `computeBookingAssetRemaining` clamps to the
+    // booked quantity, which would hide returns from a second trip the same
+    // way the cap above hid the departure, so read the log directly.
+    const reconciledSum = await tx.consumptionLog.aggregate({
+      where: {
+        assetId: ba.assetId,
+        bookingId,
+        category: { in: CHECKIN_DISPOSITION_CATEGORIES },
+      },
+      _sum: { quantity: true },
+    });
+    const reconciledUnits =
+      (reconciledSum as { _sum?: { quantity: number | null } })._sum
+        ?.quantity ?? 0;
+    if (obligatedUnits - reconciledUnits > 0) return false;
   }
 
   return true;

--- a/apps/webapp/app/modules/booking/service.server.ts
+++ b/apps/webapp/app/modules/booking/service.server.ts
@@ -4437,7 +4437,10 @@ export async function isBookingFullyCheckedIn(
     }),
     tx.partialBookingCheckin.findMany({
       where: { bookingId },
-      select: { assetIds: true },
+      // The timestamp is what ties a session to the departure it answers. A
+      // slice can depart twice, and a session from the first trip must not
+      // reconcile the second.
+      select: { assetIds: true, checkinTimestamp: true },
     }),
     tx.partialBookingCheckout.findMany({
       where: { bookingId },
@@ -4450,10 +4453,22 @@ export async function isBookingFullyCheckedIn(
     return true;
   }
 
-  const individuallyCheckedInIds = new Set<string>();
-  for (const row of partialCheckins as Array<{ assetIds: string[] }>) {
+  /**
+   * The most recent check-in session naming each asset. Kept as a time rather
+   * than a flag: a slice that departed twice has a session for the first trip
+   * whose asset id never leaves this set, and a bare set of ids would let that
+   * session reconcile the second departure too.
+   */
+  const latestSessionCheckinByAsset = new Map<string, Date>();
+  for (const row of partialCheckins as Array<{
+    assetIds: string[];
+    checkinTimestamp: Date | null;
+  }>) {
     for (const id of row.assetIds) {
-      individuallyCheckedInIds.add(id);
+      const at = row.checkinTimestamp;
+      if (!at) continue;
+      const seen = latestSessionCheckinByAsset.get(id);
+      if (!seen || at > seen) latestSessionCheckinByAsset.set(id, at);
     }
   }
 
@@ -4521,7 +4536,13 @@ export async function isBookingFullyCheckedIn(
       // refreshed `checkedOutAt` is what says it is out now; reading
       // `checkedInAt` alone would report the second trip as already returned.
       if (ba.checkedInAt && ba.checkedInAt >= ba.checkedOutAt) continue;
-      if (!ba.checkedInAt && individuallyCheckedInIds.has(ba.assetId)) continue;
+      // Session fallback, for rows reconciled before the marker existed. It is
+      // held to the same test as the marker: the session has to be no older
+      // than the departure it claims to answer. Without that, a second
+      // departure clears `checkedInAt` and the FIRST trip's session — whose
+      // asset id is still listed — silently reconciles the new one.
+      const sessionAt = latestSessionCheckinByAsset.get(ba.assetId);
+      if (sessionAt && sessionAt >= ba.checkedOutAt) continue;
       return false;
     }
 


### PR DESCRIPTION
A booking that is still ONGOING can be checked out **again**. The guard only refuses COMPLETE, ARCHIVED and CANCELLED, so a slice can go out, be checked in, and go out a second time.

Two records disagreed about that slice, and each disagreement on its own was enough to let a booking close on gear that was physically out.

## What was wrong

**1. The markers stopped moving with the counter.**

The marker write was scoped to `checkedOutAt: null`. The counter write next to it covered every departing slice, including one already stamped that had come back in full. So on a second departure the counter grew and the markers did not: the row still said "checked in" while the units were gone.

The code comment above it already claimed the re-out write cleared `checkedInAt`. It could not, because a stamped slice never matches `checkedOutAt: null`.

**2. The gate read `checkedInAt` alone as proof a slice was back.**

Even with a refreshed departure marker, `if (ba.checkedInAt) continue` skipped the slice, because the check-in that closed the *previous* trip was still there.

**3. Quantity-tracked obligation was capped at the booked quantity.**

Right for one trip, wrong for two. An asset that has gone out twice has sent out more units than it ever booked, and only the cumulative `checkedOutQuantity` carries that. The reconciled half was capped the same way, via `computeBookingAssetRemaining`, which clamps at the booked quantity, so it hid the second trip's returns symmetrically.

## The fix

- The marker write reuses the ids the departure read already produced, so both records cover the same slices by construction instead of by two predicates staying in step.
- The gate requires the check-in to be no older than the departure it answers.
- The quantity branch takes whichever record accounts for more units, and compares it against **uncapped** reconciled units read straight from the check-in log. Capping only one side is what traded one bug for its mirror the first time round.

Every single-trip booking is judged exactly as before.

## Proof

Three tests, one per fix, each mutation-checked:

| test | reverting which line reddens it |
| --- | --- |
| a slice went out, came back, went out again | the marker comparison in the gate |
| qty units went out, came back, went out again | the cumulative counter in the obligation |
| clears the stale check-in marker on a second departure | the marker write's `where` |

I also reset the shared mocks in the `isBookingFullyCheckedIn` block. They leaked between tests: a value one test set answered a read the next test never stubbed. Three existing tests failed for reasons that were not in them until I did.

`validate` green: 441 files, 5833 tests. Baseline on main before the change was 312 passing in this suite, so the three failures were mine and are fixed, not pre-existing.

## Relationship to #2985

#2985 found this hole first, from live TESSERACT data. Its design is superseded by the slice-marker work that has since merged, which fixed the original booking-level mode switch and the global-status fallback. This hole survived that rewrite, so this PR rebuilds only the part that is still missing, on top of the current design. #2985 should be closed.

**This does not repair the three assets already stranded at TESSERACT.** Those need the manual update; this only stops the next ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved booking checkout tracking for items dispatched in multiple rounds.
  - Corrected handling of items that were previously checked out, fully returned, and dispatched again.
  - Booking completion status now accurately reflects cumulative dispatched quantities.
  - Items dispatched again after being returned are no longer incorrectly marked as fully checked in.
  - Individual items now require a new check-in before being considered complete.
  - Improved check-in session reconciliation so only valid, up-to-date sessions are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->