### PR TITLE
fix(webapp): give the checklist's code column back the width it was sized for

### DIFF
--- a/apps/webapp/app/components/booking/booking-overview-pdf.tsx
+++ b/apps/webapp/app/components/booking/booking-overview-pdf.tsx
@@ -367,11 +367,14 @@ export const BookingPDFPreview = ({
               <th className="w-24 border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
                 Location
               </th>
-              {/* Sized for the code, which spans the cell under the image: at
-                  150px it gets ~130px, enough for a SAM ID or a ten-character
-                  QR id on one line and a 25-character legacy QR id on two.
-                  Longer barcode values wrap further on `break-all`. */}
-              <th className="min-w-[150px] border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
+              {/* Sized so the CODE gets ~120px, the same room the audit
+                  receipt gives it at 140px. The two numbers differ because this
+                  cell also carries the tick box and its gap on the code's line,
+                  which take 32px the audit cell does not spend. At ~120px a SAM
+                  ID or a ten-character QR id takes one line and a 25-character
+                  legacy QR id takes two; below ~166px the legacy id takes
+                  three. Longer barcode values wrap further on `break-all`. */}
+              <th className="min-w-[174px] border-b border-r border-gray-300 p-2.5 text-left text-xs font-medium">
                 Code
               </th>
             </tr>


### PR DESCRIPTION
Cosmetic follow-up to #2993. The checklist's code column is 32px narrower than it was sized to be, so long codes wrap onto a third line.

## What happened

#2993 set the column to 150px so that a 25-character legacy `Qr.id` would print on **two** lines instead of three. At that point the code sat on its own line beneath the QR image and had the whole cell.

A later commit in the same PR added the "hide the QR image" setting and moved the tick box from beside the **image** to beside the **code**, so the cell reads the same with the image and without it. That put the tick box and its `gap-3` on the code's line and took 32px off it:

| | |
|---|---|
| Column | 150px |
| less cell padding | −20px |
| less tick box | −20px |
| less gap | −12px |
| **Code gets** | **97px** |

97px is below the ~113px a 25-character id needs, so it wraps to three lines again — undoing the reason the column was widened.

## The fix

174px, which gives the code ~120px.

That is deliberately the same room the audit receipt gives it at 140px. The two numbers differ by exactly the 32px this cell spends on the tick box and gap, which the audit cell does not have. Same printed result, different column width.

## Measured, not calculated

Against production, on a workspace whose assets all carry 25-character legacy ids, with a real 25-character value in the cell:

| Column | Code gets | Lines |
|---|---|---|
| 150px (current) | 97px | 3 |
| 166px | 113px | 2 |
| **174px** | **121px** | **2** |
| 190px | 137px | 2 |

166px is the threshold; 174px takes it with headroom and lands on parity with the audit sheet. The table does not overflow its wrapper at any width tested.

Unaffected: a SAM ID or a ten-character `Qr.id` was one line before and stays one line. Only the long-code case changes.

## No test

jsdom performs no layout, so a test here could only assert that a Tailwind class string is present, which pins the character count rather than the behaviour. The comment above the header carries the threshold and the reason the two sheets use different numbers.

## Verification

- `pnpm webapp:validate`: 447 files, 5925 tests. One unrelated activity-CSV route file timed out under parallel load and passes in isolation in 3.6s; this change is a single Tailwind class in a PDF component and cannot reach it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Widened the booking assets table’s **Code** column to improve spacing for its checkbox and related content.
  * Updated the column sizing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->