### PR TITLE
fix(webapp): survive DOM rewrites by page translation during React commits

### DIFF
--- a/apps/webapp/app/components/forms/select.tsx
+++ b/apps/webapp/app/components/forms/select.tsx
@@ -9,7 +9,31 @@ const Select = SelectPrimitive.Root;
 
 const SelectGroup = SelectPrimitive.Group;
 
-const SelectValue = SelectPrimitive.Value;
+/**
+ * Radix renders a string `placeholder` as a bare text node inside the value
+ * span and removes that node when a value is picked. Page translation rewrites
+ * text nodes in place, which would make that removal target a node that is no
+ * longer there. Rendering the placeholder inside an element keeps the swap an
+ * element removal, which stays valid on a translated page.
+ */
+const SelectValue = React.forwardRef<
+  ElementRef<typeof SelectPrimitive.Value>,
+  ComponentPropsWithoutRef<typeof SelectPrimitive.Value>
+>(function SelectValue({ placeholder, ...props }, ref) {
+  return (
+    <SelectPrimitive.Value
+      ref={ref}
+      placeholder={
+        typeof placeholder === "string" ? (
+          <span>{placeholder}</span>
+        ) : (
+          placeholder
+        )
+      }
+      {...props}
+    />
+  );
+});
 
 const SelectTrigger = React.forwardRef<
   ElementRef<typeof SelectPrimitive.Trigger>,

--- a/apps/webapp/app/entry.client.tsx
+++ b/apps/webapp/app/entry.client.tsx
@@ -5,7 +5,11 @@ import { Provider as JotaiProvider } from "jotai";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+import { installDomMutationGuard } from "~/utils/dom-mutation-guard";
 import { handleClientBeforeSend } from "~/utils/sentry-filters";
+
+// Must run before hydration so every React commit goes through the guard.
+installDomMutationGuard();
 
 if (window.env?.SENTRY_DSN) {
   Sentry.init({

--- a/apps/webapp/app/utils/dom-mutation-guard.test.ts
+++ b/apps/webapp/app/utils/dom-mutation-guard.test.ts
@@ -1,3 +1,14 @@
+/**
+ * Tests for the DOM mutation guard that keeps React commits alive after page
+ * translation or a browser extension has rewritten React-owned nodes.
+ *
+ * Covers the two guarded methods (`removeChild`, `insertBefore`) against real
+ * children, translated (detached) references, reparented references, and the
+ * install / dispose lifecycle. happy-dom throws the same `NotFoundError` as the
+ * browser, which is what the unguarded baseline test relies on.
+ *
+ * @see {@link file://./dom-mutation-guard.ts}
+ */
 /* eslint-disable no-console -- the guard reports through console.warn; the tests assert on it */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -36,6 +47,8 @@ describe("installDomMutationGuard", () => {
   let parent: HTMLDivElement;
 
   beforeEach(() => {
+    // why: the guard reports through console.warn; silencing it keeps the test
+    // output clean while the spy still lets the tests assert on the calls.
     vi.spyOn(console, "warn").mockImplementation(() => {});
     parent = document.createElement("div");
     document.body.appendChild(parent);
@@ -174,6 +187,19 @@ describe("installDomMutationGuard", () => {
       expect(isDomMutationGuardInstalled()).toBe(false);
       expect(Node.prototype.removeChild).toBe(nativeRemoveChild);
       expect(Node.prototype.insertBefore).toBe(nativeInsertBefore);
+    });
+
+    it("keeps the guard when a repeated installation is disposed", () => {
+      const dispose = installDomMutationGuard();
+      const disposeAgain = installDomMutationGuard();
+
+      disposeAgain();
+
+      expect(isDomMutationGuardInstalled()).toBe(true);
+
+      dispose();
+
+      expect(isDomMutationGuardInstalled()).toBe(false);
     });
 
     it("installs nothing when given no prototype", () => {

--- a/apps/webapp/app/utils/dom-mutation-guard.test.ts
+++ b/apps/webapp/app/utils/dom-mutation-guard.test.ts
@@ -1,0 +1,184 @@
+/* eslint-disable no-console -- the guard reports through console.warn; the tests assert on it */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  installDomMutationGuard,
+  isDomMutationGuardInstalled,
+  uninstallDomMutationGuard,
+} from "./dom-mutation-guard";
+
+/**
+ * Rewrites a text node the way Chrome's page translation does: the original
+ * node is detached and a `<font><font>translated</font></font>` wrapper takes
+ * its place.
+ */
+function translateTextNode(text: Text): HTMLElement {
+  const outer = document.createElement("font");
+  const inner = document.createElement("font");
+  inner.textContent = `translated: ${text.nodeValue}`;
+  outer.appendChild(inner);
+  text.parentNode!.replaceChild(outer, text);
+  return outer;
+}
+
+/**
+ * Moves a text node into a wrapper element in place, the way an extension
+ * that decorates text (rather than replacing it) rewrites the DOM.
+ */
+function reparentTextNode(text: Text): HTMLElement {
+  const wrapper = document.createElement("mark");
+  text.parentNode!.replaceChild(wrapper, text);
+  wrapper.appendChild(text);
+  return wrapper;
+}
+
+describe("installDomMutationGuard", () => {
+  let parent: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    parent = document.createElement("div");
+    document.body.appendChild(parent);
+  });
+
+  afterEach(() => {
+    uninstallDomMutationGuard();
+    parent.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("throws NotFoundError without the guard when the child was rewritten", () => {
+    const text = document.createTextNode("Select user role");
+    parent.appendChild(text);
+    translateTextNode(text);
+
+    expect(() => parent.removeChild(text)).toThrow();
+  });
+
+  describe("removeChild", () => {
+    beforeEach(() => {
+      installDomMutationGuard();
+    });
+
+    it("removes a real child through the native method", () => {
+      const child = document.createElement("span");
+      parent.appendChild(child);
+
+      expect(parent.removeChild(child)).toBe(child);
+      expect(parent.contains(child)).toBe(false);
+    });
+
+    it("returns the node without throwing when it was rewritten by translation", () => {
+      const text = document.createTextNode("Select user role");
+      parent.appendChild(text);
+      const wrapper = translateTextNode(text);
+
+      expect(parent.removeChild(text)).toBe(text);
+      expect(parent.firstChild).toBe(wrapper);
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns once per method, not once per call", () => {
+      const a = document.createTextNode("a");
+      const b = document.createTextNode("b");
+      parent.append(a, b);
+      translateTextNode(a);
+      translateTextNode(b);
+
+      parent.removeChild(a);
+      parent.removeChild(b);
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("insertBefore", () => {
+    beforeEach(() => {
+      installDomMutationGuard();
+    });
+
+    it("inserts before a real reference through the native method", () => {
+      const first = document.createElement("i");
+      const last = document.createElement("b");
+      parent.append(first, last);
+      const inserted = document.createElement("u");
+
+      expect(parent.insertBefore(inserted, last)).toBe(inserted);
+      expect([...parent.childNodes]).toEqual([first, inserted, last]);
+    });
+
+    it("appends when the reference is null", () => {
+      const first = document.createElement("i");
+      parent.append(first);
+      const inserted = document.createElement("u");
+
+      parent.insertBefore(inserted, null);
+
+      expect([...parent.childNodes]).toEqual([first, inserted]);
+    });
+
+    it("appends when the reference was replaced by translation", () => {
+      const first = document.createElement("i");
+      const text = document.createTextNode("Select user role");
+      parent.append(first, text);
+      const wrapper = translateTextNode(text);
+      const inserted = document.createElement("u");
+
+      parent.insertBefore(inserted, text);
+
+      expect([...parent.childNodes]).toEqual([first, wrapper, inserted]);
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("inserts before the wrapper when the reference was moved into one", () => {
+      const first = document.createElement("i");
+      const text = document.createTextNode("Select user role");
+      const last = document.createElement("b");
+      parent.append(first, text, last);
+      const wrapper = reparentTextNode(text);
+      const inserted = document.createElement("u");
+
+      parent.insertBefore(inserted, text);
+
+      expect([...parent.childNodes]).toEqual([first, inserted, wrapper, last]);
+    });
+
+    it("appends when the reference is detached from the document", () => {
+      const first = document.createElement("i");
+      const reference = document.createElement("s");
+      parent.append(first, reference);
+      reference.remove();
+      const inserted = document.createElement("u");
+
+      parent.insertBefore(inserted, reference);
+
+      expect([...parent.childNodes]).toEqual([first, inserted]);
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("installs once and restores the native methods on uninstall", () => {
+      const nativeRemoveChild = Node.prototype.removeChild;
+      const nativeInsertBefore = Node.prototype.insertBefore;
+
+      installDomMutationGuard();
+      const guardedRemoveChild = Node.prototype.removeChild;
+      installDomMutationGuard();
+
+      expect(isDomMutationGuardInstalled()).toBe(true);
+      expect(Node.prototype.removeChild).toBe(guardedRemoveChild);
+      expect(Node.prototype.removeChild).not.toBe(nativeRemoveChild);
+
+      uninstallDomMutationGuard();
+
+      expect(isDomMutationGuardInstalled()).toBe(false);
+      expect(Node.prototype.removeChild).toBe(nativeRemoveChild);
+      expect(Node.prototype.insertBefore).toBe(nativeInsertBefore);
+    });
+
+    it("installs nothing when given no prototype", () => {
+      expect(installDomMutationGuard(null)).toBeTypeOf("function");
+      expect(isDomMutationGuardInstalled()).toBe(false);
+    });
+  });
+});

--- a/apps/webapp/app/utils/dom-mutation-guard.ts
+++ b/apps/webapp/app/utils/dom-mutation-guard.ts
@@ -66,7 +66,10 @@ function defaultProto(): Node | null {
 
 /**
  * Installs the guard on `proto` (defaults to the global `Node.prototype`).
- * Installing twice on the same prototype is a no-op.
+ * Installing twice on the same prototype is a no-op: the first installation
+ * owns the guard, and only its disposer restores the native methods. A repeated
+ * installation returns a disposer that does nothing, so a later caller cannot
+ * remove the protection the first caller relies on.
  *
  * @param proto - The prototype whose `removeChild` / `insertBefore` to wrap;
  *   `null` installs nothing
@@ -75,11 +78,8 @@ function defaultProto(): Node | null {
 export function installDomMutationGuard(
   proto: Node | null = defaultProto()
 ): () => void {
-  if (!proto) {
+  if (!proto || nativeMethods.has(proto)) {
     return () => {};
-  }
-  if (nativeMethods.has(proto)) {
-    return () => uninstallDomMutationGuard(proto);
   }
 
   const nativeRemoveChild = proto.removeChild;

--- a/apps/webapp/app/utils/dom-mutation-guard.ts
+++ b/apps/webapp/app/utils/dom-mutation-guard.ts
@@ -1,0 +1,147 @@
+/**
+ * Keeps React's DOM commits from throwing when something outside React has
+ * rewritten the nodes React owns.
+ *
+ * Chrome's built-in page translation (and extensions such as Google Translate
+ * or Grammarly) replace text nodes with `<font>` wrappers and reparent nodes.
+ * React keeps references to the original nodes, so its next commit calls
+ * `parent.removeChild(node)` or `parent.insertBefore(node, reference)` with a
+ * node that is no longer a child of `parent`. The browser throws
+ * `NotFoundError`, React hands it to the nearest error boundary, and the whole
+ * route is replaced by the "Oops, something went wrong" screen. On a
+ * translated page this happens on the first placeholder swap in a Select,
+ * the first conditional text node that toggles, or the first unmount.
+ *
+ * The guard wraps `Node.prototype.removeChild` and `Node.prototype.insertBefore`:
+ *
+ * - `removeChild` of a node that is not a child of the receiver returns the
+ *   node without touching the DOM. The receiver already lacks that node where
+ *   React expects it, so there is nothing to remove.
+ * - `insertBefore` with a reference that is not a child of the receiver walks
+ *   up from the reference to the nearest ancestor that IS a child and inserts
+ *   before that ancestor (a reference that was moved into a wrapper). A
+ *   reference that was detached from the document has no such ancestor and
+ *   the node is appended.
+ *
+ * Calls that satisfy the DOM contract go straight to the native method, so
+ * React's normal operation is unchanged. Install once, before hydration.
+ *
+ * @see {@link file://./../entry.client.tsx} — the install site
+ * @see {@link file://./sentry-filters.ts} — drops the same `NotFoundError`
+ *      shape from Sentry for browsers where the guard is not active
+ */
+
+type RemoveChild = Node["removeChild"];
+type InsertBefore = Node["insertBefore"];
+
+/** Native methods captured at install time, keyed by the patched prototype. */
+const nativeMethods = new WeakMap<
+  Node,
+  { removeChild: RemoveChild; insertBefore: InsertBefore }
+>();
+
+const warned = new Set<string>();
+
+/**
+ * Logs one warning per method per page load. The warning is a diagnostic for
+ * developers looking at a translated page in devtools, not an error: the
+ * guard already recovered.
+ */
+function warnOnce(method: string, receiver: Node, node: Node) {
+  if (warned.has(method)) {
+    return;
+  }
+  warned.add(method);
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[dom-mutation-guard] ${method} was called with a node that is not a child of its receiver. Something outside React (page translation or a browser extension) rewrote the DOM; React's commit continued without it.`,
+    { receiver, node }
+  );
+}
+
+/** The global `Node.prototype`, or `null` where there is no DOM (SSR). */
+function defaultProto(): Node | null {
+  return typeof Node === "function" ? Node.prototype : null;
+}
+
+/**
+ * Installs the guard on `proto` (defaults to the global `Node.prototype`).
+ * Installing twice on the same prototype is a no-op.
+ *
+ * @param proto - The prototype whose `removeChild` / `insertBefore` to wrap;
+ *   `null` installs nothing
+ * @returns A function that restores the native methods (used by tests)
+ */
+export function installDomMutationGuard(
+  proto: Node | null = defaultProto()
+): () => void {
+  if (!proto) {
+    return () => {};
+  }
+  if (nativeMethods.has(proto)) {
+    return () => uninstallDomMutationGuard(proto);
+  }
+
+  const nativeRemoveChild = proto.removeChild;
+  const nativeInsertBefore = proto.insertBefore;
+  nativeMethods.set(proto, {
+    removeChild: nativeRemoveChild,
+    insertBefore: nativeInsertBefore,
+  });
+
+  proto.removeChild = function guardedRemoveChild<T extends Node>(
+    this: Node,
+    child: T
+  ): T {
+    if (child.parentNode !== this) {
+      warnOnce("removeChild", this, child);
+      return child;
+    }
+    return nativeRemoveChild.call(this, child) as T;
+  };
+
+  proto.insertBefore = function guardedInsertBefore<T extends Node>(
+    this: Node,
+    node: T,
+    reference: Node | null
+  ): T {
+    if (reference && reference.parentNode !== this) {
+      warnOnce("insertBefore", this, reference);
+      let anchor: Node | null = reference;
+      while (anchor && anchor.parentNode !== this) {
+        anchor = anchor.parentNode;
+      }
+      return nativeInsertBefore.call(this, node, anchor) as T;
+    }
+    return nativeInsertBefore.call(this, node, reference) as T;
+  };
+
+  return () => uninstallDomMutationGuard(proto);
+}
+
+/**
+ * Restores the native methods on `proto`. No-op when the guard is not
+ * installed there.
+ */
+export function uninstallDomMutationGuard(
+  proto: Node | null = defaultProto()
+): void {
+  if (!proto) {
+    return;
+  }
+  const native = nativeMethods.get(proto);
+  if (!native) {
+    return;
+  }
+  proto.removeChild = native.removeChild;
+  proto.insertBefore = native.insertBefore;
+  nativeMethods.delete(proto);
+  warned.clear();
+}
+
+/** Whether the guard is currently installed on `proto`. */
+export function isDomMutationGuardInstalled(
+  proto: Node | null = defaultProto()
+): boolean {
+  return Boolean(proto && nativeMethods.has(proto));
+}


### PR DESCRIPTION
## Problem

On a page translated by Chrome's built-in page translation (or a translate extension), picking a role in the **Invite a user** dialog on `/settings/team/users` replaces the whole route with the generic "Oops, something went wrong" screen. Console:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

**Mechanism.** Radix `Select.Value` renders a string `placeholder` as a bare text node inside the trigger span and removes that node when a value is picked. Page translation replaces the original text node with `<font><font>…</font></font>` wrappers, so React's `removeChild(textNode)` throws during the commit and the route error boundary takes over. All 13 `SelectValue placeholder=` sites in the app behave the same way.

These crashes are invisible in Sentry: the client `beforeSend` (`utils/sentry-filters.ts`) already drops this `NotFoundError` shape, so the Error ID shown on the screen never exists there.

## Fix

1. **`components/forms/select.tsx`** — `SelectValue` renders a string placeholder inside a `<span>`. Picking a value now removes an element that is still a real child, instead of a text node that translation rewrote. This alone fixes the reported crash for all 13 placeholder sites.
2. **`utils/dom-mutation-guard.ts` + `entry.client.tsx`** — a guard installed before hydration wraps `Node.prototype.removeChild` and `insertBefore`. When the child/reference is not a child of the receiver, removal becomes a no-op and insertion anchors on the nearest ancestor that is a child (or appends). Calls that satisfy the DOM contract go straight to the native methods, so normal React operation is unchanged. This covers the other text-node removals and insertions on translated pages (for example the 8 `{cond && "text"}` sites) that Sentry cannot report. 11 unit tests.

Kept as is: the `<html lang="en">` page stays translatable (no `notranslate` meta), and the Sentry `beforeSend` filter stays for browsers where the guard is not active.

## Proof (local dev, QA workspace)

Translation was simulated the way Chrome does it: every text node replaced by `<font>` wrappers, plus a `MutationObserver` doing the same for nodes added later.

- **Before (main):** Invite a user → pick a role → route replaced by the error screen; console shows the `removeChild` NotFoundError from `react-dom`.
- **After:** same steps → role selected and shown in the trigger, invite submitted, success toast, dialog closed. No error boundary, no console error.
- `pnpm webapp:validate` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with browser translation tools and extensions, preventing DOM update errors during app interactions.
  - Select controls now display text placeholders more consistently across supported configurations.
  - Improved handling of externally changed, detached, or reparented page elements during updates.

- **Reliability**
  - Added safeguards before hydration to maintain stable rendering when external tools modify page content.
  - DOM updates now safely handle invalid removal and insertion references without interrupting the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->