### PR TITLE
fix(companion): honour the workspace booking-visibility overrides on mobile

### DIFF
--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -10,6 +10,11 @@ import {
   type AssetImageSource,
 } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
+import {
+  isSelfServiceOrBaseRole,
+  resolveCanSeeAllBookings,
+  resolveMostPrivilegedRole,
+} from "~/utils/booking-authorization.server";
 import { ShelfError } from "~/utils/error";
 import {
   type PermissionAction,
@@ -304,9 +309,22 @@ export async function getMobileUserContext(
    * `resolveMostPrivilegedRole`.
    */
   roles: OrganizationRoles[];
+  /**
+   * The most privileged role on this membership, and the only one any gate
+   * here should read. `role` above is `roles[0]`.
+   */
+  effectiveRole: OrganizationRoles;
+  /** `effectiveRole` is SELF_SERVICE or BASE. */
+  isSelfServiceOrBase: boolean;
   canUseBarcodes: boolean;
   canUseAudits: boolean;
   canSeeAllCustody: boolean;
+  /**
+   * Whether the caller may READ bookings they are not the custodian of.
+   * Never widens a mutation: writes stay on `validateBookingOwnership` and
+   * the role's permission grant.
+   */
+  canSeeAllBookings: boolean;
 }> {
   const userOrg = await db.userOrganization.findUnique({
     where: { userId_organizationId: { userId, organizationId } },
@@ -321,6 +339,12 @@ export async function getMobileUserContext(
           // here keeps it one query alongside the role.
           selfServiceCanSeeCustody: true,
           baseUserCanSeeCustody: true,
+          // why: the booking twins of the two custody flags above. Every
+          // mobile booking read - list, calendar, detail, dashboard - takes
+          // its visibility answer from this row, so the columns have to be
+          // here for the workspace setting to reach them at all.
+          selfServiceCanSeeBookings: true,
+          baseUserCanSeeBookings: true,
         },
       },
     },
@@ -340,14 +364,26 @@ export async function getMobileUserContext(
   // an empty array doesn't surface as `undefined` to downstream callers.
   const role = userOrg.roles[0] ?? OrganizationRoles.BASE;
 
+  // why: gates read the most privileged role, never roles[0]. A membership
+  // ordered [SELF_SERVICE, ADMIN] reads as SELF_SERVICE by position, which
+  // refuses a genuine admin. `role` keeps the positional value for the callers
+  // that still read it.
+  const effectiveRole = resolveMostPrivilegedRole(userOrg.roles);
+
   return {
     role,
     roles: userOrg.roles,
+    effectiveRole,
+    isSelfServiceOrBase: isSelfServiceOrBaseRole(effectiveRole),
     canUseBarcodes: canUseBarcodes(userOrg.organization),
     canUseAudits: canUseAudits(userOrg.organization),
     canSeeAllCustody: computeCanSeeAllCustody({
-      role,
+      role: effectiveRole,
       organization: userOrg.organization,
+    }),
+    canSeeAllBookings: resolveCanSeeAllBookings({
+      role: effectiveRole,
+      currentOrganization: userOrg.organization,
     }),
   };
 }

--- a/apps/webapp/app/modules/api/mobile-auth.server.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.ts
@@ -283,18 +283,28 @@ export async function requireMobilePermission({
 }
 
 /**
- * Fetches the user's role and org capability flags (barcodes, audits) for
- * a given organization. `canUseAudits`/`canUseBarcodes` reuse the canonical
- * subscription.server predicates so mobile matches webapp gating exactly.
+ * Fetches the caller's roles and the org capability and visibility flags that
+ * every mobile route gates on. `canUseAudits`/`canUseBarcodes` reuse the
+ * canonical subscription.server predicates so mobile matches webapp gating
+ * exactly.
  *
- * Also returns `canSeeAllCustody` — the mobile twin of the flag the web's
- * `requirePermission` returns (roles.server.ts:113-122): ADMIN/OWNER always
- * see all custody; SELF_SERVICE/BASE only when the matching org override
- * (`selfServiceCanSeeCustody` / `baseUserCanSeeCustody`) is enabled.
+ * Two visibility answers come off the same organization row, and they are
+ * independent — a workspace may grant either without the other:
+ *
+ * - `canSeeAllBookings` — whether the caller may READ a booking they do not
+ *   hold (`selfServiceCanSeeBookings` / `baseUserCanSeeBookings`).
+ * - `canSeeAllCustody` — whether the caller may see WHO holds something
+ *   (`selfServiceCanSeeCustody` / `baseUserCanSeeCustody`).
+ *
+ * ADMIN and OWNER get both. Both are the mobile twins of the flags web's
+ * `requirePermission` returns, resolved through the same shared helpers so the
+ * two platforms cannot disagree about what a workspace has granted. Neither
+ * widens a MUTATION: writes stay on the role's permission grant plus
+ * `validateBookingOwnership`.
  *
  * Used by mobile routes that call service layer functions requiring
- * `getAssetIndexSettings` (e.g. bulkAssignCustody, bulkReleaseCustody) and
- * by routes that must gate custody visibility server-side.
+ * `getAssetIndexSettings` (e.g. bulkAssignCustody, bulkReleaseCustody) and by
+ * every route that must gate booking or custody visibility server-side.
  */
 export async function getMobileUserContext(
   userId: string,
@@ -305,8 +315,8 @@ export async function getMobileUserContext(
    * Every role on this membership. `role` is `roles[0]`, which is wrong for
    * any authorization decision: a membership ordered `[SELF_SERVICE, ADMIN]`
    * resolves to SELF_SERVICE and an actual admin gets treated as restricted.
-   * Callers making a privilege decision should use this with
-   * `resolveMostPrivilegedRole`.
+   * Read `effectiveRole` for a privilege decision; this array is for callers
+   * that pass the whole membership on, such as `hasPermission`.
    */
   roles: OrganizationRoles[];
   /**

--- a/apps/webapp/app/modules/api/mobile-auth.server.visibility.test.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.visibility.test.ts
@@ -73,14 +73,20 @@ describe("getMobileUserContext — booking visibility", () => {
 
     await getMobileUserContext("user-1", "org-1");
 
-    const select = (findUnique.mock.calls[0]?.[0] as any).select.organization
-      .select;
-    expect(select).toMatchObject({
-      selfServiceCanSeeBookings: true,
-      baseUserCanSeeBookings: true,
-      selfServiceCanSeeCustody: true,
-      baseUserCanSeeCustody: true,
-    });
+    expect(findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          organization: expect.objectContaining({
+            select: expect.objectContaining({
+              selfServiceCanSeeBookings: true,
+              baseUserCanSeeBookings: true,
+              selfServiceCanSeeCustody: true,
+              baseUserCanSeeCustody: true,
+            }),
+          }),
+        }),
+      })
+    );
   });
 
   it.each([OrganizationRoles.ADMIN, OrganizationRoles.OWNER])(

--- a/apps/webapp/app/modules/api/mobile-auth.server.visibility.test.ts
+++ b/apps/webapp/app/modules/api/mobile-auth.server.visibility.test.ts
@@ -1,0 +1,162 @@
+/**
+ * `getMobileUserContext` is the one place the mobile API learns what a caller
+ * may see. Every booking read surface on the phone — the list, the calendar,
+ * the booking detail, the Home tab — takes its answer from here.
+ *
+ * It has to select all four organization overrides. The two custody columns
+ * decide whether a custodian may be named; the two booking columns decide
+ * which bookings exist for the caller at all. A column missing from that
+ * select cannot be honoured by any endpoint downstream, however correct their
+ * own gates are.
+ *
+ * @see {@link file://./mobile-auth.server.ts} `getMobileUserContext`
+ * @see {@link file://./../../utils/booking-authorization.server.ts} `resolveCanSeeAllBookings`
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "~/database/db.server";
+import { getMobileUserContext } from "~/modules/api/mobile-auth.server";
+
+// why: the module instantiates a real Prisma client at load and would try to
+// connect; `pnpm test:run` has no database. Only the one query this function
+// makes needs to exist.
+vi.mock("~/database/db.server", () => ({
+  db: { userOrganization: { findUnique: vi.fn() } },
+}));
+
+// why: `requireMobileAuth` validates the Bearer JWT against Supabase Admin at
+// module scope. Irrelevant here, and there is no service to reach.
+vi.mock("~/integrations/supabase/client", () => ({
+  getSupabaseAdmin: vi.fn(),
+}));
+
+// why: fire-and-forget usage recorder that would touch the mocked db.
+vi.mock("./mobile-usage.server", () => ({
+  recordMobileActivity: vi.fn(),
+}));
+
+const findUnique = vi.mocked(db.userOrganization.findUnique);
+
+/** Seeds the single membership row `getMobileUserContext` reads. */
+function membership(
+  roles: OrganizationRoles[],
+  org: Partial<{
+    selfServiceCanSeeBookings: boolean;
+    baseUserCanSeeBookings: boolean;
+    selfServiceCanSeeCustody: boolean;
+    baseUserCanSeeCustody: boolean;
+  }> = {}
+) {
+  findUnique.mockResolvedValue({
+    roles,
+    organization: {
+      barcodesEnabled: false,
+      auditsEnabled: false,
+      selfServiceCanSeeCustody: false,
+      baseUserCanSeeCustody: false,
+      selfServiceCanSeeBookings: false,
+      baseUserCanSeeBookings: false,
+      ...org,
+    },
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getMobileUserContext — booking visibility", () => {
+  it("selects the two booking overrides, not just the custody pair", async () => {
+    membership([OrganizationRoles.BASE]);
+
+    await getMobileUserContext("user-1", "org-1");
+
+    const select = (findUnique.mock.calls[0]?.[0] as any).select.organization
+      .select;
+    expect(select).toMatchObject({
+      selfServiceCanSeeBookings: true,
+      baseUserCanSeeBookings: true,
+      selfServiceCanSeeCustody: true,
+      baseUserCanSeeCustody: true,
+    });
+  });
+
+  it.each([OrganizationRoles.ADMIN, OrganizationRoles.OWNER])(
+    "lets %s see every booking regardless of the overrides",
+    async (role) => {
+      membership([role]);
+
+      const ctx = await getMobileUserContext("user-1", "org-1");
+
+      expect(ctx.canSeeAllBookings).toBe(true);
+      expect(ctx.isSelfServiceOrBase).toBe(false);
+    }
+  );
+
+  it.each([OrganizationRoles.BASE, OrganizationRoles.SELF_SERVICE])(
+    "restricts %s while the matching override is off",
+    async (role) => {
+      membership([role]);
+
+      const ctx = await getMobileUserContext("user-1", "org-1");
+
+      expect(ctx.canSeeAllBookings).toBe(false);
+      expect(ctx.isSelfServiceOrBase).toBe(true);
+    }
+  );
+
+  it("frees a BASE user when baseUserCanSeeBookings is on", async () => {
+    membership([OrganizationRoles.BASE], { baseUserCanSeeBookings: true });
+
+    const ctx = await getMobileUserContext("user-1", "org-1");
+
+    expect(ctx.canSeeAllBookings).toBe(true);
+  });
+
+  it("frees a SELF_SERVICE user when selfServiceCanSeeBookings is on", async () => {
+    membership([OrganizationRoles.SELF_SERVICE], {
+      selfServiceCanSeeBookings: true,
+    });
+
+    const ctx = await getMobileUserContext("user-1", "org-1");
+
+    expect(ctx.canSeeAllBookings).toBe(true);
+  });
+
+  it("reads the override matching the ROLE, not either one", async () => {
+    // The two flags are independent. A workspace that freed self-service users
+    // has said nothing about base users.
+    membership([OrganizationRoles.BASE], { selfServiceCanSeeBookings: true });
+
+    const ctx = await getMobileUserContext("user-1", "org-1");
+
+    expect(ctx.canSeeAllBookings).toBe(false);
+  });
+
+  it("keeps booking and custody visibility independent", async () => {
+    membership([OrganizationRoles.BASE], { baseUserCanSeeBookings: true });
+
+    const ctx = await getMobileUserContext("user-1", "org-1");
+
+    // Seeing a colleague's booking does not mean seeing who holds it.
+    expect(ctx.canSeeAllBookings).toBe(true);
+    expect(ctx.canSeeAllCustody).toBe(false);
+  });
+
+  it("resolves the most privileged role, not whichever is stored first", async () => {
+    // `role` is roles[0] and is wrong for any gate: an admin whose membership
+    // happens to start with SELF_SERVICE would be treated as restricted.
+    membership([OrganizationRoles.SELF_SERVICE, OrganizationRoles.ADMIN]);
+
+    const ctx = await getMobileUserContext("user-1", "org-1");
+
+    expect(ctx.effectiveRole).toBe(OrganizationRoles.ADMIN);
+    expect(ctx.canSeeAllBookings).toBe(true);
+    expect(ctx.canSeeAllCustody).toBe(true);
+    expect(ctx.isSelfServiceOrBase).toBe(false);
+    // The legacy field is deliberately left alone; callers still read it.
+    expect(ctx.role).toBe(OrganizationRoles.SELF_SERVICE);
+  });
+});

--- a/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.$bookingId.ts
@@ -20,15 +20,13 @@ import { isBookingArchivable } from "~/modules/booking/helpers";
 import {
   bookingDraftVisibilityClause,
   computeBookingAssetRemaining,
-  custodianScopeClause,
-  resolveCustodianScope,
   computeBookingAssetRemainingToCheckOut,
   getBookingFlags,
   getPartiallyCheckedInAssetIds,
 } from "~/modules/booking/service.server";
 import { calculateBookingLifecycleProgress } from "~/modules/booking/utils.server";
 import { getBookingSettingsForOrganization } from "~/modules/booking-settings/service.server";
-import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
+import { canSeeBooking } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import { getParams } from "~/utils/http.server";
 import {
@@ -52,18 +50,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     // details, assets, tags and action flags via mobile.
     await assertMobileCanUseBookings(organizationId);
 
-    // Self-service / base users may only read their OWN bookings. Scope the
-    // lookup by custodian like the list endpoint (bookings.ts) does, so a
-    // booking they don't own 404s instead of leaking across the workspace.
-    const { roles } = await getMobileUserContext(user.id, organizationId);
-    // `getMobileUserContext` also returns `role`, but that is `roles[0]` — a
-    // membership stored `[SELF_SERVICE, ADMIN]` reads as SELF_SERVICE and a
-    // real admin is treated as restricted. Every decision below resolves the
-    // most privileged role instead, matching what the mutation endpoints do.
-    const role = resolveMostPrivilegedRole(roles);
-    const isSelfServiceOrBase =
-      role === OrganizationRoles.SELF_SERVICE ||
-      role === OrganizationRoles.BASE;
+    // `canSeeAllBookings` answers who may READ a booking they do not custody:
+    // ADMIN/OWNER always, SELF_SERVICE/BASE only where the workspace override
+    // allows it. `isSelfServiceOrBase` is the narrower, role-only question of
+    // which ACTIONS the caller may take, and must stay role-only: the override
+    // widens reading and never writing.
+    const { canSeeAllBookings, isSelfServiceOrBase, effectiveRole, roles } =
+      await getMobileUserContext(user.id, organizationId);
 
     const { bookingId } = getParams(
       params,
@@ -78,28 +71,19 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
          * Draft privacy (web parity). A DRAFT booking is private to its
          * creator — web gates the detail route on the same shared clause, so
          * without it a direct GET here returns a colleague's unfinished draft
-         * even though the list would (now) hide it. The list fix alone is not
-         * enough: booking ids are guessable-adjacent and the detail endpoint
-         * is reachable directly.
+         * even though the list hides it. The list fix alone is not enough:
+         * booking ids are guessable-adjacent and this endpoint is reachable
+         * directly. The booking override does NOT widen this: an unfinished
+         * draft stays private to its creator either way, exactly as on web.
          *
-         * The custodian restriction joins the same AND rather than sitting
-         * beside it: custody lives on the user link OR a team-member link, so
-         * the clause is itself an OR and merging it in at this level would
-         * collide with the one above.
+         * Custody is deliberately NOT a clause here. It is a gate on the
+         * loaded row instead (`canSeeBooking`, just past the 404 below), so
+         * "you may not see this" answers 403 rather than reporting the row as
+         * missing. Putting it back in the `where` also silently re-decides
+         * visibility before the row is read, which is where it stops being
+         * able to honour the workspace override.
          */
-        AND: [
-          bookingDraftVisibilityClause(user.id),
-          ...(isSelfServiceOrBase
-            ? [
-                custodianScopeClause(
-                  await resolveCustodianScope({
-                    userId: user.id,
-                    organizationId,
-                  })
-                ),
-              ]
-            : []),
-        ],
+        AND: [bookingDraftVisibilityClause(user.id)],
       },
       select: {
         id: true,
@@ -118,6 +102,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
             lastName: true,
           },
         },
+        // why: `canSeeBooking` reads BOTH custody links, so the scalar is
+        // required even though the relation below covers display. A booking
+        // assigned to a team member with no user attached carries
+        // `custodianUserId = NULL`; matching one link alone refuses the user
+        // the booking belongs to.
+        custodianUserId: true,
         custodianUser: {
           select: {
             id: true,
@@ -131,6 +121,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           select: {
             id: true,
             name: true,
+            userId: true,
           },
         },
         tags: {
@@ -215,6 +206,20 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
     if (!booking) {
       return data({ error: { message: "Booking not found" } }, { status: 404 });
+    }
+
+    /**
+     * The custody gate. Runs on the loaded row so the answer can account for
+     * the workspace override, and refuses with 403 rather than reporting the
+     * booking as missing. Web gates its overview route with this same helper
+     * and this same status, so a booking that opens on one platform opens on
+     * the other.
+     */
+    if (!canSeeBooking({ canSeeAllBookings, booking, userId: user.id })) {
+      return data(
+        { error: { message: "You are not authorized to view this booking" } },
+        { status: 403 }
+      );
     }
 
     // Get partial check-in data for ONGOING/OVERDUE bookings
@@ -376,9 +381,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const bookingSettings =
       await getBookingSettingsForOrganization(organizationId);
     const canQuickCheckin = !(
-      (role === OrganizationRoles.ADMIN &&
+      (effectiveRole === OrganizationRoles.ADMIN &&
         bookingSettings.requireExplicitCheckinForAdmin) ||
-      (role === OrganizationRoles.SELF_SERVICE &&
+      (effectiveRole === OrganizationRoles.SELF_SERVICE &&
         bookingSettings.requireExplicitCheckinForSelfService)
     );
 

--- a/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.available-models.ts
@@ -31,11 +31,13 @@ import { getParams } from "~/utils/http.server";
  * reserve in this booking's window, plus this booking's existing model-level
  * reservations so the app can show current amounts and offer edits.
  *
- * Read-only. Org-scoped, and — like the booking detail read
- * (`bookings.$bookingId.ts`) — custodian-scoped for SELF_SERVICE / BASE so
- * they can only pick models against a booking they own. The actual
- * reserve/edit/remove mutation is enforced separately in
- * `bookings.$bookingId.model-requests.ts`.
+ * Read-only, but a MUTATION-TARGET picker: every model it lists is one the
+ * caller is about to reserve against this booking. So it scopes by custody for
+ * SELF_SERVICE / BASE — the set `bookings.$bookingId.model-requests.ts` will
+ * actually accept a write for — rather than by the wider read rule the booking
+ * list and detail use, which the workspace's booking-visibility override can
+ * widen. Offering a booking here that the mutation then refuses is the
+ * dead-end this narrower scope exists to avoid.
  *
  * @see {@link file://./../../_layout+/bookings.$bookingId.overview.manage-assets.tsx} web twin
  * @see {@link file://./../../../modules/booking-model-request/service.server.ts} shared service
@@ -70,9 +72,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       Math.max(1, parseInt(url.searchParams.get("perPage") || "50", 10) || 50)
     );
 
-    // Self-service / base users may only see their OWN bookings — scope the
-    // lookup by custodian exactly like the booking detail read, so a booking
-    // they don't own 404s instead of leaking its models/reservations.
+    // Self-service / base users may only pick models against a booking they
+    // own, so an unowned booking 404s here instead of leaking its models and
+    // reservations. Deliberately the WRITE scope, not the read scope: see the
+    // module docblock.
     const { role } = await getMobileUserContext(user.id, organizationId);
     const isSelfServiceOrBase =
       role === OrganizationRoles.SELF_SERVICE ||

--- a/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
@@ -1,4 +1,4 @@
-import { BookingStatus, OrganizationRoles } from "@prisma/client";
+import { BookingStatus } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import {
@@ -12,7 +12,6 @@ import {
   custodianScopeClause,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
-import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
@@ -186,22 +185,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
       url.searchParams.get("search")?.trim().slice(0, 100) || undefined;
 
     /**
-     * `roles`, resolved to the most privileged one - NOT the context's `role`,
-     * which is `roles[0]`. A membership stored `[SELF_SERVICE, ADMIN]` resolves
-     * to SELF_SERVICE there, so a genuine admin was narrowed to bookings they
-     * are custodian of and every colleague's booking vanished from the grid
-     * while the list lens still showed them. The sibling mobile booking routes
-     * all resolve it this way.
+     * Which bookings exist for this caller, resolved from the workspace
+     * overrides and not from the role alone. The list lens on this same screen
+     * asks the same context the same question: the two must agree, or one lens
+     * shows a booking the other says is not there.
      */
-    const { roles } = await getMobileUserContext(user.id, organizationId);
-    const role = resolveMostPrivilegedRole(roles);
-    const isSelfServiceOrBase =
-      role === OrganizationRoles.SELF_SERVICE ||
-      role === OrganizationRoles.BASE;
+    const { canSeeAllBookings, canSeeAllCustody } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
 
-    const custodianScope = isSelfServiceOrBase
-      ? await resolveCustodianScope({ userId: user.id, organizationId })
-      : null;
+    const custodianScope = canSeeAllBookings
+      ? null
+      : await resolveCustodianScope({ userId: user.id, organizationId });
 
     /**
      * Everything except the date window, so the same filter can also answer the
@@ -265,9 +261,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
         from: true,
         to: true,
         custodianUser: {
-          select: { firstName: true, lastName: true, displayName: true },
+          // `id` here and `userId` below together answer "is the custodian
+          // the caller?", which keeps their own name visible to them.
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            displayName: true,
+          },
         },
-        custodianTeamMember: { select: { name: true } },
+        custodianTeamMember: { select: { name: true, userId: true } },
       },
       // Soonest first: a calendar is read forwards.
       orderBy: [{ from: "asc" }],
@@ -326,10 +329,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
         status: b.status,
         from: b.from,
         to: b.to,
+        // Custody visibility is its own workspace override. "private" rather
+        // than null when the name is withheld: null means "no custodian".
         custodianName:
-          b.custodianTeamMember?.name ||
-          resolveUserDisplayName(b.custodianUser) ||
-          null,
+          canSeeAllCustody ||
+          b.custodianUser?.id === user.id ||
+          b.custodianTeamMember?.userId === user.id
+            ? b.custodianTeamMember?.name ||
+              resolveUserDisplayName(b.custodianUser) ||
+              null
+            : "private",
       })),
       /**
        * True when this window holds more than one response may carry, so the

--- a/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
@@ -329,12 +329,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
         status: b.status,
         from: b.from,
         to: b.to,
-        // Custody visibility is its own workspace override. "private" rather
-        // than null when the name is withheld: null means "no custodian".
+        // Custody visibility is its own workspace override. null means the
+        // booking has no custodian; "private" means it has one this caller may
+        // not see. Keep them distinct.
         custodianName:
-          canSeeAllCustody ||
-          b.custodianUser?.id === user.id ||
-          b.custodianTeamMember?.userId === user.id
+          !b.custodianTeamMember && !b.custodianUser
+            ? null
+            : canSeeAllCustody ||
+              b.custodianUser?.id === user.id ||
+              b.custodianTeamMember?.userId === user.id
             ? b.custodianTeamMember?.name ||
               resolveUserDisplayName(b.custodianUser) ||
               null

--- a/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
@@ -46,8 +46,9 @@ const MAX_BOOKINGS_PER_WINDOW = 500;
  * cannot use. The SCOPING is what matters and is mirrored exactly from the
  * mobile bookings list:
  *   - organisation scoped
- *   - SELF_SERVICE / BASE see only bookings they are custodian of
- *   - DRAFT bookings stay private to their creator
+ *   - SELF_SERVICE / BASE see only bookings they hold, unless the workspace
+ *     grants them the booking-visibility override
+ *   - DRAFT bookings stay private to their creator, override or not
  *
  * Overlap, not containment: a booking running 28 Jul to 3 Aug belongs on the
  * August calendar too. Filtering on `from` alone would hide it.

--- a/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.calendar.ts
@@ -12,12 +12,12 @@ import {
   custodianScopeClause,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
+import { resolveBookingCustodianName } from "~/utils/booking-authorization.server";
 import { makeShelfError, ShelfError } from "~/utils/error";
 import {
   PermissionAction,
   PermissionEntity,
 } from "~/utils/permissions/permission.data";
-import { resolveUserDisplayName } from "~/utils/user";
 
 /** Hard ceiling on the window a single call may ask for. */
 const MAX_RANGE_DAYS = 366;
@@ -329,19 +329,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
         status: b.status,
         from: b.from,
         to: b.to,
-        // Custody visibility is its own workspace override. null means the
-        // booking has no custodian; "private" means it has one this caller may
-        // not see. Keep them distinct.
-        custodianName:
-          !b.custodianTeamMember && !b.custodianUser
-            ? null
-            : canSeeAllCustody ||
-              b.custodianUser?.id === user.id ||
-              b.custodianTeamMember?.userId === user.id
-            ? b.custodianTeamMember?.name ||
-              resolveUserDisplayName(b.custodianUser) ||
-              null
-            : "private",
+        // Custody visibility is its own workspace override, and the shared
+        // resolver is what keeps this lens agreeing with the list lens on the
+        // same screen about who holds a booking.
+        custodianName: resolveBookingCustodianName({
+          canSeeAllCustody,
+          booking: b,
+          userId: user.id,
+        }),
       })),
       /**
        * True when this window holds more than one response may carry, so the

--- a/apps/webapp/app/routes/api+/mobile+/bookings.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.ts
@@ -1,4 +1,4 @@
-import { BookingStatus, OrganizationRoles } from "@prisma/client";
+import { BookingStatus } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import {
@@ -11,7 +11,6 @@ import {
   custodianScopeClause,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
-import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import { resolveUserDisplayName } from "~/utils/user";
 
@@ -77,23 +76,22 @@ export async function loader({ request }: LoaderFunctionArgs) {
       ];
     }
 
-    // Scope to the caller's own bookings for self-service / base users, who
-    // can only see the bookings they are the custodian of (web parity — see
-    // getBookings' `isSelfServiceOrBase` branch). Owners/admins see all. This
-    // matters especially now that DRAFT bookings appear in the default view.
     /**
-     * Resolved from `roles`, not from the context's `role`, which is `roles[0]`
-     * and wrong for any privilege decision: a membership stored
-     * `[SELF_SERVICE, ADMIN]` resolves to SELF_SERVICE there, so a genuine admin
-     * was narrowed to their own bookings. The calendar lens must reach the same
-     * verdict from the same membership, or the two lenses on this screen
-     * disagree about what exists.
+     * Two independent questions, two independent workspace overrides.
+     *
+     * `canSeeAllBookings` decides WHICH ROWS exist for this caller: ADMIN and
+     * OWNER see every booking, SELF_SERVICE and BASE see only their own unless
+     * the workspace has switched their override on. Resolve it here, never
+     * from the role alone - the role does not know what the workspace decided.
+     *
+     * `canSeeAllCustody` decides whether the custodian's NAME may be shown on
+     * a row that already exists. A workspace may grant either without the
+     * other, so never let one stand in for the other.
      */
-    const { roles } = await getMobileUserContext(user.id, organizationId);
-    const role = resolveMostPrivilegedRole(roles);
-    const isSelfServiceOrBase =
-      role === OrganizationRoles.SELF_SERVICE ||
-      role === OrganizationRoles.BASE;
+    const { canSeeAllBookings, canSeeAllCustody } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
 
     /**
      * Custodian scope (web parity). Web matches a self-service or base user's
@@ -103,9 +101,9 @@ export async function loader({ request }: LoaderFunctionArgs) {
      * a TEAM MEMBER rather than a user was visible on the website and missing
      * from the phone, for the very user it belonged to.
      */
-    const custodianScope = isSelfServiceOrBase
-      ? await resolveCustodianScope({ userId: user.id, organizationId })
-      : null;
+    const custodianScope = canSeeAllBookings
+      ? null
+      : await resolveCustodianScope({ userId: user.id, organizationId });
 
     const where = {
       organizationId,
@@ -141,6 +139,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
         : {}),
     };
 
+    /**
+     * The custodian chip is visible when the workspace grants custody
+     * visibility, or when the custodian IS the caller through either custody
+     * link. Web decides it with `userCanViewSpecificCustody`; keep the two in
+     * step, or the same booking names its holder on one platform and not the
+     * other.
+     */
+    const canSeeCustodianOf = (booking: {
+      custodianUser: { id: string } | null;
+      custodianTeamMember: { userId: string | null } | null;
+    }) =>
+      canSeeAllCustody ||
+      booking.custodianUser?.id === user.id ||
+      booking.custodianTeamMember?.userId === user.id;
+
     const [bookings, totalCount] = await Promise.all([
       db.booking.findMany({
         where,
@@ -153,6 +166,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
           createdAt: true,
           custodianUser: {
             select: {
+              // Select `id` here and `userId` on the team member below:
+              // together they answer "is the custodian the caller?", which is
+              // what keeps a restricted user's own name visible to them.
+              id: true,
               firstName: true,
               lastName: true,
               displayName: true,
@@ -160,7 +177,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
             },
           },
           custodianTeamMember: {
-            select: { name: true },
+            select: { name: true, userId: true },
           },
           _count: {
             select: {
@@ -199,11 +216,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
         from: b.from,
         to: b.to,
         createdAt: b.createdAt,
-        custodianName:
-          b.custodianTeamMember?.name ||
-          resolveUserDisplayName(b.custodianUser) ||
-          null,
-        custodianImage: b.custodianUser?.profilePicture || null,
+        // "private" rather than null when the name is withheld: null already
+        // means "this booking has no custodian", and web draws the same word
+        // in place of the badge (`TeamMemberBadge`).
+        custodianName: canSeeCustodianOf(b)
+          ? b.custodianTeamMember?.name ||
+            resolveUserDisplayName(b.custodianUser) ||
+            null
+          : "private",
+        custodianImage: canSeeCustodianOf(b)
+          ? b.custodianUser?.profilePicture || null
+          : null,
         assetCount: b._count.bookingAssets,
         // Outstanding book-by-model reservations still to assign. > 0 means the
         // booking holds reserved units with no concrete assets behind them yet.

--- a/apps/webapp/app/routes/api+/mobile+/bookings.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.ts
@@ -216,14 +216,19 @@ export async function loader({ request }: LoaderFunctionArgs) {
         from: b.from,
         to: b.to,
         createdAt: b.createdAt,
-        // "private" rather than null when the name is withheld: null already
-        // means "this booking has no custodian", and web draws the same word
-        // in place of the badge (`TeamMemberBadge`).
-        custodianName: canSeeCustodianOf(b)
-          ? b.custodianTeamMember?.name ||
-            resolveUserDisplayName(b.custodianUser) ||
-            null
-          : "private",
+        // Three distinct answers, and the app renders each differently:
+        // a name, null for "this booking has no custodian", and "private" for
+        // "it has one you may not see" - the word web draws in place of the
+        // badge (`TeamMemberBadge`). Collapsing the last two would report an
+        // unassigned booking as a withheld one.
+        custodianName:
+          !b.custodianTeamMember && !b.custodianUser
+            ? null
+            : canSeeCustodianOf(b)
+            ? b.custodianTeamMember?.name ||
+              resolveUserDisplayName(b.custodianUser) ||
+              null
+            : "private",
         custodianImage: canSeeCustodianOf(b)
           ? b.custodianUser?.profilePicture || null
           : null,

--- a/apps/webapp/app/routes/api+/mobile+/bookings.ts
+++ b/apps/webapp/app/routes/api+/mobile+/bookings.ts
@@ -11,8 +11,11 @@ import {
   custodianScopeClause,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
+import {
+  canSeeBookingCustodian,
+  resolveBookingCustodianName,
+} from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
-import { resolveUserDisplayName } from "~/utils/user";
 
 /**
  * GET /api/mobile/bookings
@@ -139,21 +142,6 @@ export async function loader({ request }: LoaderFunctionArgs) {
         : {}),
     };
 
-    /**
-     * The custodian chip is visible when the workspace grants custody
-     * visibility, or when the custodian IS the caller through either custody
-     * link. Web decides it with `userCanViewSpecificCustody`; keep the two in
-     * step, or the same booking names its holder on one platform and not the
-     * other.
-     */
-    const canSeeCustodianOf = (booking: {
-      custodianUser: { id: string } | null;
-      custodianTeamMember: { userId: string | null } | null;
-    }) =>
-      canSeeAllCustody ||
-      booking.custodianUser?.id === user.id ||
-      booking.custodianTeamMember?.userId === user.id;
-
     const [bookings, totalCount] = await Promise.all([
       db.booking.findMany({
         where,
@@ -216,20 +204,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
         from: b.from,
         to: b.to,
         createdAt: b.createdAt,
-        // Three distinct answers, and the app renders each differently:
-        // a name, null for "this booking has no custodian", and "private" for
-        // "it has one you may not see" - the word web draws in place of the
-        // badge (`TeamMemberBadge`). Collapsing the last two would report an
-        // unassigned booking as a withheld one.
-        custodianName:
-          !b.custodianTeamMember && !b.custodianUser
-            ? null
-            : canSeeCustodianOf(b)
-            ? b.custodianTeamMember?.name ||
-              resolveUserDisplayName(b.custodianUser) ||
-              null
-            : "private",
-        custodianImage: canSeeCustodianOf(b)
+        // Shared with the calendar and the dashboard so the three lenses on
+        // these rows cannot disagree about who holds a booking. Answers a
+        // name, null for "no custodian", or the withheld sentinel.
+        custodianName: resolveBookingCustodianName({
+          canSeeAllCustody,
+          booking: b,
+          userId: user.id,
+        }),
+        // The face is as identifying as the name, so it follows the same gate.
+        custodianImage: canSeeBookingCustodian({
+          canSeeAllCustody,
+          booking: b,
+          userId: user.id,
+        })
           ? b.custodianUser?.profilePicture || null
           : null,
         assetCount: b._count.bookingAssets,

--- a/apps/webapp/app/routes/api+/mobile+/dashboard.ts
+++ b/apps/webapp/app/routes/api+/mobile+/dashboard.ts
@@ -1,4 +1,3 @@
-import { OrganizationRoles } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import {
@@ -8,7 +7,10 @@ import {
 } from "~/modules/api/mobile-auth.server";
 import { resolveAssetImage } from "~/modules/asset/image-resolution";
 import { ASSET_MODEL_IMAGE_SELECT } from "~/modules/asset/image-select";
-import { getBookings } from "~/modules/booking/service.server";
+import {
+  getBookings,
+  resolveCustodianScope,
+} from "~/modules/booking/service.server";
 import { makeShelfError } from "~/utils/error";
 import type { UserNameFields } from "~/utils/user";
 import { resolveUserDisplayName } from "~/utils/user";
@@ -35,12 +37,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
     // (canUseAudits, surfaced through getMobileUserContext) so the
     // dashboard never serves activeAudits to non-add-on workspaces — a
     // paywall bypass / data leak even with the client cards hidden.
-    // The same call yields the caller's `role`, which gates booking
-    // visibility below.
-    const { canUseAudits, role } = await getMobileUserContext(
-      user.id,
-      organizationId
-    );
+    // The same call yields `canSeeAllBookings`, which decides which bookings
+    // the sections may draw from, and `canSeeAllCustody` for their names.
+    const { canUseAudits, canSeeAllBookings, canSeeAllCustody } =
+      await getMobileUserContext(user.id, organizationId);
 
     // Scope the booking sections to the caller's own bookings for
     // self-service / base users, who may only see bookings they are the
@@ -59,10 +59,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
     // empty for both). The companion's Home tab is the app's landing screen
     // for every role, not an admin analytics surface — denying it would leave
     // those users on a permanent error state rather than a scoped dashboard.
-    const isSelfServiceOrBase =
-      role === OrganizationRoles.SELF_SERVICE ||
-      role === OrganizationRoles.BASE;
-    const custodianScope = isSelfServiceOrBase ? { userId: user.id } : null;
+    //
+    // Resolved from `canSeeAllBookings`, so a workspace that lets restricted
+    // users see everyone's bookings gets the same Home tab it gets on the
+    // website. The role alone cannot answer this: it does not know what the
+    // workspace decided.
+    //
+    // `resolveCustodianScope` rather than a bare `{ userId }`: custody lives
+    // on a user link OR any of the caller's team-member links, and a bare
+    // user-link filter hides a user's own booking whenever their custody comes
+    // from a team member. The list and calendar resolve it the same way; this
+    // is the third lens on the same rows.
+    const custodianScope = canSeeAllBookings
+      ? null
+      : await resolveCustodianScope({ userId: user.id, organizationId });
 
     // Run all queries in parallel for speed
     const [
@@ -148,14 +158,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
         includeAssets: false,
         extraInclude: {
           custodianUser: {
+            // `id` and the team member's `userId` together answer "is the
+            // custodian the caller?", which keeps their own name visible.
             select: {
+              id: true,
               firstName: true,
               lastName: true,
               displayName: true,
               profilePicture: true,
             },
           },
-          custodianTeamMember: { select: { name: true } },
+          custodianTeamMember: { select: { name: true, userId: true } },
           _count: { select: { bookingAssets: true } },
         },
       }),
@@ -174,14 +187,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
         includeAssets: false,
         extraInclude: {
           custodianUser: {
+            // `id` and the team member's `userId` answer "is the caller the
+            // custodian?", which keeps their own name visible when the
+            // custody override is off.
             select: {
+              id: true,
               firstName: true,
               lastName: true,
               displayName: true,
               profilePicture: true,
             },
           },
-          custodianTeamMember: { select: { name: true } },
+          custodianTeamMember: { select: { name: true, userId: true } },
           _count: { select: { bookingAssets: true } },
         },
       }),
@@ -200,14 +217,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
         includeAssets: false,
         extraInclude: {
           custodianUser: {
+            // `id` and the team member's `userId` answer "is the caller the
+            // custodian?", which keeps their own name visible when the
+            // custody override is off.
             select: {
+              id: true,
               firstName: true,
               lastName: true,
               displayName: true,
               profilePicture: true,
             },
           },
-          custodianTeamMember: { select: { name: true } },
+          custodianTeamMember: { select: { name: true, userId: true } },
           _count: { select: { bookingAssets: true } },
         },
       }),
@@ -268,8 +289,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
        * `displayName`, so this shape cannot drift back to naming the custodian
        * by their legal name without failing to compile.
        */
-      custodianUser?: UserNameFields | null;
-      custodianTeamMember?: { name: string } | null;
+      custodianUser?: (UserNameFields & { id?: string }) | null;
+      custodianTeamMember?: { name: string; userId?: string | null } | null;
       _count?: { bookingAssets: number };
     };
 
@@ -280,9 +301,16 @@ export async function loader({ request }: LoaderFunctionArgs) {
       status: b.status,
       from: b.from instanceof Date ? b.from.toISOString() : b.from,
       to: b.to instanceof Date ? b.to.toISOString() : b.to,
-      custodianName: b.custodianUser
-        ? resolveUserDisplayName(b.custodianUser) || null
-        : b.custodianTeamMember?.name || null,
+      // Custody visibility is its own workspace override. "private" rather
+      // than null when the name is withheld: null means "no custodian".
+      custodianName:
+        canSeeAllCustody ||
+        b.custodianUser?.id === user.id ||
+        b.custodianTeamMember?.userId === user.id
+          ? b.custodianUser
+            ? resolveUserDisplayName(b.custodianUser) || null
+            : b.custodianTeamMember?.name || null
+          : "private",
       assetCount: b._count?.bookingAssets ?? 0,
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/dashboard.ts
+++ b/apps/webapp/app/routes/api+/mobile+/dashboard.ts
@@ -301,12 +301,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
       status: b.status,
       from: b.from instanceof Date ? b.from.toISOString() : b.from,
       to: b.to instanceof Date ? b.to.toISOString() : b.to,
-      // Custody visibility is its own workspace override. "private" rather
-      // than null when the name is withheld: null means "no custodian".
+      // Custody visibility is its own workspace override. null means the
+      // booking has no custodian; "private" means it has one this caller may
+      // not see. Keep them distinct.
       custodianName:
-        canSeeAllCustody ||
-        b.custodianUser?.id === user.id ||
-        b.custodianTeamMember?.userId === user.id
+        !b.custodianUser && !b.custodianTeamMember
+          ? null
+          : canSeeAllCustody ||
+            b.custodianUser?.id === user.id ||
+            b.custodianTeamMember?.userId === user.id
           ? b.custodianUser
             ? resolveUserDisplayName(b.custodianUser) || null
             : b.custodianTeamMember?.name || null

--- a/apps/webapp/app/routes/api+/mobile+/dashboard.ts
+++ b/apps/webapp/app/routes/api+/mobile+/dashboard.ts
@@ -11,9 +11,9 @@ import {
   getBookings,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
+import { resolveBookingCustodianName } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 import type { UserNameFields } from "~/utils/user";
-import { resolveUserDisplayName } from "~/utils/user";
 
 /**
  * GET /api/mobile/dashboard
@@ -289,8 +289,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
        * `displayName`, so this shape cannot drift back to naming the custodian
        * by their legal name without failing to compile.
        */
-      custodianUser?: (UserNameFields & { id?: string }) | null;
-      custodianTeamMember?: { name: string; userId?: string | null } | null;
+      /**
+       * `id` and the team member's `userId` are REQUIRED for the same reason
+       * `UserNameFields` is: they answer "is the custodian the caller?", so a
+       * projection that drops one silently redacts a user's own booking rather
+       * than failing to compile.
+       */
+      custodianUser?: (UserNameFields & { id: string }) | null;
+      custodianTeamMember?: { name: string; userId: string | null } | null;
       _count?: { bookingAssets: number };
     };
 
@@ -301,19 +307,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
       status: b.status,
       from: b.from instanceof Date ? b.from.toISOString() : b.from,
       to: b.to instanceof Date ? b.to.toISOString() : b.to,
-      // Custody visibility is its own workspace override. null means the
-      // booking has no custodian; "private" means it has one this caller may
-      // not see. Keep them distinct.
-      custodianName:
-        !b.custodianUser && !b.custodianTeamMember
-          ? null
-          : canSeeAllCustody ||
-            b.custodianUser?.id === user.id ||
-            b.custodianTeamMember?.userId === user.id
-          ? b.custodianUser
-            ? resolveUserDisplayName(b.custodianUser) || null
-            : b.custodianTeamMember?.name || null
-          : "private",
+      // Custody visibility is its own workspace override. The shared resolver
+      // is what keeps Home naming a booking's holder the same way the list and
+      // the calendar do.
+      custodianName: resolveBookingCustodianName({
+        canSeeAllCustody,
+        booking: b,
+        userId: user.id,
+      }),
       assetCount: b._count?.bookingAssets ?? 0,
     });
 

--- a/apps/webapp/app/routes/api+/mobile+/dashboard.ts
+++ b/apps/webapp/app/routes/api+/mobile+/dashboard.ts
@@ -42,34 +42,31 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const { canUseAudits, canSeeAllBookings, canSeeAllCustody } =
       await getMobileUserContext(user.id, organizationId);
 
-    // Scope the booking sections to the caller's own bookings for
-    // self-service / base users, who may only see bookings they are the
-    // custodian of. `requireOrganizationAccess` above proves membership but
-    // performs NO role check, so without this restriction any member could
-    // read every booking in the workspace — with custodian names attached —
-    // straight off the dashboard.
+    // Which bookings the Home sections may draw from.
+    // `requireOrganizationAccess` above proves membership and performs NO role
+    // check, so without a restriction here any member could read every booking
+    // in the workspace — with custodian names attached — straight off the
+    // dashboard.
     //
-    // Mirrors the mobile bookings list (`bookings.ts`), which draws the same
-    // line for the same roles. Passed as `custodianScope` — a restriction
-    // `getBookings` ANDs into the query, so it can only ever narrow. Left
-    // `null` for owners/admins, who see all bookings.
+    // `canSeeAllBookings` is that decision: ADMIN and OWNER see every booking,
+    // SELF_SERVICE and BASE see only the ones they hold unless the workspace
+    // has switched their override on. The role alone cannot answer it — it does
+    // not know what the workspace decided — so Home reads the same flag the
+    // website does and lands on the same set of bookings.
+    //
+    // `resolveCustodianScope` rather than a bare `{ userId }`: custody lives
+    // on a user link OR any of the caller's team-member links, and a bare
+    // user-link filter hides a user's own booking whenever their custody comes
+    // from a team member. The list and calendar resolve it the same way; this
+    // is the third lens on the same rows. It reaches `getBookings` as
+    // `custodianScope`, a restriction ANDed into the query, so it can only ever
+    // narrow — and `null` lifts it entirely.
     //
     // NOTE: this deliberately does not mirror the web dashboard, which denies
     // self-service/base the page outright (`PermissionEntity.dashboard` is
     // empty for both). The companion's Home tab is the app's landing screen
     // for every role, not an admin analytics surface — denying it would leave
     // those users on a permanent error state rather than a scoped dashboard.
-    //
-    // Resolved from `canSeeAllBookings`, so a workspace that lets restricted
-    // users see everyone's bookings gets the same Home tab it gets on the
-    // website. The role alone cannot answer this: it does not know what the
-    // workspace decided.
-    //
-    // `resolveCustodianScope` rather than a bare `{ userId }`: custody lives
-    // on a user link OR any of the caller's team-member links, and a bare
-    // user-link filter hides a user's own booking whenever their custody comes
-    // from a team member. The list and calendar resolve it the same way; this
-    // is the third lens on the same rows.
     const custodianScope = canSeeAllBookings
       ? null
       : await resolveCustodianScope({ userId: user.id, organizationId });

--- a/apps/webapp/app/utils/booking-authorization.server.test.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.test.ts
@@ -20,8 +20,11 @@ import { describe, expect, it } from "vitest";
 import {
   bookingWriteScopeClause,
   canSeeBooking,
+  canSeeBookingCustodian,
+  resolveBookingCustodianName,
   resolveMostPrivilegedRole,
   validateBookingOwnership,
+  WITHHELD_CUSTODIAN_NAME,
 } from "./booking-authorization.server";
 import {
   ROLE_PRECEDENCE,
@@ -343,5 +346,148 @@ describe("resolveMostPrivilegedRole", () => {
     expect([...SSO_ASSIGNABLE_ROLE_PRECEDENCE]).toEqual(
       ROLE_PRECEDENCE.filter((r) => r !== OrganizationRoles.OWNER)
     );
+  });
+});
+
+/**
+ * Naming a booking's holder.
+ *
+ * Three surfaces ask this question of the same rows — the mobile bookings
+ * list, the calendar lens on that same screen, and Home. They resolve it here
+ * so they cannot answer it differently for one booking.
+ *
+ * The three-way answer is the part that matters: a name, `null` for a booking
+ * nobody holds, and the withheld sentinel for one held by someone this viewer
+ * may not see. Collapsing the last two reports an unassigned booking as a
+ * withheld one, which reads as "someone has this and you may not know who".
+ */
+describe("resolveBookingCustodianName", () => {
+  const NAMED_USER = {
+    id: SOMEONE_ELSE,
+    displayName: "Ada Lovelace",
+    firstName: "Augusta",
+    lastName: "King",
+  };
+
+  it("returns null when the booking has no custodian at all", () => {
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: true,
+        booking: { custodianUser: null, custodianTeamMember: null },
+        userId: ME,
+      })
+    ).toBeNull();
+  });
+
+  it("withholds another user's name when custody visibility is off", () => {
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: false,
+        booking: { custodianUser: NAMED_USER, custodianTeamMember: null },
+        userId: ME,
+      })
+    ).toBe(WITHHELD_CUSTODIAN_NAME);
+  });
+
+  it("names the custodian when the workspace grants custody visibility", () => {
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: true,
+        booking: { custodianUser: NAMED_USER, custodianTeamMember: null },
+        userId: ME,
+      })
+    ).toBe("Ada Lovelace");
+  });
+
+  it("shows callers their own name through the user link", () => {
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: false,
+        booking: {
+          custodianUser: { ...NAMED_USER, id: ME },
+          custodianTeamMember: null,
+        },
+        userId: ME,
+      })
+    ).toBe("Ada Lovelace");
+  });
+
+  it("shows callers their own name through the team-member link alone", () => {
+    // Custody assigned by picking a TEAM MEMBER leaves `custodianUser` null.
+    // Matching the user link alone hides a booking's holder from the very
+    // person holding it.
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: false,
+        booking: {
+          custodianUser: null,
+          custodianTeamMember: { name: "Ada L.", userId: ME },
+        },
+        userId: ME,
+      })
+    ).toBe("Ada L.");
+  });
+
+  it("prefers the team-member name when both links are set", () => {
+    // Web's bookings list resolves it this way (`list-bookings-content.tsx`).
+    // The two normally agree because `TeamMember.name` tracks
+    // `User.displayName`; when they drift, web's answer is the one every
+    // surface has to give.
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: true,
+        booking: {
+          custodianUser: NAMED_USER,
+          custodianTeamMember: { name: "Ada from Ops", userId: SOMEONE_ELSE },
+        },
+        userId: ME,
+      })
+    ).toBe("Ada from Ops");
+  });
+
+  it("withholds a team-member custodian who is not the caller", () => {
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: false,
+        booking: {
+          custodianUser: null,
+          custodianTeamMember: { name: "Ada L.", userId: SOMEONE_ELSE },
+        },
+        userId: ME,
+      })
+    ).toBe(WITHHELD_CUSTODIAN_NAME);
+  });
+
+  it("withholds a non-user team member from a restricted viewer", () => {
+    // A team member with no account behind it belongs to nobody, so it can
+    // never be the caller.
+    expect(
+      resolveBookingCustodianName({
+        canSeeAllCustody: false,
+        booking: {
+          custodianUser: null,
+          custodianTeamMember: { name: "Loading Bay", userId: null },
+        },
+        userId: ME,
+      })
+    ).toBe(WITHHELD_CUSTODIAN_NAME);
+  });
+});
+
+describe("canSeeBookingCustodian", () => {
+  it("gates the custodian's face the same way as their name", () => {
+    // The list serves a profile picture beside the name. A face identifies as
+    // well as a name does, so the two must never come apart.
+    const booking = {
+      custodianUser: { id: SOMEONE_ELSE, displayName: "Ada Lovelace" },
+      custodianTeamMember: null,
+    };
+
+    expect(
+      canSeeBookingCustodian({ canSeeAllCustody: false, booking, userId: ME })
+    ).toBe(false);
+    expect(
+      canSeeBookingCustodian({ canSeeAllCustody: true, booking, userId: ME })
+    ).toBe(true);
   });
 });

--- a/apps/webapp/app/utils/booking-authorization.server.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.ts
@@ -209,3 +209,65 @@ export function validateBookingOwnership({
 
   // ADMIN and OWNER roles are implicitly allowed - no check needed
 }
+
+/**
+ * Whether a role is one of the two restricted, "own records only" roles.
+ *
+ * @param role - Effective role from `resolveEffectiveRole` (web) or
+ *   {@link resolveMostPrivilegedRole} (mobile).
+ * @returns `true` for SELF_SERVICE and BASE.
+ */
+export function isSelfServiceOrBaseRole(role: OrganizationRoles): boolean {
+  return (
+    role === OrganizationRoles.SELF_SERVICE || role === OrganizationRoles.BASE
+  );
+}
+
+/**
+ * Whether the caller may see bookings they are not the custodian of.
+ *
+ * ADMIN / OWNER always can. SELF_SERVICE and BASE only can when the workspace
+ * has switched the corresponding setting on. This is the standard visibility
+ * rule for bookings; every read path that can surface someone else's booking
+ * gates on it, on web (`/bookings`, the command palette, CSV export) and on
+ * mobile (the list, the calendar, the booking detail, the dashboard).
+ *
+ * Exported so callers outside `requirePermission` resolve it identically. A
+ * surface that invents its own rule disagrees with the loader that seeded it -
+ * a picker whose list changes the moment the user types, or two platforms that
+ * disagree about which bookings exist.
+ *
+ * READ only. It never widens a mutation: a restricted user may legitimately
+ * view a booking they cannot write to. Writes stay on the role's permission
+ * grant plus {@link validateBookingOwnership} / {@link bookingWriteScopeClause}.
+ *
+ * Lives here rather than in `roles.server.ts` so the mobile API can reach it:
+ * that module pulls in Sentry and the organization service, and through it
+ * Stripe and the mailer, which no mobile route or its test can carry. This
+ * module imports only Prisma types and two local helpers - keep it that way.
+ *
+ * @param args.role - The caller's effective role.
+ * @param args.currentOrganization - Workspace whose override settings apply.
+ * @returns `true` when bookings should NOT be restricted to the caller's own.
+ */
+export function resolveCanSeeAllBookings({
+  role,
+  currentOrganization,
+}: {
+  role: OrganizationRoles;
+  currentOrganization: {
+    selfServiceCanSeeBookings: boolean;
+    baseUserCanSeeBookings: boolean;
+  };
+}): boolean {
+  return (
+    // Admin/Owner always can see all
+    !isSelfServiceOrBaseRole(role) ||
+    // SELF_SERVICE can see all if org setting allows
+    (role === OrganizationRoles.SELF_SERVICE &&
+      currentOrganization.selfServiceCanSeeBookings) ||
+    // BASE can see all if org setting allows
+    (role === OrganizationRoles.BASE &&
+      currentOrganization.baseUserCanSeeBookings)
+  );
+}

--- a/apps/webapp/app/utils/booking-authorization.server.ts
+++ b/apps/webapp/app/utils/booking-authorization.server.ts
@@ -2,6 +2,7 @@ import type { Prisma } from "@prisma/client";
 import { OrganizationRoles } from "@prisma/client";
 import { ShelfError } from "./error";
 import { ROLE_PRECEDENCE } from "./role-precedence";
+import { resolveUserDisplayName, type UserNameFields } from "./user";
 
 /**
  * The minimal booking projection needed to decide whether a requester is the
@@ -269,5 +270,111 @@ export function resolveCanSeeAllBookings({
     // BASE can see all if org setting allows
     (role === OrganizationRoles.BASE &&
       currentOrganization.baseUserCanSeeBookings)
+  );
+}
+
+/**
+ * The name shown in place of a custodian the viewer may not see.
+ *
+ * The literal the web badge draws (`TeamMemberBadge`), so a booking redacted
+ * on one platform reads the same on the other. Distinct from `null`, which
+ * means the booking has no custodian at all — collapsing the two reports an
+ * unassigned booking as a withheld one.
+ */
+export const WITHHELD_CUSTODIAN_NAME = "private";
+
+/**
+ * The custody links a booking row needs for its custodian to be named.
+ *
+ * Both `custodianUser.id` and `custodianTeamMember.userId` are REQUIRED, and
+ * that is the point: they are what answer "is the custodian the caller?", so a
+ * query that omits either silently redacts a user's own booking. Required
+ * fields turn that into a compile error instead.
+ *
+ * `custodianUser` carries {@link UserNameFields} rather than the name halves
+ * spelled out, so a projection cannot drift back to naming someone by their
+ * legal name without failing to compile.
+ */
+export type BookingCustodianLinks = {
+  custodianUser?: (UserNameFields & { id: string }) | null;
+  custodianTeamMember?: { name: string; userId: string | null } | null;
+};
+
+/**
+ * Whether this viewer may see WHO holds a booking.
+ *
+ * Separate from {@link canSeeBooking}, and gated by a separate workspace
+ * override: seeing that a booking exists does not mean seeing who has it. A
+ * workspace may grant either without the other.
+ *
+ * The caller always sees their own name, through EITHER custody link — a
+ * booking assigned by picking a team member carries `custodianUserId = NULL`,
+ * so matching the user link alone hides a booking's holder from the very
+ * person holding it.
+ *
+ * @param params.canSeeAllCustody - Whether the workspace lets this role see
+ *   custody it does not hold (ADMIN/OWNER, or a granted override).
+ * @param params.booking - The booking's two custody links.
+ * @param params.userId - The viewer.
+ * @returns `true` when the custodian may be named to this viewer.
+ */
+export function canSeeBookingCustodian({
+  canSeeAllCustody,
+  booking,
+  userId,
+}: {
+  canSeeAllCustody: boolean;
+  booking: BookingCustodianLinks;
+  userId: string;
+}): boolean {
+  return (
+    canSeeAllCustody ||
+    booking.custodianUser?.id === userId ||
+    booking.custodianTeamMember?.userId === userId
+  );
+}
+
+/**
+ * The custodian name a booking row should carry for this viewer.
+ *
+ * Three distinct answers, and the app renders each differently: a name, `null`
+ * for "this booking has no custodian", and {@link WITHHELD_CUSTODIAN_NAME} for
+ * "it has one you may not see".
+ *
+ * The team-member link wins when both are set, matching the web bookings list
+ * (`list-bookings-content.tsx`). `TeamMember.name` tracks `User.displayName`,
+ * so the two normally agree — but when they do not, web's answer is the one
+ * every surface must give.
+ *
+ * Shared by the mobile list, calendar and dashboard so the three lenses on the
+ * same rows cannot disagree about who holds a booking.
+ *
+ * @param params.canSeeAllCustody - Whether custody may be shown to this viewer.
+ * @param params.booking - The booking's two custody links.
+ * @param params.userId - The viewer.
+ * @returns The custodian's name, `null` when there is none, or the withheld
+ *   sentinel when there is one this viewer may not see.
+ */
+export function resolveBookingCustodianName({
+  canSeeAllCustody,
+  booking,
+  userId,
+}: {
+  canSeeAllCustody: boolean;
+  booking: BookingCustodianLinks;
+  userId: string;
+}): string | null {
+  if (!booking.custodianUser && !booking.custodianTeamMember) {
+    return null;
+  }
+
+  if (!canSeeBookingCustodian({ canSeeAllCustody, booking, userId })) {
+    return WITHHELD_CUSTODIAN_NAME;
+  }
+
+  return (
+    booking.custodianTeamMember?.name ||
+    resolveUserDisplayName(booking.custodianUser) ||
+    null
   );
 }

--- a/apps/webapp/app/utils/roles.server.ts
+++ b/apps/webapp/app/utils/roles.server.ts
@@ -3,6 +3,10 @@ import { OrganizationRoles, Roles } from "@prisma/client";
 import * as Sentry from "@sentry/react-router";
 import { db } from "~/database/db.server";
 import { getSelectedOrganization } from "~/modules/organization/context.server";
+import {
+  isSelfServiceOrBaseRole,
+  resolveCanSeeAllBookings,
+} from "./booking-authorization.server";
 import { ShelfError } from "./error";
 import type {
   PermissionAction,
@@ -88,54 +92,19 @@ export function resolveEffectiveRole({
 }
 
 /**
- * Whether a role is one of the two restricted, "own records only" roles.
+ * `isSelfServiceOrBaseRole` and `resolveCanSeeAllBookings` are defined in
+ * `booking-authorization.server.ts` and re-exported here for the modules that
+ * import them from this path.
  *
- * @param role - Effective role from {@link resolveEffectiveRole}.
- * @returns `true` for SELF_SERVICE and BASE.
+ * They live there because the mobile API needs the same rule and cannot import
+ * this module: it pulls in Sentry and the organization service, and through it
+ * Stripe and the mailer. Import them from `booking-authorization.server` in
+ * new code.
  */
-export function isSelfServiceOrBaseRole(role: OrganizationRoles): boolean {
-  return (
-    role === OrganizationRoles.SELF_SERVICE || role === OrganizationRoles.BASE
-  );
-}
-
-/**
- * Whether the caller may see bookings they are not the custodian of.
- *
- * ADMIN / OWNER always can. SELF_SERVICE and BASE only can when the workspace
- * has switched the corresponding setting on. This is the standard visibility
- * rule for bookings; every read path that can surface someone else's booking
- * gates on it (`/bookings`, the command palette, CSV export).
- *
- * Exported so callers outside {@link requirePermission} resolve it identically.
- * A surface that invents its own rule ends up disagreeing with the loader that
- * seeded it, which is how a picker's list changes the moment a user types.
- *
- * @param args.role - Effective role from {@link resolveEffectiveRole}.
- * @param args.currentOrganization - Workspace whose override settings apply.
- * @returns `true` when bookings should NOT be restricted to the caller's own.
- */
-export function resolveCanSeeAllBookings({
-  role,
-  currentOrganization,
-}: {
-  role: OrganizationRoles;
-  currentOrganization: {
-    selfServiceCanSeeBookings: boolean;
-    baseUserCanSeeBookings: boolean;
-  };
-}): boolean {
-  return (
-    // Admin/Owner always can see all
-    !isSelfServiceOrBaseRole(role) ||
-    // SELF_SERVICE can see all if org setting allows
-    (role === OrganizationRoles.SELF_SERVICE &&
-      currentOrganization.selfServiceCanSeeBookings) ||
-    // BASE can see all if org setting allows
-    (role === OrganizationRoles.BASE &&
-      currentOrganization.baseUserCanSeeBookings)
-  );
-}
+export {
+  isSelfServiceOrBaseRole,
+  resolveCanSeeAllBookings,
+} from "./booking-authorization.server";
 
 /**
  * Whether the caller may see custody information for people other than

--- a/apps/webapp/test/helpers/mobile-user-context.ts
+++ b/apps/webapp/test/helpers/mobile-user-context.ts
@@ -1,9 +1,3 @@
-import { OrganizationRoles } from "@prisma/client";
-import {
-  isSelfServiceOrBaseRole,
-  resolveMostPrivilegedRole,
-} from "~/utils/booking-authorization.server";
-
 /**
  * Builds a `getMobileUserContext` return value for route tests.
  *
@@ -19,6 +13,13 @@ import {
  *
  *     mobileUserContext({ roles: ["BASE"], canSeeAllBookings: true })
  */
+
+import { OrganizationRoles } from "@prisma/client";
+import {
+  isSelfServiceOrBaseRole,
+  resolveMostPrivilegedRole,
+} from "~/utils/booking-authorization.server";
+
 export function mobileUserContext(
   overrides: {
     roles?: OrganizationRoles[];

--- a/apps/webapp/test/helpers/mobile-user-context.ts
+++ b/apps/webapp/test/helpers/mobile-user-context.ts
@@ -1,0 +1,45 @@
+import { OrganizationRoles } from "@prisma/client";
+import {
+  isSelfServiceOrBaseRole,
+  resolveMostPrivilegedRole,
+} from "~/utils/booking-authorization.server";
+
+/**
+ * Builds a `getMobileUserContext` return value for route tests.
+ *
+ * Route tests mock that function, so every field a route reads must be present
+ * on the mock or the route silently sees `undefined`. Build the shape here
+ * rather than hand-writing `{ roles: [...] }` literals per test: a permission
+ * field that is absent reads as `false`, which quietly inverts an assertion
+ * instead of failing it.
+ *
+ * The visibility flags default to what the role alone implies, which is the
+ * behaviour with both workspace overrides OFF. A test that cares about an
+ * override passes it explicitly:
+ *
+ *     mobileUserContext({ roles: ["BASE"], canSeeAllBookings: true })
+ */
+export function mobileUserContext(
+  overrides: {
+    roles?: OrganizationRoles[];
+    canUseBarcodes?: boolean;
+    canUseAudits?: boolean;
+    canSeeAllCustody?: boolean;
+    canSeeAllBookings?: boolean;
+  } = {}
+) {
+  const roles = overrides.roles ?? [OrganizationRoles.ADMIN];
+  const effectiveRole = resolveMostPrivilegedRole(roles);
+  const restricted = isSelfServiceOrBaseRole(effectiveRole);
+
+  return {
+    role: roles[0] ?? OrganizationRoles.BASE,
+    roles,
+    effectiveRole,
+    isSelfServiceOrBase: restricted,
+    canUseBarcodes: overrides.canUseBarcodes ?? true,
+    canUseAudits: overrides.canUseAudits ?? true,
+    canSeeAllCustody: overrides.canSeeAllCustody ?? !restricted,
+    canSeeAllBookings: overrides.canSeeAllBookings ?? !restricted,
+  };
+}

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.model-requests.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.model-requests.test.ts
@@ -30,6 +30,7 @@ import {
 import { action } from "~/routes/api+/mobile+/bookings.$bookingId.model-requests";
 
 import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 
 // @vitest-environment node
 
@@ -98,14 +99,10 @@ function makeArgs(method: "POST" | "DELETE", body: Record<string, unknown>) {
 
 /** Point `getMobileUserContext` at a specific role for the next call. */
 function withRole(role: OrganizationRoles) {
-  getMobileUserContextMock.mockResolvedValue({
-    role,
+  getMobileUserContextMock.mockResolvedValue(
     // The guard reads the full array, not roles[0].
-    roles: [role],
-    canUseBarcodes: true,
-    canUseAudits: true,
-    canSeeAllCustody: true,
-  });
+    mobileUserContext({ roles: [role] })
+  );
 }
 
 beforeEach(() => {

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.serialization.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.serialization.test.ts
@@ -23,6 +23,7 @@ import {
 import { loader } from "~/routes/api+/mobile+/bookings.$bookingId";
 
 import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 
 // @vitest-environment node
 
@@ -75,13 +76,9 @@ beforeEach(() => {
     user: { id: "user-1" },
   } as Awaited<ReturnType<typeof requireMobileAuth>>);
   requireOrganizationAccessMock.mockResolvedValue("org-1");
-  getMobileUserContextMock.mockResolvedValue({
-    role: OrganizationRoles.ADMIN,
-    roles: [OrganizationRoles.ADMIN],
-    canUseBarcodes: true,
-    canUseAudits: true,
-    canSeeAllCustody: true,
-  });
+  getMobileUserContextMock.mockResolvedValue(
+    mobileUserContext({ roles: [OrganizationRoles.ADMIN] })
+  );
 });
 
 describe("GET /api/mobile/bookings/:bookingId — model requests", () => {

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.slices.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.slices.test.ts
@@ -33,6 +33,7 @@ import type * as BookingServiceServer from "~/modules/booking/service.server";
 import { loader } from "~/routes/api+/mobile+/bookings.$bookingId";
 
 import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 
 // @vitest-environment node
 
@@ -112,13 +113,9 @@ beforeEach(() => {
     user: { id: "user-1" },
   } as Awaited<ReturnType<typeof requireMobileAuth>>);
   requireOrganizationAccessMock.mockResolvedValue("org-1");
-  getMobileUserContextMock.mockResolvedValue({
-    role: OrganizationRoles.ADMIN,
-    roles: [OrganizationRoles.ADMIN],
-    canUseBarcodes: true,
-    canUseAudits: true,
-    canSeeAllCustody: true,
-  });
+  getMobileUserContextMock.mockResolvedValue(
+    mobileUserContext({ roles: [OrganizationRoles.ADMIN] })
+  );
 });
 
 const K1 = { id: "kit-1", name: "Kit One" };

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.visibility.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.visibility.test.ts
@@ -30,6 +30,9 @@ import { mobileUserContext } from "@helpers/mobile-user-context";
 
 // @vitest-environment node
 
+// why: the module instantiates a real Prisma client at load and would try to
+// connect; the suite runs with no database. `booking.findFirst` is a spy so the
+// tests can assert the `where` this endpoint builds.
 vi.mock("~/database/db.server", () => ({
   db: {
     booking: { findFirst: vi.fn() },
@@ -38,6 +41,9 @@ vi.mock("~/database/db.server", () => ({
   },
 }));
 
+// why: JWT validation and org-membership resolution are out of scope here, and
+// the CALLER'S CONTEXT is the variable under test. The remaining exports stay
+// real (`vi.importActual`) so nothing else is silently replaced.
 vi.mock("~/modules/api/mobile-auth.server", async () => {
   const actual = await vi.importActual<typeof MobileAuthServer>(
     "~/modules/api/mobile-auth.server"
@@ -51,14 +57,16 @@ vi.mock("~/modules/api/mobile-auth.server", async () => {
   };
 });
 
-// why: booking settings and the action-permission lookup are unrelated to the
-// visibility question under test — stub them to fixed values.
+// why: the check-in policy is unrelated to the visibility question under test;
+// fixed values keep the action flags deterministic.
 vi.mock("~/modules/booking-settings/service.server", () => ({
   getBookingSettingsForOrganization: vi.fn().mockResolvedValue({
     requireExplicitCheckinForAdmin: false,
     requireExplicitCheckinForSelfService: false,
   }),
 }));
+// why: the action-availability lookup is a separate gate from the read gate
+// under test; a fixed `false` keeps it from touching the permission matrix.
 vi.mock("~/utils/permissions/permission.validator.server", () => ({
   hasPermission: vi.fn().mockResolvedValue(false),
 }));

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.visibility.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.$bookingId.visibility.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Who may OPEN a booking on the phone.
+ *
+ * The endpoint reads the booking org-scoped, then judges it with the shared
+ * `canSeeBooking` — the same helper and the same 403 the web overview route
+ * uses. Two properties follow, and both are asserted here: a refusal reads as
+ * 403 rather than as a missing row, and the answer can account for the
+ * workspace override because the row is already in hand when it is made.
+ *
+ * @see {@link file://./../../../../app/routes/api+/mobile+/bookings.$bookingId.ts} loader under test
+ * @see {@link file://./../../../../app/utils/booking-authorization.server.ts} `canSeeBooking`
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoaderArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import type * as MobileAuthServer from "~/modules/api/mobile-auth.server";
+import {
+  requireMobileAuth,
+  requireOrganizationAccess,
+  getMobileUserContext,
+} from "~/modules/api/mobile-auth.server";
+
+import { loader } from "~/routes/api+/mobile+/bookings.$bookingId";
+
+import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { mobileUserContext } from "@helpers/mobile-user-context";
+
+// @vitest-environment node
+
+vi.mock("~/database/db.server", () => ({
+  db: {
+    booking: { findFirst: vi.fn() },
+    bookingAsset: { findMany: vi.fn().mockResolvedValue([]) },
+    partialBookingCheckout: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}));
+
+vi.mock("~/modules/api/mobile-auth.server", async () => {
+  const actual = await vi.importActual<typeof MobileAuthServer>(
+    "~/modules/api/mobile-auth.server"
+  );
+  return {
+    ...actual,
+    requireMobileAuth: vi.fn(),
+    requireOrganizationAccess: vi.fn(),
+    assertMobileCanUseBookings: vi.fn(),
+    getMobileUserContext: vi.fn(),
+  };
+});
+
+// why: booking settings and the action-permission lookup are unrelated to the
+// visibility question under test — stub them to fixed values.
+vi.mock("~/modules/booking-settings/service.server", () => ({
+  getBookingSettingsForOrganization: vi.fn().mockResolvedValue({
+    requireExplicitCheckinForAdmin: false,
+    requireExplicitCheckinForSelfService: false,
+  }),
+}));
+vi.mock("~/utils/permissions/permission.validator.server", () => ({
+  hasPermission: vi.fn().mockResolvedValue(false),
+}));
+
+const CALLER = "user-1";
+const SOMEONE_ELSE = "user-2";
+
+const findFirstMock = vi.mocked(db.booking.findFirst);
+const getMobileUserContextMock = vi.mocked(getMobileUserContext);
+
+/**
+ * A minimal DRAFT-free booking row. DRAFT is avoided so the loader skips the
+ * partial-check-in lookup; custody is the only variable that matters here.
+ */
+function bookingRow(
+  custody: {
+    custodianUserId?: string | null;
+    custodianTeamMember?: {
+      id: string;
+      name: string;
+      userId: string | null;
+    } | null;
+  } = {}
+) {
+  return {
+    id: "booking-1",
+    name: "Traslado",
+    description: null,
+    status: "RESERVED",
+    from: new Date("2026-01-01T00:00:00.000Z"),
+    to: new Date("2026-01-02T00:00:00.000Z"),
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    creator: null,
+    custodianUserId: custody.custodianUserId ?? null,
+    custodianUser: null,
+    custodianTeamMember: custody.custodianTeamMember ?? null,
+    tags: [],
+    bookingAssets: [],
+    modelRequests: [],
+    _count: { bookingAssets: 0 },
+  } as never;
+}
+
+async function get() {
+  return loader(
+    createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/bookings/booking-1"
+      ),
+      params: { bookingId: "booking-1" },
+    })
+  );
+}
+
+/** The `where` the detail query actually ran with. */
+function lastWhere(): any {
+  return findFirstMock.mock.calls.at(-1)?.[0]?.where;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireMobileAuth).mockResolvedValue({
+    user: { id: CALLER },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1");
+});
+
+describe("GET /api/mobile/bookings/:bookingId — who may open it", () => {
+  it("never puts custody in the query, so the row is read before it is judged", async () => {
+    getMobileUserContextMock.mockResolvedValue(
+      mobileUserContext({ roles: [OrganizationRoles.BASE] })
+    );
+    findFirstMock.mockResolvedValue(bookingRow({ custodianUserId: CALLER }));
+
+    await get();
+
+    // A custodian clause here would decide visibility before the row is read,
+    // which both loses the workspace override and turns a refusal into a 404.
+    expect(JSON.stringify(lastWhere())).not.toContain("custodian");
+  });
+
+  it("refuses someone else's booking with 403, not 404, when the override is off", async () => {
+    getMobileUserContextMock.mockResolvedValue(
+      mobileUserContext({ roles: [OrganizationRoles.BASE] })
+    );
+    findFirstMock.mockResolvedValue(
+      bookingRow({ custodianUserId: SOMEONE_ELSE })
+    );
+
+    const response = await get();
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(403);
+  });
+
+  it.each([OrganizationRoles.BASE, OrganizationRoles.SELF_SERVICE])(
+    "opens someone else's booking for %s once the workspace override is on",
+    async (role) => {
+      getMobileUserContextMock.mockResolvedValue(
+        mobileUserContext({ roles: [role], canSeeAllBookings: true })
+      );
+      findFirstMock.mockResolvedValue(
+        bookingRow({ custodianUserId: SOMEONE_ELSE })
+      );
+
+      const response = await get();
+
+      assertIsDataWithResponseInit(response);
+      expect(response.init?.status ?? 200).toBe(200);
+    }
+  );
+
+  it("opens the caller's OWN booking through the user link", async () => {
+    // Guards the `custodianUserId` scalar in the select. `canSeeBooking` reads
+    // it, while the endpoint selects the custodianUser RELATION for display —
+    // drop the scalar and every restricted user 403s on their own booking.
+    getMobileUserContextMock.mockResolvedValue(
+      mobileUserContext({ roles: [OrganizationRoles.BASE] })
+    );
+    findFirstMock.mockResolvedValue(bookingRow({ custodianUserId: CALLER }));
+
+    const response = await get();
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status ?? 200).toBe(200);
+  });
+
+  it("opens the caller's OWN booking through the team-member link", async () => {
+    // Custody assigned by picking a team member leaves `custodianUserId` NULL.
+    // Matching the user link alone refuses the very user it belongs to.
+    getMobileUserContextMock.mockResolvedValue(
+      mobileUserContext({ roles: [OrganizationRoles.BASE] })
+    );
+    findFirstMock.mockResolvedValue(
+      bookingRow({
+        custodianUserId: null,
+        custodianTeamMember: { id: "tm-1", name: "Caller", userId: CALLER },
+      })
+    );
+
+    const response = await get();
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status ?? 200).toBe(200);
+  });
+
+  it("still 404s a booking that genuinely is not there", async () => {
+    getMobileUserContextMock.mockResolvedValue(
+      mobileUserContext({ roles: [OrganizationRoles.ADMIN] })
+    );
+    findFirstMock.mockResolvedValue(null);
+
+    const response = await get();
+
+    assertIsDataWithResponseInit(response);
+    expect(response.init?.status).toBe(404);
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/bookings.available-models.test.ts
@@ -25,6 +25,7 @@ import { getBookingModelTabData } from "~/modules/booking-model-request/service.
 import { loader } from "~/routes/api+/mobile+/bookings.available-models";
 
 import { assertIsDataWithResponseInit } from "@helpers/assertions";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 
 // @vitest-environment node
 
@@ -72,14 +73,10 @@ const ORG_ID = "org-1";
 const BOOKING_ID = "booking-1";
 
 function withRole(role: OrganizationRoles) {
-  getMobileUserContextMock.mockResolvedValue({
-    role,
+  getMobileUserContextMock.mockResolvedValue(
     // The guard reads the full array, not roles[0].
-    roles: [role],
-    canUseBarcodes: true,
-    canUseAudits: true,
-    canSeeAllCustody: true,
-  });
+    mobileUserContext({ roles: [role] })
+  );
 }
 
 function makeArgs() {

--- a/apps/webapp/test/routes-tests/api+/mobile+/dashboard.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/dashboard.test.ts
@@ -38,6 +38,7 @@ import {
 } from "~/modules/api/mobile-auth.server";
 
 import { loader } from "~/routes/api+/mobile+/dashboard";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 
 // why: the dashboard runs the REAL `getBookings`, whose `where` is the subject
 // under test. Mocking the Prisma client is what lets us capture that argument;
@@ -56,7 +57,14 @@ vi.mock("~/database/db.server", () => ({
     },
     category: { count: vi.fn().mockResolvedValue(0) },
     location: { count: vi.fn().mockResolvedValue(0) },
-    teamMember: { count: vi.fn().mockResolvedValue(0) },
+    teamMember: {
+      count: vi.fn().mockResolvedValue(0),
+      // why: `resolveCustodianScope` reads this to find the caller's
+      // team-member rows. Without it the scope resolution throws and the
+      // loader bails before any booking query runs — which every assertion
+      // below would read as "nothing leaked" rather than "nothing ran".
+      findMany: vi.fn().mockResolvedValue([]),
+    },
     auditSession: { findMany: vi.fn().mockResolvedValue([]) },
   },
 }));
@@ -92,7 +100,10 @@ const ORG_ID = "org-1";
  *
  * @param role - The caller's role in `ORG_ID`
  */
-function actAs(role: OrganizationRoles) {
+function actAs(
+  role: OrganizationRoles,
+  overrides: { canSeeAllBookings?: boolean } = {}
+) {
   requireMobileAuthMock.mockResolvedValue({
     user: {
       id: CALLER_USER_ID,
@@ -104,14 +115,14 @@ function actAs(role: OrganizationRoles) {
     },
   } as unknown as Awaited<ReturnType<typeof requireMobileAuth>>);
   requireOrganizationAccessMock.mockResolvedValue(ORG_ID);
-  getMobileUserContextMock.mockResolvedValue({
-    role,
+  getMobileUserContextMock.mockResolvedValue(
     // The guard reads the full array, not roles[0].
-    roles: [role],
-    canUseBarcodes: true,
-    canUseAudits: true,
-    canSeeAllCustody: role !== OrganizationRoles.SELF_SERVICE,
-  });
+    mobileUserContext({
+      roles: [role],
+      canSeeAllCustody: role !== OrganizationRoles.SELF_SERVICE,
+      ...overrides,
+    })
+  );
 }
 
 /**
@@ -169,6 +180,49 @@ describe("GET /api/mobile/dashboard — booking visibility", () => {
           custodianUserId: CALLER_USER_ID,
         });
       }
+    }
+  );
+
+  it("matches the caller's team-member custody links, not just the user link", async () => {
+    actAs(OrganizationRoles.BASE);
+    // Custody can sit on a team-member row with no user attached, which is
+    // how most custodians are picked. A bare `{ userId }` filter would hide a
+    // restricted user's own booking from their Home tab.
+    (db.teamMember.findMany as any).mockResolvedValue([
+      { id: "tm-1" },
+      { id: "tm-2" },
+    ]);
+
+    const wheres = await captureBookingWheres();
+
+    expect(wheres).toHaveLength(3);
+    for (const where of wheres) {
+      expect(andClausesOf(where)).toContainEqual({
+        OR: [
+          { custodianUserId: CALLER_USER_ID },
+          { custodianTeamMemberId: { in: ["tm-1", "tm-2"] } },
+        ],
+      });
+    }
+  });
+
+  it.each([OrganizationRoles.SELF_SERVICE, OrganizationRoles.BASE])(
+    "drops the restriction for %s when the workspace override is on",
+    async (role) => {
+      // Home is the third lens on these rows and honours the override the
+      // same way the list and calendar do.
+      actAs(role, { canSeeAllBookings: true });
+
+      const wheres = await captureBookingWheres();
+
+      expect(wheres).toHaveLength(3);
+      for (const where of wheres) {
+        expect(andClausesOf(where)).not.toContainEqual({
+          custodianUserId: CALLER_USER_ID,
+        });
+      }
+      // The scope is not merely widened, it is never resolved.
+      expect(db.teamMember.findMany).not.toHaveBeenCalled();
     }
   );
 

--- a/apps/webapp/test/routes-tests/api+/mobile+/team-members.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/team-members.test.ts
@@ -14,6 +14,7 @@
 
 import { OrganizationRoles } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 import { createLoaderArgs } from "@mocks/remix";
 
 import { db } from "~/database/db.server";
@@ -63,13 +64,9 @@ function actAs(
   roles: OrganizationRoles[],
   { canSeeAllCustody = false }: { canSeeAllCustody?: boolean } = {}
 ) {
-  vi.mocked(getMobileUserContext).mockResolvedValue({
-    role: roles[0],
-    roles,
-    canUseBarcodes: true,
-    canUseAudits: true,
-    canSeeAllCustody,
-  });
+  vi.mocked(getMobileUserContext).mockResolvedValue(
+    mobileUserContext({ roles, canSeeAllCustody })
+  );
 }
 
 async function get() {

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.calendar.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.calendar.test.ts
@@ -1,3 +1,4 @@
+import type { OrganizationRoles } from "@prisma/client";
 import { loader } from "~/routes/api+/mobile+/bookings.calendar";
 import { createLoaderArgs } from "@mocks/remix";
 
@@ -85,6 +86,7 @@ import {
   custodianScopeClause,
   resolveCustodianScope,
 } from "~/modules/booking/service.server";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 import {
   requireMobileAuth,
   requireOrganizationAccess,
@@ -119,7 +121,9 @@ describe("GET /api/mobile/bookings/calendar", () => {
     (requireMobileAuth as any).mockResolvedValue({ user: { id: "user-1" } });
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
-    (getMobileUserContext as any).mockResolvedValue({ roles: ["ADMIN"] });
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({ roles: ["ADMIN"] })
+    );
     mockDb.booking.findMany.mockResolvedValue([]);
     mockDb.booking.count.mockResolvedValue(0);
     mockDb.booking.findFirst.mockResolvedValue(null);
@@ -237,9 +241,9 @@ describe("GET /api/mobile/bookings/calendar", () => {
 
   describe("who can see what", () => {
     it("scopes a SELF_SERVICE user through the shared custodian clause", async () => {
-      (getMobileUserContext as any).mockResolvedValue({
-        roles: ["SELF_SERVICE"],
-      });
+      (getMobileUserContext as any).mockResolvedValue(
+        mobileUserContext({ roles: ["SELF_SERVICE"] })
+      );
 
       await loader(createLoaderArgs({ request: calendarRequest(RANGE) }));
 
@@ -260,12 +264,43 @@ describe("GET /api/mobile/bookings/calendar", () => {
     });
 
     it("scopes a BASE user the same way", async () => {
-      (getMobileUserContext as any).mockResolvedValue({ roles: ["BASE"] });
+      (getMobileUserContext as any).mockResolvedValue(
+        mobileUserContext({ roles: ["BASE"] })
+      );
 
       await loader(createLoaderArgs({ request: calendarRequest(RANGE) }));
 
       expect(custodianScopeClause).toHaveBeenCalled();
       expect(lastWhere().AND).toContainEqual({ __custodianClause: true });
+    });
+
+    it.each([["SELF_SERVICE"], ["BASE"]])(
+      "stops scoping a %s user once the workspace override is on",
+      async (role) => {
+        // The list lens on this same screen must answer identically: one lens
+        // showing a booking the other denies is the failure this guards.
+        (getMobileUserContext as any).mockResolvedValue(
+          mobileUserContext({
+            roles: [role as OrganizationRoles],
+            canSeeAllBookings: true,
+          })
+        );
+
+        await loader(createLoaderArgs({ request: calendarRequest(RANGE) }));
+
+        expect(resolveCustodianScope).not.toHaveBeenCalled();
+        expect(lastWhere().AND).not.toContainEqual({ __custodianClause: true });
+      }
+    );
+
+    it("keeps drafts private even when the override is on", async () => {
+      (getMobileUserContext as any).mockResolvedValue(
+        mobileUserContext({ roles: ["BASE"], canSeeAllBookings: true })
+      );
+
+      await loader(createLoaderArgs({ request: calendarRequest(RANGE) }));
+
+      expect(lastWhere().AND).toContainEqual({ __draftClause: true });
     });
 
     it("does not narrow an ADMIN to their own bookings", async () => {
@@ -294,9 +329,9 @@ describe("GET /api/mobile/bookings/calendar", () => {
       // membership stored `[SELF_SERVICE, ADMIN]` narrowed a genuine admin to
       // bookings they are custodian of - their colleagues' bookings vanished
       // from the grid while the list lens still showed them.
-      (getMobileUserContext as any).mockResolvedValue({
-        roles: ["SELF_SERVICE", "ADMIN"],
-      });
+      (getMobileUserContext as any).mockResolvedValue(
+        mobileUserContext({ roles: ["SELF_SERVICE", "ADMIN"] })
+      );
 
       await loader(createLoaderArgs({ request: calendarRequest(RANGE) }));
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.calendar.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.calendar.test.ts
@@ -121,7 +121,7 @@ describe("GET /api/mobile/bookings/calendar", () => {
     (requireMobileAuth as any).mockResolvedValue({ user: { id: "user-1" } });
     (requireOrganizationAccess as any).mockResolvedValue("org-1");
     (requireMobilePermission as any).mockResolvedValue(undefined);
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({ roles: ["ADMIN"] })
     );
     mockDb.booking.findMany.mockResolvedValue([]);
@@ -241,7 +241,7 @@ describe("GET /api/mobile/bookings/calendar", () => {
 
   describe("who can see what", () => {
     it("scopes a SELF_SERVICE user through the shared custodian clause", async () => {
-      (getMobileUserContext as any).mockResolvedValue(
+      vi.mocked(getMobileUserContext).mockResolvedValue(
         mobileUserContext({ roles: ["SELF_SERVICE"] })
       );
 
@@ -264,7 +264,7 @@ describe("GET /api/mobile/bookings/calendar", () => {
     });
 
     it("scopes a BASE user the same way", async () => {
-      (getMobileUserContext as any).mockResolvedValue(
+      vi.mocked(getMobileUserContext).mockResolvedValue(
         mobileUserContext({ roles: ["BASE"] })
       );
 
@@ -279,7 +279,7 @@ describe("GET /api/mobile/bookings/calendar", () => {
       async (role) => {
         // The list lens on this same screen must answer identically: one lens
         // showing a booking the other denies is the failure this guards.
-        (getMobileUserContext as any).mockResolvedValue(
+        vi.mocked(getMobileUserContext).mockResolvedValue(
           mobileUserContext({
             roles: [role as OrganizationRoles],
             canSeeAllBookings: true,
@@ -294,7 +294,7 @@ describe("GET /api/mobile/bookings/calendar", () => {
     );
 
     it("keeps drafts private even when the override is on", async () => {
-      (getMobileUserContext as any).mockResolvedValue(
+      vi.mocked(getMobileUserContext).mockResolvedValue(
         mobileUserContext({ roles: ["BASE"], canSeeAllBookings: true })
       );
 
@@ -329,7 +329,7 @@ describe("GET /api/mobile/bookings/calendar", () => {
       // membership stored `[SELF_SERVICE, ADMIN]` narrowed a genuine admin to
       // bookings they are custodian of - their colleagues' bookings vanished
       // from the grid while the list lens still showed them.
-      (getMobileUserContext as any).mockResolvedValue(
+      vi.mocked(getMobileUserContext).mockResolvedValue(
         mobileUserContext({ roles: ["SELF_SERVICE", "ADMIN"] })
       );
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.test.ts
@@ -1,3 +1,4 @@
+import { OrganizationRoles } from "@prisma/client";
 import { loader } from "~/routes/api+/mobile+/bookings";
 import { createLoaderArgs } from "@mocks/remix";
 
@@ -35,7 +36,20 @@ vi.mock("react-router", async () => ({
 vi.mock("~/modules/api/mobile-auth.server", () => ({
   requireMobileAuth: vi.fn().mockResolvedValue({ user: { id: "user-1" } }),
   requireOrganizationAccess: vi.fn().mockResolvedValue("org-1"),
-  getMobileUserContext: vi.fn().mockResolvedValue({ roles: ["ADMIN"] }),
+  // why: a plain literal, not the `mobileUserContext` helper — `vi.mock`
+  // factories are hoisted above the imports, so referencing the helper here
+  // throws before it is initialised. Every test overrides this in `beforeEach`
+  // anyway; this only has to be a valid shape.
+  getMobileUserContext: vi.fn().mockResolvedValue({
+    role: "ADMIN",
+    roles: ["ADMIN"],
+    effectiveRole: "ADMIN",
+    isSelfServiceOrBase: false,
+    canUseBarcodes: true,
+    canUseAudits: true,
+    canSeeAllCustody: true,
+    canSeeAllBookings: true,
+  }),
 }));
 
 // why: the shared visibility helpers. Stubbed to sentinels so the assertions
@@ -72,6 +86,7 @@ vi.mock("~/utils/error", () => ({
 
 import { db } from "~/database/db.server";
 import { getMobileUserContext } from "~/modules/api/mobile-auth.server";
+import { mobileUserContext } from "@helpers/mobile-user-context";
 import {
   custodianScopeClause,
   resolveCustodianScope,
@@ -90,7 +105,9 @@ describe("GET /api/mobile/bookings", () => {
     vi.clearAllMocks();
     (db.booking.findMany as any).mockResolvedValue([]);
     (db.booking.count as any).mockResolvedValue(0);
-    (getMobileUserContext as any).mockResolvedValue({ roles: ["ADMIN"] });
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({ roles: ["ADMIN"] })
+    );
     (resolveCustodianScope as any).mockResolvedValue({
       userId: "user-1",
       teamMemberIds: ["tm-1", "tm-2"],
@@ -99,9 +116,9 @@ describe("GET /api/mobile/bookings", () => {
   });
 
   it("scopes a SELF_SERVICE user through the shared custodian clause", async () => {
-    (getMobileUserContext as any).mockResolvedValue({
-      roles: ["SELF_SERVICE"],
-    });
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({ roles: ["SELF_SERVICE"] })
+    );
 
     await loader(createLoaderArgs({ request: request() }));
 
@@ -121,12 +138,114 @@ describe("GET /api/mobile/bookings", () => {
   });
 
   it("scopes a BASE user the same way", async () => {
-    (getMobileUserContext as any).mockResolvedValue({ roles: ["BASE"] });
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({ roles: ["BASE"] })
+    );
 
     await loader(createLoaderArgs({ request: request() }));
 
     expect(custodianScopeClause).toHaveBeenCalled();
     expect(lastWhere().AND).toContainEqual({ __custodianClause: true });
+  });
+
+  it.each([["SELF_SERVICE"], ["BASE"]])(
+    "stops scoping a %s user once the workspace override is on",
+    async (role) => {
+      // The workspace override, not the role, is the deciding input. With it
+      // on, the restriction is not merely widened — it is never resolved.
+      (getMobileUserContext as any).mockResolvedValue(
+        mobileUserContext({
+          roles: [role as OrganizationRoles],
+          canSeeAllBookings: true,
+        })
+      );
+
+      await loader(createLoaderArgs({ request: request() }));
+
+      expect(resolveCustodianScope).not.toHaveBeenCalled();
+      expect(lastWhere().AND).not.toContainEqual({ __custodianClause: true });
+    }
+  );
+
+  it("keeps drafts private even when the override is on", async () => {
+    // The override widens WHOSE bookings are visible. A draft stays private to
+    // its creator either way, exactly as on web.
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({ roles: ["BASE"], canSeeAllBookings: true })
+    );
+
+    await loader(createLoaderArgs({ request: request() }));
+
+    expect(lastWhere().AND).toContainEqual({ __draftClause: true });
+  });
+
+  it("hides a colleague's custodian name when only the booking override is on", async () => {
+    // Two independent settings. Seeing a booking does not mean seeing who
+    // holds it; web draws the literal "private" in that case.
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({
+        roles: ["BASE"],
+        canSeeAllBookings: true,
+        canSeeAllCustody: false,
+      })
+    );
+    (db.booking.findMany as any).mockResolvedValue([
+      {
+        id: "b-1",
+        name: "Someone else's booking",
+        status: "ONGOING",
+        from: new Date(0),
+        to: new Date(0),
+        createdAt: new Date(0),
+        custodianUser: { id: "other-user", profilePicture: "pic.jpg" },
+        custodianTeamMember: { name: "Mario", userId: "other-user" },
+        _count: { bookingAssets: 1, modelRequests: 0 },
+        modelRequests: [],
+      },
+    ]);
+    (db.booking.count as any).mockResolvedValue(1);
+
+    const response = (await loader(
+      createLoaderArgs({ request: request() })
+    )) as unknown as Response;
+    const body = await response.json();
+
+    expect(body.bookings[0].custodianName).toBe("private");
+    expect(body.bookings[0].custodianImage).toBeNull();
+  });
+
+  it("still shows the caller their OWN custodian name with custody off", async () => {
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({
+        roles: ["BASE"],
+        canSeeAllBookings: true,
+        canSeeAllCustody: false,
+      })
+    );
+    (db.booking.findMany as any).mockResolvedValue([
+      {
+        id: "b-2",
+        name: "My booking",
+        status: "ONGOING",
+        from: new Date(0),
+        to: new Date(0),
+        createdAt: new Date(0),
+        custodianUser: null,
+        // Custody through a team-member row that IS the caller. Matching only
+        // the user link would print "private" on their own booking.
+        custodianTeamMember: { name: "Caller", userId: "user-1" },
+        _count: { bookingAssets: 1, modelRequests: 0 },
+        modelRequests: [],
+      },
+    ]);
+    (db.booking.count as any).mockResolvedValue(1);
+
+    const response = (await loader(
+      createLoaderArgs({ request: request() })
+    )) as unknown as Response;
+    const body = await response.json();
+
+    expect(body.bookings[0].custodianName).toBe("Caller");
   });
 
   it("does not narrow an ADMIN to their own bookings", async () => {
@@ -141,9 +260,9 @@ describe("GET /api/mobile/bookings", () => {
     // membership stored `[SELF_SERVICE, ADMIN]` resolved to SELF_SERVICE and a
     // genuine admin was narrowed to bookings they are custodian of. The
     // calendar lens shares this scoping and has to reach the same verdict.
-    (getMobileUserContext as any).mockResolvedValue({
-      roles: ["SELF_SERVICE", "ADMIN"],
-    });
+    (getMobileUserContext as any).mockResolvedValue(
+      mobileUserContext({ roles: ["SELF_SERVICE", "ADMIN"] })
+    );
 
     await loader(createLoaderArgs({ request: request() }));
 
@@ -152,11 +271,17 @@ describe("GET /api/mobile/bookings", () => {
   });
 
   it("always applies draft privacy, whatever the role", async () => {
-    for (const role of ["ADMIN", "SELF_SERVICE", "BASE"]) {
+    for (const role of [
+      OrganizationRoles.ADMIN,
+      OrganizationRoles.SELF_SERVICE,
+      OrganizationRoles.BASE,
+    ]) {
       vi.clearAllMocks();
       (db.booking.findMany as any).mockResolvedValue([]);
       (db.booking.count as any).mockResolvedValue(0);
-      (getMobileUserContext as any).mockResolvedValue({ roles: [role] });
+      (getMobileUserContext as any).mockResolvedValue(
+        mobileUserContext({ roles: [role] })
+      );
 
       await loader(createLoaderArgs({ request: request() }));
 

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.test.ts
@@ -95,24 +95,38 @@ import {
 const request = () =>
   new Request("http://localhost/api/mobile/bookings?orgId=org-1");
 
-/** The `where` the list query actually ran with. */
-function lastWhere(): any {
-  return (db.booking.findMany as any).mock.calls.at(-1)?.[0]?.where;
+/**
+ * The `where` the list query actually ran with.
+ *
+ * Typed as a plain record rather than `Prisma.BookingWhereInput`: the generated
+ * `Exact<>` wrapper on the call signature does not assign back to the bare
+ * input type, and the assertions here only read keys.
+ */
+function lastWhere(): Record<string, unknown> {
+  const where = vi.mocked(db.booking.findMany).mock.calls.at(-1)?.[0]?.where;
+  if (!where) {
+    throw new Error("the list query never ran");
+  }
+  return where;
 }
 
 describe("GET /api/mobile/bookings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (db.booking.findMany as any).mockResolvedValue([]);
-    (db.booking.count as any).mockResolvedValue(0);
+    vi.mocked(db.booking.findMany).mockResolvedValue([]);
+    vi.mocked(db.booking.count).mockResolvedValue(0);
     vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({ roles: ["ADMIN"] })
     );
-    (resolveCustodianScope as any).mockResolvedValue({
+    vi.mocked(resolveCustodianScope).mockResolvedValue({
       userId: "user-1",
       teamMemberIds: ["tm-1", "tm-2"],
     });
-    (custodianScopeClause as any).mockReturnValue({ __custodianClause: true });
+    // A sentinel, not a real clause: the assertions are about whether the
+    // route delegates to the helper, not about the helper's own output.
+    vi.mocked(custodianScopeClause).mockReturnValue({
+      __custodianClause: true,
+    } as never);
   });
 
   it("scopes a SELF_SERVICE user through the shared custodian clause", async () => {
@@ -189,7 +203,7 @@ describe("GET /api/mobile/bookings", () => {
         canSeeAllCustody: false,
       })
     );
-    (db.booking.findMany as any).mockResolvedValue([
+    vi.mocked(db.booking.findMany).mockResolvedValue([
       {
         id: "b-1",
         name: "Someone else's booking",
@@ -202,8 +216,8 @@ describe("GET /api/mobile/bookings", () => {
         _count: { bookingAssets: 1, modelRequests: 0 },
         modelRequests: [],
       },
-    ]);
-    (db.booking.count as any).mockResolvedValue(1);
+    ] as never);
+    vi.mocked(db.booking.count).mockResolvedValue(1);
 
     const response = (await loader(
       createLoaderArgs({ request: request() })
@@ -224,7 +238,7 @@ describe("GET /api/mobile/bookings", () => {
         canSeeAllCustody: false,
       })
     );
-    (db.booking.findMany as any).mockResolvedValue([
+    vi.mocked(db.booking.findMany).mockResolvedValue([
       {
         id: "b-3",
         name: "Unassigned booking",
@@ -237,8 +251,8 @@ describe("GET /api/mobile/bookings", () => {
         _count: { bookingAssets: 0, modelRequests: 0 },
         modelRequests: [],
       },
-    ]);
-    (db.booking.count as any).mockResolvedValue(1);
+    ] as never);
+    vi.mocked(db.booking.count).mockResolvedValue(1);
 
     const response = (await loader(
       createLoaderArgs({ request: request() })
@@ -256,7 +270,7 @@ describe("GET /api/mobile/bookings", () => {
         canSeeAllCustody: false,
       })
     );
-    (db.booking.findMany as any).mockResolvedValue([
+    vi.mocked(db.booking.findMany).mockResolvedValue([
       {
         id: "b-2",
         name: "My booking",
@@ -271,8 +285,8 @@ describe("GET /api/mobile/bookings", () => {
         _count: { bookingAssets: 1, modelRequests: 0 },
         modelRequests: [],
       },
-    ]);
-    (db.booking.count as any).mockResolvedValue(1);
+    ] as never);
+    vi.mocked(db.booking.count).mockResolvedValue(1);
 
     const response = (await loader(
       createLoaderArgs({ request: request() })
@@ -311,8 +325,8 @@ describe("GET /api/mobile/bookings", () => {
       OrganizationRoles.BASE,
     ]) {
       vi.clearAllMocks();
-      (db.booking.findMany as any).mockResolvedValue([]);
-      (db.booking.count as any).mockResolvedValue(0);
+      vi.mocked(db.booking.findMany).mockResolvedValue([]);
+      vi.mocked(db.booking.count).mockResolvedValue(0);
       vi.mocked(getMobileUserContext).mockResolvedValue(
         mobileUserContext({ roles: [role] })
       );

--- a/apps/webapp/test/routes-tests/api+/mobile.bookings.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile.bookings.test.ts
@@ -105,7 +105,7 @@ describe("GET /api/mobile/bookings", () => {
     vi.clearAllMocks();
     (db.booking.findMany as any).mockResolvedValue([]);
     (db.booking.count as any).mockResolvedValue(0);
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({ roles: ["ADMIN"] })
     );
     (resolveCustodianScope as any).mockResolvedValue({
@@ -116,7 +116,7 @@ describe("GET /api/mobile/bookings", () => {
   });
 
   it("scopes a SELF_SERVICE user through the shared custodian clause", async () => {
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({ roles: ["SELF_SERVICE"] })
     );
 
@@ -138,7 +138,7 @@ describe("GET /api/mobile/bookings", () => {
   });
 
   it("scopes a BASE user the same way", async () => {
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({ roles: ["BASE"] })
     );
 
@@ -153,7 +153,7 @@ describe("GET /api/mobile/bookings", () => {
     async (role) => {
       // The workspace override, not the role, is the deciding input. With it
       // on, the restriction is not merely widened — it is never resolved.
-      (getMobileUserContext as any).mockResolvedValue(
+      vi.mocked(getMobileUserContext).mockResolvedValue(
         mobileUserContext({
           roles: [role as OrganizationRoles],
           canSeeAllBookings: true,
@@ -170,7 +170,7 @@ describe("GET /api/mobile/bookings", () => {
   it("keeps drafts private even when the override is on", async () => {
     // The override widens WHOSE bookings are visible. A draft stays private to
     // its creator either way, exactly as on web.
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({ roles: ["BASE"], canSeeAllBookings: true })
     );
 
@@ -182,7 +182,7 @@ describe("GET /api/mobile/bookings", () => {
   it("hides a colleague's custodian name when only the booking override is on", async () => {
     // Two independent settings. Seeing a booking does not mean seeing who
     // holds it; web draws the literal "private" in that case.
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({
         roles: ["BASE"],
         canSeeAllBookings: true,
@@ -214,8 +214,42 @@ describe("GET /api/mobile/bookings", () => {
     expect(body.bookings[0].custodianImage).toBeNull();
   });
 
+  it("reports a booking with no custodian as null, not private", async () => {
+    // Three distinct answers. "private" claims a custodian exists and is being
+    // withheld; an unassigned booking must not make that claim.
+    vi.mocked(getMobileUserContext).mockResolvedValue(
+      mobileUserContext({
+        roles: ["BASE"],
+        canSeeAllBookings: true,
+        canSeeAllCustody: false,
+      })
+    );
+    (db.booking.findMany as any).mockResolvedValue([
+      {
+        id: "b-3",
+        name: "Unassigned booking",
+        status: "DRAFT",
+        from: new Date(0),
+        to: new Date(0),
+        createdAt: new Date(0),
+        custodianUser: null,
+        custodianTeamMember: null,
+        _count: { bookingAssets: 0, modelRequests: 0 },
+        modelRequests: [],
+      },
+    ]);
+    (db.booking.count as any).mockResolvedValue(1);
+
+    const response = (await loader(
+      createLoaderArgs({ request: request() })
+    )) as unknown as Response;
+    const body = await response.json();
+
+    expect(body.bookings[0].custodianName).toBeNull();
+  });
+
   it("still shows the caller their OWN custodian name with custody off", async () => {
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({
         roles: ["BASE"],
         canSeeAllBookings: true,
@@ -260,7 +294,7 @@ describe("GET /api/mobile/bookings", () => {
     // membership stored `[SELF_SERVICE, ADMIN]` resolved to SELF_SERVICE and a
     // genuine admin was narrowed to bookings they are custodian of. The
     // calendar lens shares this scoping and has to reach the same verdict.
-    (getMobileUserContext as any).mockResolvedValue(
+    vi.mocked(getMobileUserContext).mockResolvedValue(
       mobileUserContext({ roles: ["SELF_SERVICE", "ADMIN"] })
     );
 
@@ -279,7 +313,7 @@ describe("GET /api/mobile/bookings", () => {
       vi.clearAllMocks();
       (db.booking.findMany as any).mockResolvedValue([]);
       (db.booking.count as any).mockResolvedValue(0);
-      (getMobileUserContext as any).mockResolvedValue(
+      vi.mocked(getMobileUserContext).mockResolvedValue(
         mobileUserContext({ roles: [role] })
       );
 


### PR DESCRIPTION
## What

A workspace can let SELF_SERVICE and BASE users see bookings they are not the custodian of, with **Settings → General → "can see other users' bookings"**. The website honours it. The companion app did not: those users got an empty Bookings tab, an empty calendar and empty Home sections in a workspace whose website listed every booking.

Reported by a customer whose base user sees two ongoing bookings on the website and "No active bookings" on Android, in the same workspace, at the same moment.

## Why it happened

`getMobileUserContext` reads the organization row and resolves the two **custody** overrides. The two **booking** overrides were never in that select, so no mobile endpoint could see the setting. Each booking read then decided from the role alone:

```ts
const isSelfServiceOrBase = role === SELF_SERVICE || role === BASE;
const custodianScope = isSelfServiceOrBase ? await resolveCustodianScope(...) : null;
```

`resolveCanSeeAllBookings` (the rule the website uses everywhere) had zero callers under `api+/mobile+/`.

## What changed

**`getMobileUserContext`** selects all four overrides on the row it already reads, and returns `canSeeAllBookings` next to the existing `canSeeAllCustody`. No extra query. It also returns `effectiveRole` and `isSelfServiceOrBase`, resolved from the most privileged role instead of `roles[0]`.

**Four read surfaces** take their answer from it:

| Endpoint | Change |
|---|---|
| `bookings.ts` (list) | resolves the custodian scope only when the caller may not see everything |
| `bookings.calendar.ts` | same, so both lenses on that screen agree about what exists |
| `bookings.$bookingId.ts` | custody moves out of the `where` and onto the loaded row via the shared `canSeeBooking`; a refusal is now **403**, not 404 |
| `dashboard.ts` | `resolveCustodianScope` instead of a bare `{ userId }`, which also matches the caller's team-member custody links |

**`resolveCanSeeAllBookings` and `isSelfServiceOrBaseRole` move** to `booking-authorization.server.ts`, re-exported from `roles.server.ts` for the existing importers. Mobile cannot import `roles.server.ts`: it pulls in Sentry and the organization service, and through it Stripe and the mailer, which no mobile route or its test can carry.

### Fixing only the list would have been worse than the bug

The detail endpoint scoped by custodian inside its `where`. Fix the list alone and the user gets two rows that both **404 on tap**. The calendar toggle on that same screen stays empty, and Home keeps disagreeing with Bookings. The four move together.

## Scope guards

- **Read only.** Every write path keeps its ownership guard unchanged: `create`, `update`, `delete`, `reserve`, `duplicate`, `archive`, `cancel`, `checkin`, `checkout`, `partial-*`, `fulfil-and-checkout`, `remove-assets`, `add-scanned-assets`, `model-requests`. `remove-assets` passes `canSeeAllBookings: false` deliberately and is left that way. `available-models` is a mutation-target picker, not a read lens, and is untouched.
- **Drafts stay private to their creator**, override or not, exactly as on web. Asserted in the list and calendar tests.
- **The custodian NAME stays behind the separate custody override** on the list, calendar and dashboard. Seeing a booking does not mean seeing who holds it. These return the literal `"private"` when it is withheld, which is the word the web badge renders; `null` already means "no custodian". The detail endpoint keeps rendering its own custodian, matching web.
- `canSeeAllCustody` now resolves from `effectiveRole` rather than `roles[0]`. A no-op on current data: the only multi-role memberships are `{ADMIN,ADMIN}` and `{BASE,BASE}`, no heterogeneous arrays exist.

## Ship path

**Server-only.** `grep -rE "baseUserCanSee|selfServiceCanSee|canSeeAllBookings|canSeeAllCustody" apps/companion/` returns nothing, the client `Organization` type carries no override flag, and the app applies no client-side custody or ownership filter. Installed binaries pick this up on deploy. No OTA, no store release.

## Tests

`pnpm webapp:validate` green: **443 files, 5,858 tests**, 0 lint errors.

New coverage, all of it confirmed to fail against the unfixed code:

- `mobile-auth.server.visibility.test.ts` — the four overrides are selected; `canSeeAllBookings` across every role x both flags; the two flags stay independent; booking and custody visibility stay independent; most-privileged-role resolution
- `bookings.$bookingId.visibility.test.ts` — no custody in the query; 403 not 404; opens for BASE/SELF_SERVICE with the override on; opens the caller's own booking through **either** custody link; still 404s a genuinely absent booking
- list, calendar and dashboard — override on drops the scope entirely, drafts stay private, custodian names gate correctly, dashboard matches team-member links

`test/helpers/mobile-user-context.ts` builds the context shape in one place. The route mocks were hand-written `{ roles: [...] }` literals, so a new permission field reads as `false` and silently inverts an assertion rather than failing it.

Reverting each gate in turn fails exactly the matching tests and nothing else.

## Verification

Confirmed against the reporting workspace: all four overrides `true`, the reporter's membership is `{BASE}`, and both bookings carry `custodianUserId = NULL` with a team-member custodian who is not them. That is the exact path `custodianScopeClause` filtered to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace settings now control whether Base and Self-Service users can view all mobile bookings.
  * Mobile booking lists, calendars, dashboards, and details consistently apply booking and custody visibility permissions.
  * Custodian names and images are hidden when viewers lack custody access; unassigned bookings show no custodian.

* **Bug Fixes**
  * Improved visibility handling for users with multiple roles and team-member custody links.
  * Unauthorized booking access now returns 403, while missing bookings continue to return 404.

* **Tests**
  * Added coverage for workspace overrides, booking access, custody privacy, and role resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->