### PR TITLE
fix(companion): scope the mobile custodian picker for BASE users

### DIFF
--- a/apps/webapp/app/routes/api+/mobile+/team-members.ts
+++ b/apps/webapp/app/routes/api+/mobile+/team-members.ts
@@ -1,4 +1,3 @@
-import { OrganizationRoles } from "@prisma/client";
 import { data, type LoaderFunctionArgs } from "react-router";
 import { db } from "~/database/db.server";
 import {
@@ -6,6 +5,8 @@ import {
   requireMobileAuth,
   requireOrganizationAccess,
 } from "~/modules/api/mobile-auth.server";
+import { resolveCustodianPickerScope } from "~/modules/team-member/service.server";
+import { resolveMostPrivilegedRole } from "~/utils/booking-authorization.server";
 import { makeShelfError } from "~/utils/error";
 
 /**
@@ -14,17 +15,35 @@ import { makeShelfError } from "~/utils/error";
  * Returns non-deleted team members for the organization.
  * Used by the mobile app's custody assignment picker.
  *
- * SELF_SERVICE callers only receive their own team member record — they may
- * only assign custody to themselves (enforced again in the custody services),
- * and the web scanner loader applies the same filter (`filterByUserId`), so
- * the full roster is never exposed to them on either platform.
+ * Every companion caller is an ASSIGNMENT picker: asset custody, kit custody,
+ * the scanner's bulk-assign sheet, and the booking custodian on create/edit.
+ * The scope therefore comes from `resolveCustodianPickerScope`, the same rule
+ * the web pickers resolve through, so the two platforms offer the same names.
+ *
+ * `booking-custodian` is the widest purpose this endpoint serves, and the one
+ * it must answer for: BASE holds `booking:create` and has to be able to put
+ * itself on a booking. Restricted roles get their own row and nothing else;
+ * ADMIN and OWNER get the roster. A caller who may not actually take asset
+ * custody is still refused by the custody services, which gate on the
+ * permission matrix rather than on this list.
  */
 export async function loader({ request }: LoaderFunctionArgs) {
   try {
     const { user } = await requireMobileAuth(request);
     const organizationId = await requireOrganizationAccess(request, user.id);
-    const { role } = await getMobileUserContext(user.id, organizationId);
-    const isSelfService = role === OrganizationRoles.SELF_SERVICE;
+    const { roles, canSeeAllCustody } = await getMobileUserContext(
+      user.id,
+      organizationId
+    );
+    // Resolved from the whole membership, not `roles[0]`: a membership ordered
+    // [SELF_SERVICE, ADMIN] reads as SELF_SERVICE by position, which narrows a
+    // genuine admin to their own row.
+    const scope = resolveCustodianPickerScope({
+      purpose: "booking-custodian",
+      role: resolveMostPrivilegedRole(roles),
+      canSeeAllCustody,
+      userId: user.id,
+    });
 
     const url = new URL(request.url);
     const search = url.searchParams.get("search") || "";
@@ -47,11 +66,24 @@ export async function loader({ request }: LoaderFunctionArgs) {
     const where = {
       organizationId,
       deletedAt: null,
-      ...(isSelfService ? { userId: user.id } : {}),
+      // `self` narrows to the caller's own team-member rows. `none` cannot
+      // arise from `booking-custodian`, but is handled so a future purpose
+      // cannot silently widen this to the whole roster.
+      ...(scope.mode === "self" ? { userId: scope.userId } : {}),
       ...(search
         ? { name: { contains: search, mode: "insensitive" as const } }
         : {}),
     };
+
+    if (scope.mode === "none") {
+      return data({
+        teamMembers: [],
+        page,
+        perPage,
+        totalCount: 0,
+        totalPages: 1,
+      });
+    }
 
     const [teamMembers, totalCount] = await Promise.all([
       db.teamMember.findMany({

--- a/apps/webapp/test/routes-tests/api+/mobile+/team-members.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/team-members.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Who the companion's custodian pickers may list.
+ *
+ * The endpoint feeds four assignment pickers — asset custody, kit custody, the
+ * scanner's bulk-assign sheet, and the booking custodian — so it resolves
+ * through `resolveCustodianPickerScope` at the `booking-custodian` purpose,
+ * the widest of the four. Restricted roles get their own row; ADMIN and OWNER
+ * get the roster. The web pickers resolve through the same function, so the
+ * two platforms offer the same names for the same caller.
+ *
+ * @see {@link file://./../../../../app/routes/api+/mobile+/team-members.ts} loader under test
+ * @see {@link file://./../../../../app/modules/team-member/service.server.ts} `resolveCustodianPickerScope`
+ */
+
+import { OrganizationRoles } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLoaderArgs } from "@mocks/remix";
+
+import { db } from "~/database/db.server";
+import {
+  getMobileUserContext,
+  requireMobileAuth,
+  requireOrganizationAccess,
+} from "~/modules/api/mobile-auth.server";
+import { loader } from "~/routes/api+/mobile+/team-members";
+
+// @vitest-environment node
+
+vi.mock("~/database/db.server", () => ({
+  db: {
+    teamMember: {
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+    },
+  },
+}));
+
+vi.mock("~/modules/api/mobile-auth.server", () => ({
+  requireMobileAuth: vi.fn(),
+  requireOrganizationAccess: vi.fn(),
+  getMobileUserContext: vi.fn(),
+}));
+
+const CALLER = "user-1";
+
+/** The `where` the roster query actually ran with. */
+function lastWhere(): any {
+  return (db.teamMember.findMany as any).mock.calls.at(-1)?.[0]?.where;
+}
+
+function actAs(
+  roles: OrganizationRoles[],
+  { canSeeAllCustody = false }: { canSeeAllCustody?: boolean } = {}
+) {
+  (getMobileUserContext as any).mockResolvedValue({
+    role: roles[0],
+    roles,
+    canUseBarcodes: true,
+    canUseAudits: true,
+    canSeeAllCustody,
+  });
+}
+
+async function get() {
+  return loader(
+    createLoaderArgs({
+      request: new Request(
+        "http://localhost:3000/api/mobile/team-members?orgId=org-1"
+      ),
+    })
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (db.teamMember.findMany as any).mockResolvedValue([]);
+  (db.teamMember.count as any).mockResolvedValue(0);
+  (requireMobileAuth as any).mockResolvedValue({ user: { id: CALLER } });
+  (requireOrganizationAccess as any).mockResolvedValue("org-1");
+});
+
+describe("GET /api/mobile/team-members — who may be listed", () => {
+  it.each([OrganizationRoles.ADMIN, OrganizationRoles.OWNER])(
+    "lists the whole roster for %s",
+    async (role) => {
+      actAs([role], { canSeeAllCustody: true });
+
+      await get();
+
+      expect(lastWhere()).not.toHaveProperty("userId");
+    }
+  );
+
+  it.each([OrganizationRoles.BASE, OrganizationRoles.SELF_SERVICE])(
+    "narrows %s to their own team-member rows",
+    async (role) => {
+      actAs([role]);
+
+      await get();
+
+      expect(lastWhere()).toMatchObject({
+        organizationId: "org-1",
+        deletedAt: null,
+        userId: CALLER,
+      });
+    }
+  );
+
+  it("keeps BASE narrowed even where the workspace grants custody visibility", async () => {
+    // The custody override governs SEEING who holds what. It never widens who
+    // a picker may hand something to, so it must not widen this list either.
+    actAs([OrganizationRoles.BASE], { canSeeAllCustody: true });
+
+    await get();
+
+    expect(lastWhere()).toMatchObject({ userId: CALLER });
+  });
+
+  it("reads the most privileged role, not whichever is stored first", async () => {
+    // `roles[0]` would read this membership as SELF_SERVICE and narrow a
+    // genuine admin to their own row.
+    actAs([OrganizationRoles.SELF_SERVICE, OrganizationRoles.ADMIN]);
+
+    await get();
+
+    expect(lastWhere()).not.toHaveProperty("userId");
+  });
+
+  it("still applies the search filter alongside the scope", async () => {
+    actAs([OrganizationRoles.BASE]);
+
+    await loader(
+      createLoaderArgs({
+        request: new Request(
+          "http://localhost:3000/api/mobile/team-members?orgId=org-1&search=mario"
+        ),
+      })
+    );
+
+    expect(lastWhere()).toMatchObject({
+      userId: CALLER,
+      name: { contains: "mario", mode: "insensitive" },
+    });
+  });
+});

--- a/apps/webapp/test/routes-tests/api+/mobile+/team-members.test.ts
+++ b/apps/webapp/test/routes-tests/api+/mobile+/team-members.test.ts
@@ -26,6 +26,9 @@ import { loader } from "~/routes/api+/mobile+/team-members";
 
 // @vitest-environment node
 
+// why: the module instantiates a real Prisma client at load and would try to
+// connect; the suite runs with no database. `teamMember.findMany` is a spy so
+// the tests can assert the `where` this endpoint builds.
 vi.mock("~/database/db.server", () => ({
   db: {
     teamMember: {
@@ -35,6 +38,8 @@ vi.mock("~/database/db.server", () => ({
   },
 }));
 
+// why: JWT validation and org-membership resolution are out of scope here, and
+// the caller's role is the variable under test.
 vi.mock("~/modules/api/mobile-auth.server", () => ({
   requireMobileAuth: vi.fn(),
   requireOrganizationAccess: vi.fn(),
@@ -43,16 +48,22 @@ vi.mock("~/modules/api/mobile-auth.server", () => ({
 
 const CALLER = "user-1";
 
-/** The `where` the roster query actually ran with. */
-function lastWhere(): any {
-  return (db.teamMember.findMany as any).mock.calls.at(-1)?.[0]?.where;
+/**
+ * The `where` the roster query actually ran with.
+ *
+ * Typed as a plain record rather than `Prisma.TeamMemberWhereInput`: the
+ * generated `Exact<>` wrapper on the call signature does not assign back to
+ * the bare input type, and the assertions here only read keys.
+ */
+function lastWhere(): Record<string, unknown> | undefined {
+  return vi.mocked(db.teamMember.findMany).mock.calls.at(-1)?.[0]?.where;
 }
 
 function actAs(
   roles: OrganizationRoles[],
   { canSeeAllCustody = false }: { canSeeAllCustody?: boolean } = {}
 ) {
-  (getMobileUserContext as any).mockResolvedValue({
+  vi.mocked(getMobileUserContext).mockResolvedValue({
     role: roles[0],
     roles,
     canUseBarcodes: true,
@@ -73,10 +84,12 @@ async function get() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (db.teamMember.findMany as any).mockResolvedValue([]);
-  (db.teamMember.count as any).mockResolvedValue(0);
-  (requireMobileAuth as any).mockResolvedValue({ user: { id: CALLER } });
-  (requireOrganizationAccess as any).mockResolvedValue("org-1");
+  vi.mocked(db.teamMember.findMany).mockResolvedValue([]);
+  vi.mocked(db.teamMember.count).mockResolvedValue(0);
+  vi.mocked(requireMobileAuth).mockResolvedValue({
+    user: { id: CALLER },
+  } as Awaited<ReturnType<typeof requireMobileAuth>>);
+  vi.mocked(requireOrganizationAccess).mockResolvedValue("org-1");
 });
 
 describe("GET /api/mobile/team-members — who may be listed", () => {


### PR DESCRIPTION
## What

`GET /api/mobile/team-members` scoped its query for `SELF_SERVICE` and for nobody else. A **BASE** caller received every team member in the workspace, with names and profile pictures.

The web equivalent returns nothing for BASE. Its pickers resolve through `resolveCustodianPickerScope`, and BASE never reaches `mode: "all"` at any purpose.

The endpoint's own doc comment claimed "the full roster is never exposed to them on either platform". That was true for SELF_SERVICE and not for BASE.

## Why it happened

```ts
const { role } = await getMobileUserContext(user.id, organizationId);
const isSelfService = role === OrganizationRoles.SELF_SERVICE;
// ...
...(isSelfService ? { userId: user.id } : {}),
```

Two problems in three lines: BASE has no arm, and `role` is `roles[0]`, which reads a `[SELF_SERVICE, ADMIN]` membership as SELF_SERVICE and narrows a genuine admin to their own row.

## What changed

The endpoint resolves through `resolveCustodianPickerScope`, the same function the web pickers use, at the `booking-custodian` purpose:

| Role | Before | After |
|---|---|---|
| OWNER / ADMIN | whole roster | whole roster |
| SELF_SERVICE | own row | own row |
| **BASE** | **whole roster** | **own row** |

The role now comes from `resolveMostPrivilegedRole(roles)`.

### Why `booking-custodian` and not `custody-assignment`

Every companion caller of this endpoint is an assignment picker: asset custody (`assets/[id]`), kit custody (`assets/kits/[id]`), the scanner's bulk-assign sheet, and the booking custodian on `bookings/new` and `bookings/edit`. `booking-custodian` is the widest of the four, and the one the endpoint has to be able to answer.

`custody-assignment` returns `none` for BASE, which is correct for asset custody — BASE holds `custody: []` in the permission matrix and may never take an asset. But this is one shared endpoint, so that mode would empty the New Booking custodian picker on **every installed app** and stop a BASE user creating a booking at all. BASE holds `booking:create` and has to be able to put itself on a booking.

A BASE caller who tries to take asset custody anyway is refused by the custody services, which gate on the permission matrix rather than on this list. The `none` branch is implemented regardless, so a future `purpose` parameter cannot silently widen the query back to the roster.

## Scope

- Read-only. No write path changes.
- ADMIN and OWNER behaviour is unchanged.
- Nothing else reads this endpoint: `team-member-picker.tsx` is its only caller.
- Independent of #2997. Neither depends on the other and they can merge in either order.

## Ship path

Server-only. Installed apps pick it up on deploy. No OTA, no store release.

## Tests

New `test/routes-tests/api+/mobile+/team-members.test.ts`: roster for ADMIN/OWNER; own row for BASE and SELF_SERVICE; BASE stays narrowed even where the workspace grants custody visibility (that override governs *seeing* custody, never *assigning* it); most-privileged-role resolution; and the search filter still composes with the scope.

Reverting the scope to the `SELF_SERVICE`-only rule fails exactly the three BASE assertions and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated mobile team-member visibility to respect the caller’s highest-priority role.
  * Limited basic and self-service access to the caller’s own team-member records.
  * Prevented visibility settings from expanding restricted access.
  * Returned no team members when the caller has no eligible access.
  * Preserved search filtering alongside access restrictions.

* **Tests**
  * Added coverage for role-based visibility, role precedence, access overrides, empty results, and search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->