### PR TITLE
feat(companion): scan to check out a booking's assets

### DIFF
--- a/apps/companion/.maestro/flows/bookings/19-scan-to-checkout.yaml
+++ b/apps/companion/.maestro/flows/bookings/19-scan-to-checkout.yaml
@@ -1,0 +1,370 @@
+appId: com.shelf.companion.carlos
+name: "Bookings - Scan to check out (mobile)"
+tags:
+  - bookings
+  - checkout
+  - scanner
+  - high-impact
+
+---
+# Progressive check-out driven by the scanner: the twin of "Scan to Check In".
+# Creates a booking, adds a kit + a standalone asset, reserves it, then checks
+# the assets out one scan at a time — asserting the kit expands to its members,
+# an off-booking asset is refused, a re-scanned kit reports it is already
+# covered, and the booking's own numbers come back from the server.
+#
+# Also covers the ONGOING entry rule: once the first batch flips the booking to
+# ONGOING, "Check Out All Assets" disappears while both progressive check-out
+# affordances stay, so the operator can keep taking the rest.
+#
+# Fixture (set up via psql before the run, torn down after), in GRANULAR
+# WORKSPACE (cmn8vu17y001rooi1l2etdpzf):
+#   Four AVAILABLE, bookable, uncustodied INDIVIDUAL assets — "E2E Checkout
+#   Alpha" and "Bravo" as the members of kit "E2E Scan Checkout Kit",
+#   "Charlie" scanned on its own, "Delta" never added to the booking. Qr rows
+#   for the kit, Charlie and Delta. The flow creates and deletes its booking.
+#
+#   Give every asset a cuid-shaped id (leading "c"): the partial-checkout
+#   endpoint validates assetIds with zod .cuid(), so any other id shape is
+#   refused with 400 before the booking is touched.
+#
+# Env: SHELF_TEST_EMAIL / SHELF_TEST_PASSWORD
+#      SHELF_TEST_CHECKOUT_KIT_QR_ID     kit QR                 (e2eskchkqr01)
+#      SHELF_TEST_CHECKOUT_ASSET_QR_ID   asset ON the booking   (e2eskchkqra3)
+#      SHELF_TEST_OFF_BOOKING_QR_ID      asset NOT on it        (e2eskchkqra4)
+
+- runFlow: ../../shared/login.yaml
+
+# The iOS "Save Password?" prompt can appear LATE (after login.yaml's own
+# dismissal), covering the nav — clear it if present, then wait for the tab bar.
+- tapOn:
+    text: "Not Now"
+    optional: true
+- extendedWaitUntil:
+    visible: "Settings"
+    timeout: 15000
+
+# ── Switch to the GRANULAR (TEAM) workspace — bookings are TEAM-only ──
+- tapOn: "Settings"
+- extendedWaitUntil:
+    visible: ".*Current workspace.*"
+    timeout: 8000
+- tapOn: ".*Current workspace.*"
+# The sheet suffixes the active workspace with "(CURRENT)", and selectors
+# full-match, so a bare name misses whenever the app is already in it.
+- tapOn: ".*GRANULAR WORKSPACE.*"
+- waitForAnimationToEnd
+
+# ── Remove a leftover booking of the same name so the selectors stay unique ──
+- tapOn: "Bookings"
+- extendedWaitUntil:
+    visible: "Create booking"
+    timeout: 15000
+- runFlow:
+    when:
+      visible: ".*E2E Scan Checkout Booking.*"
+    commands:
+      - tapOn: ".*E2E Scan Checkout Booking.*"
+      - extendedWaitUntil:
+          visible: "More booking actions"
+          timeout: 20000
+      - tapOn: "More booking actions"
+      - extendedWaitUntil:
+          visible: "Delete booking"
+          timeout: 10000
+      - tapOn:
+          text: "^Delete booking$"
+      - extendedWaitUntil:
+          visible: "Delete Booking"
+          timeout: 10000
+      - tapOn:
+          text: "^Delete$"
+      - extendedWaitUntil:
+          visible: "Create booking"
+          timeout: 20000
+
+# ── Create the booking (start/end default to tomorrow 9–17) ──
+- tapOn: "Create booking"
+- extendedWaitUntil:
+    visible: "Booking name, required"
+    timeout: 15000
+- tapOn: "Booking name, required"
+- inputText: "E2E Scan Checkout Booking"
+- tapOn: "Description"
+- scrollUntilVisible:
+    element:
+      text: "Select a custodian"
+    direction: DOWN
+    timeout: 10000
+- tapOn: "Select a custodian"
+- extendedWaitUntil:
+    visible: "Select Team Member"
+    timeout: 15000
+- tapOn: ".*Sarah Mitchell.*"
+- extendedWaitUntil:
+    visible: "Create booking"
+    timeout: 10000
+- tapOn: "Create booking"
+- extendedWaitUntil:
+    visible: "E2E Scan Checkout Booking"
+    timeout: 20000
+
+# ── Add the standalone asset via the availability picker ──
+- extendedWaitUntil:
+    visible: "Browse available assets and kits to add"
+    timeout: 15000
+- tapOn: "Browse available assets and kits to add"
+- extendedWaitUntil:
+    visible: "Search available assets"
+    timeout: 15000
+# Search rather than scroll: the list is ordered by the workspace code, and
+# fixture assets carry none, so they sort past any reasonable scroll budget.
+- tapOn: "Search available assets"
+- inputText: "E2E Checkout Charlie"
+# Submit the search to drop the keyboard. Tapping a label instead lands inside
+# the field's edit callout, which then covers the row.
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*E2E Checkout Charlie.*"
+    timeout: 20000
+# Match the row's full label: the search field holds the same words, and a bare
+# title selector taps that instead of the row.
+- tapOn: ".*E2E Checkout Charlie, QR Code ID.*"
+- extendedWaitUntil:
+    visible: ".*1 selected to booking.*"
+    timeout: 10000
+- tapOn: ".*1 selected to booking.*"
+- extendedWaitUntil:
+    visible: ".*E2E Checkout Charlie.*"
+    timeout: 20000
+
+# ── Add the kit through the add-scanner ──
+# The asset picker hides kit members (they belong to the kit), so the kit goes
+# on through the scanner. That route stores its members as loose booking rows
+# with no kit link, which is the harder case for check-out: the scanner has to
+# recognise them from the scanned kit's own payload rather than from the rows.
+- tapOn: "Scan assets or kits to add to this booking"
+- tapOn:
+    text: "Allow"
+    optional: true
+- extendedWaitUntil:
+    visible: "Add to Booking"
+    timeout: 15000
+- tapOn:
+    id: "dev-scan-toggle"
+- tapOn:
+    id: "dev-scan-input"
+- inputText: ${SHELF_TEST_CHECKOUT_KIT_QR_ID}
+- pressKey: Enter
+# Add mode batches a kit as one row, so the count is kits+assets, not members.
+- extendedWaitUntil:
+    visible: ".*1 unit scanned.*"
+    timeout: 20000
+- assertVisible: ".*E2E Scan Checkout Kit.*"
+- tapOn:
+    id: "batch-drawer-submit"
+- extendedWaitUntil:
+    visible: ".*E2E Scan Checkout Booking.*"
+    timeout: 25000
+- extendedWaitUntil:
+    visible: ".*E2E Checkout Alpha.*"
+    timeout: 25000
+
+# ── Reserve (DRAFT -> RESERVED) ──
+- extendedWaitUntil:
+    visible: "Reserve this booking"
+    timeout: 15000
+- tapOn: "Reserve this booking"
+- extendedWaitUntil:
+    visible: "Reserve Booking"
+    timeout: 10000
+- tapOn: "Reserve"
+- extendedWaitUntil:
+    visible: "Reserved"
+    timeout: 20000
+- tapOn: "OK"
+
+# ── RESERVED offers all three check-out affordances ──
+- extendedWaitUntil:
+    visible: "Check out all assets in this booking"
+    timeout: 20000
+- assertVisible: "Scan assets to check out"
+- assertVisible: "Select assets to check out"
+- takeScreenshot: checkout-reserved-buttons
+
+# ── Enter the check-out scanner ──
+- tapOn: "Scan assets to check out"
+- tapOn:
+    text: "Allow"
+    optional: true
+- extendedWaitUntil:
+    visible: "Booking Check-Out"
+    timeout: 15000
+- assertVisible: "E2E Scan Checkout Booking"
+- assertVisible: "Scan assets to check out"
+- takeScreenshot: checkout-scanner-header
+- tapOn:
+    id: "dev-scan-toggle"
+
+# ── A kit QR contributes its two members, never the kit itself ──
+- tapOn:
+    id: "dev-scan-input"
+- inputText: ${SHELF_TEST_CHECKOUT_KIT_QR_ID}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*(2 assets to check out|Booking Still Loading).*"
+    timeout: 15000
+# The booking context fetch can still be in flight on the very first scan; the
+# scanner asks for a rescan rather than guessing membership.
+- runFlow:
+    when:
+      visible: ".*Booking Still Loading.*"
+    commands:
+      - tapOn:
+          id: "dev-scan-input"
+      - inputText: ${SHELF_TEST_CHECKOUT_KIT_QR_ID}
+      - pressKey: Enter
+- extendedWaitUntil:
+    visible: "2 assets to check out"
+    timeout: 15000
+- takeScreenshot: checkout-drawer-2
+
+# ── An asset that is not on the booking is refused ──
+- tapOn:
+    id: "dev-scan-input"
+- inputText: ${SHELF_TEST_OFF_BOOKING_QR_ID}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*Not in This Booking.*"
+    timeout: 15000
+- assertVisible: "2 assets to check out"
+- takeScreenshot: checkout-error-not-in-booking
+
+# ── Re-scanning the kit reports its members are already in the list ──
+- tapOn:
+    id: "dev-scan-input"
+- inputText: ${SHELF_TEST_CHECKOUT_KIT_QR_ID}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*Already Covered.*"
+    timeout: 15000
+- assertVisible: "2 assets to check out"
+- takeScreenshot: checkout-error-already-covered
+
+# ── Submit the first batch: the server's own numbers come back ──
+- tapOn:
+    id: "batch-drawer-submit"
+- extendedWaitUntil:
+    visible: "Check Out Assets"
+    timeout: 10000
+- tapOn:
+    text: "^Check Out$"
+- extendedWaitUntil:
+    visible: ".*Checked Out.*"
+    timeout: 25000
+- assertVisible: ".*2 checked out, 1 remaining.*"
+- takeScreenshot: checkout-alert-checked-out
+- tapOn: "OK"
+
+# ── One asset still reserved, so the scanner stays put to keep scanning ──
+- assertVisible: "Booking Check-Out"
+
+# ── ONGOING entry rule: full check-out is gone, both partial paths remain ──
+- tapOn: "Go back"
+- extendedWaitUntil:
+    visible: "E2E Scan Checkout Booking"
+    timeout: 20000
+- extendedWaitUntil:
+    visible: "Ongoing"
+    timeout: 20000
+- assertVisible: "Scan assets to check out"
+- assertVisible: "Select assets to check out"
+- assertNotVisible: "Check out all assets in this booking"
+- takeScreenshot: checkout-ongoing-booking
+
+# ── Second batch: the last asset, scanned by its own QR ──
+- tapOn: "Scan assets to check out"
+- tapOn:
+    text: "Allow"
+    optional: true
+- extendedWaitUntil:
+    visible: "Booking Check-Out"
+    timeout: 15000
+- tapOn:
+    id: "dev-scan-toggle"
+- tapOn:
+    id: "dev-scan-input"
+- inputText: ${SHELF_TEST_CHECKOUT_ASSET_QR_ID}
+- pressKey: Enter
+- extendedWaitUntil:
+    visible: ".*(1 asset to check out|Booking Still Loading).*"
+    timeout: 15000
+- runFlow:
+    when:
+      visible: ".*Booking Still Loading.*"
+    commands:
+      - tapOn:
+          id: "dev-scan-input"
+      - inputText: ${SHELF_TEST_CHECKOUT_ASSET_QR_ID}
+      - pressKey: Enter
+- extendedWaitUntil:
+    visible: "1 asset to check out"
+    timeout: 15000
+- tapOn:
+    id: "batch-drawer-submit"
+- extendedWaitUntil:
+    visible: "Check Out Assets"
+    timeout: 10000
+- tapOn:
+    text: "^Check Out$"
+- extendedWaitUntil:
+    visible: ".*Checked Out.*"
+    timeout: 25000
+- assertVisible: ".*1 checked out, 0 remaining.*"
+- takeScreenshot: checkout-alert-complete
+- tapOn: "OK"
+
+# ── Nothing left to scan, so the app returns to the booking ──
+- extendedWaitUntil:
+    visible: "E2E Scan Checkout Booking"
+    timeout: 25000
+- extendedWaitUntil:
+    visible: "Check in all assets"
+    timeout: 20000
+- assertNotVisible: "Scan assets to check out"
+- takeScreenshot: checkout-all-out
+
+# ── Return everything and clean up ──
+- tapOn: "Check in all assets"
+# The confirm alert's title and its confirm button carry the same words, so
+# match the second occurrence.
+- extendedWaitUntil:
+    visible: "Check in all assets for.*"
+    timeout: 10000
+- tapOn:
+    text: "^Check In All$"
+    index: 1
+- extendedWaitUntil:
+    visible: ".*is now complete.*"
+    timeout: 25000
+- tapOn:
+    text: "OK"
+    optional: true
+- extendedWaitUntil:
+    visible: "More booking actions"
+    timeout: 20000
+- tapOn: "More booking actions"
+- extendedWaitUntil:
+    visible: "Delete booking"
+    timeout: 10000
+- tapOn:
+    text: "^Delete booking$"
+- extendedWaitUntil:
+    visible: "Delete Booking"
+    timeout: 10000
+- tapOn:
+    text: "^Delete$"
+- extendedWaitUntil:
+    visible: "Create booking"
+    timeout: 25000
+- takeScreenshot: checkout-cleaned-up

--- a/apps/companion/.maestro/flows/bookings/19-scan-to-checkout.yaml
+++ b/apps/companion/.maestro/flows/bookings/19-scan-to-checkout.yaml
@@ -8,25 +8,38 @@ tags:
 
 ---
 # Progressive check-out driven by the scanner: the twin of "Scan to Check In".
-# Creates a booking, adds a kit + a standalone asset, reserves it, then checks
-# the assets out one scan at a time — asserting the kit expands to its members,
-# an off-booking asset is refused, a re-scanned kit reports it is already
-# covered, and the booking's own numbers come back from the server.
+# Takes a reserved booking's assets out one scan at a time, asserting that a
+# scanned kit contributes its members, an off-booking asset is refused, a
+# re-scanned kit reports it is already covered, and the counts shown come from
+# the server rather than from the scan list.
 #
 # Also covers the ONGOING entry rule: once the first batch flips the booking to
 # ONGOING, "Check Out All Assets" disappears while both progressive check-out
 # affordances stay, so the operator can keep taking the rest.
 #
-# Fixture (set up via psql before the run, torn down after), in GRANULAR
+# Fixture, set up via psql before the run and removed after, in GRANULAR
 # WORKSPACE (cmn8vu17y001rooi1l2etdpzf):
-#   Four AVAILABLE, bookable, uncustodied INDIVIDUAL assets — "E2E Checkout
-#   Alpha" and "Bravo" as the members of kit "E2E Scan Checkout Kit",
-#   "Charlie" scanned on its own, "Delta" never added to the booking. Qr rows
-#   for the kit, Charlie and Delta. The flow creates and deletes its booking.
+#   - Four AVAILABLE, bookable, uncustodied INDIVIDUAL assets: "E2E Checkout
+#     Alpha" and "Bravo" as the two members of kit "E2E Scan Checkout Kit",
+#     "Charlie" scanned on its own, "Delta" never added to the booking.
+#   - Qr rows for the kit, Charlie and Delta.
+#   - A RESERVED booking "E2E Scan Checkout Booking" holding Alpha, Bravo and
+#     Charlie as standalone rows (assetKitId NULL). That is the shape the
+#     phone's scan-to-add path produces for kit members, and it is the harder
+#     case here: the scanner must recognise them from the scanned kit's own
+#     payload rather than from a kit link on the rows.
+#
+#   Seed the booking rather than building it through the picker: the picker
+#   hides kit members, so a kit can only be added through the add-scanner, and
+#   that setup path is not what this flow is testing.
 #
 #   Give every asset a cuid-shaped id (leading "c"): the partial-checkout
 #   endpoint validates assetIds with zod .cuid(), so any other id shape is
 #   refused with 400 before the booking is touched.
+#
+#   Re-seeding between runs must also reset the assets to AVAILABLE. A previous
+#   run leaves them CHECKED_OUT, and the scanner then correctly refuses them as
+#   already out.
 #
 # Env: SHELF_TEST_EMAIL / SHELF_TEST_PASSWORD
 #      SHELF_TEST_CHECKOUT_KIT_QR_ID     kit QR                 (e2eskchkqr01)
@@ -45,149 +58,41 @@ tags:
     timeout: 15000
 
 # ── Switch to the GRANULAR (TEAM) workspace — bookings are TEAM-only ──
+# Only when a switch is actually needed. The workspace row and the sheet's
+# option carry the same name, so running the switch while already in GRANULAR
+# taps the row behind the sheet and leaves the sheet covering the tab bar.
 - tapOn: "Settings"
 - extendedWaitUntil:
     visible: ".*Current workspace.*"
     timeout: 8000
-- tapOn: ".*Current workspace.*"
-# The sheet suffixes the active workspace with "(CURRENT)", and selectors
-# full-match, so a bare name misses whenever the app is already in it.
-- tapOn: ".*GRANULAR WORKSPACE.*"
-- waitForAnimationToEnd
-
-# ── Remove a leftover booking of the same name so the selectors stay unique ──
-- tapOn: "Bookings"
-- extendedWaitUntil:
-    visible: "Create booking"
-    timeout: 15000
 - runFlow:
     when:
-      visible: ".*E2E Scan Checkout Booking.*"
+      notVisible: "Current workspace: GRANULAR WORKSPACE.*"
     commands:
-      - tapOn: ".*E2E Scan Checkout Booking.*"
-      - extendedWaitUntil:
-          visible: "More booking actions"
-          timeout: 20000
-      - tapOn: "More booking actions"
-      - extendedWaitUntil:
-          visible: "Delete booking"
-          timeout: 10000
-      - tapOn:
-          text: "^Delete booking$"
-      - extendedWaitUntil:
-          visible: "Delete Booking"
-          timeout: 10000
-      - tapOn:
-          text: "^Delete$"
-      - extendedWaitUntil:
-          visible: "Create booking"
-          timeout: 20000
+      - tapOn: ".*Current workspace.*"
+      - tapOn: ".*GRANULAR WORKSPACE.*"
+      - waitForAnimationToEnd
 
-# ── Create the booking (start/end default to tomorrow 9–17) ──
-- tapOn: "Create booking"
+# ── Open the seeded booking ──
+# Search rather than scroll: the list sorts by start date ascending and pages
+# at 20, so a booking dated tomorrow can sit well past the first page. Match
+# the card's own label, since the search field holds the same words.
+- tapOn: "Bookings"
 - extendedWaitUntil:
-    visible: "Booking name, required"
-    timeout: 15000
-- tapOn: "Booking name, required"
-- inputText: "E2E Scan Checkout Booking"
-- tapOn: "Description"
-- scrollUntilVisible:
-    element:
-      text: "Select a custodian"
-    direction: DOWN
-    timeout: 10000
-- tapOn: "Select a custodian"
-- extendedWaitUntil:
-    visible: "Select Team Member"
-    timeout: 15000
-- tapOn: ".*Sarah Mitchell.*"
-- extendedWaitUntil:
-    visible: "Create booking"
-    timeout: 10000
-- tapOn: "Create booking"
-- extendedWaitUntil:
-    visible: "E2E Scan Checkout Booking"
+    visible: "Search bookings"
     timeout: 20000
-
-# ── Add the standalone asset via the availability picker ──
-- extendedWaitUntil:
-    visible: "Browse available assets and kits to add"
-    timeout: 15000
-- tapOn: "Browse available assets and kits to add"
-- extendedWaitUntil:
-    visible: "Search available assets"
-    timeout: 15000
-# Search rather than scroll: the list is ordered by the workspace code, and
-# fixture assets carry none, so they sort past any reasonable scroll budget.
-- tapOn: "Search available assets"
-- inputText: "E2E Checkout Charlie"
-# Submit the search to drop the keyboard. Tapping a label instead lands inside
-# the field's edit callout, which then covers the row.
+- tapOn: "Search bookings"
+- inputText: "E2E Scan Checkout"
 - pressKey: Enter
 - extendedWaitUntil:
-    visible: ".*E2E Checkout Charlie.*"
-    timeout: 20000
-# Match the row's full label: the search field holds the same words, and a bare
-# title selector taps that instead of the row.
-- tapOn: ".*E2E Checkout Charlie, QR Code ID.*"
-- extendedWaitUntil:
-    visible: ".*1 selected to booking.*"
-    timeout: 10000
-- tapOn: ".*1 selected to booking.*"
-- extendedWaitUntil:
-    visible: ".*E2E Checkout Charlie.*"
-    timeout: 20000
-
-# ── Add the kit through the add-scanner ──
-# The asset picker hides kit members (they belong to the kit), so the kit goes
-# on through the scanner. That route stores its members as loose booking rows
-# with no kit link, which is the harder case for check-out: the scanner has to
-# recognise them from the scanned kit's own payload rather than from the rows.
-- tapOn: "Scan assets or kits to add to this booking"
-- tapOn:
-    text: "Allow"
-    optional: true
-- extendedWaitUntil:
-    visible: "Add to Booking"
-    timeout: 15000
-- tapOn:
-    id: "dev-scan-toggle"
-- tapOn:
-    id: "dev-scan-input"
-- inputText: ${SHELF_TEST_CHECKOUT_KIT_QR_ID}
-- pressKey: Enter
-# Add mode batches a kit as one row, so the count is kits+assets, not members.
-- extendedWaitUntil:
-    visible: ".*1 unit scanned.*"
-    timeout: 20000
-- assertVisible: ".*E2E Scan Checkout Kit.*"
-- tapOn:
-    id: "batch-drawer-submit"
-- extendedWaitUntil:
-    visible: ".*E2E Scan Checkout Booking.*"
-    timeout: 25000
-- extendedWaitUntil:
-    visible: ".*E2E Checkout Alpha.*"
-    timeout: 25000
-
-# ── Reserve (DRAFT -> RESERVED) ──
-- extendedWaitUntil:
-    visible: "Reserve this booking"
-    timeout: 15000
-- tapOn: "Reserve this booking"
-- extendedWaitUntil:
-    visible: "Reserve Booking"
-    timeout: 10000
-- tapOn: "Reserve"
-- extendedWaitUntil:
-    visible: "Reserved"
-    timeout: 20000
-- tapOn: "OK"
+    visible: "Booking: E2E Scan Checkout Booking.*"
+    timeout: 30000
+- tapOn: "Booking: E2E Scan Checkout Booking.*"
 
 # ── RESERVED offers all three check-out affordances ──
 - extendedWaitUntil:
     visible: "Check out all assets in this booking"
-    timeout: 20000
+    timeout: 25000
 - assertVisible: "Scan assets to check out"
 - assertVisible: "Select assets to check out"
 - takeScreenshot: checkout-reserved-buttons
@@ -199,12 +104,14 @@ tags:
     optional: true
 - extendedWaitUntil:
     visible: "Booking Check-Out"
-    timeout: 15000
-- assertVisible: "E2E Scan Checkout Booking"
+    timeout: 20000
 - assertVisible: "Scan assets to check out"
 - takeScreenshot: checkout-scanner-header
+# The manual-entry field stays open once revealed, in which case the toggle
+# that reveals it is not rendered.
 - tapOn:
     id: "dev-scan-toggle"
+    optional: true
 
 # ── A kit QR contributes its two members, never the kit itself ──
 - tapOn:
@@ -213,7 +120,7 @@ tags:
 - pressKey: Enter
 - extendedWaitUntil:
     visible: ".*(2 assets to check out|Booking Still Loading).*"
-    timeout: 15000
+    timeout: 20000
 # The booking context fetch can still be in flight on the very first scan; the
 # scanner asks for a rescan rather than guessing membership.
 - runFlow:
@@ -226,7 +133,7 @@ tags:
       - pressKey: Enter
 - extendedWaitUntil:
     visible: "2 assets to check out"
-    timeout: 15000
+    timeout: 20000
 - takeScreenshot: checkout-drawer-2
 
 # ── An asset that is not on the booking is refused ──
@@ -236,9 +143,12 @@ tags:
 - pressKey: Enter
 - extendedWaitUntil:
     visible: ".*Not in This Booking.*"
-    timeout: 15000
+    timeout: 20000
 - assertVisible: "2 assets to check out"
 - takeScreenshot: checkout-error-not-in-booking
+# The result card covers the manual-entry field until it is dismissed; a
+# success card clears itself, an error waits for the tap.
+- tapOn: ".*Tap to dismiss.*"
 
 # ── Re-scanning the kit reports its members are already in the list ──
 - tapOn:
@@ -247,21 +157,22 @@ tags:
 - pressKey: Enter
 - extendedWaitUntil:
     visible: ".*Already Covered.*"
-    timeout: 15000
+    timeout: 20000
 - assertVisible: "2 assets to check out"
 - takeScreenshot: checkout-error-already-covered
+- tapOn: ".*Tap to dismiss.*"
 
 # ── Submit the first batch: the server's own numbers come back ──
 - tapOn:
     id: "batch-drawer-submit"
 - extendedWaitUntil:
     visible: "Check Out Assets"
-    timeout: 10000
+    timeout: 15000
 - tapOn:
     text: "^Check Out$"
 - extendedWaitUntil:
     visible: ".*Checked Out.*"
-    timeout: 25000
+    timeout: 30000
 - assertVisible: ".*2 checked out, 1 remaining.*"
 - takeScreenshot: checkout-alert-checked-out
 - tapOn: "OK"
@@ -272,33 +183,31 @@ tags:
 # ── ONGOING entry rule: full check-out is gone, both partial paths remain ──
 - tapOn: "Go back"
 - extendedWaitUntil:
-    visible: "E2E Scan Checkout Booking"
-    timeout: 20000
-- extendedWaitUntil:
     visible: "Ongoing"
-    timeout: 20000
+    timeout: 25000
 - assertVisible: "Scan assets to check out"
 - assertVisible: "Select assets to check out"
 - assertNotVisible: "Check out all assets in this booking"
 - takeScreenshot: checkout-ongoing-booking
 
-# ── Second batch: the last asset, scanned by its own QR ──
+# ── Second batch: the last reserved asset, scanned by its own QR ──
 - tapOn: "Scan assets to check out"
 - tapOn:
     text: "Allow"
     optional: true
 - extendedWaitUntil:
     visible: "Booking Check-Out"
-    timeout: 15000
+    timeout: 20000
 - tapOn:
     id: "dev-scan-toggle"
+    optional: true
 - tapOn:
     id: "dev-scan-input"
 - inputText: ${SHELF_TEST_CHECKOUT_ASSET_QR_ID}
 - pressKey: Enter
 - extendedWaitUntil:
     visible: ".*(1 asset to check out|Booking Still Loading).*"
-    timeout: 15000
+    timeout: 20000
 - runFlow:
     when:
       visible: ".*Booking Still Loading.*"
@@ -309,62 +218,27 @@ tags:
       - pressKey: Enter
 - extendedWaitUntil:
     visible: "1 asset to check out"
-    timeout: 15000
+    timeout: 20000
 - tapOn:
     id: "batch-drawer-submit"
 - extendedWaitUntil:
     visible: "Check Out Assets"
-    timeout: 10000
+    timeout: 15000
 - tapOn:
     text: "^Check Out$"
 - extendedWaitUntil:
     visible: ".*Checked Out.*"
-    timeout: 25000
+    timeout: 30000
 - assertVisible: ".*1 checked out, 0 remaining.*"
 - takeScreenshot: checkout-alert-complete
 - tapOn: "OK"
 
-# ── Nothing left to scan, so the app returns to the booking ──
+# ── Nothing left to scan, so the app returns to the booking itself ──
 - extendedWaitUntil:
     visible: "E2E Scan Checkout Booking"
-    timeout: 25000
+    timeout: 30000
 - extendedWaitUntil:
     visible: "Check in all assets"
-    timeout: 20000
+    timeout: 25000
 - assertNotVisible: "Scan assets to check out"
 - takeScreenshot: checkout-all-out
-
-# ── Return everything and clean up ──
-- tapOn: "Check in all assets"
-# The confirm alert's title and its confirm button carry the same words, so
-# match the second occurrence.
-- extendedWaitUntil:
-    visible: "Check in all assets for.*"
-    timeout: 10000
-- tapOn:
-    text: "^Check In All$"
-    index: 1
-- extendedWaitUntil:
-    visible: ".*is now complete.*"
-    timeout: 25000
-- tapOn:
-    text: "OK"
-    optional: true
-- extendedWaitUntil:
-    visible: "More booking actions"
-    timeout: 20000
-- tapOn: "More booking actions"
-- extendedWaitUntil:
-    visible: "Delete booking"
-    timeout: 10000
-- tapOn:
-    text: "^Delete booking$"
-- extendedWaitUntil:
-    visible: "Delete Booking"
-    timeout: 10000
-- tapOn:
-    text: "^Delete$"
-- extendedWaitUntil:
-    visible: "Create booking"
-    timeout: 25000
-- takeScreenshot: checkout-cleaned-up

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -1038,8 +1038,17 @@ export default function BookingDetailScreen() {
   // gates the full "Check Out All" button), so we derive our own flag for the
   // partial path — otherwise "Select to Check Out" disappears the moment the
   // first batch flips the booking to ONGOING.
+  // `reservedCount` counts whole assets, so it cannot see inside a pooled one:
+  // a partial return records the asset id, which then cancels out its own
+  // `assetCount` entry and reads as nothing left to take. Rows carry the
+  // booking-scoped remaining count when the server sends it, so trust that
+  // wherever it exists and keep the asset-level arithmetic for rows without.
+  const hasUnitsLeftToCheckOut =
+    reservedCount > 0 ||
+    booking.assets.some((a) => (a.remainingToCheckOut ?? 0) > 0);
+
   const canPartialCheckout =
-    reservedCount > 0 &&
+    hasUnitsLeftToCheckOut &&
     !hasOutstandingModelRequests &&
     ["RESERVED", "ONGOING", "OVERDUE"].includes(booking.status);
 

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -37,6 +37,8 @@ import {
   type CheckinDisposition,
 } from "@/lib/api";
 import { useOrg } from "@/lib/org-context";
+import { useAuth } from "@/lib/auth-context";
+import { userHasPermission } from "@/lib/permissions";
 import { fontSize, spacing, borderRadius, formatStatus } from "@/lib/constants";
 import { useDateFormatter } from "@/lib/use-date-formatter";
 import { useTheme } from "@/lib/theme-context";
@@ -114,6 +116,9 @@ export default function BookingDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const { currentOrg } = useOrg();
+  // Current auth user — the booking's creator/custodian ids are compared
+  // against it to mirror the server's ownership gate for restricted roles.
+  const { user } = useAuth();
   const { colors, statusBadge, bookingStatusBadge } = useTheme();
   const styles = useStyles();
   const { formatDateTime } = useDateFormatter();
@@ -1038,6 +1043,27 @@ export default function BookingDetailScreen() {
     !hasOutstandingModelRequests &&
     ["RESERVED", "ONGOING", "OVERDUE"].includes(booking.status);
 
+  /**
+   * Whether to offer the progressive check-out affordances (scan and select).
+   *
+   * Both submit to the same endpoint, so they share one gate. It mirrors what
+   * the server will accept: the `booking:checkout` permission, and — for a
+   * restricted role, whose writes are scoped to their own bookings — being the
+   * booking's creator or its custodian. Offering either to someone the server
+   * would reject just trades a visible button for a 403.
+   */
+  const canUseProgressiveCheckout =
+    canPartialCheckout &&
+    userHasPermission({
+      roles: currentOrg?.roles,
+      entity: "booking",
+      action: "checkout",
+    }) &&
+    (!isRestrictedRole ||
+      (!!user?.id &&
+        (booking.creator.id === user.id ||
+          booking.custodianUser?.id === user.id)));
+
   // Same gate the manage buttons use: an editable booking, and self-service
   // users only on their own DRAFTs (server re-checks ownership + status).
   const canManageModels =
@@ -1497,8 +1523,36 @@ export default function BookingDetailScreen() {
 
             {/* Progressive check-out persists while reserved assets remain, even
                 after the booking has gone ONGOING (canPartialCheckout, not
-                canCheckout) so the user can keep taking the rest. */}
-            {canPartialCheckout && (
+                canCheckout) so the user can keep taking the rest. Scanning is
+                the twin of "Scan to Check In" below: one asset at a time,
+                batched, submitted to the partial-checkout endpoint. */}
+            {canUseProgressiveCheckout && (
+              <TouchableOpacity
+                style={styles.actionButtonOutline}
+                onPress={() =>
+                  router.push(
+                    `/(tabs)/scanner?bookingId=${
+                      booking.id
+                    }&bookingName=${encodeURIComponent(
+                      booking.name
+                    )}&bookingAction=checkout`
+                  )
+                }
+                accessibilityLabel="Scan assets to check out"
+                accessibilityRole="button"
+              >
+                <Ionicons
+                  name="scan"
+                  size={18}
+                  color={colors.buttonSecondaryText}
+                />
+                <Text style={styles.actionButtonOutlineText}>
+                  Scan to Check Out
+                </Text>
+              </TouchableOpacity>
+            )}
+
+            {canUseProgressiveCheckout && (
               <TouchableOpacity
                 style={[
                   styles.actionButtonOutline,

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -1044,6 +1044,20 @@ export default function BookingDetailScreen() {
     ["RESERVED", "ONGOING", "OVERDUE"].includes(booking.status);
 
   /**
+   * Whether the server would scope this user's booking writes to their own
+   * bookings.
+   *
+   * Roles are a set, and the server judges a request by the most privileged
+   * one it contains, so someone holding both SELF_SERVICE and ADMIN writes to
+   * any booking. `isRestrictedRole` asks the opposite question — whether ANY
+   * restricted role is present — which is the right test for the DRAFT-only
+   * editing rules above but would hide controls from a multi-role admin here.
+   */
+  const isRestrictedToOwnBookings =
+    isRestrictedRole &&
+    !currentOrg?.roles?.some((r) => r === "OWNER" || r === "ADMIN");
+
+  /**
    * Whether to offer the progressive check-out affordances (scan and select).
    *
    * Both submit to the same endpoint, so they share one gate. It mirrors what
@@ -1059,7 +1073,7 @@ export default function BookingDetailScreen() {
       entity: "booking",
       action: "checkout",
     }) &&
-    (!isRestrictedRole ||
+    (!isRestrictedToOwnBookings ||
       (!!user?.id &&
         (booking.creator.id === user.id ||
           booking.custodianUser?.id === user.id)));

--- a/apps/companion/app/(tabs)/bookings/[id].tsx
+++ b/apps/companion/app/(tabs)/bookings/[id].tsx
@@ -991,17 +991,10 @@ export default function BookingDetailScreen() {
     booking.custodianTeamMember?.name ||
     formatPersonName(booking.custodianUser);
 
-  // Lifecycle counts for the progress bar: every asset is in exactly one of three
-  // states. `checkedOutCount` (status === CHECKED_OUT) already EXCLUDES returned
-  // assets — partial check-in flips them back to AVAILABLE — so it IS the live
-  // "on job" count, and returns are subtracted from the reserved bucket (not from
-  // checkedOutCount again, which would double-count them).
-  const checkedInCount = checkedInAssetIds.length; // returned
-  const onJobCount = booking.checkedOutCount; // still out
-  const reservedCount = Math.max(
-    0,
-    booking.assetCount - onJobCount - checkedInCount
-  ); // never checked out
+  // How many of the booking's assets have been returned. Drives whether the
+  // progress card is worth showing at all; the card's own segments come from
+  // the server's shared helper further down.
+  const checkedInCount = checkedInAssetIds.length;
   // Only show the bar once there's check-out activity — otherwise it's a flat,
   // single-colour bar that adds noise to a freshly-reserved booking.
   const showProgress =
@@ -1038,14 +1031,19 @@ export default function BookingDetailScreen() {
   // gates the full "Check Out All" button), so we derive our own flag for the
   // partial path — otherwise "Select to Check Out" disappears the moment the
   // first batch flips the booking to ONGOING.
-  // `reservedCount` counts whole assets, so it cannot see inside a pooled one:
-  // a partial return records the asset id, which then cancels out its own
-  // `assetCount` entry and reads as nothing left to take. Rows carry the
-  // booking-scoped remaining count when the server sends it, so trust that
-  // wherever it exists and keep the asset-level arithmetic for rows without.
-  const hasUnitsLeftToCheckOut =
-    reservedCount > 0 ||
-    booking.assets.some((a) => (a.remainingToCheckOut ?? 0) > 0);
+  // Each row answers for itself. Booking-wide arithmetic cannot: a pooled
+  // asset's remaining units and its global status are independent, so
+  // subtracting whole returned and checked-out assets from the total both
+  // hides the control while units remain (a partial return cancels the row
+  // against its own count) and shows it when none do (a spent row whose
+  // status is still AVAILABLE). A quantity-tracked row is answered by the
+  // booking-scoped count the server sends for it; every other row by whether
+  // it is still on the booking and not yet out.
+  const hasUnitsLeftToCheckOut = booking.assets.some((a) =>
+    typeof a.remainingToCheckOut === "number"
+      ? a.remainingToCheckOut > 0
+      : a.status !== "CHECKED_OUT" && !checkedInAssetIds.includes(a.id)
+  );
 
   const canPartialCheckout =
     hasUnitsLeftToCheckOut &&

--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -46,7 +46,11 @@ import {
   type BatchScanAction,
   type BlockerGroup,
 } from "@/lib/batch-blockers";
-import { markBookingDirty } from "@/lib/booking-refresh";
+import { markBookingDirty, markBookingsListDirty } from "@/lib/booking-refresh";
+import {
+  checkoutBlocker,
+  eligibleKitMembers,
+} from "@/lib/booking-scan-eligibility";
 import { ScannerErrorBoundary } from "@/components/scanner-error-boundary";
 import { useScanLineAnimation } from "@/hooks/use-scan-line-animation";
 import { useInactivityTimer } from "@/hooks/use-inactivity-timer";
@@ -184,7 +188,10 @@ function ScannerContent() {
   const { bookingId, bookingName, bookingAction } = useLocalSearchParams<{
     bookingId?: string;
     bookingName?: string;
-    /** "checkin" (default) or "add" — which booking flow the scanner serves. */
+    /**
+     * Which booking flow the scanner serves: "checkin" (default), "add",
+     * "fulfil" or "checkout".
+     */
     bookingAction?: string;
   }>();
   const isFocused = useIsFocused();
@@ -220,6 +227,12 @@ function ScannerContent() {
   // all the add-mode scan capture / blockers / list rendering apply to both.
   const isBookingAddMode =
     isBookingMode && (bookingAction === "add" || bookingAction === "fulfil");
+  // Progressive check-out flow: the twin of check-in. Assets already on the
+  // booking are scanned one at a time to take them out, batched into the same
+  // list, and submitted to the partial-checkout endpoint. Available on
+  // RESERVED, ONGOING and OVERDUE bookings, so an operator can keep taking the
+  // rest after a first batch has flipped the booking to ONGOING.
+  const isBookingCheckoutMode = isBookingMode && bookingAction === "checkout";
 
   // Filter scanner actions based on the user's role in the current org
   const availableActions = useMemo(
@@ -1019,6 +1032,56 @@ function ScannerContent() {
               return;
             }
 
+            // BOOKING CHECK-OUT: a kit contributes the members of it that are
+            // on this booking and still takeable; the kit itself is never a
+            // list row (web parity).
+            if (isBookingCheckoutMode) {
+              const { eligible, reason } = eligibleKitMembers(
+                { id: kit.id, name: kit.name, assets: kit.assets },
+                bookingCtx,
+                new Set(bookingCheckinItems.map((item) => item.targetId))
+              );
+
+              if (reason) {
+                flashFrame("error");
+                Haptics.notificationAsync(
+                  Haptics.NotificationFeedbackType.Warning
+                );
+                setScanResult({ type: "error", ...reason });
+                finalizeScan();
+                return;
+              }
+
+              const kitMemberItems: ScannedItem[] = eligible.map((a) => ({
+                type: "asset",
+                qrId: `${codeId}:${a.id}`,
+                targetId: a.id,
+                title: a.title,
+                status: a.status,
+                mainImage: a.mainImage,
+                category: a.category?.name ?? null,
+                kitId: a.kitId,
+              }));
+
+              setBookingCheckinItems((prev) => [...kitMemberItems, ...prev]);
+              flashFrame("success");
+              Haptics.notificationAsync(
+                Haptics.NotificationFeedbackType.Success
+              );
+              playScanSound();
+              setScanResult({
+                type: "success",
+                title: kit.name,
+                message: `Added ${eligible.length} kit asset${
+                  eligible.length === 1 ? "" : "s"
+                } (${bookingCheckinItems.length + eligible.length} items)`,
+              });
+
+              setTimeout(() => setScanResult(null), 1200);
+              finalizeScan();
+              return;
+            }
+
             const members = bookingCtx.bookedAssets.filter(
               (a) => a.kitId === kit!.id
             );
@@ -1378,6 +1441,8 @@ function ScannerContent() {
               title: "Already Scanned",
               message: isBookingAddMode
                 ? "This asset is already in your list."
+                : isBookingCheckoutMode
+                ? "This asset is already in your check-out list."
                 : "This asset is already in your check-in list.",
             });
             finalizeScan();
@@ -1433,6 +1498,49 @@ function ScannerContent() {
               title: "Booking Still Loading",
               message: "One moment — scan again.",
             });
+            finalizeScan();
+            return;
+          }
+
+          // CHECK-OUT mode has its own gates: the booking's own row carries
+          // the quantity counts a scanned QR does not, so eligibility is
+          // decided there rather than on the asset's global status alone.
+          if (isBookingCheckoutMode) {
+            const blocker = checkoutBlocker(asset, bookingCtx);
+            if (blocker) {
+              flashFrame("error");
+              Haptics.notificationAsync(
+                Haptics.NotificationFeedbackType.Warning
+              );
+              setScanResult({ type: "error", ...blocker });
+              finalizeScan();
+              return;
+            }
+
+            const row = bookingCtx.bookedAssets.find((a) => a.id === asset.id);
+            // Submitting a bare id takes every remaining unit, so name the
+            // count that implies.
+            const unitSuffix =
+              row?.type === "QUANTITY_TRACKED" &&
+              typeof row.remainingToCheckOut === "number"
+                ? ` — all ${row.remainingToCheckOut} ${
+                    row.unitOfMeasure ?? "units"
+                  }`
+                : "";
+
+            setBookingCheckinItems((prev) => [newItem, ...prev]);
+            flashFrame("success");
+            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            playScanSound();
+            setScanResult({
+              type: "success",
+              title: asset.title,
+              message: `Added to check-out (${
+                bookingCheckinItems.length + 1
+              } items)${unitSuffix}`,
+            });
+
+            setTimeout(() => setScanResult(null), 1200);
             finalizeScan();
             return;
           }
@@ -2206,6 +2314,112 @@ function ScannerContent() {
     );
   };
 
+  const handleBookingCheckout = () => {
+    if (!bookingId || !currentOrg || bookingCheckinItems.length === 0) return;
+
+    const count = bookingCheckinItems.length;
+    Alert.alert(
+      "Check Out Assets",
+      `Check out ${count} ${count === 1 ? "asset" : "assets"} for "${
+        bookingName || "this booking"
+      }"?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Check Out",
+          onPress: async () => {
+            setIsBookingSubmitting(true);
+            const assetIds = bookingCheckinItems.map((i) => i.targetId);
+            const timeZone = (() => {
+              try {
+                return (
+                  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+                );
+              } catch {
+                return "UTC";
+              }
+            })();
+
+            // No per-asset quantities: a bare id checks out every remaining
+            // unit of a quantity-tracked asset, which is the default the
+            // scanner offers. Picking a smaller count is the booking screen's
+            // "Select to Check Out" flow.
+            const { data: result, error } = await api.partialCheckoutBooking(
+              currentOrg.id,
+              bookingId,
+              assetIds,
+              timeZone
+            );
+            setIsBookingSubmitting(false);
+
+            if (error) {
+              Alert.alert("Error", error);
+              return;
+            }
+
+            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            playScanSound();
+            // Keep the scan-time gates honest for follow-up scans: the assets
+            // just submitted are now out, but the fetched context predates the
+            // submit.
+            const submittedIds = new Set(assetIds);
+            setBookingCtx((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    bookedAssets: prev.bookedAssets.map((a) =>
+                      submittedIds.has(a.id)
+                        ? {
+                            ...a,
+                            status: "CHECKED_OUT",
+                            ...(a.type === "QUANTITY_TRACKED"
+                              ? { remainingToCheckOut: 0 }
+                              : {}),
+                          }
+                        : a
+                    ),
+                  }
+                : prev
+            );
+            // The server drops ids it already counts as out, so its numbers
+            // can be lower than the submitted list — report those, not ours.
+            Alert.alert(
+              "Checked Out",
+              `${result?.checkedOutCount ?? count} checked out, ${
+                result?.remainingCount ?? "some"
+              } remaining.`,
+              [
+                {
+                  text: "OK",
+                  onPress: () => {
+                    setBookingCheckinItems([]);
+                    lastScanRef.current = "";
+                    markBookingDirty(bookingId);
+                    // The first batch flips RESERVED → ONGOING, so the list's
+                    // own freshness gate has to be bypassed too.
+                    markBookingsListDirty();
+                    if (result?.remainingCount === 0) {
+                      // Nothing left to scan. Anchored navigation — router.back()
+                      // from a tab screen falls through history and can land on
+                      // Home. Deferred past the alert dismissal (same render-loop
+                      // wedge as the add path — see handleBookingAdd).
+                      InteractionManager.runAfterInteractions(() => {
+                        pushIntoTab(
+                          "/(tabs)/bookings",
+                          `/(tabs)/bookings/${bookingId}`
+                        );
+                      });
+                    }
+                  },
+                },
+              ]
+            );
+          },
+        },
+      ]
+    );
+  };
+
   // ── Permission states ───────────────────────────────
 
   if (!permission) {
@@ -2332,10 +2546,15 @@ function ScannerContent() {
                       ? "Fulfil & Check Out"
                       : isBookingAddMode
                       ? "Add to Booking"
+                      : isBookingCheckoutMode
+                      ? "Booking Check-Out"
                       : "Booking Check-In"}
                   </Text>
                   <Text style={styles.bookingModeName} numberOfLines={1}>
-                    {bookingName || "Scan assets to check in"}
+                    {bookingName ||
+                      (isBookingCheckoutMode
+                        ? "Scan assets to check out"
+                        : "Scan assets to check in")}
                   </Text>
                   {isBookingFulfilMode &&
                     bookingCtx &&
@@ -2428,6 +2647,8 @@ function ScannerContent() {
                     ? "Scan the reserved units to assign"
                     : isBookingAddMode
                     ? "Scan assets or kits to add"
+                    : isBookingCheckoutMode
+                    ? "Scan assets to check out"
                     : "Scan assets to check in"
                   : instructionMap[action]}
               </Text>
@@ -2599,6 +2820,10 @@ function ScannerContent() {
                   ? `${bookingCheckinItems.length} unit${
                       bookingCheckinItems.length > 1 ? "s" : ""
                     } scanned`
+                  : isBookingCheckoutMode
+                  ? `${bookingCheckinItems.length} asset${
+                      bookingCheckinItems.length > 1 ? "s" : ""
+                    } to check out`
                   : `${bookingCheckinItems.length} asset${
                       bookingCheckinItems.length > 1 ? "s" : ""
                     } to check in`
@@ -2623,6 +2848,10 @@ function ScannerContent() {
                       } more to assign`
                   : isBookingAddMode
                   ? "Add to Booking"
+                  : isBookingCheckoutMode
+                  ? `Check Out ${bookingCheckinItems.length} ${
+                      bookingCheckinItems.length === 1 ? "Asset" : "Assets"
+                    }`
                   : `Check In ${bookingCheckinItems.length} ${
                       bookingCheckinItems.length === 1 ? "Asset" : "Assets"
                     }`
@@ -2632,6 +2861,8 @@ function ScannerContent() {
                   ? "log-out-outline"
                   : isBookingAddMode
                   ? "add-circle-outline"
+                  : isBookingCheckoutMode
+                  ? "log-out-outline"
                   : "log-in-outline"
               }
               isSubmitting={isBookingSubmitting}
@@ -2642,6 +2873,8 @@ function ScannerContent() {
                   ? handleBookingFulfil
                   : isBookingAddMode
                   ? handleBookingAdd
+                  : isBookingCheckoutMode
+                  ? handleBookingCheckout
                   : handleBookingCheckin
               }
               showStatus={isBookingAddMode}

--- a/apps/companion/app/(tabs)/scanner.tsx
+++ b/apps/companion/app/(tabs)/scanner.tsx
@@ -2534,7 +2534,18 @@ function ScannerContent() {
             <View style={styles.actionPickerContainer}>
               <View style={styles.bookingModeHeader}>
                 <TouchableOpacity
-                  onPress={() => router.back()}
+                  // Anchored navigation, like the submit handlers: the scanner
+                  // is a tab screen, so router.back() unwinds the tab's own
+                  // history and lands on the start page rather than on the
+                  // booking the operator came from.
+                  onPress={() =>
+                    bookingId
+                      ? pushIntoTab(
+                          "/(tabs)/bookings",
+                          `/(tabs)/bookings/${bookingId}`
+                        )
+                      : router.back()
+                  }
                   accessibilityLabel="Go back"
                   accessibilityRole="button"
                 >

--- a/apps/companion/lib/booking-scan-eligibility.test.ts
+++ b/apps/companion/lib/booking-scan-eligibility.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the booking check-out scan eligibility rules.
+ *
+ * These run under Node's test runner via tsx, so this file and the module it
+ * tests must not import React Native, Expo, or `@/`-aliased paths.
+ *
+ * Two contracts carry most of the weight here. A quantity-tracked row is
+ * judged by its remaining booked units and only falls back to the global
+ * status when the server sent no count, so a partly-checked-out asset stays
+ * scannable. And a kit's membership comes from the kit payload as well as the
+ * booking rows, because a kit added from the phone is stored as standalone
+ * rows whose `kitId` is null.
+ *
+ * @see ./booking-scan-eligibility.ts
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  checkoutBlocker,
+  eligibleKitMembers,
+  type CheckoutEligibilityContext,
+} from "./booking-scan-eligibility";
+import type { BookingAsset } from "./api/types";
+
+function row(overrides: Partial<BookingAsset> & { id: string }): BookingAsset {
+  return {
+    title: `Asset ${overrides.id}`,
+    status: "AVAILABLE",
+    mainImage: null,
+    kitId: null,
+    category: null,
+    kit: null,
+    ...overrides,
+  };
+}
+
+function ctxOf(
+  rows: BookingAsset[],
+  checkedInIds: string[] = []
+): CheckoutEligibilityContext {
+  return {
+    bookedAssetIds: new Set(rows.map((r) => r.id)),
+    checkedInAssetIds: new Set(checkedInIds),
+    bookedAssets: rows,
+  };
+}
+
+// ── checkoutBlocker ─────────────────────────────────────
+
+test("accepts an available asset that is on the booking", () => {
+  const ctx = ctxOf([row({ id: "a1" })]);
+  assert.equal(checkoutBlocker({ id: "a1", title: "Tripod" }, ctx), null);
+});
+
+test("rejects an asset that is not on the booking", () => {
+  const ctx = ctxOf([row({ id: "a1" })]);
+  const blocker = checkoutBlocker({ id: "other", title: "Tripod" }, ctx);
+  assert.equal(blocker?.title, "Not in This Booking");
+  assert.match(blocker!.message, /not part of this booking/);
+});
+
+test("rejects an asset already returned on this booking", () => {
+  const ctx = ctxOf([row({ id: "a1", status: "CHECKED_OUT" })], ["a1"]);
+  assert.equal(
+    checkoutBlocker({ id: "a1", title: "Tripod" }, ctx)?.title,
+    "Already Returned"
+  );
+});
+
+test("rejects an asset held in custody", () => {
+  const ctx = ctxOf([row({ id: "a1", status: "IN_CUSTODY" })]);
+  const blocker = checkoutBlocker({ id: "a1", title: "Tripod" }, ctx);
+  assert.equal(blocker?.title, "In Custody");
+  assert.match(blocker!.message, /release custody first/);
+});
+
+test("rejects an asset that is already checked out", () => {
+  const ctx = ctxOf([row({ id: "a1", status: "CHECKED_OUT" })]);
+  assert.equal(
+    checkoutBlocker({ id: "a1", title: "Tripod" }, ctx)?.title,
+    "Already Checked Out"
+  );
+});
+
+test("accepts a quantity-tracked asset with units still to take", () => {
+  const ctx = ctxOf([
+    row({
+      id: "qt1",
+      status: "CHECKED_OUT",
+      type: "QUANTITY_TRACKED",
+      remainingToCheckOut: 3,
+    }),
+  ]);
+  // Partly out already, so the global status reads CHECKED_OUT — the booked
+  // units left are what decides.
+  assert.equal(checkoutBlocker({ id: "qt1", title: "Cable" }, ctx), null);
+});
+
+test("rejects a quantity-tracked asset with no units left to take", () => {
+  const ctx = ctxOf([
+    row({
+      id: "qt1",
+      status: "AVAILABLE",
+      type: "QUANTITY_TRACKED",
+      remainingToCheckOut: 0,
+    }),
+  ]);
+  const blocker = checkoutBlocker({ id: "qt1", title: "Cable" }, ctx);
+  assert.equal(blocker?.title, "Already Checked Out");
+  assert.match(blocker!.message, /no units left/);
+});
+
+test("falls back to status when a quantity-tracked row carries no count", () => {
+  const ctx = ctxOf([
+    row({ id: "qt1", status: "CHECKED_OUT", type: "QUANTITY_TRACKED" }),
+  ]);
+  assert.equal(
+    checkoutBlocker({ id: "qt1", title: "Cable" }, ctx)?.title,
+    "Already Checked Out"
+  );
+});
+
+// ── eligibleKitMembers ──────────────────────────────────
+
+const kit = { id: "kit-1", name: "Camera Rig", assets: [{ id: "a1" }] };
+
+test("expands a kit into its bookable members", () => {
+  const ctx = ctxOf([row({ id: "a1" }), row({ id: "a2" })]);
+  const { eligible, reason } = eligibleKitMembers(kit, ctx, new Set());
+  assert.equal(reason, null);
+  assert.deepEqual(
+    eligible.map((r) => r.id),
+    ["a1"]
+  );
+});
+
+test("finds a member through the kit payload when the row has no kit link", () => {
+  // A kit added from the phone is stored as standalone rows, so `kitId` is
+  // null on every member and only the kit's own payload names them.
+  const ctx = ctxOf([row({ id: "a1", kitId: null })]);
+  const { eligible } = eligibleKitMembers(kit, ctx, new Set());
+  assert.deepEqual(
+    eligible.map((r) => r.id),
+    ["a1"]
+  );
+});
+
+test("finds a member through the row's kit link when the payload omits it", () => {
+  const ctx = ctxOf([row({ id: "a9", kitId: "kit-1" })]);
+  const { eligible } = eligibleKitMembers(kit, ctx, new Set());
+  assert.deepEqual(
+    eligible.map((r) => r.id),
+    ["a9"]
+  );
+});
+
+test("reports a kit with no members on the booking", () => {
+  const ctx = ctxOf([row({ id: "unrelated" })]);
+  const { eligible, reason } = eligibleKitMembers(kit, ctx, new Set());
+  assert.equal(eligible.length, 0);
+  assert.equal(reason?.title, "Not in This Booking");
+});
+
+test("reports a kit whose members are all already checked out", () => {
+  const ctx = ctxOf([row({ id: "a1", status: "CHECKED_OUT" })]);
+  const { eligible, reason } = eligibleKitMembers(kit, ctx, new Set());
+  assert.equal(eligible.length, 0);
+  assert.equal(reason?.title, "Already Checked Out");
+});
+
+test("reports a kit whose eligible members are already in the list", () => {
+  const ctx = ctxOf([row({ id: "a1" })]);
+  const { eligible, reason } = eligibleKitMembers(kit, ctx, new Set(["a1"]));
+  assert.equal(eligible.length, 0);
+  assert.equal(reason?.title, "Already Covered");
+});

--- a/apps/companion/lib/booking-scan-eligibility.test.ts
+++ b/apps/companion/lib/booking-scan-eligibility.test.ts
@@ -200,6 +200,33 @@ test("reports a kit whose members are all already checked out", () => {
   assert.equal(reason?.title, "Already Checked Out");
 });
 
+test("reports the members' own reason when a kit is blocked for one cause", () => {
+  // Custody carries a remedy; reporting "already checked out" would send the
+  // operator looking for the wrong thing.
+  const ctx = ctxOf([row({ id: "a1", status: "IN_CUSTODY" })]);
+  const { eligible, reason } = eligibleKitMembers(kit, ctx, new Set());
+  assert.equal(eligible.length, 0);
+  assert.equal(reason?.title, "In Custody");
+  assert.match(reason!.message, /release custody first/);
+});
+
+test("falls back to a neutral reason when members are blocked differently", () => {
+  const ctx = ctxOf(
+    [
+      row({ id: "a1", status: "IN_CUSTODY" }),
+      row({ id: "a2", status: "CHECKED_OUT", kitId: "kit-1" }),
+    ],
+    []
+  );
+  const { eligible, reason } = eligibleKitMembers(
+    { id: "kit-1", name: "Camera Rig", assets: [{ id: "a1" }, { id: "a2" }] },
+    ctx,
+    new Set()
+  );
+  assert.equal(eligible.length, 0);
+  assert.equal(reason?.title, "Not Available");
+});
+
 test("reports a kit whose eligible members are already in the list", () => {
   const ctx = ctxOf([row({ id: "a1" })]);
   const { eligible, reason } = eligibleKitMembers(kit, ctx, new Set(["a1"]));

--- a/apps/companion/lib/booking-scan-eligibility.test.ts
+++ b/apps/companion/lib/booking-scan-eligibility.test.ts
@@ -111,6 +111,37 @@ test("rejects a quantity-tracked asset with no units left to take", () => {
   assert.match(blocker!.message, /no units left/);
 });
 
+test("takes remaining units even when some were already returned here", () => {
+  // A partial check-in records the whole asset id, so the returned set says
+  // nothing about how many units are still reserved.
+  const ctx = ctxOf(
+    [
+      row({
+        id: "qt1",
+        status: "AVAILABLE",
+        type: "QUANTITY_TRACKED",
+        remainingToCheckOut: 2,
+      }),
+    ],
+    ["qt1"]
+  );
+  assert.equal(checkoutBlocker({ id: "qt1", title: "Cable" }, ctx), null);
+});
+
+test("takes remaining units of a quantity-tracked asset held in custody", () => {
+  // Custody on a pooled asset allocates some units to an operator; the server
+  // rejects custody only for individual assets.
+  const ctx = ctxOf([
+    row({
+      id: "qt1",
+      status: "IN_CUSTODY",
+      type: "QUANTITY_TRACKED",
+      remainingToCheckOut: 4,
+    }),
+  ]);
+  assert.equal(checkoutBlocker({ id: "qt1", title: "Cable" }, ctx), null);
+});
+
 test("falls back to status when a quantity-tracked row carries no count", () => {
   const ctx = ctxOf([
     row({ id: "qt1", status: "CHECKED_OUT", type: "QUANTITY_TRACKED" }),

--- a/apps/companion/lib/booking-scan-eligibility.ts
+++ b/apps/companion/lib/booking-scan-eligibility.ts
@@ -61,6 +61,29 @@ export function checkoutBlocker(
     };
   }
 
+  // A quantity-tracked asset is judged by its remaining booked units and by
+  // nothing else. Every rule below reads a GLOBAL, asset-level fact, and none
+  // of them describe one booking's slice of a pooled asset: units can be out
+  // on another booking, partly returned here, or allocated to an operator by a
+  // Custody row, while this booking still has units left to take. The server
+  // agrees — it caps by remaining units and exempts quantity-tracked assets
+  // from its blanket custody rejection.
+  //
+  // An older server omits the count. Then the asset-level rules below are the
+  // best answer available, which is what the booking screen and the web helper
+  // also fall back to.
+  if (
+    row.type === "QUANTITY_TRACKED" &&
+    typeof row.remainingToCheckOut === "number"
+  ) {
+    return row.remainingToCheckOut <= 0
+      ? {
+          title: "Already Checked Out",
+          message: `"${scanned.title}" has no units left to check out on this booking.`,
+        }
+      : null;
+  }
+
   if (ctx.checkedInAssetIds.has(scanned.id)) {
     return {
       title: "Already Returned",
@@ -73,23 +96,6 @@ export function checkoutBlocker(
       title: "In Custody",
       message: `"${scanned.title}" is in custody — release custody first.`,
     };
-  }
-
-  // A quantity-tracked asset is judged by its remaining booked units, not by a
-  // global status that says nothing about this booking's slice. An older
-  // server omits the count; then the status rule below is the best available
-  // answer, which is what the booking screen and the web helper also fall back
-  // to.
-  if (
-    row.type === "QUANTITY_TRACKED" &&
-    typeof row.remainingToCheckOut === "number"
-  ) {
-    return row.remainingToCheckOut <= 0
-      ? {
-          title: "Already Checked Out",
-          message: `"${scanned.title}" has no units left to check out on this booking.`,
-        }
-      : null;
   }
 
   if (row.status === "CHECKED_OUT") {

--- a/apps/companion/lib/booking-scan-eligibility.ts
+++ b/apps/companion/lib/booking-scan-eligibility.ts
@@ -32,7 +32,13 @@ export type ScanBlockReason = { title: string; message: string };
 export type CheckoutEligibilityContext = {
   /** Every asset id on the booking, including ones already checked out. */
   bookedAssetIds: ReadonlySet<string>;
-  /** Assets already returned on this booking — never checked out again. */
+  /**
+   * Assets with at least one unit checked back in on this booking. The server
+   * records a return against the whole asset id, so for a quantity-tracked
+   * asset this says only that SOME units came back, not that the booking is
+   * finished with it — which is why membership here blocks an individual
+   * asset outright but never overrides a positive remaining-unit count.
+   */
   checkedInAssetIds: ReadonlySet<string>;
   /** The booking's asset rows, carrying the booking-scoped quantity counts. */
   bookedAssets: readonly BookingAsset[];

--- a/apps/companion/lib/booking-scan-eligibility.ts
+++ b/apps/companion/lib/booking-scan-eligibility.ts
@@ -159,17 +159,31 @@ export function eligibleKitMembers(
     };
   }
 
-  const checkoutable = members.filter(
-    (row) => checkoutBlocker({ id: row.id, title: row.title }, ctx) === null
+  const blockers = members.map((row) =>
+    checkoutBlocker({ id: row.id, title: row.title }, ctx)
   );
+  const checkoutable = members.filter((_, i) => blockers[i] === null);
 
   if (checkoutable.length === 0) {
+    // Report the members' own reason rather than assuming they are all out.
+    // Custody in particular carries a remedy the operator needs, and naming
+    // the wrong cause sends them looking for the wrong thing. A set that
+    // disagrees has no single true answer, so say only what is certain.
+    const blocked = blockers.filter((b): b is ScanBlockReason => b !== null);
+    const distinctTitles = new Set(blocked.map((b) => b.title));
+
     return {
       eligible: [],
-      reason: {
-        title: "Already Checked Out",
-        message: `All of "${kit.name}"'s assets in this booking are already checked out.`,
-      },
+      reason:
+        distinctTitles.size === 1
+          ? {
+              title: blocked[0].title,
+              message: `None of "${kit.name}"'s assets in this booking can be checked out. ${blocked[0].message}`,
+            }
+          : {
+              title: "Not Available",
+              message: `None of "${kit.name}"'s assets in this booking can be checked out right now.`,
+            },
     };
   }
 

--- a/apps/companion/lib/booking-scan-eligibility.ts
+++ b/apps/companion/lib/booking-scan-eligibility.ts
@@ -1,0 +1,177 @@
+/**
+ * Scan-time eligibility rules for the booking check-out scanner.
+ *
+ * The scanner rejects an ineligible scan on the spot rather than collecting it
+ * and letting the submit fail, so these rules mirror the web partial-check-out
+ * drawer's blockers (`isAssetCheckoutEligible` + its call-site membership
+ * check) closely enough that a scan accepted here is a scan the server will
+ * take.
+ *
+ * A scanned QR carries only the asset's identity and global status — the
+ * booking-scoped facts (`type`, `remainingToCheckOut`) live on the booking's
+ * own rows. So every rule past membership is evaluated against the matching
+ * `BookingAsset` row, which is also what the submit path patches in place: a
+ * re-scan of something just checked out is rejected without a refetch.
+ *
+ * Pure by design — no React Native, Expo or `@/` imports — so it runs under
+ * Node's test runner via tsx.
+ *
+ * @see {@link file://./../app/(tabs)/scanner.tsx} the only consumer
+ * @see {@link file://./booking-scan-eligibility.test.ts}
+ */
+import type { BookingAsset } from "./api/types";
+
+/** Why a scan was refused: an alert title and the sentence under it. */
+export type ScanBlockReason = { title: string; message: string };
+
+/**
+ * The booking facts the rules read. A subset of the scanner's `bookingCtx`,
+ * narrowed to what eligibility needs and widened to readonly so callers can
+ * pass their live state without copying.
+ */
+export type CheckoutEligibilityContext = {
+  /** Every asset id on the booking, including ones already checked out. */
+  bookedAssetIds: ReadonlySet<string>;
+  /** Assets already returned on this booking — never checked out again. */
+  checkedInAssetIds: ReadonlySet<string>;
+  /** The booking's asset rows, carrying the booking-scoped quantity counts. */
+  bookedAssets: readonly BookingAsset[];
+};
+
+/** The identity a QR scan yields: enough to find the row and name it in an alert. */
+export type ScannedAssetIdentity = { id: string; title: string };
+
+/**
+ * Decide whether a scanned asset can be checked out on this booking.
+ *
+ * @param scanned Identity from the resolved QR code.
+ * @param ctx The booking's membership sets and asset rows.
+ * @returns `null` when the asset is eligible, otherwise the reason to show.
+ */
+export function checkoutBlocker(
+  scanned: ScannedAssetIdentity,
+  ctx: CheckoutEligibilityContext
+): ScanBlockReason | null {
+  const row = ctx.bookedAssets.find((a) => a.id === scanned.id);
+
+  if (!ctx.bookedAssetIds.has(scanned.id) || !row) {
+    return {
+      title: "Not in This Booking",
+      message: `"${scanned.title}" is not part of this booking.`,
+    };
+  }
+
+  if (ctx.checkedInAssetIds.has(scanned.id)) {
+    return {
+      title: "Already Returned",
+      message: `"${scanned.title}" was already checked in for this booking.`,
+    };
+  }
+
+  if (row.status === "IN_CUSTODY") {
+    return {
+      title: "In Custody",
+      message: `"${scanned.title}" is in custody — release custody first.`,
+    };
+  }
+
+  // A quantity-tracked asset is judged by its remaining booked units, not by a
+  // global status that says nothing about this booking's slice. An older
+  // server omits the count; then the status rule below is the best available
+  // answer, which is what the booking screen and the web helper also fall back
+  // to.
+  if (
+    row.type === "QUANTITY_TRACKED" &&
+    typeof row.remainingToCheckOut === "number"
+  ) {
+    return row.remainingToCheckOut <= 0
+      ? {
+          title: "Already Checked Out",
+          message: `"${scanned.title}" has no units left to check out on this booking.`,
+        }
+      : null;
+  }
+
+  if (row.status === "CHECKED_OUT") {
+    return {
+      title: "Already Checked Out",
+      message: `"${scanned.title}" is currently checked out (on this or another booking).`,
+    };
+  }
+
+  return null;
+}
+
+/** The kit shape a scan yields, carrying its own membership. */
+export type ScannedKitIdentity = {
+  id: string;
+  name: string;
+  assets: { id: string }[];
+};
+
+/**
+ * Expand a scanned kit into the members that can be checked out now.
+ *
+ * A kit is never checked out as a unit — it contributes its eligible members,
+ * matching the web drawer. Membership is read from the kit's own payload
+ * unioned with rows whose `kitId` points at it: a kit added to a booking from
+ * the phone is stored as standalone rows, so the booking rows alone do not
+ * name every member.
+ *
+ * @param kit The resolved kit, with the asset ids it contains.
+ * @param ctx The booking's membership sets and asset rows.
+ * @param alreadyScannedIds Asset ids already sitting in the scan list.
+ * @returns The rows to add, or the single reason nothing could be added.
+ */
+export function eligibleKitMembers(
+  kit: ScannedKitIdentity,
+  ctx: CheckoutEligibilityContext,
+  alreadyScannedIds: ReadonlySet<string>
+): { eligible: BookingAsset[]; reason: ScanBlockReason | null } {
+  const memberIds = new Set(
+    kit.assets.filter((a) => ctx.bookedAssetIds.has(a.id)).map((a) => a.id)
+  );
+  for (const row of ctx.bookedAssets) {
+    if (row.kitId === kit.id) memberIds.add(row.id);
+  }
+
+  const members = ctx.bookedAssets.filter((row) => memberIds.has(row.id));
+
+  if (members.length === 0) {
+    return {
+      eligible: [],
+      reason: {
+        title: "Not in This Booking",
+        message: `None of "${kit.name}"'s assets are part of this booking.`,
+      },
+    };
+  }
+
+  const checkoutable = members.filter(
+    (row) => checkoutBlocker({ id: row.id, title: row.title }, ctx) === null
+  );
+
+  if (checkoutable.length === 0) {
+    return {
+      eligible: [],
+      reason: {
+        title: "Already Checked Out",
+        message: `All of "${kit.name}"'s assets in this booking are already checked out.`,
+      },
+    };
+  }
+
+  const eligible = checkoutable.filter((row) => !alreadyScannedIds.has(row.id));
+
+  if (eligible.length === 0) {
+    return {
+      eligible: [],
+      reason: {
+        title: "Already Covered",
+        message: `All of "${kit.name}"'s assets in this booking are already in your check-out list.`,
+      },
+    };
+  }
+
+  return { eligible, reason: null };
+}


### PR DESCRIPTION
## What

Adds a **"Scan to Check Out"** mode to the companion scanner: a booking's
assets are checked out one scan at a time, batched, then submitted together.

It is the twin of the check-in mode the app already has, and it calls the
partial-checkout endpoint the app already uses for "Select to Check Out".
**No server changes.**

On a booking the trio now mirrors check-in:

| Check in                | Check out                 |
| ----------------------- | ------------------------- |
| Check In All            | Check Out All Assets      |
| Scan to Check In        | **Scan to Check Out** ← new |
| Select to Check In      | Select to Check Out       |

## Mechanism

The new mode reuses the existing batch list, booking context and drawer, and
adds a `bookingAction=checkout` branch alongside the `add` / `fulfil` ones.

Eligibility moved into a pure helper (`lib/booking-scan-eligibility.ts`) so it
is testable without a simulator:

- A scanned QR carries only the asset's identity and global status, so every
  rule past membership reads the booking's own row. That row is also what the
  submit patches, so re-scanning something just taken is refused without a
  refetch.
- A quantity-tracked row is judged by its remaining booked units, and only
  falls back to the global status when the server sent no count.
- A kit contributes its eligible members and never itself. Membership is read
  from the kit's own payload as well as from the booking rows, so members that
  were added without a kit link are still recognised.

## Permission gate

Both progressive check-out affordances now require the `booking:checkout`
permission, and for a restricted role, being the booking's creator or
custodian — the rule the server enforces. "Select to Check Out" previously had
no gate, so BASE and self-service users met it as a 403 after tapping.

## Second commit

`fix(companion): return to the booking when leaving the booking scanner` — the
header back arrow used `router.back()`. The scanner is a tab screen, so that
unwound the tab's own history and landed on the start page instead of the
booking. It is anchored now, the way the submit handlers in that file already
are. **This applies to all four booking scanner modes** (check-in, add, fulfil,
check-out), not only the new one.

## Known differences from web

- **No quantity prompt for quantity-tracked assets at scan time.** v1 checks out
  all remaining units of a scanned asset, which is the web drawer's default and
  the server's contract for a bare id. Partial quantities remain available via
  "Select to Check Out". A follow-up once the scanner quantity sheet lands.
- **An asset checked out on another booking is refused on the phone** by its
  global status. Same as web.
- **No "x of y remaining" readout** in the scanner; the check-in mode has none
  either.
- **Check-out submits require cuid-shaped asset ids.** The partial-checkout
  route validates `assetIds` with `z.string().cuid()` while its check-in twin
  uses `.min(1)`. Other id shapes are rejected before the booking is touched.
  Being fixed separately in #3003.

## Testing

`typecheck`, `lint` and `test` green — 94 unit tests, 16 new for the
eligibility rules.

New flow `.maestro/flows/bookings/19-scan-to-checkout.yaml`.

Driven end to end on **both** an iPhone 17 simulator and an Android emulator,
against a local webapp, with the database checked after each stage:

- the new button on a RESERVED booking, alongside the other two
- one kit QR expanding to its two member assets
- an asset that is not on the booking refused with "Not in This Booking"
- the kit re-scanned reporting "Already Covered"
- first batch submitted, server reporting `2 checked out, 1 remaining`
- scanner staying open so the rest can be scanned
- on the now-ONGOING booking, "Check Out All Assets" gone while both
  progressive paths remain
- final batch reporting `1 checked out, 0 remaining`, app returning to the
  booking with check-in taking over

Database after each stage matched: the first batch stamped `checkedOutAt` on
exactly the two scanned slices and left the third untouched; the second put all
three out with two recorded scan sessions.

## Ship

Client only — ships as an OTA update for runtime **1.5.0**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added progressive, scanner-driven checkout for bookings, supporting individual assets and kits.
  * Kits automatically expand into eligible member assets during scanning.
  * Added clear feedback for assets that are not booked, already checked out, unavailable, or already covered.
  * Added checkout progress updates and refreshed booking information after checkout.
  * Checkout options are limited to users with the required permission and booking access.
* **Tests**
  * Added coverage for asset, kit, quantity, membership, and checkout eligibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
